### PR TITLE
fix(docs): add redirect for /user-guide/llm-integrations URL

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -54,6 +54,20 @@ const config: Config = {
     },
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            from: '/user-guide/llm-integrations',
+            to: '/docs/user-guide/prompt-configurations/',
+          },
+        ],
+      },
+    ],
+  ],
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
## Summary
- Enables `@docusaurus/plugin-client-redirects` in the docs site
- Adds a redirect from `/user-guide/llm-integrations` to `/docs/user-guide/prompt-configurations/`
- Fixes broken link shared in upgrade notifications that was missing the `/docs/` prefix

## Test plan
- [ ] Build docs site (`cd docs && pnpm build`) and verify `build/user-guide/llm-integrations/index.html` contains the redirect
- [ ] Deploy and verify `https://docs.testplanit.com/user-guide/llm-integrations#prompt-configurations` redirects to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)