### PR TITLE
Fix Dependabot CI failures by updating lockfile

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,38 @@
+name: Update Dependabot lockfile
+
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Update lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git diff --staged --quiet || git commit -m "chore: update pnpm-lock.yaml"
+          git push


### PR DESCRIPTION
## Summary
- Adds a workflow that runs `pnpm install` on Dependabot PRs and commits the updated `pnpm-lock.yaml` back to the branch
- Fixes CI failures caused by Dependabot not updating the workspace-level lockfile when it modifies individual `package.json` files

## Test plan
- [ ] Merge this PR, then re-run CI on a failing Dependabot PR to confirm the lockfile gets updated and CI passes

Generated with [Claude Code](https://claude.com/claude-code)