### PR TITLE
Exclude @types/node from dev-dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "@types/node"
       minor-and-patch:
         dependency-type: "production"
         update-types:
@@ -20,6 +22,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "@types/node"
       minor-and-patch:
         dependency-type: "production"
         update-types:
@@ -33,6 +37,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "@types/node"
       minor-and-patch:
         dependency-type: "production"
         update-types:


### PR DESCRIPTION
## Summary
- Excludes `@types/node` from dev-dependency groups in all 3 package directories
- Prevents major `@types/node` bumps (e.g. 20→25) from blocking auto-merge on the entire dev-dependencies group
- `@types/node` will get its own separate PR instead

## Test plan
- [ ] After merge, trigger Dependabot recreate on affected PRs
- [ ] Verify dev-dependency group PRs no longer show as semver-major
- [ ] Confirm auto-merge kicks in for the dev-dependency groups

Generated with [Claude Code](https://claude.com/claude-code)