### PR TITLE
Ignore major bumps for packages that break testplanit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,21 @@ updates:
     directory: "/testplanit"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@prisma/client"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "prisma"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@zenstackhq/server"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@zenstackhq/tanstack-query"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-resizable-panels"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Summary
- Ignores major version bumps for packages that can't be upgraded without breaking changes:
  - `@prisma/client`, `prisma` (6→7)
  - `@zenstackhq/server`, `@zenstackhq/tanstack-query` (2→3)
  - `eslint`, `@eslint/js` (9→10)
  - `react-resizable-panels` (3→4)
- Minor and patch updates for these packages will still be created

## Test plan
- [ ] After merge, verify Dependabot closes the existing major bump PRs for these packages
- [ ] Confirm minor/patch updates still come through

Generated with [Claude Code](https://claude.com/claude-code)