### PR TITLE
Auto-approve Dependabot PRs before auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Adds an approve step to the auto-merge workflow for non-major Dependabot PRs
- Fixes the REVIEW_REQUIRED block that prevents auto-merge when branch protection requires approvals

## Test plan
- [ ] After merge, rebase a Dependabot PR and verify it gets approved and auto-merged

Generated with [Claude Code](https://claude.com/claude-code)