### PR TITLE
Fix security vulnerabilities in dependencies

### DIFF
--- a/forge-app/package-lock.json
+++ b/forge-app/package-lock.json
@@ -1765,22 +1765,22 @@
       "link": true
     },
     "node_modules/@forge/cli": {
-      "version": "12.14.1",
-      "resolved": "https://registry.npmjs.org/@forge/cli/-/cli-12.14.1.tgz",
-      "integrity": "sha512-cu4PixUXct+ZPtvUC+2GkQ3m2NOkH/xAR9/dFkQMT46s4kDS0w9BU53DGmqQAJvtkijuoeqHFO5+oiUvf7eKJQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/@forge/cli/-/cli-12.15.0.tgz",
+      "integrity": "sha512-rVb+x95wFxowrEMxT4nwT3gqE288gnzNIwVujmhv5DVuBix0Yj0cuRCjhvoGcTE0PP2GaRxTaSXYp3zpBRU9hg==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@forge/bundler": "6.1.19",
-        "@forge/cli-shared": "8.15.2",
+        "@forge/bundler": "6.1.20",
+        "@forge/cli-shared": "8.16.0",
         "@forge/egress": "2.3.1",
         "@forge/i18n": "0.0.7",
-        "@forge/lint": "5.15.1",
-        "@forge/manifest": "12.1.1",
+        "@forge/lint": "5.16.0",
+        "@forge/manifest": "12.2.0",
         "@forge/runtime": "6.1.2",
-        "@forge/tunnel": "6.3.10",
+        "@forge/tunnel": "6.3.11",
         "@forge/util": "2.0.1",
         "@sentry/node": "7.106.0",
         "ajv": "^8.12.0",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/@forge/cli/node_modules/@forge/bundler": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/@forge/bundler/-/bundler-6.1.19.tgz",
-      "integrity": "sha512-7d0h1I4lNGeIPkrhTN4lEQP43kmdXBxS6rNJ+NhkTUcXY51Pbiqz8Zc7TKp5AG4IaLpTCRS6DZ0kEZ9G43JZqQ==",
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@forge/bundler/-/bundler-6.1.20.tgz",
+      "integrity": "sha512-R35eolxSy6lb4oJxK8YG25pNQVn9pjZ0xuEHVksFSx5+9d17LT1dVKKzUeZRZlaIZj0NbvxxTuK3GtL5kQSoAA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -2338,10 +2338,10 @@
         "@babel/plugin-transform-react-jsx": "^7.23.4",
         "@babel/traverse": "^7.24.0",
         "@babel/types": "^7.24.0",
-        "@forge/cli-shared": "8.15.2",
+        "@forge/cli-shared": "8.16.0",
         "@forge/i18n": "0.0.7",
-        "@forge/lint": "5.15.1",
-        "@forge/manifest": "12.1.1",
+        "@forge/lint": "5.16.0",
+        "@forge/manifest": "12.2.0",
         "babel-loader": "^8.3.0",
         "cheerio": "^1.1.0",
         "cross-spawn": "^7.0.6",
@@ -2361,14 +2361,14 @@
       }
     },
     "node_modules/@forge/cli/node_modules/@forge/cli-shared": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@forge/cli-shared/-/cli-shared-8.15.2.tgz",
-      "integrity": "sha512-Kh9B7q1QLs3cNOqI4cbdIf7Fzk219EkEDoGrqaiWtmXGlzFW6He4A0J4Yh/wRQ5hJd1kgqv16m7g3TGlu9nI+g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@forge/cli-shared/-/cli-shared-8.16.0.tgz",
+      "integrity": "sha512-be+rWnOIxrat3/F0p8axm8t9FxE51L4pccul+yh3tw7PwSaGwSe2tCxzAoQnUjIczX9czanuRNhnlEjuy249iw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@forge/i18n": "0.0.7",
-        "@forge/manifest": "12.1.1",
+        "@forge/manifest": "12.2.0",
         "@forge/util": "2.0.1",
         "@sentry/node": "7.106.0",
         "adm-zip": "^0.5.10",
@@ -2437,17 +2437,17 @@
       }
     },
     "node_modules/@forge/cli/node_modules/@forge/lint": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@forge/lint/-/lint-5.15.1.tgz",
-      "integrity": "sha512-g4aUNPGseCU8mNPxx4ieOHAMieqmUcMsz+tH15gMhdp07/3qEvt7+EgNoqSiDsHrdpB6TVDl7RxjcLk6rtlwPw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@forge/lint/-/lint-5.16.0.tgz",
+      "integrity": "sha512-RDFDQAifML8THJO+pGT4Wjm2AYUgCFuu7O57bx5KK1cv15Il/k2Ei4CPfQXo7UDE90ni5dwuO9/acvptFZa8Gw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@atlassian/atlassian-openapi": "^1.0.6",
-        "@forge/cli-shared": "8.15.2",
+        "@forge/cli-shared": "8.16.0",
         "@forge/csp": "5.6.1",
         "@forge/egress": "2.3.1",
-        "@forge/manifest": "12.1.1",
+        "@forge/manifest": "12.2.0",
         "@typescript-eslint/typescript-estree": "^5.62.0",
         "array.prototype.flatmap": "^1.3.3",
         "cross-spawn": "^7.0.6",
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/@forge/cli/node_modules/@forge/manifest": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.1.1.tgz",
-      "integrity": "sha512-51+WD94QnR5BCv3TipagYqZVNZwzXMKqdhNOs5qsEI5kIPp34zuJ30x/nB43iFkiSvB986LRMS11sM/lEW8plQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.2.0.tgz",
+      "integrity": "sha512-gsBH8iVsL7S/OXhW0rCpK7AZ34zYUwLqidYvirkc5iRyy+QXrJLA5Use91HrbVbXfAM2ntjtvijUL2C0LH/ufA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -2480,14 +2480,14 @@
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@forge/cli/node_modules/@forge/tunnel": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/@forge/tunnel/-/tunnel-6.3.10.tgz",
-      "integrity": "sha512-jiD/snAg4m72eB1NKWFGaNeIvQlys3BjqQT5t8/R0wv7OlUbf5GifdVyuNZmjr/pEhLyo9hu131lr4kQ/Won5g==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/@forge/tunnel/-/tunnel-6.3.11.tgz",
+      "integrity": "sha512-0wehfZGe7dU8Ob2ypdGdadTmR1PtklFTXsfDX5DS/Ajushyu4tGM7P8OEmTuWhUdd2H23TAlLQBzBkWuSUtkuQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@forge/bundler": "6.1.19",
-        "@forge/cli-shared": "8.15.2",
+        "@forge/bundler": "6.1.20",
+        "@forge/cli-shared": "8.16.0",
         "@forge/csp": "5.6.1",
         "@forge/runtime": "6.1.2",
         "@forge/util": "^2.0.1",
@@ -8857,6 +8857,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha1-1jCrrSsUdEPyCiEpF76uaLgJLuw= sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -14296,16 +14297,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "resolved": "../node_modules/.pnpm/react@18.3.1/node_modules/react",
       "link": true
@@ -14632,27 +14623,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -14696,16 +14666,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -14973,16 +14933,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,8 +690,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
       dompurify:
-        specifier: ^3.2.4
-        version: 3.3.1
+        specifier: ^3.3.2
+        version: 3.3.2
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.4)
@@ -711,8 +711,8 @@ importers:
         specifier: ^20.8.3
         version: 20.8.3
       hono:
-        specifier: '>=4.11.10'
-        version: 4.12.2
+        specifier: ^4.12.5
+        version: 4.12.5
       html-to-adf-converter:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1465,13 +1465,13 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@atlaskit/button@23.9.6':
-    resolution: {integrity: sha512-jO7uugpob+k2fTDdFoFV2hdFr9jxQnN3dn2e+OlLsbc/13g9ktDbK0QcQbFqUPtV+Ek1uMTXswUDYDQFSzrnnw==}
+  '@atlaskit/button@23.10.0':
+    resolution: {integrity: sha512-nNY5Xl449yowkTY8oWjvMo0gGn6bJva5xw0pwHxfBu3E5bXnWGf8EPSnVfUzPDGfJTn8MOuJAqyJ/Bxv7KzWWw==}
     peerDependencies:
       react: ^18.2.0
 
-  '@atlaskit/button@23.9.9':
-    resolution: {integrity: sha512-ZmlVBgFw6pqAu9b3JiPpi2gQIBhbfWpFgJO2W2oY6JUuNZC/CRJjKHSzYQ7Awor/b6t9qPaw65wOltQKHDED6Q==}
+  '@atlaskit/button@23.9.6':
+    resolution: {integrity: sha512-jO7uugpob+k2fTDdFoFV2hdFr9jxQnN3dn2e+OlLsbc/13g9ktDbK0QcQbFqUPtV+Ek1uMTXswUDYDQFSzrnnw==}
     peerDependencies:
       react: ^18.2.0
 
@@ -1607,6 +1607,11 @@ packages:
     resolution: {integrity: sha512-j3DLHqBACSJsG3XqSgCIwZqvJhYkpSC8i+24n/JYCRjIxYEJMsuSXOtdeu0qBajREwgzmAFP6AVfVZh1zAWG/A==}
     peerDependencies:
       react: ^18.2.0
+
+  '@atlaskit/ds-lib@5.3.1':
+    resolution: {integrity: sha512-rtbWJ8trxKjNtC8sCTDjl4ZAfYWq73B3WMS8ZJyqpu8LgBYrc9e0c5b+RR0G1J6lP9Yq5lWWq+iaJ6ytX8KZRg==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
 
   '@atlaskit/dynamic-table@17.1.5':
     resolution: {integrity: sha512-lPOZjay9bs9wbwHukFRNyodKRdxONEWfFZ0TZ23O+6NmQ6mFwJl/Sj+7+qKgHd6v3vurHVJG6VdQOnKqsuVQKQ==}
@@ -2345,6 +2350,12 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
+  '@atlaskit/portal@5.2.2':
+    resolution: {integrity: sha512-WzdIV96FnSJHpYp1zaabF6+o5kXSiiLKWC8DP16LAJ7nTpwUTdZ6td9/TLjMihLfDKLROijr1IzialqQZa9TXw==}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0':
     resolution: {integrity: sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg==}
 
@@ -2495,8 +2506,8 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@atlaskit/section-message@8.12.6':
-    resolution: {integrity: sha512-WgSPm13xvHLmFZRABxugB+RawD3o9MlV5gG8I8D6o8e1vXAV2yAn+aN5BxE1OeT7VFAyRenPQ9r7WrbJ13HCJA==}
+  '@atlaskit/section-message@8.12.7':
+    resolution: {integrity: sha512-Odus8FA9o93XSC2Em968LJboqVx63R/NsCq0TJzuxcSUTfQRMu7Lzz132ezUYrgFzP1JbOOxrjrOnacDot6a1Q==}
     peerDependencies:
       react: ^18.2.0
 
@@ -2578,6 +2589,11 @@ packages:
 
   '@atlaskit/spinner@19.0.10':
     resolution: {integrity: sha512-qsywNl4OR+zMuqVJ1+jEAtlcTHh7rvQ2EwKlRYY/EyUs1Ac0rDpZP8a7vA9E9fHUlFcI7J69HuTGVTUYu+hXlA==}
+    peerDependencies:
+      react: ^18.2.0
+
+  '@atlaskit/spinner@19.0.11':
+    resolution: {integrity: sha512-Ql8fvYUNwHOX3gmpL83Gur6FKJZMeF75Ia4NDSw7pcevcXfpv9LAs/QMtfyJvRRVKnnb7I5Pj8dp+xhHJ7e19Q==}
     peerDependencies:
       react: ^18.2.0
 
@@ -2679,6 +2695,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
+  '@atlaskit/theme@22.0.0':
+    resolution: {integrity: sha512-OXTsQHeNQ8BNeSbvUpHda1eHK0YlxHqy7J+GrBI/WoxbGj8X4OnRPbNC0fPKWSfvH9qHZ4Kg9jROQ1Z9KLNAgg==}
+    peerDependencies:
+      react: ^18.2.0
+
   '@atlaskit/tile@1.0.5':
     resolution: {integrity: sha512-SSsv6qQOZvDP6BjmpHmBXi8InGTqFwfeEfSpoQJZoX1b8fT/p+Nc3zCAraoiDOhpCmgUicxHkBTlmZ20g2I+IA==}
     peerDependencies:
@@ -2724,10 +2745,10 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@atlaskit/tokens@11.0.1':
-    resolution: {integrity: sha512-3W9TncNs3TKQmJXSm2oIBoLhh9FnudLKHspT/NxlHWkVEqSWZX0gAbECMbH9wVItgaK+zqo5DyxqAPUtGRdCWg==}
+  '@atlaskit/tokens@11.0.2':
+    resolution: {integrity: sha512-77B4TbCm+MOJlZE9WIkLtwG5UyIBm8mun42aW9eTMdU5z2xFM1xk6qsV2zfpqEphg2ISCWZk9TdjLQ83+3/LlA==}
     peerDependencies:
-      react: ^18.2.0
+      react: ^18.2.0 || ^19.0.0
 
   '@atlaskit/tokens@3.3.2':
     resolution: {integrity: sha512-NgNUNwlZ4ow9IRa3dK24ZF1TBY3SyHGQJnt7WruoR/yyZjsaqQy3jcKwtiNJ1SMzZO7UkgfwwVWhlqdVnul6hA==}
@@ -2783,8 +2804,8 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  '@atlaskit/tooltip@20.14.4':
-    resolution: {integrity: sha512-rXWXuubfpjRLQnobpnlaYOldndTekfADJ5LBUMG+YRtV9aGDgu04neV63u8SnoUhYsVRbtUCqpN1ZO0gsVPVDg==}
+  '@atlaskit/tooltip@20.14.6':
+    resolution: {integrity: sha512-RKYhy7i01ntAAzs3bQ+lG9TQ6kuAESTxdpxCAHAeU9k5ow4nauG62+y7FFt5xc6/QAynhcR4HpB7c36jCtu1Cw==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -3723,6 +3744,11 @@ packages:
     resolution: {integrity: sha512-Mt6sJOwykeoToEBFbOUNR4xABi2gOr/+X5QSGqGEYiCBMh+XPDAclG2UX94zveiYJXO4AUJIQBCVwa4/lwPMBA==}
     peerDependencies:
       react: '>= 16.12.0'
+
+  '@compiled/react@0.20.0':
+    resolution: {integrity: sha512-mEJuYGFxIDST1H7CpksyE6a3HRVRQmeDal26O+bCHTEZlPp7iKvs5KD1FOmd2palng+S60dPFFG+UuoZDRILwA==}
+    peerDependencies:
+      react: '>=18.0.0'
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -5674,62 +5700,62 @@ packages:
   '@prisma/config@6.19.2':
     resolution: {integrity: sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==}
 
-  '@prisma/config@7.4.1':
-    resolution: {integrity: sha512-vteSXm8N46bo3FW9MhPGVHAj+KRgrR6TWtlSk6GqToCKjTnOexXdPZyiDyEsfVW38YhqEmVl6w/6iHN8uYVJcw==}
+  '@prisma/config@7.4.2':
+    resolution: {integrity: sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==}
 
   '@prisma/debug@6.19.2':
     resolution: {integrity: sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==}
 
-  '@prisma/debug@7.4.1':
-    resolution: {integrity: sha512-qEtzO8oLouRv18JDQUC3G3Gnv+fGVscHZm/x1DBB/WT+kOvPDQLM2woX6IGgWnSMYYlrxjuALshT7G/blvY0bQ==}
+  '@prisma/debug@7.4.2':
+    resolution: {integrity: sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==}
 
   '@prisma/dmmf@6.19.2':
     resolution: {integrity: sha512-ZHGDQlnrWKwFPAOvJ8hVbmIqNPdE0XXptTeYqmUGhYMDySSts60O8g3KNY1uAqr3nHiyDcpaGIpO1MBYoDW6gQ==}
 
-  '@prisma/dmmf@7.4.1':
-    resolution: {integrity: sha512-805aCBILKe+l3A/z3JF/X9cH0ZZZegTOfKzm8zRpoBcOhLy+SRM2kGJ4aIXp5a6ENdAh6FN2u7ikZ16UDCI9Kg==}
+  '@prisma/dmmf@7.4.2':
+    resolution: {integrity: sha512-EurUPjBwmAd69MM8PLZ5n94xeeQ+7SB3Wd9p2+YsgXhvqCa1cgJRBJiB6fTWkPTz5Lf05ySNJ/59EnuEJMAnrw==}
 
   '@prisma/driver-adapter-utils@6.19.2':
     resolution: {integrity: sha512-tkHsL3jhx81eXg2oqtJH/1IEs8uEeUb1RpqHtwYqdNb176u9D0mnHRZM1/cKca/XhLpq49Nnd9XDxdMfWcKAYA==}
 
-  '@prisma/driver-adapter-utils@7.4.1':
-    resolution: {integrity: sha512-gEZOC2tnlHaZNbHUdbK8YvQphq2tKq/Ovu1YixJ/hPSutDAvNzC3R+xUeBuJ4AJp236eELMzwxb7rgo3UbRkTg==}
+  '@prisma/driver-adapter-utils@7.4.2':
+    resolution: {integrity: sha512-REdjFpT/ye9KdDs+CXAXPIbMQkVLhne9G5Pe97sNY4Ovx4r2DAbWM9hOFvvB1Oq8H8bOCdu0Ri3AoGALquQqVw==}
 
   '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
     resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
 
-  '@prisma/engines-version@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3':
-    resolution: {integrity: sha512-fUxVd1TjOW8K4XsZ8dAm88sDW5Ry7AxWDfsYEWwScS6Fjo3caKC6hgNumUfsmsy0Il9LjDn5X0PpVXNt3iwayw==}
+  '@prisma/engines-version@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919':
+    resolution: {integrity: sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==}
 
   '@prisma/engines@6.19.2':
     resolution: {integrity: sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==}
 
-  '@prisma/engines@7.4.1':
-    resolution: {integrity: sha512-BZEBdHvNJx5PzIG37EI/Zi5UUI5hGWjkYsQmKa7OIK6evAvebOTwutjS/VRI6cA6grmA52eLZR+oekGRMqkKxQ==}
+  '@prisma/engines@7.4.2':
+    resolution: {integrity: sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==}
 
   '@prisma/fetch-engine@6.19.2':
     resolution: {integrity: sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==}
 
-  '@prisma/fetch-engine@7.4.1':
-    resolution: {integrity: sha512-Z9kbuxX2bvEsyeS3LZEiEnxG0lVtZbpYgaAnPj69N+A9f2De8Lta0EoFtld9zhfERVPIQWhSWUc8himky3qYdA==}
+  '@prisma/fetch-engine@7.4.2':
+    resolution: {integrity: sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==}
 
   '@prisma/generator-helper@6.19.2':
     resolution: {integrity: sha512-vSjDbHhtKjRDgywTDYyAJLEe+kMxq4DNLNiurk/tGca8W/H7duX4Z4UdvYXcv3kWmmgJJmdndh41dgIsrewa3w==}
 
-  '@prisma/generator-helper@7.4.1':
-    resolution: {integrity: sha512-moKkU9xHt3S3QAgh4AhVYpAjXSVH3P8N1CBmZ/hepGHSKdVn8aq+viGL942HH+5/t//1bZ0Gd9hUlCjttAn1FQ==}
+  '@prisma/generator-helper@7.4.2':
+    resolution: {integrity: sha512-PWTkqlMILGVghoWP8SZB3prw/EcthiyPYJsMoiVZrClqPMQn6doPjphCQffPDyGzZvAwmA64edbc6Gm/6Omkjg==}
 
   '@prisma/generator@6.19.2':
     resolution: {integrity: sha512-2xDQQUJh2s6Ty9I9CIGRz7Z8pEGxKxjU/lkFyLI5f83fDoISUaGhWQZGW35xMqKVDoNRM93w1ghm+1ScRy0mAA==}
 
-  '@prisma/generator@7.4.1':
-    resolution: {integrity: sha512-UO9DHDWLvZxAhOZmutOKJUVKLHCqkQze4ZzdOQpO2rbz9s4p7sa/kT1kFKGODIDaGc04T6MziKjsauQVwjKqOQ==}
+  '@prisma/generator@7.4.2':
+    resolution: {integrity: sha512-+4B8Rrq5Ef2cm7cW7Wyu6oXn/QVcDVdNti9mKEkcbPVLlA85I6Rbd+j6r+k2E2nlj0zKZbDbq8fIx/Xnt1SmkA==}
 
   '@prisma/get-platform@6.19.2':
     resolution: {integrity: sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==}
 
-  '@prisma/get-platform@7.4.1':
-    resolution: {integrity: sha512-kN4tmkQzlgm/KtE+jTNSYjsDxxe/5i6GApPI32BN9T0tlgsgSBtDJbjGBICttkAIjsh73dXf8raPKxO/2n2UUg==}
+  '@prisma/get-platform@7.4.2':
+    resolution: {integrity: sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==}
 
   '@prisma/internals@6.19.2':
     resolution: {integrity: sha512-ciXNy15WKIg4rjuA0dNZ03CMJEneoEi47a3E6Yp59KI90M7r/nieaiqSRtWakl9nKj2YKfRX6nraYC3zaeSQXQ==}
@@ -5739,8 +5765,8 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/internals@7.4.1':
-    resolution: {integrity: sha512-P57Go0nC3LVYjqEs/WT+jfak9OcdMIgAUXrIQXvMlB/tggsgVYuSCoBiOXw6o8B//D/HS/E9QMVlb3K7o/utPg==}
+  '@prisma/internals@7.4.2':
+    resolution: {integrity: sha512-hYRr4BjqGf/PeXF/GPeSjEf7pBEhvlHxm3pkt8p6xScBKXglLyDcEt/1h2E81nwjcrZsW1enVG4u+v35j2kijw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -5750,20 +5776,20 @@ packages:
   '@prisma/prisma-schema-wasm@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
     resolution: {integrity: sha512-/5JrsJQAOIWSl+9WMM/0ugd737kT9zdMNr7EFaP7ogeMxAhxQ78uaOV6JYGEocD8LC0gZx7MXmVE/CTfYdJ2iA==}
 
-  '@prisma/prisma-schema-wasm@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3':
-    resolution: {integrity: sha512-7J7kF0YCsY4blgM+VFq3rG1+mgFS8drZiKRKah1wsLN77t4ZS+6VwI89qTN6SlMakzlkd3giwQqDxr/utPgFXw==}
+  '@prisma/prisma-schema-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919':
+    resolution: {integrity: sha512-DV5lGaN01UD4t9kilHXekw7oruBvigjkvYspaCq+D961zAYJrXuSDVXe4wM0EDVml0ujoa3apNf/QRxv0ecVuA==}
 
   '@prisma/schema-engine-wasm@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
     resolution: {integrity: sha512-mXtzeePkSdqpr/HAIclqzQEf+tBzLawy7NQ9AaRCfg8N/cruavpsocgbSwOOfV7JTk9JubyzKuR3tp2bNNuWbQ==}
 
-  '@prisma/schema-engine-wasm@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3':
-    resolution: {integrity: sha512-R95Js2Kk+iPVEAan8D+aBQgSSJJIrvsDzNVwBNjsYuTd42YRoZJnJP6YJ/YNBMfNyWnjx7ulQ20Ol1ubA72xGg==}
+  '@prisma/schema-engine-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919':
+    resolution: {integrity: sha512-v7E/pxOvzJyILTK5ZvBs7fLjcoFPG2t6BdnAsfKIZtQZlQz7TyTC3kkZvcigtnV/6/ktVOsd0RQFIk0rD4e5lg==}
 
   '@prisma/schema-files-loader@6.19.2':
     resolution: {integrity: sha512-v4dHwmYn0rsn6E6Lo6EH4oT7rYVlbJTKWUL3j4gjX0AyQefm3NIITFdYuonDy1S4y2Z/3D1r8gCVjFLskKfK/A==}
 
-  '@prisma/schema-files-loader@7.4.1':
-    resolution: {integrity: sha512-w67qWHGPKvmemfk7BjMaOqzMZGc0d4BByxoQsP0B93svH/O3NwnC4gfFN4RG7T/IYgnpn6i7xAQQtPx2cyI6hQ==}
+  '@prisma/schema-files-loader@7.4.2':
+    resolution: {integrity: sha512-ZHbna/+pVxOkNas+P57jp9hKr8QYn0IJw2uznDkGbLbMToO5IiVF/nDwiIKPxdRxbHRWFS2MSXwt/GDfq2Lyrw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -10641,8 +10667,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -11875,8 +11902,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.2:
-    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -19184,6 +19211,54 @@ snapshots:
       - react-dom
       - supports-color
 
+  '@atlaskit/button@23.10.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/css': 0.19.2(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/focus-ring': 3.0.10(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/icon': 32.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/interaction-context': 3.1.0(react@18.3.1)
+      '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
+      '@atlaskit/primitives': 18.0.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/spinner': 19.0.11(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/theme': 22.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tooltip': 20.14.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/visually-hidden': 3.0.4(react@18.3.1)
+      '@babel/runtime': 7.28.6
+      '@compiled/react': 0.18.6(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
+
+  '@atlaskit/button@23.10.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@atlaskit/analytics-next': 11.1.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/css': 0.19.2(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/focus-ring': 3.0.10(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/icon': 32.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/interaction-context': 3.1.0(react@19.2.4)
+      '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
+      '@atlaskit/primitives': 18.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/spinner': 19.0.11(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/theme': 22.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tooltip': 20.14.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/visually-hidden': 3.0.4(react@19.2.4)
+      '@babel/runtime': 7.28.6
+      '@compiled/react': 0.18.6(react@19.2.4)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
+
   '@atlaskit/button@23.9.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19222,54 +19297,6 @@ snapshots:
       '@atlaskit/theme': 21.0.5(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/tokens': 11.0.0(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/tooltip': 20.14.3(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/visually-hidden': 3.0.4(react@19.2.4)
-      '@babel/runtime': 7.28.6
-      '@compiled/react': 0.18.6(react@19.2.4)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@atlaskit/button@23.9.9(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/css': 0.19.2(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/focus-ring': 3.0.10(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/icon': 32.0.0(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/interaction-context': 3.1.0(react@18.3.1)
-      '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
-      '@atlaskit/primitives': 18.0.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/spinner': 19.0.10(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/theme': 21.0.5(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/tokens': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/tooltip': 20.14.4(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/visually-hidden': 3.0.4(react@18.3.1)
-      '@babel/runtime': 7.28.6
-      '@compiled/react': 0.18.6(react@18.3.1)
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@atlaskit/button@23.9.9(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@atlaskit/analytics-next': 11.1.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/css': 0.19.2(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/focus-ring': 3.0.10(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/icon': 32.0.0(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/interaction-context': 3.1.0(react@19.2.4)
-      '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
-      '@atlaskit/primitives': 18.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/spinner': 19.0.10(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/theme': 21.0.5(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/tokens': 11.0.1(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/tooltip': 20.14.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/visually-hidden': 3.0.4(react@19.2.4)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@19.2.4)
@@ -19983,6 +20010,28 @@ snapshots:
       - '@types/react'
 
   '@atlaskit/ds-lib@5.3.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
+      '@babel/runtime': 7.28.6
+      bind-event-listener: 3.0.0
+      react: 19.2.4
+      react-uid: 2.4.0(@types/react@19.2.14)(react@19.2.4)
+      tiny-invariant: 1.3.3
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@atlaskit/ds-lib@5.3.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
+      '@babel/runtime': 7.28.6
+      bind-event-listener: 3.0.0
+      react: 18.3.1
+      react-uid: 2.4.0(@types/react@18.3.28)(react@18.3.1)
+      tiny-invariant: 1.3.3
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@atlaskit/ds-lib@5.3.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
       '@babel/runtime': 7.28.6
@@ -21466,7 +21515,7 @@ snapshots:
     dependencies:
       '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
       '@atlaskit/tile': 1.0.5(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/tokens': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@18.3.1)
       react: 18.3.1
@@ -21478,7 +21527,7 @@ snapshots:
     dependencies:
       '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
       '@atlaskit/tile': 1.0.5(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/tokens': 11.0.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@19.2.4)
       react: 19.2.4
@@ -23198,7 +23247,7 @@ snapshots:
       '@atlaskit/analytics-namespaced-context': 7.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/link': 3.3.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/section-message': 8.12.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/section-message': 8.12.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.28.6
       immer: 9.0.21
       react: 18.3.1
@@ -23214,7 +23263,7 @@ snapshots:
       '@atlaskit/analytics-namespaced-context': 7.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/analytics-next': 11.1.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/link': 3.3.3(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/section-message': 8.12.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/section-message': 8.12.7(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@babel/runtime': 7.28.6
       immer: 9.0.21
       react: 19.2.4
@@ -23960,7 +24009,7 @@ snapshots:
 
   '@atlaskit/motion@5.3.11(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
-      '@atlaskit/ds-lib': 5.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@18.3.1)
       bind-event-listener: 3.0.0
@@ -23970,7 +24019,7 @@ snapshots:
 
   '@atlaskit/motion@5.3.11(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@19.2.4)
       bind-event-listener: 3.0.0
@@ -24585,6 +24634,30 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@atlaskit/portal@5.2.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@atlaskit/app-provider': 4.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
+      '@atlaskit/theme': 22.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@babel/runtime': 7.28.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  '@atlaskit/portal@5.2.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@atlaskit/app-provider': 4.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
+      '@atlaskit/theme': 22.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@babel/runtime': 7.28.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0':
     dependencies:
       '@atlaskit/pragmatic-drag-and-drop': 1.7.7
@@ -24912,9 +24985,9 @@ snapshots:
       '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/app-provider': 4.1.0(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/css': 0.19.2(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/interaction-context': 3.1.0(react@18.3.1)
-      '@atlaskit/tokens': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/visually-hidden': 3.0.4(react@18.3.1)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@18.3.1)
@@ -24933,9 +25006,9 @@ snapshots:
       '@atlaskit/analytics-next': 11.1.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/app-provider': 4.1.0(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/css': 0.19.2(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/interaction-context': 3.1.0(react@19.2.4)
-      '@atlaskit/tokens': 11.0.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/visually-hidden': 3.0.4(react@19.2.4)
       '@babel/runtime': 7.28.6
       '@compiled/react': 0.18.6(react@19.2.4)
@@ -25522,17 +25595,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@atlaskit/section-message@8.12.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@atlaskit/section-message@8.12.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@atlaskit/button': 23.9.9(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/button': 23.10.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/css': 0.19.2(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/heading': 5.3.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/icon': 32.0.0(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/link': 3.3.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
       '@atlaskit/primitives': 18.0.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/theme': 21.0.5(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/tokens': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/theme': 22.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
       '@babel/runtime': 7.28.6
       react: 18.3.1
     transitivePeerDependencies:
@@ -25540,17 +25613,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@atlaskit/section-message@8.12.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@atlaskit/section-message@8.12.7(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@atlaskit/button': 23.9.9(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/button': 23.10.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/css': 0.19.2(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/heading': 5.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/icon': 32.0.0(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/link': 3.3.3(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
       '@atlaskit/primitives': 18.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/theme': 21.0.5(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/tokens': 11.0.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/theme': 22.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
       '@babel/runtime': 7.28.6
       react: 19.2.4
     transitivePeerDependencies:
@@ -26252,6 +26325,30 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@atlaskit/spinner@19.0.11(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@atlaskit/interaction-context': 3.1.0(react@18.3.1)
+      '@atlaskit/theme': 22.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
+      '@babel/runtime': 7.28.6
+      '@compiled/react': 0.18.6(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  '@atlaskit/spinner@19.0.11(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@atlaskit/interaction-context': 3.1.0(react@19.2.4)
+      '@atlaskit/theme': 22.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@babel/runtime': 7.28.6
+      '@compiled/react': 0.18.6(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   '@atlaskit/status@1.9.4(@babel/core@7.29.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-intl@5.25.1(react@18.3.1)(typescript@4.8.4))(react@18.3.1)':
     dependencies:
       '@atlaskit/analytics-next': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -26756,6 +26853,26 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@atlaskit/theme@22.0.0(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
+      '@babel/runtime': 7.28.6
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  '@atlaskit/theme@22.0.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@babel/runtime': 7.28.6
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   '@atlaskit/tile@1.0.5(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@atlaskit/skeleton': 2.1.7(@types/react@18.3.28)(react@18.3.1)
@@ -26923,9 +27040,9 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@atlaskit/tokens@11.0.1(@types/react@18.3.28)(react@18.3.1)':
+  '@atlaskit/tokens@11.0.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
-      '@atlaskit/ds-lib': 5.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
       '@babel/runtime': 7.28.6
       '@babel/traverse': 7.29.0
@@ -26936,9 +27053,9 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@atlaskit/tokens@11.0.1(@types/react@19.2.14)(react@19.2.4)':
+  '@atlaskit/tokens@11.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
       '@babel/runtime': 7.28.6
       '@babel/traverse': 7.29.0
@@ -27267,19 +27384,19 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@atlaskit/tooltip@20.14.4(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@atlaskit/tooltip@20.14.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@atlaskit/analytics-next': 11.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/layering': 3.6.0(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/motion': 5.3.11(@types/react@18.3.28)(react@18.3.1)
       '@atlaskit/platform-feature-flags': 1.1.3(react@18.3.1)
       '@atlaskit/popper': 7.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/portal': 5.2.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/theme': 21.0.5(@types/react@18.3.28)(react@18.3.1)
-      '@atlaskit/tokens': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/portal': 5.2.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@atlaskit/theme': 22.0.0(@types/react@18.3.28)(react@18.3.1)
+      '@atlaskit/tokens': 11.0.2(@types/react@18.3.28)(react@18.3.1)
       '@babel/runtime': 7.28.6
-      '@compiled/react': 0.18.6(react@18.3.1)
+      '@compiled/react': 0.20.0(react@18.3.1)
       bind-event-listener: 3.0.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -27287,19 +27404,19 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@atlaskit/tooltip@20.14.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@atlaskit/tooltip@20.14.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@atlaskit/analytics-next': 11.1.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/ds-lib': 5.3.1(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/layering': 3.6.0(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/motion': 5.3.11(@types/react@19.2.14)(react@19.2.4)
       '@atlaskit/platform-feature-flags': 1.1.3(react@19.2.4)
       '@atlaskit/popper': 7.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/portal': 5.2.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@atlaskit/theme': 21.0.5(@types/react@19.2.14)(react@19.2.4)
-      '@atlaskit/tokens': 11.0.1(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/portal': 5.2.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@atlaskit/theme': 22.0.0(@types/react@19.2.14)(react@19.2.4)
+      '@atlaskit/tokens': 11.0.2(@types/react@19.2.14)(react@19.2.4)
       '@babel/runtime': 7.28.6
-      '@compiled/react': 0.18.6(react@19.2.4)
+      '@compiled/react': 0.20.0(react@19.2.4)
       bind-event-listener: 3.0.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -29057,6 +29174,16 @@ snapshots:
       react: 18.3.1
 
   '@compiled/react@0.18.6(react@19.2.4)':
+    dependencies:
+      csstype: 3.2.3
+      react: 19.2.4
+
+  '@compiled/react@0.20.0(react@18.3.1)':
+    dependencies:
+      csstype: 3.2.3
+      react: 18.3.1
+
+  '@compiled/react@0.20.0(react@19.2.4)':
     dependencies:
       csstype: 3.2.3
       react: 19.2.4
@@ -30969,9 +31096,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@1.19.9(hono@4.12.2)':
+  '@hono/node-server@1.19.9(hono@4.12.5)':
     dependencies:
-      hono: 4.12.2
+      hono: 4.12.5
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
     dependencies:
@@ -31438,7 +31565,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.2)
+      '@hono/node-server': 1.19.9(hono@4.12.5)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -31448,7 +31575,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.2
+      hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -32005,7 +32132,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/config@7.4.1(magicast@0.3.5)':
+  '@prisma/config@7.4.2(magicast@0.3.5)':
     dependencies:
       c12: 3.1.0(magicast@0.3.5)
       deepmerge-ts: 7.1.5
@@ -32016,23 +32143,23 @@ snapshots:
 
   '@prisma/debug@6.19.2': {}
 
-  '@prisma/debug@7.4.1': {}
+  '@prisma/debug@7.4.2': {}
 
   '@prisma/dmmf@6.19.2': {}
 
-  '@prisma/dmmf@7.4.1': {}
+  '@prisma/dmmf@7.4.2': {}
 
   '@prisma/driver-adapter-utils@6.19.2':
     dependencies:
       '@prisma/debug': 6.19.2
 
-  '@prisma/driver-adapter-utils@7.4.1':
+  '@prisma/driver-adapter-utils@7.4.2':
     dependencies:
-      '@prisma/debug': 7.4.1
+      '@prisma/debug': 7.4.2
 
   '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
 
-  '@prisma/engines-version@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3': {}
+  '@prisma/engines-version@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919': {}
 
   '@prisma/engines@6.19.2':
     dependencies:
@@ -32041,12 +32168,12 @@ snapshots:
       '@prisma/fetch-engine': 6.19.2
       '@prisma/get-platform': 6.19.2
 
-  '@prisma/engines@7.4.1':
+  '@prisma/engines@7.4.2':
     dependencies:
-      '@prisma/debug': 7.4.1
-      '@prisma/engines-version': 7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3
-      '@prisma/fetch-engine': 7.4.1
-      '@prisma/get-platform': 7.4.1
+      '@prisma/debug': 7.4.2
+      '@prisma/engines-version': 7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919
+      '@prisma/fetch-engine': 7.4.2
+      '@prisma/get-platform': 7.4.2
 
   '@prisma/fetch-engine@6.19.2':
     dependencies:
@@ -32054,11 +32181,11 @@ snapshots:
       '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
       '@prisma/get-platform': 6.19.2
 
-  '@prisma/fetch-engine@7.4.1':
+  '@prisma/fetch-engine@7.4.2':
     dependencies:
-      '@prisma/debug': 7.4.1
-      '@prisma/engines-version': 7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3
-      '@prisma/get-platform': 7.4.1
+      '@prisma/debug': 7.4.2
+      '@prisma/engines-version': 7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919
+      '@prisma/get-platform': 7.4.2
 
   '@prisma/generator-helper@6.19.2':
     dependencies:
@@ -32066,23 +32193,23 @@ snapshots:
       '@prisma/dmmf': 6.19.2
       '@prisma/generator': 6.19.2
 
-  '@prisma/generator-helper@7.4.1':
+  '@prisma/generator-helper@7.4.2':
     dependencies:
-      '@prisma/debug': 7.4.1
-      '@prisma/dmmf': 7.4.1
-      '@prisma/generator': 7.4.1
+      '@prisma/debug': 7.4.2
+      '@prisma/dmmf': 7.4.2
+      '@prisma/generator': 7.4.2
 
   '@prisma/generator@6.19.2': {}
 
-  '@prisma/generator@7.4.1': {}
+  '@prisma/generator@7.4.2': {}
 
   '@prisma/get-platform@6.19.2':
     dependencies:
       '@prisma/debug': 6.19.2
 
-  '@prisma/get-platform@7.4.1':
+  '@prisma/get-platform@7.4.2':
     dependencies:
-      '@prisma/debug': 7.4.1
+      '@prisma/debug': 7.4.2
 
   '@prisma/internals@6.19.2(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
@@ -32105,20 +32232,20 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/internals@7.4.1(magicast@0.3.5)(typescript@5.9.3)':
+  '@prisma/internals@7.4.2(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
-      '@prisma/config': 7.4.1(magicast@0.3.5)
-      '@prisma/debug': 7.4.1
-      '@prisma/dmmf': 7.4.1
-      '@prisma/driver-adapter-utils': 7.4.1
-      '@prisma/engines': 7.4.1
-      '@prisma/fetch-engine': 7.4.1
-      '@prisma/generator': 7.4.1
-      '@prisma/generator-helper': 7.4.1
-      '@prisma/get-platform': 7.4.1
-      '@prisma/prisma-schema-wasm': 7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3
-      '@prisma/schema-engine-wasm': 7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3
-      '@prisma/schema-files-loader': 7.4.1
+      '@prisma/config': 7.4.2(magicast@0.3.5)
+      '@prisma/debug': 7.4.2
+      '@prisma/dmmf': 7.4.2
+      '@prisma/driver-adapter-utils': 7.4.2
+      '@prisma/engines': 7.4.2
+      '@prisma/fetch-engine': 7.4.2
+      '@prisma/generator': 7.4.2
+      '@prisma/generator-helper': 7.4.2
+      '@prisma/get-platform': 7.4.2
+      '@prisma/prisma-schema-wasm': 7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919
+      '@prisma/schema-engine-wasm': 7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919
+      '@prisma/schema-files-loader': 7.4.2
       arg: 5.0.2
       prompts: 2.4.2
     optionalDependencies:
@@ -32128,20 +32255,20 @@ snapshots:
 
   '@prisma/prisma-schema-wasm@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
 
-  '@prisma/prisma-schema-wasm@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3': {}
+  '@prisma/prisma-schema-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919': {}
 
   '@prisma/schema-engine-wasm@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
 
-  '@prisma/schema-engine-wasm@7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3': {}
+  '@prisma/schema-engine-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919': {}
 
   '@prisma/schema-files-loader@6.19.2':
     dependencies:
       '@prisma/prisma-schema-wasm': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
       fs-extra: 11.3.0
 
-  '@prisma/schema-files-loader@7.4.1':
+  '@prisma/schema-files-loader@7.4.2':
     dependencies:
-      '@prisma/prisma-schema-wasm': 7.5.0-4.55ae170b1ced7fc6ed07a15f110549408c501bb3
+      '@prisma/prisma-schema-wasm': 7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919
       fs-extra: 11.3.0
 
   '@radix-ui/number@1.1.1': {}
@@ -35978,7 +36105,7 @@ snapshots:
     dependencies:
       '@prisma/generator-helper': 6.19.2
       '@prisma/internals': 6.19.2(magicast@0.3.5)(typescript@5.9.3)
-      '@prisma/internals-v7': '@prisma/internals@7.4.1(magicast@0.3.5)(typescript@5.9.3)'
+      '@prisma/internals-v7': '@prisma/internals@7.4.2(magicast@0.3.5)(typescript@5.9.3)'
       '@zenstackhq/language': 2.22.2
       '@zenstackhq/runtime': 2.22.2(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(zod@4.3.6)
       langium: 1.3.1
@@ -37952,7 +38079,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.1:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -39597,7 +39724,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.2: {}
+  hono@4.12.5: {}
 
   hook-std@4.0.0: {}
 
@@ -40426,7 +40553,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.48.0
-      dompurify: 3.3.1
+      dompurify: 3.3.2
       html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
@@ -45392,7 +45519,7 @@ snapshots:
       classnames: 2.5.1
       css.escape: 1.5.1
       deep-extend: 0.6.0
-      dompurify: 3.3.1
+      dompurify: 3.3.2
       ieee754: 1.2.1
       immutable: 3.8.2
       js-file-download: 0.4.12


### PR DESCRIPTION
## Summary
- Updates dompurify, hono, @hono/node-server, multer to patched versions (testplanit)
- Runs npm audit fix in forge-app to resolve transitive vulnerabilities
- Should resolve ~25-30 of the 41 open Dependabot security alerts

## Remaining (unfixable without major bumps)
- minimatch (locked by eslint-config-next)
- serialize-javascript (transitive)
- immutable (locked by swagger-ui-react)
- svgo (locked by @svgr/webpack)
- pm2 (no patch available)
- forge-app: undici, webpack (locked by @forge/cli)

## Test plan
- [ ] CI passes
- [ ] Verify Dependabot alert count drops after merge

Generated with [Claude Code](https://claude.com/claude-code)