### PR TITLE
fix: Authentication with Microsoft SSO by sanitizeAccountData function for OAuth account linking

### DIFF
--- a/testplanit/server/auth-adapter.ts
+++ b/testplanit/server/auth-adapter.ts
@@ -4,25 +4,35 @@ import { hash } from "bcrypt";
 import type { Adapter, AdapterAccount, AdapterUser } from "next-auth/adapters";
 import { NotificationService } from "~/lib/services/notificationService";
 
+const ACCOUNT_FIELDS: Record<keyof Prisma.AccountUncheckedCreateInput, true> = {
+  id: true,
+  userId: true,
+  type: true,
+  provider: true,
+  providerAccountId: true,
+  refresh_token: true,
+  access_token: true,
+  expires_at: true,
+  token_type: true,
+  scope: true,
+  id_token: true,
+  session_state: true,
+};
+
 function sanitizeAccountData(account: AdapterAccount): Prisma.AccountUncheckedCreateInput {
-  if (!account.userId || !account.type || !account.provider || !account.providerAccountId) {
-    throw new Error("Missing required account fields for OAuth account linking");
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(ACCOUNT_FIELDS)) {
+    if (key in account) {
+      result[key] = account[key as keyof AdapterAccount];
+    }
   }
 
-  return {
-    userId: account.userId,
-    type: account.type,
-    provider: account.provider,
-    providerAccountId: account.providerAccountId,
-    refresh_token: account.refresh_token ?? null,
-    access_token: account.access_token ?? null,
-    expires_at: account.expires_at ?? null,
-    token_type: account.token_type ?? null,
-    scope: account.scope ?? null,
-    id_token: account.id_token ?? null,
-    session_state:
-      typeof account.session_state === "string" ? account.session_state : null,
-  };
+  if (result.session_state && typeof result.session_state !== "string") {
+    result.session_state = null;
+  }
+
+  return result as Prisma.AccountUncheckedCreateInput;
 }
 
 /**


### PR DESCRIPTION
## Description

- Fix Authentication with Microsoft SSO
  - Azure AD (azure-ad) returns extra OAuth token fields during sign-in, including ext_expires_in.
  - Prisma Account model does not include ext_expires_in, so prisma.account.create() failed 
  - Because account linking failed, Microsoft login was rejected even with valid credentials.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS:
- Browser (if applicable):
- Node version:

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

<!-- Any additional information that reviewers should know -->
