### PR TITLE
fix(integrations): Add validation for external project and default issue type before saving settings

### DIFF
--- a/testplanit/app/[locale]/projects/settings/[projectId]/integrations/project-integration-settings.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/integrations/project-integration-settings.tsx
@@ -345,32 +345,18 @@ export function ProjectIntegrationSettings({
 
         {/* Only show save button if there are settings to save */}
         {integration.provider !== "SIMPLE_URL" && (
-          <div className="space-y-2">
-            {!config.externalProjectId && (
-              <p className="text-sm text-destructive">
-                {t("integration.externalProjectRequired")}
-              </p>
-            )}
-            {integration.provider === "JIRA" &&
-              config.externalProjectId &&
-              !config.defaultIssueType && (
-                <p className="text-sm text-destructive">
-                  {t("integration.defaultIssueTypeRequired")}
-                </p>
+          <div className="flex justify-end">
+            <Button
+              onClick={handleSaveSettings}
+              disabled={isSaving || !canSave}
+            >
+              {isSaving ? (
+                <Loader2 className=" h-4 w-4 animate-spin" />
+              ) : (
+                <Save className=" h-4 w-4" />
               )}
-            <div className="flex justify-end">
-              <Button
-                onClick={handleSaveSettings}
-                disabled={isSaving || !canSave}
-              >
-                {isSaving ? (
-                  <Loader2 className=" h-4 w-4 animate-spin" />
-                ) : (
-                  <Save className=" h-4 w-4" />
-                )}
-                {tGlobal("admin.notifications.save")}
-              </Button>
-            </div>
+              {tGlobal("admin.notifications.save")}
+            </Button>
           </div>
         )}
       </CardContent>

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1065,8 +1065,6 @@
           "simpleUrlDescription": "This issue integration uses a simple URL pattern to link to external issues. Issues will be opened in a new tab using the configured URL pattern.",
           "externalProjectHelp": "This sets the default project for creating new issues from TestPlanIt. You can still link and sync issues from other external projects - each issue tracks its own source project.",
           "defaultIssueTypeHelp": "When creating new issues from TestPlanIt, this issue type will be automatically selected. This saves time if you typically create the same type of issues.",
-          "externalProjectRequired": "An external project must be selected before saving",
-          "defaultIssueTypeRequired": "A default issue type must be selected before saving",
           "automaticSyncHelp": "When enabled, issues will automatically sync when changes are detected in the external system (via webhooks). Manual sync is always available.",
           "removeWarningTitle": "Removing this issue integration will:",
           "removeWarning1": "Disconnect all linked issues from this issue integration (issues remain in database)",


### PR DESCRIPTION
## Description
- Implemented a `canSave` memoized function to determine if the save button should be enabled based on the selected integration provider and required fields.
- Updated UI to display error messages when required fields are not filled, enhancing user feedback.
- Modified the loading state handling in the Create Issue form for better user experience.

## Related Issue

Closes #166 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)
