### PR TITLE
Bugfix/permission issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ testplanit/backups/*
 **/.planning/*
 demo/
 .planning/**
+
+.idea/

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -24,8 +24,9 @@ import * as z from "zod/v4";
 import { emptyEditorContent } from "~/app/constants";
 import { useProjectPermissions } from "~/hooks/useProjectPermissions";
 import {
-  useCreateAttachments, useCreateResultFieldValues, useCreateTestRunResults, useCreateTestRunStepResults, useFindFirstProjects, useFindFirstRepositoryCases, useFindFirstWorkflows, useFindManyIssue, useFindManySharedStepItem, useFindManyStatus, useFindManyTemplateResultAssignment, useFindManyTestRunResults, useUpdateTestRunCases, useUpdateTestRuns
+  useCreateAttachments, useCreateResultFieldValues, useCreateTestRunStepResults, useFindFirstProjects, useFindFirstRepositoryCases, useFindFirstWorkflows, useFindManyIssue, useFindManySharedStepItem, useFindManyStatus, useFindManyTemplateResultAssignment, useFindManyTestRunResults, useUpdateTestRunCases
 } from "~/lib/hooks";
+import { submitTestRunResult } from "~/lib/test-run-result-submit";
 import { toHumanReadable } from "~/utils/duration";
 import { fetchSignedUrl } from "~/utils/fetchSignedUrl";
 import { ExtendedCases } from "./columns";
@@ -462,21 +463,11 @@ export function AddResultModal({
     },
   });
 
-  const { mutateAsync: createTestRunResult } = useCreateTestRunResults();
   const { mutateAsync: createAttachments } = useCreateAttachments();
   const { mutateAsync: updateTestRunCase } = useUpdateTestRunCases();
-  const { mutateAsync: updateTestRun } = useUpdateTestRuns();
   const { mutateAsync: createResultFieldValue } = useCreateResultFieldValues();
   const { mutateAsync: createTestRunStepResult } =
     useCreateTestRunStepResults();
-
-  // Check if this is the first result for this test run
-  const { data: existingResults } = useFindManyTestRunResults({
-    where: {
-      testRunId,
-    },
-    take: 1,
-  });
 
   // Find the first IN_PROGRESS workflow state for this project
   const { data: inProgressWorkflow } = useFindFirstWorkflows({
@@ -698,45 +689,17 @@ export function AddResultModal({
           if (!selectedCase.testRunCaseId) return;
           const caseVersion = 1;
 
-          // Create the test run result
-          const result = await createTestRunResult({
-            data: {
-              testRunId,
-              testRunCaseId: selectedCase.testRunCaseId,
-              statusId: parseInt(values.statusId as string),
-              notes: values.resultData || emptyEditorContent,
-              evidence: values.evidence as any,
-              elapsed: elapsedInSeconds,
-              executedById: session.user.id,
-              attempt: values.attempt as number,
-              testRunCaseVersion: caseVersion,
-              issues: {
-                connect: issueIdsToConnect.map((id) => ({ id })),
-              },
-            },
-          });
-
-          // If this is the first result and we have an IN_PROGRESS workflow state
-          if (existingResults?.length === 0 && inProgressWorkflow) {
-            // Update the test run's workflow state
-            await updateTestRun({
-              where: {
-                id: testRunId,
-              },
-              data: {
-                stateId: inProgressWorkflow.id,
-              },
-            });
-          }
-
-          // Update the test run case status
-          await updateTestRunCase({
-            where: {
-              id: selectedCase.testRunCaseId,
-            },
-            data: {
-              statusId: parseInt(values.statusId as string),
-            },
+          const result = await submitTestRunResult({
+            testRunId,
+            testRunCaseId: selectedCase.testRunCaseId,
+            statusId: parseInt(values.statusId as string),
+            notes: values.resultData || emptyEditorContent,
+            evidence: values.evidence as any,
+            elapsed: elapsedInSeconds,
+            attempt: values.attempt as number,
+            testRunCaseVersion: caseVersion,
+            issueIds: issueIdsToConnect,
+            inProgressStateId: inProgressWorkflow?.id ?? null,
           });
 
           // Save template field values if any exist
@@ -979,44 +942,17 @@ export function AddResultModal({
         await Promise.all(bulkPromises);
       } else if (testRunCaseId && repositoryCase?.currentVersion) {
         // Handle single result submission
-        const result = await createTestRunResult({
-          data: {
-            testRunId,
-            testRunCaseId,
-            statusId: parseInt(values.statusId as string),
-            notes: values.resultData || emptyEditorContent,
-            evidence: values.evidence as any,
-            elapsed: elapsedInSeconds,
-            executedById: session.user.id,
-            attempt: values.attempt as number,
-            testRunCaseVersion: repositoryCase.currentVersion,
-            issues: {
-              connect: issueIdsToConnect.map((id) => ({ id })),
-            },
-          },
-        });
-
-        // If this is the first result and we have an IN_PROGRESS workflow state
-        if (existingResults?.length === 0 && inProgressWorkflow) {
-          // Update the test run's workflow state
-          await updateTestRun({
-            where: {
-              id: testRunId,
-            },
-            data: {
-              stateId: inProgressWorkflow.id,
-            },
-          });
-        }
-
-        // Update the test run case status
-        await updateTestRunCase({
-          where: {
-            id: testRunCaseId,
-          },
-          data: {
-            statusId: parseInt(values.statusId as string),
-          },
+        const result = await submitTestRunResult({
+          testRunId,
+          testRunCaseId,
+          statusId: parseInt(values.statusId as string),
+          notes: values.resultData || emptyEditorContent,
+          evidence: values.evidence as any,
+          elapsed: elapsedInSeconds,
+          attempt: values.attempt as number,
+          testRunCaseVersion: repositoryCase.currentVersion,
+          issueIds: issueIdsToConnect,
+          inProgressStateId: inProgressWorkflow?.id ?? null,
         });
 
         // Save template field values if any exist

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -26,7 +26,10 @@ import { useProjectPermissions } from "~/hooks/useProjectPermissions";
 import {
   useCreateAttachments, useCreateResultFieldValues, useCreateTestRunStepResults, useFindFirstProjects, useFindFirstRepositoryCases, useFindFirstWorkflows, useFindManyIssue, useFindManySharedStepItem, useFindManyStatus, useFindManyTemplateResultAssignment, useFindManyTestRunResults, useUpdateTestRunCases
 } from "~/lib/hooks";
-import { submitTestRunResult } from "~/lib/test-run-result-submit";
+import {
+  isPermissionDeniedSubmitResultError,
+  submitTestRunResult
+} from "~/lib/test-run-result-submit";
 import { toHumanReadable } from "~/utils/duration";
 import { fetchSignedUrl } from "~/utils/fetchSignedUrl";
 import { ExtendedCases } from "./columns";
@@ -1244,9 +1247,15 @@ export function AddResultModal({
       onClose();
     } catch (error) {
       console.error("Error submitting result:", error);
-      toast.error(tCommon("errors.error"), {
-        description: tCommon("errors.somethingWentWrong"),
-      });
+      if (isPermissionDeniedSubmitResultError(error)) {
+        toast.error(tCommon("errors.accessDenied"), {
+          description: tCommon("errors.resultSubmitPermissionDenied"),
+        });
+      } else {
+        toast.error(tCommon("errors.error"), {
+          description: tCommon("errors.somethingWentWrong"),
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -228,6 +228,10 @@ export function AddResultModal({
   const locale = useLocale();
   const { data: session } = useSession();
   const queryClient = useQueryClient();
+  const invalidateAfterSubmit = async () => {
+    // submitTestRunResult uses a raw fetch call, so we manually invalidate caches.
+    await queryClient.invalidateQueries();
+  };
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [, setSelectedStatusColor] =
     useState<string>("#3b82f6");
@@ -1228,6 +1232,8 @@ export function AddResultModal({
       setSelectedMainIssues([]);
       setSelectedStepIssues({});
       setSelectedSharedItemIssues({}); // Reset shared item issues
+
+      await invalidateAfterSubmit();
 
       toast.success(
         isBulkResult

--- a/testplanit/app/api/test-runs/submit-result/route.test.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    testRunCases: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { getServerSession } from "next-auth";
+import { prisma } from "~/lib/prisma";
+
+describe("Submit Result API Route", () => {
+  const validBody = {
+    testRunId: 1,
+    testRunCaseId: 10,
+    statusId: 2,
+    attempt: 1,
+    testRunCaseVersion: 1,
+    inProgressStateId: 3,
+  };
+
+  const createRequest = (body: unknown) =>
+    new Request("http://localhost/api/test-runs/submit-result", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const baseUser = {
+    id: "user-1",
+    access: "USER",
+    role: {
+      rolePermissions: [{ canAddEdit: true }],
+    },
+  };
+
+  const baseRunCase = {
+    id: 10,
+    assignedToId: null,
+    testRun: {
+      id: 1,
+      createdById: "run-owner",
+      project: {
+        createdBy: "project-owner",
+        defaultAccessType: "DEFAULT",
+        defaultRole: null,
+        assignedUsers: [],
+        userPermissions: [
+          {
+            accessType: "SPECIFIC_ROLE",
+            role: {
+              name: "Tester",
+              rolePermissions: [{ canAddEdit: true }],
+            },
+          },
+        ],
+        groupPermissions: [],
+      },
+    },
+  };
+
+  let txMocks: {
+    testRunResults: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+    };
+    testRunCases: {
+      update: ReturnType<typeof vi.fn>;
+    };
+    testRuns: {
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getServerSession as any).mockResolvedValue({ user: { id: "user-1" } });
+    (prisma.user.findUnique as any).mockResolvedValue(baseUser);
+    (prisma.testRunCases.findFirst as any).mockResolvedValue(baseRunCase);
+
+    txMocks = {
+      testRunResults: {
+        create: vi.fn().mockResolvedValue({ id: 999 }),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      testRunCases: {
+        update: vi.fn().mockResolvedValue({ id: 10 }),
+      },
+      testRuns: {
+        update: vi.fn().mockResolvedValue({ id: 1 }),
+      },
+    };
+
+    (prisma.$transaction as any).mockImplementation(async (callback: any) =>
+      callback(txMocks)
+    );
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    (getServerSession as any).mockResolvedValue(null);
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    const response = await POST(createRequest({ testRunId: 1 }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid input");
+  });
+
+  it("returns 404 when test run case is not found", async () => {
+    (prisma.testRunCases.findFirst as any).mockResolvedValue(null);
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.code).toBe("TEST_RUN_CASE_NOT_FOUND");
+  });
+
+  it("returns 403 when user has no permission", async () => {
+    (prisma.testRunCases.findFirst as any).mockResolvedValue({
+      ...baseRunCase,
+      testRun: {
+        ...baseRunCase.testRun,
+        project: {
+          ...baseRunCase.testRun.project,
+          userPermissions: [
+            {
+              accessType: "NO_ACCESS",
+              role: null,
+            },
+          ],
+        },
+      },
+    });
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.code).toBe("PERMISSION_DENIED");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("submits result and updates test run case atomically when permission is valid", async () => {
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.result.id).toBe(999);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(txMocks.testRunResults.create).toHaveBeenCalledTimes(1);
+    expect(txMocks.testRunCases.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { statusId: 2 },
+    });
+    expect(txMocks.testRuns.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { stateId: 3 },
+    });
+  });
+
+  it("returns 500 if transaction fails", async () => {
+    txMocks.testRunCases.update.mockRejectedValue(new Error("update failed"));
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.code).toBe("SUBMIT_RESULT_FAILED");
+  });
+});

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -1,0 +1,167 @@
+import { getEnhancedDb } from "@/lib/auth/utils";
+import { Prisma } from "@prisma/client";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { z } from "zod/v4";
+import { authOptions } from "~/server/auth";
+
+const submitResultSchema = z.object({
+  testRunId: z.number().int().positive(),
+  testRunCaseId: z.number().int().positive(),
+  statusId: z.number().int().positive(),
+  notes: z.unknown().optional(),
+  evidence: z.unknown().optional(),
+  elapsed: z.number().int().nonnegative().nullable().optional(),
+  attempt: z.number().int().positive(),
+  testRunCaseVersion: z.number().int().positive(),
+  issueIds: z.array(z.number().int().positive()).optional(),
+  inProgressStateId: z.number().int().positive().nullable().optional(),
+});
+
+const ACCESS_DENIED_PATTERNS = [
+  "access policy",
+  "permission",
+  "forbidden",
+  "not authorized",
+  "unauthorized",
+];
+
+export async function POST(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = submitResultSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid input",
+          details: z.treeifyError(parsed.error),
+        },
+        { status: 400 }
+      );
+    }
+
+    const input = parsed.data;
+    const db = await getEnhancedDb(session);
+
+    const result = await (db as any).$transaction(async (tx: any) => {
+      const runCase = await tx.testRunCases.findFirst({
+        where: {
+          id: input.testRunCaseId,
+          testRunId: input.testRunId,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      if (!runCase) {
+        throw new Error("Test run case not found");
+      }
+
+      const createdResult = await tx.testRunResults.create({
+        data: {
+          testRunId: input.testRunId,
+          testRunCaseId: input.testRunCaseId,
+          statusId: input.statusId,
+          notes: input.notes,
+          evidence: input.evidence ?? {},
+          elapsed: input.elapsed ?? null,
+          executedById: session.user.id,
+          attempt: input.attempt,
+          testRunCaseVersion: input.testRunCaseVersion,
+          issues:
+            input.issueIds && input.issueIds.length > 0
+              ? { connect: input.issueIds.map((id) => ({ id })) }
+              : undefined,
+        },
+      });
+
+      await tx.testRunCases.update({
+        where: {
+          id: input.testRunCaseId,
+        },
+        data: {
+          statusId: input.statusId,
+        },
+      });
+
+      if (input.inProgressStateId) {
+        const previousResult = await tx.testRunResults.findFirst({
+          where: {
+            testRunId: input.testRunId,
+            isDeleted: false,
+            id: {
+              not: createdResult.id,
+            },
+          },
+          select: {
+            id: true,
+          },
+        });
+
+        if (!previousResult) {
+          await tx.testRuns.update({
+            where: {
+              id: input.testRunId,
+            },
+            data: {
+              stateId: input.inProgressStateId,
+            },
+          });
+        }
+      }
+
+      return createdResult;
+    });
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2025") {
+        return NextResponse.json(
+          { error: "Test run case not found", code: "TEST_RUN_CASE_NOT_FOUND" },
+          { status: 404 }
+        );
+      }
+
+      if (error.code === "P2004") {
+        return NextResponse.json(
+          { error: "Permission denied", code: "PERMISSION_DENIED" },
+          { status: 403 }
+        );
+      }
+    }
+
+    const message =
+      error instanceof Error ? error.message : "Failed to submit result";
+    const normalizedMessage = message.toLowerCase();
+    if (
+      ACCESS_DENIED_PATTERNS.some((pattern) =>
+        normalizedMessage.includes(pattern)
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Permission denied", code: "PERMISSION_DENIED" },
+        { status: 403 }
+      );
+    }
+
+    if (normalizedMessage.includes("test run case not found")) {
+      return NextResponse.json(
+        { error: "Test run case not found", code: "TEST_RUN_CASE_NOT_FOUND" },
+        { status: 404 }
+      );
+    }
+
+    console.error("Error submitting test run result:", error);
+    return NextResponse.json(
+      { error: "Failed to submit result", code: "SUBMIT_RESULT_FAILED" },
+      { status: 500 }
+    );
+  }
+}

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -1,8 +1,8 @@
-import { getEnhancedDb } from "@/lib/auth/utils";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import { z } from "zod/v4";
+import { prisma } from "~/lib/prisma";
 import { authOptions } from "~/server/auth";
 
 const submitResultSchema = z.object({
@@ -18,13 +18,130 @@ const submitResultSchema = z.object({
   inProgressStateId: z.number().int().positive().nullable().optional(),
 });
 
-const ACCESS_DENIED_PATTERNS = [
-  "access policy",
-  "permission",
-  "forbidden",
-  "not authorized",
-  "unauthorized",
-];
+type RolePermissionSnapshot =
+  | {
+      name?: string | null;
+      rolePermissions?: Array<{ canAddEdit: boolean }> | null;
+    }
+  | null
+  | undefined;
+
+type ProjectAccessTypeValue =
+  | "DEFAULT"
+  | "NO_ACCESS"
+  | "GLOBAL_ROLE"
+  | "SPECIFIC_ROLE";
+
+function roleCanAddEditTestRunResults(role: RolePermissionSnapshot): boolean {
+  return Boolean(role?.rolePermissions?.some((permission) => permission.canAddEdit));
+}
+
+function hasSubmitResultPermission({
+  user,
+  testRunCreatedById,
+  assignedToId,
+  project,
+}: {
+  user: {
+    id: string;
+    access: string;
+    role: {
+      rolePermissions: Array<{ canAddEdit: boolean }>;
+    } | null;
+  };
+  testRunCreatedById: string;
+  assignedToId: string | null;
+  project: {
+    createdBy: string;
+    defaultAccessType: ProjectAccessTypeValue;
+    defaultRole: RolePermissionSnapshot;
+    assignedUsers: Array<{ userId: string }>;
+    userPermissions: Array<{
+      accessType: ProjectAccessTypeValue;
+      role: RolePermissionSnapshot;
+    }>;
+    groupPermissions: Array<{
+      accessType: ProjectAccessTypeValue;
+      role: RolePermissionSnapshot;
+    }>;
+  };
+}): boolean {
+  if (user.access === "ADMIN") {
+    return true;
+  }
+
+  if (project.createdBy === user.id) {
+    return true;
+  }
+
+  if (testRunCreatedById === user.id) {
+    return true;
+  }
+
+  if (assignedToId === user.id) {
+    return true;
+  }
+
+  if (
+    user.access === "PROJECTADMIN" &&
+    project.assignedUsers.some((assignment) => assignment.userId === user.id)
+  ) {
+    return true;
+  }
+
+  const hasGlobalRoleResultPermission = roleCanAddEditTestRunResults(user.role);
+
+  const explicitUserPermission = project.userPermissions[0];
+  if (explicitUserPermission) {
+    if (explicitUserPermission.accessType === "NO_ACCESS") {
+      return false;
+    }
+
+    if (explicitUserPermission.accessType === "SPECIFIC_ROLE") {
+      return (
+        explicitUserPermission.role?.name === "Project Admin" ||
+        roleCanAddEditTestRunResults(explicitUserPermission.role)
+      );
+    }
+
+    if (explicitUserPermission.accessType === "GLOBAL_ROLE") {
+      return user.access !== "NONE" && hasGlobalRoleResultPermission;
+    }
+  }
+
+  const groupPermissionAllows = project.groupPermissions.some(
+    (groupPermission) => {
+      if (groupPermission.accessType === "SPECIFIC_ROLE") {
+        return (
+          groupPermission.role?.name === "Project Admin" ||
+          roleCanAddEditTestRunResults(groupPermission.role)
+        );
+      }
+
+      if (groupPermission.accessType === "GLOBAL_ROLE") {
+        return user.access !== "NONE" && hasGlobalRoleResultPermission;
+      }
+
+      return false;
+    }
+  );
+  if (groupPermissionAllows) {
+    return true;
+  }
+
+  if (project.defaultAccessType === "GLOBAL_ROLE") {
+    return user.access !== "NONE" && hasGlobalRoleResultPermission;
+  }
+
+  if (project.defaultAccessType === "SPECIFIC_ROLE") {
+    return (
+      project.assignedUsers.some((assignment) => assignment.userId === user.id) &&
+      roleCanAddEditTestRunResults(project.defaultRole)
+    );
+  }
+
+  return false;
+}
 
 export async function POST(req: Request) {
   try {
@@ -46,32 +163,179 @@ export async function POST(req: Request) {
     }
 
     const input = parsed.data;
-    const db = await getEnhancedDb(session);
-
-    const result = await (db as any).$transaction(async (tx: any) => {
-      const runCase = await tx.testRunCases.findFirst({
-        where: {
-          id: input.testRunCaseId,
-          testRunId: input.testRunId,
+    const user = await prisma.user.findUnique({
+      where: {
+        id: session.user.id,
+      },
+      select: {
+        id: true,
+        access: true,
+        role: {
+          select: {
+            rolePermissions: {
+              where: {
+                area: "TestRunResults",
+                canAddEdit: true,
+              },
+              select: {
+                canAddEdit: true,
+              },
+            },
+          },
         },
-        select: {
-          id: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const runCase = await prisma.testRunCases.findFirst({
+      where: {
+        id: input.testRunCaseId,
+        testRunId: input.testRunId,
+        testRun: {
+          isDeleted: false,
+          project: {
+            isDeleted: false,
+          },
         },
-      });
+      },
+      select: {
+        id: true,
+        assignedToId: true,
+        testRun: {
+          select: {
+            id: true,
+            createdById: true,
+            project: {
+              select: {
+                createdBy: true,
+                defaultAccessType: true,
+                assignedUsers: {
+                  where: {
+                    userId: user.id,
+                  },
+                  select: {
+                    userId: true,
+                  },
+                },
+                userPermissions: {
+                  where: {
+                    userId: user.id,
+                  },
+                  select: {
+                    accessType: true,
+                    role: {
+                      select: {
+                        name: true,
+                        rolePermissions: {
+                          where: {
+                            area: "TestRunResults",
+                            canAddEdit: true,
+                          },
+                          select: {
+                            canAddEdit: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                groupPermissions: {
+                  where: {
+                    group: {
+                      assignedUsers: {
+                        some: {
+                          userId: user.id,
+                        },
+                      },
+                    },
+                  },
+                  select: {
+                    accessType: true,
+                    role: {
+                      select: {
+                        name: true,
+                        rolePermissions: {
+                          where: {
+                            area: "TestRunResults",
+                            canAddEdit: true,
+                          },
+                          select: {
+                            canAddEdit: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                defaultRole: {
+                  select: {
+                    name: true,
+                    rolePermissions: {
+                      where: {
+                        area: "TestRunResults",
+                        canAddEdit: true,
+                      },
+                      select: {
+                        canAddEdit: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
 
-      if (!runCase) {
-        throw new Error("Test run case not found");
-      }
+    if (!runCase) {
+      return NextResponse.json(
+        { error: "Test run case not found", code: "TEST_RUN_CASE_NOT_FOUND" },
+        { status: 404 }
+      );
+    }
 
+    const canSubmit = hasSubmitResultPermission({
+      user,
+      testRunCreatedById: runCase.testRun.createdById,
+      assignedToId: runCase.assignedToId,
+      project: runCase.testRun.project,
+    });
+    if (!canSubmit) {
+      return NextResponse.json(
+        { error: "Permission denied", code: "PERMISSION_DENIED" },
+        { status: 403 }
+      );
+    }
+
+    const notesInput:
+      | Prisma.InputJsonValue
+      | Prisma.NullableJsonNullValueInput
+      | undefined =
+      input.notes === undefined
+        ? undefined
+        : input.notes === null
+          ? Prisma.JsonNull
+          : (input.notes as Prisma.InputJsonValue);
+
+    const evidenceInput: Prisma.InputJsonValue =
+      input.evidence === undefined || input.evidence === null
+        ? {}
+        : (input.evidence as Prisma.InputJsonValue);
+
+    const result = await prisma.$transaction(async (tx) => {
       const createdResult = await tx.testRunResults.create({
         data: {
           testRunId: input.testRunId,
           testRunCaseId: input.testRunCaseId,
           statusId: input.statusId,
-          notes: input.notes,
-          evidence: input.evidence ?? {},
+          notes: notesInput,
+          evidence: evidenceInput,
           elapsed: input.elapsed ?? null,
-          executedById: session.user.id,
+          executedById: user.id,
           attempt: input.attempt,
           testRunCaseVersion: input.testRunCaseVersion,
           issues:
@@ -121,7 +385,10 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ result });
   } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (
+      typeof Prisma?.PrismaClientKnownRequestError === "function" &&
+      error instanceof Prisma.PrismaClientKnownRequestError
+    ) {
       if (error.code === "P2025") {
         return NextResponse.json(
           { error: "Test run case not found", code: "TEST_RUN_CASE_NOT_FOUND" },
@@ -129,33 +396,6 @@ export async function POST(req: Request) {
         );
       }
 
-      if (error.code === "P2004") {
-        return NextResponse.json(
-          { error: "Permission denied", code: "PERMISSION_DENIED" },
-          { status: 403 }
-        );
-      }
-    }
-
-    const message =
-      error instanceof Error ? error.message : "Failed to submit result";
-    const normalizedMessage = message.toLowerCase();
-    if (
-      ACCESS_DENIED_PATTERNS.some((pattern) =>
-        normalizedMessage.includes(pattern)
-      )
-    ) {
-      return NextResponse.json(
-        { error: "Permission denied", code: "PERMISSION_DENIED" },
-        { status: 403 }
-      );
-    }
-
-    if (normalizedMessage.includes("test run case not found")) {
-      return NextResponse.json(
-        { error: "Test run case not found", code: "TEST_RUN_CASE_NOT_FOUND" },
-        { status: 404 }
-      );
     }
 
     console.error("Error submitting test run result:", error);

--- a/testplanit/components/TestRunCaseDetails.tsx
+++ b/testplanit/components/TestRunCaseDetails.tsx
@@ -21,6 +21,7 @@ import { Separator } from "@/components/ui/separator";
 import { AddResultModal } from "@/projects/repository/[projectId]/AddResultModal";
 import FieldValueRenderer from "@/projects/repository/[projectId]/[caseId]/FieldValueRenderer";
 import { Attachments, Prisma, Status } from "@prisma/client";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   Check,
   CheckCircle,
@@ -88,6 +89,7 @@ export function TestRunCaseDetails({
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] = useState<
     number | null
   >(null);
@@ -99,6 +101,10 @@ export function TestRunCaseDetails({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [_showAssignModal, _setShowAssignModal] = useState(false);
   const [isAssigning, setIsAssigning] = useState(false);
+  const invalidateAfterSubmit = async () => {
+    // submitTestRunResult uses a raw fetch call, so we manually invalidate caches.
+    await queryClient.invalidateQueries();
+  };
 
   // Fetch permissions
   const {
@@ -521,6 +527,7 @@ export function TestRunCaseDetails({
         testRunCaseVersion: testcase.currentVersion,
         inProgressStateId: inProgressWorkflow?.id ?? null,
       });
+      await invalidateAfterSubmit();
 
       // --- Trigger forecast update for this case ---
       fetch(`/api/forecast/update?caseId=${caseId}`);
@@ -718,6 +725,7 @@ export function TestRunCaseDetails({
                                 inProgressStateId:
                                   inProgressWorkflow?.id ?? null,
                               });
+                              await invalidateAfterSubmit();
 
                               toast.success(tCommon("actions.resultAdded"), {
                                 description: tCommon(

--- a/testplanit/components/TestRunCaseDetails.tsx
+++ b/testplanit/components/TestRunCaseDetails.tsx
@@ -41,7 +41,10 @@ import { useProjectPermissions } from "~/hooks/useProjectPermissions";
 import { useFindFirstRepositoryCasesFiltered } from "~/hooks/useRepositoryCasesWithFilteredFields";
 import { useFindFirstWorkflows, useFindManyStatus, useUpdateTestRunCases } from "~/lib/hooks";
 import { useFindManyTemplates } from "~/lib/hooks/templates";
-import { submitTestRunResult } from "~/lib/test-run-result-submit";
+import {
+  isPermissionDeniedSubmitResultError,
+  submitTestRunResult
+} from "~/lib/test-run-result-submit";
 import { IconName } from "~/types/globals";
 import { ForecastDisplay } from "./ForecastDisplay";
 import LinkedCasesPanel from "./LinkedCasesPanel";
@@ -546,9 +549,15 @@ export function TestRunCaseDetails({
       }
     } catch (error) {
       console.error("Error submitting result:", error);
-      toast.error(tCommon("errors.error"), {
-        description: tCommon("errors.somethingWentWrong"),
-      });
+      if (isPermissionDeniedSubmitResultError(error)) {
+        toast.error(tCommon("errors.accessDenied"), {
+          description: tCommon("errors.resultSubmitPermissionDenied"),
+        });
+      } else {
+        toast.error(tCommon("errors.error"), {
+          description: tCommon("errors.somethingWentWrong"),
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -738,11 +747,19 @@ export function TestRunCaseDetails({
                               }
                             } catch (error) {
                               console.error("Error submitting result:", error);
-                              toast.error(tCommon("errors.error"), {
-                                description: tCommon(
-                                  "errors.somethingWentWrong"
-                                ),
-                              });
+                              if (isPermissionDeniedSubmitResultError(error)) {
+                                toast.error(tCommon("errors.accessDenied"), {
+                                  description: tCommon(
+                                    "errors.resultSubmitPermissionDenied"
+                                  ),
+                                });
+                              } else {
+                                toast.error(tCommon("errors.error"), {
+                                  description: tCommon(
+                                    "errors.somethingWentWrong"
+                                  ),
+                                });
+                              }
                             } finally {
                               setIsSubmitting(false);
                             }

--- a/testplanit/components/TestRunCaseDetails.tsx
+++ b/testplanit/components/TestRunCaseDetails.tsx
@@ -39,8 +39,9 @@ import { notifyTestCaseAssignment } from "~/app/actions/test-run-notifications";
 import { emptyEditorContent } from "~/app/constants";
 import { useProjectPermissions } from "~/hooks/useProjectPermissions";
 import { useFindFirstRepositoryCasesFiltered } from "~/hooks/useRepositoryCasesWithFilteredFields";
-import { useCreateTestRunResults, useFindFirstWorkflows, useFindManyStatus, useFindManyTestRunResults, useUpdateTestRunCases, useUpdateTestRuns } from "~/lib/hooks";
+import { useFindFirstWorkflows, useFindManyStatus, useUpdateTestRunCases } from "~/lib/hooks";
 import { useFindManyTemplates } from "~/lib/hooks/templates";
+import { submitTestRunResult } from "~/lib/test-run-result-submit";
 import { IconName } from "~/types/globals";
 import { ForecastDisplay } from "./ForecastDisplay";
 import LinkedCasesPanel from "./LinkedCasesPanel";
@@ -120,17 +121,7 @@ export function TestRunCaseDetails({
     setSelectedAttachments([]);
   };
 
-  const { mutateAsync: createTestRunResult } = useCreateTestRunResults();
   const { mutateAsync: updateTestRunCase } = useUpdateTestRunCases();
-  const { mutateAsync: updateTestRun } = useUpdateTestRuns();
-
-  // Check if this is the first result for this test run
-  const { data: existingResults } = useFindManyTestRunResults({
-    where: {
-      testRunId,
-    },
-    take: 1,
-  });
 
   // Find the first IN_PROGRESS workflow state for this project
   const { data: inProgressWorkflow } = useFindFirstWorkflows({
@@ -517,41 +508,15 @@ export function TestRunCaseDetails({
         return;
       }
 
-      // Create the test run result
-      await createTestRunResult({
-        data: {
-          testRunId,
-          testRunCaseId,
-          statusId: successStatus.id,
-          notes: emptyEditorContent,
-          evidence: {},
-          executedById: session.user.id,
-          attempt: 1,
-          testRunCaseVersion: testcase.currentVersion,
-        },
-      });
-
-      // If this is the first result and we have an IN_PROGRESS workflow state
-      if (existingResults?.length === 0 && inProgressWorkflow) {
-        // Update the test run's workflow state
-        await updateTestRun({
-          where: {
-            id: testRunId,
-          },
-          data: {
-            stateId: inProgressWorkflow.id,
-          },
-        });
-      }
-
-      // Update the test run case status
-      await updateTestRunCase({
-        where: {
-          id: testRunCaseId,
-        },
-        data: {
-          statusId: successStatus.id,
-        },
+      await submitTestRunResult({
+        testRunId,
+        testRunCaseId,
+        statusId: successStatus.id,
+        notes: emptyEditorContent,
+        evidence: {},
+        attempt: 1,
+        testRunCaseVersion: testcase.currentVersion,
+        inProgressStateId: inProgressWorkflow?.id ?? null,
       });
 
       // --- Trigger forecast update for this case ---
@@ -733,28 +698,16 @@ export function TestRunCaseDetails({
                             setIsSubmitting(true);
 
                             try {
-                              // Create the test run result
-                              await createTestRunResult({
-                                data: {
-                                  testRunId,
-                                  testRunCaseId,
-                                  statusId: status.id,
-                                  notes: emptyEditorContent,
-                                  evidence: {},
-                                  executedById: session.user.id,
-                                  attempt: 1,
-                                  testRunCaseVersion: testcase.currentVersion,
-                                },
-                              });
-
-                              // Update the test run case status
-                              await updateTestRunCase({
-                                where: {
-                                  id: testRunCaseId,
-                                },
-                                data: {
-                                  statusId: status.id,
-                                },
+                              await submitTestRunResult({
+                                testRunId,
+                                testRunCaseId,
+                                statusId: status.id,
+                                notes: emptyEditorContent,
+                                evidence: {},
+                                attempt: 1,
+                                testRunCaseVersion: testcase.currentVersion,
+                                inProgressStateId:
+                                  inProgressWorkflow?.id ?? null,
                               });
 
                               toast.success(tCommon("actions.resultAdded"), {

--- a/testplanit/lib/test-run-result-submit.ts
+++ b/testplanit/lib/test-run-result-submit.ts
@@ -17,10 +17,38 @@ export interface SubmitTestRunResultResponse {
   };
 }
 
-type SubmitResultError = Error & {
+export type SubmitResultError = Error & {
   status?: number;
   code?: string;
 };
+
+const PERMISSION_DENIED_CODE = "PERMISSION_DENIED";
+const ACCESS_DENIED_PATTERNS = [
+  "permission denied",
+  "access policy",
+  "forbidden",
+  "not authorized",
+  "unauthorized",
+];
+
+export function isPermissionDeniedSubmitResultError(
+  error: unknown
+): error is SubmitResultError {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const submitError = error as SubmitResultError;
+  const normalizedMessage = submitError.message?.toLowerCase() ?? "";
+
+  return (
+    submitError.status === 403 ||
+    submitError.code === PERMISSION_DENIED_CODE ||
+    ACCESS_DENIED_PATTERNS.some((pattern) =>
+      normalizedMessage.includes(pattern)
+    )
+  );
+}
 
 export async function submitTestRunResult(
   input: SubmitTestRunResultInput

--- a/testplanit/lib/test-run-result-submit.ts
+++ b/testplanit/lib/test-run-result-submit.ts
@@ -22,15 +22,6 @@ export type SubmitResultError = Error & {
   code?: string;
 };
 
-const PERMISSION_DENIED_CODE = "PERMISSION_DENIED";
-const ACCESS_DENIED_PATTERNS = [
-  "permission denied",
-  "access policy",
-  "forbidden",
-  "not authorized",
-  "unauthorized",
-];
-
 export function isPermissionDeniedSubmitResultError(
   error: unknown
 ): error is SubmitResultError {
@@ -39,14 +30,10 @@ export function isPermissionDeniedSubmitResultError(
   }
 
   const submitError = error as SubmitResultError;
-  const normalizedMessage = submitError.message?.toLowerCase() ?? "";
 
   return (
     submitError.status === 403 ||
-    submitError.code === PERMISSION_DENIED_CODE ||
-    ACCESS_DENIED_PATTERNS.some((pattern) =>
-      normalizedMessage.includes(pattern)
-    )
+    submitError.code === "PERMISSION_DENIED"
   );
 }
 

--- a/testplanit/lib/test-run-result-submit.ts
+++ b/testplanit/lib/test-run-result-submit.ts
@@ -1,0 +1,50 @@
+export interface SubmitTestRunResultInput {
+  testRunId: number;
+  testRunCaseId: number;
+  statusId: number;
+  notes?: unknown;
+  evidence?: unknown;
+  elapsed?: number | null;
+  attempt: number;
+  testRunCaseVersion: number;
+  issueIds?: number[];
+  inProgressStateId?: number | null;
+}
+
+export interface SubmitTestRunResultResponse {
+  result: {
+    id: number;
+  };
+}
+
+type SubmitResultError = Error & {
+  status?: number;
+  code?: string;
+};
+
+export async function submitTestRunResult(
+  input: SubmitTestRunResultInput
+): Promise<SubmitTestRunResultResponse["result"]> {
+  const response = await fetch("/api/test-runs/submit-result", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | { error?: string; code?: string; result?: SubmitTestRunResultResponse["result"] }
+    | null;
+
+  if (!response.ok || !payload?.result) {
+    const error = new Error(
+      payload?.error || "Failed to submit test run result"
+    ) as SubmitResultError;
+    error.status = response.status;
+    error.code = payload?.code;
+    throw error;
+  }
+
+  return payload.result;
+}

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -554,6 +554,7 @@
       "contentRequired": "Content is required",
       "invalidContentFormat": "Invalid content format",
       "permissionDenied": "You do not have permission to access this page.",
+      "resultSubmitPermissionDenied": "You can’t submit results for this case. Ask a project admin to assign it to you.",
       "noModelsFound": "No models found",
       "failedToFetchModels": "Failed to fetch models"
     },

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -554,6 +554,7 @@
       "contentRequired": "El contenido es obligatorio",
       "invalidContentFormat": "Formato de contenido no válido",
       "permissionDenied": "No tienes permiso para acceder a esta página.",
+      "resultSubmitPermissionDenied": "No puedes enviar resultados para este caso. Pide a un administrador que te lo asigne.",
       "noModelsFound": "No se encontraron modelos",
       "failedToFetchModels": "No se pudieron obtener los modelos"
     },

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -554,6 +554,7 @@
       "contentRequired": "Le contenu est requis",
       "invalidContentFormat": "Format de contenu invalide",
       "permissionDenied": "Vous n'êtes pas autorisé à accéder à cette page.",
+      "resultSubmitPermissionDenied": "Vous ne pouvez pas soumettre de résultats pour ce cas. Demandez à un administrateur de vous l'attribuer.",
       "noModelsFound": "Aucun modèle trouvé",
       "failedToFetchModels": "Impossible de récupérer les modèles"
     },

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -2328,7 +2328,21 @@ model TestRunCases {
         testRun.project.creator == auth() ||
         testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                          (role.name == 'Project Admin' ||
-                                          role.rolePermissions?[area == 'TestRuns' && canAddEdit])] ||
+                                          role.rolePermissions?[area == 'TestRuns' && canAddEdit] ||
+                                          role.rolePermissions?[area == 'TestRunResults' && canAddEdit])] ||
+        testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'SPECIFIC_ROLE' &&
+                                          role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'GLOBAL_ROLE' &&
+                                          auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+        (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+        (testRun.project.assignedUsers?[user == auth()] &&
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
         testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
     )
 

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -2328,21 +2328,7 @@ model TestRunCases {
         testRun.project.creator == auth() ||
         testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                          (role.name == 'Project Admin' ||
-                                          role.rolePermissions?[area == 'TestRuns' && canAddEdit] ||
-                                          role.rolePermissions?[area == 'TestRunResults' && canAddEdit])] ||
-        testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
-                                         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
-        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
-                                          accessType == 'SPECIFIC_ROLE' &&
-                                          role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
-        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
-                                          accessType == 'GLOBAL_ROLE' &&
-                                          auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
-        (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
-         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
-        (testRun.project.assignedUsers?[user == auth()] &&
-         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
-         testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+                                          role.rolePermissions?[area == 'TestRuns' && canAddEdit])] ||
         testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
     )
 


### PR DESCRIPTION
## Description

This PR fixes a data consistency bug in test run result submission.

Previously, submitting a result did two separate writes:

1. Create a TestRunResults row
2. Update TestRunCases.statusId

If step 2 failed (most often due to permission mismatch), step 1 could still succeed, leaving test run data out of sync.

## Related Issue

Closes #177 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS:Win 11
- Browser (if applicable): Firefox
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

1. Atomic result submission endpoint
2. Manual permission enforcement in API route
3. Clear API error codes
4. React Query cache invalidation after raw fetch
