### PR TITLE
fix(add-user): reset form values and clear errors when closing user c…

### DIFF
--- a/testplanit/app/[locale]/admin/users/AddUser.tsx
+++ b/testplanit/app/[locale]/admin/users/AddUser.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCreateManyGroupAssignment,
   useCreateManyProjectAssignment,
@@ -182,26 +182,33 @@ export function AddUserModal() {
 
   const handleCancel = () => setOpen(false);
 
-  // Use the new form-specific validation schema
-  const form = useForm<z.infer<typeof AddUserFormValidationSchema>>({
-    resolver: zodResolver(AddUserFormValidationSchema),
-    defaultValues: {
+  const defaultFormValues = useMemo(
+    () => ({
       name: "",
       email: "",
       password: "",
       confirmPassword: "",
       isActive: true,
-      access: "USER",
+      access: "USER" as const,
       roleId: defaultRoleId ? defaultRoleId.toString() : "",
       isApi: false,
-      projects: [],
-      groups: [],
-    },
+      projects: [] as number[],
+      groups: [] as number[],
+    }),
+    [defaultRoleId]
+  );
+
+  // Use the new form-specific validation schema
+  const form = useForm<z.infer<typeof AddUserFormValidationSchema>>({
+    resolver: zodResolver(AddUserFormValidationSchema),
+    defaultValues: defaultFormValues,
   });
 
   const {
     setValue,
     control,
+    reset,
+    clearErrors,
     formState: { errors },
   } = form;
 
@@ -217,6 +224,16 @@ export function AddUserModal() {
       }
     }
   }, [roles, setValue, form]);
+
+  useEffect(() => {
+    if (!open) {
+      reset(defaultFormValues);
+      clearErrors();
+      setDeletedUser(null);
+      setShowRestoreDialog(false);
+      setIsSubmitting(false);
+    }
+  }, [open, defaultFormValues, reset, clearErrors]);
 
   // Check if email server is configured
   useEffect(() => {


### PR DESCRIPTION
## Description

I'm pretty sure thats a bug:
The Add user dialog was never reseted. (Values stayed filled out after submitting a new user, including password)

Alternative would be to clear on submit 🤔 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS:
- Browser (if applicable):
- Node version:

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)
