### PR TITLE
fix(docs): pin webpackbar to 7.x to satisfy webpack 5.106 ProgressPlugin schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
             "fast-xml-parser": ">=5.5.7",
             "esbuild": ">=0.25.0",
             "webpack": ">=5.104.1",
+            "webpackbar": ">=7.0.0",
             "markdown-it": ">=14.1.1",
             "ajv": ">=8.18.0",
             "eslint>ajv": "^6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
   fast-xml-parser: '>=5.5.7'
   esbuild: '>=0.25.0'
   webpack: '>=5.104.1'
+  webpackbar: '>=7.0.0'
   markdown-it: '>=14.1.1'
   ajv: '>=8.18.0'
   eslint>ajv: ^6.14.0
@@ -9095,6 +9096,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
+
   ansis@4.0.0-node10:
     resolution: {integrity: sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==}
     engines: {node: '>=10'}
@@ -13242,9 +13247,6 @@ packages:
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
-
-  markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -17982,11 +17984,17 @@ packages:
       webpack-cli:
         optional: true
 
-  webpackbar@6.0.1:
-    resolution: {integrity: sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==}
+  webpackbar@7.0.0:
+    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
+      '@rspack/core': '*'
       webpack: '>=5.104.1'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -26035,7 +26043,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0))(webpack@5.106.0)
       webpack: 5.106.0
-      webpackbar: 6.0.1(webpack@5.106.0)
+      webpackbar: 7.0.0(webpack@5.106.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -26076,7 +26084,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.0))(webpack@5.106.0)
       webpack: 5.106.0
-      webpackbar: 6.0.1(webpack@5.106.0)
+      webpackbar: 7.0.0(webpack@5.106.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -32211,7 +32219,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.3)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.2(@types/node@25.5.2)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.3)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -32653,6 +32661,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  ansis@3.17.0: {}
 
   ansis@4.0.0-node10: {}
 
@@ -37310,10 +37320,6 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
-
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
 
@@ -43153,17 +43159,14 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.106.0):
+  webpackbar@7.0.0(webpack@5.106.0):
     dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
+      ansis: 3.17.0
       consola: 3.4.2
-      figures: 3.2.0
-      markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
+    optionalDependencies:
       webpack: 5.106.0
-      wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
The docs Docker build started failing on main with a webpack ProgressPlugin schema validation error:

  Invalid options object. Progress Plugin has been initialized using
  an options object that does not match the API schema.
   - options has an unknown property name
   - options has an unknown property color
   - options has an unknown property reporters
   - options has an unknown property reporter

Root cause is webpackbar 6.0.1 in combination with webpack 5.106.0.

webpackbar 6.0.1 extends ProgressPlugin and overwrites the parent this.options field with its own shape (name, color, reporters, reporter, etc.) instead of the webpack-defined ProgressPluginOptions shape (activeModules, dependencies, modules, percentBy, etc.).

webpack 5.105.x never validated this.options at apply() time, so the type mismatch went undetected. webpack 5.106.0 added schema validation against this.options in _applyOnCompiler, which now rejects webpackbar's shape.

webpackbar 7.0.0 (released 2024-11-06) fixes the bug by storing its config in a separate this.webpackbar property and leaving ProgressPlugin's this.options alone. Pinning to >=7.0.0 via the existing root pnpm.overrides block forces all docs paths to resolve to 7.0.0 while leaving the other workspaces (testplanit, forge-app) on their existing webpack 5.105.x where the bug is dormant.

Verified locally:
- cd docs && pnpm build — succeeds Server: Compiled successfully in 11.39s Client: Compiled successfully in 14.77s
- cd testplanit && pnpm type-check — passes
- pnpm why webpackbar -r --filter docs confirms all 7.0.0
