### PR TITLE
fix(ssrf): respect ALLOWED_PRIVATE_HOSTS in isSsrfSafe and assertSsrfSafeResolved

### DIFF
--- a/testplanit/utils/ssrf.test.ts
+++ b/testplanit/utils/ssrf.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLookup = vi.hoisted(() => vi.fn());
+const mockGetAllowedPrivateHosts = vi.hoisted(() => vi.fn(() => new Set<string>()));
 
 vi.mock("node:dns/promises", () => ({
   default: { lookup: mockLookup },
   lookup: mockLookup,
+}));
+
+vi.mock("~/lib/utils/ssrf", () => ({
+  getAllowedPrivateHosts: mockGetAllowedPrivateHosts,
 }));
 
 import { assertSsrfSafeResolved, isSsrfSafe } from "./ssrf";
@@ -124,6 +129,33 @@ describe("isSsrfSafe", () => {
       expect(isSsrfSafe("")).toBe(false);
     });
   });
+
+  describe("respects ALLOWED_PRIVATE_HOSTS", () => {
+    it("allows private IP when hostname is in allowlist", () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["192.168.1.100"]));
+      expect(isSsrfSafe("http://192.168.1.100:3000/api")).toBe(true);
+    });
+
+    it("allows localhost when in allowlist", () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["localhost"]));
+      expect(isSsrfSafe("http://localhost:3000/api")).toBe(true);
+    });
+
+    it("still blocks private IP not in allowlist", () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["other.host"]));
+      expect(isSsrfSafe("http://192.168.1.100:3000/api")).toBe(false);
+    });
+
+    it("accepts explicit allowedHosts parameter over env", () => {
+      const explicit = new Set(["10.0.0.5"]);
+      expect(isSsrfSafe("https://10.0.0.5/api", explicit)).toBe(true);
+    });
+
+    it("still blocks non-HTTP protocols even if host is allowed", () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["localhost"]));
+      expect(isSsrfSafe("ftp://localhost/file")).toBe(false);
+    });
+  });
 });
 
 describe("assertSsrfSafeResolved", () => {
@@ -196,6 +228,37 @@ describe("assertSsrfSafeResolved", () => {
       await expect(
         assertSsrfSafeResolved("https://nonexistent.example.com/api")
       ).rejects.toThrow("DNS resolution failed");
+    });
+  });
+
+  describe("respects ALLOWED_PRIVATE_HOSTS", () => {
+    it("skips DNS check when hostname is in allowlist", async () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["gitea.local"]));
+
+      await expect(
+        assertSsrfSafeResolved("http://gitea.local:3000/api")
+      ).resolves.not.toThrow();
+
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it("still blocks hostname not in allowlist that resolves to private IP", async () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["other.host"]));
+      mockLookup.mockResolvedValueOnce({ address: "192.168.1.100", family: 4 });
+
+      await expect(
+        assertSsrfSafeResolved("https://gitea.local/api")
+      ).rejects.toThrow("hostname resolves to a private or internal address");
+    });
+
+    it("accepts explicit allowedHosts parameter", async () => {
+      const explicit = new Set(["internal.gitea.corp"]);
+
+      await expect(
+        assertSsrfSafeResolved("https://internal.gitea.corp/api", explicit)
+      ).resolves.not.toThrow();
+
+      expect(mockLookup).not.toHaveBeenCalled();
     });
   });
 });

--- a/testplanit/utils/ssrf.ts
+++ b/testplanit/utils/ssrf.ts
@@ -1,4 +1,5 @@
 import { lookup } from "node:dns/promises";
+import { getAllowedPrivateHosts } from "~/lib/utils/ssrf";
 
 // Private IP ranges that must be blocked to prevent SSRF attacks
 const PRIVATE_RANGES: RegExp[] = [
@@ -32,22 +33,29 @@ function isPrivateIp(ip: string): boolean {
  * Use this before making any HTTP request to a user-supplied URL
  * (e.g., GitLab self-hosted baseUrl, Azure DevOps organizationUrl).
  */
-export function isSsrfSafe(url: string): boolean {
+export function isSsrfSafe(
+  url: string,
+  allowedHosts?: Set<string>
+): boolean {
   try {
     const parsed = new URL(url);
     // Strip brackets from IPv6 addresses (URL.hostname returns "[::1]" for IPv6)
     const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+
+    // Only allow http/https
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+
+    // If this hostname is in the operator allowlist, skip private-IP checks
+    const allowed = allowedHosts ?? getAllowedPrivateHosts();
+    if (allowed.has(hostname.toLowerCase())) return true;
 
     // Block localhost by name
     if (hostname === "localhost") return false;
 
     // Block if hostname is a private/loopback IP
     if (isPrivateIp(hostname)) return false;
-
-    // Only allow http/https
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return false;
-    }
 
     return true;
   } catch {
@@ -64,9 +72,18 @@ export function isSsrfSafe(url: string): boolean {
  * Call this immediately before fetch() to minimize the TOCTOU window.
  * Throws if the resolved address is private or the hostname cannot be resolved.
  */
-export async function assertSsrfSafeResolved(url: string): Promise<void> {
+export async function assertSsrfSafeResolved(
+  url: string,
+  allowedHosts?: Set<string>
+): Promise<void> {
   const parsed = new URL(url);
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+
+  // If this hostname is in the operator allowlist, skip all private-IP checks
+  const allowed = allowedHosts ?? getAllowedPrivateHosts();
+  if (allowed.has(hostname.toLowerCase())) {
+    return;
+  }
 
   // Skip DNS lookup for raw IP addresses — already checked by isSsrfSafe()
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(":")) {


### PR DESCRIPTION
## Summary
- `isSsrfSafe()` and `assertSsrfSafeResolved()` in `utils/ssrf.ts` were blocking private/internal hosts without checking the `ALLOWED_PRIVATE_HOSTS` env var
- Self-hosted integrations (Gitea, GitLab, etc.) on private networks failed even when the hostname/IP was in the allowlist
- Both functions now import and check `getAllowedPrivateHosts()` before rejecting

## Test plan
- [x] Existing 81 SSRF tests pass
- [x] New tests verify allowlist is respected for both functions
- [ ] Manual: set `ALLOWED_PRIVATE_HOSTS=<internal-host>` and confirm Gitea connection succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)