### PR TITLE
enhancement(api): add API token auth to custom endpoints and k6 load test suite

### DIFF
--- a/testplanit/app/api/test-runs/submit-result/route.test.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
@@ -7,6 +8,10 @@ vi.mock("next-auth", () => ({
 
 vi.mock("~/server/auth", () => ({
   authOptions: {},
+}));
+
+vi.mock("~/lib/api-token-auth", () => ({
+  authenticateRequest: vi.fn(),
 }));
 
 vi.mock("~/lib/prisma", () => ({
@@ -22,6 +27,7 @@ vi.mock("~/lib/prisma", () => ({
 }));
 
 import { getServerSession } from "next-auth";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
 
 describe("Submit Result API Route", () => {
@@ -35,7 +41,7 @@ describe("Submit Result API Route", () => {
   };
 
   const createRequest = (body: unknown) =>
-    new Request("http://localhost/api/test-runs/submit-result", {
+    new NextRequest("http://localhost/api/test-runs/submit-result", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -90,6 +96,10 @@ describe("Submit Result API Route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getServerSession as any).mockResolvedValue({ user: { id: "user-1" } });
+    (authenticateRequest as any).mockResolvedValue({
+      authenticated: true,
+      user: { userId: "user-1", access: "USER" },
+    });
     (prisma.user.findUnique as any).mockResolvedValue(baseUser);
     (prisma.testRunCases.findFirst as any).mockResolvedValue(baseRunCase);
 
@@ -113,6 +123,11 @@ describe("Submit Result API Route", () => {
 
   it("returns 401 when user is not authenticated", async () => {
     (getServerSession as any).mockResolvedValue(null);
+    (authenticateRequest as any).mockResolvedValue({
+      authenticated: false,
+      error: "Unauthorized",
+      status: 401,
+    });
 
     const response = await POST(createRequest(validBody));
     const data = await response.json();

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -1,7 +1,8 @@
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod/v4";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
 import { authOptions } from "~/server/auth";
 
@@ -143,12 +144,17 @@ function hasSubmitResultPermission({
   return false;
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const auth = await authenticateRequest(req, session);
+    if (!auth.authenticated) {
+      return NextResponse.json(
+        { error: auth.error, code: auth.errorCode },
+        { status: auth.status }
+      );
     }
+    const authenticatedUserId = auth.user.userId;
 
     const body = await req.json();
     const parsed = submitResultSchema.safeParse(body);
@@ -165,7 +171,7 @@ export async function POST(req: Request) {
     const input = parsed.data;
     const user = await prisma.user.findUnique({
       where: {
-        id: session.user.id,
+        id: authenticatedUserId,
       },
       select: {
         id: true,

--- a/testplanit/lib/api-token-auth.ts
+++ b/testplanit/lib/api-token-auth.ts
@@ -158,3 +158,60 @@ export function hasBearerToken(request: NextRequest): boolean {
   const authHeader = request.headers.get("authorization");
   return authHeader?.startsWith("Bearer tpi_") ?? false;
 }
+
+export interface AuthenticatedUser {
+  userId: string;
+  access?: string | null;
+}
+
+/**
+ * Authenticate a request using session first, falling back to API token.
+ *
+ * Use this in custom API routes that need to support both browser sessions
+ * and programmatic API token access (CI/CD, load testing, external tools).
+ *
+ * @param request - The Next.js request object (needed for API token extraction)
+ * @param session - The result of getServerSession(authOptions) or getServerAuthSession()
+ * @returns The authenticated user info, or null if neither auth method succeeds
+ */
+export async function authenticateRequest(
+  request: NextRequest,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  session: { user?: { id?: string; access?: string | null; [key: string]: any } } | null
+): Promise<
+  | { authenticated: true; user: AuthenticatedUser }
+  | { authenticated: false; error: string; errorCode?: string; status: number }
+> {
+  // Try session auth first
+  if (session?.user?.id) {
+    return {
+      authenticated: true,
+      user: { userId: session.user.id, access: session.user.access },
+    };
+  }
+
+  // Fall back to API token
+  const token = extractBearerToken(request);
+  if (!token) {
+    return {
+      authenticated: false,
+      error: "Unauthorized",
+      status: 401,
+    };
+  }
+
+  const apiAuth = await authenticateApiToken(request);
+  if (!apiAuth.authenticated) {
+    return {
+      authenticated: false,
+      error: apiAuth.error ?? "Unauthorized",
+      errorCode: apiAuth.errorCode,
+      status: 401,
+    };
+  }
+
+  return {
+    authenticated: true,
+    user: { userId: apiAuth.userId!, access: apiAuth.access },
+  };
+}

--- a/testplanit/lib/api-token-auth.ts
+++ b/testplanit/lib/api-token-auth.ts
@@ -176,8 +176,7 @@ export interface AuthenticatedUser {
  */
 export async function authenticateRequest(
   request: NextRequest,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  session: { user?: { id?: string; access?: string | null; [key: string]: any } } | null
+  session: { user?: { id?: string; access?: string | null; [key: string]: unknown } } | null
 ): Promise<
   | { authenticated: true; user: AuthenticatedUser }
   | { authenticated: false; error: string; errorCode?: string; status: number }

--- a/testplanit/load-tests/README.md
+++ b/testplanit/load-tests/README.md
@@ -1,0 +1,219 @@
+# TestPlanIt Load Testing Suite
+
+Performance and load testing for TestPlanIt using [k6](https://grafana.com/docs/k6/).
+
+## Prerequisites
+
+Install k6:
+
+```bash
+# macOS
+brew install k6
+
+# Linux (Debian/Ubuntu)
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | \
+  sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+
+# Docker
+docker pull grafana/k6
+```
+
+## Setup
+
+### 1. Create an API Token
+
+1. Log in to TestPlanIt as an admin user
+2. Go to Admin > Users > edit the test user > enable **API Access**
+3. Go to user profile > **API Tokens** > create a new token
+4. Copy the `tpi_...` token — it's only shown once
+
+### 2. Seed Test Data
+
+Before running load tests, populate the environment with realistic data:
+
+```bash
+k6 run --env BASE_URL=http://your-instance:3000 \
+       --env API_TOKEN=tpi_your_token \
+       --env SEED_PROJECTS=10 \
+       --env SEED_CASES_PER_PROJECT=500 \
+       --env SEED_FOLDERS_PER_PROJECT=20 \
+       --env SEED_RUNS_PER_PROJECT=10 \
+       seed.js
+```
+
+For BBVA-scale testing (millions of tests), increase the counts:
+
+```bash
+k6 run --env BASE_URL=http://your-instance:3000 \
+       --env API_TOKEN=tpi_your_token \
+       --env SEED_PROJECTS=100 \
+       --env SEED_CASES_PER_PROJECT=10000 \
+       --env SEED_FOLDERS_PER_PROJECT=50 \
+       --env SEED_RUNS_PER_PROJECT=50 \
+       seed.js
+```
+
+### 3. Note the Project ID
+
+After seeding, pick a project ID to use for single-project tests. You can find IDs
+in the seed output or via the app.
+
+## Running Tests
+
+### Individual Scenarios
+
+Each scenario tests a specific use case in isolation:
+
+```bash
+# Browse project hierarchy
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/01-browse-hierarchy.js
+
+# Test case CRUD and versioning
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/02-versioning-crud.js
+
+# Test run lifecycle (create, execute, complete)
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/03-test-lifecycle.js
+
+# Search with filters and typeahead
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/04-search.js
+
+# Cross-project reporting and analytics
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/05-reporting.js
+
+# CI/CD JUnit result ingestion
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 scenarios/06-cicd-ingestion.js
+```
+
+### Mixed Workload (Primary Test)
+
+Combines all scenarios with realistic traffic distribution:
+
+```bash
+k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+       --env PROJECT_ID=1 --env PROFILE=load mixed-workload.js
+```
+
+### Load Profiles
+
+Control the VU ramp pattern via the `PROFILE` env var:
+
+| Profile    | VUs    | Duration | Purpose                              |
+|------------|--------|----------|--------------------------------------|
+| `smoke`    | 5      | 2 min    | Verify scripts work correctly        |
+| `baseline` | 10     | 5 min    | Single-user response time baselines  |
+| `load`     | 50-100 | 16 min   | Normal expected traffic              |
+| `stress`   | 50-500 | 16 min   | Find the breaking point              |
+| `soak`     | 100    | 2+ hrs   | Memory leaks, connection exhaustion  |
+
+```bash
+# Smoke test first
+k6 run --env PROFILE=smoke --env BASE_URL=http://... --env API_TOKEN=tpi_... mixed-workload.js
+
+# Then baseline
+k6 run --env PROFILE=baseline --env BASE_URL=http://... --env API_TOKEN=tpi_... mixed-workload.js
+
+# Then load
+k6 run --env PROFILE=load --env BASE_URL=http://... --env API_TOKEN=tpi_... mixed-workload.js
+
+# Then stress (find ceiling)
+k6 run --env PROFILE=stress --env BASE_URL=http://... --env API_TOKEN=tpi_... mixed-workload.js
+```
+
+## Environment Variables
+
+| Variable                   | Required | Default              | Description                        |
+|----------------------------|----------|----------------------|------------------------------------|
+| `BASE_URL`                 | Yes      | `http://localhost:3000` | TestPlanIt instance URL         |
+| `API_TOKEN`                | Yes      | —                    | API token (`tpi_...`)              |
+| `PROJECT_ID`               | No       | `1`                  | Project ID for single-project tests|
+| `PROFILE`                  | No       | `smoke`              | Load profile name                  |
+| `SEED_PROJECTS`            | No       | `10`                 | Seeding: number of projects        |
+| `SEED_CASES_PER_PROJECT`   | No       | `500`                | Seeding: cases per project         |
+| `SEED_FOLDERS_PER_PROJECT` | No       | `20`                 | Seeding: folders per project       |
+| `SEED_RUNS_PER_PROJECT`    | No       | `10`                 | Seeding: runs per project          |
+
+## Output and Reporting
+
+### Console Output
+
+k6 prints a summary with key metrics after each run:
+- `http_req_duration` — response time percentiles (p50, p90, p95, p99)
+- `http_req_failed` — error rate
+- `http_reqs` — total requests and throughput (req/s)
+- Per-scenario metrics tagged by `scenario` name
+
+### JSON Output
+
+Export results for post-processing:
+
+```bash
+k6 run --out json=results.json --env PROFILE=load ... mixed-workload.js
+```
+
+### Grafana Dashboard (Real-Time)
+
+For live monitoring during tests, stream metrics to InfluxDB + Grafana:
+
+```bash
+k6 run --out influxdb=http://localhost:8086/k6 --env PROFILE=load ... mixed-workload.js
+```
+
+## File Structure
+
+```
+load-tests/
+├── config.js                       # Configuration, profiles, thresholds
+├── helpers/
+│   ├── api.js                      # ZenStack CRUD API wrappers
+│   └── data.js                     # Test data generators
+├── scenarios/
+│   ├── 01-browse-hierarchy.js      # UC1: Organization & Hierarchy
+│   ├── 02-versioning-crud.js       # UC2: Versioning & Reusability
+│   ├── 03-test-lifecycle.js        # UC3: End-to-End Test Lifecycle
+│   ├── 04-search.js                # Search performance
+│   ├── 05-reporting.js             # UC5: Analytics & Reporting
+│   └── 06-cicd-ingestion.js        # CI/CD JUnit ingestion
+├── mixed-workload.js               # Combined realistic traffic
+├── seed.js                         # Data seeding script
+└── README.md                       # This file
+```
+
+## Interpreting Results
+
+### Key Metrics to Watch
+
+| Metric | Good | Warning | Critical |
+|--------|------|---------|----------|
+| p95 latency (browse) | < 500ms | 500ms-1s | > 1s |
+| p95 latency (search) | < 300ms | 300ms-1s | > 1s |
+| p95 latency (CRUD) | < 1s | 1s-2s | > 2s |
+| p95 latency (reports) | < 3s | 3s-5s | > 5s |
+| Error rate | < 0.1% | 0.1%-1% | > 1% |
+| Throughput | > 100 req/s | 50-100 req/s | < 50 req/s |
+
+### Common Bottlenecks
+
+1. **Database connections exhausted** — errors spike suddenly at a specific VU count.
+   Fix: Increase `connection_limit` in DATABASE_URL or add PgBouncer.
+
+2. **Response times degrade linearly** — CPU-bound on app server.
+   Fix: Scale horizontally (more app replicas).
+
+3. **Search latency increases with data** — Elasticsearch heap pressure.
+   Fix: Increase ES heap (`-Xms2g -Xmx2g`), add nodes for sharding.
+
+4. **Report queries timeout** — cross-project aggregation too heavy.
+   Fix: Add database indexes, cache report results, limit project count.
+
+5. **CI/CD imports queue up** — worker processing can't keep up.
+   Fix: Increase worker concurrency, scale worker processes.

--- a/testplanit/load-tests/config.js
+++ b/testplanit/load-tests/config.js
@@ -1,0 +1,112 @@
+/**
+ * TestPlanIt Load Testing Configuration
+ *
+ * Central configuration for all k6 load test scenarios.
+ * Override via environment variables when running tests.
+ */
+
+// Base URL of the TestPlanIt instance under test
+export const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+// API token for authentication (create via Admin > Users > API Access)
+export const API_TOKEN = __ENV.API_TOKEN || "";
+
+// Project ID to use for single-project tests
+export const PROJECT_ID = __ENV.PROJECT_ID ? parseInt(__ENV.PROJECT_ID) : 1;
+
+// Common HTTP headers
+export const headers = {
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${API_TOKEN}`,
+};
+
+// ---------------------------------------------------------------------------
+// Threshold Presets
+// ---------------------------------------------------------------------------
+// Use these as starting points. Adjust after baseline runs reveal actual p95s.
+
+export const thresholds = {
+  // Global
+  http_req_failed: ["rate<0.01"], // <1% errors
+  http_req_duration: ["p(95)<2000"], // p95 under 2s
+
+  // Per-scenario (tagged in each script)
+  "http_req_duration{scenario:browse}": ["p(95)<1000"],
+  "http_req_duration{scenario:crud}": ["p(95)<1500"],
+  "http_req_duration{scenario:search}": ["p(95)<1000"],
+  "http_req_duration{scenario:reporting}": ["p(95)<5000"],
+  "http_req_duration{scenario:test_run}": ["p(95)<2000"],
+  "http_req_duration{scenario:cicd}": ["p(95)<3000"],
+};
+
+// ---------------------------------------------------------------------------
+// Load Profiles
+// ---------------------------------------------------------------------------
+// Each profile defines VU ramp stages. Pick one via __ENV.PROFILE.
+
+export const profiles = {
+  // Quick smoke test — confirms scripts work
+  smoke: {
+    stages: [
+      { duration: "30s", target: 5 },
+      { duration: "1m", target: 5 },
+      { duration: "30s", target: 0 },
+    ],
+  },
+
+  // Baseline — find single-user response times with light load
+  baseline: {
+    stages: [
+      { duration: "1m", target: 10 },
+      { duration: "3m", target: 10 },
+      { duration: "1m", target: 0 },
+    ],
+  },
+
+  // Load — normal expected traffic
+  load: {
+    stages: [
+      { duration: "2m", target: 50 },
+      { duration: "5m", target: 50 },
+      { duration: "2m", target: 100 },
+      { duration: "5m", target: 100 },
+      { duration: "2m", target: 0 },
+    ],
+  },
+
+  // Stress — find the breaking point
+  stress: {
+    stages: [
+      { duration: "2m", target: 50 },
+      { duration: "3m", target: 100 },
+      { duration: "3m", target: 200 },
+      { duration: "3m", target: 300 },
+      { duration: "3m", target: 500 },
+      { duration: "2m", target: 0 },
+    ],
+  },
+
+  // Soak — sustained load to find memory leaks / connection exhaustion
+  soak: {
+    stages: [
+      { duration: "5m", target: 100 },
+      { duration: "2h", target: 100 },
+      { duration: "5m", target: 0 },
+    ],
+  },
+};
+
+/**
+ * Returns the active profile based on the PROFILE env var.
+ * Defaults to "smoke" if not set.
+ */
+export function getProfile() {
+  const name = __ENV.PROFILE || "smoke";
+  const profile = profiles[name];
+  if (!profile) {
+    throw new Error(
+      `Unknown profile "${name}". Valid: ${Object.keys(profiles).join(", ")}`
+    );
+  }
+  return profile;
+}

--- a/testplanit/load-tests/helpers/api.js
+++ b/testplanit/load-tests/helpers/api.js
@@ -1,0 +1,134 @@
+/**
+ * ZenStack CRUD API helpers for k6 load tests.
+ *
+ * Wraps the /api/model/{model}/{operation} pattern with proper
+ * query encoding and error checking.
+ */
+
+import http from "k6/http";
+import { check } from "k6";
+import { BASE_URL, headers } from "../config.js";
+
+/**
+ * findMany — list records with optional filtering, pagination, and includes.
+ *
+ * @param {string} model - ZenStack model name (e.g. "projects", "repositoryCases")
+ * @param {object} query - Prisma-style query object ({ where, include, take, skip, orderBy })
+ * @param {object} [opts] - Extra options ({ tags, scenarioTag })
+ * @returns {object} Parsed JSON response
+ */
+export function findMany(model, query = {}, opts = {}) {
+  const q = encodeURIComponent(JSON.stringify(query));
+  const url = `${BASE_URL}/api/model/${model}/findMany?q=${q}`;
+  const tags = buildTags(opts);
+  const res = http.get(url, { headers, tags });
+  check(res, {
+    [`${model}.findMany status 200`]: (r) => r.status === 200,
+  });
+  return safeJson(res);
+}
+
+/**
+ * findFirst — fetch a single record.
+ */
+export function findFirst(model, query = {}, opts = {}) {
+  const q = encodeURIComponent(JSON.stringify(query));
+  const url = `${BASE_URL}/api/model/${model}/findFirst?q=${q}`;
+  const tags = buildTags(opts);
+  const res = http.get(url, { headers, tags });
+  check(res, {
+    [`${model}.findFirst status 200`]: (r) => r.status === 200,
+  });
+  return safeJson(res);
+}
+
+/**
+ * count — count matching records.
+ */
+export function count(model, query = {}, opts = {}) {
+  const q = encodeURIComponent(JSON.stringify(query));
+  const url = `${BASE_URL}/api/model/${model}/count?q=${q}`;
+  const tags = buildTags(opts);
+  const res = http.get(url, { headers, tags });
+  check(res, {
+    [`${model}.count status 200`]: (r) => r.status === 200,
+  });
+  return safeJson(res);
+}
+
+/**
+ * create — create a new record.
+ *
+ * @param {string} model - ZenStack model name
+ * @param {object} data - Record data (Prisma create input)
+ * @param {object} [opts] - Extra options
+ * @returns {object} Created record
+ */
+export function create(model, data, opts = {}) {
+  const url = `${BASE_URL}/api/model/${model}/create`;
+  const tags = buildTags(opts);
+  const body = JSON.stringify({ data });
+  const res = http.post(url, body, { headers, tags });
+  check(res, {
+    [`${model}.create status 201`]: (r) => r.status === 200 || r.status === 201,
+  });
+  return safeJson(res);
+}
+
+/**
+ * update — update an existing record.
+ *
+ * @param {string} model - ZenStack model name
+ * @param {number|string} id - Record ID
+ * @param {object} data - Fields to update
+ * @param {object} [opts] - Extra options
+ * @returns {object} Updated record
+ */
+export function update(model, id, data, opts = {}) {
+  const url = `${BASE_URL}/api/model/${model}/update`;
+  const tags = buildTags(opts);
+  const body = JSON.stringify({ where: { id }, data });
+  const res = http.put(url, body, { headers, tags });
+  check(res, {
+    [`${model}.update status 200`]: (r) => r.status === 200,
+  });
+  return safeJson(res);
+}
+
+/**
+ * Custom POST to any API endpoint.
+ */
+export function postApi(path, body = {}, opts = {}) {
+  const url = `${BASE_URL}${path}`;
+  const tags = buildTags(opts);
+  const res = http.post(url, JSON.stringify(body), { headers, tags });
+  return { res, data: safeJson(res) };
+}
+
+/**
+ * Custom GET to any API endpoint.
+ */
+export function getApi(path, opts = {}) {
+  const url = `${BASE_URL}${path}`;
+  const tags = buildTags(opts);
+  const res = http.get(url, { headers, tags });
+  return { res, data: safeJson(res) };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function buildTags(opts) {
+  const tags = {};
+  if (opts.scenarioTag) tags.scenario = opts.scenarioTag;
+  return Object.keys(tags).length > 0 ? tags : undefined;
+}
+
+function safeJson(res) {
+  try {
+    return res.json();
+  } catch {
+    return null;
+  }
+}

--- a/testplanit/load-tests/helpers/data.js
+++ b/testplanit/load-tests/helpers/data.js
@@ -1,0 +1,176 @@
+/**
+ * Test data generators for k6 load tests.
+ *
+ * Produces randomized but realistic data for creating test entities.
+ * Uses k6's built-in randomization (no external deps).
+ */
+
+/**
+ * Generate a unique identifier string.
+ * k6 doesn't have crypto.randomUUID(), so we build one from Math.random + timestamp.
+ */
+export function uniqueId() {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+}
+
+/**
+ * Generate a test case name that looks realistic.
+ */
+export function testCaseName() {
+  const prefixes = [
+    "Verify",
+    "Validate",
+    "Check",
+    "Ensure",
+    "Confirm",
+    "Test",
+  ];
+  const actions = [
+    "user login",
+    "password reset",
+    "data export",
+    "API response",
+    "form submission",
+    "navigation flow",
+    "error handling",
+    "permission check",
+    "notification delivery",
+    "search results",
+    "pagination",
+    "file upload",
+    "session timeout",
+    "concurrent access",
+    "data integrity",
+    "bulk import",
+    "webhook trigger",
+    "cache invalidation",
+    "rate limiting",
+    "rollback behavior",
+  ];
+  const conditions = [
+    "with valid credentials",
+    "with invalid input",
+    "under high load",
+    "after timeout",
+    "with special characters",
+    "in offline mode",
+    "with large payload",
+    "across browsers",
+    "with 2FA enabled",
+    "as read-only user",
+  ];
+
+  const prefix = pick(prefixes);
+  const action = pick(actions);
+  const condition = pick(conditions);
+  return `${prefix} ${action} ${condition} [${uniqueId()}]`;
+}
+
+/**
+ * Generate a folder name.
+ */
+export function folderName() {
+  const modules = [
+    "Authentication",
+    "User Management",
+    "Payments",
+    "Notifications",
+    "Search",
+    "Dashboard",
+    "Reports",
+    "Settings",
+    "API Gateway",
+    "Data Pipeline",
+    "Mobile App",
+    "Web Portal",
+    "Admin Console",
+    "Integration Layer",
+    "Compliance",
+  ];
+  return `${pick(modules)} - ${uniqueId()}`;
+}
+
+/**
+ * Generate a project name.
+ */
+export function projectName() {
+  const products = [
+    "Core Banking",
+    "Mobile Banking",
+    "Payment Gateway",
+    "Risk Engine",
+    "Compliance Suite",
+    "Customer Portal",
+    "Internal Tools",
+    "Data Platform",
+    "API Services",
+    "Identity Provider",
+  ];
+  return `${pick(products)} Tests [${uniqueId()}]`;
+}
+
+/**
+ * Generate test case steps as a JSON-compatible array.
+ */
+export function testSteps(count) {
+  const n = count || randomInt(3, 8);
+  const steps = [];
+  for (let i = 0; i < n; i++) {
+    steps.push({
+      order: i + 1,
+      action: `Step ${i + 1}: ${pick(["Navigate to", "Click on", "Enter", "Verify", "Wait for", "Select"])} ${pick(["the button", "the input field", "the dropdown", "the modal", "the table row", "the link"])}`,
+      expected: `Expected: ${pick(["Element is visible", "Value is updated", "Page loads", "Error message appears", "Data is saved", "Redirect occurs"])}`,
+    });
+  }
+  return steps;
+}
+
+/**
+ * Generate a JUnit XML string for CI/CD ingestion testing.
+ */
+export function junitXml(suiteCount, casesPerSuite) {
+  const suites = suiteCount || randomInt(1, 5);
+  const cases = casesPerSuite || randomInt(5, 20);
+
+  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n';
+
+  for (let s = 0; s < suites; s++) {
+    const suiteName = `com.testplanit.loadtest.Suite${s}_${uniqueId()}`;
+    let failures = 0;
+    let caseXml = "";
+
+    for (let c = 0; c < cases; c++) {
+      const caseName = `test_${pick(["login", "logout", "create", "update", "delete", "search", "export", "import", "validate", "sync"])}_${c}`;
+      const time = (Math.random() * 5).toFixed(3);
+
+      // ~10% of cases fail
+      if (Math.random() < 0.1) {
+        failures++;
+        caseXml += `    <testcase classname="${suiteName}" name="${caseName}" time="${time}">\n`;
+        caseXml += `      <failure message="Assertion failed" type="AssertionError">Expected true but got false</failure>\n`;
+        caseXml += `    </testcase>\n`;
+      } else {
+        caseXml += `    <testcase classname="${suiteName}" name="${caseName}" time="${time}" />\n`;
+      }
+    }
+
+    xml += `  <testsuite name="${suiteName}" tests="${cases}" failures="${failures}" time="${(Math.random() * 30).toFixed(3)}">\n`;
+    xml += caseXml;
+    xml += `  </testsuite>\n`;
+  }
+
+  xml += "</testsuites>";
+  return xml;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/testplanit/load-tests/mixed-workload.js
+++ b/testplanit/load-tests/mixed-workload.js
@@ -20,8 +20,8 @@
 
 import { sleep, check } from "k6";
 import http from "k6/http";
-import { findMany, findFirst, create, update, postApi, getApi } from "./helpers/api.js";
-import { testCaseName, testSteps, junitXml, uniqueId } from "./helpers/data.js";
+import { findMany, create, update, postApi, getApi } from "./helpers/api.js";
+import { testCaseName, junitXml, uniqueId } from "./helpers/data.js";
 import { getProfile, thresholds, PROJECT_ID, BASE_URL, headers } from "./config.js";
 
 export const options = {

--- a/testplanit/load-tests/mixed-workload.js
+++ b/testplanit/load-tests/mixed-workload.js
@@ -1,0 +1,368 @@
+/**
+ * Mixed Workload — Realistic Production Traffic Simulation
+ *
+ * Combines all scenarios with weighted distribution to simulate
+ * what actual production traffic looks like:
+ *
+ *   60% — Browsing (read-heavy: listing projects, folders, cases)
+ *   15% — Test execution (creating runs, submitting results)
+ *   10% — Search (full-text, filtered, typeahead)
+ *    5% — CRUD (creating/editing test cases)
+ *    5% — Reporting (single + cross-project)
+ *    5% — CI/CD ingestion (JUnit uploads)
+ *
+ * This is the primary script to run for capacity planning.
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+ *          --env PROFILE=load --env PROJECT_ID=1 mixed-workload.js
+ */
+
+import { sleep, check } from "k6";
+import http from "k6/http";
+import { findMany, findFirst, create, update, postApi, getApi } from "./helpers/api.js";
+import { testCaseName, testSteps, junitXml, uniqueId } from "./helpers/data.js";
+import { getProfile, thresholds, PROJECT_ID, BASE_URL, headers } from "./config.js";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+// ---------------------------------------------------------------------------
+// Scenario weights — adjust these to model different traffic patterns
+// ---------------------------------------------------------------------------
+
+const SCENARIOS = [
+  { name: "browse", weight: 60, fn: browseScenario },
+  { name: "test_run", weight: 15, fn: testRunScenario },
+  { name: "search", weight: 10, fn: searchScenario },
+  { name: "crud", weight: 5, fn: crudScenario },
+  { name: "reporting", weight: 5, fn: reportingScenario },
+  { name: "cicd", weight: 5, fn: cicdScenario },
+];
+
+// Build cumulative weights for random selection
+const totalWeight = SCENARIOS.reduce((sum, s) => sum + s.weight, 0);
+const cumulative = [];
+let running = 0;
+for (const s of SCENARIOS) {
+  running += s.weight;
+  cumulative.push({ ...s, threshold: running / totalWeight });
+}
+
+export default function () {
+  const rand = Math.random();
+  const scenario = cumulative.find((s) => rand <= s.threshold);
+  scenario.fn();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario implementations (simplified versions of the standalone scripts)
+// ---------------------------------------------------------------------------
+
+function browseScenario() {
+  const TAG = "browse";
+
+  // List projects
+  const projects = findMany(
+    "projects",
+    {
+      where: { isDeleted: false },
+      select: { id: true, name: true },
+      take: 50,
+      orderBy: { name: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+  sleep(0.5);
+
+  const projectId =
+    projects?.data?.length > 0
+      ? projects.data[Math.floor(Math.random() * projects.data.length)].id
+      : PROJECT_ID;
+
+  // Load folders
+  findMany(
+    "repositoryFolders",
+    {
+      where: { projectId, isDeleted: false },
+      select: { id: true, name: true, parentId: true },
+      orderBy: { order: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+  sleep(0.3);
+
+  // Folder stats
+  getApi(`/api/projects/${projectId}/folders/stats`, { scenarioTag: TAG });
+  sleep(0.3);
+
+  // Browse cases (paginated)
+  findMany(
+    "repositoryCases",
+    {
+      where: { projectId, isDeleted: false },
+      include: {
+        template: { select: { id: true, templateName: true } },
+      },
+      take: 25,
+      skip: Math.floor(Math.random() * 5) * 25, // random page
+      orderBy: { name: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(1 + Math.random() * 3);
+}
+
+function testRunScenario() {
+  const TAG = "test_run";
+
+  // Get cases and statuses
+  const cases = findMany(
+    "repositoryCases",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true },
+      take: 15,
+      orderBy: { createdAt: "desc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  const statuses = findMany(
+    "status",
+    {
+      where: { isDeleted: false, isEnabled: true },
+      select: { id: true, name: true, isSuccess: true, isFailure: true },
+    },
+    { scenarioTag: TAG }
+  );
+
+  if (!cases?.data?.length || !statuses?.data?.length) {
+    sleep(2);
+    return;
+  }
+
+  const defaultStatus = statuses.data.find((s) => !s.isSuccess && !s.isFailure) || statuses.data[0];
+  const passedStatus = statuses.data.find((s) => s.isSuccess) || statuses.data[0];
+
+  // Get run workflow state
+  const runWorkflows = findMany("workflows", { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 }, { scenarioTag: TAG });
+  const runStateId = runWorkflows?.data?.[0]?.id;
+  if (!runStateId) { sleep(1); return; }
+
+  // Create run
+  const testRun = create(
+    "testRuns",
+    {
+      name: `Mixed Load Run ${uniqueId()}`,
+      isCompleted: false,
+      isDeleted: false,
+      testRunType: "REGULAR",
+      project: { connect: { id: PROJECT_ID } },
+      state: { connect: { id: runStateId } },
+    },
+    { scenarioTag: TAG }
+  );
+
+  const testRunId = testRun?.data?.id;
+  if (!testRunId) { sleep(1); return; }
+
+  // Add 5-10 cases
+  const casesToAdd = cases.data.slice(0, 5 + Math.floor(Math.random() * 6));
+  const trcIds = [];
+
+  for (let i = 0; i < casesToAdd.length; i++) {
+    const trc = create(
+      "testRunCases",
+      {
+        order: i + 1,
+        isCompleted: false,
+        testRun: { connect: { id: testRunId } },
+        repositoryCase: { connect: { id: casesToAdd[i].id } },
+        status: { connect: { id: defaultStatus.id } },
+      },
+      { scenarioTag: TAG }
+    );
+    if (trc?.data?.id) trcIds.push({ id: trc.data.id, version: trc.data.version || 1 });
+  }
+
+  sleep(0.5);
+
+  // Submit results
+  for (const trc of trcIds) {
+    postApi(
+      "/api/test-runs/submit-result",
+      {
+        testRunId,
+        testRunCaseId: trc.id,
+        statusId: passedStatus.id,
+        elapsed: Math.floor(500 + Math.random() * 10000),
+        attempt: 1,
+        testRunCaseVersion: trc.version,
+      },
+      { scenarioTag: TAG }
+    );
+    sleep(0.1 + Math.random() * 0.3);
+  }
+
+  // Complete
+  update("testRuns", testRunId, { isCompleted: true, completedAt: new Date().toISOString() }, { scenarioTag: TAG });
+  sleep(1 + Math.random() * 2);
+}
+
+function searchScenario() {
+  const TAG = "search";
+  const queries = ["login", "payment", "API", "security", "validation", "error", "mobile"];
+  const query = queries[Math.floor(Math.random() * queries.length)];
+
+  const { res } = postApi(
+    "/api/repository-cases/search",
+    {
+      query,
+      filters: { projectIds: [PROJECT_ID] },
+      pagination: { page: 1, size: 25 },
+      highlight: true,
+    },
+    { scenarioTag: TAG }
+  );
+  check(res, { "search 200": (r) => r.status === 200 });
+
+  sleep(0.5);
+
+  // Page 2
+  postApi(
+    "/api/repository-cases/search",
+    {
+      query,
+      filters: { projectIds: [PROJECT_ID] },
+      pagination: { page: 2, size: 25 },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(1 + Math.random() * 2);
+}
+
+function crudScenario() {
+  const TAG = "crud";
+
+  const folders = findMany(
+    "repositoryFolders",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true },
+      take: 5,
+    },
+    { scenarioTag: TAG }
+  );
+
+  const folderId = folders?.data?.length > 0
+    ? folders.data[Math.floor(Math.random() * folders.data.length)].id
+    : null;
+
+  if (!folderId) { sleep(2); return; }
+
+  // Get repo, template, and workflow state for creating cases
+  const repos = findMany("repositories", { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 1 }, { scenarioTag: TAG });
+  const templates = findMany("templates", { where: { isDefault: true }, select: { id: true }, take: 1 }, { scenarioTag: TAG });
+  const workflows = findMany("workflows", { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 }, { scenarioTag: TAG });
+  const repoId = repos?.data?.[0]?.id;
+  const templateId = templates?.data?.[0]?.id;
+  const stateId = workflows?.data?.[0]?.id;
+  if (!repoId || !templateId || !stateId) { sleep(2); return; }
+
+  // Create
+  const created = create(
+    "repositoryCases",
+    {
+      name: testCaseName(),
+      automated: false,
+      isDeleted: false,
+      project: { connect: { id: PROJECT_ID } },
+      folder: { connect: { id: folderId } },
+      repository: { connect: { id: repoId } },
+      template: { connect: { id: templateId } },
+      state: { connect: { id: stateId } },
+    },
+    { scenarioTag: TAG }
+  );
+
+  if (created?.data?.id) {
+    sleep(0.5);
+    // Update
+    update("repositoryCases", created.data.id, { name: `${created.data.name} [EDITED]` }, { scenarioTag: TAG });
+  }
+
+  sleep(1 + Math.random() * 2);
+}
+
+function reportingScenario() {
+  const TAG = "reporting";
+
+  // Single-project report
+  const { res: execRes } = postApi(
+    "/api/report-builder/test-execution",
+    {
+      projectId: PROJECT_ID,
+      dimensions: [{ id: "status" }],
+      metrics: [{ id: "executionCount", aggregation: "sum" }],
+      filters: {},
+      limit: 100,
+    },
+    { scenarioTag: TAG }
+  );
+  check(execRes, { "report 200": (r) => r.status === 200 });
+
+  sleep(0.5);
+
+  // Cross-project report
+  const projects = findMany(
+    "projects",
+    { where: { isDeleted: false }, select: { id: true }, take: 20 },
+    { scenarioTag: TAG }
+  );
+
+  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
+
+  const { res: crossRes } = postApi(
+    "/api/report-builder/cross-project-test-execution",
+    {
+      projectIds,
+      dimensions: [{ id: "project" }],
+      metrics: [{ id: "executionCount", aggregation: "sum" }],
+      filters: {},
+      limit: 500,
+    },
+    { scenarioTag: TAG }
+  );
+  check(crossRes, { "cross-project report 200": (r) => r.status === 200 });
+
+  sleep(2 + Math.random() * 4);
+}
+
+function cicdScenario() {
+  const TAG = "cicd";
+
+  const xml = junitXml(2, 15);
+
+  const res = http.post(
+    `${BASE_URL}/api/test-results/import`,
+    {
+      file: http.file(xml, `ci-${uniqueId()}.xml`, "application/xml"),
+      format: "junit",
+      projectId: String(PROJECT_ID),
+      name: `CI Pipeline ${uniqueId()}`,
+    },
+    {
+      headers: { Authorization: headers.Authorization },
+      tags: { scenario: TAG },
+      timeout: "60s",
+    }
+  );
+  check(res, { "import 200": (r) => r.status === 200 });
+
+  sleep(0.5 + Math.random() * 2);
+}

--- a/testplanit/load-tests/scenarios/01-browse-hierarchy.js
+++ b/testplanit/load-tests/scenarios/01-browse-hierarchy.js
@@ -1,0 +1,127 @@
+/**
+ * Scenario 1: Enterprise-Grade Organization & Hierarchy
+ *
+ * BBVA Use Case: "Structured management of the testing ecosystem,
+ * demonstrating how to organize assets by Project, Application,
+ * and hierarchical folders to ensure multi-level visibility."
+ *
+ * Simulates a user browsing the project hierarchy:
+ * 1. List all accessible projects
+ * 2. Pick a project and load its repositories
+ * 3. Load folder tree for the repository
+ * 4. Browse test cases in folders (paginated)
+ * 5. Load folder statistics (case counts)
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/01-browse-hierarchy.js
+ */
+
+import { sleep } from "k6";
+import { findMany, count, getApi } from "../helpers/api.js";
+import { getProfile, thresholds, PROJECT_ID } from "../config.js";
+
+const TAG = "browse";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+export default function () {
+  // 1. List projects the user can access
+  const projects = findMany(
+    "projects",
+    {
+      where: { isDeleted: false },
+      select: { id: true, name: true },
+      take: 50,
+      orderBy: { name: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(1); // simulate user reading project list
+
+  // 2. Load repositories for the target project
+  const projectId =
+    projects?.data?.length > 0 ? projects.data[0].id : PROJECT_ID;
+
+  const repos = findMany(
+    "repositories",
+    {
+      where: { projectId, isDeleted: false },
+      select: { id: true, isActive: true },
+      take: 10,
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(0.5);
+
+  // 3. Load folder tree for the project
+  const folders = findMany(
+    "repositoryFolders",
+    {
+      where: { projectId, isDeleted: false },
+      select: { id: true, name: true, parentId: true, order: true },
+      orderBy: { order: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(0.5);
+
+  // 4. Browse test cases in the first folder (paginated)
+  const folderId = folders?.data?.length > 0 ? folders.data[0].id : null;
+  if (folderId) {
+    // Page 1 — use include (not select) to get related data
+    findMany(
+      "repositoryCases",
+      {
+        where: { projectId, folderId, isDeleted: false },
+        include: {
+          template: { select: { id: true, templateName: true } },
+        },
+        take: 25,
+        skip: 0,
+        orderBy: { name: "asc" },
+      },
+      { scenarioTag: TAG }
+    );
+
+    sleep(1);
+
+    // Page 2
+    findMany(
+      "repositoryCases",
+      {
+        where: { projectId, folderId, isDeleted: false },
+        select: {
+          id: true,
+          name: true,
+          automated: true,
+          createdAt: true,
+        },
+        take: 25,
+        skip: 25,
+        orderBy: { name: "asc" },
+      },
+      { scenarioTag: TAG }
+    );
+  }
+
+  // 6. Count total cases in the project (for dashboard)
+  count(
+    "repositoryCases",
+    {
+      where: { projectId, isDeleted: false },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  return 1 + Math.random() * 3; // 1-4 seconds
+}

--- a/testplanit/load-tests/scenarios/01-browse-hierarchy.js
+++ b/testplanit/load-tests/scenarios/01-browse-hierarchy.js
@@ -17,7 +17,7 @@
  */
 
 import { sleep } from "k6";
-import { findMany, count, getApi } from "../helpers/api.js";
+import { findMany, count } from "../helpers/api.js";
 import { getProfile, thresholds, PROJECT_ID } from "../config.js";
 
 const TAG = "browse";
@@ -46,7 +46,7 @@ export default function () {
   const projectId =
     projects?.data?.length > 0 ? projects.data[0].id : PROJECT_ID;
 
-  const repos = findMany(
+  findMany(
     "repositories",
     {
       where: { projectId, isDeleted: false },

--- a/testplanit/load-tests/scenarios/02-versioning-crud.js
+++ b/testplanit/load-tests/scenarios/02-versioning-crud.js
@@ -1,0 +1,173 @@
+/**
+ * Scenario 2: Lifecycle Management — Versioning & Reusability
+ *
+ * BBVA Use Case: "Managing large-scale test libraries and maintaining
+ * version control across multiple releases, ensuring efficient test
+ * case reuse and history tracking."
+ *
+ * Simulates:
+ * 1. Create a new test case with steps
+ * 2. Read it back (confirm creation)
+ * 3. Update the test case (edit title, add step)
+ * 4. Read version history
+ * 5. Create a copy in another folder (reuse)
+ * 6. List test cases with includes (template, tags, custom fields)
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/02-versioning-crud.js
+ */
+
+import { sleep, check } from "k6";
+import { findMany, findFirst, create, update, postApi } from "../helpers/api.js";
+import { testCaseName, testSteps, uniqueId } from "../helpers/data.js";
+import { getProfile, thresholds, PROJECT_ID } from "../config.js";
+
+const TAG = "crud";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+export default function () {
+  // 1. Get a folder to put test cases in
+  const folders = findMany(
+    "repositoryFolders",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true },
+      take: 5,
+    },
+    { scenarioTag: TAG }
+  );
+
+  const folderId =
+    folders?.data?.length > 0
+      ? folders.data[Math.floor(Math.random() * folders.data.length)].id
+      : null;
+
+  if (!folderId) {
+    console.warn("No folders found — skipping CRUD iteration");
+    sleep(2);
+    return;
+  }
+
+  // Get repository, template, and default workflow state
+  const repos = findMany(
+    "repositories",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const templates = findMany(
+    "templates",
+    { where: { isDefault: true }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+
+  const repoId = repos?.data?.[0]?.id;
+  const templateId = templates?.data?.[0]?.id;
+  const stateId = workflows?.data?.[0]?.id;
+
+  if (!repoId || !templateId || !stateId) {
+    console.warn("Missing repo, template, or workflow state — skipping CRUD iteration");
+    sleep(2);
+    return;
+  }
+
+  sleep(0.5);
+
+  // 2. Create a new test case
+  const caseName = testCaseName();
+  const created = create(
+    "repositoryCases",
+    {
+      name: caseName,
+      automated: false,
+      isDeleted: false,
+      project: { connect: { id: PROJECT_ID } },
+      folder: { connect: { id: folderId } },
+      repository: { connect: { id: repoId } },
+      template: { connect: { id: templateId } },
+      state: { connect: { id: stateId } },
+    },
+    { scenarioTag: TAG }
+  );
+
+  const caseId = created?.data?.id;
+  if (!caseId) {
+    console.warn("Failed to create test case — skipping rest of iteration");
+    sleep(2);
+    return;
+  }
+
+  sleep(0.5);
+
+  // 3. Read it back with full details
+  findFirst(
+    "repositoryCases",
+    {
+      where: { id: caseId },
+      include: {
+        template: true,
+        folder: true,
+        steps: true,
+      },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(1);
+
+  // 4. Update the test case — simulate editing
+  update(
+    "repositoryCases",
+    caseId,
+    {
+      name: `${caseName} [UPDATED]`,
+      automated: true,
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(0.5);
+
+  // 5. Create steps for the test case
+  const steps = testSteps(3);
+  for (let i = 0; i < steps.length; i++) {
+    create(
+      "steps",
+      {
+        order: steps[i].order,
+        testCase: { connect: { id: caseId } },
+      },
+      { scenarioTag: TAG }
+    );
+  }
+
+  sleep(0.5);
+
+  // 6. List test cases with rich includes (simulates loading the case list page)
+  findMany(
+    "repositoryCases",
+    {
+      where: { projectId: PROJECT_ID, folderId, isDeleted: false },
+      include: {
+        template: { select: { id: true, templateName: true } },
+      },
+      take: 25,
+      orderBy: { createdAt: "desc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  return 1 + Math.random() * 3;
+}

--- a/testplanit/load-tests/scenarios/02-versioning-crud.js
+++ b/testplanit/load-tests/scenarios/02-versioning-crud.js
@@ -17,9 +17,9 @@
  *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/02-versioning-crud.js
  */
 
-import { sleep, check } from "k6";
-import { findMany, findFirst, create, update, postApi } from "../helpers/api.js";
-import { testCaseName, testSteps, uniqueId } from "../helpers/data.js";
+import { sleep } from "k6";
+import { findMany, findFirst, create, update } from "../helpers/api.js";
+import { testCaseName, testSteps } from "../helpers/data.js";
 import { getProfile, thresholds, PROJECT_ID } from "../config.js";
 
 const TAG = "crud";

--- a/testplanit/load-tests/scenarios/03-test-lifecycle.js
+++ b/testplanit/load-tests/scenarios/03-test-lifecycle.js
@@ -18,7 +18,6 @@
  */
 
 import { sleep, check } from "k6";
-import http from "k6/http";
 import {
   findMany,
   findFirst,
@@ -27,7 +26,7 @@ import {
   postApi,
 } from "../helpers/api.js";
 import { uniqueId } from "../helpers/data.js";
-import { getProfile, thresholds, PROJECT_ID, BASE_URL, headers } from "../config.js";
+import { getProfile, thresholds, PROJECT_ID } from "../config.js";
 
 const TAG = "test_run";
 

--- a/testplanit/load-tests/scenarios/03-test-lifecycle.js
+++ b/testplanit/load-tests/scenarios/03-test-lifecycle.js
@@ -1,0 +1,208 @@
+/**
+ * Scenario 3: End-to-End Test Lifecycle Evolution
+ *
+ * BBVA Use Case: "Demonstration of the full lifecycle: starting from
+ * initial manual test creation and its subsequent transition into an
+ * automated asset. Includes local QA execution, seamless CI/CD
+ * integration, and final automated result ingestion."
+ *
+ * Simulates the full lifecycle:
+ * 1. Create a test run
+ * 2. Add test cases to the run
+ * 3. Execute test cases (submit results one by one)
+ * 4. Complete the test run
+ * 5. View test run summary
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/03-test-lifecycle.js
+ */
+
+import { sleep, check } from "k6";
+import http from "k6/http";
+import {
+  findMany,
+  findFirst,
+  create,
+  update,
+  postApi,
+} from "../helpers/api.js";
+import { uniqueId } from "../helpers/data.js";
+import { getProfile, thresholds, PROJECT_ID, BASE_URL, headers } from "../config.js";
+
+const TAG = "test_run";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+export default function () {
+  // 1. Get available test cases and statuses for this project
+  const cases = findMany(
+    "repositoryCases",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true, name: true },
+      take: 20, // pick up to 20 cases for this run
+      orderBy: { createdAt: "desc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  const statuses = findMany(
+    "status",
+    {
+      where: { isDeleted: false, isEnabled: true },
+      select: { id: true, name: true, isSuccess: true, isFailure: true },
+    },
+    { scenarioTag: TAG }
+  );
+
+  if (!cases?.data?.length || !statuses?.data?.length) {
+    console.warn("No cases or statuses found — skipping test run iteration");
+    sleep(2);
+    return;
+  }
+
+  // Find untested, passed, and failed statuses
+  const defaultStatus =
+    statuses.data.find((s) => !s.isSuccess && !s.isFailure) || statuses.data[0];
+  const passedStatus =
+    statuses.data.find((s) => s.isSuccess) || statuses.data[0];
+  const failedStatus =
+    statuses.data.find((s) => s.isFailure) || defaultStatus;
+
+  // Get default run workflow state
+  const runWorkflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const runStateId = runWorkflows?.data?.[0]?.id;
+  if (!runStateId) { console.warn("No run workflow state"); sleep(2); return; }
+
+  sleep(0.5);
+
+  // 2. Create a test run
+  const runName = `Load Test Run ${uniqueId()}`;
+  const testRun = create(
+    "testRuns",
+    {
+      name: runName,
+      isCompleted: false,
+      isDeleted: false,
+      testRunType: "REGULAR",
+      project: { connect: { id: PROJECT_ID } },
+      state: { connect: { id: runStateId } },
+    },
+    { scenarioTag: TAG }
+  );
+
+  const testRunId = testRun?.data?.id;
+  if (!testRunId) {
+    console.warn("Failed to create test run");
+    sleep(2);
+    return;
+  }
+
+  sleep(0.5);
+
+  // 3. Add test cases to the run
+  const casesToAdd = cases.data.slice(
+    0,
+    Math.min(cases.data.length, 10 + Math.floor(Math.random() * 10))
+  );
+  const testRunCaseIds = [];
+
+  for (let i = 0; i < casesToAdd.length; i++) {
+    const trc = create(
+      "testRunCases",
+      {
+        order: i + 1,
+        isCompleted: false,
+        testRun: { connect: { id: testRunId } },
+        repositoryCase: { connect: { id: casesToAdd[i].id } },
+        status: { connect: { id: defaultStatus.id } },
+      },
+      { scenarioTag: TAG }
+    );
+    if (trc?.data?.id) {
+      testRunCaseIds.push({
+        id: trc.data.id,
+        version: trc.data.version || 1,
+      });
+    }
+  }
+
+  sleep(1); // simulate user reviewing the run before executing
+
+  // 4. Execute test cases — submit results
+  for (let i = 0; i < testRunCaseIds.length; i++) {
+    const trc = testRunCaseIds[i];
+    // 80% pass, 15% fail, 5% skip (no result submission)
+    const rand = Math.random();
+    if (rand < 0.05) continue; // skip
+
+    const statusId = rand < 0.80 ? passedStatus.id : failedStatus.id;
+    const elapsed = Math.floor(500 + Math.random() * 30000); // 0.5s to 30s
+
+    const body = {
+      testRunId,
+      testRunCaseId: trc.id,
+      statusId,
+      elapsed,
+      attempt: 1,
+      testRunCaseVersion: trc.version,
+    };
+
+    const { res } = postApi("/api/test-runs/submit-result", body, {
+      scenarioTag: TAG,
+    });
+
+    check(res, {
+      "submit-result status 200": (r) => r.status === 200,
+    });
+
+    // Brief pause between submissions (realistic human pace)
+    sleep(0.2 + Math.random() * 0.5);
+  }
+
+  sleep(0.5);
+
+  // 5. Complete the test run
+  update(
+    "testRuns",
+    testRunId,
+    {
+      isCompleted: true,
+      completedAt: new Date().toISOString(),
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(0.5);
+
+  // 6. View completed test run summary
+  findFirst(
+    "testRuns",
+    {
+      where: { id: testRunId },
+      include: {
+        testRunCases: {
+          select: {
+            id: true,
+            status: { select: { id: true, name: true } },
+            repositoryCase: { select: { id: true, name: true } },
+          },
+        },
+      },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  return 1 + Math.random() * 3;
+}

--- a/testplanit/load-tests/scenarios/04-search.js
+++ b/testplanit/load-tests/scenarios/04-search.js
@@ -1,0 +1,181 @@
+/**
+ * Scenario 4: Search with Filters and Facets
+ *
+ * Tests Elasticsearch search performance under load.
+ * This is critical for BBVA's "millions of tests" requirement —
+ * search must remain fast as data scales.
+ *
+ * Simulates:
+ * 1. Full-text search with various queries
+ * 2. Filtered search (by template, tags, automated status)
+ * 3. Paginated search results
+ * 4. Search suggestions (typeahead)
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/04-search.js
+ */
+
+import { sleep, check } from "k6";
+import { postApi, getApi, findMany } from "../helpers/api.js";
+import { getProfile, thresholds, PROJECT_ID } from "../config.js";
+
+const TAG = "search";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+// Realistic search queries a QA engineer might type
+const SEARCH_QUERIES = [
+  "login",
+  "payment",
+  "authentication",
+  "API",
+  "timeout",
+  "error handling",
+  "mobile",
+  "regression",
+  "smoke test",
+  "database",
+  "validation",
+  "security",
+  "performance",
+  "user profile",
+  "notification",
+  "export",
+  "import",
+  "webhook",
+  "SAML",
+  "OAuth",
+];
+
+// Typeahead prefixes (user typing progressively)
+const TYPEAHEAD_SEQUENCES = [
+  ["l", "lo", "log", "logi", "login"],
+  ["p", "pa", "pay", "paym", "payment"],
+  ["a", "au", "aut", "auth"],
+  ["s", "se", "sec", "secu", "security"],
+  ["t", "te", "tes", "test"],
+];
+
+export default function () {
+  // Get project context (templates, tags) for filtered searches
+  const templates = findMany(
+    "templates",
+    {
+      where: { isDefault: true },
+      select: { id: true },
+      take: 5,
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(0.3);
+
+  // 1. Simple full-text search
+  const query = SEARCH_QUERIES[Math.floor(Math.random() * SEARCH_QUERIES.length)];
+  const { res: searchRes } = postApi(
+    "/api/repository-cases/search",
+    {
+      query,
+      filters: {
+        projectIds: [PROJECT_ID],
+      },
+      pagination: { page: 1, size: 25 },
+      highlight: true,
+    },
+    { scenarioTag: TAG }
+  );
+  check(searchRes, {
+    "search status 200": (r) => r.status === 200,
+  });
+
+  sleep(1);
+
+  // 2. Filtered search — by template
+  if (templates?.data?.length > 0) {
+    const templateId = templates.data[0].id;
+    const { res: filteredRes } = postApi(
+      "/api/repository-cases/search",
+      {
+        query: "",
+        filters: {
+          projectIds: [PROJECT_ID],
+          templateIds: [templateId],
+          automated: false,
+        },
+        pagination: { page: 1, size: 25 },
+      },
+      { scenarioTag: TAG }
+    );
+    check(filteredRes, {
+      "filtered search status 200": (r) => r.status === 200,
+    });
+  }
+
+  sleep(0.5);
+
+  // 3. Paginated search — page 2 and 3
+  for (let page = 2; page <= 3; page++) {
+    const { res: pageRes } = postApi(
+      "/api/repository-cases/search",
+      {
+        query,
+        filters: { projectIds: [PROJECT_ID] },
+        pagination: { page, size: 25 },
+      },
+      { scenarioTag: TAG }
+    );
+    check(pageRes, {
+      [`search page ${page} status 200`]: (r) => r.status === 200,
+    });
+    sleep(0.5);
+  }
+
+  // 4. Typeahead simulation — rapid sequential requests
+  const sequence =
+    TYPEAHEAD_SEQUENCES[
+      Math.floor(Math.random() * TYPEAHEAD_SEQUENCES.length)
+    ];
+
+  for (const prefix of sequence) {
+    const { res: suggestRes } = getApi(
+      `/api/repository-cases/search?prefix=${encodeURIComponent(prefix)}&field=name&size=10`,
+      { scenarioTag: TAG }
+    );
+    check(suggestRes, {
+      "typeahead status 200": (r) => r.status === 200,
+    });
+    sleep(0.15); // fast typing simulation (~150ms between keystrokes)
+  }
+
+  // 5. Search with date range filter
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const { res: dateRes } = postApi(
+    "/api/repository-cases/search",
+    {
+      query: "",
+      filters: {
+        projectIds: [PROJECT_ID],
+        dateRange: {
+          field: "createdAt",
+          from: thirtyDaysAgo.toISOString(),
+          to: now.toISOString(),
+        },
+      },
+      pagination: { page: 1, size: 25 },
+    },
+    { scenarioTag: TAG }
+  );
+  check(dateRes, {
+    "date-filtered search status 200": (r) => r.status === 200,
+  });
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  return 1 + Math.random() * 3;
+}

--- a/testplanit/load-tests/scenarios/05-reporting.js
+++ b/testplanit/load-tests/scenarios/05-reporting.js
@@ -1,0 +1,183 @@
+/**
+ * Scenario 5: Data Strategy & Global Analytics
+ *
+ * BBVA Use Case: "Capabilities for cross-project data aggregation
+ * to provide a unified global view. Includes real-time dashboarding
+ * (coverage, trends) and raw data export to a DataLake."
+ *
+ * Simulates:
+ * 1. Single-project report queries (test execution, health, automation)
+ * 2. Cross-project aggregation (the heaviest queries)
+ * 3. Dashboard loading (multiple report calls in parallel)
+ *
+ * These are expected to be the slowest endpoints — cross-project
+ * queries aggregate across all accessible projects with cartesian
+ * dimension × metric products.
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/05-reporting.js
+ */
+
+import { sleep, check } from "k6";
+import { postApi, findMany } from "../helpers/api.js";
+import { getProfile, thresholds, PROJECT_ID } from "../config.js";
+
+const TAG = "reporting";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+export default function () {
+  // 1. Get accessible projects for cross-project reports
+  const projects = findMany(
+    "projects",
+    {
+      where: { isDeleted: false },
+      select: { id: true },
+      take: 50,
+    },
+    { scenarioTag: TAG }
+  );
+
+  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
+
+  sleep(0.5);
+
+  // 2. Single-project: Test execution report
+  const { res: execRes } = postApi(
+    "/api/report-builder/test-execution",
+    {
+      projectId: PROJECT_ID,
+      dimensions: [{ id: "status" }],
+      metrics: [{ id: "executionCount", aggregation: "sum" }],
+      filters: {},
+      limit: 100,
+    },
+    { scenarioTag: TAG }
+  );
+  check(execRes, {
+    "test-execution report 200": (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // 3. Single-project: Test case health
+  const { res: healthRes } = postApi(
+    "/api/report-builder/test-case-health",
+    {
+      projectId: PROJECT_ID,
+      dimensions: [{ id: "template" }],
+      metrics: [{ id: "caseCount", aggregation: "sum" }],
+      filters: {},
+      limit: 100,
+    },
+    { scenarioTag: TAG }
+  );
+  check(healthRes, {
+    "test-case-health report 200": (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // 4. Single-project: Automation trends
+  const { res: autoRes } = postApi(
+    "/api/report-builder/automation-trends",
+    {
+      projectId: PROJECT_ID,
+      dimensions: [{ id: "month" }],
+      metrics: [
+        { id: "automatedCount", aggregation: "sum" },
+        { id: "manualCount", aggregation: "sum" },
+      ],
+      filters: {},
+      limit: 100,
+    },
+    { scenarioTag: TAG }
+  );
+  check(autoRes, {
+    "automation-trends report 200": (r) => r.status === 200,
+  });
+
+  sleep(1);
+
+  // 5. Cross-project: Test execution across all projects (HEAVY)
+  const { res: crossExecRes } = postApi(
+    "/api/report-builder/cross-project-test-execution",
+    {
+      projectIds,
+      dimensions: [{ id: "project" }, { id: "status" }],
+      metrics: [{ id: "executionCount", aggregation: "sum" }],
+      filters: {},
+      limit: 500,
+    },
+    { scenarioTag: TAG }
+  );
+  check(crossExecRes, {
+    "cross-project execution 200": (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // 6. Cross-project: Repository stats (case counts, automation %)
+  const { res: crossRepoRes } = postApi(
+    "/api/report-builder/cross-project-repository-stats",
+    {
+      projectIds,
+      dimensions: [{ id: "project" }],
+      metrics: [
+        { id: "totalCases", aggregation: "sum" },
+        { id: "automatedPercentage", aggregation: "avg" },
+      ],
+      filters: {},
+      limit: 500,
+    },
+    { scenarioTag: TAG }
+  );
+  check(crossRepoRes, {
+    "cross-project repo stats 200": (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // 7. Cross-project: Flaky tests (complex join)
+  const { res: flakyRes } = postApi(
+    "/api/report-builder/cross-project-flaky-tests",
+    {
+      projectIds,
+      dimensions: [{ id: "project" }],
+      metrics: [{ id: "flakyCount", aggregation: "sum" }],
+      filters: {},
+      limit: 500,
+    },
+    { scenarioTag: TAG }
+  );
+  check(flakyRes, {
+    "cross-project flaky tests 200": (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // 8. Cross-project: User engagement
+  const { res: engageRes } = postApi(
+    "/api/report-builder/cross-project-user-engagement",
+    {
+      projectIds,
+      dimensions: [{ id: "user" }],
+      metrics: [{ id: "executionCount", aggregation: "sum" }],
+      filters: {},
+      limit: 100,
+    },
+    { scenarioTag: TAG }
+  );
+  check(engageRes, {
+    "cross-project user engagement 200": (r) => r.status === 200,
+  });
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  return 2 + Math.random() * 4; // longer think time — user analyzes reports
+}

--- a/testplanit/load-tests/scenarios/06-cicd-ingestion.js
+++ b/testplanit/load-tests/scenarios/06-cicd-ingestion.js
@@ -1,0 +1,108 @@
+/**
+ * Scenario 6: CI/CD JUnit Result Ingestion
+ *
+ * BBVA Use Case: "Seamless CI/CD integration and final automated
+ * result ingestion."
+ *
+ * Simulates automated CI/CD pipelines uploading test results:
+ * 1. Generate JUnit XML with realistic test suite data
+ * 2. Upload via the test-results/import endpoint
+ * 3. Verify the import completed
+ *
+ * This tests the system's ability to handle burst CI/CD traffic —
+ * many pipelines completing around the same time (e.g., after a
+ * deploy across multiple microservices).
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/06-cicd-ingestion.js
+ */
+
+import { sleep, check } from "k6";
+import http from "k6/http";
+import { findMany } from "../helpers/api.js";
+import { junitXml, uniqueId } from "../helpers/data.js";
+import { getProfile, thresholds, PROJECT_ID, BASE_URL, headers } from "../config.js";
+
+const TAG = "cicd";
+
+export const options = {
+  ...getProfile(),
+  thresholds,
+};
+
+export default function () {
+  // 1. Get a folder to place imported cases
+  const folders = findMany(
+    "repositoryFolders",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true },
+      take: 5,
+    },
+    { scenarioTag: TAG }
+  );
+
+  const folderId =
+    folders?.data?.length > 0
+      ? folders.data[Math.floor(Math.random() * folders.data.length)].id
+      : null;
+
+  // 2. Generate JUnit XML — varies in size to simulate different projects
+  //    Small pipeline: 1 suite, 10 cases
+  //    Medium pipeline: 3 suites, 50 cases
+  //    Large pipeline: 5 suites, 100 cases
+  const sizes = [
+    { suites: 1, cases: 10 },
+    { suites: 3, cases: 15 },
+    { suites: 5, cases: 20 },
+  ];
+  const size = sizes[Math.floor(Math.random() * sizes.length)];
+  const xml = junitXml(size.suites, size.cases);
+
+  // 3. Upload via multipart form
+  const formData = {
+    file: http.file(xml, `results-${uniqueId()}.xml`, "application/xml"),
+    format: "junit",
+    projectId: String(PROJECT_ID),
+    name: `CI Run ${uniqueId()}`,
+  };
+
+  if (folderId) {
+    formData.parentFolderId = String(folderId);
+  }
+
+  const res = http.post(`${BASE_URL}/api/test-results/import`, formData, {
+    headers: {
+      Authorization: headers.Authorization,
+      // Don't set Content-Type — k6 sets multipart boundary automatically
+    },
+    tags: { scenario: TAG },
+    timeout: "60s", // imports can take longer
+  });
+
+  check(res, {
+    "import status 200": (r) => r.status === 200,
+    "import not 500": (r) => r.status !== 500,
+  });
+
+  sleep(1);
+
+  // 4. List recent test runs to verify import created one
+  findMany(
+    "testRuns",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      select: { id: true, name: true, createdAt: true, testRunType: true },
+      take: 5,
+      orderBy: { createdAt: "desc" },
+    },
+    { scenarioTag: TAG }
+  );
+
+  sleep(randomThinkTime());
+}
+
+function randomThinkTime() {
+  // CI/CD is automated — shorter intervals between pipeline completions
+  return 0.5 + Math.random() * 2;
+}

--- a/testplanit/load-tests/seed.js
+++ b/testplanit/load-tests/seed.js
@@ -24,15 +24,14 @@
  */
 
 import { sleep } from "k6";
-import { create, findMany, postApi } from "./helpers/api.js";
+import { create, findMany } from "./helpers/api.js";
 import {
   projectName,
   folderName,
   testCaseName,
-  testSteps,
   uniqueId,
 } from "./helpers/data.js";
-import { BASE_URL, headers } from "./config.js";
+import { BASE_URL } from "./config.js";
 
 const SEED_PROJECTS = parseInt(__ENV.SEED_PROJECTS || "10");
 const SEED_CASES_PER_PROJECT = parseInt(__ENV.SEED_CASES_PER_PROJECT || "500");

--- a/testplanit/load-tests/seed.js
+++ b/testplanit/load-tests/seed.js
@@ -1,0 +1,235 @@
+/**
+ * Data Seeding Script for Load Testing
+ *
+ * Creates a realistic data volume before running load tests.
+ * Run this once per test environment setup, NOT as a load test.
+ *
+ * What it creates:
+ * - Multiple projects
+ * - Folder hierarchy per project
+ * - Test cases with steps (bulk)
+ * - Templates and tags
+ * - Historical test runs with results
+ *
+ * Run:
+ *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... \
+ *          --env SEED_PROJECTS=10 --env SEED_CASES_PER_PROJECT=1000 \
+ *          seed.js
+ *
+ * Environment variables:
+ *   SEED_PROJECTS           — Number of projects to create (default: 10)
+ *   SEED_CASES_PER_PROJECT  — Test cases per project (default: 500)
+ *   SEED_FOLDERS_PER_PROJECT — Folders per project (default: 20)
+ *   SEED_RUNS_PER_PROJECT   — Test runs per project (default: 10)
+ */
+
+import { sleep } from "k6";
+import { create, findMany, postApi } from "./helpers/api.js";
+import {
+  projectName,
+  folderName,
+  testCaseName,
+  testSteps,
+  uniqueId,
+} from "./helpers/data.js";
+import { BASE_URL, headers } from "./config.js";
+
+const SEED_PROJECTS = parseInt(__ENV.SEED_PROJECTS || "10");
+const SEED_CASES_PER_PROJECT = parseInt(__ENV.SEED_CASES_PER_PROJECT || "500");
+const SEED_FOLDERS_PER_PROJECT = parseInt(__ENV.SEED_FOLDERS_PER_PROJECT || "20");
+const SEED_RUNS_PER_PROJECT = parseInt(__ENV.SEED_RUNS_PER_PROJECT || "10");
+
+// Seeding runs as a single VU with one iteration
+export const options = {
+  vus: 1,
+  iterations: 1,
+  // No time limit — seeding can take a while
+  duration: undefined,
+  // Disable thresholds for seeding
+  thresholds: {},
+};
+
+export default function () {
+  console.log(`\n=== TestPlanIt Load Test Data Seeding ===`);
+  console.log(`Projects: ${SEED_PROJECTS}`);
+  console.log(`Cases per project: ${SEED_CASES_PER_PROJECT}`);
+  console.log(`Folders per project: ${SEED_FOLDERS_PER_PROJECT}`);
+  console.log(`Runs per project: ${SEED_RUNS_PER_PROJECT}`);
+  console.log(`Target: ${BASE_URL}\n`);
+
+  for (let p = 0; p < SEED_PROJECTS; p++) {
+    const projectNum = p + 1;
+    console.log(`\n--- Creating project ${projectNum}/${SEED_PROJECTS} ---`);
+
+    // 1. Create project
+    const project = create("projects", {
+      name: projectName(),
+      isDeleted: false,
+    });
+
+    const projectId = project?.data?.id;
+    if (!projectId) {
+      console.error(`Failed to create project ${projectNum} — skipping`);
+      continue;
+    }
+    console.log(`  Project created: id=${projectId}`);
+
+    // 2. Get statuses, repo, template, and workflow state
+    sleep(1); // give the system a moment to create defaults
+
+    const statuses = findMany("status", {
+      where: { isDeleted: false, isEnabled: true },
+      select: { id: true, name: true, isSuccess: true, isFailure: true },
+    });
+
+    const defaultStatus = statuses?.data?.find((s) => !s.isSuccess && !s.isFailure) || statuses?.data?.[0];
+    const passedStatus = statuses?.data?.find((s) => s.isSuccess) || defaultStatus;
+    const failedStatus = statuses?.data?.find((s) => s.isFailure) || defaultStatus;
+
+    // Get repo (created automatically with project)
+    const repos = findMany("repositories", {
+      where: { projectId, isDeleted: false }, select: { id: true }, take: 1,
+    });
+    const repoId = repos?.data?.[0]?.id;
+
+    // Get default template and workflow state
+    const templates = findMany("templates", { where: { isDefault: true }, select: { id: true }, take: 1 });
+    const templateId = templates?.data?.[0]?.id;
+
+    const workflows = findMany("workflows", { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 });
+    const stateId = workflows?.data?.[0]?.id;
+
+    if (!defaultStatus) {
+      console.warn(`  No statuses found — skipping runs`);
+    }
+    if (!repoId || !templateId || !stateId) {
+      console.warn(`  Missing repo(${repoId}), template(${templateId}), or state(${stateId}) — cases will fail`);
+    }
+
+    // 3. Create folder hierarchy
+    const folderIds = [];
+    const topLevelCount = Math.min(SEED_FOLDERS_PER_PROJECT, 8);
+    const subFolderCount = SEED_FOLDERS_PER_PROJECT - topLevelCount;
+
+    // Top-level folders
+    for (let f = 0; f < topLevelCount; f++) {
+      const folder = create("repositoryFolders", {
+        name: folderName(),
+        order: f + 1,
+        project: { connect: { id: projectId } },
+        isDeleted: false,
+      });
+      if (folder?.data?.id) folderIds.push(folder.data.id);
+    }
+
+    // Sub-folders (nested under random top-level folders)
+    for (let f = 0; f < subFolderCount && folderIds.length > 0; f++) {
+      const parentId = folderIds[Math.floor(Math.random() * Math.min(folderIds.length, topLevelCount))];
+      const folder = create("repositoryFolders", {
+        name: folderName(),
+        order: f + 1,
+        project: { connect: { id: projectId } },
+        parent: { connect: { id: parentId } },
+        isDeleted: false,
+      });
+      if (folder?.data?.id) folderIds.push(folder.data.id);
+    }
+
+    console.log(`  Folders created: ${folderIds.length}`);
+
+    // 4. Create test cases spread across folders
+    const caseIds = [];
+    const batchSize = 50;
+    const totalCases = SEED_CASES_PER_PROJECT;
+
+    for (let c = 0; c < totalCases; c++) {
+      const folderId = folderIds.length > 0
+        ? folderIds[Math.floor(Math.random() * folderIds.length)]
+        : null;
+
+      const caseData = {
+        name: testCaseName(),
+        automated: Math.random() < 0.3, // 30% automated
+        isDeleted: false,
+        project: { connect: { id: projectId } },
+        repository: { connect: { id: repoId } },
+        template: { connect: { id: templateId } },
+        state: { connect: { id: stateId } },
+      };
+      if (folderId) caseData.folder = { connect: { id: folderId } };
+
+      const tc = create("repositoryCases", caseData);
+      if (tc?.data?.id) caseIds.push(tc.data.id);
+
+      // Progress logging
+      if ((c + 1) % batchSize === 0) {
+        console.log(`  Cases: ${c + 1}/${totalCases}`);
+        sleep(0.1); // brief pause to avoid overwhelming the server
+      }
+    }
+
+    console.log(`  Test cases created: ${caseIds.length}`);
+
+    // Get default run workflow state
+    const runWorkflows = findMany("workflows", { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 });
+    const runStateId = runWorkflows?.data?.[0]?.id;
+
+    // 5. Create test runs with results
+    if (defaultStatus && caseIds.length > 0 && runStateId) {
+      for (let r = 0; r < SEED_RUNS_PER_PROJECT; r++) {
+        const testRun = create("testRuns", {
+          name: `Seed Run ${r + 1} [${uniqueId()}]`,
+          isCompleted: true,
+          isDeleted: false,
+          testRunType: "REGULAR",
+          completedAt: new Date(
+            Date.now() - (SEED_RUNS_PER_PROJECT - r) * 24 * 60 * 60 * 1000
+          ).toISOString(), // spread across days
+          project: { connect: { id: projectId } },
+          state: { connect: { id: runStateId } },
+        });
+
+        const runId = testRun?.data?.id;
+        if (!runId) continue;
+
+        // Add a subset of cases to each run (20-50 cases)
+        const runCaseCount = Math.min(
+          caseIds.length,
+          20 + Math.floor(Math.random() * 31)
+        );
+        const shuffled = [...caseIds].sort(() => Math.random() - 0.5);
+        const runCases = shuffled.slice(0, runCaseCount);
+
+        for (let i = 0; i < runCases.length; i++) {
+          // Pick a status — 70% pass, 20% fail, 10% untested
+          const rand = Math.random();
+          const statusId =
+            rand < 0.7 ? passedStatus?.id : rand < 0.9 ? failedStatus?.id : defaultStatus?.id;
+
+          create("testRunCases", {
+            order: i + 1,
+            isCompleted: rand < 0.9, // 90% completed
+            testRun: { connect: { id: runId } },
+            repositoryCase: { connect: { id: runCases[i] } },
+            status: { connect: { id: statusId || defaultStatus.id } },
+          });
+
+          if ((i + 1) % 20 === 0) sleep(0.05);
+        }
+
+        console.log(`  Run ${r + 1}/${SEED_RUNS_PER_PROJECT}: ${runCaseCount} cases`);
+      }
+    }
+
+    console.log(`  Project ${projectNum} complete`);
+  }
+
+  console.log(`\n=== Seeding complete ===\n`);
+  console.log(`Total projects: ${SEED_PROJECTS}`);
+  console.log(
+    `Approximate total cases: ${SEED_PROJECTS * SEED_CASES_PER_PROJECT}`
+  );
+  console.log(
+    `Approximate total runs: ${SEED_PROJECTS * SEED_RUNS_PER_PROJECT}`
+  );
+}

--- a/testplanit/utils/reportApiUtils.ts
+++ b/testplanit/utils/reportApiUtils.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { reportRequestSchema } from "~/lib/schemas/reportRequestSchema";
 import { authOptions } from "~/server/auth";
 
@@ -79,7 +80,11 @@ export async function handleReportGET(req: NextRequest, config: ReportConfig) {
     const isSharedReportBypass = req.headers.get("x-shared-report-bypass") === "true";
     if (config.requiresAdmin && !isSharedReportBypass) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }
@@ -137,7 +142,11 @@ export async function handleReportPOST(req: NextRequest, config: ReportConfig) {
     const isSharedReportBypass = req.headers.get("x-shared-report-bypass") === "true";
     if (config.requiresAdmin && !isSharedReportBypass) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }


### PR DESCRIPTION
## Summary
- Add authenticateRequest() shared helper to lib/api-token-auth.ts -- tries session auth first, falls back to API token auth via Bearer token
- Apply API token auth support to submit-result and report-builder endpoints so they work with Authorization: Bearer tpi_... tokens
- Add complete k6 load test suite (load-tests/) covering 6 scenarios mapped to enterprise evaluation use cases: browse hierarchy, CRUD/versioning, test lifecycle, search, reporting, and CI/CD ingestion
- Includes configurable load profiles (smoke/baseline/load/stress/soak), data seeding script, and InfluxDB+Grafana integration for historical tracking

## Test plan
- [x] TypeScript type-check passes (0 errors)
- [x] submit-result unit tests pass (6/6)
- [x] k6 smoke tests validated against live tenant for browse, CRUD, search scenarios
- [ ] Deploy and verify submit-result works with API token end-to-end
- [ ] Deploy and verify report-builder works with API token end-to-end
- [ ] Run full mixed-workload load test after deployment

Generated with [Claude Code](https://claude.com/claude-code)