### PR TITLE
enhancement(api): add API token auth fallback to remaining report utility handlers

### DIFF
--- a/testplanit/load-tests/mixed-workload.js
+++ b/testplanit/load-tests/mixed-workload.js
@@ -306,11 +306,10 @@ function reportingScenario() {
   const { res: execRes } = postApi(
     "/api/report-builder/test-execution",
     {
+      reportType: "test-execution",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: ["status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -319,22 +318,12 @@ function reportingScenario() {
   sleep(0.5);
 
   // Cross-project report
-  const projects = findMany(
-    "projects",
-    { where: { isDeleted: false }, select: { id: true }, take: 20 },
-    { scenarioTag: TAG }
-  );
-
-  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
-
   const { res: crossRes } = postApi(
     "/api/report-builder/cross-project-test-execution",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-execution",
+      dimensions: ["project"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );

--- a/testplanit/load-tests/scenarios/03-test-lifecycle.js
+++ b/testplanit/load-tests/scenarios/03-test-lifecycle.js
@@ -187,7 +187,7 @@ export default function () {
     {
       where: { id: testRunId },
       include: {
-        testRunCases: {
+        testCases: {
           select: {
             id: true,
             status: { select: { id: true, name: true } },

--- a/testplanit/load-tests/scenarios/05-reporting.js
+++ b/testplanit/load-tests/scenarios/05-reporting.js
@@ -11,15 +11,14 @@
  * 3. Dashboard loading (multiple report calls in parallel)
  *
  * These are expected to be the slowest endpoints — cross-project
- * queries aggregate across all accessible projects with cartesian
- * dimension × metric products.
+ * queries aggregate across all accessible projects.
  *
  * Run:
  *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/05-reporting.js
  */
 
 import { sleep, check } from "k6";
-import { postApi, findMany } from "../helpers/api.js";
+import { postApi } from "../helpers/api.js";
 import { getProfile, thresholds, PROJECT_ID } from "../config.js";
 
 const TAG = "reporting";
@@ -30,30 +29,14 @@ export const options = {
 };
 
 export default function () {
-  // 1. Get accessible projects for cross-project reports
-  const projects = findMany(
-    "projects",
-    {
-      where: { isDeleted: false },
-      select: { id: true },
-      take: 50,
-    },
-    { scenarioTag: TAG }
-  );
-
-  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
-
-  sleep(0.5);
-
-  // 2. Single-project: Test execution report
+  // 1. Single-project: Test execution report (status dimension, testResults metric)
   const { res: execRes } = postApi(
     "/api/report-builder/test-execution",
     {
+      reportType: "test-execution",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: ["status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -63,15 +46,14 @@ export default function () {
 
   sleep(0.5);
 
-  // 3. Single-project: Test case health
+  // 2. Single-project: Test case health (pre-built report, no dims/metrics required)
   const { res: healthRes } = postApi(
     "/api/report-builder/test-case-health",
     {
+      reportType: "test-case-health",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "template" }],
-      metrics: [{ id: "caseCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -81,18 +63,14 @@ export default function () {
 
   sleep(0.5);
 
-  // 4. Single-project: Automation trends
+  // 3. Single-project: Automation trends (pre-built)
   const { res: autoRes } = postApi(
     "/api/report-builder/automation-trends",
     {
+      reportType: "automation-trends",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "month" }],
-      metrics: [
-        { id: "automatedCount", aggregation: "sum" },
-        { id: "manualCount", aggregation: "sum" },
-      ],
-      filters: {},
-      limit: 100,
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -102,15 +80,13 @@ export default function () {
 
   sleep(1);
 
-  // 5. Cross-project: Test execution across all projects (HEAVY)
+  // 4. Cross-project: Test execution (HEAVY — aggregates across projects)
   const { res: crossExecRes } = postApi(
     "/api/report-builder/cross-project-test-execution",
     {
-      projectIds,
-      dimensions: [{ id: "project" }, { id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-execution",
+      dimensions: ["project", "status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -120,36 +96,29 @@ export default function () {
 
   sleep(0.5);
 
-  // 6. Cross-project: Repository stats (case counts, automation %)
-  const { res: crossRepoRes } = postApi(
-    "/api/report-builder/cross-project-repository-stats",
+  // 5. Cross-project: Test case health (pre-built)
+  const { res: crossHealthRes } = postApi(
+    "/api/report-builder/cross-project-test-case-health",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [
-        { id: "totalCases", aggregation: "sum" },
-        { id: "automatedPercentage", aggregation: "avg" },
-      ],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-case-health",
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
-  check(crossRepoRes, {
-    "cross-project repo stats 200": (r) => r.status === 200,
+  check(crossHealthRes, {
+    "cross-project health 200": (r) => r.status === 200,
   });
 
   sleep(0.5);
 
-  // 7. Cross-project: Flaky tests (complex join)
+  // 6. Cross-project: Flaky tests (pre-built)
   const { res: flakyRes } = postApi(
     "/api/report-builder/cross-project-flaky-tests",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [{ id: "flakyCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-flaky-tests",
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -159,15 +128,13 @@ export default function () {
 
   sleep(0.5);
 
-  // 8. Cross-project: User engagement
+  // 7. Cross-project: User engagement (user dim, execution count metric)
   const { res: engageRes } = postApi(
     "/api/report-builder/cross-project-user-engagement",
     {
-      projectIds,
-      dimensions: [{ id: "user" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      reportType: "cross-project-user-engagement",
+      dimensions: ["user"],
+      metrics: ["executionCount"],
     },
     { scenarioTag: TAG }
   );

--- a/testplanit/utils/automationTrendsUtils.ts
+++ b/testplanit/utils/automationTrendsUtils.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 interface PeriodData {
@@ -72,7 +73,11 @@ export async function handleAutomationTrendsPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/flakyTestsUtils.ts
+++ b/testplanit/utils/flakyTestsUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 interface ExecutionStatus {
@@ -104,7 +105,11 @@ export async function handleFlakyTestsPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/issueTestCoverageUtils.ts
+++ b/testplanit/utils/issueTestCoverageUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 // Flat row structure for grouping-based approach
@@ -96,7 +97,11 @@ export async function handleIssueTestCoveragePOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/testCaseHealthUtils.ts
+++ b/testplanit/utils/testCaseHealthUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 export type HealthStatus =
@@ -148,7 +149,11 @@ export async function handleTestCaseHealthPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }


### PR DESCRIPTION
## Summary
- Extends the authenticateRequest() pattern from PR #189 to 4 additional report utility handlers that were still using getServerSession() only
- Updates k6 load test scripts to use correct report request schema (reportType required, dimensions/metrics as string arrays)
- Fixes testRuns include relation name (testCases, not testRunCases)

## Files changed
- utils/testCaseHealthUtils.ts - cross-project health report
- utils/flakyTestsUtils.ts - cross-project flaky tests report
- utils/automationTrendsUtils.ts - cross-project automation trends
- utils/issueTestCoverageUtils.ts - cross-project issue-test coverage
- load-tests/scenarios/03-test-lifecycle.js - fix include field name
- load-tests/scenarios/05-reporting.js - use correct report schema
- load-tests/mixed-workload.js - use correct report schema

## Test plan
- [x] Lint passes (0 errors)
- [x] Verified submit-result and test-execution reports now work with API token
- [ ] Deploy and verify remaining cross-project reports work with API token

Generated with [Claude Code](https://claude.com/claude-code)