### PR TITLE
fix: Shared Steps improvements (group permissions + resizable panels)

### DIFF
--- a/testplanit/app/[locale]/projects/shared-steps/[projectId]/page.tsx
+++ b/testplanit/app/[locale]/projects/shared-steps/[projectId]/page.tsx
@@ -21,6 +21,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { ApplicationArea } from "@prisma/client";
 import { CircleSlash2, Edit, Layers, PlusCircle, Save, Search, Trash2, Upload } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -323,8 +328,10 @@ export default function SharedStepsPage() {
 
   return (
     <div className="flex h-full w-full" data-testid="shared-steps-page">
+      <ResizablePanelGroup direction="horizontal" autoSaveId="shared-steps-panels">
       {/* Left Pane: Group List & Filter */}
-      <div className="w-1/3 min-w-[280px] max-w-[600px] border-r bg-primary-foreground p-4 flex flex-col">
+      <ResizablePanel id="shared-steps-left" defaultSize={30} minSize={15} maxSize={50}>
+      <div className="h-full bg-primary-foreground p-4 flex flex-col">
         {canEdit && (
           <div className="mb-4 flex gap-2 justify-between w-fill">
             <Button
@@ -434,8 +441,11 @@ export default function SharedStepsPage() {
           )}
         </div>
       </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
       {/* Right Pane: Steps Display/Edit */}
-      <div className="flex-1 p-6 overflow-y-auto">
+      <ResizablePanel id="shared-steps-right" defaultSize={70}>
+      <div className="h-full p-6 overflow-y-auto">
         {!selectedGroup ? (
           <div className="text-muted-foreground text-center mt-20">
             {t("selectGroupPrompt")}
@@ -548,6 +558,8 @@ export default function SharedStepsPage() {
           </Card>
         )}
       </div>
+      </ResizablePanel>
+      </ResizablePanelGroup>
       {/* Delete confirmation dialog */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -3159,7 +3159,10 @@ model SharedStepItem {
         sharedStepGroup.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                                  (role.name == 'Project Admin' ||
                                                   role.rolePermissions?[area == 'SharedSteps' && (canAddEdit || canDelete)])] ||
-        sharedStepGroup.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+        sharedStepGroup.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+        sharedStepGroup.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                                  accessType == 'SPECIFIC_ROLE' &&
+                                                  role.rolePermissions?[area == 'SharedSteps' && (canAddEdit || canDelete)]]
     )
 
     @@allow('all', auth().access == 'ADMIN')


### PR DESCRIPTION
## Description

Two shared-steps improvements:

- **Fix #193** — Users with admin-equivalent rights via **group membership** could not save the contents of a shared step. The `SharedStepItem` create/update/delete policy only checked `userPermissions` and `assignedUsers`, missing the `groupPermissions` branch that the parent `SharedStepGroup` already supports. Added the same group-permissions check to `SharedStepItem`.
- **Enhancement** — Resizable panels on the shared steps management page for improved layout.

## Related Issue

Closes #193

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Manual testing:**
- Verified the ZenStack policy now allows SharedStepItem create/update/delete for users whose SharedSteps canAddEdit/canDelete rights come via group membership
- Verified the policy still rejects users without any admin path
- Verified existing paths (project creator, direct userPermissions, PROJECTADMIN assignedUsers, system admin) continue to work
- Verified resizable panels on the shared steps page

**Test Configuration:**
- OS: macOS
- Browser: Chrome
- Node version: 22.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

See #193 for the bug report screenshots.

## Additional Notes

**Schema change only** — no migration, no code changes. The fix adds one branch to the `@@allow('create,update,delete', ...)` rule on the `SharedStepItem` model. ZenStack regenerates the policy metadata at build time; no database schema changes.