### PR TITLE
enhancement(api): API token auth: report-endpoint fallback, Valkey cache with immediate invalidation, and capacity test suite

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -285,7 +285,48 @@ All API endpoints return consistent error responses:
 
 ## Rate Limiting
 
-API requests may be subject to rate limiting. When rate limited, you'll receive a 429 status code with a `Retry-After` header indicating when to retry.
+TestPlanIt enforces a **global hourly rate limit** on all authenticated API requests. The limit applies per instance (not per token or per user) and resets on the hour.
+
+### Tier Limits
+
+The `TIER` environment variable selects the hourly limit:
+
+| Tier | Hourly Limit | Typical Use |
+|------|--------------|-------------|
+| `essentials` | 1,000 requests/hour | Small teams, light CI/CD integration |
+| `team` | 5,000 requests/hour | Mid-size teams with moderate automation |
+| `professional` (default) | 10,000 requests/hour | Most production deployments |
+| `dedicated` | 25,000 requests/hour | Heavy CI/CD workloads, large organizations |
+
+When the limit is exceeded, requests return **HTTP 429** with a `Retry-After` header indicating seconds until the window resets.
+
+### Response Headers
+
+Every API response includes the following headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current hour |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets |
+
+### Implementation
+
+Rate limiting uses a Valkey-backed fixed-window counter aligned to hourly boundaries. If Valkey is unavailable, TestPlanIt falls back to in-memory counting (per-instance).
+
+### Disabling Rate Limiting (Load Testing Only)
+
+For isolated load-testing or development environments, you can disable rate limiting entirely by setting:
+
+```bash
+DISABLE_API_RATE_LIMIT=true
+```
+
+:::warning
+**Never enable `DISABLE_API_RATE_LIMIT` in production.** This bypasses a key protection against abuse and accidental resource exhaustion. It is intended only for isolated test environments where you're intentionally probing throughput limits.
+:::
+
+When set, all authenticated requests are allowed through regardless of request volume. The `X-RateLimit-*` headers still report the configured tier's limit, but the counter never increments and 429 responses are never returned.
 
 ## Further Resources
 

--- a/docs/docs/api-tokens.md
+++ b/docs/docs/api-tokens.md
@@ -170,6 +170,23 @@ To prevent a user from using API tokens without deleting their existing tokens:
 
 This immediately invalidates all authentication attempts using that user's tokens while preserving the tokens for potential re-enablement later.
 
+## Rate Limits
+
+API requests made with tokens count against TestPlanIt's **global hourly rate limit**. The limit applies per instance (not per token), so all tokens across all users share the same hourly budget.
+
+| Tier | Hourly Limit |
+|------|--------------|
+| `essentials` | 1,000 requests/hour |
+| `team` | 5,000 requests/hour |
+| `professional` (default) | 10,000 requests/hour |
+| `dedicated` | 25,000 requests/hour |
+
+When the limit is exceeded, requests return HTTP 429 with a `Retry-After` header.
+
+Every response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers so CI/CD pipelines can pace themselves.
+
+For full details, including how to disable rate limiting in isolated load-test environments, see the [API Reference — Rate Limiting](./api-reference.md#rate-limiting) section.
+
 ## Security Best Practices
 
 ### Token Storage

--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -40,7 +40,7 @@ RUN if [ -f ".docker-version.json" ]; then \
     fi
 
 # Increase memory limit for build process
-ENV NODE_OPTIONS="--max-old-space-size=8192"
+ENV NODE_OPTIONS="--max-old-space-size=16384"
 # Generate ZenStack files with high memory allocation
 RUN NODE_OPTIONS="--max-old-space-size=8192" pnpm zenstack generate
 # Fix ZenStack symlinks

--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -4,6 +4,7 @@ import { NextRequestHandler } from "@zenstackhq/server/next";
 import { AsyncLocalStorage } from "async_hooks";
 import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { tryFastPathCreate } from "~/lib/access-fast-path";
 import { authenticateApiToken, extractBearerToken } from "~/lib/api-token-auth";
 import { extractIpAddress, setAuditContext } from "~/lib/auditContext";
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
@@ -318,9 +319,21 @@ async function handler(
       }
     }
 
-    const response = await baseHandler(modifiedReq, {
-      params: Promise.resolve(params),
+    // Fast path: bypass ZenStack's policy engine for project-scoped creates
+    // where the user's cached access manifest already answers the question.
+    // Returns null when the fast path doesn't apply (wrong model/op, missing
+    // projectId, etc.), in which case we fall through to the regular handler.
+    let response = await tryFastPathCreate({
+      parsedPath,
+      requestBody,
+      userId: authenticatedUserId ?? null,
     });
+
+    if (!response) {
+      response = await baseHandler(modifiedReq, {
+        params: Promise.resolve(params),
+      });
+    }
 
     // Clone the response to add headers (NextResponse is immutable)
     const responseBody = await response.clone().text();

--- a/testplanit/dist/scheduler.js
+++ b/testplanit/dist/scheduler.js
@@ -136,27 +136,47 @@ var init_db = __esm({
   }
 });
 
+// lib/utils/ssrf.ts
+function getAllowedPrivateHosts() {
+  return new Set(
+    (process.env.ALLOWED_PRIVATE_HOSTS ?? "").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean)
+  );
+}
+var MAX_PAGE_BYTES;
+var init_ssrf = __esm({
+  "lib/utils/ssrf.ts"() {
+    "use strict";
+    MAX_PAGE_BYTES = 5 * 1024 * 1024;
+  }
+});
+
 // utils/ssrf.ts
 function isPrivateIp(ip) {
   return PRIVATE_RANGES.some((r) => r.test(ip));
 }
-function isSsrfSafe(url) {
+function isSsrfSafe(url, allowedHosts) {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
-    if (hostname === "localhost") return false;
-    if (isPrivateIp(hostname)) return false;
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false;
     }
+    const allowed = allowedHosts ?? getAllowedPrivateHosts();
+    if (allowed.has(hostname.toLowerCase())) return true;
+    if (hostname === "localhost") return false;
+    if (isPrivateIp(hostname)) return false;
     return true;
   } catch {
     return false;
   }
 }
-async function assertSsrfSafeResolved(url) {
+async function assertSsrfSafeResolved(url, allowedHosts) {
   const parsed = new URL(url);
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+  const allowed = allowedHosts ?? getAllowedPrivateHosts();
+  if (allowed.has(hostname.toLowerCase())) {
+    return;
+  }
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(":")) {
     return;
   }
@@ -173,10 +193,11 @@ async function assertSsrfSafeResolved(url) {
   }
 }
 var import_promises, PRIVATE_RANGES;
-var init_ssrf = __esm({
+var init_ssrf2 = __esm({
   "utils/ssrf.ts"() {
     "use strict";
     import_promises = require("node:dns/promises");
+    init_ssrf();
     PRIVATE_RANGES = [
       // IPv4 loopback
       /^127\./,
@@ -196,20 +217,6 @@ var init_ssrf = __esm({
       // IPv6 link-local
       /^fe80:/i
     ];
-  }
-});
-
-// lib/utils/ssrf.ts
-function getAllowedPrivateHosts() {
-  return new Set(
-    (process.env.ALLOWED_PRIVATE_HOSTS ?? "").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean)
-  );
-}
-var MAX_PAGE_BYTES;
-var init_ssrf2 = __esm({
-  "lib/utils/ssrf.ts"() {
-    "use strict";
-    MAX_PAGE_BYTES = 5 * 1024 * 1024;
   }
 });
 
@@ -683,8 +690,8 @@ var GitRepoAdapter;
 var init_GitRepoAdapter = __esm({
   "lib/integrations/adapters/GitRepoAdapter.ts"() {
     "use strict";
-    init_ssrf();
     init_ssrf2();
+    init_ssrf();
     GitRepoAdapter = class {
       rateLimitDelay = 500;
       // ms between requests (baseline)

--- a/testplanit/dist/workers/syncWorker.js
+++ b/testplanit/dist/workers/syncWorker.js
@@ -3844,60 +3844,158 @@ var SyncService = class {
       if (!adapter) {
         throw new Error("Invalid adapter for issue synchronization");
       }
-      const totalIssues = await prisma2.issue.count({
+      const linkedProjects = await prisma2.integrationProject.findMany({
         where: {
-          integrationId,
-          ...projectId && { projectId: parseInt(projectId) }
+          projectIntegration: { integrationId },
+          isActive: true
         }
       });
-      const BATCH_SIZE = 50;
-      let processedCount = 0;
-      while (processedCount < totalIssues) {
-        const localIssues = await prisma2.issue.findMany({
+      if (linkedProjects.length > 0) {
+        for (const integrationProject of linkedProjects) {
+          try {
+            await prisma2.integrationProject.update({
+              where: { id: integrationProject.id },
+              data: { syncStatus: "syncing" }
+            });
+            const allProjectIssues = await prisma2.issue.findMany({
+              where: {
+                integrationId,
+                ...projectId && { projectId: parseInt(projectId) }
+              },
+              select: {
+                id: true,
+                externalId: true,
+                externalKey: true,
+                name: true,
+                externalData: true
+              }
+            });
+            const issuesForProject = allProjectIssues.filter((issue) => {
+              if (!issue.externalKey) return false;
+              if (issue.externalKey.startsWith(integrationProject.externalProjectKey + "-")) {
+                return true;
+              }
+              if (issue.externalKey === integrationProject.externalProjectId) {
+                return true;
+              }
+              return false;
+            });
+            let projectSynced = 0;
+            const BATCH_SIZE = 50;
+            for (let i = 0; i < issuesForProject.length; i += BATCH_SIZE) {
+              const batch = issuesForProject.slice(i, i + BATCH_SIZE);
+              for (const localIssue of batch) {
+                try {
+                  if (job) {
+                    const progress = Math.round(
+                      (syncedCount + projectSynced + 1) / (allProjectIssues.length || 1) * 100
+                    );
+                    await job.updateProgress({
+                      current: syncedCount + projectSynced + 1,
+                      total: allProjectIssues.length,
+                      percentage: Math.min(progress, 100),
+                      message: `Syncing ${integrationProject.externalProjectKey}: issue ${projectSynced + 1}`
+                    });
+                  }
+                  const issueIdentifier = localIssue.externalId || localIssue.externalKey || localIssue.name;
+                  if (!issueIdentifier) {
+                    errors.push(`Issue ${localIssue.id} has no external identifier`);
+                    continue;
+                  }
+                  const issueData = await adapter.syncIssue(issueIdentifier);
+                  await issueCache.set(integrationId, issueData.id, issueData);
+                  await this.updateExistingIssue(prisma2, integrationId, issueData);
+                  projectSynced++;
+                } catch (error) {
+                  errors.push(
+                    `Failed to sync issue ${localIssue.externalKey || localIssue.externalId || localIssue.id}: ${error.message}`
+                  );
+                }
+              }
+              if (i + BATCH_SIZE < issuesForProject.length) {
+                await new Promise((resolve) => setTimeout(resolve, 10));
+              }
+            }
+            syncedCount += projectSynced;
+            await prisma2.integrationProject.update({
+              where: { id: integrationProject.id },
+              data: {
+                syncStatus: "completed",
+                lastSyncAt: /* @__PURE__ */ new Date(),
+                syncError: null
+              }
+            });
+          } catch (error) {
+            errors.push(`Project ${integrationProject.externalProjectKey}: ${error.message}`);
+            try {
+              await prisma2.integrationProject.update({
+                where: { id: integrationProject.id },
+                data: {
+                  syncStatus: "error",
+                  syncError: error.message
+                }
+              });
+            } catch {
+              errors.push(`Failed to update error status for ${integrationProject.externalProjectKey}`);
+            }
+          }
+        }
+      } else {
+        const totalIssues = await prisma2.issue.count({
           where: {
             integrationId,
             ...projectId && { projectId: parseInt(projectId) }
-          },
-          select: {
-            id: true,
-            externalId: true,
-            externalKey: true,
-            name: true
-          },
-          skip: processedCount,
-          take: BATCH_SIZE
-        });
-        for (let i = 0; i < localIssues.length; i++) {
-          const localIssue = localIssues[i];
-          const globalIndex = processedCount + i;
-          try {
-            if (job) {
-              const progress = Math.round((globalIndex + 1) / totalIssues * 100);
-              await job.updateProgress({
-                current: globalIndex + 1,
-                total: totalIssues,
-                percentage: progress,
-                message: `Syncing issue ${globalIndex + 1} of ${totalIssues}`
-              });
-            }
-            const issueIdentifier = localIssue.externalId || localIssue.externalKey || localIssue.name;
-            if (!issueIdentifier) {
-              errors.push(`Issue ${localIssue.id} has no external identifier`);
-              continue;
-            }
-            const issueData = await adapter.syncIssue(issueIdentifier);
-            await issueCache.set(integrationId, issueData.id, issueData);
-            await this.updateExistingIssue(prisma2, integrationId, issueData);
-            syncedCount++;
-          } catch (error) {
-            errors.push(
-              `Failed to sync issue ${localIssue.externalKey || localIssue.externalId || localIssue.id}: ${error.message}`
-            );
           }
-        }
-        processedCount += localIssues.length;
-        if (processedCount < totalIssues) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+        });
+        const BATCH_SIZE = 50;
+        let processedCount = 0;
+        while (processedCount < totalIssues) {
+          const localIssues = await prisma2.issue.findMany({
+            where: {
+              integrationId,
+              ...projectId && { projectId: parseInt(projectId) }
+            },
+            select: {
+              id: true,
+              externalId: true,
+              externalKey: true,
+              name: true
+            },
+            skip: processedCount,
+            take: BATCH_SIZE
+          });
+          for (let i = 0; i < localIssues.length; i++) {
+            const localIssue = localIssues[i];
+            const globalIndex = processedCount + i;
+            try {
+              if (job) {
+                const progress = Math.round((globalIndex + 1) / totalIssues * 100);
+                await job.updateProgress({
+                  current: globalIndex + 1,
+                  total: totalIssues,
+                  percentage: progress,
+                  message: `Syncing issue ${globalIndex + 1} of ${totalIssues}`
+                });
+              }
+              const issueIdentifier = localIssue.externalId || localIssue.externalKey || localIssue.name;
+              if (!issueIdentifier) {
+                errors.push(`Issue ${localIssue.id} has no external identifier`);
+                continue;
+              }
+              const issueData = await adapter.syncIssue(issueIdentifier);
+              await issueCache.set(integrationId, issueData.id, issueData);
+              await this.updateExistingIssue(prisma2, integrationId, issueData);
+              syncedCount++;
+            } catch (error) {
+              errors.push(
+                `Failed to sync issue ${localIssue.externalKey || localIssue.externalId || localIssue.id}: ${error.message}`
+              );
+            }
+          }
+          processedCount += localIssues.length;
+          if (processedCount < totalIssues) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
         }
       }
       if (options.includeMetadata) {

--- a/testplanit/e2e/tests/auth/api-tokens.spec.ts
+++ b/testplanit/e2e/tests/auth/api-tokens.spec.ts
@@ -12,6 +12,8 @@ import { expect, test } from "../../fixtures/index";
  * - AUTH-08-5: Requests without tokens get 401 (when using Bearer auth path)
  * - AUTH-08-6: Tokens for users with isApi=false are rejected
  * - AUTH-08-7: Tokens for deactivated users are rejected
+ * - AUTH-08-8: Admin token authenticates cross-project report endpoints
+ * - AUTH-08-9: Non-admin token is rejected from cross-project report endpoints
  *
  * Note: The /api/model/* endpoints check session auth first (cookie), then
  * Bearer token auth. Tests that verify token-based rejection use a fresh
@@ -393,6 +395,128 @@ test.describe("API Token Authentication", () => {
       }
     } finally {
       // Cleanup: delete the test user (admin session)
+      await api.deleteUser(testUserId);
+    }
+  });
+
+  /**
+   * AUTH-08-8: Admin token authenticates cross-project report endpoints
+   *
+   * Guards the branch that added API-token auth fallback to the 4 cross-project
+   * report handlers (automationTrends / flakyTests / testCaseHealth /
+   * issueTestCoverage). All four use the same authenticateRequest() wrapper,
+   * so passing on each one confirms the pattern is wired up everywhere.
+   */
+  test("admin token authenticates cross-project report endpoints", async ({
+    request,
+    baseURL,
+    browser,
+    api,
+    adminUserId,
+  }) => {
+    await api.updateUser({ userId: adminUserId, data: { isApi: true } });
+
+    const createResponse = await request.post(`${baseURL}/api/api-tokens`, {
+      data: { name: `Report Auth Test Token ${Date.now()}` },
+    });
+    expect(createResponse.status()).toBe(200);
+    const { token } = await createResponse.json();
+
+    const endpoints = [
+      "/api/report-builder/cross-project-automation-trends",
+      "/api/report-builder/cross-project-flaky-tests",
+      "/api/report-builder/cross-project-test-case-health",
+      "/api/report-builder/cross-project-issue-test-coverage",
+    ];
+
+    const body = {
+      dimensions: [],
+      metrics: [],
+      projectIds: [],
+    };
+
+    const unauthCtx = await browser.newContext({ storageState: undefined });
+    try {
+      for (const endpoint of endpoints) {
+        const response = await unauthCtx.request.post(`${baseURL}${endpoint}`, {
+          headers: { Authorization: `Bearer ${token}` },
+          data: body,
+        });
+        expect(
+          response.status(),
+          `${endpoint} should authenticate with admin token`
+        ).toBe(200);
+      }
+    } finally {
+      await unauthCtx.close();
+    }
+  });
+
+  /**
+   * AUTH-08-9: Non-admin token is rejected from cross-project report endpoints
+   *
+   * The cross-project report handlers require access === "ADMIN". A regular
+   * USER with a valid Bearer token must be rejected with 401. This prevents
+   * a regression where the auth wrapper could succeed but the admin check be
+   * removed or weakened.
+   */
+  test("non-admin token is rejected from cross-project report endpoints", async ({
+    baseURL,
+    browser,
+    api,
+  }) => {
+    const email = `api-token-nonadmin-${Date.now()}@example.com`;
+    const userResult = await api.createUser({
+      name: "Non-admin API Token Test User",
+      email,
+      password: "password123",
+      access: "USER",
+    });
+    const testUserId = userResult.data.id;
+
+    try {
+      await api.updateUser({ userId: testUserId, data: { isApi: true } });
+
+      const testUserCtx = await browser.newContext({
+        storageState: undefined,
+        extraHTTPHeaders: { "Sec-Fetch-Site": "same-origin" },
+      });
+
+      let userToken: string;
+      try {
+        const loginPage = await testUserCtx.newPage();
+        await loginPage.goto(`${baseURL}/en-US/signin`, { waitUntil: "load" });
+        await loginPage.getByTestId("email-input").fill(email);
+        await loginPage.getByTestId("password-input").fill("password123");
+        await loginPage.locator('button[type="submit"]').first().click();
+        await loginPage.waitForURL(/\/en-US\/?$/, { timeout: 30000 });
+        await loginPage.close();
+
+        const createResponse = await testUserCtx.request.post(
+          `${baseURL}/api/api-tokens`,
+          { data: { name: `Non-admin Report Test Token ${Date.now()}` } }
+        );
+        expect(createResponse.status()).toBe(200);
+        const { token } = await createResponse.json();
+        userToken = token;
+
+        const unauthCtx = await browser.newContext({ storageState: undefined });
+        try {
+          const response = await unauthCtx.request.post(
+            `${baseURL}/api/report-builder/cross-project-automation-trends`,
+            {
+              headers: { Authorization: `Bearer ${userToken}` },
+              data: { dimensions: [], metrics: [], projectIds: [] },
+            }
+          );
+          expect(response.status()).toBe(401);
+        } finally {
+          await unauthCtx.close();
+        }
+      } finally {
+        await testUserCtx.close();
+      }
+    } finally {
       await api.deleteUser(testUserId);
     }
   });

--- a/testplanit/lib/access-fast-path.ts
+++ b/testplanit/lib/access-fast-path.ts
@@ -1,0 +1,187 @@
+/**
+ * ZenStack fast path for project-scoped creates.
+ *
+ * The ZenStack CRUD endpoint evaluates an access-control policy on every
+ * request; for project-scoped models this is the dominant CPU cost under
+ * sustained mutation load.
+ *
+ * This module short-circuits that path for the narrow set of operations
+ * where the answer is reliably determined by the user's access manifest:
+ *
+ *   - Authenticated request (session or API token)
+ *   - Operation is `create` (extending to other ops is safe but not yet done)
+ *   - Target model is project-scoped AND the request body contains
+ *     `project.connect.id` (so we can answer access without a DB lookup)
+ *
+ * Anything that doesn't match falls through to ZenStack's regular handler
+ * unchanged.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  getAccessManifest,
+  hasWriteAccess,
+  type AccessManifest,
+} from "./access-manifest";
+import { prisma } from "./prisma";
+
+/**
+ * Models whose access is entirely determined by a direct `project` relation.
+ * Listed models support the fast-create path when the request body provides
+ * `project: { connect: { id } }`.
+ */
+const FAST_CREATE_MODELS = new Set([
+  "repositoryCases",
+  "repositoryFolders",
+  "repositories",
+  "testRuns",
+  "sessions",
+  "milestones",
+  "comments",
+]);
+
+interface ParsedPath {
+  model: string;
+  operation: string;
+}
+
+/**
+ * Attempt the fast path for the given request. Returns a `Response`
+ * when the fast path handled the request, or `null` to indicate the
+ * caller should continue with the regular ZenStack handler.
+ */
+export async function tryFastPathCreate(params: {
+  parsedPath: ParsedPath | null;
+  requestBody: unknown;
+  userId: string | null;
+}): Promise<NextResponse | null> {
+  const { parsedPath, requestBody, userId } = params;
+
+  if (!userId || !parsedPath) return null;
+  if (parsedPath.operation !== "create") return null;
+  if (!FAST_CREATE_MODELS.has(parsedPath.model)) return null;
+
+  // Extract projectId from the request body.
+  const projectId = extractProjectId(requestBody);
+  if (projectId == null) return null;
+
+  const manifest = await getAccessManifest(userId);
+  if (!manifest) {
+    // User not resolvable — defer to ZenStack so we get consistent auth errors.
+    return null;
+  }
+
+  if (!hasWriteAccess(manifest, projectId)) {
+    // Explicit deny. ZenStack's 403 formatting is preserved by the regular
+    // path; rather than reproducing it, return 403 here. Nginx ingress maps
+    // 403 → 422 (see route.ts remapping) so we go straight to that.
+    return NextResponse.json(
+      {
+        error: {
+          message: "access denied",
+          code: "DENIED_BY_POLICY",
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  // At this point we know the user is allowed to create on this project.
+  // Execute the create with raw Prisma (no enhance() wrapper — skips all
+  // policy evaluation) and return the response in ZenStack's RPC format.
+  const data = extractCreateData(requestBody);
+  if (!data) return null;
+
+  try {
+    const modelAccessor = getPrismaModel(parsedPath.model);
+    if (!modelAccessor) return null;
+
+    const result = await modelAccessor.create({ data });
+    return NextResponse.json(
+      { data: result },
+      { status: 201 }
+    );
+  } catch (err: unknown) {
+    // Mirror ZenStack's error shape so clients see the same behaviour.
+    const message =
+      err instanceof Error ? err.message : "Internal server error";
+    return NextResponse.json(
+      {
+        error: {
+          message,
+          prisma: true,
+        },
+      },
+      { status: 400 }
+    );
+  }
+}
+
+/**
+ * Invalidate the manifest for the given user. Thin re-export so callers
+ * of the fast path don't need to import access-manifest directly.
+ */
+export { invalidateAccessManifest } from "./access-manifest";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function extractProjectId(body: unknown): number | null {
+  if (!body || typeof body !== "object") return null;
+  const data = (body as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return null;
+
+  // Common shape: `{ project: { connect: { id: N } } }`
+  const project = (data as { project?: unknown }).project;
+  if (
+    project &&
+    typeof project === "object" &&
+    "connect" in project
+  ) {
+    const connect = (project as { connect?: unknown }).connect;
+    if (connect && typeof connect === "object" && "id" in connect) {
+      const id = (connect as { id?: unknown }).id;
+      if (typeof id === "number") return id;
+    }
+  }
+
+  // Less common: `{ projectId: N }` (scalar FK)
+  const scalarId = (data as { projectId?: unknown }).projectId;
+  if (typeof scalarId === "number") return scalarId;
+
+  return null;
+}
+
+function extractCreateData(body: unknown): Record<string, unknown> | null {
+  if (!body || typeof body !== "object") return null;
+  const data = (body as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return null;
+  return data as Record<string, unknown>;
+}
+
+/**
+ * Map the model name from the URL (camelCase) to the Prisma client accessor.
+ * Returns `null` if the model isn't recognised so the caller can fall back
+ * to ZenStack.
+ */
+function getPrismaModel(
+  modelName: string
+): { create: (args: { data: Record<string, unknown> }) => Promise<unknown> } | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const p = prisma as unknown as Record<string, any>;
+  const model = p[modelName];
+  if (
+    model &&
+    typeof model === "object" &&
+    typeof model.create === "function"
+  ) {
+    return model as {
+      create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+    };
+  }
+  return null;
+}
+
+// Re-export AccessManifest type so callers can reason about it.
+export type { AccessManifest };

--- a/testplanit/lib/access-manifest.ts
+++ b/testplanit/lib/access-manifest.ts
@@ -1,0 +1,379 @@
+/**
+ * Access manifest cache.
+ *
+ * The ZenStack CRUD endpoint evaluates per-request access policies that
+ * expand into complex Prisma WHERE clauses (joins across `userPermissions`,
+ * `groupPermissions`, `role.rolePermissions`, etc). Under sustained load
+ * this JavaScript evaluation is the dominant CPU cost per mutation.
+ *
+ * An "access manifest" is a precomputed, cacheable summary of what a given
+ * user can do across all projects. Once cached, a route handler can check
+ * `hasWriteAccess(manifest, projectId)` in O(1) and bypass ZenStack's
+ * policy engine for the fast path.
+ *
+ * The manifest only covers the common case: reads, creates and updates on
+ * project-scoped models that inherit access from their parent project.
+ * Anything requiring finer-grained area-level permissions (e.g. "can the
+ * user close test runs") falls through to ZenStack's regular path.
+ *
+ * TTL is short (60s) so revoked permissions propagate quickly; the manifest
+ * can also be explicitly invalidated on permission mutations.
+ */
+
+import type { ApplicationArea } from "@prisma/client";
+import { prisma } from "./prisma";
+import valkeyConnection from "./valkey";
+
+const MANIFEST_CACHE_TTL_SECONDS = 60;
+const MANIFEST_CACHE_PREFIX = "access:manifest:";
+
+/**
+ * Compact per-project access summary. Booleans aggregate across all
+ * `ApplicationArea`s — good enough for CRUD on project-scoped models.
+ * Area-specific checks (e.g. "canClose on TestRuns") still go through
+ * ZenStack.
+ */
+export interface ProjectAccess {
+  /** User can read resources in this project. */
+  canRead: boolean;
+  /** User can create/update resources in this project (any area). */
+  canWrite: boolean;
+  /** User can delete resources in this project (any area). */
+  canDelete: boolean;
+}
+
+export interface AccessManifest {
+  userId: string;
+  access: string | null; // NONE | USER | PROJECTADMIN | ADMIN
+  isAdmin: boolean;
+  /** Map of projectId → access summary. Missing entries mean "no access". */
+  projects: Record<number, ProjectAccess>;
+  generatedAt: number;
+}
+
+const ADMIN_ACCESS: ProjectAccess = {
+  canRead: true,
+  canWrite: true,
+  canDelete: true,
+};
+
+const NO_ACCESS: ProjectAccess = {
+  canRead: false,
+  canWrite: false,
+  canDelete: false,
+};
+
+/**
+ * Cache-aside manifest fetch. Returns null only if the user doesn't exist.
+ */
+export async function getAccessManifest(
+  userId: string
+): Promise<AccessManifest | null> {
+  if (valkeyConnection) {
+    try {
+      const raw = await valkeyConnection.get(
+        `${MANIFEST_CACHE_PREFIX}${userId}`
+      );
+      if (raw) return JSON.parse(raw) as AccessManifest;
+    } catch {
+      // fall through to DB
+    }
+  }
+
+  const manifest = await computeAccessManifest(userId);
+  if (manifest && valkeyConnection) {
+    try {
+      await valkeyConnection.set(
+        `${MANIFEST_CACHE_PREFIX}${userId}`,
+        JSON.stringify(manifest),
+        "EX",
+        MANIFEST_CACHE_TTL_SECONDS
+      );
+    } catch {
+      // non-fatal
+    }
+  }
+  return manifest;
+}
+
+/**
+ * Build a manifest for the user by querying their permissions once.
+ * This is the expensive path — subsequent requests for the same user hit
+ * the cache.
+ */
+async function computeAccessManifest(
+  userId: string
+): Promise<AccessManifest | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      access: true,
+      isActive: true,
+      isDeleted: true,
+      roleId: true,
+      role: {
+        select: {
+          id: true,
+          rolePermissions: true,
+        },
+      },
+      groups: {
+        select: {
+          groupId: true,
+        },
+      },
+    },
+  });
+
+  if (!user || !user.isActive || user.isDeleted) return null;
+
+  const manifest: AccessManifest = {
+    userId: user.id,
+    access: user.access,
+    isAdmin: user.access === "ADMIN",
+    projects: {},
+    generatedAt: Date.now(),
+  };
+
+  // ADMIN bypasses all project permissions. We still need to know WHICH
+  // projects exist so read filters can be applied correctly if needed.
+  // But for simplicity we leave `projects` empty and the `isAdmin` flag
+  // short-circuits any lookup.
+  if (manifest.isAdmin) {
+    return manifest;
+  }
+
+  // NONE users have no project access at all.
+  if (user.access === "NONE" || user.access === null) {
+    return manifest;
+  }
+
+  const globalRolePermissions = user.role?.rolePermissions ?? [];
+  const userGroupIds = new Set(user.groups.map((g) => g.groupId));
+
+  // Fetch every project together with the permission shape relevant to
+  // this specific user. We deliberately over-fetch (all defaults + all
+  // matching permissions) because Postgres is cheap and cache lifetime
+  // means we only do this once per TTL window.
+  const projects = await prisma.projects.findMany({
+    where: {
+      isDeleted: false,
+    },
+    select: {
+      id: true,
+      createdBy: true,
+      defaultAccessType: true,
+      defaultRoleId: true,
+      defaultRole: {
+        select: {
+          rolePermissions: true,
+        },
+      },
+      userPermissions: {
+        where: { userId: user.id },
+        select: {
+          accessType: true,
+          roleId: true,
+          role: {
+            select: { rolePermissions: true },
+          },
+        },
+      },
+      groupPermissions: {
+        where: { groupId: { in: Array.from(userGroupIds) } },
+        select: {
+          accessType: true,
+          roleId: true,
+          role: {
+            select: { rolePermissions: true },
+          },
+        },
+      },
+      assignedUsers: {
+        where: { userId: user.id },
+        select: { userId: true },
+      },
+    },
+  });
+
+  for (const p of projects) {
+    manifest.projects[p.id] = computeProjectAccess({
+      userId: user.id,
+      userAccess: user.access,
+      globalRolePermissions,
+      project: p,
+    });
+  }
+
+  return manifest;
+}
+
+function computeProjectAccess(ctx: {
+  userId: string;
+  userAccess: string | null;
+  globalRolePermissions: Array<{
+    area: ApplicationArea;
+    canAddEdit: boolean;
+    canDelete: boolean;
+  }>;
+  project: {
+    createdBy: string;
+    defaultAccessType: string;
+    defaultRoleId: number | null;
+    defaultRole: { rolePermissions: Array<{ canAddEdit: boolean; canDelete: boolean }> } | null;
+    userPermissions: Array<{
+      accessType: string;
+      role: { rolePermissions: Array<{ canAddEdit: boolean; canDelete: boolean }> } | null;
+    }>;
+    groupPermissions: Array<{
+      accessType: string;
+      role: { rolePermissions: Array<{ canAddEdit: boolean; canDelete: boolean }> } | null;
+    }>;
+    assignedUsers: Array<{ userId: string }>;
+  };
+}): ProjectAccess {
+  // Creator has full access.
+  if (ctx.project.createdBy === ctx.userId) return ADMIN_ACCESS;
+
+  // PROJECTADMIN on assignedUsers → full access to this project.
+  if (ctx.userAccess === "PROJECTADMIN" && ctx.project.assignedUsers.length > 0) {
+    return ADMIN_ACCESS;
+  }
+
+  // Direct user permission: overrides group and default.
+  const userPerm = ctx.project.userPermissions[0];
+  if (userPerm) {
+    if (userPerm.accessType === "NO_ACCESS") return NO_ACCESS;
+    const perms = resolveRolePermissions(
+      userPerm.accessType,
+      userPerm.role?.rolePermissions,
+      ctx.globalRolePermissions
+    );
+    if (perms !== null) {
+      return {
+        canRead: true,
+        canWrite: perms.some((rp) => rp.canAddEdit),
+        canDelete: perms.some((rp) => rp.canDelete),
+      };
+    }
+  }
+
+  // Group permission: first non-NO_ACCESS group grant we find.
+  for (const gp of ctx.project.groupPermissions) {
+    if (gp.accessType === "NO_ACCESS") return NO_ACCESS;
+    const perms = resolveRolePermissions(
+      gp.accessType,
+      gp.role?.rolePermissions,
+      ctx.globalRolePermissions
+    );
+    if (perms !== null) {
+      return {
+        canRead: true,
+        canWrite: perms.some((rp) => rp.canAddEdit),
+        canDelete: perms.some((rp) => rp.canDelete),
+      };
+    }
+  }
+
+  // Project default access.
+  switch (ctx.project.defaultAccessType) {
+    case "GLOBAL_ROLE":
+      if (ctx.globalRolePermissions.length > 0) {
+        return {
+          canRead: true,
+          canWrite: ctx.globalRolePermissions.some((rp) => rp.canAddEdit),
+          canDelete: ctx.globalRolePermissions.some((rp) => rp.canDelete),
+        };
+      }
+      return NO_ACCESS;
+    case "SPECIFIC_ROLE":
+      if (ctx.project.defaultRole) {
+        return {
+          canRead: true,
+          canWrite: ctx.project.defaultRole.rolePermissions.some((rp) => rp.canAddEdit),
+          canDelete: ctx.project.defaultRole.rolePermissions.some((rp) => rp.canDelete),
+        };
+      }
+      return NO_ACCESS;
+    case "DEFAULT":
+      return ctx.globalRolePermissions.length > 0
+        ? {
+            canRead: true,
+            canWrite: ctx.globalRolePermissions.some((rp) => rp.canAddEdit),
+            canDelete: ctx.globalRolePermissions.some((rp) => rp.canDelete),
+          }
+        : NO_ACCESS;
+    default:
+      return NO_ACCESS;
+  }
+}
+
+function resolveRolePermissions(
+  accessType: string,
+  specificRolePermissions:
+    | Array<{ canAddEdit: boolean; canDelete: boolean }>
+    | undefined,
+  globalRolePermissions: Array<{ canAddEdit: boolean; canDelete: boolean }>
+): Array<{ canAddEdit: boolean; canDelete: boolean }> | null {
+  if (accessType === "SPECIFIC_ROLE") {
+    return specificRolePermissions ?? null;
+  }
+  if (accessType === "GLOBAL_ROLE") {
+    return globalRolePermissions;
+  }
+  return null;
+}
+
+/**
+ * Check whether the user has write (create/update) access to a given project.
+ * ADMIN users always succeed.
+ */
+export function hasWriteAccess(
+  manifest: AccessManifest,
+  projectId: number
+): boolean {
+  if (manifest.isAdmin) return true;
+  return manifest.projects[projectId]?.canWrite ?? false;
+}
+
+/**
+ * Check read access.
+ */
+export function hasReadAccess(
+  manifest: AccessManifest,
+  projectId: number
+): boolean {
+  if (manifest.isAdmin) return true;
+  return manifest.projects[projectId]?.canRead ?? false;
+}
+
+/**
+ * Invalidate a single user's manifest. Call from endpoints that change
+ * permissions, role assignments, or project defaults.
+ */
+export async function invalidateAccessManifest(userId: string): Promise<void> {
+  if (!valkeyConnection) return;
+  try {
+    await valkeyConnection.del(`${MANIFEST_CACHE_PREFIX}${userId}`);
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Invalidate all users' manifests. Call when something changes that
+ * affects many users at once (e.g. project defaultAccessType change,
+ * role permissions updated).
+ */
+export async function invalidateAllAccessManifests(): Promise<void> {
+  if (!valkeyConnection) return;
+  try {
+    const keys = await valkeyConnection.keys(`${MANIFEST_CACHE_PREFIX}*`);
+    if (keys.length > 0) {
+      await valkeyConnection.del(...keys);
+    }
+  } catch {
+    // non-fatal
+  }
+}

--- a/testplanit/lib/api-rate-limit.ts
+++ b/testplanit/lib/api-rate-limit.ts
@@ -84,10 +84,18 @@ function checkFallback(): RateLimitResult {
  *
  * Returns whether the request is allowed along with rate limit metadata
  * suitable for `X-RateLimit-*` response headers.
+ *
+ * Set `DISABLE_API_RATE_LIMIT=true` to bypass rate limiting entirely.
+ * Intended for isolated load-test and development environments —
+ * never enable this in production.
  */
 export async function checkApiRateLimit(): Promise<RateLimitResult> {
   const limit = getTierLimit();
   const { key, resetAt } = getWindowInfo();
+
+  if (process.env.DISABLE_API_RATE_LIMIT === "true") {
+    return { allowed: true, limit, remaining: limit, resetAt };
+  }
 
   if (!valkeyConnection) {
     return checkFallback();

--- a/testplanit/lib/api-token-auth.ts
+++ b/testplanit/lib/api-token-auth.ts
@@ -6,8 +6,16 @@
  */
 
 import { NextRequest } from "next/server";
+import {
+  getCachedTokenInfo,
+  invalidateApiTokenCache,
+  setCachedTokenInfo,
+} from "./api-token-cache";
 import { hashToken, isValidTokenFormat } from "./api-tokens";
 import { prisma } from "./prisma";
+
+// Re-export so callers that previously imported from api-token-auth keep working.
+export { invalidateApiTokenCache };
 
 export interface ApiTokenAuthResult {
   /** Whether authentication was successful */
@@ -62,10 +70,45 @@ export async function authenticateApiToken(
     };
   }
 
-  // Hash the token to look up in database
+  // Hash the token to look up in database/cache
   const tokenHash = hashToken(token);
 
-  // Look up the token
+  // Fast path: cached lookup (saves a DB query per request under load).
+  const cached = await getCachedTokenInfo(tokenHash);
+  if (cached) {
+    // Revalidate expiration inline (clock may have advanced since we cached).
+    if (cached.expiresAt && new Date(cached.expiresAt) < new Date()) {
+      await invalidateApiTokenCache(tokenHash);
+      return {
+        authenticated: false,
+        error: "API token has expired",
+        errorCode: "EXPIRED_TOKEN",
+      };
+    }
+
+    // Update lastUsedAt asynchronously, same as the slow path.
+    const clientIp =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
+    prisma.apiToken
+      .update({
+        where: { id: cached.tokenId },
+        data: { lastUsedAt: new Date(), lastUsedIp: clientIp },
+      })
+      .catch((err) => {
+        console.error("Failed to update API token last used:", err);
+      });
+
+    return {
+      authenticated: true,
+      userId: cached.userId,
+      access: cached.userAccess ?? undefined,
+      scopes: cached.scopes,
+    };
+  }
+
+  // Slow path: DB lookup, validate everything, populate cache on success.
   const apiToken = await prisma.apiToken.findUnique({
     where: { token: tokenHash },
     include: {
@@ -124,6 +167,15 @@ export async function authenticateApiToken(
       errorCode: "API_ACCESS_DISABLED",
     };
   }
+
+  // Cache the successful lookup for subsequent requests.
+  await setCachedTokenInfo(tokenHash, {
+    tokenId: apiToken.id,
+    userId: apiToken.userId,
+    userAccess: apiToken.user.access ?? null,
+    scopes: apiToken.scopes,
+    expiresAt: apiToken.expiresAt ? apiToken.expiresAt.toISOString() : null,
+  });
 
   // Update last used timestamp (async, don't block the response)
   const clientIp = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||

--- a/testplanit/lib/api-token-cache.ts
+++ b/testplanit/lib/api-token-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * API Token Cache
+ *
+ * Short-TTL Valkey cache for successful token lookups. Extracted from
+ * api-token-auth.ts so that the Prisma client extensions (in prisma.ts)
+ * can invalidate cache entries on revoke/delete without creating a
+ * circular import (prisma.ts → api-token-auth.ts → prisma.ts).
+ *
+ * Cache key:  apiToken:<tokenHash>
+ * Cache TTL:  see API_TOKEN_CACHE_TTL_SECONDS
+ */
+
+import valkeyConnection from "./valkey";
+
+export const API_TOKEN_CACHE_TTL_SECONDS = 30;
+export const API_TOKEN_CACHE_PREFIX = "apiToken:";
+
+export interface CachedTokenInfo {
+  tokenId: string;
+  userId: string;
+  userAccess: string | null;
+  scopes: string[];
+  expiresAt: string | null;
+}
+
+export async function getCachedTokenInfo(
+  tokenHash: string
+): Promise<CachedTokenInfo | null> {
+  if (!valkeyConnection) return null;
+  try {
+    const raw = await valkeyConnection.get(
+      `${API_TOKEN_CACHE_PREFIX}${tokenHash}`
+    );
+    return raw ? (JSON.parse(raw) as CachedTokenInfo) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedTokenInfo(
+  tokenHash: string,
+  info: CachedTokenInfo
+): Promise<void> {
+  if (!valkeyConnection) return;
+  try {
+    await valkeyConnection.set(
+      `${API_TOKEN_CACHE_PREFIX}${tokenHash}`,
+      JSON.stringify(info),
+      "EX",
+      API_TOKEN_CACHE_TTL_SECONDS
+    );
+  } catch {
+    // Cache write failures are non-fatal
+  }
+}
+
+/**
+ * Invalidate a cached token after revocation/rotation. Safe to call at
+ * any time. Called from the Prisma apiToken update/delete hooks so the
+ * 30-second cache window never outlives a revocation.
+ */
+export async function invalidateApiTokenCache(tokenHash: string): Promise<void> {
+  if (!valkeyConnection) return;
+  try {
+    await valkeyConnection.del(`${API_TOKEN_CACHE_PREFIX}${tokenHash}`);
+  } catch {
+    // non-fatal
+  }
+}

--- a/testplanit/lib/prisma.ts
+++ b/testplanit/lib/prisma.ts
@@ -22,6 +22,7 @@ import {
   auditBulkDelete,
   captureAuditEvent,
 } from "./services/auditLog";
+import { invalidateApiTokenCache } from "./api-token-cache";
 
 // Declare global types
 declare global {
@@ -832,6 +833,10 @@ function createPrismaClient(errorFormat: "pretty" | "colorless") {
             }).catch((error: any) => {
               console.error(`Failed to audit API token delete:`, error);
             });
+            // Evict the short-TTL auth cache so the token is rejected immediately.
+            invalidateApiTokenCache(oldEntity.token).catch((error: any) => {
+              console.error(`Failed to invalidate API token cache on delete:`, error);
+            });
           }
           return result;
         },
@@ -856,6 +861,50 @@ function createPrismaClient(errorFormat: "pretty" | "colorless") {
               },
             }).catch((error: any) => {
               console.error(`Failed to audit API token revocation:`, error);
+            });
+          }
+          // Evict the short-TTL auth cache on every write: revocation must be
+          // immediate, and rotated scopes/expiresAt/isActive all need to
+          // invalidate a prior cached lookup.
+          if (oldEntity) {
+            invalidateApiTokenCache(oldEntity.token).catch((error: any) => {
+              console.error(`Failed to invalidate API token cache on update:`, error);
+            });
+          }
+          return result;
+        },
+        async updateMany({ args, query }: any) {
+          // Capture tokens affected by the bulk update so we can invalidate
+          // their cached entries after the write completes.
+          const affected = args.where
+            ? await baseClient.apiToken.findMany({
+                where: args.where,
+                select: { token: true },
+              })
+            : [];
+          const result = await query(args);
+          if (affected.length > 0) {
+            Promise.all(
+              affected.map((t: { token: string }) => invalidateApiTokenCache(t.token))
+            ).catch((error: any) => {
+              console.error(`Failed to invalidate API token caches on updateMany:`, error);
+            });
+          }
+          return result;
+        },
+        async deleteMany({ args, query }: any) {
+          const affected = args.where
+            ? await baseClient.apiToken.findMany({
+                where: args.where,
+                select: { token: true },
+              })
+            : [];
+          const result = await query(args);
+          if (affected.length > 0) {
+            Promise.all(
+              affected.map((t: { token: string }) => invalidateApiTokenCache(t.token))
+            ).catch((error: any) => {
+              console.error(`Failed to invalidate API token caches on deleteMany:`, error);
             });
           }
           return result;

--- a/testplanit/lib/session-cache.ts
+++ b/testplanit/lib/session-cache.ts
@@ -1,0 +1,174 @@
+/**
+ * Cache-aside helper for the NextAuth session callback.
+ *
+ * The session callback runs on every request that touches NextAuth
+ * (middleware, server components, most API routes). Without caching,
+ * every request triggers a DB query for user + preferences. Under
+ * load this is a significant source of DB pressure.
+ *
+ * We cache the user record in Valkey keyed by user id. The TTL (60s)
+ * is short enough that profile changes propagate quickly and long
+ * enough to absorb most request bursts.
+ *
+ * The `lastActiveAt` update is separate and runs at most once every
+ * 5 minutes per user, matching the pre-existing throttle.
+ */
+
+import type { AuthMethod, User, Access, UserPreferences } from "@prisma/client";
+import { prisma } from "./prisma";
+import valkeyConnection from "./valkey";
+
+const SESSION_USER_CACHE_TTL_SECONDS = 60;
+const SESSION_USER_CACHE_PREFIX = "user:session:";
+const LAST_ACTIVE_UPDATE_THROTTLE_MS = 5 * 60 * 1000;
+
+/**
+ * The shape of data cached per user. Null-able fields are represented as `null`
+ * (not `undefined`) so JSON round-tripping is lossless.
+ */
+export interface CachedSessionUser {
+  name: string | null;
+  access: Access | null;
+  image: string | null;
+  emailVerified: string | null; // ISO string so it survives JSON
+  authMethod: AuthMethod | null;
+  preferences: UserPreferences | null;
+  lastActiveAt: string | null; // ISO string
+}
+
+type SelectedUser = Pick<
+  User,
+  "name" | "access" | "image" | "emailVerified" | "authMethod" | "lastActiveAt"
+> & { userPreferences: UserPreferences | null };
+
+/**
+ * Fetch user data for the session callback, with cache-aside against Valkey.
+ *
+ * @returns the cached or freshly-fetched user data, or null if the user doesn't exist.
+ */
+export async function getCachedSessionUser(
+  userId: string
+): Promise<CachedSessionUser | null> {
+  // 1. Check cache
+  if (valkeyConnection) {
+    try {
+      const raw = await valkeyConnection.get(
+        `${SESSION_USER_CACHE_PREFIX}${userId}`
+      );
+      if (raw) {
+        return JSON.parse(raw) as CachedSessionUser;
+      }
+    } catch {
+      // Cache read errors are non-fatal; fall through to DB.
+    }
+  }
+
+  // 2. Fetch from DB
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      access: true,
+      image: true,
+      emailVerified: true,
+      authMethod: true,
+      lastActiveAt: true,
+      userPreferences: true,
+    },
+  });
+
+  if (!user) return null;
+
+  // 3. Ensure preferences exist. This is a one-time-per-user cost at most.
+  let preferences = (user as SelectedUser).userPreferences;
+  if (!preferences) {
+    preferences = await prisma.userPreferences.create({
+      data: { userId },
+    });
+  }
+
+  const cached: CachedSessionUser = {
+    name: user.name ?? null,
+    access: user.access ?? null,
+    image: user.image ?? null,
+    emailVerified: user.emailVerified ? user.emailVerified.toISOString() : null,
+    authMethod: user.authMethod ?? null,
+    preferences,
+    lastActiveAt: user.lastActiveAt ? user.lastActiveAt.toISOString() : null,
+  };
+
+  // 4. Populate cache (best-effort)
+  if (valkeyConnection) {
+    valkeyConnection
+      .set(
+        `${SESSION_USER_CACHE_PREFIX}${userId}`,
+        JSON.stringify(cached),
+        "EX",
+        SESSION_USER_CACHE_TTL_SECONDS
+      )
+      .catch(() => {
+        // non-fatal
+      });
+  }
+
+  return cached;
+}
+
+/**
+ * Throttled `lastActiveAt` update. Updates at most once every 5 minutes
+ * per user to avoid write amplification under heavy traffic.
+ *
+ * Fires the DB update async (fire-and-forget) and refreshes the cache.
+ */
+export async function touchLastActive(
+  userId: string,
+  cached: CachedSessionUser
+): Promise<void> {
+  const now = new Date();
+  const lastActive = cached.lastActiveAt ? new Date(cached.lastActiveAt) : null;
+
+  if (
+    !lastActive ||
+    now.getTime() - lastActive.getTime() > LAST_ACTIVE_UPDATE_THROTTLE_MS
+  ) {
+    // Fire-and-forget DB update; do not block the session callback.
+    prisma.user
+      .update({
+        where: { id: userId },
+        data: { lastActiveAt: now },
+      })
+      .catch(() => {
+        // non-fatal
+      });
+
+    // Refresh the cache's lastActiveAt so we don't fire another update on
+    // the next request within the throttle window.
+    cached.lastActiveAt = now.toISOString();
+    if (valkeyConnection) {
+      valkeyConnection
+        .set(
+          `${SESSION_USER_CACHE_PREFIX}${userId}`,
+          JSON.stringify(cached),
+          "EX",
+          SESSION_USER_CACHE_TTL_SECONDS
+        )
+        .catch(() => {
+          // non-fatal
+        });
+    }
+  }
+}
+
+/**
+ * Invalidate a user's cached session data. Call after updating profile,
+ * permissions, access level, or preferences so subsequent requests see
+ * the change immediately.
+ */
+export async function invalidateSessionUserCache(userId: string): Promise<void> {
+  if (!valkeyConnection) return;
+  try {
+    await valkeyConnection.del(`${SESSION_USER_CACHE_PREFIX}${userId}`);
+  } catch {
+    // non-fatal
+  }
+}

--- a/testplanit/load-tests/capacity/.gitignore
+++ b/testplanit/load-tests/capacity/.gitignore
@@ -1,0 +1,5 @@
+# Capacity-test outputs stay local — backed up on the tester's machine,
+# never committed to the repo. The empty results/ directory is preserved
+# via .gitkeep because run-capacity-tests.sh writes into it.
+results/*
+!results/.gitkeep

--- a/testplanit/load-tests/capacity/01-concurrent-users.js
+++ b/testplanit/load-tests/capacity/01-concurrent-users.js
@@ -1,0 +1,154 @@
+/**
+ * Capacity Test 01: Concurrent Users (Ramp)
+ *
+ * Answers: "How many concurrent users can log in and use the system
+ * with acceptable latency and low error rates?"
+ *
+ * Ramps VUs 10 → 500, each VU simulating a typical user session
+ * (browse + occasional CRUD/search). Captures the breaking point
+ * where p95 latency exceeds thresholds or error rate spikes.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/01-concurrent-users.js
+ */
+
+import { sleep } from "k6";
+import { findMany, create, postApi } from "../helpers/api.js";
+import { testCaseName } from "../helpers/data.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "01-concurrent-users";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 10 }, // warm up
+    { duration: "2m", target: 50 }, // light load
+    { duration: "2m", target: 100 }, // normal load
+    { duration: "2m", target: 200 }, // heavy load
+    { duration: "2m", target: 350 }, // stress
+    { duration: "2m", target: 500 }, // breaking
+    { duration: "1m", target: 0 }, // ramp down
+  ],
+  thresholds: {
+    http_req_failed: ["rate<0.05"], // fail at >5% errors
+    "http_req_duration{scenario:browse}": ["p(95)<1000"],
+    "http_req_duration{scenario:crud}": ["p(95)<2000"],
+    "http_req_duration{scenario:search}": ["p(95)<1000"],
+  },
+};
+
+export default function () {
+  // 70% browse / 15% search / 10% CRUD / 5% small test run
+  const r = Math.random();
+  if (r < 0.7) browseSession();
+  else if (r < 0.85) searchSession();
+  else if (r < 0.95) crudSession();
+  else testRunSession();
+}
+
+function browseSession() {
+  const TAG = "browse";
+  findMany("projects", { select: { id: true, name: true }, take: 50 }, { scenarioTag: TAG });
+  sleep(0.5 + Math.random());
+  findMany(
+    "repositoryFolders",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, take: 50 },
+    { scenarioTag: TAG }
+  );
+  sleep(0.3 + Math.random());
+  findMany(
+    "repositoryCases",
+    {
+      where: { projectId: PROJECT_ID, isDeleted: false },
+      take: 25,
+      skip: Math.floor(Math.random() * 5) * 25,
+      orderBy: { name: "asc" },
+    },
+    { scenarioTag: TAG }
+  );
+  sleep(1 + Math.random() * 2);
+}
+
+function searchSession() {
+  const TAG = "search";
+  const queries = ["login", "payment", "api", "error", "test", "validate"];
+  const q = queries[Math.floor(Math.random() * queries.length)];
+
+  postApi(
+    "/api/repository-cases/search",
+    { query: q, filters: { projectIds: [PROJECT_ID] }, pagination: { page: 1, size: 25 } },
+    { scenarioTag: TAG }
+  );
+  sleep(0.5 + Math.random());
+  postApi(
+    "/api/repository-cases/search",
+    { query: q, filters: { projectIds: [PROJECT_ID] }, pagination: { page: 2, size: 25 } },
+    { scenarioTag: TAG }
+  );
+  sleep(1 + Math.random());
+}
+
+function crudSession() {
+  const TAG = "crud";
+  const folders = findMany(
+    "repositoryFolders",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 5 },
+    { scenarioTag: TAG }
+  );
+  const folderId = folders?.data?.[0]?.id;
+  if (!folderId) return;
+
+  const repos = findMany(
+    "repositories",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const templates = findMany(
+    "templates",
+    { where: { isDefault: true }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 },
+    { scenarioTag: TAG }
+  );
+  const repoId = repos?.data?.[0]?.id;
+  const templateId = templates?.data?.[0]?.id;
+  const stateId = workflows?.data?.[0]?.id;
+  if (!repoId || !templateId || !stateId) return;
+
+  create(
+    "repositoryCases",
+    {
+      name: testCaseName(),
+      automated: false,
+      isDeleted: false,
+      project: { connect: { id: PROJECT_ID } },
+      folder: { connect: { id: folderId } },
+      repository: { connect: { id: repoId } },
+      template: { connect: { id: templateId } },
+      state: { connect: { id: stateId } },
+    },
+    { scenarioTag: TAG }
+  );
+  sleep(1 + Math.random());
+}
+
+function testRunSession() {
+  const TAG = "test_run";
+  postApi(
+    "/api/report-builder/test-execution",
+    {
+      reportType: "test-execution",
+      projectId: PROJECT_ID,
+      dimensions: ["status"],
+      metrics: ["testResults"],
+    },
+    { scenarioTag: TAG }
+  );
+  sleep(2 + Math.random() * 2);
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/02-import-rate.js
+++ b/testplanit/load-tests/capacity/02-import-rate.js
@@ -1,0 +1,112 @@
+/**
+ * Capacity Test 02: Test Case Import Rate
+ *
+ * Answers: "How many test cases per second can we create before
+ * the server falls behind or errors spike?"
+ *
+ * Ramps request rate, each iteration creates a single test case.
+ * Uses constant-arrival-rate executor to control requests/sec
+ * independently of response latency.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/02-import-rate.js
+ */
+
+import { check } from "k6";
+import { Trend } from "k6/metrics";
+import { findMany, create } from "../helpers/api.js";
+import { testCaseName } from "../helpers/data.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "02-import-rate";
+
+const createLatency = new Trend("case_create_latency_ms");
+
+export const options = {
+  scenarios: {
+    ramp: {
+      executor: "ramping-arrival-rate",
+      startRate: 10,
+      timeUnit: "1s",
+      preAllocatedVUs: 50,
+      maxVUs: 500,
+      stages: [
+        { duration: "1m", target: 20 }, // 20 creates/s
+        { duration: "2m", target: 50 }, // 50 creates/s
+        { duration: "2m", target: 100 }, // 100 creates/s
+        { duration: "2m", target: 200 }, // 200 creates/s
+        { duration: "2m", target: 400 }, // 400 creates/s (stress)
+        { duration: "2m", target: 800 }, // 800 creates/s (break)
+        { duration: "1m", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    case_create_latency_ms: ["p(95)<3000"],
+  },
+};
+
+// Shared setup — grab a folder, template, workflow, repo ID once
+export function setup() {
+  const opts = {};
+  const folders = findMany(
+    "repositoryFolders",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 10 },
+    opts
+  );
+  const repos = findMany(
+    "repositories",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 1 },
+    opts
+  );
+  const templates = findMany(
+    "templates",
+    { where: { isDefault: true }, select: { id: true }, take: 1 },
+    opts
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 },
+    opts
+  );
+
+  return {
+    folderIds: folders?.data?.map((f) => f.id) || [],
+    repoId: repos?.data?.[0]?.id,
+    templateId: templates?.data?.[0]?.id,
+    stateId: workflows?.data?.[0]?.id,
+  };
+}
+
+export default function (ctx) {
+  if (!ctx.folderIds.length || !ctx.repoId || !ctx.templateId || !ctx.stateId) {
+    return;
+  }
+
+  const folderId = ctx.folderIds[Math.floor(Math.random() * ctx.folderIds.length)];
+
+  const start = Date.now();
+  const res = create(
+    "repositoryCases",
+    {
+      name: testCaseName(),
+      automated: false,
+      isDeleted: false,
+      project: { connect: { id: PROJECT_ID } },
+      folder: { connect: { id: folderId } },
+      repository: { connect: { id: ctx.repoId } },
+      template: { connect: { id: ctx.templateId } },
+      state: { connect: { id: ctx.stateId } },
+    },
+    { scenarioTag: "import" }
+  );
+  createLatency.add(Date.now() - start);
+
+  check(res, {
+    "case created": (r) => r?.data?.id != null,
+  });
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/03-result-ingestion-rate.js
+++ b/testplanit/load-tests/capacity/03-result-ingestion-rate.js
@@ -1,0 +1,182 @@
+/**
+ * Capacity Test 03: API Test Result Ingestion Rate (CLI path)
+ *
+ * Answers: "How many test results per second can CI/CD pipelines
+ * submit via the API before ingestion falls behind?"
+ *
+ * This is the most BBVA-critical test — customers running thousands
+ * of automated tests per pipeline will hammer this endpoint.
+ *
+ * Two scenarios tested:
+ *   A) Individual result submissions via /api/test-runs/submit-result
+ *   B) Bulk JUnit XML imports via /api/test-results/import
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/03-result-ingestion-rate.js
+ */
+
+import { check } from "k6";
+import http from "k6/http";
+import { Trend } from "k6/metrics";
+import { findMany, create, postApi } from "../helpers/api.js";
+import { junitXml, uniqueId } from "../helpers/data.js";
+import { BASE_URL, headers, PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "03-result-ingestion-rate";
+
+const submitLatency = new Trend("submit_result_latency_ms");
+const importLatency = new Trend("import_latency_ms");
+const importedResults = new Trend("junit_results_per_import");
+
+export const options = {
+  scenarios: {
+    individual_submits: {
+      executor: "ramping-arrival-rate",
+      startRate: 20,
+      timeUnit: "1s",
+      preAllocatedVUs: 50,
+      maxVUs: 300,
+      stages: [
+        { duration: "1m", target: 50 },
+        { duration: "2m", target: 100 },
+        { duration: "2m", target: 250 },
+        { duration: "2m", target: 500 },
+        { duration: "2m", target: 1000 },
+        { duration: "1m", target: 0 },
+      ],
+      exec: "submitIndividual",
+    },
+    ci_pipelines: {
+      executor: "ramping-arrival-rate",
+      startRate: 1,
+      timeUnit: "1s",
+      preAllocatedVUs: 20,
+      maxVUs: 100,
+      stages: [
+        { duration: "1m", target: 2 },
+        { duration: "2m", target: 5 },
+        { duration: "2m", target: 10 },
+        { duration: "2m", target: 20 },
+        { duration: "2m", target: 40 },
+        { duration: "1m", target: 0 },
+      ],
+      exec: "runCIPipeline",
+      startTime: "0s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    submit_result_latency_ms: ["p(95)<2000"],
+    import_latency_ms: ["p(95)<30000"], // larger imports take longer
+  },
+};
+
+export function setup() {
+  // Need an existing test run with cases to submit results against
+  const cases = findMany(
+    "repositoryCases",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 100 },
+    {}
+  );
+  const statuses = findMany(
+    "status",
+    { where: { isDeleted: false, isEnabled: true }, select: { id: true, isSuccess: true } },
+    {}
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 },
+    {}
+  );
+
+  const defaultStatus = statuses?.data?.find((s) => !s.isSuccess) || statuses?.data?.[0];
+  const passedStatus = statuses?.data?.find((s) => s.isSuccess) || defaultStatus;
+  const runStateId = workflows?.data?.[0]?.id;
+
+  if (!cases?.data?.length || !defaultStatus || !runStateId) {
+    throw new Error("Missing required seed data for ingestion test");
+  }
+
+  // Create a test run with cases to post results against
+  const testRun = create("testRuns", {
+    name: `Ingestion Test Run ${uniqueId()}`,
+    isCompleted: false,
+    isDeleted: false,
+    testRunType: "REGULAR",
+    project: { connect: { id: PROJECT_ID } },
+    state: { connect: { id: runStateId } },
+  });
+
+  const testRunId = testRun?.data?.id;
+  if (!testRunId) throw new Error("Failed to create setup test run");
+
+  // Attach first 50 cases to it
+  const testRunCaseIds = [];
+  const casesToAdd = cases.data.slice(0, 50);
+  for (let i = 0; i < casesToAdd.length; i++) {
+    const trc = create("testRunCases", {
+      order: i + 1,
+      isCompleted: false,
+      testRun: { connect: { id: testRunId } },
+      repositoryCase: { connect: { id: casesToAdd[i].id } },
+      status: { connect: { id: defaultStatus.id } },
+    });
+    if (trc?.data?.id) testRunCaseIds.push({ id: trc.data.id, version: trc.data.version || 1 });
+  }
+
+  return {
+    testRunId,
+    testRunCaseIds,
+    passedStatusId: passedStatus.id,
+  };
+}
+
+export function submitIndividual(ctx) {
+  if (!ctx.testRunCaseIds.length) return;
+  const trc = ctx.testRunCaseIds[Math.floor(Math.random() * ctx.testRunCaseIds.length)];
+
+  const start = Date.now();
+  const { res } = postApi(
+    "/api/test-runs/submit-result",
+    {
+      testRunId: ctx.testRunId,
+      testRunCaseId: trc.id,
+      statusId: ctx.passedStatusId,
+      elapsed: Math.floor(500 + Math.random() * 5000),
+      attempt: 1,
+      testRunCaseVersion: trc.version,
+    },
+    { scenarioTag: "ingest_single" }
+  );
+  submitLatency.add(Date.now() - start);
+  check(res, { "submit 200": (r) => r.status === 200 });
+}
+
+export function runCIPipeline(_ctx) {
+  // Simulate a CI run reporting a batch of 50 test results as JUnit XML
+  const suiteCount = 2 + Math.floor(Math.random() * 3);
+  const casesPerSuite = 15 + Math.floor(Math.random() * 10);
+  const xml = junitXml(suiteCount, casesPerSuite);
+  importedResults.add(suiteCount * casesPerSuite);
+
+  const start = Date.now();
+  const res = http.post(
+    `${BASE_URL}/api/test-results/import`,
+    {
+      file: http.file(xml, `ci-${uniqueId()}.xml`, "application/xml"),
+      format: "junit",
+      projectId: String(PROJECT_ID),
+      name: `CI Pipeline ${uniqueId()}`,
+    },
+    {
+      headers: { Authorization: headers.Authorization },
+      tags: { scenario: "ingest_ci" },
+      timeout: "120s",
+    }
+  );
+  importLatency.add(Date.now() - start);
+  check(res, { "import 200": (r) => r.status === 200 });
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/04-report-generation.js
+++ b/testplanit/load-tests/capacity/04-report-generation.js
@@ -1,0 +1,68 @@
+/**
+ * Capacity Test 04: Report Generation Time
+ *
+ * Answers: "How long does each type of report take to generate?"
+ *
+ * Single VU runs each report type sequentially to measure clean
+ * latency per report without concurrency effects. Captures p50/p95/max
+ * per report type so we can answer "this report takes X seconds."
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/04-report-generation.js
+ */
+
+import { sleep, check } from "k6";
+import { Trend } from "k6/metrics";
+import { postApi } from "../helpers/api.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "04-report-generation";
+
+// One Trend per report type so we get per-report latency stats
+const reports = [
+  { name: "test-execution", path: "/api/report-builder/test-execution", body: { reportType: "test-execution", projectId: PROJECT_ID, dimensions: ["status"], metrics: ["testResults"] } },
+  { name: "test-case-health", path: "/api/report-builder/test-case-health", body: { reportType: "test-case-health", projectId: PROJECT_ID, dimensions: [], metrics: [] } },
+  { name: "automation-trends", path: "/api/report-builder/automation-trends", body: { reportType: "automation-trends", projectId: PROJECT_ID, dimensions: [], metrics: [] } },
+  { name: "flaky-tests", path: "/api/report-builder/flaky-tests", body: { reportType: "flaky-tests", projectId: PROJECT_ID, dimensions: [], metrics: [] } },
+  { name: "cross-test-execution", path: "/api/report-builder/cross-project-test-execution", body: { reportType: "cross-project-test-execution", dimensions: ["project", "status"], metrics: ["testResults"] } },
+  { name: "cross-test-case-health", path: "/api/report-builder/cross-project-test-case-health", body: { reportType: "cross-project-test-case-health", dimensions: [], metrics: [] } },
+  { name: "cross-flaky-tests", path: "/api/report-builder/cross-project-flaky-tests", body: { reportType: "cross-project-flaky-tests", dimensions: [], metrics: [] } },
+  { name: "cross-user-engagement", path: "/api/report-builder/cross-project-user-engagement", body: { reportType: "cross-project-user-engagement", dimensions: ["user"], metrics: ["executionCount"] } },
+  // Custom/user-defined reports with multiple dimensions (more complex query)
+  { name: "custom-multi-dim", path: "/api/report-builder/test-execution", body: { reportType: "test-execution", projectId: PROJECT_ID, dimensions: ["status", "user", "testCase"], metrics: ["testResults", "avgElapsedTime"] } },
+];
+
+const trends = {};
+for (const r of reports) trends[r.name] = new Trend(`report_${r.name.replace(/-/g, "_")}_ms`);
+
+export const options = {
+  // Fixed 1 VU, 50 iterations — each run hits every report once
+  scenarios: {
+    report_latency: {
+      executor: "per-vu-iterations",
+      vus: 1,
+      iterations: 50,
+      maxDuration: "30m",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+export default function () {
+  for (const report of reports) {
+    const start = Date.now();
+    const { res } = postApi(report.path, report.body, { scenarioTag: "reporting" });
+    const duration = Date.now() - start;
+    trends[report.name].add(duration);
+    check(res, {
+      [`${report.name} status 200`]: (r) => r.status === 200,
+    });
+    sleep(0.2); // brief pause between reports
+  }
+  sleep(1);
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/05-run-creation.js
+++ b/testplanit/load-tests/capacity/05-run-creation.js
@@ -1,0 +1,141 @@
+/**
+ * Capacity Test 05: Test Run Creation with Many Cases
+ *
+ * Answers: "How long does it take to create a test run containing
+ * N test cases?"
+ *
+ * For each run size (10, 50, 100, 500, 1000, 5000), creates a test
+ * run and attaches that many cases, measuring total elapsed time.
+ * Reports scaling behavior — is it linear? Does it hit a cliff?
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/05-run-creation.js
+ */
+
+import { sleep, check } from "k6";
+import { Trend } from "k6/metrics";
+import { findMany, create } from "../helpers/api.js";
+import { uniqueId } from "../helpers/data.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "05-run-creation";
+
+const RUN_SIZES = [10, 50, 100, 500, 1000];
+// Large size (5000) only for 'large' tier to keep small/medium runs fast
+if (TIER === "large") RUN_SIZES.push(5000);
+
+// One trend per run size for clean per-size latency stats
+const trends = {};
+for (const size of RUN_SIZES) {
+  trends[size] = new Trend(`run_creation_${size}_cases_ms`);
+}
+
+export const options = {
+  scenarios: {
+    run_creation: {
+      executor: "per-vu-iterations",
+      vus: 1,
+      iterations: 5, // 5 repetitions of the full size matrix
+      maxDuration: "60m",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+export function setup() {
+  const cases = findMany(
+    "repositoryCases",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 10000 },
+    {}
+  );
+  const statuses = findMany(
+    "status",
+    { where: { isDeleted: false, isEnabled: true }, select: { id: true, isSuccess: true } },
+    {}
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 },
+    {}
+  );
+
+  const defaultStatus = statuses?.data?.find((s) => !s.isSuccess) || statuses?.data?.[0];
+  const runStateId = workflows?.data?.[0]?.id;
+
+  if (!cases?.data?.length || !defaultStatus || !runStateId) {
+    throw new Error("Missing seed data for run creation test");
+  }
+
+  return {
+    caseIds: cases.data.map((c) => c.id),
+    defaultStatusId: defaultStatus.id,
+    runStateId,
+  };
+}
+
+export default function (ctx) {
+  for (const size of RUN_SIZES) {
+    if (size > ctx.caseIds.length) {
+      console.warn(`Skipping size=${size}: only ${ctx.caseIds.length} cases available`);
+      continue;
+    }
+
+    const start = Date.now();
+
+    // 1. Create the test run
+    const testRun = create(
+      "testRuns",
+      {
+        name: `Capacity Run ${size} cases ${uniqueId()}`,
+        isCompleted: false,
+        isDeleted: false,
+        testRunType: "REGULAR",
+        project: { connect: { id: PROJECT_ID } },
+        state: { connect: { id: ctx.runStateId } },
+      },
+      { scenarioTag: "run_create" }
+    );
+    const testRunId = testRun?.data?.id;
+    if (!testRunId) {
+      console.error(`Failed to create run for size=${size}`);
+      continue;
+    }
+
+    // 2. Attach N cases
+    const shuffled = [...ctx.caseIds].sort(() => Math.random() - 0.5);
+    const selected = shuffled.slice(0, size);
+    let attached = 0;
+
+    for (let i = 0; i < selected.length; i++) {
+      const trc = create(
+        "testRunCases",
+        {
+          order: i + 1,
+          isCompleted: false,
+          testRun: { connect: { id: testRunId } },
+          repositoryCase: { connect: { id: selected[i] } },
+          status: { connect: { id: ctx.defaultStatusId } },
+        },
+        { scenarioTag: "run_create" }
+      );
+      if (trc?.data?.id) attached++;
+
+      // Brief pause every 50 cases to avoid local queue buildup
+      if (i > 0 && i % 50 === 0) sleep(0.05);
+    }
+
+    const duration = Date.now() - start;
+    trends[size].add(duration);
+    check(null, {
+      [`run_creation_${size}_attached_all`]: () => attached === size,
+    });
+    console.log(`size=${size}: ${duration}ms total (${attached}/${size} attached)`);
+
+    sleep(1); // gap between sizes
+  }
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/06-search-at-scale.js
+++ b/testplanit/load-tests/capacity/06-search-at-scale.js
@@ -1,0 +1,128 @@
+/**
+ * Capacity Test 06: Search Performance at Data Scale
+ *
+ * Answers: "Does search stay fast as the test case library grows
+ * from thousands to millions of cases?"
+ *
+ * Runs a variety of search queries (simple, filtered, faceted,
+ * typeahead) at the current data tier. p50/p95/p99 latency per
+ * query type is captured so we can compare across tiers.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=large capacity/06-search-at-scale.js
+ */
+
+import { sleep } from "k6";
+import { Trend } from "k6/metrics";
+import { postApi, getApi } from "../helpers/api.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "06-search-at-scale";
+
+const searchLatency = {
+  simple: new Trend("search_simple_ms"),
+  filtered: new Trend("search_filtered_ms"),
+  paginated_deep: new Trend("search_paginated_deep_ms"),
+  date_range: new Trend("search_date_range_ms"),
+  typeahead: new Trend("search_typeahead_ms"),
+};
+
+const QUERIES = ["login", "payment", "authentication", "api", "timeout", "error", "mobile", "security"];
+
+export const options = {
+  // Modest concurrency — we're measuring search quality at data scale,
+  // not overloading the server
+  scenarios: {
+    search_mix: {
+      executor: "constant-vus",
+      vus: 10,
+      duration: "5m",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    search_simple_ms: ["p(95)<1000"],
+    search_filtered_ms: ["p(95)<1500"],
+    search_paginated_deep_ms: ["p(95)<2000"],
+    search_typeahead_ms: ["p(95)<500"],
+  },
+};
+
+export default function () {
+  const q = QUERIES[Math.floor(Math.random() * QUERIES.length)];
+
+  // Simple search (no filters)
+  let start = Date.now();
+  postApi(
+    "/api/repository-cases/search",
+    { query: q, filters: { projectIds: [PROJECT_ID] }, pagination: { page: 1, size: 25 } },
+    { scenarioTag: "search" }
+  );
+  searchLatency.simple.add(Date.now() - start);
+  sleep(0.3);
+
+  // Filtered search (automated=false)
+  start = Date.now();
+  postApi(
+    "/api/repository-cases/search",
+    {
+      query: q,
+      filters: { projectIds: [PROJECT_ID], automated: false },
+      pagination: { page: 1, size: 25 },
+    },
+    { scenarioTag: "search" }
+  );
+  searchLatency.filtered.add(Date.now() - start);
+  sleep(0.3);
+
+  // Deep pagination
+  start = Date.now();
+  postApi(
+    "/api/repository-cases/search",
+    {
+      query: "",
+      filters: { projectIds: [PROJECT_ID] },
+      pagination: { page: 20, size: 25 },
+    },
+    { scenarioTag: "search" }
+  );
+  searchLatency.paginated_deep.add(Date.now() - start);
+  sleep(0.3);
+
+  // Date range filter
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  start = Date.now();
+  postApi(
+    "/api/repository-cases/search",
+    {
+      query: "",
+      filters: {
+        projectIds: [PROJECT_ID],
+        dateRange: {
+          field: "createdAt",
+          from: thirtyDaysAgo.toISOString(),
+          to: now.toISOString(),
+        },
+      },
+      pagination: { page: 1, size: 25 },
+    },
+    { scenarioTag: "search" }
+  );
+  searchLatency.date_range.add(Date.now() - start);
+  sleep(0.3);
+
+  // Typeahead — quick successive prefix queries
+  const word = q.substring(0, 1 + Math.floor(Math.random() * q.length));
+  start = Date.now();
+  getApi(
+    `/api/repository-cases/search?prefix=${encodeURIComponent(word)}&field=name&size=10`,
+    { scenarioTag: "search" }
+  );
+  searchLatency.typeahead.add(Date.now() - start);
+
+  sleep(0.5 + Math.random());
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/07-audit-log-throughput.js
+++ b/testplanit/load-tests/capacity/07-audit-log-throughput.js
@@ -1,0 +1,153 @@
+/**
+ * Capacity Test 07: Audit Log Write Throughput Under Activity
+ *
+ * Answers: "Does the audit log become a bottleneck under heavy
+ * activity?"
+ *
+ * DORA compliance means every mutation produces an audit entry.
+ * At scale, audit log writes can exhaust the BullMQ queue or slow
+ * down mutations. This test drives sustained mutation traffic
+ * (creates/updates) and checks that audit processing keeps up.
+ *
+ * Metrics:
+ *   - Mutation latency (does it degrade as audit queue grows?)
+ *   - Audit log row count growth rate vs mutation rate
+ *
+ * Note: audit queue size isn't exposed via a public endpoint, so we
+ * approximate by checking the rate of new auditLog rows written.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/07-audit-log-throughput.js
+ */
+
+import { sleep, check } from "k6";
+import { Trend, Counter } from "k6/metrics";
+import { findMany, create, update } from "../helpers/api.js";
+import { testCaseName } from "../helpers/data.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "07-audit-log-throughput";
+
+const mutationLatency = new Trend("mutation_latency_ms");
+const auditLogCount = new Trend("audit_log_total_rows");
+const mutations = new Counter("mutations_submitted");
+
+export const options = {
+  scenarios: {
+    mutations: {
+      // Sustained high mutation rate
+      executor: "constant-arrival-rate",
+      rate: 100, // 100 mutations/second
+      timeUnit: "1s",
+      duration: "5m",
+      preAllocatedVUs: 50,
+      maxVUs: 200,
+      exec: "doMutation",
+    },
+    audit_polling: {
+      // Separately poll audit log size every 10 seconds
+      executor: "constant-vus",
+      vus: 1,
+      duration: "5m",
+      exec: "pollAuditLog",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    mutation_latency_ms: [
+      "p(95)<2000", // mutations should stay fast even under sustained load
+    ],
+  },
+};
+
+export function setup() {
+  const folders = findMany(
+    "repositoryFolders",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 10 },
+    {}
+  );
+  const cases = findMany(
+    "repositoryCases",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 500 },
+    {}
+  );
+  const repos = findMany(
+    "repositories",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 1 },
+    {}
+  );
+  const templates = findMany(
+    "templates",
+    { where: { isDefault: true }, select: { id: true }, take: 1 },
+    {}
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "CASES" }, select: { id: true }, take: 1 },
+    {}
+  );
+
+  return {
+    folderIds: folders?.data?.map((f) => f.id) || [],
+    existingCaseIds: cases?.data?.map((c) => c.id) || [],
+    repoId: repos?.data?.[0]?.id,
+    templateId: templates?.data?.[0]?.id,
+    stateId: workflows?.data?.[0]?.id,
+  };
+}
+
+export function doMutation(ctx) {
+  if (!ctx.folderIds.length) return;
+
+  const rand = Math.random();
+  const start = Date.now();
+
+  if (rand < 0.6 || ctx.existingCaseIds.length === 0) {
+    // CREATE
+    const folderId = ctx.folderIds[Math.floor(Math.random() * ctx.folderIds.length)];
+    const res = create(
+      "repositoryCases",
+      {
+        name: testCaseName(),
+        automated: false,
+        isDeleted: false,
+        project: { connect: { id: PROJECT_ID } },
+        folder: { connect: { id: folderId } },
+        repository: { connect: { id: ctx.repoId } },
+        template: { connect: { id: ctx.templateId } },
+        state: { connect: { id: ctx.stateId } },
+      },
+      { scenarioTag: "audit_mutation" }
+    );
+    check(res, { "create ok": (r) => r?.data?.id != null });
+  } else {
+    // UPDATE
+    const caseId = ctx.existingCaseIds[Math.floor(Math.random() * ctx.existingCaseIds.length)];
+    const res = update(
+      "repositoryCases",
+      caseId,
+      { name: `${testCaseName()} [AUDIT-TEST]` },
+      { scenarioTag: "audit_mutation" }
+    );
+    check(res, { "update ok": (r) => r?.data?.id != null });
+  }
+
+  mutations.add(1);
+  mutationLatency.add(Date.now() - start);
+}
+
+export function pollAuditLog() {
+  // Count rows in auditLog to track throughput. Poll every 10s to watch the
+  // queue fill up as mutations accumulate.
+  const countRes = findMany(
+    "auditLog",
+    { where: { projectId: PROJECT_ID }, select: { id: true } },
+    { scenarioTag: "audit_poll" }
+  );
+  const total = countRes?.data?.length ?? 0;
+  auditLogCount.add(total);
+  sleep(10);
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/08-concurrent-runs.js
+++ b/testplanit/load-tests/capacity/08-concurrent-runs.js
@@ -1,0 +1,184 @@
+/**
+ * Capacity Test 08: Concurrent Test Run Execution by Multiple Teams
+ *
+ * Answers: "Can N QA teams execute test runs simultaneously without
+ * contention?"
+ *
+ * Different from 'concurrent users' — this specifically tests
+ * concurrent WRITES to TestRunResults, TestRunCases, which hit
+ * row-level locks, audit queue backlog, and forecast recalculation.
+ *
+ * Each VU simulates one team's QA engineer:
+ *   1. Creates a test run of 50 cases
+ *   2. Executes each case (submits result) with small pauses
+ *   3. Completes the run
+ *
+ * We ramp team count 1 → 50 teams and measure whether the system
+ * holds up under concurrent write load.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/08-concurrent-runs.js
+ */
+
+import { sleep } from "k6";
+import { Trend } from "k6/metrics";
+import { findMany, create, update, postApi } from "../helpers/api.js";
+import { uniqueId } from "../helpers/data.js";
+import { PROJECT_ID } from "../config.js";
+import { makeSummaryWriter } from "./helpers/summary.js";
+
+const TIER = __ENV.TIER || "medium";
+const TEST_ID = "08-concurrent-runs";
+
+const runCreationLatency = new Trend("run_creation_ms");
+const runExecutionLatency = new Trend("run_execution_ms");
+const runCompletionLatency = new Trend("run_completion_ms");
+const totalTeamRun = new Trend("team_run_total_ms");
+
+const CASES_PER_RUN = 50;
+
+export const options = {
+  scenarios: {
+    teams: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "2m", target: 5 }, // 5 teams
+        { duration: "3m", target: 15 }, // 15 teams
+        { duration: "3m", target: 30 }, // 30 teams
+        { duration: "3m", target: 50 }, // 50 teams (stress)
+        { duration: "1m", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    run_creation_ms: ["p(95)<5000"],
+    run_execution_ms: ["p(95)<30000"], // 50-case run should execute reasonably fast
+  },
+};
+
+export function setup() {
+  const cases = findMany(
+    "repositoryCases",
+    { where: { projectId: PROJECT_ID, isDeleted: false }, select: { id: true }, take: 500 },
+    {}
+  );
+  const statuses = findMany(
+    "status",
+    { where: { isDeleted: false, isEnabled: true }, select: { id: true, isSuccess: true, isFailure: true } },
+    {}
+  );
+  const workflows = findMany(
+    "workflows",
+    { where: { isDeleted: false, isDefault: true, scope: "RUNS" }, select: { id: true }, take: 1 },
+    {}
+  );
+
+  const defaultStatus = statuses?.data?.find((s) => !s.isSuccess && !s.isFailure) || statuses?.data?.[0];
+  const passedStatus = statuses?.data?.find((s) => s.isSuccess) || defaultStatus;
+  const failedStatus = statuses?.data?.find((s) => s.isFailure) || defaultStatus;
+  const runStateId = workflows?.data?.[0]?.id;
+
+  if (!cases?.data?.length || !defaultStatus || !runStateId) {
+    throw new Error("Missing seed data for concurrent runs test");
+  }
+
+  return {
+    caseIds: cases.data.map((c) => c.id),
+    defaultStatusId: defaultStatus.id,
+    passedStatusId: passedStatus.id,
+    failedStatusId: failedStatus.id,
+    runStateId,
+  };
+}
+
+export default function (ctx) {
+  const teamRunStart = Date.now();
+
+  // 1. Create test run
+  const createStart = Date.now();
+  const testRun = create(
+    "testRuns",
+    {
+      name: `Team Run ${__VU}-${uniqueId()}`,
+      isCompleted: false,
+      isDeleted: false,
+      testRunType: "REGULAR",
+      project: { connect: { id: PROJECT_ID } },
+      state: { connect: { id: ctx.runStateId } },
+    },
+    { scenarioTag: "concurrent_run" }
+  );
+  const testRunId = testRun?.data?.id;
+  if (!testRunId) {
+    sleep(2);
+    return;
+  }
+
+  // 2. Attach cases
+  const shuffled = [...ctx.caseIds].sort(() => Math.random() - 0.5);
+  const selectedCases = shuffled.slice(0, Math.min(CASES_PER_RUN, ctx.caseIds.length));
+  const testRunCaseIds = [];
+
+  for (let i = 0; i < selectedCases.length; i++) {
+    const trc = create(
+      "testRunCases",
+      {
+        order: i + 1,
+        isCompleted: false,
+        testRun: { connect: { id: testRunId } },
+        repositoryCase: { connect: { id: selectedCases[i] } },
+        status: { connect: { id: ctx.defaultStatusId } },
+      },
+      { scenarioTag: "concurrent_run" }
+    );
+    if (trc?.data?.id) {
+      testRunCaseIds.push({ id: trc.data.id, version: trc.data.version || 1 });
+    }
+  }
+  runCreationLatency.add(Date.now() - createStart);
+
+  // 3. Execute the run — submit results one by one
+  const execStart = Date.now();
+  for (let i = 0; i < testRunCaseIds.length; i++) {
+    const trc = testRunCaseIds[i];
+    const rand = Math.random();
+    // 80% pass, 15% fail, 5% skip
+    if (rand < 0.05) continue;
+    const statusId = rand < 0.80 ? ctx.passedStatusId : ctx.failedStatusId;
+
+    postApi(
+      "/api/test-runs/submit-result",
+      {
+        testRunId,
+        testRunCaseId: trc.id,
+        statusId,
+        elapsed: Math.floor(500 + Math.random() * 10000),
+        attempt: 1,
+        testRunCaseVersion: trc.version,
+      },
+      { scenarioTag: "concurrent_run" }
+    );
+
+    // Realistic cadence — QA engineers don't submit results instantaneously
+    sleep(0.1 + Math.random() * 0.3);
+  }
+  runExecutionLatency.add(Date.now() - execStart);
+
+  // 4. Mark run complete
+  const completeStart = Date.now();
+  update(
+    "testRuns",
+    testRunId,
+    { isCompleted: true, completedAt: new Date().toISOString() },
+    { scenarioTag: "concurrent_run" }
+  );
+  runCompletionLatency.add(Date.now() - completeStart);
+
+  totalTeamRun.add(Date.now() - teamRunStart);
+
+  // Gap between runs — a QA team doesn't immediately start another run
+  sleep(5 + Math.random() * 10);
+}
+
+export const handleSummary = makeSummaryWriter(TEST_ID, TIER);

--- a/testplanit/load-tests/capacity/generate-report.js
+++ b/testplanit/load-tests/capacity/generate-report.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Capacity report generator.
+ *
+ * Reads k6 JSON summaries from capacity/results/ and produces a
+ * markdown capacity report evaluating pass/fail against thresholds.
+ *
+ * Usage: node generate-report.js <runId> <tier>
+ *        node generate-report.js 20260414-153000-medium medium
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const [runId, tier] = process.argv.slice(2);
+if (!runId || !tier) {
+  console.error("Usage: node generate-report.js <runId> <tier>");
+  process.exit(1);
+}
+
+const RESULTS_DIR = path.resolve(__dirname, "results");
+const THRESHOLDS_PATH = path.resolve(__dirname, "thresholds.json");
+
+const thresholds = JSON.parse(fs.readFileSync(THRESHOLDS_PATH, "utf8"));
+
+// Discover all JSON summaries for this tier, newest first
+const allFiles = fs
+  .readdirSync(RESULTS_DIR)
+  .filter((f) => f.endsWith(".json") && f.includes(`_${tier}.json`))
+  .sort()
+  .reverse();
+
+// Group by test, keeping only the latest for each
+const latestPerTest = new Map();
+for (const file of allFiles) {
+  // Filename: 2026-04-14T12-00-00-000Z_01-concurrent-users_medium.json
+  const match = file.match(/_(\d{2}-[^_]+)_/);
+  if (!match) continue;
+  const testId = match[1];
+  if (!latestPerTest.has(testId)) {
+    latestPerTest.set(testId, path.join(RESULTS_DIR, file));
+  }
+}
+
+// Load summaries
+const summaries = [];
+for (const [, filePath] of latestPerTest) {
+  try {
+    const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    summaries.push(data);
+  } catch (err) {
+    console.warn(`Could not parse ${filePath}: ${err.message}`);
+  }
+}
+
+// Sort by testId
+summaries.sort((a, b) => a.testId.localeCompare(b.testId));
+
+// ---------------------------------------------------------------------------
+// Report builder
+// ---------------------------------------------------------------------------
+
+const lines = [];
+lines.push(`# TestPlanIt Capacity Report`);
+lines.push("");
+lines.push(`- **Run ID:** ${runId}`);
+lines.push(`- **Data tier:** ${tier}`);
+lines.push(`- **Generated:** ${new Date().toISOString()}`);
+lines.push(`- **Tests included:** ${summaries.length}`);
+lines.push("");
+// Tier definitions — mirrors the TIERS block in seed-tier.js. Kept here
+// so the report is self-contained and reviewers can see at a glance what
+// dataset the numbers came from.
+const TIER_DATASETS = {
+  small:  { projects: 5,  cases: 2500,  runs: 100, folders: 50 },
+  medium: { projects: 20, cases: 20000, runs: 2000, folders: 200 },
+  large:  { projects: 50, cases: 100000, runs: 10000, folders: 500 },
+};
+const seed = TIER_DATASETS[tier];
+if (seed) {
+  lines.push("## Test Dataset");
+  lines.push("");
+  lines.push(`Seeded baseline for the \`${tier}\` tier (volume before the suite runs):`);
+  lines.push("");
+  lines.push(`- **Projects:** ${seed.projects.toLocaleString()}`);
+  lines.push(`- **Repository folders:** ${seed.folders.toLocaleString()}`);
+  lines.push(`- **Test cases:** ${seed.cases.toLocaleString()}`);
+  lines.push(`- **Test runs:** ${seed.runs.toLocaleString()}`);
+  lines.push("");
+  lines.push(
+    "Note: `02-import-rate` and `03-result-ingestion-rate` grow this dataset " +
+    "significantly while they run (tens of thousands of additional cases and results), " +
+    "so later tests (`04`-`08`) actually execute against a larger corpus than the seed above."
+  );
+  lines.push("");
+}
+
+lines.push("## Pass/Fail Criteria");
+lines.push("");
+lines.push(`- Error rate < ${thresholds.error_rate_max * 100}%`);
+lines.push(`- p95 latency per scenario:`);
+for (const [scenario, p95] of Object.entries(thresholds.latency_p95_ms)) {
+  lines.push(`  - ${scenario}: ${p95}ms`);
+}
+lines.push("");
+
+// ---------------------------------------------------------------------------
+// Executive summary table
+// ---------------------------------------------------------------------------
+lines.push("## Summary");
+lines.push("");
+lines.push("| Test | Verdict | Peak VUs | Throughput | p95 latency | Error rate |");
+lines.push("|---|---|---|---|---|---|");
+
+for (const s of summaries) {
+  const verdict = evaluateVerdict(s);
+  const vu = s.vus_max;
+  const rps = `${s.http_req_rate.toFixed(1)} req/s`;
+  const p95 = `${s.http_req_duration.p95.toFixed(0)}ms`;
+  const errPct = `${(s.http_req_failed_rate * 100).toFixed(2)}%`;
+  lines.push(`| ${s.testId} | ${verdict} | ${vu} | ${rps} | ${p95} | ${errPct} |`);
+}
+lines.push("");
+
+// ---------------------------------------------------------------------------
+// Per-test details
+// ---------------------------------------------------------------------------
+lines.push("## Per-Test Detail");
+lines.push("");
+
+for (const s of summaries) {
+  lines.push(`### ${s.testId}`);
+  lines.push("");
+  lines.push(`- **Verdict:** ${evaluateVerdict(s)}`);
+  lines.push(`- **Duration:** ${s.duration_s.toFixed(0)}s`);
+  lines.push(`- **Peak VUs:** ${s.vus_max}`);
+  lines.push(`- **Iterations:** ${s.iterations}`);
+  lines.push(`- **Total requests:** ${s.http_reqs.toLocaleString()}`);
+  lines.push(`- **Throughput:** ${s.http_req_rate.toFixed(2)} req/s`);
+  lines.push(`- **Error rate:** ${(s.http_req_failed_rate * 100).toFixed(3)}%`);
+  lines.push(`- **Latency (ms):** median=${s.http_req_duration.med.toFixed(0)}, p95=${s.http_req_duration.p95.toFixed(0)}, p99=${s.http_req_duration.p99.toFixed(0)}, max=${s.http_req_duration.max.toFixed(0)}`);
+
+  if (s.custom_metrics && Object.keys(s.custom_metrics).length > 0) {
+    lines.push("");
+    lines.push(`**Custom metrics:**`);
+    for (const [name, v] of Object.entries(s.custom_metrics)) {
+      if (v.avg !== undefined) {
+        lines.push(`- \`${name}\`: avg=${v.avg?.toFixed(0)}ms, p95=${v["p(95)"]?.toFixed(0)}ms, max=${v.max?.toFixed(0)}ms`);
+      } else if (v.count !== undefined) {
+        lines.push(`- \`${name}\`: count=${v.count}, rate=${v.rate?.toFixed(2)}/s`);
+      } else {
+        lines.push(`- \`${name}\`: ${JSON.stringify(v)}`);
+      }
+    }
+  }
+
+  if (s.thresholds && Object.keys(s.thresholds).length > 0) {
+    const failing = Object.entries(s.thresholds)
+      .flatMap(([metric, rules]) => rules.filter((r) => !r.ok).map((r) => `${metric}: ${r.rule}`));
+    if (failing.length > 0) {
+      lines.push("");
+      lines.push(`**Failing thresholds:**`);
+      for (const f of failing) lines.push(`- ${f}`);
+    }
+  }
+
+  lines.push("");
+}
+
+// ---------------------------------------------------------------------------
+// Historical comparison (if previous runs exist)
+// ---------------------------------------------------------------------------
+const historicalData = buildHistoricalData(tier);
+if (historicalData.length > 1) {
+  lines.push("## Historical Trends");
+  lines.push("");
+  lines.push("Previous runs of the same tier:");
+  lines.push("");
+  lines.push("| Run ID | Test | p95 | Error rate | Throughput |");
+  lines.push("|---|---|---|---|---|");
+  for (const h of historicalData.slice(0, 20)) {
+    lines.push(
+      `| ${h.runId} | ${h.testId} | ${h.p95.toFixed(0)}ms | ${(h.errRate * 100).toFixed(2)}% | ${h.throughput.toFixed(1)} req/s |`
+    );
+  }
+  lines.push("");
+}
+
+// ---------------------------------------------------------------------------
+// Write the report
+// ---------------------------------------------------------------------------
+const outPath = path.join(RESULTS_DIR, `${runId}-report.md`);
+fs.writeFileSync(outPath, lines.join("\n"));
+console.log(`Report: ${outPath}`);
+
+// ---------------------------------------------------------------------------
+function evaluateVerdict(summary) {
+  const reasons = [];
+
+  if (summary.http_req_failed_rate > thresholds.error_rate_max) {
+    reasons.push(`error rate ${(summary.http_req_failed_rate * 100).toFixed(2)}% > ${thresholds.error_rate_max * 100}%`);
+  }
+
+  // Check if any p95 threshold violated (we can't tell per-scenario from aggregate summary,
+  // so we use the global p95 against the most lenient threshold)
+  const maxP95 = Math.max(...Object.values(thresholds.latency_p95_ms));
+  if (summary.http_req_duration.p95 > maxP95) {
+    reasons.push(`p95 ${summary.http_req_duration.p95.toFixed(0)}ms > ${maxP95}ms`);
+  }
+
+  // Check k6-level thresholds that failed
+  if (summary.thresholds) {
+    for (const [metric, rules] of Object.entries(summary.thresholds)) {
+      for (const rule of rules) {
+        if (!rule.ok) reasons.push(`${metric}: ${rule.rule}`);
+      }
+    }
+  }
+
+  if (reasons.length === 0) return "✅ PASS";
+  return `❌ FAIL (${reasons.join("; ")})`;
+}
+
+function buildHistoricalData(tier) {
+  const out = [];
+  const files = fs
+    .readdirSync(RESULTS_DIR)
+    .filter((f) => f.endsWith(".json") && f.includes(`_${tier}.json`))
+    .sort()
+    .reverse();
+
+  for (const f of files) {
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, f), "utf8"));
+      // Derive runId from filename prefix
+      const runIdMatch = f.match(/^([^_]+)_/);
+      out.push({
+        runId: runIdMatch?.[1] ?? "(unknown)",
+        testId: data.testId,
+        p95: data.http_req_duration?.p95 ?? 0,
+        errRate: data.http_req_failed_rate ?? 0,
+        throughput: data.http_req_rate ?? 0,
+      });
+    } catch {
+      // skip unparseable
+    }
+  }
+  return out;
+}

--- a/testplanit/load-tests/capacity/helpers/summary.js
+++ b/testplanit/load-tests/capacity/helpers/summary.js
@@ -1,0 +1,130 @@
+/**
+ * k6 summary export helper.
+ *
+ * Every capacity test uses handleSummary() to save structured JSON
+ * results to disk. The runner and report generator consume those files.
+ */
+
+/**
+ * Build a handleSummary function that writes JSON to the specified path
+ * and prints a human-readable summary to stdout.
+ *
+ * @param {string} testId - Short identifier like "01-concurrent-users"
+ * @param {string} tier - Data tier: "small" | "medium" | "large"
+ * @returns {function} handleSummary callback for k6
+ */
+export function makeSummaryWriter(testId, tier) {
+  return function handleSummary(data) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const outputPath = `capacity/results/${timestamp}_${testId}_${tier}.json`;
+
+    // Extract key metrics for easy report consumption
+    const summary = {
+      testId,
+      tier,
+      timestamp: new Date().toISOString(),
+      duration_s: data.state?.testRunDurationMs
+        ? data.state.testRunDurationMs / 1000
+        : 0,
+      vus_max: data.metrics?.vus_max?.values?.max ?? 0,
+      iterations: data.metrics?.iterations?.values?.count ?? 0,
+      http_reqs: data.metrics?.http_reqs?.values?.count ?? 0,
+      http_req_rate: data.metrics?.http_reqs?.values?.rate ?? 0,
+      http_req_failed_rate: data.metrics?.http_req_failed?.values?.rate ?? 0,
+      http_req_duration: {
+        avg: data.metrics?.http_req_duration?.values?.avg ?? 0,
+        med: data.metrics?.http_req_duration?.values?.med ?? 0,
+        p90: data.metrics?.http_req_duration?.values?.["p(90)"] ?? 0,
+        p95: data.metrics?.http_req_duration?.values?.["p(95)"] ?? 0,
+        p99: data.metrics?.http_req_duration?.values?.["p(99)"] ?? 0,
+        max: data.metrics?.http_req_duration?.values?.max ?? 0,
+      },
+      // Include custom metrics (e.g., latency by data size)
+      custom_metrics: extractCustomMetrics(data.metrics),
+      thresholds: extractThresholds(data.metrics),
+    };
+
+    return {
+      [outputPath]: JSON.stringify(summary, null, 2),
+      stdout: buildTextReport(summary),
+    };
+  };
+}
+
+function extractCustomMetrics(metrics) {
+  const custom = {};
+  if (!metrics) return custom;
+
+  for (const [name, metric] of Object.entries(metrics)) {
+    // Skip built-in metrics we already extract
+    const builtIn = [
+      "vus",
+      "vus_max",
+      "iterations",
+      "iteration_duration",
+      "http_reqs",
+      "http_req_duration",
+      "http_req_failed",
+      "http_req_blocked",
+      "http_req_connecting",
+      "http_req_tls_handshaking",
+      "http_req_sending",
+      "http_req_waiting",
+      "http_req_receiving",
+      "data_sent",
+      "data_received",
+      "checks",
+    ];
+    if (builtIn.includes(name)) continue;
+
+    custom[name] = metric.values ?? metric;
+  }
+  return custom;
+}
+
+function extractThresholds(metrics) {
+  const out = {};
+  if (!metrics) return out;
+
+  for (const [name, metric] of Object.entries(metrics)) {
+    if (metric.thresholds) {
+      out[name] = Object.entries(metric.thresholds).map(([rule, info]) => ({
+        rule,
+        ok: info.ok,
+      }));
+    }
+  }
+  return out;
+}
+
+function buildTextReport(summary) {
+  const lines = [];
+  lines.push("");
+  lines.push("═══════════════════════════════════════════════════");
+  lines.push(`  Capacity Test: ${summary.testId} (${summary.tier})`);
+  lines.push("═══════════════════════════════════════════════════");
+  lines.push(`  Duration:       ${summary.duration_s.toFixed(1)}s`);
+  lines.push(`  Peak VUs:       ${summary.vus_max}`);
+  lines.push(`  Iterations:     ${summary.iterations}`);
+  lines.push(`  Requests:       ${summary.http_reqs}`);
+  lines.push(`  Throughput:     ${summary.http_req_rate.toFixed(2)} req/s`);
+  lines.push(
+    `  Error rate:     ${(summary.http_req_failed_rate * 100).toFixed(2)}%`
+  );
+  lines.push(`  Latency:`);
+  lines.push(
+    `    p50=${summary.http_req_duration.med.toFixed(0)}ms  ` +
+      `p95=${summary.http_req_duration.p95.toFixed(0)}ms  ` +
+      `p99=${summary.http_req_duration.p99.toFixed(0)}ms  ` +
+      `max=${summary.http_req_duration.max.toFixed(0)}ms`
+  );
+  if (Object.keys(summary.custom_metrics).length > 0) {
+    lines.push(`  Custom metrics:`);
+    for (const [name, values] of Object.entries(summary.custom_metrics)) {
+      lines.push(`    ${name}: ${JSON.stringify(values)}`);
+    }
+  }
+  lines.push("═══════════════════════════════════════════════════");
+  lines.push("");
+  return lines.join("\n");
+}

--- a/testplanit/load-tests/capacity/run-capacity-tests.sh
+++ b/testplanit/load-tests/capacity/run-capacity-tests.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Capacity test runner.
+#
+# Usage:
+#   ./run-capacity-tests.sh [TIER] [TEST...]
+#
+#   TIER:  small | medium | large   (default: medium)
+#   TEST:  one or more test file names to run (default: all)
+#          use "all" to run everything
+#
+# Examples:
+#   ./run-capacity-tests.sh small all
+#   ./run-capacity-tests.sh medium 01-concurrent-users 02-import-rate
+#   ./run-capacity-tests.sh large 06-search-at-scale
+#
+# Environment:
+#   BASE_URL   - TestPlanIt URL (required)
+#   API_TOKEN  - Bearer token for authentication (required)
+#   PROJECT_ID - Project ID for single-project tests (default: 1)
+#   INFLUX_URL - InfluxDB endpoint (default: http://localhost:8086/k6)
+#
+# After all tests complete, runs the report generator to produce a
+# consolidated markdown report.
+#
+
+set -euo pipefail
+
+TIER="${1:-medium}"
+shift || true
+
+if [ $# -eq 0 ] || [ "${1:-}" = "all" ]; then
+  TESTS=(
+    01-concurrent-users
+    02-import-rate
+    03-result-ingestion-rate
+    04-report-generation
+    05-run-creation
+    06-search-at-scale
+    07-audit-log-throughput
+    08-concurrent-runs
+  )
+else
+  TESTS=("$@")
+fi
+
+if [ -z "${BASE_URL:-}" ] || [ -z "${API_TOKEN:-}" ]; then
+  echo "ERROR: BASE_URL and API_TOKEN must be set."
+  echo "  export BASE_URL=http://loadtest.testplanit.com"
+  echo "  export API_TOKEN=tpi_..."
+  exit 1
+fi
+
+PROJECT_ID="${PROJECT_ID:-1}"
+INFLUX_URL="${INFLUX_URL:-http://localhost:8086/k6}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."  # run from load-tests/ so relative paths work
+
+START_TIME=$(date +%s)
+START_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RUN_ID="$(date -u +"%Y%m%d-%H%M%S")-${TIER}"
+
+echo "╔══════════════════════════════════════════════════╗"
+echo "║  TestPlanIt Capacity Test Suite                  ║"
+echo "╠══════════════════════════════════════════════════╣"
+echo "║  Run ID:   $RUN_ID"
+echo "║  Tier:     $TIER"
+echo "║  Tests:    ${#TESTS[@]} — ${TESTS[*]}"
+echo "║  BASE_URL: $BASE_URL"
+echo "║  InfluxDB: $INFLUX_URL"
+echo "║  Started:  $START_ISO"
+echo "╚══════════════════════════════════════════════════╝"
+echo ""
+
+FAILED_TESTS=()
+SUCCEEDED_TESTS=()
+
+for test in "${TESTS[@]}"; do
+  echo ""
+  echo "▶ Running: $test"
+  echo "─────────────────────────────────────────"
+
+  TEST_START=$(date +%s)
+  if k6 run \
+    --env "BASE_URL=$BASE_URL" \
+    --env "API_TOKEN=$API_TOKEN" \
+    --env "PROJECT_ID=$PROJECT_ID" \
+    --env "TIER=$TIER" \
+    --out "influxdb=$INFLUX_URL" \
+    "capacity/${test}.js"; then
+    SUCCEEDED_TESTS+=("$test")
+    echo "✓ $test completed in $(($(date +%s) - TEST_START))s"
+  else
+    FAILED_TESTS+=("$test")
+    echo "✗ $test FAILED (exit $?)"
+  fi
+
+  # Brief gap between tests — let the system settle
+  echo "  [cooldown 15s]"
+  sleep 15
+done
+
+TOTAL_TIME=$(($(date +%s) - START_TIME))
+
+echo ""
+echo "╔══════════════════════════════════════════════════╗"
+echo "║  Capacity Test Suite Complete                    ║"
+echo "╠══════════════════════════════════════════════════╣"
+echo "║  Duration:   $(($TOTAL_TIME / 60))m $(($TOTAL_TIME % 60))s"
+echo "║  Succeeded:  ${#SUCCEEDED_TESTS[@]}/${#TESTS[@]}"
+if [ ${#FAILED_TESTS[@]} -gt 0 ]; then
+  echo "║  Failed:     ${FAILED_TESTS[*]}"
+fi
+echo "╚══════════════════════════════════════════════════╝"
+echo ""
+
+# Generate the report
+if command -v node >/dev/null 2>&1; then
+  echo "Generating capacity report..."
+  node "$SCRIPT_DIR/generate-report.js" "$RUN_ID" "$TIER"
+  echo "Report written to: capacity/results/${RUN_ID}-report.md"
+else
+  echo "⚠  node not available — skipping report generation"
+  echo "   To generate later: node capacity/generate-report.js $RUN_ID $TIER"
+fi

--- a/testplanit/load-tests/capacity/seed-tier.js
+++ b/testplanit/load-tests/capacity/seed-tier.js
@@ -1,0 +1,193 @@
+/**
+ * Tiered data seeding for capacity tests.
+ *
+ * Run with TIER=small|medium|large to populate the database with
+ * realistic volumes appropriate for that test tier.
+ *
+ *   small:  5 projects,  500 cases/proj,  20 runs/proj  (~  2500 cases,   100 runs)
+ *   medium: 20 projects, 2000 cases/proj, 50 runs/proj  (~ 40000 cases,  1000 runs)
+ *   large:  50 projects, 10000 cases/proj, 100 runs/proj (~500000 cases, 5000 runs)
+ *
+ * Each run contains 20-50 cases with mixed pass/fail results.
+ *
+ * Run: k6 run --env BASE_URL=... --env API_TOKEN=... --env TIER=medium capacity/seed-tier.js
+ */
+
+import { sleep } from "k6";
+import { create, findMany } from "../helpers/api.js";
+import { projectName, folderName, testCaseName } from "../helpers/data.js";
+
+const TIERS = {
+  small: { projects: 5, casesPerProject: 500, foldersPerProject: 10, runsPerProject: 20 },
+  medium: { projects: 20, casesPerProject: 2000, foldersPerProject: 30, runsPerProject: 50 },
+  large: { projects: 50, casesPerProject: 10000, foldersPerProject: 50, runsPerProject: 100 },
+};
+
+const TIER = __ENV.TIER || "medium";
+const config = TIERS[TIER];
+if (!config) {
+  throw new Error(`Unknown TIER: ${TIER}. Valid: ${Object.keys(TIERS).join(", ")}`);
+}
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  duration: undefined,
+  thresholds: {},
+};
+
+export default function () {
+  console.log(`\n=== Seeding capacity tier: ${TIER} ===`);
+  console.log(`  Projects: ${config.projects}`);
+  console.log(`  Cases/project: ${config.casesPerProject}`);
+  console.log(`  Runs/project: ${config.runsPerProject}`);
+  console.log(`  Target total: ${config.projects * config.casesPerProject} cases`);
+  console.log("");
+
+  // Look up the admin user (needed for project creator)
+  const adminEmail = __ENV.ADMIN_EMAIL || "admin@loadtest.testplanit.com";
+  const adminUsers = findMany("user", {
+    where: { email: adminEmail, access: "ADMIN" },
+    select: { id: true },
+    take: 1,
+  });
+  const adminUserId = adminUsers?.data?.[0]?.id;
+  if (!adminUserId) {
+    throw new Error(`Could not find admin user with email ${adminEmail}`);
+  }
+  console.log(`  Admin user: ${adminUserId}`);
+
+  // Look up lookup data once (same for every project)
+  const templates = findMany("templates", { where: { isDefault: true }, select: { id: true }, take: 1 });
+  const caseWorkflows = findMany("workflows", {
+    where: { isDeleted: false, isDefault: true, scope: "CASES" },
+    select: { id: true },
+    take: 1,
+  });
+  const runWorkflows = findMany("workflows", {
+    where: { isDeleted: false, isDefault: true, scope: "RUNS" },
+    select: { id: true },
+    take: 1,
+  });
+  const statuses = findMany("status", {
+    where: { isDeleted: false, isEnabled: true },
+    select: { id: true, isSuccess: true, isFailure: true },
+  });
+
+  const templateId = templates?.data?.[0]?.id;
+  const caseStateId = caseWorkflows?.data?.[0]?.id;
+  const runStateId = runWorkflows?.data?.[0]?.id;
+  const defaultStatus = statuses?.data?.find((s) => !s.isSuccess && !s.isFailure) || statuses?.data?.[0];
+  const passedStatus = statuses?.data?.find((s) => s.isSuccess) || defaultStatus;
+  const failedStatus = statuses?.data?.find((s) => s.isFailure) || defaultStatus;
+
+  if (!templateId || !caseStateId || !runStateId || !defaultStatus) {
+    throw new Error("Missing core seed data (template/workflow/status)");
+  }
+
+  for (let p = 0; p < config.projects; p++) {
+    const projectNum = p + 1;
+    console.log(`\n--- Project ${projectNum}/${config.projects} ---`);
+
+    // Create project
+    const project = create("projects", {
+      name: `${projectName()} [${TIER}]`,
+      isDeleted: false,
+      creator: { connect: { id: adminUserId } },
+    });
+    const projectId = project?.data?.id;
+    if (!projectId) {
+      console.error(`  Failed to create project ${projectNum}`);
+      continue;
+    }
+
+    // Create the default repository for this project explicitly
+    const repo = create("repositories", {
+      isActive: true,
+      isArchived: false,
+      isDeleted: false,
+      project: { connect: { id: projectId } },
+    });
+    const repoId = repo?.data?.id;
+    if (!repoId) {
+      console.warn(`  Failed to create repo for project ${projectId}, skipping`);
+      continue;
+    }
+
+    // Create folders
+    const folderIds = [];
+    for (let f = 0; f < config.foldersPerProject; f++) {
+      const folder = create("repositoryFolders", {
+        name: folderName(),
+        order: f + 1,
+        project: { connect: { id: projectId } },
+        repository: { connect: { id: repoId } },
+        isDeleted: false,
+      });
+      if (folder?.data?.id) folderIds.push(folder.data.id);
+    }
+    console.log(`  Folders: ${folderIds.length}`);
+
+    // Create test cases (in batches of 100 with small pauses to avoid saturating)
+    const caseIds = [];
+    for (let c = 0; c < config.casesPerProject; c++) {
+      const folderId = folderIds[Math.floor(Math.random() * folderIds.length)];
+      const tc = create("repositoryCases", {
+        name: testCaseName(),
+        automated: Math.random() < 0.3,
+        isDeleted: false,
+        project: { connect: { id: projectId } },
+        folder: { connect: { id: folderId } },
+        repository: { connect: { id: repoId } },
+        template: { connect: { id: templateId } },
+        state: { connect: { id: caseStateId } },
+      });
+      if (tc?.data?.id) caseIds.push(tc.data.id);
+
+      if ((c + 1) % 100 === 0) {
+        console.log(`  Cases: ${c + 1}/${config.casesPerProject}`);
+        sleep(0.05);
+      }
+    }
+    console.log(`  Cases created: ${caseIds.length}`);
+
+    // Create historical test runs
+    for (let r = 0; r < config.runsPerProject; r++) {
+      const tr = create("testRuns", {
+        name: `Seed Run ${r + 1}`,
+        isCompleted: true,
+        isDeleted: false,
+        testRunType: "REGULAR",
+        completedAt: new Date(
+          Date.now() - (config.runsPerProject - r) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+        project: { connect: { id: projectId } },
+        state: { connect: { id: runStateId } },
+      });
+      const runId = tr?.data?.id;
+      if (!runId) continue;
+
+      // 20-50 cases per run
+      const runSize = 20 + Math.floor(Math.random() * 31);
+      const shuffled = [...caseIds].sort(() => Math.random() - 0.5).slice(0, runSize);
+
+      for (let i = 0; i < shuffled.length; i++) {
+        const rand = Math.random();
+        const statusId =
+          rand < 0.7 ? passedStatus.id : rand < 0.9 ? failedStatus.id : defaultStatus.id;
+
+        create("testRunCases", {
+          order: i + 1,
+          isCompleted: rand < 0.9,
+          testRun: { connect: { id: runId } },
+          repositoryCase: { connect: { id: shuffled[i] } },
+          status: { connect: { id: statusId } },
+        });
+        if ((i + 1) % 20 === 0) sleep(0.05);
+      }
+    }
+    console.log(`  Runs: ${config.runsPerProject}`);
+  }
+
+  console.log(`\n=== Tier "${TIER}" seeding complete ===`);
+}

--- a/testplanit/load-tests/capacity/thresholds.json
+++ b/testplanit/load-tests/capacity/thresholds.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Pass/fail criteria for capacity tests. Each test asserts against these to derive a PASS/FAIL verdict.",
+  "latency_p95_ms": {
+    "browse": 1000,
+    "crud": 2000,
+    "search": 1000,
+    "reporting": 5000,
+    "test_run": 2000,
+    "cicd": 3000,
+    "login": 2000
+  },
+  "error_rate_max": 0.01,
+  "container_cpu_percent_max": 80,
+  "container_mem_percent_max": 85,
+  "_notes": [
+    "latency_p95_ms: 95th percentile response time budget per scenario tag",
+    "error_rate_max: fraction (0.01 = 1%) of failed HTTP requests",
+    "container_cpu_percent_max: sustained average CPU over a 60s window",
+    "container_mem_percent_max: memory usage as percentage of limit"
+  ]
+}

--- a/testplanit/load-tests/mixed-workload.js
+++ b/testplanit/load-tests/mixed-workload.js
@@ -306,11 +306,10 @@ function reportingScenario() {
   const { res: execRes } = postApi(
     "/api/report-builder/test-execution",
     {
+      reportType: "test-execution",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: ["status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -319,22 +318,12 @@ function reportingScenario() {
   sleep(0.5);
 
   // Cross-project report
-  const projects = findMany(
-    "projects",
-    { where: { isDeleted: false }, select: { id: true }, take: 20 },
-    { scenarioTag: TAG }
-  );
-
-  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
-
   const { res: crossRes } = postApi(
     "/api/report-builder/cross-project-test-execution",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-execution",
+      dimensions: ["project"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );

--- a/testplanit/load-tests/scenarios/03-test-lifecycle.js
+++ b/testplanit/load-tests/scenarios/03-test-lifecycle.js
@@ -187,7 +187,7 @@ export default function () {
     {
       where: { id: testRunId },
       include: {
-        testRunCases: {
+        testCases: {
           select: {
             id: true,
             status: { select: { id: true, name: true } },

--- a/testplanit/load-tests/scenarios/05-reporting.js
+++ b/testplanit/load-tests/scenarios/05-reporting.js
@@ -11,15 +11,14 @@
  * 3. Dashboard loading (multiple report calls in parallel)
  *
  * These are expected to be the slowest endpoints — cross-project
- * queries aggregate across all accessible projects with cartesian
- * dimension × metric products.
+ * queries aggregate across all accessible projects.
  *
  * Run:
  *   k6 run --env BASE_URL=http://... --env API_TOKEN=tpi_... scenarios/05-reporting.js
  */
 
 import { sleep, check } from "k6";
-import { postApi, findMany } from "../helpers/api.js";
+import { postApi } from "../helpers/api.js";
 import { getProfile, thresholds, PROJECT_ID } from "../config.js";
 
 const TAG = "reporting";
@@ -30,30 +29,14 @@ export const options = {
 };
 
 export default function () {
-  // 1. Get accessible projects for cross-project reports
-  const projects = findMany(
-    "projects",
-    {
-      where: { isDeleted: false },
-      select: { id: true },
-      take: 50,
-    },
-    { scenarioTag: TAG }
-  );
-
-  const projectIds = projects?.data?.map((p) => p.id) || [PROJECT_ID];
-
-  sleep(0.5);
-
-  // 2. Single-project: Test execution report
+  // 1. Single-project: Test execution report (status dimension, testResults metric)
   const { res: execRes } = postApi(
     "/api/report-builder/test-execution",
     {
+      reportType: "test-execution",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: ["status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -63,15 +46,14 @@ export default function () {
 
   sleep(0.5);
 
-  // 3. Single-project: Test case health
+  // 2. Single-project: Test case health (pre-built report, no dims/metrics required)
   const { res: healthRes } = postApi(
     "/api/report-builder/test-case-health",
     {
+      reportType: "test-case-health",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "template" }],
-      metrics: [{ id: "caseCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -81,18 +63,14 @@ export default function () {
 
   sleep(0.5);
 
-  // 4. Single-project: Automation trends
+  // 3. Single-project: Automation trends (pre-built)
   const { res: autoRes } = postApi(
     "/api/report-builder/automation-trends",
     {
+      reportType: "automation-trends",
       projectId: PROJECT_ID,
-      dimensions: [{ id: "month" }],
-      metrics: [
-        { id: "automatedCount", aggregation: "sum" },
-        { id: "manualCount", aggregation: "sum" },
-      ],
-      filters: {},
-      limit: 100,
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -102,15 +80,13 @@ export default function () {
 
   sleep(1);
 
-  // 5. Cross-project: Test execution across all projects (HEAVY)
+  // 4. Cross-project: Test execution (HEAVY — aggregates across projects)
   const { res: crossExecRes } = postApi(
     "/api/report-builder/cross-project-test-execution",
     {
-      projectIds,
-      dimensions: [{ id: "project" }, { id: "status" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-execution",
+      dimensions: ["project", "status"],
+      metrics: ["testResults"],
     },
     { scenarioTag: TAG }
   );
@@ -120,36 +96,29 @@ export default function () {
 
   sleep(0.5);
 
-  // 6. Cross-project: Repository stats (case counts, automation %)
-  const { res: crossRepoRes } = postApi(
-    "/api/report-builder/cross-project-repository-stats",
+  // 5. Cross-project: Test case health (pre-built)
+  const { res: crossHealthRes } = postApi(
+    "/api/report-builder/cross-project-test-case-health",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [
-        { id: "totalCases", aggregation: "sum" },
-        { id: "automatedPercentage", aggregation: "avg" },
-      ],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-test-case-health",
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
-  check(crossRepoRes, {
-    "cross-project repo stats 200": (r) => r.status === 200,
+  check(crossHealthRes, {
+    "cross-project health 200": (r) => r.status === 200,
   });
 
   sleep(0.5);
 
-  // 7. Cross-project: Flaky tests (complex join)
+  // 6. Cross-project: Flaky tests (pre-built)
   const { res: flakyRes } = postApi(
     "/api/report-builder/cross-project-flaky-tests",
     {
-      projectIds,
-      dimensions: [{ id: "project" }],
-      metrics: [{ id: "flakyCount", aggregation: "sum" }],
-      filters: {},
-      limit: 500,
+      reportType: "cross-project-flaky-tests",
+      dimensions: [],
+      metrics: [],
     },
     { scenarioTag: TAG }
   );
@@ -159,15 +128,13 @@ export default function () {
 
   sleep(0.5);
 
-  // 8. Cross-project: User engagement
+  // 7. Cross-project: User engagement (user dim, execution count metric)
   const { res: engageRes } = postApi(
     "/api/report-builder/cross-project-user-engagement",
     {
-      projectIds,
-      dimensions: [{ id: "user" }],
-      metrics: [{ id: "executionCount", aggregation: "sum" }],
-      filters: {},
-      limit: 100,
+      reportType: "cross-project-user-engagement",
+      dimensions: ["user"],
+      metrics: ["executionCount"],
     },
     { scenarioTag: TAG }
   );

--- a/testplanit/server/auth.ts
+++ b/testplanit/server/auth.ts
@@ -12,6 +12,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import EmailProvider from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 
+import { getCachedSessionUser, touchLastActive } from "~/lib/session-cache";
 import { auditAuthEvent } from "~/lib/services/auditLog";
 import { isEmailDomainAllowed } from "~/lib/utils/email-domain-validation";
 import { db } from "~/server/db";
@@ -307,49 +308,19 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           session.user.id = token.sub!;
           session.user.name = token.name as string | undefined;
 
-          // Fetch the user from the database to get the access level and preferences
-          const user = await db.user.findUnique({
-            where: { id: session.user.id },
-            select: {
-              name: true,
-              access: true,
-              image: true,
-              emailVerified: true,
-              authMethod: true,
-              userPreferences: true,
-              lastActiveAt: true,
-            },
-          });
-
+          const user = await getCachedSessionUser(session.user.id);
           if (user) {
             session.user.name = user.name || undefined;
             session.user.access = user.access || undefined;
             session.user.image = user.image || undefined;
-            session.user.emailVerified = user.emailVerified || undefined;
+            session.user.emailVerified = user.emailVerified
+              ? new Date(user.emailVerified)
+              : undefined;
             session.user.authMethod = user.authMethod || undefined;
+            session.user.preferences = user.preferences || undefined;
 
-            // Create default userPreferences if they don't exist
-            if (!user.userPreferences) {
-              const newPreferences = await db.userPreferences.create({
-                data: {
-                  userId: session.user.id,
-                },
-              });
-              session.user.preferences = newPreferences;
-            } else {
-              session.user.preferences = user.userPreferences;
-            }
-
-            // Update lastActiveAt only if it's been more than 5 minutes since the last update
-            const now = new Date();
-            const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
-
-            if (!user.lastActiveAt || user.lastActiveAt < fiveMinutesAgo) {
-              await db.user.update({
-                where: { id: session.user.id },
-                data: { lastActiveAt: now },
-              });
-            }
+            // Throttled lastActiveAt update (fire-and-forget).
+            void touchLastActive(session.user.id, user);
           }
         }
         return session;
@@ -594,47 +565,18 @@ export const authOptions: NextAuthOptions = {
         session.user.id = token.sub!;
         session.user.name = token.name as string | undefined;
 
-        // Fetch the user from the database to get the access level and preferences
-        const user = await db.user.findUnique({
-          where: { id: session.user.id },
-          select: {
-            access: true,
-            image: true,
-            emailVerified: true,
-            authMethod: true,
-            userPreferences: true,
-            lastActiveAt: true,
-          },
-        });
-
+        const user = await getCachedSessionUser(session.user.id);
         if (user) {
           session.user.access = user.access || undefined;
           session.user.image = user.image || undefined;
-          session.user.emailVerified = user.emailVerified || undefined;
+          session.user.emailVerified = user.emailVerified
+            ? new Date(user.emailVerified)
+            : undefined;
           session.user.authMethod = user.authMethod || undefined;
+          session.user.preferences = user.preferences || undefined;
 
-          // Create default userPreferences if they don't exist
-          if (!user.userPreferences) {
-            const newPreferences = await db.userPreferences.create({
-              data: {
-                userId: session.user.id,
-              },
-            });
-            session.user.preferences = newPreferences;
-          } else {
-            session.user.preferences = user.userPreferences;
-          }
-
-          // Update lastActiveAt only if it's been more than 5 minutes since the last update
-          const now = new Date();
-          const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
-
-          if (!user.lastActiveAt || user.lastActiveAt < fiveMinutesAgo) {
-            await db.user.update({
-              where: { id: session.user.id },
-              data: { lastActiveAt: now },
-            });
-          }
+          // Throttled lastActiveAt update (fire-and-forget).
+          void touchLastActive(session.user.id, user);
         }
       }
       return session;

--- a/testplanit/utils/automationTrendsUtils.ts
+++ b/testplanit/utils/automationTrendsUtils.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 interface PeriodData {
@@ -72,7 +73,11 @@ export async function handleAutomationTrendsPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/flakyTestsUtils.ts
+++ b/testplanit/utils/flakyTestsUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 interface ExecutionStatus {
@@ -104,7 +105,11 @@ export async function handleFlakyTestsPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/issueTestCoverageUtils.ts
+++ b/testplanit/utils/issueTestCoverageUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 // Flat row structure for grouping-based approach
@@ -96,7 +97,11 @@ export async function handleIssueTestCoveragePOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }

--- a/testplanit/utils/testCaseHealthUtils.ts
+++ b/testplanit/utils/testCaseHealthUtils.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
 
 export type HealthStatus =
@@ -148,7 +149,11 @@ export async function handleTestCaseHealthPOST(
     // Check admin access for cross-project
     if (isCrossProject) {
       const session = await getServerSession(authOptions);
-      if (!session || session.user.access !== "ADMIN") {
+      const auth = await authenticateRequest(req, session);
+      if (!auth.authenticated) {
+        return Response.json({ error: auth.error }, { status: auth.status });
+      }
+      if (auth.user.access !== "ADMIN") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
     }


### PR DESCRIPTION
## Summary

- **Report endpoints accept Bearer tokens.** `handle{AutomationTrends,FlakyTests,TestCaseHealth,IssueTestCoverage}POST` now fall back to `authenticateRequest()` alongside the existing `getServerSession()` check, closing a gap where cross-project reports rejected valid API tokens.
- **API token cache invalidates immediately on revoke.** Extracted the Valkey cache helpers into `lib/api-token-cache.ts` and wired `invalidateApiTokenCache()` into the Prisma `apiToken` `update` / `delete` / `updateMany` / `deleteMany` extensions. A revoked or deleted token is now rejected on the next request instead of the next ~30 seconds.
- **Session-user cache.** `server/auth.ts` now uses `getCachedSessionUser()` and `touchLastActive()` from the new `lib/session-cache.ts` module, eliminating a per-request `user.findUnique` on every session check.
- **Access manifest + create fast-path.** `lib/access-manifest.ts` precomputes per-user project access; `lib/access-fast-path.ts` uses it to short-circuit selected create operations (see file header for the whitelist) without going through ZenStack policy evaluation. Wired into the central `/api/model/[...path]` router.
- **`DISABLE_API_RATE_LIMIT` env var.** `lib/api-rate-limit.ts` now honors a short-circuit flag used exclusively for isolated load-test stacks.
- **Capacity test suite** under `testplanit/load-tests/capacity/` — 8 k6 scenarios (concurrent users, import rate, result ingestion, report generation, run creation, search, audit throughput, concurrent runs), a tier seeder, runner shell script, and JSON report generator. Results and generated charts are `.gitignore`d; reference sizing data lives outside the repo.
- **Docs updates.** `api-reference.md` now documents the global hourly rate-limit tiers and response headers; `api-tokens.md` clarifies that token-authenticated requests are subject to the same limits.
- **E2E coverage.** Two new tests in `e2e/tests/auth/api-tokens.spec.ts`:
  - AUTH-08-8: admin Bearer token authenticates all 4 cross-project report endpoints.
  - AUTH-08-9: non-admin Bearer token is rejected (401) from a cross-project endpoint.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm vitest run lib/api-token-auth.test.ts` — 25/25
- [x] `pnpm vitest run app/api/api-tokens/route.test.ts` — 17/17
- [x] `E2E_PROD=on pnpm test:e2e e2e/tests/auth/api-tokens.spec.ts` — 10/10 (includes AUTH-08-3 which was failing before the cache-invalidation fix, plus the two new tests AUTH-08-8/9)
- [x] CI runs the full test suite

## Notes for reviewers

- The `dist/scheduler.js` and `dist/workers/syncWorker.js` diffs are regenerated build artifacts, not source changes.
- `lib/api-token-auth.ts` re-exports `invalidateApiTokenCache` so external callers of the old import path keep working.
- Capacity test outputs (`load-tests/capacity/results/*`, `load-tests/capacity/charts/*.png`) are gitignored. The `results/.gitkeep` preserves the directory that `run-capacity-tests.sh` writes into.