### PR TITLE
fix(encryption): Harden encryption: AES-256-GCM for 2FA secrets, mandatory ENCRYPTION_KEY in production

### DIFF
--- a/testplanit/instrumentation.ts
+++ b/testplanit/instrumentation.ts
@@ -1,0 +1,25 @@
+/**
+ * Next.js server instrumentation hook. Runs once when the server starts
+ * (nodejs runtime only, not edge), before any request is served.
+ *
+ * Use this to fail fast on missing security-critical configuration. A
+ * production deployment without ENCRYPTION_KEY would silently fall back
+ * to a built-in default key and effectively publish every encrypted
+ * secret in the database — better to refuse to start than to run insecure.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const { assertEncryptionConfigured } = await import("~/utils/encryption");
+  try {
+    assertEncryptionConfigured();
+    // Intentionally terse — never log the key itself.
+    console.info("[startup] ENCRYPTION_KEY configured ✓");
+  } catch (error) {
+    // Re-throw so the server process exits instead of accepting traffic.
+    // The deploy platform's health check will see the failure and hold
+    // the rollout.
+    console.error("[startup] encryption misconfiguration:", error);
+    throw error;
+  }
+}

--- a/testplanit/lib/two-factor.test.ts
+++ b/testplanit/lib/two-factor.test.ts
@@ -2,6 +2,7 @@ import { generate, generateSecret } from "otplib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   decryptSecret, encryptSecret, generateBackupCodes, generateQRCodeDataURL, generateTOTPSecret, hashBackupCode,
+  isLegacyEncryption,
   verifyBackupCode, verifyTOTP
 } from "./two-factor";
 
@@ -15,7 +16,10 @@ vi.mock("qrcode", () => ({
 describe("Two-Factor Authentication", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set encryption key for tests
+    // Encryption keys for tests. ENCRYPTION_KEY powers the v2 (AES) path used
+    // by new writes; TWO_FACTOR_ENCRYPTION_KEY is kept only so the legacy v1
+    // (XOR) decrypt path is exercisable by the backward-compat test below.
+    vi.stubEnv("ENCRYPTION_KEY", "test-encryption-key-for-aes-gcm-path!!");
     vi.stubEnv("TWO_FACTOR_ENCRYPTION_KEY", "test-encryption-key-32-chars!!");
     vi.stubEnv("NEXTAUTH_SECRET", "fallback-secret-key");
   });
@@ -256,40 +260,38 @@ describe("Two-Factor Authentication", () => {
   });
 
   describe("encryptSecret", () => {
-    it("should encrypt secret with version prefix", () => {
+    it("should encrypt secret with v2 version prefix (AES-256-GCM)", () => {
       const secret = "TESTSECRET123456";
 
       const encrypted = encryptSecret(secret);
 
-      expect(encrypted).toMatch(/^v1:/);
+      expect(encrypted).toMatch(/^v2:/);
     });
 
     it("should produce base64 encoded output", () => {
       const secret = "TESTSECRET";
 
       const encrypted = encryptSecret(secret);
-      const base64Part = encrypted.replace(/^v1:/, "");
+      const base64Part = encrypted.replace(/^v2:/, "");
 
       expect(() => Buffer.from(base64Part, "base64")).not.toThrow();
     });
 
-    it("should throw error when encryption key not configured", () => {
+    it("should throw when ENCRYPTION_KEY not configured in production", () => {
       vi.unstubAllEnvs();
-      vi.stubEnv("TWO_FACTOR_ENCRYPTION_KEY", "");
-      vi.stubEnv("NEXTAUTH_SECRET", "");
+      vi.stubEnv("NODE_ENV", "production");
 
-      expect(() => encryptSecret("secret")).toThrow(
-        "Encryption key not configured"
-      );
+      expect(() => encryptSecret("secret")).toThrow(/ENCRYPTION_KEY/);
     });
 
-    it("should use NEXTAUTH_SECRET as fallback", () => {
+    it("should use the default dev key when ENCRYPTION_KEY is unset in non-production", () => {
       vi.unstubAllEnvs();
-      vi.stubEnv("TWO_FACTOR_ENCRYPTION_KEY", "");
-      vi.stubEnv("NEXTAUTH_SECRET", "fallback-key");
+      vi.stubEnv("NODE_ENV", "test");
+      // Silence the expected dev-mode warning
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      // Should not throw
       expect(() => encryptSecret("secret")).not.toThrow();
+      warn.mockRestore();
     });
 
     it("should produce different output for different secrets", () => {
@@ -299,13 +301,15 @@ describe("Two-Factor Authentication", () => {
       expect(encrypted1).not.toBe(encrypted2);
     });
 
-    it("should produce consistent output for same secret", () => {
+    it("should produce non-deterministic output for the same secret (random salt/iv)", () => {
+      // AES-GCM with a fresh salt + IV per call must never repeat ciphertext;
+      // deterministic output would be a subtle regression to a weaker scheme.
       const secret = "CONSISTENTSECRET";
 
       const encrypted1 = encryptSecret(secret);
       const encrypted2 = encryptSecret(secret);
 
-      expect(encrypted1).toBe(encrypted2);
+      expect(encrypted1).not.toBe(encrypted2);
     });
   });
 
@@ -323,20 +327,45 @@ describe("Two-Factor Authentication", () => {
       const originalSecret = "SECRETWITHPREFIX";
 
       const encrypted = encryptSecret(originalSecret);
-      expect(encrypted).toMatch(/^v1:/);
+      expect(encrypted).toMatch(/^v2:/);
 
       const decrypted = decryptSecret(encrypted);
       expect(decrypted).toBe(originalSecret);
     });
 
-    it("should throw error when encryption key not configured", () => {
+    it("should throw when v2 record is present but ENCRYPTION_KEY missing in production", () => {
+      // Encrypt while config is good, then tear down prod config and attempt decrypt.
+      const encrypted = encryptSecret("PRODSECRET");
       vi.unstubAllEnvs();
-      vi.stubEnv("TWO_FACTOR_ENCRYPTION_KEY", "");
-      vi.stubEnv("NEXTAUTH_SECRET", "");
+      vi.stubEnv("NODE_ENV", "production");
 
-      expect(() => decryptSecret("v1:encrypted")).toThrow(
-        "Encryption key not configured"
+      expect(() => decryptSecret(encrypted)).toThrow(/ENCRYPTION_KEY/);
+    });
+
+    it("should reject unknown version prefixes", () => {
+      expect(() => decryptSecret("v99:garbage")).toThrow(
+        /version prefix/
       );
+      expect(() => decryptSecret("no-prefix-at-all")).toThrow(
+        /version prefix/
+      );
+    });
+
+    it("should decrypt legacy v1 (XOR) records for backward compatibility", () => {
+      // Construct a v1 record the same way the legacy implementation did, so
+      // we prove the migration window works for existing production data.
+      const secret = "LEGACYSECRET";
+      const legacyKey = "test-encryption-key-32-chars!!"; // matches TWO_FACTOR_ENCRYPTION_KEY above
+      const secretBuffer = Buffer.from(secret);
+      const keyBuffer = Buffer.from(legacyKey);
+      const encrypted = Buffer.alloc(secretBuffer.length);
+      for (let i = 0; i < secretBuffer.length; i++) {
+        encrypted[i] = secretBuffer[i] ^ keyBuffer[i % keyBuffer.length];
+      }
+      const v1Record = `v1:${encrypted.toString("base64")}`;
+
+      expect(isLegacyEncryption(v1Record)).toBe(true);
+      expect(decryptSecret(v1Record)).toBe(secret);
     });
 
     it("should decrypt with same key used for encryption", () => {
@@ -376,6 +405,18 @@ describe("Two-Factor Authentication", () => {
     });
   });
 
+  describe("isLegacyEncryption", () => {
+    it("returns true for v1 prefix", () => {
+      expect(isLegacyEncryption("v1:anything")).toBe(true);
+    });
+    it("returns false for v2 prefix", () => {
+      expect(isLegacyEncryption("v2:anything")).toBe(false);
+    });
+    it("returns false for unprefixed input", () => {
+      expect(isLegacyEncryption("raw")).toBe(false);
+    });
+  });
+
   describe("Integration", () => {
     it("should complete full 2FA setup and verification flow", async () => {
       // 1. Generate secret
@@ -388,7 +429,7 @@ describe("Two-Factor Authentication", () => {
 
       // 3. Encrypt secret for storage
       const encryptedSecret = encryptSecret(secret);
-      expect(encryptedSecret).toMatch(/^v1:/);
+      expect(encryptedSecret).toMatch(/^v2:/);
 
       // 4. Decrypt secret for verification
       const decryptedSecret = decryptSecret(encryptedSecret);

--- a/testplanit/lib/two-factor.ts
+++ b/testplanit/lib/two-factor.ts
@@ -1,8 +1,26 @@
 import { createHash, randomBytes } from "crypto";
 import { generateSecret, generateURI, verify } from "otplib";
 import QRCode from "qrcode";
+import { EncryptionService, getMasterKey } from "~/utils/encryption";
 
 const APP_NAME = "TestPlanIt";
+
+// Version prefixes for encrypted 2FA secrets stored in the DB:
+//   v1: legacy XOR + repeating key (insecure — decrypt-only for migration)
+//   v2: AES-256-GCM via EncryptionService, using ENCRYPTION_KEY
+const LEGACY_PREFIX = "v1:";
+const CURRENT_PREFIX = "v2:";
+
+// The legacy XOR path used its own env var. Keep the resolution logic for
+// backward-compatible decryption of existing v1 records; new writes always
+// use the shared ENCRYPTION_KEY via getMasterKey().
+function getLegacyKey(): string {
+  const key = process.env.TWO_FACTOR_ENCRYPTION_KEY || process.env.NEXTAUTH_SECRET || "";
+  if (!key) {
+    throw new Error("Encryption key not configured");
+  }
+  return key;
+}
 
 // Configuration options for TOTP
 const TOTP_OPTIONS = {
@@ -88,48 +106,54 @@ export function verifyBackupCode(
 }
 
 /**
- * Encrypt a secret for database storage
- * In production, use a proper encryption library like node-forge or crypto
+ * Encrypt a TOTP secret for database storage using AES-256-GCM.
+ * Writes `v2:` prefixed ciphertext. Legacy `v1:` (XOR) records remain
+ * decryptable via decryptSecret for backward compatibility.
  */
 export function encryptSecret(secret: string): string {
-  // For simplicity, we're using base64 encoding with a prefix
-  // In production, use proper AES encryption with a key from env
-  const key = process.env.TWO_FACTOR_ENCRYPTION_KEY || process.env.NEXTAUTH_SECRET || "";
-  if (!key) {
-    throw new Error("Encryption key not configured");
-  }
-
-  // Simple XOR encryption with the key (for demo purposes)
-  // In production, use crypto.createCipheriv with AES-256-GCM
-  const keyBuffer = Buffer.from(key);
-  const secretBuffer = Buffer.from(secret);
-  const encrypted = Buffer.alloc(secretBuffer.length);
-
-  for (let i = 0; i < secretBuffer.length; i++) {
-    encrypted[i] = secretBuffer[i] ^ keyBuffer[i % keyBuffer.length];
-  }
-
-  return `v1:${encrypted.toString("base64")}`;
+  const ciphertext = EncryptionService.encrypt(secret, getMasterKey());
+  return `${CURRENT_PREFIX}${ciphertext}`;
 }
 
 /**
- * Decrypt a secret from database storage
+ * Decrypt a TOTP secret from database storage. Transparently handles both
+ * the current AES-256-GCM format (`v2:` prefix) and the legacy XOR format
+ * (`v1:` prefix) so existing enrollments keep working during the migration
+ * window. Check `isLegacyEncryption(s)` after decrypt and re-persist via
+ * encryptSecret to upgrade a record in place.
  */
 export function decryptSecret(encryptedSecret: string): string {
-  const key = process.env.TWO_FACTOR_ENCRYPTION_KEY || process.env.NEXTAUTH_SECRET || "";
-  if (!key) {
-    throw new Error("Encryption key not configured");
+  if (encryptedSecret.startsWith(CURRENT_PREFIX)) {
+    const payload = encryptedSecret.slice(CURRENT_PREFIX.length);
+    return EncryptionService.decrypt(payload, getMasterKey());
   }
 
-  // Remove version prefix
-  const data = encryptedSecret.replace(/^v1:/, "");
+  if (encryptedSecret.startsWith(LEGACY_PREFIX)) {
+    return decryptLegacyV1(encryptedSecret);
+  }
+
+  throw new Error("Unknown or missing encrypted-secret version prefix");
+}
+
+/**
+ * True if the stored secret is still in the legacy XOR format and should
+ * be re-encrypted with AES-256-GCM on the next convenient write.
+ */
+export function isLegacyEncryption(encryptedSecret: string): boolean {
+  return encryptedSecret.startsWith(LEGACY_PREFIX);
+}
+
+// Legacy XOR decryption path. Retained only so existing `v1:` records keep
+// working until they're re-encrypted as `v2:` on next read. Do not add new
+// callers — new writes go through encryptSecret (AES-256-GCM).
+function decryptLegacyV1(encryptedSecret: string): string {
+  const key = getLegacyKey();
+  const data = encryptedSecret.slice(LEGACY_PREFIX.length);
   const encryptedBuffer = Buffer.from(data, "base64");
   const keyBuffer = Buffer.from(key);
   const decrypted = Buffer.alloc(encryptedBuffer.length);
-
   for (let i = 0; i < encryptedBuffer.length; i++) {
     decrypted[i] = encryptedBuffer[i] ^ keyBuffer[i % keyBuffer.length];
   }
-
   return decrypted.toString();
 }

--- a/testplanit/server/auth.ts
+++ b/testplanit/server/auth.ts
@@ -800,8 +800,24 @@ function authorize(prisma: PrismaClient) {
         }
 
         // Verify TOTP token - dynamic import to avoid circular deps
-        const { verifyTOTP, decryptSecret, verifyBackupCode } = await import("~/lib/two-factor");
+        const { verifyTOTP, decryptSecret, encryptSecret, isLegacyEncryption, verifyBackupCode } =
+          await import("~/lib/two-factor");
         const secret = decryptSecret(user.twoFactorSecret);
+
+        // Opportunistically upgrade legacy (v1 / XOR) records to v2 / AES-256-GCM
+        // on the login path. Best-effort: a failure here must not block login.
+        if (isLegacyEncryption(user.twoFactorSecret)) {
+          try {
+            const upgraded = encryptSecret(secret);
+            await prisma.user.update({
+              where: { id: user.id },
+              data: { twoFactorSecret: upgraded },
+            });
+          } catch (err) {
+            console.error("Failed to upgrade legacy 2FA secret for user", user.id, err);
+          }
+        }
+
         let verified = await verifyTOTP(credentials.twoFactorToken, secret);
 
         // Try backup code if TOTP failed

--- a/testplanit/utils/encryption.test.ts
+++ b/testplanit/utils/encryption.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  assertEncryptionConfigured,
   decrypt, encrypt, EncryptionService, getMasterKey, isEncrypted
 } from "./encryption";
 
@@ -18,19 +19,61 @@ afterEach(() => {
 describe("getMasterKey", () => {
   it("should return the ENCRYPTION_KEY when set", () => {
     process.env.ENCRYPTION_KEY = "my-secure-encryption-key";
-    // Need to re-import to get fresh module
     expect(getMasterKey()).toBe("my-secure-encryption-key");
   });
 
-  it("should return default development key when ENCRYPTION_KEY is not set", () => {
+  it("should return default development key (with warning) when unset in non-production", () => {
     delete process.env.ENCRYPTION_KEY;
+    vi.stubEnv("NODE_ENV", "test");
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     const key = getMasterKey();
+
     expect(key).toBe("development-key-do-not-use-in-production-please!");
     expect(consoleSpy).toHaveBeenCalledWith(
       "ENCRYPTION_KEY not set, using default key for development"
     );
     consoleSpy.mockRestore();
+  });
+
+  it("should throw in production when ENCRYPTION_KEY is not set", () => {
+    delete process.env.ENCRYPTION_KEY;
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(() => getMasterKey()).toThrow(/ENCRYPTION_KEY/);
+  });
+
+  it("should return the configured ENCRYPTION_KEY in production when set", () => {
+    process.env.ENCRYPTION_KEY = "prod-key-abc";
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(getMasterKey()).toBe("prod-key-abc");
+  });
+});
+
+describe("assertEncryptionConfigured", () => {
+  it("returns the key when configured", () => {
+    process.env.ENCRYPTION_KEY = "configured-key";
+    expect(assertEncryptionConfigured()).toBe("configured-key");
+  });
+
+  it("throws in production when ENCRYPTION_KEY is missing", () => {
+    delete process.env.ENCRYPTION_KEY;
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(() => assertEncryptionConfigured()).toThrow(/ENCRYPTION_KEY/);
+  });
+
+  it("returns the dev fallback (with warning) in non-production when missing", () => {
+    delete process.env.ENCRYPTION_KEY;
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const key = assertEncryptionConfigured();
+
+    expect(key).toBe("development-key-do-not-use-in-production-please!");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/testplanit/utils/encryption.ts
+++ b/testplanit/utils/encryption.ts
@@ -7,15 +7,35 @@ const tagLength = 16;
 const iterations = 100000;
 const keyLength = 32;
 
-// Get encryption key from environment variable or generate a default one for development
+const DEV_FALLBACK_KEY = "development-key-do-not-use-in-production-please!";
+
+// Get encryption key from environment variable. In production, the key is
+// mandatory and missing config is a hard error — running with a known default
+// would leave every encrypted field (integration credentials, OAuth tokens,
+// LLM API keys, 2FA secrets) effectively plaintext to anyone with the source.
+// In dev/test we keep the convenient fallback with a warning.
 export const getMasterKey = (): string => {
   const key = process.env.ENCRYPTION_KEY;
-  if (!key) {
-    // In development, use a default key (DO NOT use in production)
-    console.warn("ENCRYPTION_KEY not set, using default key for development");
-    return "development-key-do-not-use-in-production-please!";
+  if (key) return key;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "ENCRYPTION_KEY is not set. Refusing to start — running with the " +
+        "built-in default key would expose every encrypted secret in the " +
+        "database. Configure ENCRYPTION_KEY as a long, random value before " +
+        "deploying to production."
+    );
   }
-  return key;
+  console.warn("ENCRYPTION_KEY not set, using default key for development");
+  return DEV_FALLBACK_KEY;
+};
+
+/**
+ * Startup probe — call during app boot to fail fast on misconfiguration
+ * rather than when the first encrypt/decrypt happens mid-request.
+ * Safe to call multiple times; returns the resolved key on success.
+ */
+export const assertEncryptionConfigured = (): string => {
+  return getMasterKey();
 };
 
 // Alias for backward compatibility


### PR DESCRIPTION
Closes #204.

## Summary

Two encryption-subsystem gaps from the security review, fixed together because they touch the same boot path:

- **2FA TOTP secrets now use AES-256-GCM** via the shared `EncryptionService` + `ENCRYPTION_KEY`. The previous XOR-with-repeating-key path (acknowledged as a placeholder in an in-file comment) was cryptographically broken against anyone with read access to the `User` table. The legacy `v1:` format is still decryptable for backward compatibility during migration; new writes are `v2:`.
- **Production refuses to start without `ENCRYPTION_KEY`.** `getMasterKey()` throws in production when the key is unset, instead of silently falling back to the built-in default and effectively publishing every encrypted secret in the DB. Non-production keeps the convenient dev fallback with a warning.
- **Startup probe** in `instrumentation.ts` calls `assertEncryptionConfigured()` on server boot so misconfiguration surfaces immediately, not on the first encrypt/decrypt mid-request.
- **Opportunistic write-back** in the 2FA login path (`server/auth.ts`): when a user's stored secret is still `v1:`, re-encrypt as `v2:` and persist. Best-effort — a failure doesn't block login.

## Pre-deploy migration (already completed in production)

Before this PR is deployed, every production tenant must have `ENCRYPTION_KEY` set — otherwise the startup probe crashes the container. This was done ahead of this PR:

- All 26 active production tenants now have a unique 64-char hex `ENCRYPTION_KEY` in their `.env.production` + k8s Secret.
- Encrypted rows that had been encrypted with the hardcoded default key (`Integration.credentials`, `LlmIntegration.credentials`, `CodeRepository.credentials`, `UserIntegrationAuth.accessToken/refreshToken`, `User.twoFactorSecret`) were cleared and affected integrations marked `INACTIVE`. Audit showed only 4 customer tenants (allego, ashwini, bhargavqa, rubenmariorossi) had any affected rows; zero 2FA enrollments and zero OAuth tokens across the fleet.
- The orphaned `bradfreetrial` DB (and its role) was dropped — it had no corresponding deployment.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 5,593/5,593 passing (full suite)
- [x] `pnpm vitest run lib/two-factor.test.ts utils/encryption.test.ts` — covers: AES round-trip, legacy `v1:` decrypt backward-compat, unknown-version rejection, non-determinism of AES output, production-mode startup failure when `ENCRYPTION_KEY` is unset, dev-mode warn path, `isLegacyEncryption` helper
- [ ] Post-deploy: look for `[startup] ENCRYPTION_KEY configured ✓` in each tenant's first-boot logs
- [ ] Post-deploy: confirm 2FA login flow works end-to-end (zero enrolled users today, but the path is still exercised on image restart)

## Notes for reviewers

- `utils/encryption.ts` gained `assertEncryptionConfigured()` as an explicit startup-probe export; `getMasterKey()` is still the primary entry point for encrypt/decrypt callers.
- The legacy XOR path (`decryptLegacyV1`) stays in the codebase until `v1:` records are confirmed purged. Track removal as a follow-up.
- Deterministic-output assertion in the old test suite was replaced with a non-determinism assertion — AES-GCM with per-call random salt/IV must never repeat ciphertext, and a determinism test would mask a regression to a weaker scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
