### PR TITLE
fix(#217): highlight recently added test cases

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
@@ -2890,6 +2890,7 @@ export default function Cases({
         comments: t("comments.title"),
         configuration: t("common.fields.configuration"),
         lastTestResult: t("repository.columns.lastTestResult"),
+        newBadge: t("common.labels.new"),
       },
       isRunMode,
       isSelectionMode,

--- a/testplanit/app/[locale]/projects/repository/[projectId]/LastTestResultCell.test.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/LastTestResultCell.test.tsx
@@ -187,6 +187,7 @@ describe("LastTestResultCell via getColumns", () => {
     comments: "Comments",
     configuration: "Configuration",
     lastTestResult: "Last Result",
+    newBadge: "New",
   };
 
   describe("Column definition", () => {

--- a/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
@@ -76,6 +76,7 @@ import {
   Bot,
   Check,
   ExternalLink,
+  Flame,
   Folder,
   GripVertical,
   LinkIcon,
@@ -1281,6 +1282,7 @@ export const getColumns = (
     comments: string;
     configuration: string;
     lastTestResult: string;
+    newBadge: string;
   },
   isRunMode: boolean = false,
   isSelectionMode: boolean = false,
@@ -1664,33 +1666,53 @@ export const getColumns = (
       size: 400,
       minSize: 100,
       maxSize: 1200,
-      cell: ({ row, column }) => (
-        <NameCell
-          name={row.original.name}
-          id={row.original.id}
-          projectId={row.original.projectId}
-          isRunMode={isRunMode}
-          isSelectionMode={isSelectionMode}
-          columnSize={column.getSize()}
-          onTestCaseClick={onTestCaseClick}
-          folder={
-            row.original.folder
-              ? {
-                  id: row.original.folder.id,
-                  name: row.original.folder.name,
-                  path: row.original.folder.name,
+      cell: ({ row, column }) => {
+        const isNew =
+          row.original.createdAt &&
+          Date.now() - new Date(row.original.createdAt).getTime() <
+            5 * 60 * 1000;
+        return (
+          <div className="flex items-center min-w-0">
+            {isNew && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Flame className="h-4 w-4 mr-1 shrink-0 text-orange-500 fill-orange-500 animate-pulse" />
+                  </TooltipTrigger>
+                  <TooltipContent>{columnTranslations.newBadge}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            <div className="min-w-0 flex-1">
+              <NameCell
+                name={row.original.name}
+                id={row.original.id}
+                projectId={row.original.projectId}
+                isRunMode={isRunMode}
+                isSelectionMode={isSelectionMode}
+                columnSize={column.getSize()}
+                onTestCaseClick={onTestCaseClick}
+                folder={
+                  row.original.folder
+                    ? {
+                        id: row.original.folder.id,
+                        name: row.original.folder.name,
+                        path: row.original.folder.name,
+                      }
+                    : undefined
                 }
-              : undefined
-          }
-          viewType={viewType}
-          automated={row.original.automated}
-          canAddEditResults={canAddEditResults}
-          source={row.original.source}
-          isSoftDeletedInRun={isRunMode && row.original.isDeleted}
-          showDescendants={showDescendants}
-          folderPathMap={folderPathMap}
-        />
-      ),
+                viewType={viewType}
+                automated={row.original.automated}
+                canAddEditResults={canAddEditResults}
+                source={row.original.source}
+                isSoftDeletedInRun={isRunMode && row.original.isDeleted}
+                showDescendants={showDescendants}
+                folderPathMap={folderPathMap}
+              />
+            </div>
+          </div>
+        );
+      },
     },
     ...(isRunMode
       ? [

--- a/testplanit/lib/validate-password-policy.test.ts
+++ b/testplanit/lib/validate-password-policy.test.ts
@@ -22,7 +22,6 @@ const mockFindFirst = vi.mocked(db.registrationSettings.findFirst);
 const mockIsPasswordInHistory = vi.mocked(isPasswordInHistory);
 
 /** Helper: build a settings object with sensible defaults (all rules disabled). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeSettings(
   overrides: Partial<{
     minPasswordLength: number;

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -569,6 +569,7 @@
       "file": "file",
       "files": "files",
       "existingAttachments": "Existing Attachments",
+      "new": "New",
       "noElapsedTime": "No time recorded",
       "untested": "Untested",
       "noResults": "No Results",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -569,6 +569,7 @@
       "file": "archivo",
       "files": "archivos",
       "existingAttachments": "Adjuntos existentes",
+      "new": "Nuevo",
       "noElapsedTime": "No hay tiempo registrado",
       "untested": "Sin probar",
       "noResults": "Sin resultados",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -569,6 +569,7 @@
       "file": "déposer",
       "files": "fichiers",
       "existingAttachments": "Pièces jointes existantes",
+      "new": "Nouveau",
       "noElapsedTime": "Aucune heure enregistrée",
       "untested": "Non testé",
       "noResults": "Aucun résultat",


### PR DESCRIPTION
## Description

Highlight recently added test cases in the repository with a pulsing orange flame icon next to the case name. The icon appears for cases created within the last 5 minutes and disappears automatically on the next re-render after the threshold passes.

- Pulsing filled orange `Flame` icon (Lucide) before the case type icon
- "New" tooltip on hover via shadcn Tooltip component
- No row background changes — icon-only approach works across all themes and pinned columns
- Added `common.labels.new` i18n key with Spanish and French translations

## Related Issue

Closes #217

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing — Verified with newly created and imported test cases

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Browser: Chrome
- Node version: 22.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Pulsing flame icon next to recently created test cases -->

## Additional Notes

- 5-minute threshold is a constant in `columns.tsx` — can be made configurable later if needed
- The highlight clears on re-render after the threshold, not via a live timer

