### PR TITLE
enhancement: dialog polish, share link password policy, and review field fixes

### DIFF
--- a/testplanit/app/[locale]/admin/projects/CreateProjectWizard.tsx
+++ b/testplanit/app/[locale]/admin/projects/CreateProjectWizard.tsx
@@ -1343,7 +1343,6 @@ export function CreateProjectWizard({
                 })}
               </div>
             </ScrollArea>
-
           </div>
         );
 

--- a/testplanit/app/[locale]/admin/projects/CreateProjectWizard.tsx
+++ b/testplanit/app/[locale]/admin/projects/CreateProjectWizard.tsx
@@ -1251,7 +1251,7 @@ export function CreateProjectWizard({
 
       case WizardStep.TEMPLATES:
         return (
-          <div className="space-y-4">
+          <div className="space-y-4 flex flex-col h-full">
             <Alert>
               <AlertDescription className="flex items-center gap-1">
                 <AlertCircle className="h-4 w-4" />
@@ -1268,7 +1268,7 @@ export function CreateProjectWizard({
               </Alert>
             )}
 
-            <ScrollArea className="h-[400px] border rounded-lg">
+            <ScrollArea className="flex-1 border rounded-lg">
               <div className="p-4 space-y-4">
                 {templates?.map((template) => {
                   const isSelected = localSelectedTemplates.includes(
@@ -1344,25 +1344,6 @@ export function CreateProjectWizard({
               </div>
             </ScrollArea>
 
-            <div className="flex items-center justify-between text-sm text-muted-foreground">
-              <span>
-                {t("admin.projects.wizard.labels.selected")}:{" "}
-                {localSelectedTemplates.length}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const defaultTemplate = templates?.find((t) => t.isDefault);
-                  if (defaultTemplate) {
-                    setLocalSelectedTemplates([defaultTemplate.id]);
-                    setValue("selectedTemplates", [defaultTemplate.id]);
-                  }
-                }}
-              >
-                {t("admin.projects.wizard.actions.selectDefault")}
-              </Button>
-            </div>
           </div>
         );
 

--- a/testplanit/app/[locale]/admin/projects/EditProject.tsx
+++ b/testplanit/app/[locale]/admin/projects/EditProject.tsx
@@ -767,7 +767,7 @@ export function EditProjectModal({
         }
       }}
     >
-      <DialogContent className="sm:max-w-[600px] lg:max-w-[1000px]">
+      <DialogContent className="sm:max-w-[600px] lg:max-w-[1000px] h-[90vh] flex flex-col overflow-hidden">
         <Form {...form}>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 mt-4">
             <DialogHeader>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -824,47 +824,53 @@ const GeneratedTestCaseCard = memo(function GeneratedTestCaseCard({
         .filter((field: any) => {
           // In read-only mode, skip fields with no value
           if (!isEdit) {
-            const val = field.caseField.type.type === "Steps"
-              ? getTestCaseSteps(testCase, selectedTemplateFields)
-              : testCase.fieldValues[field.caseField.displayName];
-            return val != null && val !== "" && !(Array.isArray(val) && val.length === 0);
+            const val =
+              field.caseField.type.type === "Steps"
+                ? getTestCaseSteps(testCase, selectedTemplateFields)
+                : testCase.fieldValues[field.caseField.displayName];
+            return (
+              val != null &&
+              val !== "" &&
+              !(Array.isArray(val) && val.length === 0)
+            );
           }
           return true;
         })
         .map((field: any) => {
-        const displayName = field.caseField.displayName;
-        const fieldId = field.caseField.id.toString();
-        const fieldType = field.caseField.type.type;
+          const displayName = field.caseField.displayName;
+          const fieldId = field.caseField.id.toString();
+          const fieldType = field.caseField.type.type;
 
-        const commonProps = {
-          fieldType,
-          caseId: `generated-${testCase.id}`,
-          template,
-          fieldId: field.caseField.id,
-          session,
-          projectId,
-          previousFieldValue: undefined,
-          fieldValue: testCase.fieldValues[displayName],
-          stepsForDisplay: fieldType === "Steps" ? stepsForDisplay : undefined,
-          explicitFieldNameForSteps:
-            fieldType === "Steps" ? fieldId : undefined,
-        } as const;
+          const commonProps = {
+            fieldType,
+            caseId: `generated-${testCase.id}`,
+            template,
+            fieldId: field.caseField.id,
+            session,
+            projectId,
+            previousFieldValue: undefined,
+            fieldValue: testCase.fieldValues[displayName],
+            stepsForDisplay:
+              fieldType === "Steps" ? stepsForDisplay : undefined,
+            explicitFieldNameForSteps:
+              fieldType === "Steps" ? fieldId : undefined,
+          } as const;
 
-        return (
-          <div key={`field-${field.caseField.id}`} className="space-y-2">
-            <div className="font-medium text-sm text-primary border-b border-muted-foreground/50 pb-1">
-              {displayName}
+          return (
+            <div key={`field-${field.caseField.id}`} className="space-y-2">
+              <div className="font-medium text-sm text-primary border-b border-muted-foreground/50 pb-1">
+                {displayName}
+              </div>
+              <FieldValueRenderer
+                {...commonProps}
+                isEditMode={isEdit}
+                isSubmitting={false}
+                control={control}
+                errors={errors}
+              />
             </div>
-            <FieldValueRenderer
-              {...commonProps}
-              isEditMode={isEdit}
-              isSubmitting={false}
-              control={control}
-              errors={errors}
-            />
-          </div>
-        );
-      })}
+          );
+        })}
     </div>
   );
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -820,7 +820,18 @@ const GeneratedTestCaseCard = memo(function GeneratedTestCaseCard({
 
   const renderFieldList = (isEdit: boolean) => (
     <div className="mt-3 border-t pt-3 space-y-4">
-      {selectedTemplateFields.map((field: any) => {
+      {selectedTemplateFields
+        .filter((field: any) => {
+          // In read-only mode, skip fields with no value
+          if (!isEdit) {
+            const val = field.caseField.type.type === "Steps"
+              ? getTestCaseSteps(testCase, selectedTemplateFields)
+              : testCase.fieldValues[field.caseField.displayName];
+            return val != null && val !== "" && !(Array.isArray(val) && val.length === 0);
+          }
+          return true;
+        })
+        .map((field: any) => {
         const displayName = field.caseField.displayName;
         const fieldId = field.caseField.id.toString();
         const fieldType = field.caseField.type.type;

--- a/testplanit/app/actions/upgrade-notifications.ts
+++ b/testplanit/app/actions/upgrade-notifications.ts
@@ -90,15 +90,22 @@ export async function checkUpgradeNotifications(): Promise<{
         ? pendingNotifications[0].notification.title
         : `What's New in TestPlanIt`;
 
+    // Strip HTML tags for the plain text message field
+    const stripHtml = (html: string) =>
+      html
+        .replace(/<[^>]*>/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+
     let message: string;
     if (pendingNotifications.length === 1) {
-      message = pendingNotifications[0].notification.message;
+      message = stripHtml(pendingNotifications[0].notification.message);
     } else {
       // Combine multiple notifications into a single message
       message = pendingNotifications
         .map(
           ({ version, notification }) =>
-            `**${notification.title}** (v${version})\n${notification.message}`
+            `**${notification.title}** (v${version})\n${stripHtml(notification.message)}`
         )
         .join("\n\n");
     }

--- a/testplanit/app/actions/upgrade-notifications.ts
+++ b/testplanit/app/actions/upgrade-notifications.ts
@@ -91,11 +91,16 @@ export async function checkUpgradeNotifications(): Promise<{
         : `What's New in TestPlanIt`;
 
     // Strip HTML tags for the plain text message field
-    const stripHtml = (html: string) =>
-      html
-        .replace(/<[^>]*>/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
+    // Loop until no tags remain to handle nested/malformed tags (CodeQL CWE-20)
+    const stripHtml = (html: string) => {
+      let result = html;
+      let prev;
+      do {
+        prev = result;
+        result = result.replace(/<[^>]*>/g, "");
+      } while (result !== prev);
+      return result.replace(/\s+/g, " ").trim();
+    };
 
     let message: string;
     if (pendingNotifications.length === 1) {

--- a/testplanit/components/reports/ShareDialog.tsx
+++ b/testplanit/components/reports/ShareDialog.tsx
@@ -33,8 +33,12 @@ import { Asterisk, Calendar as CalendarIcon, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
-import { useCreateShareLink } from "~/lib/hooks";
+import { useCreateShareLink, useFindFirstRegistrationSettings } from "~/lib/hooks";
 import { cn } from "~/utils";
+import {
+  PasswordStrengthIndicator,
+  type PasswordPolicy,
+} from "@/components/PasswordStrengthIndicator";
 
 interface ShareDialogProps {
   open: boolean;
@@ -55,6 +59,16 @@ export function ShareDialog({
   const tCommon = useTranslations("common");
   const tAuth = useTranslations("auth.signup.errors");
   const { data: session } = useSession();
+  const { data: registrationSettings } = useFindFirstRegistrationSettings();
+  const policy: PasswordPolicy | null = registrationSettings
+    ? {
+        minPasswordLength: registrationSettings.minPasswordLength ?? 8,
+        requireUppercase: registrationSettings.requireUppercase ?? false,
+        requireLowercase: registrationSettings.requireLowercase ?? false,
+        requireNumbers: registrationSettings.requireNumbers ?? false,
+        requiredSpecialChars: registrationSettings.requiredSpecialChars ?? null,
+      }
+    : null;
   const [activeTab, setActiveTab] = useState<"create" | "list">("create");
 
   // Form state
@@ -91,10 +105,28 @@ export function ShareDialog({
         return;
       }
 
-      // Validate password for PASSWORD_PROTECTED mode
-      if (mode === "PASSWORD_PROTECTED" && (!password || password.length < 4)) {
-        setPasswordError(tAuth("passwordRequired"));
-        return;
+      // Validate password for PASSWORD_PROTECTED mode against admin policy
+      if (mode === "PASSWORD_PROTECTED") {
+        if (!password) {
+          setPasswordError(tAuth("passwordRequired"));
+          return;
+        }
+        const minLen = policy?.minPasswordLength ?? 8;
+        const meetsPolicy =
+          password.length >= minLen &&
+          (!policy?.requireUppercase || /[A-Z]/.test(password)) &&
+          (!policy?.requireLowercase || /[a-z]/.test(password)) &&
+          (!policy?.requireNumbers || /\d/.test(password)) &&
+          (!policy?.requiredSpecialChars ||
+            [...policy.requiredSpecialChars].some((c) =>
+              password.includes(c)
+            ));
+        if (!meetsPolicy) {
+          setPasswordError(
+            tCommon("errors.passwordDoesNotMeetPolicy")
+          );
+          return;
+        }
       }
 
       if (mode === "PASSWORD_PROTECTED" && password !== confirmPassword) {
@@ -194,7 +226,7 @@ export function ShareDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl h-[90vh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t("dialogTitle")}</DialogTitle>
           <DialogDescription>{t("dialogDescription")}</DialogDescription>
@@ -203,8 +235,9 @@ export function ShareDialog({
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as "create" | "list")}
+          className="flex-1 flex flex-col min-h-0"
         >
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-2 shrink-0">
             <TabsTrigger data-testid="share-tab-create" value="create">
               {t("tabs.create")}
             </TabsTrigger>
@@ -213,7 +246,7 @@ export function ShareDialog({
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="create" className="space-y-4 mt-4">
+          <TabsContent value="create" className="space-y-4 mt-4 flex-1 min-h-0 overflow-y-auto">
             {error && (
               <Alert variant="destructive">
                 <AlertDescription>{error}</AlertDescription>
@@ -320,6 +353,10 @@ export function ShareDialog({
                     placeholder="••••••••"
                     required
                     className={passwordError ? "border-destructive" : ""}
+                  />
+                  <PasswordStrengthIndicator
+                    password={password}
+                    policy={policy}
                   />
                   {passwordError && (
                     <p className="text-sm text-destructive">{passwordError}</p>

--- a/testplanit/components/reports/ShareDialog.tsx
+++ b/testplanit/components/reports/ShareDialog.tsx
@@ -33,7 +33,10 @@ import { Asterisk, Calendar as CalendarIcon, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
-import { useCreateShareLink, useFindFirstRegistrationSettings } from "~/lib/hooks";
+import {
+  useCreateShareLink,
+  useFindFirstRegistrationSettings,
+} from "~/lib/hooks";
 import { cn } from "~/utils";
 import {
   PasswordStrengthIndicator,
@@ -118,13 +121,9 @@ export function ShareDialog({
           (!policy?.requireLowercase || /[a-z]/.test(password)) &&
           (!policy?.requireNumbers || /\d/.test(password)) &&
           (!policy?.requiredSpecialChars ||
-            [...policy.requiredSpecialChars].some((c) =>
-              password.includes(c)
-            ));
+            [...policy.requiredSpecialChars].some((c) => password.includes(c)));
         if (!meetsPolicy) {
-          setPasswordError(
-            tCommon("errors.passwordDoesNotMeetPolicy")
-          );
+          setPasswordError(tCommon("errors.passwordDoesNotMeetPolicy"));
           return;
         }
       }
@@ -246,7 +245,10 @@ export function ShareDialog({
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="create" className="space-y-4 mt-4 flex-1 min-h-0 overflow-y-auto">
+          <TabsContent
+            value="create"
+            className="space-y-4 mt-4 flex-1 min-h-0 overflow-y-auto"
+          >
             {error && (
               <Alert variant="destructive">
                 <AlertDescription>{error}</AlertDescription>

--- a/testplanit/components/share/EditShareLinkDialog.tsx
+++ b/testplanit/components/share/EditShareLinkDialog.tsx
@@ -26,8 +26,12 @@ import { format } from "date-fns";
 import { Asterisk, Calendar as CalendarIcon, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { useUpdateShareLink } from "~/lib/hooks";
+import { useUpdateShareLink, useFindFirstRegistrationSettings } from "~/lib/hooks";
 import { cn } from "~/utils";
+import {
+  PasswordStrengthIndicator,
+  type PasswordPolicy,
+} from "@/components/PasswordStrengthIndicator";
 
 interface EditShareLinkDialogProps {
   open: boolean;
@@ -44,6 +48,16 @@ export function EditShareLinkDialog({
 }: EditShareLinkDialogProps) {
   const t = useTranslations("reports.shareDialog");
   const tCommon = useTranslations("common");
+  const { data: registrationSettings } = useFindFirstRegistrationSettings();
+  const policy: PasswordPolicy | null = registrationSettings
+    ? {
+        minPasswordLength: registrationSettings.minPasswordLength ?? 8,
+        requireUppercase: registrationSettings.requireUppercase ?? false,
+        requireLowercase: registrationSettings.requireLowercase ?? false,
+        requireNumbers: registrationSettings.requireNumbers ?? false,
+        requiredSpecialChars: registrationSettings.requiredSpecialChars ?? null,
+      }
+    : null;
 
   // Form state
   const [mode, setMode] = useState<ShareLinkMode>(shareLink.mode);
@@ -94,13 +108,26 @@ export function EditShareLinkDialog({
         mode === "PASSWORD_PROTECTED" &&
         (modeChanged || !shareLink.passwordHash)
       ) {
-        if (!password || password.length < 4) {
-          setPasswordError("Password must be at least 4 characters long.");
+        if (!password) {
+          setPasswordError(tCommon("errors.passwordRequired"));
           return;
         }
-
+        const minLen = policy?.minPasswordLength ?? 8;
+        const meetsPolicy =
+          password.length >= minLen &&
+          (!policy?.requireUppercase || /[A-Z]/.test(password)) &&
+          (!policy?.requireLowercase || /[a-z]/.test(password)) &&
+          (!policy?.requireNumbers || /\d/.test(password)) &&
+          (!policy?.requiredSpecialChars ||
+            [...policy.requiredSpecialChars].some((c) =>
+              password.includes(c)
+            ));
+        if (!meetsPolicy) {
+          setPasswordError(tCommon("errors.passwordDoesNotMeetPolicy"));
+          return;
+        }
         if (password !== confirmPassword) {
-          setPasswordError("Passwords do not match.");
+          setPasswordError(tCommon("errors.passwordsDoNotMatch"));
           return;
         }
       }
@@ -293,6 +320,10 @@ export function EditShareLinkDialog({
                   }
                   required={modeChanged || !shareLink.passwordHash}
                   className={passwordError ? "border-destructive" : ""}
+                />
+                <PasswordStrengthIndicator
+                  password={password}
+                  policy={policy}
                 />
                 {passwordError && (
                   <p className="text-sm text-destructive">{passwordError}</p>

--- a/testplanit/components/share/EditShareLinkDialog.tsx
+++ b/testplanit/components/share/EditShareLinkDialog.tsx
@@ -26,7 +26,10 @@ import { format } from "date-fns";
 import { Asterisk, Calendar as CalendarIcon, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { useUpdateShareLink, useFindFirstRegistrationSettings } from "~/lib/hooks";
+import {
+  useUpdateShareLink,
+  useFindFirstRegistrationSettings,
+} from "~/lib/hooks";
 import { cn } from "~/utils";
 import {
   PasswordStrengthIndicator,
@@ -119,9 +122,7 @@ export function EditShareLinkDialog({
           (!policy?.requireLowercase || /[a-z]/.test(password)) &&
           (!policy?.requireNumbers || /\d/.test(password)) &&
           (!policy?.requiredSpecialChars ||
-            [...policy.requiredSpecialChars].some((c) =>
-              password.includes(c)
-            ));
+            [...policy.requiredSpecialChars].some((c) => password.includes(c)));
         if (!meetsPolicy) {
           setPasswordError(tCommon("errors.passwordDoesNotMeetPolicy"));
           return;

--- a/testplanit/components/share/ShareDialog.test.tsx
+++ b/testplanit/components/share/ShareDialog.test.tsx
@@ -27,6 +27,15 @@ vi.mock("~/lib/hooks", () => ({
     mutateAsync: mockMutateAsync,
     isPending: false,
   }),
+  useFindFirstRegistrationSettings: () => ({
+    data: {
+      minPasswordLength: 8,
+      requireUppercase: false,
+      requireLowercase: false,
+      requireNumbers: false,
+      requiredSpecialChars: null,
+    },
+  }),
 }));
 
 // Mock server actions

--- a/testplanit/e2e/tests/auth/signup.spec.ts
+++ b/testplanit/e2e/tests/auth/signup.spec.ts
@@ -123,9 +123,9 @@ test.describe("User Signup", () => {
 
     await page.getByRole("button", { name: /sign up/i }).click();
 
-    // Should show password length error - look for the actual message (using first() since both fields show the error)
+    // Should show password policy error
     await expect(
-      page.getByText(/password must be at least \d+ characters/i).first()
+      page.getByText(/password.*does not meet|security requirements/i).first()
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/testplanit/e2e/tests/share/password-protected-share.spec.ts
+++ b/testplanit/e2e/tests/share/password-protected-share.spec.ts
@@ -376,21 +376,23 @@ test.describe("Password-Protected Share Flow", () => {
     const passwordModeRadio = page.getByTestId("share-mode-password");
     await passwordModeRadio.click();
 
-    // Enter mismatched passwords
+    // Enter mismatched passwords (strong enough to pass policy)
     const passwordInput = page.getByTestId("share-password-input");
-    await passwordInput.fill("Password123");
+    await passwordInput.fill("StrongPassword123!");
 
     const confirmPasswordInput = page.getByTestId(
       "share-confirm-password-input"
     );
-    await confirmPasswordInput.fill("DifferentPassword456");
+    await confirmPasswordInput.fill("DifferentPassword456!");
 
     // Try to create the share
     const createButton = page.getByTestId("share-create-button");
     await createButton.click();
 
-    // Should see validation error
-    const errorMessage = page.locator("text=/passwords do not match/i");
+    // Should see validation error (password mismatch or policy error)
+    const errorMessage = page.locator(
+      "text=/passwords do not match|password.*do not match/i"
+    );
     await expect(errorMessage.first()).toBeVisible({ timeout: 5000 });
 
     // Share should NOT be created

--- a/testplanit/lib/upgrade-notifications.test.ts
+++ b/testplanit/lib/upgrade-notifications.test.ts
@@ -154,4 +154,44 @@ describe("upgrade-notifications", () => {
       });
     });
   });
+
+  describe("notification messages as plain text", () => {
+    const stripHtml = (html: string) =>
+      html
+        .replace(/<[^>]*>/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    it("should produce non-empty plain text when HTML is stripped from messages", () => {
+      for (const [version, notification] of Object.entries(
+        upgradeNotifications
+      )) {
+        const plainText = stripHtml(notification.message);
+        expect(plainText.length).toBeGreaterThan(0);
+        // Should not contain any HTML tags
+        expect(plainText).not.toMatch(/<[^>]*>/);
+      }
+    });
+
+    it("should not contain raw HTML entities after stripping", () => {
+      for (const [_version, notification] of Object.entries(
+        upgradeNotifications
+      )) {
+        const plainText = stripHtml(notification.message);
+        expect(plainText).not.toContain("<strong>");
+        expect(plainText).not.toContain("<p>");
+        expect(plainText).not.toContain("<ul>");
+        expect(plainText).not.toContain("<li>");
+      }
+    });
+
+    it("should preserve meaningful content after stripping HTML", () => {
+      // Test with a known notification that has HTML
+      const notification = upgradeNotifications["0.5.0"]; // Audit Logs has HTML
+      if (notification) {
+        const plainText = stripHtml(notification.message);
+        expect(plainText).toContain("audit");
+      }
+    });
+  });
 });

--- a/testplanit/lib/upgrade-notifications.test.ts
+++ b/testplanit/lib/upgrade-notifications.test.ts
@@ -156,14 +156,18 @@ describe("upgrade-notifications", () => {
   });
 
   describe("notification messages as plain text", () => {
-    const stripHtml = (html: string) =>
-      html
-        .replace(/<[^>]*>/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
+    const stripHtml = (html: string) => {
+      let result = html;
+      let prev;
+      do {
+        prev = result;
+        result = result.replace(/<[^>]*>/g, "");
+      } while (result !== prev);
+      return result.replace(/\s+/g, " ").trim();
+    };
 
     it("should produce non-empty plain text when HTML is stripped from messages", () => {
-      for (const [version, notification] of Object.entries(
+      for (const [_version, notification] of Object.entries(
         upgradeNotifications
       )) {
         const plainText = stripHtml(notification.message);

--- a/testplanit/lib/validate-password-policy.test.ts
+++ b/testplanit/lib/validate-password-policy.test.ts
@@ -22,7 +22,6 @@ const mockFindFirst = vi.mocked(db.registrationSettings.findFirst);
 const mockIsPasswordInHistory = vi.mocked(isPasswordInHistory);
 
 /** Helper: build a settings object with sensible defaults (all rules disabled). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeSettings(
   overrides: Partial<{
     minPasswordLength: number;

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -498,8 +498,9 @@
       "somethingWentWrong": "An unexpected error occurred. Please try again later.",
       "emailRequired": "Enter your email address.",
       "emailInvalid": "This is not a valid email address.",
-      "passwordRequired": "Password must be at least 4 characters long.",
+      "passwordRequired": "Password is required.",
       "confirmPasswordRequired": "Confirm your password.",
+      "passwordDoesNotMeetPolicy": "Password does not meet the security requirements.",
       "passwordsDoNotMatch": "The passwords do not match",
       "nameRequired": "Please enter your full name",
       "duplicate": "Please choose a unique name.",
@@ -891,8 +892,8 @@
       "signIn": "Sign into your existing account.",
       "errors": {
         "emailRequired": "Email is required",
-        "passwordRequired": "Password must be at least 4 characters",
-        "confirmPasswordRequired": "Confirm password must be at least 4 characters",
+        "passwordRequired": "Password does not meet the security requirements",
+        "confirmPasswordRequired": "Confirm password is required",
         "passwordsDoNotMatch": "Passwords do not match",
         "domainRestricted": "Registration is restricted to approved email domains. Please contact your administrator if you believe this is an error."
       }
@@ -1607,7 +1608,7 @@
         "confirmPasswordLabel": "Confirm New Password",
         "validation": {
           "passwordsDoNotMatch": "New passwords do not match.",
-          "newPasswordTooShort": "New password must be at least 4 characters long."
+          "newPasswordTooShort": "New password does not meet the security requirements."
         },
         "success": {
           "passwordChanged": "Password changed successfully."

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -498,8 +498,9 @@
       "somethingWentWrong": "Se ha producido un error inesperado. Inténtalo de nuevo más tarde.",
       "emailRequired": "Introduzca su dirección de correo electrónico.",
       "emailInvalid": "Esta no es una dirección de correo electrónico válida.",
-      "passwordRequired": "La contraseña debe tener al menos 4 caracteres.",
+      "passwordRequired": "Se requiere contraseña.",
       "confirmPasswordRequired": "Confirme su contraseña.",
+      "passwordDoesNotMeetPolicy": "La contraseña no cumple con los requisitos de seguridad.",
       "passwordsDoNotMatch": "Las contraseñas no coinciden",
       "nameRequired": "Por favor, introduzca su nombre completo",
       "duplicate": "Por favor, elija un nombre único.",
@@ -891,8 +892,8 @@
       "signIn": "Inicia sesión en tu cuenta existente.",
       "errors": {
         "emailRequired": "Se requiere correo electrónico",
-        "passwordRequired": "La contraseña debe tener al menos 4 caracteres",
-        "confirmPasswordRequired": "Confirmar contraseña debe tener al menos 4 caracteres",
+        "passwordRequired": "La contraseña no cumple con los requisitos de seguridad.",
+        "confirmPasswordRequired": "Se requiere confirmar la contraseña.",
         "passwordsDoNotMatch": "Las contraseñas no coinciden",
         "domainRestricted": "El registro está restringido a dominios de correo electrónico aprobados. Si cree que se trata de un error, póngase en contacto con su administrador."
       }
@@ -1606,7 +1607,7 @@
         "confirmPasswordLabel": "Confirmar nueva contraseña",
         "validation": {
           "passwordsDoNotMatch": "Las nuevas contraseñas no coinciden.",
-          "newPasswordTooShort": "La nueva contraseña debe tener al menos 4 caracteres."
+          "newPasswordTooShort": "La nueva contraseña no cumple con los requisitos de seguridad."
         },
         "success": {
           "passwordChanged": "Contraseña cambiada con éxito."

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -498,8 +498,9 @@
       "somethingWentWrong": "Une erreur inattendue s'est produite. Veuillez réessayer plus tard.",
       "emailRequired": "Saisissez votre adresse e-mail.",
       "emailInvalid": "Ceci n'est pas une adresse e-mail valide.",
-      "passwordRequired": "Le mot de passe doit comporter au moins 4 caractères.",
+      "passwordRequired": "Un mot de passe est requis.",
       "confirmPasswordRequired": "Confirmez votre mot de passe.",
+      "passwordDoesNotMeetPolicy": "Le mot de passe ne répond pas aux exigences de sécurité.",
       "passwordsDoNotMatch": "Les mots de passe ne correspondent pas.",
       "nameRequired": "Veuillez saisir votre nom complet",
       "duplicate": "Veuillez choisir un nom unique.",
@@ -891,8 +892,8 @@
       "signIn": "Connectez-vous à votre compte existant.",
       "errors": {
         "emailRequired": "L'adresse électronique est requise.",
-        "passwordRequired": "Le mot de passe doit comporter au moins 4 caractères.",
-        "confirmPasswordRequired": "Confirmez que le mot de passe doit comporter au moins 4 caractères.",
+        "passwordRequired": "Le mot de passe ne répond pas aux exigences de sécurité",
+        "confirmPasswordRequired": "Confirmer le mot de passe est requis",
         "passwordsDoNotMatch": "Les mots de passe ne correspondent pas.",
         "domainRestricted": "L'inscription est réservée aux domaines de messagerie approuvés. Veuillez contacter votre administrateur si vous pensez qu'il s'agit d'une erreur."
       }
@@ -1606,7 +1607,7 @@
         "confirmPasswordLabel": "Confirmer le nouveau mot de passe",
         "validation": {
           "passwordsDoNotMatch": "Les nouveaux mots de passe ne correspondent pas.",
-          "newPasswordTooShort": "Le nouveau mot de passe doit comporter au moins 4 caractères."
+          "newPasswordTooShort": "Le nouveau mot de passe ne répond pas aux exigences de sécurité."
         },
         "success": {
           "passwordChanged": "Mot de passe modifié avec succès."


### PR DESCRIPTION
## Description

Dialog polish, share link password policy enforcement, and generate wizard review improvements.

- Static height (`h-[90vh]`) for tabbed dialogs (ShareDialog, EditProject) to prevent layout shifts between tabs
- CreateProjectWizard template step fills available space, removed redundant Selected/Use Default buttons
- Share link passwords now validate against admin password policy with real-time PasswordStrengthIndicator (both create and edit dialogs)
- Generate wizard review step hides fields with null/empty values instead of showing empty labels
- Updated hardcoded "4 characters" validation strings to policy-aware messages
- ShareDialog Create tab scrolls when content overflows
- E2E tests updated for new validation messages

## Related Issue

Partially addresses #227 (password policy strings)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — 5664 tests passing, 0 errors
- [ ] Integration tests
- [x] E2E tests — signup and password-protected share tests updated and passing
- [x] Manual testing — Share link password validation, dialog heights, generate wizard review

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Browser: Chrome
- Node version: 22.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Dialog polish, password strength indicator on share links -->

## Additional Notes

- Filed #227 for full i18n of server-side password policy violation messages (separate effort)
- Share link password validation is client-side only — server-side enforcement deferred to #227
