### PR TITLE
refactor(audit): split enqueue helpers out of auditContextWrappers

### DIFF
--- a/testplanit/app/api/admin/elasticsearch/reindex/route.ts
+++ b/testplanit/app/api/admin/elasticsearch/reindex/route.ts
@@ -3,8 +3,8 @@ import { prisma } from "@/lib/prisma";
 import { getElasticsearchReindexQueue } from "@/lib/queues";
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateApiToken } from "~/lib/api-token-auth";
+import { enqueueWithAuditContext } from "~/lib/auditContextEnqueue";
 import {
-  enqueueWithAuditContext,
   enrichFromApiAuth,
   withAuditContext,
 } from "~/lib/auditContextWrappers";

--- a/testplanit/app/api/imports/testmo/jobs/[jobId]/import/route.ts
+++ b/testplanit/app/api/imports/testmo/jobs/[jobId]/import/route.ts
@@ -1,10 +1,8 @@
 import { Prisma } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  enqueueWithAuditContext,
-  withAuditContext,
-} from "~/lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "~/lib/auditContextEnqueue";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import { getTestmoImportQueue, TESTMO_IMPORT_QUEUE_NAME } from "~/lib/queues";
 import { captureAuditEvent } from "~/lib/services/auditLog";

--- a/testplanit/app/api/imports/testmo/jobs/route.ts
+++ b/testplanit/app/api/imports/testmo/jobs/route.ts
@@ -1,9 +1,7 @@
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  enqueueWithAuditContext,
-  withAuditContext,
-} from "~/lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "~/lib/auditContextEnqueue";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import { getTestmoImportQueue, TESTMO_IMPORT_QUEUE_NAME } from "~/lib/queues";
 import { authOptions } from "~/server/auth";

--- a/testplanit/app/api/repository/copy-move/route.ts
+++ b/testplanit/app/api/repository/copy-move/route.ts
@@ -2,10 +2,8 @@ import { getCurrentTenantId } from "@/lib/multiTenantPrisma";
 import { enhance } from "@zenstackhq/runtime";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  enqueueWithAuditContext,
-  withAuditContext,
-} from "~/lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "~/lib/auditContextEnqueue";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { prisma } from "~/lib/prisma";
 import { getCopyMoveQueue } from "~/lib/queues";
 import { authOptions } from "~/server/auth";

--- a/testplanit/lib/auditContextEnqueue.test.ts
+++ b/testplanit/lib/auditContextEnqueue.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuditContext,
+  runWithAuditContext,
+  type AuditContext,
+  SYSTEM_ACTOR_ID,
+} from "./auditContext";
+import { enqueueWithAuditContext } from "./auditContextEnqueue";
+
+// Hand-rolled Queue mock — no real BullMQ or Valkey connection.
+type QueueMock = {
+  add: ReturnType<typeof vi.fn>;
+};
+function makeQueueMock(): QueueMock {
+  return { add: vi.fn(async () => ({ id: "job-mock" })) };
+}
+
+// This suite intentionally does NOT mock next/headers. The enqueue module
+// is runtime-agnostic and must load cleanly in environments where Next.js
+// is not installed (e.g. the workers Docker image).
+describe("enqueueWithAuditContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges ALS context into actorContext when ALS is present", async () => {
+    const queue = makeQueueMock();
+    const ctx: AuditContext = {
+      userId: "u-42",
+      userEmail: "u42@example.com",
+      userName: "User 42",
+      ipAddress: "198.51.100.2",
+      userAgent: "UA/enqueue",
+      requestId: "req_fixed_42",
+    };
+
+    await runWithAuditContext(ctx, async () => {
+      await enqueueWithAuditContext(
+        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+        "job-alpha",
+        { foo: "bar" }
+      );
+    });
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [jobName, payload] = queue.add.mock.calls[0];
+    expect(jobName).toBe("job-alpha");
+    expect(payload).toMatchObject({
+      foo: "bar",
+      actorContext: {
+        userId: "u-42",
+        userEmail: "u42@example.com",
+        userName: "User 42",
+        ipAddress: "198.51.100.2",
+        userAgent: "UA/enqueue",
+        requestId: "req_fixed_42",
+      },
+    });
+    // No root-level systemReason mirror when not system-stamped
+    expect((payload as Record<string, unknown>).systemReason).toBeUndefined();
+  });
+
+  it("throws when ALS is empty and no systemReason is provided", async () => {
+    const queue = makeQueueMock();
+
+    // Call OUTSIDE any runWithAuditContext frame — ALS is empty.
+    await expect(
+      enqueueWithAuditContext(
+        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+        "job-beta",
+        { foo: "bar" }
+      )
+    ).rejects.toThrow(/no audit context present/);
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it("throws when ALS contains only empty-string fields and no systemReason (WR-01 hardening)", async () => {
+    const queue = makeQueueMock();
+    const emptyCtx: AuditContext = {
+      userId: "",
+      userEmail: "",
+      userName: "",
+      ipAddress: "",
+      userAgent: "",
+      requestId: "",
+    };
+
+    await expect(
+      runWithAuditContext(emptyCtx, async () => {
+        await enqueueWithAuditContext(
+          queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+          "job-empty-strings",
+          { foo: "bar" }
+        );
+      })
+    ).rejects.toThrow(/no audit context present/);
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it("does NOT misattribute when ALS has a populated userId but empty ipAddress (WR-01 future-refactor guard)", async () => {
+    const queue = makeQueueMock();
+    const ctx: AuditContext = {
+      userId: "u-real",
+      userEmail: "real@example.com",
+      userName: "Real User",
+      ipAddress: "", // future-refactor scenario: extractIpAddress defaulted to ""
+      userAgent: "UA/real",
+      requestId: "req_real_1",
+    };
+
+    await runWithAuditContext(ctx, async () => {
+      await enqueueWithAuditContext(
+        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+        "job-mixed",
+        { foo: "bar" }
+      );
+    });
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = queue.add.mock.calls[0];
+    // The user is real, so user-attribution wins (the empty ipAddress is
+    // faithfully carried through — we do NOT rewrite it, we just do not
+    // let it alone flip the branch). The job payload reflects the
+    // actual ALS state; consumers / expectAuditRowComplete catch the
+    // incomplete ipAddress downstream via WR-03.
+    expect((payload as Record<string, unknown>).actorContext).toMatchObject({
+      userId: "u-real",
+      ipAddress: "",
+    });
+  });
+
+  it("stamps __system__ with systemReason embedded in actorContext when ALS is empty", async () => {
+    const queue = makeQueueMock();
+
+    await enqueueWithAuditContext(
+      queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+      "job-gamma",
+      { foo: "bar" },
+      { systemReason: "scheduled:test-rollup" }
+    );
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [jobName, payload] = queue.add.mock.calls[0];
+    expect(jobName).toBe("job-gamma");
+    expect(payload).toMatchObject({
+      foo: "bar",
+      actorContext: {
+        userId: SYSTEM_ACTOR_ID,
+        systemReason: "scheduled:test-rollup",
+      },
+    });
+  });
+
+  it("sets root-level systemReason mirror on the job payload", async () => {
+    const queue = makeQueueMock();
+
+    await enqueueWithAuditContext(
+      queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+      "job-delta",
+      { foo: "bar" },
+      { systemReason: "scheduled:mirror-test" }
+    );
+
+    const payload = queue.add.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.systemReason).toBe("scheduled:mirror-test");
+  });
+
+  it("prefers ALS context over systemReason when both present", async () => {
+    const queue = makeQueueMock();
+    const ctx: AuditContext = {
+      userId: "u-user-wins",
+      userEmail: "user@example.com",
+      userName: "Real User",
+      requestId: "req_user_wins",
+    };
+
+    await runWithAuditContext(ctx, async () => {
+      await enqueueWithAuditContext(
+        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
+        "job-epsilon",
+        { foo: "bar" },
+        { systemReason: "scheduled:should-be-ignored" }
+      );
+    });
+
+    const payload = queue.add.mock.calls[0][1] as Record<string, unknown>;
+    expect((payload.actorContext as AuditContext).userId).toBe("u-user-wins");
+    // No __system__ anywhere in actorContext
+    expect((payload.actorContext as AuditContext).userId).not.toBe(
+      SYSTEM_ACTOR_ID
+    );
+    // No systemReason leaks in on the user-attributed branch
+    expect(payload.systemReason).toBeUndefined();
+    expect((payload.actorContext as AuditContext).systemReason).toBeUndefined();
+  });
+
+  it("sanity: getAuditContext is the same module both tests import", async () => {
+    // Guard against a stealth duplicate-module issue where the enqueue
+    // module's ALS store diverges from the test's. If this ever fails,
+    // the tsconfig path alias or vitest resolver has drifted.
+    await runWithAuditContext({ userId: "sanity" }, async () => {
+      expect(getAuditContext()?.userId).toBe("sanity");
+    });
+  });
+});

--- a/testplanit/lib/auditContextEnqueue.ts
+++ b/testplanit/lib/auditContextEnqueue.ts
@@ -1,0 +1,132 @@
+import type { Job, JobsOptions, Queue } from "bullmq";
+import {
+  type AuditContext,
+  SYSTEM_ACTOR_ID,
+  getAuditContext,
+} from "~/lib/auditContext";
+
+/**
+ * Runtime-agnostic BullMQ audit-context helpers.
+ *
+ * This module is intentionally free of any `next/*` imports so that it can
+ * be loaded by BullMQ workers, which run against a Docker image that
+ * strips Next.js from node_modules to save ~900MB. The Next.js-specific
+ * HOFs (withAuditContext, withActionAuditContext, enrichFromApiAuth) live
+ * in `./auditContextWrappers.ts` and MUST NOT be imported from here.
+ */
+
+/**
+ * System-actor stamping options. Callers that legitimately enqueue jobs
+ * from outside any user request (scheduled jobs, worker-to-worker where
+ * no upstream context exists, infrastructure tasks) MUST pass a
+ * `systemReason` so the audit log records WHY the event has no actor.
+ *
+ * Convention: `scope:identifier` e.g. `"scheduled:daily-report-rollup"`,
+ * `"scheduled:budget-alert-check"`, `"fixture:test-fixture"`. Free-form
+ * is acceptable — it is stored as-is on the ALS frame and merged into
+ * event.metadata by captureAuditEvent.
+ *
+ * Per Phase 64 D-14 / D-15 / W5.
+ */
+export interface EnqueueSystemOptions {
+  systemReason: string;
+}
+
+export type ActorContextJobData<T> = T & {
+  actorContext: AuditContext;
+  /** Mirror of actorContext.systemReason for consumers that read job root directly. */
+  systemReason?: string;
+};
+
+/**
+ * Enqueue a job with actor context stamped from the current ALS frame,
+ * OR explicitly stamp as `__system__` when no ALS context is available
+ * and a `systemReason` is provided.
+ *
+ * Throws at enqueue-time when no ALS context is present AND no
+ * systemReason is provided — this is intentional: callers must decide
+ * consciously whether a job is user-attributed or system-initiated.
+ *
+ * When stamping `__system__`, the systemReason is embedded INSIDE
+ * actorContext (so `runWithAuditContext(job.data.actorContext, ...)` in
+ * the worker re-populates ALS with systemReason, and captureAuditEvent
+ * merges it into event.metadata — see W5 Option A). A root-level mirror
+ * of systemReason is preserved for consumers that read the job data
+ * directly.
+ *
+ * Per Phase 64 D-08 / D-14 / W5.
+ */
+export function enqueueWithAuditContext<T extends object>(
+  queue: Queue,
+  name: string,
+  data: T,
+  opts?: JobsOptions
+): Promise<Job<ActorContextJobData<T>>>;
+export function enqueueWithAuditContext<T extends object>(
+  queue: Queue,
+  name: string,
+  data: T,
+  systemOpts: EnqueueSystemOptions,
+  opts?: JobsOptions
+): Promise<Job<ActorContextJobData<T>>>;
+export async function enqueueWithAuditContext<T extends object>(
+  queue: Queue,
+  name: string,
+  data: T,
+  optsOrSystem?: JobsOptions | EnqueueSystemOptions,
+  maybeOpts?: JobsOptions
+): Promise<Job<ActorContextJobData<T>>> {
+  const isSystemOpts =
+    typeof optsOrSystem === "object" &&
+    optsOrSystem !== null &&
+    "systemReason" in optsOrSystem &&
+    typeof (optsOrSystem as EnqueueSystemOptions).systemReason === "string";
+
+  const jobOpts: JobsOptions | undefined = isSystemOpts
+    ? maybeOpts
+    : (optsOrSystem as JobsOptions | undefined);
+
+  const alsContext = getAuditContext();
+  // WR-01: empty strings are "present but empty", which is just as
+  // invalid as absent. Compare explicitly against null/undefined AND ""
+  // so a future refactor that defaults a field to "" does not silently
+  // flip a user-attributed event into the system branch.
+  const isPresent = (value: unknown): boolean =>
+    typeof value === "string" && value.length > 0;
+  const hasAlsIdentity = Boolean(
+    alsContext &&
+    (isPresent(alsContext.userId) ||
+      isPresent(alsContext.userEmail) ||
+      isPresent(alsContext.userName) ||
+      isPresent(alsContext.ipAddress) ||
+      isPresent(alsContext.userAgent) ||
+      isPresent(alsContext.requestId))
+  );
+
+  let payload: ActorContextJobData<T>;
+
+  if (hasAlsIdentity && alsContext) {
+    payload = {
+      ...data,
+      actorContext: { ...alsContext },
+    };
+  } else if (isSystemOpts) {
+    const systemReason = (optsOrSystem as EnqueueSystemOptions).systemReason;
+    payload = {
+      ...data,
+      actorContext: { userId: SYSTEM_ACTOR_ID, systemReason },
+      systemReason,
+    };
+  } else {
+    throw new Error(
+      "enqueueWithAuditContext: no audit context present; pass { systemReason } to stamp __system__"
+    );
+  }
+
+  return queue.add(
+    name,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    payload as any,
+    jobOpts
+  ) as Promise<Job<ActorContextJobData<T>>>;
+}

--- a/testplanit/lib/auditContextWrappers.test.ts
+++ b/testplanit/lib/auditContextWrappers.test.ts
@@ -4,10 +4,8 @@ import {
   getAuditContext,
   runWithAuditContext,
   type AuditContext,
-  SYSTEM_ACTOR_ID,
 } from "./auditContext";
 import {
-  enqueueWithAuditContext,
   enrichFromApiAuth,
   withActionAuditContext,
   withAuditContext,
@@ -29,14 +27,6 @@ vi.mock("next/headers", () => ({
     };
   }),
 }));
-
-// Hand-rolled Queue mock — no real BullMQ or Valkey connection.
-type QueueMock = {
-  add: ReturnType<typeof vi.fn>;
-};
-function makeQueueMock(): QueueMock {
-  return { add: vi.fn(async () => ({ id: "job-mock" })) };
-}
 
 /**
  * Build a fake NextRequest whose `headers` supports `get(...)` with the
@@ -142,185 +132,6 @@ describe("withActionAuditContext", () => {
 
     expect(seen).toHaveLength(2);
     expect(seen[0]).not.toBe(seen[1]);
-  });
-});
-
-describe("enqueueWithAuditContext", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("merges ALS context into actorContext when ALS is present", async () => {
-    const queue = makeQueueMock();
-    const ctx: AuditContext = {
-      userId: "u-42",
-      userEmail: "u42@example.com",
-      userName: "User 42",
-      ipAddress: "198.51.100.2",
-      userAgent: "UA/enqueue",
-      requestId: "req_fixed_42",
-    };
-
-    await runWithAuditContext(ctx, async () => {
-      await enqueueWithAuditContext(
-        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-        "job-alpha",
-        { foo: "bar" }
-      );
-    });
-
-    expect(queue.add).toHaveBeenCalledTimes(1);
-    const [jobName, payload] = queue.add.mock.calls[0];
-    expect(jobName).toBe("job-alpha");
-    expect(payload).toMatchObject({
-      foo: "bar",
-      actorContext: {
-        userId: "u-42",
-        userEmail: "u42@example.com",
-        userName: "User 42",
-        ipAddress: "198.51.100.2",
-        userAgent: "UA/enqueue",
-        requestId: "req_fixed_42",
-      },
-    });
-    // No root-level systemReason mirror when not system-stamped
-    expect((payload as Record<string, unknown>).systemReason).toBeUndefined();
-  });
-
-  it("throws when ALS is empty and no systemReason is provided", async () => {
-    const queue = makeQueueMock();
-
-    // Call OUTSIDE any runWithAuditContext frame — ALS is empty.
-    await expect(
-      enqueueWithAuditContext(
-        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-        "job-beta",
-        { foo: "bar" }
-      )
-    ).rejects.toThrow(/no audit context present/);
-
-    expect(queue.add).not.toHaveBeenCalled();
-  });
-
-  it("throws when ALS contains only empty-string fields and no systemReason (WR-01 hardening)", async () => {
-    const queue = makeQueueMock();
-    const emptyCtx: AuditContext = {
-      userId: "",
-      userEmail: "",
-      userName: "",
-      ipAddress: "",
-      userAgent: "",
-      requestId: "",
-    };
-
-    await expect(
-      runWithAuditContext(emptyCtx, async () => {
-        await enqueueWithAuditContext(
-          queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-          "job-empty-strings",
-          { foo: "bar" }
-        );
-      })
-    ).rejects.toThrow(/no audit context present/);
-
-    expect(queue.add).not.toHaveBeenCalled();
-  });
-
-  it("does NOT misattribute when ALS has a populated userId but empty ipAddress (WR-01 future-refactor guard)", async () => {
-    const queue = makeQueueMock();
-    const ctx: AuditContext = {
-      userId: "u-real",
-      userEmail: "real@example.com",
-      userName: "Real User",
-      ipAddress: "", // future-refactor scenario: extractIpAddress defaulted to ""
-      userAgent: "UA/real",
-      requestId: "req_real_1",
-    };
-
-    await runWithAuditContext(ctx, async () => {
-      await enqueueWithAuditContext(
-        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-        "job-mixed",
-        { foo: "bar" }
-      );
-    });
-
-    expect(queue.add).toHaveBeenCalledTimes(1);
-    const [, payload] = queue.add.mock.calls[0];
-    // The user is real, so user-attribution wins (the empty ipAddress is
-    // faithfully carried through — we do NOT rewrite it, we just do not
-    // let it alone flip the branch). The job payload reflects the
-    // actual ALS state; consumers / expectAuditRowComplete catch the
-    // incomplete ipAddress downstream via WR-03.
-    expect((payload as Record<string, unknown>).actorContext).toMatchObject({
-      userId: "u-real",
-      ipAddress: "",
-    });
-  });
-
-  it("stamps __system__ with systemReason embedded in actorContext when ALS is empty", async () => {
-    const queue = makeQueueMock();
-
-    await enqueueWithAuditContext(
-      queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-      "job-gamma",
-      { foo: "bar" },
-      { systemReason: "scheduled:test-rollup" }
-    );
-
-    expect(queue.add).toHaveBeenCalledTimes(1);
-    const [jobName, payload] = queue.add.mock.calls[0];
-    expect(jobName).toBe("job-gamma");
-    expect(payload).toMatchObject({
-      foo: "bar",
-      actorContext: {
-        userId: SYSTEM_ACTOR_ID,
-        systemReason: "scheduled:test-rollup",
-      },
-    });
-  });
-
-  it("sets root-level systemReason mirror on the job payload", async () => {
-    const queue = makeQueueMock();
-
-    await enqueueWithAuditContext(
-      queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-      "job-delta",
-      { foo: "bar" },
-      { systemReason: "scheduled:mirror-test" }
-    );
-
-    const payload = queue.add.mock.calls[0][1] as Record<string, unknown>;
-    expect(payload.systemReason).toBe("scheduled:mirror-test");
-  });
-
-  it("prefers ALS context over systemReason when both present", async () => {
-    const queue = makeQueueMock();
-    const ctx: AuditContext = {
-      userId: "u-user-wins",
-      userEmail: "user@example.com",
-      userName: "Real User",
-      requestId: "req_user_wins",
-    };
-
-    await runWithAuditContext(ctx, async () => {
-      await enqueueWithAuditContext(
-        queue as unknown as Parameters<typeof enqueueWithAuditContext>[0],
-        "job-epsilon",
-        { foo: "bar" },
-        { systemReason: "scheduled:should-be-ignored" }
-      );
-    });
-
-    const payload = queue.add.mock.calls[0][1] as Record<string, unknown>;
-    expect((payload.actorContext as AuditContext).userId).toBe("u-user-wins");
-    // No __system__ anywhere in actorContext
-    expect((payload.actorContext as AuditContext).userId).not.toBe(
-      SYSTEM_ACTOR_ID
-    );
-    // No systemReason leaks in on the user-attributed branch
-    expect(payload.systemReason).toBeUndefined();
-    expect((payload.actorContext as AuditContext).systemReason).toBeUndefined();
   });
 });
 

--- a/testplanit/lib/auditContextWrappers.ts
+++ b/testplanit/lib/auditContextWrappers.ts
@@ -1,18 +1,22 @@
-// NOTE: `next/headers` is intentionally NOT imported at module-top.
-// This file is imported by BullMQ workers (via enqueueWithAuditContext), and
-// the workers Docker image strips Next.js deps to save ~900MB. A top-level
-// `import "next/headers"` would fail at worker startup with "Cannot find module".
-// The one function that needs it (withActionAuditContext) dynamic-imports below.
+import { headers as nextHeaders } from "next/headers";
 import type { NextRequest } from "next/server";
-import type { Job, JobsOptions, Queue } from "bullmq";
 import {
   type AuditContext,
-  SYSTEM_ACTOR_ID,
   extractAuditContextFromHeaders,
-  getAuditContext,
   runWithAuditContext,
   updateAuditContext,
 } from "~/lib/auditContext";
+
+/**
+ * Next.js-specific audit-context HOFs.
+ *
+ * This file transitively imports `next/headers`, which is NOT present in
+ * the workers Docker image (Next.js deps are stripped to save ~900MB).
+ * Runtime-agnostic enqueue helpers (`enqueueWithAuditContext`,
+ * `ActorContextJobData`, `EnqueueSystemOptions`) live in
+ * `./auditContextEnqueue.ts` — workers and other non-Next.js contexts
+ * MUST import from there, never from this file.
+ */
 
 /**
  * HOF that wraps an API route handler in an AsyncLocalStorage frame
@@ -54,9 +58,6 @@ export function withActionAuditContext<TArgs extends unknown[], TReturn>(
   fn: (...args: TArgs) => Promise<TReturn>
 ): (...args: TArgs) => Promise<TReturn> {
   return async (...args: TArgs): Promise<TReturn> => {
-    // Dynamic import keeps workers (which don't have next/ in node_modules)
-    // from crashing when this file is required for its enqueue helpers.
-    const { headers: nextHeaders } = await import("next/headers");
     const headersList = await nextHeaders();
     // next/headers returns ReadonlyHeaders which is structurally compatible
     // with Headers for the extractor's purposes.
@@ -87,120 +88,4 @@ export function enrichFromApiAuth(apiAuth: {
     userEmail: apiAuth.userEmail,
     userName: apiAuth.userName,
   });
-}
-
-/**
- * System-actor stamping options. Callers that legitimately enqueue jobs
- * from outside any user request (scheduled jobs, worker-to-worker where
- * no upstream context exists, infrastructure tasks) MUST pass a
- * `systemReason` so the audit log records WHY the event has no actor.
- *
- * Convention: `scope:identifier` e.g. `"scheduled:daily-report-rollup"`,
- * `"scheduled:budget-alert-check"`, `"fixture:test-fixture"`. Free-form
- * is acceptable — it is stored as-is on the ALS frame and merged into
- * event.metadata by captureAuditEvent.
- *
- * Per Phase 64 D-14 / D-15 / W5.
- */
-export interface EnqueueSystemOptions {
-  systemReason: string;
-}
-
-export type ActorContextJobData<T> = T & {
-  actorContext: AuditContext;
-  /** Mirror of actorContext.systemReason for consumers that read job root directly. */
-  systemReason?: string;
-};
-
-/**
- * Enqueue a job with actor context stamped from the current ALS frame,
- * OR explicitly stamp as `__system__` when no ALS context is available
- * and a `systemReason` is provided.
- *
- * Throws at enqueue-time when no ALS context is present AND no
- * systemReason is provided — this is intentional: callers must decide
- * consciously whether a job is user-attributed or system-initiated.
- *
- * When stamping `__system__`, the systemReason is embedded INSIDE
- * actorContext (so `runWithAuditContext(job.data.actorContext, ...)` in
- * the worker re-populates ALS with systemReason, and captureAuditEvent
- * merges it into event.metadata — see W5 Option A). A root-level mirror
- * of systemReason is preserved for consumers that read the job data
- * directly.
- *
- * Per Phase 64 D-08 / D-14 / W5.
- */
-export function enqueueWithAuditContext<T extends object>(
-  queue: Queue,
-  name: string,
-  data: T,
-  opts?: JobsOptions
-): Promise<Job<ActorContextJobData<T>>>;
-export function enqueueWithAuditContext<T extends object>(
-  queue: Queue,
-  name: string,
-  data: T,
-  systemOpts: EnqueueSystemOptions,
-  opts?: JobsOptions
-): Promise<Job<ActorContextJobData<T>>>;
-export async function enqueueWithAuditContext<T extends object>(
-  queue: Queue,
-  name: string,
-  data: T,
-  optsOrSystem?: JobsOptions | EnqueueSystemOptions,
-  maybeOpts?: JobsOptions
-): Promise<Job<ActorContextJobData<T>>> {
-  const isSystemOpts =
-    typeof optsOrSystem === "object" &&
-    optsOrSystem !== null &&
-    "systemReason" in optsOrSystem &&
-    typeof (optsOrSystem as EnqueueSystemOptions).systemReason === "string";
-
-  const jobOpts: JobsOptions | undefined = isSystemOpts
-    ? maybeOpts
-    : (optsOrSystem as JobsOptions | undefined);
-
-  const alsContext = getAuditContext();
-  // WR-01: empty strings are "present but empty", which is just as
-  // invalid as absent. Compare explicitly against null/undefined AND ""
-  // so a future refactor that defaults a field to "" does not silently
-  // flip a user-attributed event into the system branch.
-  const isPresent = (value: unknown): boolean =>
-    typeof value === "string" && value.length > 0;
-  const hasAlsIdentity = Boolean(
-    alsContext &&
-    (isPresent(alsContext.userId) ||
-      isPresent(alsContext.userEmail) ||
-      isPresent(alsContext.userName) ||
-      isPresent(alsContext.ipAddress) ||
-      isPresent(alsContext.userAgent) ||
-      isPresent(alsContext.requestId))
-  );
-
-  let payload: ActorContextJobData<T>;
-
-  if (hasAlsIdentity && alsContext) {
-    payload = {
-      ...data,
-      actorContext: { ...alsContext },
-    };
-  } else if (isSystemOpts) {
-    const systemReason = (optsOrSystem as EnqueueSystemOptions).systemReason;
-    payload = {
-      ...data,
-      actorContext: { userId: SYSTEM_ACTOR_ID, systemReason },
-      systemReason,
-    };
-  } else {
-    throw new Error(
-      "enqueueWithAuditContext: no audit context present; pass { systemReason } to stamp __system__"
-    );
-  }
-
-  return queue.add(
-    name,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    payload as any,
-    jobOpts
-  ) as Promise<Job<ActorContextJobData<T>>>;
 }

--- a/testplanit/lib/integrations/services/SyncService.ts
+++ b/testplanit/lib/integrations/services/SyncService.ts
@@ -2,7 +2,7 @@ import { prisma as defaultPrisma } from "@/lib/prismaBase";
 import type { PrismaClient } from "@prisma/client";
 import { Job, JobsOptions } from "bullmq";
 import { syncIssueToElasticsearch } from "~/services/issueSearch";
-import { enqueueWithAuditContext } from "../../auditContextWrappers";
+import { enqueueWithAuditContext } from "../../auditContextEnqueue";
 import { getCurrentTenantId } from "../../multiTenantPrisma";
 import { getSyncQueue } from "../../queues";
 import type { IssueAdapter, IssueData } from "../adapters/IssueAdapter";

--- a/testplanit/scripts/test-budget-alert.ts
+++ b/testplanit/scripts/test-budget-alert.ts
@@ -13,7 +13,7 @@
  */
 
 import { Queue } from "bullmq";
-import { enqueueWithAuditContext } from "../lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "../lib/auditContextEnqueue";
 import { BUDGET_ALERT_QUEUE_NAME } from "../lib/queueNames";
 import valkeyConnection from "../lib/valkey";
 

--- a/testplanit/scripts/trigger-forecast-recalc.ts
+++ b/testplanit/scripts/trigger-forecast-recalc.ts
@@ -1,4 +1,4 @@
-import { enqueueWithAuditContext } from "../lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "../lib/auditContextEnqueue";
 import { getAllTenantIds, isMultiTenantMode } from "../lib/multiTenantPrisma";
 import { getForecastQueue } from "../lib/queues";
 import { JOB_UPDATE_ALL_CASES } from "../workers/forecastWorker";

--- a/testplanit/scripts/trigger-milestone-notifications.ts
+++ b/testplanit/scripts/trigger-milestone-notifications.ts
@@ -1,4 +1,4 @@
-import { enqueueWithAuditContext } from "../lib/auditContextWrappers";
+import { enqueueWithAuditContext } from "../lib/auditContextEnqueue";
 import { getAllTenantIds, isMultiTenantMode } from "../lib/multiTenantPrisma";
 import { getForecastQueue } from "../lib/queues";
 import { JOB_MILESTONE_DUE_NOTIFICATIONS } from "../workers/forecastWorker";

--- a/testplanit/workers/copyMoveWorker.ts
+++ b/testplanit/workers/copyMoveWorker.ts
@@ -1,7 +1,7 @@
 import { Job, Worker } from "bullmq";
 import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
-import type { ActorContextJobData } from "../lib/auditContextWrappers";
+import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,

--- a/testplanit/workers/forecastWorker.ts
+++ b/testplanit/workers/forecastWorker.ts
@@ -1,7 +1,7 @@
 import { Job, Worker } from "bullmq";
 import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
-import type { ActorContextJobData } from "../lib/auditContextWrappers";
+import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,

--- a/testplanit/workers/syncWorker.ts
+++ b/testplanit/workers/syncWorker.ts
@@ -1,7 +1,7 @@
 import { Job, Worker } from "bullmq";
 import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
-import type { ActorContextJobData } from "../lib/auditContextWrappers";
+import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
   SyncJobData,
   syncService,

--- a/testplanit/workers/testmoImportWorker.test.ts
+++ b/testplanit/workers/testmoImportWorker.test.ts
@@ -296,7 +296,7 @@ describe("testmoImportWorker — CTX-03 actor context propagation", () => {
     const { runWithAuditContext, updateAuditContext } =
       await import("../lib/auditContext");
     const { enqueueWithAuditContext } =
-      await import("../lib/auditContextWrappers");
+      await import("../lib/auditContextEnqueue");
     const { expectAuditRowComplete } =
       await import("../lib/testing/auditAssertions");
 
@@ -373,7 +373,7 @@ describe("testmoImportWorker — CTX-03 actor context propagation", () => {
   it("system path: audit row carries __system__ userId and systemReason when enqueued with no upstream context", async () => {
     const { SYSTEM_ACTOR_ID } = await import("../lib/auditContext");
     const { enqueueWithAuditContext } =
-      await import("../lib/auditContextWrappers");
+      await import("../lib/auditContextEnqueue");
     const { expectAuditRowComplete } =
       await import("../lib/testing/auditAssertions");
 

--- a/testplanit/workers/testmoImportWorker.ts
+++ b/testplanit/workers/testmoImportWorker.ts
@@ -28,7 +28,7 @@ import { runWithAuditContext } from "../lib/auditContext";
 import {
   enqueueWithAuditContext,
   type ActorContextJobData,
-} from "../lib/auditContextWrappers";
+} from "../lib/auditContextEnqueue";
 import {
   getElasticsearchReindexQueue,
   TESTMO_IMPORT_QUEUE_NAME,


### PR DESCRIPTION
## Description

Splits `lib/auditContextWrappers.ts` along concern boundaries so BullMQ workers no longer transitively depend on Next.js.

**Background.** On 2026-04-22 the multitenant-workers deployment crashlooped at startup with `Error: Cannot find module 'next/headers'`. Root cause: `workers/testmoImportWorker.ts` imported `enqueueWithAuditContext` from `lib/auditContextWrappers.ts`, which had a module-top `import { headers } from "next/headers"`. The workers Docker image intentionally strips Next.js from `node_modules` to save ~900MB (see `Dockerfile` `deps-workers` stage), so the require failed.

Hotfix c804cace lazy-loaded `next/headers` inside `withActionAuditContext`. This PR replaces that band-aid with a real split.

**Changes**

- **New `lib/auditContextEnqueue.ts`** — runtime-agnostic BullMQ helpers:
  - `enqueueWithAuditContext` (function)
  - `ActorContextJobData` (type)
  - `EnqueueSystemOptions` (interface)
  - Zero `next/*` imports. Safe to load in any Node.js context.
- **`lib/auditContextWrappers.ts`** — now Next.js-only:
  - `withAuditContext`, `withActionAuditContext`, `enrichFromApiAuth`
  - Reverted the hotfix's dynamic `await import("next/headers")` back to a normal top-level `import { headers } from "next/headers"`.
  - Doc header warns workers / non-Next contexts to use `./auditContextEnqueue`.
- **Workers updated to the new module**:
  - `workers/testmoImportWorker.ts` (real imports)
  - `workers/copyMoveWorker.ts`, `workers/syncWorker.ts`, `workers/forecastWorker.ts` (type-only imports)
  - `workers/testmoImportWorker.test.ts` (both dynamic `await import(...)` call sites)
- **Also updated** (caught by transitive-coupling audit):
  - `lib/integrations/services/SyncService.ts` — pulled in by `syncWorker.ts`; keeping the wrapper import here would have re-introduced the coupling.
  - `scripts/test-budget-alert.ts`, `scripts/trigger-forecast-recalc.ts`, `scripts/trigger-milestone-notifications.ts` — run as tsx outside Next.
  - `app/api/repository/copy-move/route.ts`, `app/api/admin/elasticsearch/reindex/route.ts`, `app/api/imports/testmo/jobs/route.ts`, `app/api/imports/testmo/jobs/[jobId]/import/route.ts` — these had `enqueueWithAuditContext` alongside a Next HOF in one import block; split into two blocks so the wrapper file no longer has to re-export runtime-agnostic symbols.
- **Tests split**:
  - `lib/auditContextEnqueue.test.ts` (new) — enqueue tests, no `next/headers` mock. Passing this file without any Next.js mock is the implicit proof that the module loads in a Next-free environment.
  - `lib/auditContextWrappers.test.ts` — keeps the `withAuditContext` / `withActionAuditContext` / `enrichFromApiAuth` tests and the `next/headers` mock.

**Verification**

```
$ grep -rn "next/" workers/*.ts
(no results for non-test worker files)

$ grep -rn "auditContextWrappers" workers/*.ts
(no results)
```

## Related Issue

Follow-up to hotfix c804cace (workers crashloop 2026-04-22 16:30 UTC).

## Type of Change

- [x] Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing (verification greps above)

Ran locally:

```
NODE_OPTIONS='--max-old-space-size=16382' pnpm test run \
  lib/auditContextEnqueue.test.ts lib/auditContextWrappers.test.ts \
  workers/testmoImportWorker.test.ts workers/copyMoveWorker.test.ts \
  workers/syncWorker.test.ts workers/forecastWorker.test.ts
→ 2 test files + 4 worker test files, 81 tests passed

NODE_OPTIONS='--max-old-space-size=16382' pnpm type-check    → clean
pnpm exec eslint <touched files>                             → 0 errors, same 6 pre-existing warnings as main (not introduced by this PR)
pnpm exec prettier --check <touched files>                   → clean
```

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Node version: via `pnpm` (repo-pinned)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

This is PR 1 of 3 follow-ups from the 2026-04-22 workers crashloop post-mortem:

1. **This PR** — split along concern boundaries (architectural fix).
2. **PR 2 (planned)** — CI smoke test that boots the workers image so this class of bug can't ship again.
3. **PR 3 (planned)** — SHA-tagged worker images so `kubectl rollout undo` actually works when a bad image does ship.
