### PR TITLE
ci(workers): smoke-test worker image boots before promoting to :latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,17 @@ jobs:
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
 
+    - name: Smoke-test workers image (AMD64)
+      run: |
+        VERSION="${{ github.ref_name }}"
+        VERSION_NUM="${VERSION#v}"
+        IMAGE="ghcr.io/${REPO_LC}:${VERSION_NUM}-workers-amd64"
+        docker pull "$IMAGE"
+        # Fail fast if any worker entrypoint's require graph is broken
+        # (e.g. a missing native dep or a stripped package — the failure
+        # mode from the 2026-04-22 next/headers incident).
+        docker run --rm --entrypoint node "$IMAGE" ./scripts/smoke-test-workers.js
+
   # Build ARM64 images natively on macOS arm64 runner (using Colima)
   build-arm64:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
@@ -145,6 +156,17 @@ jobs:
           --set "*.args.VERSION=${VERSION}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
+
+    - name: Smoke-test workers image (ARM64)
+      run: |
+        VERSION="${{ github.ref_name }}"
+        VERSION_NUM="${VERSION#v}"
+        IMAGE="ghcr.io/${REPO_LC}:${VERSION_NUM}-workers-arm64"
+        docker pull "$IMAGE"
+        # Fail fast if any worker entrypoint's require graph is broken
+        # (e.g. a missing native dep or a stripped package — the failure
+        # mode from the 2026-04-22 next/headers incident).
+        docker run --rm --entrypoint node "$IMAGE" ./scripts/smoke-test-workers.js
 
   # Merge architecture-specific images into multi-arch manifests
   merge-manifests:
@@ -259,6 +281,12 @@ jobs:
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
 
+    - name: Smoke-test workers image (AMD64)
+      run: |
+        IMAGE="ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-workers-amd64"
+        docker pull "$IMAGE"
+        docker run --rm --entrypoint node "$IMAGE" ./scripts/smoke-test-workers.js
+
   # Manual build: ARM64 images natively on macOS arm64 runner (using Colima)
   docker-manual-arm64:
     if: github.event_name == 'workflow_dispatch'
@@ -313,6 +341,12 @@ jobs:
           --set "*.args.VERSION=${{ github.event.inputs.tag }}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
+
+    - name: Smoke-test workers image (ARM64)
+      run: |
+        IMAGE="ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-workers-arm64"
+        docker pull "$IMAGE"
+        docker run --rm --entrypoint node "$IMAGE" ./scripts/smoke-test-workers.js
 
   # Manual build: Merge architecture-specific images into multi-arch manifests
   docker-manual-merge:

--- a/testplanit/scripts/smoke-test-workers.js
+++ b/testplanit/scripts/smoke-test-workers.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test: verify every worker's compiled entry point loads cleanly
+ * inside the workers Docker image.
+ *
+ * Background: on 2026-04-22 the multitenant-workers deploy crashlooped
+ * at startup because a module imported by testmoImportWorker had a
+ * top-level `import "next/headers"` — but the workers image strips
+ * Next.js from node_modules to save ~900MB. `docker build` never
+ * surfaces this: the build only compiles files, never loads them at
+ * runtime. This script closes that gap.
+ *
+ * What it does: `require()` each compiled worker entry so Node's CJS
+ * resolver walks the full import graph. Any missing/unresolved module
+ * throws synchronously and fails this script. Only require-time errors
+ * count; the workers' connection attempts to Valkey/Postgres that fire
+ * from the main-guard (`typeof import.meta === "undefined"` branch)
+ * happen asynchronously and we exit(0) before they escape, so we
+ * don't need a live Valkey/Postgres in CI.
+ *
+ * Keep the list in sync with ecosystem.config.js + scripts/build-workers.js.
+ */
+
+const path = require("path");
+
+// Worker entrypoints — must match scripts/build-workers.js entryPoints.
+const WORKERS = [
+  "notificationWorker",
+  "emailWorker",
+  "forecastWorker",
+  "syncWorker",
+  "testmoImportWorker",
+  "elasticsearchReindexWorker",
+  "auditLogWorker",
+  "autoTagWorker",
+  "budgetAlertWorker",
+  "repoCacheWorker",
+  "copyMoveWorker",
+  "duplicateScanWorker",
+  "magicSelectWorker",
+  "stepSequenceScanWorker",
+  "generateFromUrlWorker",
+];
+
+const entryPoints = [
+  ...WORKERS.map((name) => ({ name, file: `dist/workers/${name}.js` })),
+  { name: "scheduler", file: "dist/scheduler.js" },
+];
+
+let failed = 0;
+for (const { name, file } of entryPoints) {
+  const abs = path.resolve(process.cwd(), file);
+  try {
+    require(abs);
+    console.log(`✓ ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`✗ ${name}: ${err && err.message ? err.message : err}`);
+    if (err && err.stack) {
+      console.error(err.stack);
+    }
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} worker entrypoint(s) failed to load.`);
+  // Exit on the next tick so pending error logs flush before we bail.
+  process.exit(1);
+}
+
+console.log(
+  `\nAll ${entryPoints.length} worker entrypoints loaded successfully.`
+);
+// Force exit to short-circuit any async startup work (BullMQ workers
+// keep the event loop alive once new Worker(...) has been called).
+process.exit(0);


### PR DESCRIPTION
## Description

Adds a smoke-test step to every workers Docker image build so a broken require graph can't silently ship again.

**Background.** On 2026-04-22 the multitenant-workers deploy crashlooped at startup with `Error: Cannot find module 'next/headers'`. The bug was a module import that was fine in the Next.js server image but unresolvable in the workers image (Next.js is intentionally stripped to save ~900MB — see `Dockerfile` `deps-workers` stage). `docker build` compiles files but never executes the entrypoints, so CI stayed green and the failure only surfaced at `kubectl rollout`. This PR closes that gap.

**Changes**

- **New** `testplanit/scripts/smoke-test-workers.js` — CJS script that `require()`s each compiled worker entry plus `dist/scheduler.js`. Any require-time error (missing module, unreachable native dep, bundler-stripped package) throws synchronously and the script fails with a clear message. After the loop it calls `process.exit(0)` to short-circuit the async `startWorker()` side-effects that fire from the `typeof import.meta === "undefined"` branch of each worker's main-guard — this is why CI doesn't need live Valkey/Postgres to run the probe.
- **Modified** `.github/workflows/release.yml` — one new step per build job, run right after `docker buildx bake --push`:
  - `build-amd64` + `build-arm64` (tag-push)
  - `docker-manual-amd64` + `docker-manual-arm64` (manual dispatch)
  - Pulls the image we just pushed, then runs `docker run --rm --entrypoint node <image> ./scripts/smoke-test-workers.js`.
  - A failure blocks the per-arch job, which blocks `merge-manifests`, which is what retags `:latest-workers`. A broken image can't promote to the floating tag.

The smoke script ships inside the workers image already (`COPY --from=build /app/scripts ./scripts` at `Dockerfile:329`), so no Dockerfile changes are needed.

## Related Issue

Follow-up to hotfix c804cace (workers crashloop 2026-04-22 16:30 UTC). Companion to #235 (the architectural fix for that incident).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

The fix is a CI-only guardrail; runtime behavior is unchanged.

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Built workers locally (`pnpm build:workers`) and ran the smoke script against the real compiled `dist/`:

```
$ node testplanit/scripts/smoke-test-workers.js
✓ notificationWorker
✓ emailWorker
✓ forecastWorker
✓ syncWorker
✓ testmoImportWorker
✓ elasticsearchReindexWorker
✓ auditLogWorker
✓ autoTagWorker
✓ budgetAlertWorker
✓ repoCacheWorker
✓ copyMoveWorker
✓ duplicateScanWorker
✓ magicSelectWorker
✓ stepSequenceScanWorker
✓ generateFromUrlWorker
✓ scheduler

All 16 worker entrypoints loaded successfully.
$ echo $?
0
```

Verified the failure path by injecting a missing `require("definitely-not-a-real-module")` into one compiled worker:

```
✗ auditLogWorker: Cannot find module 'definitely-not-a-real-module'
Require stack:
- .../dist/workers/auditLogWorker.js
- .../scripts/smoke-test-workers.js

1 worker entrypoint(s) failed to load.
$ echo $?
1
```

That is the exact failure shape that would have caught the next/headers incident.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Node version: v24.14.0 (matches `Dockerfile` `FROM node:24-alpine`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

**Maintenance contract.** When adding a new worker, update three files (existing convention, per CLAUDE memory):
- `scripts/build-workers.js` — add to `entryPoints`
- `ecosystem.config.js` — add to PM2 `apps`
- `package.json` — add `worker:<name>` script + include in `workers` concurrently list

This PR adds a fourth:
- `scripts/smoke-test-workers.js` — add to `WORKERS` array

A comment in the new file points at `ecosystem.config.js` + `scripts/build-workers.js` as the two lists that must stay in sync. It's explicit rather than metaprogrammed on purpose: a smoke test that silently skips a new worker would defeat its own purpose.

**Why require() instead of the one-liner in the post-mortem.** The user-suggested `docker run --entrypoint node <image> -e "require('./dist/workers/testmoImportWorker.js')"` would hang: workers use a main-guard (`typeof import.meta === "undefined"` branch fires under Node's CJS loader) that kicks off BullMQ's background Valkey connection. Without `process.exit(0)` after the require, the Node event loop stays busy until the Valkey connection errors after its timeout — slow, and the failure mode is noisy and easy to misread. The script wraps every require in a try/catch, force-exits cleanly, and gives one pass/fail line per worker — much easier to read in a CI log.

**Scope.** This PR is CI/test-only. It does not change worker runtime, does not change Dockerfile stages, and does not change what images are tagged where. PR 3 (next) addresses the floating-tag problem that made rollback impossible during the incident.
