### PR TITLE
ci(workers): publish SHA-tagged workers image alongside :latest-workers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,14 @@
 # - Production image: ghcr.io/testplanit/testplanit:latest (for Next.js server)
 # - Workers image: ghcr.io/testplanit/testplanit:latest-workers (for background workers)
 #
+# Workers image SHA tags:
+# - Every build also publishes ghcr.io/testplanit/testplanit:workers-sha-<short-sha>
+#   so the k8s Deployment can pin to a specific commit rather than the floating
+#   :latest-workers tag. :latest-workers is retained as a convenience alias but
+#   Deployments SHOULD reference :workers-sha-<short-sha> so `kubectl rollout
+#   undo` has real history to roll back to. See multitenant-workers Deployment
+#   manifest in the private-ops repo.
+#
 # IMPORTANT: Docker images are built with BASE_DOMAIN=testplanit.com which enables a wildcard
 # pattern (*.testplanit.com) for Next.js image optimization. This allows a SINGLE Docker image
 # to serve ALL customer subdomains (e.g., company1.testplanit.com, company2.testplanit.com, etc.)
@@ -77,6 +85,7 @@ jobs:
       run: |
         VERSION="${{ github.ref_name }}"
         VERSION_NUM="${VERSION#v}"
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
 
         docker buildx bake -f docker-bake.hcl --push \
           --set "*.platform=linux/amd64" \
@@ -84,6 +93,7 @@ jobs:
           --set "production.tags=ghcr.io/${REPO_LC}:${VERSION}-amd64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${VERSION_NUM}-workers-amd64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${VERSION}-workers-amd64" \
+          --set "workers.tags=ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-amd64" \
           --set "*.args.VERSION=${VERSION}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
@@ -135,6 +145,7 @@ jobs:
       run: |
         VERSION="${{ github.ref_name }}"
         VERSION_NUM="${VERSION#v}"
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
 
         docker buildx bake -f docker-bake.hcl --push \
           --set "*.platform=linux/arm64" \
@@ -142,6 +153,7 @@ jobs:
           --set "production.tags=ghcr.io/${REPO_LC}:${VERSION}-arm64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${VERSION_NUM}-workers-arm64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${VERSION}-workers-arm64" \
+          --set "workers.tags=ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-arm64" \
           --set "*.args.VERSION=${VERSION}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
@@ -175,6 +187,7 @@ jobs:
       run: |
         VERSION="${{ github.ref_name }}"
         VERSION_NUM="${VERSION#v}"
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
 
         # Create production manifests
         docker buildx imagetools create -t ghcr.io/${REPO_LC}:${VERSION_NUM} \
@@ -193,6 +206,12 @@ jobs:
         docker buildx imagetools create -t ghcr.io/${REPO_LC}:${VERSION}-workers \
           ghcr.io/${REPO_LC}:${VERSION}-workers-amd64 \
           ghcr.io/${REPO_LC}:${VERSION}-workers-arm64
+
+        # SHA-pinned workers manifest — the k8s Deployment SHOULD reference
+        # this tag (not :latest-workers) so rollbacks work.
+        docker buildx imagetools create -t ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA} \
+          ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-amd64 \
+          ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-arm64
 
         # Only update 'latest' if this is the newest semantic version
         # Filter to only 3-part semver tags (vX.Y.Z) to avoid non-semver tags like v1.1 breaking the comparison
@@ -251,10 +270,12 @@ jobs:
     - name: Build and push AMD64 images
       working-directory: ./testplanit
       run: |
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         docker buildx bake -f docker-bake.hcl --push \
           --set "*.platform=linux/amd64" \
           --set "production.tags=ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-amd64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-workers-amd64" \
+          --set "workers.tags=ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-amd64" \
           --set "*.args.VERSION=${{ github.event.inputs.tag }}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
@@ -306,10 +327,12 @@ jobs:
     - name: Build and push ARM64 images
       working-directory: ./testplanit
       run: |
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         docker buildx bake -f docker-bake.hcl --push \
           --set "*.platform=linux/arm64" \
           --set "production.tags=ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-arm64" \
           --set "workers.tags=ghcr.io/${REPO_LC}:${{ github.event.inputs.tag }}-workers-arm64" \
+          --set "workers.tags=ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-arm64" \
           --set "*.args.VERSION=${{ github.event.inputs.tag }}" \
           --set "*.args.GIT_COMMIT=${{ github.sha }}" \
           --set "*.args.BASE_DOMAIN=testplanit.com"
@@ -342,6 +365,7 @@ jobs:
     - name: Create multi-arch manifests
       run: |
         VERSION="${{ github.event.inputs.tag }}"
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
 
         # Create production manifest
         docker buildx imagetools create -t ghcr.io/${REPO_LC}:${VERSION} \
@@ -352,6 +376,12 @@ jobs:
         docker buildx imagetools create -t ghcr.io/${REPO_LC}:${VERSION}-workers \
           ghcr.io/${REPO_LC}:${VERSION}-workers-amd64 \
           ghcr.io/${REPO_LC}:${VERSION}-workers-arm64
+
+        # SHA-pinned workers manifest — the k8s Deployment SHOULD reference
+        # this tag (not :latest-workers) so rollbacks work.
+        docker buildx imagetools create -t ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA} \
+          ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-amd64 \
+          ghcr.io/${REPO_LC}:workers-sha-${SHORT_SHA}-arm64
 
         # Update 'latest' if this is the newest semantic version
         # Filter to only 3-part semver tags (vX.Y.Z) to avoid non-semver tags like v1.1 breaking the comparison


### PR DESCRIPTION
## Description

Publishes a SHA-pinned workers image tag on every build so the k8s Deployment can stop pointing at the floating `:latest-workers` tag.

**Background.** On 2026-04-22, rollback of the multitenant-workers crashloop was effectively impossible: every revision in `kubectl rollout history` pointed at the same tag (`:latest-workers`), and the broken image had already overwritten the good one in GHCR. "Undo" had nowhere to roll back to.

**What this PR does** — in `.github/workflows/release.yml`:

- Derives `SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)` inside each build job.
- Adds one extra tag to the workers image in all 4 build jobs (tag-push + manual-dispatch, amd64 + arm64):
  - `ghcr.io/testplanit/testplanit:workers-sha-<short-sha>-<arch>`
- Adds a multi-arch manifest for the SHA tag in both merge jobs:
  - `ghcr.io/testplanit/testplanit:workers-sha-<short-sha>` (manifest list over amd64 + arm64)

Nothing is removed. `:latest-workers` and `:${VERSION}-workers` are still published and `:latest-workers` is still retagged by the existing "is this the newest semver" logic. This PR is purely additive.

## What is NOT in this PR

The k8s Deployment manifest that references `:latest-workers` lives in the **private-ops repo**, not here (see the comment block in `testplanit/k8s/multitenant-workers-rbac.yaml` — it describes this split). A **companion PR in private-ops** is needed to change the Deployment's `image:` to `:workers-sha-<short-sha>`, parameterized per deploy.

Intermediate state while that PR is pending: this repo publishes the SHA tag but nothing consumes it yet. That's safe — the existing `:latest-workers` path is unchanged, so no behavior differs until ops flips the Deployment.

## Related Issue

Follow-up to hotfix c804cace (workers crashloop 2026-04-22 16:30 UTC). Third of three post-mortem follow-ups:
- #235 — split `auditContextWrappers.ts` so workers don't transitively import Next.js (root-cause fix).
- #237 — CI smoke test that boots each worker entrypoint (catches this class of bug pre-deploy).
- **This PR** — SHA-tagged workers images (gives ops a real rollback path when a bad image does ship anyway).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

Technically a CI/ops-infrastructure fix. No runtime code changes.

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

The workflow file itself was validated:
- YAML parses cleanly (`js-yaml` load, six jobs present).
- All 4 build jobs set `SHORT_SHA` and add a `workers-sha-${SHORT_SHA}-<arch>` tag to the bake `--set`.
- Both merge jobs create a multi-arch manifest list for `:workers-sha-${SHORT_SHA}`.

The first real tag-push after this merges will publish the new tag as a side effect — that's the soonest a live run happens. The changes are additive and the tag-creation logic mirrors the established shape of the existing version/workers tags, so risk of breaking the current release path is low.

**Test Configuration:**
- N/A — workflow file change only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (inline in the workflow header)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

**Tag format choice.** Short 8-char SHA (e.g., `workers-sha-c804cace`) matches the example in the post-mortem and the convention elsewhere in the project. Full 40-char SHAs are unambiguous but unwieldy as image tags.

**Why workers only, not production.** The 2026-04-22 incident was workers-specific and the user's post-mortem scoped this PR to workers. The production image has the same failure mode in principle (`:latest` is also floating), but extending the SHA-tag convention to production is a separate decision with its own deploy-flow implications. Happy to open a follow-up if ops wants it.

**Rebase note.** #237 also touches `release.yml` (adding smoke-test steps to the same build jobs). The two PRs are logically independent; whichever merges first, the second needs a trivial rebase — edits are in adjacent-but-not-overlapping blocks.
