### PR TITLE
fix(workers): use require.main === module guard so require() doesn't start workers

### DIFF
--- a/testplanit/workers/auditLogWorker.ts
+++ b/testplanit/workers/auditLogWorker.ts
@@ -1,6 +1,5 @@
 import type { Prisma } from "@prisma/client";
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -166,13 +165,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as unknown as { url?: string })?.url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("[AuditLogWorker] Running as standalone process...");
   startWorker().catch((err) => {
     console.error("[AuditLogWorker] Failed to start:", err);

--- a/testplanit/workers/autoTagWorker.ts
+++ b/testplanit/workers/autoTagWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { TagAnalysisService } from "../lib/llm/services/auto-tag/tag-analysis.service";
 import type { EntityType } from "../lib/llm/services/auto-tag/types";
 import { LlmManager } from "../lib/llm/services/llm-manager.service";
@@ -380,13 +379,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Auto-tag worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start auto-tag worker:", err);

--- a/testplanit/workers/budgetAlertWorker.ts
+++ b/testplanit/workers/budgetAlertWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -99,13 +98,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as unknown as { url?: string })?.url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("[BudgetAlertWorker] Running as standalone process...");
   startWorker().catch((err) => {
     console.error("[BudgetAlertWorker] Failed to start:", err);

--- a/testplanit/workers/copyMoveWorker.ts
+++ b/testplanit/workers/copyMoveWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -926,13 +925,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Copy-move worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start copy-move worker:", err);

--- a/testplanit/workers/duplicateScanWorker.ts
+++ b/testplanit/workers/duplicateScanWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { DuplicateScanService } from "../lib/services/duplicateScanService";
 import {
   disconnectAllTenantClients,
@@ -338,13 +337,8 @@ export function startDuplicateScanWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Duplicate scan worker running...");
   startDuplicateScanWorker();
 }

--- a/testplanit/workers/elasticsearchReindexWorker.ts
+++ b/testplanit/workers/elasticsearchReindexWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { getElasticsearchClient } from "~/services/elasticsearchService";
 import { syncProjectIssuesToElasticsearch } from "~/services/issueSearch";
 import { syncProjectMilestonesToElasticsearch } from "~/services/milestoneSearch";
@@ -435,13 +434,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Elasticsearch reindex worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start Elasticsearch reindex worker:", err);

--- a/testplanit/workers/emailWorker.ts
+++ b/testplanit/workers/emailWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   sendDigestEmail,
   sendNotificationEmail,
@@ -539,13 +538,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Email worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start email worker:", err);

--- a/testplanit/workers/forecastWorker.ts
+++ b/testplanit/workers/forecastWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -507,15 +506,8 @@ async function startWorker() {
   }
 }
 
-// Conditionally call startWorker only when this file is executed directly
-// This check ensures importing the file doesn't automatically start the worker
-// Works with both ESM and CommonJS
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start worker:", err);
     process.exit(1);

--- a/testplanit/workers/magicSelectWorker.ts
+++ b/testplanit/workers/magicSelectWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   createBatches,
   executeBatches,
@@ -1137,13 +1136,8 @@ export function startMagicSelectWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Magic select worker running...");
   startMagicSelectWorker();
 }

--- a/testplanit/workers/notificationWorker.ts
+++ b/testplanit/workers/notificationWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -262,13 +261,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Notification worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start notification worker:", err);

--- a/testplanit/workers/repoCacheWorker.ts
+++ b/testplanit/workers/repoCacheWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { repoFileCache } from "../lib/integrations/cache/RepoFileCache";
 import {
   disconnectAllTenantClients,
@@ -172,12 +171,7 @@ async function startWorker() {
   }
 }
 
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start worker:", err);
     process.exit(1);

--- a/testplanit/workers/stepSequenceScanWorker.ts
+++ b/testplanit/workers/stepSequenceScanWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -237,13 +236,8 @@ export function startStepSequenceScanWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Step-scan worker running...");
   startStepSequenceScanWorker();
 }

--- a/testplanit/workers/syncWorker.ts
+++ b/testplanit/workers/syncWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -261,13 +260,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Sync worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start sync worker:", err);

--- a/testplanit/workers/testmoImportWorker.ts
+++ b/testplanit/workers/testmoImportWorker.ts
@@ -15,7 +15,6 @@ import bcrypt from "bcrypt";
 import { Job, Worker } from "bullmq";
 import { Window as HappyDOMWindow } from "happy-dom";
 import { Readable } from "node:stream";
-import { pathToFileURL } from "node:url";
 import { emptyEditorContent } from "../app/constants/backend";
 import {
   disconnectAllTenantClients,
@@ -7986,12 +7985,7 @@ async function startWorker() {
 }
 
 // Start worker when file is run directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start Testmo import worker:", err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Replace the broken ESM-style `import.meta.url` main guard in all 14 workers with the canonical CJS pattern `require.main === module`.
- Drop the now-unused `pathToFileURL` import from each worker.

## Why it matters — unblocks releases
PR #237's worker smoke test has been failing on every release since it merged. Root cause: esbuild compiles workers to CommonJS and polyfills `import.meta` as a plain object whose `.url` is `undefined`. The old guard was:

```ts
if (
  (typeof import.meta !== "undefined" &&
    import.meta.url === pathToFileURL(process.argv[1]).href) ||
  typeof import.meta === "undefined" ||
  (import.meta as any).url === undefined
) { startWorker()... }
```

At runtime `import.meta.url === void 0` is always true in the CJS output, so the guard always fires — meaning `require("./forecastWorker")` actually runs `startWorker()`, opens Valkey connections, etc. Three workers (`forecastWorker`, `repoCacheWorker`, `testmoImportWorker`) then `process.exit(1)` synchronously when Valkey isn't reachable, killing the CI smoke test mid-loop.

With this change, `require()` in the smoke test only loads the module graph — exactly the guarantee #237 was supposed to provide. PM2 still starts each worker normally because it invokes them directly as `node dist/workers/<name>.js` (so `require.main === module`).

## Scope
All 14 worker files in `testplanit/workers/` except `generateFromUrlWorker.ts` (which didn't have the guard):

- auditLogWorker · autoTagWorker · budgetAlertWorker · copyMoveWorker · duplicateScanWorker · elasticsearchReindexWorker · emailWorker · forecastWorker · magicSelectWorker · notificationWorker · repoCacheWorker · stepSequenceScanWorker · syncWorker · testmoImportWorker

Net: +26 / -112 lines.

## Test plan
- [ ] CI: smoke-test steps (AMD64 + ARM64) pass after merge — that's the primary validation this is fixing
- [ ] Local: `node scripts/smoke-test-workers.js` passes against a freshly built `dist/`
- [ ] Post-merge: verify PM2 still starts all workers in the `:latest-workers` image (bbva / production pods should come up healthy on next rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)