### PR TITLE
fix(workers): guard generateFromUrlWorker + stub env in smoke test

### DIFF
--- a/testplanit/scripts/smoke-test-workers.js
+++ b/testplanit/scripts/smoke-test-workers.js
@@ -12,14 +12,27 @@
  *
  * What it does: `require()` each compiled worker entry so Node's CJS
  * resolver walks the full import graph. Any missing/unresolved module
- * throws synchronously and fails this script. Only require-time errors
- * count; the workers' connection attempts to Valkey/Postgres that fire
- * from the main-guard (`typeof import.meta === "undefined"` branch)
- * happen asynchronously and we exit(0) before they escape, so we
- * don't need a live Valkey/Postgres in CI.
+ * throws synchronously and fails this script. Workers use a
+ * `require.main === module` guard so startup side-effects (BullMQ
+ * Worker construction, Valkey connection) only fire when the file is
+ * executed directly — not when loaded via require here.
+ *
+ * Env shims below satisfy modules that validate process.env at load
+ * time (env.js uses @t3-oss/env-nextjs which throws synchronously on
+ * missing DATABASE_URL / NEXTAUTH_* during createEnv). We're not
+ * testing runtime config correctness, just module-graph integrity.
  *
  * Keep the list in sync with ecosystem.config.js + scripts/build-workers.js.
  */
+
+// Fill in dummy values for any env vars validated at module load time.
+// Using `||=` so any real value injected by the CI runner is preserved.
+process.env.DATABASE_URL ||= "postgresql://dummy:dummy@dummy:5432/dummy";
+process.env.NEXTAUTH_SECRET ||= "dummy-smoke-test-secret-min-32-characters-long";
+process.env.NEXTAUTH_URL ||= "http://localhost:3000";
+process.env.VALKEY_URL ||= "valkey://dummy:6379";
+process.env.NODE_ENV ||= "production";
+process.env.SKIP_VALKEY_CONNECTION ||= "true";
 
 const path = require("path");
 

--- a/testplanit/scripts/smoke-test-workers.js
+++ b/testplanit/scripts/smoke-test-workers.js
@@ -28,7 +28,7 @@
 // Fill in dummy values for any env vars validated at module load time.
 // Using `||=` so any real value injected by the CI runner is preserved.
 process.env.DATABASE_URL ||= "postgresql://dummy:dummy@dummy:5432/dummy";
-process.env.NEXTAUTH_SECRET ||= "dummy-smoke-test-secret-min-32-characters-long";
+process.env.NEXTAUTH_SECRET ||= "dummy-secret-for-smoke-test-32ch";
 process.env.NEXTAUTH_URL ||= "http://localhost:3000";
 process.env.VALKEY_URL ||= "valkey://dummy:6379";
 process.env.NODE_ENV ||= "production";

--- a/testplanit/workers/auditLogWorker.ts
+++ b/testplanit/workers/auditLogWorker.ts
@@ -1,6 +1,5 @@
 import type { Prisma } from "@prisma/client";
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -166,13 +165,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as unknown as { url?: string })?.url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("[AuditLogWorker] Running as standalone process...");
   startWorker().catch((err) => {
     console.error("[AuditLogWorker] Failed to start:", err);

--- a/testplanit/workers/autoTagWorker.ts
+++ b/testplanit/workers/autoTagWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { TagAnalysisService } from "../lib/llm/services/auto-tag/tag-analysis.service";
 import type { EntityType } from "../lib/llm/services/auto-tag/types";
 import { LlmManager } from "../lib/llm/services/llm-manager.service";
@@ -380,13 +379,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Auto-tag worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start auto-tag worker:", err);

--- a/testplanit/workers/budgetAlertWorker.ts
+++ b/testplanit/workers/budgetAlertWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -99,13 +98,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as unknown as { url?: string })?.url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("[BudgetAlertWorker] Running as standalone process...");
   startWorker().catch((err) => {
     console.error("[BudgetAlertWorker] Failed to start:", err);

--- a/testplanit/workers/copyMoveWorker.ts
+++ b/testplanit/workers/copyMoveWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -926,13 +925,8 @@ const startWorker = async () => {
   });
 };
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Copy-move worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start copy-move worker:", err);

--- a/testplanit/workers/duplicateScanWorker.ts
+++ b/testplanit/workers/duplicateScanWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { DuplicateScanService } from "../lib/services/duplicateScanService";
 import {
   disconnectAllTenantClients,
@@ -338,13 +337,8 @@ export function startDuplicateScanWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Duplicate scan worker running...");
   startDuplicateScanWorker();
 }

--- a/testplanit/workers/elasticsearchReindexWorker.ts
+++ b/testplanit/workers/elasticsearchReindexWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { getElasticsearchClient } from "~/services/elasticsearchService";
 import { syncProjectIssuesToElasticsearch } from "~/services/issueSearch";
 import { syncProjectMilestonesToElasticsearch } from "~/services/milestoneSearch";
@@ -435,13 +434,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Elasticsearch reindex worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start Elasticsearch reindex worker:", err);

--- a/testplanit/workers/emailWorker.ts
+++ b/testplanit/workers/emailWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   sendDigestEmail,
   sendNotificationEmail,
@@ -539,13 +538,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Email worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start email worker:", err);

--- a/testplanit/workers/forecastWorker.ts
+++ b/testplanit/workers/forecastWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -507,15 +506,8 @@ async function startWorker() {
   }
 }
 
-// Conditionally call startWorker only when this file is executed directly
-// This check ensures importing the file doesn't automatically start the worker
-// Works with both ESM and CommonJS
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start worker:", err);
     process.exit(1);

--- a/testplanit/workers/generateFromUrlWorker.ts
+++ b/testplanit/workers/generateFromUrlWorker.ts
@@ -355,5 +355,7 @@ export function startGenerateFromUrlWorker() {
   return worker;
 }
 
-// Auto-start
-startGenerateFromUrlWorker();
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
+  startGenerateFromUrlWorker();
+}

--- a/testplanit/workers/magicSelectWorker.ts
+++ b/testplanit/workers/magicSelectWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   createBatches,
   executeBatches,
@@ -1137,13 +1136,8 @@ export function startMagicSelectWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Magic select worker running...");
   startMagicSelectWorker();
 }

--- a/testplanit/workers/notificationWorker.ts
+++ b/testplanit/workers/notificationWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -262,13 +261,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Notification worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start notification worker:", err);

--- a/testplanit/workers/repoCacheWorker.ts
+++ b/testplanit/workers/repoCacheWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { repoFileCache } from "../lib/integrations/cache/RepoFileCache";
 import {
   disconnectAllTenantClients,
@@ -172,12 +171,7 @@ async function startWorker() {
   }
 }
 
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start worker:", err);
     process.exit(1);

--- a/testplanit/workers/stepSequenceScanWorker.ts
+++ b/testplanit/workers/stepSequenceScanWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import {
   disconnectAllTenantClients,
   getPrismaClientForJob,
@@ -237,13 +236,8 @@ export function startStepSequenceScanWorker() {
   return worker;
 }
 
-// Run the worker if this file is executed directly
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Step-scan worker running...");
   startStepSequenceScanWorker();
 }

--- a/testplanit/workers/syncWorker.ts
+++ b/testplanit/workers/syncWorker.ts
@@ -1,5 +1,4 @@
 import { Job, Worker } from "bullmq";
-import { pathToFileURL } from "node:url";
 import { runWithAuditContext } from "../lib/auditContext";
 import type { ActorContextJobData } from "../lib/auditContextEnqueue";
 import {
@@ -261,13 +260,8 @@ const startWorker = async () => {
   process.on("SIGTERM", shutdown);
 };
 
-// Run the worker if this file is executed directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+// Run the worker only when this file is executed directly (not on require)
+if (require.main === module) {
   console.log("Sync worker running...");
   startWorker().catch((err) => {
     console.error("Failed to start sync worker:", err);

--- a/testplanit/workers/testmoImportWorker.ts
+++ b/testplanit/workers/testmoImportWorker.ts
@@ -15,7 +15,6 @@ import bcrypt from "bcrypt";
 import { Job, Worker } from "bullmq";
 import { Window as HappyDOMWindow } from "happy-dom";
 import { Readable } from "node:stream";
-import { pathToFileURL } from "node:url";
 import { emptyEditorContent } from "../app/constants/backend";
 import {
   disconnectAllTenantClients,
@@ -7986,12 +7985,7 @@ async function startWorker() {
 }
 
 // Start worker when file is run directly (works with both ESM and CommonJS)
-if (
-  (typeof import.meta !== "undefined" &&
-    import.meta.url === pathToFileURL(process.argv[1]).href) ||
-  typeof import.meta === "undefined" ||
-  (import.meta as any).url === undefined
-) {
+if (require.main === module) {
   startWorker().catch((err) => {
     console.error("Failed to start Testmo import worker:", err);
     process.exit(1);


### PR DESCRIPTION
## Summary

Follow-up to #239. v0.22.9's smoke-test run surfaced two issues that were hidden behind the broken main-guard:

1. **`generateFromUrlWorker.ts` had no main guard at all** — called `startGenerateFromUrlWorker()` at module scope unconditionally, so `require()`ing it tried to construct a BullMQ Worker with no Valkey (`Worker requires a connection`). Added the same `if (require.main === module)` wrapper as the other 14 workers.

2. **`env.js` validates env at module-load time** via `@t3-oss/env-nextjs`, throwing zod `invalid_type` errors for `DATABASE_URL` / `NEXTAUTH_SECRET` / `NEXTAUTH_URL`. Affected any worker whose transitive imports reach `env.js`: `syncWorker`, `elasticsearchReindexWorker`, `copyMoveWorker`, `duplicateScanWorker`, `magicSelectWorker`.

   Fixed by shimming dummy values at the top of `scripts/smoke-test-workers.js` using `||=`, so real CI-provided env still wins. Rationale: the smoke test is verifying module-graph integrity, not runtime config correctness.

## Failure observed in v0.22.9

```
✗ syncWorker: Invalid environment variables
  (zod: DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL required)
✗ elasticsearchReindexWorker: Invalid environment variables
✗ copyMoveWorker: Invalid environment variables
✗ duplicateScanWorker: Invalid environment variables
✗ magicSelectWorker: Invalid environment variables
✗ generateFromUrlWorker: Worker requires a connection
```

## Test plan
- [ ] CI smoke test (AMD64 + ARM64) passes after merge on the next release
- [ ] Local build + `node scripts/smoke-test-workers.js` — all 15 worker entrypoints + scheduler log `✓`

🤖 Generated with [Claude Code](https://claude.com/claude-code)