### PR TITLE
fix(e2e): unblock 9 skipped/flaky tests + spawn BullMQ workers in E2E

### DIFF
--- a/testplanit/app/[locale]/admin/tags/AddTag.tsx
+++ b/testplanit/app/[locale]/admin/tags/AddTag.tsx
@@ -48,8 +48,13 @@ export function AddTag({ open, onClose }: AddTagProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { mutateAsync: createTag } = useCreateTags();
   const { mutateAsync: updateTag } = useUpdateTags();
-  // Query all tags (including soft-deleted) for case-insensitive duplicate checking
-  const { data: allTags } = useFindManyTags({
+  // Query all tags (including soft-deleted) for case-insensitive duplicate
+  // checking. Track loading state so we can block submit until the data
+  // arrives — without this the user can race the query, `allTags` is
+  // undefined, the existing-tag check is skipped, and the create call
+  // hits a P2002 unique-constraint error instead of triggering the
+  // soft-deleted-tag restore path.
+  const { data: allTags, isPending: isAllTagsPending } = useFindManyTags({
     select: { id: true, name: true, isDeleted: true },
   });
 
@@ -167,7 +172,7 @@ export function AddTag({ open, onClose }: AddTagProps) {
               <Button variant="outline" type="button" onClick={onClose}>
                 {tCommon("cancel")}
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
+              <Button type="submit" disabled={isSubmitting || isAllTagsPending}>
                 {isSubmitting
                   ? tCommon("actions.submitting")
                   : tCommon("actions.submit")}

--- a/testplanit/e2e/global-setup.ts
+++ b/testplanit/e2e/global-setup.ts
@@ -1,10 +1,41 @@
 import { chromium, FullConfig } from "@playwright/test";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 
 const AUTH_DIR = path.join(__dirname, ".auth");
 const ADMIN_AUTH_FILE = path.join(AUTH_DIR, "admin.json");
+const WORKERS_PID_FILE = path.join(AUTH_DIR, "workers.pid");
+
+/**
+ * Spawn the BullMQ workers (`pnpm workers`) as a detached child process so
+ * the copy-move / sync / etc. queues actually have consumers during the
+ * E2E run. Without this, any test that submits a job (`Copy data carry-
+ * over verification`, `Move operation`, etc.) will time out waiting for
+ * a job that nobody is consuming. global-teardown.ts kills the process
+ * group when the suite finishes.
+ *
+ * Playwright's `webServer` config can't host this — workers don't expose
+ * HTTP, and using a second `webServer` entry that shares Next's URL gets
+ * silently skipped due to `reuseExistingServer: true` (or fails port-
+ * conflict checks if false).
+ */
+function spawnWorkers(): void {
+  console.log("Spawning BullMQ workers (pnpm workers)...");
+  const child = spawn("pnpm", ["workers"], {
+    cwd: path.join(__dirname, ".."),
+    env: process.env,
+    detached: true,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  if (typeof child.pid !== "number") {
+    console.error("Failed to spawn workers — no PID returned");
+    return;
+  }
+  fs.writeFileSync(WORKERS_PID_FILE, String(child.pid));
+  child.unref();
+  console.log(`Workers spawned with PID ${child.pid}`);
+}
 
 async function globalSetup(config: FullConfig) {
   console.log("Running global setup...");
@@ -86,6 +117,10 @@ async function globalSetup(config: FullConfig) {
     await context.close();
     await browser.close();
   }
+
+  // Spawn BullMQ workers as a detached child process. global-teardown
+  // kills the process group when the suite finishes.
+  spawnWorkers();
 
   console.log("Global setup complete.");
 }

--- a/testplanit/e2e/global-teardown.ts
+++ b/testplanit/e2e/global-teardown.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+
+const WORKERS_PID_FILE = path.join(__dirname, ".auth", "workers.pid");
+
+/**
+ * Stop the BullMQ workers spawned by global-setup. Kills the entire process
+ * group (negative PID) so that the `pnpm workers` parent and all of its
+ * `concurrently`-spawned children are terminated, not just the parent —
+ * otherwise the per-worker `tsx` processes outlive the test run and bind
+ * Redis connections / file descriptors.
+ */
+async function globalTeardown(): Promise<void> {
+  if (!fs.existsSync(WORKERS_PID_FILE)) return;
+  const raw = fs.readFileSync(WORKERS_PID_FILE, "utf8").trim();
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    fs.rmSync(WORKERS_PID_FILE, { force: true });
+    return;
+  }
+  try {
+    // Negative PID targets the process group spawned by detached:true.
+    process.kill(-pid, "SIGTERM");
+    console.log(`Sent SIGTERM to workers process group (pgid=${pid})`);
+  } catch (err) {
+    // ESRCH: process group already gone (clean exit).
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+      console.error("Failed to stop workers process group:", err);
+    }
+  } finally {
+    fs.rmSync(WORKERS_PID_FILE, { force: true });
+  }
+}
+
+export default globalTeardown;

--- a/testplanit/e2e/playwright.config.ts
+++ b/testplanit/e2e/playwright.config.ts
@@ -106,6 +106,9 @@ export default defineConfig({
         stderr: "pipe",
       },
 
+  // Global teardown stops the BullMQ workers spawned by globalSetup.
+  globalTeardown: require.resolve("./global-teardown"),
+
   // Output directory
   outputDir: "test-results",
 });

--- a/testplanit/e2e/tests/admin/users/user-updates.spec.ts
+++ b/testplanit/e2e/tests/admin/users/user-updates.spec.ts
@@ -510,11 +510,15 @@ test.describe("User Update Operations", () => {
         const submitButton = dialog.getByRole("button", { name: /submit/i });
         await submitButton.click();
 
-        // Wait for restore dialog to appear
+        // Wait for restore dialog to appear. The flow is: submit →
+        // server P2002 unique constraint → client `findFirst` for the
+        // soft-deleted user → state update → dialog render. Under
+        // 8-worker parallel load each step can add latency, so 5s
+        // wasn't enough.
         const restoreDialog = page
           .locator('[role="dialog"]')
           .filter({ hasText: /restore deleted user/i });
-        await expect(restoreDialog).toBeVisible({ timeout: 5000 });
+        await expect(restoreDialog).toBeVisible({ timeout: 15000 });
 
         // Verify the restore dialog message contains the email
         await expect(restoreDialog.getByText(testEmail)).toBeVisible();

--- a/testplanit/e2e/tests/api/access-control.spec.ts
+++ b/testplanit/e2e/tests/api/access-control.spec.ts
@@ -674,12 +674,7 @@ test.describe("Access Control - GLOBAL_ROLE Steps Permission (ACL-06)", () => {
     await memberCtx.close();
   });
 
-  // TODO(flake-cleanup): The first ACL-06 test fails consistently (twice with
-  // retries) — manifest cache race when computing access for the freshly
-  // created member user. The subsequent update/delete tests in the same
-  // describe pass because the cache is warm by then. Skip until manifest
-  // invalidation is tightened on user create.
-  test.skip("GLOBAL_ROLE member can create a Step on a RepositoryCase", async ({
+  test("GLOBAL_ROLE member can create a Step on a RepositoryCase", async ({
     baseURL,
   }) => {
     // This tests the fix: GLOBAL_ROLE users could create RepositoryCases
@@ -740,8 +735,7 @@ test.describe("Access Control - GLOBAL_ROLE Steps Permission (ACL-06)", () => {
     expect(result.data.testCaseId).toBe(caseId);
   });
 
-  // TODO(flake-cleanup): Same manifest cache race as ACL-06 create.
-  test.skip("GLOBAL_ROLE member can update a Step", async ({ baseURL }) => {
+  test("GLOBAL_ROLE member can update a Step", async ({ baseURL }) => {
     // First create a step
     const createResponse = await memberCtx.request.post(
       `${baseURL}/api/model/steps/create`,
@@ -802,10 +796,7 @@ test.describe("Access Control - GLOBAL_ROLE Steps Permission (ACL-06)", () => {
     expect(updateResponse.status()).toBe(200);
   });
 
-  // TODO(flake-cleanup): Same manifest cache race as ACL-06 create.
-  test.skip("GLOBAL_ROLE member can soft-delete a Step", async ({
-    baseURL,
-  }) => {
+  test("GLOBAL_ROLE member can soft-delete a Step", async ({ baseURL }) => {
     // Create a step to delete
     const createResponse = await memberCtx.request.post(
       `${baseURL}/api/model/steps/create`,

--- a/testplanit/e2e/tests/api/copy-move-endpoints.spec.ts
+++ b/testplanit/e2e/tests/api/copy-move-endpoints.spec.ts
@@ -898,8 +898,10 @@ test.describe("Copy-Move API Endpoints", () => {
             })
           )}`
         );
-        const targetFolders = await foldersRes.json();
-        const parentFolderInTarget = targetFolders.find(
+        // ZenStack's RPC findMany wraps the rows in `{ data: [...] }`,
+        // not a bare array.
+        const targetFoldersBody = await foldersRes.json();
+        const parentFolderInTarget = targetFoldersBody.data.find(
           (f: any) => f.name === "ParentFolder"
         );
         expect(parentFolderInTarget).toBeTruthy();
@@ -917,8 +919,8 @@ test.describe("Copy-Move API Endpoints", () => {
               })
             )}`
           );
-          const subFolders = await subFoldersRes.json();
-          const childFolderInTarget = subFolders.find(
+          const subFoldersBody = await subFoldersRes.json();
+          const childFolderInTarget = subFoldersBody.data.find(
             (f: any) => f.name === "ChildFolder"
           );
           expect(childFolderInTarget).toBeTruthy();
@@ -992,8 +994,9 @@ test.describe("Copy-Move API Endpoints", () => {
             JSON.stringify({ where: { id: sourceFolderId } })
           )}`
         );
+        // ZenStack's RPC findFirst wraps the row in `{ data: { ... } }`.
         const updatedSourceFolder = await sourceFolderRes.json();
-        expect(updatedSourceFolder.isDeleted).toBe(true);
+        expect(updatedSourceFolder.data.isDeleted).toBe(true);
       }
     });
   });

--- a/testplanit/e2e/tests/auth/sso-magic-link.spec.ts
+++ b/testplanit/e2e/tests/auth/sso-magic-link.spec.ts
@@ -463,10 +463,7 @@ test.describe("SSO and Magic Link", () => {
     }
   });
 
-  // TODO(flake-cleanup): Magic link callback redirects to a non `/en-US` URL
-  // (likely signin or error) instead of completing auth. Fails twice with
-  // retries on, suggesting a real auth-flow regression rather than a flake.
-  test.skip("Magic link full authentication flow via DB token", async ({
+  test("Magic link full authentication flow via DB token", async ({
     page,
     api,
     baseURL,
@@ -482,20 +479,6 @@ test.describe("SSO and Magic Link", () => {
       return;
     }
 
-    // Check if email provider is configured (required for NextAuth email callback)
-    // If no email server is configured, NextAuth won't register the email provider
-    const checkRes = await page.request.get(
-      `${baseURL}/api/auth/callback/email?token=test&email=test@example.com&callbackUrl=/`
-    );
-    const checkText = await checkRes.text();
-    if (checkText.includes("not supported")) {
-      test.skip(
-        true,
-        "Email provider not configured in test environment - skipping magic link token flow test"
-      );
-      return;
-    }
-
     const userResult = await api.createUser({
       name: `Magic Link User ${timestamp}`,
       email: testEmail,
@@ -506,6 +489,28 @@ test.describe("SSO and Magic Link", () => {
     try {
       // Sign in as admin to insert the verificationToken via authenticated API
       await signInAsAdmin(page, baseURL!);
+
+      // Ensure a MAGIC_LINK SsoProvider record exists. Without one, the
+      // server's `getAuthOptions` won't register the NextAuth EmailProvider
+      // and /api/auth/callback/email returns "not supported". Doing this
+      // after admin sign-in (the API requires admin) and before the email-
+      // provider availability check below.
+      await ensureSsoProvider(page, baseURL!, "MAGIC_LINK", "Magic Link", {});
+
+      // Confirm the email provider is available — if the env doesn't have
+      // EMAIL_SERVER_* configured, NextAuth still won't register it and we
+      // should skip rather than fail the assertion.
+      const checkRes = await page.request.get(
+        `${baseURL}/api/auth/callback/email?token=test&email=test@example.com&callbackUrl=/`
+      );
+      const checkText = await checkRes.text();
+      if (checkText.includes("not supported")) {
+        test.skip(
+          true,
+          "Email provider not configured in test environment - skipping magic link token flow test"
+        );
+        return;
+      }
 
       // Generate a known token pair
       const plainToken = randomBytes(32).toString("hex");
@@ -540,10 +545,18 @@ test.describe("SSO and Magic Link", () => {
         timeout: 15000,
       });
 
-      // Assert user is authenticated (not redirected to signin)
+      // Assert user is authenticated. Don't constrain on a specific locale
+      // prefix — NextAuth's callbackUrl handling can land on `/` (no locale)
+      // and middleware doesn't always rewrite client-side URLs immediately.
+      // The only meaningful signal here is "not redirected back to signin"
+      // and "the session cookie resolves to a real user".
       const currentUrl = page.url();
       expect(currentUrl).not.toContain("/signin");
-      expect(currentUrl).toContain("/en-US");
+
+      const sessionRes = await page.request.get(`${baseURL}/api/auth/session`);
+      expect(sessionRes.ok()).toBeTruthy();
+      const session = await sessionRes.json();
+      expect(session?.user?.email).toBe(testEmail);
     } finally {
       await api.deleteUser(userId);
     }

--- a/testplanit/e2e/tests/repository/Test Repository Management/documentation.spec.ts
+++ b/testplanit/e2e/tests/repository/Test Repository Management/documentation.spec.ts
@@ -433,13 +433,7 @@ test.describe("Documentation", () => {
     expect(hasContent || hasPlaceholder !== null).toBeTruthy();
   });
 
-  // TODO(flake-cleanup): Tiptap consistently swallows the leading keystroke
-  // after editor click + select-all on this page, leaving the doc as
-  // `placeholder + typed-text-minus-first-char`. Fails twice with retries.
-  test.skip("Documentation persists after page reload", async ({
-    api,
-    page,
-  }) => {
+  test("Documentation persists after page reload", async ({ api, page }) => {
     const projectId = await createTestProject(api);
     await page.goto(`/projects/documentation/${projectId}`);
     await page.waitForLoadState("networkidle");
@@ -456,10 +450,22 @@ test.describe("Documentation", () => {
     await page.waitForLoadState("networkidle");
 
     const editor = page.locator(".ProseMirror").first();
+    // Tiptap's ProseMirror takes a tick after the edit-mode transition to
+    // become a fully-wired contenteditable. Under heavy parallel load the
+    // click → Ctrl+A → type sequence races initialization and the first
+    // typed keystroke gets eaten ("Persistent" → "ersistent"). Wait for
+    // contenteditable + focus before each input step so the editor has
+    // settled before we drive it.
+    await expect(editor).toHaveAttribute("contenteditable", "true");
     await editor.click();
+    await expect(editor).toBeFocused();
 
     const testContent = `Persistent content ${Date.now()}`;
     await page.keyboard.press("ControlOrMeta+a");
+    // Let the select-all selection register in ProseMirror's view before
+    // the first keystroke arrives — without this Tiptap occasionally
+    // swallows the leading character.
+    await page.waitForTimeout(100);
     await page.keyboard.type(testContent);
 
     // Save

--- a/testplanit/e2e/tests/repository/Test Repository Management/sorting.spec.ts
+++ b/testplanit/e2e/tests/repository/Test Repository Management/sorting.spec.ts
@@ -174,34 +174,22 @@ test.describe("Sorting", () => {
     await repositoryPage.goto(projectId);
 
     await repositoryPage.selectFolder(folderId);
-    await page.waitForLoadState("networkidle");
+    await waitForTableStable(page);
 
-    // Verify the table is visible
-    const table = page.locator("table").first();
+    // Use the cases-table testid — `page.locator("table").first()` can match
+    // the folder tree or another table on the page before the cases table
+    // hydrates, which produced a "Received: 10" mismatch under load.
+    const table = repositoryPage.casesTable;
     await expect(table).toBeVisible({ timeout: 10000 });
 
-    // Wait for rows to appear in tbody
     const rows = table.locator("tbody tr");
-    await expect(rows.first()).toBeVisible({ timeout: 10000 });
-    expect(await rows.count()).toBe(2);
+    await expect(rows).toHaveCount(2, { timeout: 10000 });
 
     // Find the State column sort button
-    const stateHeader = table
-      .locator("th")
-      .filter({ hasText: "State" })
-      .first();
-    await expect(stateHeader).toBeVisible({ timeout: 5000 });
+    await clickSortButton(page, "State");
 
-    // The sort button is inside the header with accessible name "Sort column"
-    const sortButton = stateHeader
-      .getByRole("button", { name: "Sort column" })
-      .first();
-    await expect(sortButton).toBeVisible({ timeout: 5000 });
-    await sortButton.click();
-
-    // Wait for rows to reappear after sort (sorting triggers data refetch)
-    await expect(rows.first()).toBeVisible({ timeout: 10000 });
-    expect(await rows.count()).toBe(2);
+    // Verify rows still present after sort
+    await expect(rows).toHaveCount(2);
   });
 
   test("Maintain Test Case Order Within Folder", async ({ api, page }) => {

--- a/testplanit/e2e/tests/sessions/session-configuration-combobox.spec.ts
+++ b/testplanit/e2e/tests/sessions/session-configuration-combobox.spec.ts
@@ -236,7 +236,10 @@ test.describe("Session Configuration Combobox", () => {
     await expect(submitButton).toBeVisible();
     await submitButton.click();
 
-    // Wait for dialog to close (indicates successful creation)
-    await expect(dialog).not.toBeVisible({ timeout: 15000 });
+    // Wait for dialog to close (indicates successful creation). 15s wasn't
+    // enough under 8-worker load — the new-session create path includes
+    // configuration linkage + ES indexing + multiple round-trips, and the
+    // form's submit→close transition is gated on all of them resolving.
+    await expect(dialog).not.toBeVisible({ timeout: 30000 });
   });
 });


### PR DESCRIPTION
## Description

Stabilizes the E2E suite by fixing seven distinct test/app issues that were blocking previously-skipped tests and producing flaky failures under 8-worker parallel load. Bundled into a single PR to avoid CI-churn from many small fixes.

After this PR the full suite goes from ~4–8 random failures per run to **0 failures** in **~7m45s wall-clock**, with only a handful of recovered-on-retry flakes.

### What's in this PR

**1. `magic-link DB-token` test (unskip)** — `d8760ca8`
- Wrong success assertion (`currentUrl.toContain("/en-US")`) — NextAuth honors the literal `callbackUrl` and middleware doesn't guarantee a locale prefix; replaced with a `/api/auth/session` fetch that asserts the user email.
- The "email provider not supported" guard ran before `ensureSsoProvider`, so on a clean DB the test always early-skipped. Reordered the guard.

**2. `Documentation persists after page reload` test (unskip)** — `022019c5`
- Tiptap was swallowing the leading keystroke under load when click→Ctrl+A→type raced ProseMirror's hydration. Added deterministic guards: wait for `[contenteditable="true"]`, wait for `editor.toBeFocused()` after click, plus a 100ms settle after Ctrl+A so the select-all view update commits before the first typed character lands.

**3. BullMQ workers running during E2E** — `d276645b`
- Playwright's `webServer` config only started Next.js (`pnpm start`), never the BullMQ workers (`pnpm workers`). Without consumers, every test that submitted a copy/move/sync job sat in Redis forever and timed out — this is why "Copy data carry-over verification" and the "folder tree copy/move" describes were chronically flaky.
- Workers don't expose HTTP, so `webServer` can't host them (a sibling entry was tried and Playwright silently skipped it via `reuseExistingServer: true`, or hit port-conflict with reuse off). Spawn `pnpm workers` as a detached child in `globalSetup` and SIGTERM the process group from a new `globalTeardown` so the `concurrently`-spawned `tsx` children don't leak.

**4. `folderTree copy/move` tests (test bugs surfaced once workers actually run)** — `d276645b`
- `targetFolders.find(...)`, `subFolders.find(...)`, and `updatedSourceFolder.isDeleted` all assumed the ZenStack RPC response was a bare row/array, but `findMany`/`findFirst` wrap it in `{ data: ... }`. Previously the `if (200)` branch never executed (queue returned 503 with no workers); now that workers run, the bugs surface.

**5. `ACL-06` GLOBAL_ROLE Step tests (unskip 3 tests)** — `d276645b`
- Leftover from PR #245: that PR fixed the underlying role-`isDefault` corruption (the `Admin can toggle default role status` cleanup picking a random role, leaving the seeded `user` role no longer default), but never removed the `test.skip` markers.

**6. `sorting > Sort Test Cases by State Column` (flaky)** — `4ac8b173`
- Used the generic `page.locator("table").first()` which under load matched the folder tree (10 nodes) before the cases table hydrated. Ported to `repositoryPage.casesTable` + `waitForTableStable` + `clickSortButton` helpers — the same pattern the sibling "Sort by Name" test already uses successfully.

**7. `user-updates > restore-soft-deleted-user` (flaky timeout bump)** — `4ac8b173`
- The flow is multi-step (submit → P2002 → client `findFirst` → state update → dialog render). 5s wasn't enough under load; bumped to 15s.

**8. `tags > Restore Soft-Deleted Tag on Create` (real app bug)** — `4ac8b173`
- `AddTag.tsx` was using client-cached `allTags` to detect an existing soft-deleted tag and trigger a restore. Under load a user can open the dialog and submit before that React Query resolves — `allTags` is `undefined`, the duplicate check is skipped, and the create call hits a P2002 unique-constraint error. Fix: track `isPending: isAllTagsPending` from `useFindManyTags` and disable the submit button until the duplicate-check data is available.

**9. `session-configuration-combobox > should create session with selected configuration` (flaky timeout bump)** — `4ac8b173`
- Submit→close gated on configuration linkage + ES indexing + multiple round-trips; 15s → 30s.

## Related Issue

N/A — this is a continuation of the flake-cleanup effort tracked in PRs #246 and `0.22.14`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] E2E tests

```
$ time E2E_PROD=on pnpm test:e2e
...
0 failed
5 flaky    (different tests each run — recovered on retry)
5 skipped  (legitimate env-dependent skips)
1068 passed
real    7m45.271s
```

All 9 targeted tests pass on the first attempt:

| Test | Pass time |
|---|---|
| Magic link full authentication flow via DB token | 2.8s |
| Documentation persists after page reload | 3.7s |
| Copy data carry-over verification (3 tests) | 537ms / 15ms / 13ms |
| folder tree copy/move (2 tests) | 2.1s / 2.0s |
| ACL-06 GLOBAL_ROLE Step tests (3 tests) | 70ms / 152ms / 124ms |
| Sort Test Cases by State Column | 4.0s |
| Admin can restore soft-deleted user | 4.0s |
| Restore Soft-Deleted Tag on Create | 3.8s |
| Session create with selected configuration | 4.2s |

**Test Configuration:**
- OS: macOS (darwin 25.4.0)
- 8 parallel workers, prod build
- `NODE_OPTIONS='--max-old-space-size=16382' pnpm build && E2E_PROD=on pnpm test:e2e`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The only "real" application change in this PR is `AddTag.tsx` — disabling the submit button while the duplicate-check query is loading. Everything else is test-side: unskips, deterministic waits, response-shape fixes, and globalSetup/teardown for workers.