### PR TITLE
fix: workflow type translations + linked projects on integration card

### DIFF
--- a/testplanit/app/[locale]/admin/workflows/columns.tsx
+++ b/testplanit/app/[locale]/admin/workflows/columns.tsx
@@ -25,7 +25,7 @@ const isLastWorkflowOfType = (
 
 export const getColumns = (
   workflows: ExtendedWorkflows[],
-  t: ReturnType<typeof useTranslations<"common">>,
+  tWorkflowTypes: ReturnType<typeof useTranslations<"enums.WorkflowType">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   handleToggleEnabled: (id: number, isEnabled: boolean) => void,
   handleToggleDefault: (
@@ -65,7 +65,7 @@ export const getColumns = (
     size: 100,
     cell: ({ row }) => (
       <div className="text-center">
-        {t(`types.${row.original.workflowType}` as any)}
+        {tWorkflowTypes(row.original.workflowType)}
       </div>
     ),
   },

--- a/testplanit/app/[locale]/admin/workflows/page.tsx
+++ b/testplanit/app/[locale]/admin/workflows/page.tsx
@@ -57,6 +57,7 @@ function WorkflowComponent() {
   const router = useRouter();
   const t = useTranslations("admin.workflows");
   const tCommon = useTranslations("common");
+  const tWorkflowTypes = useTranslations("enums.WorkflowType");
   const [pageSize] = useState(10);
   const queryClient = useQueryClient();
 
@@ -196,7 +197,7 @@ function WorkflowComponent() {
 
   const columns = getColumns(
     data || [],
-    t,
+    tWorkflowTypes,
     tCommon,
     handleToggleEnabled,
     handleToggleDefault,

--- a/testplanit/components/admin/integrations/integrations-list.tsx
+++ b/testplanit/components/admin/integrations/integrations-list.tsx
@@ -26,6 +26,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import {
   useDeleteProjectIntegration,
+  useFindManyIntegrationProject,
   useUpdateManyProjectIntegration,
   useUpsertProjectIntegration,
 } from "~/lib/hooks";
@@ -58,6 +59,19 @@ export function IntegrationsList({
     useUpsertProjectIntegration();
   const { mutateAsync: updateManyProjectIntegration } =
     useUpdateManyProjectIntegration();
+
+  const { data: linkedProjects } = useFindManyIntegrationProject(
+    {
+      where: {
+        projectIntegrationId: currentIntegration?.id ?? "",
+        isActive: true,
+      },
+      orderBy: [{ isDefault: "desc" }, { externalProjectName: "asc" }],
+    },
+    {
+      enabled: !!currentIntegration?.id,
+    }
+  );
 
   const handleAssignIntegrationClick = (integrationId: number) => {
     // If there's already an active integration, show warning dialog
@@ -172,7 +186,7 @@ export function IntegrationsList({
                 </Badge>
               )}
             </CardHeader>
-            <CardContent className="grow">
+            <CardContent className="grow space-y-3">
               <div
                 className={`flex items-start gap-3${isDimmed ? " opacity-70" : ""}`}
               >
@@ -193,6 +207,31 @@ export function IntegrationsList({
                   </p>
                 </div>
               </div>
+              {isActive &&
+                integration.provider !== "SIMPLE_URL" &&
+                linkedProjects &&
+                linkedProjects.length > 0 && (
+                  <div className="space-y-1.5">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {t("integration.linkedProjects")}
+                    </p>
+                    <ul className="space-y-1">
+                      {linkedProjects.map((lp) => (
+                        <li
+                          key={lp.id}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <Badge variant="outline" className="text-xs shrink-0">
+                            {lp.externalProjectKey}
+                          </Badge>
+                          <span className="truncate">
+                            {lp.externalProjectName}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
             </CardContent>
             <CardFooter>
               <div className="flex gap-2 w-full">


### PR DESCRIPTION
## Description

Two unrelated UI fixes scoped tight to the bugs reported:

1. **Admin > Workflows table** — the Type column rendered raw i18n keys (`admin.workflows.types.NOT_STARTED` etc.) because it called `t(\`types.${workflowType}\`)` under the `admin.workflows` namespace, where no `types.*` keys exist. Reused the existing `enums.WorkflowType.*` keys (already used by the Add/Edit dialogs) via a `tWorkflowTypes` hook. Also corrected the misleading `<"common">` typing on the column factory parameter.

2. **Project > Integrations card** — the active integration card showed only an "Active" badge with no preview of which external projects were linked. After #188 replaced the single-project select with a list of links, there was no glanceable summary on the card itself. Now the active card lists each linked project as `[KEY] Full Name` (skipped for SIMPLE_URL and the empty state).

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Manual testing

**Test Configuration:**
- OS: macOS
- Browser: Chrome
- Node version: project default

Verified locally:
- Admin > Workflows table shows "Not Started" / "In Progress" / "Done" instead of raw keys.
- Project > Integrations active card lists each linked Jira project with key badge + full name when projects are linked; renders unchanged for SIMPLE_URL and the no-projects-yet state.

## Checklist

- [x] My code follows the project's style guidelines (precommit passes: lint + prettier + tsc)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The "missing connected projects" item was originally framed as a missing UI affordance; the connected projects list was actually already present in the settings card below the integration grid. The on-card preview is still included as a discoverability improvement so users don't have to scroll.
