### PR TITLE
enhancement: smooth out jira issue create-and-link flow

### DIFF
--- a/testplanit/components/issues/create-issue-jira-form.test.tsx
+++ b/testplanit/components/issues/create-issue-jira-form.test.tsx
@@ -240,8 +240,9 @@ describe("CreateIssueJiraForm", () => {
     });
   });
 
-  it("shows exactly the linked projects (no unlinked projects in the selector)", async () => {
-    // Only one linked project
+  it("hides the project selector when only one linked project is available", async () => {
+    // Only one linked project — selector should be skipped and the project
+    // auto-used silently
     mockUseFindManyIntegrationProject.mockReturnValue({
       data: [
         makeIntegrationProject("ip-1", "ABT", "Allego Bug Tracking", true),
@@ -252,9 +253,12 @@ describe("CreateIssueJiraForm", () => {
     render(<CreateIssueJiraForm {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.queryByTestId("select-item-ABT")).toBeTruthy();
-      // LIV not linked — should not appear
-      expect(screen.queryByTestId("select-item-LIV")).toBeNull();
+      // Selector is not rendered
+      expect(screen.queryByTestId("select-item-ABT")).toBeNull();
+      // Form still auto-selects ABT — verified by issue-types fetch URL
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("projectKey=ABT")
+      );
     });
   });
 

--- a/testplanit/components/issues/create-issue-jira-form.tsx
+++ b/testplanit/components/issues/create-issue-jira-form.tsx
@@ -85,6 +85,7 @@ export function CreateIssueJiraForm({
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState<JiraField[]>([]);
   const [fieldsLoading, setFieldsLoading] = useState(false);
+  const [issueTypesLoading, setIssueTypesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [issueTypes, setIssueTypes] = useState<
     Array<{ id: string; name: string }>
@@ -214,6 +215,7 @@ export function CreateIssueJiraForm({
     const fetchIssueTypes = async () => {
       if (!open || !selectedProjectKey) return;
 
+      setIssueTypesLoading(true);
       try {
         const response = await fetch(
           `/api/integrations/${integrationId}/issue-types?projectKey=${selectedProjectKey}`
@@ -239,6 +241,8 @@ export function CreateIssueJiraForm({
         }
       } catch (error) {
         console.error("Failed to fetch issue types:", error);
+      } finally {
+        setIssueTypesLoading(false);
       }
     };
 
@@ -476,7 +480,7 @@ export function CreateIssueJiraForm({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("issues.createIssueInJira")}</DialogTitle>
           <DialogDescription>
@@ -492,14 +496,19 @@ export function CreateIssueJiraForm({
               {t("issues.integrationNotConfiguredDescription")}
             </AlertDescription>
           </Alert>
-        ) : fieldsLoading || projectsLoading ? (
-          <div className="flex items-center justify-center p-8">
-            <Loader2 className="h-8 w-8 animate-spin" />
-          </div>
         ) : error ? (
           <Alert variant="destructive">
             <AlertDescription>{error}</AlertDescription>
           </Alert>
+        ) : projectsLoading ||
+          issueTypesLoading ||
+          fieldsLoading ||
+          // Cover render gaps between the chained projects → issue-types → fields
+          // effects so the spinner stays continuous until the form is ready.
+          (projects.length > 0 && fields.length === 0) ? (
+          <div className="flex justify-center p-8">
+            <Loader2 className="h-8 w-8 animate-spin" />
+          </div>
         ) : (
           <Form {...form}>
             <form
@@ -511,8 +520,9 @@ export function CreateIssueJiraForm({
               className="space-y-4"
               autoComplete="off"
             >
-              {/* Project Selector */}
-              {projects.length > 0 && (
+              {/* Project Selector — hide when only one project is available
+                  since selection is automatic */}
+              {projects.length > 1 && (
                 <FormItem>
                   <FormLabel className="inline-flex items-center gap-0.5">
                     {t("issues.externalProject")}

--- a/testplanit/components/issues/search-issues-dialog.tsx
+++ b/testplanit/components/issues/search-issues-dialog.tsx
@@ -20,7 +20,7 @@ import { useFindManyIssue } from "@/lib/hooks/issue";
 import { useFindManyProjectIntegration } from "@/lib/hooks/project-integration";
 import { AlertCircle, ExternalLink, Loader2, Plus, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useFindManyIntegrationProject } from "~/lib/hooks";
 import { CreateIssueDialog } from "./create-issue-dialog";
@@ -123,6 +123,11 @@ export function SearchIssuesDialog({
 
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
 
+  // Tracks the key of a just-created issue we're polling for. While set, the
+  // debounce-triggered search effect skips firing for that key so it can't race
+  // with and overwrite the polling loop's results.
+  const pollingForKeyRef = useRef<string | null>(null);
+
   // Fetch project integrations
   const { data: projectIntegrations } = useFindManyProjectIntegration({
     where: {
@@ -205,14 +210,22 @@ export function SearchIssuesDialog({
   // Trigger external search when searchExternal changes or query changes
   useEffect(() => {
     if (searchExternal && debouncedSearchQuery.length > 0) {
+      // Polling loop owns this key — skip to avoid overwriting its results
+      if (pollingForKeyRef.current === debouncedSearchQuery) return;
       void searchExternalIssues();
     }
   }, [searchExternal, debouncedSearchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const searchExternalIssues = async () => {
-    if (!activeIntegration) return;
+  const searchExternalIssues = async (
+    queryOverride?: string,
+    options?: { manageLoadingState?: boolean }
+  ): Promise<ExternalIssue[] | null> => {
+    if (!activeIntegration) return null;
 
-    setIsSearching(true);
+    const query = queryOverride ?? debouncedSearchQuery;
+    const manageLoadingState = options?.manageLoadingState ?? true;
+
+    if (manageLoadingState) setIsSearching(true);
     setAuthError(null);
     setSearchFailures([]);
 
@@ -229,7 +242,7 @@ export function SearchIssuesDialog({
           integrationConfig.externalProjectKey ||
           "";
 
-        const searchParams = new URLSearchParams({ q: debouncedSearchQuery });
+        const searchParams = new URLSearchParams({ q: query });
         if (externalProjectId) {
           searchParams.set("projectId", externalProjectId);
         }
@@ -242,7 +255,7 @@ export function SearchIssuesDialog({
           const errorData = await response.json();
           setAuthError(errorData.authUrl || "Authentication required");
           setExternalIssues([]);
-          return;
+          return null;
         }
 
         if (!response.ok) {
@@ -270,14 +283,14 @@ export function SearchIssuesDialog({
           isExternal: true,
         }));
         setExternalIssues(formattedIssues);
-        return;
+        return formattedIssues;
       }
 
       // Fan-out search: call search API once per IntegrationProject (per D-04)
       const searchPromises = projectsToSearch.map(async (ip) => {
         try {
           const searchParams = new URLSearchParams({
-            q: debouncedSearchQuery,
+            q: query,
             projectId: ip.externalProjectId,
           });
 
@@ -355,10 +368,43 @@ export function SearchIssuesDialog({
 
       setExternalIssues(allIssues);
       setSearchFailures(failures);
+      return allIssues;
     } catch (error) {
       console.error("Failed to search external issues:", error);
       setExternalIssues([]);
+      return null;
     } finally {
+      if (manageLoadingState) setIsSearching(false);
+    }
+  };
+
+  // Jira's JQL search index is eventually consistent — a just-created issue
+  // may take a few seconds to appear. Re-fire the search until the new key
+  // shows up or we give up. Keep isSearching true throughout so the user sees
+  // a continuous spinner instead of a flickering "No results" state.
+  const pollForCreatedIssue = async (key: string) => {
+    const delaysMs = [0, 800, 1200, 1600, 2000];
+    pollingForKeyRef.current = key;
+    setIsSearching(true);
+    try {
+      for (const delay of delaysMs) {
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+        // User changed the query mid-poll — abandon
+        if (pollingForKeyRef.current !== key) return;
+        const results = await searchExternalIssues(key, {
+          manageLoadingState: false,
+        });
+        if (results === null) return;
+        if (results.some((i) => i.key === key || i.externalKey === key)) {
+          return;
+        }
+      }
+    } finally {
+      if (pollingForKeyRef.current === key) {
+        pollingForKeyRef.current = null;
+      }
       setIsSearching(false);
     }
   };
@@ -482,7 +528,10 @@ export function SearchIssuesDialog({
               <Input
                 placeholder={t("issues.searchPlaceholder")}
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  pollingForKeyRef.current = null;
+                  setSearchQuery(e.target.value);
+                }}
                 className="pl-10"
               />
             </div>
@@ -761,6 +810,7 @@ export function SearchIssuesDialog({
               // This will trigger the search and show the new issue
               if (createdIssue.key) {
                 setSearchQuery(createdIssue.key);
+                void pollForCreatedIssue(createdIssue.key);
               }
             }}
           />
@@ -778,10 +828,18 @@ export function SearchIssuesDialog({
 
               // Set the search query to the newly created issue key or title
               // This will trigger the search and show the new issue
-              if (createdIssue.key || createdIssue.externalKey) {
-                setSearchQuery(createdIssue.key || createdIssue.externalKey);
-              } else if (createdIssue.title || createdIssue.name) {
-                setSearchQuery(createdIssue.title || createdIssue.name);
+              const searchKey =
+                createdIssue.key ||
+                createdIssue.externalKey ||
+                createdIssue.title ||
+                createdIssue.name;
+              if (searchKey) {
+                setSearchQuery(searchKey);
+                if (createdIssue.key || createdIssue.externalKey) {
+                  void pollForCreatedIssue(
+                    createdIssue.key || createdIssue.externalKey
+                  );
+                }
               }
             }}
           />


### PR DESCRIPTION
## Description

Smooths out several rough edges in the Jira issue create-and-link flow that surface when creating a new issue from the "Link Jira issue" dialog inside a repository case:

- **Search retry after issue creation.** Jira's JQL search index is eventually consistent — when a brand-new issue is created via REST, the immediate `setSearchQuery(newKey)` → debounced fetch usually returned empty results because Jira hadn't indexed the issue yet. Now the dialog polls the search at 0/800/1200/1600/2000 ms (≈5.6s window) until the new key appears, with a `pollingForKeyRef` guarding the debounce-triggered effect so it can't race in and overwrite the polled results. Polling is abandoned if the user types in the search box.
- **Continuous spinner during retries.** Previously the spinner flickered between "spinning" and "no results found" between each polling attempt. The polling loop now owns `isSearching` for the whole window so the user sees one steady spinner.
- **Hide single-project selector.** The Jira create-issue form rendered a project dropdown with one auto-selected entry when only one Jira project was linked. Now that selector is hidden when `projects.length <= 1`.
- **Continuous spinner while the create-issue form initializes.** The form has three sequential async loads (projects → issue types → fields) but only the first and last had loading states, leaving a flicker where the form briefly rendered without fields. Added `issueTypesLoading` and a derived render guard that keeps the spinner on through every gap, including the inter-effect render gaps.
- **Fixed dialog height.** Set the create-issue dialog to a fixed `h-[90vh]` so it doesn't jump from spinner-sized to form-sized as content loads. Spinner anchored to the top so it sits where the form will render.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

The `create-issue-jira-form.test.tsx` suite (16 tests) was updated to reflect the new "hide selector when only one project" behavior and all tests pass. `tsc --noEmit` and `prettier --check` both clean.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0)
- Browser (if applicable): n/a
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The `enhancement:` commit prefix triggers a semantic-release patch bump.
