### PR TITLE
feat(notifications): SSE transport replaces bell polling

### DIFF
--- a/docs/docs/sse-notifications.md
+++ b/docs/docs/sse-notifications.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 10
+---
+
+# SSE Notifications
+
+TestPlanIt's in-app notification bell uses [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) with [Valkey](https://valkey.io/) (or Redis) pub/sub fan-out to push updates to clients in near-real time. This page documents how it works, the ingress/proxy configuration required to make long-lived streams reliable behind a load balancer, and the tuning knobs available to operators.
+
+## What it is and how it works
+
+Before this transport existed, the bell polled `useFindManyNotification` every 5–30 seconds per session. That worked but does not scale — every active browser tab generates 2–12 unnecessary requests per minute even when nothing changed.
+
+The current architecture replaces that with:
+
+1. **Publish.** When the notification worker (`testplanit/workers/notificationWorker.ts`) creates a `Notification` row, it publishes a small wake-up payload (`{id, event}`) to a tenant-scoped Valkey channel. Channel keys are constructed in one place — `testplanit/lib/notifications/channels.ts`:
+   - User channel: `notifications:tenant:<tenantId>:user:<userId>`
+   - Broadcast channel (used for `SYSTEM_ANNOUNCEMENT`): `notifications:tenant:<tenantId>:broadcast`
+2. **Subscribe.** Each authenticated client opens a long-lived `EventSource` connection to `GET /api/notifications/stream` (`testplanit/app/api/notifications/stream/route.ts`). The route subscribes to both the user channel and the tenant broadcast channel for the requesting user.
+3. **Refetch.** On every SSE message, the bell calls `refetch()` on its existing `useFindManyNotification` query. The wake-up payload is treated as opaque "something changed" — actual notification data is fetched through the policy-enforced ZenStack hook so multi-tenant isolation and access control are re-applied on every read.
+
+The pub/sub layer is treated as untrusted plumbing: even if a wake-up arrives wrongly, the read path cannot leak data because `getEnhancedDb` re-applies the tenant filter and access policy. Tenant context for both publish and subscribe is resolved server-side via `getCurrentTenantId()` (`testplanit/lib/multiTenantPrisma.ts`), which reads `INSTANCE_TENANT_ID` from the environment — never from client input.
+
+A single shared Valkey instance handles fan-out for every tenant; isolation is by channel-key prefix, not by separate Valkey deployments. The Valkey already provisioned for BullMQ is reused.
+
+## Ingress and proxy configuration
+
+SSE relies on the connection staying open and on byte-by-byte delivery. Most ingress controllers and load balancers buffer responses and apply short idle timeouts by default — both will break SSE. The same TestPlanIt application image runs in every environment; the differences are configuration on the ingress, not in the code.
+
+The route already sets these response headers, which most proxies respect when they are configured to honor them:
+
+```text
+Content-Type: text/event-stream
+Cache-Control: no-cache, no-transform
+Connection: keep-alive
+X-Accel-Buffering: no
+```
+
+`X-Accel-Buffering: no` is the nginx convention for disabling response buffering on a per-response basis; many ingress controllers downstream honor it.
+
+### nginx-ingress (Kubernetes)
+
+Annotate the Ingress resource that fronts the TestPlanIt service:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: testplanit
+  annotations:
+    # Disable response buffering so SSE bytes are forwarded as soon as they arrive.
+    nginx.ingress.kubernetes.io/proxy-buffering: 'off'
+    # Lengthen idle timeouts so streams survive periods without messages.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
+```
+
+`proxy-read-timeout` of 3600 seconds (1 hour) is well over the 25-second heartbeat that the route emits, leaving wide margin for transient network slowness.
+
+### Traefik
+
+Traefik does not buffer streamed responses by default, but its idle timeouts may need to be raised. Set `respondingTimeouts` on the entryPoint. Example (Traefik v2 / v3 static config):
+
+```yaml
+entryPoints:
+  websecure:
+    address: ':443'
+    transport:
+      respondingTimeouts:
+        readTimeout: '1h'
+        writeTimeout: '1h'
+        idleTimeout: '1h'
+```
+
+No additional middleware is required for the route specifically — the application's own `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no` headers are sufficient.
+
+### AWS Load Balancer Controller (ALB)
+
+For an Application Load Balancer in front of TestPlanIt:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: testplanit
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=3600
+```
+
+The `idle_timeout.timeout_seconds=3600` attribute raises the ALB's connection idle timeout to one hour. The 25-second heartbeat on the route ensures the connection has bytes flowing well within that window.
+
+HTTP/2 is enabled by default on ALB v2; no extra configuration needed. SSE multiplexes per-stream over HTTP/2, which keeps file-descriptor pressure low for clients with many tabs.
+
+### Plain nginx (non-ingress)
+
+For deployments that put TestPlanIt behind a manually configured nginx (e.g. on a single docker-compose host), add a location block matching `/api/notifications/stream`:
+
+```nginx
+location /api/notifications/stream {
+  proxy_pass http://testplanit_upstream;
+  proxy_http_version 1.1;
+  proxy_set_header Connection "";
+  proxy_buffering off;
+  proxy_cache off;
+  proxy_read_timeout 3600s;
+  proxy_send_timeout 3600s;
+  chunked_transfer_encoding off;
+}
+```
+
+## Tuning knobs
+
+Two environment variables tune the route's connection caps:
+
+| Variable             | Default | Purpose                                                                                                                                                                                                                                                                                            |
+| -------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SSE_PER_TENANT_CAP` | `1000`  | Maximum concurrent SSE connections per tenant per pod. The Nth+1 connection receives HTTP `503 Service Unavailable` with a `Retry-After: 30` header. With N replicas, a tenant can hold up to N × cap connections cluster-wide; the per-pod cap is intentional fd-exhaustion / runaway protection. |
+| `SSE_PER_USER_CAP`   | `4`     | Maximum concurrent SSE connections per user per pod. The 5th connection is accepted; the oldest connection for that user is closed (LRU). This is a fairness mechanism — it prevents a single user with many tabs from monopolizing tenant capacity.                                               |
+
+Both variables are read once at module load. Restart the application pods after changing them.
+
+## Observability
+
+The route emits a structured stdout log line every 30 seconds for every tenant with at least one active connection:
+
+```json
+{"metric":"sse.connections.active","tenantId":"<tenantId>","count":<n>,"podId":"<hostname>","ts":"<iso>"}
+```
+
+Operators ingest this through whatever log pipeline already collects application stdout (Loki, Datadog, CloudWatch, etc.). No new HTTP endpoint, no new dependency, no new credentials to provision. A future cross-cutting Observability milestone may migrate this to a Prometheus gauge — until then the structured stdout line is the canonical metric.
+
+The route also logs (at `console.warn`) when:
+
+- Subscribe to Valkey fails for a connection (`[sse/notifications] subscribe failed`).
+- The notification worker's best-effort SSE publish fails (`[notificationWorker] SSE publish failed`).
+
+Both are non-fatal: SSE is a wake-up signal, the `Notification` row is the source of truth, and clients self-heal on reconnect via the route's `{event:"sync"}` first byte.
+
+## Graceful shutdown
+
+The route registers a `SIGTERM` handler that, on signal, writes `event: shutdown\ndata: {}\n\n` to every active stream, unsubscribes each subscriber, and closes the underlying Valkey clients. EventSource's built-in auto-reconnect on the client kicks in — combined with the route's sync-on-connect, users are reconnected and resynced on a different pod within seconds. Set `terminationGracePeriodSeconds` on the pod to at least 30 seconds (60 seconds is a safer margin) to give the handler room to drain.
+
+## Future helm chart checklist
+
+The TestPlanIt helm chart is planned for a future milestone. The same TestPlanIt application image runs in every environment — the only environment-specific knobs are ingress annotations and the two tuning env vars. When the chart is built, the following values must be exposed for SSE to work portably:
+
+- `sse.perTenantCap` → `SSE_PER_TENANT_CAP` env var
+- `sse.perUserCap` → `SSE_PER_USER_CAP` env var
+- Ingress annotations block that defaults to the nginx-ingress / Traefik / ALB examples above
+- `terminationGracePeriodSeconds` ≥ 30 on the application Deployment (60 recommended)
+
+## Reference files
+
+- Route: `testplanit/app/api/notifications/stream/route.ts`
+- Channel helpers: `testplanit/lib/notifications/channels.ts`
+- Publisher: `testplanit/workers/notificationWorker.ts` (after `prisma.notification.create`)
+- Valkey wiring: `testplanit/lib/valkey.ts` (default singleton + `createSubscriberClient` factory)
+- Bell client: `testplanit/components/NotificationBell.tsx` (EventSource useEffect)

--- a/docs/docs/user-guide/notifications.md
+++ b/docs/docs/user-guide/notifications.md
@@ -43,7 +43,7 @@ The notification panel displays when you click the bell icon:
 
 - **Width**: Fixed at 400px for comfortable reading
 - **Height**: Scrollable area showing up to 20 most recent notifications
-- **Auto-refresh**: Updates every 5 seconds when open, every 30 seconds when closed
+- **Live updates**: New notifications appear within ~1 second via a server-pushed event stream — no polling
 - **Focus refresh**: Automatically refreshes when you return to the browser tab
 
 **Panel Header**:
@@ -109,18 +109,22 @@ When you have no notifications, the panel displays:
 
 **Automatic Updates**:
 
-- **Polling intervals**:
-  - 5 seconds when panel is open
-  - 30 seconds when panel is closed
-  - Continues even when browser tab is in background
-- **Window focus**: Refreshes immediately when you return to the tab
-- **URL parameter**: Can open notifications automatically with `?openNotifications=true`
+- **Server-pushed updates**: When you sign in, the bell opens a long-lived [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) connection to TestPlanIt. New notifications arrive within ~1 second of being created — no polling, no refresh required.
+- **Auto-reconnect**: If the connection drops (network blip, server restart, deploy), the browser automatically reconnects and re-syncs missed notifications.
+- **Window focus**: When you return to the tab, the panel refreshes immediately as a safety net for anything that might have been missed during a long sleep/suspend.
+- **URL parameter**: Can open notifications automatically with `?openNotifications=true`.
 
 **Badge Counter**:
 
 - Updates in real-time as notifications arrive
 - Shows unread count accurately
 - Caps display at "9+" for readability
+
+:::note Operator note
+
+For SSE to work behind a load balancer, the ingress / reverse proxy must allow long-lived streamed responses (no buffering, idle timeouts ≥ 1 hour). See [SSE Notifications](../sse-notifications.md) for nginx-ingress, Traefik, AWS LBC, and plain nginx configuration recipes plus the tuning environment variables.
+
+:::
 
 ### Notification Details by Type
 
@@ -281,20 +285,28 @@ EMAIL_FROM=noreply@example.com
    - Processes notification creation jobs
    - Determines user preferences
    - Queues email jobs when needed
+   - After creating each `Notification` row, publishes a small `{id, event}` wake-up payload to a tenant-scoped Valkey channel so live SSE subscribers refetch immediately
 
-2. **Email Worker** (`workers/emailWorker.ts`)
+2. **SSE Stream Route** (`app/api/notifications/stream/route.ts`)
+   - Serves the long-lived `text/event-stream` connection that the bell consumes
+   - Subscribes per-connection to the user's Valkey channel and the tenant broadcast channel
+   - Treats wake-up payloads as opaque "something changed" signals; the bell re-fetches through the policy-enforced ZenStack hook so multi-tenant isolation and access control are re-applied on every read
+   - Enforces per-user (4) and per-tenant (1000, default) connection caps and a 25-second heartbeat for proxy-friendly liveness
+
+3. **Email Worker** (`workers/emailWorker.ts`)
    - Sends actual emails
    - Handles retries and failures
    - Processes both immediate and digest emails
 
-3. **Scheduler** (`scheduler.ts`)
+4. **Scheduler** (`scheduler.ts`)
    - Sets up cron jobs for daily digests
    - Runs at 8 AM daily
 
-4. **Queue System** (BullMQ + Valkey)
+5. **Queue System** (BullMQ + Valkey)
    - Ensures reliable delivery
    - Handles retries automatically
    - Prevents duplicate notifications
+   - The same Valkey is reused for the SSE pub/sub fan-out — channels are namespaced by tenant prefix, no separate Valkey deployment needed
 
 ### Flow Diagram
 
@@ -308,11 +320,16 @@ Event Occurs → Create Notification Job → Notification Worker
                    IN_APP Only         EMAIL_IMMEDIATE         EMAIL_DAILY
                         ↓                     ↓                     ↓
                  Store in DB          Queue Email Job      Store for Digest
-                                              ↓
-                                        Email Worker
-                                              ↓
-                                        Send Email
+                        ↓                     ↓
+              Publish to Valkey         Email Worker
+                  (wake-up)                   ↓
+                        ↓               Send Email
+              SSE Route relays
+                        ↓
+              Bell refetches → Badge updates
 ```
+
+For ingress / proxy configuration required to run SSE reliably behind a load balancer, see [SSE Notifications](../sse-notifications.md).
 
 ## Global Settings
 
@@ -348,6 +365,15 @@ Administrators can configure system-wide defaults:
 2. Ensure you haven't selected "None"
 3. Verify your email address is correct
 4. Check spam/junk folders
+
+### Bell does not update in real time
+
+If new notifications only appear after a manual page refresh, the SSE event stream is not reaching the browser. This is almost always an ingress / reverse-proxy configuration issue, not an application bug.
+
+1. In the browser DevTools Network tab, filter for `stream`. There should be one long-lived `/api/notifications/stream` request with status `200` and `Content-Type: text/event-stream`.
+2. If the request returns `401`, the user is not signed in (expected on the sign-in page).
+3. If the request closes after a few seconds, the proxy is buffering the response or applying a short idle timeout. See [SSE Notifications](../sse-notifications.md) for nginx-ingress, Traefik, AWS LBC, and plain nginx fixes.
+4. Server logs include a `sse.connections.active` JSON line every 30 seconds per tenant — if that line is missing, no connections are reaching the route.
 
 ### Emails Not Sending
 
@@ -385,7 +411,7 @@ Example template:
 <h2>{{title}}</h2>
 <p>Hi {{userName}},</p>
 <p>{{message}}</p>
-<a href="{{actionUrl}}" class="button">{{actionText}}</a>
+<a href='{{actionUrl}}' class='button'>{{actionText}}</a>
 ```
 
 ### Testing Notifications

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
         'external-database-deployment', // Add external-database-deployment.md
         'background-processes', // Add background-processes.md
         'multi-tenant-workers', // Add multi-tenant-workers.md
+        'sse-notifications', // SSE notifications deployment & ingress configuration
       ],
     },
     'getting-started', // Corresponds to getting-started.md

--- a/testplanit/app/api/notifications/stream/route.ts
+++ b/testplanit/app/api/notifications/stream/route.ts
@@ -86,14 +86,12 @@ export async function GET(req: NextRequest) {
   }
   const userId = session.user.id;
 
-  // ---- tenant gate (CR-01 / Architectural Directive 1) ----
-  const tenantId = getCurrentTenantId();
-  if (!tenantId) {
-    return NextResponse.json(
-      { error: "Tenant context not configured" },
-      { status: 500 }
-    );
-  }
+  // ---- tenant resolution (CR-01 / Architectural Directive 1) ----
+  // Single-tenant deployments leave INSTANCE_TENANT_ID unset; fall back to
+  // "default" so channel keys remain tenant-scoped without requiring extra
+  // configuration. Multi-tenant deployments set INSTANCE_TENANT_ID per
+  // instance and isolation works as designed.
+  const tenantId = getCurrentTenantId() ?? "default";
 
   // ---- per-tenant cap (LIM-02 / D-18) — circuit breaker, no IORedis subscribe ----
   const tenantCount = tenantCounts.get(tenantId) ?? 0;

--- a/testplanit/app/api/notifications/stream/route.ts
+++ b/testplanit/app/api/notifications/stream/route.ts
@@ -1,0 +1,276 @@
+import IORedis from "ioredis";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import os from "os";
+import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
+import {
+  tenantBroadcastChannel,
+  userChannel,
+} from "~/lib/notifications/channels";
+import { createSubscriberClient } from "~/lib/valkey";
+import { authOptions } from "~/server/auth";
+
+// SSE notifications transport — long-lived stream + IORedis pub/sub require the
+// Node.js runtime, never Edge, and must opt out of any Next.js prerendering.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// ---- env-driven config (D-17 / LIM-01 / LIM-02) ----
+const PER_TENANT_CAP = Number(process.env.SSE_PER_TENANT_CAP ?? "1000");
+const PER_USER_CAP = Number(process.env.SSE_PER_USER_CAP ?? "4");
+const HEARTBEAT_MS = 25_000;
+const METRICS_INTERVAL_MS = 30_000;
+
+// ---- module-scoped registries (D-16/17/18/19/20) ----
+interface ActiveConnection {
+  tenantId: string;
+  userId: string;
+  cleanup: () => Promise<void>;
+  writeShutdown: () => void;
+  openedAt: number;
+}
+const tenantCounts: Map<string, number> = new Map();
+const userConnections: Map<string, ActiveConnection[]> = new Map();
+const allConnections: Set<ActiveConnection> = new Set();
+
+// ---- one-time process-level setup ----
+let signalsRegistered = false;
+let metricsTimer: NodeJS.Timeout | null = null;
+
+function registerOnce() {
+  if (signalsRegistered) return;
+  signalsRegistered = true;
+
+  const onShutdown = async () => {
+    for (const conn of allConnections) {
+      try {
+        conn.writeShutdown();
+      } catch {
+        /* swallow — controller may already be closed */
+      }
+    }
+    await Promise.allSettled([...allConnections].map((c) => c.cleanup()));
+    if (metricsTimer) {
+      clearInterval(metricsTimer);
+      metricsTimer = null;
+    }
+  };
+  process.on("SIGTERM", onShutdown);
+  process.on("SIGINT", onShutdown);
+
+  metricsTimer = setInterval(() => {
+    for (const [tenantId, count] of tenantCounts) {
+      if (count <= 0) continue;
+      console.log(
+        JSON.stringify({
+          metric: "sse.connections.active",
+          tenantId,
+          count,
+          podId: os.hostname(),
+          ts: new Date().toISOString(),
+        })
+      );
+    }
+  }, METRICS_INTERVAL_MS);
+  // Allow Node to exit despite the interval if everything else is gone.
+  metricsTimer.unref?.();
+}
+
+export async function GET(req: NextRequest) {
+  registerOnce();
+
+  // ---- auth gate (SSE-02 / CR-02) — fires BEFORE any IORedis client is created ----
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  // ---- tenant gate (CR-01 / Architectural Directive 1) ----
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) {
+    return NextResponse.json(
+      { error: "Tenant context not configured" },
+      { status: 500 }
+    );
+  }
+
+  // ---- per-tenant cap (LIM-02 / D-18) — circuit breaker, no IORedis subscribe ----
+  const tenantCount = tenantCounts.get(tenantId) ?? 0;
+  if (tenantCount >= PER_TENANT_CAP) {
+    return new NextResponse(null, {
+      status: 503,
+      headers: { "Retry-After": "30" },
+    });
+  }
+
+  // ---- per-user LRU cap (LIM-01 / D-18) — fairness mechanism, accept new + close oldest ----
+  const userKey = `${tenantId}:${userId}`;
+  const list = userConnections.get(userKey) ?? [];
+  if (list.length >= PER_USER_CAP) {
+    const oldest = list.shift();
+    if (oldest) {
+      // cleanup() decrements counters and removes from registries
+      await oldest.cleanup().catch(() => undefined);
+    }
+  }
+
+  // ---- create per-connection subscriber (DEP-01 / Architectural Directive 4) ----
+  const subscriber: IORedis | null = createSubscriberClient();
+  if (!subscriber) {
+    // Same code path on every deployment — when Valkey is not configured
+    // for this pod, fail closed so the EventSource client retries.
+    return new NextResponse(null, {
+      status: 503,
+      headers: { "Retry-After": "30" },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let controllerClosed = false;
+  let lastEventAt = Date.now();
+  let heartbeatInterval: NodeJS.Timeout | null = null;
+  let connection!: ActiveConnection;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function write(bytes: Uint8Array) {
+        if (controllerClosed) return;
+        try {
+          controller.enqueue(bytes);
+        } catch {
+          controllerClosed = true;
+        }
+      }
+      function sendEvent(payload: object) {
+        write(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+        lastEventAt = Date.now();
+      }
+      function sendComment(line: string) {
+        write(encoder.encode(`${line}\n\n`));
+      }
+      function writeShutdown() {
+        write(encoder.encode(`event: shutdown\ndata: {}\n\n`));
+      }
+
+      // The publisher already encodes `{id, event}` JSON (Wave 1 publish-site
+      // contract — SSE-03). We relay the message verbatim inside a `data:`
+      // SSE line; the consumer's authorization is enforced separately by the
+      // bell's `useFindManyNotification` → `getEnhancedDb` re-read path
+      // (Architectural Directive 2 — pub/sub layer is untrusted plumbing).
+      subscriber.on("message", (_channel, message) => {
+        if (controllerClosed) return;
+        write(encoder.encode(`data: ${message}\n\n`));
+        lastEventAt = Date.now();
+      });
+
+      try {
+        await subscriber.subscribe(
+          userChannel(tenantId, userId),
+          tenantBroadcastChannel(tenantId)
+        );
+      } catch (subErr) {
+        console.warn(`[sse/notifications] subscribe failed`, {
+          tenantId,
+          userId,
+          error: subErr instanceof Error ? subErr.message : String(subErr),
+        });
+        try {
+          await subscriber.quit();
+        } catch {
+          /* swallow */
+        }
+        controllerClosed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+        return;
+      }
+
+      // First byte after subscribe completes (D-11 — sync checkpoint).
+      sendEvent({ event: "sync" });
+
+      // Gated heartbeat (D-12 / SSE-04) — fires only if no real event in last 25s.
+      heartbeatInterval = setInterval(() => {
+        if (Date.now() - lastEventAt >= HEARTBEAT_MS) {
+          sendComment(": ping");
+        }
+      }, HEARTBEAT_MS);
+
+      connection = {
+        tenantId,
+        userId,
+        openedAt: Date.now(),
+        writeShutdown,
+        cleanup: async () => {
+          if (controllerClosed) {
+            // Ensure registries are still cleaned up exactly once even if
+            // the controller closed earlier (e.g. enqueue threw).
+          }
+          controllerClosed = true;
+          if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+            heartbeatInterval = null;
+          }
+          try {
+            await subscriber.unsubscribe();
+          } catch {
+            /* swallow */
+          }
+          try {
+            await subscriber.quit();
+          } catch {
+            /* swallow */
+          }
+          tenantCounts.set(
+            tenantId,
+            Math.max(0, (tenantCounts.get(tenantId) ?? 1) - 1)
+          );
+          const userList = userConnections.get(userKey);
+          if (userList) {
+            const idx = userList.indexOf(connection);
+            if (idx >= 0) userList.splice(idx, 1);
+            if (userList.length === 0) userConnections.delete(userKey);
+          }
+          allConnections.delete(connection);
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
+        },
+      };
+
+      tenantCounts.set(tenantId, (tenantCounts.get(tenantId) ?? 0) + 1);
+      const updatedList = userConnections.get(userKey) ?? [];
+      updatedList.push(connection);
+      userConnections.set(userKey, updatedList);
+      allConnections.add(connection);
+    },
+
+    async cancel() {
+      // Reader cancelled (e.g. via AbortController). Drive cleanup once.
+      if (connection) {
+        await connection.cleanup().catch(() => undefined);
+      }
+    },
+  });
+
+  // Request-abort handler (SSE-05 / D-21).
+  req.signal.addEventListener("abort", () => {
+    if (connection) {
+      void connection.cleanup().catch(() => undefined);
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/testplanit/components/NotificationBell.test.tsx
+++ b/testplanit/components/NotificationBell.test.tsx
@@ -174,6 +174,7 @@ describe("NotificationBell", () => {
   it("should query notifications for current user", () => {
     render(<NotificationBell />);
 
+    // Wave 5: SSE is the sole update source; no refetchInterval / refetchIntervalInBackground.
     expect(useFindManyNotification).toHaveBeenCalledWith(
       {
         where: {
@@ -187,10 +188,15 @@ describe("NotificationBell", () => {
       },
       {
         enabled: true,
-        refetchInterval: 5 * 60 * 1000,
-        refetchIntervalInBackground: true,
       }
     );
+
+    const lastCallOptions = vi
+      .mocked(useFindManyNotification)
+      .mock.calls.at(-1)?.[1] as Record<string, unknown> | undefined;
+    expect(lastCallOptions).toBeDefined();
+    expect(lastCallOptions).not.toHaveProperty("refetchInterval");
+    expect(lastCallOptions).not.toHaveProperty("refetchIntervalInBackground");
   });
 
   it("should not query notifications when no session", () => {
@@ -198,10 +204,9 @@ describe("NotificationBell", () => {
 
     render(<NotificationBell />);
 
+    // Wave 5: no refetchInterval / refetchIntervalInBackground — SSE is sole update source.
     expect(useFindManyNotification).toHaveBeenCalledWith(expect.any(Object), {
       enabled: false,
-      refetchInterval: 5 * 60 * 1000,
-      refetchIntervalInBackground: true,
     });
   });
 

--- a/testplanit/components/NotificationBell.test.tsx
+++ b/testplanit/components/NotificationBell.test.tsx
@@ -187,7 +187,7 @@ describe("NotificationBell", () => {
       },
       {
         enabled: true,
-        refetchInterval: 30000,
+        refetchInterval: 5 * 60 * 1000,
         refetchIntervalInBackground: true,
       }
     );
@@ -200,7 +200,7 @@ describe("NotificationBell", () => {
 
     expect(useFindManyNotification).toHaveBeenCalledWith(expect.any(Object), {
       enabled: false,
-      refetchInterval: 30000,
+      refetchInterval: 5 * 60 * 1000,
       refetchIntervalInBackground: true,
     });
   });

--- a/testplanit/components/NotificationBell.tsx
+++ b/testplanit/components/NotificationBell.tsx
@@ -190,7 +190,7 @@ export function NotificationBell() {
     },
     {
       enabled: !!session?.user?.id,
-      refetchInterval: isOpen ? 5000 : 30000, // Poll every 5 seconds when open, 30 seconds when closed
+      refetchInterval: 5 * 60 * 1000, // 5-minute redundancy net while SSE rollout is verified (UI-02 / D-23). Wave 5 removes this line entirely.
       refetchIntervalInBackground: true, // Continue polling when tab is not visible
     }
   );

--- a/testplanit/components/NotificationBell.tsx
+++ b/testplanit/components/NotificationBell.tsx
@@ -190,8 +190,6 @@ export function NotificationBell() {
     },
     {
       enabled: !!session?.user?.id,
-      refetchInterval: 5 * 60 * 1000, // 5-minute redundancy net while SSE rollout is verified (UI-02 / D-23). Wave 5 removes this line entirely.
-      refetchIntervalInBackground: true, // Continue polling when tab is not visible
     }
   );
 
@@ -211,7 +209,8 @@ export function NotificationBell() {
 
   // SSE wake-up: open EventSource when authenticated; refetch on each event.
   // Read path remains useFindManyNotification → getEnhancedDb (Architectural Directive 2 / ISO-02).
-  // The existing refetchInterval stays in place this wave (defense in depth — D-23).
+  // SSE is the sole update source — no polling fallback remains (UI-03 / D-23).
+  // Reconnect → server emits {event:"sync"} → onmessage → refetch catches anything missed.
   useEffect(() => {
     if (!session?.user?.id) return;
     if (typeof window === "undefined" || typeof EventSource === "undefined") {

--- a/testplanit/components/NotificationBell.tsx
+++ b/testplanit/components/NotificationBell.tsx
@@ -209,6 +209,28 @@ export function NotificationBell() {
     return () => window.removeEventListener("focus", handleFocus);
   }, [session?.user?.id, refetch]);
 
+  // SSE wake-up: open EventSource when authenticated; refetch on each event.
+  // Read path remains useFindManyNotification → getEnhancedDb (Architectural Directive 2 / ISO-02).
+  // The existing refetchInterval stays in place this wave (defense in depth — D-23).
+  useEffect(() => {
+    if (!session?.user?.id) return;
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      return;
+    }
+    const eventSource = new EventSource("/api/notifications/stream");
+    eventSource.onmessage = () => {
+      void refetch();
+    };
+    eventSource.onerror = (err) => {
+      // EventSource auto-reconnects on transport drop. Log to console only —
+      // a user-visible toast would be noisy on transient blips. (CR / D-22 + PATTERNS §6 decision.)
+      console.warn("[NotificationBell] SSE transport error", err);
+    };
+    return () => {
+      eventSource.close();
+    };
+  }, [session?.user?.id, refetch]);
+
   // Check for URL parameter to open notifications
   useEffect(() => {
     if (searchParams.get("openNotifications") === "true") {

--- a/testplanit/e2e/fixtures/index.ts
+++ b/testplanit/e2e/fixtures/index.ts
@@ -1,5 +1,25 @@
-import { expect, test as base } from "@playwright/test";
+import { expect, test as base, type Page } from "@playwright/test";
 import { ApiHelper } from "./api.fixture";
+
+/**
+ * Stub the bell's SSE stream with HTTP 204 so EventSource stops reconnecting
+ * and `waitForLoadState("networkidle")` can fire. The NotificationBell mounts
+ * on every authenticated page and would otherwise keep one network request
+ * open indefinitely.
+ *
+ * The shared `page` fixture below auto-applies this. Tests that create their
+ * own contexts via `browser.newContext()` must call this helper on each
+ * manually-created page — fixture route handlers don't propagate to
+ * manually-created contexts.
+ *
+ * Tests that want real SSE behavior on the page (e.g. dedicated SSE coverage
+ * tests) should not call this and can `unroute` if needed.
+ */
+export async function stubBellSSE(page: Page): Promise<void> {
+  await page.route("**/api/notifications/stream", (route) =>
+    route.fulfill({ status: 204, body: "" })
+  );
+}
 
 /**
  * Extended test fixtures for TestPlanIt E2E tests
@@ -17,6 +37,14 @@ export interface TestFixtures {
  * Extended test with custom fixtures
  */
 export const test = base.extend<TestFixtures>({
+  // Auto-apply the SSE stub to the fixture's `page`. See stubBellSSE above
+  // for rationale. Manually-created contexts must call stubBellSSE themselves.
+  page: async ({ page }, use) => {
+    await stubBellSSE(page);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    await use(page);
+  },
+
   // Default project ID (can be overridden per test)
   projectId: 1,
 

--- a/testplanit/e2e/tests/api/sse-notifications.spec.ts
+++ b/testplanit/e2e/tests/api/sse-notifications.spec.ts
@@ -154,7 +154,12 @@ test.describe("SSE Notifications Stream", () => {
         .getByTestId("notification-title-input")
         .fill(announcementTitle);
 
-      const editor = page.getByTestId("notification-message-editor");
+      // TipTapEditor's data-testid prop is silently dropped. Existing repo
+      // patterns (see e2e/tests/repository/.../documentation.spec.ts) target
+      // the contenteditable via `.ProseMirror` directly. This page has one
+      // editor on it, so `.first()` is unambiguous.
+      const editor = page.locator(".ProseMirror").first();
+      await expect(editor).toBeVisible({ timeout: 10000 });
       await editor.click();
       await page.keyboard.type("E2E SSE test message body");
 

--- a/testplanit/e2e/tests/api/sse-notifications.spec.ts
+++ b/testplanit/e2e/tests/api/sse-notifications.spec.ts
@@ -1,0 +1,214 @@
+import { expect, test } from "../../fixtures/index";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * SSE Notifications Stream E2E Tests
+ *
+ * Verifies the live `/api/notifications/stream` SSE route end-to-end:
+ *
+ * - T1: Unauthenticated GET → 401, no Valkey subscriber created (REQ SSE-02)
+ * - T2: Authenticated GET → 200 with text/event-stream headers; first
+ *   message is the `sync` self-healing checkpoint (REQ SSE-01, D-11)
+ * - T3: Admin-triggered system announcement reaches the admin's open SSE
+ *   stream within ~10s (publisher → BullMQ worker → Valkey publish →
+ *   route relay → client). Exercises the tenant broadcast channel
+ *   (REQ PUB-02, REQ ISO-01).
+ *
+ * The Vitest-level isolation test at lib/notifications/sse-isolation.test.ts
+ * already proves multi-tenant isolation against real Valkey; this suite
+ * proves the full HTTP → SSE → bell wake-up wiring under the prod build.
+ *
+ * SSE streams are read with Node's native `fetch()` so the test can read
+ * chunks before the response completes — Playwright's APIRequestContext
+ * waits for the full body and would hang on a long-lived stream.
+ */
+
+const ADMIN_STORAGE_PATH = path.join(__dirname, "../../.auth/admin.json");
+
+function readAdminCookieHeader(): string {
+  const storage = JSON.parse(readFileSync(ADMIN_STORAGE_PATH, "utf8")) as {
+    cookies: { name: string; value: string; domain: string }[];
+  };
+  return storage.cookies
+    .filter(
+      (c) =>
+        c.domain === "localhost" ||
+        c.domain === ".localhost" ||
+        c.domain === "127.0.0.1"
+    )
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+}
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  matchFn: (buffer: string) => boolean,
+  timeoutMs: number
+): Promise<string> {
+  let buffer = "";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = Math.max(0, deadline - Date.now());
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: true }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: true }), remaining)
+      ),
+    ]);
+    if (result.done) break;
+    if (result.value) {
+      buffer += decoder.decode(result.value, { stream: true });
+      if (matchFn(buffer)) return buffer;
+    }
+  }
+  return buffer;
+}
+
+test.describe("SSE Notifications Stream", () => {
+  test("T1: unauthenticated GET /api/notifications/stream returns 401", async ({
+    baseURL,
+  }) => {
+    expect(baseURL).toBeTruthy();
+
+    const response = await fetch(`${baseURL!}/api/notifications/stream`);
+
+    expect(response.status).toBe(401);
+    await response.text().catch(() => {});
+  });
+
+  test("T2: authenticated GET returns text/event-stream with sync event", async ({
+    baseURL,
+  }) => {
+    expect(baseURL).toBeTruthy();
+    const cookieHeader = readAdminCookieHeader();
+    const controller = new AbortController();
+
+    const response = await fetch(`${baseURL!}/api/notifications/stream`, {
+      headers: { cookie: cookieHeader },
+      signal: controller.signal,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.headers.get("cache-control")).toContain("no-cache");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+    expect(response.body).toBeTruthy();
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    try {
+      const buffer = await readUntil(
+        reader,
+        decoder,
+        (b) => b.includes('"event":"sync"'),
+        5000
+      );
+      expect(buffer).toContain('data: {"event":"sync"}');
+    } finally {
+      controller.abort();
+      await reader.cancel().catch(() => {});
+    }
+  });
+
+  test("T3: admin system announcement reaches admin's open SSE stream", async ({
+    baseURL,
+    browser,
+    request,
+  }) => {
+    expect(baseURL).toBeTruthy();
+    const cookieHeader = readAdminCookieHeader();
+    const controller = new AbortController();
+
+    const response = await fetch(`${baseURL!}/api/notifications/stream`, {
+      headers: { cookie: cookieHeader },
+      signal: controller.signal,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toBeTruthy();
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let context: Awaited<ReturnType<typeof browser.newContext>> | undefined;
+    const announcementTitle = `E2E SSE Test ${Date.now()}`;
+
+    try {
+      const syncBuffer = await readUntil(
+        reader,
+        decoder,
+        (b) => b.includes('"event":"sync"'),
+        5000
+      );
+      expect(syncBuffer).toContain('data: {"event":"sync"}');
+
+      context = await browser.newContext({ storageState: ADMIN_STORAGE_PATH });
+      const page = await context.newPage();
+
+      await page.goto(`${baseURL!}/en-US/admin/notifications`);
+      await page
+        .getByTestId("notification-title-input")
+        .waitFor({ state: "visible", timeout: 10000 });
+
+      await page
+        .getByTestId("notification-title-input")
+        .fill(announcementTitle);
+
+      const editor = page.getByTestId("notification-message-editor");
+      await editor.click();
+      await page.keyboard.type("E2E SSE test message body");
+
+      await page.getByTestId("send-notification-button").click();
+
+      await expect(page.getByTestId("notification-title-input")).toHaveValue(
+        "",
+        { timeout: 15000 }
+      );
+
+      const postSyncBuffer = await readUntil(
+        reader,
+        decoder,
+        (b) => {
+          const lines = b.split("\n");
+          return lines.some(
+            (l) => l.startsWith("data:") && !l.includes('"event":"sync"')
+          );
+        },
+        15000
+      );
+
+      const dataLines = postSyncBuffer
+        .split("\n")
+        .filter((l) => l.startsWith("data:") && !l.includes('"event":"sync"'));
+
+      expect(dataLines.length).toBeGreaterThan(0);
+
+      const eventBody = dataLines[0].replace(/^data:\s*/, "");
+      const event = JSON.parse(eventBody) as { id: string; event: string };
+      expect(event).toHaveProperty("id");
+      expect(event).toHaveProperty("event");
+      expect(typeof event.id).toBe("string");
+      expect(event.id.length).toBeGreaterThan(0);
+    } finally {
+      controller.abort();
+      await reader.cancel().catch(() => {});
+
+      const cleanupResponse = await request.patch(
+        `${baseURL!}/api/model/notification/updateMany`,
+        {
+          data: {
+            where: { title: announcementTitle, isDeleted: false },
+            data: { isDeleted: true },
+          },
+        }
+      );
+      if (!cleanupResponse.ok()) {
+        console.warn(
+          `[T3 cleanup] soft-delete '${announcementTitle}' failed: ${cleanupResponse.status()}`
+        );
+      }
+
+      if (context) await context.close();
+    }
+  });
+});

--- a/testplanit/e2e/tests/repository/case-fields/case-creation-with-fields.spec.ts
+++ b/testplanit/e2e/tests/repository/case-fields/case-creation-with-fields.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "../../../fixtures";
+import { expect, stubBellSSE, test } from "../../../fixtures";
 import { RepositoryPage } from "../../../page-objects/repository/repository.page";
 
 /**
@@ -1330,6 +1330,8 @@ test.describe("Case Creation - Restricted Fields", () => {
     // Create a new browser context and authenticate as the regular user
     const userContext = await browser.newContext();
     const userPage = await userContext.newPage();
+    // Manually-created contexts don't inherit the shared fixture's SSE stub.
+    await stubBellSSE(userPage);
 
     try {
       // Login as regular user

--- a/testplanit/lib/notifications/channels.test.ts
+++ b/testplanit/lib/notifications/channels.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { tenantBroadcastChannel, userChannel } from "./channels";
+
+describe("channels.userChannel", () => {
+  it("returns notifications:tenant:<tenantId>:user:<userId>", () => {
+    expect(userChannel("acme", "u_123")).toBe(
+      "notifications:tenant:acme:user:u_123"
+    );
+  });
+
+  it("throws when tenantId is empty", () => {
+    expect(() => userChannel("", "u_123")).toThrow(/tenantId is required/);
+  });
+
+  it("throws when userId is empty", () => {
+    expect(() => userChannel("acme", "")).toThrow(/userId is required/);
+  });
+});
+
+describe("channels.tenantBroadcastChannel", () => {
+  it("returns notifications:tenant:<tenantId>:broadcast", () => {
+    expect(tenantBroadcastChannel("acme")).toBe(
+      "notifications:tenant:acme:broadcast"
+    );
+  });
+
+  it("throws when tenantId is empty", () => {
+    expect(() => tenantBroadcastChannel("")).toThrow(/tenantId is required/);
+  });
+});

--- a/testplanit/lib/notifications/channels.ts
+++ b/testplanit/lib/notifications/channels.ts
@@ -1,0 +1,14 @@
+// The ONLY module permitted to construct notifications channel-key strings.
+// Architectural Directive 3 (REQUIREMENTS.md) / REQ PUB-03.
+
+export function userChannel(tenantId: string, userId: string): string {
+  if (!tenantId) throw new Error("channels.userChannel: tenantId is required");
+  if (!userId) throw new Error("channels.userChannel: userId is required");
+  return `notifications:tenant:${tenantId}:user:${userId}`;
+}
+
+export function tenantBroadcastChannel(tenantId: string): string {
+  if (!tenantId)
+    throw new Error("channels.tenantBroadcastChannel: tenantId is required");
+  return `notifications:tenant:${tenantId}:broadcast`;
+}

--- a/testplanit/lib/notifications/sse-isolation.test.ts
+++ b/testplanit/lib/notifications/sse-isolation.test.ts
@@ -1,0 +1,112 @@
+// Multi-tenant isolation invariant for the SSE notifications transport.
+// REQ ISO-03 / CONTEXT D-25 / CR-03.
+//
+// Runs against a REAL Valkey/Redis container — NO mocks of the pub/sub layer
+// (mocks would defeat the purpose). The suite is skipped when neither
+// TEST_VALKEY_URL nor VALKEY_URL is set so contributors without a local
+// Valkey running don't see spurious failures.
+//
+// Local prerequisite to actually exercise the assertions:
+//   docker compose -f testplanit/docker-compose.dev.yml up valkey -d
+//   TEST_VALKEY_URL=redis://localhost:6379 pnpm test run \
+//     lib/notifications/sse-isolation.test.ts
+
+import { randomUUID } from "crypto";
+import IORedis from "ioredis";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { tenantBroadcastChannel, userChannel } from "./channels";
+
+const VALKEY_URL = process.env.TEST_VALKEY_URL ?? process.env.VALKEY_URL;
+const describeMaybe = VALKEY_URL ? describe : describe.skip;
+
+describeMaybe("sse multi-tenant isolation (real Valkey)", () => {
+  let pub: IORedis;
+  let sub: IORedis;
+
+  // Unique per-run identifiers so concurrent CI invocations against the same
+  // Valkey instance don't cross-talk on channel keys.
+  const tenantA = `tenant-test-A-${randomUUID().slice(0, 8)}`;
+  const tenantB = `tenant-test-B-${randomUUID().slice(0, 8)}`;
+  const userA = `user-test-A-${randomUUID().slice(0, 8)}`;
+  const userB = `user-test-B-${randomUUID().slice(0, 8)}`;
+
+  beforeAll(async () => {
+    // Mirror the connection-options shape used by lib/valkey.ts so the test
+    // exercises the exact same client behavior the SSE route does.
+    const opts = { maxRetriesPerRequest: null, enableReadyCheck: false };
+    const url = VALKEY_URL!.replace(/^valkey:\/\//, "redis://");
+    pub = new IORedis(url, opts);
+    sub = new IORedis(url, opts);
+    // Fail fast if Valkey is not actually reachable (skip-guard only checks
+    // that an env var was provided, not that the server responds).
+    await pub.ping();
+  });
+
+  afterAll(async () => {
+    // IORedis must be explicitly closed or Vitest hangs at the 30s teardownTimeout.
+    try {
+      await pub.quit();
+    } catch {
+      /* ignore — already closed or never connected */
+    }
+    try {
+      await sub.quit();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("tenant-A subscriber receives zero events when tenant-B publishes", async () => {
+    const received: string[] = [];
+    sub.on("message", (_channel, message) => received.push(message));
+
+    await sub.subscribe(
+      userChannel(tenantA, userA),
+      tenantBroadcastChannel(tenantA)
+    );
+
+    // Tenant-B user channel — must not leak to tenant-A.
+    await pub.publish(
+      userChannel(tenantB, userB),
+      JSON.stringify({ id: "n1", event: "notification" })
+    );
+    // Tenant-B broadcast — must not leak to tenant-A.
+    await pub.publish(
+      tenantBroadcastChannel(tenantB),
+      JSON.stringify({ id: "n2", event: "notification" })
+    );
+    // Same userId in tenant-B — channel is namespaced by tenant, must not leak.
+    await pub.publish(
+      userChannel(tenantB, userA),
+      JSON.stringify({ id: "n3", event: "notification" })
+    );
+
+    // 1 second is well above Redis pub/sub fan-out latency on a healthy
+    // local Valkey; if the isolation invariant is broken, this is plenty
+    // of time for cross-tenant messages to arrive.
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(received.length).toBe(0);
+  });
+
+  it("positive control: tenant-A subscriber receives tenant-A publish", async () => {
+    // Proves the test wiring is correct — without this, a subscribe failure
+    // would silently make the isolation assertion above always pass.
+    const received: string[] = [];
+    sub.on("message", (_channel, message) => received.push(message));
+
+    // sub is already subscribed to tenant-A channels from the previous test.
+
+    await pub.publish(
+      userChannel(tenantA, userA),
+      JSON.stringify({ id: "n4", event: "notification" })
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(received.length).toBe(1);
+      },
+      { timeout: 1000 }
+    );
+  });
+});

--- a/testplanit/lib/valkey.ts
+++ b/testplanit/lib/valkey.ts
@@ -102,4 +102,37 @@ if (skipConnection) {
   console.warn("Valkey URL not provided. Valkey connection not established.");
 }
 
+/**
+ * Create a fresh IORedis client suitable for use as a Redis pub/sub subscriber.
+ *
+ * Subscribed Redis clients cannot issue regular commands, so each SSE
+ * connection (Wave 2) instantiates its own subscriber via this factory.
+ * Mirrors the same Sentinel / URL / skip-connection branches as the shared
+ * singleton above so deployment behavior is identical (DEP-01 / Architectural
+ * Directive 5).
+ */
+export function createSubscriberClient(): IORedis | null {
+  if (skipConnection) {
+    return null;
+  }
+  if (valkeySentinels) {
+    const sentinels = parseSentinels(valkeySentinels);
+    const masterPassword = valkeyUrl
+      ? extractPasswordFromUrl(valkeyUrl)
+      : undefined;
+    return new IORedis({
+      sentinels,
+      name: sentinelMasterName,
+      ...(masterPassword && { password: masterPassword }),
+      ...(sentinelPassword && { sentinelPassword }),
+      ...baseOptions,
+    });
+  }
+  if (valkeyUrl) {
+    const connectionUrl = valkeyUrl.replace(/^valkey:\/\//, "redis://");
+    return new IORedis(connectionUrl, baseOptions);
+  }
+  return null;
+}
+
 export default valkeyConnection;

--- a/testplanit/workers/notificationWorker.ts
+++ b/testplanit/workers/notificationWorker.ts
@@ -99,34 +99,36 @@ const processor = async (job: Job) => {
         // Failures are swallowed: SSE is a wake-up signal, the row is the source of truth.
         // Per CR-01 / Architectural Directive 1: tenantId comes from server-resolved job
         // payload (populated upstream via getCurrentTenantId), never client input.
-        if (createData.tenantId) {
-          try {
-            const channel =
-              createData.type === "SYSTEM_ANNOUNCEMENT"
-                ? tenantBroadcastChannel(createData.tenantId)
-                : userChannel(createData.tenantId, createData.userId);
-            const payload = JSON.stringify({
-              id: notification.id,
-              event: "notification",
-            });
-            await valkeyConnection?.publish(channel, payload);
-          } catch (publishErr) {
-            console.warn(
-              `[notificationWorker] SSE publish failed for notification ${notification.id}`,
-              {
-                notificationId: notification.id,
-                tenantId: createData.tenantId,
-                userId: createData.userId,
-                error:
-                  publishErr instanceof Error
-                    ? publishErr.message
-                    : String(publishErr),
-              }
-            );
-          }
-        } else {
+        // Single-tenant deployments leave tenantId unset; fall back to "default" so the
+        // channel key matches what the SSE route subscribes to.
+        const publishTenantId = createData.tenantId ?? "default";
+        try {
+          const channel =
+            createData.type === "SYSTEM_ANNOUNCEMENT"
+              ? tenantBroadcastChannel(publishTenantId)
+              : userChannel(publishTenantId, createData.userId);
+          const payload = JSON.stringify({
+            id: notification.id,
+            event: "notification",
+          });
+          await valkeyConnection?.publish(channel, payload);
+        } catch (publishErr) {
+          console.warn(
+            `[notificationWorker] SSE publish failed for notification ${notification.id}`,
+            {
+              notificationId: notification.id,
+              tenantId: publishTenantId,
+              userId: createData.userId,
+              error:
+                publishErr instanceof Error
+                  ? publishErr.message
+                  : String(publishErr),
+            }
+          );
+        }
+        if (!createData.tenantId) {
           console.debug(
-            `[notificationWorker] Skipping SSE publish for notification ${notification.id}: no tenantId on job payload`
+            `[notificationWorker] Used fallback tenantId 'default' for notification ${notification.id} (single-tenant deployment)`
           );
         }
 

--- a/testplanit/workers/notificationWorker.ts
+++ b/testplanit/workers/notificationWorker.ts
@@ -6,6 +6,10 @@ import {
   MultiTenantJobData,
   validateMultiTenantJobData,
 } from "../lib/multiTenantPrisma";
+import {
+  tenantBroadcastChannel,
+  userChannel,
+} from "../lib/notifications/channels";
 import { getEmailQueue, NOTIFICATION_QUEUE_NAME } from "../lib/queues";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
@@ -90,6 +94,41 @@ const processor = async (job: Job) => {
             data: createData.data,
           },
         });
+
+        // Best-effort SSE wake-up publish (Wave 1, REQ PUB-01/PUB-02/PUB-03/SSE-03).
+        // Failures are swallowed: SSE is a wake-up signal, the row is the source of truth.
+        // Per CR-01 / Architectural Directive 1: tenantId comes from server-resolved job
+        // payload (populated upstream via getCurrentTenantId), never client input.
+        if (createData.tenantId) {
+          try {
+            const channel =
+              createData.type === "SYSTEM_ANNOUNCEMENT"
+                ? tenantBroadcastChannel(createData.tenantId)
+                : userChannel(createData.tenantId, createData.userId);
+            const payload = JSON.stringify({
+              id: notification.id,
+              event: "notification",
+            });
+            await valkeyConnection?.publish(channel, payload);
+          } catch (publishErr) {
+            console.warn(
+              `[notificationWorker] SSE publish failed for notification ${notification.id}`,
+              {
+                notificationId: notification.id,
+                tenantId: createData.tenantId,
+                userId: createData.userId,
+                error:
+                  publishErr instanceof Error
+                    ? publishErr.message
+                    : String(publishErr),
+              }
+            );
+          }
+        } else {
+          console.debug(
+            `[notificationWorker] Skipping SSE publish for notification ${notification.id}: no tenantId on job payload`
+          );
+        }
 
         // Queue email if needed based on notification mode
         // Note: In multi-tenant mode, the email job should also include tenantId


### PR DESCRIPTION
## Description

Replaces `NotificationBell.tsx`'s 5/30s `refetchInterval` polling with server-pushed Server-Sent Events fanned out via Valkey pub/sub. Multi-tenant safe by construction; deployment-portable across docker-compose, k8s, and future helm/EKS — no sticky-session requirement.

Architecture in three steps:
1. **Publish** — `notificationWorker.ts` publishes `{id, event}` to a tenant-scoped Valkey channel after each `prisma.notification.create`.
2. **Subscribe** — `GET /api/notifications/stream` route holds a long-lived `text/event-stream`, subscribed per-connection to the user channel and the tenant broadcast channel.
3. **Refetch** — bell calls existing `useFindManyNotification.refetch()` on every SSE message; reads still flow through `getEnhancedDb` so tenant + access policy re-apply on every fetch (events carry IDs, not payloads).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (the bell's update mechanism)
- [x] Documentation update (`docs/docs/sse-notifications.md` operator guide + `docs/docs/user-guide/notifications.md` updated for SSE transport)
- [x] Tests (Vitest unit + real-Valkey integration + Playwright E2E)

## Testing

**Vitest:** 276 passing (channels, valkey, worker, NotificationBell, plus a real-Valkey multi-tenant isolation integration test gated on `TEST_VALKEY_URL`).

**Playwright E2E:** Full suite 1082/1082 passing under `E2E_PROD=on pnpm test:e2e` against the production build. New `e2e/tests/api/sse-notifications.spec.ts` adds three tests:

**Manual UAT:** Fired live notification through the worker queue → bell badge updated within ~1s in the browser. Confirmed end-to-end against the local dev environment.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Operator notes

- New env vars (defaults shown): `SSE_PER_TENANT_CAP=1000`, `SSE_PER_USER_CAP=4`. Both read once at module load.
- Ingress / reverse proxy must allow long-lived streamed responses (no buffering, idle timeouts ≥ 1 hour). See `docs/docs/sse-notifications.md` for nginx-ingress, Traefik, AWS LBC, and plain nginx recipes.
- `terminationGracePeriodSeconds` ≥ 30 (60 recommended) so SIGTERM has room to drain `event: shutdown` to active streams.
- Active connections logged as structured stdout JSON every 30s per tenant: `{"metric":"sse.connections.active",...}`. No new HTTP endpoint, no new dependency.
