### PR TITLE
fix(comments): enforce per-user project access on mention notifications

### DIFF
--- a/docs/docs/user-guide/comments.md
+++ b/docs/docs/user-guide/comments.md
@@ -119,6 +119,10 @@ When you're mentioned in a comment:
    - Which item was commented on (test case, run, session, or milestone)
    - A direct link to the comment
 
+#### Mentions in Projects You Cannot Access
+
+If someone mentions you in a comment on a project you do not have access to, you still receive a notification, but the message is redacted to protect the project's contents. The notification tells you who mentioned you and which project the comment is in, but does not name the specific item or include a clickable link. To gain access, contact a project admin.
+
 ### Notification Settings
 
 Control how you're notified about comments:

--- a/docs/docs/user-guide/notifications.md
+++ b/docs/docs/user-guide/notifications.md
@@ -156,6 +156,8 @@ When someone mentions you with `@username`:
 - Includes project context
 - Direct navigation to the comment
 
+If you are mentioned in a project you do not have access to, the notification is redacted: the message names the project and who mentioned you, but does not name the specific item or include a clickable link. This protects the project's contents while still letting you know that someone tried to loop you in.
+
 #### System Announcement Notifications
 
 **Special Formatting**:

--- a/testplanit/lib/services/commentService.test.ts
+++ b/testplanit/lib/services/commentService.test.ts
@@ -34,12 +34,37 @@ const mockFindManyUsers = vi.fn();
 const mockCreateManyMentions = vi.fn();
 const mockDeleteManyMentions = vi.fn();
 
+// Project access check — defaults to "user has access". Individual tests
+// override via `mockProjectsFindFirst.mockResolvedValueOnce(null)` to
+// exercise the no-access branch (redacted notification message).
+const mockProjectsFindFirst = vi.fn();
+
 vi.mock("~/lib/prisma", () => ({
   prisma: {
     user: {
       findMany: (...args: any[]) => mockFindManyUsers(...args),
     },
+    projects: {
+      findFirst: (...args: any[]) => mockProjectsFindFirst(...args),
+    },
   },
+}));
+
+// `buildProjectAccessWhere` is dynamically imported by commentService;
+// stub returns a marker object so test assertions can verify it was
+// invoked with the expected (projectId, userId, isAdmin, isProjectAdmin)
+// shape without coupling to the real where-clause structure.
+vi.mock("~/lib/project-access", () => ({
+  buildProjectAccessWhere: vi.fn(
+    (
+      projectId: number,
+      userId: string,
+      isAdmin: boolean,
+      isProjectAdmin: boolean
+    ) => ({
+      __access: { projectId, userId, isAdmin, isProjectAdmin },
+    })
+  ),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -54,6 +79,9 @@ vi.mock("~/server/db", () => ({
 describe("CommentService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: every mentioned user has project access. Tests that
+    // need the no-access branch override per-call.
+    mockProjectsFindFirst.mockResolvedValue({ id: 1 });
   });
 
   afterEach(() => {
@@ -143,8 +171,20 @@ describe("CommentService", () => {
       };
 
       mockFindManyUsers.mockResolvedValue([
-        { id: "user-1", name: "Alice", email: "alice@test.com", role: "USER" },
-        { id: "user-2", name: "Bob", email: "bob@test.com", role: "USER" },
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
+        {
+          id: "user-2",
+          name: "Bob",
+          email: "bob@test.com",
+          role: "USER",
+          access: "USER",
+        },
       ]);
 
       const result = await CommentService.processMentions(
@@ -175,7 +215,13 @@ describe("CommentService", () => {
       };
 
       mockFindManyUsers.mockResolvedValue([
-        { id: "user-1", name: "Alice", email: "alice@test.com", role: "USER" },
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
       ]);
 
       await CommentService.processMentions(
@@ -217,7 +263,13 @@ describe("CommentService", () => {
       };
 
       mockFindManyUsers.mockResolvedValue([
-        { id: "user-1", name: "Alice", email: "alice@test.com", role: "USER" },
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
       ]);
 
       await CommentService.processMentions(
@@ -256,7 +308,13 @@ describe("CommentService", () => {
       };
 
       mockFindManyUsers.mockResolvedValue([
-        { id: "user-1", name: "Alice", email: "alice@test.com", role: "USER" },
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
       ]);
 
       await CommentService.processMentions(
@@ -295,7 +353,13 @@ describe("CommentService", () => {
       };
 
       mockFindManyUsers.mockResolvedValue([
-        { id: "user-1", name: "Alice", email: "alice@test.com", role: "USER" },
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
       ]);
 
       await CommentService.processMentions(
@@ -345,6 +409,7 @@ describe("CommentService", () => {
           name: "Active User",
           email: "active@test.com",
           role: "USER",
+          access: "USER",
         },
       ]);
 
@@ -370,6 +435,174 @@ describe("CommentService", () => {
         expect.objectContaining({
           userId: "user-active",
         })
+      );
+    });
+
+    it("should send a redacted notification when the mentioned user has no project access", async () => {
+      const content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "mention", attrs: { id: "user-1" } }],
+          },
+        ],
+      };
+
+      mockFindManyUsers.mockResolvedValue([
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
+      ]);
+      // Simulate no project access — `findFirst` returns null because
+      // the buildProjectAccessWhere predicate filters Alice out.
+      mockProjectsFindFirst.mockResolvedValueOnce(null);
+
+      await CommentService.processMentions(
+        baseParams.commentId,
+        content,
+        baseParams.creatorId,
+        baseParams.creatorName,
+        baseParams.projectId,
+        baseParams.projectName,
+        baseParams.entityType,
+        baseParams.entityName,
+        baseParams.entityId
+      );
+
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+      const call = mockCreateNotification.mock.calls[0][0];
+      // Notification still goes out, but the message is redacted and
+      // the entity link payload is suppressed.
+      expect(call.userId).toBe("user-1");
+      expect(call.message).toContain("do not have access");
+      expect(call.message).not.toContain("Test Case 1");
+      expect(call.relatedEntityId).toBeUndefined();
+      expect(call.relatedEntityType).toBeUndefined();
+      expect(call.data.hasProjectAccess).toBe(false);
+    });
+
+    it("should send a full notification when the mentioned user has project access", async () => {
+      const content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "mention", attrs: { id: "user-1" } }],
+          },
+        ],
+      };
+
+      mockFindManyUsers.mockResolvedValue([
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@test.com",
+          role: "USER",
+          access: "USER",
+        },
+      ]);
+      // beforeEach default already returns a non-null project, but be
+      // explicit so this test reads independently.
+      mockProjectsFindFirst.mockResolvedValueOnce({ id: 1 });
+
+      await CommentService.processMentions(
+        baseParams.commentId,
+        content,
+        baseParams.creatorId,
+        baseParams.creatorName,
+        baseParams.projectId,
+        baseParams.projectName,
+        baseParams.entityType,
+        baseParams.entityName,
+        baseParams.entityId
+      );
+
+      const call = mockCreateNotification.mock.calls[0][0];
+      expect(call.message).toContain("Test Case 1");
+      expect(call.relatedEntityId).toBe("comment-123");
+      expect(call.relatedEntityType).toBe("Comment");
+      expect(call.data.hasProjectAccess).toBe(true);
+      expect(call.data.repositoryCaseId).toBe(100);
+    });
+
+    it("should pass isAdmin/isProjectAdmin flags to buildProjectAccessWhere based on user.access", async () => {
+      const content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "mention", attrs: { id: "user-admin" } },
+              { type: "mention", attrs: { id: "user-projectadmin" } },
+              { type: "mention", attrs: { id: "user-regular" } },
+            ],
+          },
+        ],
+      };
+
+      mockFindManyUsers.mockResolvedValue([
+        {
+          id: "user-admin",
+          name: "Admin User",
+          email: "admin@test.com",
+          role: "USER",
+          access: "ADMIN",
+        },
+        {
+          id: "user-projectadmin",
+          name: "Project Admin",
+          email: "padmin@test.com",
+          role: "USER",
+          access: "PROJECTADMIN",
+        },
+        {
+          id: "user-regular",
+          name: "Regular User",
+          email: "regular@test.com",
+          role: "USER",
+          access: "USER",
+        },
+      ]);
+
+      const { buildProjectAccessWhere } = await import("~/lib/project-access");
+
+      await CommentService.processMentions(
+        baseParams.commentId,
+        content,
+        baseParams.creatorId,
+        baseParams.creatorName,
+        baseParams.projectId,
+        baseParams.projectName,
+        baseParams.entityType,
+        baseParams.entityName,
+        baseParams.entityId
+      );
+
+      // ADMIN: isAdmin=true, isProjectAdmin=false
+      expect(buildProjectAccessWhere).toHaveBeenCalledWith(
+        baseParams.projectId,
+        "user-admin",
+        true,
+        false
+      );
+      // PROJECTADMIN: isAdmin=false, isProjectAdmin=true
+      expect(buildProjectAccessWhere).toHaveBeenCalledWith(
+        baseParams.projectId,
+        "user-projectadmin",
+        false,
+        true
+      );
+      // USER: both false
+      expect(buildProjectAccessWhere).toHaveBeenCalledWith(
+        baseParams.projectId,
+        "user-regular",
+        false,
+        false
       );
     });
   });

--- a/testplanit/lib/services/commentService.ts
+++ b/testplanit/lib/services/commentService.ts
@@ -54,11 +54,12 @@ export class CommentService {
       return [];
     }
 
-    // Import db to check user access
     const { prisma } = await import("~/lib/prisma");
+    const { buildProjectAccessWhere } = await import("~/lib/project-access");
 
-    // Get user details - basic info only for now
-    // TODO: Implement proper project access checking with ZenStack
+    // Fetch the mentioned user records — `access` is the Access enum
+    // (ADMIN / PROJECTADMIN / USER / NONE) used to gate the project
+    // access check below.
     const mentionedUsers = await prisma.user.findMany({
       where: {
         id: { in: usersToNotify },
@@ -70,16 +71,40 @@ export class CommentService {
         name: true,
         email: true,
         role: true,
+        access: true,
       },
     });
 
-    // For now, assume all mentioned users have access
-    // In production, you would check project permissions here
+    // Per-user project access check. The notification message + link
+    // payload differ depending on whether the mentioned user can
+    // actually open the linked entity:
+    //   - has access → message names the entity, payload carries IDs
+    //     so the bell-icon link routes to the case/run/session/milestone.
+    //   - no access  → message is a redacted "you were mentioned, but
+    //     you don't have access to this project" line, no entity ID.
+    // Reuses the canonical `buildProjectAccessWhere` access predicate
+    // (direct user permissions, group permissions, GLOBAL_ROLE
+    // default-access projects, PROJECTADMIN direct assignment) so the
+    // policy stays in lock-step with the rest of the app.
+    const accessByUserId = new Map<string, boolean>();
+    await Promise.all(
+      mentionedUsers.map(async (user) => {
+        const hit = await prisma.projects.findFirst({
+          where: buildProjectAccessWhere(
+            projectId,
+            user.id,
+            user.access === "ADMIN",
+            user.access === "PROJECTADMIN"
+          ),
+          select: { id: true },
+        });
+        accessByUserId.set(user.id, hit !== null);
+      })
+    );
+
     // Create notification for each mentioned user
     const notificationPromises = mentionedUsers.map((user) => {
-      // Simplified access check - assume has access for now
-      // TODO: Implement proper project access logic using ZenStack
-      const hasProjectAccess = true;
+      const hasProjectAccess = accessByUserId.get(user.id) ?? false;
 
       const entityTypeLabel =
         entityType === "RepositoryCase"


### PR DESCRIPTION
## Description

Closes two pre-existing TODOs in `lib/services/commentService.ts` that hardcoded `hasProjectAccess = true`, which silently disabled the redacted "you don't have access" notification path. Mentioned users now run through `buildProjectAccessWhere` (the canonical access predicate) so a user mentioned in a project they cannot access gets a notification with the entity name and link suppressed, while ADMIN / PROJECTADMIN / regular users with access keep the full message.

## Related Issue

<!-- TODO closure, no public tracker issue. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS: macOS 14 (Apple Silicon)
- Browser (if applicable): n/a
- Node version: 20.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Notification messages are still rendered as hardcoded English at write time. Localization of server-rendered notifications is intentionally out of scope here — a separate PR is being scoped from a whole-codebase audit of unlocalized user-facing strings.
