### PR TITLE
chore(gitignore): exclude .localization-audit* (local planning artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,8 @@ testplanit/backups/*
 demo/
 .planning/**
 
+# Local-only planning artifacts — scoping notes / audit reports that
+# stay on the author's machine alongside `.planning/`.
+.localization-audit*
+
 .idea/


### PR DESCRIPTION
## Description

Adds `.localization-audit*` to the root `.gitignore` so local audits / scoping notes generated alongside multi-PR refactors stay on the author's machine. Mirrors the existing `.planning/**` rule.

## Related Issue

<!-- chore — no tracker issue. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Chore / build / config

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS: macOS 14 (Apple Silicon)
- Browser (if applicable): n/a
- Node version: n/a

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

One-line `.gitignore` change. No code or documentation impact.
