### PR TITLE
fix(webhooks): make outbox + retention workers multi-tenant aware

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -16,7 +16,7 @@ TestPlanIt includes interactive Swagger UI documentation for exploring and testi
 The interactive documentation is organized into categories:
 
 | Category | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | **Custom API Endpoints** | Authentication, file uploads, JUnit imports, search, and admin endpoints |
 | **Projects & Folders** | Project and folder management |
 | **Test Cases & Repository** | Test case management, steps, templates, and custom fields |
@@ -237,7 +237,7 @@ curl -X POST "https://your-domain.com/api/junit/import" \
 **Parameters:**
 
 | Parameter | Required | Description |
-|-----------|----------|-------------|
+| ----------- | ---------- | ------------- |
 | `name` | Yes | Name for the test run |
 | `projectId` | Yes | Project ID |
 | `files` | Yes | One or more JUnit XML files |
@@ -274,7 +274,7 @@ All API endpoints return consistent error responses:
 ### Common HTTP Status Codes
 
 | Status | Description |
-|--------|-------------|
+| -------- | ------------- |
 | 200 | Success |
 | 201 | Created |
 | 400 | Bad Request - Invalid parameters |
@@ -292,7 +292,7 @@ TestPlanIt enforces a **global hourly rate limit** on all authenticated API requ
 The `TIER` environment variable selects the hourly limit:
 
 | Tier | Hourly Limit | Typical Use |
-|------|--------------|-------------|
+| ------ | -------------- | ------------- |
 | `essentials` | 1,000 requests/hour | Small teams, light CI/CD integration |
 | `team` | 5,000 requests/hour | Mid-size teams with moderate automation |
 | `professional` (default) | 10,000 requests/hour | Most production deployments |
@@ -305,7 +305,7 @@ When the limit is exceeded, requests return **HTTP 429** with a `Retry-After` he
 Every API response includes the following headers:
 
 | Header | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `X-RateLimit-Limit` | Maximum requests allowed in the current hour |
 | `X-RateLimit-Remaining` | Requests remaining in the current window |
 | `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets |

--- a/docs/docs/api-tokens.md
+++ b/docs/docs/api-tokens.md
@@ -175,7 +175,7 @@ This immediately invalidates all authentication attempts using that user's token
 API requests made with tokens count against TestPlanIt's **global hourly rate limit**. The limit applies per instance (not per token), so all tokens across all users share the same hourly budget.
 
 | Tier | Hourly Limit |
-|------|--------------|
+| ------ | -------------- |
 | `essentials` | 1,000 requests/hour |
 | `team` | 5,000 requests/hour |
 | `professional` (default) | 10,000 requests/hour |
@@ -253,7 +253,7 @@ import_results:
 ### Authentication Errors
 
 | Error Code | HTTP Status | Description |
-|------------|-------------|-------------|
+| ------------ | ------------- | ------------- |
 | `NO_TOKEN` | 401 | No Bearer token provided in Authorization header |
 | `INVALID_FORMAT` | 401 | Token does not match expected format |
 | `INVALID_TOKEN` | 401 | Token not found or incorrect |
@@ -302,7 +302,7 @@ if (response.status === 401) {
 All API token operations are recorded in the [audit log](/docs/user-guide/audit-logs) for security and compliance:
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `API_KEY_CREATED` | Logged when a user creates a new API token |
 | `API_KEY_DELETED` | Logged when a user deletes their own token |
 | `API_KEY_REVOKED` | Logged when an administrator revokes a token |

--- a/docs/docs/background-processes.md
+++ b/docs/docs/background-processes.md
@@ -21,7 +21,10 @@ The application uses the following background processes:
 9. **Budget Alert Worker** - Checks and sends alerts for AI model budget thresholds
 10. **Repo Cache Worker** - Automatically refreshes expired code repository caches for QuickScript
 11. **Magic Select Worker** - Processes AI-powered test case selection jobs for test runs
-12. **Scheduler** - Sets up recurring jobs (cron jobs)
+12. **Webhook Dispatch Worker** - Delivers outbound webhooks to subscribed external endpoints
+13. **Webhook Outbox Worker** - Polls the outbox table and fans events out to webhook configs
+14. **Webhook Retention Worker** - Daily purge of webhook delivery / dedup / outbox rows older than 30 days
+15. **Scheduler** - Sets up recurring jobs (cron jobs)
 
 ## Workers
 
@@ -111,6 +114,28 @@ The application uses the following background processes:
 - Default concurrency: 1 (each job involves multiple LLM batch calls)
 - Location: `workers/magicSelectWorker.ts`
 
+### Webhook Dispatch Worker
+
+- Consumes the `webhook-dispatch` BullMQ queue and POSTs each event to its subscribed endpoints
+- Honors per-config retry curve (0s, 30s, 5m, 30m, 2h, 6h, 12h) and writes a `WebhookDelivery` row per attempt
+- Caps response-body buffering to prevent a misbehaving consumer from exhausting worker memory
+- Default concurrency: 5 (overridable via `WEBHOOK_DISPATCH_CONCURRENCY`)
+- Location: `workers/webhookDispatchWorker.ts`
+
+### Webhook Outbox Worker
+
+- Polls `WebhookOutboxEvent` every 2s using `FOR UPDATE SKIP LOCKED` and fans matched events into the dispatch queue
+- Multi-tenant aware: in `MULTI_TENANT_MODE=true` it iterates every configured tenant per cycle and stamps `tenantId` onto each enqueued dispatch job
+- Multiple replicas can run concurrently without double-claiming
+- Location: `workers/webhookOutboxWorker.ts`
+
+### Webhook Retention Worker
+
+- Wakes once per day and purges `WebhookDelivery`, `WebhookEventDedup`, and dispatched `WebhookOutboxEvent` rows older than 30 days
+- Multi-tenant aware: runs the purge against every configured tenant database per cycle and emits one audit row per (tenant, run)
+- Batched `LIMIT 1000` deletes to avoid lock contention
+- Location: `workers/webhookRetentionWorker.ts`
+
 ### Scheduler
 
 - Sets up recurring jobs using cron patterns
@@ -194,8 +219,19 @@ pnpm pm2:delete
 The PM2 configuration is defined in `ecosystem.config.js`. Each worker is configured with:
 
 - Automatic restart on failure
-- Memory limit of 1GB
+- Per-worker `max_memory_restart` and `--max-old-space-size` tuned to that worker's footprint
 - Production environment variables
+
+### Worker memory tiers
+
+Most workers run with a 512 MB `max_memory_restart` ceiling and a 384 MB old-space limit, which is sufficient for lightweight queue consumers. The following workers run with elevated ceilings because they load a heavier dependency tree at idle and/or carry larger payloads:
+
+| Worker | `max_memory_restart` | `--max-old-space-size` | Why |
+| --- | --- | --- | --- |
+| Sync Worker | 1G | 768M | Loads integration adapters + Elasticsearch sync extensions |
+| Webhook Dispatch Worker | 1G | 768M | Loads ZenStack runtime + ES sync services + audit log service; carries full `test_run.completed` payloads under concurrency=5 |
+| Webhook Outbox Worker | 1G | 768M | Same dependency tree as dispatch; in multi-tenant mode also caches one Prisma client per tenant |
+| Webhook Retention Worker | 1G | 768M | Multi-tenant batched-delete loop reuses the same heavy module graph; headroom prevents PM2 SIGKILL/restart thrash on tenants with large retention backlogs |
 
 ## Persistence Across Reboots
 
@@ -259,8 +295,8 @@ You can monitor worker health and performance using:
 
 ### Memory issues
 
-- Workers are configured with 1GB memory limit
-- Adjust in `ecosystem.config.js` if needed
+- Most workers run with a 512 MB ceiling; sync, dispatch, outbox, and retention workers run with a 1 GB ceiling. See the **Worker memory tiers** table above.
+- If a worker is being killed and restarted by PM2 in a tight loop (visible as repeated `restart` events in `pm2 status`), raise `max_memory_restart` and `--max-old-space-size` in `ecosystem.config.js` for that worker before assuming there is a real leak.
 - Monitor with `pm2 monit`
 
 ## Environment Variables
@@ -315,6 +351,11 @@ ELASTICSEARCH_REINDEX_CONCURRENCY=2
 # Audit Log Worker (lightweight independent writes, default: 10)
 # Can safely be set higher on powerful machines
 AUDIT_LOG_CONCURRENCY=10
+
+# Webhook Dispatch Worker (I/O-intensive, default: 5)
+# Each job POSTs to one external endpoint with a 10s timeout; raise on
+# beefier hosts, lower if external endpoints are slow or rate-limited
+WEBHOOK_DISPATCH_CONCURRENCY=5
 ```
 
 ### Setting Concurrency Values

--- a/docs/docs/copy-move-test-cases.md
+++ b/docs/docs/copy-move-test-cases.md
@@ -100,7 +100,7 @@ If the selected cases reference shared step groups, you can choose how those gro
 ## What Data is Carried Over
 
 | Data | Copied | Moved | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Test steps | Yes | Yes | All steps recreated in target |
 | Custom field values | Yes | Yes | Field option IDs re-resolved by option name when templates differ; values are dropped if no matching option is found |
 | Tags | Yes | Yes | Connected to target case |
@@ -116,7 +116,7 @@ If the selected cases reference shared step groups, you can choose how those gro
 The following data is **not transferred** during copy or move operations:
 
 | Data | Reason |
-|---|---|
+| --- | --- |
 | **Test run results** | Test execution history (pass/fail results, run assignments) is tied to test runs in the source project and is not carried over. Copied or moved cases start with no test run history in the target project. |
 | **Result field values** | Custom field values recorded during test execution belong to the source project's test runs. |
 | **Automated test results** | Imported JUnit, TestNG, xUnit, NUnit, and other automated test results are linked to source project test runs. |
@@ -126,7 +126,7 @@ The following data is **not transferred** during copy or move operations:
 ## Copy vs Move Differences
 
 | Aspect | Copy | Move |
-|---|---|---|
+| --- | --- | --- |
 | Source case | Unchanged | Removed from source project (soft-deleted) |
 | Version history | Starts at version 1 with no prior history | Full version history preserved |
 | Comments | Not included | Preserved |

--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -30,7 +30,7 @@ The Docker Compose setup starts these containerized services:
 - **RAM Requirements:**
 
   | Phase                    | Minimum | Recommended | Notes                                      |
-  |--------------------------|---------|-------------|--------------------------------------------|
+  | -------------------------- | --------- | ------------- | -------------------------------------------- |
   | **Building**             | 16GB    | 16GB+       | Required during initial build and updates  |
   | **Running (Full Stack)** | 7GB     | 11GB        | All services combined                      |
 
@@ -39,7 +39,7 @@ The Docker Compose setup starts these containerized services:
   **Per-service breakdown (running):**
 
   | Service                | Minimum  | Recommended |
-  |------------------------|----------|-------------|
+  | ------------------------ | ---------- | ------------- |
   | TestPlanIt Application | 3GB      | 4GB         |
   | Background Workers     | 512MB    | 1GB         |
   | PostgreSQL             | 1GB      | 2GB         |

--- a/docs/docs/e2e-testing.md
+++ b/docs/docs/e2e-testing.md
@@ -159,7 +159,7 @@ The Playwright configuration is in `testplanit/e2e/playwright.config.ts`.
 ### Key Settings
 
 | Setting | Value | Description |
-| --------- | ------- |------------- |
+| --------- | ------- | ------------- |
 | Port | 3002 | E2E tests run on port 3002 to avoid conflicts with dev server |
 | Timeout | 60s | Global test timeout |
 | Retries | 2 (CI only) | Tests retry on CI, not locally |

--- a/docs/docs/import-export.md
+++ b/docs/docs/import-export.md
@@ -49,7 +49,7 @@ The fields available for mapping depend on the template you select. You'll alway
 **System Fields (always available):**
 
 | Field | Required | Description |
-|-------|----------|-------------|
+| ------- | ---------- | ------------- |
 | Name | Yes | Test case name/title |
 | Steps | No | Test steps (formatted) |
 | Tags | No | Comma-separated tags |
@@ -214,7 +214,7 @@ Import automated test results from multiple testing frameworks and formats.
 TestPlanIt supports importing test results from the following formats:
 
 | Format | File Types | Description |
-|--------|-----------|-------------|
+| -------- | ----------- | ------------- |
 | **JUnit XML** | `.xml` | Standard JUnit XML format (Java, Python pytest, etc.) |
 | **TestNG XML** | `.xml` | TestNG XML reports from Java projects |
 | **NUnit XML** | `.xml` | NUnit v2/v3 XML reports from .NET projects |
@@ -390,7 +390,7 @@ There are two ways to start a test results import:
 Test result statuses are automatically mapped to TestPlanIt statuses:
 
 | Source Status | TestPlanIt Status | Description |
-|--------------|-------------------|-------------|
+| -------------- | ------------------- | ------------- |
 | pass, passed, success, ok | Passed | Test executed successfully |
 | fail, failed, failure | Failed | Test assertion failed |
 | error, errored, broken | Error | Test execution error |
@@ -532,7 +532,7 @@ Export complete project data including:
 **PDF Export Options:**
 
 | Option | Values | Description |
-|--------|--------|-------------|
+| -------- | -------- | ------------- |
 | **Scope** | Selected / All Filtered / All Project | Which test cases to include |
 | **Columns** | Visible / All | Which fields to export |
 | **Text Fields** | JSON / Plain Text | How to format rich text content (Markdown option available in CSV only) |

--- a/docs/docs/import-markdown.md
+++ b/docs/docs/import-markdown.md
@@ -57,7 +57,7 @@ smoke, authentication, login
 **How it maps:**
 
 | Markdown Element | Detected Column | Maps To |
-|------------------|----------------|---------|
+| ------------------ | ---------------- | --------- |
 | `#` heading text | `name` | **Name** (system field, required) |
 | `## Steps` list items | `steps` | **Steps** (system field) |
 | `## Expected Results` list items | `steps` | **Steps** expected result, paired by position |
@@ -127,7 +127,7 @@ Define test cases in a Markdown table. Each row becomes a test case.
 
 ```markdown
 | Name | Steps | Expected Result | Tags |
-|------|-------|-----------------|------|
+| ------ | ------- | ----------------- | ------ |
 | Login Test | Navigate to login page and enter credentials | User is redirected to dashboard | smoke, login |
 | Logout Test | Click the logout button | User is redirected to login page | smoke, logout |
 | Password Reset | Click forgot password and enter email | Reset email is sent | security |
@@ -136,7 +136,7 @@ Define test cases in a Markdown table. Each row becomes a test case.
 **Recognized column headers:**
 
 | Column Header | Detected As |
-|---------------|-------------|
+| --------------- | ------------- |
 | `Name`, `Title`, `Test Case`, `Test Name` | `name` — maps to **Name** (system field, required) |
 | `Steps`, `Procedure`, `Actions`, `Test Steps` | `steps` — maps to **Steps** (system field) |
 | `Expected Result`, `Expected Results`, `Expected`, `Result` | Expected result on steps |
@@ -325,7 +325,7 @@ During import, the parser detects columns from your Markdown and you map them to
 These fields exist on every test case regardless of template:
 
 | Detected Column | System Field | Notes |
-|-----------------|--------------|-------|
+| ----------------- | -------------- | ------- |
 | `name` (from headings, table `Name`/`Title` column) | **Name** | Required. Falls back to "Test Case 1", "Test Case 2", etc. |
 | `steps` (from `## Steps`, inline lists, table `Steps` column) | **Steps** | Supports numbered and bulleted lists. Expected results paired by position or inline separators. |
 | `tags` (from `## Tags`, table `Tags`/`Labels` column) | **Tags** | Comma-separated values or list items |
@@ -339,7 +339,7 @@ All other detected columns — `description`, `preconditions`, `Priority`, `Note
 Common examples:
 
 | Detected Column | Typical Template Field |
-|-----------------|----------------------|
+| ----------------- | ---------------------- |
 | `description` (text between heading and first sub-heading) | A "Description" or "Summary" text field |
 | `preconditions` (from `## Preconditions` / `## Prerequisites`) | A "Preconditions" text field |
 | `Priority` (from `## Priority` or table column) | A "Priority" dropdown or text field |
@@ -451,7 +451,7 @@ tag3, tag4
 
 ```markdown
 | Name | Description | Steps | Expected Result | Tags | Priority |
-|------|-------------|-------|-----------------|------|----------|
+| ------ | ------------- | ------- | ----------------- | ------ | ---------- |
 | [Test Name] | [Description] | [Step text] | [Expected result] | [tag1, tag2] | [High] |
 | [Test Name] | [Description] | [Step text] | [Expected result] | [tag1, tag2] | [Medium] |
 ```
@@ -477,7 +477,7 @@ Very large Markdown files may take longer to parse, especially with AI-assisted 
 ## Comparison: CSV vs Markdown Import
 
 | Feature | CSV Import | Markdown Import |
-|---------|-----------|----------------|
+| --------- | ----------- | ---------------- |
 | Multi-step formatting | Pipe-separated in a single cell | Native numbered/bulleted lists |
 | Expected results | Pipe separator in step cell | `->`, `\|` inline, or separate section |
 | Rich text in fields | Auto-detected (Markdown, HTML, JSON) | Native Markdown |

--- a/docs/docs/multi-tenant-workers.md
+++ b/docs/docs/multi-tenant-workers.md
@@ -106,7 +106,7 @@ TENANT_TENANT_B_ELASTICSEARCH_INDEX="tenant_b"
 ### Web Application Instance
 
 | Variable | Description | Required |
-|----------|-------------|----------|
+| ---------- | ------------- | ---------- |
 | `INSTANCE_TENANT_ID` | Unique identifier for this tenant instance | Yes (multi-tenant) |
 | `DATABASE_URL` | PostgreSQL connection string for this tenant | Yes |
 | `VALKEY_URL` | Shared Valkey/Redis connection string | Yes |
@@ -114,7 +114,7 @@ TENANT_TENANT_B_ELASTICSEARCH_INDEX="tenant_b"
 ### Worker Container
 
 | Variable | Description | Required |
-|----------|-------------|----------|
+| ---------- | ------------- | ---------- |
 | `MULTI_TENANT_MODE` | Set to `"true"` to enable multi-tenant mode | Yes |
 | `VALKEY_URL` | Shared Valkey/Redis connection string | Yes |
 | `TENANT_CONFIGS` | JSON object with tenant configurations | One of these |
@@ -157,7 +157,7 @@ This prevents cross-tenant data leakage in the admin interface.
 All workers support multi-tenant mode:
 
 | Worker | Multi-tenant | Notes |
-|--------|--------------|-------|
+| -------- | -------------- | ------- |
 | Notification Worker | Yes | Creates tenant-specific notifications |
 | Email Worker | Yes | Sends emails for correct tenant |
 | Forecast Worker | Yes | Updates forecasts per tenant database |
@@ -168,6 +168,9 @@ All workers support multi-tenant mode:
 | Budget Alert Worker | Yes | Checks budgets per tenant database |
 | Repo Cache Worker | Yes | Refreshes tenant-scoped Valkey caches |
 | Testmo Import Worker | Yes | Memory-intensive; consider per-tenant deployment for frequent imports |
+| Webhook Dispatch Worker | Yes | Routes per-job via `tenantId` stamped on each dispatch job by the outbox poller |
+| Webhook Outbox Worker | Yes | Polls every configured tenant per cycle, claims per-tenant batches via `FOR UPDATE SKIP LOCKED`, stamps `tenantId` on each enqueued dispatch job |
+| Webhook Retention Worker | Yes | Runs the daily 30-day purge against every configured tenant database, emits one audit row per tenant per run |
 
 ### Testmo Import Worker Note
 
@@ -297,7 +300,7 @@ In multi-tenant mode, Elasticsearch indices are automatically prefixed with the 
 ### Index Naming Convention
 
 | Entity Type | Single-Tenant Index | Multi-Tenant Index (Tenant A) |
-|-------------|---------------------|-------------------------------|
+| ------------- | --------------------- | ------------------------------- |
 | Repository Cases | `testplanit-repository-cases` | `testplanit-tenant-a-repository-cases` |
 | Shared Steps | `testplanit-shared-steps` | `testplanit-tenant-a-shared-steps` |
 | Test Runs | `testplanit-test-runs` | `testplanit-tenant-a-test-runs` |

--- a/docs/docs/sdk/api-client.md
+++ b/docs/docs/sdk/api-client.md
@@ -65,7 +65,7 @@ const client = new TestPlanItClient({
 ```
 
 | Option | Type | Required | Default | Description |
-|--------|------|----------|---------|-------------|
+| -------- | ------ | ---------- | --------- | ------------- |
 | `baseUrl` | string | Yes | - | Base URL of your TestPlanIt instance |
 | `apiToken` | string | Yes | - | API token for authentication (starts with `tpi_`) |
 | `timeout` | number | No | 30000 | Request timeout in milliseconds |
@@ -316,7 +316,7 @@ try {
 ### Common Error Codes
 
 | Status Code | Description |
-|-------------|-------------|
+| ------------- | ------------- |
 | 400 | Bad Request - Invalid parameters |
 | 401 | Unauthorized - Invalid or missing API token |
 | 403 | Forbidden - Insufficient permissions |

--- a/docs/docs/sdk/index.md
+++ b/docs/docs/sdk/index.md
@@ -11,7 +11,7 @@ TestPlanIt provides official npm packages to integrate with your test automation
 ## Available Packages
 
 | Package | Description | npm |
-|---------|-------------|-----|
+| --------- | ------------- | ----- |
 | [`@testplanit/api`](./api-client.md) | Official JavaScript/TypeScript API client | [![npm](https://img.shields.io/npm/v/@testplanit/api)](https://www.npmjs.com/package/@testplanit/api) |
 | [`@testplanit/wdio-reporter`](./wdio-overview.md) | WebdriverIO reporter | [![npm](https://img.shields.io/npm/v/@testplanit/wdio-reporter)](https://www.npmjs.com/package/@testplanit/wdio-reporter) |
 

--- a/docs/docs/sdk/jira-forge-app.md
+++ b/docs/docs/sdk/jira-forge-app.md
@@ -165,7 +165,7 @@ See [CUSTOM_DOMAIN_SETUP.md](https://github.com/testplanit/testplanit/blob/main/
 The app calls these endpoints on your TestPlanIt instance:
 
 | Endpoint | Purpose |
-|----------|---------|
+| ---------- | --------- |
 | `GET /version.json` | Connection test (returns app version) |
 | `GET /api/integrations/jira/test-info` | Fetch linked test cases, runs, and sessions |
 

--- a/docs/docs/user-guide/audit-log-reliability.md
+++ b/docs/docs/user-guide/audit-log-reliability.md
@@ -18,7 +18,7 @@ The audit log queue (`audit-log-queue`) uses BullMQ's `defaultJobOptions`
 with the following configuration:
 
 | Setting | Value | Rationale |
-|---------|-------|-----------|
+| --------- | ------- | ----------- |
 | `attempts` | `3` | A transient Valkey or database hiccup should auto-recover; three tries is the conventional BullMQ default for background jobs where per-job idempotency makes retries safe. |
 | `backoff.type` | `exponential` | Spreads retry load when Valkey or the database is under pressure. |
 | `backoff.delay` | `5000ms` | First retry at 5s, second at 10s, third at 20s. Keeps total retry window under a minute while giving transient infrastructure issues time to clear. |
@@ -142,7 +142,7 @@ critical workers in `testplanit/lib/queues.ts` use intentionally
 different configs — for example:
 
 | Queue | `attempts` | `backoff` | `delay` | `removeOnComplete.age` | Rationale |
-|-------|-----------|-----------|---------|------------------------|-----------|
+| ------- | ----------- | ----------- | --------- | ------------------------ | ----------- |
 | `audit-log-queue` | 3 | exponential | 5000ms | 1 year | This queue — forensic retention, auto-retry on transient issues |
 | `notification-queue` | 3 | exponential | 5000ms | 7 days | Analogous critical worker — notifications are transient so retention is shorter |
 | `testmo-import-queue` | 1 | n/a | n/a | 30 days | Single attempt by design — imports should not silently retry; users trigger them manually |

--- a/docs/docs/user-guide/audit-logs.md
+++ b/docs/docs/user-guide/audit-logs.md
@@ -32,7 +32,7 @@ Only users with administrative privileges can access the audit log viewer.
 ### Authentication Events
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `LOGIN` | User successfully logged in |
 | `LOGOUT` | User logged out |
 | `LOGIN_FAILED` | Failed login attempt |
@@ -48,7 +48,7 @@ Only users with administrative privileges can access the audit log viewer.
 ### Data Operations
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `CREATE` | A new record was created |
 | `UPDATE` | An existing record was modified |
 | `DELETE` | A record was deleted (soft delete) |
@@ -59,7 +59,7 @@ Only users with administrative privileges can access the audit log viewer.
 ### Permission & Access Control
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `PERMISSION_GRANT` | User/group granted access to a project |
 | `PERMISSION_REVOKE` | User/group access revoked from a project |
 | `ROLE_CHANGED` | User's system-wide role was changed |
@@ -67,7 +67,7 @@ Only users with administrative privileges can access the audit log viewer.
 ### API Token Management
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `API_KEY_CREATED` | A new API token was created |
 | `API_KEY_DELETED` | An API token was deleted |
 | `API_KEY_REVOKED` | An API token was revoked by an administrator |
@@ -76,7 +76,7 @@ Only users with administrative privileges can access the audit log viewer.
 ### Security Administration
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `PASSWORD_POLICY_CHANGED` | Password policy or lockout settings were modified |
 | `FORCE_PASSWORD_CHANGE` | User(s) required to change password on next login (individual or bulk) |
 | `PASSWORD_REVOKED` | A user's password was removed by an administrator |
@@ -86,14 +86,14 @@ Only users with administrative privileges can access the audit log viewer.
 ### System Configuration
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `SYSTEM_CONFIG_CHANGED` | Application configuration was modified (includes queue operator actions, integration sync, LLM cache operations) |
 | `SSO_CONFIG_CHANGED` | SSO provider settings were updated |
 
 ### Share Links
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `SHARE_LINK_CREATED` | A share link was generated |
 | `SHARE_LINK_ACCESSED` | A share link was opened |
 | `SHARE_LINK_PASSWORD_VERIFY` | A password-protected share link was unlocked (success) or rejected (failure, for brute-force detection) |
@@ -102,14 +102,14 @@ Only users with administrative privileges can access the audit log viewer.
 ### Imports & Data Quality
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `IMPORT_STARTED` | A data import run (e.g., Testmo) was kicked off; pairs with the worker's `BULK_CREATE` event when the import completes |
 | `DUPLICATE_RESOLVED` | A duplicate-case scan result was resolved (merged, linked, or dismissed) |
 
 ### Data Export
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `DATA_EXPORTED` | Data was exported from the system |
 
 ## Tracked Entities
@@ -139,7 +139,7 @@ The audit log viewer supports filtering by:
 Each audit log entry contains:
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | Timestamp | When the action occurred |
 | User | Who performed the action (name, email) |
 | Action | The type of action performed |

--- a/docs/docs/user-guide/integrations.md
+++ b/docs/docs/user-guide/integrations.md
@@ -438,7 +438,7 @@ Regular health checks verify:
 Integration and project-integration records are tracked in the [audit log](/docs/user-guide/audit-logs) via the standard CRUD actions:
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `CREATE` | A new integration or project-integration mapping was created |
 | `UPDATE` | An integration was reconfigured (settings, credentials, endpoint changes) |
 | `DELETE` | An integration or project-integration mapping was removed |
@@ -553,7 +553,7 @@ curl -H "Authorization: token YOUR_PAT" \
 ### Jira Cloud vs Server Differences
 
 | Feature | Cloud | Server/DC |
-|---------|-------|-----------|
+| --------- | ------- | ----------- |
 | Authentication | OAuth 2.0, API Key | Basic Auth, PAT |
 | API Version | v3 | v2/v3 |
 | User IDs | accountId | username |

--- a/docs/docs/user-guide/llm-quickscript.md
+++ b/docs/docs/user-guide/llm-quickscript.md
@@ -78,7 +78,7 @@ The AI prompt for QuickScript can be customized in **Administration > [Prompt Co
 ### Available Prompt Variables
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `{{FRAMEWORK}}` | Target test framework from the selected template (e.g., Playwright, pytest) |
 | `{{LANGUAGE}}` | Target programming language (e.g., TypeScript, Python) |
 | `{{CASE_NAME}}` | Name of the test case being generated |

--- a/docs/docs/user-guide/projects/duplicate-detection.md
+++ b/docs/docs/user-guide/projects/duplicate-detection.md
@@ -32,7 +32,7 @@ When no LLM integration is configured, the scan returns fuzzy-only results and s
 ### Confidence Levels
 
 | Level | Meaning |
-|---|---|
+| --- | --- |
 | **High** | Cases are very likely duplicates. Review and resolve promptly. |
 | **Medium** | Cases share significant overlap. Review to confirm whether they are intentional duplicates. |
 | **Low** | Cases share some similarity. Use your judgment — they may be testing related but distinct behavior. |

--- a/docs/docs/user-guide/prompt-configurations.md
+++ b/docs/docs/user-guide/prompt-configurations.md
@@ -109,7 +109,7 @@ This allows different projects to use different AI behaviors — for example, a 
 User prompts can include `{{variable}}` placeholders that are replaced at runtime with actual values. The available variables depend on the feature:
 
 | Feature | Common Variables |
-|---------|-----------------|
+| --------- | ----------------- |
 | Test Case Generation | `{{sourceContent}}`, `{{fields}}`, `{{numberOfCases}}` |
 | Markdown Parsing | `{{markdownContent}}`, `{{fields}}` |
 | Smart Test Case Selection | `{{testCases}}`, `{{context}}` |

--- a/docs/docs/user-guide/quickscript-templates.md
+++ b/docs/docs/user-guide/quickscript-templates.md
@@ -25,7 +25,7 @@ To manage QuickScript templates, navigate to **Administration** and select **Qui
 Templates are organized by category in collapsible accordion sections. Each section shows a count of templates in that category. The table columns are:
 
 | Column | Description |
-|--------|-------------|
+| -------- | ------------- |
 | **Name** | Template name (e.g., "Playwright (TypeScript)") |
 | **Framework** | The testing framework or tool |
 | **File Extension** | Output file extension (e.g., `.spec.ts`) |
@@ -99,7 +99,7 @@ Templates use [Mustache](https://mustache.github.io/) syntax. The Template Body 
 #### Case Fields
 
 | Variable | Type | Description |
-|----------|------|-------------|
+| ---------- | ------ | ------------- |
 | `{{name}}` | Text | Test case name |
 | `{{id}}` | Integer | Test case ID |
 | `{{folder}}` | Text | Folder name |
@@ -121,7 +121,7 @@ Use a Mustache section block to iterate over test steps:
 ```
 
 | Variable | Type | Description |
-|----------|------|-------------|
+| ---------- | ------ | ------------- |
 | `{{#steps}}...{{/steps}}` | Block | Iterates over each step |
 | `{{order}}` | Integer | Step number (1-indexed) |
 | `{{step}}` | Text | Step description |

--- a/docs/docs/user-guide/two-factor-authentication.md
+++ b/docs/docs/user-guide/two-factor-authentication.md
@@ -149,7 +149,7 @@ When enabled:
 ### Enforcement Behavior
 
 | Setting | Password Login | SSO Login |
-|---------|----------------|-----------|
+| --------- | ---------------- | ----------- |
 | Both disabled | 2FA optional | 2FA optional |
 | Non-SSO only | 2FA required | 2FA optional |
 | All logins | 2FA required | 2FA required |
@@ -196,7 +196,7 @@ If a user is locked out:
 All 2FA-related actions emit entries in the [audit log](/docs/user-guide/audit-logs):
 
 | Action | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `TWO_FACTOR_SETUP_REQUIRED` | Administrator enforced 2FA setup for a user |
 | `TWO_FACTOR_ENABLED` | User completed 2FA enrollment |
 | `TWO_FACTOR_VERIFIED` | User passed a 2FA challenge during the SSO flow |

--- a/testplanit/ecosystem.config.js
+++ b/testplanit/ecosystem.config.js
@@ -246,8 +246,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "512M",
-      node_args: "--max-old-space-size=384",
+      max_memory_restart: "1G",
+      node_args: "--max-old-space-size=768",
       env: {
         NODE_ENV: "production",
       },
@@ -261,8 +261,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "512M",
-      node_args: "--max-old-space-size=384",
+      max_memory_restart: "1G",
+      node_args: "--max-old-space-size=768",
       env: {
         NODE_ENV: "production",
       },
@@ -276,8 +276,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "256M",
-      node_args: "--max-old-space-size=192",
+      max_memory_restart: "1G",
+      node_args: "--max-old-space-size=768",
       env: {
         NODE_ENV: "production",
       },

--- a/testplanit/lib/webhooks/dispatch.test.ts
+++ b/testplanit/lib/webhooks/dispatch.test.ts
@@ -796,4 +796,40 @@ describe("dispatchWebhook — replay + eventId threading ( / + )", () => {
     expect(createCall.data.error).toMatch(/^500_/);
     expect(createCall.data.eventId).toBe("evt_500");
   });
+
+  it("R6. non-2xx with a huge streaming response body: error sentinel stays bounded and the underlying stream is cancelled before draining", async () => {
+    // Misbehaving consumer that keeps emitting 64 KB chunks indefinitely.
+    // Without the capped reader the worker would buffer the whole thing
+    // into memory; cancel() must fire as soon as the cap is reached.
+    let pulls = 0;
+    let cancelled = false;
+    const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
+    const stream = new ReadableStream({
+      pull(controller) {
+        pulls++;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const hugeResponse = new Response(stream, { status: 502 });
+    const fetchSpy = vi.fn().mockResolvedValue(hugeResponse);
+    globalThis.fetch = fetchSpy as any;
+    const prismaMock = buildPrismaMock({
+      outboxEvent: { ...baseOutboxEvent, eventId: "evt_huge" },
+      config: baseConfig(),
+    });
+
+    await expect(dispatchWebhook(baseJobData, prismaMock)).rejects.toThrow();
+
+    const createCall = prismaMock.webhookDelivery.create.mock.calls[0][0];
+    // Sentinel still capped by MAX_ERROR_LEN (1024).
+    expect(createCall.data.error.length).toBeLessThanOrEqual(1024);
+    expect(createCall.data.error).toMatch(/^502_/);
+    // We pulled at most a couple of chunks before hitting the cap and
+    // cancelling — NOT enough to consume an unbounded stream.
+    expect(pulls).toBeLessThan(5);
+    expect(cancelled).toBe(true);
+  });
 });

--- a/testplanit/lib/webhooks/dispatch.ts
+++ b/testplanit/lib/webhooks/dispatch.ts
@@ -71,6 +71,7 @@ export type DispatchOutcome =
 
 const HTTP_TIMEOUT_MS = 10_000;
 const MAX_ERROR_LEN = 1024;
+const MAX_RESPONSE_BODY_BYTES = 8 * 1024;
 
 /** Synthetic event from sendTestOutboundWebhook bypasses subscription matching. */
 const DIAGNOSTIC_EVENT_NAME = "webhook.test" as const;
@@ -256,7 +257,10 @@ export async function dispatchWebhook(
     });
     statusCode = response.status;
     if (!response.ok) {
-      const responseText = await response.text().catch(() => "");
+      const responseText = await readBodyCapped(
+        response,
+        MAX_RESPONSE_BODY_BYTES
+      ).catch(() => "");
       errorSentinel = `${response.status}_${truncate(
         responseText,
         MAX_ERROR_LEN - 32
@@ -338,6 +342,50 @@ export async function dispatchWebhook(
 function truncate(s: string, n: number): string {
   if (!s) return "";
   return s.length <= n ? s : s.slice(0, n) + "…";
+}
+
+/**
+ * Read at most `maxBytes` from a fetch Response body, then cancel the rest.
+ * Prevents a misbehaving consumer that returns a huge response body from
+ * blowing up worker memory via `response.text()`.
+ */
+async function readBodyCapped(
+  response: Response,
+  maxBytes: number
+): Promise<string> {
+  if (!response.body) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    while (received < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      const remaining = maxBytes - received;
+      if (value.byteLength > remaining) {
+        chunks.push(value.subarray(0, remaining));
+        received += remaining;
+        break;
+      }
+      chunks.push(value);
+      received += value.byteLength;
+    }
+  } finally {
+    // Discard the rest of the stream so the connection can be released
+    // without waiting on a multi-MB body we don't care about.
+    reader.cancel().catch(() => {});
+  }
+  if (chunks.length === 0) return "";
+  const merged = new Uint8Array(received);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: false }).decode(merged);
 }
 
 function mapFetchError(err: unknown): string {

--- a/testplanit/workers/webhookOutboxWorker.test.ts
+++ b/testplanit/workers/webhookOutboxWorker.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClaim = vi.fn();
 const mockFanout = vi.fn();
 const mockGetQueue = vi.fn();
+const mockIsMultiTenantMode = vi.fn();
+const mockGetAllTenantIds = vi.fn();
+const mockGetTenantPrismaClient = vi.fn();
 
 vi.mock("../lib/prisma", () => ({
   prisma: { __mock: "prisma" },
@@ -18,7 +21,15 @@ vi.mock("../lib/queues", () => ({
   WEBHOOK_DISPATCH_QUEUE_NAME: "webhook-dispatch",
 }));
 
-import { pollOnce } from "./webhookOutboxWorker";
+vi.mock("../lib/multiTenantPrisma", () => ({
+  isMultiTenantMode: () => mockIsMultiTenantMode(),
+  getAllTenantIds: () => mockGetAllTenantIds(),
+  getTenantPrismaClient: (tenantId: string) =>
+    mockGetTenantPrismaClient(tenantId),
+  disconnectAllTenantClients: vi.fn(),
+}));
+
+import { pollAllTenantsOnce, pollOnce } from "./webhookOutboxWorker";
 
 const sampleRow = {
   id: "outbox-1",
@@ -37,6 +48,10 @@ describe("webhookOutboxWorker.pollOnce", () => {
     mockClaim.mockReset();
     mockFanout.mockReset();
     mockGetQueue.mockReset();
+    mockIsMultiTenantMode.mockReset();
+    mockGetAllTenantIds.mockReset();
+    mockGetTenantPrismaClient.mockReset();
+    mockIsMultiTenantMode.mockReturnValue(false);
   });
 
   it("1. calls claimOutboxBatch with prisma and 100 (default batch size)", async () => {
@@ -160,5 +175,124 @@ describe("webhookOutboxWorker.pollOnce", () => {
     );
     expect(fanoutLog).toBeDefined();
     logSpy.mockRestore();
+  });
+
+  it("9. when called with explicit tenantId, stamps it on the enqueued dispatch job", async () => {
+    mockClaim.mockResolvedValue([sampleRow]);
+    mockFanout.mockResolvedValue(["c1"]);
+    const addSpy = vi.fn();
+    mockGetQueue.mockReturnValue({ add: addSpy });
+
+    await pollOnce({ __mock: "tenant-prisma" } as never, "tenant-a");
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(addSpy.mock.calls[0][1]).toMatchObject({
+      outboxEventId: "outbox-1",
+      webhookConfigId: "c1",
+      attempt: 1,
+      tenantId: "tenant-a",
+    });
+    expect(mockClaim).toHaveBeenCalledWith({ __mock: "tenant-prisma" }, 100);
+  });
+});
+
+describe("webhookOutboxWorker.pollAllTenantsOnce", () => {
+  beforeEach(() => {
+    mockClaim.mockReset();
+    mockFanout.mockReset();
+    mockGetQueue.mockReset();
+    mockIsMultiTenantMode.mockReset();
+    mockGetAllTenantIds.mockReset();
+    mockGetTenantPrismaClient.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("single-tenant mode: delegates to pollOnce against the singleton client", async () => {
+    mockIsMultiTenantMode.mockReturnValue(false);
+    mockClaim.mockResolvedValue([]);
+    mockGetQueue.mockReturnValue({ add: vi.fn() });
+
+    const n = await pollAllTenantsOnce();
+
+    expect(n).toBe(0);
+    expect(mockClaim).toHaveBeenCalledTimes(1);
+    expect(mockClaim).toHaveBeenCalledWith({ __mock: "prisma" }, 100);
+    expect(mockGetTenantPrismaClient).not.toHaveBeenCalled();
+  });
+
+  it("multi-tenant mode: polls every tenant with its own prisma client and stamps tenantId on each enqueued job", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    const tenantAPrisma = { __mock: "tenantA" };
+    const tenantBPrisma = { __mock: "tenantB" };
+    mockGetTenantPrismaClient.mockImplementation((id: string) =>
+      id === "tenant-a" ? tenantAPrisma : tenantBPrisma
+    );
+    // Each tenant claims one row
+    mockClaim
+      .mockResolvedValueOnce([{ ...sampleRow, id: "outbox-a" }])
+      .mockResolvedValueOnce([{ ...sampleRow, id: "outbox-b" }]);
+    mockFanout.mockResolvedValue(["c1"]);
+    const addSpy = vi.fn();
+    mockGetQueue.mockReturnValue({ add: addSpy });
+
+    const n = await pollAllTenantsOnce();
+
+    expect(n).toBe(2);
+    expect(mockGetTenantPrismaClient).toHaveBeenCalledWith("tenant-a");
+    expect(mockGetTenantPrismaClient).toHaveBeenCalledWith("tenant-b");
+    // claim was called with each tenant's client
+    expect(mockClaim).toHaveBeenNthCalledWith(1, tenantAPrisma, 100);
+    expect(mockClaim).toHaveBeenNthCalledWith(2, tenantBPrisma, 100);
+    // dispatch jobs are stamped with the right tenantId
+    expect(addSpy).toHaveBeenCalledTimes(2);
+    expect(addSpy.mock.calls[0][1]).toMatchObject({
+      outboxEventId: "outbox-a",
+      tenantId: "tenant-a",
+    });
+    expect(addSpy.mock.calls[1][1]).toMatchObject({
+      outboxEventId: "outbox-b",
+      tenantId: "tenant-b",
+    });
+  });
+
+  it("multi-tenant mode: a tenant-level error does NOT abort other tenants", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    mockGetTenantPrismaClient.mockImplementation((id: string) => {
+      if (id === "tenant-a") {
+        throw new Error("tenant-a config missing");
+      }
+      return { __mock: "tenantB" };
+    });
+    mockClaim.mockResolvedValueOnce([{ ...sampleRow, id: "outbox-b" }]);
+    mockFanout.mockResolvedValue(["c1"]);
+    const addSpy = vi.fn();
+    mockGetQueue.mockReturnValue({ add: addSpy });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const n = await pollAllTenantsOnce();
+
+    expect(n).toBe(1);
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(addSpy.mock.calls[0][1]).toMatchObject({
+      outboxEventId: "outbox-b",
+      tenantId: "tenant-b",
+    });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("multi-tenant mode with zero tenants returns 0 without polling", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue([]);
+
+    const n = await pollAllTenantsOnce();
+
+    expect(n).toBe(0);
+    expect(mockClaim).not.toHaveBeenCalled();
   });
 });

--- a/testplanit/workers/webhookOutboxWorker.ts
+++ b/testplanit/workers/webhookOutboxWorker.ts
@@ -1,3 +1,11 @@
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  disconnectAllTenantClients,
+  getAllTenantIds,
+  getTenantPrismaClient,
+  isMultiTenantMode,
+} from "../lib/multiTenantPrisma";
 import { prisma } from "../lib/prisma";
 import { getWebhookDispatchQueue } from "../lib/queues";
 import { claimOutboxBatch, fanoutToConfigs } from "../lib/webhooks/outbox";
@@ -8,13 +16,16 @@ import { claimOutboxBatch, fanoutToConfigs } from "../lib/webhooks/outbox";
  * Single-process polled loop (NOT a BullMQ Worker — claims its own work
  * directly from Postgres via FOR UPDATE SKIP LOCKED). Multiple replicas
  * can run concurrently without double-claiming.
- * *
+ *
+ * Multi-tenant mode: iterates getAllTenantIds() once per cadence and
+ * polls each tenant's database via getTenantPrismaClient(tenantId). The
+ * per-tenant tenantId is stamped onto every enqueued dispatch job so the
+ * dispatch worker routes to the correct tenant DB.
+ *
  * Note on `attempt: 1` in the enqueued job: this is the INITIAL attempt
  * value. The dispatch worker overrides this on every processor
  * invocation with `job.attemptsMade + 1` so retry rows have the correct
- * 1-indexed attempt number. We could omit `attempt` here entirely and let
- * the processor compute it from scratch, but keeping `attempt: 1` makes
- * the initial-attempt case explicit in the job data.
+ * 1-indexed attempt number.
  */
 
 const POLL_INTERVAL_MS = 2_000;
@@ -23,8 +34,11 @@ const BATCH_SIZE = 100;
 let stopRequested = false;
 let inflight: Promise<number> | null = null;
 
-export async function pollOnce(): Promise<number> {
-  const claimed = await claimOutboxBatch(prisma, BATCH_SIZE);
+export async function pollOnce(
+  client: PrismaClient = prisma,
+  tenantId?: string
+): Promise<number> {
+  const claimed = await claimOutboxBatch(client, BATCH_SIZE);
   if (claimed.length === 0) return 0;
 
   const queue = getWebhookDispatchQueue();
@@ -35,9 +49,11 @@ export async function pollOnce(): Promise<number> {
     return claimed.length;
   }
 
+  const effectiveTenantId = tenantId ?? process.env.TENANT_ID ?? undefined;
+
   for (const row of claimed) {
     try {
-      const configIds = await fanoutToConfigs(row, prisma);
+      const configIds = await fanoutToConfigs(row, client);
       for (const webhookConfigId of configIds) {
         await queue.add(
           "dispatch",
@@ -45,7 +61,7 @@ export async function pollOnce(): Promise<number> {
             outboxEventId: row.id,
             webhookConfigId,
             attempt: 1, // initial attempt; processor overrides on retries via job.attemptsMade + 1
-            tenantId: process.env.TENANT_ID ?? undefined,
+            tenantId: effectiveTenantId,
           },
           {
             // Idempotent — re-enqueue same row produces no duplicate (BullMQ
@@ -58,11 +74,11 @@ export async function pollOnce(): Promise<number> {
         );
       }
       console.log(
-        `[WebhookOutboxWorker] Fan-out: outbox=${row.id} event=${row.eventName} configs=${configIds.length}`
+        `[WebhookOutboxWorker] Fan-out: outbox=${row.id} event=${row.eventName} configs=${configIds.length}${effectiveTenantId ? ` tenant=${effectiveTenantId}` : ""}`
       );
     } catch (err) {
       console.error(
-        `[WebhookOutboxWorker] Fan-out error for outbox row ${row.id} (${row.eventName}):`,
+        `[WebhookOutboxWorker] Fan-out error for outbox row ${row.id} (${row.eventName})${effectiveTenantId ? ` tenant=${effectiveTenantId}` : ""}:`,
         err
       );
       // Continue with next row — do NOT abort the whole batch
@@ -71,20 +87,55 @@ export async function pollOnce(): Promise<number> {
   return claimed.length;
 }
 
+/**
+ * Run one polling pass across every configured tenant in multi-tenant mode,
+ * or against the singleton client in single-tenant mode. Returns the total
+ * number of rows claimed across all tenants this pass.
+ */
+export async function pollAllTenantsOnce(): Promise<number> {
+  if (!isMultiTenantMode()) {
+    return pollOnce();
+  }
+
+  const tenantIds = getAllTenantIds();
+  if (tenantIds.length === 0) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const tenantId of tenantIds) {
+    try {
+      const client = getTenantPrismaClient(tenantId);
+      const claimed = await pollOnce(client, tenantId);
+      total += claimed;
+    } catch (err) {
+      console.error(
+        `[WebhookOutboxWorker] Poll error for tenant ${tenantId}:`,
+        err
+      );
+    }
+  }
+  return total;
+}
+
 export async function startLoop(): Promise<void> {
-  console.log(
-    "[WebhookOutboxWorker] Starting poll loop (cadence=" +
-      POLL_INTERVAL_MS +
-      "ms)"
-  );
+  if (isMultiTenantMode()) {
+    console.log(
+      `[WebhookOutboxWorker] Starting MULTI-TENANT poll loop (cadence=${POLL_INTERVAL_MS}ms, tenants=${getAllTenantIds().length})`
+    );
+  } else {
+    console.log(
+      `[WebhookOutboxWorker] Starting SINGLE-TENANT poll loop (cadence=${POLL_INTERVAL_MS}ms)`
+    );
+  }
   while (!stopRequested) {
     try {
-      inflight = pollOnce();
+      inflight = pollAllTenantsOnce();
       const n = await inflight;
       if (n === 0) {
         await sleep(POLL_INTERVAL_MS);
       }
-      // If batch was full (n === BATCH_SIZE), do not sleep — drain backlog ASAP.
+      // If we got rows on this pass, do not sleep — drain backlog ASAP.
     } catch (err) {
       console.error("[WebhookOutboxWorker] Poll error:", err);
       await sleep(POLL_INTERVAL_MS);
@@ -108,6 +159,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
     } catch {
       // Ignore errors from the in-flight poll — startLoop catches them
     }
+  }
+  if (isMultiTenantMode()) {
+    await disconnectAllTenantClients();
   }
   process.exit(0);
 }

--- a/testplanit/workers/webhookRetentionWorker.test.ts
+++ b/testplanit/workers/webhookRetentionWorker.test.ts
@@ -16,6 +16,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecuteRaw = vi.fn();
 const mockCaptureAuditEvent = vi.fn();
+const mockIsMultiTenantMode = vi.fn();
+const mockGetAllTenantIds = vi.fn();
+const mockGetTenantPrismaClient = vi.fn();
 
 vi.mock("../lib/prisma", () => ({
   prisma: {
@@ -27,7 +30,15 @@ vi.mock("../lib/services/auditLog", () => ({
   captureAuditEvent: (...args: unknown[]) => mockCaptureAuditEvent(...args),
 }));
 
-import { purgeOnce } from "./webhookRetentionWorker";
+vi.mock("../lib/multiTenantPrisma", () => ({
+  isMultiTenantMode: () => mockIsMultiTenantMode(),
+  getAllTenantIds: () => mockGetAllTenantIds(),
+  getTenantPrismaClient: (tenantId: string) =>
+    mockGetTenantPrismaClient(tenantId),
+  disconnectAllTenantClients: vi.fn(),
+}));
+
+import { purgeAllTenantsOnce, purgeOnce } from "./webhookRetentionWorker";
 
 /**
  * Helper — flatten the tagged-template SQL strings array into a single string
@@ -80,6 +91,10 @@ describe("workers/webhookRetentionWorker.purgeOnce", () => {
     vi.setSystemTime(new Date("2026-04-29T03:00:00.000Z"));
     mockExecuteRaw.mockReset();
     mockCaptureAuditEvent.mockReset();
+    mockIsMultiTenantMode.mockReset();
+    mockGetAllTenantIds.mockReset();
+    mockGetTenantPrismaClient.mockReset();
+    mockIsMultiTenantMode.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -249,5 +264,102 @@ describe("workers/webhookRetentionWorker.purgeOnce", () => {
 
     // And spelled out: 2026-03-30T03:00:00.000Z
     expect(cutoffArg.toISOString()).toBe("2026-03-30T03:00:00.000Z");
+  });
+
+  it("9. accepts an explicit Prisma client and tenantId, and stamps tenantId on the audit event", async () => {
+    const tenantExecute = vi.fn().mockResolvedValue(0);
+    const tenantClient = { $executeRaw: tenantExecute } as never;
+
+    await purgeOnce(tenantClient, "tenant-a");
+
+    // Default mockExecuteRaw was NOT used — the per-tenant client was.
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(tenantExecute).toHaveBeenCalled();
+    const event = mockCaptureAuditEvent.mock.calls[0][0];
+    expect(event.tenantId).toBe("tenant-a");
+  });
+});
+
+describe("workers/webhookRetentionWorker.purgeAllTenantsOnce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-29T03:00:00.000Z"));
+    mockExecuteRaw.mockReset();
+    mockCaptureAuditEvent.mockReset();
+    mockIsMultiTenantMode.mockReset();
+    mockGetAllTenantIds.mockReset();
+    mockGetTenantPrismaClient.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("single-tenant mode: runs purgeOnce against the singleton client and returns one result", async () => {
+    mockIsMultiTenantMode.mockReturnValue(false);
+    mockExecuteRaw.mockResolvedValue(0);
+
+    const results = await purgeAllTenantsOnce();
+
+    expect(results).toHaveLength(1);
+    expect(mockExecuteRaw).toHaveBeenCalled();
+    expect(mockGetTenantPrismaClient).not.toHaveBeenCalled();
+    expect(mockCaptureAuditEvent).toHaveBeenCalledTimes(1);
+    expect(mockCaptureAuditEvent.mock.calls[0][0].tenantId).toBeUndefined();
+  });
+
+  it("multi-tenant mode: runs purgeOnce per tenant with that tenant's client and emits one audit row per tenant", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    const tenantAExecute = vi.fn().mockResolvedValue(0);
+    const tenantBExecute = vi.fn().mockResolvedValue(0);
+    mockGetTenantPrismaClient.mockImplementation((id: string) =>
+      id === "tenant-a"
+        ? { $executeRaw: tenantAExecute }
+        : { $executeRaw: tenantBExecute }
+    );
+
+    const results = await purgeAllTenantsOnce();
+
+    expect(results).toHaveLength(2);
+    expect(tenantAExecute).toHaveBeenCalled();
+    expect(tenantBExecute).toHaveBeenCalled();
+    expect(mockCaptureAuditEvent).toHaveBeenCalledTimes(2);
+    expect(mockCaptureAuditEvent.mock.calls[0][0].tenantId).toBe("tenant-a");
+    expect(mockCaptureAuditEvent.mock.calls[1][0].tenantId).toBe("tenant-b");
+  });
+
+  it("multi-tenant mode: a tenant-level error does NOT abort other tenants", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    const tenantBExecute = vi.fn().mockResolvedValue(0);
+    mockGetTenantPrismaClient.mockImplementation((id: string) => {
+      if (id === "tenant-a") {
+        throw new Error("tenant-a config missing");
+      }
+      return { $executeRaw: tenantBExecute };
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const results = await purgeAllTenantsOnce();
+
+    // Only tenant-b succeeded
+    expect(results).toHaveLength(1);
+    expect(tenantBExecute).toHaveBeenCalled();
+    expect(mockCaptureAuditEvent).toHaveBeenCalledTimes(1);
+    expect(mockCaptureAuditEvent.mock.calls[0][0].tenantId).toBe("tenant-b");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("multi-tenant mode with zero tenants returns an empty array", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue([]);
+
+    const results = await purgeAllTenantsOnce();
+
+    expect(results).toEqual([]);
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(mockCaptureAuditEvent).not.toHaveBeenCalled();
   });
 });

--- a/testplanit/workers/webhookRetentionWorker.ts
+++ b/testplanit/workers/webhookRetentionWorker.ts
@@ -1,5 +1,13 @@
-import { prisma } from "../lib/prisma";
+import type { PrismaClient } from "@prisma/client";
+
 import { SYSTEM_ACTOR_ID } from "../lib/auditContext";
+import {
+  disconnectAllTenantClients,
+  getAllTenantIds,
+  getTenantPrismaClient,
+  isMultiTenantMode,
+} from "../lib/multiTenantPrisma";
+import { prisma } from "../lib/prisma";
 import { captureAuditEvent } from "../lib/services/auditLog";
 
 /**
@@ -9,7 +17,7 @@ import { captureAuditEvent } from "../lib/services/auditLog";
  * sleeps until the next scheduled hour. Three purges per pass:
  *   1. WebhookDelivery rows where receivedAt < (now - 30 days)
  *   2. WebhookEventDedup rows where processedAt < (now - 30 days)
- *      (column is processedAt per schema.zmodel:3591 — pass-1 fix lock)
+ *      (column is processedAt per schema.zmodel WebhookEventDedup model)
  *   3. WebhookOutboxEvent rows where dispatchedAt IS NOT NULL
  *      AND dispatchedAt < (now - 30 days). Un-dispatched (in-flight) rows
  *      always survive.
@@ -20,13 +28,16 @@ import { captureAuditEvent } from "../lib/services/auditLog";
  * pattern is the standard Postgres idiom for batched deletes — `LIMIT` is
  * illegal in Postgres `DELETE` directly, but legal in the inner subquery.
  *
- * One audit row per run with totals + duration so operators can answer
- * "did purge run last night, and how much was deleted?".
+ * Multi-tenant mode: iterates getAllTenantIds() once per cadence and
+ * runs purgeOnce against each tenant's database via getTenantPrismaClient().
+ *
+ * One audit row per (tenant, run) with totals + duration so operators can
+ * answer "did purge run last night, and how much was deleted?".
  */
 
 const RETENTION_DAYS = 30;
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
-// 24h cadence — wake once per day, run purgeOnce(), sleep again.
+// 24h cadence — wake once per day, run purgeAllTenantsOnce(), sleep again.
 const POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export interface PurgeResult {
@@ -37,12 +48,15 @@ export interface PurgeResult {
 }
 
 let stopRequested = false;
-let inflight: Promise<PurgeResult> | null = null;
+let inflight: Promise<unknown> | null = null;
 
-async function batchedDeleteWebhookDelivery(cutoff: Date): Promise<number> {
+async function batchedDeleteWebhookDelivery(
+  client: PrismaClient,
+  cutoff: Date
+): Promise<number> {
   let total = 0;
   while (true) {
-    const rowsAffected = await prisma.$executeRaw`
+    const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookDelivery"
       WHERE id IN (
         SELECT id FROM "WebhookDelivery"
@@ -57,10 +71,13 @@ async function batchedDeleteWebhookDelivery(cutoff: Date): Promise<number> {
   return total;
 }
 
-async function batchedDeleteWebhookEventDedup(cutoff: Date): Promise<number> {
+async function batchedDeleteWebhookEventDedup(
+  client: PrismaClient,
+  cutoff: Date
+): Promise<number> {
   let total = 0;
   while (true) {
-    const rowsAffected = await prisma.$executeRaw`
+    const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookEventDedup"
       WHERE id IN (
         SELECT id FROM "WebhookEventDedup"
@@ -75,10 +92,13 @@ async function batchedDeleteWebhookEventDedup(cutoff: Date): Promise<number> {
   return total;
 }
 
-async function batchedDeleteWebhookOutboxEvent(cutoff: Date): Promise<number> {
+async function batchedDeleteWebhookOutboxEvent(
+  client: PrismaClient,
+  cutoff: Date
+): Promise<number> {
   let total = 0;
   while (true) {
-    const rowsAffected = await prisma.$executeRaw`
+    const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookOutboxEvent"
       WHERE id IN (
         SELECT id FROM "WebhookOutboxEvent"
@@ -94,23 +114,36 @@ async function batchedDeleteWebhookOutboxEvent(cutoff: Date): Promise<number> {
   return total;
 }
 
-export async function purgeOnce(): Promise<PurgeResult> {
+export async function purgeOnce(
+  client: PrismaClient = prisma,
+  tenantId?: string
+): Promise<PurgeResult> {
   const startedAt = Date.now();
   const cutoff = new Date(startedAt - RETENTION_MS);
+  const tenantSuffix = tenantId ? ` tenant=${tenantId}` : "";
 
-  const webhookDeliveryRows = await batchedDeleteWebhookDelivery(cutoff);
+  const webhookDeliveryRows = await batchedDeleteWebhookDelivery(
+    client,
+    cutoff
+  );
   console.log(
-    `[WebhookRetention] purged ${webhookDeliveryRows} WebhookDelivery rows (cutoff=${cutoff.toISOString()})`
+    `[WebhookRetention] purged ${webhookDeliveryRows} WebhookDelivery rows (cutoff=${cutoff.toISOString()})${tenantSuffix}`
   );
 
-  const webhookEventDedupRows = await batchedDeleteWebhookEventDedup(cutoff);
+  const webhookEventDedupRows = await batchedDeleteWebhookEventDedup(
+    client,
+    cutoff
+  );
   console.log(
-    `[WebhookRetention] purged ${webhookEventDedupRows} WebhookEventDedup rows`
+    `[WebhookRetention] purged ${webhookEventDedupRows} WebhookEventDedup rows${tenantSuffix}`
   );
 
-  const webhookOutboxEventRows = await batchedDeleteWebhookOutboxEvent(cutoff);
+  const webhookOutboxEventRows = await batchedDeleteWebhookOutboxEvent(
+    client,
+    cutoff
+  );
   console.log(
-    `[WebhookRetention] purged ${webhookOutboxEventRows} WebhookOutboxEvent rows`
+    `[WebhookRetention] purged ${webhookOutboxEventRows} WebhookOutboxEvent rows${tenantSuffix}`
   );
 
   const durationMs = Date.now() - startedAt;
@@ -119,6 +152,7 @@ export async function purgeOnce(): Promise<PurgeResult> {
     entityType: "WebhookDelivery",
     entityId: `retention-${cutoff.toISOString()}`,
     userId: SYSTEM_ACTOR_ID,
+    tenantId,
     metadata: {
       retentionDays: RETENTION_DAYS,
       webhookDeliveryRows,
@@ -137,13 +171,49 @@ export async function purgeOnce(): Promise<PurgeResult> {
   };
 }
 
+/**
+ * Run one purge pass across every configured tenant in multi-tenant mode,
+ * or against the singleton client in single-tenant mode.
+ */
+export async function purgeAllTenantsOnce(): Promise<PurgeResult[]> {
+  if (!isMultiTenantMode()) {
+    return [await purgeOnce()];
+  }
+
+  const tenantIds = getAllTenantIds();
+  if (tenantIds.length === 0) {
+    return [];
+  }
+
+  const results: PurgeResult[] = [];
+  for (const tenantId of tenantIds) {
+    try {
+      const client = getTenantPrismaClient(tenantId);
+      const result = await purgeOnce(client, tenantId);
+      results.push(result);
+    } catch (err) {
+      console.error(
+        `[WebhookRetention] Purge error for tenant ${tenantId}:`,
+        err
+      );
+    }
+  }
+  return results;
+}
+
 export async function startLoop(): Promise<void> {
-  console.log(
-    `[WebhookRetention] Starting daily retention loop (cadence=${POLL_INTERVAL_MS}ms)`
-  );
+  if (isMultiTenantMode()) {
+    console.log(
+      `[WebhookRetention] Starting MULTI-TENANT daily retention loop (cadence=${POLL_INTERVAL_MS}ms, tenants=${getAllTenantIds().length})`
+    );
+  } else {
+    console.log(
+      `[WebhookRetention] Starting SINGLE-TENANT daily retention loop (cadence=${POLL_INTERVAL_MS}ms)`
+    );
+  }
   while (!stopRequested) {
     try {
-      inflight = purgeOnce();
+      inflight = purgeAllTenantsOnce();
       await inflight;
     } catch (err) {
       console.error("[WebhookRetention] Purge error:", err);
@@ -168,6 +238,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
     } catch {
       // Ignore — startLoop catches purge errors
     }
+  }
+  if (isMultiTenantMode()) {
+    await disconnectAllTenantClients();
   }
   process.exit(0);
 }


### PR DESCRIPTION
## Description

Three production bugs in the v0.23.0 outbound-webhook stack are fixed in one branch, all flowing from the same root cause in the original feature PR (#264 — webhook dispatch).

**Bug 1 — multi-tenant workers crashing.** `workers/webhookOutboxWorker.ts` and `workers/webhookRetentionWorker.ts` imported `lib/prisma.ts` directly. In the multi-tenant cluster (`MULTI_TENANT_MODE=true`, `DATABASE_URL=postgresql://placeholder...`) every query crashed with `PrismaClientInitializationError: Can't reach database server at localhost:5432`. Result: outbox poller never claimed work, retention purger never ran, and PM2 restarted both processes in a tight loop (~1.5 cores burned per pod). Both workers now use the same multi-tenant pattern as `webhookDispatchWorker`: iterate `getAllTenantIds()` per cycle and route through `getTenantPrismaClient(tenantId)`. The outbox poller stamps the per-tenant `tenantId` on every enqueued dispatch job; the retention purger emits one audit row per (tenant, run).

**Bug 2 — PM2 ceilings too low.** All three webhook workers load a heavy module graph at idle (PrismaClient + Rust query engine + ZenStack runtime + 7 ES sync services + audit-log service + 4 webhook event-emitter modules + ioredis + BullMQ). Even before traffic, `--max-old-space-size=384` / `max_memory_restart=512M` was tight; under real `test_run.completed` payload traffic at concurrency=5 it triggered SIGKILL/restart thrash. Raised dispatch / outbox / retention to `1G` / `--max-old-space-size=768`.

**Bug 3 — uncapped response body buffering.** `lib/webhooks/dispatch.ts` read non-2xx response bodies via `response.text()` with no size cap. A misbehaving consumer returning a multi-MB body could blow up worker memory. Replaced with `readBodyCapped` that streams at most 8 KB and cancels the rest of the response.

Docs cover the three webhook workers in `background-processes.md` (overview, per-worker reference, new "Worker memory tiers" table, troubleshooting note pointing at the table, `WEBHOOK_DISPATCH_CONCURRENCY` env var) and in `multi-tenant-workers.md` (supported-workers table). Markdown table separators across `docs/docs/` were normalized to the spaced style to clear pre-existing markdownlint MD060 warnings.

## Related Issue

N/A — production bug found by direct triage of pod logs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Browser (if applicable): N/A
- Node version: project default

New unit tests:
- `pollAllTenantsOnce` — single-tenant delegation, multi-tenant per-tenant client routing, per-tenant `tenantId` stamping on dispatch jobs, tenant-level error containment, zero-tenant short-circuit.
- `purgeAllTenantsOnce` — single-tenant delegation, per-tenant audit row emission, tenant-level error containment, zero-tenant short-circuit.
- `dispatchWebhook` R6 — non-2xx with a streaming "infinite chunks" response body verifies the 8 KB cap fires and the underlying stream is cancelled before draining.

Verification:

```
pnpm vitest run workers/webhookOutboxWorker.test.ts workers/webhookRetentionWorker.test.ts lib/webhooks/dispatch.test.ts
# 56 passed (3 files)

pnpm precommit
# Test Files  392 passed | 1 skipped
# Tests       6486 passed | 2 skipped

NODE_OPTIONS='--max-old-space-size=16382' pnpm type-check
# clean (after pnpm generate)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A — backend / worker / infra change.

## Additional Notes

- The fix is sequential per cycle (one tenant after another) inside a single replica. Multiple replicas can still run concurrently because the outbox claim uses `FOR UPDATE SKIP LOCKED` per-tenant; the retention purger is idempotent at the row level. If per-cycle latency becomes a concern with many tenants, the next step is bounded `Promise.all` parallelism inside `pollAllTenantsOnce` / `purgeAllTenantsOnce` — kept sequential here to minimize blast radius and match the existing `scheduler.ts` iteration style.
- The 8 KB body cap is well above the eventual `MAX_ERROR_LEN - 32 ≈ 992` characters we keep in the sentinel, so behavior is unchanged for normal-sized error bodies.
- Retention worker memory was raised to `1G` even though its module graph is unchanged from before, because the new multi-tenant batched-delete loop reuses that graph against N tenant DBs back-to-back; headroom prevents thrash on tenants with large purge backlogs. Worth revisiting once we have real per-tenant retention metrics.
