### PR TITLE
fix(webhooks): tenant-aware jobId, retention memory hygiene, raised PM2 ceilings

### DIFF
--- a/docs/docs/background-processes.md
+++ b/docs/docs/background-processes.md
@@ -73,6 +73,7 @@ The application uses the following background processes:
 - Location: `workers/elasticsearchReindexWorker.ts`
 
 **Supported Operations:**
+
 - Full reindex of all entities
 - Selective reindex by entity type (repository-cases, test-runs, sessions, etc.)
 - Project-specific reindexing
@@ -229,9 +230,9 @@ Most workers run with a 512 MB `max_memory_restart` ceiling and a 384 MB old-spa
 | Worker | `max_memory_restart` | `--max-old-space-size` | Why |
 | --- | --- | --- | --- |
 | Sync Worker | 1G | 768M | Loads integration adapters + Elasticsearch sync extensions |
-| Webhook Dispatch Worker | 1G | 768M | Loads ZenStack runtime + ES sync services + audit log service; carries full `test_run.completed` payloads under concurrency=5 |
-| Webhook Outbox Worker | 1G | 768M | Same dependency tree as dispatch; in multi-tenant mode also caches one Prisma client per tenant |
-| Webhook Retention Worker | 1G | 768M | Multi-tenant batched-delete loop reuses the same heavy module graph; headroom prevents PM2 SIGKILL/restart thrash on tenants with large retention backlogs |
+| Webhook Dispatch Worker | 3G | 2304M | Loads ZenStack runtime + ES sync services + audit log service; carries full `test_run.completed` payloads under concurrency=5; observed steady-state RSS in multi-tenant clusters sits near 1.9 GB |
+| Webhook Outbox Worker | 3G | 2304M | Same heavy dependency tree as dispatch; caches one Prisma client per tenant in multi-tenant mode |
+| Webhook Retention Worker | 3G | 2304M | Iterates every tenant's database per pass; headroom protects against batched-delete loops on tenants with large retention backlogs. Tenant Prisma clients are disconnected after each pass to release Rust query engine buffers, so steady-state should drop substantially after the first few passes — these ceilings can be lowered once production telemetry confirms it. |
 
 ## Persistence Across Reboots
 
@@ -295,7 +296,7 @@ You can monitor worker health and performance using:
 
 ### Memory issues
 
-- Most workers run with a 512 MB ceiling; sync, dispatch, outbox, and retention workers run with a 1 GB ceiling. See the **Worker memory tiers** table above.
+- Most workers run with a 512 MB ceiling; the sync worker runs with a 1 GB ceiling; the three webhook workers (dispatch, outbox, retention) run with a 3 GB ceiling. See the **Worker memory tiers** table above for the rationale on each elevated tier.
 - If a worker is being killed and restarted by PM2 in a tight loop (visible as repeated `restart` events in `pm2 status`), raise `max_memory_restart` and `--max-old-space-size` in `ecosystem.config.js` for that worker before assuming there is a real leak.
 - Monitor with `pm2 monit`
 

--- a/testplanit/ecosystem.config.js
+++ b/testplanit/ecosystem.config.js
@@ -246,8 +246,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "1G",
-      node_args: "--max-old-space-size=768",
+      max_memory_restart: "3G",
+      node_args: "--max-old-space-size=2304",
       env: {
         NODE_ENV: "production",
       },
@@ -261,8 +261,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "1G",
-      node_args: "--max-old-space-size=768",
+      max_memory_restart: "3G",
+      node_args: "--max-old-space-size=2304",
       env: {
         NODE_ENV: "production",
       },
@@ -276,8 +276,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "1G",
-      node_args: "--max-old-space-size=768",
+      max_memory_restart: "3G",
+      node_args: "--max-old-space-size=2304",
       env: {
         NODE_ENV: "production",
       },

--- a/testplanit/workers/webhookOutboxWorker.test.ts
+++ b/testplanit/workers/webhookOutboxWorker.test.ts
@@ -194,6 +194,18 @@ describe("webhookOutboxWorker.pollOnce", () => {
     });
     expect(mockClaim).toHaveBeenCalledWith({ __mock: "tenant-prisma" }, 100);
   });
+
+  it("10. tenant-aware jobId: `${tenantId}--${row.id}--${webhookConfigId}` to namespace BullMQ idempotency keys per tenant", async () => {
+    mockClaim.mockResolvedValue([sampleRow]);
+    mockFanout.mockResolvedValue(["c1", "c2"]);
+    const addSpy = vi.fn();
+    mockGetQueue.mockReturnValue({ add: addSpy });
+
+    await pollOnce({ __mock: "tenant-prisma" } as never, "tenant-a");
+
+    expect(addSpy.mock.calls[0][2].jobId).toBe("tenant-a--outbox-1--c1");
+    expect(addSpy.mock.calls[1][2].jobId).toBe("tenant-a--outbox-1--c2");
+  });
 });
 
 describe("webhookOutboxWorker.pollAllTenantsOnce", () => {

--- a/testplanit/workers/webhookOutboxWorker.ts
+++ b/testplanit/workers/webhookOutboxWorker.ts
@@ -69,7 +69,16 @@ export async function pollOnce(
             // BullMQ rejects custom IDs containing colons (`Custom Id cannot
             // contain :` thrown from Job.addJob; verified against
             // node_modules/bullmq/src/classes/job.ts).
-            jobId: `${row.id}--${webhookConfigId}`,
+            //
+            // Tenant prefix: in multi-tenant mode each tenant has its own DB,
+            // so two tenants can independently mint outbox rows whose ids
+            // happen to collide (extremely unlikely with cuid/uuid but not
+            // impossible). Prefixing with tenantId namespaces the BullMQ
+            // idempotency key per tenant. Single-tenant mode (no tenantId)
+            // falls back to the original `${id}--${cfg}` shape.
+            jobId: effectiveTenantId
+              ? `${effectiveTenantId}--${row.id}--${webhookConfigId}`
+              : `${row.id}--${webhookConfigId}`,
           }
         );
       }

--- a/testplanit/workers/webhookRetentionWorker.test.ts
+++ b/testplanit/workers/webhookRetentionWorker.test.ts
@@ -19,6 +19,7 @@ const mockCaptureAuditEvent = vi.fn();
 const mockIsMultiTenantMode = vi.fn();
 const mockGetAllTenantIds = vi.fn();
 const mockGetTenantPrismaClient = vi.fn();
+const mockDisconnectAllTenantClients = vi.fn();
 
 vi.mock("../lib/prisma", () => ({
   prisma: {
@@ -35,7 +36,7 @@ vi.mock("../lib/multiTenantPrisma", () => ({
   getAllTenantIds: () => mockGetAllTenantIds(),
   getTenantPrismaClient: (tenantId: string) =>
     mockGetTenantPrismaClient(tenantId),
-  disconnectAllTenantClients: vi.fn(),
+  disconnectAllTenantClients: () => mockDisconnectAllTenantClients(),
 }));
 
 import { purgeAllTenantsOnce, purgeOnce } from "./webhookRetentionWorker";
@@ -94,6 +95,8 @@ describe("workers/webhookRetentionWorker.purgeOnce", () => {
     mockIsMultiTenantMode.mockReset();
     mockGetAllTenantIds.mockReset();
     mockGetTenantPrismaClient.mockReset();
+    mockDisconnectAllTenantClients.mockReset();
+    mockDisconnectAllTenantClients.mockResolvedValue(undefined);
     mockIsMultiTenantMode.mockReturnValue(false);
   });
 
@@ -278,6 +281,51 @@ describe("workers/webhookRetentionWorker.purgeOnce", () => {
     const event = mockCaptureAuditEvent.mock.calls[0][0];
     expect(event.tenantId).toBe("tenant-a");
   });
+
+  it("10. truncated=false on a successful sweep that finishes inside the time budget", async () => {
+    setupTableQueues({
+      WebhookDelivery: [47, 0],
+      WebhookEventDedup: [13, 0],
+      WebhookOutboxEvent: [89, 0],
+    });
+
+    const result = await purgeOnce();
+
+    expect(result.truncated).toBe(false);
+    expect(mockCaptureAuditEvent.mock.calls[0][0].metadata.truncated).toBe(
+      false
+    );
+  });
+
+  it("11. truncated=true when the per-tenant time budget elapses; remaining rows are left for next pass", async () => {
+    // budget=0 forces every batched-delete loop to exit on its first
+    // Date.now()<deadline check. The DELETE for WebhookDelivery still runs
+    // once via the existing while-true semantics? No — the new gate is
+    // `while (Date.now() < deadlineMs)`, which evaluates BEFORE the first
+    // call when budgetMs=0 and timers are fake. So the helpers no-op and
+    // the truncated flag fires.
+    setupTableQueues({
+      WebhookDelivery: [0],
+      WebhookEventDedup: [0],
+      WebhookOutboxEvent: [0],
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await purgeOnce(undefined, undefined, 0);
+
+    expect(result.truncated).toBe(true);
+    expect(mockCaptureAuditEvent.mock.calls[0][0].metadata.truncated).toBe(
+      true
+    );
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        args.some(
+          (a) => typeof a === "string" && a.includes("tenant time budget")
+        )
+      )
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
 });
 
 describe("workers/webhookRetentionWorker.purgeAllTenantsOnce", () => {
@@ -289,6 +337,8 @@ describe("workers/webhookRetentionWorker.purgeAllTenantsOnce", () => {
     mockIsMultiTenantMode.mockReset();
     mockGetAllTenantIds.mockReset();
     mockGetTenantPrismaClient.mockReset();
+    mockDisconnectAllTenantClients.mockReset();
+    mockDisconnectAllTenantClients.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -361,5 +411,41 @@ describe("workers/webhookRetentionWorker.purgeAllTenantsOnce", () => {
     expect(results).toEqual([]);
     expect(mockExecuteRaw).not.toHaveBeenCalled();
     expect(mockCaptureAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("multi-tenant mode: disconnects all tenant Prisma clients after the pass to free Rust query engine buffers", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    mockGetTenantPrismaClient.mockImplementation(() => ({
+      $executeRaw: vi.fn().mockResolvedValue(0),
+    }));
+
+    await purgeAllTenantsOnce();
+
+    expect(mockDisconnectAllTenantClients).toHaveBeenCalledTimes(1);
+  });
+
+  it("multi-tenant mode: disconnect still runs even when a tenant errors mid-pass", async () => {
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    mockGetTenantPrismaClient.mockImplementation((id: string) => {
+      if (id === "tenant-a") throw new Error("boom");
+      return { $executeRaw: vi.fn().mockResolvedValue(0) };
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await purgeAllTenantsOnce();
+
+    expect(mockDisconnectAllTenantClients).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it("single-tenant mode: does NOT disconnect tenant clients (the singleton client is owned elsewhere)", async () => {
+    mockIsMultiTenantMode.mockReturnValue(false);
+    mockExecuteRaw.mockResolvedValue(0);
+
+    await purgeAllTenantsOnce();
+
+    expect(mockDisconnectAllTenantClients).not.toHaveBeenCalled();
   });
 });

--- a/testplanit/workers/webhookRetentionWorker.ts
+++ b/testplanit/workers/webhookRetentionWorker.ts
@@ -39,12 +39,24 @@ const RETENTION_DAYS = 30;
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 // 24h cadence — wake once per day, run purgeAllTenantsOnce(), sleep again.
 const POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+// Per-tenant time budget. A tenant with a huge first-time backlog could keep
+// the LIMIT-1000 batched-delete loop running for hours and starve every other
+// tenant on the same worker. Capping at 5 minutes lets us make forward
+// progress on every tenant per cycle; whatever rows remain get cleaned up on
+// the next daily pass.
+const TENANT_PURGE_BUDGET_MS = 5 * 60 * 1000;
 
 export interface PurgeResult {
   webhookDeliveryRows: number;
   webhookEventDedupRows: number;
   webhookOutboxEventRows: number;
   durationMs: number;
+  /**
+   * True when the per-tenant time budget elapsed before the batched-delete
+   * loop reached a 0-row sweep. The remaining rows are picked up on the next
+   * daily pass — this is informational, not an error.
+   */
+  truncated: boolean;
 }
 
 let stopRequested = false;
@@ -52,10 +64,11 @@ let inflight: Promise<unknown> | null = null;
 
 async function batchedDeleteWebhookDelivery(
   client: PrismaClient,
-  cutoff: Date
+  cutoff: Date,
+  deadlineMs: number
 ): Promise<number> {
   let total = 0;
-  while (true) {
+  while (Date.now() < deadlineMs) {
     const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookDelivery"
       WHERE id IN (
@@ -73,10 +86,11 @@ async function batchedDeleteWebhookDelivery(
 
 async function batchedDeleteWebhookEventDedup(
   client: PrismaClient,
-  cutoff: Date
+  cutoff: Date,
+  deadlineMs: number
 ): Promise<number> {
   let total = 0;
-  while (true) {
+  while (Date.now() < deadlineMs) {
     const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookEventDedup"
       WHERE id IN (
@@ -94,10 +108,11 @@ async function batchedDeleteWebhookEventDedup(
 
 async function batchedDeleteWebhookOutboxEvent(
   client: PrismaClient,
-  cutoff: Date
+  cutoff: Date,
+  deadlineMs: number
 ): Promise<number> {
   let total = 0;
-  while (true) {
+  while (Date.now() < deadlineMs) {
     const rowsAffected = await client.$executeRaw`
       DELETE FROM "WebhookOutboxEvent"
       WHERE id IN (
@@ -116,15 +131,18 @@ async function batchedDeleteWebhookOutboxEvent(
 
 export async function purgeOnce(
   client: PrismaClient = prisma,
-  tenantId?: string
+  tenantId?: string,
+  budgetMs: number = TENANT_PURGE_BUDGET_MS
 ): Promise<PurgeResult> {
   const startedAt = Date.now();
+  const deadlineMs = startedAt + budgetMs;
   const cutoff = new Date(startedAt - RETENTION_MS);
   const tenantSuffix = tenantId ? ` tenant=${tenantId}` : "";
 
   const webhookDeliveryRows = await batchedDeleteWebhookDelivery(
     client,
-    cutoff
+    cutoff,
+    deadlineMs
   );
   console.log(
     `[WebhookRetention] purged ${webhookDeliveryRows} WebhookDelivery rows (cutoff=${cutoff.toISOString()})${tenantSuffix}`
@@ -132,7 +150,8 @@ export async function purgeOnce(
 
   const webhookEventDedupRows = await batchedDeleteWebhookEventDedup(
     client,
-    cutoff
+    cutoff,
+    deadlineMs
   );
   console.log(
     `[WebhookRetention] purged ${webhookEventDedupRows} WebhookEventDedup rows${tenantSuffix}`
@@ -140,13 +159,21 @@ export async function purgeOnce(
 
   const webhookOutboxEventRows = await batchedDeleteWebhookOutboxEvent(
     client,
-    cutoff
+    cutoff,
+    deadlineMs
   );
   console.log(
     `[WebhookRetention] purged ${webhookOutboxEventRows} WebhookOutboxEvent rows${tenantSuffix}`
   );
 
   const durationMs = Date.now() - startedAt;
+  const truncated = Date.now() >= deadlineMs;
+  if (truncated) {
+    console.warn(
+      `[WebhookRetention] tenant time budget (${budgetMs}ms) elapsed${tenantSuffix}; remaining rows will be purged on the next pass`
+    );
+  }
+
   await captureAuditEvent({
     action: "WEBHOOK_RETENTION_PURGED",
     entityType: "WebhookDelivery",
@@ -159,6 +186,7 @@ export async function purgeOnce(
       webhookEventDedupRows,
       webhookOutboxEventRows,
       durationMs,
+      truncated,
       cutoff: cutoff.toISOString(),
     },
   });
@@ -168,12 +196,21 @@ export async function purgeOnce(
     webhookEventDedupRows,
     webhookOutboxEventRows,
     durationMs,
+    truncated,
   };
 }
 
 /**
  * Run one purge pass across every configured tenant in multi-tenant mode,
  * or against the singleton client in single-tenant mode.
+ *
+ * Memory hygiene: in multi-tenant mode, after the full pass we
+ * `disconnectAllTenantClients()` so the Prisma Rust query engine releases
+ * the buffers it accumulated while iterating 30+ tenant DBs. The retention
+ * worker is a 24h-cadence loop, so reusing a long-lived client cache offers
+ * no throughput benefit but keeps RSS climbing across passes. The dispatch
+ * worker still benefits from caching per-job clients — that decision lives
+ * inside `getTenantPrismaClient`'s callsite, not here.
  */
 export async function purgeAllTenantsOnce(): Promise<PurgeResult[]> {
   if (!isMultiTenantMode()) {
@@ -186,14 +223,25 @@ export async function purgeAllTenantsOnce(): Promise<PurgeResult[]> {
   }
 
   const results: PurgeResult[] = [];
-  for (const tenantId of tenantIds) {
+  try {
+    for (const tenantId of tenantIds) {
+      try {
+        const client = getTenantPrismaClient(tenantId);
+        const result = await purgeOnce(client, tenantId);
+        results.push(result);
+      } catch (err) {
+        console.error(
+          `[WebhookRetention] Purge error for tenant ${tenantId}:`,
+          err
+        );
+      }
+    }
+  } finally {
     try {
-      const client = getTenantPrismaClient(tenantId);
-      const result = await purgeOnce(client, tenantId);
-      results.push(result);
+      await disconnectAllTenantClients();
     } catch (err) {
       console.error(
-        `[WebhookRetention] Purge error for tenant ${tenantId}:`,
+        "[WebhookRetention] Failed to disconnect tenant clients after pass:",
         err
       );
     }


### PR DESCRIPTION
## Description

Follow-up fixes to #271 based on telemetry from the production multi-tenant deployment. Three issues were flagged by live monitoring and are addressed here:

**Outbox dispatch jobId is now tenant-aware.** PR #271 stamped `tenantId` onto the dispatch job payload but kept the BullMQ `jobId` at `${row.id}--${webhookConfigId}`. In multi-tenant mode, two tenants minting outbox rows with the same id (extremely unlikely with cuid/uuid, but not impossible across separate DBs) would produce a BullMQ idempotency-key collision. The jobId is now `${tenantId}--${row.id}--${webhookConfigId}` whenever a tenantId is present; single-tenant mode keeps the original shape.

**Retention worker memory hygiene.** Live observation showed retention worker RSS climbing across passes — the cause was the cached Prisma client per tenant in `getTenantPrismaClient()` keeping the Rust query engine's buffers around forever. Two changes:

1. After every full `purgeAllTenantsOnce()` pass, `disconnectAllTenantClients()` runs in a `finally` block so the Rust engine releases per-tenant buffers. Disconnect still fires even when a mid-pass tenant errors. The retention worker is a 24h-cadence loop, so a long-lived client cache offers no throughput benefit; the dispatch worker's per-job cache is unaffected.
2. Per-tenant 5-minute time budget. A tenant with a giant first-time retention backlog (think 30+ days of unpurged rows × 3 tables × hundreds of thousands of rows) could keep the LIMIT-1000 batched-delete loop running for hours and starve every other tenant on that pass. The deadline is checked at the top of each iteration of `while (Date.now() < deadlineMs)`. A new `truncated` flag is threaded into both the `PurgeResult` return value and the audit-row metadata so operators can see which tenants hit the cap.

**PM2 ceilings raised to 3 GB.** During the deploy of PR #271, the new 1 GB ceiling triggered SIGKILL/restart thrash. A live hot-patch to 3 GB / `--max-old-space-size=2304` stabilized them at ~1.9 GB steady-state RSS. Baking those values into `ecosystem.config.js` for the three webhook workers. The sync worker's 1 GB tier is unchanged.

Docs (`docs/docs/background-processes.md`) updated: the **Worker memory tiers** table now shows `3G` / `2304M` for the three webhook workers with the new operational notes about live RSS and the disconnect-after-pass behavior. Troubleshooting bullet revised to match.

## Related Issue

Follow-up to #271 (which closed the original P0 cluster crash). Driven by direct triage of multi-tenant pod telemetry — no separate issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Browser (if applicable): N/A
- Node version: project default

New unit tests:

- Outbox `pollOnce` test 10 — `${tenantId}--${row.id}--${cfg}` idempotency key shape verified.
- Retention `purgeOnce` test 10 — `truncated=false` on a clean sweep that finishes inside the budget.
- Retention `purgeOnce` test 11 — `truncated=true` and the warn-log fires when `budgetMs=0` forces immediate budget elapse; metadata carries `truncated: true`.
- Retention `purgeAllTenantsOnce` — `disconnectAllTenantClients()` is called exactly once per pass after all tenants finish; still runs when a tenant errors mid-pass; not called in single-tenant mode.

Verification:

```
pnpm vitest run workers/webhookOutboxWorker.test.ts workers/webhookRetentionWorker.test.ts
# 32 passed (2 files)

pnpm precommit
# Test Files  392 passed | 1 skipped
# Tests       6495 passed | 2 skipped

pnpm type-check
# clean
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A — backend / worker / infra change.

## Additional Notes

- The 5-minute per-tenant budget is conservative — current tenant counts × 5 min still fit comfortably inside the 24h cadence with room for many cycles. We can tighten this once production telemetry shows steady-state purge times.
- After the disconnect-after-pass fix lands and live RSS drops, the retention worker's 3 GB ceiling is a candidate for being lowered back to 1 GB. Leaving the bump in for now is the conservative choice while we measure; would rather avoid another round of restart thrash.
- The new `truncated` flag in `PurgeResult` is additive — no existing callers break.
- The audit row payload now carries `truncated: boolean` in `metadata`, which is purely additive; the audit-log worker doesn't validate metadata shape.
