### PR TITLE
fix(i18n): localize magic-link email, validation errors, success toasts

### DIFF
--- a/testplanit/app/[locale]/admin/code-repositories/page.tsx
+++ b/testplanit/app/[locale]/admin/code-repositories/page.tsx
@@ -218,11 +218,11 @@ function CodeRepositoryList() {
       },
       {
         onSuccess: () => {
-          toast.success("Repository deleted");
+          toast.success(tCommon("errors.repositoryDeleted"));
           void refetch();
         },
         onError: (error) => {
-          toast.error("Failed to delete repository", {
+          toast.error(tCommon("errors.failedToDeleteRepository"), {
             description: error.message,
           });
         },

--- a/testplanit/app/[locale]/admin/configurations/EditCategory.tsx
+++ b/testplanit/app/[locale]/admin/configurations/EditCategory.tsx
@@ -75,8 +75,7 @@ export function EditCategory({ category, open, onClose }: EditCategoryProps) {
       if (err.info?.prisma && err.info?.code === "P2002") {
         form.setError("name", {
           type: "custom",
-          message:
-            "Category name already exists. Please choose a different name.",
+          message: tCommon("errors.categoryNameExists"),
         });
       } else {
         form.setError("root", {

--- a/testplanit/app/[locale]/admin/configurations/EditConfig.tsx
+++ b/testplanit/app/[locale]/admin/configurations/EditConfig.tsx
@@ -79,8 +79,7 @@ export function EditConfiguration({
       if (err.info?.prisma && err.info?.code === "P2002") {
         form.setError("name", {
           type: "custom",
-          message:
-            "Configuration name already exists. Please choose a different name.",
+          message: tCommon("errors.configurationNameExists"),
         });
       } else {
         form.setError("root", {

--- a/testplanit/app/[locale]/admin/configurations/EditVariantModal.tsx
+++ b/testplanit/app/[locale]/admin/configurations/EditVariantModal.tsx
@@ -83,13 +83,12 @@ export function EditVariantModal({
       if (err.info?.prisma && err.info?.code === "P2002") {
         form.setError("name", {
           type: "custom",
-          message:
-            "Variant name already exists. Please choose a different name.",
+          message: tCommon("errors.variantNameExists"),
         });
       } else {
         form.setError("root", {
           type: "custom",
-          message: "An unknown error occurred.",
+          message: tCommon("errors.unknown"),
         });
       }
       setIsSubmitting(false);

--- a/testplanit/app/[locale]/admin/fields/AddCaseField.tsx
+++ b/testplanit/app/[locale]/admin/fields/AddCaseField.tsx
@@ -51,60 +51,66 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 
-const FormSchema = z
-  .object({
-    displayName: z.string().min(1, {
-      message: "Enter a display name for the Case Field.",
-    }),
-    systemName: z
-      .string()
-      .min(1, {
-        message: "System Name cannot be empty.",
-      })
-      .regex(/^[A-Za-z][A-Za-z0-9_]*$/, {
-        message:
-          "System Name must start with a letter and can only contain letters, numbers, and underscores.",
+// Schema is built per-render so Zod messages reflect the active locale.
+// `t` is the unscoped translator from useTranslations(); keep paths
+// fully-qualified. Typed loosely because next-intl's typed translator
+// rejects dynamic key strings.
+function buildFormSchema(t: (key: any) => string) {
+  return z
+    .object({
+      displayName: z.string().min(1, {
+        message: t("common.fields.options.validation.displayNameRequiredCase"),
       }),
-    typeId: z.string().min(1, {
-      message: "Field Type is required.",
-    }),
-    hint: z.string().optional(),
-    isEnabled: z.boolean().default(true).optional(),
-    isRequired: z.boolean().default(false).optional(),
-    isRestricted: z.boolean().default(false).optional(),
-    defaultValue: z.string().optional(),
-    isChecked: z.boolean().default(false).optional(),
-    minValue: z.number().nullable().optional(),
-    maxValue: z.number().nullable().optional(),
-    minIntegerValue: z.int().nullable().optional(),
-    maxIntegerValue: z.int().nullable().optional(),
-    initialHeight: z.int().nullable().optional(),
-    dropdownOptions: z.array(z.string()).optional(),
-  })
-  .refine(
-    (data) =>
-      (data.minValue == null && data.maxValue == null) ||
-      (data.minValue != null &&
-        data.maxValue != null &&
-        data.minValue < data.maxValue),
-    {
-      path: ["minValue"],
-      message:
-        "Minimum value must be less than maximum value, and both must be set if one is set.",
-    }
-  )
-  .refine(
-    (data) =>
-      (data.minIntegerValue == null && data.maxIntegerValue == null) ||
-      (data.minIntegerValue != null &&
-        data.maxIntegerValue != null &&
-        data.minIntegerValue < data.maxIntegerValue),
-    {
-      path: ["minIntegerValue"],
-      message:
-        "Minimum integer value must be less than maximum integer value, and both must be set if one is set.",
-    }
-  );
+      systemName: z
+        .string()
+        .min(1, {
+          message: t("common.fields.options.validation.systemNameRequired"),
+        })
+        .regex(/^[A-Za-z][A-Za-z0-9_]*$/, {
+          message: t("common.fields.options.validation.systemNameRegex"),
+        }),
+      typeId: z.string().min(1, {
+        message: t("common.fields.options.validation.fieldTypeRequired"),
+      }),
+      hint: z.string().optional(),
+      isEnabled: z.boolean().default(true).optional(),
+      isRequired: z.boolean().default(false).optional(),
+      isRestricted: z.boolean().default(false).optional(),
+      defaultValue: z.string().optional(),
+      isChecked: z.boolean().default(false).optional(),
+      minValue: z.number().nullable().optional(),
+      maxValue: z.number().nullable().optional(),
+      minIntegerValue: z.int().nullable().optional(),
+      maxIntegerValue: z.int().nullable().optional(),
+      initialHeight: z.int().nullable().optional(),
+      dropdownOptions: z.array(z.string()).optional(),
+    })
+    .refine(
+      (data) =>
+        (data.minValue == null && data.maxValue == null) ||
+        (data.minValue != null &&
+          data.maxValue != null &&
+          data.minValue < data.maxValue),
+      {
+        path: ["minValue"],
+        message: t("common.fields.options.validation.minValueMaxValue"),
+      }
+    )
+    .refine(
+      (data) =>
+        (data.minIntegerValue == null && data.maxIntegerValue == null) ||
+        (data.minIntegerValue != null &&
+          data.maxIntegerValue != null &&
+          data.minIntegerValue < data.maxIntegerValue),
+      {
+        path: ["minIntegerValue"],
+        message: t("common.fields.options.validation.minMaxValueInteger"),
+      }
+    );
+}
+
+type FormSchemaType = ReturnType<typeof buildFormSchema>;
+type FormValues = z.infer<FormSchemaType>;
 
 export interface FieldDraftOption {
   name: string;
@@ -119,13 +125,13 @@ export interface AddCaseFieldModalProps {
   open: boolean;
   onClose: () => void;
   onSubmitField?: (payload: {
-    values: z.infer<typeof FormSchema>;
+    values: FormValues;
     dropdownOptions: FieldOptions[];
     defaultOptionId: number | null;
     typeName: string | undefined;
   }) => Promise<boolean | void> | boolean | void;
   draft?: {
-    values?: Partial<z.infer<typeof FormSchema>>;
+    values?: Partial<FormValues>;
     options?: FieldDraftOption[];
   };
   submitLabel?: string;
@@ -193,7 +199,7 @@ export function AddCaseFieldModal({
 
   const validationSchema = useMemo(
     () =>
-      FormSchema.superRefine((data, ctx) => {
+      buildFormSchema(tGlobal).superRefine((data, ctx) => {
         const normalizedSystemName = data.systemName
           ? data.systemName.trim().toLowerCase()
           : null;
@@ -208,7 +214,7 @@ export function AddCaseFieldModal({
           });
         }
       }),
-    [existingSystemNames, tCommon]
+    [existingSystemNames, tCommon, tGlobal]
   );
 
   const typeOptions =
@@ -281,7 +287,7 @@ export function AddCaseFieldModal({
     }
   };
 
-  const form = useForm<z.infer<typeof FormSchema>>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(validationSchema),
     defaultValues: {
       displayName: "",
@@ -370,7 +376,7 @@ export function AddCaseFieldModal({
       minIntegerValue: null,
       maxIntegerValue: null,
       initialHeight: null,
-    } satisfies Partial<z.infer<typeof FormSchema>>;
+    } satisfies Partial<FormValues>;
 
     reset({
       ...baseDefaults,
@@ -488,7 +494,7 @@ export function AddCaseFieldModal({
         return (
           <Controller
             key={option.key}
-            name={option.key as keyof z.infer<typeof FormSchema>}
+            name={option.key as keyof FormValues}
             control={form.control}
             render={({ field, fieldState }) => (
               <FormItem>
@@ -620,18 +626,18 @@ export function AddCaseFieldModal({
   ) {
     const value = e.target.value;
     if (value === "") {
-      form.setValue(key as keyof z.infer<typeof FormSchema>, null);
+      form.setValue(key as keyof FormValues, null);
     } else {
       const numericValue = isInteger ? parseInt(value, 10) : parseFloat(value);
       if (!isNaN(numericValue)) {
-        form.setValue(key as keyof z.infer<typeof FormSchema>, numericValue);
+        form.setValue(key as keyof FormValues, numericValue);
       } else {
-        form.setValue(key as keyof z.infer<typeof FormSchema>, null);
+        form.setValue(key as keyof FormValues, null);
       }
     }
   }
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       if (onSubmitField) {

--- a/testplanit/app/[locale]/admin/fields/AddResultField.tsx
+++ b/testplanit/app/[locale]/admin/fields/AddResultField.tsx
@@ -53,72 +53,80 @@ import {
 import { HelpPopover } from "@/components/ui/help-popover";
 import type { FieldDraftOption } from "./AddCaseField";
 
-const FormSchema = z
-  .object({
-    displayName: z.string().min(1, {
-      message: "Enter a display name for the Result Field.",
-    }),
-    systemName: z
-      .string()
-      .min(1, {
-        message: "System Name cannot be empty.",
-      })
-      .regex(/^[A-Za-z][A-Za-z0-9_]*$/, {
-        message:
-          "System Name must start with a letter and can only contain letters, numbers, and underscores.",
+// Schema is built per-render so Zod messages reflect the active locale.
+// `t` is the unscoped translator from useTranslations(); keep paths
+// fully-qualified. Typed loosely because next-intl's typed translator
+// rejects dynamic key strings.
+function buildFormSchema(t: (key: any) => string) {
+  return z
+    .object({
+      displayName: z.string().min(1, {
+        message: t(
+          "common.fields.options.validation.displayNameRequiredResult"
+        ),
       }),
-    typeId: z.string().min(1, {
-      message: "Field Type is required.",
-    }),
-    hint: z.string().optional(),
-    isEnabled: z.boolean().default(true).optional(),
-    isRequired: z.boolean().default(false).optional(),
-    isRestricted: z.boolean().default(false).optional(),
-    defaultValue: z.string().optional(),
-    isChecked: z.boolean().default(false).optional(),
-    minValue: z.number().nullable().optional(),
-    maxValue: z.number().nullable().optional(),
-    minIntegerValue: z.int().nullable().optional(),
-    maxIntegerValue: z.int().nullable().optional(),
-    initialHeight: z.int().nullable().optional(),
-    dropdownOptions: z.array(z.string()).optional(),
-  })
-  .refine(
-    (data) =>
-      (data.minValue == null && data.maxValue == null) ||
-      (data.minValue != null &&
-        data.maxValue != null &&
-        data.minValue < data.maxValue),
-    {
-      path: ["minValue"],
-      message:
-        "Minimum value must be less than maximum value, and both must be set if one is set.",
-    }
-  )
-  .refine(
-    (data) =>
-      (data.minIntegerValue == null && data.maxIntegerValue == null) ||
-      (data.minIntegerValue != null &&
-        data.maxIntegerValue != null &&
-        data.minIntegerValue < data.maxIntegerValue),
-    {
-      path: ["minIntegerValue"],
-      message:
-        "Minimum integer value must be less than maximum integer value, and both must be set if one is set.",
-    }
-  );
+      systemName: z
+        .string()
+        .min(1, {
+          message: t("common.fields.options.validation.systemNameRequired"),
+        })
+        .regex(/^[A-Za-z][A-Za-z0-9_]*$/, {
+          message: t("common.fields.options.validation.systemNameRegex"),
+        }),
+      typeId: z.string().min(1, {
+        message: t("common.fields.options.validation.fieldTypeRequired"),
+      }),
+      hint: z.string().optional(),
+      isEnabled: z.boolean().default(true).optional(),
+      isRequired: z.boolean().default(false).optional(),
+      isRestricted: z.boolean().default(false).optional(),
+      defaultValue: z.string().optional(),
+      isChecked: z.boolean().default(false).optional(),
+      minValue: z.number().nullable().optional(),
+      maxValue: z.number().nullable().optional(),
+      minIntegerValue: z.int().nullable().optional(),
+      maxIntegerValue: z.int().nullable().optional(),
+      initialHeight: z.int().nullable().optional(),
+      dropdownOptions: z.array(z.string()).optional(),
+    })
+    .refine(
+      (data) =>
+        (data.minValue == null && data.maxValue == null) ||
+        (data.minValue != null &&
+          data.maxValue != null &&
+          data.minValue < data.maxValue),
+      {
+        path: ["minValue"],
+        message: t("common.fields.options.validation.minValueMaxValue"),
+      }
+    )
+    .refine(
+      (data) =>
+        (data.minIntegerValue == null && data.maxIntegerValue == null) ||
+        (data.minIntegerValue != null &&
+          data.maxIntegerValue != null &&
+          data.minIntegerValue < data.maxIntegerValue),
+      {
+        path: ["minIntegerValue"],
+        message: t("common.fields.options.validation.minMaxValueInteger"),
+      }
+    );
+}
+
+type FormSchemaType = ReturnType<typeof buildFormSchema>;
+type FormValues = z.infer<FormSchemaType>;
 
 export interface AddResultFieldModalProps {
   open: boolean;
   onClose: () => void;
   onSubmitField?: (payload: {
-    values: z.infer<typeof FormSchema>;
+    values: FormValues;
     dropdownOptions: FieldOptions[];
     defaultOptionId: number | null;
     typeName: string | undefined;
   }) => Promise<boolean | void> | boolean | void;
   draft?: {
-    values?: Partial<z.infer<typeof FormSchema>>;
+    values?: Partial<FormValues>;
     options?: FieldDraftOption[];
   };
   submitLabel?: string;
@@ -185,7 +193,7 @@ export function AddResultFieldModal({
 
   const validationSchema = useMemo(
     () =>
-      FormSchema.superRefine((data, ctx) => {
+      buildFormSchema(tGlobal).superRefine((data, ctx) => {
         const normalizedSystemName = data.systemName
           ? data.systemName.trim().toLowerCase()
           : null;
@@ -200,7 +208,7 @@ export function AddResultFieldModal({
           });
         }
       }),
-    [existingSystemNames, tCommon]
+    [existingSystemNames, tCommon, tGlobal]
   );
 
   const typeOptions =
@@ -275,7 +283,7 @@ export function AddResultFieldModal({
     }
   };
 
-  const form = useForm<z.infer<typeof FormSchema>>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(validationSchema),
     defaultValues: {
       displayName: "",
@@ -364,7 +372,7 @@ export function AddResultFieldModal({
       minIntegerValue: null,
       maxIntegerValue: null,
       initialHeight: null,
-    } satisfies Partial<z.infer<typeof FormSchema>>;
+    } satisfies Partial<FormValues>;
 
     reset({
       ...baseDefaults,
@@ -482,7 +490,7 @@ export function AddResultFieldModal({
         return (
           <Controller
             key={option.key}
-            name={option.key as keyof z.infer<typeof FormSchema>}
+            name={option.key as keyof FormValues}
             control={form.control}
             render={({ field, fieldState }) => (
               <FormItem>
@@ -614,18 +622,18 @@ export function AddResultFieldModal({
   ) {
     const value = e.target.value;
     if (value === "") {
-      form.setValue(key as keyof z.infer<typeof FormSchema>, null);
+      form.setValue(key as keyof FormValues, null);
     } else {
       const numericValue = isInteger ? parseInt(value, 10) : parseFloat(value);
       if (!isNaN(numericValue)) {
-        form.setValue(key as keyof z.infer<typeof FormSchema>, numericValue);
+        form.setValue(key as keyof FormValues, numericValue);
       } else {
-        form.setValue(key as keyof z.infer<typeof FormSchema>, null);
+        form.setValue(key as keyof FormValues, null);
       }
     }
   }
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       if (onSubmitField) {

--- a/testplanit/app/[locale]/admin/fields/EditTemplate.tsx
+++ b/testplanit/app/[locale]/admin/fields/EditTemplate.tsx
@@ -55,16 +55,20 @@ import { Switch } from "@/components/ui/switch";
 
 import { useTranslations } from "next-intl";
 
-const FormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Please enter a name for the Template",
-  }),
-  isDefault: z.boolean().prefault(false),
-  isEnabled: z.boolean().prefault(false),
-  projects: z.array(z.number()).optional(),
-  caseFields: z.array(z.number()).optional(),
-  resultFields: z.array(z.number()).optional(),
-});
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.templateNameRequired"),
+    }),
+    isDefault: z.boolean().prefault(false),
+    isEnabled: z.boolean().prefault(false),
+    projects: z.array(z.number()).optional(),
+    caseFields: z.array(z.number()).optional(),
+    resultFields: z.array(z.number()).optional(),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface ExtendedTemplateCaseField {
   caseFieldId: number;
@@ -170,8 +174,9 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
     [template]
   );
 
+  const formSchema = useMemo(() => buildFormSchema(tGlobal), [tGlobal]);
   const form = useForm({
-    resolver: zodResolver(FormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: defaultFormValues,
   });
 
@@ -274,7 +279,7 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
     }
   };
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       if (data.isDefault) {

--- a/testplanit/app/[locale]/admin/groups/AddGroup.tsx
+++ b/testplanit/app/[locale]/admin/groups/AddGroup.tsx
@@ -3,7 +3,7 @@ import { HelpPopover } from "@/components/ui/help-popover";
 import { User } from "@prisma/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   useCreateGroups,
   useCreateManyGroupAssignment,
@@ -41,13 +41,15 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 
-const AddGroupFormSchema = z.object({
-  name: z.string().min(1, {
-    error: "Group Name is required",
-  }),
-});
+function buildAddGroupFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(1, {
+      error: t("common.errors.groupNameRequired"),
+    }),
+  });
+}
 
-type AddGroupFormData = z.infer<typeof AddGroupFormSchema>;
+type AddGroupFormData = z.infer<ReturnType<typeof buildAddGroupFormSchema>>;
 
 interface AddGroupProps {
   open: boolean;
@@ -72,8 +74,9 @@ export function AddGroup({ open, onClose }: AddGroupProps) {
 
   const allUsers: User[] | undefined = allUsersData as User[] | undefined;
 
+  const formSchema = useMemo(() => buildAddGroupFormSchema(tGlobal), [tGlobal]);
   const form = useForm<AddGroupFormData>({
-    resolver: zodResolver(AddGroupFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
     },

--- a/testplanit/app/[locale]/admin/groups/EditGroup.tsx
+++ b/testplanit/app/[locale]/admin/groups/EditGroup.tsx
@@ -2,7 +2,7 @@
 import { HelpPopover } from "@/components/ui/help-popover";
 import { Groups, User } from "@prisma/client";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCreateManyGroupAssignment,
   useDeleteManyGroupAssignment,
@@ -47,17 +47,20 @@ interface EditGroupProps {
   onClose: () => void;
 }
 
-const EditGroupFormSchema = z.object({
-  name: z.string().min(1, {
-    error: "Group Name is required",
-  }),
-});
+function buildEditGroupFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(1, {
+      error: t("common.errors.groupNameRequired"),
+    }),
+  });
+}
 
-type EditGroupFormData = z.infer<typeof EditGroupFormSchema>;
+type EditGroupFormData = z.infer<ReturnType<typeof buildEditGroupFormSchema>>;
 
 export function EditGroup({ group, open, onClose }: EditGroupProps) {
   const t = useTranslations("admin.groups");
   const tCommon = useTranslations("common");
+  const tGlobal = useTranslations();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [assignedUsers, setAssignedUsers] = useState<User[]>([]);
   const [initialAssignedUserIds, setInitialAssignedUserIds] = useState<
@@ -91,8 +94,12 @@ export function EditGroup({ group, open, onClose }: EditGroupProps) {
     }
   }, [allUsers, groupAssignments]);
 
+  const formSchema = useMemo(
+    () => buildEditGroupFormSchema(tGlobal),
+    [tGlobal]
+  );
   const form = useForm<EditGroupFormData>({
-    resolver: zodResolver(EditGroupFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: group.name,
     },

--- a/testplanit/app/[locale]/admin/milestones/EditMilestoneTypes.tsx
+++ b/testplanit/app/[locale]/admin/milestones/EditMilestoneTypes.tsx
@@ -69,7 +69,7 @@ export function EditMilestoneType({
 
   const FormSchema = z.object({
     name: z.string().min(2, {
-      error: "Milestone Type name must be at least 2 characters.",
+      error: tCommon("errors.milestoneTypeNameMinLength"),
     }),
     isDefault: z.boolean(),
     projects: z.array(z.number()).optional(),

--- a/testplanit/app/[locale]/admin/milestones/MilestoneFormDialog.tsx
+++ b/testplanit/app/[locale]/admin/milestones/MilestoneFormDialog.tsx
@@ -44,24 +44,30 @@ import { useFindManyMilestoneTypes } from "~/lib/hooks";
 import { IconName } from "~/types/globals";
 import { MilestoneFormData } from "./AddMilestonesToProjectsWizard";
 
-const FormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Please enter a name for the Milestone",
-  }),
-  note: z.any().nullable(),
-  docs: z.any().nullable(),
-  isStarted: z.boolean(),
-  isCompleted: z.boolean(),
-  startedAt: z.date().nullable().optional(),
-  completedAt: z.date().nullable().optional(),
-  automaticCompletion: z.boolean(),
-  enableNotifications: z.boolean(),
-  notifyDaysBefore: z.number().min(0),
-  milestoneTypeId: z.number({
-    error: (issue) =>
-      issue.input === undefined ? "Please select a Milestone Type" : undefined,
-  }),
-});
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.milestoneNameRequired"),
+    }),
+    note: z.any().nullable(),
+    docs: z.any().nullable(),
+    isStarted: z.boolean(),
+    isCompleted: z.boolean(),
+    startedAt: z.date().nullable().optional(),
+    completedAt: z.date().nullable().optional(),
+    automaticCompletion: z.boolean(),
+    enableNotifications: z.boolean(),
+    notifyDaysBefore: z.number().min(0),
+    milestoneTypeId: z.number({
+      error: (issue) =>
+        issue.input === undefined
+          ? t("common.errors.milestoneTypeRequired")
+          : undefined,
+    }),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface MilestoneFormDialogProps {
   open: boolean;
@@ -150,8 +156,9 @@ export const MilestoneFormDialog: React.FC<MilestoneFormDialogProps> = ({
     (type) => type.isDefault
   )?.id;
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(t), [t]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
       note: null,
@@ -222,7 +229,7 @@ export const MilestoneFormDialog: React.FC<MilestoneFormDialogProps> = ({
     return null;
   }
 
-  async function handleFormSubmit(data: z.infer<typeof FormSchema>) {
+  async function handleFormSubmit(data: FormValues) {
     if (!session?.user?.id) {
       form.setError("root", {
         type: "custom",

--- a/testplanit/app/[locale]/admin/projects/EditProject.tsx
+++ b/testplanit/app/[locale]/admin/projects/EditProject.tsx
@@ -7,7 +7,7 @@ import {
   UserProjectPermission,
 } from "@prisma/client";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCreateManyProjectAssignment,
   useDeleteManyGroupProjectPermission,
@@ -83,35 +83,37 @@ interface EditProjectModalProps {
   onClose: () => void;
 }
 
-const EditProjectFormSchema = z.object({
-  iconUrl: optionalImageUrlSchema,
-  name: z.string().min(1, {
-    error: "Project Name is required",
-  }),
-  note: z.string().optional(),
-  isCompleted: z.boolean(),
-  completedAt: z.date().optional().nullable(),
-  defaultAccessType: z.enum(ProjectAccessType),
-  defaultRoleId: z.string().nullable(),
-  userPermissions: z
-    .record(
-      z.string(),
-      z.object({
-        accessType: z.string(),
-        roleId: z.string().nullable(),
-      })
-    )
-    .optional(),
-  groupPermissions: z
-    .record(
-      z.string(),
-      z.object({
-        accessType: z.string(),
-        roleId: z.string().nullable(),
-      })
-    )
-    .optional(),
-});
+function buildEditProjectFormSchema(t: (key: any) => string) {
+  return z.object({
+    iconUrl: optionalImageUrlSchema,
+    name: z.string().min(1, {
+      error: t("common.errors.projectNameRequired"),
+    }),
+    note: z.string().optional(),
+    isCompleted: z.boolean(),
+    completedAt: z.date().optional().nullable(),
+    defaultAccessType: z.enum(ProjectAccessType),
+    defaultRoleId: z.string().nullable(),
+    userPermissions: z
+      .record(
+        z.string(),
+        z.object({
+          accessType: z.string(),
+          roleId: z.string().nullable(),
+        })
+      )
+      .optional(),
+    groupPermissions: z
+      .record(
+        z.string(),
+        z.object({
+          accessType: z.string(),
+          roleId: z.string().nullable(),
+        })
+      )
+      .optional(),
+  });
+}
 
 // --- Type for User Permission in Form State ---
 // We use string for accessType to allow for "PROJECT_DEFAULT"
@@ -128,7 +130,9 @@ type GroupPermissionFormState = {
 };
 
 // Use inferred type from Zod schema directly
-type EditProjectFormData = z.infer<typeof EditProjectFormSchema>;
+type EditProjectFormData = z.infer<
+  ReturnType<typeof buildEditProjectFormSchema>
+>;
 
 // --- Export Types Needed by Child Component ---
 export type {
@@ -251,9 +255,17 @@ export function EditProjectModal({
 
   const handleCancel = () => onClose();
 
+  const t = useTranslations("admin.projects.edit");
+  const tGlobal = useTranslations();
+  const tCommon = useTranslations("common");
+
   // Use inferred type for useForm
+  const formSchema = useMemo(
+    () => buildEditProjectFormSchema(tGlobal),
+    [tGlobal]
+  );
   const form = useForm<EditProjectFormData>({
-    resolver: zodResolver(EditProjectFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       iconUrl: project.iconUrl ?? null,
       name: project.name ?? "",
@@ -281,10 +293,6 @@ export function EditProjectModal({
 
   const isCompleted = watch("isCompleted");
   const defaultAccessType = watch("defaultAccessType");
-
-  const t = useTranslations("admin.projects.edit");
-  const tGlobal = useTranslations();
-  const tCommon = useTranslations("common");
 
   // Store initial permissions to compare against on submit
   const [initialUserPermissions, setInitialUserPermissions] = useState<Record<
@@ -435,7 +443,7 @@ export function EditProjectModal({
       ) {
         setError("defaultRoleId", {
           type: "manual",
-          message: "Invalid Role ID",
+          message: tCommon("errors.invalidRoleId"),
         });
         setIsSubmitting(false);
         return;

--- a/testplanit/app/[locale]/admin/roles/AddRoles.tsx
+++ b/testplanit/app/[locale]/admin/roles/AddRoles.tsx
@@ -42,22 +42,24 @@ import { Label } from "@radix-ui/react-label";
 const applicationAreaValues = Object.values(ApplicationArea);
 
 // Define Zod schema for the form including permissions (copied from EditRoles)
-const AddRoleFormSchema = z.object({
-  name: z.string().min(1, {
-    error: "Role name cannot be empty",
-  }),
-  isDefault: z.boolean(),
-  permissions: z.partialRecord(
-    z.enum(ApplicationArea),
-    z.object({
-      canAddEdit: z.boolean(),
-      canDelete: z.boolean(),
-      canClose: z.boolean(),
-    })
-  ),
-});
+function buildAddRoleFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(1, {
+      error: t("common.errors.roleNameEmpty"),
+    }),
+    isDefault: z.boolean(),
+    permissions: z.partialRecord(
+      z.enum(ApplicationArea),
+      z.object({
+        canAddEdit: z.boolean(),
+        canDelete: z.boolean(),
+        canClose: z.boolean(),
+      })
+    ),
+  });
+}
 
-type AddRoleFormData = z.infer<typeof AddRoleFormSchema>;
+type AddRoleFormData = z.infer<ReturnType<typeof buildAddRoleFormSchema>>;
 
 interface AddRoleProps {
   open: boolean;
@@ -85,8 +87,9 @@ export function AddRole({ open, onClose }: AddRoleProps) {
     []
   );
 
+  const formSchema = useMemo(() => buildAddRoleFormSchema(t), [t]);
   const form = useForm<AddRoleFormData>({
-    resolver: zodResolver(AddRoleFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
       isDefault: false,

--- a/testplanit/app/[locale]/admin/roles/EditRoles.tsx
+++ b/testplanit/app/[locale]/admin/roles/EditRoles.tsx
@@ -49,22 +49,24 @@ interface EditRoleProps {
 }
 
 // Define Zod schema for the form including permissions
-const EditRoleFormSchema = z.object({
-  name: z.string().min(1, {
-    error: "Role name cannot be empty",
-  }),
-  isDefault: z.boolean(),
-  permissions: z.partialRecord(
-    z.enum(ApplicationArea),
-    z.object({
-      canAddEdit: z.boolean(),
-      canDelete: z.boolean(),
-      canClose: z.boolean(),
-    })
-  ),
-});
+function buildEditRoleFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(1, {
+      error: t("common.errors.roleNameEmpty"),
+    }),
+    isDefault: z.boolean(),
+    permissions: z.partialRecord(
+      z.enum(ApplicationArea),
+      z.object({
+        canAddEdit: z.boolean(),
+        canDelete: z.boolean(),
+        canClose: z.boolean(),
+      })
+    ),
+  });
+}
 
-type EditRoleFormData = z.infer<typeof EditRoleFormSchema>;
+type EditRoleFormData = z.infer<ReturnType<typeof buildEditRoleFormSchema>>;
 
 export function EditRole({ role, open, onClose }: EditRoleProps) {
   const t = useTranslations();
@@ -110,8 +112,9 @@ export function EditRole({ role, open, onClose }: EditRoleProps) {
     };
   }, [role.name, role.isDefault, existingPermissions]);
 
+  const formSchema = useMemo(() => buildEditRoleFormSchema(t), [t]);
   const form = useForm<EditRoleFormData>({
-    resolver: zodResolver(EditRoleFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: defaultFormValues, // Use pre-calculated defaults
   });
   const {

--- a/testplanit/app/[locale]/admin/workflows/AddWorkflow.tsx
+++ b/testplanit/app/[locale]/admin/workflows/AddWorkflow.tsx
@@ -1,6 +1,6 @@
 "use client";
 /* eslint-disable react-hooks/incompatible-library */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCreateManyProjectWorkflowAssignment,
   useCreateWorkflows,
@@ -69,21 +69,25 @@ const getWorkflowTypeOptions = (
   { value: WorkflowType.DONE, label: tWorkflowTypes("DONE") },
 ];
 
-const FormSchema: any = z.object({
-  scope: z.enum(scopeKeys, {
-    message: `Please choose a Workflow for the State`,
-  }),
-  name: z.string().min(1, {
-    error: "Please enter a name for the Workflow State",
-  }),
-  workflowType: z.enum(WorkflowType, {
-    error: (issue) =>
-      issue.input === undefined ? "Please select a workflow type" : undefined,
-  }),
-  isDefault: z.boolean().prefault(false).optional(),
-  isEnabled: z.boolean().prefault(true).optional(),
-  projects: z.array(z.number()).optional(),
-});
+function buildFormSchema(t: (key: any) => string): any {
+  return z.object({
+    scope: z.enum(scopeKeys, {
+      message: t("common.errors.workflowScopeRequired"),
+    }),
+    name: z.string().min(1, {
+      error: t("common.errors.workflowStateNameRequired"),
+    }),
+    workflowType: z.enum(WorkflowType, {
+      error: (issue) =>
+        issue.input === undefined
+          ? t("common.errors.workflowTypeRequired")
+          : undefined,
+    }),
+    isDefault: z.boolean().prefault(false).optional(),
+    isEnabled: z.boolean().prefault(true).optional(),
+    projects: z.array(z.number()).optional(),
+  });
+}
 
 interface AddWorkflowsProps {
   open: boolean;
@@ -140,8 +144,9 @@ export function AddWorkflows({ open, onClose }: AddWorkflowsProps) {
     setSelectedColorId(colorId);
   };
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(tGlobal), [tGlobal]);
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       scope: undefined,
       name: "",
@@ -164,7 +169,7 @@ export function AddWorkflows({ open, onClose }: AddWorkflowsProps) {
     }
   }, [defaultIconData, defaultColorData]);
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: z.infer<typeof formSchema>) {
     setIsSubmitting(true);
     try {
       if (data.isDefault) {
@@ -217,12 +222,14 @@ export function AddWorkflows({ open, onClose }: AddWorkflowsProps) {
       if (err.info?.prisma && err.info?.code === "P2002") {
         form.setError("name", {
           type: "custom",
-          message: "Workflow State already exists. Please choose a new name.",
+          message: tCommon("errors.workflowStateExists"),
         });
       } else {
         form.setError("root", {
           type: "custom",
-          message: `An unknown error occurred. Error: ${err.message}`,
+          message: tCommon("errors.unknownErrorWithMessage", {
+            message: err.message ?? "",
+          }),
         });
       }
       setIsSubmitting(false);

--- a/testplanit/app/[locale]/admin/workflows/EditWorkflow.tsx
+++ b/testplanit/app/[locale]/admin/workflows/EditWorkflow.tsx
@@ -157,7 +157,9 @@ export function EditWorkflows({
     }),
     workflowType: z.enum(WorkflowType, {
       error: (issue) =>
-        issue.input === undefined ? "Please select a workflow type" : undefined,
+        issue.input === undefined
+          ? tCommon("errors.workflowTypeRequired")
+          : undefined,
     }),
     isDefault: z.boolean().prefault(false).optional(),
     isEnabled: z.boolean().prefault(true).optional(),
@@ -239,13 +241,14 @@ export function EditWorkflows({
       if (err.info?.prisma && err.info?.code === "P2002") {
         form.setError("name", {
           type: "nameExists",
-          message:
-            "Workflow State name already exists. Please choose a different name.",
+          message: tCommon("errors.workflowStateNameExists"),
         });
       } else {
         form.setError("root", {
           type: "unknown",
-          message: `An unknown error occurred. Error: ${err.message}`,
+          message: tCommon("errors.unknownErrorWithMessage", {
+            message: err.message ?? "",
+          }),
         });
       }
       setIsSubmitting(false);

--- a/testplanit/app/[locale]/auth/two-factor-setup/page.tsx
+++ b/testplanit/app/[locale]/auth/two-factor-setup/page.tsx
@@ -21,6 +21,7 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Alert } from "~/components/ui/alert";
+import { translateServerError } from "~/lib/i18n/translateServerError";
 import { useRouter } from "~/lib/navigation";
 import svgIcon from "~/public/tpi_logo.svg";
 
@@ -113,7 +114,7 @@ export default function TwoFactorSetupPage() {
       });
       const data = await response.json();
       if (!response.ok) {
-        throw new Error(data.error || "Failed to enable 2FA");
+        throw new Error(translateServerError(t, data, "Failed to enable 2FA"));
       }
       setBackupCodes(data.backupCodes);
       setStep("backup");

--- a/testplanit/app/[locale]/auth/two-factor-verify/page.tsx
+++ b/testplanit/app/[locale]/auth/two-factor-verify/page.tsx
@@ -19,6 +19,7 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useState } from "react";
+import { translateServerError } from "~/lib/i18n/translateServerError";
 import { useRouter } from "~/lib/navigation";
 import svgIcon from "~/public/tpi_logo.svg";
 
@@ -48,7 +49,9 @@ export default function TwoFactorVerifyPage() {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || "Verification failed");
+        throw new Error(
+          translateServerError(t, data, t("auth.errors.invalid2FACode"))
+        );
       }
 
       // Update the session to mark 2FA as verified
@@ -57,7 +60,9 @@ export default function TwoFactorVerifyPage() {
       // Redirect to home
       router.push("/");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Verification failed");
+      setError(
+        err instanceof Error ? err.message : t("auth.errors.invalid2FACode")
+      );
     } finally {
       setIsLoading(false);
     }

--- a/testplanit/app/[locale]/projects/milestones/CompleteMilestoneDialog.tsx
+++ b/testplanit/app/[locale]/projects/milestones/CompleteMilestoneDialog.tsx
@@ -184,7 +184,7 @@ export function CompleteMilestoneDialog({
       if (result.status === "success") {
         // The server action completed the milestone directly (no dependencies)
         toast.success(
-          result.message || `Milestone "${milestoneToComplete.name}" completed.`
+          t("milestones.toast.completed", { name: milestoneToComplete.name })
         );
         onCompleteSuccess();
         onOpenChange(false);
@@ -202,12 +202,12 @@ export function CompleteMilestoneDialog({
           await handleForceComplete(data.completionDate);
         }
       } else if (result.status === "error") {
-        toast.error(result.message || "An unknown error occurred.");
+        toast.error(result.message || tCommon("errors.unknown"));
         onOpenChange(false);
       }
     } catch (error) {
       console.error("Failed to preview milestone completion:", error);
-      toast.error("An unknown error occurred.");
+      toast.error(tCommon("errors.unknown"));
       onOpenChange(false);
     } finally {
       setIsSubmitting(false);
@@ -230,17 +230,19 @@ export function CompleteMilestoneDialog({
 
       if (result.status === "success") {
         toast.success(
-          result.message || `Milestone "${milestoneToComplete.name}" completed.`
+          t("milestones.toast.completedWithDependencies", {
+            name: milestoneToComplete.name,
+          })
         );
         onCompleteSuccess();
         onOpenChange(false);
       } else {
-        toast.error(result.message || "An unknown error occurred.");
+        toast.error(result.message || tCommon("errors.unknown"));
         if (result.status === "error") onOpenChange(false);
       }
     } catch (error) {
       console.error("Failed to complete milestone with force:", error);
-      toast.error("An unknown error occurred.");
+      toast.error(tCommon("errors.unknown"));
       onOpenChange(false);
     } finally {
       setIsSubmitting(false);

--- a/testplanit/app/[locale]/projects/milestones/[projectId]/AddMilestoneModal.tsx
+++ b/testplanit/app/[locale]/projects/milestones/[projectId]/AddMilestoneModal.tsx
@@ -37,7 +37,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { z } from "zod/v4";
 import { emptyEditorContent } from "~/app/constants";
@@ -48,25 +48,33 @@ import {
 } from "~/lib/hooks";
 import { IconName } from "~/types/globals";
 
-const FormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Please enter a name for the Milestone",
-  }),
-  parentId: z.union([z.string().nullable(), z.number().optional()]).optional(),
-  note: z.any().nullable(),
-  docs: z.any().nullable(),
-  isStarted: z.boolean(),
-  isCompleted: z.boolean(),
-  startedAt: z.date().nullable().optional(),
-  completedAt: z.date().nullable().optional(),
-  automaticCompletion: z.boolean(),
-  enableNotifications: z.boolean(),
-  notifyDaysBefore: z.number().min(0),
-  milestoneTypeId: z.number({
-    error: (issue) =>
-      issue.input === undefined ? "Please select a Milestone Type" : undefined,
-  }),
-});
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.milestoneNameRequired"),
+    }),
+    parentId: z
+      .union([z.string().nullable(), z.number().optional()])
+      .optional(),
+    note: z.any().nullable(),
+    docs: z.any().nullable(),
+    isStarted: z.boolean(),
+    isCompleted: z.boolean(),
+    startedAt: z.date().nullable().optional(),
+    completedAt: z.date().nullable().optional(),
+    automaticCompletion: z.boolean(),
+    enableNotifications: z.boolean(),
+    notifyDaysBefore: z.number().min(0),
+    milestoneTypeId: z.number({
+      error: (issue) =>
+        issue.input === undefined
+          ? t("common.errors.milestoneTypeRequired")
+          : undefined,
+    }),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface AddMilestoneProps {
   open: boolean;
@@ -142,8 +150,9 @@ export function AddMilestone({ open, onClose }: AddMilestoneProps) {
   const [noteContent, setNoteContent] = useState<object>({});
   const [docsContent, setDocsContent] = useState<object>({});
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(t), [t]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
       parentId: undefined,
@@ -193,7 +202,7 @@ export function AddMilestone({ open, onClose }: AddMilestoneProps) {
     return null;
   }
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       if (session) {

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
@@ -82,7 +82,7 @@ interface SharedStepGroupWithItems {
   items: SharedStepItemDetail[];
 }
 
-const mapFieldToZodType = (field: any) => {
+const mapFieldToZodType = (field: any, t: (key: any) => string) => {
   const isRequired = field.caseField.isRequired;
 
   const _addMinMax = (schema: z.ZodNumber) => {
@@ -194,7 +194,7 @@ const mapFieldToZodType = (field: any) => {
               }
             },
             {
-              error: "This field is required",
+              error: t("common.errors.fieldRequired"),
             }
           )
         : z.string().optional();
@@ -215,18 +215,22 @@ const mapFieldToZodType = (field: any) => {
   }
 };
 
-const createFormSchema = (fields: any[]) => {
+const createFormSchema = (fields: any[], t: (key: any) => string) => {
   const baseSchema = {
     name: z.string().min(2, {
-      error: "Please enter a name for the Test Case",
+      error: t("common.errors.caseNameRequired"),
     }),
     templateId: z.number({
       error: (issue) =>
-        issue.input === undefined ? "Please select a Template" : undefined,
+        issue.input === undefined
+          ? t("common.errors.caseTemplateRequired")
+          : undefined,
     }),
     workflowId: z.number({
       error: (issue) =>
-        issue.input === undefined ? "Please select a State" : undefined,
+        issue.input === undefined
+          ? t("common.errors.caseStateRequired")
+          : undefined,
     }),
     estimate: z
       .string()
@@ -238,8 +242,7 @@ const createFormSchema = (fields: any[]) => {
           return durationInMilliseconds !== null;
         },
         {
-          error:
-            "Invalid duration format. Try something like 30m, 1 week or 1h 25m",
+          error: t("common.validation.invalidDurationFormat"),
         }
       )
       .refine(
@@ -251,7 +254,7 @@ const createFormSchema = (fields: any[]) => {
           return durationInSeconds <= MAX_DURATION;
         },
         {
-          error: "Estimate is too large",
+          error: t("common.errors.estimateTooLarge"),
         }
       ),
     automated: z.boolean().prefault(false),
@@ -262,7 +265,7 @@ const createFormSchema = (fields: any[]) => {
       const fieldName = field.caseField.id.toString();
       // Skip Date fields entirely - we'll handle them manually without validation
       if (field.caseField.type.type !== "Date") {
-        schema[fieldName] = mapFieldToZodType(field);
+        schema[fieldName] = mapFieldToZodType(field, t);
       }
       return schema;
     },
@@ -304,7 +307,7 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
   const [isTemplateReady, setIsTemplateReady] = useState(false);
   const panelRef = useRef<React.ComponentRef<typeof ResizablePanel>>(null);
 
-  const [formSchema, setFormSchema] = useState(createFormSchema([]));
+  const [formSchema, setFormSchema] = useState(() => createFormSchema([], t));
   const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(
     null
   );
@@ -568,7 +571,7 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
       (template) => template.id === selectedTemplateId
     );
     if (selectedTemplate) {
-      setFormSchema(createFormSchema(selectedTemplate.caseFields));
+      setFormSchema(createFormSchema(selectedTemplate.caseFields, t));
       const defaultValues: Partial<FormValues> = {
         name: "",
         templateId: selectedTemplateId ?? 0,

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCaseRow.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCaseRow.tsx
@@ -17,7 +17,7 @@ import { PlusSquare } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v4";
@@ -31,19 +31,25 @@ import {
 } from "~/lib/hooks";
 import { IconName } from "~/types/globals";
 
-const FormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Please enter a name for the Test Case",
-  }),
-  workflowId: z
-    .number({
-      error: (issue) =>
-        issue.input === undefined ? "Please select a State" : undefined,
-    })
-    .refine((value) => !isNaN(value), {
-      error: "Please select a valid State",
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.caseNameRequired"),
     }),
-});
+    workflowId: z
+      .number({
+        error: (issue) =>
+          issue.input === undefined
+            ? t("common.errors.caseStateRequired")
+            : undefined,
+      })
+      .refine((value) => !isNaN(value), {
+        error: t("common.errors.caseStateInvalid"),
+      }),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface AddCaseRowProps {
   folderId: number;
@@ -149,8 +155,9 @@ export function AddCaseRow({ folderId }: AddCaseRowProps) {
       ),
     })) || [];
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(t), [t]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
       workflowId: defaultWorkflowId,
@@ -196,7 +203,7 @@ export function AddCaseRow({ folderId }: AddCaseRowProps) {
     return null;
   }
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       if (session) {
@@ -279,7 +286,7 @@ export function AddCaseRow({ folderId }: AddCaseRowProps) {
 
         reset({ name: "", workflowId: defaultWorkflowId });
 
-        toast.success("New Test Case Added", {
+        toast.success(t("common.errors.newTestCaseAdded"), {
           position: "bottom-right",
         });
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddFolder.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddFolder.tsx
@@ -28,7 +28,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { CircleX, Undo2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { emptyEditorContent } from "~/app/constants";
@@ -38,12 +38,16 @@ import {
   useFindManyRepositoryFolders,
 } from "~/lib/hooks";
 
-const FormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Please enter a name for the Folder",
-  }),
-  docs: z.any().optional(),
-});
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.folderNameRequired"),
+    }),
+    docs: z.any().optional(),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface AddFolderProps {
   projectId: number;
@@ -96,8 +100,9 @@ export function AddFolder({
     },
   });
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(t), [t]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
       docs: emptyEditorContent,
@@ -112,7 +117,7 @@ export function AddFolder({
     formState: { errors },
   } = form;
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     if (session) {
       try {

--- a/testplanit/app/[locale]/projects/repository/[projectId]/BulkEditModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/BulkEditModal.tsx
@@ -1082,22 +1082,22 @@ export function BulkEditModal({
             },
             {
               message: isRequired
-                ? "Estimate is required and must be a valid duration (e.g., 1h 30m)"
-                : "Invalid duration format or exceeds maximum limit (e.g., 1h 30m)",
+                ? t("common.errors.estimateRequiredValid")
+                : t("common.errors.invalidDurationOrExceedsMax"),
             }
           );
       } else if (fieldKey === "tags") {
         let tagsSchema = z.array(z.number());
         if (isRequired)
           tagsSchema = tagsSchema.min(1, {
-            message: "At least one tag is required",
+            message: t("common.errors.atLeastOneTagRequired"),
           });
         schema = isRequired ? tagsSchema : tagsSchema.nullable(); // Apply nullability correctly
       } else if (fieldKey === "issues") {
         let issuesSchema = z.array(z.number());
         if (isRequired)
           issuesSchema = issuesSchema.min(1, {
-            message: "At least one issue is required",
+            message: t("common.errors.atLeastOneIssueRequired"),
           });
         schema = isRequired ? issuesSchema : issuesSchema.nullable();
       } else if (fieldDef.isCustom && fieldDef.field) {
@@ -1118,7 +1118,7 @@ export function BulkEditModal({
             let multiSchema = z.array(z.number());
             if (isRequired)
               multiSchema = multiSchema.min(1, {
-                message: "At least one option must be selected",
+                message: t("common.errors.atLeastOneOptionRequired"),
               });
             schema = isRequired ? multiSchema : multiSchema.nullable();
             break;
@@ -1153,7 +1153,9 @@ export function BulkEditModal({
           case "Text String": // Text String field type
             let strSchema = z.string();
             if (isRequired)
-              strSchema = strSchema.min(1, { message: "Value is required" });
+              strSchema = strSchema.min(1, {
+                message: t("common.errors.valueRequired"),
+              });
             schema = strSchema.nullable(); // Allow null/empty string if not required
             break;
           case "Text Long":
@@ -1171,7 +1173,7 @@ export function BulkEditModal({
                     return false;
                   } // Invalid JSON doesn't satisfy required
                 },
-                { message: "Content is required" }
+                { message: t("common.errors.contentRequired") }
               );
             } else {
               // If not required, allow null/undefined, OR valid JSON string (can be empty)
@@ -1188,7 +1190,7 @@ export function BulkEditModal({
                     }
                   },
                   {
-                    message: "Invalid content format",
+                    message: t("common.errors.invalidContentFormat"),
                   }
                 )
                 .nullable();

--- a/testplanit/app/[locale]/projects/repository/[projectId]/EditFolder.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/EditFolder.tsx
@@ -41,12 +41,16 @@ const parseTipTapContent = (content: any) => {
   return content;
 };
 
-const FormSchema = z.object({
-  name: z.string().min(1, {
-    error: "Enter a name for the Folder.",
-  }),
-  docs: z.any().optional(),
-});
+function buildFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(1, {
+      error: t("common.errors.folderNameRequiredEnter"),
+    }),
+    docs: z.any().optional(),
+  });
+}
+
+type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 
 interface EditRepositoryFolderModalProps {
   folderId: number;
@@ -84,8 +88,9 @@ export function EditFolderModal({
     [folder]
   );
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const formSchema = useMemo(() => buildFormSchema(t), [t]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
     defaultValues: defaultFormValues,
   });
 
@@ -111,7 +116,7 @@ export function EditFolderModal({
     formState: { errors },
   } = form;
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
       await updateRepositoryFolder({

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
@@ -145,7 +145,7 @@ const parseJsonToTipTap = (
   return emptyEditorContent;
 };
 
-const mapFieldToZodType = (field: any) => {
+const mapFieldToZodType = (field: any, t: (key: any) => string) => {
   const isRequired = field.caseField.isRequired;
 
   const addMinMax = (schema: z.ZodNumber) => {
@@ -210,7 +210,9 @@ const mapFieldToZodType = (field: any) => {
             }
           },
           {
-            message: isRequired ? "This field is required" : "Invalid content",
+            message: isRequired
+              ? t("common.errors.fieldRequired")
+              : t("common.errors.invalidContent"),
           }
         )
       );
@@ -231,18 +233,22 @@ const mapFieldToZodType = (field: any) => {
   }
 };
 
-const createFormSchema = (fields: any[]) => {
+const createFormSchema = (fields: any[], t: (key: any) => string) => {
   const baseSchema = {
     name: z.string().min(2, {
-      error: "Please enter a name for the Test Case",
+      error: t("common.errors.caseNameRequired"),
     }),
     workflowId: z.number({
       error: (issue) =>
-        issue.input === undefined ? "Please select a State" : undefined,
+        issue.input === undefined
+          ? t("common.errors.caseStateRequired")
+          : undefined,
     }),
     folderId: z.number({
       error: (issue) =>
-        issue.input === undefined ? "Please select a Folder" : undefined,
+        issue.input === undefined
+          ? t("common.errors.caseFolderRequired")
+          : undefined,
     }),
     estimate: z
       .string()
@@ -254,8 +260,7 @@ const createFormSchema = (fields: any[]) => {
           return durationInMilliseconds !== null;
         },
         {
-          error:
-            "Invalid duration format. Try something like 30m, 1 week or 1h 25m",
+          error: t("common.validation.invalidDurationFormat"),
         }
       )
       .refine(
@@ -267,7 +272,7 @@ const createFormSchema = (fields: any[]) => {
           return durationInSeconds <= MAX_DURATION;
         },
         {
-          error: "Estimate is too large",
+          error: t("common.errors.estimateTooLarge"),
         }
       ),
     automated: z.boolean().prefault(false),
@@ -295,7 +300,7 @@ const createFormSchema = (fields: any[]) => {
         field.caseField.displayName !== "Steps" &&
         field.caseField.type.type !== "Date"
       ) {
-        schema[fieldName] = mapFieldToZodType(field);
+        schema[fieldName] = mapFieldToZodType(field, t);
       }
       return schema;
     },
@@ -709,8 +714,8 @@ export default function TestCaseDetails() {
     return transformFolders(folders || []);
   }, [folders]);
 
-  const [, setFormSchema] = useState(
-    createFormSchema(testcase?.template?.caseFields || [])
+  const [, setFormSchema] = useState(() =>
+    createFormSchema(testcase?.template?.caseFields || [], t)
   );
 
   const { data: workflows } = useFindManyWorkflows(
@@ -811,10 +816,12 @@ export default function TestCaseDetails() {
   useEffect(() => {
     if (!isFormInitialized.current || !testcase || !templates) return;
 
-    const selectedTemplate = templates.find((t) => t.id === selectedTemplateId);
+    const selectedTemplate = templates.find(
+      (template) => template.id === selectedTemplateId
+    );
     const caseFieldsForSchema =
       selectedTemplate?.caseFields || (selectedTemplateId === null ? [] : []);
-    const newSchema = createFormSchema(caseFieldsForSchema);
+    const newSchema = createFormSchema(caseFieldsForSchema, t);
     setFormSchema(newSchema);
 
     // Get current form values to preserve external issues
@@ -874,6 +881,7 @@ export default function TestCaseDetails() {
     reset,
     setFormSchema,
     getValues,
+    t,
     // parseJsonToTipTap, formatSeconds, emptyEditorContent are assumed stable
   ]);
 
@@ -948,7 +956,7 @@ export default function TestCaseDetails() {
     ) {
       methods.setError("name", {
         type: "manual",
-        message: "Please enter a name for the Test Case",
+        message: t("common.errors.caseNameRequired"),
       });
       hasErrors = true;
     }
@@ -956,7 +964,7 @@ export default function TestCaseDetails() {
     if (!data.workflowId) {
       methods.setError("workflowId", {
         type: "manual",
-        message: "Please select a State",
+        message: t("common.errors.caseStateRequired"),
       });
       hasErrors = true;
     }
@@ -964,7 +972,7 @@ export default function TestCaseDetails() {
     if (!data.folderId) {
       methods.setError("folderId", {
         type: "manual",
-        message: "Please select a Folder",
+        message: t("common.errors.caseFolderRequired"),
       });
       hasErrors = true;
     }
@@ -975,8 +983,7 @@ export default function TestCaseDetails() {
       if (durationInMilliseconds === null) {
         methods.setError("estimate", {
           type: "manual",
-          message:
-            "Invalid duration format. Try something like 30m, 1 week or 1h 25m",
+          message: t("common.validation.invalidDurationFormat"),
         });
         hasErrors = true;
       } else {
@@ -984,7 +991,7 @@ export default function TestCaseDetails() {
         if (durationInSeconds > MAX_DURATION) {
           methods.setError("estimate", {
             type: "manual",
-            message: "Estimate is too large",
+            message: t("common.errors.estimateTooLarge"),
           });
           hasErrors = true;
         }

--- a/testplanit/app/[locale]/projects/runs/[projectId]/AddTestRunModal.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/AddTestRunModal.tsx
@@ -84,33 +84,40 @@ interface ConfigurationOption {
   name: string;
 }
 
-// Define the form schemas at the top level
-const BasicInfoFormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Name must be at least 2 characters.",
-  }),
-  configIds: z.array(z.number()),
-  milestoneId: z.number().nullable(),
-  stateId: z.number().min(1, {
-    error: "State is required.",
-  }),
-  note: z.any().nullable(),
-  docs: z.any().nullable(),
-  attachments: z.array(z.any()).optional(),
-});
+// Define the form schemas via factory so messages reflect the active locale.
+function buildBasicInfoFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.testRunNameMinLength"),
+    }),
+    configIds: z.array(z.number()),
+    milestoneId: z.number().nullable(),
+    stateId: z.number().min(1, {
+      error: t("common.errors.stateRequiredDot"),
+    }),
+    note: z.any().nullable(),
+    docs: z.any().nullable(),
+    attachments: z.array(z.any()).optional(),
+  });
+}
 
-const BaseFormSchema = z.object({
-  name: z.string().min(2, {
-    error: "Name must be at least 2 characters.",
-  }),
-  configIds: z.array(z.number()),
-  milestoneId: z.number().nullable(),
-  stateId: z.number(),
-  note: z.any().nullable(),
-  docs: z.any().nullable(),
-  attachments: z.array(z.any()).optional(),
-  testCases: z.array(z.number()),
-});
+function buildBaseFormSchema(t: (key: any) => string) {
+  return z.object({
+    name: z.string().min(2, {
+      error: t("common.errors.testRunNameMinLength"),
+    }),
+    configIds: z.array(z.number()),
+    milestoneId: z.number().nullable(),
+    stateId: z.number(),
+    note: z.any().nullable(),
+    docs: z.any().nullable(),
+    attachments: z.array(z.any()).optional(),
+    testCases: z.array(z.number()),
+  });
+}
+
+type BasicInfoFormValues = z.infer<ReturnType<typeof buildBasicInfoFormSchema>>;
+type BaseFormValues = z.infer<ReturnType<typeof buildBaseFormSchema>>;
 
 // Step 1: Basic Information Dialog
 const BasicInfoDialog = React.memo(
@@ -140,8 +147,9 @@ const BasicInfoDialog = React.memo(
     const tCommon = useTranslations("common");
     const parentMilestoneId = form.getValues("milestoneId") ?? null;
 
-    const basicInfoForm = useForm<z.infer<typeof BasicInfoFormSchema>>({
-      resolver: zodResolver(BasicInfoFormSchema),
+    const basicInfoFormSchema = useMemo(() => buildBasicInfoFormSchema(t), [t]);
+    const basicInfoForm = useForm<BasicInfoFormValues>({
+      resolver: zodResolver(basicInfoFormSchema),
       defaultValues: {
         name: form.getValues("name"),
         configIds: form.getValues("configIds"),
@@ -840,6 +848,7 @@ export default function AddTestRunModal({
   const numericProjectId = Number(projectId);
   const t = useTranslations("runs.add");
   const tCommon = useTranslations("common");
+  const tGlobal = useTranslations();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [creationProgress, setCreationProgress] = useState({
     current: 0,
@@ -916,8 +925,9 @@ export default function AddTestRunModal({
     }
   };
 
-  const form = useForm<z.infer<typeof BaseFormSchema>>({
-    resolver: zodResolver(BaseFormSchema),
+  const baseFormSchema = useMemo(() => buildBaseFormSchema(tGlobal), [tGlobal]);
+  const form = useForm<BaseFormValues>({
+    resolver: zodResolver(baseFormSchema),
     defaultValues: {
       name: duplicationPreset
         ? `${duplicationPreset.originalName} - ${tCommon("actions.duplicate")}`
@@ -1165,7 +1175,7 @@ export default function AddTestRunModal({
     return null;
   }
 
-  async function onSubmit(data: z.infer<typeof BaseFormSchema>) {
+  async function onSubmit(data: BaseFormValues) {
     if (!session?.user?.id) {
       toast.error(tCommon("errors.notAuthenticated.title"), {
         description: tCommon("errors.notAuthenticated.message"),

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-outbound-form.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-outbound-form.tsx
@@ -61,6 +61,7 @@ import {
   updateOutboundSubscriptions,
 } from "~/app/actions/webhook-config";
 import { useFindManyWebhookConfig } from "~/lib/hooks";
+import { translateServerError } from "~/lib/i18n/translateServerError";
 import { isSlackWebhookUrl } from "~/lib/webhooks/slack-url-detection";
 import { z } from "zod";
 
@@ -294,7 +295,9 @@ export function WebhookOutboundForm({ projectId }: WebhookOutboundFormProps) {
         subscribedEvents: createSubscriptions,
       });
       if (!result.success) {
-        toast.error(result.error ?? t("outboundCreateError"));
+        toast.error(
+          translateServerError(tGlobal, result, t("outboundCreateError"))
+        );
         return;
       }
       toast.success(t("outboundCreateSuccess"));

--- a/testplanit/app/[locale]/signup/page.tsx
+++ b/testplanit/app/[locale]/signup/page.tsx
@@ -14,6 +14,7 @@ import {
   useFindFirstRegistrationSettings,
   useFindManySsoProvider,
 } from "~/lib/hooks";
+import { translateServerError } from "~/lib/i18n/translateServerError";
 import { useRouter } from "~/lib/navigation";
 
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -219,7 +220,11 @@ const Signup: NextPage = () => {
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error || "Failed to create user");
+        // Surface the localized message via errorCode when present, falling
+        // back to the legacy English `error` field for old responses.
+        throw new Error(
+          translateServerError(t, error, t("common.errors.unknown"))
+        );
       }
 
       newUser = await response.json().then((r) => r.data);
@@ -229,12 +234,7 @@ const Signup: NextPage = () => {
         await resendVerificationEmail(data.email);
       }
     } catch (err: any) {
-      // Handle user-friendly error messages
-      if (err.message?.includes("already exists")) {
-        setSubmissionError(t("common.errors.userExists"));
-      } else {
-        setSubmissionError(t("common.errors.unknown"));
-      }
+      setSubmissionError(err.message || t("common.errors.unknown"));
       return;
     }
 

--- a/testplanit/app/[locale]/users/profile/[userId]/TwoFactorSettings.tsx
+++ b/testplanit/app/[locale]/users/profile/[userId]/TwoFactorSettings.tsx
@@ -36,6 +36,7 @@ import { Check, Copy, Info, Loader2, RefreshCw, Shield } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { translateServerError } from "~/lib/i18n/translateServerError";
 
 interface TwoFactorSettingsProps {
   userId: string;
@@ -131,7 +132,7 @@ export function TwoFactorSettings({
       });
       const data = await response.json();
       if (!response.ok) {
-        throw new Error(data.error || "Failed to enable 2FA");
+        throw new Error(translateServerError(t, data, "Failed to enable 2FA"));
       }
       setBackupCodes(data.backupCodes);
       onUpdate?.();

--- a/testplanit/app/actions/milestoneActions.test.ts
+++ b/testplanit/app/actions/milestoneActions.test.ts
@@ -303,9 +303,7 @@ describe("milestoneActions", () => {
         });
 
         expect(result.status).toBe("success");
-        expect(result.message).toBe(
-          "Milestone and dependencies completed successfully."
-        );
+        expect(result.message).toBeUndefined();
       });
 
       it("should complete milestone with force flag despite dependencies", async () => {

--- a/testplanit/app/actions/milestoneActions.ts
+++ b/testplanit/app/actions/milestoneActions.ts
@@ -272,10 +272,9 @@ export async function completeMilestoneCascade(
       }
     });
 
-    return {
-      status: "success",
-      message: "Milestone and dependencies completed successfully.",
-    };
+    // Success path returns no `message`; the client renders a localized
+    // toast based on whether dependencies were involved.
+    return { status: "success" };
   } catch (error) {
     console.error("Error during actual milestone completion:", error);
     let message = "Failed to complete milestone.";

--- a/testplanit/app/actions/webhook-config.test.ts
+++ b/testplanit/app/actions/webhook-config.test.ts
@@ -1049,8 +1049,16 @@ describe("webhook-config server actions", () => {
         url: "https://example.com/hook",
       });
 
-      expect(r1).toEqual({ success: false, error: "Name is required" });
-      expect(r2).toEqual({ success: false, error: "Name is required" });
+      expect(r1).toEqual({
+        success: false,
+        errorCode: "projects.webhooks.outboundCreateNameRequired",
+        error: "Name is required",
+      });
+      expect(r2).toEqual({
+        success: false,
+        errorCode: "projects.webhooks.outboundCreateNameRequired",
+        error: "Name is required",
+      });
       expect(mockWebhookConfigCreate).not.toHaveBeenCalled();
     });
 
@@ -1077,7 +1085,11 @@ describe("webhook-config server actions", () => {
         url: "not-a-url",
       });
 
-      expect(result).toEqual({ success: false, error: "Invalid URL" });
+      expect(result).toEqual({
+        success: false,
+        errorCode: "projects.webhooks.outboundCreateUrlInvalid",
+        error: "Invalid URL",
+      });
       expect(mockWebhookConfigCreate).not.toHaveBeenCalled();
     });
 
@@ -1090,7 +1102,11 @@ describe("webhook-config server actions", () => {
         url: "http://example.com/hook",
       });
 
-      expect(result).toEqual({ success: false, error: "URL must use HTTPS" });
+      expect(result).toEqual({
+        success: false,
+        errorCode: "projects.webhooks.outboundCreateUrlMustUseHttps",
+        error: "URL must use HTTPS",
+      });
       expect(mockWebhookConfigCreate).not.toHaveBeenCalled();
     });
 

--- a/testplanit/app/actions/webhook-config.ts
+++ b/testplanit/app/actions/webhook-config.ts
@@ -680,6 +680,12 @@ export interface CreateOutboundResult {
   /** Plaintext secret — show ONCE on creation. Only set for GENERIC_HMAC. */
   secret?: string;
   error?: string;
+  /**
+   * i18n key for the error, set on user-actionable validation failures
+   * (empty name, invalid URL, missing HTTPS). Diagnostic / authorization
+   * errors keep `error` in English by project policy.
+   */
+  errorCode?: string;
 }
 
 /**
@@ -707,7 +713,11 @@ export async function createOutboundWebhook(input: {
   // Validate trim-non-empty up front.
   const trimmedName = input.name?.trim() ?? "";
   if (trimmedName.length === 0) {
-    return { success: false, error: "Name is required" };
+    return {
+      success: false,
+      errorCode: "projects.webhooks.outboundCreateNameRequired",
+      error: "Name is required",
+    };
   }
 
   // URL validation runs BEFORE auth so invalid input doesn't probe the
@@ -716,10 +726,18 @@ export async function createOutboundWebhook(input: {
   try {
     parsedUrl = new URL(input.url);
   } catch {
-    return { success: false, error: "Invalid URL" };
+    return {
+      success: false,
+      errorCode: "projects.webhooks.outboundCreateUrlInvalid",
+      error: "Invalid URL",
+    };
   }
   if (parsedUrl.protocol !== "https:" && !isHttpOutboundAllowed()) {
-    return { success: false, error: "URL must use HTTPS" };
+    return {
+      success: false,
+      errorCode: "projects.webhooks.outboundCreateUrlMustUseHttps",
+      error: "URL must use HTTPS",
+    };
   }
 
   let authorized: boolean;

--- a/testplanit/app/api/auth/send-magic-link/route.ts
+++ b/testplanit/app/api/auth/send-magic-link/route.ts
@@ -23,10 +23,16 @@ export const POST = withAuditContext(async (req: NextRequest) => {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
     }
 
-    // Check if user exists and is active
+    // Check if user exists and is active. Pull `userPreferences.locale`
+    // so the email is rendered in the recipient's language; falls back
+    // to en_US.
     const user = await prisma.user.findUnique({
       where: { email },
-      select: { id: true, isActive: true },
+      select: {
+        id: true,
+        isActive: true,
+        userPreferences: { select: { locale: true } },
+      },
     });
 
     if (!user || !user.isActive) {
@@ -80,32 +86,12 @@ export const POST = withAuditContext(async (req: NextRequest) => {
 
     const url = `${baseUrl}/api/auth/callback/email?callbackUrl=${encodeURIComponent(finalCallbackUrl)}&token=${token}&email=${encodeURIComponent(email)}`;
 
-    // Send the email using nodemailer (same as NextAuth)
-    const nodemailer = await import("nodemailer");
-    const transport = nodemailer.createTransport({
-      host: process.env.EMAIL_SERVER_HOST,
-      port: Number(process.env.EMAIL_SERVER_PORT),
-      auth: {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      },
-    });
-
-    await transport.sendMail({
+    // Render and send the localized magic-link email via the shared helper.
+    const { sendMagicLinkEmail } = await import("~/lib/email/magicLink");
+    await sendMagicLinkEmail({
       to: email,
-      from: process.env.EMAIL_FROM,
-      subject: "Sign in to TestPlanIt",
-      text: `Sign in to TestPlanIt\n\nClick the link below to sign in:\n${url}\n\nIf you did not request this email, you can safely ignore it.`,
-      html: `
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2 style="color: #333;">Sign in to TestPlanIt</h2>
-          <p>Click the button below to sign in:</p>
-          <a href="${url}" style="display: inline-block; background-color: #7c3aed; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 16px 0;">Sign In</a>
-          <p style="color: #666; font-size: 14px;">Or copy and paste this link into your browser:</p>
-          <p style="color: #666; font-size: 14px; word-break: break-all;">${url}</p>
-          <p style="color: #999; font-size: 12px; margin-top: 32px;">If you did not request this email, you can safely ignore it.</p>
-        </div>
-      `,
+      url,
+      locale: user.userPreferences?.locale ?? "en_US",
     });
 
     // Audit magic-link request (the generated token is NOT logged — only

--- a/testplanit/app/api/auth/signup/route.ts
+++ b/testplanit/app/api/auth/signup/route.ts
@@ -44,7 +44,10 @@ export async function POST(req: NextRequest) {
 
     if (existingUser) {
       return NextResponse.json(
-        { error: "User with this email already exists" },
+        {
+          errorCode: "common.errors.userExists",
+          error: "User with this email already exists",
+        },
         { status: 400 }
       );
     }
@@ -124,7 +127,10 @@ export async function POST(req: NextRequest) {
     // Handle Prisma unique constraint violation
     if (error.code === "P2002") {
       return NextResponse.json(
-        { error: "User with this email already exists" },
+        {
+          errorCode: "common.errors.userExists",
+          error: "User with this email already exists",
+        },
         { status: 400 }
       );
     }

--- a/testplanit/app/api/auth/two-factor/enable-required/route.ts
+++ b/testplanit/app/api/auth/two-factor/enable-required/route.ts
@@ -29,7 +29,10 @@ export const POST = withAuditContext(async (request: NextRequest) => {
 
     if (!token || typeof token !== "string") {
       return NextResponse.json(
-        { error: "Verification code is required" },
+        {
+          errorCode: "auth.errors.verificationCodeRequired",
+          error: "Verification code is required",
+        },
         { status: 400 }
       );
     }

--- a/testplanit/app/api/auth/two-factor/enable/route.ts
+++ b/testplanit/app/api/auth/two-factor/enable/route.ts
@@ -25,7 +25,13 @@ export const POST = withAuditContext(async (request: NextRequest) => {
     const { token } = body;
 
     if (!token || typeof token !== "string") {
-      return NextResponse.json({ error: "Token is required" }, { status: 400 });
+      return NextResponse.json(
+        {
+          errorCode: "auth.errors.twoFactorTokenRequired",
+          error: "Token is required",
+        },
+        { status: 400 }
+      );
     }
 
     const user = await prisma.user.findUnique({

--- a/testplanit/app/api/auth/two-factor/verify-sso/route.ts
+++ b/testplanit/app/api/auth/two-factor/verify-sso/route.ts
@@ -24,7 +24,10 @@ export const POST = withAuditContext(async (request: NextRequest) => {
 
     if (!token) {
       return NextResponse.json(
-        { error: "Verification code is required" },
+        {
+          errorCode: "auth.errors.verificationCodeRequired",
+          error: "Verification code is required",
+        },
         { status: 400 }
       );
     }

--- a/testplanit/lib/email/magicLink.ts
+++ b/testplanit/lib/email/magicLink.ts
@@ -1,0 +1,85 @@
+import nodemailer from "nodemailer";
+
+import {
+  getServerTranslation,
+  getServerTranslations,
+} from "../server-translations";
+
+interface SendMagicLinkEmailArgs {
+  /** Recipient email address. */
+  to: string;
+  /** Pre-built sign-in URL with the verification token. */
+  url: string;
+  /** Recipient's locale (`en_US` / `es_ES` / `fr_FR`). Falls back to en_US. */
+  locale?: string | null;
+  /** Override the From: address. Defaults to `process.env.EMAIL_FROM`. */
+  from?: string;
+}
+
+const PURPLE = "#7c3aed";
+
+/**
+ * Send a localized magic-link sign-in email.
+ *
+ * Both NextAuth's email provider hook (server/auth.ts) and the
+ * trial-admin provisioning route (app/api/auth/send-magic-link/route.ts)
+ * call this helper so the rendered email subject/body is consistent and
+ * stays in lock-step with the recipient's locale.
+ *
+ * Errors from the SMTP transport are intentionally NOT propagated —
+ * surfacing them to the caller would let an attacker probe whether a
+ * user exists by triggering different code paths. The caller is
+ * expected to look up the user before invoking this helper.
+ */
+export async function sendMagicLinkEmail(
+  args: SendMagicLinkEmailArgs
+): Promise<void> {
+  const userLocale = args.locale || "en_US";
+
+  // Pull every key in one batched call to avoid N round-trips through
+  // the JSON loader. `getServerTranslations` falls back to en-US per
+  // key when the requested locale has no entry.
+  const t = await getServerTranslations(userLocale, [
+    "email.magicLink.subject",
+    "email.magicLink.heading",
+    "email.magicLink.intro",
+    "email.magicLink.signInButton",
+    "email.magicLink.copyPasteIntro",
+    "email.magicLink.disclaimer",
+    "email.magicLink.textBody",
+  ]);
+
+  const text = await getServerTranslation(
+    userLocale,
+    "email.magicLink.textBody",
+    { url: args.url }
+  );
+
+  const transport = nodemailer.createTransport({
+    host: process.env.EMAIL_SERVER_HOST,
+    port: Number(process.env.EMAIL_SERVER_PORT),
+    auth: {
+      user: process.env.EMAIL_SERVER_USER,
+      pass: process.env.EMAIL_SERVER_PASSWORD,
+    },
+  });
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2 style="color: #333;">${t["email.magicLink.heading"]}</h2>
+      <p>${t["email.magicLink.intro"]}</p>
+      <a href="${args.url}" style="display: inline-block; background-color: ${PURPLE}; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 16px 0;">${t["email.magicLink.signInButton"]}</a>
+      <p style="color: #666; font-size: 14px;">${t["email.magicLink.copyPasteIntro"]}</p>
+      <p style="color: #666; font-size: 14px; word-break: break-all;">${args.url}</p>
+      <p style="color: #999; font-size: 12px; margin-top: 32px;">${t["email.magicLink.disclaimer"]}</p>
+    </div>
+  `;
+
+  await transport.sendMail({
+    to: args.to,
+    from: args.from ?? process.env.EMAIL_FROM,
+    subject: t["email.magicLink.subject"],
+    text,
+    html,
+  });
+}

--- a/testplanit/lib/i18n/translateServerError.test.ts
+++ b/testplanit/lib/i18n/translateServerError.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { translateServerError } from "./translateServerError";
+
+describe("translateServerError", () => {
+  it("returns translated string when errorCode is present and key resolves", () => {
+    const t = vi.fn(() => "Translated message");
+    const result = translateServerError(
+      t,
+      { errorCode: "errors.foo", error: "English fallback" },
+      "Generic"
+    );
+    expect(result).toBe("Translated message");
+    expect(t).toHaveBeenCalledWith("errors.foo");
+  });
+
+  it("falls back to legacy `error` when next-intl returns the raw key", () => {
+    // next-intl returns the key string when no translation exists.
+    const t = vi.fn((key: string) => key);
+    const result = translateServerError(
+      t,
+      { errorCode: "errors.missing", error: "English fallback" },
+      "Generic"
+    );
+    expect(result).toBe("English fallback");
+  });
+
+  it("falls back to caller-supplied fallback when both lookup and `error` are missing", () => {
+    const t = vi.fn((key: string) => key);
+    const result = translateServerError(
+      t,
+      { errorCode: "errors.missing" },
+      "Generic"
+    );
+    expect(result).toBe("Generic");
+  });
+
+  it("returns `error` when no errorCode is present (legacy server response)", () => {
+    const t = vi.fn();
+    const result = translateServerError(
+      t,
+      { error: "Server told us something" },
+      "Generic"
+    );
+    expect(result).toBe("Server told us something");
+    expect(t).not.toHaveBeenCalled();
+  });
+
+  it("returns fallback when result is null/undefined", () => {
+    const t = vi.fn();
+    expect(translateServerError(t, null, "Generic")).toBe("Generic");
+    expect(translateServerError(t, undefined, "Generic")).toBe("Generic");
+    expect(t).not.toHaveBeenCalled();
+  });
+
+  it("returns empty string when result is null and no fallback supplied", () => {
+    const t = vi.fn();
+    expect(translateServerError(t, null)).toBe("");
+  });
+
+  it("recovers when the translator throws on a missing key", () => {
+    const t = vi.fn(() => {
+      throw new Error("MISSING_MESSAGE");
+    });
+    const result = translateServerError(
+      t,
+      { errorCode: "errors.unknown", error: "Legacy English" },
+      "Generic"
+    );
+    expect(result).toBe("Legacy English");
+  });
+
+  it("does not call translator when errorCode is empty string", () => {
+    const t = vi.fn();
+    const result = translateServerError(
+      t,
+      { errorCode: "", error: "English" },
+      "Generic"
+    );
+    expect(result).toBe("English");
+    expect(t).not.toHaveBeenCalled();
+  });
+});

--- a/testplanit/lib/i18n/translateServerError.ts
+++ b/testplanit/lib/i18n/translateServerError.ts
@@ -1,0 +1,56 @@
+/**
+ * Resolve a server-returned error to a localized string for display in
+ * the client UI.
+ *
+ * Server actions and API routes that produce **user-actionable**
+ * validation errors (form input the user can fix — invalid email,
+ * required field, etc.) return BOTH:
+ *
+ *   - `errorCode`: a stable, fully-qualified i18n key
+ *                  (e.g. `"errors.validation.emailRequired"`).
+ *   - `error`:     the legacy English message, kept as a fallback so
+ *                  pre-i18n call sites and old clients still display
+ *                  something readable.
+ *
+ * This helper looks up `errorCode` via the supplied translator and
+ * falls back to `error` (or the caller-supplied default) if the
+ * translation is missing or `errorCode` is absent. Pass an
+ * unscoped `useTranslations()` so the full key paths resolve.
+ *
+ * Out of scope by project policy: diagnostic / non-actionable
+ * server errors keep `error` only and surface in English. See the
+ * `feedback_server_errors_stay_english` memory.
+ */
+// next-intl's translator narrows `key` to a generated literal-union of
+// namespaced keys; server-returned `errorCode` values are dynamic strings
+// the type-checker can't statically know. Accept the translator as
+// `unknown`-callable here and cast at the call site to avoid forcing
+// callers to pre-cast.
+type TranslateFn = (key: any, params?: any) => string;
+
+interface ServerErrorPayload {
+  errorCode?: string;
+  error?: string;
+}
+
+export function translateServerError(
+  t: TranslateFn,
+  result: ServerErrorPayload | null | undefined,
+  fallback?: string
+): string {
+  if (!result) return fallback ?? "";
+  const code = result.errorCode;
+  if (code) {
+    try {
+      const translated = t(code);
+      // next-intl returns the key when no translation exists. In that
+      // case prefer the explicit English fallback over the raw key.
+      if (translated && translated !== code) {
+        return translated;
+      }
+    } catch {
+      // Translator threw (missing key in strict mode) — fall through.
+    }
+  }
+  return result.error ?? fallback ?? "";
+}

--- a/testplanit/lib/server-translations.ts
+++ b/testplanit/lib/server-translations.ts
@@ -2,16 +2,36 @@ import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 
-// Get the current directory (works in both ESM and CommonJS after build)
-
-// @ts-ignore - __dirname is available in CommonJS after build
+// Resolve the messages directory in two phases so this module works under
+// every consumer: Next.js (Turbopack/Webpack server bundles), the workers
+// build (esbuild), and unit tests (vitest).
+//
+// Turbopack rewrites `__dirname` in server chunks to a `/ROOT/...` sentinel
+// that doesn't exist at runtime, so a `__dirname`-based path produces ENOENT
+// when the magic-link sender runs from a Next.js route. Worker builds, by
+// contrast, retain a real on-disk `__dirname`. We try `process.cwd()` first
+// (works in Next.js when invoked from the project root) and fall back to a
+// `__dirname`-relative resolution for the worker context.
+// @ts-ignore - __dirname is only available in CommonJS after build
 const currentDir =
   typeof __dirname !== "undefined"
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
+async function resolveMessagesDir(): Promise<string> {
+  const cwdCandidate = path.join(process.cwd(), "messages");
+  try {
+    await fs.access(cwdCandidate);
+    return cwdCandidate;
+  } catch {
+    // Fall through to the build-relative path.
+  }
+  return path.join(currentDir, "..", "messages");
+}
+
 // Cache for loaded translations
 const translationCache = new Map<string, any>();
+let messagesDirPromise: Promise<string> | null = null;
 
 /**
  * Load translations for a specific locale
@@ -26,13 +46,9 @@ async function loadTranslations(locale: string): Promise<any> {
   }
 
   try {
-    // Load the translation file
-    const translationPath = path.join(
-      currentDir,
-      "..",
-      "messages",
-      `${normalizedLocale}.json`
-    );
+    if (!messagesDirPromise) messagesDirPromise = resolveMessagesDir();
+    const messagesDir = await messagesDirPromise;
+    const translationPath = path.join(messagesDir, `${normalizedLocale}.json`);
     const translationContent = await fs.readFile(translationPath, "utf-8");
     const translations = JSON.parse(translationContent);
 

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -366,7 +366,10 @@
           "displayNameRequiredResult": "Enter a display name for the Result Field.",
           "displayNameRequiredCase": "Enter a display name for the Case Field.",
           "minValueMaxValue": "Minimum value must be less than maximum value, and both must be set if one is set.",
-          "minMaxValueInteger": "Minimum integer value must be less than maximum integer value, and both must be set if one is set."
+          "minMaxValueInteger": "Minimum integer value must be less than maximum integer value, and both must be set if one is set.",
+          "systemNameRequired": "System Name cannot be empty.",
+          "systemNameRegex": "System Name must start with a letter and can only contain letters, numbers, and underscores.",
+          "fieldTypeRequired": "Field Type is required."
         }
       },
       "placeholders": {
@@ -557,6 +560,36 @@
       "valueRequired": "Value is required",
       "contentRequired": "Content is required",
       "invalidContentFormat": "Invalid content format",
+      "caseNameRequired": "Please enter a name for the Test Case",
+      "caseStateRequired": "Please select a State",
+      "caseFolderRequired": "Please select a Folder",
+      "estimateTooLarge": "Estimate is too large",
+      "estimateRequiredValid": "Estimate is required and must be a valid duration (e.g., 1h 30m)",
+      "invalidDurationOrExceedsMax": "Invalid duration format or exceeds maximum limit (e.g., 1h 30m)",
+      "configurationNameExists": "Configuration name already exists. Please choose a different name.",
+      "variantNameExists": "Variant name already exists. Please choose a different name.",
+      "categoryNameExists": "Category name already exists. Please choose a different name.",
+      "workflowStateNameExists": "Workflow State name already exists. Please choose a different name.",
+      "folderNameRequired": "Please enter a name for the Folder",
+      "folderNameRequiredEnter": "Enter a name for the Folder.",
+      "workflowStateNameRequired": "Please enter a name for the Workflow State",
+      "roleNameEmpty": "Role name cannot be empty",
+      "groupNameRequired": "Group Name is required",
+      "templateNameRequired": "Please enter a name for the Template",
+      "caseStateInvalid": "Please select a valid State",
+      "caseTemplateRequired": "Please select a Template",
+      "invalidContent": "Invalid content",
+      "milestoneNameRequired": "Please enter a name for the Milestone",
+      "milestoneTypeRequired": "Please select a Milestone Type",
+      "testRunNameMinLength": "Name must be at least 2 characters.",
+      "stateRequiredDot": "State is required.",
+      "milestoneTypeNameMinLength": "Milestone Type name must be at least 2 characters.",
+      "projectNameRequired": "Project Name is required",
+      "workflowScopeRequired": "Please choose a Workflow for the State",
+      "workflowTypeRequired": "Please select a workflow type",
+      "newTestCaseAdded": "New Test Case Added",
+      "repositoryDeleted": "Repository deleted",
+      "failedToDeleteRepository": "Failed to delete repository",
       "permissionDenied": "You do not have permission to access this page.",
       "resultSubmitPermissionDenied": "You can’t submit results for this case. Ask a project admin to assign it to you.",
       "noModelsFound": "No models found",
@@ -889,7 +922,9 @@
       "accessDenied": "Access denied. Your account may be inactive or you don't have permission to sign in.",
       "configuration": "There is a problem with the server configuration.",
       "verification": "The verification token has expired or has already been used.",
-      "invalid2FACode": "Invalid verification code. Please try again."
+      "invalid2FACode": "Invalid verification code. Please try again.",
+      "twoFactorTokenRequired": "Token is required",
+      "verificationCodeRequired": "Verification code is required"
     },
     "signup": {
       "description": "Enter your information to sign up for a new account.",
@@ -1187,6 +1222,7 @@
         "outboundCreateNameRequired": "Name is required.",
         "outboundCreateUrlRequired": "URL is required.",
         "outboundCreateUrlInvalid": "Enter a valid URL (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "URL must use HTTPS",
         "outboundNameLabel": "Name",
         "outboundUnnamedConfig": "(unnamed webhook)",
         "outboundCreateUrl": "URL",
@@ -1585,7 +1621,9 @@
     "toast": {
       "deleted": "Milestone {name} deleted",
       "updated": "Milestone updated",
-      "updateFailed": "Failed to update milestone"
+      "updateFailed": "Failed to update milestone",
+      "completed": "Milestone \"{name}\" completed.",
+      "completedWithDependencies": "Milestone and dependencies completed successfully."
     },
     "errors": {
       "nameExists": "A milestone with this name already exists",
@@ -6472,6 +6510,15 @@
       "unsubscribe": "Unsubscribe",
       "managePreferences": "Manage Preferences",
       "allRightsReserved": "All rights reserved."
+    },
+    "magicLink": {
+      "subject": "Sign in to TestPlanIt",
+      "heading": "Sign in to TestPlanIt",
+      "intro": "Click the button below to sign in:",
+      "signInButton": "Sign In",
+      "copyPasteIntro": "Or copy and paste this link into your browser:",
+      "disclaimer": "If you did not request this email, you can safely ignore it.",
+      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nIf you did not request this email, you can safely ignore it."
     }
   },
   "comments": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -366,7 +366,10 @@
           "displayNameRequiredResult": "Introduzca un nombre para mostrar el campo resultante.",
           "displayNameRequiredCase": "Introduzca un nombre para mostrar el campo Caso.",
           "minValueMaxValue": "El valor mínimo debe ser menor que el valor máximo, y ambos deben establecerse si se establece uno.",
-          "minMaxValueInteger": "El valor entero mínimo debe ser menor que el valor entero máximo, y ambos deben establecerse si se establece uno."
+          "minMaxValueInteger": "El valor entero mínimo debe ser menor que el valor entero máximo, y ambos deben establecerse si se establece uno.",
+          "systemNameRequired": "El nombre del sistema no puede estar vacío.",
+          "systemNameRegex": "El nombre del sistema debe comenzar con una letra y solo puede contener letras, números y guiones bajos.",
+          "fieldTypeRequired": "El tipo de campo es obligatorio."
         }
       },
       "placeholders": {
@@ -557,6 +560,36 @@
       "valueRequired": "Se requiere valor",
       "contentRequired": "El contenido es obligatorio",
       "invalidContentFormat": "Formato de contenido no válido",
+      "caseNameRequired": "Por favor, introduzca un nombre para el caso de prueba.",
+      "caseStateRequired": "Seleccione un estado",
+      "caseFolderRequired": "Seleccione una carpeta",
+      "estimateTooLarge": "La estimación es demasiado grande.",
+      "estimateRequiredValid": "Se requiere una estimación y debe tener una duración válida (por ejemplo, 1h 30m).",
+      "invalidDurationOrExceedsMax": "Formato de duración no válido o excede el límite máximo (por ejemplo, 1h 30m).",
+      "configurationNameExists": "El nombre de configuración ya existe. Por favor, elija un nombre diferente.",
+      "variantNameExists": "Ya existe una variante con ese nombre. Por favor, elija un nombre diferente.",
+      "categoryNameExists": "La categoría con ese nombre ya existe. Por favor, elija un nombre diferente.",
+      "workflowStateNameExists": "El nombre \"Estado del flujo de trabajo\" ya existe. Por favor, elija un nombre diferente.",
+      "folderNameRequired": "Por favor, introduzca un nombre para la carpeta.",
+      "folderNameRequiredEnter": "Introduzca un nombre para la carpeta.",
+      "workflowStateNameRequired": "Introduzca un nombre para el estado del flujo de trabajo.",
+      "roleNameEmpty": "El nombre del rol no puede estar vacío.",
+      "groupNameRequired": "Se requiere el nombre del grupo.",
+      "templateNameRequired": "Por favor, introduzca un nombre para la plantilla.",
+      "caseStateInvalid": "Seleccione un estado válido.",
+      "caseTemplateRequired": "Seleccione una plantilla.",
+      "invalidContent": "Contenido no válido",
+      "milestoneNameRequired": "Por favor, introduzca un nombre para el Hito.",
+      "milestoneTypeRequired": "Seleccione un tipo de hito.",
+      "testRunNameMinLength": "El nombre debe tener al menos 2 caracteres.",
+      "stateRequiredDot": "Se requiere estado.",
+      "milestoneTypeNameMinLength": "El nombre del tipo de hito debe tener al menos 2 caracteres.",
+      "projectNameRequired": "Se requiere el nombre del proyecto.",
+      "workflowScopeRequired": "Por favor, seleccione un flujo de trabajo para el estado.",
+      "workflowTypeRequired": "Seleccione un tipo de flujo de trabajo.",
+      "newTestCaseAdded": "Se ha añadido un nuevo caso de prueba.",
+      "repositoryDeleted": "Repositorio eliminado",
+      "failedToDeleteRepository": "Error al eliminar el repositorio",
       "permissionDenied": "No tienes permiso para acceder a esta página.",
       "resultSubmitPermissionDenied": "No puedes enviar los resultados de este caso. Pídele a un administrador del proyecto que te lo asigne.",
       "noModelsFound": "No se encontraron modelos",
@@ -889,7 +922,9 @@
       "accessDenied": "Acceso denegado. Es posible que tu cuenta esté inactiva o que no tengas permiso para iniciar sesión.",
       "configuration": "Hay un problema con la configuración del servidor.",
       "verification": "El token de verificación ha expirado o ya ha sido utilizado.",
-      "invalid2FACode": "Código de verificación no válido. Inténtalo de nuevo."
+      "invalid2FACode": "Código de verificación no válido. Inténtalo de nuevo.",
+      "twoFactorTokenRequired": "Se requiere token",
+      "verificationCodeRequired": "Se requiere un código de verificación."
     },
     "signup": {
       "description": "Introduzca su información para registrarse en una nueva cuenta.",
@@ -1187,6 +1222,7 @@
         "outboundCreateNameRequired": "Se requiere el nombre.",
         "outboundCreateUrlRequired": "Se requiere una URL.",
         "outboundCreateUrlInvalid": "Introduzca una URL válida (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "La URL debe usar HTTPS.",
         "outboundNameLabel": "Nombre",
         "outboundUnnamedConfig": "(webhook sin nombre)",
         "outboundCreateUrl": "URL",
@@ -1585,7 +1621,9 @@
     "toast": {
       "deleted": "Hito {name} eliminado",
       "updated": "Hito actualizado",
-      "updateFailed": "Error al actualizar el hito"
+      "updateFailed": "Error al actualizar el hito",
+      "completed": "Hito \"{name}\" completado.",
+      "completedWithDependencies": "Los hitos y las dependencias se completaron con éxito."
     },
     "errors": {
       "nameExists": "Ya existe un hito con este nombre",
@@ -6472,6 +6510,15 @@
       "unsubscribe": "Darse de baja",
       "managePreferences": "Administrar preferencias",
       "allRightsReserved": "Todos los derechos reservados."
+    },
+    "magicLink": {
+      "subject": "Inicia sesión en TestPlanIt",
+      "heading": "Inicia sesión en TestPlanIt",
+      "intro": "Haz clic en el botón de abajo para iniciar sesión:",
+      "signInButton": "Iniciar sesión",
+      "copyPasteIntro": "O bien, copie y pegue este enlace en su navegador:",
+      "disclaimer": "Si no solicitaste este correo electrónico, puedes ignorarlo sin problema.",
+      "textBody": "Inicia sesión en TestPlanIt\n\nHaz clic en el enlace de abajo para iniciar sesión:\n{url}\n\nSi no solicitaste este correo electrónico, puedes ignorarlo sin problema."
     }
   },
   "comments": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -366,7 +366,10 @@
           "displayNameRequiredResult": "Saisissez un nom d'affichage pour le champ Résultat.",
           "displayNameRequiredCase": "Saisissez un nom d'affichage pour le champ « Dossier ».",
           "minValueMaxValue": "La valeur minimale doit être inférieure à la valeur maximale, et les deux doivent être définies si l'une d'elles l'est déjà.",
-          "minMaxValueInteger": "La valeur entière minimale doit être inférieure à la valeur entière maximale, et les deux doivent être définies si l'une d'elles l'est déjà."
+          "minMaxValueInteger": "La valeur entière minimale doit être inférieure à la valeur entière maximale, et les deux doivent être définies si l'une d'elles l'est déjà.",
+          "systemNameRequired": "Le nom du système ne peut pas être vide.",
+          "systemNameRegex": "Le nom du système doit commencer par une lettre et ne peut contenir que des lettres, des chiffres et des traits de soulignement.",
+          "fieldTypeRequired": "Le type de champ est obligatoire."
         }
       },
       "placeholders": {
@@ -557,6 +560,36 @@
       "valueRequired": "Une valeur est requise",
       "contentRequired": "Le contenu est requis",
       "invalidContentFormat": "Format de contenu invalide",
+      "caseNameRequired": "Veuillez saisir un nom pour le cas de test.",
+      "caseStateRequired": "Veuillez sélectionner un État",
+      "caseFolderRequired": "Veuillez sélectionner un dossier",
+      "estimateTooLarge": "L'estimation est trop élevée.",
+      "estimateRequiredValid": "Une estimation est requise et doit correspondre à une durée valide (par exemple, 1h 30m).",
+      "invalidDurationOrExceedsMax": "Format de durée invalide ou dépasse la limite maximale (ex. : 1 h 30).",
+      "configurationNameExists": "Ce nom de configuration existe déjà. Veuillez choisir un autre nom.",
+      "variantNameExists": "Ce nom existe déjà. Veuillez choisir un autre nom.",
+      "categoryNameExists": "Cette catégorie existe déjà. Veuillez choisir un autre nom.",
+      "workflowStateNameExists": "Le nom de l'état du flux de travail existe déjà. Veuillez choisir un autre nom.",
+      "folderNameRequired": "Veuillez saisir un nom pour le dossier",
+      "folderNameRequiredEnter": "Saisissez un nom pour le dossier.",
+      "workflowStateNameRequired": "Veuillez saisir un nom pour l'état du flux de travail",
+      "roleNameEmpty": "Le nom du rôle ne peut pas être vide.",
+      "groupNameRequired": "Le nom du groupe est requis.",
+      "templateNameRequired": "Veuillez saisir un nom pour le modèle",
+      "caseStateInvalid": "Veuillez sélectionner un État valide",
+      "caseTemplateRequired": "Veuillez sélectionner un modèle",
+      "invalidContent": "Contenu invalide",
+      "milestoneNameRequired": "Veuillez saisir un nom pour l'étape importante.",
+      "milestoneTypeRequired": "Veuillez sélectionner un type d'étape importante",
+      "testRunNameMinLength": "Le nom doit comporter au moins 2 caractères.",
+      "stateRequiredDot": "L'État est requis.",
+      "milestoneTypeNameMinLength": "Le nom du type d'étape doit comporter au moins 2 caractères.",
+      "projectNameRequired": "Le nom du projet est requis.",
+      "workflowScopeRequired": "Veuillez choisir un flux de travail pour l'État",
+      "workflowTypeRequired": "Veuillez sélectionner un type de flux de travail",
+      "newTestCaseAdded": "Nouveau cas de test ajouté",
+      "repositoryDeleted": "Dépôt supprimé",
+      "failedToDeleteRepository": "Échec de la suppression du dépôt",
       "permissionDenied": "Vous n'êtes pas autorisé à accéder à cette page.",
       "resultSubmitPermissionDenied": "Vous ne pouvez pas soumettre de résultats pour ce dossier. Veuillez demander à un administrateur de projet de vous l'attribuer.",
       "noModelsFound": "Aucun modèle trouvé",
@@ -889,7 +922,9 @@
       "accessDenied": "Accès refusé. Votre compte est peut-être inactif ou vous n'avez pas l'autorisation de vous connecter.",
       "configuration": "Il y a un problème avec la configuration du serveur.",
       "verification": "Le jeton de vérification a expiré ou a déjà été utilisé.",
-      "invalid2FACode": "Code de vérification invalide. Veuillez réessayer."
+      "invalid2FACode": "Code de vérification invalide. Veuillez réessayer.",
+      "twoFactorTokenRequired": "Un jeton est requis.",
+      "verificationCodeRequired": "Un code de vérification est requis."
     },
     "signup": {
       "description": "Saisissez vos informations pour créer un nouveau compte.",
@@ -1187,6 +1222,7 @@
         "outboundCreateNameRequired": "Le nom est obligatoire.",
         "outboundCreateUrlRequired": "L'URL est requise.",
         "outboundCreateUrlInvalid": "Saisissez une URL valide (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "L'URL doit utiliser HTTPS.",
         "outboundNameLabel": "Nom",
         "outboundUnnamedConfig": "(webhook non nommé)",
         "outboundCreateUrl": "URL",
@@ -1585,7 +1621,9 @@
     "toast": {
       "deleted": "Étape {name} supprimée",
       "updated": "Étape importante mise à jour",
-      "updateFailed": "Échec de la mise à jour de l'étape clé"
+      "updateFailed": "Échec de la mise à jour de l'étape clé",
+      "completed": "Étape importante «{name}» terminée.",
+      "completedWithDependencies": "Étape importante et dépendances remplies avec succès."
     },
     "errors": {
       "nameExists": "Un jalon portant ce nom existe déjà.",
@@ -6472,6 +6510,15 @@
       "unsubscribe": "Se désabonner",
       "managePreferences": "Gérer les préférences",
       "allRightsReserved": "Tous droits réservés."
+    },
+    "magicLink": {
+      "subject": "Connectez-vous à TestPlanIt",
+      "heading": "Connectez-vous à TestPlanIt",
+      "intro": "Cliquez sur le bouton ci-dessous pour vous connecter :",
+      "signInButton": "Se connecter",
+      "copyPasteIntro": "Ou copiez et collez ce lien dans votre navigateur :",
+      "disclaimer": "Si vous n'avez pas demandé cet e-mail, vous pouvez l'ignorer sans problème.",
+      "textBody": "Connectez-vous à TestPlanIt\n\nCliquez sur le lien ci-dessous pour vous connecter :\n{url}\n\nSi vous n’avez pas demandé cet e-mail, vous pouvez l’ignorer sans risque."
     }
   },
   "comments": {

--- a/testplanit/server/auth.ts
+++ b/testplanit/server/auth.ts
@@ -228,11 +228,17 @@ async function getDynamicProviders() {
               }) => {
                 // Wrap everything in try-catch to ensure we NEVER throw errors
                 try {
-                  // Check if user exists and is active
+                  // Check if user exists and is active. Pull
+                  // `userPreferences.locale` so the email is rendered
+                  // in the recipient's language; fall back to en_US.
                   const user = await db.user
                     .findUnique({
                       where: { email },
-                      select: { id: true, isActive: true },
+                      select: {
+                        id: true,
+                        isActive: true,
+                        userPreferences: { select: { locale: true } },
+                      },
                     })
                     .catch((err) => {
                       console.error("Database error checking user:", err);
@@ -246,38 +252,16 @@ async function getDynamicProviders() {
                     return Promise.resolve();
                   }
 
-                  // Send the magic link email using nodemailer
-                  const nodemailer = await import("nodemailer");
-                  const transport = nodemailer.createTransport({
-                    host: process.env.EMAIL_SERVER_HOST,
-                    port: Number(process.env.EMAIL_SERVER_PORT),
-                    auth: {
-                      user: process.env.EMAIL_SERVER_USER,
-                      pass: process.env.EMAIL_SERVER_PASSWORD,
-                    },
+                  const { sendMagicLinkEmail } =
+                    await import("~/lib/email/magicLink");
+                  await sendMagicLinkEmail({
+                    to: email,
+                    url,
+                    locale: user.userPreferences?.locale ?? "en_US",
+                  }).catch((err) => {
+                    console.error("Error sending magic link email:", err);
+                    // Swallow error - we don't want to reveal if email was sent or not
                   });
-
-                  await transport
-                    .sendMail({
-                      to: email,
-                      from: process.env.EMAIL_FROM,
-                      subject: "Sign in to TestPlanIt",
-                      text: `Sign in to TestPlanIt\n\nClick the link below to sign in:\n${url}\n\nIf you did not request this email, you can safely ignore it.`,
-                      html: `
-                      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-                        <h2 style="color: #333;">Sign in to TestPlanIt</h2>
-                        <p>Click the button below to sign in:</p>
-                        <a href="${url}" style="display: inline-block; background-color: #7c3aed; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 16px 0;">Sign In</a>
-                        <p style="color: #666; font-size: 14px;">Or copy and paste this link into your browser:</p>
-                        <p style="color: #666; font-size: 14px; word-break: break-all;">${url}</p>
-                        <p style="color: #999; font-size: 12px; margin-top: 32px;">If you did not request this email, you can safely ignore it.</p>
-                      </div>
-                    `,
-                    })
-                    .catch((err) => {
-                      console.error("Error sending magic link email:", err);
-                      // Swallow error - we don't want to reveal if email was sent or not
-                    });
 
                   return Promise.resolve();
                 } catch (error) {


### PR DESCRIPTION
## Description

Closes the remaining i18n gaps users actually see, after the earlier rounds covered notifications, signin SSO buttons, and the upgrade-notification badge.

Three buckets:

1. **Magic-link email body** — both senders (NextAuth's `sendVerificationRequest` hook in `server/auth.ts` and the trial-admin provisioning route) had identical inline English subject/text/HTML. Extracted to `lib/email/magicLink.ts` which renders in the recipient's preferences locale (defaults to en_US) using new `email.magicLink.*` keys.

2. **User-actionable server validation errors** — backward-compatible dual-return pattern: server returns BOTH `errorCode` (i18n key) and `error` (legacy English fallback). New `lib/i18n/translateServerError` helper resolves `errorCode` through next-intl, falling back to `error` for old clients during deploy/rollback. Wired through signup, 2FA enable / verify-sso / enable-required, and webhook outbound name / URL / HTTPS validators.

3. **Zod schema validation messages** — sweep of ~36 hardcoded English strings across 16 form modals. Module-level schemas converted to `buildFormSchema(t)` factories memoized inside the component; in-component schemas use `t()` directly. Files: BulkEditModal, repository case page, AddCase / AddCaseRow / Add+Edit Folder, AddCaseField / AddResultField, milestone modals, Add+Edit Workflow, Add+Edit Roles, Add+Edit Group, EditTemplate, EditMilestoneTypes, AddTestRunModal, EditConfig / EditCategory / EditVariantModal, EditProject.

Plus user-facing success toasts (milestone completion, new test case, repository deleted) and a path-resolution fix in `lib/server-translations.ts` so the loader works under Turbopack (whose `__dirname` rewrite was breaking the magic-link sender at runtime).

Translations for es-ES.json and fr-FR.json synced via `pnpm crowdin:sync`.

## Related Issue

Continuation of the v0.24.x i18n cleanup (notifications i18n was #272).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change which improves code structure)

## Out of Scope (intentionally English by project policy)

- Diagnostic server errors and admin/health endpoint responses — diagnosability (grep / Google / support tickets) beats locale fidelity per the existing project policy
- LLM streaming SSE error messages — `GenerateTestCasesWizard` does substring-based categorization on the English text to pick a localized title; changing this requires a code-based protocol restructuring, better as its own PR
- Shared schemas in `lib/schemas/*` and `app/api/api-tokens` — server-side with English fallback per the same policy. `reportRequestSchema` already carries `params.i18nKey` for client translation

## Testing

- [x] Typecheck clean (`tsc --noEmit`)
- [x] Prettier clean (`pnpm format:check`)
- [x] Unit tests: 6503 pass, 2 skipped
- [x] Updated `webhook-config.test.ts` (3 assertions) and `milestoneActions.test.ts` (1 assertion) for the new return shapes
- [x] New `lib/i18n/translateServerError.test.ts` covers happy-path, missing-key, throwing-translator, no-fallback edge cases
- [x] Crowdin sync round-trip for es-ES.json and fr-FR.json
- [x] Manual spot-checks across fr-FR and es-ES locales: magic-link email, webhook HTTPS validation, test case Zod errors, custom field system-name regex, workflow state already-exists, 2FA verification code, milestone completion toast, folder name required

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to translations (en-US.json + crowdin sync)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
