### PR TITLE
fix(duplicates): exclude source case from creation-time scan and fire toast from inline AddCaseRow

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCaseRow.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCaseRow.tsx
@@ -15,9 +15,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { PlusSquare } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v4";
@@ -57,6 +57,7 @@ interface AddCaseRowProps {
 
 export function AddCaseRow({ folderId }: AddCaseRowProps) {
   const t = useTranslations();
+  const locale = useLocale();
   const { data: session } = useSession();
   const { projectId } = useParams();
   const queryClient = useQueryClient();
@@ -203,6 +204,70 @@ export function AddCaseRow({ folderId }: AddCaseRowProps) {
     return null;
   }
 
+  const checkForDuplicates = async (caseName: string, caseId: number) => {
+    try {
+      const res = await fetch("/api/duplicate-scan/check-new", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: Number(projectId),
+          caseId,
+          name: caseName,
+          tags: [],
+        }),
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.cases && data.cases.length > 0) {
+        const caseLinks = data.cases.map((c: { id: number; name: string }) =>
+          React.createElement(
+            "a",
+            {
+              key: c.id,
+              href: `/${locale}/projects/repository/${projectId}/${c.id}`,
+              target: "_blank",
+              rel: "noopener noreferrer",
+              style: {
+                textDecoration: "underline",
+                display: "block",
+                marginTop: 4,
+              },
+            },
+            c.name
+          )
+        );
+        toast.warning(t("repository.duplicates.duplicateWarning"), {
+          description: React.createElement(
+            "div",
+            null,
+            t("repository.duplicates.duplicateWarningDescription", {
+              count: data.cases.length,
+            }),
+            ...caseLinks,
+            React.createElement(
+              "a",
+              {
+                href: `/${locale}/projects/repository/${projectId}/duplicates`,
+                target: "_blank",
+                rel: "noopener noreferrer",
+                style: {
+                  textDecoration: "underline",
+                  fontWeight: 500,
+                  display: "block",
+                  marginTop: 8,
+                },
+              },
+              t("repository.duplicates.duplicateWarningReview")
+            )
+          ),
+          duration: 15000,
+        });
+      }
+    } catch {
+      // Silently ignore — duplicate check is advisory only
+    }
+  };
+
   async function onSubmit(data: FormValues) {
     setIsSubmitting(true);
     try {
@@ -289,6 +354,8 @@ export function AddCaseRow({ folderId }: AddCaseRowProps) {
         toast.success(t("common.errors.newTestCaseAdded"), {
           position: "bottom-right",
         });
+
+        checkForDuplicates(data.name, newCase.id).catch(() => {});
 
         setIsSubmitting(false);
         setHasSubmitted(true);

--- a/testplanit/app/api/duplicate-scan/check-new/route.test.ts
+++ b/testplanit/app/api/duplicate-scan/check-new/route.test.ts
@@ -63,9 +63,12 @@ function makeRequest(body: Record<string, unknown>): Request {
   });
 }
 
-function makePair(caseBId: number, score = 0.85) {
+function makePair(candidateId: number, score = 0.85, sourceId = 0) {
+  // Canonical ordering: caseAId < caseBId (matches DuplicateScanService)
+  const [caseAId, caseBId] =
+    sourceId < candidateId ? [sourceId, candidateId] : [candidateId, sourceId];
   return {
-    caseAId: 0,
+    caseAId,
     caseBId,
     score,
     confidence: score >= 0.9 ? "HIGH" : score >= 0.8 ? "MEDIUM" : "LOW",
@@ -128,6 +131,67 @@ describe("POST /api/duplicate-scan/check-new", () => {
     expect(data.cases).toEqual([]);
   });
 
+  it("forwards caseId into findSimilarCases so the source case can be excluded", async () => {
+    mockFindSimilarCases.mockResolvedValue([]);
+
+    const { POST } = await import("./route");
+    await POST(
+      makeRequest({
+        projectId: 1,
+        caseId: 98361,
+        name: "New manually added test case",
+        tags: ["regression"],
+      })
+    );
+
+    expect(mockFindSimilarCases).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 98361 }),
+      1,
+      "tenant-1"
+    );
+  });
+
+  it("returns the OTHER side of the pair when caseId matches caseAId (canonical ordering)", async () => {
+    // Source caseId=50 is the lower ID, so canonical ordering puts it in caseAId.
+    // Candidate is caseBId=100. Route must return 100, not 50.
+    const sourceId = 50;
+    mockFindSimilarCases.mockResolvedValue([
+      makePair(100, 0.92, sourceId),
+      makePair(200, 0.85, sourceId),
+    ]);
+    mockFindMany.mockResolvedValue([
+      { id: 100, name: "Candidate One" },
+      { id: 200, name: "Candidate Two" },
+    ]);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({ projectId: 1, caseId: sourceId, name: "Test" })
+    );
+    const data = await res.json();
+
+    expect(data.cases).toHaveLength(2);
+    expect(data.cases.map((c: { id: number }) => c.id)).toEqual([100, 200]);
+    // Regression guard: must never echo the source case back as a candidate
+    expect(data.cases.map((c: { id: number }) => c.id)).not.toContain(sourceId);
+  });
+
+  it("returns the OTHER side of the pair when caseId matches caseBId", async () => {
+    // Source caseId=500 is the higher ID, so canonical ordering puts it in caseBId.
+    const sourceId = 500;
+    mockFindSimilarCases.mockResolvedValue([makePair(10, 0.9, sourceId)]);
+    mockFindMany.mockResolvedValue([{ id: 10, name: "Candidate" }]);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({ projectId: 1, caseId: sourceId, name: "Test" })
+    );
+    const data = await res.json();
+
+    expect(data.cases).toHaveLength(1);
+    expect(data.cases[0].id).toBe(10);
+  });
+
   it("returns top 3 candidates with names, scores, and matchedFields", async () => {
     mockFindSimilarCases.mockResolvedValue([
       makePair(10, 0.95),
@@ -181,8 +245,8 @@ describe("POST /api/duplicate-scan/check-new", () => {
 
     it("creates DuplicateScanResult records when caseId is provided", async () => {
       mockFindSimilarCases.mockResolvedValue([
-        makePair(10, 0.92),
-        makePair(20, 0.85),
+        makePair(10, 0.92, 99),
+        makePair(20, 0.85, 99),
       ]);
       mockFindMany.mockResolvedValue([
         { id: 10, name: "Login Test" },
@@ -208,7 +272,7 @@ describe("POST /api/duplicate-scan/check-new", () => {
 
     it("uses canonical ordering (lowId, highId) for caseAId and caseBId", async () => {
       // caseId=99, candidateId=10 → lowId=10, highId=99
-      mockFindSimilarCases.mockResolvedValue([makePair(10, 0.9)]);
+      mockFindSimilarCases.mockResolvedValue([makePair(10, 0.9, 99)]);
       mockFindMany.mockResolvedValue([{ id: 10, name: "Login Test" }]);
 
       const { POST } = await import("./route");
@@ -244,7 +308,7 @@ describe("POST /api/duplicate-scan/check-new", () => {
 
     it("uses canonical ordering when caseId is lower than candidateId", async () => {
       // caseId=5, candidateId=100 → lowId=5, highId=100
-      mockFindSimilarCases.mockResolvedValue([makePair(100, 0.88)]);
+      mockFindSimilarCases.mockResolvedValue([makePair(100, 0.88, 5)]);
       mockFindMany.mockResolvedValue([{ id: 100, name: "Some Test" }]);
 
       const { POST } = await import("./route");
@@ -264,7 +328,7 @@ describe("POST /api/duplicate-scan/check-new", () => {
     });
 
     it("still returns cases even if persistence fails", async () => {
-      mockFindSimilarCases.mockResolvedValue([makePair(10, 0.9)]);
+      mockFindSimilarCases.mockResolvedValue([makePair(10, 0.9, 50)]);
       mockFindMany.mockResolvedValue([{ id: 10, name: "Login Test" }]);
       mockUpsert.mockRejectedValue(new Error("DB connection failed"));
 
@@ -298,9 +362,9 @@ describe("POST /api/duplicate-scan/check-new", () => {
 
     it("persists each candidate with its own score from the similarity engine", async () => {
       mockFindSimilarCases.mockResolvedValue([
-        makePair(10, 0.95),
-        makePair(20, 0.82),
-        makePair(30, 0.71),
+        makePair(10, 0.95, 50),
+        makePair(20, 0.82, 50),
+        makePair(30, 0.71, 50),
       ]);
       mockFindMany.mockResolvedValue([
         { id: 10, name: "A" },

--- a/testplanit/app/api/duplicate-scan/check-new/route.ts
+++ b/testplanit/app/api/duplicate-scan/check-new/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
 
     const service = new DuplicateScanService(prisma, esClient);
     const pairs = await service.findSimilarCases(
-      { name, tags: tags?.map((t) => ({ name: t })) },
+      { id: caseId, name, tags: tags?.map((t) => ({ name: t })) },
       projectId,
       tenantId
     );
@@ -55,10 +55,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ cases: [] });
     }
 
-    // The new case has no id, so DuplicateScanService sets caseAId=0 and caseBId=candidate.id
-    // Collect the candidate IDs (caseBId when caseAId is 0)
     const caseIds = top3.map((pair) =>
-      pair.caseAId === 0 ? pair.caseBId : pair.caseAId
+      pair.caseAId === (caseId ?? 0) ? pair.caseBId : pair.caseAId
     );
 
     const caseRecords = await prisma.repositoryCases.findMany({
@@ -69,7 +67,8 @@ export async function POST(request: Request) {
     const caseNameMap = new Map(caseRecords.map((c) => [c.id, c.name]));
 
     const cases = top3.map((pair) => {
-      const candidateId = pair.caseAId === 0 ? pair.caseBId : pair.caseAId;
+      const candidateId =
+        pair.caseAId === (caseId ?? 0) ? pair.caseBId : pair.caseAId;
       return {
         id: candidateId,
         name: caseNameMap.get(candidateId) ?? "",


### PR DESCRIPTION
## Description

Two related bugs in creation-time duplicate detection:

1. **Self-match in the comparison dialog.** `/api/duplicate-scan/check-new` accepted `caseId` from the client but never forwarded it to `findSimilarCases`, so the just-created case was not excluded from its own search. Elasticsearch returned the new case as a candidate, the route echoed it back, and the comparison dialog loaded both Case A and Case B from the same ID — showing a case as a duplicate of itself.

   Fix: pass `id: caseId` into the service so the existing exclusion check fires, and pick the non-source side of each pair via `pair.caseAId === (caseId ?? 0) ? pair.caseBId : pair.caseAId`.

2. **Inline `AddCaseRow` never triggered the duplicate check.** The full Add Case dialog calls `/api/duplicate-scan/check-new` after creation and surfaces a toast, but the inline row used in the repository view did not. Mirrored the toast logic from `AddCase.tsx` so both creation paths behave consistently.

### Why tests missed bug #1

The existing `makePair` test helper hardcoded `caseAId: 0` — the shape `findSimilarCases` returns only when no source ID is supplied. Persistence tests passed `caseId: 99` to the route but fed it pairs that pretended no source existed, never exercising the canonical-ordering branch where the source ID lands in `caseAId` or `caseBId`.

`makePair` now takes a `sourceId` parameter and applies real canonical ordering. New tests assert `caseId` is forwarded to `findSimilarCases` and that the response never echoes the source ID back as a candidate.

## Related Issue

N/A — reported during manual QA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests (3 new tests in `route.test.ts`, all 6,512 unit tests pass)
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing (reproduced the self-match on the comparison dialog before the fix; confirmed inline row had no toast before)

**Test Configuration:**
- OS: macOS (Darwin 25.4.0)
- Browser: Chrome
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The toast logic now lives in two places (`AddCase.tsx` and `AddCaseRow.tsx`). A third caller — `ImportCasesWizard.tsx` — uses the same endpoint with different UX (inline pre-import warnings, not a toast). Extracting a shared `lib/utils/duplicateCaseToast.tsx` helper for the two toast call sites is a reasonable follow-up but felt out of scope for the bug fix.
