### PR TITLE
fix(i18n): localize tiptap rich-text toolbar tooltips

### DIFF
--- a/testplanit/components/tiptap/menus/TextMenu/TextMenu.tsx
+++ b/testplanit/components/tiptap/menus/TextMenu/TextMenu.tsx
@@ -5,6 +5,7 @@ import { Toolbar } from "@/components/tiptap/ui/Toolbar";
 import * as Popover from "@radix-ui/react-popover";
 import { Editor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
+import { useTranslations } from "next-intl";
 import { memo } from "react";
 import { ContentTypePicker } from "./components/ContentTypePicker";
 import { EditLinkPopover } from "./components/EditLinkPopover";
@@ -30,6 +31,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
   const commands = useTextmenuCommands(editor);
   const states = useTextmenuStates(editor);
   const blockOptions = useTextmenuContentTypes(editor);
+  const t = useTranslations("common.editor.textMenu");
 
   return (
     <BubbleMenu
@@ -51,7 +53,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
         />
         <Toolbar.Divider />
         <MemoButton
-          tooltip="Bold"
+          tooltip={t("bold")}
           tooltipShortcut={["Mod", "B"]}
           onClick={commands.onBold}
           active={states.isBold}
@@ -59,7 +61,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
           <Icon name="Bold" />
         </MemoButton>
         <MemoButton
-          tooltip="Italic"
+          tooltip={t("italic")}
           tooltipShortcut={["Mod", "I"]}
           onClick={commands.onItalic}
           active={states.isItalic}
@@ -67,7 +69,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
           <Icon name="Italic" />
         </MemoButton>
         <MemoButton
-          tooltip="Underline"
+          tooltip={t("underline")}
           tooltipShortcut={["Mod", "U"]}
           onClick={commands.onUnderline}
           active={states.isUnderline}
@@ -75,7 +77,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
           <Icon name="Underline" />
         </MemoButton>
         <MemoButton
-          tooltip="Strikehrough"
+          tooltip={t("strikethrough")}
           tooltipShortcut={["Mod", "Shift", "S"]}
           onClick={commands.onStrike}
           active={states.isStrike}
@@ -83,14 +85,14 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
           <Icon name="Strikethrough" />
         </MemoButton>
         <MemoButton
-          tooltip="Code"
+          tooltip={t("code")}
           tooltipShortcut={["Mod", "E"]}
           onClick={commands.onCode}
           active={states.isCode}
         >
           <Icon name="Code" />
         </MemoButton>
-        <MemoButton tooltip="Code block" onClick={commands.onCodeBlock}>
+        <MemoButton tooltip={t("codeBlock")} onClick={commands.onCodeBlock}>
           <Icon name="Code" />
         </MemoButton>
         <EditLinkPopover onSetLink={commands.onLink} />
@@ -98,7 +100,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
           <Popover.Trigger asChild>
             <MemoButton
               active={!!states.currentHighlight}
-              tooltip="Highlight text"
+              tooltip={t("highlightText")}
             >
               <Icon name="Highlighter" />
             </MemoButton>
@@ -120,7 +122,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
         </Popover.Root>
         <Popover.Root>
           <Popover.Trigger asChild>
-            <MemoButton active={!!states.currentColor} tooltip="Text color">
+            <MemoButton active={!!states.currentColor} tooltip={t("textColor")}>
               <Icon name="Palette" />
             </MemoButton>
           </Popover.Trigger>
@@ -141,14 +143,14 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
         </Popover.Root>
         <Popover.Root>
           <Popover.Trigger asChild>
-            <MemoButton tooltip="More options">
+            <MemoButton tooltip={t("moreOptions")}>
               <Icon name="EllipsisVertical" />
             </MemoButton>
           </Popover.Trigger>
           <Popover.Content side="top" asChild>
             <Toolbar.Wrapper>
               <MemoButton
-                tooltip="Subscript"
+                tooltip={t("subscript")}
                 tooltipShortcut={["Mod", "."]}
                 onClick={commands.onSubscript}
                 active={states.isSubscript}
@@ -156,7 +158,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
                 <Icon name="Subscript" />
               </MemoButton>
               <MemoButton
-                tooltip="Superscript"
+                tooltip={t("superscript")}
                 tooltipShortcut={["Mod", ","]}
                 onClick={commands.onSuperscript}
                 active={states.isSuperscript}
@@ -165,7 +167,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
               </MemoButton>
               <Toolbar.Divider />
               <MemoButton
-                tooltip="Align left"
+                tooltip={t("alignLeft")}
                 tooltipShortcut={["Shift", "Mod", "L"]}
                 onClick={commands.onAlignLeft}
                 active={states.isAlignLeft}
@@ -173,7 +175,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
                 <Icon name="TextAlignStart" />
               </MemoButton>
               <MemoButton
-                tooltip="Align center"
+                tooltip={t("alignCenter")}
                 tooltipShortcut={["Shift", "Mod", "E"]}
                 onClick={commands.onAlignCenter}
                 active={states.isAlignCenter}
@@ -181,7 +183,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
                 <Icon name="TextAlignCenter" />
               </MemoButton>
               <MemoButton
-                tooltip="Align right"
+                tooltip={t("alignRight")}
                 tooltipShortcut={["Shift", "Mod", "R"]}
                 onClick={commands.onAlignRight}
                 active={states.isAlignRight}
@@ -189,7 +191,7 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
                 <Icon name="TextAlignEnd" />
               </MemoButton>
               <MemoButton
-                tooltip="Justify"
+                tooltip={t("justify")}
                 tooltipShortcut={["Shift", "Mod", "J"]}
                 onClick={commands.onAlignJustify}
                 active={states.isAlignJustify}

--- a/testplanit/components/tiptap/menus/TextMenu/components/EditLinkPopover.tsx
+++ b/testplanit/components/tiptap/menus/TextMenu/components/EditLinkPopover.tsx
@@ -2,16 +2,18 @@ import { LinkEditorPanel } from "@/components/tiptap/panels";
 import { Icon } from "@/components/tiptap/ui/Icon";
 import { Toolbar } from "@/components/tiptap/ui/Toolbar";
 import * as Popover from "@radix-ui/react-popover";
+import { useTranslations } from "next-intl";
 
 export type EditLinkPopoverProps = {
   onSetLink: (link: string, openInNewTab?: boolean) => void;
 };
 
 export const EditLinkPopover = ({ onSetLink }: EditLinkPopoverProps) => {
+  const t = useTranslations("common.editor.textMenu");
   return (
     <Popover.Root>
       <Popover.Trigger asChild>
-        <Toolbar.Button tooltip="Set Link">
+        <Toolbar.Button tooltip={t("setLink")}>
           <Icon name="Link" />
         </Toolbar.Button>
       </Popover.Trigger>

--- a/testplanit/components/tiptap/panels/Colorpicker/Colorpicker.tsx
+++ b/testplanit/components/tiptap/panels/Colorpicker/Colorpicker.tsx
@@ -1,4 +1,5 @@
 import { themeColors } from "@/constants";
+import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { HexColorPicker } from "react-colorful";
 import { Icon } from "../../ui/Icon";
@@ -12,6 +13,7 @@ export type ColorPickerProps = {
 };
 
 export const ColorPicker = ({ color, onChange, onClear }: ColorPickerProps) => {
+  const t = useTranslations("common.editor.textMenu");
   const [colorInputValue, setColorInputValue] = useState(color || "");
 
   const handleColorUpdate = useCallback(
@@ -61,7 +63,7 @@ export const ColorPicker = ({ color, onChange, onClear }: ColorPickerProps) => {
             onColorChange={onChange}
           />
         ))}
-        <Toolbar.Button tooltip="Reset color to default" onClick={onClear}>
+        <Toolbar.Button tooltip={t("resetColorToDefault")} onClick={onClear}>
           <Icon name="Undo" />
         </Toolbar.Button>
       </div>

--- a/testplanit/components/tiptap/panels/LinkPreviewPanel/LinkPreviewPanel.tsx
+++ b/testplanit/components/tiptap/panels/LinkPreviewPanel/LinkPreviewPanel.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@/components/tiptap/ui/Icon";
 import { Surface } from "@/components/tiptap/ui/Surface";
 import { Toolbar } from "@/components/tiptap/ui/Toolbar";
 import Tooltip from "@/components/tiptap/ui/Tooltip";
+import { useTranslations } from "next-intl";
 
 export type LinkPreviewPanelProps = {
   url: string;
@@ -14,6 +15,7 @@ export const LinkPreviewPanel = ({
   onEdit,
   url,
 }: LinkPreviewPanelProps) => {
+  const t = useTranslations("common.editor.textMenu");
   return (
     <Surface className="flex items-center gap-2 p-2">
       <a
@@ -25,12 +27,12 @@ export const LinkPreviewPanel = ({
         {url}
       </a>
       <Toolbar.Divider />
-      <Tooltip title="Edit link">
+      <Tooltip title={t("editLink")}>
         <Toolbar.Button onClick={onEdit}>
           <Icon name="Pen" />
         </Toolbar.Button>
       </Tooltip>
-      <Tooltip title="Remove link">
+      <Tooltip title={t("removeLink")}>
         <Toolbar.Button onClick={onClear}>
           <Icon name="Trash2" />
         </Toolbar.Button>

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -830,6 +830,27 @@
         "addParagraphBelow": "Add paragraph below",
         "clearFormatting": "Clear formatting",
         "copyToClipboard": "Copy to clipboard"
+      },
+      "textMenu": {
+        "bold": "Bold",
+        "italic": "Italic",
+        "underline": "Underline",
+        "strikethrough": "Strikethrough",
+        "code": "Code",
+        "codeBlock": "Code block",
+        "highlightText": "Highlight text",
+        "textColor": "Text color",
+        "moreOptions": "More options",
+        "subscript": "Subscript",
+        "superscript": "Superscript",
+        "alignLeft": "Align left",
+        "alignCenter": "Align center",
+        "alignRight": "Align right",
+        "justify": "Justify",
+        "setLink": "Set Link",
+        "editLink": "Edit link",
+        "removeLink": "Remove link",
+        "resetColorToDefault": "Reset color to default"
       }
     },
     "ai": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -830,6 +830,27 @@
         "addParagraphBelow": "Añadir párrafo a continuación",
         "clearFormatting": "Borrar formato",
         "copyToClipboard": "Copiar al portapapeles"
+      },
+      "textMenu": {
+        "bold": "Atrevido",
+        "italic": "Itálico",
+        "underline": "Subrayar",
+        "strikethrough": "Tachado",
+        "code": "Código",
+        "codeBlock": "Bloque de código",
+        "highlightText": "Resaltar texto",
+        "textColor": "Color del texto",
+        "moreOptions": "Más opciones",
+        "subscript": "Subíndice",
+        "superscript": "Sobrescrito",
+        "alignLeft": "Alinear a la izquierda",
+        "alignCenter": "Alinear al centro",
+        "alignRight": "Alinear a la derecha",
+        "justify": "Justificar",
+        "setLink": "Establecer enlace",
+        "editLink": "Editar enlace",
+        "removeLink": "Eliminar enlace",
+        "resetColorToDefault": "Restablecer el color a los valores predeterminados"
       }
     },
     "ai": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -830,6 +830,27 @@
         "addParagraphBelow": "Ajoutez un paragraphe ci-dessous",
         "clearFormatting": "Mise en forme claire",
         "copyToClipboard": "Copier dans le presse-papiers"
+      },
+      "textMenu": {
+        "bold": "Audacieux",
+        "italic": "Italique",
+        "underline": "Souligner",
+        "strikethrough": "barré",
+        "code": "Code",
+        "codeBlock": "Bloc de code",
+        "highlightText": "Surligner le texte",
+        "textColor": "Couleur du texte",
+        "moreOptions": "Plus d'options",
+        "subscript": "Indice",
+        "superscript": "Exposant",
+        "alignLeft": "Aligner à gauche",
+        "alignCenter": "Centre d'alignement",
+        "alignRight": "Alignez à droite",
+        "justify": "Justifier",
+        "setLink": "Définir le lien",
+        "editLink": "Modifier le lien",
+        "removeLink": "Supprimer le lien",
+        "resetColorToDefault": "Réinitialiser la couleur par défaut"
       }
     },
     "ai": {


### PR DESCRIPTION
## Description

Sweeps the ~19 hardcoded English tooltips in the tiptap rich-text editor that the earlier i18n PRs deferred. Self-contained, all under `components/tiptap/`. New keys live in `common.editor.textMenu.*`.

- **TextMenu.tsx** — 14 button tooltips: Bold, Italic, Underline, Strikethrough, Code, Code block, Highlight text, Text color, More options, Subscript, Superscript, Align left/center/right, Justify. Also fixes a pre-existing **"Strikehrough"** typo → "Strikethrough" — the visible label was always meant to be the standard spelling.
- **EditLinkPopover.tsx** — "Set Link"
- **LinkPreviewPanel.tsx** — "Edit link", "Remove link"
- **Colorpicker.tsx** — "Reset color to default"

Each component reads `useTranslations("common.editor.textMenu")`.

## Related Issue

Continuation of the v0.24.x i18n cleanup (last PR was #275 covering React stragglers + LLM error codes).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change which improves code structure)

## Out of Scope

- **`title="Video controls"` on the Tiptap video extension** (`components/tiptap/video.ts`) — runs in the schema's `renderHTML` outside React, so plumbing a translator there is non-trivial. Low impact (browser tooltip on the video element); revisit if needed.
- **`handleAiPrompt("translate", "English"|"Spanish"|"French")` arguments in TipTapEditor.tsx** — these are LLM-prompt API parameters, not UI labels, and stay English by design.

## Testing

- [x] Typecheck clean (`tsc --noEmit`)
- [x] Prettier clean (`pnpm format:check`)
- [x] Unit tests: 6531 pass, 2 skipped
- [x] `pnpm precommit` green (lint + format:check + test)
- [x] Crowdin sync round-trip for es-ES.json and fr-FR.json

## Spot-check guide

Switch locale: User Menu → Settings → User Preferences → Language → save → refresh.

- Open any test case detail or session detail → focus inside the rich-text editor → select some text → the floating bubble menu appears at the top with the formatting toolbar. Hover each button — the tooltip should be in the active locale.
- Hit the "..." (More options) button to see Subscript/Superscript/Align/Justify tooltips.
- Click the link button (Set Link), set a link, then hover the resulting link preview — Edit/Remove tooltips should be localized.
- Click the text-color or highlight button → in the popover, hover the "reset" Undo button at the end of the swatches.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to translations (en-US.json + crowdin sync)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass locally
