### PR TITLE
fix(tiptap): drop pseudo-element backticks; remove bounded-height/expand wrappers

### DIFF
--- a/testplanit/app/[locale]/admin/notifications/columns.tsx
+++ b/testplanit/app/[locale]/admin/notifications/columns.tsx
@@ -109,8 +109,6 @@ export const getColumns = (
                 jsonString={JSON.stringify(richContent)}
                 format="html"
                 room={`notification-history-${isPreview ? "preview" : "full"}-${notification.id}`}
-                expand={!isPreview}
-                expandable={false}
               />
             </div>
           );

--- a/testplanit/app/[locale]/projects/milestones/[projectId]/MilestoneItemCard.tsx
+++ b/testplanit/app/[locale]/projects/milestones/[projectId]/MilestoneItemCard.tsx
@@ -158,7 +158,6 @@ const MilestoneItemCard: React.FC<MilestoneItemCardProps> = ({
                 jsonString={milestone.note as string}
                 format="text"
                 room={`milestone-note-${milestone.id}`}
-                expand={false}
               />
             </p>
             <div className={`${compact ? "hidden" : "hidden sm:block"} ml-7`}>

--- a/testplanit/app/[locale]/projects/milestones/[projectId]/[milestoneId]/MilestoneFormControls.tsx
+++ b/testplanit/app/[locale]/projects/milestones/[projectId]/[milestoneId]/MilestoneFormControls.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { MoreHorizontal } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import React, { useEffect, useMemo, useRef, useState } from "react";
@@ -374,45 +373,21 @@ export default function MilestoneFormControls({
             (milestone?.note &&
               milestone?.note !== JSON.stringify(emptyEditorContent)) ? (
               <FormControl>
-                <div
-                  className={`relative group ${
-                    !isEditMode
-                      ? "max-h-[4em] overflow-hidden hover:max-h-none hover:overflow-visible hover:z-10"
-                      : ""
-                  }`}
-                >
-                  {!isEditMode && (
-                    <>
-                      <div className="absolute group-hover:hidden" />
-                      <MoreHorizontal className="absolute right-0 bottom-0 h-4 w-4 bg-primary-foreground shrink-0 text-muted-foreground group-hover:hidden z-50" />
-                    </>
-                  )}
-                  <div
-                    className={`${
-                      !isEditMode
-                        ? "group-hover:rounded-md group-hover:p-0 group-hover:bg-background"
-                        : ""
-                    }`}
-                  >
-                    <TipTapEditor
-                      key={`editing-note-${isEditMode}`}
-                      content={
-                        field.value
-                          ? JSON.parse(field.value)
-                          : emptyEditorContent
-                      }
-                      onUpdate={(newContent) => {
-                        if (isEditMode) {
-                          field.onChange(JSON.stringify(newContent));
-                        }
-                      }}
-                      readOnly={!isEditMode}
-                      className="h-auto"
-                      placeholder={t("placeholders.description")}
-                      projectId={projectId}
-                    />
-                  </div>
-                </div>
+                <TipTapEditor
+                  key={`editing-note-${isEditMode}`}
+                  content={
+                    field.value ? JSON.parse(field.value) : emptyEditorContent
+                  }
+                  onUpdate={(newContent) => {
+                    if (isEditMode) {
+                      field.onChange(JSON.stringify(newContent));
+                    }
+                  }}
+                  readOnly={!isEditMode}
+                  className="h-auto"
+                  placeholder={t("placeholders.description")}
+                  projectId={projectId}
+                />
               </FormControl>
             ) : (
               <div className="text-muted-foreground text-sm">

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.tsx
@@ -547,7 +547,7 @@ const FieldValueRenderer: React.FC<FieldValueRendererProps> = ({
                 content={content}
                 projectId={projectId?.toString()}
                 readOnly
-                className="max-h-[100px] overflow-auto hover:max-h-fit"
+                className="h-auto"
               />
             );
           })
@@ -567,7 +567,7 @@ const FieldValueRenderer: React.FC<FieldValueRendererProps> = ({
                 content={content}
                 projectId={projectId?.toString()}
                 readOnly
-                className="max-h-[100px] overflow-auto hover:max-h-fit"
+                className="h-auto"
               />
             );
           })()

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/StepsDisplay.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/StepsDisplay.tsx
@@ -1,19 +1,7 @@
 import TextFromJson from "@/components/TextFromJson";
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-  ChevronRightCircle,
-  Layers,
-  Minus,
-  Plus,
-  SearchCheck,
-} from "lucide-react";
+import { Layers, Minus, Plus, SearchCheck } from "lucide-react";
 import { useTranslations } from "next-intl";
-import React, { useState } from "react";
+import React from "react";
 import { emptyEditorContent } from "~/app/constants";
 import { useFindManySharedStepItem } from "~/lib/hooks";
 
@@ -38,13 +26,11 @@ interface StepsProps {
 interface RenderSharedGroupItemsProps {
   sharedStepGroupId: number;
   sharedStepGroupName: string;
-  expandAll: boolean;
 }
 
 const RenderSharedGroupItems: React.FC<RenderSharedGroupItemsProps> = ({
   sharedStepGroupId,
   sharedStepGroupName: _sharedStepGroupName,
-  expandAll,
 }) => {
   const t_steps = useTranslations("repository.steps");
 
@@ -117,7 +103,6 @@ const RenderSharedGroupItems: React.FC<RenderSharedGroupItemsProps> = ({
                   item.step,
                   undefined,
                   `shared-${sharedStepGroupId}-item-${item.id || itemIndex}-step`,
-                  expandAll,
                   false
                 )}
               </div>
@@ -129,7 +114,6 @@ const RenderSharedGroupItems: React.FC<RenderSharedGroupItemsProps> = ({
                   item.expectedResult,
                   undefined,
                   `shared-${sharedStepGroupId}-item-${item.id || itemIndex}-expected`,
-                  expandAll,
                   false
                 )}
               </div>
@@ -145,7 +129,6 @@ const renderFieldValue = (
   fieldValue: any,
   previousFieldValue: any | undefined,
   key: string,
-  expand: boolean,
   showDiff: boolean
 ) => {
   // Ensure we have a valid JSON string for the TipTapEditor
@@ -216,7 +199,6 @@ const renderFieldValue = (
           jsonString={fieldValueString}
           room={key}
           format="html"
-          expand={expand}
         />
       </div>
     );
@@ -235,7 +217,6 @@ const renderFieldValue = (
             jsonString={fieldValueString}
             room={key}
             format="html"
-            expand={expand}
           />
         </span>
       </div>
@@ -262,7 +243,6 @@ const renderFieldValue = (
               jsonString={previousFieldValueString}
               room={"prev" + key}
               format="html"
-              expand={expand}
             />
           </span>
         </div>
@@ -277,7 +257,6 @@ const renderFieldValue = (
               jsonString={fieldValueString}
               room={key}
               format="html"
-              expand={expand}
             />
           </span>
         </div>
@@ -291,7 +270,6 @@ const renderFieldValue = (
           jsonString={fieldValueString}
           room={key}
           format="html"
-          expand={expand}
         />
       </div>
     );
@@ -302,7 +280,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
   steps,
   previousSteps,
 }) => {
-  const [expandAll, setExpandAll] = useState(false);
   const t_repo_steps = useTranslations("repository.steps");
   const tGlobal = useTranslations();
 
@@ -315,38 +292,7 @@ export const StepsDisplay: React.FC<StepsProps> = ({
   return (
     <div data-testid="steps-display">
       <div className="flex items-center">
-        <div className="font-bold">{tGlobal("common.fields.steps")}</div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setExpandAll(!expandAll);
-                return false;
-              }}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                return false;
-              }}
-            >
-              <ChevronRightCircle
-                className={`h-4 w-4 shrink-0 transition-transform ${
-                  expandAll ? "rotate-90" : ""
-                }`}
-              />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <div>
-              {expandAll ? t_repo_steps("collapse") : t_repo_steps("expand")}
-            </div>
-          </TooltipContent>
-        </Tooltip>
+        <div className="font-bold pb-2">{tGlobal("common.fields.steps")}</div>
       </div>
       {steps.length > 0 && (
         <ol className="ml-1 mr-6 min-w-[200px]">
@@ -401,7 +347,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
                           step.sharedStepGroupName ||
                           "Shared Steps"
                         }
-                        expandAll={expandAll}
                       />
                     </div>
                   </div>
@@ -432,7 +377,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
                         step.step || "",
                         previousStep ? previousStep.step || "" : undefined,
                         step.id.toString(),
-                        expandAll,
                         showDiff
                       )}
                     </div>
@@ -449,7 +393,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
                           ? previousStep.expectedResult || ""
                           : undefined,
                         step.id.toString() + "-expected",
-                        expandAll,
                         showDiff
                       )}
                     </div>
@@ -522,7 +465,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
                             jsonString={ensureValidJsonString(step.step)}
                             room={"prev" + step.id.toString()}
                             format="html"
-                            expand={expandAll}
                           />
                         </span>
                       </div>
@@ -542,7 +484,6 @@ export const StepsDisplay: React.FC<StepsProps> = ({
                             )}
                             room={"prev" + step.id.toString() + "-expected"}
                             format="html"
-                            expand={expandAll}
                           />
                         </span>
                       </div>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
@@ -1610,16 +1610,12 @@ export const getColumns = (
                       jsonString={value}
                       room={row.original.id.toString()}
                       format="html"
-                      expand={true}
-                      expandable={false}
                     />
                   ) : (
                     <PlainTextFromJson
                       jsonString={JSON.stringify(value).toString()}
                       room={row.original.id.toString()}
                       format="html"
-                      expand={true}
-                      expandable={false}
                     />
                   )}
                 </div>

--- a/testplanit/app/[locale]/projects/runs/[projectId]/TestRunItem.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/TestRunItem.tsx
@@ -294,7 +294,6 @@ const TestRunItem: React.FC<TestRunItemProps> = ({
                   jsonString={testRun.note}
                   format="text"
                   room={`testrun-note-${testRun.id}`}
-                  expand={false}
                 />
               )}
             </div>

--- a/testplanit/app/[locale]/projects/sessions/[projectId]/SessionItem.tsx
+++ b/testplanit/app/[locale]/projects/sessions/[projectId]/SessionItem.tsx
@@ -170,7 +170,6 @@ const SessionItem: React.FC<SessionItemProps> = ({
                 jsonString={testSession.note as string}
                 format="text"
                 room={`session-note-${testSession.id}`}
-                expand={false}
               />
             )}
           </div>

--- a/testplanit/components/AttachmentsDisplay.tsx
+++ b/testplanit/components/AttachmentsDisplay.tsx
@@ -340,7 +340,7 @@ export const AttachmentsDisplay: React.FC<AttachmentsProps> = ({
                             )}
                           />
                         ) : (
-                          <div className="w-full min-h-10 max-h-10 overflow-y-auto hover:max-h-24">
+                          <div className="w-full">
                             {displayValues.note || t("common.access.none")}
                           </div>
                         )}

--- a/testplanit/components/NotificationContent.tsx
+++ b/testplanit/components/NotificationContent.tsx
@@ -565,7 +565,6 @@ export function NotificationContent({
                 jsonString={JSON.stringify(notification.data.richContent)}
                 format="html"
                 room="notification"
-                expand={false}
               />
             </div>
           ) : (

--- a/testplanit/components/TestResultHistory.tsx
+++ b/testplanit/components/TestResultHistory.tsx
@@ -1559,7 +1559,7 @@ export default function TestResultHistory({
                                             ? String(projectId)
                                             : undefined
                                         }
-                                        className="max-h-[100px] overflow-auto hover:max-h-fit"
+                                        className="h-auto"
                                       />
                                     </div>
                                   </div>
@@ -1570,7 +1570,7 @@ export default function TestResultHistory({
                                     <div className="text-xs text-muted-foreground">
                                       {tCommon("fields.notes")}
                                     </div>
-                                    <pre className="whitespace-pre-wrap wrap-break-word bg-background border rounded p-2 mt-1 max-h-[100px] overflow-auto hover:max-h-fit text-sm">
+                                    <pre className="whitespace-pre-wrap wrap-break-word bg-background border rounded p-2 mt-1 text-sm">
                                       {result.content}
                                     </pre>
                                   </div>

--- a/testplanit/components/TextFromJson.tsx
+++ b/testplanit/components/TextFromJson.tsx
@@ -1,120 +1,39 @@
 import TipTapEditor from "@/components/tiptap/TipTapEditor";
-import { Button } from "@/components/ui/button";
-import { ChevronDownCircle } from "lucide-react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { extractTextFromNode } from "~/utils/extractTextFromJson";
 
 interface TextFromJsonProps {
   jsonString: string | object;
   format?: "text" | "html";
   room: string;
-  expand?: boolean;
-  expandable?: boolean;
 }
 
 const TextFromJson: React.FC<TextFromJsonProps> = ({
   jsonString: jsonStringProp,
   format = "text",
   room,
-  expand = false,
-  expandable = true,
 }) => {
-  // Normalize input: if an object is passed instead of a string, stringify it
   const jsonString =
     typeof jsonStringProp === "string"
       ? jsonStringProp
       : JSON.stringify(jsonStringProp);
   const [plainText, setPlainText] = useState("");
-  const [isOpen, setIsOpen] = useState(expand);
-  const [showButton, setShowButton] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (format !== "text") return;
     try {
-      if (format === "text") {
-        const jsonContent = JSON.parse(jsonString);
-        const text = extractTextFromNode(jsonContent);
-        setPlainText(text);
-      } else {
-        setPlainText(jsonString);
-      }
+      const jsonContent = JSON.parse(jsonString);
+      setPlainText(extractTextFromNode(jsonContent));
     } catch {
       setPlainText(jsonString);
     }
   }, [jsonString, format]);
 
-  useEffect(() => {
-    const checkHeight = () => {
-      if (contentRef.current) {
-        // Check if there's actual overflow by comparing scrollHeight with clientHeight
-        const hasOverflow =
-          contentRef.current.scrollHeight > contentRef.current.clientHeight;
-        setShowButton(expandable && hasOverflow);
-      }
-    };
+  if (format === "text") {
+    return <span>{plainText}</span>;
+  }
 
-    // Check immediately after render
-    const timeoutId = setTimeout(checkHeight, 0);
-
-    // Watch for content changes (DOM mutations)
-    const mutationObserver = new MutationObserver(checkHeight);
-
-    // Watch for size changes (container width/height changes)
-    const resizeObserver = new ResizeObserver(checkHeight);
-
-    if (contentRef.current) {
-      mutationObserver.observe(contentRef.current, {
-        childList: true,
-        subtree: true,
-      });
-      resizeObserver.observe(contentRef.current);
-    }
-
-    return () => {
-      clearTimeout(timeoutId);
-      mutationObserver.disconnect();
-      resizeObserver.disconnect();
-    };
-  }, [plainText, expandable]);
-
-  useEffect(() => {
-    setIsOpen(expand);
-  }, [expand]);
-
-  return format === "text" ? (
-    <span>{plainText}</span>
-  ) : (
-    <div>
-      <div className="flex items-start">
-        <div
-          ref={contentRef}
-          className={`overflow-hidden transition-max-height duration-500 ease-in-out ${
-            isOpen ? "" : "max-h-[75px]"
-          }`}
-        >
-          <TipTapEditorWrapper jsonString={jsonString} room={room} />
-        </div>
-      </div>
-      {showButton && (
-        <div className="flex whitespace-nowrap items-center mt-2">
-          <div className="border-t-2 border-double border-primary w-1/2" />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            <ChevronDownCircle
-              className={`text-primary/50 h-5 w-5 shrink-0 transition-transform ${
-                isOpen ? "rotate-180" : ""
-              }`}
-            />
-          </Button>
-          <div className="border-t-2 border-double border-primary w-1/2" />
-        </div>
-      )}
-    </div>
-  );
+  return <TipTapEditorWrapper jsonString={jsonString} room={room} />;
 };
 
 const isValidTipTapContent = (content: any): boolean => {

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -2107,8 +2107,6 @@
       "addSharedSteps": "Add Shared Steps",
       "delete": "Delete Step",
       "confirmDelete": "Confirm delete Step {number}?",
-      "expand": "Expand all steps",
-      "collapse": "Collapse all steps",
       "createSharedSteps": "Create Shared {number, plural, one {Step} other {Steps}}",
       "sharedStepsName": "Shared Steps Name",
       "sharedStepsDescription": "Enter a name for your new shared {number, plural, one {step} other {steps}}. This will include {number, plural, one {# selected step} other {# selected steps}}.",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -2107,8 +2107,6 @@
       "addSharedSteps": "Añadir pasos compartidos",
       "delete": "Eliminar paso",
       "confirmDelete": "¿Borrar paso {number}?",
-      "expand": "Expandir todos los pasos",
-      "collapse": "Colapsar todos los pasos",
       "createSharedSteps": "¡Crear compartido {number, plural, one {Paso} other {¡Pasos}}",
       "sharedStepsName": "Nombre de pasos compartidos",
       "sharedStepsDescription": "¡Introduce un nombre para tu nuevo {number, plural, one {paso} other {pasos}}. ¡Esto incluirá {number, plural, one {# paso seleccionado} other {# ¡pasos seleccionados}}.",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -2107,8 +2107,6 @@
       "addSharedSteps": "Ajouter des étapes partagées",
       "delete": "Supprimer l'étape",
       "confirmDelete": "Confirmer la suppression Étape {number}?",
-      "expand": "Développer toutes les étapes",
-      "collapse": "Réduire toutes les étapes",
       "createSharedSteps": "Créer une étape partagée {number, plural, one {Étapes} other {Étapes}}",
       "sharedStepsName": "Nom des étapes partagées",
       "sharedStepsDescription": "Saisissez un nom pour votre nouvelle étape partagée {number, plural, one {} other {étapes}}. Cela inclura {number, plural, one {# étape sélectionnée} other {# étapes sélectionnées}}.",

--- a/testplanit/styles/globals.css
+++ b/testplanit/styles/globals.css
@@ -378,6 +378,23 @@ mark {
   margin-bottom: 0;
 }
 
+/* Strip the backticks @tailwindcss/typography injects around inline <code>,
+ * and give it a theme-aware background so it stays legible in both modes.
+ * Scoped to inline code only — pre > code keeps its code-block styling. */
+.prose code::before,
+.prose code::after {
+  content: none;
+}
+
+.prose :not(pre) > code {
+  background-color: hsl(var(--foreground) / 0.1);
+  color: hsl(var(--foreground));
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-weight: 500;
+  font-size: 0.875em;
+}
+
 /* Firefox-specific fixes for resizable panels */
 @-moz-document url-prefix() {
   /* Prevent text selection during drag in Firefox */

--- a/testplanit/styles/partials/code.css
+++ b/testplanit/styles/partials/code.css
@@ -1,9 +1,9 @@
 .ProseMirror {
   code {
-    @apply caret-white text-white bg-neutral-900 rounded-sm shadow-lg font-mono;
+    @apply caret-white text-white bg-accent rounded-sm shadow-lg font-mono;
 
     &::selection {
-      @apply bg-white/30;
+      @apply bg-accent;
     }
   }
 


### PR DESCRIPTION
## Description

Two related fixes to TipTap rich-text rendering across the app:

1. **Inline code rendered with literal backticks.** `@tailwindcss/typography` injects `` ` `` characters around `<code>` via `::before`/`::after` pseudo-elements, which showed up alongside TipTap's own code styling. Override those pseudo-elements globally under `.prose`, then style `.prose :not(pre) > code` with a translucent foreground background so the code chip stays visible in both light and dark themes (the shadcn `--muted` token is nearly identical to `--background` in dark mode and was invisible there).
2. **Removed the bounded-height / hover-to-expand pattern from rich-text rendering.** `TextFromJson` clamped every rich-text instance to 75px with a chevron toggle, MutationObserver/ResizeObserver, and `expand`/`expandable` props threaded through every consumer. `FieldValueRenderer`, `MilestoneFormControls`, `AttachmentsDisplay`, and `TestResultHistory` each re-implemented the same idea with `max-h-* hover:max-h-*`. The collapsed state hid useful content and the hover-expand was awkward to use. Now everything renders full-height inline.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

`pnpm precommit` clean (lint 0 errors, prettier clean, 6531 tests pass, 2 skipped). Manually verified the inline-code fix in light + dark mode and spot-checked the rich-text render in steps display, milestone description, attachment notes, and the case-detail rich-text fields.

**Test Configuration:**
- OS: macOS (darwin 25.4.0)
- Browser: Chrome
- Node version: per `.nvmrc`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

Before: inline code rendered as `` `edit` `` with literal backticks visible inside the code chip.
After: inline code renders as a clean `edit` chip with theme-aware translucent background.

## Additional Notes

* `repository.steps.expand` and `repository.steps.collapse` i18n keys were removed; en-US/es-ES/fr-FR all kept in sync.
* `expand` and `expandable` props were dropped from `TextFromJson` and all 12 call sites updated.
* `MilestoneFormControls` lost the `MoreHorizontal` "click to expand" indicator overlay since the parent wrapper that gated it is gone.
* `styles/partials/code.css` is orphaned (not imported anywhere); the small change there is cosmetic and groups thematically with the inline-code rewrite.
