### PR TITLE
enhancement(audit): system actor badge + wrap remaining routes with audit context

### DIFF
--- a/testplanit/app/[locale]/admin/audit-logs/columns.tsx
+++ b/testplanit/app/[locale]/admin/audit-logs/columns.tsx
@@ -8,8 +8,9 @@ import {
 } from "@/components/ui/tooltip";
 import { AuditAction, AuditLog } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
-import { Eye } from "lucide-react";
+import { Cog, Eye } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { SYSTEM_ACTOR_ID } from "~/lib/auditContextConstants";
 
 export interface ExtendedAuditLog extends AuditLog {
   project?: {
@@ -135,8 +136,27 @@ export const getColumns = (
     enableSorting: true,
     size: 200,
     cell: ({ row }) => {
+      const userId = row.original.userId;
       const email = row.original.userEmail;
       const name = row.original.userName;
+      const isSystemActor = userId === SYSTEM_ACTOR_ID;
+      if (isSystemActor) {
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant="secondary"
+                className="gap-1 font-medium"
+                data-testid="audit-log-system-actor-badge"
+              >
+                <Cog className="h-3 w-3" aria-hidden="true" />
+                {t("systemActor")}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>{t("systemActorTooltip")}</TooltipContent>
+          </Tooltip>
+        );
+      }
       return (
         <div className="flex flex-col">
           {name && <span className="font-medium text-sm">{name}</span>}

--- a/testplanit/app/api/share/[shareKey]/report/route.test.ts
+++ b/testplanit/app/api/share/[shareKey]/report/route.test.ts
@@ -23,6 +23,7 @@ vi.mock("~/lib/config/reportTypes", () => ({
 }));
 
 import { getServerSession } from "next-auth/next";
+import { getAuditContext, type AuditContext } from "~/lib/auditContext";
 import {
   getCrossProjectReportTypes,
   getProjectReportTypes,
@@ -432,6 +433,31 @@ describe("GET /api/share/[shareKey]/report", () => {
 
       expect(response.status).toBe(500);
       expect(data.error).toContain("Failed to load report data");
+    });
+  });
+
+  describe("withAuditContext wrapper", () => {
+    it("seeds ALS with request headers inside the GET handler", async () => {
+      let capturedCtx: AuditContext | undefined;
+      (getServerSession as any).mockResolvedValue(null);
+      (prisma.shareLink.findUnique as any).mockImplementation(() => {
+        capturedCtx = getAuditContext();
+        return Promise.resolve(mockShareLink);
+      });
+
+      const url = new URL(`http://localhost/api/share/abc123/report`);
+      const req = new NextRequest(url.toString(), {
+        headers: {
+          "x-forwarded-for": "203.0.113.99",
+          "user-agent": "vitest-share-report",
+        },
+      });
+      await GET(req, { params: Promise.resolve({ shareKey: "abc123" }) });
+
+      expect(capturedCtx).toBeDefined();
+      expect(capturedCtx?.ipAddress).toBe("203.0.113.99");
+      expect(capturedCtx?.userAgent).toBe("vitest-share-report");
+      expect(capturedCtx?.requestId).toMatch(/^req_\d+_[a-z0-9]+$/);
     });
   });
 });

--- a/testplanit/app/api/share/[shareKey]/report/route.ts
+++ b/testplanit/app/api/share/[shareKey]/report/route.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import {
   getCrossProjectReportTypes,
   getProjectReportTypes,
@@ -14,283 +15,296 @@ export const dynamic = "force-dynamic";
  * Fetch report data for a shared link (public access)
  * This endpoint is accessible without authentication for PUBLIC and PASSWORD_PROTECTED shares
  */
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ shareKey: string }> }
-) {
-  try {
-    const { shareKey } = await params;
-    const session = await getServerSession(authOptions);
+export const GET = withAuditContext(
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ shareKey: string }> }
+  ) => {
+    try {
+      const { shareKey } = await params;
+      const session = await getServerSession(authOptions);
 
-    // Get token from query params (for password-protected shares)
-    const { searchParams } = new URL(req.url);
-    const token = searchParams.get("token");
+      // Get token from query params (for password-protected shares)
+      const { searchParams } = new URL(req.url);
+      const token = searchParams.get("token");
 
-    // Fetch share link
-    const shareLink = await prisma.shareLink.findUnique({
-      where: { shareKey },
-      include: {
-        project: {
-          select: {
-            id: true,
-            name: true,
-            createdBy: true,
-            userPermissions: {
-              where: session?.user?.id
-                ? { userId: session.user.id }
-                : undefined,
+      // Fetch share link
+      const shareLink = await prisma.shareLink.findUnique({
+        where: { shareKey },
+        include: {
+          project: {
+            select: {
+              id: true,
+              name: true,
+              createdBy: true,
+              userPermissions: {
+                where: session?.user?.id
+                  ? { userId: session.user.id }
+                  : undefined,
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    if (!shareLink) {
-      return NextResponse.json(
-        { error: "Share link not found" },
-        { status: 404 }
-      );
-    }
+      if (!shareLink) {
+        return NextResponse.json(
+          { error: "Share link not found" },
+          { status: 404 }
+        );
+      }
 
-    // Check if revoked
-    if (shareLink.isRevoked) {
-      return NextResponse.json(
-        { error: "This share link has been revoked" },
-        { status: 403 }
-      );
-    }
+      // Check if revoked
+      if (shareLink.isRevoked) {
+        return NextResponse.json(
+          { error: "This share link has been revoked" },
+          { status: 403 }
+        );
+      }
 
-    // Check if expired
-    if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
-      return NextResponse.json(
-        { error: "This share link has expired" },
-        { status: 403 }
-      );
-    }
+      // Check if expired
+      if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
+        return NextResponse.json(
+          { error: "This share link has expired" },
+          { status: 403 }
+        );
+      }
 
-    // Handle PASSWORD_PROTECTED mode
-    if (shareLink.mode === "PASSWORD_PROTECTED") {
-      // Check if user has project access (bypass password)
-      if (session) {
+      // Handle PASSWORD_PROTECTED mode
+      if (shareLink.mode === "PASSWORD_PROTECTED") {
+        // Check if user has project access (bypass password)
+        if (session) {
+          const hasProjectAccess =
+            session.user.access === "ADMIN" ||
+            !shareLink.project ||
+            shareLink.project.createdBy === session.user.id ||
+            shareLink.project.userPermissions.length > 0;
+
+          if (!hasProjectAccess && token !== shareKey) {
+            return NextResponse.json(
+              { error: "Valid token required" },
+              { status: 401 }
+            );
+          }
+        } else {
+          // Not logged in, require valid token
+          if (token !== shareKey) {
+            return NextResponse.json(
+              { error: "Valid token required" },
+              { status: 401 }
+            );
+          }
+        }
+      }
+
+      // Handle AUTHENTICATED mode
+      if (shareLink.mode === "AUTHENTICATED") {
+        if (!session) {
+          return NextResponse.json(
+            { error: "Authentication required" },
+            { status: 401 }
+          );
+        }
+
         const hasProjectAccess =
           session.user.access === "ADMIN" ||
           !shareLink.project ||
           shareLink.project.createdBy === session.user.id ||
           shareLink.project.userPermissions.length > 0;
 
-        if (!hasProjectAccess && token !== shareKey) {
-          return NextResponse.json(
-            { error: "Valid token required" },
-            { status: 401 }
-          );
-        }
-      } else {
-        // Not logged in, require valid token
-        if (token !== shareKey) {
-          return NextResponse.json(
-            { error: "Valid token required" },
-            { status: 401 }
-          );
+        if (!hasProjectAccess) {
+          return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
       }
-    }
 
-    // Handle AUTHENTICATED mode
-    if (shareLink.mode === "AUTHENTICATED") {
-      if (!session) {
+      // Only REPORT entity type is supported for now
+      if (shareLink.entityType !== "REPORT") {
         return NextResponse.json(
-          { error: "Authentication required" },
-          { status: 401 }
+          { error: "Only report shares are supported" },
+          { status: 400 }
         );
       }
 
-      const hasProjectAccess =
-        session.user.access === "ADMIN" ||
-        !shareLink.project ||
-        shareLink.project.createdBy === session.user.id ||
-        shareLink.project.userPermissions.length > 0;
-
-      if (!hasProjectAccess) {
-        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      const config = shareLink.entityConfig as any;
+      if (!config) {
+        return NextResponse.json(
+          { error: "Invalid report configuration" },
+          { status: 400 }
+        );
       }
-    }
 
-    // Only REPORT entity type is supported for now
-    if (shareLink.entityType !== "REPORT") {
-      return NextResponse.json(
-        { error: "Only report shares are supported" },
-        { status: 400 }
+      // Get all available report types
+      const projectReportTypes = getProjectReportTypes((key: string) => key);
+      const crossProjectReportTypes = getCrossProjectReportTypes(
+        (key: string) => key
       );
-    }
+      const allReportTypes = [
+        ...projectReportTypes,
+        ...crossProjectReportTypes,
+      ];
 
-    const config = shareLink.entityConfig as any;
-    if (!config) {
-      return NextResponse.json(
-        { error: "Invalid report configuration" },
-        { status: 400 }
+      // Find the report type configuration
+      const reportType = allReportTypes.find(
+        (rt) => rt.id === config.reportType
       );
-    }
-
-    // Get all available report types
-    const projectReportTypes = getProjectReportTypes((key: string) => key);
-    const crossProjectReportTypes = getCrossProjectReportTypes(
-      (key: string) => key
-    );
-    const allReportTypes = [...projectReportTypes, ...crossProjectReportTypes];
-
-    // Find the report type configuration
-    const reportType = allReportTypes.find((rt) => rt.id === config.reportType);
-    if (!reportType) {
-      return NextResponse.json(
-        { error: "Unsupported report type" },
-        { status: 400 }
-      );
-    }
-
-    const endpoint = reportType.endpoint;
-
-    // Use localhost for internal server-to-server communication to avoid SSL issues
-    const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
-
-    // First, fetch metadata (dimensions and metrics with labels) from GET endpoint
-    const metadataUrl = new URL(endpoint, baseUrl);
-    if (shareLink.projectId) {
-      metadataUrl.searchParams.set("projectId", shareLink.projectId.toString());
-    }
-
-    const metadataResponse = await fetch(metadataUrl.toString(), {
-      method: "GET",
-      headers: {
-        // Forward cookies for authentication if user is logged in
-        ...(req.headers.get("cookie")
-          ? { Cookie: req.headers.get("cookie")! }
-          : {}),
-        // Add bypass header for shared reports to allow access without admin permissions
-        "x-shared-report-bypass": "true",
-      },
-    });
-
-    if (!metadataResponse.ok) {
-      const errorData = await metadataResponse.json();
-      return NextResponse.json(
-        { error: errorData.error || "Failed to fetch report metadata" },
-        { status: metadataResponse.status }
-      );
-    }
-
-    const metadata = await metadataResponse.json();
-
-    // Then, call the report builder POST endpoint to get data
-    // Always fetch ALL results for shared reports (ignore saved pagination settings)
-    const reportBuilderUrl = new URL(endpoint, baseUrl);
-
-    // Forward ALL config parameters to the report endpoint (generic approach)
-    // This ensures pre-built reports get all their required parameters
-    const { reportType: _, ...requestParams } = config;
-    const requestBody = {
-      ...requestParams, // Spread all saved parameters from the config
-      page: 1,
-      pageSize: "All", // Always fetch all results for shared reports
-    };
-
-    const reportResponse = await fetch(reportBuilderUrl.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        // Forward cookies for authentication if user is logged in
-        ...(req.headers.get("cookie")
-          ? { Cookie: req.headers.get("cookie")! }
-          : {}),
-        // Add bypass header for shared reports to allow access without admin permissions
-        "x-shared-report-bypass": "true",
-      },
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!reportResponse.ok) {
-      const errorData = await reportResponse.json();
-      return NextResponse.json(
-        { error: errorData.error || "Failed to build report" },
-        { status: reportResponse.status }
-      );
-    }
-
-    const reportData = await reportResponse.json();
-
-    // Check if this is a pre-built report (empty dimensions/metrics in config)
-    // Pre-built reports save empty arrays because they don't use the standard dimension/metric selector
-    const isPreBuiltReport =
-      (!config.dimensions || config.dimensions.length === 0) &&
-      (!config.metrics || config.metrics.length === 0);
-
-    let dimensionsWithLabels: any[] = [];
-    let metricsWithLabels: any[] = [];
-    let results: any[] = [];
-    let chartData: any[] = [];
-
-    if (isPreBuiltReport) {
-      // Pre-built reports return data in { data: [...] } format
-      // Don't generate dimension/metric metadata - let the frontend handle column generation
-      results = reportData.data || [];
-      chartData = reportData.data || [];
-      // Leave dimensions and metrics empty for pre-built reports
-      dimensionsWithLabels = [];
-      metricsWithLabels = [];
-    } else {
-      // Dynamic reports: Map dimension and metric IDs to their full metadata objects
-      dimensionsWithLabels = config.dimensions.map((dimId: string) => {
-        const metadataDim = metadata.dimensions.find(
-          (d: any) => d.id === dimId
+      if (!reportType) {
+        return NextResponse.json(
+          { error: "Unsupported report type" },
+          { status: 400 }
         );
-        // ReportChart expects { value, label } format
-        return metadataDim
-          ? { value: metadataDim.id, label: metadataDim.label }
-          : { value: dimId, label: dimId };
+      }
+
+      const endpoint = reportType.endpoint;
+
+      // Use localhost for internal server-to-server communication to avoid SSL issues
+      const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+
+      // First, fetch metadata (dimensions and metrics with labels) from GET endpoint
+      const metadataUrl = new URL(endpoint, baseUrl);
+      if (shareLink.projectId) {
+        metadataUrl.searchParams.set(
+          "projectId",
+          shareLink.projectId.toString()
+        );
+      }
+
+      const metadataResponse = await fetch(metadataUrl.toString(), {
+        method: "GET",
+        headers: {
+          // Forward cookies for authentication if user is logged in
+          ...(req.headers.get("cookie")
+            ? { Cookie: req.headers.get("cookie")! }
+            : {}),
+          // Add bypass header for shared reports to allow access without admin permissions
+          "x-shared-report-bypass": "true",
+        },
       });
 
-      metricsWithLabels = config.metrics.map((metricId: string) => {
-        const metadataMetric = metadata.metrics.find(
-          (m: any) => m.id === metricId
+      if (!metadataResponse.ok) {
+        const errorData = await metadataResponse.json();
+        return NextResponse.json(
+          { error: errorData.error || "Failed to fetch report metadata" },
+          { status: metadataResponse.status }
         );
-        // ReportChart expects { value, label } format
-        return metadataMetric
-          ? { value: metadataMetric.id, label: metadataMetric.label }
-          : { value: metricId, label: metricId };
+      }
+
+      const metadata = await metadataResponse.json();
+
+      // Then, call the report builder POST endpoint to get data
+      // Always fetch ALL results for shared reports (ignore saved pagination settings)
+      const reportBuilderUrl = new URL(endpoint, baseUrl);
+
+      // Forward ALL config parameters to the report endpoint (generic approach)
+      // This ensures pre-built reports get all their required parameters
+      const { reportType: _, ...requestParams } = config;
+      const requestBody = {
+        ...requestParams, // Spread all saved parameters from the config
+        page: 1,
+        pageSize: "All", // Always fetch all results for shared reports
+      };
+
+      const reportResponse = await fetch(reportBuilderUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          // Forward cookies for authentication if user is logged in
+          ...(req.headers.get("cookie")
+            ? { Cookie: req.headers.get("cookie")! }
+            : {}),
+          // Add bypass header for shared reports to allow access without admin permissions
+          "x-shared-report-bypass": "true",
+        },
+        body: JSON.stringify(requestBody),
       });
 
-      results = reportData.results;
-      chartData = reportData.allResults || reportData.results;
+      if (!reportResponse.ok) {
+        const errorData = await reportResponse.json();
+        return NextResponse.json(
+          { error: errorData.error || "Failed to build report" },
+          { status: reportResponse.status }
+        );
+      }
+
+      const reportData = await reportResponse.json();
+
+      // Check if this is a pre-built report (empty dimensions/metrics in config)
+      // Pre-built reports save empty arrays because they don't use the standard dimension/metric selector
+      const isPreBuiltReport =
+        (!config.dimensions || config.dimensions.length === 0) &&
+        (!config.metrics || config.metrics.length === 0);
+
+      let dimensionsWithLabels: any[] = [];
+      let metricsWithLabels: any[] = [];
+      let results: any[] = [];
+      let chartData: any[] = [];
+
+      if (isPreBuiltReport) {
+        // Pre-built reports return data in { data: [...] } format
+        // Don't generate dimension/metric metadata - let the frontend handle column generation
+        results = reportData.data || [];
+        chartData = reportData.data || [];
+        // Leave dimensions and metrics empty for pre-built reports
+        dimensionsWithLabels = [];
+        metricsWithLabels = [];
+      } else {
+        // Dynamic reports: Map dimension and metric IDs to their full metadata objects
+        dimensionsWithLabels = config.dimensions.map((dimId: string) => {
+          const metadataDim = metadata.dimensions.find(
+            (d: any) => d.id === dimId
+          );
+          // ReportChart expects { value, label } format
+          return metadataDim
+            ? { value: metadataDim.id, label: metadataDim.label }
+            : { value: dimId, label: dimId };
+        });
+
+        metricsWithLabels = config.metrics.map((metricId: string) => {
+          const metadataMetric = metadata.metrics.find(
+            (m: any) => m.id === metricId
+          );
+          // ReportChart expects { value, label } format
+          return metadataMetric
+            ? { value: metadataMetric.id, label: metadataMetric.label }
+            : { value: metricId, label: metricId };
+        });
+
+        results = reportData.results;
+        chartData = reportData.allResults || reportData.results;
+      }
+
+      // Format the response to match what StaticReportViewer expects
+      // Note: columns are generated client-side using useReportColumns hook
+      const responsePayload = {
+        results,
+        chartData,
+        dimensions: dimensionsWithLabels,
+        metrics: metricsWithLabels,
+        pagination: {
+          totalCount:
+            reportData.totalCount || reportData.total || results.length,
+          page: reportData.page || 1,
+          pageSize: reportData.pageSize || "All",
+        },
+        // Pass through additional fields for specialized reports (automation-trends, flaky-tests, etc.)
+        ...(reportData.projects && { projects: reportData.projects }),
+        ...(reportData.dateGrouping && {
+          dateGrouping: reportData.dateGrouping,
+        }),
+        ...(reportData.consecutiveRuns && {
+          consecutiveRuns: reportData.consecutiveRuns,
+        }),
+        ...(reportData.totalFlakyTests && {
+          totalFlakyTests: reportData.totalFlakyTests,
+        }),
+      };
+
+      return NextResponse.json(responsePayload);
+    } catch (error) {
+      console.error("Error fetching report data for share:", error);
+      return NextResponse.json(
+        { error: "Failed to load report data" },
+        { status: 500 }
+      );
     }
-
-    // Format the response to match what StaticReportViewer expects
-    // Note: columns are generated client-side using useReportColumns hook
-    const responsePayload = {
-      results,
-      chartData,
-      dimensions: dimensionsWithLabels,
-      metrics: metricsWithLabels,
-      pagination: {
-        totalCount: reportData.totalCount || reportData.total || results.length,
-        page: reportData.page || 1,
-        pageSize: reportData.pageSize || "All",
-      },
-      // Pass through additional fields for specialized reports (automation-trends, flaky-tests, etc.)
-      ...(reportData.projects && { projects: reportData.projects }),
-      ...(reportData.dateGrouping && { dateGrouping: reportData.dateGrouping }),
-      ...(reportData.consecutiveRuns && {
-        consecutiveRuns: reportData.consecutiveRuns,
-      }),
-      ...(reportData.totalFlakyTests && {
-        totalFlakyTests: reportData.totalFlakyTests,
-      }),
-    };
-
-    return NextResponse.json(responsePayload);
-  } catch (error) {
-    console.error("Error fetching report data for share:", error);
-    return NextResponse.json(
-      { error: "Failed to load report data" },
-      { status: 500 }
-    );
   }
-}
+);

--- a/testplanit/app/api/share/[shareKey]/route.test.ts
+++ b/testplanit/app/api/share/[shareKey]/route.test.ts
@@ -38,6 +38,7 @@ vi.mock("~/lib/services/notificationService", () => ({
 
 import bcrypt from "bcrypt";
 import { getServerSession } from "next-auth";
+import { getAuditContext, type AuditContext } from "~/lib/auditContext";
 import { prisma } from "~/lib/prisma";
 import { expectAuditRowComplete } from "~/lib/testing/auditAssertions";
 import { GET, POST } from "./route";
@@ -473,13 +474,70 @@ describe("POST /api/share/[shareKey]", () => {
       // is not yet withAuditContext-wrapped (Phase 64 CR-01 covered sync
       // routes; share-access routes are deferred). Until that route is
       // wrapped, this test synthesizes a requestId to satisfy
-      // expectAuditRowComplete's requestId non-null guard. When a future
-      // phase wraps share/[shareKey]/route.ts, remove the synthesis and
-      // read requestId from the real ALS-populated metadata. This test's
-      // current SCOPE is D-18 identity completeness on the authenticated
-      // path only.
+      // expectAuditRowComplete's requestId non-null guard. The wrap was
+      // applied in the audit-context follow-ups PR (999.4) — the route
+      // now runs inside an ALS frame seeded with request metadata. The
+      // inline `prisma.auditLog.create` here still doesn't read FROM
+      // ALS, however; migrating it to `captureAuditEvent` (which DOES
+      // consume ALS) is the next step. Until that migration lands, the
+      // inline audit row's metadata still won't carry requestId.
       requestId: "req-synthesized-for-legacy-route",
       metadata: md,
     });
+  });
+
+  it("withAuditContext seeds ALS with request headers inside the POST handler", async () => {
+    let capturedCtx: AuditContext | undefined;
+    (getServerSession as any).mockResolvedValue(null);
+    (prisma.shareLink.findUnique as any).mockImplementation(() => {
+      capturedCtx = getAuditContext();
+      return Promise.resolve(mockShareLink);
+    });
+
+    const req = new NextRequest(`http://localhost/api/share/abc123`, {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-for": "203.0.113.7, 10.0.0.1",
+        "user-agent": "vitest-share-post",
+      },
+    });
+    await POST(req, { params: Promise.resolve({ shareKey: "abc123" }) });
+
+    // Wrapper proved: handler observed an ALS frame populated from request
+    // headers. Ipv4 with comma-separated x-forwarded-for takes the first IP.
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.ipAddress).toBe("203.0.113.7");
+    expect(capturedCtx?.userAgent).toBe("vitest-share-post");
+    expect(capturedCtx?.requestId).toMatch(/^req_\d+_[a-z0-9]+$/);
+  });
+});
+
+describe("withAuditContext on share/[shareKey] GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getServerSession as any).mockResolvedValue(null);
+  });
+
+  it("seeds ALS with request headers inside the GET handler", async () => {
+    let capturedCtx: AuditContext | undefined;
+    (prisma.shareLink.findUnique as any).mockImplementation(() => {
+      capturedCtx = getAuditContext();
+      return Promise.resolve(mockShareLink);
+    });
+
+    const req = new NextRequest(`http://localhost/api/share/abc123`, {
+      headers: {
+        "x-forwarded-for": "203.0.113.42",
+        "user-agent": "vitest-share-get",
+      },
+    });
+    await GET(req, { params: Promise.resolve({ shareKey: "abc123" }) });
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.ipAddress).toBe("203.0.113.42");
+    expect(capturedCtx?.userAgent).toBe("vitest-share-get");
+    expect(capturedCtx?.requestId).toMatch(/^req_\d+_[a-z0-9]+$/);
   });
 });

--- a/testplanit/app/api/share/[shareKey]/route.ts
+++ b/testplanit/app/api/share/[shareKey]/route.ts
@@ -2,6 +2,7 @@ import { AuditAction } from "@prisma/client";
 import bcrypt from "bcrypt";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { prisma } from "~/lib/prisma";
 import { NotificationService } from "~/lib/services/notificationService";
 import { authOptions } from "~/server/auth";
@@ -13,187 +14,172 @@ export const dynamic = "force-dynamic";
  * Fetch share link metadata (without accessing content)
  * No authentication required
  */
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ shareKey: string }> }
-) {
-  try {
-    const { shareKey } = await params;
+export const GET = withAuditContext(
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ shareKey: string }> }
+  ) => {
+    try {
+      const { shareKey } = await params;
 
-    // Fetch share link with project info (no auth required)
-    const shareLink = await prisma.shareLink.findUnique({
-      where: { shareKey },
-      include: {
-        project: {
-          select: {
-            id: true,
-            name: true,
+      // Fetch share link with project info (no auth required)
+      const shareLink = await prisma.shareLink.findUnique({
+        where: { shareKey },
+        include: {
+          project: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          createdBy: {
+            select: {
+              id: true,
+              name: true,
+            },
           },
         },
-        createdBy: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-      },
-    });
+      });
 
-    if (!shareLink) {
+      if (!shareLink) {
+        return NextResponse.json(
+          { error: "Share link not found" },
+          { status: 404 }
+        );
+      }
+
+      // Check if deleted
+      if (shareLink.isDeleted) {
+        return NextResponse.json(
+          { error: "This share link has been deleted", deleted: true },
+          { status: 404 }
+        );
+      }
+
+      // Check if revoked
+      if (shareLink.isRevoked) {
+        return NextResponse.json(
+          { error: "This share link has been revoked", revoked: true },
+          { status: 403 }
+        );
+      }
+
+      // Check if expired
+      if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
+        return NextResponse.json(
+          { error: "This share link has expired", expired: true },
+          { status: 403 }
+        );
+      }
+
+      // Return metadata (without passwordHash)
+      return NextResponse.json({
+        id: shareLink.id,
+        entityType: shareLink.entityType,
+        entityId: shareLink.entityId,
+        entityConfig: shareLink.entityConfig,
+        mode: shareLink.mode,
+        title: shareLink.title,
+        description: shareLink.description,
+        projectId: shareLink.projectId,
+        projectName: shareLink.project?.name || null,
+        createdBy: shareLink.createdBy.name,
+        viewCount: shareLink.viewCount,
+        requiresPassword: shareLink.mode === "PASSWORD_PROTECTED",
+      });
+    } catch (error) {
+      console.error("Error fetching share link:", error);
       return NextResponse.json(
-        { error: "Share link not found" },
-        { status: 404 }
+        { error: "Failed to fetch share link" },
+        { status: 500 }
       );
     }
-
-    // Check if deleted
-    if (shareLink.isDeleted) {
-      return NextResponse.json(
-        { error: "This share link has been deleted", deleted: true },
-        { status: 404 }
-      );
-    }
-
-    // Check if revoked
-    if (shareLink.isRevoked) {
-      return NextResponse.json(
-        { error: "This share link has been revoked", revoked: true },
-        { status: 403 }
-      );
-    }
-
-    // Check if expired
-    if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
-      return NextResponse.json(
-        { error: "This share link has expired", expired: true },
-        { status: 403 }
-      );
-    }
-
-    // Return metadata (without passwordHash)
-    return NextResponse.json({
-      id: shareLink.id,
-      entityType: shareLink.entityType,
-      entityId: shareLink.entityId,
-      entityConfig: shareLink.entityConfig,
-      mode: shareLink.mode,
-      title: shareLink.title,
-      description: shareLink.description,
-      projectId: shareLink.projectId,
-      projectName: shareLink.project?.name || null,
-      createdBy: shareLink.createdBy.name,
-      viewCount: shareLink.viewCount,
-      requiresPassword: shareLink.mode === "PASSWORD_PROTECTED",
-    });
-  } catch (error) {
-    console.error("Error fetching share link:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch share link" },
-      { status: 500 }
-    );
   }
-}
+);
 
 /**
  * POST /api/share/[shareKey]
  * Access shared content (with password verification if needed)
  * Logs access and triggers notifications
  */
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ shareKey: string }> }
-) {
-  try {
-    const { shareKey } = await params;
-    const session = await getServerSession(authOptions);
-    const body = await req.json();
-    const { password, token } = body;
+export const POST = withAuditContext(
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ shareKey: string }> }
+  ) => {
+    try {
+      const { shareKey } = await params;
+      const session = await getServerSession(authOptions);
+      const body = await req.json();
+      const { password, token } = body;
 
-    // Fetch share link with full details
-    const shareLink = await prisma.shareLink.findUnique({
-      where: { shareKey },
-      include: {
-        project: {
-          select: {
-            id: true,
-            name: true,
-            createdBy: true,
-            userPermissions: {
-              where: session?.user?.id
-                ? { userId: session.user.id }
-                : undefined,
+      // Fetch share link with full details
+      const shareLink = await prisma.shareLink.findUnique({
+        where: { shareKey },
+        include: {
+          project: {
+            select: {
+              id: true,
+              name: true,
+              createdBy: true,
+              userPermissions: {
+                where: session?.user?.id
+                  ? { userId: session.user.id }
+                  : undefined,
+              },
+            },
+          },
+          createdBy: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
             },
           },
         },
-        createdBy: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-      },
-    });
+      });
 
-    if (!shareLink) {
-      return NextResponse.json(
-        { error: "Share link not found" },
-        { status: 404 }
-      );
-    }
-
-    // Check if deleted
-    if (shareLink.isDeleted) {
-      return NextResponse.json(
-        { error: "This share link has been deleted" },
-        { status: 404 }
-      );
-    }
-
-    // Check if revoked
-    if (shareLink.isRevoked) {
-      return NextResponse.json(
-        { error: "This share link has been revoked" },
-        { status: 403 }
-      );
-    }
-
-    // Check if expired
-    if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
-      return NextResponse.json(
-        { error: "This share link has expired" },
-        { status: 403 }
-      );
-    }
-
-    // Handle AUTHENTICATED mode
-    if (shareLink.mode === "AUTHENTICATED") {
-      if (!session) {
+      if (!shareLink) {
         return NextResponse.json(
-          { error: "Authentication required", requiresAuth: true },
-          { status: 401 }
+          { error: "Share link not found" },
+          { status: 404 }
         );
       }
 
-      // Check if user has project access (or if it's a cross-project report)
-      const hasProjectAccess =
-        session.user.access === "ADMIN" ||
-        !shareLink.project || // Cross-project reports accessible to all authenticated users
-        shareLink.project.createdBy === session.user.id ||
-        shareLink.project.userPermissions.length > 0;
-
-      if (!hasProjectAccess) {
+      // Check if deleted
+      if (shareLink.isDeleted) {
         return NextResponse.json(
-          { error: "You do not have access to this project" },
+          { error: "This share link has been deleted" },
+          { status: 404 }
+        );
+      }
+
+      // Check if revoked
+      if (shareLink.isRevoked) {
+        return NextResponse.json(
+          { error: "This share link has been revoked" },
           { status: 403 }
         );
       }
-    }
 
-    // Handle PASSWORD_PROTECTED mode
-    if (shareLink.mode === "PASSWORD_PROTECTED") {
-      // Check if user has project access (bypass password)
-      if (session) {
+      // Check if expired
+      if (shareLink.expiresAt && new Date(shareLink.expiresAt) < new Date()) {
+        return NextResponse.json(
+          { error: "This share link has expired" },
+          { status: 403 }
+        );
+      }
+
+      // Handle AUTHENTICATED mode
+      if (shareLink.mode === "AUTHENTICATED") {
+        if (!session) {
+          return NextResponse.json(
+            { error: "Authentication required", requiresAuth: true },
+            { status: 401 }
+          );
+        }
+
+        // Check if user has project access (or if it's a cross-project report)
         const hasProjectAccess =
           session.user.access === "ADMIN" ||
           !shareLink.project || // Cross-project reports accessible to all authenticated users
@@ -201,161 +187,180 @@ export async function POST(
           shareLink.project.userPermissions.length > 0;
 
         if (!hasProjectAccess) {
-          // User is logged in but doesn't have project access, require password
-          if (!password || !shareLink.passwordHash) {
-            return NextResponse.json(
-              { error: "Password required", requiresPassword: true },
-              { status: 401 }
-            );
-          }
-
-          // Verify password
-          const isValid = await bcrypt.compare(
-            password,
-            shareLink.passwordHash
+          return NextResponse.json(
+            { error: "You do not have access to this project" },
+            { status: 403 }
           );
-          if (!isValid) {
-            return NextResponse.json(
-              { error: "Invalid password" },
-              { status: 401 }
-            );
-          }
         }
-        // User has project access, bypass password
-      } else {
-        // Not logged in, require password or valid token
-        // Token is provided after successful password verification
-        const hasValidToken = token === shareKey;
+      }
 
-        if (!hasValidToken) {
-          if (!password || !shareLink.passwordHash) {
-            return NextResponse.json(
-              { error: "Password required", requiresPassword: true },
-              { status: 401 }
+      // Handle PASSWORD_PROTECTED mode
+      if (shareLink.mode === "PASSWORD_PROTECTED") {
+        // Check if user has project access (bypass password)
+        if (session) {
+          const hasProjectAccess =
+            session.user.access === "ADMIN" ||
+            !shareLink.project || // Cross-project reports accessible to all authenticated users
+            shareLink.project.createdBy === session.user.id ||
+            shareLink.project.userPermissions.length > 0;
+
+          if (!hasProjectAccess) {
+            // User is logged in but doesn't have project access, require password
+            if (!password || !shareLink.passwordHash) {
+              return NextResponse.json(
+                { error: "Password required", requiresPassword: true },
+                { status: 401 }
+              );
+            }
+
+            // Verify password
+            const isValid = await bcrypt.compare(
+              password,
+              shareLink.passwordHash
             );
+            if (!isValid) {
+              return NextResponse.json(
+                { error: "Invalid password" },
+                { status: 401 }
+              );
+            }
           }
+          // User has project access, bypass password
+        } else {
+          // Not logged in, require password or valid token
+          // Token is provided after successful password verification
+          const hasValidToken = token === shareKey;
 
-          // Verify password
-          const isValid = await bcrypt.compare(
-            password,
-            shareLink.passwordHash
-          );
-          if (!isValid) {
-            return NextResponse.json(
-              { error: "Invalid password" },
-              { status: 401 }
+          if (!hasValidToken) {
+            if (!password || !shareLink.passwordHash) {
+              return NextResponse.json(
+                { error: "Password required", requiresPassword: true },
+                { status: 401 }
+              );
+            }
+
+            // Verify password
+            const isValid = await bcrypt.compare(
+              password,
+              shareLink.passwordHash
             );
+            if (!isValid) {
+              return NextResponse.json(
+                { error: "Invalid password" },
+                { status: 401 }
+              );
+            }
           }
         }
       }
-    }
 
-    // Log access
-    const ipAddress =
-      req.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
-      req.headers.get("x-real-ip") ||
-      null;
-    const userAgent = req.headers.get("user-agent") || null;
+      // Log access
+      const ipAddress =
+        req.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+        req.headers.get("x-real-ip") ||
+        null;
+      const userAgent = req.headers.get("user-agent") || null;
 
-    await prisma.shareLinkAccessLog.create({
-      data: {
-        shareLinkId: shareLink.id,
-        accessedById: session?.user?.id || null,
-        ipAddress,
-        userAgent,
-        wasAuthenticated: !!session,
-      },
-    });
-
-    // Increment view count and update last viewed
-    await prisma.shareLink.update({
-      where: { id: shareLink.id },
-      data: {
-        viewCount: { increment: 1 },
-        lastViewedAt: new Date(),
-      },
-    });
-
-    // Create audit log
-    await prisma.auditLog.create({
-      data: {
-        userId: session?.user?.id || null,
-        userEmail: session?.user?.email || null,
-        userName: session?.user?.name || "Anonymous",
-        action: AuditAction.SHARE_LINK_ACCESSED,
-        entityType: "ShareLink",
-        entityId: shareLink.id,
-        entityName: shareLink.title || `${shareLink.entityType} share`,
-        metadata: {
-          shareKey,
-          entityType: shareLink.entityType,
-          mode: shareLink.mode,
+      await prisma.shareLinkAccessLog.create({
+        data: {
+          shareLinkId: shareLink.id,
+          accessedById: session?.user?.id || null,
           ipAddress,
           userAgent,
+          wasAuthenticated: !!session,
         },
-        projectId: shareLink.projectId,
-      },
-    });
+      });
 
-    // Trigger notification if enabled
-    if (shareLink.notifyOnView) {
-      try {
-        // Build a descriptive title for the notification
-        let notificationTitle = shareLink.title;
+      // Increment view count and update last viewed
+      await prisma.shareLink.update({
+        where: { id: shareLink.id },
+        data: {
+          viewCount: { increment: 1 },
+          lastViewedAt: new Date(),
+        },
+      });
 
-        if (!notificationTitle) {
-          // Generate title from entity type and project
-          if (shareLink.entityType === "REPORT" && shareLink.entityConfig) {
-            const config = shareLink.entityConfig as any;
-            const reportType = config.reportType
-              ? config.reportType.replace(/-/g, " ")
-              : "report";
-            notificationTitle = shareLink.project?.name
-              ? `${reportType} for ${shareLink.project.name}`
-              : reportType;
-          } else {
-            const entityType = shareLink.entityType
-              .toLowerCase()
-              .replace(/_/g, " ");
-            notificationTitle = shareLink.project?.name
-              ? `${entityType} for ${shareLink.project.name}`
-              : entityType;
+      // Create audit log
+      await prisma.auditLog.create({
+        data: {
+          userId: session?.user?.id || null,
+          userEmail: session?.user?.email || null,
+          userName: session?.user?.name || "Anonymous",
+          action: AuditAction.SHARE_LINK_ACCESSED,
+          entityType: "ShareLink",
+          entityId: shareLink.id,
+          entityName: shareLink.title || `${shareLink.entityType} share`,
+          metadata: {
+            shareKey,
+            entityType: shareLink.entityType,
+            mode: shareLink.mode,
+            ipAddress,
+            userAgent,
+          },
+          projectId: shareLink.projectId,
+        },
+      });
+
+      // Trigger notification if enabled
+      if (shareLink.notifyOnView) {
+        try {
+          // Build a descriptive title for the notification
+          let notificationTitle = shareLink.title;
+
+          if (!notificationTitle) {
+            // Generate title from entity type and project
+            if (shareLink.entityType === "REPORT" && shareLink.entityConfig) {
+              const config = shareLink.entityConfig as any;
+              const reportType = config.reportType
+                ? config.reportType.replace(/-/g, " ")
+                : "report";
+              notificationTitle = shareLink.project?.name
+                ? `${reportType} for ${shareLink.project.name}`
+                : reportType;
+            } else {
+              const entityType = shareLink.entityType
+                .toLowerCase()
+                .replace(/_/g, " ");
+              notificationTitle = shareLink.project?.name
+                ? `${entityType} for ${shareLink.project.name}`
+                : entityType;
+            }
           }
+
+          await NotificationService.createShareLinkAccessedNotification(
+            shareLink.createdById,
+            notificationTitle || "Shared content",
+            session?.user?.name || null,
+            session?.user?.email || null,
+            shareLink.id,
+            shareLink.projectId ?? undefined
+          );
+        } catch (error) {
+          console.error("Failed to send share access notification:", error);
+          // Don't fail the request if notification fails
         }
-
-        await NotificationService.createShareLinkAccessedNotification(
-          shareLink.createdById,
-          notificationTitle || "Shared content",
-          session?.user?.name || null,
-          session?.user?.email || null,
-          shareLink.id,
-          shareLink.projectId ?? undefined
-        );
-      } catch (error) {
-        console.error("Failed to send share access notification:", error);
-        // Don't fail the request if notification fails
       }
-    }
 
-    // Return share link data
-    return NextResponse.json({
-      id: shareLink.id,
-      entityType: shareLink.entityType,
-      entityId: shareLink.entityId,
-      entityConfig: shareLink.entityConfig,
-      mode: shareLink.mode,
-      title: shareLink.title,
-      description: shareLink.description,
-      projectId: shareLink.projectId,
-      projectName: shareLink.project?.name || null,
-      viewCount: shareLink.viewCount + 1,
-      accessed: true,
-    });
-  } catch (error) {
-    console.error("Error accessing share link:", error);
-    return NextResponse.json(
-      { error: "Failed to access share link" },
-      { status: 500 }
-    );
+      // Return share link data
+      return NextResponse.json({
+        id: shareLink.id,
+        entityType: shareLink.entityType,
+        entityId: shareLink.entityId,
+        entityConfig: shareLink.entityConfig,
+        mode: shareLink.mode,
+        title: shareLink.title,
+        description: shareLink.description,
+        projectId: shareLink.projectId,
+        projectName: shareLink.project?.name || null,
+        viewCount: shareLink.viewCount + 1,
+        accessed: true,
+      });
+    } catch (error) {
+      console.error("Error accessing share link:", error);
+      return NextResponse.json(
+        { error: "Failed to access share link" },
+        { status: 500 }
+      );
+    }
   }
-}
+);

--- a/testplanit/app/api/test-helpers/verify-email/route.test.ts
+++ b/testplanit/app/api/test-helpers/verify-email/route.test.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { getAuditContext, type AuditContext } from "~/lib/auditContext";
+import { prisma } from "~/lib/prisma";
+import { POST } from "./route";
+
+describe("withAuditContext wrapper on test-helpers/verify-email POST", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalE2EProd = process.env.E2E_PROD;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.E2E_PROD = "on";
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete (process.env as any).NODE_ENV;
+    } else {
+      (process.env as any).NODE_ENV = originalNodeEnv;
+    }
+    if (originalE2EProd === undefined) {
+      delete process.env.E2E_PROD;
+    } else {
+      process.env.E2E_PROD = originalE2EProd;
+    }
+  });
+
+  it("seeds ALS with request headers inside the handler", async () => {
+    let capturedCtx: AuditContext | undefined;
+    (prisma.user.update as any).mockImplementation(() => {
+      capturedCtx = getAuditContext();
+      return Promise.resolve({ id: "user-123" });
+    });
+
+    const req = new NextRequest(
+      "http://localhost/api/test-helpers/verify-email",
+      {
+        method: "POST",
+        body: JSON.stringify({ userId: "user-123" }),
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "203.0.113.42, 10.0.0.1",
+          "user-agent": "vitest-verify-email",
+        },
+      }
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.ipAddress).toBe("203.0.113.42");
+    expect(capturedCtx?.userAgent).toBe("vitest-verify-email");
+    expect(capturedCtx?.requestId).toMatch(/^req_\d+_[a-z0-9]+$/);
+  });
+
+  it("returns 403 when not in E2E test environment", async () => {
+    delete process.env.E2E_PROD;
+    (process.env as any).NODE_ENV = "production";
+
+    const req = new NextRequest(
+      "http://localhost/api/test-helpers/verify-email",
+      {
+        method: "POST",
+        body: JSON.stringify({ userId: "user-123" }),
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/testplanit/app/api/test-helpers/verify-email/route.ts
+++ b/testplanit/app/api/test-helpers/verify-email/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { prisma } from "~/lib/prisma";
 
 /**
@@ -7,7 +8,7 @@ import { prisma } from "~/lib/prisma";
  * It bypasses normal authentication to allow E2E tests to create verified users.
  */
 
-export async function POST(req: NextRequest) {
+export const POST = withAuditContext(async (req: NextRequest) => {
   // Only allow when explicitly running E2E tests
   // Never available in actual production deployments
   const isE2ETest =
@@ -45,4 +46,4 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/testplanit/lib/auditContext.ts
+++ b/testplanit/lib/auditContext.ts
@@ -1,6 +1,12 @@
 import { AsyncLocalStorage } from "async_hooks";
 import type { NextRequest } from "next/server";
 
+// Re-export the client-safe constants so existing server-side imports keep
+// working unchanged. Client/edge code should import from
+// `auditContextConstants` directly to avoid pulling AsyncLocalStorage into
+// browser bundles.
+export { SYSTEM_ACTOR_ID, type SystemActor } from "~/lib/auditContextConstants";
+
 /**
  * Context for audit logging, propagated through the request lifecycle
  * using AsyncLocalStorage to avoid passing context through all functions.
@@ -34,19 +40,6 @@ export interface AuditContext {
    */
   suppressWebhooks?: boolean;
 }
-
-/**
- * Sentinel userId for audit events that have no originating human actor
- * (scheduled jobs, worker-to-worker fan-outs, infrastructure tasks).
- *
- * Per Phase 64 D-12 / D-13: no schema migration is introduced — this
- * string literal lives in the existing userId column. Queries that
- * exclude system-initiated events use `WHERE "userId" <> '__system__'`.
- */
-export const SYSTEM_ACTOR_ID = "__system__" as const;
-
-/** Type-level alias for code that must branch on system-vs-human actors. */
-export type SystemActor = typeof SYSTEM_ACTOR_ID;
 
 /**
  * AsyncLocalStorage instance for audit context.

--- a/testplanit/lib/auditContextConstants.ts
+++ b/testplanit/lib/auditContextConstants.ts
@@ -1,0 +1,21 @@
+/**
+ * Audit-context constants that are safe to import from anywhere — including
+ * client components and edge runtimes. Anything that pulls in `async_hooks`
+ * (the AsyncLocalStorage frame) lives in `auditContext.ts` and must not be
+ * imported from a browser bundle. The constants here are pure values, so
+ * client code (e.g. the audit-log table renderer) can import them without
+ * dragging Node-only deps into the client chunk.
+ */
+
+/**
+ * Sentinel userId for audit events that have no originating human actor
+ * (scheduled jobs, worker-to-worker fan-outs, infrastructure tasks).
+ *
+ * Per Phase 64 D-12 / D-13: no schema migration is introduced — this
+ * string literal lives in the existing userId column. Queries that
+ * exclude system-initiated events use `WHERE "userId" <> '__system__'`.
+ */
+export const SYSTEM_ACTOR_ID = "__system__" as const;
+
+/** Type-level alias for code that must branch on system-vs-human actors. */
+export type SystemActor = typeof SYSTEM_ACTOR_ID;

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -4858,7 +4858,9 @@
         "last30d": "Last 30 days",
         "last90d": "Last 90 days",
         "allTime": "All time"
-      }
+      },
+      "systemActor": "System",
+      "systemActorTooltip": "Action performed by the system, not a logged-in user"
     }
   },
   "components": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -4858,7 +4858,9 @@
         "last30d": "Últimos 30 días",
         "last90d": "Últimos 90 días",
         "allTime": "Todos los tiempos"
-      }
+      },
+      "systemActor": "Sistema",
+      "systemActorTooltip": "Acción realizada por el sistema, no por un usuario que haya iniciado sesión."
     }
   },
   "components": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -4858,7 +4858,9 @@
         "last30d": "30 derniers jours",
         "last90d": "90 derniers jours",
         "allTime": "Tout le temps"
-      }
+      },
+      "systemActor": "Système",
+      "systemActorTooltip": "Action effectuée par le système, et non par un utilisateur connecté"
     }
   },
   "components": {


### PR DESCRIPTION
## Description

Closes three v0.22.1 audit-coverage follow-ups deferred as 999.x:

- **999.8 — System actor badge UI polish.** Audit-log rows with `userId="__system__"` now render as a Cog-iconed Badge with tooltip on the `/admin/audit-logs` page (previously shown as raw `__system__` text).
- **999.4 — Wrap `share/[shareKey]` route + report sub-route** with `withAuditContext` so AsyncLocalStorage is seeded with `ipAddress` / `userAgent` / `requestId` for any downstream audit emission.
- **999.7 — Wrap `test-helpers/verify-email` route** with `withAuditContext` for the same reason.

Side effect: extracted `SYSTEM_ACTOR_ID` into `lib/auditContextConstants.ts` (client-safe — no `async_hooks` import) so admin column code can import the sentinel without dragging Node-only deps into the browser bundle. Crowdin synced for es-ES + fr-FR.

Tagged `enhancement` so semantic-release cuts a patch bump, not a minor.

## Related Issue

Closes the 999.x audit-coverage follow-ups recorded at v0.22.1 milestone close.

## Type of Change

- [x] Enhancement (small non-breaking polish)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Unit tests pass (\`pnpm test\` — 6536 passed)
- [x] Production build succeeds (\`pnpm build\`)
- [x] Lint + format clean (\`pnpm precommit\`)
- [x] Manual verification: inserted system-actor audit rows directly in dev DB; new badge renders with Cog icon + tooltip
- [x] Manual curls against all three wrapped routes return expected status codes (404 / 403)
- [x] Wrapper-verification unit tests assert \`getAuditContext()\` returns populated values inside each wrapped handler

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [x] i18n keys added to en-US.json and synced via crowdin

🤖 Generated with [Claude Code](https://claude.com/claude-code)