### PR TITLE
fix: search access for non-direct project members + automated flag promotion on result submission

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
@@ -2547,6 +2547,7 @@ export default function Cases({
         completedAt: trc.completedAt,
         elapsed: trc.elapsed,
         order: trc.order,
+        testRunId: trc.testRun?.id,
         testRunConfiguration: trc.testRun?.configuration,
       }));
     }
@@ -2774,14 +2775,21 @@ export default function Cases({
         setRowSelection(rangeSelection);
 
         // Convert to IDs for the global selection
+        const getCaseId = (tc: (typeof MappedCases)[number]) =>
+          isMultiConfigMode && (tc as any).testRunCaseId
+            ? (tc as any).testRunCaseId
+            : tc.id;
         const selectedIds = Object.entries(rangeSelection)
           .filter(([_, isSelected]) => isSelected)
-          .map(([index]) => MappedCases[parseInt(index)]?.id)
+          .map(([index]) => {
+            const tc = MappedCases[parseInt(index)];
+            return tc ? getCaseId(tc) : undefined;
+          })
           .filter((id): id is number => id !== undefined);
 
         if (isSelectionMode && onSelectionChange) {
           // Get IDs from other pages
-          const allCaseIdsOnCurrentPage = MappedCases.map((tc) => tc.id);
+          const allCaseIdsOnCurrentPage = MappedCases.map(getCaseId);
           const selectedIdsFromOtherPages = selectedTestCases.filter(
             (id) => !allCaseIdsOnCurrentPage.includes(id)
           );
@@ -2882,20 +2890,24 @@ export default function Cases({
           });
           setRowSelection(newSelection);
 
+          const getDeselectCaseId = (tc: (typeof MappedCases)[number]) =>
+            isMultiConfigMode && (tc as any).testRunCaseId
+              ? (tc as any).testRunCaseId
+              : tc.id;
+          const currentPageIds = selectableRows.map(getDeselectCaseId);
+
           if (isSelectionMode && onSelectionChange) {
             // Remove current page IDs from selection
-            const currentPageIds = selectableRows.map((tc) => tc.id);
-            const newSelection = selectedTestCases.filter(
-              (id) => !currentPageIds.includes(id)
+            onSelectionChange(
+              selectedTestCases.filter((id) => !currentPageIds.includes(id))
             );
-            onSelectionChange(newSelection);
           } else {
-            // For bulk edit mode, we typically clear all when deselecting current page
-            const currentPageIds = selectableRows.map((tc) => tc.id);
-            const newSelection = selectedCaseIdsForBulkEdit.filter(
-              (id) => !currentPageIds.includes(id)
+            // For bulk edit mode, remove current page IDs from selection
+            setSelectedCaseIdsForBulkEdit(
+              selectedCaseIdsForBulkEdit.filter(
+                (id) => !currentPageIds.includes(id)
+              )
             );
-            setSelectedCaseIdsForBulkEdit(newSelection);
           }
         } else {
           // Select all selectable rows on current page
@@ -2905,11 +2917,15 @@ export default function Cases({
           });
           setRowSelection(newSelection);
 
-          const selectedIds = selectableRows.map((tc) => tc.id);
+          const getSelectAllCaseId = (tc: (typeof MappedCases)[number]) =>
+            isMultiConfigMode && (tc as any).testRunCaseId
+              ? (tc as any).testRunCaseId
+              : tc.id;
+          const selectedIds = selectableRows.map(getSelectAllCaseId);
 
           if (isSelectionMode && onSelectionChange) {
             // Add current page IDs to existing selection
-            const currentPageIds = MappedCases.map((tc) => tc.id);
+            const currentPageIds = MappedCases.map(getSelectAllCaseId);
             const selectedIdsFromOtherPages = selectedTestCases.filter(
               (id) => !currentPageIds.includes(id)
             );
@@ -3016,7 +3032,10 @@ export default function Cases({
         setAddResultModalState({
           isOpen: true,
           ...modalData,
-          configuration: testRunData?.configuration || null,
+          configuration:
+            modalData.configuration !== undefined
+              ? modalData.configuration
+              : testRunData?.configuration || null,
         });
       },
       // Pass isMultiConfigRun flag
@@ -3028,9 +3047,11 @@ export default function Cases({
         ? selectedTestCases.length
         : selectedCaseIdsForBulkEdit.length,
       // Pass enableReorder to show/hide grip handle
+      // Disabled in multi-config mode: ordering a merged view of multiple runs is undefined
       isDefaultSort &&
         !isSelectionMode &&
         !isCompleted &&
+        !isMultiConfigMode &&
         ((isRunMode && canAddEditRun) || (!isRunMode && canAddEdit)),
       // QuickScript per-row action
       quickScriptEnabled,
@@ -3710,6 +3731,7 @@ export default function Cases({
                   isDefaultSort &&
                   !isSelectionMode &&
                   !isCompleted &&
+                  !isMultiConfigMode &&
                   ((isRunMode && canAddEditRun) || (!isRunMode && canAddEdit))
                 }
                 onReorder={handleReorder}

--- a/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/columns.tsx
@@ -160,6 +160,7 @@ export interface ExtendedCases extends RepositoryCases {
     };
   }[];
   // Test run specific fields
+  testRunId?: number;
   testRunCaseId?: number;
   testRunStatus?: {
     id: number;
@@ -492,6 +493,7 @@ const TestRunStatusCell = React.memo(function TestRunStatusCell({
     isBulkResult?: boolean;
     selectedCases?: ExtendedCases[];
     steps?: any[];
+    configuration?: { id: number; name: string } | null;
   }) => void;
 }) {
   const [showAssignModal, setShowAssignModal] = useState(false);
@@ -1310,6 +1312,7 @@ export const getColumns = (
     isBulkResult?: boolean;
     selectedCases?: ExtendedCases[];
     steps?: any[];
+    configuration?: { id: number; name: string } | null;
   }) => void,
   isMultiConfigRun?: boolean,
   totalItems?: number,
@@ -2184,7 +2187,7 @@ export const getColumns = (
             caseId={row.original.id}
             testRunCaseId={row.original.testRunCaseId}
             currentAssignee={row.original.assignedTo}
-            testRunId={runId || 0}
+            testRunId={row.original.testRunId || runId || 0}
             caseName={row.original.name}
             projectId={Number(row.original.projectId || 0)}
             table={table}
@@ -2197,7 +2200,15 @@ export const getColumns = (
             isCompleted={isCompleted || !canAddEditResults}
             steps={row.original.steps || []}
             isSoftDeletedInRun={isSoftDeletedInRun}
-            onOpenAddResultModal={onOpenAddResultModal}
+            onOpenAddResultModal={
+              onOpenAddResultModal
+                ? (modalData) =>
+                    onOpenAddResultModal({
+                      ...modalData,
+                      configuration: row.original.testRunConfiguration,
+                    })
+                : undefined
+            }
           />
         );
       },

--- a/testplanit/app/api/test-runs/submit-result/route.test.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.test.ts
@@ -233,7 +233,9 @@ describe("Submit Result API Route", () => {
     };
 
     it("flips repositoryCase.automated to true when an automated run submits a result for a manual case", async () => {
-      (prisma.testRunCases.findFirst as any).mockResolvedValue(automatedRunCase);
+      (prisma.testRunCases.findFirst as any).mockResolvedValue(
+        automatedRunCase
+      );
 
       const response = await POST(createRequest(validBody));
 
@@ -245,7 +247,9 @@ describe("Submit Result API Route", () => {
     });
 
     it("triggers ES re-sync after flipping the automated flag", async () => {
-      (prisma.testRunCases.findFirst as any).mockResolvedValue(automatedRunCase);
+      (prisma.testRunCases.findFirst as any).mockResolvedValue(
+        automatedRunCase
+      );
 
       await POST(createRequest(validBody));
 
@@ -275,21 +279,26 @@ describe("Submit Result API Route", () => {
       expect(syncRepositoryCaseToElasticsearch).not.toHaveBeenCalled();
     });
 
-    it.each(["JUNIT", "TESTNG", "XUNIT", "NUNIT", "MSTEST", "MOCHA", "CUCUMBER"])(
-      "flips the flag for automated run type %s",
-      async (testRunType) => {
-        (prisma.testRunCases.findFirst as any).mockResolvedValue({
-          ...automatedRunCase,
-          testRun: { ...automatedRunCase.testRun, testRunType },
-        });
+    it.each([
+      "JUNIT",
+      "TESTNG",
+      "XUNIT",
+      "NUNIT",
+      "MSTEST",
+      "MOCHA",
+      "CUCUMBER",
+    ])("flips the flag for automated run type %s", async (testRunType) => {
+      (prisma.testRunCases.findFirst as any).mockResolvedValue({
+        ...automatedRunCase,
+        testRun: { ...automatedRunCase.testRun, testRunType },
+      });
 
-        await POST(createRequest(validBody));
+      await POST(createRequest(validBody));
 
-        expect(txMocks.repositoryCases.update).toHaveBeenCalledWith({
-          where: { id: 55 },
-          data: { automated: true },
-        });
-      }
-    );
+      expect(txMocks.repositoryCases.update).toHaveBeenCalledWith({
+        where: { id: 55 },
+        data: { automated: true },
+      });
+    });
   });
 });

--- a/testplanit/app/api/test-runs/submit-result/route.test.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.test.ts
@@ -26,9 +26,14 @@ vi.mock("~/lib/prisma", () => ({
   },
 }));
 
+vi.mock("~/services/repositoryCaseSync", () => ({
+  syncRepositoryCaseToElasticsearch: vi.fn().mockResolvedValue(true),
+}));
+
 import { getServerSession } from "next-auth";
 import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
+import { syncRepositoryCaseToElasticsearch } from "~/services/repositoryCaseSync";
 
 describe("Submit Result API Route", () => {
   const validBody = {
@@ -58,9 +63,12 @@ describe("Submit Result API Route", () => {
   const baseRunCase = {
     id: 10,
     assignedToId: null,
+    repositoryCaseId: 55,
+    repositoryCase: { automated: false },
     testRun: {
       id: 1,
       createdById: "run-owner",
+      testRunType: "REGULAR",
       project: {
         createdBy: "project-owner",
         defaultAccessType: "DEFAULT",
@@ -88,6 +96,9 @@ describe("Submit Result API Route", () => {
     testRunCases: {
       update: ReturnType<typeof vi.fn>;
     };
+    repositoryCases: {
+      update: ReturnType<typeof vi.fn>;
+    };
     testRuns: {
       update: ReturnType<typeof vi.fn>;
     };
@@ -110,6 +121,9 @@ describe("Submit Result API Route", () => {
       },
       testRunCases: {
         update: vi.fn().mockResolvedValue({ id: 10 }),
+      },
+      repositoryCases: {
+        update: vi.fn().mockResolvedValue({ id: 55 }),
       },
       testRuns: {
         update: vi.fn().mockResolvedValue({ id: 1 }),
@@ -205,5 +219,77 @@ describe("Submit Result API Route", () => {
 
     expect(response.status).toBe(500);
     expect(data.code).toBe("SUBMIT_RESULT_FAILED");
+  });
+
+  describe("automated flag promotion", () => {
+    const automatedRunCase = {
+      ...baseRunCase,
+      repositoryCaseId: 55,
+      repositoryCase: { automated: false },
+      testRun: {
+        ...baseRunCase.testRun,
+        testRunType: "JUNIT",
+      },
+    };
+
+    it("flips repositoryCase.automated to true when an automated run submits a result for a manual case", async () => {
+      (prisma.testRunCases.findFirst as any).mockResolvedValue(automatedRunCase);
+
+      const response = await POST(createRequest(validBody));
+
+      expect(response.status).toBe(200);
+      expect(txMocks.repositoryCases.update).toHaveBeenCalledWith({
+        where: { id: 55 },
+        data: { automated: true },
+      });
+    });
+
+    it("triggers ES re-sync after flipping the automated flag", async () => {
+      (prisma.testRunCases.findFirst as any).mockResolvedValue(automatedRunCase);
+
+      await POST(createRequest(validBody));
+
+      // Allow the fire-and-forget void promise to settle
+      await Promise.resolve();
+
+      expect(syncRepositoryCaseToElasticsearch).toHaveBeenCalledWith(55);
+    });
+
+    it("does not flip automated flag when run type is REGULAR", async () => {
+      // baseRunCase already has testRunType: "REGULAR"
+      await POST(createRequest(validBody));
+
+      expect(txMocks.repositoryCases.update).not.toHaveBeenCalled();
+      expect(syncRepositoryCaseToElasticsearch).not.toHaveBeenCalled();
+    });
+
+    it("does not flip automated flag when case is already marked automated", async () => {
+      (prisma.testRunCases.findFirst as any).mockResolvedValue({
+        ...automatedRunCase,
+        repositoryCase: { automated: true },
+      });
+
+      await POST(createRequest(validBody));
+
+      expect(txMocks.repositoryCases.update).not.toHaveBeenCalled();
+      expect(syncRepositoryCaseToElasticsearch).not.toHaveBeenCalled();
+    });
+
+    it.each(["JUNIT", "TESTNG", "XUNIT", "NUNIT", "MSTEST", "MOCHA", "CUCUMBER"])(
+      "flips the flag for automated run type %s",
+      async (testRunType) => {
+        (prisma.testRunCases.findFirst as any).mockResolvedValue({
+          ...automatedRunCase,
+          testRun: { ...automatedRunCase.testRun, testRunType },
+        });
+
+        await POST(createRequest(validBody));
+
+        expect(txMocks.repositoryCases.update).toHaveBeenCalledWith({
+          where: { id: 55 },
+          data: { automated: true },
+        });
+      }
+    );
   });
 });

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -342,7 +342,8 @@ export async function POST(req: NextRequest) {
         : (input.evidence as Prisma.InputJsonValue);
 
     const isAutomatedRun = runCase.testRun.testRunType !== "REGULAR";
-    const needsAutomatedFlip = isAutomatedRun && !runCase.repositoryCase.automated;
+    const needsAutomatedFlip =
+      isAutomatedRun && !runCase.repositoryCase.automated;
 
     const result = await prisma.$transaction(async (tx) => {
       const createdResult = await tx.testRunResults.create({

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod/v4";
 import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
 import { authOptions } from "~/server/auth";
+import { syncRepositoryCaseToElasticsearch } from "~/services/repositoryCaseSync";
 
 const submitResultSchema = z.object({
   testRunId: z.number().int().positive(),
@@ -213,10 +214,15 @@ export async function POST(req: NextRequest) {
       select: {
         id: true,
         assignedToId: true,
+        repositoryCaseId: true,
+        repositoryCase: {
+          select: { automated: true },
+        },
         testRun: {
           select: {
             id: true,
             createdById: true,
+            testRunType: true,
             project: {
               select: {
                 createdBy: true,
@@ -335,6 +341,9 @@ export async function POST(req: NextRequest) {
         ? {}
         : (input.evidence as Prisma.InputJsonValue);
 
+    const isAutomatedRun = runCase.testRun.testRunType !== "REGULAR";
+    const needsAutomatedFlip = isAutomatedRun && !runCase.repositoryCase.automated;
+
     const result = await prisma.$transaction(async (tx) => {
       const createdResult = await tx.testRunResults.create({
         data: {
@@ -362,6 +371,13 @@ export async function POST(req: NextRequest) {
           statusId: input.statusId,
         },
       });
+
+      if (needsAutomatedFlip) {
+        await tx.repositoryCases.update({
+          where: { id: runCase.repositoryCaseId },
+          data: { automated: true },
+        });
+      }
 
       if (input.inProgressStateId) {
         const previousResult = await tx.testRunResults.findFirst({
@@ -391,6 +407,16 @@ export async function POST(req: NextRequest) {
 
       return createdResult;
     });
+
+    if (needsAutomatedFlip) {
+      void syncRepositoryCaseToElasticsearch(runCase.repositoryCaseId).catch(
+        (err) =>
+          console.error(
+            `ES sync failed after automated flag update for case ${runCase.repositoryCaseId}:`,
+            err
+          )
+      );
+    }
 
     return NextResponse.json({ result });
   } catch (error) {

--- a/testplanit/e2e/tests/test-runs/test-run-multi-config-interaction.spec.ts
+++ b/testplanit/e2e/tests/test-runs/test-run-multi-config-interaction.spec.ts
@@ -1,0 +1,293 @@
+import { randomUUID } from "crypto";
+import { expect, test } from "../../fixtures";
+
+/**
+ * Multi-Config Run — Result Submission and Checkbox Selection
+ *
+ * These tests cover two bugs that existed when multiple configurations are
+ * selected on a test run page (the ?configs=run1Id,run2Id view):
+ *
+ * BUG 1 — Wrong testRunId on result submission
+ *   The status dropdown in each table row always sent testRunId = the URL's
+ *   primary run, regardless of which config's row was clicked. When Config B's
+ *   row was clicked, the POST went to Config A's run.
+ *
+ * BUG 2 — Checkbox ID collision in shift-select and select-all
+ *   The shift-click range and "select all on page" paths used repositoryCaseId
+ *   as the row identifier. In multi-config mode the same repo case appears once
+ *   per config, so all copies shared an ID — causing incorrect range boundaries
+ *   and duplicate entries in the selection set.
+ */
+test.describe("Multi-Config Run Interaction", () => {
+  /**
+   * Set up a minimal multi-config test run:
+   *   - 2 configurations, 2 sibling runs sharing a configurationGroupId
+   *   - 1 repo case added to BOTH runs
+   * Returns the run IDs and the testRunCaseId for run2's copy of the case
+   * so the result submission test can verify the payload.
+   */
+  async function setupMultiConfigRun(
+    api: any,
+    ts: number,
+    caseCount = 1
+  ): Promise<{
+    projectId: number;
+    config1Name: string;
+    config2Name: string;
+    run1Id: number;
+    run2Id: number;
+    caseIds: number[];
+    run1CaseIds: number[];
+    run2CaseIds: number[];
+  }> {
+    const projectId = await api.createProject(`E2E MC ${ts}`);
+    const config1Name = `Chrome-${ts}`;
+    const config2Name = `Firefox-${ts}`;
+    const config1Id = await api.createConfiguration(config1Name);
+    const config2Id = await api.createConfiguration(config2Name);
+
+    const groupId = randomUUID();
+    const run1Id = await api.createTestRun(projectId, `Chrome Run ${ts}`, {
+      configId: config1Id,
+      configurationGroupId: groupId,
+    });
+    const run2Id = await api.createTestRun(projectId, `Firefox Run ${ts}`, {
+      configId: config2Id,
+      configurationGroupId: groupId,
+    });
+
+    const folderId = await api.createFolder(projectId, `MC Folder ${ts}`);
+    const caseIds: number[] = [];
+    const run1CaseIds: number[] = [];
+    const run2CaseIds: number[] = [];
+
+    for (let i = 0; i < caseCount; i++) {
+      const caseId = await api.createTestCase(
+        projectId,
+        folderId,
+        `MC Case ${i + 1} ${ts}`
+      );
+      caseIds.push(caseId);
+      const rc1Id = await api.addTestCaseToTestRun(run1Id, caseId, {
+        order: i,
+      });
+      const rc2Id = await api.addTestCaseToTestRun(run2Id, caseId, {
+        order: i,
+      });
+      run1CaseIds.push(rc1Id);
+      run2CaseIds.push(rc2Id);
+    }
+
+    return {
+      projectId,
+      config1Name,
+      config2Name,
+      run1Id,
+      run2Id,
+      caseIds,
+      run1CaseIds,
+      run2CaseIds,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // BUG 1: result submission must go to the row's own run, not the URL run
+  // ---------------------------------------------------------------------------
+  test("submits result to the correct testRunId for the clicked config row", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    const { projectId, config2Name, run1Id, run2Id, run2CaseIds } =
+      await setupMultiConfigRun(api, ts, 1);
+    const rc2Id = run2CaseIds[0]; // testRunCaseId that belongs to run2
+
+    // Capture POST bodies sent to the submit-result endpoint
+    const submitted: Array<{ testRunId: number; testRunCaseId: number }> = [];
+    await page.route("**/api/test-runs/submit-result", async (route) => {
+      const body = route.request().postDataJSON();
+      submitted.push({ testRunId: body.testRunId, testRunCaseId: body.testRunCaseId });
+      await route.continue();
+    });
+
+    // Navigate to run1 with both runs' configs selected
+    await page.goto(
+      `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
+    );
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(3000);
+
+    // Table should show 2 rows — one row per config for the shared case
+    const rows = page.locator("tbody tr");
+    await expect(rows).toHaveCount(2, { timeout: 10000 });
+
+    // Find run2's row by the Firefox config badge text and click its status button
+    const run2Row = rows.filter({ hasText: config2Name });
+    await expect(run2Row).toBeVisible({ timeout: 8000 });
+
+    const statusButton = run2Row
+      .locator("button")
+      .filter({ hasText: /untested/i })
+      .first();
+    await expect(statusButton).toBeVisible({ timeout: 8000 });
+    await statusButton.click();
+
+    // Status dropdown menu opens; pick the first available status
+    const dropdownMenu = page.locator('[role="menu"]');
+    await expect(dropdownMenu).toBeVisible({ timeout: 8000 });
+    const firstStatusOption = dropdownMenu.locator('[role="menuitem"]').first();
+    await expect(firstStatusOption).toBeVisible({ timeout: 5000 });
+    await firstStatusOption.click();
+
+    // AddResultModal dialog should open
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 8000 });
+
+    // Submit the result (Save button)
+    const saveButton = dialog
+      .locator('button[type="submit"], button:has-text("Save")')
+      .last();
+    await expect(saveButton).toBeVisible({ timeout: 5000 });
+    await saveButton.click();
+
+    // Wait for the request to fire and be captured
+    await page.waitForTimeout(2000);
+
+    // The submitted payload must target run2, not run1
+    expect(submitted.length).toBeGreaterThan(0);
+    const payload = submitted[submitted.length - 1];
+    expect(payload.testRunId).toBe(run2Id);
+    expect(payload.testRunCaseId).toBe(rc2Id);
+    expect(payload.testRunId).not.toBe(run1Id);
+  });
+
+  // ---------------------------------------------------------------------------
+  // BUG 2a: select-all header checkbox must mark every row as selected
+  // ---------------------------------------------------------------------------
+  test("select-all header checkbox checks all rows independently in multi-config mode", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    // 2 cases × 2 configs = 4 rows
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
+      api,
+      ts,
+      2
+    );
+
+    await page.goto(
+      `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
+    );
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(3000);
+
+    // All 4 rows must be visible before we start
+    const bodyRows = page.locator("tbody tr");
+    await expect(bodyRows).toHaveCount(4, { timeout: 10000 });
+
+    // Click the "Select Case" header checkbox (select-all)
+    const headerCheckbox = page
+      .locator("thead")
+      .getByRole("checkbox", { name: /select case/i });
+    await expect(headerCheckbox).toBeVisible({ timeout: 5000 });
+    await headerCheckbox.click();
+
+    // Every row checkbox must now be checked
+    const rowCheckboxes = page
+      .locator("tbody")
+      .getByRole("checkbox");
+    const count = await rowCheckboxes.count();
+    expect(count).toBe(4);
+    for (let i = 0; i < count; i++) {
+      await expect(rowCheckboxes.nth(i)).toBeChecked({ timeout: 5000 });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // BUG 2a-deselect: clicking header checkbox again must uncheck all rows
+  // ---------------------------------------------------------------------------
+  test("select-all header checkbox unchecks all rows on second click", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
+      api,
+      ts,
+      2
+    );
+
+    await page.goto(
+      `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
+    );
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(3000);
+
+    await expect(page.locator("tbody tr")).toHaveCount(4, { timeout: 10000 });
+
+    const headerCheckbox = page
+      .locator("thead")
+      .getByRole("checkbox", { name: /select case/i });
+    await expect(headerCheckbox).toBeVisible({ timeout: 5000 });
+
+    // First click: select all
+    await headerCheckbox.click();
+    const rowCheckboxes = page.locator("tbody").getByRole("checkbox");
+    for (let i = 0; i < 4; i++) {
+      await expect(rowCheckboxes.nth(i)).toBeChecked({ timeout: 5000 });
+    }
+
+    // Second click: deselect all
+    await headerCheckbox.click();
+    await page.waitForTimeout(500); // let useLayoutEffect settle
+    for (let i = 0; i < 4; i++) {
+      await expect(rowCheckboxes.nth(i)).not.toBeChecked({ timeout: 5000 });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // BUG 2b: shift-click range must check every row between the two clicks
+  // ---------------------------------------------------------------------------
+  test("shift-click selects the correct range of rows in multi-config mode", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    // 2 cases × 2 configs = 4 rows — expect rows ordered: C1/cfg1, C1/cfg2, C2/cfg1, C2/cfg2
+    // (actual order depends on server sort, but we need ≥4 rows to test a range)
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
+      api,
+      ts,
+      2
+    );
+
+    await page.goto(
+      `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
+    );
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(3000);
+
+    const bodyRows = page.locator("tbody tr");
+    await expect(bodyRows).toHaveCount(4, { timeout: 10000 });
+
+    const rowCheckboxes = page.locator("tbody").getByRole("checkbox");
+    await expect(rowCheckboxes).toHaveCount(4, { timeout: 5000 });
+
+    // Click row 0 (first row)
+    await rowCheckboxes.nth(0).click();
+    await expect(rowCheckboxes.nth(0)).toBeChecked({ timeout: 3000 });
+
+    // Shift-click row 2 to select rows 0–2
+    await page.keyboard.down("Shift");
+    await rowCheckboxes.nth(2).click();
+    await page.keyboard.up("Shift");
+
+    // Rows 0, 1, and 2 should all be checked
+    await expect(rowCheckboxes.nth(0)).toBeChecked({ timeout: 5000 });
+    await expect(rowCheckboxes.nth(1)).toBeChecked({ timeout: 5000 });
+    await expect(rowCheckboxes.nth(2)).toBeChecked({ timeout: 5000 });
+    // Row 3 should remain unchecked
+    await expect(rowCheckboxes.nth(3)).not.toBeChecked({ timeout: 3000 });
+  });
+});

--- a/testplanit/e2e/tests/test-runs/test-run-multi-config-interaction.spec.ts
+++ b/testplanit/e2e/tests/test-runs/test-run-multi-config-interaction.spec.ts
@@ -106,7 +106,10 @@ test.describe("Multi-Config Run Interaction", () => {
     const submitted: Array<{ testRunId: number; testRunCaseId: number }> = [];
     await page.route("**/api/test-runs/submit-result", async (route) => {
       const body = route.request().postDataJSON();
-      submitted.push({ testRunId: body.testRunId, testRunCaseId: body.testRunCaseId });
+      submitted.push({
+        testRunId: body.testRunId,
+        testRunCaseId: body.testRunCaseId,
+      });
       await route.continue();
     });
 
@@ -170,11 +173,7 @@ test.describe("Multi-Config Run Interaction", () => {
   }) => {
     const ts = Date.now();
     // 2 cases × 2 configs = 4 rows
-    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
-      api,
-      ts,
-      2
-    );
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(api, ts, 2);
 
     await page.goto(
       `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
@@ -194,9 +193,7 @@ test.describe("Multi-Config Run Interaction", () => {
     await headerCheckbox.click();
 
     // Every row checkbox must now be checked
-    const rowCheckboxes = page
-      .locator("tbody")
-      .getByRole("checkbox");
+    const rowCheckboxes = page.locator("tbody").getByRole("checkbox");
     const count = await rowCheckboxes.count();
     expect(count).toBe(4);
     for (let i = 0; i < count; i++) {
@@ -212,11 +209,7 @@ test.describe("Multi-Config Run Interaction", () => {
     page,
   }) => {
     const ts = Date.now();
-    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
-      api,
-      ts,
-      2
-    );
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(api, ts, 2);
 
     await page.goto(
       `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`
@@ -256,11 +249,7 @@ test.describe("Multi-Config Run Interaction", () => {
     const ts = Date.now();
     // 2 cases × 2 configs = 4 rows — expect rows ordered: C1/cfg1, C1/cfg2, C2/cfg1, C2/cfg2
     // (actual order depends on server sort, but we need ≥4 rows to test a range)
-    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(
-      api,
-      ts,
-      2
-    );
+    const { projectId, run1Id, run2Id } = await setupMultiConfigRun(api, ts, 2);
 
     await page.goto(
       `/en-US/projects/runs/${projectId}/${run1Id}?configs=${run1Id},${run2Id}`

--- a/testplanit/lib/services/searchQueryBuilder.test.ts
+++ b/testplanit/lib/services/searchQueryBuilder.test.ts
@@ -1099,7 +1099,9 @@ describe("buildElasticsearchQuery", () => {
     // Path 2: explicit user permission (not NO_ACCESS)
     expect(orClauses).toContainEqual(
       expect.objectContaining({
-        userPermissions: { some: expect.objectContaining({ userId: "user-789" }) },
+        userPermissions: {
+          some: expect.objectContaining({ userId: "user-789" }),
+        },
       })
     );
 

--- a/testplanit/lib/services/searchQueryBuilder.test.ts
+++ b/testplanit/lib/services/searchQueryBuilder.test.ts
@@ -23,8 +23,8 @@ import {
 // Mock the server/db module for buildElasticsearchQuery tests
 vi.mock("~/server/db", () => ({
   db: {
-    projectAssignment: {
-      findMany: vi.fn().mockResolvedValue([{ projectId: 1 }, { projectId: 2 }]),
+    projects: {
+      findMany: vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]),
     },
   },
 }));
@@ -1039,12 +1039,9 @@ describe("buildElasticsearchQuery", () => {
     expect(projectFilter).toBeUndefined();
   });
 
-  it("non-admin user gets project ID filter from DB", async () => {
+  it("non-admin user gets project ID filter from accessible projects", async () => {
     const { db } = await import("~/server/db");
-    (db.projectAssignment.findMany as any).mockResolvedValue([
-      { projectId: 10 },
-      { projectId: 20 },
-    ]);
+    (db.projects.findMany as any).mockResolvedValue([{ id: 10 }, { id: 20 }]);
 
     const result = await buildElasticsearchQuery(
       { query: "test" },
@@ -1057,9 +1054,9 @@ describe("buildElasticsearchQuery", () => {
     expect(projectFilter).toEqual({ terms: { projectId: [10, 20] } });
   });
 
-  it("non-admin user with no project assignments gets impossible filter", async () => {
+  it("non-admin user with no accessible projects gets impossible filter", async () => {
     const { db } = await import("~/server/db");
-    (db.projectAssignment.findMany as any).mockResolvedValue([]);
+    (db.projects.findMany as any).mockResolvedValue([]);
 
     const result = await buildElasticsearchQuery(
       { query: "test" },
@@ -1070,6 +1067,80 @@ describe("buildElasticsearchQuery", () => {
       (f: any) => f.terms?.projectId
     );
     expect(projectFilter).toEqual({ terms: { projectId: [-1] } });
+  });
+
+  it("queries projects using all four access paths for non-admin user", async () => {
+    const { db } = await import("~/server/db");
+    (db.projects.findMany as any).mockResolvedValue([{ id: 5 }]);
+
+    await buildElasticsearchQuery(
+      { query: "test" },
+      { access: "USER", id: "user-789" }
+    );
+
+    const callArgs = (db.projects.findMany as any).mock.calls[0][0];
+
+    // Must exclude projects where user has explicit NO_ACCESS
+    expect(callArgs.where.userPermissions).toMatchObject({
+      none: { userId: "user-789" },
+    });
+
+    // OR conditions must include all four paths
+    const orClauses = callArgs.where.OR;
+    expect(orClauses).toBeDefined();
+
+    // Path 1: direct assignment
+    expect(orClauses).toContainEqual(
+      expect.objectContaining({
+        assignedUsers: { some: { userId: "user-789" } },
+      })
+    );
+
+    // Path 2: explicit user permission (not NO_ACCESS)
+    expect(orClauses).toContainEqual(
+      expect.objectContaining({
+        userPermissions: { some: expect.objectContaining({ userId: "user-789" }) },
+      })
+    );
+
+    // Path 3: group-based permission
+    expect(orClauses).toContainEqual(
+      expect.objectContaining({
+        groupPermissions: {
+          some: expect.objectContaining({
+            group: { assignedUsers: { some: { userId: "user-789" } } },
+          }),
+        },
+      })
+    );
+
+    // Path 4: open default access type (GLOBAL_ROLE / SPECIFIC_ROLE / DEFAULT)
+    const defaultAccessClause = orClauses.find(
+      (c: any) => c.defaultAccessType?.in
+    );
+    expect(defaultAccessClause).toBeDefined();
+    expect(defaultAccessClause.defaultAccessType.in).toEqual(
+      expect.arrayContaining(["GLOBAL_ROLE", "SPECIFIC_ROLE", "DEFAULT"])
+    );
+  });
+
+  it("skips defaultAccessType OR clause for NONE-access users", async () => {
+    const { db } = await import("~/server/db");
+    (db.projects.findMany as any).mockResolvedValue([]);
+
+    await buildElasticsearchQuery(
+      { query: "test" },
+      { access: "NONE", id: "user-none" }
+    );
+
+    const callArgs = (db.projects.findMany as any).mock.calls[0][0];
+    const orClauses = callArgs.where.OR;
+
+    // defaultAccessType check must NOT be present for NONE users
+    const defaultAccessClause = orClauses.find(
+      (c: any) => c.defaultAccessType?.in
+    );
+    expect(defaultAccessClause).toBeUndefined();
   });
 
   it("always adds isDeleted filter for non-admin", async () => {

--- a/testplanit/lib/services/searchQueryBuilder.ts
+++ b/testplanit/lib/services/searchQueryBuilder.ts
@@ -205,19 +205,63 @@ export async function buildElasticsearchQuery(
 
   // Add user access control
   if (user.access !== "ADMIN") {
-    // Get user's assigned project IDs
     const { db } = await import("~/server/db");
-    const userProjectAssignments = await db.projectAssignment.findMany({
-      where: { userId: user.id },
-      select: { projectId: true },
-    });
-    const userProjectIds = userProjectAssignments.map((pa) => pa.projectId);
+    const { ProjectAccessType } = await import("@prisma/client");
 
-    // If user has no project assignments, they should see no results
+    // Resolve the full set of projects this user can access, mirroring the
+    // ZenStack access rules on the Projects model:
+    //   1. Directly assigned to the project (ProjectAssignment)
+    //   2. Explicit user-level permission (UserProjectPermission, not NO_ACCESS)
+    //   3. Group-based permission (GroupProjectPermission, not NO_ACCESS)
+    //   4. Project has an open default access type (GLOBAL_ROLE / SPECIFIC_ROLE / DEFAULT)
+    // All paths are vetoed if the user has an explicit NO_ACCESS UserProjectPermission.
+    const accessibleProjects = await db.projects.findMany({
+      where: {
+        isDeleted: false,
+        userPermissions: {
+          none: { userId: user.id, accessType: ProjectAccessType.NO_ACCESS },
+        },
+        OR: [
+          { assignedUsers: { some: { userId: user.id } } },
+          {
+            userPermissions: {
+              some: {
+                userId: user.id,
+                accessType: { not: ProjectAccessType.NO_ACCESS },
+              },
+            },
+          },
+          {
+            groupPermissions: {
+              some: {
+                accessType: { not: ProjectAccessType.NO_ACCESS },
+                group: { assignedUsers: { some: { userId: user.id } } },
+              },
+            },
+          },
+          ...(user.access !== "NONE"
+            ? [
+                {
+                  defaultAccessType: {
+                    in: [
+                      ProjectAccessType.GLOBAL_ROLE,
+                      ProjectAccessType.SPECIFIC_ROLE,
+                      ProjectAccessType.DEFAULT,
+                    ],
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+      select: { id: true },
+    });
+
+    const userProjectIds = accessibleProjects.map((p) => p.id);
+
     if (userProjectIds.length === 0) {
-      filter.push({ terms: { projectId: [-1] } }); // Non-existent project ID
+      filter.push({ terms: { projectId: [-1] } });
     } else {
-      // Restrict search to only user's assigned projects
       filter.push({ terms: { projectId: userProjectIds } });
     }
   }


### PR DESCRIPTION
## Description

Three fixes shipped together:

**1. Search visibility for non-direct project members** — `searchQueryBuilder.ts` was querying `projectAssignment` (direct members only), so users with access via user permissions, group permissions, or default access type got zero search results. Replaced with a `projects.findMany` query covering all four access paths.

**2. Automated flag promotion on result submission** — When an automated test runner (JUnit, TestNG, xUnit, NUnit, MSTest, Mocha, Cucumber) submits a result for a test case still marked `automated: false`, the case is now atomically flipped to `automated: true` inside the same transaction. A fire-and-forget Elasticsearch re-sync runs afterward to keep search results consistent.

**3. Multi-config run interaction E2E tests** — Added E2E tests covering two bugs in multi-config run views: result submission always used the URL primary run ID instead of the clicked row run ID, and checkbox IDs collided in shift-select/select-all because `repositoryCaseId` was the row key (duplicated across configs).

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Unit tests — `searchQueryBuilder.test.ts` verifies all four access paths are queried; `submit-result/route.test.ts` has 5 new tests for automated flag promotion including a parameterized test across all 7 automated run types
- [x] E2E tests — `test-run-multi-config-interaction.spec.ts` covers result submission correctness and checkbox behavior in multi-config mode
- [x] Manual testing — confirmed search results appear for users with indirect project access

**Test Configuration:**
- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the [CLA](https://testplanit.com/cla)