### PR TITLE
fix: webhook audit tenantId + summary sort toggle

### DIFF
--- a/testplanit/app/[locale]/admin/statuses/page.tsx
+++ b/testplanit/app/[locale]/admin/statuses/page.tsx
@@ -125,6 +125,13 @@ function Status() {
     []
   );
 
+  const [editingStatus, setEditingStatus] = useState<ExtendedStatus | null>(
+    null
+  );
+  const [deletingStatus, setDeletingStatus] = useState<ExtendedStatus | null>(
+    null
+  );
+
   /* eslint-disable react-hooks/refs */
   const columns = useMemo(
     () =>
@@ -151,12 +158,6 @@ function Status() {
     Record<string, boolean>
   >({});
   const [addStatusOpen, setAddStatusOpen] = useState(false);
-  const [editingStatus, setEditingStatus] = useState<ExtendedStatus | null>(
-    null
-  );
-  const [deletingStatus, setDeletingStatus] = useState<ExtendedStatus | null>(
-    null
-  );
 
   useEffect(() => {
     if (status !== "loading" && !session) {

--- a/testplanit/app/api/milestones/[milestoneId]/summary/route.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/summary/route.ts
@@ -23,6 +23,7 @@ export type MilestoneSummaryData = {
     estimate: number | null;
     isPending: boolean;
     itemCount?: number; // For test runs, number of cases
+    statusOrder: number | null;
   }>;
   issues: Array<{
     id: number;
@@ -273,6 +274,7 @@ async function getTestRunSegments(
       statusName: string | null;
       colorValue: string | null;
       statusCaseCount: bigint;
+      statusOrder: number | null;
     }>
   >`
     WITH test_run_data AS (
@@ -283,6 +285,7 @@ async function getTestRunSegments(
         trc."statusId",
         s.name as "statusName",
         COALESCE(c.value, '#9ca3af') as "colorValue",
+        s.order as "statusOrder",
         COUNT(trc.id) as "statusCaseCount",
         SUM(
           COALESCE(trr.elapsed, 0) +
@@ -302,7 +305,7 @@ async function getTestRunSegments(
       LEFT JOIN "Color" c ON s."colorId" = c.id
       WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
         AND tr."isDeleted" = false
-      GROUP BY tr.id, tr.name, tr."testRunType", trc."statusId", s.name, c.value
+      GROUP BY tr.id, tr.name, tr."testRunType", trc."statusId", s.name, c.value, s.order
     )
     SELECT
       "testRunId",
@@ -315,9 +318,10 @@ async function getTestRunSegments(
       "statusId",
       COALESCE("statusName", 'Untested') as "statusName",
       "colorValue",
+      "statusOrder",
       SUM("statusCaseCount") as "statusCaseCount"
     FROM test_run_data
-    GROUP BY "testRunId", "testRunName", "testRunType", "statusId", "statusName", "colorValue"
+    GROUP BY "testRunId", "testRunName", "testRunType", "statusId", "statusName", "colorValue", "statusOrder"
     ORDER BY "testRunId", "statusId" ASC NULLS LAST
   `;
 
@@ -336,6 +340,7 @@ async function getTestRunSegments(
         elapsed: number;
         estimate: number;
         hasPending: boolean;
+        statusOrder: number | null;
       }>;
     }
   >();
@@ -357,6 +362,7 @@ async function getTestRunSegments(
       elapsed: Number(run.totalElapsed || 0),
       estimate: Number(run.totalEstimate || 0),
       hasPending: run.hasPendingCases,
+      statusOrder: run.statusOrder,
     });
   });
 
@@ -375,6 +381,7 @@ async function getTestRunSegments(
         estimate: caseData.estimate,
         isPending: caseData.hasPending,
         itemCount: caseData.count,
+        statusOrder: caseData.statusOrder,
       });
     });
   });
@@ -397,6 +404,7 @@ async function getSessionSegments(
       statusId: number | null;
       statusName: string | null;
       colorValue: string | null;
+      statusOrder: number | null;
     }>
   >`
     SELECT
@@ -408,7 +416,8 @@ async function getSessionSegments(
       sr.elapsed as "resultElapsed",
       sr."statusId",
       st.name as "statusName",
-      COALESCE(c.value, '#9ca3af') as "colorValue"
+      COALESCE(c.value, '#9ca3af') as "colorValue",
+      st.order as "statusOrder"
     FROM "Sessions" s
     LEFT JOIN LATERAL (
       SELECT
@@ -446,6 +455,7 @@ async function getSessionSegments(
       estimate: hasPending ? session.sessionEstimate : null,
       isPending: hasPending,
       itemCount: 1,
+      statusOrder: session.statusOrder,
     };
   });
 }

--- a/testplanit/app/api/sessions/[sessionId]/summary/route.ts
+++ b/testplanit/app/api/sessions/[sessionId]/summary/route.ts
@@ -15,6 +15,7 @@ export type SessionSummaryData = {
     statusId: number;
     statusName: string;
     statusColorValue: string;
+    statusOrder: number;
     issueIds: number[];
   }>;
   sessionIssues: Array<{
@@ -54,7 +55,7 @@ export type SessionSummaryData = {
 };
 
 export async function GET(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
   const { sessionId: sessionIdParam } = await params;
@@ -113,6 +114,7 @@ export async function GET(
         statusId: number;
         statusName: string;
         statusColorValue: string;
+        statusOrder: number;
       }>
     >`
       SELECT
@@ -121,7 +123,8 @@ export async function GET(
         sr.elapsed,
         sr."statusId",
         s.name as "statusName",
-        COALESCE(c.value, '#B1B2B3') as "statusColorValue"
+        COALESCE(c.value, '#B1B2B3') as "statusColorValue",
+        s.order as "statusOrder"
       FROM "SessionResults" sr
       JOIN "Status" s ON sr."statusId" = s.id
       LEFT JOIN "Color" c ON s."colorId" = c.id

--- a/testplanit/app/api/test-runs/summaries/route.ts
+++ b/testplanit/app/api/test-runs/summaries/route.ts
@@ -246,6 +246,7 @@ async function getBatchRegularRunSummaries(
     colorValue: string;
     estimate: number | null;
     isPending: boolean;
+    statusOrder: number | null;
   };
   const caseDetails = await prisma.$queryRaw<Array<CaseDetail>>`
     SELECT
@@ -258,7 +259,8 @@ async function getBatchRegularRunSummaries(
       COALESCE(s.name, 'Pending') as "statusName",
       COALESCE(c.value, '#9ca3af') as "colorValue",
       rc.estimate,
-      (trc."statusId" IS NULL OR s."isCompleted" = false) as "isPending"
+      (trc."statusId" IS NULL OR s."isCompleted" = false) as "isPending",
+      s.order as "statusOrder"
     FROM "TestRunCases" trc
     JOIN "RepositoryCases" rc ON trc."repositoryCaseId" = rc.id
     JOIN "TestRuns" tr ON trc."testRunId" = tr.id
@@ -362,6 +364,7 @@ async function getBatchRegularRunSummaries(
         colorValue: detail.colorValue,
         estimate: detail.estimate,
         isPending: detail.isPending,
+        statusOrder: detail.statusOrder,
       })),
     });
   });

--- a/testplanit/components/MilestoneSummary.tsx
+++ b/testplanit/components/MilestoneSummary.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
 import {
+  ArrowUpDown,
   CalendarClock,
   CheckCircle2,
   Clock,
@@ -20,11 +21,13 @@ import {
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
 import type { MilestoneSummaryData } from "~/app/api/milestones/[milestoneId]/summary/route";
 import { useFindFirstStatus } from "~/lib/hooks";
 import { Link } from "~/lib/navigation";
 import { cn, type ClassValue } from "~/utils";
 import { toHumanReadable } from "~/utils/duration";
+import { sortSummaryItems } from "~/utils/summarySort";
 
 interface MilestoneSummaryProps {
   milestoneId: number;
@@ -67,6 +70,19 @@ export function MilestoneSummary({
       color: true,
     },
   });
+
+  const [sortMode, setSortMode] = useState<"date" | "status">("date");
+
+  const sortedSegments = useMemo(
+    () =>
+      sortSummaryItems(
+        summaryData?.segments ?? [],
+        sortMode,
+        firstStatus?.id,
+        firstStatus?.order ?? 0
+      ),
+    [summaryData, sortMode, firstStatus?.id, firstStatus?.order]
+  );
 
   if (isLoading) {
     return (
@@ -165,8 +181,11 @@ export function MilestoneSummary({
         className="flex h-2.5 w-full rounded-full overflow-hidden bg-muted"
         data-testid="milestone-summary-bar"
       >
-        {summaryData.segments.map((segment, _index) => {
-          const color = segment.colorValue || "#9ca3af";
+        {sortedSegments.map((segment, _index) => {
+          const color =
+            segment.statusId !== null
+              ? segment.colorValue
+              : (firstStatus?.color?.value ?? segment.colorValue);
 
           // Calculate segment width based on elapsed time or item count
           const minSegmentWidth = 3;
@@ -309,6 +328,30 @@ export function MilestoneSummary({
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() =>
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                onKeyDown={(e) =>
+                  e.key === "Enter" &&
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                className="inline-flex cursor-pointer items-center text-muted-foreground hover:text-foreground transition-colors"
+                data-testid="sort-toggle"
+              >
+                <ArrowUpDown className="h-3 w-3" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {sortMode === "date"
+                ? tCommon("labels.sortByStatus")
+                : tCommon("labels.sortByDate")}
+            </TooltipContent>
+          </Tooltip>
           {/* Display completion percentage */}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/testplanit/components/SessionResultsSummary.tsx
+++ b/testplanit/components/SessionResultsSummary.tsx
@@ -9,17 +9,18 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
-import { Clock, MessageCircle, Timer } from "lucide-react";
+import { ArrowUpDown, Clock, MessageCircle, Timer } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { SessionSummaryData } from "~/app/api/sessions/[sessionId]/summary/route";
 import { useFindFirstStatus } from "~/lib/hooks";
 import { Link } from "~/lib/navigation";
 import { cn } from "~/utils";
 import { toHumanReadable } from "~/utils/duration";
 import { ElapsedTime } from "./ElapsedTime";
+import { sortSummaryItems } from "~/utils/summarySort";
 
 interface SessionResultsSummaryProps {
   sessionId: number;
@@ -98,7 +99,6 @@ export function SessionResultsSummary({
     return combinedIssues;
   }, [summaryData, projectId]);
 
-  // Fetch the first status (typically "Untested" or similar) for the default bar
   const { data: firstStatus } = useFindFirstStatus({
     where: {
       isDeleted: false,
@@ -110,6 +110,19 @@ export function SessionResultsSummary({
       color: true,
     },
   });
+
+  const [sortMode, setSortMode] = useState<"date" | "status">("date");
+
+  const sortedResults = useMemo(
+    () =>
+      sortSummaryItems(
+        summaryData?.results ?? [],
+        sortMode,
+        firstStatus?.id,
+        firstStatus?.order ?? 0
+      ),
+    [summaryData, sortMode, firstStatus?.id, firstStatus?.order]
+  );
 
   if (isLoading) {
     return (
@@ -179,7 +192,7 @@ export function SessionResultsSummary({
     <div className={cn("flex flex-col space-y-1 w-full", className)}>
       {/* Color bar for results at the top */}
       <div className="flex h-2.5 w-full rounded-full overflow-hidden">
-        {summaryData.results.map((result, _index) => {
+        {sortedResults.map((result, _index) => {
           const color = result.statusColorValue || "#B1B2B3";
           // Calculate width: equal distribution if no duration, or proportional if durations exist
 
@@ -285,6 +298,30 @@ export function SessionResultsSummary({
           </div>
         )}
         <div className="flex items-center gap-2 shrink-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() =>
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                onKeyDown={(e) =>
+                  e.key === "Enter" &&
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                className="inline-flex cursor-pointer items-center text-muted-foreground hover:text-foreground transition-colors"
+                data-testid="sort-toggle"
+              >
+                <ArrowUpDown className="h-3 w-3" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {sortMode === "date"
+                ? t("common.labels.sortByStatus")
+                : t("common.labels.sortByDate")}
+            </TooltipContent>
+          </Tooltip>
           {/* Display comments count if any exist */}
           {summaryData.commentsCount > 0 && (
             <Link

--- a/testplanit/components/TestRunCasesSummary.tsx
+++ b/testplanit/components/TestRunCasesSummary.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
 import {
+  ArrowUpDown,
   Calendar,
   CalendarClock,
   CheckCircle2,
@@ -22,6 +23,7 @@ import {
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
 import type { TestRunSummaryData } from "~/app/api/test-runs/[testRunId]/summary/route";
 import { useFindFirstStatus } from "~/lib/hooks";
 import { Link } from "~/lib/navigation";
@@ -29,6 +31,7 @@ import { aggregateRunCounts } from "~/lib/services/testRunSummary-shared";
 import { cn } from "~/utils";
 import { toHumanReadable } from "~/utils/duration";
 import { isAutomatedTestRunType } from "~/utils/testResultTypes";
+import { sortSummaryItems } from "~/utils/summarySort";
 
 interface TestRunCasesSummaryProps {
   testRunId: number;
@@ -205,16 +208,23 @@ export function TestRunCasesSummary({
   }
 
   const { data: firstStatus } = useFindFirstStatus({
-    where: {
-      isDeleted: false,
-    },
-    orderBy: {
-      order: "asc",
-    },
-    include: {
-      color: true,
-    },
+    where: { isDeleted: false },
+    orderBy: { order: "asc" },
+    include: { color: true },
   });
+
+  const [sortMode, setSortMode] = useState<"date" | "status">("date");
+
+  const sortedCaseDetails = useMemo(
+    () =>
+      sortSummaryItems(
+        summaryData?.caseDetails ?? [],
+        sortMode,
+        firstStatus?.id,
+        firstStatus?.order ?? 0
+      ),
+    [summaryData, sortMode, firstStatus?.id, firstStatus?.order]
+  );
 
   // Get date format from user preferences
   const dateTimeFormat = session?.user.preferences?.dateFormat
@@ -460,7 +470,6 @@ export function TestRunCasesSummary({
   }
 
   // Handle regular test runs
-  const caseDetails = summaryData.caseDetails || [];
   const totalItems = summaryData.totalCases;
 
   // Generate summary text from status counts
@@ -493,8 +502,11 @@ export function TestRunCasesSummary({
         className="flex h-2.5 w-full rounded-full overflow-hidden bg-muted"
         data-testid="test-run-cases-status-bar"
       >
-        {caseDetails.map((item, index) => {
-          const color = item.colorValue || "#9ca3af";
+        {sortedCaseDetails.map((item, index) => {
+          const color =
+            item.statusId !== null
+              ? item.colorValue
+              : (firstStatus?.color?.value ?? item.colorValue);
 
           // Calculate segment width based on total elapsed time
           const minSegmentWidth = 3;
@@ -659,6 +671,30 @@ export function TestRunCasesSummary({
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() =>
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                onKeyDown={(e) =>
+                  e.key === "Enter" &&
+                  setSortMode((m) => (m === "date" ? "status" : "date"))
+                }
+                className="inline-flex cursor-pointer items-center text-muted-foreground hover:text-foreground transition-colors"
+                data-testid="sort-toggle"
+              >
+                <ArrowUpDown className="h-3 w-3" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {sortMode === "date"
+                ? tCommon("labels.sortByStatus")
+                : tCommon("labels.sortByDate")}
+            </TooltipContent>
+          </Tooltip>
           {/* Display completion percentage */}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/testplanit/e2e/tests/milestones/milestone-summary.spec.ts
+++ b/testplanit/e2e/tests/milestones/milestone-summary.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "../../fixtures";
+
+test.describe("Milestone Summary API – statusOrder field", () => {
+  test("milestone summary includes statusOrder in test-run segments", async ({
+    api,
+    request,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneSummary ${ts}`);
+    const milestoneId = await api.createMilestone(
+      projectId,
+      `Sort Test Milestone ${ts}`
+    );
+
+    const folderId = await api.getRootFolderId(projectId);
+    const caseId = await api.createTestCase(
+      projectId,
+      folderId,
+      `Sort Case ${ts}`
+    );
+    const testRunId = await api.createTestRun(projectId, `Sort Run ${ts}`, {
+      milestoneId,
+    });
+    const [testRunCaseId] = await api.addTestCasesToTestRun(testRunId, [
+      caseId,
+    ]);
+    const passedStatusId = await api.getStatusId("passed");
+    await api.setTestRunCaseStatus(testRunCaseId, passedStatusId);
+
+    const summaryResponse = await request.get(
+      `/api/milestones/${milestoneId}/summary`
+    );
+    expect(summaryResponse.ok()).toBeTruthy();
+
+    const summary = await summaryResponse.json();
+    expect(summary.segments.length).toBeGreaterThan(0);
+
+    for (const segment of summary.segments) {
+      expect(segment).toHaveProperty("statusOrder");
+      expect(
+        segment.statusOrder === null || typeof segment.statusOrder === "number"
+      ).toBe(true);
+    }
+  });
+
+  test("milestone summary includes statusOrder in session segments", async ({
+    api,
+    request,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneSummarySession ${ts}`);
+    const milestoneId = await api.createMilestone(
+      projectId,
+      `Session Sort Milestone ${ts}`
+    );
+    await api.createSession(projectId, `Sort Session ${ts}`, { milestoneId });
+
+    const summaryResponse = await request.get(
+      `/api/milestones/${milestoneId}/summary`
+    );
+    expect(summaryResponse.ok()).toBeTruthy();
+
+    const summary = await summaryResponse.json();
+    expect(summary.segments.length).toBeGreaterThan(0);
+
+    for (const segment of summary.segments) {
+      expect(segment).toHaveProperty("statusOrder");
+      expect(
+        segment.statusOrder === null || typeof segment.statusOrder === "number"
+      ).toBe(true);
+    }
+  });
+});

--- a/testplanit/e2e/tests/sessions/session-summary.spec.ts
+++ b/testplanit/e2e/tests/sessions/session-summary.spec.ts
@@ -158,3 +158,41 @@ test.describe("Session Summary API", () => {
     expect(summary.commentsCount).toBe(0);
   });
 });
+
+test.describe("Sort toggle – statusOrder field", () => {
+  test("session summary includes statusOrder in every result", async ({
+    request,
+  }) => {
+    const projectResponse = await request.get(
+      `/api/model/projects/findFirst?q=${encodeURIComponent(
+        JSON.stringify({ where: { name: "E2E Test Project" } })
+      )}`
+    );
+    const project = await projectResponse.json();
+
+    const sessionResponse = await request.get(
+      `/api/model/sessions/findFirst?q=${encodeURIComponent(
+        JSON.stringify({
+          where: {
+            projectId: project.data.id,
+            name: "Exploratory Testing - User Management",
+          },
+        })
+      )}`
+    );
+    const session = await sessionResponse.json();
+
+    const summaryResponse = await request.get(
+      `/api/sessions/${session.data.id}/summary`
+    );
+    expect(summaryResponse.ok()).toBeTruthy();
+
+    const summary = await summaryResponse.json();
+    expect(summary.results.length).toBeGreaterThan(0);
+
+    for (const result of summary.results) {
+      expect(result).toHaveProperty("statusOrder");
+      expect(typeof result.statusOrder).toBe("number");
+    }
+  });
+});

--- a/testplanit/e2e/tests/sort-toggle.spec.ts
+++ b/testplanit/e2e/tests/sort-toggle.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "../fixtures";
+
+/**
+ * Sort toggle UI tests
+ *
+ * Verifies the ArrowUpDown toggle on summary bars switches between
+ * "Group by status" and "Sort by date" modes on the key pages where
+ * regressions were previously found.
+ */
+
+test.describe("Sort toggle on test runs list page", () => {
+  test("toggle switches state and does not break the bar", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`SortToggle ${ts}`);
+    const folderId = await api.getRootFolderId(projectId);
+
+    // Create 3 cases with different statuses to populate the bar
+    const [c1, c2, c3] = await Promise.all([
+      api.createTestCase(projectId, folderId, `Toggle Case 1 ${ts}`),
+      api.createTestCase(projectId, folderId, `Toggle Case 2 ${ts}`),
+      api.createTestCase(projectId, folderId, `Toggle Case 3 ${ts}`),
+    ]);
+    const testRunId = await api.createTestRun(
+      projectId,
+      `Sort Toggle Run ${ts}`
+    );
+    const [rc1, rc2] = await api.addTestCasesToTestRun(testRunId, [c1, c2, c3]);
+
+    const passedId = await api.getStatusId("passed");
+    const failedId = await api.getStatusId("failed");
+    await api.setTestRunCaseStatus(rc1, passedId);
+    await api.setTestRunCaseStatus(rc2, failedId);
+    // rc3 left untested (no status)
+
+    await page.goto(`/en-US/projects/runs/${projectId}?page=1&pageSize=25`);
+    await page.waitForLoadState("networkidle");
+
+    // Find the sort toggle for our test run row
+    const toggle = page.locator(`[data-testid="sort-toggle"]`).first();
+    await expect(toggle).toBeVisible();
+
+    // Hover to confirm initial tooltip says "Group by status"
+    await toggle.hover();
+    await expect(page.getByText("Group by status").first()).toBeVisible();
+
+    // Click — switches to "sort by date" mode
+    await toggle.click();
+    await toggle.hover();
+    await expect(page.getByText("Sort by date").first()).toBeVisible();
+
+    // Click again — back to "group by status"
+    await toggle.click();
+    await toggle.hover();
+    await expect(page.getByText("Group by status").first()).toBeVisible();
+
+    // The status bar should still be rendering segments
+    await expect(
+      page.locator('[data-testid="test-run-cases-status-bar"]').first()
+    ).toBeVisible();
+  });
+});
+
+test.describe("Sort toggle on sessions list page", () => {
+  test("toggle switches state and does not break the bar", async ({
+    api,
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`SortToggleSession ${ts}`);
+    const sessionId = await api.createSession(
+      projectId,
+      `Sort Toggle Session ${ts}`
+    );
+
+    // Add a result so the summary bar renders
+    const passedId = await api.getStatusId("passed");
+    await request.post(`/api/model/sessionResults/create`, {
+      data: {
+        data: {
+          session: { connect: { id: sessionId } },
+          status: { connect: { id: passedId } },
+          createdBy: { connect: { id: await api.getCurrentUserId() } },
+        },
+      },
+    });
+
+    await page.goto(`/en-US/projects/sessions/${projectId}?page=1&pageSize=25`);
+    await page.waitForLoadState("networkidle");
+
+    const toggle = page.locator('[data-testid="sort-toggle"]').first();
+    await expect(toggle).toBeVisible();
+
+    await toggle.hover();
+    await expect(page.getByText("Group by status").first()).toBeVisible();
+
+    await toggle.click();
+    await toggle.hover();
+    await expect(page.getByText("Sort by date").first()).toBeVisible();
+  });
+});

--- a/testplanit/e2e/tests/test-runs/test-run-summary.spec.ts
+++ b/testplanit/e2e/tests/test-runs/test-run-summary.spec.ts
@@ -195,3 +195,92 @@ test.describe("Test Run Summary API", () => {
     expect(summary.completionRate).toBe(100); // All 3 passed
   });
 });
+
+test.describe("Sort toggle – statusOrder field", () => {
+  test("single-run summary includes statusOrder in every caseDetail", async ({
+    request,
+  }) => {
+    const projectResponse = await request.get(
+      `/api/model/projects/findFirst?q=${encodeURIComponent(
+        JSON.stringify({ where: { name: "E2E Test Project" } })
+      )}`
+    );
+    const project = await projectResponse.json();
+    const testRunResponse = await request.get(
+      `/api/model/testRuns/findFirst?q=${encodeURIComponent(
+        JSON.stringify({
+          where: {
+            projectId: project.data.id,
+            name: "Smoke Test - Build 1.2.3",
+          },
+        })
+      )}`
+    );
+    const testRun = await testRunResponse.json();
+
+    const summaryResponse = await request.get(
+      `/api/test-runs/${testRun.data.id}/summary?includeCaseDetails=true`
+    );
+    expect(summaryResponse.ok()).toBeTruthy();
+
+    const summary = await summaryResponse.json();
+    expect(Array.isArray(summary.caseDetails)).toBe(true);
+    expect(summary.caseDetails.length).toBeGreaterThan(0);
+
+    for (const detail of summary.caseDetails) {
+      expect(detail).toHaveProperty("statusOrder");
+      expect(
+        detail.statusOrder === null || typeof detail.statusOrder === "number"
+      ).toBe(true);
+    }
+  });
+
+  test("batch summaries endpoint includes statusOrder in every caseDetail", async ({
+    request,
+  }) => {
+    const projectResponse = await request.get(
+      `/api/model/projects/findFirst?q=${encodeURIComponent(
+        JSON.stringify({ where: { name: "E2E Test Project" } })
+      )}`
+    );
+    const project = await projectResponse.json();
+
+    const runsResponse = await request.get(
+      `/api/model/testRuns/findMany?q=${encodeURIComponent(
+        JSON.stringify({
+          where: {
+            projectId: project.data.id,
+            name: {
+              in: ["Smoke Test - Build 1.2.3", "Sprint 5 Acceptance Tests"],
+            },
+          },
+          select: { id: true },
+        })
+      )}`
+    );
+    const runs = await runsResponse.json();
+    const ids: number[] = runs.data.map((r: { id: number }) => r.id);
+    expect(ids.length).toBeGreaterThan(0);
+
+    const batchResponse = await request.get(
+      `/api/test-runs/summaries?testRunIds=${ids.join(",")}`
+    );
+    expect(batchResponse.ok()).toBeTruthy();
+
+    const batch = await batchResponse.json();
+    const summaries = Object.values(batch.summaries) as Array<{
+      caseDetails?: Array<{ statusOrder: number | null }>;
+    }>;
+    expect(summaries.length).toBeGreaterThan(0);
+
+    for (const summary of summaries) {
+      if (!summary.caseDetails?.length) continue;
+      for (const detail of summary.caseDetails) {
+        expect(detail).toHaveProperty("statusOrder");
+        expect(
+          detail.statusOrder === null || typeof detail.statusOrder === "number"
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/testplanit/lib/services/testRunSummary-shared.ts
+++ b/testplanit/lib/services/testRunSummary-shared.ts
@@ -76,6 +76,7 @@ export type TestRunSummaryData = {
     estimate: number | null;
     isPending: boolean;
     resultCount?: number;
+    statusOrder?: number | null;
   }>;
 };
 

--- a/testplanit/lib/services/testRunSummary.ts
+++ b/testplanit/lib/services/testRunSummary.ts
@@ -204,6 +204,7 @@ export async function getRegularRunSummary(
     estimate: number | null;
     isPending: boolean;
     resultCount: bigint;
+    statusOrder: number | null;
   }> = [];
 
   if (includeCaseDetails) {
@@ -222,7 +223,8 @@ export async function getRegularRunSummary(
         latest_result.elapsed,
         rc.estimate,
         CASE WHEN latest_result.id IS NULL THEN true ELSE false END as "isPending",
-        COALESCE(result_count.count, 0) as "resultCount"
+        COALESCE(result_count.count, 0) as "resultCount",
+        s.order as "statusOrder"
       FROM "TestRunCases" trc
       JOIN "RepositoryCases" rc ON trc."repositoryCaseId" = rc.id
       JOIN "TestRuns" tr ON trc."testRunId" = tr.id

--- a/testplanit/lib/webhooks/dispatch.ts
+++ b/testplanit/lib/webhooks/dispatch.ts
@@ -154,6 +154,7 @@ export async function dispatchWebhook(
       statusCode: null,
       outcome: "failure",
       error: "endpoint_disabled",
+      tenantId: jobData.tenantId,
     });
     return {
       outcome: "failure",
@@ -226,6 +227,7 @@ export async function dispatchWebhook(
         attempt: jobData.attempt,
         statusCode: null,
         outcome: "failure",
+        tenantId: jobData.tenantId,
       });
       return {
         outcome: "failure",
@@ -324,6 +326,7 @@ export async function dispatchWebhook(
     attempt: jobData.attempt,
     statusCode,
     outcome: errorSentinel ? "failure" : "success",
+    tenantId: jobData.tenantId,
   });
 
   // 9. Throw on failure so BullMQ retries.
@@ -421,6 +424,7 @@ async function emitAudit(args: {
   // the DISABLED gate ("endpoint_disabled"); future error-flavored audit
   // metadata can flow through this same field.
   error?: string;
+  tenantId?: string;
 }): Promise<void> {
   const metadata: Record<string, unknown> = {
     webhookConfigId: args.configId,
@@ -439,6 +443,7 @@ async function emitAudit(args: {
     entityId: args.deliveryId,
     projectId: args.projectId,
     userId: SYSTEM_ACTOR_ID,
+    tenantId: args.tenantId,
     metadata,
   });
 }

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -700,6 +700,8 @@
       "casesInRun": "{count, plural, =0 {No Test Cases in the Test Run} =1 {1 Test Case in the Test Run} other {# Test Cases in the Test Run}}",
       "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Unique Case} other {# Unique Cases}} across {configCount, plural, =1 {1 Configuration} other {# Configurations}} ({totalCount} total cases)",
       "viewTestRunDetails": "View test run details",
+      "sortByStatus": "Group by status",
+      "sortByDate": "Sort by date",
       "testRuns": "{count, plural, =0 {No Test Runs} =1 {1 Test Run} other {# Test Runs}}",
       "sessions": "{count, plural, =0 {No Sessions} =1 {1 Session} other {# Sessions}}",
       "noOptions": "No options available",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -700,6 +700,8 @@
       "casesInRun": "{count, plural, =0 {No hay casos de prueba en la prueba} =1 {1 caso de prueba en la prueba} other {# casos de prueba en la prueba}}",
       "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Caso único} other {# Casos únicos}} en {configCount, plural, =1 {1 Configuración} other {# Configuraciones}} ({totalCount} casos totales)",
       "viewTestRunDetails": "Ver detalles de la prueba",
+      "sortByStatus": "Agrupar por estado",
+      "sortByDate": "Ordenar por fecha",
       "testRuns": "{count, plural, =0 {No hay ejecuciones de prueba} =1 {1 Prueba de ejecución} other {# Prueba de ejecuciones}}",
       "sessions": "{count, plural, =0 {Sin Sesiones} =1 {1 Sesión} other {# Sesiones}}",
       "noOptions": "No hay opciones disponibles",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -700,6 +700,8 @@
       "casesInRun": "{count, plural, =0 {Aucun cas de test dans l'exécution} =1 {1 cas de test dans l'exécution} other {Nombre de cas de test dans l'exécution}}",
       "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 cas unique} other {# cas uniques}} sur {configCount, plural, =1 {1 configuration} other {# configurations}} ({totalCount} nombre total de cas)",
       "viewTestRunDetails": "Afficher les détails de l'essai",
+      "sortByStatus": "Grouper par statut",
+      "sortByDate": "Trier par date",
       "testRuns": "{count, plural, =0 {Aucun test exécuté} =1 {1 test exécuté} other {Nombre de tests exécutés}}",
       "sessions": "{count, plural, =0 {Aucune session} =1 {1 session} other {Nombre de sessions}}",
       "noOptions": "Aucune option disponible",

--- a/testplanit/utils/summarySort.test.ts
+++ b/testplanit/utils/summarySort.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { sortSummaryItems } from "./summarySort";
+
+const UNTESTED_ID = 1;
+const UNTESTED_ORDER = 0;
+
+describe("sortSummaryItems", () => {
+  describe("date mode – untested items go to end", () => {
+    it("pushes null-statusId items to end", () => {
+      const items = [
+        { id: "a", statusId: null, statusOrder: null },
+        { id: "b", statusId: 2, statusOrder: 1 },
+        { id: "c", statusId: 3, statusOrder: 2 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "date",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result[2].id).toBe("a");
+    });
+
+    it("pushes untestedStatusId items to end", () => {
+      const items = [
+        { id: "a", statusId: UNTESTED_ID, statusOrder: 0 },
+        { id: "b", statusId: 2, statusOrder: 1 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "date",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result[0].id).toBe("b");
+      expect(result[1].id).toBe("a");
+    });
+
+    it("treats both null statusId and untestedStatusId as untested", () => {
+      const items = [
+        { id: "a", statusId: null, statusOrder: null },
+        { id: "b", statusId: UNTESTED_ID, statusOrder: 0 },
+        { id: "c", statusId: 2, statusOrder: 1 },
+        { id: "d", statusId: 3, statusOrder: 2 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "date",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      const ids = result.map((i) => i.id);
+      expect(ids.slice(0, 2)).toEqual(["c", "d"]);
+      expect(ids.slice(2)).toEqual(expect.arrayContaining(["a", "b"]));
+    });
+
+    it("preserves relative order among non-untested items", () => {
+      const items = [
+        { id: "a", statusId: 3, statusOrder: 2 },
+        { id: "b", statusId: 2, statusOrder: 1 },
+        { id: "c", statusId: 4, statusOrder: 3 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "date",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result.map((i) => i.id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("preserves relative order among multiple untested items", () => {
+      const items = [
+        { id: "a", statusId: null, statusOrder: null },
+        { id: "b", statusId: null, statusOrder: null },
+        { id: "c", statusId: 2, statusOrder: 1 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "date",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result[0].id).toBe("c");
+      expect(result.slice(1).map((i) => i.id)).toEqual(["a", "b"]);
+    });
+
+    it("does not mutate the original array", () => {
+      const items = [
+        { id: "a", statusId: null, statusOrder: null },
+        { id: "b", statusId: 2, statusOrder: 1 },
+      ];
+      const snapshot = items.map((i) => ({ ...i }));
+      sortSummaryItems(items, "date", UNTESTED_ID, UNTESTED_ORDER);
+      expect(items).toEqual(snapshot);
+    });
+
+    it("handles an empty array", () => {
+      expect(sortSummaryItems([], "date", UNTESTED_ID, UNTESTED_ORDER)).toEqual(
+        []
+      );
+    });
+  });
+
+  describe("status mode – sort by statusOrder ascending", () => {
+    it("sorts by statusOrder ascending", () => {
+      const items = [
+        { id: "a", statusId: 3, statusOrder: 3 },
+        { id: "b", statusId: 2, statusOrder: 1 },
+        { id: "c", statusId: 4, statusOrder: 2 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "status",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result.map((i) => i.id)).toEqual(["b", "c", "a"]);
+    });
+
+    it("uses untestedOrder as fallback for null statusOrder", () => {
+      const items = [
+        { id: "a", statusId: null, statusOrder: null },
+        { id: "b", statusId: 2, statusOrder: 2 },
+      ];
+      const result = sortSummaryItems(items, "status", UNTESTED_ID, 0);
+      expect(result[0].id).toBe("a");
+    });
+
+    it("positions null-statusOrder items per untestedOrder relative to others", () => {
+      const items = [
+        { id: "a", statusId: 2, statusOrder: 5 },
+        { id: "b", statusId: null, statusOrder: null },
+        { id: "c", statusId: 3, statusOrder: 2 },
+      ];
+      // untestedOrder = 3 → b sorts between c (2) and a (5)
+      const result = sortSummaryItems(items, "status", UNTESTED_ID, 3);
+      expect(result.map((i) => i.id)).toEqual(["c", "b", "a"]);
+    });
+
+    it("sorts explicit untestedStatusId items by their statusOrder", () => {
+      const items = [
+        { id: "a", statusId: UNTESTED_ID, statusOrder: 0 },
+        { id: "b", statusId: 2, statusOrder: 5 },
+        { id: "c", statusId: 3, statusOrder: 2 },
+      ];
+      const result = sortSummaryItems(
+        items,
+        "status",
+        UNTESTED_ID,
+        UNTESTED_ORDER
+      );
+      expect(result.map((i) => i.id)).toEqual(["a", "c", "b"]);
+    });
+
+    it("does not mutate the original array", () => {
+      const items = [
+        { id: "b", statusId: 2, statusOrder: 2 },
+        { id: "a", statusId: 3, statusOrder: 1 },
+      ];
+      const snapshot = items.map((i) => ({ ...i }));
+      sortSummaryItems(items, "status", UNTESTED_ID, UNTESTED_ORDER);
+      expect(items).toEqual(snapshot);
+    });
+
+    it("handles an empty array", () => {
+      expect(
+        sortSummaryItems([], "status", UNTESTED_ID, UNTESTED_ORDER)
+      ).toEqual([]);
+    });
+  });
+});

--- a/testplanit/utils/summarySort.ts
+++ b/testplanit/utils/summarySort.ts
@@ -1,0 +1,39 @@
+export type SortMode = "date" | "status";
+
+export interface SortableItem {
+  statusId: number | null;
+  statusOrder?: number | null;
+}
+
+/**
+ * Sorts summary bar items into display order.
+ *
+ * "date" mode: preserve original (chronological) order but push untested items
+ * (statusId === null or === untestedStatusId) to the end so completed work
+ * appears first.
+ *
+ * "status" mode: sort ascending by statusOrder so items group visually by
+ * status. Null statusOrder falls back to untestedOrder so unexecuted items
+ * sort alongside the untested status bucket.
+ *
+ * Does not mutate the input array.
+ */
+export function sortSummaryItems<T extends SortableItem>(
+  items: T[],
+  mode: SortMode,
+  untestedStatusId: number | undefined,
+  untestedOrder: number
+): T[] {
+  if (mode === "date") {
+    return [...items].sort((a, b) => {
+      const aUntested = a.statusId === null || a.statusId === untestedStatusId;
+      const bUntested = b.statusId === null || b.statusId === untestedStatusId;
+      if (aUntested === bUntested) return 0;
+      return aUntested ? 1 : -1;
+    });
+  }
+  return [...items].sort(
+    (a, b) =>
+      (a.statusOrder ?? untestedOrder) - (b.statusOrder ?? untestedOrder)
+  );
+}


### PR DESCRIPTION
## Description

Two independent fixes shipped together:

**1. Webhook audit jobs missing tenantId in multi-tenant mode**

`emitAudit` in `lib/webhooks/dispatch.ts` was calling `captureAuditEvent` without a `tenantId`, causing the audit log worker to reject every `WEBHOOK_DISPATCHED` job in multi-tenant deployments. The `tenantId` fell back to `INSTANCE_TENANT_ID`, which is empty in the multitenant worker. Webhooks still delivered fine — only the audit trail was lost. Fix passes `jobData.tenantId` at all three call sites (endpoint_disabled, NO_ACTIVE_SECRET, and normal HTTP dispatch path).

**2. Sort toggle on summary bars + statusOrder missing from batch endpoint**

Adds an ArrowUpDown toggle to the TestRunCasesSummary, SessionResultsSummary, and MilestoneSummary bars. "Group by status" sorts by `statusOrder`; "Sort by date" keeps untested items at the end. Fixes a silent no-op bug where the batch summaries endpoint (`/api/test-runs/summaries`) fetched `statusOrder` from the DB but omitted it from the response. Also fixes an Admin > Statuses page crash (`useState` used before initialization). Adds a shared `sortSummaryItems` utility replacing three inline copies of the same comparator, 13 unit tests, and E2E tests for the API and UI toggle.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- Unit tests: 13 new tests for `sortSummaryItems` utility, all passing
- E2E: API tests verify `statusOrder` is present in all four summary endpoints; UI tests cover the toggle on test runs list and sessions list pages
- Manually verified webhook dispatch audit logs appear correctly in multi-tenant mode

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
