### PR TITLE
fix: stabilize column hooks to prevent Jira popover flicker and broken checkboxes

### DIFF
--- a/testplanit/app/[locale]/admin/api-tokens/columns.tsx
+++ b/testplanit/app/[locale]/admin/api-tokens/columns.tsx
@@ -6,162 +6,170 @@ import { ApiToken, User } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { Ban } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 export interface ExtendedApiToken extends ApiToken {
   user: Pick<User, "id" | "name" | "email" | "image">;
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   onRevoke: (token: ExtendedApiToken) => void,
   t: ReturnType<typeof useTranslations<"admin.apiTokens">>,
   tCommon: ReturnType<typeof useTranslations<"common">>
-): ColumnDef<ExtendedApiToken>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    size: 200,
-    cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
-  },
-  {
-    id: "user",
-    accessorKey: "userId",
-    header: tCommon("access.user"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 200,
-    cell: ({ row }) => <UserNameCell userId={row.original.userId} />,
-  },
-  {
-    id: "tokenPrefix",
-    accessorKey: "tokenPrefix",
-    header: tCommon("fields.token"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => (
-      <code className="bg-muted px-2 py-1 rounded text-xs">
-        {row.original.tokenPrefix}
-        {"••••••••"}
-      </code>
-    ),
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: tCommon("fields.created"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap text-sm text-muted-foreground">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-          }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "lastUsedAt",
-    accessorKey: "lastUsedAt",
-    header: t("columns.lastUsed"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => (
-      <div className="whitespace-nowrap text-sm text-muted-foreground">
-        {row.original.lastUsedAt ? (
-          <DateFormatter
-            date={row.original.lastUsedAt}
-            formatString={
-              userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-            }
-            timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-          />
-        ) : (
-          <span className="text-muted-foreground/50">{tCommon("never")}</span>
-        )}
-      </div>
-    ),
-  },
-  {
-    id: "expiresAt",
-    accessorKey: "expiresAt",
-    header: t("columns.expires"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => {
-      const expiresAt = row.original.expiresAt;
-      if (!expiresAt) {
-        return <Badge variant="outline">{t("noExpiry")}</Badge>;
-      }
-      const isExpired = new Date(expiresAt) < new Date();
-      return (
-        <Badge variant={isExpired ? "destructive" : "secondary"}>
-          <DateFormatter
-            date={expiresAt}
-            formatString={
-              userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-            }
-            timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-          />
-        </Badge>
-      );
-    },
-  },
-  {
-    id: "status",
-    accessorKey: "isActive",
-    header: tCommon("actions.status"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => {
-      const isActive = row.original.isActive;
-      const expiresAt = row.original.expiresAt;
-      const isExpired = expiresAt && new Date(expiresAt) < new Date();
+): ColumnDef<ExtendedApiToken>[] => {
+  const dateFormat =
+    userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH";
+  const timezone = userPreferences.user.preferences?.timezone || "Etc/UTC";
 
-      if (!isActive) {
-        return <Badge variant="destructive">{t("status.revoked")}</Badge>;
-      }
-      if (isExpired) {
-        return <Badge variant="destructive">{t("status.expired")}</Badge>;
-      }
-      return <Badge variant="default">{tCommon("fields.isActive")}</Badge>;
-    },
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: false,
-    enableSorting: false,
-    enableHiding: false,
-    size: 80,
-    cell: ({ row }) => {
-      const token = row.original;
-      // Only show revoke button for active tokens
-      if (!token.isActive) {
-        return null;
-      }
-      return (
-        <Button
-          variant="destructive"
-          onClick={() => onRevoke(token)}
-          className="px-2 py-1 h-auto"
-          title={t("revokeToken")}
-        >
-          <Ban className="h-4 w-4" />
-        </Button>
-      );
-    },
-  },
-];
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        size: 200,
+        cell: ({ row }) => (
+          <div className="font-medium">{row.original.name}</div>
+        ),
+      },
+      {
+        id: "user",
+        accessorKey: "userId",
+        header: tCommon("access.user"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 200,
+        cell: ({ row }) => <UserNameCell userId={row.original.userId} />,
+      },
+      {
+        id: "tokenPrefix",
+        accessorKey: "tokenPrefix",
+        header: tCommon("fields.token"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => (
+          <code className="bg-muted px-2 py-1 rounded text-xs">
+            {row.original.tokenPrefix}
+            {"••••••••"}
+          </code>
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.created"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap text-sm text-muted-foreground">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat}
+              timezone={timezone}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "lastUsedAt",
+        accessorKey: "lastUsedAt",
+        header: t("columns.lastUsed"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => (
+          <div className="whitespace-nowrap text-sm text-muted-foreground">
+            {row.original.lastUsedAt ? (
+              <DateFormatter
+                date={row.original.lastUsedAt}
+                formatString={dateFormat}
+                timezone={timezone}
+              />
+            ) : (
+              <span className="text-muted-foreground/50">
+                {tCommon("never")}
+              </span>
+            )}
+          </div>
+        ),
+      },
+      {
+        id: "expiresAt",
+        accessorKey: "expiresAt",
+        header: t("columns.expires"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const expiresAt = row.original.expiresAt;
+          if (!expiresAt) {
+            return <Badge variant="outline">{t("noExpiry")}</Badge>;
+          }
+          const isExpired = new Date(expiresAt) < new Date();
+          return (
+            <Badge variant={isExpired ? "destructive" : "secondary"}>
+              <DateFormatter
+                date={expiresAt}
+                formatString={dateFormat}
+                timezone={timezone}
+              />
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "status",
+        accessorKey: "isActive",
+        header: tCommon("actions.status"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => {
+          const isActive = row.original.isActive;
+          const expiresAt = row.original.expiresAt;
+          const isExpired = expiresAt && new Date(expiresAt) < new Date();
+
+          if (!isActive) {
+            return <Badge variant="destructive">{t("status.revoked")}</Badge>;
+          }
+          if (isExpired) {
+            return <Badge variant="destructive">{t("status.expired")}</Badge>;
+          }
+          return <Badge variant="default">{tCommon("fields.isActive")}</Badge>;
+        },
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: false,
+        enableSorting: false,
+        enableHiding: false,
+        size: 80,
+        cell: ({ row }) => {
+          const token = row.original;
+          // Only show revoke button for active tokens
+          if (!token.isActive) {
+            return null;
+          }
+          return (
+            <Button
+              variant="destructive"
+              onClick={() => onRevoke(token)}
+              className="px-2 py-1 h-auto"
+              title={t("revokeToken")}
+            >
+              <Ban className="h-4 w-4" />
+            </Button>
+          );
+        },
+      },
+    ],
+    [dateFormat, timezone, onRevoke, t, tCommon]
+  );
+};

--- a/testplanit/app/[locale]/admin/api-tokens/page.tsx
+++ b/testplanit/app/[locale]/admin/api-tokens/page.tsx
@@ -14,7 +14,7 @@ import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
 import { DataTable } from "@/components/tables/DataTable";
 import { useFindManyApiToken, useUpdateApiToken } from "~/lib/hooks";
-import { ExtendedApiToken, getColumns } from "./columns";
+import { ExtendedApiToken, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 
@@ -312,10 +312,7 @@ function ApiTokensList() {
     [dateFormat, timezone]
   );
 
-  const columns = useMemo(
-    () => getColumns(userPreferences, handleRevoke, t, tCommon),
-    [userPreferences, handleRevoke, t, tCommon]
-  );
+  const columns = useColumns(userPreferences, handleRevoke, t, tCommon);
 
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>

--- a/testplanit/app/[locale]/admin/audit-logs/columns.tsx
+++ b/testplanit/app/[locale]/admin/audit-logs/columns.tsx
@@ -10,6 +10,7 @@ import { AuditAction, AuditLog } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { Cog, Eye } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { SYSTEM_ACTOR_ID } from "~/lib/auditContextConstants";
 
 export interface ExtendedAuditLog extends AuditLog {
@@ -59,147 +60,154 @@ function formatAction(action: AuditAction): string {
   return action.replace(/_/g, " ");
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: { user: { preferences: { timezone?: string } } },
   onViewDetails: (log: ExtendedAuditLog) => void,
   t: ReturnType<typeof useTranslations<"admin.auditLogs">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   tUserMenu: ReturnType<typeof useTranslations<"userMenu">>
-): ColumnDef<ExtendedAuditLog>[] => [
-  {
-    id: "timestamp",
-    accessorKey: "timestamp",
-    header: t("columns.timestamp"),
-    enableSorting: true,
-    size: 180,
-    cell: ({ row: _row, getValue }) => (
-      <div className="whitespace-nowrap text-sm">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString="MM-dd-yyyy HH:mm:ss"
-          timezone={userPreferences?.user?.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "action",
-    accessorKey: "action",
-    header: t("filterAction"),
-    enableSorting: true,
-    size: 150,
-    cell: ({ getValue }) => {
-      const action = getValue() as AuditAction;
-      return (
-        <Badge variant={getActionBadgeVariant(action)}>
-          {formatAction(action)}
-        </Badge>
-      );
-    },
-  },
-  {
-    id: "entityType",
-    accessorKey: "entityType",
-    header: t("filterEntityType"),
-    enableSorting: true,
-    size: 150,
-    cell: ({ getValue }) => (
-      <span className="font-mono text-sm">{getValue() as string}</span>
-    ),
-  },
-  {
-    id: "entityName",
-    accessorKey: "entityName",
-    header: t("columns.entityName"),
-    enableSorting: false,
-    size: 200,
-    cell: ({ getValue }) => {
-      const name = getValue() as string | null;
-      return name ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="truncate max-w-[200px] block">{name}</span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{name}</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <span className="text-muted-foreground">-</span>
-      );
-    },
-  },
-  {
-    id: "userEmail",
-    accessorKey: "userEmail",
-    header: tCommon("access.user"),
-    enableSorting: true,
-    size: 200,
-    cell: ({ row }) => {
-      const userId = row.original.userId;
-      const email = row.original.userEmail;
-      const name = row.original.userName;
-      const isSystemActor = userId === SYSTEM_ACTOR_ID;
-      if (isSystemActor) {
-        return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge
-                variant="secondary"
-                className="gap-1 font-medium"
-                data-testid="audit-log-system-actor-badge"
-              >
-                <Cog className="h-3 w-3" aria-hidden="true" />
-                {t("systemActor")}
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent>{t("systemActorTooltip")}</TooltipContent>
-          </Tooltip>
-        );
-      }
-      return (
-        <div className="flex flex-col">
-          {name && <span className="font-medium text-sm">{name}</span>}
-          {email && (
-            <span className="text-xs text-muted-foreground">{email}</span>
-          )}
-          {!name && !email && (
-            <span className="text-muted-foreground">
-              {tUserMenu("themes.system")}
-            </span>
-          )}
-        </div>
-      );
-    },
-  },
-  {
-    id: "project",
-    accessorKey: "project",
-    header: tCommon("fields.project"),
-    enableSorting: false,
-    size: 150,
-    cell: ({ row }) => {
-      const project = row.original.project;
-      return project?.name ? (
-        <span className="text-sm">{project.name}</span>
-      ) : (
-        <span className="text-muted-foreground">-</span>
-      );
-    },
-  },
-  {
-    id: "actions",
-    header: "",
-    size: 50,
-    cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        className="px-2 py-1 h-auto"
-        onClick={() => onViewDetails(row.original)}
-        title={t("viewDetails")}
-      >
-        <Eye className="h-4 w-4" />
-      </Button>
-    ),
-  },
-];
+): ColumnDef<ExtendedAuditLog>[] => {
+  return useMemo(
+    () => [
+      {
+        id: "timestamp",
+        accessorKey: "timestamp",
+        header: t("columns.timestamp"),
+        enableSorting: true,
+        size: 180,
+        cell: ({ row: _row, getValue }) => (
+          <div className="whitespace-nowrap text-sm">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString="MM-dd-yyyy HH:mm:ss"
+              timezone={
+                userPreferences?.user?.preferences?.timezone || "Etc/UTC"
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "action",
+        accessorKey: "action",
+        header: t("filterAction"),
+        enableSorting: true,
+        size: 150,
+        cell: ({ getValue }) => {
+          const action = getValue() as AuditAction;
+          return (
+            <Badge variant={getActionBadgeVariant(action)}>
+              {formatAction(action)}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "entityType",
+        accessorKey: "entityType",
+        header: t("filterEntityType"),
+        enableSorting: true,
+        size: 150,
+        cell: ({ getValue }) => (
+          <span className="font-mono text-sm">{getValue() as string}</span>
+        ),
+      },
+      {
+        id: "entityName",
+        accessorKey: "entityName",
+        header: t("columns.entityName"),
+        enableSorting: false,
+        size: 200,
+        cell: ({ getValue }) => {
+          const name = getValue() as string | null;
+          return name ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="truncate max-w-[200px] block">{name}</span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{name}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          );
+        },
+      },
+      {
+        id: "userEmail",
+        accessorKey: "userEmail",
+        header: tCommon("access.user"),
+        enableSorting: true,
+        size: 200,
+        cell: ({ row }) => {
+          const userId = row.original.userId;
+          const email = row.original.userEmail;
+          const name = row.original.userName;
+          const isSystemActor = userId === SYSTEM_ACTOR_ID;
+          if (isSystemActor) {
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="secondary"
+                    className="gap-1 font-medium"
+                    data-testid="audit-log-system-actor-badge"
+                  >
+                    <Cog className="h-3 w-3" aria-hidden="true" />
+                    {t("systemActor")}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>{t("systemActorTooltip")}</TooltipContent>
+              </Tooltip>
+            );
+          }
+          return (
+            <div className="flex flex-col">
+              {name && <span className="font-medium text-sm">{name}</span>}
+              {email && (
+                <span className="text-xs text-muted-foreground">{email}</span>
+              )}
+              {!name && !email && (
+                <span className="text-muted-foreground">
+                  {tUserMenu("themes.system")}
+                </span>
+              )}
+            </div>
+          );
+        },
+      },
+      {
+        id: "project",
+        accessorKey: "project",
+        header: tCommon("fields.project"),
+        enableSorting: false,
+        size: 150,
+        cell: ({ row }) => {
+          const project = row.original.project;
+          return project?.name ? (
+            <span className="text-sm">{project.name}</span>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: "",
+        size: 50,
+        cell: ({ row }) => (
+          <Button
+            variant="ghost"
+            className="px-2 py-1 h-auto"
+            onClick={() => onViewDetails(row.original)}
+            title={t("viewDetails")}
+          >
+            <Eye className="h-4 w-4" />
+          </Button>
+        ),
+      },
+    ],
+    [userPreferences, onViewDetails, t, tCommon, tUserMenu]
+  );
+};

--- a/testplanit/app/[locale]/admin/audit-logs/page.tsx
+++ b/testplanit/app/[locale]/admin/audit-logs/page.tsx
@@ -32,7 +32,7 @@ import type { Session } from "next-auth";
 import { useCountAuditLog, useFindManyAuditLog } from "~/lib/hooks";
 import { logDataExport } from "~/lib/services/auditClient";
 import { AuditLogDetailModal } from "./AuditLogDetailModal";
-import { ExtendedAuditLog, getColumns } from "./columns";
+import { ExtendedAuditLog, useColumns } from "./columns";
 
 type PageSizeOption = number | "All";
 
@@ -391,9 +391,12 @@ function AuditLogsContent({ session }: { session: Session }) {
     [dateFormat, timezone]
   );
 
-  const columns = useMemo(
-    () => getColumns(userPreferences, handleViewDetails, t, tCommon, tUserMenu),
-    [userPreferences, handleViewDetails, t, tCommon, tUserMenu]
+  const columns = useColumns(
+    userPreferences,
+    handleViewDetails,
+    t,
+    tCommon,
+    tUserMenu
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/configurations/Categories.tsx
+++ b/testplanit/app/[locale]/admin/configurations/Categories.tsx
@@ -22,7 +22,7 @@ import { PlusCircle, SquarePen, Trash } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { z } from "zod/v4";
 import {
   useCreateConfigCategories,
@@ -32,7 +32,7 @@ import {
   useUpdateManyConfigurations,
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
-import { ConfigCategoryWithVariants, getColumns } from "./categoryColumns";
+import { ConfigCategoryWithVariants, useColumns } from "./categoryColumns";
 import { DeleteConfigCategory } from "./DeleteCategory";
 import { EditCategory } from "./EditCategory";
 import { DeleteVariantModal } from "./DeleteVariantModal";
@@ -328,10 +328,7 @@ function ConfigCategoriesList() {
   const [deletingCategory, setDeletingCategory] =
     useState<ConfigCategoryWithVariants | null>(null);
 
-  const columns = useMemo(
-    () => getColumns(tCommon, setEditingCategory, setDeletingCategory),
-    [tCommon]
-  );
+  const columns = useColumns(tCommon, setEditingCategory, setDeletingCategory);
 
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>

--- a/testplanit/app/[locale]/admin/configurations/Configurations.tsx
+++ b/testplanit/app/[locale]/admin/configurations/Configurations.tsx
@@ -15,7 +15,7 @@ import {
   useUpdateConfigurations,
 } from "~/lib/hooks";
 import AddConfigurationWizard from "./AddConfigurationWizard";
-import { ConfigWithVariants, getColumns } from "./configColumns";
+import { ConfigWithVariants, useColumns } from "./configColumns";
 import { DeleteConfiguration } from "./DeleteConfig";
 import { EditConfiguration } from "./EditConfig";
 
@@ -122,16 +122,11 @@ function Configurations(): React.ReactElement | null {
   const [deletingConfiguration, setDeletingConfiguration] =
     useState<ConfigWithVariants | null>(null);
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        tCommon,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggle,
-        setEditingConfiguration,
-        setDeletingConfiguration
-      ),
-    [tCommon, handleToggle]
+  const columns = useColumns(
+    tCommon,
+    handleToggle,
+    setEditingConfiguration,
+    setDeletingConfiguration
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/configurations/categoryColumns.tsx
+++ b/testplanit/app/[locale]/admin/configurations/categoryColumns.tsx
@@ -17,6 +17,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 export type ConfigCategoryWithVariants = ConfigCategories & {
   variants: {
@@ -27,122 +28,126 @@ export type ConfigCategoryWithVariants = ConfigCategories & {
   }[];
 };
 
-export const getColumns = (
+export const useColumns = (
   tCommon: ReturnType<typeof useTranslations<"common">>,
   onEditCategory?: (category: ConfigCategoryWithVariants) => void,
   onDeleteCategory?: (category: ConfigCategoryWithVariants) => void
-): ColumnDef<ConfigCategoryWithVariants>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => {
-      return (
-        <div
-          onClick={(e) => {
-            e.stopPropagation();
-            row.toggleExpanded();
-          }}
-          className="flex items-center cursor-pointer"
-        >
-          <button
-            className="mr-2"
-            onClick={(e) => {
-              e.stopPropagation();
-              row.toggleExpanded();
-            }}
-            aria-label={row.getIsExpanded() ? "Collapse" : "Expand"}
-          >
-            {row.getIsExpanded() ? (
-              <ChevronDown className="h-5 w-5" />
-            ) : (
-              <ChevronRight className="h-5 w-5" />
-            )}
-          </button>
-          <span>{row.original.name}</span>
-        </div>
-      );
-    },
-  },
-  {
-    id: "variants",
-    accessorKey: "variants",
-    accessorFn: (row) => row.variants,
-    header: tCommon("fields.variants"),
-    enableSorting: false,
-    enableResizing: true,
-    enableHiding: false,
-    size: 100,
-    cell: ({ row }) => {
-      const hasVariants = row.original.variants.length > 0;
-      if (!hasVariants) return null;
-      return (
-        <div className="text-center">
-          <Popover>
-            <PopoverTrigger
-              className="cursor-default"
+): ColumnDef<ConfigCategoryWithVariants>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => {
+          return (
+            <div
               onClick={(e) => {
                 e.stopPropagation();
+                row.toggleExpanded();
               }}
+              className="flex items-center cursor-pointer"
             >
-              <Badge>
-                <Component className="w-4 h-4 mr-1" />
-                {row.original.variants.length}
-              </Badge>
-            </PopoverTrigger>
-            <PopoverContent>
-              {row.original.variants.map((variant) => (
-                <Badge key={variant.id}>
-                  {variant.isEnabled ? (
-                    <CircleCheckBig className="w-4 h-4" />
-                  ) : (
-                    <CircleSlash2 className="w-4 h-4 text-destructive" />
-                  )}
-                  <span className="ml-1">{variant.name}</span>
-                </Badge>
-              ))}
-            </PopoverContent>
-          </Popover>
-        </div>
-      );
-    },
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableSorting: false,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div
-        className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-        }}
-      >
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditCategory?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="destructive"
-          className="px-2 py-1 h-auto"
-          onClick={() => onDeleteCategory?.(row.original)}
-        >
-          <Trash2 className="h-5 w-5" />
-        </Button>
-      </div>
-    ),
-  },
-];
+              <button
+                className="mr-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  row.toggleExpanded();
+                }}
+                aria-label={row.getIsExpanded() ? "Collapse" : "Expand"}
+              >
+                {row.getIsExpanded() ? (
+                  <ChevronDown className="h-5 w-5" />
+                ) : (
+                  <ChevronRight className="h-5 w-5" />
+                )}
+              </button>
+              <span>{row.original.name}</span>
+            </div>
+          );
+        },
+      },
+      {
+        id: "variants",
+        accessorKey: "variants",
+        accessorFn: (row) => row.variants,
+        header: tCommon("fields.variants"),
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        size: 100,
+        cell: ({ row }) => {
+          const hasVariants = row.original.variants.length > 0;
+          if (!hasVariants) return null;
+          return (
+            <div className="text-center">
+              <Popover>
+                <PopoverTrigger
+                  className="cursor-default"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <Badge>
+                    <Component className="w-4 h-4 mr-1" />
+                    {row.original.variants.length}
+                  </Badge>
+                </PopoverTrigger>
+                <PopoverContent>
+                  {row.original.variants.map((variant) => (
+                    <Badge key={variant.id}>
+                      {variant.isEnabled ? (
+                        <CircleCheckBig className="w-4 h-4" />
+                      ) : (
+                        <CircleSlash2 className="w-4 h-4 text-destructive" />
+                      )}
+                      <span className="ml-1">{variant.name}</span>
+                    </Badge>
+                  ))}
+                </PopoverContent>
+              </Popover>
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div
+            className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditCategory?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteCategory?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [tCommon, onEditCategory, onDeleteCategory]
+  );

--- a/testplanit/app/[locale]/admin/configurations/configColumns.tsx
+++ b/testplanit/app/[locale]/admin/configurations/configColumns.tsx
@@ -17,6 +17,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 export type ConfigWithVariants = Configurations & {
   variants: {
@@ -29,115 +30,121 @@ export type ConfigWithVariants = Configurations & {
   }[];
 };
 
-export const getColumns = (
+export const useColumns = (
   t: ReturnType<typeof useTranslations<"common">>,
   handleToggle: (id: number, isEnabled: boolean) => void,
   onEditConfiguration?: (config: ConfigWithVariants) => void,
   onDeleteConfiguration?: (config: ConfigWithVariants) => void
-): ColumnDef<ConfigWithVariants>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    accessorFn: (row) => row.name,
-    header: t("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => {
-      // Check if any variant is disabled
-      const hasDisabledVariant = row.original.variants.some(
-        ({ variant }) => !variant.isEnabled
-      );
+): ColumnDef<ConfigWithVariants>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: t("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => {
+          // Check if any variant is disabled
+          const hasDisabledVariant = row.original.variants.some(
+            ({ variant }) => !variant.isEnabled
+          );
 
-      return (
-        <Label className="flex items-center space-x-2">
-          <Switch
-            checked={row.original.isEnabled}
-            onCheckedChange={() =>
-              handleToggle(row.original.id, !row.original.isEnabled)
-            }
-            disabled={hasDisabledVariant}
-          />
-          <div
-            className={row.original.isEnabled ? "" : "text-muted-foreground"}
-          >
-            {row.original.name}
-          </div>
-        </Label>
-      );
-    },
-  },
-  {
-    id: "variants",
-    accessorKey: "variants",
-    accessorFn: (row) => row.name,
-    header: t("fields.variants"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => {
-      const hasVariants = row.original.variants.length > 0;
-      return (
-        <div className="text-center">
-          {hasVariants && (
-            <Popover>
-              <PopoverTrigger
-                className="cursor-default"
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
+          return (
+            <Label className="flex items-center space-x-2">
+              <Switch
+                checked={row.original.isEnabled}
+                onCheckedChange={() =>
+                  handleToggle(row.original.id, !row.original.isEnabled)
+                }
+                disabled={hasDisabledVariant}
+              />
+              <div
+                className={
+                  row.original.isEnabled ? "" : "text-muted-foreground"
+                }
               >
-                <Badge>
-                  {" "}
-                  <Component className="w-4 h-4 mr-1" />
-                  {row.original.variants.length}
-                </Badge>
-              </PopoverTrigger>
-              <PopoverContent>
-                {row.original.variants.map((variant) => (
-                  <Badge key={variant.variant.id}>
-                    {variant.variant.isEnabled ? (
-                      <CircleCheckBig className="w-4 h-4" />
-                    ) : (
-                      <CircleSlash2 className="w-4 h-4 text-destructive" />
-                    )}
-                    <span className="ml-1">{variant.variant.name}</span>
-                  </Badge>
-                ))}
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
-      );
-    },
-  },
-  {
-    id: "actions",
-    header: t("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditConfiguration?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="destructive"
-          className="px-2 py-1 h-auto"
-          onClick={() => onDeleteConfiguration?.(row.original)}
-        >
-          <Trash2 className="h-5 w-5" />
-        </Button>
-      </div>
-    ),
-  },
-];
+                {row.original.name}
+              </div>
+            </Label>
+          );
+        },
+      },
+      {
+        id: "variants",
+        accessorKey: "variants",
+        accessorFn: (row) => row.name,
+        header: t("fields.variants"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => {
+          const hasVariants = row.original.variants.length > 0;
+          return (
+            <div className="text-center">
+              {hasVariants && (
+                <Popover>
+                  <PopoverTrigger
+                    className="cursor-default"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    <Badge>
+                      {" "}
+                      <Component className="w-4 h-4 mr-1" />
+                      {row.original.variants.length}
+                    </Badge>
+                  </PopoverTrigger>
+                  <PopoverContent>
+                    {row.original.variants.map((variant) => (
+                      <Badge key={variant.variant.id}>
+                        {variant.variant.isEnabled ? (
+                          <CircleCheckBig className="w-4 h-4" />
+                        ) : (
+                          <CircleSlash2 className="w-4 h-4 text-destructive" />
+                        )}
+                        <span className="ml-1">{variant.variant.name}</span>
+                      </Badge>
+                    ))}
+                  </PopoverContent>
+                </Popover>
+              )}
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: t("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditConfiguration?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteConfiguration?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [t, handleToggle, onEditConfiguration, onDeleteConfiguration]
+  );

--- a/testplanit/app/[locale]/admin/fields/CaseFields.tsx
+++ b/testplanit/app/[locale]/admin/fields/CaseFields.tsx
@@ -7,11 +7,11 @@ import { Button } from "@/components/ui/button";
 import { CirclePlus, LayoutList } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFindManyCaseFields, useUpdateCaseFields } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import { AddCaseFieldModal } from "./AddCaseField";
-import { ExtendedCaseFields, getColumns } from "./caseFieldColumns";
+import { ExtendedCaseFields, useColumns } from "./caseFieldColumns";
 import { DeleteCaseField } from "./DeleteCaseField";
 import { EditCaseField } from "./EditCaseField";
 
@@ -96,17 +96,12 @@ export default function CaseFields() {
   const [deletingCaseField, setDeletingCaseField] =
     useState<ExtendedCaseFields | null>(null);
 
-  const columns: CustomColumnDef<ExtendedCaseFields>[] = useMemo(
-    () =>
-      getColumns(
-        t,
-        tCommon,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggle,
-        setEditingCaseField,
-        setDeletingCaseField
-      ),
-    [handleToggle, t, tCommon]
+  const columns: CustomColumnDef<ExtendedCaseFields>[] = useColumns(
+    t,
+    tCommon,
+    handleToggle,
+    setEditingCaseField,
+    setDeletingCaseField
   );
 
   const [addCaseFieldOpen, setAddCaseFieldOpen] = useState(false);

--- a/testplanit/app/[locale]/admin/fields/ResultFields.tsx
+++ b/testplanit/app/[locale]/admin/fields/ResultFields.tsx
@@ -7,13 +7,13 @@ import { Button } from "@/components/ui/button";
 import { CirclePlus, SquareCheck } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFindManyResultFields, useUpdateResultFields } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import { AddResultFieldModal } from "./AddResultField";
 import { DeleteResultField } from "./DeleteResultField";
 import { EditResultField } from "./EditResultField";
-import { ExtendedResultFields, getColumns } from "./resultFieldColumns";
+import { ExtendedResultFields, useColumns } from "./resultFieldColumns";
 
 export default function ResultFields() {
   const { data: session, status } = useSession();
@@ -96,17 +96,12 @@ export default function ResultFields() {
   const [deletingResultField, setDeletingResultField] =
     useState<ExtendedResultFields | null>(null);
 
-  const columns: CustomColumnDef<ExtendedResultFields>[] = useMemo(
-    () =>
-      getColumns(
-        t,
-        tCommon,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggle,
-        setEditingResultField,
-        setDeletingResultField
-      ),
-    [handleToggle, t, tCommon]
+  const columns: CustomColumnDef<ExtendedResultFields>[] = useColumns(
+    t,
+    tCommon,
+    handleToggle,
+    setEditingResultField,
+    setDeletingResultField
   );
 
   const [addResultFieldOpen, setAddResultFieldOpen] = useState(false);

--- a/testplanit/app/[locale]/admin/fields/Templates.tsx
+++ b/testplanit/app/[locale]/admin/fields/Templates.tsx
@@ -17,7 +17,7 @@ import { Templates } from "@prisma/client";
 import { CirclePlus, LayoutTemplate } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   useCreateManyTemplateProjectAssignment,
   useDeleteManyTemplateProjectAssignment,
@@ -30,7 +30,7 @@ import { useRouter } from "~/lib/navigation";
 import { AddTemplate } from "./AddTemplate";
 import { DeleteTemplate } from "./DeleteTemplate";
 import { EditTemplate } from "./EditTemplate";
-import { ExtendedTemplates, getColumns } from "./templateColumns";
+import { ExtendedTemplates, useColumns } from "./templateColumns";
 
 export default function TemplateComponent() {
   const { data: session, status } = useSession();
@@ -146,17 +146,12 @@ export default function TemplateComponent() {
     }
   };
 
-  const columns: any[] = useMemo(
-    () =>
-      getColumns(
-        tCommon,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggleEnabled,
-        handleToggleDefault,
-        setEditingTemplate,
-        setDeletingTemplate
-      ),
-    [handleToggleEnabled, handleToggleDefault, tCommon]
+  const columns: any[] = useColumns(
+    tCommon,
+    handleToggleEnabled,
+    handleToggleDefault,
+    setEditingTemplate,
+    setDeletingTemplate
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/fields/caseFieldColumns.tsx
+++ b/testplanit/app/[locale]/admin/fields/caseFieldColumns.tsx
@@ -5,6 +5,7 @@ import { CaseFields, Color, FieldIcon, FieldOptions } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 interface ExtendedFieldOptions extends FieldOptions {
   icon?: FieldIcon;
@@ -27,7 +28,7 @@ export interface ExtendedCaseFields extends CaseFields {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   t: ReturnType<typeof useTranslations<"admin.templates.caseFields">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   handleToggle: (
@@ -37,133 +38,137 @@ export const getColumns = (
   ) => void,
   onEditCaseField?: (casefield: ExtendedCaseFields) => void,
   onDeleteCaseField?: (casefield: ExtendedCaseFields) => void
-): ColumnDef<ExtendedCaseFields>[] => [
-  {
-    id: "displayName",
-    accessorKey: "displayName",
-    header: tCommon("fields.displayName"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    maxSize: 500,
-    size: 350,
-    cell: ({ row }) => row.original.displayName,
-  },
-  {
-    id: "systemName",
-    accessorKey: "systemName",
-    header: tCommon("fields.systemName"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => row.original.systemName,
-  },
-  {
-    id: "typeId",
-    accessorKey: "typeId",
-    header: tCommon("fields.fieldType"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="whitespace-nowrap">{row.original.type.type}</div>
-    ),
-  },
-  {
-    id: "templates",
-    accessorKey: "templates",
-    header: tCommon("fields.templates"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <TemplateListDisplay templates={row.original.templates} />
-      </div>
-    ),
-  },
-  {
-    id: "isEnabled",
-    accessorKey: "isEnabled",
-    header: tCommon("fields.enabled"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isEnabled}
-          onCheckedChange={(checked) =>
-            handleToggle(row.original.id, "isEnabled", checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isRequired",
-    accessorKey: "isRequired",
-    header: tCommon("fields.required"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isRequired}
-          onCheckedChange={(checked) =>
-            handleToggle(row.original.id, "isRequired", checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isRestricted",
-    accessorKey: "isRestricted",
-    header: tCommon("fields.restricted"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isRestricted}
-          onCheckedChange={(checked) =>
-            handleToggle(row.original.id, "isRestricted", checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          data-testid="edit-case-field-button"
-          onClick={() => onEditCaseField?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="destructive"
-          className="px-2 py-1 h-auto"
-          data-testid="delete-case-field-button"
-          onClick={() => onDeleteCaseField?.(row.original)}
-        >
-          <Trash2 className="h-5 w-5" />
-        </Button>
-      </div>
-    ),
-  },
-];
+): ColumnDef<ExtendedCaseFields>[] =>
+  useMemo(
+    () => [
+      {
+        id: "displayName",
+        accessorKey: "displayName",
+        header: tCommon("fields.displayName"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        maxSize: 500,
+        size: 350,
+        cell: ({ row }) => row.original.displayName,
+      },
+      {
+        id: "systemName",
+        accessorKey: "systemName",
+        header: tCommon("fields.systemName"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => row.original.systemName,
+      },
+      {
+        id: "typeId",
+        accessorKey: "typeId",
+        header: tCommon("fields.fieldType"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="whitespace-nowrap">{row.original.type.type}</div>
+        ),
+      },
+      {
+        id: "templates",
+        accessorKey: "templates",
+        header: tCommon("fields.templates"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <TemplateListDisplay templates={row.original.templates} />
+          </div>
+        ),
+      },
+      {
+        id: "isEnabled",
+        accessorKey: "isEnabled",
+        header: tCommon("fields.enabled"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isEnabled}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isEnabled", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isRequired",
+        accessorKey: "isRequired",
+        header: tCommon("fields.required"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isRequired}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isRequired", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isRestricted",
+        accessorKey: "isRestricted",
+        header: tCommon("fields.restricted"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isRestricted}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isRestricted", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              data-testid="edit-case-field-button"
+              onClick={() => onEditCaseField?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              data-testid="delete-case-field-button"
+              onClick={() => onDeleteCaseField?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [tCommon, handleToggle, onEditCaseField, onDeleteCaseField]
+  );

--- a/testplanit/app/[locale]/admin/fields/resultFieldColumns.tsx
+++ b/testplanit/app/[locale]/admin/fields/resultFieldColumns.tsx
@@ -5,6 +5,7 @@ import { Color, FieldIcon, FieldOptions, ResultFields } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 interface ExtendedFieldOptions extends FieldOptions {
   icon?: FieldIcon;
@@ -27,7 +28,7 @@ export interface ExtendedResultFields extends ResultFields {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   t: ReturnType<typeof useTranslations<"common">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   handleToggle: (
@@ -38,133 +39,136 @@ export const getColumns = (
   onEditResultField?: (resultfield: ExtendedResultFields) => void,
   onDeleteResultField?: (resultfield: ExtendedResultFields) => void
 ): ColumnDef<ExtendedResultFields>[] => {
-  return [
-    {
-      id: "displayName",
-      accessorKey: "displayName",
-      header: tCommon("fields.displayName"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 350,
-      cell: ({ row }) => row.original.displayName,
-    },
-    {
-      id: "systemName",
-      accessorKey: "systemName",
-      header: tCommon("fields.systemName"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      cell: ({ row }) => row.original.systemName,
-    },
-    {
-      id: "typeId",
-      accessorKey: "typeId",
-      header: tCommon("fields.fieldType"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="whitespace-nowrap">{row.original.type.type}</div>
-      ),
-    },
-    {
-      id: "templates",
-      accessorKey: "templates",
-      header: tCommon("fields.templates"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <TemplateListDisplay templates={row.original.templates} />
-        </div>
-      ),
-    },
-    {
-      id: "isEnabled",
-      accessorKey: "isEnabled",
-      header: tCommon("fields.enabled"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isEnabled}
-            onCheckedChange={(checked) =>
-              handleToggle(row.original.id, "isEnabled", checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "isRequired",
-      accessorKey: "isRequired",
-      header: tCommon("fields.required"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isRequired}
-            onCheckedChange={(checked) =>
-              handleToggle(row.original.id, "isRequired", checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "isRestricted",
-      accessorKey: "isRestricted",
-      header: tCommon("fields.restricted"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isRestricted}
-            onCheckedChange={(checked) =>
-              handleToggle(row.original.id, "isRestricted", checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "actions",
-      header: tCommon("actions.actionsLabel"),
-      enableResizing: true,
-      enableSorting: false,
-      enableHiding: false,
-      meta: { isPinned: "right" },
-      size: 80,
-      cell: ({ row }) => (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto"
-            data-testid="edit-result-field-button"
-            onClick={() => onEditResultField?.(row.original)}
-          >
-            <SquarePen className="h-5 w-5" />
-          </Button>
-          <Button
-            variant="destructive"
-            className="px-2 py-1 h-auto"
-            data-testid="delete-result-field-button"
-            onClick={() => onDeleteResultField?.(row.original)}
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        </div>
-      ),
-    },
-  ];
+  return useMemo(
+    () => [
+      {
+        id: "displayName",
+        accessorKey: "displayName",
+        header: tCommon("fields.displayName"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 350,
+        cell: ({ row }) => row.original.displayName,
+      },
+      {
+        id: "systemName",
+        accessorKey: "systemName",
+        header: tCommon("fields.systemName"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => row.original.systemName,
+      },
+      {
+        id: "typeId",
+        accessorKey: "typeId",
+        header: tCommon("fields.fieldType"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="whitespace-nowrap">{row.original.type.type}</div>
+        ),
+      },
+      {
+        id: "templates",
+        accessorKey: "templates",
+        header: tCommon("fields.templates"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <TemplateListDisplay templates={row.original.templates} />
+          </div>
+        ),
+      },
+      {
+        id: "isEnabled",
+        accessorKey: "isEnabled",
+        header: tCommon("fields.enabled"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isEnabled}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isEnabled", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isRequired",
+        accessorKey: "isRequired",
+        header: tCommon("fields.required"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isRequired}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isRequired", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isRestricted",
+        accessorKey: "isRestricted",
+        header: tCommon("fields.restricted"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isRestricted}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isRestricted", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              data-testid="edit-result-field-button"
+              onClick={() => onEditResultField?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              data-testid="delete-result-field-button"
+              onClick={() => onDeleteResultField?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [tCommon, handleToggle, onEditResultField, onDeleteResultField]
+  );
 };

--- a/testplanit/app/[locale]/admin/fields/templateColumns.tsx
+++ b/testplanit/app/[locale]/admin/fields/templateColumns.tsx
@@ -7,6 +7,7 @@ import { Templates } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 export interface ExtendedTemplates extends Templates {
   projects: {
@@ -23,137 +24,146 @@ export interface ExtendedTemplates extends Templates {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   tCommon: ReturnType<typeof useTranslations<"common">>,
   handleToggleEnabled: (id: number, isEnabled: boolean) => void,
   handleToggleDefault: (id: number, isDefault: boolean) => void,
   onEditTemplate?: (template: ExtendedTemplates) => void,
   onDeleteTemplate?: (template: ExtendedTemplates) => void
 ): ColumnDef<ExtendedTemplates>[] => {
-  return [
-    {
-      id: "templateName",
-      accessorKey: "templateName",
-      header: tCommon("name"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 500,
-      cell: ({ row }) => row.original.templateName,
-    },
-    {
-      id: "caseFields",
-      accessorKey: "caseFields",
-      header: tCommon("fields.caseFields"),
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <CaseFieldListDisplay caseFields={row.original.caseFields} />
-        </div>
-      ),
-    },
-    {
-      id: "resultFields",
-      accessorKey: "resultFields",
-      header: tCommon("fields.resultFields"),
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <ResultFieldListDisplay resultFields={row.original.resultFields} />
-        </div>
-      ),
-    },
-    {
-      id: "projects",
-      accessorKey: "projects",
-      header: tCommon("fields.projects"),
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <ProjectListDisplay projects={row.original.projects} />
-        </div>
-      ),
-    },
-    {
-      id: "isEnabled",
-      accessorKey: "isEnabled",
-      header: tCommon("fields.enabled"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isEnabled}
-            onCheckedChange={(checked) =>
-              handleToggleEnabled(row.original.id, checked)
-            }
-            disabled={row.original.isDefault}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "isDefault",
-      accessorKey: "isDefault",
-      header: tCommon("fields.default"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isDefault}
-            disabled={row.original.isDefault}
-            onCheckedChange={(checked) =>
-              handleToggleDefault(row.original.id, checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "actions",
-      header: tCommon("actions.actionsLabel"),
-      enableResizing: true,
-      enableSorting: false,
-      enableHiding: false,
-      meta: { isPinned: "right" },
-      size: 80,
-      cell: ({ row }) => (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto"
-            data-testid="edit-template-button"
-            onClick={() => onEditTemplate?.(row.original)}
-          >
-            <SquarePen className="h-5 w-5" />
-          </Button>
-          {row.original.isDefault ? (
+  return useMemo(
+    () => [
+      {
+        id: "templateName",
+        accessorKey: "templateName",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => row.original.templateName,
+      },
+      {
+        id: "caseFields",
+        accessorKey: "caseFields",
+        header: tCommon("fields.caseFields"),
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <CaseFieldListDisplay caseFields={row.original.caseFields} />
+          </div>
+        ),
+      },
+      {
+        id: "resultFields",
+        accessorKey: "resultFields",
+        header: tCommon("fields.resultFields"),
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <ResultFieldListDisplay resultFields={row.original.resultFields} />
+          </div>
+        ),
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <ProjectListDisplay projects={row.original.projects} />
+          </div>
+        ),
+      },
+      {
+        id: "isEnabled",
+        accessorKey: "isEnabled",
+        header: tCommon("fields.enabled"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isEnabled}
+              onCheckedChange={(checked) =>
+                handleToggleEnabled(row.original.id, checked)
+              }
+              disabled={row.original.isDefault}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggleDefault(row.original.id, checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
             <Button
               variant="ghost"
-              className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
-              disabled
-            >
-              <Trash2 className="h-5 w-5" />
-            </Button>
-          ) : (
-            <Button
-              variant="destructive"
               className="px-2 py-1 h-auto"
-              data-testid="delete-template-button"
-              onClick={() => onDeleteTemplate?.(row.original)}
+              data-testid="edit-template-button"
+              onClick={() => onEditTemplate?.(row.original)}
             >
-              <Trash2 className="h-5 w-5" />
+              <SquarePen className="h-5 w-5" />
             </Button>
-          )}
-        </div>
-      ),
-    },
-  ];
+            {row.original.isDefault ? (
+              <Button
+                variant="ghost"
+                className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
+                disabled
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            ) : (
+              <Button
+                variant="destructive"
+                className="px-2 py-1 h-auto"
+                data-testid="delete-template-button"
+                onClick={() => onDeleteTemplate?.(row.original)}
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [
+      tCommon,
+      handleToggleEnabled,
+      handleToggleDefault,
+      onEditTemplate,
+      onDeleteTemplate,
+    ]
+  );
 };

--- a/testplanit/app/[locale]/admin/groups/columns.spec.tsx
+++ b/testplanit/app/[locale]/admin/groups/columns.spec.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import { ExtendedGroups, getColumns } from "./columns";
+import { ExtendedGroups, useColumns } from "./columns";
 
 // Mock next-intl
 vi.mock("next-intl", () => ({
@@ -46,7 +46,7 @@ function makeQueryClient() {
 }
 
 function renderCell(
-  columns: ReturnType<typeof getColumns>,
+  columns: ReturnType<typeof useColumns>,
   columnId: string,
   row: ExtendedGroups
 ) {
@@ -88,7 +88,8 @@ const emptyGroup: ExtendedGroups = {
 };
 
 describe("Groups columns", () => {
-  const columns = getColumns(mockTranslations);
+  const { result } = renderHook(() => useColumns(mockTranslations));
+  const columns = result.current;
 
   describe("column definitions", () => {
     test("returns four columns in order: name, users, projects, actions", () => {

--- a/testplanit/app/[locale]/admin/groups/columns.tsx
+++ b/testplanit/app/[locale]/admin/groups/columns.tsx
@@ -5,6 +5,7 @@ import { Groups } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { GroupNameCell } from "~/components/tables/GroupNameCell";
 
 export interface ExtendedGroups extends Groups {
@@ -16,76 +17,82 @@ export interface ExtendedGroups extends Groups {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   t: ReturnType<typeof useTranslations<"common">>,
   onEditGroup?: (group: ExtendedGroups) => void,
   onDeleteGroup?: (group: ExtendedGroups) => void
-): ColumnDef<ExtendedGroups>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    accessorFn: (row) => row.name,
-    header: t("fields.groupName"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    size: 500,
-    meta: { isPinned: "left" },
-    cell: ({ row }) => <GroupNameCell groupId={row.original.id.toString()} />,
-  },
-  {
-    id: "users",
-    accessorKey: "users",
-    accessorFn: (row) => row.assignedUsers,
-    header: t("fields.users"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <UserListDisplay users={row.original.assignedUsers} />
-      </div>
-    ),
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    accessorFn: (row) => row.projectPermissions,
-    header: t("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <ProjectListDisplay projects={row.original.projectPermissions} />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: t("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditGroup?.(row.original)}
-        >
-          <SquarePen className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="destructive"
-          className="px-2 py-1 h-auto"
-          onClick={() => onDeleteGroup?.(row.original)}
-        >
-          <Trash2 className="h-5 w-5" />
-        </Button>
-      </div>
-    ),
-  },
-];
+): ColumnDef<ExtendedGroups>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: t("fields.groupName"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        size: 500,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => (
+          <GroupNameCell groupId={row.original.id.toString()} />
+        ),
+      },
+      {
+        id: "users",
+        accessorKey: "users",
+        accessorFn: (row) => row.assignedUsers,
+        header: t("fields.users"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <UserListDisplay users={row.original.assignedUsers} />
+          </div>
+        ),
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        accessorFn: (row) => row.projectPermissions,
+        header: t("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <ProjectListDisplay projects={row.original.projectPermissions} />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: t("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditGroup?.(row.original)}
+            >
+              <SquarePen className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteGroup?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [t, onEditGroup, onDeleteGroup]
+  );

--- a/testplanit/app/[locale]/admin/groups/page.tsx
+++ b/testplanit/app/[locale]/admin/groups/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   PaginationProvider,
   usePagination,
@@ -14,7 +14,7 @@ import { useDebounce } from "@/components/Debounce";
 import { CustomColumnDef } from "@/components/tables/ColumnSelection";
 import { DataTable } from "@/components/tables/DataTable";
 import { useFindManyGroups } from "~/lib/hooks";
-import { ExtendedGroups, getColumns } from "./columns";
+import { ExtendedGroups, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 import { PaginationComponent } from "@/components/tables/Pagination";
@@ -188,9 +188,10 @@ function GroupList() {
     setCurrentPage(1);
   };
 
-  const columns: CustomColumnDef<ExtendedGroups>[] = useMemo(
-    () => getColumns(tCommon, setEditingGroup, setDeletingGroup),
-    [tCommon]
+  const columns: CustomColumnDef<ExtendedGroups>[] = useColumns(
+    tCommon,
+    setEditingGroup,
+    setDeletingGroup
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/integrations/columns.tsx
+++ b/testplanit/app/[locale]/admin/integrations/columns.tsx
@@ -5,6 +5,7 @@ import { Integration } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { Link, Plug } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { siGithub, siJira } from "simple-icons";
 import { DeleteIntegrationButton } from "./DeleteIntegrationButton";
 import { EditIntegrationButton } from "./EditIntegrationButton";
@@ -34,7 +35,7 @@ export interface ExtendedIntegration extends Integration {
   projectIntegrations?: { projectId: number }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   handleEditIntegration: (integration: Integration) => void,
   handleDeleteClick: (integration: Integration) => void,
@@ -42,180 +43,193 @@ export const getColumns = (
   tCommon: ReturnType<typeof useTranslations<"common">>,
   t: ReturnType<typeof useTranslations<"admin.integrations">>,
   _tApiTokens: ReturnType<typeof useTranslations<"admin.apiTokens">>
-): ColumnDef<ExtendedIntegration>[] => [
-  {
-    id: "provider",
-    accessorKey: "provider",
-    header: () => (
-      <div className="bg-primary-foreground">{tCommon("fields.provider")}</div>
-    ),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 150,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground flex items-center gap-2">
-        {providerIcons[row.original.provider]}
-        <span className="font-medium">{row.original.provider}</span>
-      </div>
-    ),
-  },
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 200,
-    cell: ({ row }) => (
-      <div className="flex items-center gap-1">
-        <Plug className="h-4 w-4 text-muted-foreground" />
-        <span className="font-medium">{row.original.name}</span>
-      </div>
-    ),
-  },
-  {
-    id: "status",
-    accessorKey: "status",
-    header: tCommon("actions.status"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => {
-      const statusColors: Record<string, string> = {
-        ACTIVE: "default",
-        INACTIVE: "secondary",
-        ERROR: "destructive",
-      };
+): ColumnDef<ExtendedIntegration>[] => {
+  const dateFormat =
+    userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH";
+  const timezone = userPreferences.user.preferences?.timezone || "Etc/UTC";
 
-      return (
-        <Badge variant={statusColors[row.original.status] as any}>
-          {t(`status.${row.original.status.toLowerCase()}` as any)}
-        </Badge>
-      );
-    },
-  },
-  {
-    id: "projects",
-    accessorKey: "projectIntegrations",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const projects = row.original.projectIntegrations || [];
+  return useMemo(
+    () => [
+      {
+        id: "provider",
+        accessorKey: "provider",
+        header: () => (
+          <div className="bg-primary-foreground">
+            {tCommon("fields.provider")}
+          </div>
+        ),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 150,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground flex items-center gap-2">
+            {providerIcons[row.original.provider]}
+            <span className="font-medium">{row.original.provider}</span>
+          </div>
+        ),
+      },
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 200,
+        cell: ({ row }) => (
+          <div className="flex items-center gap-1">
+            <Plug className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        id: "status",
+        accessorKey: "status",
+        header: tCommon("actions.status"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const statusColors: Record<string, string> = {
+            ACTIVE: "default",
+            INACTIVE: "secondary",
+            ERROR: "destructive",
+          };
 
-      if (projects.length === 0) {
-        return null;
-      }
+          return (
+            <Badge variant={statusColors[row.original.status] as any}>
+              {t(`status.${row.original.status.toLowerCase()}` as any)}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "projects",
+        accessorKey: "projectIntegrations",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const projects = row.original.projectIntegrations || [];
 
-      return <ProjectListDisplay projects={projects} usePopover={true} />;
-    },
-  },
-  {
-    id: "lastSyncAt",
-    accessorKey: "lastSyncAt",
-    header: t("table.lastSync"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 180,
-    cell: ({ getValue }) => {
-      const lastSyncAt = getValue() as Date | string | null;
-
-      if (!lastSyncAt) {
-        return (
-          <span className="text-sm text-muted-foreground">
-            {tCommon("never")}
-          </span>
-        );
-      }
-
-      return (
-        <div className="whitespace-nowrap">
-          <DateFormatter
-            date={lastSyncAt}
-            formatString={
-              userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-            }
-            timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-          />
-        </div>
-      );
-    },
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: tCommon("fields.createdAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
+          if (projects.length === 0) {
+            return null;
           }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "updatedAt",
-    accessorKey: "updatedAt",
-    header: tCommon("fields.updatedAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
+
+          return <ProjectListDisplay projects={projects} usePopover={true} />;
+        },
+      },
+      {
+        id: "lastSyncAt",
+        accessorKey: "lastSyncAt",
+        header: t("table.lastSync"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 180,
+        cell: ({ getValue }) => {
+          const lastSyncAt = getValue() as Date | string | null;
+
+          if (!lastSyncAt) {
+            return (
+              <span className="text-sm text-muted-foreground">
+                {tCommon("never")}
+              </span>
+            );
           }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    size: 200,
-    meta: { isPinned: "right" },
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <SyncIntegrationButton
-          key={`sync-${row.original.id}`}
-          integration={row.original}
-        />
-        <TestIntegrationButton
-          key={`test-${row.original.id}`}
-          integration={row.original}
-          onTest={handleTestConnection}
-        />
-        <EditIntegrationButton
-          key={`edit-${row.original.id}`}
-          integration={row.original}
-          onEdit={handleEditIntegration}
-        />
-        <DeleteIntegrationButton
-          key={`delete-${row.original.id}`}
-          integration={row.original}
-          onDelete={handleDeleteClick}
-        />
-      </div>
-    ),
-  },
-];
+
+          return (
+            <div className="whitespace-nowrap">
+              <DateFormatter
+                date={lastSyncAt}
+                formatString={dateFormat}
+                timezone={timezone}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.createdAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat}
+              timezone={timezone}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "updatedAt",
+        accessorKey: "updatedAt",
+        header: tCommon("fields.updatedAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat}
+              timezone={timezone}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        size: 200,
+        meta: { isPinned: "right" },
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <SyncIntegrationButton
+              key={`sync-${row.original.id}`}
+              integration={row.original}
+            />
+            <TestIntegrationButton
+              key={`test-${row.original.id}`}
+              integration={row.original}
+              onTest={handleTestConnection}
+            />
+            <EditIntegrationButton
+              key={`edit-${row.original.id}`}
+              integration={row.original}
+              onEdit={handleEditIntegration}
+            />
+            <DeleteIntegrationButton
+              key={`delete-${row.original.id}`}
+              integration={row.original}
+              onDelete={handleDeleteClick}
+            />
+          </div>
+        ),
+      },
+    ],
+    [
+      dateFormat,
+      timezone,
+      handleEditIntegration,
+      handleDeleteClick,
+      handleTestConnection,
+      tCommon,
+      t,
+    ]
+  );
+};

--- a/testplanit/app/[locale]/admin/integrations/page.tsx
+++ b/testplanit/app/[locale]/admin/integrations/page.tsx
@@ -41,7 +41,7 @@ import {
 } from "~/lib/contexts/PaginationContext";
 import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
-import { type ExtendedIntegration, getColumns } from "./columns";
+import { type ExtendedIntegration, useColumns } from "./columns";
 
 export default function IntegrationsPage() {
   return (
@@ -276,26 +276,14 @@ function IntegrationList() {
     [dateFormat, timezone]
   );
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        userPreferences,
-        handleEditIntegration,
-        handleDeleteClick,
-        handleTestConnection,
-        tCommon,
-        t,
-        tApiTokens
-      ),
-    [
-      userPreferences,
-      handleEditIntegration,
-      handleDeleteClick,
-      handleTestConnection,
-      tCommon,
-      t,
-      tApiTokens,
-    ]
+  const columns = useColumns(
+    userPreferences,
+    handleEditIntegration,
+    handleDeleteClick,
+    handleTestConnection,
+    tCommon,
+    t,
+    tApiTokens
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/issues/columns.tsx
+++ b/testplanit/app/[locale]/admin/issues/columns.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/popover";
 import { Issue } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
 import DOMPurify from "dompurify";
 import { Plug, SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -60,401 +61,405 @@ export function useIssueColumns({
   onEditIssue?: (issue: ExtendedIssue) => void;
   onDeleteIssue?: (issue: ExtendedIssue) => void;
 }): ColumnDef<ExtendedIssue>[] {
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      accessorFn: (row) => row.name,
-      header: tCommon("name"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const issue = row.original;
-        const projectIds = issue.projects?.map((p) => p.id) || [];
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const issue = row.original;
+          const projectIds = issue.projects?.map((p) => p.id) || [];
 
-        return (
-          <div
-            style={{ maxWidth: column.getSize() }}
-            className="overflow-hidden"
-          >
-            <IssuesDisplay
-              id={issue.id}
-              name={issue.name}
-              title={issue.title}
-              status={issue.status || undefined}
-              externalId={issue.externalId || undefined}
-              externalUrl={issue.externalUrl || undefined}
-              projectIds={projectIds}
-              data={issue.externalData}
-              integrationProvider={issue.integration?.provider}
-              integrationId={issue.integrationId || undefined}
-              issueTypeName={issue.issueTypeName}
-              issueTypeIconUrl={issue.issueTypeIconUrl}
-              size="small"
-            />
-          </div>
-        );
+          return (
+            <div
+              style={{ maxWidth: column.getSize() }}
+              className="overflow-hidden"
+            >
+              <IssuesDisplay
+                id={issue.id}
+                name={issue.name}
+                title={issue.title}
+                status={issue.status || undefined}
+                externalId={issue.externalId || undefined}
+                externalUrl={issue.externalUrl || undefined}
+                projectIds={projectIds}
+                data={issue.externalData}
+                integrationProvider={issue.integration?.provider}
+                integrationId={issue.integrationId || undefined}
+                issueTypeName={issue.issueTypeName}
+                issueTypeIconUrl={issue.issueTypeIconUrl}
+                size="small"
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "title",
-      accessorKey: "title",
-      accessorFn: (row) => row.title,
-      header: tCommon("fields.title"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const title = row.original.title;
-        const hasHtml = title && /<[^>]+>/.test(title);
-        const plainText = stripHtmlTags(title);
+      {
+        id: "title",
+        accessorKey: "title",
+        accessorFn: (row) => row.title,
+        header: tCommon("fields.title"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const title = row.original.title;
+          const hasHtml = title && /<[^>]+>/.test(title);
+          const plainText = stripHtmlTags(title);
 
-        if (!title) return <span className="text-muted-foreground">-</span>;
+          if (!title) return <span className="text-muted-foreground">-</span>;
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
-                title={plainText}
-              >
-                {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">
-                  {tCommon("fields.title")}
-                </h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(title, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{title}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">
+                    {tCommon("fields.title")}
+                  </h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(title, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{title}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
       },
-    },
-    {
-      id: "description",
-      accessorKey: "description",
-      accessorFn: (row) => stripHtmlTags(row.description),
-      header: tCommon("fields.description"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const description = row.original.description;
-        const plainText = stripHtmlTags(description);
+      {
+        id: "description",
+        accessorKey: "description",
+        accessorFn: (row) => stripHtmlTags(row.description),
+        header: tCommon("fields.description"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const description = row.original.description;
+          const plainText = stripHtmlTags(description);
 
-        if (!plainText) return <span className="text-muted-foreground">-</span>;
+          if (!plainText)
+            return <span className="text-muted-foreground">-</span>;
 
-        const hasHtml = description && /<[^>]+>/.test(description);
+          const hasHtml = description && /<[^>]+>/.test(description);
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
-                title={plainText}
-              >
-                {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">
-                  {tCommon("fields.description")}
-                </h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(description, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                          "blockquote",
-                          "code",
-                          "pre",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{description}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">
+                    {tCommon("fields.description")}
+                  </h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(description, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                            "blockquote",
+                            "code",
+                            "pre",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{description}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
       },
-    },
-    {
-      id: "status",
-      accessorKey: "status",
-      accessorFn: (row) => row.status || "",
-      header: tCommon("actions.status"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const status = row.original.status;
-        return <IssueStatusDisplay status={status} className="capitalize" />;
+      {
+        id: "status",
+        accessorKey: "status",
+        accessorFn: (row) => row.status || "",
+        header: tCommon("actions.status"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const status = row.original.status;
+          return <IssueStatusDisplay status={status} className="capitalize" />;
+        },
       },
-    },
-    {
-      id: "priority",
-      accessorKey: "priority",
-      accessorFn: (row) => row.priority || "",
-      header: tCommon("fields.priority"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const priority = row.original.priority;
-        return (
-          <IssuePriorityDisplay priority={priority} className="capitalize" />
-        );
+      {
+        id: "priority",
+        accessorKey: "priority",
+        accessorFn: (row) => row.priority || "",
+        header: tCommon("fields.priority"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const priority = row.original.priority;
+          return (
+            <IssuePriorityDisplay priority={priority} className="capitalize" />
+          );
+        },
       },
-    },
-    {
-      id: "lastSyncedAt",
-      accessorKey: "lastSyncedAt",
-      accessorFn: (row) => row.lastSyncedAt,
-      header: tCommon("fields.lastSyncedAt"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      minSize: 80,
-      maxSize: 250,
-      cell: ({ row, column }) => {
-        const lastSyncedAt = row.original.lastSyncedAt;
-        if (!lastSyncedAt)
-          return <span className="text-muted-foreground">-</span>;
-        return (
-          <span
-            className="text-sm truncate overflow-hidden block"
-            style={{ maxWidth: column.getSize() }}
-          >
-            <DateFormatter date={lastSyncedAt} formatString="PPp" />
-          </span>
-        );
-      },
-    },
-    {
-      id: "cases",
-      accessorKey: "repositoryCases",
-      accessorFn: (row) => row.repositoryCases,
-      header: tCommon("fields.testCases"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.repositoryCasesCount;
-        return (
-          <div className="text-center">
-            <CasesListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "testRuns",
-      accessorKey: "testRuns",
-      accessorFn: (row) => row.testRuns,
-      header: tCommon("fields.testRuns"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.testRunsCount;
-        return (
-          <div className="text-center">
-            <TestRunsListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "sessions",
-      accessorKey: "sessions",
-      accessorFn: (row) => row.sessions,
-      header: tCommon("fields.sessions"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.sessionsCount;
-        return (
-          <div className="text-center">
-            <SessionsListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "projects",
-      accessorKey: "projects",
-      header: tCommon("fields.projects"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const projects = row.original.projects || [];
-        return (
-          <div className="text-center">
-            <ProjectListDisplay
-              projects={projects}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "integration",
-      accessorKey: "integration",
-      accessorFn: (row) => row.integration?.name || "",
-      header: tCommon("fields.integration"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      minSize: 100,
-      maxSize: 250,
-      cell: ({ row }) => {
-        return (
-          <div className="flex items-center gap-1">
-            <Plug className="h-4 w-4 text-muted-foreground" />
-            <span className="font-medium">
-              {row.original.integration?.name || "-"}
+      {
+        id: "lastSyncedAt",
+        accessorKey: "lastSyncedAt",
+        accessorFn: (row) => row.lastSyncedAt,
+        header: tCommon("fields.lastSyncedAt"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        minSize: 80,
+        maxSize: 250,
+        cell: ({ row, column }) => {
+          const lastSyncedAt = row.original.lastSyncedAt;
+          if (!lastSyncedAt)
+            return <span className="text-muted-foreground">-</span>;
+          return (
+            <span
+              className="text-sm truncate overflow-hidden block"
+              style={{ maxWidth: column.getSize() }}
+            >
+              <DateFormatter date={lastSyncedAt} formatString="PPp" />
             </span>
-          </div>
-        );
+          );
+        },
       },
-    },
-    {
-      id: "actions",
-      header: tCommon("actions.actionsLabel"),
-      enableResizing: true,
-      enableSorting: false,
-      enableHiding: false,
-      meta: { isPinned: "right" },
-      size: 150,
-      minSize: 120,
-      maxSize: 200,
-      cell: ({ row }) => (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <SyncIssue key={`sync-${row.original.id}`} issue={row.original} />
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto"
-            onClick={() => onEditIssue?.(row.original)}
-          >
-            <SquarePen className="h-5 w-5" />
-          </Button>
-          <Button
-            variant="destructive"
-            className="px-2 py-1 h-auto"
-            onClick={() => onDeleteIssue?.(row.original)}
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        </div>
-      ),
-    },
-  ];
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => row.repositoryCases,
+        header: tCommon("fields.testCases"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.repositoryCasesCount;
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "testRuns",
+        accessorKey: "testRuns",
+        accessorFn: (row) => row.testRuns,
+        header: tCommon("fields.testRuns"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.testRunsCount;
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => row.sessions,
+        header: tCommon("fields.sessions"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.sessionsCount;
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const projects = row.original.projects || [];
+          return (
+            <div className="text-center">
+              <ProjectListDisplay
+                projects={projects}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "integration",
+        accessorKey: "integration",
+        accessorFn: (row) => row.integration?.name || "",
+        header: tCommon("fields.integration"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        minSize: 100,
+        maxSize: 250,
+        cell: ({ row }) => {
+          return (
+            <div className="flex items-center gap-1">
+              <Plug className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">
+                {row.original.integration?.name || "-"}
+              </span>
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 150,
+        minSize: 120,
+        maxSize: 200,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <SyncIssue key={`sync-${row.original.id}`} issue={row.original} />
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditIssue?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteIssue?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [tCommon, onEditIssue, onDeleteIssue]
+  );
 }

--- a/testplanit/app/[locale]/admin/llm/columns.tsx
+++ b/testplanit/app/[locale]/admin/llm/columns.tsx
@@ -6,7 +6,7 @@ import { LlmIntegration, LlmProviderConfig } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { CheckCircle, Edit, Sparkles, Trash2, XCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type MutableRefObject } from "react";
+import { useMemo, type MutableRefObject } from "react";
 import { Button } from "@/components/ui/button";
 import { LlmProviderBadge } from "~/lib/llm/provider-styles";
 import { TestLlmIntegration } from "./TestLlmIntegration";
@@ -17,7 +17,7 @@ export interface ExtendedLlmIntegration extends LlmIntegration {
   projectLlmIntegrations?: { projectId: number }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   handleToggle: (
     id: number,
@@ -31,266 +31,289 @@ export const getColumns = (
   totalIntegrations: number = 0,
   onEditIntegration?: (integration: ExtendedLlmIntegration) => void,
   onDeleteIntegration?: (integration: ExtendedLlmIntegration) => void
-): ColumnDef<ExtendedLlmIntegration>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: () => (
-      <div className="bg-primary-foreground">{tCommon("name")}</div>
-    ),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 300,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground flex items-center gap-2">
-        <Sparkles className="h-4 w-4 text-muted-foreground shrink-0" />
-        <span className="font-medium">{row.original.name}</span>
-      </div>
-    ),
-  },
-  {
-    id: "provider",
-    accessorKey: "provider",
-    header: tCommon("fields.provider"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => <LlmProviderBadge provider={row.original.provider} />,
-  },
-  {
-    id: "status",
-    accessorKey: "status",
-    header: tCommon("actions.status"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => {
-      const isActive = row.original.status === "ACTIVE";
-      const isConnected = row.original.isConnected;
-
-      return (
-        <div className="flex items-center gap-2">
-          <Badge variant={isActive ? "default" : "secondary"}>
-            {row.original.status}
-          </Badge>
-          {isConnected !== undefined &&
-            (isConnected ? (
-              <CheckCircle className="h-4 w-4 text-success" />
-            ) : (
-              <XCircle className="h-4 w-4 text-destructive" />
-            ))}
-        </div>
-      );
-    },
-  },
-
-  {
-    id: "projects",
-    accessorKey: "projectLlmIntegrations",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const projects = row.original.projectLlmIntegrations || [];
-
-      if (projects.length === 0) {
-        return null;
-      }
-
-      return <ProjectListDisplay projects={projects} usePopover={true} />;
-    },
-  },
-  {
-    id: "defaultModel",
-    accessorKey: "llmProviderConfig.defaultModel",
-    header: t("defaultModel"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 200,
-    cell: ({ row }) => (
-      <span className="text-sm text-muted-foreground">
-        {row.original.llmProviderConfig?.defaultModel || t("notConfigured")}
-      </span>
-    ),
-  },
-  {
-    id: "monthlyBudget",
-    accessorKey: "llmProviderConfig.monthlyBudget",
-    header: t("budgetUsage"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 200,
-    cell: ({ row }) => {
-      const budget = row.original.llmProviderConfig?.monthlyBudget;
-      const usage = usageByIntegrationIdRef.current.get(row.original.id) ?? 0;
-
-      if (!budget || Number(budget) === 0) {
-        return (
-          <span className="text-sm text-muted-foreground">
-            {`$${usage.toFixed(4)}`}
-          </span>
-        );
-      }
-
-      const percentage = (usage / Number(budget)) * 100;
-      const isOverBudget = percentage > 100;
-
-      return (
-        <div className="space-y-1">
-          <div className="text-sm">
-            {`$${usage.toFixed(4)} / $${Number(budget).toFixed(2)}`}
+): ColumnDef<ExtendedLlmIntegration>[] => {
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: () => (
+          <div className="bg-primary-foreground">{tCommon("name")}</div>
+        ),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 300,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="font-medium">{row.original.name}</span>
           </div>
-          <div className="w-24 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-            <div
-              className={`h-full transition-all ${
-                isOverBudget
-                  ? "bg-destructive"
-                  : percentage > 80
-                    ? "bg-warning"
-                    : "bg-success"
-              }`}
-              style={{ width: `${Math.min(percentage, 100)}%` }}
+        ),
+      },
+      {
+        id: "provider",
+        accessorKey: "provider",
+        header: tCommon("fields.provider"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => (
+          <LlmProviderBadge provider={row.original.provider} />
+        ),
+      },
+      {
+        id: "status",
+        accessorKey: "status",
+        header: tCommon("actions.status"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const isActive = row.original.status === "ACTIVE";
+          const isConnected = row.original.isConnected;
+
+          return (
+            <div className="flex items-center gap-2">
+              <Badge variant={isActive ? "default" : "secondary"}>
+                {row.original.status}
+              </Badge>
+              {isConnected !== undefined &&
+                (isConnected ? (
+                  <CheckCircle className="h-4 w-4 text-success" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-destructive" />
+                ))}
+            </div>
+          );
+        },
+      },
+
+      {
+        id: "projects",
+        accessorKey: "projectLlmIntegrations",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const projects = row.original.projectLlmIntegrations || [];
+
+          if (projects.length === 0) {
+            return null;
+          }
+
+          return <ProjectListDisplay projects={projects} usePopover={true} />;
+        },
+      },
+      {
+        id: "defaultModel",
+        accessorKey: "llmProviderConfig.defaultModel",
+        header: t("defaultModel"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 200,
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground">
+            {row.original.llmProviderConfig?.defaultModel || t("notConfigured")}
+          </span>
+        ),
+      },
+      {
+        id: "monthlyBudget",
+        accessorKey: "llmProviderConfig.monthlyBudget",
+        header: t("budgetUsage"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 200,
+        cell: ({ row }) => {
+          const budget = row.original.llmProviderConfig?.monthlyBudget;
+          const usage =
+            usageByIntegrationIdRef.current.get(row.original.id) ?? 0;
+
+          if (!budget || Number(budget) === 0) {
+            return (
+              <span className="text-sm text-muted-foreground">
+                {`$${usage.toFixed(4)}`}
+              </span>
+            );
+          }
+
+          const percentage = (usage / Number(budget)) * 100;
+          const isOverBudget = percentage > 100;
+
+          return (
+            <div className="space-y-1">
+              <div className="text-sm">
+                {`$${usage.toFixed(4)} / $${Number(budget).toFixed(2)}`}
+              </div>
+              <div className="w-24 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className={`h-full transition-all ${
+                    isOverBudget
+                      ? "bg-destructive"
+                      : percentage > 80
+                        ? "bg-warning"
+                        : "bg-success"
+                  }`}
+                  style={{ width: `${Math.min(percentage, 100)}%` }}
+                />
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        id: "streamingEnabled",
+        accessorKey: "llmProviderConfig.streamingEnabled",
+        header: t("streaming"),
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={
+                row.original.llmProviderConfig?.streamingEnabled || false
+              }
+              onCheckedChange={(checked) =>
+                handleToggle(
+                  row.original.id,
+                  "streamingEnabled",
+                  checked,
+                  row.original.llmProviderConfig?.id
+                )
+              }
             />
           </div>
-        </div>
-      );
-    },
-  },
-  {
-    id: "streamingEnabled",
-    accessorKey: "llmProviderConfig.streamingEnabled",
-    header: t("streaming"),
-    enableSorting: false,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.llmProviderConfig?.streamingEnabled || false}
-          onCheckedChange={(checked) =>
-            handleToggle(
-              row.original.id,
-              "streamingEnabled",
-              checked,
-              row.original.llmProviderConfig?.id
-            )
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: tCommon("fields.createdAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue, row: _row }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-          }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "updatedAt",
-    accessorKey: "updatedAt",
-    header: tCommon("fields.updatedAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue, row: _row }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-          }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isDefault",
-    accessorKey: "llmProviderConfig.isDefault",
-    header: tCommon("fields.default"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.llmProviderConfig?.isDefault || false}
-          disabled={row.original.llmProviderConfig?.isDefault}
-          onCheckedChange={(checked) =>
-            handleToggle(
-              row.original.id,
-              "isDefault",
-              checked,
-              row.original.llmProviderConfig?.id
-            )
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    size: 150,
-    meta: { isPinned: "right" },
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex">
-        <TestLlmIntegration
-          key={`test-${row.original.id}`}
-          integration={row.original}
-        />
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onEditIntegration?.(row.original)}
-          className="px-2 py-1 h-auto"
-          data-testid="llm-edit-button"
-        >
-          <Edit className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="destructive"
-          size="icon"
-          onClick={() => onDeleteIntegration?.(row.original)}
-          className="px-2 py-1 h-auto"
-          disabled={
-            row.original.llmProviderConfig?.isDefault && totalIntegrations > 1
-          }
-          title={
-            row.original.llmProviderConfig?.isDefault && totalIntegrations > 1
-              ? t("delete.cannotDeleteDefault")
-              : undefined
-          }
-          data-testid="llm-delete-button"
-        >
-          <Trash2 className="h-8 w-8 shrink-0" />
-        </Button>
-      </div>
-    ),
-  },
-];
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.createdAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue, row: _row }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={
+                userPreferences.user.preferences?.dateFormat ||
+                "MM_DD_YYYY_DASH"
+              }
+              timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "updatedAt",
+        accessorKey: "updatedAt",
+        header: tCommon("fields.updatedAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue, row: _row }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={
+                userPreferences.user.preferences?.dateFormat ||
+                "MM_DD_YYYY_DASH"
+              }
+              timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isDefault",
+        accessorKey: "llmProviderConfig.isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.llmProviderConfig?.isDefault || false}
+              disabled={row.original.llmProviderConfig?.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggle(
+                  row.original.id,
+                  "isDefault",
+                  checked,
+                  row.original.llmProviderConfig?.id
+                )
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        size: 150,
+        meta: { isPinned: "right" },
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex">
+            <TestLlmIntegration
+              key={`test-${row.original.id}`}
+              integration={row.original}
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onEditIntegration?.(row.original)}
+              className="px-2 py-1 h-auto"
+              data-testid="llm-edit-button"
+            >
+              <Edit className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="destructive"
+              size="icon"
+              onClick={() => onDeleteIntegration?.(row.original)}
+              className="px-2 py-1 h-auto"
+              disabled={
+                row.original.llmProviderConfig?.isDefault &&
+                totalIntegrations > 1
+              }
+              title={
+                row.original.llmProviderConfig?.isDefault &&
+                totalIntegrations > 1
+                  ? t("delete.cannotDeleteDefault")
+                  : undefined
+              }
+              data-testid="llm-delete-button"
+            >
+              <Trash2 className="h-8 w-8 shrink-0" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      userPreferences,
+      handleToggle,
+      tCommon,
+      t,
+      totalIntegrations,
+      onEditIntegration,
+      onDeleteIntegration,
+    ]
+  );
+};

--- a/testplanit/app/[locale]/admin/llm/page.tsx
+++ b/testplanit/app/[locale]/admin/llm/page.tsx
@@ -33,7 +33,7 @@ import { getBillingPeriodStart } from "~/lib/utils/billingPeriod";
 import { AddLlmIntegration } from "./AddLlmIntegration";
 import { DeleteLlmIntegration } from "./DeleteLlmIntegration";
 import { EditLlmIntegration } from "./EditLlmIntegration";
-import { ExtendedLlmIntegration, getColumns } from "./columns";
+import { ExtendedLlmIntegration, useColumns } from "./columns";
 
 export default function LlmAdminPage() {
   return (
@@ -288,20 +288,16 @@ function LlmIntegrationList() {
   const [deletingIntegration, setDeletingIntegration] =
     useState<ExtendedLlmIntegration | null>(null);
 
-  const columns = useMemo(
-    // eslint-disable-next-line react-hooks/refs
-    () =>
-      getColumns(
-        userPreferences,
-        handleToggle,
-        tCommon,
-        t,
-        usageByIntegrationIdRef,
-        integrations?.length ?? 0,
-        setEditingIntegration,
-        setDeletingIntegration
-      ),
-    [userPreferences, handleToggle, tCommon, t, integrations?.length]
+  // eslint-disable-next-line react-hooks/refs
+  const columns = useColumns(
+    userPreferences,
+    handleToggle,
+    tCommon,
+    t,
+    usageByIntegrationIdRef,
+    integrations?.length ?? 0,
+    setEditingIntegration,
+    setDeletingIntegration
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/milestones/columns.tsx
+++ b/testplanit/app/[locale]/admin/milestones/columns.tsx
@@ -6,6 +6,7 @@ import { FieldIcon, MilestoneTypes } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { IconName } from "~/types/globals";
 
 export interface ExtendedMilestoneTypes extends MilestoneTypes {
@@ -15,99 +16,103 @@ export interface ExtendedMilestoneTypes extends MilestoneTypes {
   icon?: FieldIcon | null;
 }
 
-export const getColumns = (
+export const useColumns = (
   handleToggleDefault: (id: number, isDefault: boolean) => void,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   onEditMilestoneType?: (milestoneType: ExtendedMilestoneTypes) => void,
   onDeleteMilestoneType?: (milestoneType: ExtendedMilestoneTypes) => void
-): ColumnDef<ExtendedMilestoneTypes>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => (
-      <div className="flex space-x-2 items-center">
-        <div>
-          {row.original.icon?.name && (
-            <DynamicIcon name={row.original.icon.name as IconName} />
-          )}
-        </div>
-        <div>{row.original.name}</div>
-      </div>
-    ),
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    header: tCommon("fields.projects"),
-    enableResizing: true,
-    enableSorting: false,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <ProjectListDisplay projects={row.original.projects} />
-      </div>
-    ),
-  },
-  {
-    id: "isDefault",
-    accessorKey: "isDefault",
-    header: tCommon("fields.default"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isDefault}
-          disabled={row.original.isDefault}
-          onCheckedChange={(checked) =>
-            handleToggleDefault(row.original.id, checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditMilestoneType?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        {row.original.isDefault ? (
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
-            disabled
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        ) : (
-          <Button
-            variant="destructive"
-            className="px-2 py-1 h-auto"
-            onClick={() => onDeleteMilestoneType?.(row.original)}
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        )}
-      </div>
-    ),
-  },
-];
+): ColumnDef<ExtendedMilestoneTypes>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <div className="flex space-x-2 items-center">
+            <div>
+              {row.original.icon?.name && (
+                <DynamicIcon name={row.original.icon.name as IconName} />
+              )}
+            </div>
+            <div>{row.original.name}</div>
+          </div>
+        ),
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableResizing: true,
+        enableSorting: false,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <ProjectListDisplay projects={row.original.projects} />
+          </div>
+        ),
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggleDefault(row.original.id, checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditMilestoneType?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            {row.original.isDefault ? (
+              <Button
+                variant="ghost"
+                className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
+                disabled
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            ) : (
+              <Button
+                variant="destructive"
+                className="px-2 py-1 h-auto"
+                onClick={() => onDeleteMilestoneType?.(row.original)}
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [tCommon, handleToggleDefault, onEditMilestoneType, onDeleteMilestoneType]
+  );

--- a/testplanit/app/[locale]/admin/milestones/page.tsx
+++ b/testplanit/app/[locale]/admin/milestones/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   PaginationProvider,
   usePagination,
@@ -48,7 +48,7 @@ import {
 } from "~/lib/hooks";
 import AddMilestonesToProjectsWizard from "./AddMilestonesToProjectsWizard";
 import { AddMilestoneType } from "./AddMilestoneTypes";
-import { ExtendedMilestoneTypes, getColumns } from "./columns";
+import { ExtendedMilestoneTypes, useColumns } from "./columns";
 import { DeleteMilestoneType } from "./DeleteMilestoneTypes";
 import { EditMilestoneType } from "./EditMilestoneTypes";
 
@@ -247,15 +247,11 @@ function MilestoneTypes() {
     }
   };
 
-  const columns: CustomColumnDef<ExtendedMilestoneTypes>[] = useMemo(
-    () =>
-      getColumns(
-        handleToggleDefault,
-        tCommon,
-        setEditingMilestoneType,
-        setDeletingMilestoneType
-      ),
-    [handleToggleDefault, tCommon]
+  const columns: CustomColumnDef<ExtendedMilestoneTypes>[] = useColumns(
+    handleToggleDefault,
+    tCommon,
+    setEditingMilestoneType,
+    setDeletingMilestoneType
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/notifications/columns.tsx
+++ b/testplanit/app/[locale]/admin/notifications/columns.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 
 export interface NotificationHistoryItem {
@@ -28,7 +29,7 @@ export interface NotificationHistoryItem {
   };
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: {
     user: {
       preferences: {
@@ -40,160 +41,167 @@ export const getColumns = (
   },
   t: ReturnType<typeof useTranslations<"admin.notifications">>,
   tCommon: ReturnType<typeof useTranslations<"common">>
-): ColumnDef<NotificationHistoryItem>[] => [
-  {
-    id: "title",
-    accessorKey: "title",
-    header: tCommon("fields.title"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 250,
-    minSize: 100,
-    maxSize: 500,
-    cell: ({ getValue, column }) => {
-      const title = getValue() as string;
-      const columnWidth = column.getSize();
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span
-              className="font-medium truncate block"
-              style={{ maxWidth: columnWidth - 20 }}
-            >
-              {title}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{title}</p>
-          </TooltipContent>
-        </Tooltip>
-      );
-    },
-  },
-  {
-    id: "message",
-    accessorKey: "message",
-    header: tCommon("actions.automated.message"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 400,
-    minSize: 150,
-    maxSize: 800,
-    cell: ({ row, column }) => {
-      const notification = row.original;
-      const columnWidth = column.getSize();
-      const richContent = notification.data?.richContent;
-      const htmlContent = notification.data?.htmlContent;
-      const message = notification.message;
-
-      // Determine content type: TipTap JSON object, HTML string (from richContent, htmlContent, or message)
-      const isTipTapJson =
-        richContent && typeof richContent === "object" && "type" in richContent;
-
-      // Check for HTML content in richContent, htmlContent, or message field
-      const htmlSource =
-        typeof richContent === "string" &&
-        (richContent.startsWith("<") || richContent.includes("</"))
-          ? richContent
-          : htmlContent
-            ? htmlContent
-            : message && (message.startsWith("<") || message.includes("</"))
-              ? message
-              : null;
-
-      const renderContent = (isPreview: boolean) => {
-        if (isTipTapJson) {
+): ColumnDef<NotificationHistoryItem>[] => {
+  return useMemo(
+    () => [
+      {
+        id: "title",
+        accessorKey: "title",
+        header: tCommon("fields.title"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 250,
+        minSize: 100,
+        maxSize: 500,
+        cell: ({ getValue, column }) => {
+          const title = getValue() as string;
+          const columnWidth = column.getSize();
           return (
-            <div className="text-sm text-muted-foreground">
-              <TextFromJson
-                jsonString={JSON.stringify(richContent)}
-                format="html"
-                room={`notification-history-${isPreview ? "preview" : "full"}-${notification.id}`}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="font-medium truncate block"
+                  style={{ maxWidth: columnWidth - 20 }}
+                >
+                  {title}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{title}</p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        },
+      },
+      {
+        id: "message",
+        accessorKey: "message",
+        header: tCommon("actions.automated.message"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 400,
+        minSize: 150,
+        maxSize: 800,
+        cell: ({ row, column }) => {
+          const notification = row.original;
+          const columnWidth = column.getSize();
+          const richContent = notification.data?.richContent;
+          const htmlContent = notification.data?.htmlContent;
+          const message = notification.message;
+
+          // Determine content type: TipTap JSON object, HTML string (from richContent, htmlContent, or message)
+          const isTipTapJson =
+            richContent &&
+            typeof richContent === "object" &&
+            "type" in richContent;
+
+          // Check for HTML content in richContent, htmlContent, or message field
+          const htmlSource =
+            typeof richContent === "string" &&
+            (richContent.startsWith("<") || richContent.includes("</"))
+              ? richContent
+              : htmlContent
+                ? htmlContent
+                : message && (message.startsWith("<") || message.includes("</"))
+                  ? message
+                  : null;
+
+          const renderContent = (isPreview: boolean) => {
+            if (isTipTapJson) {
+              return (
+                <div className="text-sm text-muted-foreground">
+                  <TextFromJson
+                    jsonString={JSON.stringify(richContent)}
+                    format="html"
+                    room={`notification-history-${isPreview ? "preview" : "full"}-${notification.id}`}
+                  />
+                </div>
+              );
+            }
+            if (htmlSource) {
+              return (
+                <div
+                  className={
+                    isPreview
+                      ? "text-sm text-muted-foreground line-clamp-2"
+                      : "text-sm text-muted-foreground prose prose-sm dark:prose-invert max-w-none prose-headings:text-foreground prose-strong:text-foreground prose-strong:font-semibold prose-a:text-primary prose-a:underline"
+                  }
+                  dangerouslySetInnerHTML={{ __html: htmlSource }}
+                />
+              );
+            }
+            // Plain text fallback
+            return (
+              <span
+                className={isPreview ? "truncate block" : "whitespace-pre-wrap"}
+              >
+                {message}
+              </span>
+            );
+          };
+
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="max-h-16 overflow-hidden cursor-pointer hover:bg-muted/50 rounded p-1 -m-1"
+                  style={{ maxWidth: columnWidth - 20 }}
+                >
+                  {renderContent(true)}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-[500px] max-w-[90vw]"
+                side="bottom"
+                align="start"
+              >
+                <div className="max-h-[400px] overflow-y-auto">
+                  {renderContent(false)}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
+      },
+      {
+        id: "sentBy",
+        accessorKey: "data.sentByName",
+        header: t("systemNotification.history.sentBy"),
+        enableSorting: false,
+        size: 180,
+        cell: ({ row }) => (
+          <UserDisplay
+            userId={row.original.data?.sentById}
+            userName={row.original.data?.sentByName || "Administrator"}
+          />
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: t("systemNotification.history.sentAt"),
+        enableSorting: false,
+        size: 180,
+        cell: ({ getValue }) => {
+          const date = getValue() as Date | string;
+          const timezone =
+            userPreferences?.user?.preferences?.timezone || "Etc/UTC";
+          const dateFormat =
+            userPreferences?.user?.preferences?.dateFormat || "MM_DD_YYYY_DASH";
+          const timeFormat =
+            userPreferences?.user?.preferences?.timeFormat || "HH_MM_24";
+          return (
+            <div className="whitespace-nowrap text-sm cursor-default">
+              <DateFormatter
+                date={date}
+                formatString={`${dateFormat} ${timeFormat}`}
+                timezone={timezone}
               />
             </div>
           );
-        }
-        if (htmlSource) {
-          return (
-            <div
-              className={
-                isPreview
-                  ? "text-sm text-muted-foreground line-clamp-2"
-                  : "text-sm text-muted-foreground prose prose-sm dark:prose-invert max-w-none prose-headings:text-foreground prose-strong:text-foreground prose-strong:font-semibold prose-a:text-primary prose-a:underline"
-              }
-              dangerouslySetInnerHTML={{ __html: htmlSource }}
-            />
-          );
-        }
-        // Plain text fallback
-        return (
-          <span
-            className={isPreview ? "truncate block" : "whitespace-pre-wrap"}
-          >
-            {message}
-          </span>
-        );
-      };
-
-      return (
-        <Popover>
-          <PopoverTrigger asChild>
-            <div
-              className="max-h-16 overflow-hidden cursor-pointer hover:bg-muted/50 rounded p-1 -m-1"
-              style={{ maxWidth: columnWidth - 20 }}
-            >
-              {renderContent(true)}
-            </div>
-          </PopoverTrigger>
-          <PopoverContent
-            className="w-[500px] max-w-[90vw]"
-            side="bottom"
-            align="start"
-          >
-            <div className="max-h-[400px] overflow-y-auto">
-              {renderContent(false)}
-            </div>
-          </PopoverContent>
-        </Popover>
-      );
-    },
-  },
-  {
-    id: "sentBy",
-    accessorKey: "data.sentByName",
-    header: t("systemNotification.history.sentBy"),
-    enableSorting: false,
-    size: 180,
-    cell: ({ row }) => (
-      <UserDisplay
-        userId={row.original.data?.sentById}
-        userName={row.original.data?.sentByName || "Administrator"}
-      />
-    ),
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: t("systemNotification.history.sentAt"),
-    enableSorting: false,
-    size: 180,
-    cell: ({ getValue }) => {
-      const date = getValue() as Date | string;
-      const timezone =
-        userPreferences?.user?.preferences?.timezone || "Etc/UTC";
-      const dateFormat =
-        userPreferences?.user?.preferences?.dateFormat || "MM_DD_YYYY_DASH";
-      const timeFormat =
-        userPreferences?.user?.preferences?.timeFormat || "HH_MM_24";
-      return (
-        <div className="whitespace-nowrap text-sm cursor-default">
-          <DateFormatter
-            date={date}
-            formatString={`${dateFormat} ${timeFormat}`}
-            timezone={timezone}
-          />
-        </div>
-      );
-    },
-  },
-];
+        },
+      },
+    ],
+    [userPreferences, t, tCommon]
+  );
+};

--- a/testplanit/app/[locale]/admin/notifications/page.tsx
+++ b/testplanit/app/[locale]/admin/notifications/page.tsx
@@ -40,7 +40,7 @@ import {
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import { extractTextFromNode } from "~/utils/extractTextFromJson";
-import { getColumns, NotificationHistoryItem } from "./columns";
+import { useColumns, NotificationHistoryItem } from "./columns";
 
 export default function NotificationSettingsPage() {
   return (
@@ -91,10 +91,7 @@ function NotificationSettingsContent() {
     [dateFormat, timezone, timeFormat]
   );
 
-  const columns = useMemo(
-    () => getColumns(userPreferences, t, tCommon),
-    [userPreferences, t, tCommon]
-  );
+  const columns = useColumns(userPreferences, t, tCommon);
 
   const tableData: NotificationHistoryItem[] = useMemo(
     () =>

--- a/testplanit/app/[locale]/admin/projects/columns.spec.tsx
+++ b/testplanit/app/[locale]/admin/projects/columns.spec.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import { ExtendedProjects, getColumns } from "./columns";
+import { ExtendedProjects, useColumns } from "./columns";
 
 // Mock next-intl
 vi.mock("next-intl", () => ({
@@ -104,7 +104,7 @@ function makeQueryClient() {
 }
 
 function renderCell(
-  columns: ReturnType<typeof getColumns>,
+  columns: ReturnType<typeof useColumns>,
   columnId: string,
   row: ExtendedProjects
 ) {
@@ -179,12 +179,15 @@ const projectWithNoIntegrations: ExtendedProjects = {
 };
 
 describe("Projects columns", () => {
-  const columns = getColumns(
-    mockUserPreferences,
-    mockToggleCompleted,
-    mockOpenEditModal,
-    mockTranslations
+  const { result } = renderHook(() =>
+    useColumns(
+      mockUserPreferences,
+      mockToggleCompleted,
+      mockOpenEditModal,
+      mockTranslations
+    )
   );
+  const columns = result.current;
 
   describe("column definitions", () => {
     test("includes groups column", () => {

--- a/testplanit/app/[locale]/admin/projects/columns.tsx
+++ b/testplanit/app/[locale]/admin/projects/columns.tsx
@@ -22,6 +22,7 @@ import {
 import { ColumnDef } from "@tanstack/react-table";
 import { Bug, GitBranchIcon, SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { LlmProviderBadge } from "~/lib/llm/provider-styles";
 
 export interface ExtendedProjects extends Projects {
@@ -49,277 +50,289 @@ export interface ExtendedProjects extends Projects {
   effectiveUserIds: string[];
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   handleToggleCompleted: (id: number, isCompleted: boolean) => void,
   handleOpenEditModal: (project: ExtendedProjects) => void,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   onDeleteProject?: (project: ExtendedProjects) => void
 ): ColumnDef<ExtendedProjects>[] => {
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      header: tCommon("name"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 500,
-      cell: ({ row }) => (
-        <div className="flex items-start gap-1">
-          <span className="mt-1 shrink-0">
-            <ProjectIcon iconUrl={row.original.iconUrl} />
-          </span>
-          <ProjectNameCell
-            value={row.original.name}
-            projectId={row.original.id}
-            note={row.original.note}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "users",
-      accessorKey: "users",
-      header: tCommon("fields.members"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <UserListDisplay
-            users={row.original.effectiveUserIds.map((id) => ({ userId: id }))}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "groups",
-      accessorKey: "groups",
-      accessorFn: (row) => row.groupPermissions,
-      header: tCommon("fields.groups"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <GroupListDisplay groups={row.original.groupPermissions} />
-        </div>
-      ),
-    },
-    {
-      id: "milestoneTypes",
-      accessorKey: "milestoneTypes",
-      header: tCommon("fields.milestoneTypes"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <MilestoneTypeListDisplay
-            milestoneTypes={row.original.milestoneTypes}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "milestones",
-      accessorKey: "milestones",
-      header: tCommon("fields.milestones"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <MilestoneListDisplay milestones={row.original.milestones} />
-        </div>
-      ),
-    },
-    {
-      id: "integration",
-      accessorKey: "projectIntegrations",
-      header: tCommon("fields.issueTracker"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      cell: ({ row }) => {
-        const activeIntegration = row.original.projectIntegrations?.find(
-          (pi) => pi.isActive
-        );
-        return (
-          <div className="flex items-center gap-1">
-            <div className="whitespace-nowrap">
-              <Bug className="h-4 w-4 opacity-50" />
-            </div>
-            <div className="whitespace-nowrap">
-              {activeIntegration?.integration.name ??
-                tCommon("status.notApplicable")}
-            </div>
-          </div>
-        );
-      },
-    },
-    {
-      id: "codeRepository",
-      accessorKey: "codeRepositoryConfig",
-      header: tCommon("fields.codeRepository"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 150,
-      cell: ({ row }) => {
-        const config = row.original.codeRepositoryConfig;
-        return (
-          <div
-            className="flex items-center gap-1"
-            data-testid="code-repo-indicator"
-            data-active={!!config}
-          >
-            <GitBranchIcon
-              className={`h-4 w-4 shrink-0 ${config ? "text-primary" : "opacity-25"}`}
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <div className="flex items-start gap-1">
+            <span className="mt-1 shrink-0">
+              <ProjectIcon iconUrl={row.original.iconUrl} />
+            </span>
+            <ProjectNameCell
+              value={row.original.name}
+              projectId={row.original.id}
+              note={row.original.note}
             />
-            <span className="truncate whitespace-nowrap">
-              {config
-                ? config.repository.name
-                : tCommon("status.notApplicable")}
-            </span>
           </div>
-        );
+        ),
       },
-    },
-    {
-      id: "aiModels",
-      accessorKey: "projectLlmIntegrations",
-      accessorFn: (row) => row.projectLlmIntegrations,
-      header: tCommon("fields.aiModels"),
-      enableSorting: false,
-      enableResizing: true,
-      size: 150,
-      cell: ({ row }) => {
-        const activeModels = row.original.projectLlmIntegrations?.filter(
-          (i) => i.isActive
-        );
-        const hasActive = activeModels && activeModels.length > 0;
-        if (!hasActive) {
-          return (
-            <span
-              className="text-muted-foreground text-sm"
-              data-testid="ai-model-indicator"
-              data-active={false}
-            >
-              {tCommon("status.notApplicable")}
-            </span>
+      {
+        id: "users",
+        accessorKey: "users",
+        header: tCommon("fields.members"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <UserListDisplay
+              users={row.original.effectiveUserIds.map((id) => ({
+                userId: id,
+              }))}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "groups",
+        accessorKey: "groups",
+        accessorFn: (row) => row.groupPermissions,
+        header: tCommon("fields.groups"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <GroupListDisplay groups={row.original.groupPermissions} />
+          </div>
+        ),
+      },
+      {
+        id: "milestoneTypes",
+        accessorKey: "milestoneTypes",
+        header: tCommon("fields.milestoneTypes"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <MilestoneTypeListDisplay
+              milestoneTypes={row.original.milestoneTypes}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "milestones",
+        accessorKey: "milestones",
+        header: tCommon("fields.milestones"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <MilestoneListDisplay milestones={row.original.milestones} />
+          </div>
+        ),
+      },
+      {
+        id: "integration",
+        accessorKey: "projectIntegrations",
+        header: tCommon("fields.issueTracker"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const activeIntegration = row.original.projectIntegrations?.find(
+            (pi) => pi.isActive
           );
-        }
-        return (
-          <div
-            className="flex flex-wrap gap-1"
-            data-testid="ai-model-indicator"
-            data-active={true}
-          >
-            {activeModels.map((m) => (
-              <LlmProviderBadge
-                key={m.llmIntegration.name}
-                provider={m.llmIntegration.provider}
-                name={m.llmIntegration.name}
-                showIcon
+          return (
+            <div className="flex items-center gap-1">
+              <div className="whitespace-nowrap">
+                <Bug className="h-4 w-4 opacity-50" />
+              </div>
+              <div className="whitespace-nowrap">
+                {activeIntegration?.integration.name ??
+                  tCommon("status.notApplicable")}
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        id: "codeRepository",
+        accessorKey: "codeRepositoryConfig",
+        header: tCommon("fields.codeRepository"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const config = row.original.codeRepositoryConfig;
+          return (
+            <div
+              className="flex items-center gap-1"
+              data-testid="code-repo-indicator"
+              data-active={!!config}
+            >
+              <GitBranchIcon
+                className={`h-4 w-4 shrink-0 ${config ? "text-primary" : "opacity-25"}`}
               />
-            ))}
-          </div>
-        );
+              <span className="truncate whitespace-nowrap">
+                {config
+                  ? config.repository.name
+                  : tCommon("status.notApplicable")}
+              </span>
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "createdAt",
-      accessorKey: "createdAt",
-      header: tCommon("fields.created"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ getValue }) => {
-        const date = getValue() as Date | string;
-        return date ? (
+      {
+        id: "aiModels",
+        accessorKey: "projectLlmIntegrations",
+        accessorFn: (row) => row.projectLlmIntegrations,
+        header: tCommon("fields.aiModels"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => {
+          const activeModels = row.original.projectLlmIntegrations?.filter(
+            (i) => i.isActive
+          );
+          const hasActive = activeModels && activeModels.length > 0;
+          if (!hasActive) {
+            return (
+              <span
+                className="text-muted-foreground text-sm"
+                data-testid="ai-model-indicator"
+                data-active={false}
+              >
+                {tCommon("status.notApplicable")}
+              </span>
+            );
+          }
+          return (
+            <div
+              className="flex flex-wrap gap-1"
+              data-testid="ai-model-indicator"
+              data-active={true}
+            >
+              {activeModels.map((m) => (
+                <LlmProviderBadge
+                  key={m.llmIntegration.name}
+                  provider={m.llmIntegration.provider}
+                  name={m.llmIntegration.name}
+                  showIcon
+                />
+              ))}
+            </div>
+          );
+        },
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.created"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ getValue }) => {
+          const date = getValue() as Date | string;
+          return date ? (
+            <div className="whitespace-nowrap">
+              <RelativeTimeTooltip date={date} />
+            </div>
+          ) : null;
+        },
+      },
+      {
+        id: "isCompleted",
+        accessorKey: "isCompleted",
+        header: tCommon("fields.completed"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isCompleted}
+              onCheckedChange={(checked) =>
+                handleToggleCompleted(row.original.id, checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "completedAt",
+        accessorKey: "completedAt",
+        header: tCommon("fields.completedOn"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ getValue }) => (
           <div className="whitespace-nowrap">
-            <RelativeTimeTooltip date={date} />
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={
+                userPreferences.user.preferences?.dateFormat ||
+                "MM_DD_YYYY_DASH"
+              }
+              timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
+            />
           </div>
-        ) : null;
+        ),
       },
-    },
-    {
-      id: "isCompleted",
-      accessorKey: "isCompleted",
-      header: tCommon("fields.completed"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isCompleted}
-            onCheckedChange={(checked) =>
-              handleToggleCompleted(row.original.id, checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "completedAt",
-      accessorKey: "completedAt",
-      header: tCommon("fields.completedOn"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ getValue }) => (
-        <div className="whitespace-nowrap">
-          <DateFormatter
-            date={getValue() as Date | string}
-            formatString={
-              userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-            }
-            timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "createdBy",
-      accessorKey: "createdBy",
-      header: tCommon("fields.createdBy"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      cell: (info) => <UserNameCell userId={info.row.original.creator.id} />,
-    },
-    {
-      id: "actions",
-      header: tCommon("actions.actionsLabel"),
-      enableSorting: false,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "right" },
-      size: 80,
-      cell: ({ row }) => (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => handleOpenEditModal(row.original)}
-            className="px-2 py-1 h-auto"
-          >
-            <SquarePen className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="destructive"
-            size="icon"
-            className="px-2 py-1 h-auto"
-            onClick={() => onDeleteProject?.(row.original)}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-      ),
-    },
-  ];
+      {
+        id: "createdBy",
+        accessorKey: "createdBy",
+        header: tCommon("fields.createdBy"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: (info) => <UserNameCell userId={info.row.original.creator.id} />,
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleOpenEditModal(row.original)}
+              className="px-2 py-1 h-auto"
+            >
+              <SquarePen className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="destructive"
+              size="icon"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteProject?.(row.original)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [
+      userPreferences,
+      handleToggleCompleted,
+      handleOpenEditModal,
+      tCommon,
+      onDeleteProject,
+    ]
+  );
 };

--- a/testplanit/app/[locale]/admin/projects/page.tsx
+++ b/testplanit/app/[locale]/admin/projects/page.tsx
@@ -21,7 +21,7 @@ import {
   useFindManyUser,
   useUpdateProjects,
 } from "~/lib/hooks";
-import { ExtendedProjects, getColumns } from "./columns";
+import { ExtendedProjects, useColumns } from "./columns";
 
 import { CreateProjectWizard } from "@/admin/projects/CreateProjectWizard";
 import { Filter } from "@/components/tables/Filter";
@@ -423,17 +423,13 @@ function ProjectAdmin() {
     [dateFormat, timezone]
   );
 
-  const columns: CustomColumnDef<ExtendedProjects>[] = useMemo(
-    () =>
-      getColumns(
-        userPreferences,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggleCompleted,
-        handleOpenEditModal,
-        tCommon,
-        setDeletingProject
-      ),
-    [userPreferences, handleToggleCompleted, handleOpenEditModal, tCommon]
+  const columns: CustomColumnDef<ExtendedProjects>[] = useColumns(
+    userPreferences,
+    // eslint-disable-next-line react-hooks/refs
+    handleToggleCompleted,
+    handleOpenEditModal,
+    tCommon,
+    setDeletingProject
   );
 
   useEffect(() => {

--- a/testplanit/app/[locale]/admin/prompts/columns.tsx
+++ b/testplanit/app/[locale]/admin/prompts/columns.tsx
@@ -7,6 +7,7 @@ import { Projects, PromptConfig, PromptConfigPrompt } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { Edit, MessageSquareCode, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { useCountProjects } from "~/lib/hooks/projects";
 
 export interface PromptConfigPromptWithIntegration extends PromptConfigPrompt {
@@ -35,216 +36,230 @@ function DefaultPromptProjectList({ configId }: { configId: string }) {
   );
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   handleToggleDefault: (id: string, currentIsDefault: boolean) => void,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   t: ReturnType<typeof useTranslations<"admin.prompts">>,
   onEditConfig?: (config: ExtendedPromptConfig) => void,
   onDeleteConfig?: (config: ExtendedPromptConfig) => void
-): ColumnDef<ExtendedPromptConfig>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: () => (
-      <div className="bg-primary-foreground">{tCommon("name")}</div>
-    ),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 300,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground flex items-center gap-2">
-        <MessageSquareCode className="h-4 w-4 text-muted-foreground" />
-        <span className="font-medium">{row.original.name}</span>
-        {row.original.isDefault && (
-          <Badge variant="secondary" className="text-xs">
-            {tCommon("fields.default")}
-          </Badge>
-        )}
-      </div>
-    ),
-  },
-  {
-    id: "description",
-    accessorKey: "description",
-    header: tCommon("fields.description"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 300,
-    cell: ({ row }) => (
-      <span className="text-sm text-muted-foreground">
-        {row.original.description || "-"}
-      </span>
-    ),
-  },
-  {
-    id: "llmIntegrations",
-    header: t("llmColumn"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 160,
-    cell: ({ row }) => {
-      const prompts = row.original.prompts || [];
-      // Collect unique non-null integration IDs with names
-      const integrationMap = new Map<number, string>();
-      for (const p of prompts) {
-        if (p.llmIntegrationId && p.llmIntegration) {
-          integrationMap.set(p.llmIntegrationId, p.llmIntegration.name);
-        }
-      }
+): ColumnDef<ExtendedPromptConfig>[] => {
+  const dateFormat = userPreferences?.user?.preferences?.dateFormat;
+  const timezone = userPreferences?.user?.preferences?.timezone;
 
-      if (integrationMap.size === 0) {
-        return (
-          <span className="text-sm text-muted-foreground">
-            {t("llmIntegrationPlaceholder")}
-          </span>
-        );
-      }
-
-      if (integrationMap.size === 1) {
-        const [, name] = [...integrationMap.entries()][0];
-        return (
-          <Badge variant="outline" className="text-xs">
-            {name}
-          </Badge>
-        );
-      }
-
-      // Mixed integrations
-      return (
-        <Badge variant="secondary" className="text-xs">
-          {t("mixedLlms", { count: integrationMap.size })}
-        </Badge>
-      );
-    },
-  },
-  {
-    id: "projects",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => {
-      if (row.original.isDefault) {
-        return (
-          <div className="text-center">
-            <DefaultPromptProjectList configId={row.original.id} />
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: () => (
+          <div className="bg-primary-foreground">{tCommon("name")}</div>
+        ),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 300,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground flex items-center gap-2">
+            <MessageSquareCode className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">{row.original.name}</span>
+            {row.original.isDefault && (
+              <Badge variant="secondary" className="text-xs">
+                {tCommon("fields.default")}
+              </Badge>
+            )}
           </div>
-        );
-      }
-      const projects = row.original.projects || [];
-      return (
-        <div className="text-center">
-          <ProjectListDisplay projects={projects} />
-        </div>
-      );
-    },
-  },
-  {
-    id: "isDefault",
-    accessorKey: "isDefault",
-    header: tCommon("fields.default"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isDefault}
-          disabled={row.original.isDefault}
-          onCheckedChange={() =>
-            handleToggleDefault(row.original.id, row.original.isDefault)
+        ),
+      },
+      {
+        id: "description",
+        accessorKey: "description",
+        header: tCommon("fields.description"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 300,
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground">
+            {row.original.description || "-"}
+          </span>
+        ),
+      },
+      {
+        id: "llmIntegrations",
+        header: t("llmColumn"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 160,
+        cell: ({ row }) => {
+          const prompts = row.original.prompts || [];
+          // Collect unique non-null integration IDs with names
+          const integrationMap = new Map<number, string>();
+          for (const p of prompts) {
+            if (p.llmIntegrationId && p.llmIntegration) {
+              integrationMap.set(p.llmIntegrationId, p.llmIntegration.name);
+            }
           }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isActive",
-    accessorKey: "isActive",
-    header: tCommon("fields.isActive"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <Badge variant={row.original.isActive ? "default" : "secondary"}>
-        {row.original.isActive ? "Active" : "Inactive"}
-      </Badge>
-    ),
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: tCommon("fields.createdAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
+
+          if (integrationMap.size === 0) {
+            return (
+              <span className="text-sm text-muted-foreground">
+                {t("llmIntegrationPlaceholder")}
+              </span>
+            );
           }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "updatedAt",
-    accessorKey: "updatedAt",
-    header: tCommon("fields.updatedAt"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
+
+          if (integrationMap.size === 1) {
+            const [, name] = [...integrationMap.entries()][0];
+            return (
+              <Badge variant="outline" className="text-xs">
+                {name}
+              </Badge>
+            );
           }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    size: 100,
-    meta: { isPinned: "right" },
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onEditConfig?.(row.original)}
-          className="px-2 py-1 h-auto"
-        >
-          <Edit className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="destructive"
-          size="icon"
-          onClick={() => onDeleteConfig?.(row.original)}
-          className="px-2 py-1 h-auto"
-          disabled={row.original.isDefault}
-          title={row.original.isDefault ? t("cannotDeleteDefault") : undefined}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </div>
-    ),
-  },
-];
+
+          // Mixed integrations
+          return (
+            <Badge variant="secondary" className="text-xs">
+              {t("mixedLlms", { count: integrationMap.size })}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => {
+          if (row.original.isDefault) {
+            return (
+              <div className="text-center">
+                <DefaultPromptProjectList configId={row.original.id} />
+              </div>
+            );
+          }
+          const projects = row.original.projects || [];
+          return (
+            <div className="text-center">
+              <ProjectListDisplay projects={projects} />
+            </div>
+          );
+        },
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={() =>
+                handleToggleDefault(row.original.id, row.original.isDefault)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isActive",
+        accessorKey: "isActive",
+        header: tCommon("fields.isActive"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <Badge variant={row.original.isActive ? "default" : "secondary"}>
+            {row.original.isActive ? "Active" : "Inactive"}
+          </Badge>
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.createdAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat || "MM_DD_YYYY_DASH"}
+              timezone={timezone || "Etc/UTC"}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "updatedAt",
+        accessorKey: "updatedAt",
+        header: tCommon("fields.updatedAt"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat || "MM_DD_YYYY_DASH"}
+              timezone={timezone || "Etc/UTC"}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        size: 100,
+        meta: { isPinned: "right" },
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onEditConfig?.(row.original)}
+              className="px-2 py-1 h-auto"
+            >
+              <Edit className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="destructive"
+              size="icon"
+              onClick={() => onDeleteConfig?.(row.original)}
+              className="px-2 py-1 h-auto"
+              disabled={row.original.isDefault}
+              title={
+                row.original.isDefault ? t("cannotDeleteDefault") : undefined
+              }
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [
+      tCommon,
+      t,
+      handleToggleDefault,
+      onEditConfig,
+      onDeleteConfig,
+      dateFormat,
+      timezone,
+    ]
+  );
+};

--- a/testplanit/app/[locale]/admin/prompts/page.tsx
+++ b/testplanit/app/[locale]/admin/prompts/page.tsx
@@ -25,7 +25,7 @@ import {
   useUpdatePromptConfig,
 } from "~/lib/hooks/prompt-config";
 import { AddPromptConfig } from "./AddPromptConfig";
-import { ExtendedPromptConfig, getColumns } from "./columns";
+import { ExtendedPromptConfig, useColumns } from "./columns";
 import { DeletePromptConfig } from "./DeletePromptConfig";
 import { EditPromptConfig } from "./EditPromptConfig";
 
@@ -215,18 +215,14 @@ function PromptConfigList() {
   const [deletingConfig, setDeletingConfig] =
     useState<ExtendedPromptConfig | null>(null);
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        userPreferences,
-        // eslint-disable-next-line react-hooks/refs
-        handleToggleDefault,
-        tCommon,
-        t,
-        setEditingConfig,
-        setDeletingConfig
-      ),
-    [userPreferences, handleToggleDefault, tCommon, t]
+  const columns = useColumns(
+    userPreferences,
+    // eslint-disable-next-line react-hooks/refs
+    handleToggleDefault,
+    tCommon,
+    t,
+    setEditingConfig,
+    setDeletingConfig
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/quickscripts/quickScriptTemplateColumns.tsx
+++ b/testplanit/app/[locale]/admin/quickscripts/quickScriptTemplateColumns.tsx
@@ -4,8 +4,9 @@ import { CaseExportTemplate } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { Pencil, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
-export const getColumns = (
+export const useColumns = (
   t: ReturnType<typeof useTranslations<"admin.exportTemplates">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   handleToggleEnabled: (id: number, isEnabled: boolean) => void,
@@ -13,123 +14,134 @@ export const getColumns = (
   onEditTemplate?: (template: CaseExportTemplate) => void,
   onDeleteTemplate?: (template: CaseExportTemplate) => void
 ): ColumnDef<CaseExportTemplate>[] => {
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      header: tCommon("name"),
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 300,
-      cell: ({ row }) => row.original.name,
-    },
-    {
-      id: "category",
-      accessorKey: "category",
-      header: t("fields.category"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      cell: ({ row }) => row.original.category,
-    },
-    {
-      id: "fileExtension",
-      accessorKey: "fileExtension",
-      header: t("fields.fileExtension"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 120,
-      cell: ({ row }) => (
-        <code className="text-sm">{row.original.fileExtension}</code>
-      ),
-    },
-    {
-      id: "language",
-      accessorKey: "language",
-      header: tCommon("fields.locale"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 120,
-      cell: ({ row }) => row.original.language,
-    },
-    {
-      id: "isEnabled",
-      accessorKey: "isEnabled",
-      header: tCommon("fields.enabled"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isEnabled}
-            onCheckedChange={(checked) =>
-              handleToggleEnabled(row.original.id, checked)
-            }
-            disabled={row.original.isDefault}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "isDefault",
-      accessorKey: "isDefault",
-      header: tCommon("fields.default"),
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      cell: ({ row }) => (
-        <div className="text-center">
-          <Switch
-            checked={row.original.isDefault}
-            disabled={row.original.isDefault}
-            onCheckedChange={(checked) =>
-              handleToggleDefault(row.original.id, checked)
-            }
-          />
-        </div>
-      ),
-    },
-    {
-      id: "actions",
-      header: tCommon("actions.actionsLabel"),
-      enableResizing: true,
-      enableSorting: false,
-      enableHiding: false,
-      meta: { isPinned: "right" },
-      size: 80,
-      cell: ({ row }) => (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <Button
-            variant="outline"
-            className="px-2 py-1 h-auto"
-            data-testid="edit-export-template-button"
-            onClick={() => onEditTemplate?.(row.original)}
-          >
-            <Pencil className="h-5 w-5" />
-          </Button>
-          {row.original.isDefault ? (
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 300,
+        cell: ({ row }) => row.original.name,
+      },
+      {
+        id: "category",
+        accessorKey: "category",
+        header: t("fields.category"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => row.original.category,
+      },
+      {
+        id: "fileExtension",
+        accessorKey: "fileExtension",
+        header: t("fields.fileExtension"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 120,
+        cell: ({ row }) => (
+          <code className="text-sm">{row.original.fileExtension}</code>
+        ),
+      },
+      {
+        id: "language",
+        accessorKey: "language",
+        header: tCommon("fields.locale"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 120,
+        cell: ({ row }) => row.original.language,
+      },
+      {
+        id: "isEnabled",
+        accessorKey: "isEnabled",
+        header: tCommon("fields.enabled"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isEnabled}
+              onCheckedChange={(checked) =>
+                handleToggleEnabled(row.original.id, checked)
+              }
+              disabled={row.original.isDefault}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggleDefault(row.original.id, checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
             <Button
-              variant="ghost"
-              className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
-              disabled
-            >
-              <Trash2 className="h-5 w-5" />
-            </Button>
-          ) : (
-            <Button
-              variant="destructive"
+              variant="outline"
               className="px-2 py-1 h-auto"
-              data-testid="delete-export-template-button"
-              onClick={() => onDeleteTemplate?.(row.original)}
+              data-testid="edit-export-template-button"
+              onClick={() => onEditTemplate?.(row.original)}
             >
-              <Trash2 className="h-5 w-5" />
+              <Pencil className="h-5 w-5" />
             </Button>
-          )}
-        </div>
-      ),
-    },
-  ];
+            {row.original.isDefault ? (
+              <Button
+                variant="ghost"
+                className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
+                disabled
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            ) : (
+              <Button
+                variant="destructive"
+                className="px-2 py-1 h-auto"
+                data-testid="delete-export-template-button"
+                onClick={() => onDeleteTemplate?.(row.original)}
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [
+      t,
+      tCommon,
+      handleToggleEnabled,
+      handleToggleDefault,
+      onEditTemplate,
+      onDeleteTemplate,
+    ]
+  );
 };

--- a/testplanit/app/[locale]/admin/roles/columns.tsx
+++ b/testplanit/app/[locale]/admin/roles/columns.tsx
@@ -4,6 +4,7 @@ import { Roles } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { RoleNameCell } from "~/components/tables/RoleNameCell";
 import { UserListDisplay } from "~/components/tables/UserListDisplay";
 
@@ -15,91 +16,95 @@ export interface ExtendedRoles extends Roles {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   handleToggleDefault: (id: number, isDefault: boolean) => void,
   tCommon: ReturnType<typeof useTranslations<"common">>,
   onEditRole?: (role: ExtendedRoles) => void,
   onDeleteRole?: (role: ExtendedRoles) => void
-): ColumnDef<ExtendedRoles>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => <RoleNameCell roleId={row.original.id.toString()} />,
-  },
-  {
-    id: "isDefault",
-    accessorKey: "isDefault",
-    header: tCommon("fields.default"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isDefault}
-          disabled={row.original.isDefault}
-          onCheckedChange={(checked) =>
-            handleToggleDefault(row.original.id, checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "assignedUsers",
-    header: tCommon("fields.users"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const users = row.original.users;
-      const mappedUsers = users
-        ? users.map((user) => ({ userId: user.id }))
-        : [];
-      return <UserListDisplay users={mappedUsers} />;
-    },
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditRole?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        {row.original.isDefault ? (
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
-            disabled
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        ) : (
-          <Button
-            variant="destructive"
-            className="px-2 py-1 h-auto"
-            onClick={() => onDeleteRole?.(row.original)}
-          >
-            <Trash2 className="h-5 w-5" />
-          </Button>
-        )}
-      </div>
-    ),
-  },
-];
+): ColumnDef<ExtendedRoles>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => <RoleNameCell roleId={row.original.id.toString()} />,
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggleDefault(row.original.id, checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "assignedUsers",
+        header: tCommon("fields.users"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const users = row.original.users;
+          const mappedUsers = users
+            ? users.map((user) => ({ userId: user.id }))
+            : [];
+          return <UserListDisplay users={mappedUsers} />;
+        },
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditRole?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            {row.original.isDefault ? (
+              <Button
+                variant="ghost"
+                className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
+                disabled
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            ) : (
+              <Button
+                variant="destructive"
+                className="px-2 py-1 h-auto"
+                onClick={() => onDeleteRole?.(row.original)}
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [tCommon, handleToggleDefault, onEditRole, onDeleteRole]
+  );

--- a/testplanit/app/[locale]/admin/roles/page.tsx
+++ b/testplanit/app/[locale]/admin/roles/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   PaginationProvider,
   usePagination,
@@ -17,7 +17,7 @@ import {
   useUpdateManyRoles,
   useUpdateRoles,
 } from "~/lib/hooks";
-import { ExtendedRoles, getColumns } from "./columns";
+import { ExtendedRoles, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 import { PaginationComponent } from "@/components/tables/Pagination";
@@ -203,16 +203,12 @@ function RoleList() {
     []
   );
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        // eslint-disable-next-line react-hooks/refs
-        handleToggleDefault,
-        tCommon,
-        setEditingRole,
-        setDeletingRole
-      ),
-    [handleToggleDefault, tCommon]
+  const columns = useColumns(
+    // eslint-disable-next-line react-hooks/refs
+    handleToggleDefault,
+    tCommon,
+    setEditingRole,
+    setDeletingRole
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/tags/columns.tsx
+++ b/testplanit/app/[locale]/admin/tags/columns.tsx
@@ -7,6 +7,7 @@ import { Tags } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 export interface ExtendedTags extends Tags {
   repositoryCases: { id: number }[];
@@ -18,147 +19,154 @@ export interface ExtendedTags extends Tags {
   testRunsCount?: number;
 }
 
-export const getColumns = (
+export const useColumns = (
   tCommon: ReturnType<typeof useTranslations<"common">>,
   isLoadingCounts: boolean = false,
   onEditTag?: (tag: ExtendedTags) => void,
   onDeleteTag?: (tag: ExtendedTags) => void
-): ColumnDef<ExtendedTags>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    accessorFn: (row) => row.name,
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    maxSize: 500,
-    cell: ({ row }) => row.original.name,
-  },
-  {
-    id: "cases",
-    accessorKey: "repositoryCases",
-    accessorFn: (row) => row.repositoryCases,
-    header: tCommon("fields.testCases"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const count = row.original.repositoryCasesCount;
-      return (
-        <div className="text-center">
-          <CasesListDisplay
-            count={count}
-            filter={{
-              tags: {
-                some: {
-                  id: row.original.id,
-                },
-              },
-            }}
-            isLoading={isLoadingCounts}
-          />
-        </div>
-      );
-    },
-  },
-  {
-    id: "testRuns",
-    accessorKey: "testRuns",
-    accessorFn: (row) => row.testRuns,
-    header: tCommon("fields.testRuns"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const count = row.original.testRunsCount;
-      return (
-        <div className="text-center">
-          <TestRunsListDisplay
-            count={count}
-            filter={{
-              tags: {
-                some: {
-                  id: row.original.id,
-                },
-              },
-            }}
-            isLoading={isLoadingCounts}
-          />
-        </div>
-      );
-    },
-  },
-  {
-    id: "sessions",
-    accessorKey: "sessions",
-    accessorFn: (row) => row.sessions,
-    header: tCommon("fields.sessions"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const count = row.original.sessionsCount;
-      return (
-        <div className="text-center">
-          <SessionsListDisplay
-            count={count}
-            filter={{
-              tags: {
-                some: {
-                  id: row.original.id,
-                },
-              },
-            }}
-            isLoading={isLoadingCounts}
-          />
-        </div>
-      );
-    },
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => {
-      const projects = row.original.projects || [];
-      return (
-        <div className="text-center">
-          <ProjectListDisplay projects={projects} isLoading={isLoadingCounts} />
-        </div>
-      );
-    },
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-        <Button
-          variant="ghost"
-          className="px-2 py-1 h-auto"
-          onClick={() => onEditTag?.(row.original)}
-        >
-          <SquarePen className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="destructive"
-          className="px-2 py-1 h-auto"
-          onClick={() => onDeleteTag?.(row.original)}
-        >
-          <Trash2 className="h-5 w-5" />
-        </Button>
-      </div>
-    ),
-  },
-];
+): ColumnDef<ExtendedTags>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        maxSize: 500,
+        cell: ({ row }) => row.original.name,
+      },
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => row.repositoryCases,
+        header: tCommon("fields.testCases"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.repositoryCasesCount;
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "testRuns",
+        accessorKey: "testRuns",
+        accessorFn: (row) => row.testRuns,
+        header: tCommon("fields.testRuns"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.testRunsCount;
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => row.sessions,
+        header: tCommon("fields.sessions"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.sessionsCount;
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => {
+          const projects = row.original.projects || [];
+          return (
+            <div className="text-center">
+              <ProjectListDisplay
+                projects={projects}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+            <Button
+              variant="ghost"
+              className="px-2 py-1 h-auto"
+              onClick={() => onEditTag?.(row.original)}
+            >
+              <SquarePen className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="px-2 py-1 h-auto"
+              onClick={() => onDeleteTag?.(row.original)}
+            >
+              <Trash2 className="h-5 w-5" />
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [tCommon, onEditTag, onDeleteTag]
+  );

--- a/testplanit/app/[locale]/admin/tags/page.tsx
+++ b/testplanit/app/[locale]/admin/tags/page.tsx
@@ -27,7 +27,7 @@ import {
 import { CirclePlus } from "lucide-react";
 import { useCountTags, useFindManyTags } from "~/lib/hooks";
 import { AddTag } from "./AddTag";
-import { ExtendedTags, getColumns } from "./columns";
+import { ExtendedTags, useColumns } from "./columns";
 import { DeleteTag } from "./DeleteTag";
 import { EditTag } from "./EditTag";
 
@@ -258,9 +258,11 @@ function TagList() {
     }
   }, [status, session, router]);
 
-  const columns = useMemo(
-    () => getColumns(tCommon, isLoadingCounts, setEditingTag, setDeletingTag),
-    [tCommon, isLoadingCounts]
+  const columns = useColumns(
+    tCommon,
+    isLoadingCounts,
+    setEditingTag,
+    setDeletingTag
   );
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>

--- a/testplanit/app/[locale]/admin/users/columns.tsx
+++ b/testplanit/app/[locale]/admin/users/columns.tsx
@@ -18,6 +18,7 @@ import { User } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { MoreHorizontal } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { LastActiveDisplay } from "~/components/LastActiveDisplay";
 export interface ExtendedUser extends User {
   createdBy: {
@@ -43,7 +44,7 @@ export interface ExtendedUser extends User {
   }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   userPreferences: any,
   handleToggle: (id: string, key: keyof ExtendedUser, value: boolean) => void,
   tCommon: ReturnType<typeof useTranslations<"common">>,
@@ -52,227 +53,250 @@ export const getColumns = (
   onDeleteUser?: (user: ExtendedUser) => void,
   onForceChangePassword?: (user: ExtendedUser) => void,
   onRevokePassword?: (user: ExtendedUser) => void
-): ColumnDef<ExtendedUser>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: () => (
-      <div className="bg-primary-foreground">{tCommon("name")}</div>
-    ),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground">
-        <UserNameCell userId={row.original.id} />
-      </div>
-    ),
-  },
-  {
-    id: "email",
-    accessorKey: "email",
-    header: tCommon("fields.email"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 150,
-    cell: ({ row }) => <EmailCell email={row.original.email} />,
-  },
-  {
-    id: "emailVerified",
-    accessorKey: "emailVerified",
-    header: tCommon("fields.emailVerified"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-          }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isActive",
-    accessorKey: "isActive",
-    header: tCommon("fields.isActive"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          data-testid={`user-active-toggle-${row.original.id}`}
-          checked={row.original.isActive}
-          disabled={row.original.id === userPreferences.user.id}
-          onCheckedChange={(checked) =>
-            handleToggle(row.original.id, "isActive", checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "lastActiveAt",
-    accessorKey: "lastActiveAt",
-    header: tCommon("fields.lastActive"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => <LastActiveDisplay date={row.original.lastActiveAt} />,
-  },
-  {
-    id: "access",
-    accessorKey: "access",
-    header: tCommon("fields.access"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => <AccessLevelDisplay accessLevel={row.original.access} />,
-  },
-  {
-    id: "roleId",
-    accessorKey: "roleId",
-    header: tCommon("fields.role"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => <RoleNameCell roleId={row.original.roleId.toString()} />,
-  },
-  {
-    id: "groups",
-    accessorKey: "groups",
-    header: tCommon("fields.groups"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <GroupListDisplay groups={row.original.groups} />
-      </div>
-    ),
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <UserProjectsDisplay userId={row.original.id} />
-      </div>
-    ),
-  },
-  {
-    id: "isApi",
-    accessorKey: "isApi",
-    header: tCommon("fields.apiAccess"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: true,
-    meta: { isVisible: false },
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isApi}
-          disabled={row.original.access === "ADMIN"}
-          onCheckedChange={(checked) =>
-            handleToggle(row.original.id, "isApi", checked)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "createdAt",
-    accessorKey: "createdAt",
-    header: tCommon("fields.createdAt"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 100,
-    cell: ({ getValue }) => (
-      <div className="whitespace-nowrap">
-        <DateFormatter
-          date={getValue() as Date | string}
-          formatString={
-            userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH"
-          }
-          timezone={userPreferences.user.preferences?.timezone || "Etc/UTC"}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "createdById",
-    accessorKey: "createdById",
-    header: tCommon("fields.createdBy"),
-    enableSorting: true,
-    enableResizing: true,
-    meta: { isVisible: false },
-    size: 150,
-    cell: (info) =>
-      info.row.original.createdBy?.id ? (
-        <UserNameCell userId={info.row.original.createdBy.id} />
-      ) : (
-        "Self-Registration"
-      ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    size: 60,
-    meta: { isPinned: "right" },
-    cell: ({ row }) => (
-      <div className="flex justify-center">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="px-2 py-1 h-auto">
-              <MoreHorizontal className="h-5 w-5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onEditUser?.(row.original)}>
-              {tCommon("actions.edit")}
-            </DropdownMenuItem>
-            {row.original.authMethod !== "SSO" &&
-              row.original.id !== userPreferences.user.id && (
-                <>
+): ColumnDef<ExtendedUser>[] => {
+  const dateFormat =
+    userPreferences.user.preferences?.dateFormat || "MM_DD_YYYY_DASH";
+  const timezone = userPreferences.user.preferences?.timezone || "Etc/UTC";
+  const currentUserId = userPreferences.user.id;
+
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: () => (
+          <div className="bg-primary-foreground">{tCommon("name")}</div>
+        ),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground">
+            <UserNameCell userId={row.original.id} />
+          </div>
+        ),
+      },
+      {
+        id: "email",
+        accessorKey: "email",
+        header: tCommon("fields.email"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        cell: ({ row }) => <EmailCell email={row.original.email} />,
+      },
+      {
+        id: "emailVerified",
+        accessorKey: "emailVerified",
+        header: tCommon("fields.emailVerified"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat}
+              timezone={timezone}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isActive",
+        accessorKey: "isActive",
+        header: tCommon("fields.isActive"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              data-testid={`user-active-toggle-${row.original.id}`}
+              checked={row.original.isActive}
+              disabled={row.original.id === currentUserId}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isActive", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "lastActiveAt",
+        accessorKey: "lastActiveAt",
+        header: tCommon("fields.lastActive"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => (
+          <LastActiveDisplay date={row.original.lastActiveAt} />
+        ),
+      },
+      {
+        id: "access",
+        accessorKey: "access",
+        header: tCommon("fields.access"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <AccessLevelDisplay accessLevel={row.original.access} />
+        ),
+      },
+      {
+        id: "roleId",
+        accessorKey: "roleId",
+        header: tCommon("fields.role"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <RoleNameCell roleId={row.original.roleId.toString()} />
+        ),
+      },
+      {
+        id: "groups",
+        accessorKey: "groups",
+        header: tCommon("fields.groups"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <GroupListDisplay groups={row.original.groups} />
+          </div>
+        ),
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <UserProjectsDisplay userId={row.original.id} />
+          </div>
+        ),
+      },
+      {
+        id: "isApi",
+        accessorKey: "isApi",
+        header: tCommon("fields.apiAccess"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: true,
+        meta: { isVisible: false },
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isApi}
+              disabled={row.original.access === "ADMIN"}
+              onCheckedChange={(checked) =>
+                handleToggle(row.original.id, "isApi", checked)
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: tCommon("fields.createdAt"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        cell: ({ getValue }) => (
+          <div className="whitespace-nowrap">
+            <DateFormatter
+              date={getValue() as Date | string}
+              formatString={dateFormat}
+              timezone={timezone}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "createdById",
+        accessorKey: "createdById",
+        header: tCommon("fields.createdBy"),
+        enableSorting: true,
+        enableResizing: true,
+        meta: { isVisible: false },
+        size: 150,
+        cell: (info) =>
+          info.row.original.createdBy?.id ? (
+            <UserNameCell userId={info.row.original.createdBy.id} />
+          ) : (
+            "Self-Registration"
+          ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        size: 60,
+        meta: { isPinned: "right" },
+        cell: ({ row }) => (
+          <div className="flex justify-center">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="px-2 py-1 h-auto">
+                  <MoreHorizontal className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onEditUser?.(row.original)}>
+                  {tCommon("actions.edit")}
+                </DropdownMenuItem>
+                {row.original.authMethod !== "SSO" &&
+                  row.original.id !== currentUserId && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => onForceChangePassword?.(row.original)}
+                      >
+                        {tAdmin("forcePasswordChange")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => onRevokePassword?.(row.original)}
+                      >
+                        {tAdmin("revokePassword")}
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                <DropdownMenuSeparator />
+                {row.original.id !== currentUserId ? (
                   <DropdownMenuItem
-                    onClick={() => onForceChangePassword?.(row.original)}
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => onDeleteUser?.(row.original)}
                   >
-                    {tAdmin("forcePasswordChange")}
+                    {tCommon("actions.delete")}
                   </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => onRevokePassword?.(row.original)}
-                  >
-                    {tAdmin("revokePassword")}
-                  </DropdownMenuItem>
-                </>
-              )}
-            <DropdownMenuSeparator />
-            {row.original.id !== userPreferences.user.id ? (
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onClick={() => onDeleteUser?.(row.original)}
-              >
-                {tCommon("actions.delete")}
-              </DropdownMenuItem>
-            ) : null}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    ),
-  },
-];
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ),
+      },
+    ],
+    [
+      dateFormat,
+      timezone,
+      currentUserId,
+      handleToggle,
+      tCommon,
+      tAdmin,
+      onEditUser,
+      onDeleteUser,
+      onForceChangePassword,
+      onRevokePassword,
+    ]
+  );
+};

--- a/testplanit/app/[locale]/admin/users/page.tsx
+++ b/testplanit/app/[locale]/admin/users/page.tsx
@@ -15,7 +15,7 @@ import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
 import { DataTable } from "@/components/tables/DataTable";
 import { useFindManyUser } from "~/lib/hooks";
-import { ExtendedUser, getColumns } from "./columns";
+import { ExtendedUser, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 
@@ -260,19 +260,15 @@ function UserList() {
     [userId, dateFormat, timezone]
   );
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        userPreferences,
-        handleToggle,
-        tCommon,
-        tAdmin,
-        setEditingUser,
-        setDeletingUser,
-        setForcingUser,
-        setRevokingUser
-      ),
-    [userPreferences, handleToggle, tCommon, tAdmin]
+  const columns = useColumns(
+    userPreferences,
+    handleToggle,
+    tCommon,
+    tAdmin,
+    setEditingUser,
+    setDeletingUser,
+    setForcingUser,
+    setRevokingUser
   );
 
   const [columnVisibility, setColumnVisibility] = useState<

--- a/testplanit/app/[locale]/admin/workflows/columns.tsx
+++ b/testplanit/app/[locale]/admin/workflows/columns.tsx
@@ -6,6 +6,7 @@ import { WorkflowScope } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import { GripVertical, SquarePen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { IconName } from "~/types/globals";
 import { ExtendedWorkflows } from "~/types/Workflows";
 
@@ -23,7 +24,7 @@ const isLastWorkflowOfType = (
   return sameTypeAndScope.length === 1;
 };
 
-export const getColumns = (
+export const useColumns = (
   workflows: ExtendedWorkflows[],
   tWorkflowTypes: ReturnType<typeof useTranslations<"enums.WorkflowType">>,
   tCommon: ReturnType<typeof useTranslations<"common">>,
@@ -35,136 +36,153 @@ export const getColumns = (
   ) => void,
   onEditWorkflow?: (workflow: ExtendedWorkflows) => void,
   onDeleteWorkflow?: (workflow: ExtendedWorkflows) => void
-): ColumnDef<ExtendedWorkflows>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("fields.state"),
-    enableSorting: false,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => (
-      <div className="relative flex items-center gap-1 group/row">
-        <GripVertical className="absolute -left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground opacity-0 group-hover/row:opacity-100 transition-opacity cursor-grab" />
-        <DynamicIcon
-          name={row.original.icon.name as IconName}
-          color={row.original.color.value}
-        />
-        <span>{row.original.name}</span>
-      </div>
-    ),
-  },
-  {
-    id: "workflowType",
-    accessorKey: "workflowType",
-    header: tCommon("fields.type"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        {tWorkflowTypes(row.original.workflowType)}
-      </div>
-    ),
-  },
-  {
-    id: "isDefault",
-    accessorKey: "isDefault",
-    header: tCommon("fields.default"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isDefault}
-          disabled={row.original.isDefault}
-          onCheckedChange={(checked) =>
-            handleToggleDefault(row.original.id, checked, row.original.scope)
-          }
-        />
-      </div>
-    ),
-  },
-  {
-    id: "isEnabled",
-    accessorKey: "isEnabled",
-    header: tCommon("fields.enabled"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <Switch
-          checked={row.original.isEnabled}
-          onCheckedChange={(checked) =>
-            handleToggleEnabled(row.original.id, checked)
-          }
-          disabled={row.original.isDefault}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 100,
-    cell: ({ row }) => (
-      <div className="text-center">
-        <ProjectListDisplay
-          projects={row.original.projects.map((p) => ({
-            projectId: p.projectId,
-            name: p.project.name,
-          }))}
-        />
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    header: tCommon("actions.actionsLabel"),
-    enableResizing: true,
-    enableSorting: false,
-    enableHiding: false,
-    meta: { isPinned: "right" },
-    size: 80,
-    cell: ({ row }) => {
-      const workflow = row.original;
-      const canDelete =
-        !isLastWorkflowOfType(workflow, workflows) && !workflow.isDefault;
-      return (
-        <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-          <Button
-            variant="ghost"
-            className="px-2 py-1 h-auto"
-            onClick={() => onEditWorkflow?.(workflow)}
-          >
-            <SquarePen className="h-5 w-5" />
-          </Button>
-          {canDelete ? (
-            <Button
-              variant="destructive"
-              className="px-2 py-1 h-auto"
-              onClick={() => onDeleteWorkflow?.(workflow)}
-            >
-              <Trash2 className="h-5 w-5" />
-            </Button>
-          ) : (
-            <Button
-              variant="ghost"
-              className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
-              disabled
-            >
-              <Trash2 className="h-5 w-5" />
-            </Button>
-          )}
-        </div>
-      );
-    },
-  },
-];
+): ColumnDef<ExtendedWorkflows>[] => {
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("fields.state"),
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <div className="relative flex items-center gap-1 group/row">
+            <GripVertical className="absolute -left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground opacity-0 group-hover/row:opacity-100 transition-opacity cursor-grab" />
+            <DynamicIcon
+              name={row.original.icon.name as IconName}
+              color={row.original.color.value}
+            />
+            <span>{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        id: "workflowType",
+        accessorKey: "workflowType",
+        header: tCommon("fields.type"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            {tWorkflowTypes(row.original.workflowType)}
+          </div>
+        ),
+      },
+      {
+        id: "isDefault",
+        accessorKey: "isDefault",
+        header: tCommon("fields.default"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isDefault}
+              disabled={row.original.isDefault}
+              onCheckedChange={(checked) =>
+                handleToggleDefault(
+                  row.original.id,
+                  checked,
+                  row.original.scope
+                )
+              }
+            />
+          </div>
+        ),
+      },
+      {
+        id: "isEnabled",
+        accessorKey: "isEnabled",
+        header: tCommon("fields.enabled"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <Switch
+              checked={row.original.isEnabled}
+              onCheckedChange={(checked) =>
+                handleToggleEnabled(row.original.id, checked)
+              }
+              disabled={row.original.isDefault}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 100,
+        cell: ({ row }) => (
+          <div className="text-center">
+            <ProjectListDisplay
+              projects={row.original.projects.map((p) => ({
+                projectId: p.projectId,
+                name: p.project.name,
+              }))}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: tCommon("actions.actionsLabel"),
+        enableResizing: true,
+        enableSorting: false,
+        enableHiding: false,
+        meta: { isPinned: "right" },
+        size: 80,
+        cell: ({ row }) => {
+          const workflow = row.original;
+          const canDelete =
+            !isLastWorkflowOfType(workflow, workflows) && !workflow.isDefault;
+          return (
+            <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
+              <Button
+                variant="ghost"
+                className="px-2 py-1 h-auto"
+                onClick={() => onEditWorkflow?.(workflow)}
+              >
+                <SquarePen className="h-5 w-5" />
+              </Button>
+              {canDelete ? (
+                <Button
+                  variant="destructive"
+                  className="px-2 py-1 h-auto"
+                  onClick={() => onDeleteWorkflow?.(workflow)}
+                >
+                  <Trash2 className="h-5 w-5" />
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  className="px-2 py-1 h-auto text-muted-foreground cursor-not-allowed"
+                  disabled
+                >
+                  <Trash2 className="h-5 w-5" />
+                </Button>
+              )}
+            </div>
+          );
+        },
+      },
+    ],
+    [
+      workflows,
+      tWorkflowTypes,
+      tCommon,
+      handleToggleEnabled,
+      handleToggleDefault,
+      onEditWorkflow,
+      onDeleteWorkflow,
+    ]
+  );
+};

--- a/testplanit/app/[locale]/admin/workflows/page.tsx
+++ b/testplanit/app/[locale]/admin/workflows/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import { performOptimisticReorder } from "~/utils/optimistic-updates";
-import { getColumns } from "./columns";
+import { useColumns } from "./columns";
 
 import { WorkflowDragPreview } from "@/components/dnd/WorkflowDragPreview";
 import { Button } from "@/components/ui/button";
@@ -138,8 +138,6 @@ function WorkflowComponent() {
     }
   }, [status, session, router]);
 
-  if (status === "loading") return null;
-
   const handleToggleEnabled = async (id: number, isEnabled: boolean) => {
     try {
       await updateWorkflows({
@@ -160,6 +158,18 @@ function WorkflowComponent() {
     setSelectedWorkflowScope(scope);
     setIsAlertDialogOpen(true);
   };
+
+  const columns = useColumns(
+    data || [],
+    tWorkflowTypes,
+    tCommon,
+    handleToggleEnabled,
+    handleToggleDefault,
+    setEditingWorkflow,
+    setDeletingWorkflow
+  );
+
+  if (status === "loading") return null;
 
   const handleConfirmToggleDefault = async () => {
     setIsAlertDialogOpen(false);
@@ -194,16 +204,6 @@ function WorkflowComponent() {
       console.error("Failed to update workflow:", error);
     }
   };
-
-  const columns = getColumns(
-    data || [],
-    tWorkflowTypes,
-    tCommon,
-    handleToggleEnabled,
-    handleToggleDefault,
-    setEditingWorkflow,
-    setDeletingWorkflow
-  );
 
   const renderWorkflowCard = (
     workflows: ExtendedWorkflows[],

--- a/testplanit/app/[locale]/issues/columns.tsx
+++ b/testplanit/app/[locale]/issues/columns.tsx
@@ -15,6 +15,7 @@ import { Issue } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import DOMPurify from "dompurify";
 import { Plug } from "lucide-react";
+import { useMemo } from "react";
 
 // Helper function to strip HTML tags and get plain text
 function stripHtmlTags(html: string | null): string {
@@ -66,373 +67,403 @@ export function useIssueColumns({
   };
   isLoadingCounts?: boolean;
 }): ColumnDef<ExtendedIssues>[] {
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      accessorFn: (row) => row.name,
-      header: translations.name,
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        return (
-          <div
-            data-row-id={row.original.id}
-            style={{ maxWidth: column.getSize() }}
-            className="overflow-hidden"
-          >
-            <IssuesDisplay
-              id={row.original.id}
-              name={row.original.name}
-              externalId={row.original.externalId}
-              externalUrl={row.original.externalUrl}
-              title={row.original.title}
-              status={row.original.externalStatus}
-              projectIds={row.original.projectIds}
-              size="small"
-              data={row.original.data}
-              integrationProvider={row.original.integration?.provider}
-              integrationId={row.original.integration?.id}
-              issueTypeName={row.original.issueTypeName}
-              issueTypeIconUrl={row.original.issueTypeIconUrl}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "title",
-      accessorKey: "title",
-      accessorFn: (row) => row.title,
-      header: translations.title,
-      enableSorting: true,
-      enableResizing: true,
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const title = row.original.title;
-        const hasHtml = title && /<[^>]+>/.test(title);
-        const plainText = stripHtmlTags(title);
+  // Destructure to primitive deps so useMemo only re-runs when strings change (locale switch),
+  // not on every parent render that creates a new translations object.
+  const {
+    name: tName,
+    title: tTitle,
+    description: tDescription,
+    status: tStatus,
+    priority: tPriority,
+    lastSyncedAt: tLastSyncedAt,
+    testCases: tTestCases,
+    sessions: tSessions,
+    testRuns: tTestRuns,
+    projects: tProjects,
+    integration: tIntegration,
+  } = translations;
 
-        if (!title) return <span className="text-muted-foreground">-</span>;
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: tName,
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          return (
+            <div
+              data-row-id={row.original.id}
+              style={{ maxWidth: column.getSize() }}
+              className="overflow-hidden"
+            >
+              <IssuesDisplay
+                id={row.original.id}
+                name={row.original.name}
+                externalId={row.original.externalId}
+                externalUrl={row.original.externalUrl}
+                title={row.original.title}
+                status={row.original.externalStatus}
+                projectIds={row.original.projectIds}
+                size="small"
+                data={row.original.data}
+                integrationProvider={row.original.integration?.provider}
+                integrationId={row.original.integration?.id}
+                issueTypeName={row.original.issueTypeName}
+                issueTypeIconUrl={row.original.issueTypeIconUrl}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "title",
+        accessorKey: "title",
+        accessorFn: (row) => row.title,
+        header: tTitle,
+        enableSorting: true,
+        enableResizing: true,
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const title = row.original.title;
+          const hasHtml = title && /<[^>]+>/.test(title);
+          const plainText = stripHtmlTags(title);
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
-                title={plainText}
-              >
-                {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">{translations.title}</h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(title, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{title}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
-      },
-    },
-    {
-      id: "description",
-      accessorKey: "description",
-      accessorFn: (row) => stripHtmlTags(row.description),
-      header: translations.description,
-      enableSorting: false,
-      enableResizing: true,
-      size: 300,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const description = row.original.description;
-        const plainText = stripHtmlTags(description);
+          if (!title) return <span className="text-muted-foreground">-</span>;
 
-        if (!plainText) return <span className="text-muted-foreground">-</span>;
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">{tTitle}</h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(title, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{title}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
+      },
+      {
+        id: "description",
+        accessorKey: "description",
+        accessorFn: (row) => stripHtmlTags(row.description),
+        header: tDescription,
+        enableSorting: false,
+        enableResizing: true,
+        size: 300,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const description = row.original.description;
+          const plainText = stripHtmlTags(description);
 
-        const hasHtml = description && /<[^>]+>/.test(description);
+          if (!plainText)
+            return <span className="text-muted-foreground">-</span>;
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
-                title={plainText}
-              >
-                {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">
-                  {translations.description}
-                </h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(description, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                          "blockquote",
-                          "code",
-                          "pre",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{description}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
+          const hasHtml = description && /<[^>]+>/.test(description);
+
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">{tDescription}</h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(description, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                            "blockquote",
+                            "code",
+                            "pre",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{description}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
       },
-    },
-    {
-      id: "status",
-      accessorKey: "status",
-      accessorFn: (row) => row.status || "",
-      header: translations.status,
-      enableSorting: true,
-      enableResizing: true,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const status = row.original.status;
-        return <IssueStatusDisplay status={status} className="capitalize" />;
+      {
+        id: "status",
+        accessorKey: "status",
+        accessorFn: (row) => row.status || "",
+        header: tStatus,
+        enableSorting: true,
+        enableResizing: true,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const status = row.original.status;
+          return <IssueStatusDisplay status={status} className="capitalize" />;
+        },
       },
-    },
-    {
-      id: "priority",
-      accessorKey: "priority",
-      accessorFn: (row) => row.priority || "",
-      header: translations.priority,
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const priority = row.original.priority;
-        return (
-          <IssuePriorityDisplay priority={priority} className="capitalize" />
-        );
+      {
+        id: "priority",
+        accessorKey: "priority",
+        accessorFn: (row) => row.priority || "",
+        header: tPriority,
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const priority = row.original.priority;
+          return (
+            <IssuePriorityDisplay priority={priority} className="capitalize" />
+          );
+        },
       },
-    },
-    {
-      id: "lastSyncedAt",
-      accessorKey: "lastSyncedAt",
-      accessorFn: (row) => row.lastSyncedAt,
-      header: translations.lastSyncedAt,
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      minSize: 80,
-      maxSize: 250,
-      cell: ({ row, column }) => {
-        const lastSyncedAt = row.original.lastSyncedAt;
-        if (!lastSyncedAt)
-          return <span className="text-muted-foreground">-</span>;
-        return (
-          <span
-            className="text-sm truncate overflow-hidden block"
-            style={{ maxWidth: column.getSize() }}
-          >
-            <DateFormatter date={lastSyncedAt} formatString="PPp" />
-          </span>
-        );
-      },
-    },
-    {
-      id: "cases",
-      accessorKey: "repositoryCases",
-      accessorFn: (row) => row.repositoryCasesCount ?? 0,
-      header: translations.testCases,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.repositoryCasesCount;
-        return (
-          <div className="text-center">
-            <CasesListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "testRuns",
-      accessorKey: "aggregatedTestRunIds",
-      accessorFn: (row) => row.testRunsCount ?? 0,
-      header: translations.testRuns,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.testRunsCount;
-        return (
-          <div className="text-center">
-            <TestRunsListDisplay
-              key={`tr-${row.original.id}`}
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "sessions",
-      accessorKey: "sessions",
-      accessorFn: (row) => row.sessionsCount ?? 0,
-      header: translations.sessions,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.sessionsCount;
-        return (
-          <div className="text-center">
-            <SessionsListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
-                  },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "projects",
-      accessorKey: "projects",
-      accessorFn: (row) => (row.projects || []).length,
-      header: translations.projects,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const projects = row.original.projects || [];
-        return (
-          <div className="text-center">
-            <ProjectListDisplay
-              projects={projects}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "integration",
-      accessorKey: "integration",
-      accessorFn: (row) => row.integration?.name || "",
-      header: translations.integration,
-      enableSorting: false,
-      enableResizing: true,
-      size: 150,
-      minSize: 100,
-      maxSize: 150,
-      cell: ({ row }) => {
-        return (
-          <div className="flex items-center gap-1">
-            <Plug className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span className="font-medium truncate">
-              {row.original.integration?.name || "-"}
+      {
+        id: "lastSyncedAt",
+        accessorKey: "lastSyncedAt",
+        accessorFn: (row) => row.lastSyncedAt,
+        header: tLastSyncedAt,
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        minSize: 80,
+        maxSize: 250,
+        cell: ({ row, column }) => {
+          const lastSyncedAt = row.original.lastSyncedAt;
+          if (!lastSyncedAt)
+            return <span className="text-muted-foreground">-</span>;
+          return (
+            <span
+              className="text-sm truncate overflow-hidden block"
+              style={{ maxWidth: column.getSize() }}
+            >
+              <DateFormatter date={lastSyncedAt} formatString="PPp" />
             </span>
-          </div>
-        );
+          );
+        },
       },
-    },
-  ];
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => row.repositoryCasesCount ?? 0,
+        header: tTestCases,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.repositoryCasesCount;
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "testRuns",
+        accessorKey: "aggregatedTestRunIds",
+        accessorFn: (row) => row.testRunsCount ?? 0,
+        header: tTestRuns,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.testRunsCount;
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                key={`tr-${row.original.id}`}
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => row.sessionsCount ?? 0,
+        header: tSessions,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.sessionsCount;
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
+                  },
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        accessorFn: (row) => (row.projects || []).length,
+        header: tProjects,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const projects = row.original.projects || [];
+          return (
+            <div className="text-center">
+              <ProjectListDisplay
+                projects={projects}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
+      },
+      {
+        id: "integration",
+        accessorKey: "integration",
+        accessorFn: (row) => row.integration?.name || "",
+        header: tIntegration,
+        enableSorting: false,
+        enableResizing: true,
+        size: 150,
+        minSize: 100,
+        maxSize: 150,
+        cell: ({ row }) => {
+          return (
+            <div className="flex items-center gap-1">
+              <Plug className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="font-medium truncate">
+                {row.original.integration?.name || "-"}
+              </span>
+            </div>
+          );
+        },
+      },
+    ],
+    [
+      tName,
+      tTitle,
+      tDescription,
+      tStatus,
+      tPriority,
+      tLastSyncedAt,
+      tTestCases,
+      tSessions,
+      tTestRuns,
+      tProjects,
+      tIntegration,
+    ]
+  );
 }

--- a/testplanit/app/[locale]/projects/issues/[projectId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/issues/[projectId]/columns.tsx
@@ -13,6 +13,7 @@ import {
 import { Issue } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
 import DOMPurify from "dompurify";
+import { useMemo } from "react";
 import { buildSimpleUrlLink } from "~/lib/integrations/simpleUrl";
 
 function resolveIssueUrl(row: ExtendedIssues): string | null {
@@ -85,362 +86,388 @@ export function useIssueColumns({
    *  when the project only has SIMPLE_URL integrations — those columns never have values. */
   hideSyncedFields?: boolean;
 }): ColumnDef<ExtendedIssues>[] {
-  const columns: ColumnDef<ExtendedIssues>[] = [
-    {
-      id: "name",
-      accessorKey: "name",
-      accessorFn: (row) => row.name,
-      header: translations.name,
-      enableSorting: true,
-      enableResizing: true,
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 400,
-      minSize: 150,
-      maxSize: 800,
-      cell: ({ row, column }) => {
-        return (
-          <div
-            data-row-id={row.original.id}
-            style={{ maxWidth: column.getSize() }}
-            className="overflow-hidden"
-          >
-            <IssuesDisplay
-              id={row.original.id}
-              name={row.original.name}
-              externalId={row.original.externalId}
-              externalUrl={resolveIssueUrl(row.original)}
-              title={row.original.title}
-              status={row.original.externalStatus}
-              projectIds={row.original.projectIds}
-              size="small"
-              data={row.original.data}
-              integrationProvider={row.original.integration?.provider}
-              integrationId={row.original.integration?.id}
-              issueTypeName={row.original.issueTypeName}
-              issueTypeIconUrl={row.original.issueTypeIconUrl}
-            />
-          </div>
-        );
-      },
-    },
-    {
-      id: "title",
-      accessorKey: "title",
-      accessorFn: (row) => row.title,
-      header: translations.title,
-      enableSorting: true,
-      enableResizing: true,
-      size: 250,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const title = row.original.title;
-        const externalUrl = resolveIssueUrl(row.original);
-        const hasHtml = title && /<[^>]+>/.test(title);
-        const plainText = stripHtmlTags(title);
+  // Destructure to primitive deps so useMemo only re-runs when strings change (locale switch),
+  // not on every parent render that creates a new translations object.
+  const {
+    name: tName,
+    title: tTitle,
+    description: tDescription,
+    status: tStatus,
+    priority: tPriority,
+    lastSyncedAt: tLastSyncedAt,
+    testCases: tTestCases,
+    sessions: tSessions,
+    testRuns: tTestRuns,
+  } = translations;
 
-        if (!title) return <span className="text-muted-foreground">-</span>;
-
-        // If the issue has an externalUrl and the title is plain text,
-        // render the title as a link to the external system.
-        if (externalUrl && !hasHtml) {
+  return useMemo(() => {
+    const columns: ColumnDef<ExtendedIssues>[] = [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: tName,
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 400,
+        minSize: 150,
+        maxSize: 800,
+        cell: ({ row, column }) => {
           return (
-            <a
-              href={externalUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={plainText}
-              className="line-clamp-2 overflow-hidden text-ellipsis text-sm hover:text-primary hover:underline block px-1 -mx-1 py-0.5"
+            <div
+              data-row-id={row.original.id}
               style={{ maxWidth: column.getSize() }}
-              onClick={(e) => e.stopPropagation()}
+              className="overflow-hidden"
             >
-              {plainText}
-            </a>
+              <IssuesDisplay
+                id={row.original.id}
+                name={row.original.name}
+                externalId={row.original.externalId}
+                externalUrl={resolveIssueUrl(row.original)}
+                title={row.original.title}
+                status={row.original.externalStatus}
+                projectIds={row.original.projectIds}
+                size="small"
+                data={row.original.data}
+                integrationProvider={row.original.integration?.provider}
+                integrationId={row.original.integration?.id}
+                issueTypeName={row.original.issueTypeName}
+                issueTypeIconUrl={row.original.issueTypeIconUrl}
+              />
+            </div>
           );
-        }
+        },
+      },
+      {
+        id: "title",
+        accessorKey: "title",
+        accessorFn: (row) => row.title,
+        header: tTitle,
+        enableSorting: true,
+        enableResizing: true,
+        size: 250,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const title = row.original.title;
+          const externalUrl = resolveIssueUrl(row.original);
+          const hasHtml = title && /<[^>]+>/.test(title);
+          const plainText = stripHtmlTags(title);
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
+          if (!title) return <span className="text-muted-foreground">-</span>;
+
+          // If the issue has an externalUrl and the title is plain text,
+          // render the title as a link to the external system.
+          if (externalUrl && !hasHtml) {
+            return (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
                 title={plainText}
+                className="line-clamp-2 overflow-hidden text-ellipsis text-sm hover:text-primary hover:underline block px-1 -mx-1 py-0.5"
+                style={{ maxWidth: column.getSize() }}
+                onClick={(e) => e.stopPropagation()}
               >
                 {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">{translations.title}</h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(title, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{title}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
-      },
-    },
-    {
-      id: "description",
-      accessorKey: "description",
-      accessorFn: (row) => stripHtmlTags(row.description),
-      header: translations.description,
-      enableSorting: false,
-      enableResizing: true,
-      size: 250,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row, column }) => {
-        const description = row.original.description;
-        const plainText = stripHtmlTags(description);
+              </a>
+            );
+          }
 
-        if (!plainText) return <span className="text-muted-foreground">-</span>;
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">{tTitle}</h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(title, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{title}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
+      },
+      {
+        id: "description",
+        accessorKey: "description",
+        accessorFn: (row) => stripHtmlTags(row.description),
+        header: tDescription,
+        enableSorting: false,
+        enableResizing: true,
+        size: 250,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row, column }) => {
+          const description = row.original.description;
+          const plainText = stripHtmlTags(description);
 
-        const hasHtml = description && /<[^>]+>/.test(description);
+          if (!plainText)
+            return <span className="text-muted-foreground">-</span>;
 
-        return (
-          <Popover>
-            <PopoverTrigger asChild>
-              <div
-                className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
-                style={{ maxWidth: column.getSize() }}
-                title={plainText}
-              >
-                {plainText}
-              </div>
-            </PopoverTrigger>
-            <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
-              <div className="space-y-2">
-                <h4 className="font-semibold text-sm">
-                  {translations.description}
-                </h4>
-                {hasHtml ? (
-                  <div
-                    className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(description, {
-                        ALLOWED_TAGS: [
-                          "p",
-                          "br",
-                          "a",
-                          "strong",
-                          "em",
-                          "u",
-                          "ul",
-                          "ol",
-                          "li",
-                          "h1",
-                          "h2",
-                          "h3",
-                          "h4",
-                          "h5",
-                          "h6",
-                          "blockquote",
-                          "code",
-                          "pre",
-                        ],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                ) : (
-                  <p className="text-sm whitespace-pre-wrap">{description}</p>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        );
+          const hasHtml = description && /<[^>]+>/.test(description);
+
+          return (
+            <Popover>
+              <PopoverTrigger asChild>
+                <div
+                  className="line-clamp-2 overflow-hidden text-ellipsis text-sm cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+                  style={{ maxWidth: column.getSize() }}
+                  title={plainText}
+                >
+                  {plainText}
+                </div>
+              </PopoverTrigger>
+              <PopoverContent className="w-[500px] max-h-[400px] overflow-auto">
+                <div className="space-y-2">
+                  <h4 className="font-semibold text-sm">{tDescription}</h4>
+                  {hasHtml ? (
+                    <div
+                      className="text-sm [&_a]:text-primary [&_a]:underline [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:ml-4 [&_ol]:list-decimal [&_ol]:ml-4"
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(description, {
+                          ALLOWED_TAGS: [
+                            "p",
+                            "br",
+                            "a",
+                            "strong",
+                            "em",
+                            "u",
+                            "ul",
+                            "ol",
+                            "li",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                            "blockquote",
+                            "code",
+                            "pre",
+                          ],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{description}</p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        },
       },
-    },
-    {
-      id: "status",
-      accessorKey: "status",
-      accessorFn: (row) => row.status || "",
-      header: translations.status,
-      enableSorting: true,
-      enableResizing: true,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const status = row.original.status;
-        return <IssueStatusDisplay status={status} className="capitalize" />;
+      {
+        id: "status",
+        accessorKey: "status",
+        accessorFn: (row) => row.status || "",
+        header: tStatus,
+        enableSorting: true,
+        enableResizing: true,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const status = row.original.status;
+          return <IssueStatusDisplay status={status} className="capitalize" />;
+        },
       },
-    },
-    {
-      id: "priority",
-      accessorKey: "priority",
-      accessorFn: (row) => row.priority || "",
-      header: translations.priority,
-      enableSorting: true,
-      enableResizing: true,
-      size: 100,
-      minSize: 80,
-      maxSize: 200,
-      cell: ({ row }) => {
-        const priority = row.original.priority;
-        return (
-          <IssuePriorityDisplay priority={priority} className="capitalize" />
-        );
+      {
+        id: "priority",
+        accessorKey: "priority",
+        accessorFn: (row) => row.priority || "",
+        header: tPriority,
+        enableSorting: true,
+        enableResizing: true,
+        size: 100,
+        minSize: 80,
+        maxSize: 200,
+        cell: ({ row }) => {
+          const priority = row.original.priority;
+          return (
+            <IssuePriorityDisplay priority={priority} className="capitalize" />
+          );
+        },
       },
-    },
-    {
-      id: "lastSyncedAt",
-      accessorKey: "lastSyncedAt",
-      accessorFn: (row) => row.lastSyncedAt,
-      header: translations.lastSyncedAt,
-      enableSorting: true,
-      enableResizing: true,
-      size: 150,
-      minSize: 80,
-      maxSize: 250,
-      cell: ({ row, column }) => {
-        const lastSyncedAt = row.original.lastSyncedAt;
-        if (!lastSyncedAt)
-          return <span className="text-muted-foreground">-</span>;
-        return (
-          <span
-            className="text-sm truncate overflow-hidden block"
-            style={{ maxWidth: column.getSize() }}
-          >
-            <DateFormatter date={lastSyncedAt} formatString="PPp" />
-          </span>
-        );
+      {
+        id: "lastSyncedAt",
+        accessorKey: "lastSyncedAt",
+        accessorFn: (row) => row.lastSyncedAt,
+        header: tLastSyncedAt,
+        enableSorting: true,
+        enableResizing: true,
+        size: 150,
+        minSize: 80,
+        maxSize: 250,
+        cell: ({ row, column }) => {
+          const lastSyncedAt = row.original.lastSyncedAt;
+          if (!lastSyncedAt)
+            return <span className="text-muted-foreground">-</span>;
+          return (
+            <span
+              className="text-sm truncate overflow-hidden block"
+              style={{ maxWidth: column.getSize() }}
+            >
+              <DateFormatter date={lastSyncedAt} formatString="PPp" />
+            </span>
+          );
+        },
       },
-    },
-    {
-      id: "cases",
-      accessorKey: "repositoryCases",
-      accessorFn: (row) => row.repositoryCasesCount ?? 0,
-      header: translations.testCases,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.repositoryCasesCount;
-        return (
-          <div className="text-center">
-            <CasesListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => row.repositoryCasesCount ?? 0,
+        header: tTestCases,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.repositoryCasesCount;
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "testRuns",
-      accessorKey: "aggregatedTestRunIds",
-      accessorFn: (row) => row.testRunsCount ?? 0,
-      header: translations.testRuns,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.testRunsCount;
-        return (
-          <div className="text-center">
-            <TestRunsListDisplay
-              key={`tr-${row.original.id}`}
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
+      {
+        id: "testRuns",
+        accessorKey: "aggregatedTestRunIds",
+        accessorFn: (row) => row.testRunsCount ?? 0,
+        header: tTestRuns,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.testRunsCount;
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                key={`tr-${row.original.id}`}
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "sessions",
-      accessorKey: "sessions",
-      accessorFn: (row) => row.sessionsCount ?? 0,
-      header: translations.sessions,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      minSize: 60,
-      maxSize: 150,
-      cell: ({ row }) => {
-        const count = row.original.sessionsCount;
-        return (
-          <div className="text-center">
-            <SessionsListDisplay
-              count={count}
-              filter={{
-                issues: {
-                  some: {
-                    id: row.original.id,
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => row.sessionsCount ?? 0,
+        header: tSessions,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        minSize: 60,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const count = row.original.sessionsCount;
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                count={count}
+                filter={{
+                  issues: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-  ];
+    ];
 
-  // Hide columns that are populated only via external API sync when the project
-  // only has SIMPLE_URL integrations — those columns would always be empty.
-  if (hideSyncedFields) {
-    const syncedOnly = new Set([
-      "description",
-      "status",
-      "priority",
-      "lastSyncedAt",
-    ]);
-    return columns.filter((c) => !syncedOnly.has(c.id as string));
-  }
+    // Hide columns that are populated only via external API sync when the project
+    // only has SIMPLE_URL integrations — those columns would always be empty.
+    if (hideSyncedFields) {
+      const syncedOnly = new Set([
+        "description",
+        "status",
+        "priority",
+        "lastSyncedAt",
+      ]);
+      return columns.filter((c) => !syncedOnly.has(c.id as string));
+    }
 
-  return columns;
+    return columns;
+  }, [
+    tName,
+    tTitle,
+    tDescription,
+    tStatus,
+    tPriority,
+    tLastSyncedAt,
+    tTestCases,
+    tSessions,
+    tTestRuns,
+    hideSyncedFields,
+  ]);
 }

--- a/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/columns.tsx
@@ -8,10 +8,11 @@ import {
 } from "@/components/ui/tooltip";
 import { ColumnDef } from "@tanstack/react-table";
 import { CheckCircle2, PlayCircle } from "lucide-react";
+import { useMemo } from "react";
 import { Link } from "~/lib/navigation";
 import { cn } from "~/utils";
 
-export const getCaseColumns = (translations: {
+export const useCaseColumns = (translations: {
   testCases: string;
   type: string;
   manual: string;
@@ -23,50 +24,55 @@ export const getCaseColumns = (translations: {
   automated?: boolean;
   projectId: number;
 }>[] => {
-  return [
-    {
-      id: "testCase",
-      header: translations.testCases,
-      size: 600,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => {
-        return (
-          <div className="w-full min-w-0 overflow-hidden">
-            <CaseDisplay
-              id={row.original.id}
-              name={row.original.name}
-              link={`/projects/repository/${row.original.projectId}/${row.original.id}`}
-              source={row.original.source}
-              automated={row.original.automated}
-              maxLines={2}
-            />
-          </div>
-        );
+  const { testCases, type, manual, automated } = translations;
+
+  return useMemo(
+    () => [
+      {
+        id: "testCase",
+        header: testCases,
+        size: 600,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => {
+          return (
+            <div className="w-full min-w-0 overflow-hidden">
+              <CaseDisplay
+                id={row.original.id}
+                name={row.original.name}
+                link={`/projects/repository/${row.original.projectId}/${row.original.id}`}
+                source={row.original.source}
+                automated={row.original.automated}
+                maxLines={2}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "type",
-      header: translations.type,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isAutomated = row.original.automated;
-        return (
-          <Badge variant={isAutomated ? "default" : "secondary"}>
-            {isAutomated ? translations.automated : translations.manual}
-          </Badge>
-        );
+      {
+        id: "type",
+        header: type,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isAutomated = row.original.automated;
+          return (
+            <Badge variant={isAutomated ? "default" : "secondary"}>
+              {isAutomated ? automated : manual}
+            </Badge>
+          );
+        },
       },
-    },
-  ];
+    ],
+    [testCases, type, manual, automated]
+  );
 };
 
-export const getSessionColumns = (translations: {
+export const useSessionColumns = (translations: {
   sessions: string;
   status: string;
   completed: string;
@@ -77,48 +83,53 @@ export const getSessionColumns = (translations: {
   isCompleted: boolean;
   projectId: number;
 }>[] => {
-  return [
-    {
-      id: "session",
-      header: translations.sessions,
-      size: 600,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => (
-        <div className="w-full min-w-0 overflow-hidden">
-          <SessionTableDisplay
-            id={row.original.id}
-            name={row.original.name}
-            link={`/projects/sessions/${row.original.projectId}/${row.original.id}`}
-            maxLines={2}
-            isCompleted={row.original.isCompleted}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "status",
-      header: translations.status,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isCompleted = row.original.isCompleted;
-        return (
-          <Badge
-            variant={isCompleted ? "outline" : "default"}
-            className={cn("gap-1", isCompleted && "text-muted-foreground")}
-          >
-            {isCompleted && <CheckCircle2 className="h-3 w-3" />}
-            {isCompleted ? translations.completed : translations.inProgress}
-          </Badge>
-        );
+  const { sessions, status, completed, inProgress } = translations;
+
+  return useMemo(
+    () => [
+      {
+        id: "session",
+        header: sessions,
+        size: 600,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => (
+          <div className="w-full min-w-0 overflow-hidden">
+            <SessionTableDisplay
+              id={row.original.id}
+              name={row.original.name}
+              link={`/projects/sessions/${row.original.projectId}/${row.original.id}`}
+              maxLines={2}
+              isCompleted={row.original.isCompleted}
+            />
+          </div>
+        ),
       },
-    },
-  ];
+      {
+        id: "status",
+        header: status,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isCompleted = row.original.isCompleted;
+          return (
+            <Badge
+              variant={isCompleted ? "outline" : "default"}
+              className={cn("gap-1", isCompleted && "text-muted-foreground")}
+            >
+              {isCompleted && <CheckCircle2 className="h-3 w-3" />}
+              {isCompleted ? completed : inProgress}
+            </Badge>
+          );
+        },
+      },
+    ],
+    [sessions, status, completed, inProgress]
+  );
 };
 
 const TestRunLinkDisplay: React.FC<{
@@ -166,7 +177,7 @@ const TestRunLinkDisplay: React.FC<{
   );
 };
 
-export const getTestRunColumns = (translations: {
+export const useTestRunColumns = (translations: {
   testRuns: string;
   status: string;
   completed: string;
@@ -177,46 +188,51 @@ export const getTestRunColumns = (translations: {
   isCompleted: boolean;
   projectId: number;
 }>[] => {
-  return [
-    {
-      id: "testRun",
-      header: translations.testRuns,
-      size: 600,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => (
-        <div className="w-full min-w-0 overflow-hidden">
-          <TestRunLinkDisplay
-            id={row.original.id}
-            name={row.original.name}
-            projectId={row.original.projectId}
-            isCompleted={row.original.isCompleted}
-            maxLines={2}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "status",
-      header: translations.status,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isCompleted = row.original.isCompleted;
-        return (
-          <Badge
-            variant={isCompleted ? "outline" : "default"}
-            className={cn("gap-1", isCompleted && "text-muted-foreground")}
-          >
-            {isCompleted && <CheckCircle2 className="h-3 w-3" />}
-            {isCompleted ? translations.completed : translations.inProgress}
-          </Badge>
-        );
+  const { testRuns, status, completed, inProgress } = translations;
+
+  return useMemo(
+    () => [
+      {
+        id: "testRun",
+        header: testRuns,
+        size: 600,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => (
+          <div className="w-full min-w-0 overflow-hidden">
+            <TestRunLinkDisplay
+              id={row.original.id}
+              name={row.original.name}
+              projectId={row.original.projectId}
+              isCompleted={row.original.isCompleted}
+              maxLines={2}
+            />
+          </div>
+        ),
       },
-    },
-  ];
+      {
+        id: "status",
+        header: status,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isCompleted = row.original.isCompleted;
+          return (
+            <Badge
+              variant={isCompleted ? "outline" : "default"}
+              className={cn("gap-1", isCompleted && "text-muted-foreground")}
+            >
+              {isCompleted && <CheckCircle2 className="h-3 w-3" />}
+              {isCompleted ? completed : inProgress}
+            </Badge>
+          );
+        },
+      },
+    ],
+    [testRuns, status, completed, inProgress]
+  );
 };

--- a/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/page.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/page.tsx
@@ -35,9 +35,9 @@ import {
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import {
-  getCaseColumns,
-  getSessionColumns,
-  getTestRunColumns,
+  useCaseColumns,
+  useSessionColumns,
+  useTestRunColumns,
 } from "./columns";
 
 type TabType = "cases" | "sessions" | "testRuns";
@@ -354,38 +354,26 @@ function TagDetail() {
   }, [testRuns, projectId]);
 
   // Column definitions
-  const caseColumns = useMemo(
-    () =>
-      getCaseColumns({
-        testCases: t("common.fields.testCases"),
-        type: t("common.fields.type"),
-        manual: t("common.fields.manual"),
-        automated: t("common.fields.automated"),
-      }),
-    [t]
-  );
+  const caseColumns = useCaseColumns({
+    testCases: t("common.fields.testCases"),
+    type: t("common.fields.type"),
+    manual: t("common.fields.manual"),
+    automated: t("common.fields.automated"),
+  });
 
-  const sessionColumns = useMemo(
-    () =>
-      getSessionColumns({
-        sessions: t("common.fields.sessions"),
-        status: t("common.actions.status"),
-        completed: t("common.fields.completed"),
-        inProgress: t("milestones.statusLabels.IN_PROGRESS"),
-      }),
-    [t]
-  );
+  const sessionColumns = useSessionColumns({
+    sessions: t("common.fields.sessions"),
+    status: t("common.actions.status"),
+    completed: t("common.fields.completed"),
+    inProgress: t("milestones.statusLabels.IN_PROGRESS"),
+  });
 
-  const testRunColumns = useMemo(
-    () =>
-      getTestRunColumns({
-        testRuns: t("common.fields.testRuns"),
-        status: t("common.actions.status"),
-        completed: t("common.fields.completed"),
-        inProgress: t("milestones.statusLabels.IN_PROGRESS"),
-      }),
-    [t]
-  );
+  const testRunColumns = useTestRunColumns({
+    testRuns: t("common.fields.testRuns"),
+    status: t("common.actions.status"),
+    completed: t("common.fields.completed"),
+    inProgress: t("milestones.statusLabels.IN_PROGRESS"),
+  });
 
   // Pagination calculations
   const casesTotalPages = Math.ceil((casesCount ?? 0) / effectiveCasesPageSize);

--- a/testplanit/app/[locale]/projects/tags/[projectId]/columns.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/columns.tsx
@@ -4,6 +4,7 @@ import { TagsDisplay } from "@/components/tables/TagDisplay";
 import { TestRunsListDisplay } from "@/components/tables/TestRunsListDisplay";
 import { Tags } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 export interface ExtendedTags extends Tags {
   repositoryCases: { id: number; name: string }[];
@@ -15,7 +16,7 @@ export interface ExtendedTags extends Tags {
   testRuns: { id: number; name: string; isCompleted?: boolean }[];
 }
 
-export const getColumns = (
+export const useColumns = (
   projectId: string,
   activeCaseMap: Record<number, string>,
   activeSessionMap: Record<number, string>,
@@ -25,155 +26,167 @@ export const getColumns = (
 ): ColumnDef<ExtendedTags>[] => {
   const projectIdNumber = Number(projectId);
 
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      accessorFn: (row) => row.name,
-      header: t("common.name"),
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "alphanumeric",
-      meta: { isPinned: "left" },
-      enableHiding: false,
-      size: 500,
-      cell: ({ row }) => (
-        <TagsDisplay
-          id={row.original.id}
-          name={row.original.name}
-          link={`/projects/tags/${projectId}/${row.original.id}`}
-        />
-      ),
-    },
-    {
-      id: "cases",
-      accessorKey: "repositoryCases",
-      accessorFn: (row) => {
-        // Return the filtered count for sorting
-        return row.repositoryCases.filter((c) =>
-          Object.prototype.hasOwnProperty.call(activeCaseMap, c.id)
-        ).length;
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: t("common.name"),
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "alphanumeric",
+        meta: { isPinned: "left" },
+        enableHiding: false,
+        size: 500,
+        cell: ({ row }) => (
+          <TagsDisplay
+            id={row.original.id}
+            name={row.original.name}
+            link={`/projects/tags/${projectId}/${row.original.id}`}
+          />
+        ),
       },
-      header: t("common.fields.testCases"),
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const repositoryCaseIds = row.original.repositoryCases
-          .filter((c) =>
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => {
+          // Return the filtered count for sorting
+          return row.repositoryCases.filter((c) =>
             Object.prototype.hasOwnProperty.call(activeCaseMap, c.id)
-          )
-          .map((c) => c.id);
+          ).length;
+        },
+        header: t("common.fields.testCases"),
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const repositoryCaseIds = row.original.repositoryCases
+            .filter((c) =>
+              Object.prototype.hasOwnProperty.call(activeCaseMap, c.id)
+            )
+            .map((c) => c.id);
 
-        return (
-          <div className="text-center">
-            <CasesListDisplay
-              caseIds={repositoryCaseIds}
-              count={repositoryCaseIds.length}
-              filter={{
-                ...(isNaN(projectIdNumber)
-                  ? {}
-                  : { projectId: projectIdNumber }),
-                tags: {
-                  some: {
-                    id: row.original.id,
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                caseIds={repositoryCaseIds}
+                count={repositoryCaseIds.length}
+                filter={{
+                  ...(isNaN(projectIdNumber)
+                    ? {}
+                    : { projectId: projectIdNumber }),
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "sessions",
-      accessorKey: "sessions",
-      accessorFn: (row) => {
-        // Return the filtered count for sorting
-        return row.sessions.filter((s) =>
-          Object.prototype.hasOwnProperty.call(activeSessionMap, s.id)
-        ).length;
-      },
-      header: t("common.fields.sessions"),
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const filteredSessions = row.original.sessions.filter((s) =>
-          Object.prototype.hasOwnProperty.call(activeSessionMap, s.id)
-        );
-        const sessionCount = filteredSessions.length;
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => {
+          // Return the filtered count for sorting
+          return row.sessions.filter((s) =>
+            Object.prototype.hasOwnProperty.call(activeSessionMap, s.id)
+          ).length;
+        },
+        header: t("common.fields.sessions"),
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const filteredSessions = row.original.sessions.filter((s) =>
+            Object.prototype.hasOwnProperty.call(activeSessionMap, s.id)
+          );
+          const sessionCount = filteredSessions.length;
 
-        return (
-          <div className="text-center">
-            <SessionsListDisplay
-              sessions={filteredSessions.map((session) => ({
-                id: session.id,
-                name: session.name,
-                projectId: Number(projectId),
-                isCompleted: !!session.isCompleted,
-              }))}
-              count={sessionCount}
-              filter={{
-                projectId: Number(projectId),
-                tags: {
-                  some: {
-                    id: row.original.id,
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                sessions={filteredSessions.map((session) => ({
+                  id: session.id,
+                  name: session.name,
+                  projectId: Number(projectId),
+                  isCompleted: !!session.isCompleted,
+                }))}
+                count={sessionCount}
+                filter={{
+                  projectId: Number(projectId),
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "runs",
-      accessorKey: "testRuns",
-      accessorFn: (row) => {
-        // Return the filtered count for sorting
-        return row.testRuns.filter((r) =>
-          Object.prototype.hasOwnProperty.call(activeRunMap, r.id)
-        ).length;
-      },
-      header: t("common.fields.testRuns"),
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const filteredRuns = row.original.testRuns.filter((r) =>
-          Object.prototype.hasOwnProperty.call(activeRunMap, r.id)
-        );
-        const runCount = filteredRuns.length;
+      {
+        id: "runs",
+        accessorKey: "testRuns",
+        accessorFn: (row) => {
+          // Return the filtered count for sorting
+          return row.testRuns.filter((r) =>
+            Object.prototype.hasOwnProperty.call(activeRunMap, r.id)
+          ).length;
+        },
+        header: t("common.fields.testRuns"),
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const filteredRuns = row.original.testRuns.filter((r) =>
+            Object.prototype.hasOwnProperty.call(activeRunMap, r.id)
+          );
+          const runCount = filteredRuns.length;
 
-        return (
-          <div className="text-center">
-            <TestRunsListDisplay
-              testRuns={filteredRuns.map((run) => ({
-                id: run.id,
-                name: run.name,
-                projectId: Number(projectId),
-                isCompleted: !!run.isCompleted,
-              }))}
-              count={runCount}
-              filter={{
-                projectId: Number(projectId),
-                tags: {
-                  some: {
-                    id: row.original.id,
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                testRuns={filteredRuns.map((run) => ({
+                  id: run.id,
+                  name: run.name,
+                  projectId: Number(projectId),
+                  isCompleted: !!run.isCompleted,
+                }))}
+                count={runCount}
+                filter={{
+                  projectId: Number(projectId),
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-  ];
+    ],
+    // isLoadingCounts intentionally excluded — stale closure is fine for skeleton display
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      projectId,
+      projectIdNumber,
+      activeCaseMap,
+      activeSessionMap,
+      activeRunMap,
+      t,
+    ]
+  );
 };

--- a/testplanit/app/[locale]/projects/tags/[projectId]/page.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/page.tsx
@@ -33,7 +33,7 @@ import {
   useFindManyTestRuns,
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
-import { getColumns } from "./columns";
+import { useColumns } from "./columns";
 
 export default function ProjectTagListPage() {
   return (
@@ -483,24 +483,13 @@ function TagList() {
 
   const isLoadingCounts = isLoadingCases || isLoadingSessions || isLoadingRuns;
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        projectId as string,
-        activeCaseMap,
-        activeSessionMap,
-        activeRunMap,
-        t,
-        isLoadingCounts
-      ),
-    [
-      projectId,
-      activeCaseMap,
-      activeSessionMap,
-      activeRunMap,
-      t,
-      isLoadingCounts,
-    ]
+  const columns = useColumns(
+    projectId as string,
+    activeCaseMap,
+    activeSessionMap,
+    activeRunMap,
+    t,
+    isLoadingCounts
   );
 
   // Wait for all data to load - this prevents the flash

--- a/testplanit/app/[locale]/tags/[tagId]/columns.tsx
+++ b/testplanit/app/[locale]/tags/[tagId]/columns.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ColumnDef } from "@tanstack/react-table";
 import { CheckCircle2, PlayCircle } from "lucide-react";
+import { useMemo } from "react";
 import { Link } from "~/lib/navigation";
 import { cn } from "~/utils";
 
@@ -35,7 +36,7 @@ const ProjectCell: React.FC<{
   );
 };
 
-export const getCaseColumns = (translations: {
+export const useCaseColumns = (translations: {
   testCases: string;
   type: string;
   manual: string;
@@ -51,68 +52,73 @@ export const getCaseColumns = (translations: {
   projectName?: string;
   iconUrl?: string | null;
 }>[] => {
-  return [
-    {
-      id: "testCase",
-      header: translations.testCases,
-      size: 500,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => {
-        return (
-          <div className="w-full min-w-0 overflow-hidden">
-            <CaseDisplay
-              id={row.original.id}
-              name={row.original.name}
-              link={`/projects/repository/${row.original.projectId}/${row.original.id}`}
-              source={row.original.source}
-              automated={row.original.automated}
-              maxLines={2}
-            />
-          </div>
-        );
+  const { testCases, type, manual, automated, project, noProject } =
+    translations;
+  return useMemo(
+    () => [
+      {
+        id: "testCase",
+        header: testCases,
+        size: 500,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => {
+          return (
+            <div className="w-full min-w-0 overflow-hidden">
+              <CaseDisplay
+                id={row.original.id}
+                name={row.original.name}
+                link={`/projects/repository/${row.original.projectId}/${row.original.id}`}
+                source={row.original.source}
+                automated={row.original.automated}
+                maxLines={2}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "type",
-      header: translations.type,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isAutomated = row.original.automated;
-        return (
-          <Badge variant={isAutomated ? "default" : "secondary"}>
-            {isAutomated ? translations.automated : translations.manual}
-          </Badge>
-        );
+      {
+        id: "type",
+        header: type,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isAutomated = row.original.automated;
+          return (
+            <Badge variant={isAutomated ? "default" : "secondary"}>
+              {isAutomated ? automated : manual}
+            </Badge>
+          );
+        },
       },
-    },
-    {
-      id: "project",
-      header: translations.project,
-      enableSorting: false,
-      enableResizing: true,
-      enableHiding: false,
-      size: 150,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row }) => (
-        <ProjectCell
-          projectName={row.original.projectName || translations.noProject}
-          projectId={row.original.projectId || 0}
-          iconUrl={row.original.iconUrl || null}
-          noProject={translations.noProject}
-        />
-      ),
-    },
-  ];
+      {
+        id: "project",
+        header: project,
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        size: 150,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row }) => (
+          <ProjectCell
+            projectName={row.original.projectName || noProject}
+            projectId={row.original.projectId || 0}
+            iconUrl={row.original.iconUrl || null}
+            noProject={noProject}
+          />
+        ),
+      },
+    ],
+    [testCases, type, manual, automated, project, noProject]
+  );
 };
 
-export const getSessionColumns = (translations: {
+export const useSessionColumns = (translations: {
   sessions: string;
   status: string;
   completed: string;
@@ -127,66 +133,71 @@ export const getSessionColumns = (translations: {
   projectName?: string;
   iconUrl?: string | null;
 }>[] => {
-  return [
-    {
-      id: "session",
-      header: translations.sessions,
-      size: 500,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => (
-        <div className="w-full min-w-0 overflow-hidden">
-          <SessionTableDisplay
-            id={row.original.id}
-            name={row.original.name}
-            link={`/projects/sessions/${row.original.projectId}/${row.original.id}`}
-            maxLines={2}
-            isCompleted={row.original.isCompleted}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "status",
-      header: translations.status,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isCompleted = row.original.isCompleted;
-        return (
-          <Badge
-            variant={isCompleted ? "outline" : "default"}
-            className={cn("gap-1", isCompleted && "text-muted-foreground")}
-          >
-            {isCompleted && <CheckCircle2 className="h-3 w-3" />}
-            {isCompleted ? translations.completed : translations.inProgress}
-          </Badge>
-        );
+  const { sessions, status, completed, inProgress, project, noProject } =
+    translations;
+  return useMemo(
+    () => [
+      {
+        id: "session",
+        header: sessions,
+        size: 500,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => (
+          <div className="w-full min-w-0 overflow-hidden">
+            <SessionTableDisplay
+              id={row.original.id}
+              name={row.original.name}
+              link={`/projects/sessions/${row.original.projectId}/${row.original.id}`}
+              maxLines={2}
+              isCompleted={row.original.isCompleted}
+            />
+          </div>
+        ),
       },
-    },
-    {
-      id: "project",
-      header: translations.project,
-      enableSorting: false,
-      enableResizing: true,
-      enableHiding: false,
-      size: 250,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row }) => (
-        <ProjectCell
-          projectName={row.original.projectName || translations.noProject}
-          projectId={row.original.projectId || 0}
-          iconUrl={row.original.iconUrl || null}
-          noProject={translations.noProject}
-        />
-      ),
-    },
-  ];
+      {
+        id: "status",
+        header: status,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isCompleted = row.original.isCompleted;
+          return (
+            <Badge
+              variant={isCompleted ? "outline" : "default"}
+              className={cn("gap-1", isCompleted && "text-muted-foreground")}
+            >
+              {isCompleted && <CheckCircle2 className="h-3 w-3" />}
+              {isCompleted ? completed : inProgress}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "project",
+        header: project,
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        size: 250,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row }) => (
+          <ProjectCell
+            projectName={row.original.projectName || noProject}
+            projectId={row.original.projectId || 0}
+            iconUrl={row.original.iconUrl || null}
+            noProject={noProject}
+          />
+        ),
+      },
+    ],
+    [sessions, status, completed, inProgress, project, noProject]
+  );
 };
 
 const TestRunLinkDisplay: React.FC<{
@@ -234,7 +245,7 @@ const TestRunLinkDisplay: React.FC<{
   );
 };
 
-export const getTestRunColumns = (translations: {
+export const useTestRunColumns = (translations: {
   testRuns: string;
   status: string;
   completed: string;
@@ -249,64 +260,69 @@ export const getTestRunColumns = (translations: {
   projectName?: string;
   iconUrl?: string | null;
 }>[] => {
-  return [
-    {
-      id: "testRun",
-      header: translations.testRuns,
-      size: 500,
-      minSize: 200,
-      maxSize: 1200,
-      enableResizing: true,
-      meta: { isPinned: "left" },
-      cell: ({ row }) => (
-        <div className="w-full min-w-0 overflow-hidden">
-          <TestRunLinkDisplay
-            id={row.original.id}
-            name={row.original.name}
-            projectId={row.original.projectId || 0}
-            isCompleted={row.original.isCompleted}
-            maxLines={2}
-          />
-        </div>
-      ),
-    },
-    {
-      id: "status",
-      header: translations.status,
-      size: 120,
-      minSize: 80,
-      maxSize: 200,
-      enableResizing: true,
-      cell: ({ row }) => {
-        const isCompleted = row.original.isCompleted;
-        return (
-          <Badge
-            variant={isCompleted ? "outline" : "default"}
-            className={cn("gap-1", isCompleted && "text-muted-foreground")}
-          >
-            {isCompleted && <CheckCircle2 className="h-3 w-3" />}
-            {isCompleted ? translations.completed : translations.inProgress}
-          </Badge>
-        );
+  const { testRuns, status, completed, inProgress, project, noProject } =
+    translations;
+  return useMemo(
+    () => [
+      {
+        id: "testRun",
+        header: testRuns,
+        size: 500,
+        minSize: 200,
+        maxSize: 1200,
+        enableResizing: true,
+        meta: { isPinned: "left" },
+        cell: ({ row }) => (
+          <div className="w-full min-w-0 overflow-hidden">
+            <TestRunLinkDisplay
+              id={row.original.id}
+              name={row.original.name}
+              projectId={row.original.projectId || 0}
+              isCompleted={row.original.isCompleted}
+              maxLines={2}
+            />
+          </div>
+        ),
       },
-    },
-    {
-      id: "project",
-      header: translations.project,
-      enableSorting: false,
-      enableResizing: true,
-      enableHiding: false,
-      size: 250,
-      minSize: 150,
-      maxSize: 500,
-      cell: ({ row }) => (
-        <ProjectCell
-          projectName={row.original.projectName || translations.noProject}
-          projectId={row.original.projectId || 0}
-          iconUrl={row.original.iconUrl || null}
-          noProject={translations.noProject}
-        />
-      ),
-    },
-  ];
+      {
+        id: "status",
+        header: status,
+        size: 120,
+        minSize: 80,
+        maxSize: 200,
+        enableResizing: true,
+        cell: ({ row }) => {
+          const isCompleted = row.original.isCompleted;
+          return (
+            <Badge
+              variant={isCompleted ? "outline" : "default"}
+              className={cn("gap-1", isCompleted && "text-muted-foreground")}
+            >
+              {isCompleted && <CheckCircle2 className="h-3 w-3" />}
+              {isCompleted ? completed : inProgress}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "project",
+        header: project,
+        enableSorting: false,
+        enableResizing: true,
+        enableHiding: false,
+        size: 250,
+        minSize: 150,
+        maxSize: 500,
+        cell: ({ row }) => (
+          <ProjectCell
+            projectName={row.original.projectName || noProject}
+            projectId={row.original.projectId || 0}
+            iconUrl={row.original.iconUrl || null}
+            noProject={noProject}
+          />
+        ),
+      },
+    ],
+    [testRuns, status, completed, inProgress, project, noProject]
+  );
 };

--- a/testplanit/app/[locale]/tags/[tagId]/page.tsx
+++ b/testplanit/app/[locale]/tags/[tagId]/page.tsx
@@ -35,9 +35,9 @@ import {
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import {
-  getCaseColumns,
-  getSessionColumns,
-  getTestRunColumns,
+  useCaseColumns,
+  useSessionColumns,
+  useTestRunColumns,
 } from "./columns";
 
 type TabType = "cases" | "sessions" | "testRuns";
@@ -390,44 +390,32 @@ function TagDetail() {
   }, [testRuns, t]);
 
   // Column definitions
-  const caseColumns = useMemo(
-    () =>
-      getCaseColumns({
-        testCases: t("common.fields.testCases"),
-        type: t("common.fields.type"),
-        manual: t("common.fields.manual"),
-        automated: t("common.fields.automated"),
-        project: t("common.fields.project"),
-        noProject: t("tags.noProject"),
-      }),
-    [t]
-  );
+  const caseColumns = useCaseColumns({
+    testCases: t("common.fields.testCases"),
+    type: t("common.fields.type"),
+    manual: t("common.fields.manual"),
+    automated: t("common.fields.automated"),
+    project: t("common.fields.project"),
+    noProject: t("tags.noProject"),
+  });
 
-  const sessionColumns = useMemo(
-    () =>
-      getSessionColumns({
-        sessions: t("common.fields.sessions"),
-        status: t("common.actions.status"),
-        completed: t("common.fields.completed"),
-        inProgress: t("milestones.statusLabels.IN_PROGRESS"),
-        project: t("common.fields.project"),
-        noProject: t("tags.noProject"),
-      }),
-    [t]
-  );
+  const sessionColumns = useSessionColumns({
+    sessions: t("common.fields.sessions"),
+    status: t("common.actions.status"),
+    completed: t("common.fields.completed"),
+    inProgress: t("milestones.statusLabels.IN_PROGRESS"),
+    project: t("common.fields.project"),
+    noProject: t("tags.noProject"),
+  });
 
-  const testRunColumns = useMemo(
-    () =>
-      getTestRunColumns({
-        testRuns: t("common.fields.testRuns"),
-        status: t("common.actions.status"),
-        completed: t("common.fields.completed"),
-        inProgress: t("milestones.statusLabels.IN_PROGRESS"),
-        project: t("common.fields.project"),
-        noProject: t("tags.noProject"),
-      }),
-    [t]
-  );
+  const testRunColumns = useTestRunColumns({
+    testRuns: t("common.fields.testRuns"),
+    status: t("common.actions.status"),
+    completed: t("common.fields.completed"),
+    inProgress: t("milestones.statusLabels.IN_PROGRESS"),
+    project: t("common.fields.project"),
+    noProject: t("tags.noProject"),
+  });
 
   // Pagination calculations
   const casesTotalPages = Math.ceil((casesCount ?? 0) / effectiveCasesPageSize);

--- a/testplanit/app/[locale]/tags/columns.tsx
+++ b/testplanit/app/[locale]/tags/columns.tsx
@@ -5,6 +5,7 @@ import { TagsDisplay } from "@/components/tables/TagDisplay";
 import { TestRunsListDisplay } from "@/components/tables/TestRunsListDisplay";
 import { Tags } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 export interface ExtendedTags extends Tags {
   repositoryCases: { id: number }[];
@@ -16,7 +17,7 @@ export interface ExtendedTags extends Tags {
   testRunsCount?: number;
 }
 
-export const getColumns = (
+export const useTagColumns = (
   translations: {
     name: string;
     testCases: string;
@@ -26,130 +27,134 @@ export const getColumns = (
   },
   isLoadingCounts: boolean = false
 ): ColumnDef<ExtendedTags>[] => {
-  return [
-    {
-      id: "name",
-      accessorKey: "name",
-      accessorFn: (row) => row.name,
-      header: translations.name,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "alphanumeric",
-      enableHiding: false,
-      meta: { isPinned: "left" },
-      size: 500,
-      cell: ({ row }) => (
-        <TagsDisplay
-          id={row.original.id}
-          name={row.original.name}
-          link={`/tags/${row.original.id}`}
-        />
-      ),
-    },
-    {
-      id: "cases",
-      accessorKey: "repositoryCases",
-      accessorFn: (row) => row.repositoryCasesCount ?? 0,
-      header: translations.testCases,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const count = row.original.repositoryCasesCount;
-        return (
-          <div className="text-center">
-            <CasesListDisplay
-              count={count}
-              filter={{
-                tags: {
-                  some: {
-                    id: row.original.id,
+  const { name, testCases, sessions, testRuns, projects } = translations;
+  return useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        accessorFn: (row) => row.name,
+        header: name,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "alphanumeric",
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <TagsDisplay
+            id={row.original.id}
+            name={row.original.name}
+            link={`/tags/${row.original.id}`}
+          />
+        ),
+      },
+      {
+        id: "cases",
+        accessorKey: "repositoryCases",
+        accessorFn: (row) => row.repositoryCasesCount ?? 0,
+        header: testCases,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.repositoryCasesCount;
+          return (
+            <div className="text-center">
+              <CasesListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "testRuns",
-      accessorKey: "testRuns",
-      accessorFn: (row) => row.testRunsCount ?? 0,
-      header: translations.testRuns,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const count = row.original.testRunsCount;
-        return (
-          <div className="text-center">
-            <TestRunsListDisplay
-              count={count}
-              filter={{
-                tags: {
-                  some: {
-                    id: row.original.id,
+      {
+        id: "testRuns",
+        accessorKey: "testRuns",
+        accessorFn: (row) => row.testRunsCount ?? 0,
+        header: testRuns,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.testRunsCount;
+          return (
+            <div className="text-center">
+              <TestRunsListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "sessions",
-      accessorKey: "sessions",
-      accessorFn: (row) => row.sessionsCount ?? 0,
-      header: translations.sessions,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const count = row.original.sessionsCount;
-        return (
-          <div className="text-center">
-            <SessionsListDisplay
-              count={count}
-              filter={{
-                tags: {
-                  some: {
-                    id: row.original.id,
+      {
+        id: "sessions",
+        accessorKey: "sessions",
+        accessorFn: (row) => row.sessionsCount ?? 0,
+        header: sessions,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const count = row.original.sessionsCount;
+          return (
+            <div className="text-center">
+              <SessionsListDisplay
+                count={count}
+                filter={{
+                  tags: {
+                    some: {
+                      id: row.original.id,
+                    },
                   },
-                },
-              }}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+                }}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-    {
-      id: "projects",
-      accessorKey: "projects",
-      accessorFn: (row) => (row.projects || []).length,
-      header: translations.projects,
-      enableSorting: true,
-      enableResizing: true,
-      sortingFn: "basic",
-      size: 75,
-      cell: ({ row }) => {
-        const projects = row.original.projects || [];
-        return (
-          <div className="text-center">
-            <ProjectListDisplay
-              projects={projects}
-              isLoading={isLoadingCounts}
-            />
-          </div>
-        );
+      {
+        id: "projects",
+        accessorKey: "projects",
+        accessorFn: (row) => (row.projects || []).length,
+        header: projects,
+        enableSorting: true,
+        enableResizing: true,
+        sortingFn: "basic",
+        size: 75,
+        cell: ({ row }) => {
+          const projects = row.original.projects || [];
+          return (
+            <div className="text-center">
+              <ProjectListDisplay
+                projects={projects}
+                isLoading={isLoadingCounts}
+              />
+            </div>
+          );
+        },
       },
-    },
-  ];
+    ],
+    [name, testCases, sessions, testRuns, projects]
+  );
 };

--- a/testplanit/app/[locale]/tags/page.tsx
+++ b/testplanit/app/[locale]/tags/page.tsx
@@ -42,7 +42,7 @@ import {
 } from "~/lib/hooks";
 import { useRouter } from "~/lib/navigation";
 import { cn } from "~/utils";
-import { getColumns } from "./columns";
+import { useTagColumns } from "./columns";
 
 export default function TagList() {
   return (
@@ -371,19 +371,15 @@ function Tags() {
     }
   }, [status, session, router]);
 
-  const columns = useMemo(
-    () =>
-      getColumns(
-        {
-          name: t("common.name"),
-          testCases: t("common.fields.testCases"),
-          sessions: t("common.fields.sessions"),
-          testRuns: t("common.fields.testRuns"),
-          projects: t("common.fields.projects"),
-        },
-        isLoadingCounts
-      ),
-    [t, isLoadingCounts]
+  const columns = useTagColumns(
+    {
+      name: t("common.name"),
+      testCases: t("common.fields.testCases"),
+      sessions: t("common.fields.sessions"),
+      testRuns: t("common.fields.testRuns"),
+      projects: t("common.fields.projects"),
+    },
+    isLoadingCounts
   );
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>

--- a/testplanit/app/[locale]/users/columns.tsx
+++ b/testplanit/app/[locale]/users/columns.tsx
@@ -3,6 +3,7 @@ import { UserNameCell } from "@/components/tables/UserNameCell";
 import { UserProjectsDisplay } from "@/components/tables/UserProjectsDisplay";
 import { User } from "@prisma/client";
 import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 export interface ExtendedUser extends User {
   projects: {
@@ -11,42 +12,46 @@ export interface ExtendedUser extends User {
 }
 
 // Remove the hooks and only accept the translation function
-export const getColumns = (tCommon: any): ColumnDef<ExtendedUser>[] => [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: tCommon("name"),
-    enableSorting: true,
-    enableResizing: true,
-    enableHiding: false,
-    meta: { isPinned: "left" },
-    size: 500,
-    cell: ({ row }) => (
-      <div className="flex items-center">
-        <UserNameCell userId={row.original.id} />
-      </div>
-    ),
-  },
-  {
-    id: "email",
-    accessorKey: "email",
-    header: tCommon("fields.email"),
-    enableSorting: true,
-    enableResizing: true,
-    size: 200,
-    cell: ({ row }) => <EmailCell email={row.original.email} />,
-  },
-  {
-    id: "projects",
-    accessorKey: "projects",
-    header: tCommon("fields.projects"),
-    enableSorting: false,
-    enableResizing: true,
-    size: 75,
-    cell: ({ row }) => (
-      <div className="bg-primary-foreground text-center">
-        <UserProjectsDisplay userId={row.original.id} />
-      </div>
-    ),
-  },
-];
+export const useUserColumns = (tCommon: any): ColumnDef<ExtendedUser>[] =>
+  useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: tCommon("name"),
+        enableSorting: true,
+        enableResizing: true,
+        enableHiding: false,
+        meta: { isPinned: "left" },
+        size: 500,
+        cell: ({ row }) => (
+          <div className="flex items-center">
+            <UserNameCell userId={row.original.id} />
+          </div>
+        ),
+      },
+      {
+        id: "email",
+        accessorKey: "email",
+        header: tCommon("fields.email"),
+        enableSorting: true,
+        enableResizing: true,
+        size: 200,
+        cell: ({ row }) => <EmailCell email={row.original.email} />,
+      },
+      {
+        id: "projects",
+        accessorKey: "projects",
+        header: tCommon("fields.projects"),
+        enableSorting: false,
+        enableResizing: true,
+        size: 75,
+        cell: ({ row }) => (
+          <div className="bg-primary-foreground text-center">
+            <UserProjectsDisplay userId={row.original.id} />
+          </div>
+        ),
+      },
+    ],
+    [tCommon]
+  );

--- a/testplanit/app/[locale]/users/page.tsx
+++ b/testplanit/app/[locale]/users/page.tsx
@@ -13,7 +13,7 @@ import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
 import { DataTable } from "@/components/tables/DataTable";
 import { useFindManyUser } from "~/lib/hooks";
-import { ExtendedUser, getColumns } from "./columns";
+import { ExtendedUser, useUserColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 import { PaginationComponent } from "@/components/tables/Pagination";
@@ -157,6 +157,8 @@ function Users() {
     setCurrentPage(1);
   }, [pageSize, setCurrentPage]);
 
+  const columns = useUserColumns(tCommon);
+
   if (status === "loading") return null;
 
   const handleSortChange = (column: string) => {
@@ -169,8 +171,6 @@ function Users() {
     setSortConfig({ column, direction });
     setCurrentPage(1); // Reset to first page when sorting changes
   };
-
-  const columns = getColumns(tCommon);
 
   if (session && session.user.access !== "NONE") {
     return (

--- a/testplanit/components/tables/DataTable.tsx
+++ b/testplanit/components/tables/DataTable.tsx
@@ -290,7 +290,7 @@ export function DataTable<TData extends DataRow, TValue>({
     return columns;
   }, [columns, effectiveColumnVisibility, columnVisibility]);
 
-  const [localData, setLocalData] = useState<TData[]>([]);
+  const [localData, setLocalData] = useState<TData[]>(() => data || []);
   const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({
     left: [],
     right: [],
@@ -446,6 +446,7 @@ export function DataTable<TData extends DataRow, TValue>({
   const table = useReactTable({
     data: localData,
     columns: finalColumns,
+    getRowId: (row) => String(row.id),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getGroupedRowModel:

--- a/testplanit/components/tables/DataTable.tsx
+++ b/testplanit/components/tables/DataTable.tsx
@@ -446,7 +446,6 @@ export function DataTable<TData extends DataRow, TValue>({
   const table = useReactTable({
     data: localData,
     columns: finalColumns,
-    getRowId: (row) => String(row.id),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getGroupedRowModel:

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -116,15 +116,15 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
     integrationProvider?.toUpperCase() === "JIRA" && integrationId;
   useEffect(() => {
     if (!isExternalDebug) return;
-    console.debug(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
+    console.log(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
     return () => {
-      console.debug(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
+      console.log(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   useEffect(() => {
     if (!isExternalDebug) return;
-    console.debug(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
+    console.log(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
   }, [isOpen, id, isExternalDebug]);
 
   // Cleanup timeout on unmount
@@ -258,7 +258,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
       <div
         className="flex items-center group max-w-full"
         onMouseEnter={() => {
-          console.debug(`[IssuesDisplay] onMouseEnter id=${id}`);
+          console.log(`[IssuesDisplay] onMouseEnter id=${id}`);
           // Trigger background sync if needed
           triggerSyncIfNeeded();
 
@@ -270,7 +270,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
           }, 200); // 200ms delay before opening
         }}
         onMouseLeave={() => {
-          console.debug(`[IssuesDisplay] onMouseLeave id=${id}`);
+          console.log(`[IssuesDisplay] onMouseLeave id=${id}`);
           if (hoverTimeoutRef.current) {
             clearTimeout(hoverTimeoutRef.current);
           }
@@ -282,7 +282,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
         <Popover
           open={isOpen}
           onOpenChange={(open) => {
-            console.debug(
+            console.log(
               `[IssuesDisplay] onOpenChange open=${open} id=${id} stack=`,
               new Error().stack?.split("\n")[2]?.trim()
             );

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -110,6 +110,23 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
     });
   };
 
+  // DEBUG: track mount/unmount and open state to diagnose hover-sync flicker.
+  // Remove before merging.
+  const isExternalDebug =
+    integrationProvider?.toUpperCase() === "JIRA" && integrationId;
+  useEffect(() => {
+    if (!isExternalDebug) return;
+    console.debug(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
+    return () => {
+      console.debug(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useEffect(() => {
+    if (!isExternalDebug) return;
+    console.debug(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
+  }, [isOpen, id, isExternalDebug]);
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -241,6 +258,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
       <div
         className="flex items-center group max-w-full"
         onMouseEnter={() => {
+          console.debug(`[IssuesDisplay] onMouseEnter id=${id}`);
           // Trigger background sync if needed
           triggerSyncIfNeeded();
 
@@ -252,6 +270,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
           }, 200); // 200ms delay before opening
         }}
         onMouseLeave={() => {
+          console.debug(`[IssuesDisplay] onMouseLeave id=${id}`);
           if (hoverTimeoutRef.current) {
             clearTimeout(hoverTimeoutRef.current);
           }
@@ -260,7 +279,17 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
           }, 100); // 100ms delay before closing
         }}
       >
-        <Popover open={isOpen} onOpenChange={setIsOpen} modal={false}>
+        <Popover
+          open={isOpen}
+          onOpenChange={(open) => {
+            console.debug(
+              `[IssuesDisplay] onOpenChange open=${open} id=${id} stack=`,
+              new Error().stack?.split("\n")[2]?.trim()
+            );
+            setIsOpen(open);
+          }}
+          modal={false}
+        >
           <PopoverTrigger asChild>{badgeContent}</PopoverTrigger>
           <PopoverContent
             className="w-96 p-0"

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -98,22 +98,6 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const syncTriggeredRef = useRef(false);
 
-  // DEBUG: remove before merging
-  const isExternalDebug =
-    integrationProvider?.toUpperCase() === "JIRA" && integrationId;
-  useEffect(() => {
-    if (!isExternalDebug) return;
-    console.log(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
-    return () => {
-      console.log(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  useEffect(() => {
-    if (!isExternalDebug) return;
-    console.log(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
-  }, [isOpen, id, isExternalDebug]);
-
   // Subscribe to live updates for this issue's project(s) — webhook → sync
   // events fan out via the singleton SSE manager so any number of
   // IssuesDisplay instances on the same project share a single connection.
@@ -303,11 +287,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
           }, 100);
         }}
       >
-        <Popover
-          open={isOpen}
-          onOpenChange={updateIsOpen}
-          modal={false}
-        >
+        <Popover open={isOpen} onOpenChange={updateIsOpen} modal={false}>
           <PopoverTrigger asChild>{badgeContent}</PopoverTrigger>
           <PopoverContent
             className="w-96 p-0"

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -15,7 +15,7 @@ import { useIssueColors } from "@/hooks/useIssueColors";
 import DOMPurify from "dompurify";
 import { ExternalLink, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useIssueUpdateStream } from "~/hooks/useIssueUpdateStream";
 import { Link } from "~/lib/navigation";
 import { IssueTypeIcon } from "~/utils/issueTypeIcons";
@@ -64,6 +64,14 @@ interface JiraIssueDetails {
   updated: string;
 }
 
+// Module-level stores that survive component remounts caused by parent query
+// invalidations. When the SSE sync fires → queryClient.invalidateQueries →
+// parent re-renders → IssuesDisplay unmounts+remounts, these maps let each
+// instance restore its prior open/data state so the popover stays visible.
+// Entries are cleared when the popover closes, so they only hold in-flight data.
+const issuePopoverOpen = new Map<number, boolean>();
+const issueJiraCache = new Map<number, JiraIssueDetails>();
+
 export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
   id,
   name,
@@ -81,17 +89,35 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
 }) => {
   const t = useTranslations();
   const { getPriorityStyle } = useIssueColors();
-  const [isOpen, setIsOpen] = useState(false);
-  const [jiraDetails, setJiraDetails] = useState<JiraIssueDetails | null>(null);
+  const [isOpen, setIsOpen] = useState(() => issuePopoverOpen.get(id) ?? false);
+  const [jiraDetails, setJiraDetails] = useState<JiraIssueDetails | null>(
+    () => issueJiraCache.get(id) ?? null
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const syncTriggeredRef = useRef(false); // Avoid duplicate fetches per mount.
+  const syncTriggeredRef = useRef(false);
 
   // Subscribe to live updates for this issue's project(s) — webhook → sync
   // events fan out via the singleton SSE manager so any number of
   // IssuesDisplay instances on the same project share a single connection.
   useIssueUpdateStream(projectIds);
+
+  // Update module-level open state and clear cached data when closing so the
+  // next open always re-fetches fresh Jira details.
+  const updateIsOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        issuePopoverOpen.set(id, true);
+      } else {
+        issuePopoverOpen.delete(id);
+        issueJiraCache.delete(id);
+        setJiraDetails(null);
+      }
+      setIsOpen(open);
+    },
+    [id]
+  );
 
   // Trigger a background sync for this issue. The freshness gate lives
   // server-side now (?trigger=hover → 5-min skip window in SyncService);
@@ -109,23 +135,6 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
       // Silently fail — this is a background optimization.
     });
   };
-
-  // DEBUG: track mount/unmount and open state to diagnose hover-sync flicker.
-  // Remove before merging.
-  const isExternalDebug =
-    integrationProvider?.toUpperCase() === "JIRA" && integrationId;
-  useEffect(() => {
-    if (!isExternalDebug) return;
-    console.log(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
-    return () => {
-      console.log(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  useEffect(() => {
-    if (!isExternalDebug) return;
-    console.log(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
-  }, [isOpen, id, isExternalDebug]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -172,6 +181,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
           return res.json();
         })
         .then((data) => {
+          issueJiraCache.set(id, data);
           setJiraDetails(data);
           setIsLoading(false);
         })
@@ -187,6 +197,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
     integrationId,
     name,
     jiraDetails,
+    id,
   ]);
 
   // Issue config is no longer needed as we use integrations directly
@@ -258,36 +269,27 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
       <div
         className="flex items-center group max-w-full"
         onMouseEnter={() => {
-          console.log(`[IssuesDisplay] onMouseEnter id=${id}`);
-          // Trigger background sync if needed
           triggerSyncIfNeeded();
 
           if (hoverTimeoutRef.current) {
             clearTimeout(hoverTimeoutRef.current);
           }
           hoverTimeoutRef.current = setTimeout(() => {
-            setIsOpen(true);
-          }, 200); // 200ms delay before opening
+            updateIsOpen(true);
+          }, 200);
         }}
         onMouseLeave={() => {
-          console.log(`[IssuesDisplay] onMouseLeave id=${id}`);
           if (hoverTimeoutRef.current) {
             clearTimeout(hoverTimeoutRef.current);
           }
           hoverTimeoutRef.current = setTimeout(() => {
-            setIsOpen(false);
-          }, 100); // 100ms delay before closing
+            updateIsOpen(false);
+          }, 100);
         }}
       >
         <Popover
           open={isOpen}
-          onOpenChange={(open) => {
-            console.log(
-              `[IssuesDisplay] onOpenChange open=${open} id=${id} stack=`,
-              new Error().stack?.split("\n")[2]?.trim()
-            );
-            setIsOpen(open);
-          }}
+          onOpenChange={updateIsOpen}
           modal={false}
         >
           <PopoverTrigger asChild>{badgeContent}</PopoverTrigger>
@@ -305,7 +307,7 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
                 clearTimeout(hoverTimeoutRef.current);
               }
               hoverTimeoutRef.current = setTimeout(() => {
-                setIsOpen(false);
+                updateIsOpen(false);
               }, 100);
             }}
           >
@@ -453,7 +455,6 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
         <div
           className="flex items-center group max-w-full"
           onMouseEnter={() => {
-            // Trigger background sync if needed
             triggerSyncIfNeeded();
           }}
         >

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -98,6 +98,22 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const syncTriggeredRef = useRef(false);
 
+  // DEBUG: remove before merging
+  const isExternalDebug =
+    integrationProvider?.toUpperCase() === "JIRA" && integrationId;
+  useEffect(() => {
+    if (!isExternalDebug) return;
+    console.log(`[IssuesDisplay] MOUNT id=${id} name=${name}`);
+    return () => {
+      console.log(`[IssuesDisplay] UNMOUNT id=${id} name=${name}`);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useEffect(() => {
+    if (!isExternalDebug) return;
+    console.log(`[IssuesDisplay] isOpen=${isOpen} id=${id}`);
+  }, [isOpen, id, isExternalDebug]);
+
   // Subscribe to live updates for this issue's project(s) — webhook → sync
   // events fan out via the singleton SSE manager so any number of
   // IssuesDisplay instances on the same project share a single connection.

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -51,7 +51,7 @@ export function useIssueUpdateStream(
   useEffect(() => {
     if (depKey === "") return;
     const onUpdate = () => {
-      console.debug(`[useIssueUpdateStream] SSE fired for projects=${depKey}`);
+      console.log(`[useIssueUpdateStream] SSE fired for projects=${depKey}`);
       // ZenStack's queryKey shape is `["zenstack", model, operation, args,
       // options]` (verified against the v2.22 / v3.6 runtimes). React
       // Query treats a partial key as a prefix, so `["zenstack"]` matches

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -51,7 +51,6 @@ export function useIssueUpdateStream(
   useEffect(() => {
     if (depKey === "") return;
     const onUpdate = () => {
-      console.log(`[useIssueUpdateStream] SSE fired for projects=${depKey}`);
       // ZenStack's queryKey shape is `["zenstack", model, operation, args,
       // options]` (verified against the v2.22 / v3.6 runtimes). React
       // Query treats a partial key as a prefix, so `["zenstack"]` matches

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -51,6 +51,7 @@ export function useIssueUpdateStream(
   useEffect(() => {
     if (depKey === "") return;
     const onUpdate = () => {
+      console.log(`[useIssueUpdateStream] SSE fired for projects=${depKey}`);
       // ZenStack's queryKey shape is `["zenstack", model, operation, args,
       // options]` (verified against the v2.22 / v3.6 runtimes). React
       // Query treats a partial key as a prefix, so `["zenstack"]` matches

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -51,6 +51,7 @@ export function useIssueUpdateStream(
   useEffect(() => {
     if (depKey === "") return;
     const onUpdate = () => {
+      console.debug(`[useIssueUpdateStream] SSE fired for projects=${depKey}`);
       // ZenStack's queryKey shape is `["zenstack", model, operation, args,
       // options]` (verified against the v2.22 / v3.6 runtimes). React
       // Query treats a partial key as a prefix, so `["zenstack"]` matches

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -2978,6 +2978,7 @@
       "webhooks": "Webhooks",
       "llm": "AI Models",
       "prompts": "Prompt Configs",
+      "exportTemplates": "Export Templates",
       "codeRepositories": "Code Repositories",
       "quickScript": "QuickScript",
       "sso": "Authentication",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -2978,6 +2978,7 @@
       "webhooks": "Webhooks",
       "llm": "AI Models",
       "prompts": "Configuraciones de aviso",
+      "exportTemplates": "Exportar plantillas",
       "codeRepositories": "Repositorios de código",
       "quickScript": "Script rápido",
       "sso": "Autenticación",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -2978,6 +2978,7 @@
       "webhooks": "Webhooks",
       "llm": "Modèles d'IA",
       "prompts": "Configurations d'invite",
+      "exportTemplates": "Modèles d'exportation",
       "codeRepositories": "Dépôts de code",
       "quickScript": "QuickScript",
       "sso": "Authentification",


### PR DESCRIPTION
## Description

Two related rendering bugs fixed in this PR.

**Jira hover popover closes during background sync**

When a webhook fires a sync event, the SSE connection notifies the client, which calls `queryClient.invalidateQueries`. This causes parent components to re-render, which recreated column definition arrays on every render. TanStack Table calls `React.createElement(columnDef.cell, context)` via `flexRender` — an unstable `cell` function reference is treated as a changed element type, so React unmounts and remounts the entire cell subtree. Any `IssuesDisplay` component that had an open Jira popover would lose its `isOpen` state and close.

Fix: wrap all column definition arrays in `useMemo` with primitive string deps (translation strings). Column references are now stable across parent re-renders triggered by SSE events.

**Checkbox selection broken after DataTable change**

A previous commit added `getRowId: (row) => String(row.id)` to DataTable, switching TanStack Table from default index-based row IDs (`"0"`, `"1"`, `"2"`) to data-ID-based row IDs (`"123"`, `"456"`). Parent components that manage `rowSelection` state use index-based keys, so selection state stopped matching — clicking "Select All" or shift-clicking rows had no effect.

Fix: remove `getRowId` to restore default index-based row IDs.

## Changes

- Wrapped column definitions in `useMemo` across 30 column files (issues, tags, users, all admin tables)
- Renamed bare `getColumns` functions to `useColumns` hooks (React naming convention for hooks)
- Moved hook calls before early returns in `workflows/page.tsx` and `users/page.tsx` to satisfy Rules of Hooks
- Removed `getRowId` from `DataTable.tsx`
- Removed debug `console.log` statements from `IssuesDisplay` and `useIssueUpdateStream`
- Added missing `admin.menu.exportTemplates` i18n key (was causing a runtime error on the trash page)

## Type of Change

- [x] Bug fix

## Testing

- Precommit passed (lint + format)
- All 6608 unit tests pass
- Verified Jira popover stays open while SSE sync fires in the background
- Checkbox selection behavior restored (bulk operations, shift-click)