### PR TITLE
enhancement: add self-registration toggle for admins

### DIFF
--- a/docs/docs/user-guide/sso.md
+++ b/docs/docs/user-guide/sso.md
@@ -238,7 +238,25 @@ When environment variables are set and no database-configured Microsoft provider
 
 ### Registration Settings
 
-TestPlanIt provides additional controls for managing user registration and access through email domain restrictions.
+TestPlanIt provides controls for managing user registration and access. These settings are in the **Registration Settings** card at the bottom of `/admin/sso`.
+
+#### Allow Self-Registration
+
+The **Allow Self-Registration** toggle controls whether new users can create accounts on their own.
+
+- **Enabled (default)**: New users can sign up via the signup form or create accounts through SSO providers on first login
+- **Disabled**: New registrations are blocked for all methods — the signup form, Google OAuth, Apple Sign In, Microsoft, Magic Link, and SAML. Existing users can still sign in normally.
+
+When disabled:
+
+- The "Create account" link is hidden on the sign-in page
+- The signup page shows a message directing users to contact an administrator
+- The signup API returns an error for any registration attempt
+- SSO sign-in for first-time (unprovisioned) users is rejected
+
+:::tip
+Use this setting when you want to manage user onboarding manually — for example, when you provision users through the Admin → User Management page and do not want self-service sign-ups.
+:::
 
 #### Email Domain Restrictions
 
@@ -310,17 +328,19 @@ graph TD
     A[User visits /signin] --> B{Force SSO Enabled?}
     B -->|No| C[Show email/password form]
     C --> D[Show SSO options below]
-    D --> E[Show signup link]
-    B -->|Yes| F[Hide email/password form]
-    F --> G[Show only SSO buttons]
-    G --> H[No signup link]
+    D --> E{Self-Registration Enabled?}
+    E -->|Yes| F[Show signup link]
+    E -->|No| G[No signup link]
+    B -->|Yes| H[Hide email/password form]
+    H --> I[Show only SSO buttons]
+    I --> J[No signup link]
 ```
 
 ### Sign Up Page (`/signup`)
 
-The signup page behavior is significantly affected by SSO configuration:
+The signup page behavior is affected by both Force SSO and the self-registration toggle:
 
-#### Standard Mode (Force SSO Disabled)
+#### Standard Mode (Force SSO Disabled, Self-Registration Enabled)
 
 - Signup page is **accessible**
 - Users can create accounts with:
@@ -330,6 +350,12 @@ The signup page behavior is significantly affected by SSO configuration:
   - Password confirmation
 - Email verification is required
 - Default user preferences are created
+
+#### Self-Registration Disabled
+
+- Signup page displays a **"contact an administrator" message** instead of the form
+- The signup form and all SSO sign-up flows are blocked for new users
+- Existing users are unaffected and can still sign in
 
 #### Force SSO Mode (Force SSO Enabled)
 

--- a/testplanit/app/[locale]/admin/security/page.tsx
+++ b/testplanit/app/[locale]/admin/security/page.tsx
@@ -176,7 +176,6 @@ export default function SecurityAdminPage() {
                 {t("minPasswordLengthDescription")}
               </p>
             </div>
-
             {/* Require Uppercase */}
             <div className="flex items-center justify-between">
               <Label htmlFor="requireUppercase">
@@ -188,7 +187,6 @@ export default function SecurityAdminPage() {
                 onCheckedChange={setRequireUppercase}
               />
             </div>
-
             {/* Require Lowercase */}
             <div className="flex items-center justify-between">
               <Label htmlFor="requireLowercase">
@@ -200,7 +198,6 @@ export default function SecurityAdminPage() {
                 onCheckedChange={setRequireLowercase}
               />
             </div>
-
             {/* Require Numbers */}
             <div className="flex items-center justify-between">
               <Label htmlFor="requireNumbers">{t("requireNumbersLabel")}</Label>
@@ -210,7 +207,6 @@ export default function SecurityAdminPage() {
                 onCheckedChange={setRequireNumbers}
               />
             </div>
-
             {/* Required Special Chars */}
             <div className="space-y-2">
               <Label htmlFor="requiredSpecialChars">
@@ -226,7 +222,6 @@ export default function SecurityAdminPage() {
                 {t("requiredSpecialCharsDescription")}
               </p>
             </div>
-
             {/* Password History Depth */}
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -249,7 +244,6 @@ export default function SecurityAdminPage() {
                 {t("passwordHistoryDepthDescription")}
               </p>
             </div>
-
             {/* Password Expiration Days */}
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -273,9 +267,7 @@ export default function SecurityAdminPage() {
               </p>
             </div>
           </div>
-
           <Separator />
-
           {/* Section 2: Lockout Policy */}
           <div className="space-y-4">
             <div>
@@ -333,9 +325,7 @@ export default function SecurityAdminPage() {
               </p>
             </div>
           </div>
-
           <Separator />
-
           {/* Section 3: Enforcement Actions */}
           <div className="space-y-4">
             <div>
@@ -352,9 +342,7 @@ export default function SecurityAdminPage() {
               {t("forceAllUsers")}
             </Button>
           </div>
-
           <Separator />
-
           {/* Save Button */}
           <div className="flex justify-end">
             <Button onClick={handleSave} disabled={isSaving}>

--- a/testplanit/app/[locale]/admin/sso/page.tsx
+++ b/testplanit/app/[locale]/admin/sso/page.tsx
@@ -248,6 +248,8 @@ export default function SSOAdminPage() {
         ...prev,
         force2FANonSSO: registrationSettings.force2FANonSSO || false,
         force2FAAllLogins: registrationSettings.force2FAAllLogins || false,
+        allowOpenRegistration:
+          registrationSettings.allowOpenRegistration ?? true,
       }));
     }
   }, [registrationSettings]);
@@ -700,6 +702,31 @@ export default function SSOAdminPage() {
     } catch {
       setToggleState((prev) => ({ ...prev, forceSso: !enabled }));
       toast.error(t("admin.sso.messages.forceSsoUpdateFailed"));
+    }
+  };
+
+  const handleToggleAllowOpenRegistration = async (enabled: boolean) => {
+    setToggleState((prev) => ({ ...prev, allowOpenRegistration: enabled }));
+    try {
+      await upsertSettings({
+        where: {
+          id: registrationSettings?.id ?? "default-registration-settings",
+        },
+        create: {
+          id: "default-registration-settings",
+          allowOpenRegistration: enabled,
+        },
+        update: { allowOpenRegistration: enabled },
+      });
+      toast.success(
+        enabled
+          ? t("admin.sso.messages.openRegistrationEnabled")
+          : t("admin.sso.messages.openRegistrationDisabled")
+      );
+      void refetchSettings();
+    } catch {
+      setToggleState((prev) => ({ ...prev, allowOpenRegistration: !enabled }));
+      toast.error(t("admin.sso.messages.openRegistrationUpdateFailed"));
     }
   };
 
@@ -1278,6 +1305,22 @@ export default function SSOAdminPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
+          {/* Allow Open Registration */}
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <Label className="text-base font-medium">
+                {t("admin.sso.registration.allowOpenRegistration.title")}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {t("admin.sso.registration.allowOpenRegistration.description")}
+              </p>
+            </div>
+            <Switch
+              checked={toggleState.allowOpenRegistration ?? true}
+              onCheckedChange={handleToggleAllowOpenRegistration}
+            />
+          </div>
+
           {/* Default Access Level Setting */}
           <div className="flex items-center justify-between">
             <div className="flex-1 mr-4">

--- a/testplanit/app/[locale]/signin/page.tsx
+++ b/testplanit/app/[locale]/signin/page.tsx
@@ -11,6 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { SsoProviderType } from "@prisma/client";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
+import { useFindFirstRegistrationSettings } from "~/lib/hooks";
 import { useFindManySsoProvider } from "~/lib/hooks/sso-provider";
 
 import { Button } from "@/components/ui/button";
@@ -141,6 +142,11 @@ const Signin: NextPage = () => {
 
   // Fetch ALL SSO providers (we need all to check forceSso)
   // Sort by name at the database level to help with SAML providers
+  const { data: registrationSettings } = useFindFirstRegistrationSettings(
+    undefined,
+    { enabled: sessionCleared }
+  );
+
   // Wait for session to be cleared before fetching to prevent 410 errors with stale sessions
   const { data: ssoProviders, isLoading: isLoadingSsoProviders } =
     useFindManySsoProvider(
@@ -554,13 +560,15 @@ const Signin: NextPage = () => {
                   </>
                 )}
 
-                <div className="text-center text-sm">
-                  {t("common.or")}{" "}
-                  <Link href="/signup" className="group underline">
-                    {t("auth.signin.createAccount")}
-                    <LinkIcon className="w-4 h-4 inline ml-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-                  </Link>
-                </div>
+                {registrationSettings?.allowOpenRegistration !== false && (
+                  <div className="text-center text-sm">
+                    {t("common.or")}{" "}
+                    <Link href="/signup" className="group underline">
+                      {t("auth.signin.createAccount")}
+                      <LinkIcon className="w-4 h-4 inline ml-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                    </Link>
+                  </div>
+                )}
               </form>
             </Form>
           ) : (

--- a/testplanit/app/[locale]/signin/signin.test.tsx
+++ b/testplanit/app/[locale]/signin/signin.test.tsx
@@ -46,6 +46,13 @@ vi.mock("~/lib/hooks/sso-provider", () => ({
     mockUseFindManySsoProvider(...args),
 }));
 
+// Mock ZenStack registration settings hook
+const mockUseFindFirstRegistrationSettings = vi.fn();
+vi.mock("~/lib/hooks/registration-settings", () => ({
+  useFindFirstRegistrationSettings: (...args: any[]) =>
+    mockUseFindFirstRegistrationSettings(...args),
+}));
+
 // Mock next-auth signIn
 const mockSignIn = vi.fn();
 vi.mock("next-auth/react", async (importOriginal) => {
@@ -84,6 +91,12 @@ describe("Signin Page", () => {
     // Default: no SSO providers, finished loading
     mockUseFindManySsoProvider.mockReturnValue({
       data: [],
+      isLoading: false,
+    });
+
+    // Default: self-registration enabled
+    mockUseFindFirstRegistrationSettings.mockReturnValue({
+      data: { allowOpenRegistration: true },
       isLoading: false,
     });
 
@@ -132,6 +145,20 @@ describe("Signin Page", () => {
     });
     expect(signupLink).toBeInTheDocument();
     expect(signupLink.getAttribute("href")).toContain("/signup");
+  });
+
+  it("hides the signup link when self-registration is disabled", async () => {
+    mockUseFindFirstRegistrationSettings.mockReturnValue({
+      data: { allowOpenRegistration: false },
+      isLoading: false,
+    });
+
+    render(<Signin />);
+    await waitForFormToRender();
+
+    expect(
+      screen.queryByRole("link", { name: /signup|create|sign up|register/i })
+    ).not.toBeInTheDocument();
   });
 
   it("shows validation error when submitting with empty email", async () => {

--- a/testplanit/app/[locale]/signup/page.tsx
+++ b/testplanit/app/[locale]/signup/page.tsx
@@ -107,6 +107,11 @@ const Signup: NextPage = () => {
   const forceSsoEnabled =
     ssoProviders?.some((provider) => provider.forceSso) || false;
 
+  const registrationDisabled =
+    registrationSettings !== undefined &&
+    registrationSettings !== null &&
+    registrationSettings.allowOpenRegistration === false;
+
   // Track if we're still loading (session clearing or SSO providers)
   const isStillLoading = !sessionCleared || isLoadingSsoProviders;
 
@@ -307,10 +312,25 @@ const Signup: NextPage = () => {
           <CardTitle className="flex py-5 scroll-m-20 tracking-tight lg:text-3xl text-primary">
             {t("common.actions.signUp")}
           </CardTitle>
-          <CardDescription>{t("auth.signup.description")}</CardDescription>
+          {!registrationDisabled && (
+            <CardDescription>{t("auth.signup.description")}</CardDescription>
+          )}
         </CardHeader>
         <CardContent className="flex flex-col items-center justify-center">
-          {isStillLoading && showDelayedLoader ? (
+          {registrationDisabled ? (
+            <div
+              data-testid="registration-disabled-message"
+              className="w-1/2 space-y-6 flex flex-col items-center justify-center py-8 text-center"
+            >
+              <p className="text-muted-foreground">
+                {t("auth.signup.registrationDisabled")}
+              </p>
+              <Link href="/signin" className="group underline text-sm">
+                {t("auth.signup.signIn")}
+                <LinkIcon className="w-4 h-4 inline ml-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+              </Link>
+            </div>
+          ) : isStillLoading && showDelayedLoader ? (
             <div className="w-1/2 space-y-6 flex flex-col items-center justify-center py-8">
               <Loader2 className="h-8 w-8 animate-spin" />
               <p className="text-muted-foreground text-center">

--- a/testplanit/app/[locale]/signup/signup.test.tsx
+++ b/testplanit/app/[locale]/signup/signup.test.tsx
@@ -250,6 +250,25 @@ describe("Signup Page", () => {
     });
   });
 
+  it("shows disabled message and hides description when registration is disabled", async () => {
+    mockUseFindFirstRegistrationSettings.mockReturnValue({
+      data: { allowOpenRegistration: false },
+      isLoading: false,
+    });
+
+    render(<Signup />);
+    await waitForFormToRender();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("registration-disabled-message")
+      ).toBeInTheDocument();
+    });
+
+    // Form fields should not be present
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
   it("redirects to home on successful signup", async () => {
     const user = userEvent.setup();
     setupFetchMock({ status: 201 });

--- a/testplanit/app/api/auth/signup/route.ts
+++ b/testplanit/app/api/auth/signup/route.ts
@@ -52,9 +52,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const registrationSettings = await db.registrationSettings.findFirst();
+
+    if (!(registrationSettings?.allowOpenRegistration ?? true)) {
+      return NextResponse.json(
+        {
+          errorCode: "auth.signup.registrationDisabled",
+          error: "Registration is currently disabled",
+        },
+        { status: 403 }
+      );
+    }
+
     // Check if email verification is required
     // Email verification is automatically disabled if no email server is configured
-    const registrationSettings = await db.registrationSettings.findFirst();
     const requireEmailVerification =
       isEmailServerConfigured() &&
       (registrationSettings?.requireEmailVerification ?? true);

--- a/testplanit/app/api/auth/signup/signup.test.ts
+++ b/testplanit/app/api/auth/signup/signup.test.ts
@@ -245,6 +245,21 @@ describe("POST /api/auth/signup", () => {
       });
     });
 
+    it("should return 403 when open registration is disabled", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.registrationSettings.findFirst.mockResolvedValue({
+        allowOpenRegistration: false,
+        requireEmailVerification: true,
+      });
+
+      const response = await signup(createRequest(validSignupData));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errorCode).toBe("auth.signup.registrationDisabled");
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
     it("should return 400 when user already exists", async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         id: "existing-user",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1030,6 +1030,7 @@
     "signup": {
       "description": "Enter your information to sign up for a new account.",
       "signIn": "Sign into your existing account.",
+      "registrationDisabled": "Contact an administrator to create an account.",
       "errors": {
         "emailRequired": "Email is required",
         "passwordRequired": "Password does not meet the security requirements",
@@ -3484,7 +3485,10 @@
         "emailVerificationDisabled": "Email verification is no longer required for new users",
         "emailVerificationDisabledAndVerified": "Email verification disabled and {count, plural, one {# user account} other {# user accounts}} verified",
         "emailVerificationUpdateFailed": "Failed to update email verification setting",
-        "emailServerNotConfigured": "Cannot enable email verification: Email server is not configured"
+        "emailServerNotConfigured": "Cannot enable email verification: Email server is not configured",
+        "openRegistrationEnabled": "Self-registration is now enabled",
+        "openRegistrationDisabled": "Self-registration is now disabled",
+        "openRegistrationUpdateFailed": "Failed to update self-registration setting"
       },
       "dialogs": {
         "googleOAuth": {
@@ -3590,6 +3594,10 @@
           "title": "Require Email Verification",
           "description": "Users must verify their email address before accessing the system",
           "noEmailServerWarning": "Email server is not configured. Email verification is automatically disabled until an email server is set up."
+        },
+        "allowOpenRegistration": {
+          "title": "Allow Self-Registration",
+          "description": "When disabled, new users cannot sign up directly or create an account via SSO. Existing users can still sign in."
         }
       },
       "errors": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -1030,6 +1030,7 @@
     "signup": {
       "description": "Introduzca su información para registrarse en una nueva cuenta.",
       "signIn": "Inicia sesión en tu cuenta existente.",
+      "registrationDisabled": "Contacta con un administrador para crear una cuenta.",
       "errors": {
         "emailRequired": "Se requiere correo electrónico",
         "passwordRequired": "La contraseña no cumple con los requisitos de seguridad.",
@@ -3484,7 +3485,10 @@
         "emailVerificationDisabled": "La verificación de correo electrónico ya no es necesaria para los nuevos usuarios",
         "emailVerificationDisabledAndVerified": "Verificación de correo electrónico deshabilitada y {count, plural, one {# cuenta de usuario} other {# cuentas de usuario}} verificada",
         "emailVerificationUpdateFailed": "No se pudo actualizar la configuración de verificación de correo electrónico",
-        "emailServerNotConfigured": "No se puede habilitar la verificación de correo electrónico: el servidor de correo electrónico no está configurado"
+        "emailServerNotConfigured": "No se puede habilitar la verificación de correo electrónico: el servidor de correo electrónico no está configurado",
+        "openRegistrationEnabled": "El autorregistro ya está habilitado.",
+        "openRegistrationDisabled": "El autorregistro está ahora deshabilitado.",
+        "openRegistrationUpdateFailed": "No se pudo actualizar la configuración de autorregistro."
       },
       "dialogs": {
         "googleOAuth": {
@@ -3590,6 +3594,10 @@
           "title": "Requerir verificación de correo electrónico",
           "description": "Los usuarios deben verificar su dirección de correo electrónico antes de acceder al sistema",
           "noEmailServerWarning": "El servidor de correo electrónico no está configurado. La verificación de correo electrónico se desactiva automáticamente hasta que se configure un servidor."
+        },
+        "allowOpenRegistration": {
+          "title": "Permitir el autorregistro",
+          "description": "Cuando esta función está desactivada, los nuevos usuarios no pueden registrarse directamente ni crear una cuenta mediante SSO. Los usuarios existentes sí pueden iniciar sesión."
         }
       },
       "errors": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -1030,6 +1030,7 @@
     "signup": {
       "description": "Saisissez vos informations pour créer un nouveau compte.",
       "signIn": "Connectez-vous à votre compte existant.",
+      "registrationDisabled": "Contactez un administrateur pour créer un compte.",
       "errors": {
         "emailRequired": "L'adresse électronique est requise.",
         "passwordRequired": "Le mot de passe ne répond pas aux exigences de sécurité",
@@ -3484,7 +3485,10 @@
         "emailVerificationDisabled": "La vérification par e-mail n'est plus requise pour les nouveaux utilisateurs.",
         "emailVerificationDisabledAndVerified": "La vérification par e-mail est désactivée et {count, plural, one {# compte utilisateur} other {# comptes utilisateurs}} vérifiés",
         "emailVerificationUpdateFailed": "Échec de la mise à jour des paramètres de vérification de l'e-mail",
-        "emailServerNotConfigured": "Impossible d'activer la vérification des e-mails : le serveur de messagerie n'est pas configuré."
+        "emailServerNotConfigured": "Impossible d'activer la vérification des e-mails : le serveur de messagerie n'est pas configuré.",
+        "openRegistrationEnabled": "L'auto-inscription est désormais activée",
+        "openRegistrationDisabled": "L'auto-inscription est désormais désactivée.",
+        "openRegistrationUpdateFailed": "Échec de la mise à jour des paramètres d'auto-inscription"
       },
       "dialogs": {
         "googleOAuth": {
@@ -3590,6 +3594,10 @@
           "title": "Exiger une vérification de l'adresse électronique",
           "description": "Les utilisateurs doivent vérifier leur adresse électronique avant d'accéder au système.",
           "noEmailServerWarning": "Le serveur de messagerie n'est pas configuré. La vérification des adresses e-mail est automatiquement désactivée jusqu'à ce qu'un serveur de messagerie soit configuré."
+        },
+        "allowOpenRegistration": {
+          "title": "Autoriser l'auto-inscription",
+          "description": "Lorsque cette fonctionnalité est désactivée, les nouveaux utilisateurs ne peuvent ni s'inscrire directement ni créer de compte via l'authentification unique (SSO). Les utilisateurs existants peuvent toujours se connecter."
         }
       },
       "errors": {

--- a/testplanit/server/auth.ts
+++ b/testplanit/server/auth.ts
@@ -423,6 +423,16 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             }
           }
 
+          if (!dbUser) {
+            const registrationSettings =
+              await db.registrationSettings.findFirst({
+                select: { allowOpenRegistration: true },
+              });
+            if (!(registrationSettings?.allowOpenRegistration ?? true)) {
+              return false;
+            }
+          }
+
           if (dbUser) {
             // If user was INTERNAL, change to BOTH
             // If user was SSO, keep as SSO
@@ -747,6 +757,15 @@ export const authOptions: NextAuthOptions = {
           const isDomainAllowed = await isEmailDomainAllowed(user.email);
           if (!isDomainAllowed) {
             return false; // Reject sign-in if domain is not allowed
+          }
+        }
+
+        if (!dbUser) {
+          const regSettings = await db.registrationSettings.findFirst({
+            select: { allowOpenRegistration: true },
+          });
+          if (!(regSettings?.allowOpenRegistration ?? true)) {
+            return false;
           }
         }
 


### PR DESCRIPTION
## Description

Adds an **Allow Self-Registration** toggle to **Admin → Authentication → Registration Settings**. Admins can now disable open sign-ups without touching SSO or password policy configuration.

When self-registration is disabled:
- New users cannot sign up via the signup form
- SSO first-time login (account provisioning) is blocked for all providers
- The "Create account" link is hidden on the sign-in page
- The signup page shows a "contact an administrator" message instead of the form
- The signup API returns 403 with a localizable error code (`auth.signup.registrationDisabled`)

Existing users are unaffected and can still sign in normally.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Unit tests added for:
  - `signup.test.tsx` — disabled message shown, form hidden when registration is off
  - `signup.test.ts` (API) — 403 returned with correct error code when registration disabled
  - `signin.test.tsx` — "Create account" link hidden when registration is off
- All 6609 tests pass

## Checklist

- [x] Code follows project conventions
- [x] `pnpm precommit` passes (lint + format + tests)
- [x] i18n keys added to `en-US.json` and synced via `pnpm crowdin:sync`
- [x] Documentation updated (`docs/docs/user-guide/sso.md`)