### PR TITLE
fix: make TESTPLANIT_API_URL optional with SaaS default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ demo/
 # stay on the author's machine alongside `.planning/`.
 .localization-audit*
 
-.idea/
+.idea/testplanit/prisma/seedMcpDemo.ts

--- a/packages/mcp-server/src/env.ts
+++ b/packages/mcp-server/src/env.ts
@@ -1,10 +1,12 @@
 import * as z from "zod/v4";
 
+const DEFAULT_API_URL = "https://app.testplanit.com";
+
 const EnvSchema = z.object({
   TESTPLANIT_API_TOKEN: z
     .string()
     .regex(/^tpi_/, "Token must start with tpi_"),
-  TESTPLANIT_API_URL: z.string().url(),
+  TESTPLANIT_API_URL: z.string().url().default(DEFAULT_API_URL),
 });
 
 export interface EnvConfig {
@@ -17,7 +19,7 @@ export interface EnvConfig {
  *
  * Throws a zod validation error when:
  *  - `TESTPLANIT_API_TOKEN` is missing or does not start with `tpi_`
- *  - `TESTPLANIT_API_URL` is missing or is not a valid URL
+ *  - `TESTPLANIT_API_URL` is set but is not a valid URL (omitting it uses the SaaS default)
  *
  * The returned `apiUrl` is normalized (trailing slash stripped).
  */


### PR DESCRIPTION
## Description

`TESTPLANIT_API_URL` now defaults to `https://app.testplanit.com` when omitted, so SaaS users do not need to set it. Self-hosted users must still set it explicitly.

This unblocks the `packages-release` workflow: the `@testplanit/mcp-server` publish was failing because two tests in `env.test.ts` expected the URL to be optional, but `env.ts` on main still required it.

## Related Issue

Unblocks `@testplanit/mcp-server` npm publish.

## Type of Change

- [x] Bug fix

## Testing

- `packages/mcp-server/src/env.test.ts` — all 7 tests pass with this change
- The `packages-release` workflow will re-run automatically after merge

## Checklist

- [x] Code follows project conventions
- [x] Tests pass
- [x] `pnpm precommit` passes