### PR TITLE
fix(ci): run prisma generate before mcp-server build in packages-release

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -59,6 +59,9 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
+      - name: Generate Prisma client
+        run: pnpm --filter "testplanit" exec prisma generate
+
       - name: Run package tests
         run: |
           pnpm --filter "@testplanit/api" test -- --run


### PR DESCRIPTION
## Summary

The `packages-release` workflow installs with `--ignore-scripts`, so `prisma generate` never runs. This leaves the generated `Prisma` namespace unavailable at DTS build time, causing `@testplanit/mcp-server` to fail with `TS2305: Module '"@prisma/client"' has no exported member 'Prisma'`.

Adds a single `Generate Prisma client` step between install and tests/build. No source files changed.

## Type of Change

- [x] Bug fix (CI/workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)