### PR TITLE
fix: correct repository.url casing in package.json files

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testplanit/testplanit.git",
+    "url": "https://github.com/TestPlanIt/testplanit.git",
     "directory": "packages/api"
   },
   "bugs": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testplanit/testplanit.git",
+    "url": "https://github.com/TestPlanIt/testplanit.git",
     "directory": "packages/mcp-server"
   },
   "bugs": {

--- a/packages/wdio-testplanit-reporter/package.json
+++ b/packages/wdio-testplanit-reporter/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/testplanit/testplanit.git",
+    "url": "https://github.com/TestPlanIt/testplanit.git",
     "directory": "packages/wdio-testplanit-reporter"
   },
   "bugs": {


### PR DESCRIPTION
npm sigstore provenance validation is case-sensitive. The repository.url in all three packages used lowercase testplanit but the actual GitHub org is TestPlanIt, causing a 422 error on publish. Fixes the mcp-server npm publish.