### PR TITLE
fix: correct MCP server docs link in v0.25.0 upgrade notification

### DIFF
--- a/testplanit/lib/upgrade-notifications.ts
+++ b/testplanit/lib/upgrade-notifications.ts
@@ -272,7 +272,7 @@ export const upgradeNotifications: Record<string, UpgradeNotification> = {
         <li>Link test cases (and other entities) to issues in a single call — no manual UI step</li>
       </ul>
       <p>All reads are scoped to your API token permissions — the AI only sees what your account can see.</p>
-      <p>See the <a href="/docs/mcp-server" target="_blank">MCP Server documentation</a> to install and connect your AI assistant.</p>
+      <p>See the <a href="https://docs.testplanit.com/docs/sdk/mcp-overview/" target="_blank">MCP Server documentation</a> to install and connect your AI assistant.</p>
     `,
   },
   "0.22.0": {


### PR DESCRIPTION
The upgrade notification for v0.25.0 linked to /docs/mcp-server (in-app route that does not exist). Fixed to point to the correct external docs URL.