### PR TITLE
fix: disable generate button with no folders; two-phase test case generation to avoid timeouts

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -1283,8 +1283,6 @@ export function GenerateTestCasesWizard({
   const abortControllerRef = useRef<AbortController | null>(null);
   // Track last crawl job ID for cleanup after import
   const lastCrawlJobIdRef = useRef<string | null>(null);
-  // Ref on the wizard's scrollable content area
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
   // Throttle streaming UI updates to once per animation frame
   const pendingStreamUpdateRef = useRef<GeneratedTestCase[] | null>(null);
   const rafIdRef = useRef<number>(0);
@@ -1548,17 +1546,6 @@ export function GenerateTestCasesWizard({
       }
     }
   }, [selectedTemplateId, templates, currentStep]);
-
-  // Auto-scroll to bottom when new cards stream in.
-  // requestAnimationFrame ensures the new card is laid out before we read scrollHeight.
-  useEffect(() => {
-    if (!isGenerating || generatedTestCases.length === 0) return;
-    const frame = requestAnimationFrame(() => {
-      const el = scrollContainerRef.current;
-      if (el) el.scrollTop = el.scrollHeight;
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [isGenerating, generatedTestCases.length]);
 
   // Convert option names → IDs for dropdown/multi-select fields in generated test cases.
   // The worker returns string names but the UI expects numeric option IDs.
@@ -2719,7 +2706,10 @@ export function GenerateTestCasesWizard({
                   try {
                     const data = JSON.parse(line.slice(6));
                     if (data.type === "done" && data.testCase) {
-                      const tc = convertFieldOptionIds(data.testCase);
+                      const tc = convertFieldOptionIds({
+                        ...data.testCase,
+                        id: `expand_${i}_${data.testCase.id ?? i}`,
+                      });
                       setExpandedCases((prev) => {
                         const next = [...prev];
                         next[i] = tc;
@@ -3501,10 +3491,7 @@ export function GenerateTestCasesWizard({
               </div>
             )}
 
-          <div
-            ref={scrollContainerRef}
-            className="flex-1 min-h-0 px-4 overflow-y-auto"
-          >
+          <div className="flex-1 min-h-0 px-4 overflow-y-auto">
             {isNotificationReopen ? (
               <div className="flex flex-col items-center justify-center py-20 space-y-4">
                 <Loader2 className="w-8 h-8 animate-spin text-primary" />
@@ -4761,6 +4748,39 @@ export function GenerateTestCasesWizard({
                                 })}
                               </AlertDescription>
                             </Alert>
+                          )}
+                          {caseOutlines.length > 0 && (
+                            <div className="space-y-1.5">
+                              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                                <span>
+                                  {t("generateTestCases.expandProgress", {
+                                    done: caseOutlines.filter(
+                                      (o) =>
+                                        o.status === "done" ||
+                                        o.status === "error" ||
+                                        o.status === "cancelled"
+                                    ).length,
+                                    total: caseOutlines.length,
+                                  })}
+                                </span>
+                                {isGenerating && (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                )}
+                              </div>
+                              <Progress
+                                value={
+                                  (caseOutlines.filter(
+                                    (o) =>
+                                      o.status === "done" ||
+                                      o.status === "error" ||
+                                      o.status === "cancelled"
+                                  ).length /
+                                    caseOutlines.length) *
+                                  100
+                                }
+                                className="h-1.5"
+                              />
+                            </div>
                           )}
                           {caseOutlines.length > 0
                             ? caseOutlines.map((outline, i) => {

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -1259,6 +1259,21 @@ export function GenerateTestCasesWizard({
   );
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatingStatus, setGeneratingStatus] = useState("");
+
+  // Two-phase generation state
+  interface CaseOutlineStatus {
+    title: string;
+    summary: string;
+    status: "pending" | "generating" | "done" | "error" | "cancelled";
+    errorMessage?: string;
+  }
+  const [caseOutlines, setCaseOutlines] = useState<CaseOutlineStatus[]>([]);
+  const [expandedCases, setExpandedCases] = useState<
+    (GeneratedTestCase | null)[]
+  >([]);
+  const expandAbortControllersRef = useRef<Map<number, AbortController>>(
+    new Map()
+  );
   const [urlStreamingPageInfo, setUrlStreamingPageInfo] = useState<{
     current: number;
     total: number;
@@ -2006,15 +2021,13 @@ export function GenerateTestCasesWizard({
     goPrev();
   }, [goPrev]);
 
-  const handleNext = useCallback(async () => {
+  const handleNext = async () => {
     if (currentStep === WizardStep.ADD_NOTES) {
-      // Generate test cases when moving from notes step
       await generateTestCases();
     } else {
       goNext();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStep, goNext]); // generateTestCases is intentionally not included as it's not memoized
+  };
 
   const resetWizard = () => {
     // Abort any in-progress SSE stream
@@ -2052,6 +2065,10 @@ export function GenerateTestCasesWizard({
     setQuantity("several");
     setGeneratedTestCases([]);
     setSelectedTestCases(new Set());
+    setCaseOutlines([]);
+    setExpandedCases([]);
+    for (const ac of expandAbortControllersRef.current.values()) ac.abort();
+    expandAbortControllersRef.current.clear();
     setCrawledPagesResult([]);
     setIsGenerating(false);
     setIsImporting(false);
@@ -2510,8 +2527,11 @@ export function GenerateTestCasesWizard({
     setGeneratedTestCases([]);
     setSelectedTestCases(new Set());
     setDroppedLinkedIssues([]);
+    setCaseOutlines([]);
+    setExpandedCases([]);
+    for (const ac of expandAbortControllersRef.current.values()) ac.abort();
+    expandAbortControllersRef.current.clear();
     setCurrentStep(WizardStep.REVIEW_GENERATED);
-    // Cancel any in-flight generation
     abortControllerRef.current?.abort();
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
@@ -2537,79 +2557,6 @@ export function GenerateTestCasesWizard({
         };
       } else {
         throw new Error(t("generateTestCases.errors.invalidSourceConfig"));
-      }
-
-      setGeneratingStatus("calling_ai");
-
-      // Build the request payload
-      const requestBody = {
-        projectId,
-        issue: issueData,
-        template: {
-          id: template?.id,
-          name: template?.templateName,
-          fields: template?.caseFields
-            .filter((cf) => selectedFieldIds.has(cf.caseFieldId))
-            .sort((a, b) => a.order - b.order)
-            .map((cf) => ({
-              id: cf.caseField.id,
-              name: cf.caseField.displayName,
-              type: cf.caseField.type.type,
-              required: cf.caseField.isRequired,
-              options:
-                cf.caseField.fieldOptions &&
-                cf.caseField.fieldOptions.length > 0
-                  ? cf.caseField.fieldOptions.map((fo) => fo.fieldOption.name)
-                  : undefined,
-            })),
-        },
-        context: {
-          userNotes,
-          folderContext: folderId,
-        },
-        quantity,
-        autoGenerateTags,
-      };
-
-      // Use SSE streaming endpoint for real-time feedback
-      const response = await fetch("/api/llm/generate-test-cases/stream", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-        signal: abortController.signal,
-      });
-
-      if (!response.ok) {
-        const errorData = await response.text();
-        let errorMessage = t("generateTestCases.errors.generateFailed");
-        let parsedError: any = null;
-
-        try {
-          parsedError = JSON.parse(errorData);
-          if (parsedError.error) {
-            errorMessage = parsedError.error;
-          } else if (parsedError.message) {
-            errorMessage = parsedError.message;
-          }
-        } catch {
-          if (
-            errorData.includes("<!DOCTYPE html>") ||
-            errorData.includes("<html>") ||
-            errorData.includes("Synology")
-          ) {
-            errorMessage = t("generateTestCases.errors.networkRoutingError");
-          } else if (errorData && errorData.trim().length > 0) {
-            errorMessage = errorData.trim();
-          } else {
-            errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-          }
-        }
-
-        const errorObj = {
-          message: errorMessage,
-          ...(parsedError && { enhancedError: parsedError }),
-        };
-        throw new Error(JSON.stringify(errorObj));
       }
 
       // Helper: convert option names → IDs for a single test case
@@ -2642,10 +2589,12 @@ export function GenerateTestCasesWizard({
         return { ...tc, fieldValues: converted };
       };
 
-      // Build template fields descriptor once for parsing
-      const templateFields =
-        template?.caseFields
+      const templatePayload = {
+        id: template?.id,
+        name: template?.templateName,
+        fields: template?.caseFields
           .filter((cf) => selectedFieldIds.has(cf.caseFieldId))
+          .sort((a, b) => a.order - b.order)
           .map((cf) => ({
             id: cf.caseField.id,
             name: cf.caseField.displayName,
@@ -2655,143 +2604,37 @@ export function GenerateTestCasesWizard({
               cf.caseField.fieldOptions && cf.caseField.fieldOptions.length > 0
                 ? cf.caseField.fieldOptions.map((fo) => fo.fieldOption.name)
                 : undefined,
-          })) ?? [];
-
-      const templateForParsing = {
-        id: template?.id ?? 0,
-        name: template?.templateName ?? "",
-        fields: templateFields,
+          })),
       };
 
-      const issueForParsing = {
-        key: issueData.key ?? "",
-        title: issueData.title,
-        description: issueData.description,
-        status: issueData.status ?? "",
-        priority: issueData.priority,
-        comments: issueData.comments,
-      };
+      const contextPayload = { userNotes, folderContext: folderId };
 
-      // Lazy-import the shared parsers once
-      const { extractStreamedTestCases, parseAndValidateTestCases } =
-        await import("~/app/api/llm/generate-test-cases/shared");
+      // Phase 1: Get test case titles from the outline endpoint
+      setGeneratingStatus("calling_ai");
+      const outlineRes = await fetch("/api/llm/generate-test-cases/outline", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          issue: issueData,
+          context: contextPayload,
+          quantity,
+        }),
+        signal: abortController.signal,
+      });
 
-      // Consume the SSE stream with incremental rendering:
-      // - Finalized cases: fully-closed JSON objects, rendered permanently
-      // - Streaming stub: the in-progress test case, updated live as fields arrive
-      const reader = response.body!.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      let accumulated = "";
-      let streamDone = false;
-      let streamError: string | undefined;
-      let streamErrorCode: LlmErrorType | undefined;
-      let yieldedCount = 0; // how many test cases we've already rendered
-      const finalizedCases: GeneratedTestCase[] = [];
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const parts = buffer.split("\n\n");
-        buffer = parts.pop() ?? "";
-
-        for (const part of parts) {
-          const line = part.trim();
-          if (!line.startsWith("data: ")) continue;
-          try {
-            const data = JSON.parse(line.slice(6));
-            if (data.type === "stage") {
-              if (data.stage === "calling_ai") {
-                setGeneratingStatus("calling_ai");
-              } else if (data.stage === "resolving") {
-                setGeneratingStatus("preparing");
-              } else if (data.stage === "validating") {
-                setGeneratingStatus("preparing");
-              }
-            } else if (data.type === "chunk") {
-              accumulated += data.delta;
-              setGeneratingStatus("streaming");
-
-              // 1. Extract fully-closed test case objects
-              const newCases = extractStreamedTestCases(
-                accumulated,
-                templateForParsing,
-                yieldedCount
-              );
-
-              if (newCases.length > 0) {
-                const converted = newCases.map(convertFieldOptionIds);
-                yieldedCount += newCases.length;
-                finalizedCases.push(...converted);
-
-                setSelectedTestCases((prev) => {
-                  const next = new Set(prev);
-                  converted.forEach((tc) => next.add(tc.id));
-                  return next;
-                });
-              }
-
-              // 2. Extract the in-progress (partial) test case
-              const partials = extractPartialTestCases(
-                accumulated,
-                yieldedCount
-              );
-
-              const streamingStub = partials.map((tc) => ({
-                ...tc,
-                id: `streaming_issue`,
-              }));
-
-              // 3. Throttle UI updates to once per animation frame
-              const allCases = [...finalizedCases, ...streamingStub];
-              pendingStreamUpdateRef.current = allCases;
-              if (!rafIdRef.current) {
-                rafIdRef.current = requestAnimationFrame(() => {
-                  if (pendingStreamUpdateRef.current) {
-                    setGeneratedTestCases(pendingStreamUpdateRef.current);
-                    pendingStreamUpdateRef.current = null;
-                  }
-                  rafIdRef.current = 0;
-                });
-              }
-            } else if (data.type === "done") {
-              streamDone = true;
-              if (Array.isArray(data.metadata?.droppedLinkedIssues)) {
-                setDroppedLinkedIssues(data.metadata.droppedLinkedIssues);
-              } else {
-                setDroppedLinkedIssues([]);
-              }
-            } else if (data.type === "error") {
-              streamError = data.message;
-              if (typeof data.code === "string") {
-                streamErrorCode = data.code as LlmErrorType;
-              }
-            }
-          } catch (e) {
-            if (e instanceof SyntaxError) continue;
-            throw e;
-          }
-        }
-      }
-
-      // Flush any pending rAF update
-      if (rafIdRef.current) {
-        cancelAnimationFrame(rafIdRef.current);
-        rafIdRef.current = 0;
-        pendingStreamUpdateRef.current = null;
-      }
-      // Remove any lingering streaming stub
-      setGeneratedTestCases([...finalizedCases]);
-
-      if (streamError) {
+      if (!outlineRes.ok) {
+        const errData = await outlineRes.json().catch(() => ({}));
         throw new Error(
-          JSON.stringify({ message: streamError, code: streamErrorCode })
+          JSON.stringify({
+            message:
+              errData.error || t("generateTestCases.errors.generateFailed"),
+          })
         );
       }
 
-      if (!accumulated && !streamDone) {
+      const { outlines } = await outlineRes.json();
+      if (!Array.isArray(outlines) || outlines.length === 0) {
         throw new Error(
           JSON.stringify({
             message: t("generateTestCases.errors.generateFailed"),
@@ -2799,38 +2642,137 @@ export function GenerateTestCasesWizard({
         );
       }
 
-      // Final parse with full recovery logic for any trailing content
-      setGeneratingStatus("processing");
-      const { testCases: finalTestCases, parseError } =
-        parseAndValidateTestCases(
-          accumulated,
-          templateForParsing,
-          issueForParsing,
-          autoGenerateTags,
-          quantity
-        );
+      // Show outline cards immediately — user sees titles before details arrive
+      setCaseOutlines(
+        outlines.map((o: { title: string; summary: string }) => ({
+          ...o,
+          status: "pending" as const,
+        }))
+      );
+      setExpandedCases(new Array(outlines.length).fill(null));
+      setGeneratingStatus("streaming");
 
-      if (parseError && yieldedCount === 0) {
-        throw new Error(
-          JSON.stringify({
-            message: parseError.userError,
-            enhancedError: {
-              error: parseError.userError,
-              suggestions: parseError.userSuggestions,
-              details: parseError.errorMessage,
-            },
-          })
-        );
-      }
+      // Phase 2: Expand each outline in parallel
+      await Promise.all(
+        outlines.map(
+          async (outline: { title: string; summary: string }, i: number) => {
+            if (abortController.signal.aborted) return;
 
-      // Replace all incrementally-yielded cases with the final validated set
-      // (the final parse may recover a truncated last case that the stream
-      // parser skipped, and also normalises IDs consistently)
-      if (finalTestCases.length > 0) {
-        const allConverted = finalTestCases.map(convertFieldOptionIds);
-        setGeneratedTestCases(allConverted);
-        setSelectedTestCases(new Set(allConverted.map((tc) => tc.id)));
-      }
+            const ac = new AbortController();
+            expandAbortControllersRef.current.set(i, ac);
+            abortController.signal.addEventListener("abort", () => ac.abort());
+
+            setCaseOutlines((prev) => {
+              const next = [...prev];
+              next[i] = { ...next[i], status: "generating" };
+              return next;
+            });
+
+            try {
+              const expandRes = await fetch(
+                "/api/llm/generate-test-cases/expand",
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    projectId,
+                    issue: issueData,
+                    template: templatePayload,
+                    context: contextPayload,
+                    outline,
+                    autoGenerateTags,
+                  }),
+                  signal: ac.signal,
+                }
+              );
+
+              if (!expandRes.ok) {
+                const errData = await expandRes.json().catch(() => ({}));
+                setCaseOutlines((prev) => {
+                  const next = [...prev];
+                  next[i] = {
+                    ...next[i],
+                    status: "error",
+                    errorMessage:
+                      errData.error ||
+                      t("generateTestCases.errors.generateFailed"),
+                  };
+                  return next;
+                });
+                return;
+              }
+
+              // Consume the SSE stream — we only care about the final "done" event
+              const reader = expandRes.body!.getReader();
+              const decoder = new TextDecoder();
+              let buffer = "";
+
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
+                const parts = buffer.split("\n\n");
+                buffer = parts.pop() ?? "";
+                for (const part of parts) {
+                  const line = part.trim();
+                  if (!line.startsWith("data: ")) continue;
+                  try {
+                    const data = JSON.parse(line.slice(6));
+                    if (data.type === "done" && data.testCase) {
+                      const tc = convertFieldOptionIds(data.testCase);
+                      setExpandedCases((prev) => {
+                        const next = [...prev];
+                        next[i] = tc;
+                        return next;
+                      });
+                      setGeneratedTestCases((prev) => [...prev, tc]);
+                      setSelectedTestCases((prev) => new Set([...prev, tc.id]));
+                      setCaseOutlines((prev) => {
+                        const next = [...prev];
+                        next[i] = { ...next[i], status: "done" };
+                        return next;
+                      });
+                    } else if (data.type === "error") {
+                      setCaseOutlines((prev) => {
+                        const next = [...prev];
+                        next[i] = {
+                          ...next[i],
+                          status: "error",
+                          errorMessage: data.message,
+                        };
+                        return next;
+                      });
+                    }
+                  } catch (e) {
+                    if (e instanceof SyntaxError) continue;
+                  }
+                }
+              }
+            } catch (err: any) {
+              if (err.name === "AbortError") {
+                setCaseOutlines((prev) => {
+                  const next = [...prev];
+                  if (next[i]?.status !== "cancelled") {
+                    next[i] = { ...next[i], status: "cancelled" };
+                  }
+                  return next;
+                });
+                return;
+              }
+              setCaseOutlines((prev) => {
+                const next = [...prev];
+                next[i] = {
+                  ...next[i],
+                  status: "error",
+                  errorMessage: err.message,
+                };
+                return next;
+              });
+            }
+          }
+        )
+      );
+
       setGeneratingStatus("");
     } catch (error) {
       console.error("Error generating test cases:", error);
@@ -3088,6 +3030,9 @@ export function GenerateTestCasesWizard({
     // Cancel SSE streaming (issue/document/URL generation)
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
+    // Cancel any in-flight expand requests
+    for (const ac of expandAbortControllersRef.current.values()) ac.abort();
+    expandAbortControllersRef.current.clear();
     // Cancel URL crawl background job if still running
     if (urlJobId) {
       fetch(`/api/llm/generate-from-url/cancel/${urlJobId}`, {
@@ -3102,6 +3047,16 @@ export function GenerateTestCasesWizard({
 
   const handleRetryGeneration = () => {
     void generateTestCases();
+  };
+
+  const handleCancelExpand = (index: number) => {
+    const ac = expandAbortControllersRef.current.get(index);
+    if (ac) ac.abort();
+    setCaseOutlines((prev) => {
+      const next = [...prev];
+      if (next[index]) next[index] = { ...next[index], status: "cancelled" };
+      return next;
+    });
   };
 
   const handleCopyErrorDetails = async () => {
@@ -4785,7 +4740,7 @@ export function GenerateTestCasesWizard({
                         </Alert>
                       ) : (
                         <div
-                          className={`space-y-4 transition-opacity duration-300 ${isGenerating ? "opacity-60" : "opacity-100"}`}
+                          className={`space-y-4 transition-opacity duration-300 ${isGenerating && caseOutlines.length === 0 ? "opacity-60" : "opacity-100"}`}
                         >
                           {droppedLinkedIssues.length > 0 && (
                             <Alert>
@@ -4803,62 +4758,186 @@ export function GenerateTestCasesWizard({
                               </AlertDescription>
                             </Alert>
                           )}
-                          {generatedTestCases
-                            .filter(
-                              (tc) =>
-                                !reviewPageFilter ||
-                                tc.sourceUrl === reviewPageFilter
-                            )
-                            .map((testCase, index) => {
-                              const template = templates?.find(
-                                (t) => t.id === selectedTemplateId
-                              );
-                              if (!template) {
-                                return null;
-                              }
+                          {caseOutlines.length > 0
+                            ? caseOutlines.map((outline, i) => {
+                                const tc = expandedCases[i];
+                                const cardTemplate = templates?.find(
+                                  (t) => t.id === selectedTemplateId
+                                );
 
-                              return (
-                                <GeneratedTestCaseCard
-                                  key={testCase.id}
-                                  testCase={testCase}
-                                  template={template}
-                                  selectedFieldIds={selectedFieldIds}
-                                  isSelected={selectedTestCases.has(
-                                    testCase.id
-                                  )}
-                                  onSelectionChange={(checked) =>
-                                    toggleTestCaseSelection(
-                                      testCase.id,
-                                      checked
-                                    )
+                                if (
+                                  outline.status === "done" &&
+                                  tc &&
+                                  cardTemplate
+                                ) {
+                                  return (
+                                    <GeneratedTestCaseCard
+                                      key={`outline-${i}`}
+                                      testCase={tc}
+                                      template={cardTemplate}
+                                      selectedFieldIds={selectedFieldIds}
+                                      isSelected={selectedTestCases.has(tc.id)}
+                                      onSelectionChange={(checked) =>
+                                        toggleTestCaseSelection(tc.id, checked)
+                                      }
+                                      isEditing={editingTestCaseIds.has(tc.id)}
+                                      onStartEdit={() =>
+                                        startEditingTestCase(tc.id)
+                                      }
+                                      onCancelEdit={() =>
+                                        stopEditingTestCase(tc.id)
+                                      }
+                                      onSave={handleSaveEditedTestCase}
+                                      autoGenerateTags={autoGenerateTags}
+                                      disabled={false}
+                                      t={t}
+                                      tCommon={tCommon}
+                                      session={session}
+                                      projectId={projectId}
+                                      index={i}
+                                      formSubmitHandlersRef={
+                                        formSubmitHandlersRef
+                                      }
+                                    />
+                                  );
+                                }
+
+                                if (outline.status === "generating") {
+                                  return (
+                                    <div
+                                      key={`outline-${i}`}
+                                      className="rounded-lg border bg-card p-4 flex items-center justify-between gap-3"
+                                    >
+                                      <div className="flex items-center gap-3 min-w-0">
+                                        <Loader2 className="h-4 w-4 animate-spin shrink-0 text-muted-foreground" />
+                                        <div className="min-w-0">
+                                          <p className="text-sm font-medium truncate">
+                                            {outline.title}
+                                          </p>
+                                          <p className="text-xs text-muted-foreground">
+                                            {outline.summary}
+                                          </p>
+                                        </div>
+                                      </div>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="shrink-0 h-7 w-7"
+                                        onClick={() => handleCancelExpand(i)}
+                                      >
+                                        <X className="h-3.5 w-3.5" />
+                                      </Button>
+                                    </div>
+                                  );
+                                }
+
+                                if (outline.status === "pending") {
+                                  return (
+                                    <div
+                                      key={`outline-${i}`}
+                                      className="rounded-lg border bg-card p-4 animate-pulse"
+                                    >
+                                      <p className="text-sm font-medium text-muted-foreground">
+                                        {outline.title}
+                                      </p>
+                                      <p className="text-xs text-muted-foreground mt-1">
+                                        {outline.summary}
+                                      </p>
+                                    </div>
+                                  );
+                                }
+
+                                if (outline.status === "error") {
+                                  return (
+                                    <div
+                                      key={`outline-${i}`}
+                                      className="rounded-lg border border-destructive/50 bg-destructive/5 p-4"
+                                    >
+                                      <p className="text-sm font-medium">
+                                        {outline.title}
+                                      </p>
+                                      <p className="text-xs text-destructive mt-1">
+                                        {outline.errorMessage ||
+                                          t(
+                                            "generateTestCases.errors.generateFailed"
+                                          )}
+                                      </p>
+                                    </div>
+                                  );
+                                }
+
+                                // cancelled
+                                return (
+                                  <div
+                                    key={`outline-${i}`}
+                                    className="rounded-lg border bg-muted/30 p-4 opacity-50"
+                                  >
+                                    <p className="text-sm font-medium line-through text-muted-foreground">
+                                      {outline.title}
+                                    </p>
+                                  </div>
+                                );
+                              })
+                            : generatedTestCases
+                                .filter(
+                                  (tc) =>
+                                    !reviewPageFilter ||
+                                    tc.sourceUrl === reviewPageFilter
+                                )
+                                .map((testCase, index) => {
+                                  const template = templates?.find(
+                                    (t) => t.id === selectedTemplateId
+                                  );
+                                  if (!template) {
+                                    return null;
                                   }
-                                  isEditing={editingTestCaseIds.has(
-                                    testCase.id
-                                  )}
-                                  onStartEdit={() =>
-                                    startEditingTestCase(testCase.id)
-                                  }
-                                  onCancelEdit={() =>
-                                    stopEditingTestCase(testCase.id)
-                                  }
-                                  onSave={handleSaveEditedTestCase}
-                                  autoGenerateTags={autoGenerateTags}
-                                  disabled={isGenerating}
-                                  t={t}
-                                  tCommon={tCommon}
-                                  session={session}
-                                  projectId={projectId}
-                                  index={index}
-                                  formSubmitHandlersRef={formSubmitHandlersRef}
-                                  folderLabel={
-                                    crawledPagesResult.length > 1 &&
-                                    testCase.sourceUrl
-                                      ? folderNameFromUrl(testCase.sourceUrl)
-                                      : undefined
-                                  }
-                                />
-                              );
-                            })}
+
+                                  return (
+                                    <GeneratedTestCaseCard
+                                      key={testCase.id}
+                                      testCase={testCase}
+                                      template={template}
+                                      selectedFieldIds={selectedFieldIds}
+                                      isSelected={selectedTestCases.has(
+                                        testCase.id
+                                      )}
+                                      onSelectionChange={(checked) =>
+                                        toggleTestCaseSelection(
+                                          testCase.id,
+                                          checked
+                                        )
+                                      }
+                                      isEditing={editingTestCaseIds.has(
+                                        testCase.id
+                                      )}
+                                      onStartEdit={() =>
+                                        startEditingTestCase(testCase.id)
+                                      }
+                                      onCancelEdit={() =>
+                                        stopEditingTestCase(testCase.id)
+                                      }
+                                      onSave={handleSaveEditedTestCase}
+                                      autoGenerateTags={autoGenerateTags}
+                                      disabled={isGenerating}
+                                      t={t}
+                                      tCommon={tCommon}
+                                      session={session}
+                                      projectId={projectId}
+                                      index={index}
+                                      formSubmitHandlersRef={
+                                        formSubmitHandlersRef
+                                      }
+                                      folderLabel={
+                                        crawledPagesResult.length > 1 &&
+                                        testCase.sourceUrl
+                                          ? folderNameFromUrl(
+                                              testCase.sourceUrl
+                                            )
+                                          : undefined
+                                      }
+                                    />
+                                  );
+                                })}
                         </div>
                       )}
                     </CardContent>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -4678,7 +4678,9 @@ export function GenerateTestCasesWizard({
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
-                      {isGenerating && generatedTestCases.length === 0 ? (
+                      {isGenerating &&
+                      generatedTestCases.length === 0 &&
+                      caseOutlines.length === 0 ? (
                         // No cards yet — show stage indicator / spinner
                         <div className="flex flex-col items-center justify-center py-12 space-y-4">
                           <Sparkles className="w-8 h-8 text-primary shrink-0" />
@@ -4731,7 +4733,9 @@ export function GenerateTestCasesWizard({
                             </div>
                           </div>
                         </div>
-                      ) : !isGenerating && generatedTestCases.length === 0 ? (
+                      ) : !isGenerating &&
+                        generatedTestCases.length === 0 &&
+                        caseOutlines.length === 0 ? (
                         <Alert>
                           <AlertTriangle className="h-4 w-4" />
                           <AlertDescription>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/ProjectRepository.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/ProjectRepository.tsx
@@ -1690,6 +1690,13 @@ const ProjectRepository: React.FC<ProjectRepositoryProps> = ({
                               </Button>
                               <FindDuplicatesButton
                                 projectId={projectIdParam}
+                                disabled={
+                                  !folderStatsData ||
+                                  folderStatsData.reduce(
+                                    (sum, s) => sum + s.totalCaseCount,
+                                    0
+                                  ) === 0
+                                }
                               />
                               <Button
                                 variant="default"

--- a/testplanit/app/[locale]/projects/repository/[projectId]/ProjectRepository.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/ProjectRepository.tsx
@@ -1679,6 +1679,7 @@ const ProjectRepository: React.FC<ProjectRepositoryProps> = ({
                               )}
                               <Button
                                 variant="outline"
+                                disabled={folderHierarchy.length === 0}
                                 onClick={() => setGenerateWizardOpen(true)}
                                 className="group px-4 hover:px-4 transition-all duration-200 gap-0 hover:gap-2"
                               >

--- a/testplanit/app/api/llm/generate-test-cases/expand/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/expand/route.ts
@@ -1,0 +1,290 @@
+import { LLM_FEATURES } from "@/lib/llm/constants";
+import { LlmManager } from "@/lib/llm/services/llm-manager.service";
+import { PromptResolver } from "@/lib/llm/services/prompt-resolver.service";
+import type { LlmRequest } from "@/lib/llm/types";
+import { prisma } from "@/lib/prisma";
+import { ProjectAccessType } from "@prisma/client";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { authOptions } from "~/server/auth";
+import {
+  buildExpandSystemPrompt,
+  buildExpandUserPrompt,
+  parseAndValidateTestCases,
+  type GenerationContext,
+  type IssueData,
+  type TemplateData,
+  type TestCaseOutline,
+} from "../shared";
+import {
+  classifyLlmStreamError,
+  type LlmStreamErrorCode,
+} from "../error-codes";
+
+function formatError(err: unknown): string {
+  if (!(err instanceof Error)) return "AI generation failed";
+  const parts: string[] = [err.message];
+  let cause = (err as { cause?: unknown }).cause;
+  while (cause) {
+    if (cause instanceof Error) {
+      parts.push(cause.message);
+      cause = (cause as { cause?: unknown }).cause;
+    } else if (typeof cause === "object" && cause !== null && "code" in cause) {
+      parts.push(String((cause as { code: unknown }).code));
+      break;
+    } else {
+      break;
+    }
+  }
+  return parts.filter(Boolean).join(": ");
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { projectId, issue, template, context, outline, autoGenerateTags } =
+    body as {
+      projectId: number;
+      issue: IssueData;
+      template: TemplateData;
+      context: GenerationContext;
+      outline: TestCaseOutline;
+      autoGenerateTags?: boolean;
+    };
+
+  if (!projectId || !issue || !template || !outline) {
+    return NextResponse.json(
+      { error: "Missing required parameters", errorCode: "invalid_request" },
+      { status: 400 }
+    );
+  }
+
+  const encoder = new TextEncoder();
+  let controllerClosed = false;
+
+  function send(
+    controller: ReadableStreamDefaultController,
+    data: object
+  ): void {
+    if (controllerClosed) return;
+    try {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+    } catch {
+      controllerClosed = true;
+    }
+  }
+
+  function keepAlive(controller: ReadableStreamDefaultController): void {
+    if (controllerClosed) return;
+    try {
+      controller.enqueue(encoder.encode(": keepalive\n\n"));
+    } catch {
+      controllerClosed = true;
+    }
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const heartbeat = setInterval(() => keepAlive(controller), 15_000);
+      try {
+        keepAlive(controller);
+
+        const isAdmin = session.user.access === "ADMIN";
+        const isProjectAdmin = session.user.access === "PROJECTADMIN";
+
+        const projectAccessWhere = isAdmin
+          ? { id: projectId, isDeleted: false }
+          : {
+              id: projectId,
+              isDeleted: false,
+              OR: [
+                {
+                  userPermissions: {
+                    some: {
+                      userId: session.user.id,
+                      accessType: { not: ProjectAccessType.NO_ACCESS },
+                    },
+                  },
+                },
+                {
+                  groupPermissions: {
+                    some: {
+                      group: {
+                        assignedUsers: { some: { userId: session.user.id } },
+                      },
+                      accessType: { not: ProjectAccessType.NO_ACCESS },
+                    },
+                  },
+                },
+                { defaultAccessType: ProjectAccessType.GLOBAL_ROLE },
+                ...(isProjectAdmin
+                  ? [{ assignedUsers: { some: { userId: session.user.id } } }]
+                  : []),
+              ],
+            };
+
+        const project = await prisma.projects.findFirst({
+          where: projectAccessWhere,
+          select: { id: true },
+        });
+
+        if (!project) {
+          send(controller, {
+            type: "error",
+            code: "project_not_found" satisfies LlmStreamErrorCode,
+            message: "Project not found or access denied",
+          });
+          return;
+        }
+
+        const manager = LlmManager.getInstance(prisma);
+        const resolver = new PromptResolver(prisma);
+        const resolvedPrompt = await resolver.resolve(
+          LLM_FEATURES.TEST_CASE_GENERATION,
+          projectId
+        );
+
+        const resolved = await manager.resolveIntegration(
+          LLM_FEATURES.TEST_CASE_GENERATION,
+          projectId,
+          resolvedPrompt
+        );
+
+        if (!resolved) {
+          send(controller, {
+            type: "error",
+            code: "no_integration" satisfies LlmStreamErrorCode,
+            message: "No active LLM integration found for this project",
+          });
+          return;
+        }
+
+        const systemPromptBase =
+          resolvedPrompt.source !== "fallback"
+            ? resolvedPrompt.systemPrompt
+            : undefined;
+        const userPromptBase =
+          resolvedPrompt.source !== "fallback"
+            ? resolvedPrompt.userPrompt || undefined
+            : undefined;
+
+        const systemPrompt = buildExpandSystemPrompt(
+          template,
+          autoGenerateTags,
+          systemPromptBase
+        );
+        const userPrompt = buildExpandUserPrompt(
+          issue,
+          outline,
+          context,
+          userPromptBase
+        );
+
+        let maxTokens = resolvedPrompt.maxOutputTokens ?? 4096;
+        const providerConfig = await (
+          prisma as any
+        ).llmProviderConfig.findFirst({
+          where: { llmIntegrationId: resolved.integrationId },
+        });
+        if (providerConfig) {
+          maxTokens =
+            providerConfig.defaultMaxTokens ??
+            resolvedPrompt.maxOutputTokens ??
+            4096;
+        }
+
+        const llmRequest: LlmRequest = {
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          temperature: resolvedPrompt.temperature,
+          maxTokens,
+          userId: session.user.id,
+          feature: "test_case_generation",
+          ...(resolved.model ? { model: resolved.model } : {}),
+          timeout: providerConfig?.timeout ?? 0,
+          metadata: {
+            projectId,
+            issueKey: issue.key,
+            templateId: template.id,
+            timestamp: new Date().toISOString(),
+          },
+        };
+
+        let accumulated = "";
+        let finishReason: string | undefined;
+
+        try {
+          for await (const chunk of manager.chatStream(
+            resolved.integrationId,
+            llmRequest
+          )) {
+            if (chunk.finishReason) finishReason = chunk.finishReason;
+            if (chunk.delta) {
+              accumulated += chunk.delta;
+              send(controller, { type: "chunk", delta: chunk.delta });
+            }
+          }
+        } catch (err) {
+          const message = formatError(err);
+          send(controller, {
+            type: "error",
+            code: classifyLlmStreamError(message),
+            message,
+          });
+          return;
+        }
+
+        const { testCases, parseError } = parseAndValidateTestCases(
+          accumulated,
+          template,
+          issue,
+          autoGenerateTags,
+          "just_one"
+        );
+
+        if (parseError || testCases.length === 0) {
+          send(controller, {
+            type: "error",
+            code: "generic" satisfies LlmStreamErrorCode,
+            message: parseError?.userError ?? "No test case generated",
+          });
+          return;
+        }
+
+        send(controller, {
+          type: "done",
+          finishReason,
+          testCase: { ...testCases[0], name: outline.title },
+        });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Internal server error";
+        send(controller, {
+          type: "error",
+          code: classifyLlmStreamError(message),
+          message,
+        });
+      } finally {
+        clearInterval(heartbeat);
+        if (!controllerClosed) {
+          controllerClosed = true;
+          controller.close();
+        }
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/testplanit/app/api/llm/generate-test-cases/outline/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/outline/route.ts
@@ -1,0 +1,171 @@
+import { LLM_FEATURES, SYNC_RETRY_PROFILE } from "@/lib/llm/constants";
+import { LlmManager } from "@/lib/llm/services/llm-manager.service";
+import { PromptResolver } from "@/lib/llm/services/prompt-resolver.service";
+import type { LlmRequest } from "@/lib/llm/types";
+import { prisma } from "@/lib/prisma";
+import { ProjectAccessType } from "@prisma/client";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { authOptions } from "~/server/auth";
+import {
+  buildOutlineSystemPrompt,
+  buildOutlineUserPrompt,
+  type GenerationContext,
+  type IssueData,
+  type TestCaseOutline,
+} from "../shared";
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { projectId, issue, context, quantity } = body as {
+      projectId: number;
+      issue: IssueData;
+      context: GenerationContext;
+      quantity?: string;
+    };
+
+    if (!projectId || !issue) {
+      return NextResponse.json(
+        { error: "Missing required parameters" },
+        { status: 400 }
+      );
+    }
+
+    const isAdmin = session.user.access === "ADMIN";
+    const isProjectAdmin = session.user.access === "PROJECTADMIN";
+
+    const projectAccessWhere = isAdmin
+      ? { id: projectId, isDeleted: false }
+      : {
+          id: projectId,
+          isDeleted: false,
+          OR: [
+            {
+              userPermissions: {
+                some: {
+                  userId: session.user.id,
+                  accessType: { not: ProjectAccessType.NO_ACCESS },
+                },
+              },
+            },
+            {
+              groupPermissions: {
+                some: {
+                  group: {
+                    assignedUsers: { some: { userId: session.user.id } },
+                  },
+                  accessType: { not: ProjectAccessType.NO_ACCESS },
+                },
+              },
+            },
+            { defaultAccessType: ProjectAccessType.GLOBAL_ROLE },
+            ...(isProjectAdmin
+              ? [{ assignedUsers: { some: { userId: session.user.id } } }]
+              : []),
+          ],
+        };
+
+    const project = await prisma.projects.findFirst({
+      where: projectAccessWhere,
+      select: { id: true },
+    });
+
+    if (!project) {
+      return NextResponse.json(
+        { error: "Project not found or access denied" },
+        { status: 404 }
+      );
+    }
+
+    const manager = LlmManager.getInstance(prisma);
+    const resolver = new PromptResolver(prisma);
+    const resolvedPrompt = await resolver.resolve(
+      LLM_FEATURES.TEST_CASE_GENERATION,
+      projectId
+    );
+
+    const resolved = await manager.resolveIntegration(
+      LLM_FEATURES.TEST_CASE_GENERATION,
+      projectId,
+      resolvedPrompt
+    );
+    if (!resolved) {
+      return NextResponse.json(
+        { error: "No active LLM integration found for this project" },
+        { status: 400 }
+      );
+    }
+
+    const systemPrompt = buildOutlineSystemPrompt(quantity);
+    const userPrompt = buildOutlineUserPrompt(issue, context);
+
+    let maxTokens = resolvedPrompt.maxOutputTokens ?? 1024;
+    const providerConfig = await (prisma as any).llmProviderConfig.findFirst({
+      where: { llmIntegrationId: resolved.integrationId },
+    });
+    if (providerConfig) {
+      maxTokens = Math.min(providerConfig.defaultMaxTokens ?? 1024, 1024);
+    }
+
+    const llmRequest: LlmRequest = {
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      temperature: resolvedPrompt.temperature,
+      maxTokens,
+      userId: session.user.id,
+      feature: "test_case_generation",
+      ...(resolved.model ? { model: resolved.model } : {}),
+      metadata: {
+        projectId,
+        issueKey: issue.key,
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    const { maxRetries, baseDelayMs } = SYNC_RETRY_PROFILE;
+    const response = await manager.chat(resolved.integrationId, llmRequest, {
+      maxRetries,
+      baseDelayMs,
+    });
+
+    const raw = response.content.trim();
+    let parsed: { outlines: TestCaseOutline[] };
+
+    try {
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) throw new Error("No JSON found in response");
+      parsed = JSON.parse(jsonMatch[0]);
+    } catch {
+      return NextResponse.json(
+        { error: "Failed to parse outline response from LLM" },
+        { status: 500 }
+      );
+    }
+
+    if (!Array.isArray(parsed.outlines) || parsed.outlines.length === 0) {
+      return NextResponse.json(
+        { error: "LLM returned no outlines" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ outlines: parsed.outlines });
+  } catch (error) {
+    console.error("Error in POST /api/llm/generate-test-cases/outline:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to generate outlines",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/testplanit/app/api/llm/generate-test-cases/shared.ts
+++ b/testplanit/app/api/llm/generate-test-cases/shared.ts
@@ -753,6 +753,118 @@ export function getQuantityGuidance(quantity: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Two-phase generation: outline + expand
+// ---------------------------------------------------------------------------
+
+export interface TestCaseOutline {
+  title: string;
+  summary: string;
+}
+
+export function buildOutlineSystemPrompt(quantity?: string): string {
+  const quantityGuidance = quantity ? getQuantityGuidance(quantity) : "3-5";
+  return `You are a test case planning assistant. Given a software issue, generate a concise list of test case titles and one-sentence summaries.
+
+CRITICAL: Respond with ONLY valid JSON. No explanations, no text before or after.
+
+JSON structure (EXACT format required):
+{
+  "outlines": [
+    { "title": "Descriptive test case name", "summary": "One sentence describing what this test validates." }
+  ]
+}
+
+REQUIREMENTS:
+- Generate ${quantityGuidance}
+- Each title must be specific to the issue — no generic names
+- Each summary must be a single sentence explaining what the test validates
+- Titles and summaries must be distinct — no duplicates or overlapping coverage
+- Do NOT include field values, steps, or any other detail — only title and summary
+
+Return ONLY the JSON.`;
+}
+
+export function buildOutlineUserPrompt(
+  issue: IssueData,
+  context: GenerationContext
+): string {
+  let prompt = `ISSUE TO TEST: ${issue.key} - "${issue.title}"
+
+ISSUE DETAILS:
+${issue.description || "No description provided"}
+
+STATUS: ${issue.status}${issue.priority ? ` | PRIORITY: ${issue.priority}` : ""}`;
+
+  if (context.userNotes) {
+    prompt += `\n\nADDITIONAL TESTING GUIDANCE: ${context.userNotes}`;
+  }
+
+  prompt += `\n\nGenerate a list of test case titles and one-sentence summaries that cover the key scenarios for this issue.`;
+  return prompt;
+}
+
+export function buildExpandSystemPrompt(
+  template: TemplateData,
+  autoGenerateTags?: boolean,
+  baseTemplate?: string
+): string {
+  return buildSystemPrompt(
+    template,
+    { folderContext: 0 },
+    "just_one",
+    autoGenerateTags,
+    baseTemplate
+  );
+}
+
+export function buildExpandUserPrompt(
+  issue: IssueData,
+  outline: TestCaseOutline,
+  context: GenerationContext,
+  baseTemplate?: string
+): string {
+  const outlineSection = `\n\nTEST CASE TO GENERATE:\nTitle: "${outline.title}"\nSummary: ${outline.summary}\n\nGenerate a complete test case for the title and summary above. The test case must match that title exactly.`;
+
+  if (baseTemplate) {
+    return baseTemplate
+      .replace("{{ISSUE_KEY}}", issue.key)
+      .replace("{{ISSUE_TITLE}}", issue.title)
+      .replace(
+        "{{ISSUE_DESCRIPTION}}",
+        issue.description || "No description provided"
+      )
+      .replace("{{ISSUE_STATUS}}", issue.status)
+      .replace(
+        "{{ISSUE_PRIORITY}}",
+        issue.priority ? ` | PRIORITY: ${issue.priority}` : ""
+      )
+      .replace("{{COMMENTS_SECTION}}", "")
+      .replace("{{LINKED_ISSUES_SECTION}}", "")
+      .replace(
+        "{{USER_NOTES_SECTION}}",
+        context.userNotes
+          ? `\n\nADDITIONAL TESTING GUIDANCE: ${context.userNotes}`
+          : ""
+      )
+      .replace("{{EXISTING_CASES_SECTION}}", outlineSection);
+  }
+
+  let prompt = `ISSUE TO TEST: ${issue.key} - "${issue.title}"
+
+ISSUE DETAILS:
+${issue.description || "No description provided"}
+
+STATUS: ${issue.status}${issue.priority ? ` | PRIORITY: ${issue.priority}` : ""}`;
+
+  if (context.userNotes) {
+    prompt += `\n\nADDITIONAL TESTING GUIDANCE: ${context.userNotes}`;
+  }
+
+  prompt += outlineSection;
+  return prompt;
+}
+
+// ---------------------------------------------------------------------------
 // Response parsing & validation
 // ---------------------------------------------------------------------------
 

--- a/testplanit/components/duplicates/FindDuplicatesButton.tsx
+++ b/testplanit/components/duplicates/FindDuplicatesButton.tsx
@@ -25,11 +25,15 @@ interface StatusData {
 
 interface FindDuplicatesButtonProps {
   projectId: string;
+  disabled?: boolean;
 }
 
 const STORAGE_KEY_PREFIX = "duplicate-scan-job:";
 
-export function FindDuplicatesButton({ projectId }: FindDuplicatesButtonProps) {
+export function FindDuplicatesButton({
+  projectId,
+  disabled,
+}: FindDuplicatesButtonProps) {
   const t = useTranslations("repository.duplicates");
   const storageKey = `${STORAGE_KEY_PREFIX}${projectId}`;
 
@@ -236,6 +240,7 @@ export function FindDuplicatesButton({ projectId }: FindDuplicatesButtonProps) {
     <Button
       data-testid="find-duplicates-button"
       variant="outline"
+      disabled={disabled}
       onClick={handleScan}
       className="group px-4 hover:px-4 transition-all duration-200 gap-0 hover:gap-2"
     >

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -2681,6 +2681,7 @@
         "allPages": "All pages ({pages, plural, one {# page} other {# pages}}, {cases, plural, one {# case} other {# cases}})"
       },
       "generatingLegacy": "Generating test cases with AI...",
+      "expandProgress": "{done} of {total} generated",
       "import": "{count, plural, =0 {Import Test Cases} =1 {Import 1 Test Case} other {Import # Test Cases}}",
       "importing": "{count, plural, =0 {Importing Test Cases...} =1 {Importing 1 Test Case...} other {Importing # Test Cases...}}",
       "openInExternalSystem": "Open in {provider}",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -2681,6 +2681,7 @@
         "allPages": "Todas las páginas ({pages, plural, one {# página} other {# páginas}}, {cases, plural, one {# caso} other {# casos}})"
       },
       "generatingLegacy": "Generación de casos de prueba con IA...",
+      "expandProgress": "{done} de {total} generado",
       "import": "{count, plural, =0 {Importar casos de prueba} =1 {Importar 1 caso de prueba} other {Importar # casos de prueba}}",
       "importing": "{count, plural, =0 {Importando casos de prueba...} =1 {Importando 1 caso de prueba...} other {Importando # casos de prueba...}}",
       "openInExternalSystem": "Abrir en {provider}",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -2681,6 +2681,7 @@
         "allPages": "Toutes les pages ({pages, plural, one {# page} other {# pages}}, {cases, plural, one {# cas} other {# cas}})"
       },
       "generatingLegacy": "Générer des cas de test avec l'IA...",
+      "expandProgress": "{done} de {total} généré",
       "import": "{count, plural, =0 {Importer les cas de test} =1 {Importer 1 cas de test} other {Importer # cas de test}}",
       "importing": "{count, plural, =0 {Importation des cas de test...} =1 {Importation de 1 cas de test...} other {Importation de # cas de test...}}",
       "openInExternalSystem": "Ouvrir dans {provider}",


### PR DESCRIPTION
## Description

Three related fixes to the Generate Test Cases wizard:

1. **Disable Generate button when no folders exist** — previously the button was always enabled; clicking it with no folders would attempt to import into a null folder and error.

2. **Fix quantity selection being ignored** — the wizard's `handleNext` was wrapped in `useCallback` with `generateTestCases` excluded from the deps array (stale closure), so any change to the quantity or notes after arriving at the Add Notes step was silently ignored. Fixed by removing the unnecessary `useCallback`.

3. **Two-phase generation to eliminate timeouts** — requesting "Many" (7–10) test cases in a single LLM call was hitting provider timeouts. Generation now uses two phases:
   - **Phase 1**: A lightweight request to the new `/api/llm/generate-test-cases/outline` endpoint returns just the titles and one-line summaries for all requested cases. This is fast and never times out.
   - **Phase 2**: Each title is expanded into a full test case in parallel via the new `/api/llm/generate-test-cases/expand` SSE endpoint. Users see all titles appear immediately and can cancel individual cases before they finish.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Manual testing

Tested all three fixes manually:
- Verified generate button is disabled when no folders exist in repository
- Verified quantity selection (Just One / Many / etc.) is correctly sent to the LLM
- Verified two-phase flow shows titles immediately, expands in parallel, and per-case cancel works

**Test Configuration:**
- OS: macOS
- Browser: Chrome
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The two-phase approach matches the pattern used elsewhere in the UI (similar to how URL-based generation streams results per page). The outline endpoint caps token output at 1024 since it only needs titles; the expand endpoint uses the full provider token budget per case.