### PR TITLE
feat(i18n): add localization support for 13 languages

### DIFF
--- a/docs/blog/2026-05-12-multilingual-support.md
+++ b/docs/blog/2026-05-12-multilingual-support.md
@@ -1,0 +1,60 @@
+---
+slug: multilingual-support
+title: "TestPlanIt Now Speaks 13 Languages"
+description: "v0.27.0 ships full UI localization in 13 languages, including German, Italian, Japanese, Korean, Chinese, and more — with a single source of truth that makes adding new languages straightforward."
+authors: [bdermanouelian]
+tags: [release, announcement]
+---
+
+Test management is a global discipline. Your QA team might be spread across São Paulo, Amsterdam, Warsaw, and Tokyo, and until now they've all been working in English whether they wanted to or not. That changes today.
+
+TestPlanIt v0.27.0 ships full UI localization in **13 languages**.
+
+<!-- truncate -->
+
+## The Languages
+
+The full list, in the language picker order you'll see in your profile:
+
+| Language | Locale |
+| --- | --- |
+| Deutsch (German) | de-DE |
+| English (US) | en-US |
+| Español (Spanish) | es-ES |
+| Français (French) | fr-FR |
+| Italiano (Italian) | it-IT |
+| Nederlands (Dutch) | nl-NL |
+| Polski (Polish) | pl-PL |
+| Português (Brazilian Portuguese) | pt-BR |
+| Tiếng Việt (Vietnamese) | vi-VN |
+| 中文（简体）(Chinese Simplified) | zh-CN |
+| 中文（繁體）(Chinese Traditional) | zh-TW |
+| 日本語 (Japanese) | ja-JP |
+| 한국어 (Korean) | ko-KR |
+
+## How It Works
+
+Switch languages under **Profile → Preferences → Locale**. The entire UI — navigation, forms, tables, and notifications — updates to match your selected language.
+
+Date format, time format, and timezone are separate preferences you control independently, so you can use German UI with US date formatting, or any other combination that fits how you work.
+
+Translations are managed through [Crowdin](https://crowdin.com) using machine pre-translation as a baseline. The source strings are always English, and we use a Crowdin glossary to protect brand names and technical terms from being altered during translation.
+
+## Contributing Translations
+
+If you spot an awkward translation or want to improve coverage in your language, we welcome contributions through our [Crowdin project](https://crowdin.com/project/testplanit). No pull request needed — join the project directly and suggest improvements in the Crowdin editor.
+
+If you'd like to see a language that isn't listed yet, open a GitHub issue and we'll add it to the Crowdin project.
+
+## Upgrade to v0.27.0
+
+Pull the latest, install, and build. No database migrations are required beyond what the standard upgrade process covers. Full upgrade steps are in the [upgrade guide](/docs/installation).
+
+## Get Involved
+
+- Star the repo on [GitHub](https://github.com/testplanit/testplanit)
+- Follow [@TestPlanItHQ](https://x.com/TestPlanItHQ) for updates
+- Join our [Community Discord](https://discord.gg/kpfha4W2JH)
+- Report issues and suggest features on GitHub
+
+Thank you for using TestPlanIt!

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -83,7 +83,7 @@ Yes, TestPlanIt integrates with various LLM providers including OpenAI, Azure Op
 
 ### Does TestPlanIt support multiple languages?
 
-The TestPlanIt interface supports multiple languages including English, Spanish, and French. Contributions for additional languages are welcome.
+The TestPlanIt interface supports 13 languages: English (US), Deutsch (German), Español (Spanish), Français (French), Italiano (Italian), Nederlands (Dutch), Polski (Polish), Português (Portuguese Brazil), Tiếng Việt (Vietnamese), 中文简体 (Chinese Simplified), 中文繁體 (Chinese Traditional), 日本語 (Japanese), and 한국어 (Korean). Contributions for additional languages are welcome.
 
 ## Administration
 

--- a/docs/docs/user-guide/user-profile.md
+++ b/docs/docs/user-guide/user-profile.md
@@ -64,7 +64,7 @@ When viewing your own profile, you can view and edit these preferences:
 #### Display Preferences
 
 - **Theme**: Choose from Light, Dark, System, Green, Orange, or Purple themes (with color indicators)
-- **Locale**: Language preference (English US, Español ES)
+- **Locale**: Language preference (English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Vietnamese, Chinese Simplified, Chinese Traditional, Japanese, Korean)
 - **Items Per Page**: Number of items to show in paginated tables (10, 25, 50, 100)
 
 #### Date & Time Formatting

--- a/testplanit/app/[locale]/signin/page.server.tsx
+++ b/testplanit/app/[locale]/signin/page.server.tsx
@@ -1,4 +1,6 @@
 import { cookies, headers } from "next/headers";
+
+import { locales, defaultLocale, type Locale } from "~/i18n/navigation";
 import { redirect } from "~/lib/navigation";
 
 export default async function SigninPage() {
@@ -8,19 +10,12 @@ export default async function SigninPage() {
 
   // Get browser's preferred language
   const headersList = await headers();
-  const acceptLanguage = headersList.get("accept-language");
+  const acceptLanguage = headersList.get("accept-language") ?? "";
 
-  // Parse accept-language header to get preferred locale
-  let browserLocale = "en-US"; // default
-  if (acceptLanguage) {
-    // Look for es-ES or en-US in accept-language header
-    if (acceptLanguage.includes("es")) {
-      browserLocale = "es-ES";
-    } else if (acceptLanguage.includes("en")) {
-      browserLocale = "en-US";
-    }
-  }
+  // Match the first supported locale whose language tag appears in Accept-Language
+  const matched = locales.find((locale) =>
+    acceptLanguage.includes(locale.substring(0, 2))
+  );
 
-  // Redirect to the correct locale version
-  redirect({ href: `/signin`, locale: browserLocale as "en-US" | "es-ES" });
+  redirect({ href: `/signin`, locale: (matched ?? defaultLocale) as Locale });
 }

--- a/testplanit/app/[locale]/users/profile/[userId]/page.tsx
+++ b/testplanit/app/[locale]/users/profile/[userId]/page.tsx
@@ -72,6 +72,7 @@ import { use, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { useFindFirstUser, useFindUniqueAppConfig } from "~/lib/hooks";
+import { languageNames } from "~/i18n/navigation";
 import { useRouter } from "~/lib/navigation";
 import { ApiTokenSettings } from "./ApiTokenSettings";
 import { ChangePasswordModal } from "./ChangePasswordModal";
@@ -358,18 +359,8 @@ const UserProfile: React.FC<UserProfileProps> = ({
     }
   };
 
-  const getLocaleLabel = (locale: Locale) => {
-    switch (locale) {
-      case "en_US":
-        return "English (US)";
-      case "es_ES":
-        return "Español (ES)";
-      case "fr_FR":
-        return "Français (France)";
-      default:
-        return locale;
-    }
-  };
+  const getLocaleLabel = (locale: Locale) =>
+    languageNames[locale.replace("_", "-")] ?? locale;
 
   const getThemeIcon = (themeName: Theme) => {
     switch (themeName) {

--- a/testplanit/app/api/users/[userId]/route.test.ts
+++ b/testplanit/app/api/users/[userId]/route.test.ts
@@ -629,6 +629,24 @@ describe("User Update API Endpoint (PATCH /api/users/[userId])", () => {
       expect(data.error).toBe("Invalid input");
     });
 
+    it("accepts all supported locale values", async () => {
+      const locales = ["en_US", "es_ES", "fr_FR", "it_IT", "de_DE"];
+
+      for (const locale of locales) {
+        const updatedUser = {
+          ...mockExistingUser,
+          userPreferences: { ...mockExistingUser.userPreferences, locale },
+        };
+        (prisma.$transaction as any).mockResolvedValue(updatedUser);
+
+        const request = createRequest({ userPreferences: { locale } });
+        const context = createContext("user-123");
+        const response = await PATCH(request, context);
+
+        expect(response.status).toBe(200);
+      }
+    });
+
     it("accepts valid request with all supported theme values", async () => {
       const themes = ["Light", "Dark", "System", "Green", "Orange", "Purple"];
 

--- a/testplanit/app/api/users/[userId]/route.ts
+++ b/testplanit/app/api/users/[userId]/route.ts
@@ -31,7 +31,23 @@ const updateUserSchema = z.object({
       theme: z
         .enum(["Light", "Dark", "System", "Green", "Orange", "Purple"])
         .optional(),
-      locale: z.enum(["en_US", "es_ES", "fr_FR"]).optional(),
+      locale: z
+        .enum([
+          "en_US",
+          "es_ES",
+          "fr_FR",
+          "it_IT",
+          "de_DE",
+          "nl_NL",
+          "pl_PL",
+          "pt_BR",
+          "vi_VN",
+          "zh_CN",
+          "zh_TW",
+          "ja_JP",
+          "ko_KR",
+        ])
+        .optional(),
       itemsPerPage: z.enum(["P10", "P25", "P50", "P100", "P250"]).optional(),
       dateFormat: z
         .enum([

--- a/testplanit/components/onboarding/InitialPreferencesDialog.tsx
+++ b/testplanit/components/onboarding/InitialPreferencesDialog.tsx
@@ -320,8 +320,7 @@ export function InitialPreferencesDialog() {
       // Mark theme as saved so we don't revert it
       originalThemeRef.current = undefined;
 
-      const localeChanged =
-        data.locale !== userPreferences?.locale;
+      const localeChanged = data.locale !== userPreferences?.locale;
 
       if (localeChanged) {
         const urlLocale = data.locale.replace("_", "-");

--- a/testplanit/components/onboarding/InitialPreferencesDialog.tsx
+++ b/testplanit/components/onboarding/InitialPreferencesDialog.tsx
@@ -47,6 +47,7 @@ import {
   useFindFirstUserPreferences,
   useUpdateUserPreferences,
 } from "~/lib/hooks";
+import { languageNames } from "~/i18n/navigation";
 
 type TimezoneOption = {
   id: string;
@@ -263,18 +264,8 @@ export function InitialPreferencesDialog() {
     [setTheme]
   );
 
-  const getLocaleLabel = (locale: Locale) => {
-    switch (locale) {
-      case "en_US":
-        return "English (US)";
-      case "es_ES":
-        return "Español (ES)";
-      case "fr_FR":
-        return "Français (FR)";
-      default:
-        return locale;
-    }
-  };
+  const getLocaleLabel = (locale: Locale) =>
+    languageNames[locale.replace("_", "-")] ?? locale;
 
   const getNotificationModeLabel = (mode: NotificationMode) => {
     switch (mode) {
@@ -328,6 +319,16 @@ export function InitialPreferencesDialog() {
 
       // Mark theme as saved so we don't revert it
       originalThemeRef.current = undefined;
+
+      const localeChanged =
+        data.locale !== userPreferences?.locale;
+
+      if (localeChanged) {
+        const urlLocale = data.locale.replace("_", "-");
+        document.cookie = `NEXT_LOCALE=${urlLocale};path=/;max-age=31536000`;
+        window.location.reload();
+        return;
+      }
 
       toast.success(t("success"));
       setIsOpen(false);

--- a/testplanit/crowdin.yml
+++ b/testplanit/crowdin.yml
@@ -9,5 +9,15 @@ files:
     languages_mapping:
       locale:
         # Map Crowdin locale codes to our locale format
+        de: "de-DE"
         es-ES: "es-ES"
         fr: "fr-FR"
+        it: "it-IT"
+        nl: "nl-NL"
+        pl: "pl-PL"
+        pt-BR: "pt-BR"
+        vi: "vi-VN"
+        zh-CN: "zh-CN"
+        zh-TW: "zh-TW"
+        ja: "ja-JP"
+        ko: "ko-KR"

--- a/testplanit/i18n/dateFnsLocales.test.ts
+++ b/testplanit/i18n/dateFnsLocales.test.ts
@@ -1,0 +1,48 @@
+import { enUS } from "date-fns/locale/en-US";
+import { es } from "date-fns/locale/es";
+import { fr } from "date-fns/locale/fr";
+import { it } from "date-fns/locale/it";
+import { de } from "date-fns/locale/de";
+import { describe, expect, it as test } from "vitest";
+
+import { dateFnsLocaleFor, dateFnsLocaleMap } from "./dateFnsLocales";
+import { locales } from "./navigation";
+
+describe("dateFnsLocaleMap", () => {
+  test("covers every locale in the navigation locales array", () => {
+    for (const locale of locales) {
+      expect(dateFnsLocaleMap).toHaveProperty(locale);
+    }
+  });
+
+  test("maps each supported locale to the correct date-fns object", () => {
+    expect(dateFnsLocaleMap["en-US"]).toBe(enUS);
+    expect(dateFnsLocaleMap["es-ES"]).toBe(es);
+    expect(dateFnsLocaleMap["fr-FR"]).toBe(fr);
+    expect(dateFnsLocaleMap["it-IT"]).toBe(it);
+    expect(dateFnsLocaleMap["de-DE"]).toBe(de);
+  });
+});
+
+describe("dateFnsLocaleFor", () => {
+  test("returns correct locale for hyphen format", () => {
+    expect(dateFnsLocaleFor("en-US")).toBe(enUS);
+    expect(dateFnsLocaleFor("es-ES")).toBe(es);
+    expect(dateFnsLocaleFor("fr-FR")).toBe(fr);
+    expect(dateFnsLocaleFor("it-IT")).toBe(it);
+    expect(dateFnsLocaleFor("de-DE")).toBe(de);
+  });
+
+  test("normalises underscore format to hyphen before lookup", () => {
+    expect(dateFnsLocaleFor("it_IT")).toBe(it);
+    expect(dateFnsLocaleFor("de_DE")).toBe(de);
+    expect(dateFnsLocaleFor("es_ES")).toBe(es);
+    expect(dateFnsLocaleFor("fr_FR")).toBe(fr);
+  });
+
+  test("falls back to enUS for unknown locales", () => {
+    expect(dateFnsLocaleFor("xx-XX")).toBe(enUS);
+    expect(dateFnsLocaleFor("unknown")).toBe(enUS);
+    expect(dateFnsLocaleFor("")).toBe(enUS);
+  });
+});

--- a/testplanit/i18n/dateFnsLocales.ts
+++ b/testplanit/i18n/dateFnsLocales.ts
@@ -1,0 +1,40 @@
+import { type Locale } from "date-fns";
+import { enUS } from "date-fns/locale/en-US";
+import { de } from "date-fns/locale/de";
+import { es } from "date-fns/locale/es";
+import { fr } from "date-fns/locale/fr";
+import { it } from "date-fns/locale/it";
+import { nl } from "date-fns/locale/nl";
+import { pl } from "date-fns/locale/pl";
+import { ptBR } from "date-fns/locale/pt-BR";
+import { vi } from "date-fns/locale/vi";
+import { zhCN } from "date-fns/locale/zh-CN";
+import { zhTW } from "date-fns/locale/zh-TW";
+import { ja } from "date-fns/locale/ja";
+import { ko } from "date-fns/locale/ko";
+
+import { locales } from "./navigation";
+
+export const dateFnsLocaleMap: Record<string, Locale> = {
+  "de-DE": de,
+  "en-US": enUS,
+  "es-ES": es,
+  "fr-FR": fr,
+  "it-IT": it,
+  "nl-NL": nl,
+  "pl-PL": pl,
+  "pt-BR": ptBR,
+  "vi-VN": vi,
+  "zh-CN": zhCN,
+  "zh-TW": zhTW,
+  "ja-JP": ja,
+  "ko-KR": ko,
+};
+
+export function dateFnsLocaleFor(appLocale: string): Locale {
+  if (!appLocale) return enUS;
+  const normalized = appLocale.replace("_", "-");
+  return dateFnsLocaleMap[normalized] ?? enUS;
+}
+
+export { locales };

--- a/testplanit/i18n/navigation.ts
+++ b/testplanit/i18n/navigation.ts
@@ -1,11 +1,37 @@
-export const locales = ["en-US", "es-ES", "fr-FR"] as const;
+// Ordered alphabetically by each language's native name (endonym).
+// Latin-script languages first, CJK at the end (no universal alpha order).
+export const locales = [
+  "de-DE",
+  "en-US",
+  "es-ES",
+  "fr-FR",
+  "it-IT",
+  "nl-NL",
+  "pl-PL",
+  "pt-BR",
+  "vi-VN",
+  "zh-CN",
+  "zh-TW",
+  "ja-JP",
+  "ko-KR",
+] as const;
 
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale = "en-US" as const;
 
 export const languageNames: Record<string, string> = {
+  "de-DE": "Deutsch (Deutschland)",
   "en-US": "English (US)",
   "es-ES": "Español (España)",
   "fr-FR": "Français (France)",
+  "it-IT": "Italiano (Italia)",
+  "nl-NL": "Nederlands (Nederland)",
+  "pl-PL": "Polski (Polska)",
+  "pt-BR": "Português (Brasil)",
+  "vi-VN": "Tiếng Việt",
+  "zh-CN": "中文（简体）",
+  "zh-TW": "中文（繁體）",
+  "ja-JP": "日本語",
+  "ko-KR": "한국어",
 };

--- a/testplanit/i18n/request.ts
+++ b/testplanit/i18n/request.ts
@@ -10,9 +10,13 @@ export default getRequestConfig(async ({ requestLocale }) => {
     locale = "en-US";
   }
 
+  const messages = await import(`../messages/${locale}.json`).catch(
+    () => import("../messages/en-US.json")
+  );
+
   return {
     locale: locale as Locale,
-    messages: (await import(`../messages/${locale}.json`)).default,
+    messages: messages.default,
     timeZone: "UTC",
   };
 });

--- a/testplanit/lib/server-date-formatter.test.ts
+++ b/testplanit/lib/server-date-formatter.test.ts
@@ -1,6 +1,8 @@
 import { enUS } from "date-fns/locale/en-US";
 import { es } from "date-fns/locale/es";
 import { fr } from "date-fns/locale/fr";
+import { it as itLocale } from "date-fns/locale/it";
+import { de } from "date-fns/locale/de";
 import { describe, expect, it } from "vitest";
 import {
   formatEmailDate,
@@ -27,6 +29,16 @@ describe("server-date-formatter", () => {
       expect(getServerDateFnsLocale("fr_FR")).toBe(fr);
     });
 
+    it("should return correct locale for it-IT", () => {
+      expect(getServerDateFnsLocale("it-IT")).toBe(itLocale);
+      expect(getServerDateFnsLocale("it_IT")).toBe(itLocale);
+    });
+
+    it("should return correct locale for de-DE", () => {
+      expect(getServerDateFnsLocale("de-DE")).toBe(de);
+      expect(getServerDateFnsLocale("de_DE")).toBe(de);
+    });
+
     it("should return enUS as default for unknown locale", () => {
       expect(getServerDateFnsLocale("unknown")).toBe(enUS);
       expect(getServerDateFnsLocale("xx-XX")).toBe(enUS);
@@ -43,6 +55,16 @@ describe("server-date-formatter", () => {
       const result = formatEmailDate(testDate, "es-ES");
       expect(result).toBe("julio 10, 2025");
     });
+
+    it("should format date in Italian", () => {
+      const result = formatEmailDate(testDate, "it-IT");
+      expect(result).toBe("luglio 10, 2025");
+    });
+
+    it("should format date in German", () => {
+      const result = formatEmailDate(testDate, "de-DE");
+      expect(result).toBe("Juli 10, 2025");
+    });
   });
 
   describe("formatEmailDateTime", () => {
@@ -56,6 +78,19 @@ describe("server-date-formatter", () => {
       const result = formatEmailDateTime(testDate, "es-ES");
       expect(result).toContain("julio 10, 2025 a las");
       expect(result).toMatch(/a las \d{2}:\d{2} [AP]M$/);
+    });
+
+    it("should format date time in Italian", () => {
+      const result = formatEmailDateTime(testDate, "it-IT");
+      expect(result).toContain("luglio 10, 2025 alle");
+      expect(result).toMatch(/alle \d{2}:\d{2} [AP]M$/);
+    });
+
+    it("should format date time in German", () => {
+      const result = formatEmailDateTime(testDate, "de-DE");
+      expect(result).toContain("Juli 10, 2025 um");
+      // German date-fns uses "vorm."/"nachm." not AM/PM
+      expect(result).toMatch(/um \d{2}:\d{2} \S+$/);
     });
 
     it("should handle underscore locale format", () => {

--- a/testplanit/lib/server-date-formatter.ts
+++ b/testplanit/lib/server-date-formatter.ts
@@ -1,25 +1,9 @@
-import { format, Locale } from "date-fns";
-import { enUS } from "date-fns/locale/en-US";
-import { es } from "date-fns/locale/es";
-import { fr } from "date-fns/locale/fr";
+import { format, type Locale } from "date-fns";
 
-// Map locales to date-fns locales
-const localeMap: Record<string, Locale> = {
-  "en-US": enUS,
-  en_US: enUS,
-  "es-ES": es,
-  es_ES: es,
-  "fr-FR": fr,
-  fr_FR: fr,
-};
+import { dateFnsLocaleFor } from "~/i18n/dateFnsLocales";
 
-/**
- * Get date-fns locale from locale string
- */
 export function getServerDateFnsLocale(locale: string): Locale {
-  // Normalize locale format
-  const normalizedLocale = locale.replace("_", "-");
-  return localeMap[normalizedLocale] || localeMap[locale] || enUS;
+  return dateFnsLocaleFor(locale);
 }
 
 /**
@@ -52,9 +36,15 @@ export function formatEmailDateTime(
 ): string {
   // Use localized "at" word for different languages
   const atWordMap: Record<string, string> = {
+    de: "um",
     en: "at",
     es: "a las",
     fr: "à",
+    it: "alle",
+    nl: "om",
+    pl: "o",
+    pt: "às",
+    vi: "lúc",
   };
 
   const langCode = locale.substring(0, 2);

--- a/testplanit/lib/utils/dateFnsLocale.ts
+++ b/testplanit/lib/utils/dateFnsLocale.ts
@@ -1,7 +1,1 @@
-import { type Locale, enUS, es, fr } from "date-fns/locale";
-
-export function dateFnsLocaleFor(appLocale: string): Locale {
-  if (appLocale.startsWith("fr")) return fr;
-  if (appLocale.startsWith("es")) return es;
-  return enUS;
-}
+export { dateFnsLocaleFor } from "~/i18n/dateFnsLocales";

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Name",
+    "cancel": "Stornieren",
+    "dismiss": "Zurückweisen",
+    "of": "von",
+    "on": "An",
+    "at": "bei",
+    "in": "In",
+    "add": "Hinzufügen",
+    "never": "Niemals",
+    "select": "Wählen...",
+    "file": "Datei",
+    "selectMultiple": "Mehrere auswählen...",
+    "searchUsers": "Benutzer suchen...",
+    "searchCases": "{count, plural, =0 {Fälle durchsuchen} one {Fall Nr. durchsuchen} other {Fälle Nr. durchsuchen}}",
+    "searchProjects": "{count, plural, =0 {Projekte suchen} one {Projekt Nr. suchen} other {Projekte Nr. suchen}}",
+    "searchTags": "Nach Schlagwörtern suchen...",
+    "searchRuns": "{count, plural, =0 {Suche Testläufe} one {Suche # Testläufe} other {Suche # Testläufe}}",
+    "searchSessions": "{count, plural, =0 {Sitzungen durchsuchen} one {Sitzung Nr. durchsuchen} other {Sitzung Nr. durchsuchen}}",
+    "search": "Suchen...",
+    "defaultOption": "Standardoption",
+    "yes": "Ja",
+    "no": "NEIN",
+    "updated": "Aktualisiert",
+    "groupedBy": "gruppiert nach",
+    "lastEditedBy": "Zuletzt bearbeitet von",
+    "actions": {
+      "edit": "Bearbeiten",
+      "save": "Speichern",
+      "delete": "Löschen",
+      "create": "Erstellen",
+      "submit": "Einreichen",
+      "close": "Schließen",
+      "done": "Erledigt",
+      "verify": "Verifizieren",
+      "signIn": "Anmelden",
+      "signOut": "Abmelden",
+      "signUp": "Melden Sie sich an",
+      "resend": "Erneut senden",
+      "deleting": "Löschen...",
+      "next": "Nächste",
+      "previous": "Vorherige",
+      "finish": "Beenden",
+      "download": "Herunterladen",
+      "apply": "Anwenden",
+      "confirm": "Bestätigen",
+      "confirmDelete": "Löschen bestätigen",
+      "saveChanges": "Änderungen speichern",
+      "saving": "Speichern...",
+      "submitting": "Wird übermittelt...",
+      "start": "Start",
+      "pause": "Pause",
+      "reset": "Zurücksetzen",
+      "copy": "Kopie",
+      "copyLink": "Link kopieren",
+      "copied": "Kopiert!",
+      "complete": "Vollständig",
+      "back": "Zurück",
+      "clear": "Klar",
+      "expand": "Expandieren",
+      "collapse": "Zusammenbruch",
+      "addResult": "Ergebnis hinzufügen",
+      "passAndNext": "Weitergehen & Weiter",
+      "viewInRepository": "Im Repository anzeigen",
+      "resultAdded": "Testergebnis hinzugefügt",
+      "resultAddedDescription": "Das Testergebnis wurde erfolgreich hinzugefügt.",
+      "resultUpdated": "Testergebnis aktualisiert",
+      "resultDeleted": "Testergebnis gelöscht",
+      "deleteResult": "Testergebnis löschen",
+      "deleteResultConfirmation": "Sind Sie sicher, dass Sie dieses Testergebnis löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "editResult": "Ergebnis des Bearbeitungstests",
+      "resultDetails": "Ergebnisdetails",
+      "actionsLabel": "Aktionen",
+      "assign": "Zuordnen",
+      "assignSelected": "Weisen Sie {count, plural, one {zu # Fall} other {# Fälle}} zu",
+      "refresh": "Aktualisieren",
+      "addResultSelected": "Füge Ergebnis zu {count, plural, one {hinzu # Fall} other {# Fälle}}",
+      "resultsAdded": "{count, plural, one {# Ergebnis} other {# Ergebnisse}} Hinzugefügt",
+      "resultsAddedDescription": "{count, plural, one {Ergebnis wurde zu Testfall # hinzugefügt} other {Ergebnisse wurden zu Testfällen # hinzugefügt}} erfolgreich",
+      "addingResultsToMultiple": "Ergebnisse zu {count, plural, one {hinzufügen # Testfall} other {# Testfälle}} hinzufügen",
+      "addedToTestRun": "Zum Testlauf hinzugefügt",
+      "addedToTestRunDescription": "Der Testfall wurde dem Testlauf hinzugefügt.",
+      "noAvailableTestRuns": "Alle aktiven Testläufe beinhalten diesen Testfall bereits.",
+      "resultUpdateError": "Testergebnis konnte nicht aktualisiert werden",
+      "resultDeleteError": "Testergebnis konnte nicht gelöscht werden",
+      "selectStatus": "Status auswählen",
+      "addToTestRun": "Zum Testlauf hinzufügen",
+      "status": "Status",
+      "resultDetailsPlaceholder": "Ergebnisdetails eingeben...",
+      "selectAll": "Alle auswählen",
+      "deselectAll": "Alle abwählen",
+      "clearAll": "Alles löschen",
+      "selectFile": "Datei auswählen",
+      "restore": "Wiederherstellen",
+      "purge": "Säubern",
+      "previousCase": "Vorheriger Fall",
+      "nextCase": "Nächster Fall",
+      "startTesting": "Testen starten",
+      "expandLeftPanel": "Linke Seite erweitern",
+      "collapseLeftPanel": "Linke Seite ausblenden",
+      "expandRightPanel": "Rechtes Bedienfeld erweitern",
+      "collapseRightPanel": "Rechtes Bedienfeld ausklappen",
+      "createTag": "Tag erstellen \"{name}\"",
+      "noTagsFound": "Keine Tags gefunden",
+      "duplicate": "Duplikat",
+      "exportPdf": "PDF exportieren",
+      "exportingPdf": "Exportieren...",
+      "change": "Ändern",
+      "viewAll": "Alle anzeigen",
+      "undo": "Rückgängig machen",
+      "undoDelete": "Löschen rückgängig machen",
+      "automated": {
+        "details": "Details zum automatisierten Test",
+        "message": "Nachricht",
+        "line": "Linie",
+        "testSuite": "Testsuite:"
+      },
+      "junit": {
+        "details": "Details zum Ergebnis des automatisierten Tests",
+        "import": {
+          "title": "Ergebnisse des Importtests",
+          "description": "Laden Sie Testergebnisdateien hoch, um sie in einen neuen Testlauf zu importieren. Unterstützt die Formate JUnit, TestNG, xUnit, NUnit, MSTest, Mocha und Cucumber.",
+          "testRun": {
+            "label": "Probelauf",
+            "placeholder": "Wählen Sie einen Testlauf aus"
+          },
+          "file": {
+            "label": "Testergebnisdateien"
+          },
+          "import": "Import",
+          "selectFolder": "Wählen Sie einen Ordner aus",
+          "createNewFolder": "Neuen Ordner erstellen",
+          "createNewFolderNamed": "Neuen Ordner erstellen: {name}",
+          "progress": {
+            "initializing": "Import wird initialisiert...",
+            "validating": "Eingabedaten werden validiert...",
+            "creatingRun": "Testlauf wird erstellt...",
+            "fetchingTemplate": "Vorlagendaten werden abgerufen...",
+            "countingTests": "Verarbeitung von {count} Testfällen aus {files} Datei(en)...",
+            "parsingFile": "Datei {current} von {total}wird analysiert ...",
+            "processingSuite": "Verarbeitungssuite: {name}",
+            "processingCase": "Verarbeitung des Testfalls {current} von {total}...",
+            "finalizing": "Import wird abgeschlossen...",
+            "completed": "Import erfolgreich abgeschlossen!",
+            "errorParsing": "Fehler beim Parsen der Datei {index}: {error}",
+            "skippingFile": "Ungültige Datei wird übersprungen {index}"
+          },
+          "error": {
+            "title": "Importfehler",
+            "importFailed": "Die Testergebnisse konnten nicht importiert werden. Bitte versuchen Sie es erneut."
+          },
+          "success": {
+            "title": "Import erfolgreich",
+            "description": "Die Testergebnisse wurden erfolgreich importiert."
+          },
+          "fileRequired": "Bitte laden Sie mindestens eine Testergebnisdatei hoch."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Ergebnisformat",
+            "placeholder": "Format auswählen"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Wiederherstellung bestätigen",
+      "confirmPurgeTitle": "Bestätigen Sie die Löschung.",
+      "remove": "Entfernen",
+      "reconfigure": "Neu konfigurieren und erneut versuchen"
+    },
+    "permissions": {
+      "addEdit": "Hinzufügen/Bearbeiten"
+    },
+    "auth": {
+      "internal": "E-Mail/Passwort",
+      "sso": "Nur SSO",
+      "both": "E-Mail & SSO"
+    },
+    "status": {
+      "deleted": "Gelöscht",
+      "disabled": "Deaktiviert",
+      "noCustomFieldData": "Keine weiteren Details.",
+      "pending": "Ausstehend",
+      "uploading": "Wird hochgeladen...",
+      "notApplicable": "N / A",
+      "redirecting": "Weiterleitung...",
+      "pendingDelete": "Wird gelöscht",
+      "pendingChanges": "Anstehende Änderungen",
+      "importing": "Importiert...",
+      "addingTestCases": "Testfälle werden hinzugefügt..."
+    },
+    "priority": {
+      "low": "Niedrig",
+      "medium": "Medium",
+      "high": "Hoch"
+    },
+    "filters": {
+      "allStatuses": "Alle Status",
+      "allPriorities": "Alle Prioritäten"
+    },
+    "fields": {
+      "groupName": "Gruppenname",
+      "users": "Benutzer",
+      "mixed": "Alle Werte",
+      "type": "Typ",
+      "default": "Standard",
+      "enabled": "Ermöglicht",
+      "projects": "Projekte",
+      "iconColor": "Symbol/Farbe",
+      "selectWorkflow": "Workflow auswählen",
+      "icon": "Symbol",
+      "systemName": "Systemname",
+      "aliases": "Aliase",
+      "scope": "Umfang",
+      "success": "Erfolg",
+      "failure": "Versagen",
+      "completed": "Vollendet",
+      "elapsed": "Verstrichene Zeit",
+      "totalElapsed": "Gesamte verstrichene Zeit",
+      "totalEstimate": "Geschätzte verbleibende Zeit",
+      "completionRate": "Fertigstellungsrate",
+      "attachments": "Anlagen",
+      "documentation": "Dokumentation",
+      "state": "Zustand",
+      "configuration": "Konfiguration",
+      "configurations": "Konfigurationen",
+      "milestone": "Meilenstein",
+      "tags": "Tags",
+      "createdBy": "Erstellt von",
+      "description": "Beschreibung",
+      "description_placeholder": "Füge eine Beschreibung hinzu...",
+      "testCases": "Testfälle",
+      "sessions": "Sitzungen",
+      "sharedSteps": "Gemeinsame Schritte",
+      "email": "E-Mail",
+      "password": "Passwort",
+      "confirmPassword": "Passwort bestätigen",
+      "token": "Token",
+      "access": "Zugang",
+      "avatar": "Avatar",
+      "steps": "Schritte",
+      "step": "Schritt",
+      "expectedResult": "Erwartetes Ergebnis",
+      "notes": "Anmerkungen",
+      "estimate": "Schätzen",
+      "date": "Datum",
+      "size": "Größe",
+      "created": "Erstellt",
+      "template": "Vorlage",
+      "mission": "Mission",
+      "assignedTo": "Zugewiesen an",
+      "executedBy": "Ausgeführt von",
+      "optional": "Optional",
+      "role": "Rolle",
+      "defaultRole": "Standardrolle",
+      "systemAccess": "Systemzugriff",
+      "authMethod": "Authentifizierungsmethode",
+      "dateCreated": "Erstellungsdatum",
+      "apiUser": "API-Benutzer",
+      "unverified": "Unbestätigt",
+      "selfRegistered": "Selbstregistriert",
+      "role_placeholder": "Wählen Sie eine Rolle aus",
+      "usersCreated": "Benutzer erstellt",
+      "groups": "Gruppen",
+      "apiAccess": "API-Zugriff",
+      "requiredForAdmin": "Erforderlich für Administratoren",
+      "account": "Konto",
+      "accountHistory": "Kontoverlauf",
+      "activity": "Aktivität",
+      "lastActive": "Zuletzt aktiv",
+      "theme": "Thema",
+      "locale": "Sprache",
+      "timezone": "Zeitzone",
+      "itemsPerPage": "Elemente pro Seite",
+      "notificationMode": "Benachrichtigungen",
+      "value": "Wert",
+      "key": "Schlüssel",
+      "configurationDetails": "Konfigurationsdetails",
+      "isActive": "Aktiv",
+      "members": "Mitglieder",
+      "milestoneTypes": "Meilensteintypen",
+      "milestones": "Meilensteine",
+      "createdAt": "Erstellt am",
+      "completedOn": "Abgeschlossen am",
+      "variants": "Varianten",
+      "emailVerified": "E-Mail verifiziert",
+      "issueTracker": "Problemverfolgung",
+      "caseFields": "Fallfelder",
+      "resultFields": "Ergebnisfelder",
+      "displayName": "Anzeigename",
+      "hint": "Hinweis",
+      "required": "Erforderlich",
+      "restricted": "Eingeschränkt",
+      "fieldType": "Feldtyp",
+      "templates": "Vorlagen",
+      "started": "Begonnen",
+      "startDate": "Startdatum",
+      "automated": "Automatisiert",
+      "manual": "Handbuch",
+      "notAutomated": "Nicht automatisiert",
+      "testRuns": "Testläufe",
+      "title": "Titel",
+      "project": "Projekt",
+      "priority": "Priorität",
+      "integration": "Integration",
+      "lastSyncedAt": "Zuletzt synchronisiert",
+      "externalKey": "Externer Schlüssel",
+      "initialHeight": "Anfangshöhe",
+      "minValue": "Minimalwert",
+      "maxValue": "Maximalwert",
+      "minIntegerValue": "Minimaler ganzzahliger Wert",
+      "maxIntegerValue": "Maximaler ganzzahliger Wert",
+      "defaultValue": "Standardwert",
+      "checked": "Geprüft",
+      "version": "Version",
+      "issues": "Probleme",
+      "internalIssues": "Interne Probleme",
+      "externalIssues": "{provider} Probleme",
+      "data": "Daten",
+      "note": "Notiz",
+      "externalId": "Externe ID",
+      "forecast": "Vorhersage",
+      "forecastManual": "Prognosehandbuch",
+      "forecastAutomated": "Automatisierte Prognose",
+      "executedAt": "Ausgeführt in",
+      "className": "Klasse",
+      "suiteName": "Suite",
+      "duration": "Dauer",
+      "session": "Sitzung",
+      "charter": "Charta",
+      "summary": "Zusammenfassung",
+      "progress": "Fortschritt",
+      "assertions": "Behauptungen",
+      "properties": "Eigenschaften",
+      "systemOutput": "Testfallprotokolle",
+      "systemError": "Systemfehler",
+      "resultStatus": "Ergebnis",
+      "links": "Links",
+      "id": "AUSWEIS",
+      "JUNIT": "JUnit-Import",
+      "API": "API",
+      "folder": "Ordner",
+      "parentFolder": "Übergeordneter Ordner für neue Fälle",
+      "multipleValues": "Mehrere Werte",
+      "provider": "Anbieter",
+      "updatedAt": "Aktualisiert am",
+      "tools": "Werkzeuge",
+      "codeRepository": "Code-Repository",
+      "aiModels": "Standard-LLM",
+      "configKeys": {
+        "edit_results_duration": "Bearbeitungsdauer der Ergebnisse",
+        "project_docs_default": "Standardeinstellungen für Projektdokumente",
+        "notificationSettings": "Globale Benachrichtigungseinstellungen",
+        "elasticsearch_replicas": "Elasticsearch-Replikate"
+      },
+      "options": {
+        "label": "Etikett",
+        "validation": {
+          "empty": "Die Option darf nicht leer sein.",
+          "invalidChars": "Option enthält ein ungültiges Zeichen: \"{char}\"",
+          "duplicate": "Die Option muss eindeutig sein.",
+          "systemNameError": "Der Systemname ist ungültig.",
+          "initialHeightMax": "Die Anfangshöhe darf nicht größer als 600px sein.",
+          "displayNameRequiredResult": "Geben Sie einen Anzeigenamen für das Ergebnisfeld ein.",
+          "displayNameRequiredCase": "Geben Sie einen Anzeigenamen für das Feld „Fall“ ein.",
+          "minValueMaxValue": "Der Minimalwert muss kleiner als der Maximalwert sein, und wenn einer von beiden festgelegt ist, müssen beide festgelegt werden.",
+          "minMaxValueInteger": "Der kleinste ganzzahlige Wert muss kleiner als der größte ganzzahlige Wert sein, und beide müssen festgelegt werden, wenn einer festgelegt ist.",
+          "systemNameRequired": "Der Systemname darf nicht leer sein.",
+          "systemNameRegex": "Der Systemname muss mit einem Buchstaben beginnen und darf nur Buchstaben, Zahlen und Unterstriche enthalten.",
+          "fieldTypeRequired": "Das Feld „Typ“ ist erforderlich."
+        }
+      },
+      "placeholders": {
+        "key": "Eingabetaste",
+        "value": "Wert eingeben",
+        "addVariant": "Variante hinzufügen",
+        "addCategory": "Kategorie hinzufügen",
+        "displayName": "Geben Sie den Anzeigenamen ein",
+        "systemName": "Systemnamen eingeben",
+        "hint": "Hinweis eingeben"
+      },
+      "hints": {
+        "systemName": "Der Systemname muss eindeutig sein und darf nur Buchstaben, Zahlen und Unterstriche enthalten.",
+        "fieldType": "(Der Feldtyp kann nach der Erstellung nicht mehr geändert werden.)"
+      },
+      "validation": {
+        "nameRequired": "Name erforderlich",
+        "stateRequired": "Der Staat ist erforderlich",
+        "urlRequired": "Eine URL ist erforderlich.",
+        "invalidUrl": "Ungültiges URL-Format"
+      }
+    },
+    "filter": {
+      "placeholder": "Filter {item}..."
+    },
+    "access": {
+      "admin": "Administrator",
+      "projectAdmin": "Projektadministrator",
+      "user": "Benutzer",
+      "none": "Keiner"
+    },
+    "validation": {
+      "required": "Bitte geben Sie {field}ein.",
+      "invalidDuration": "Bitte geben Sie eine gültige Dauer ein.",
+      "maxDuration": "Die Dauer darf {max} Minuten nicht überschreiten.",
+      "minLength": "{field} muss mindestens {min} Zeichen lang sein",
+      "emailFormat": "Ungültiges E-Mail-Format",
+      "passwordMatch": "Passwörter müssen übereinstimmen",
+      "unique": "{field} muss eindeutig sein",
+      "roleRequired": "Die Stelle ist erforderlich",
+      "nameMinLength": "Der Name muss mindestens 2 Zeichen lang sein.",
+      "invalidDurationFormat": "Ungültiges Zeitformat. Versuchen Sie es mit beispielsweise 30 Minuten, 1 Woche oder 1 Stunde 25 Minuten."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Bestätigen {action}",
+        "message": "Bist du sicher, dass du {action}möchtest?"
+      },
+      "confirmDelete": {
+        "description": "Sind Sie sicher, dass Sie diesen Eintrag löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+      },
+      "assign": {
+        "title": "Testfall zuweisen",
+        "description": "Weisen Sie den Testfall \"{testCase}\" einem Benutzer zu",
+        "selectUser": "Wählen Sie einen Benutzer aus"
+      },
+      "assignBulk": {
+        "title": "Testfälle massenhaft zuweisen",
+        "description": "Weisen Sie {count, plural, one {# ausgewählten Testfall} other {# ausgewählten Testfall}} einem Benutzer zu"
+      },
+      "complete": {
+        "title": "Vollständiger Testlauf",
+        "description": "Sind Sie sicher, dass Sie diesen Testlauf durchführen möchten?",
+        "warning": "Nach Abschluss des Testlaufs kann dieser nicht mehr verändert werden.",
+        "apple": {
+          "title": "Apple-Anmeldung konfigurieren",
+          "description": "Richten Sie Ihre Apple-Anmeldedaten ein. Diese erhalten Sie im Apple Developer Portal.",
+          "clientId": "Dienst-ID",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "Team-ID",
+          "teamIdPlaceholder": "Ihre 10-stellige Team-ID",
+          "keyId": "Schlüssel-ID",
+          "keyIdPlaceholder": "Ihre 10-stellige Schlüssel-ID",
+          "privateKey": "Privater Schlüssel",
+          "privateKeyPlaceholder": "Fügen Sie hier den Inhalt Ihres privaten Schlüssels in der .p8-Datei ein.",
+          "instructions": {
+            "title": "Installationsanleitung:",
+            "step1": "Gehen Sie zum Apple Developer Portal",
+            "step2": "Erstellen Sie eine Dienst-ID und konfigurieren Sie „Mit Apple anmelden“.",
+            "step3": "Erstellen Sie einen Schlüssel für die Anmeldung mit Apple",
+            "step4": "Laden Sie die .p8-Datei mit dem privaten Schlüssel herunter.",
+            "step5": "Fügen Sie die folgende Weiterleitungs-URL hinzu:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Alle Felder sind Pflichtfelder."
+          }
+        }
+      },
+      "delete": {
+        "title": "Löschen {item}",
+        "description": "Möchten Sie {name}wirklich löschen?",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden. Sie löscht {item}endgültig."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Element erfolgreich gelöscht",
+      "deleteError": "Beim Löschen des Eintrags ist ein Fehler aufgetreten.",
+      "moveSuccess": "Artikel erfolgreich verschoben",
+      "moveError": "Beim Verschieben des Artikels ist ein Fehler aufgetreten.",
+      "updateSuccess": "Artikel erfolgreich aktualisiert",
+      "updateError": "Beim Aktualisieren des Artikels ist ein Fehler aufgetreten.",
+      "linkCopied": "Link in die Zwischenablage kopiert",
+      "copyFailed": "Link konnte nicht in die Zwischenablage kopiert werden",
+      "created": "Testlauf erfolgreich erstellt",
+      "createdDescription": "Der Testlauf wurde erstellt und ist nun in der Liste der Testläufe sichtbar.",
+      "createError": "Es ist ein unbekannter Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+      "emptyActive": "Keine aktiven Testläufe",
+      "emptyCompleted": "Keine abgeschlossenen Testläufe",
+      "projectUpdated": "Projekt erfolgreich aktualisiert",
+      "projectUpdateError": "Beim Aktualisieren des Projekts ist ein Fehler aufgetreten.",
+      "noProjects": "Keine Projekte gefunden"
+    },
+    "placeholders": {
+      "email": "E-Mail-Adresse",
+      "name": "Name eingeben",
+      "mission": "Beschreiben Sie Ihre Mission...",
+      "selectMilestone": "Meilenstein auswählen",
+      "selectStatus": "Wählen Sie einen Status aus",
+      "selectTemplate": "Vorlage auswählen",
+      "duration": "z. B. 1 Stunde 30 Minuten oder 90 Minuten",
+      "docs": "Dokumentation hinzufügen...",
+      "select": "Wählen",
+      "selectState": "Bundesland auswählen",
+      "selectConfiguration": "Konfiguration auswählen",
+      "selectConfigurations": "Konfigurationen auswählen",
+      "selectOption": "Wählen Sie eine Option aus",
+      "date": "Wählen Sie ein Datum aus",
+      "selectEncoding": "Kodierung auswählen...",
+      "selectATemplate": "Wählen Sie eine Vorlage aus...",
+      "selectVersion": "Version auswählen",
+      "selectAModel": "Wählen Sie ein Modell aus",
+      "selectWorkflowType": "Workflow-Typ auswählen",
+      "addAnOption": "Option hinzufügen",
+      "addADescription": "Füge eine Beschreibung hinzu...",
+      "optionalDescription": "Optionale Beschreibung...",
+      "projectNotes": "Projektnotizen...",
+      "filterByName": "Nach Namen filtern...",
+      "filterByValue": "Nach Wert filtern...",
+      "selectOperator": "Wählen Sie den Operator aus.",
+      "searchIcons": "Suchsymbole...",
+      "value": "Wert",
+      "stepCount": "Schrittzahl",
+      "enterText": "Text eingeben...",
+      "enterUrl": "URL eingeben",
+      "issueIdExample": "AUSGABE-123",
+      "selectPriorityValuesOrEmpty": "Prioritätswerte auswählen (oder für alle leer lassen)"
+    },
+    "errors": {
+      "error": "Fehler",
+      "somethingWentWrong": "Es ist ein unerwarteter Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
+      "emailRequired": "Geben Sie Ihre E-Mail-Adresse ein.",
+      "emailInvalid": "Dies ist keine gültige E-Mail-Adresse.",
+      "passwordRequired": "Ein Passwort ist erforderlich.",
+      "confirmPasswordRequired": "Bestätigen Sie Ihr Passwort.",
+      "passwordDoesNotMeetPolicy": "Das Passwort erfüllt nicht die Sicherheitsanforderungen.",
+      "passwordsDoNotMatch": "Die Passwörter stimmen nicht überein.",
+      "nameRequired": "Bitte geben Sie Ihren vollständigen Namen ein",
+      "duplicate": "Bitte wählen Sie einen eindeutigen Namen.",
+      "userExists": "Dieser Benutzer existiert bereits.",
+      "unknown": "Es ist ein unbekannter Fehler aufgetreten.",
+      "invalidCredentials": "Ungültiger Benutzername oder ungültiges Passwort",
+      "projectNotFound": "Projekt nicht gefunden",
+      "projectNotFoundDescription": "Das Projekt, das Sie suchen, existiert nicht oder Sie haben keinen Zugriff darauf.",
+      "tokenRequired": "Geben Sie Ihr E-Mail-Bestätigungstoken ein oder klicken Sie auf den Link in Ihrer E-Mail.",
+      "noSuccessStatus": "Kein Erfolgsstatus ausgewählt",
+      "missingTestRunCase": "Die Testlauf-Fall-ID fehlt.",
+      "fieldRequired": "Dieses Feld ist erforderlich",
+      "projectNameExists": "Ein Projekt mit diesem Namen existiert bereits.",
+      "defaultNotFound": "Standardwert nicht gefunden",
+      "emailExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits.",
+      "nameExists": "Ein Benutzer mit diesem Namen existiert bereits.",
+      "duplicateValue": "Dieser Wert ist bereits in Gebrauch.",
+      "unauthorized": "Sie sind nicht befugt, diese Aktion durchzuführen.",
+      "accessDenied": "Zugriff verweigert",
+      "sessionNotFound": "Sitzung nicht gefunden oder ungültig.",
+      "issueTrackerNotConfigured": "Für dieses Projekt ist kein Issue-Tracker konfiguriert.",
+      "noUserSession": "Keine Benutzersitzung gefunden",
+      "noProjectId": "Keine Projekt-ID gefunden",
+      "unknownErrorWithMessage": "Es ist ein unbekannter Fehler aufgetreten. {message}",
+      "unauthenticated": "Benutzer nicht authentifiziert",
+      "fetchFailed": "Die Daten konnten nicht abgerufen werden. Bitte versuchen Sie es später erneut.",
+      "unsupportedFieldType": "Nicht unterstützter Feldtyp",
+      "notAuthenticated": {
+        "title": "Nicht authentifiziert",
+        "message": "Sie müssen angemeldet sein, um diese Aktion durchzuführen."
+      },
+      "failedToFetchAssignments": {
+        "title": "Fehler beim Abrufen der Aufgaben",
+        "message": "Die Aufgaben konnten nicht abgerufen werden. Bitte versuchen Sie es später erneut."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Problem erfolgreich verknüpft",
+        "linkError": "Fehler beim Verknüpfen",
+        "unlinkedSuccess": "Problem erfolgreich entkoppelt",
+        "unlinkError": "Fehler beim Aufheben der Verknüpfung",
+        "noActiveIntegration": "Für dieses Projekt wurde keine aktive Integration gefunden."
+      },
+      "roleRequiredForSpecificRole": "Die Angabe einer Rolle ist erforderlich, wenn der Zugriffstyp „Spezifische Rolle“ lautet.",
+      "projectCreationFailed": "Projekterstellung fehlgeschlagen, keine ID zurückgegeben.",
+      "invalidRoleId": "Ungültige Rollen-ID",
+      "workflowStateExists": "Der Workflow-Status existiert bereits. Bitte wählen Sie einen neuen Namen.",
+      "failedToLoadCaseData": "Die Falldaten konnten nicht geladen werden. Speichern nicht möglich.",
+      "atLeastOneTagRequired": "Mindestens ein Tag ist erforderlich.",
+      "atLeastOneIssueRequired": "Mindestens eine Ausgabe muss vorliegen",
+      "atLeastOneOptionRequired": "Mindestens eine Option muss ausgewählt werden.",
+      "valueRequired": "Wert erforderlich",
+      "contentRequired": "Inhalte werden benötigt",
+      "invalidContentFormat": "Ungültiges Inhaltsformat",
+      "caseNameRequired": "Bitte geben Sie einen Namen für den Testfall ein.",
+      "caseStateRequired": "Bitte wählen Sie einen Bundesstaat aus.",
+      "caseFolderRequired": "Bitte wählen Sie einen Ordner aus.",
+      "estimateTooLarge": "Die Schätzung ist zu groß",
+      "estimateRequiredValid": "Eine Schätzung ist erforderlich und muss eine gültige Dauer angeben (z. B. 1 Stunde 30 Minuten).",
+      "invalidDurationOrExceedsMax": "Ungültiges Dauerformat oder Überschreitung des Maximalwerts (z. B. 1 Stunde 30 Minuten).",
+      "configurationNameExists": "Dieser Konfigurationsname ist bereits vergeben. Bitte wählen Sie einen anderen Namen.",
+      "variantNameExists": "Dieser Variantenname ist bereits vergeben. Bitte wählen Sie einen anderen Namen.",
+      "categoryNameExists": "Dieser Kategoriename ist bereits vergeben. Bitte wählen Sie einen anderen Namen.",
+      "workflowStateNameExists": "Der Workflow-Statusname ist bereits vergeben. Bitte wählen Sie einen anderen Namen.",
+      "folderNameRequired": "Bitte geben Sie einen Namen für den Ordner ein.",
+      "folderNameRequiredEnter": "Geben Sie einen Namen für den Ordner ein.",
+      "workflowStateNameRequired": "Bitte geben Sie einen Namen für den Workflow-Status ein.",
+      "roleNameEmpty": "Der Rollenname darf nicht leer sein.",
+      "groupNameRequired": "Gruppenname erforderlich",
+      "templateNameRequired": "Bitte geben Sie einen Namen für die Vorlage ein.",
+      "caseStateInvalid": "Bitte wählen Sie einen gültigen Bundesstaat aus.",
+      "caseTemplateRequired": "Bitte wählen Sie eine Vorlage aus.",
+      "invalidContent": "Ungültiger Inhalt",
+      "milestoneNameRequired": "Bitte geben Sie einen Namen für den Meilenstein ein.",
+      "milestoneTypeRequired": "Bitte wählen Sie einen Meilensteintyp aus.",
+      "testRunNameMinLength": "Der Name muss mindestens 2 Zeichen lang sein.",
+      "stateRequiredDot": "Ein Bundesstaat ist erforderlich.",
+      "milestoneTypeNameMinLength": "Der Name des Meilensteintyps muss mindestens 2 Zeichen lang sein.",
+      "projectNameRequired": "Projektname erforderlich",
+      "workflowScopeRequired": "Bitte wählen Sie einen Workflow für den Staat aus.",
+      "workflowTypeRequired": "Bitte wählen Sie einen Workflow-Typ aus.",
+      "newTestCaseAdded": "Neuer Testfall hinzugefügt",
+      "repositoryDeleted": "Repository gelöscht",
+      "failedToDeleteRepository": "Fehler beim Löschen des Repositorys",
+      "permissionDenied": "Sie haben keine Berechtigung, auf diese Seite zuzugreifen.",
+      "resultSubmitPermissionDenied": "Sie können für diesen Fall keine Ergebnisse einreichen. Bitten Sie einen Projektadministrator, Ihnen den Fall zuzuweisen.",
+      "noModelsFound": "Keine Modelle gefunden",
+      "failedToFetchModels": "Modelle konnten nicht abgerufen werden",
+      "failedToCopyToClipboard": "Fehler beim Kopieren in die Zwischenablage",
+      "failedToLoadJobResults": "Job-Ergebnisse konnten nicht geladen werden",
+      "failedToUpdateRepositoryStatus": "Repository-Status konnte nicht aktualisiert werden"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "Armaturenbrett",
+      "twoFactorVerification": "Zwei-Faktor-Verifizierung",
+      "changePassword": "Kennwort ändern",
+      "twoFactorSetup": "Zwei-Faktor-Einrichtung",
+      "signUp": "Melden Sie sich an",
+      "signIn": "Anmelden",
+      "verifyEmail": "E-Mail-Adresse bestätigen",
+      "trialExpired": "Probezeit abgelaufen",
+      "linkSsoAccount": "SSO-Konto verknüpfen",
+      "userProfile": "Benutzerprofil",
+      "users": "Benutzer",
+      "issues": "Probleme",
+      "tags": "Tags",
+      "tagDetails": "Tag-Details",
+      "aiModels": "KI-Modelle",
+      "integrations": "Integrationen",
+      "quickscript": "QuickScript",
+      "webhooks": "Webhooks",
+      "shares": "Aktien",
+      "repository": "Repository",
+      "testCaseVersion": "Testfallversion",
+      "duplicateTestCases": "Doppelte Testfälle",
+      "documentation": "Dokumentation",
+      "sharedSteps": "Gemeinsame Schritte",
+      "stepDuplicates": "Schrittduplikate",
+      "sessions": "Sitzungen",
+      "sessionVersion": "Sitzungsversion",
+      "milestones": "Meilensteine",
+      "testRuns": "Testläufe",
+      "reports": "Berichte",
+      "adminSamlConfig": "Admin - SAML-Konfiguration",
+      "apiDocumentation": "API-Dokumentation",
+      "sharedContent": "Gemeinsame Inhalte"
+    },
+    "aria": {
+      "userMenu": "Benutzermenü",
+      "search": "Suchen",
+      "helpMenu": "Hilfemenü",
+      "help": "Helfen",
+      "grouped": "Gruppiert",
+      "group": "Gruppe",
+      "selectAll": "Alle auswählen",
+      "selectRow": "Zeile auswählen",
+      "removeIssue": "Problem beheben",
+      "selectDeselectAllAddEdit": "Alle auswählen/abwählen Hinzufügen/Bearbeiten",
+      "selectDeselectAllDelete": "Alle auswählen/abwählen Löschen",
+      "selectDeselectAllClose": "Alle auswählen/abwählen Schließen",
+      "clearFilter": "Filter löschen",
+      "olderVersion": "Ältere Version",
+      "newerVersion": "Neuere Version",
+      "deletedUser": "Gelöschter Benutzer",
+      "restrictedField": "Eingeschränktes Feld",
+      "backToTestCase": "Zurück zum Testfall"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Projekt} other {# Projekte}}",
+      "templates": "Vorlagen & Felder",
+      "workflows": "Arbeitsabläufe",
+      "statuses": "Status",
+      "roles": "Rollen",
+      "unknownRole": "Unbekannte Rolle",
+      "unknownGroup": "Unbekannte Gruppe",
+      "file": "Datei",
+      "files": "Dateien",
+      "existingAttachments": "Vorhandene Anhänge",
+      "new": "Neu",
+      "noElapsedTime": "Keine Zeitangabe",
+      "untested": "Ungetestet",
+      "noResults": "Keine Ergebnisse",
+      "resultsWithNoElapsedTime": "Für die Ergebnisse wurde keine Zeit erfasst.",
+      "total": "Gesamt",
+      "noCases": "Keine Testfälle",
+      "unknown": "Unbekannt",
+      "selectedTestCases": "Ausgewählte Testfälle",
+      "editToModifyCasesTitle": "Diese Liste kann nicht geändert werden.",
+      "editToModifyCases": "Bearbeiten Sie den Testlauf und klicken Sie auf Ausgewählte Testfälle, um die Liste zu ändern.",
+      "noTestCasesSelected": "Keine Testfälle ausgewählt",
+      "editToSelectTestCases": "Bearbeiten Sie den Testlauf, um Testfälle auszuwählen.",
+      "casesInRun": "{count, plural, =0 {Keine Testfälle im Testlauf} =1 {1 Testfall im Testlauf} other {Anzahl Testfälle im Testlauf}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 eindeutiger Fall} other {# eindeutige Fälle}} insgesamt {configCount, plural, =1 {1 Konfiguration} other {# Konfigurationen}} ({totalCount} insgesamt Fälle)",
+      "viewTestRunDetails": "Details zum Testlauf anzeigen",
+      "sortByStatus": "Nach Status gruppieren",
+      "sortByDate": "Nach Datum sortieren",
+      "testRuns": "{count, plural, =0 {Keine Testläufe} =1 {1 Testlauf} other {Anzahl Testläufe}}",
+      "sessions": "{count, plural, =0 {Keine Sitzungen} =1 {1 Sitzung} other {Anzahl Sitzungen}}",
+      "noOptions": "Keine Optionen verfügbar",
+      "multiConfiguration": "Teil einer Multi-Konfigurationsgruppe",
+      "otherConfigurations": "Andere Konfigurationen",
+      "selected": "Ausgewählt: {count}",
+      "defaultProjectAccess": "Standard-Projektzugriff",
+      "defaultAccessType": "Standardzugriffstyp",
+      "assignedUsersCount": "{count, plural, =0 {Keine Benutzer zugewiesen} =1 {# Benutzer zugewiesen} other {# Benutzer zugewiesen}}",
+      "successRate": "Erfolgsquote",
+      "unassigned": "Nicht zugewiesen",
+      "testRunName": "Name des Testlaufs",
+      "estimatesEllipsis": "Schätzungen...",
+      "access": {
+        "noAccess": "Kein Zugriff",
+        "globalRole": "Globale Rolle verwenden",
+        "specificRole": "Spezifische Rolle",
+        "projectDefault": "Projektstandard",
+        "usersGlobalRole": "Globale Rolle des Benutzers"
+      },
+      "unknownUser": "Unbekannter Benutzer",
+      "unknownProject": "Unbekanntes Projekt",
+      "unknownTag": "Unbekanntes Tag",
+      "filesSelectedForUpload": "{count, plural, =1 {1 Datei zum Hochladen ausgewählt} other {# Dateien zum Hochladen ausgewählt}}"
+    },
+    "empty": {
+      "description": "Keine Beschreibung",
+      "documentation": "Keine Dokumentation",
+      "childMilestones": "Keine kindlichen Meilensteine",
+      "sessions": "Keine Sitzungen",
+      "activeSessions": "Keine aktiven Sitzungen",
+      "completedSessions": "Keine abgeschlossenen Sitzungen",
+      "testCase": "Kein Testfall gefunden",
+      "noTestCasesOrSessions": "Es wurden keine Testfälle oder Sitzungen gefunden.",
+      "noTestCasesSessionsOrRuns": "Es wurden keine Testfälle, Sitzungen oder Testläufe gefunden."
+    },
+    "or": "oder",
+    "for": "für",
+    "and": "Und",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt-Logo",
+      "tagline": "Teste alles, was es gibt!"
+    },
+    "table": {
+      "columns": {
+        "columns": "Spalten",
+        "required": "(erforderlich)"
+      },
+      "filter": "Filterliste...",
+      "selectNone": "Keine auswählen",
+      "sort": "Spalte sortieren",
+      "sortAscending": "Aufsteigend sortiert",
+      "sortDescending": "Absteigend sortiert",
+      "sortNone": "Nicht sortiert",
+      "resize": "Spalte vergrößern"
+    },
+    "pagination": {
+      "selectPage": "Seite auswählen",
+      "morePages": "Weitere Seiten",
+      "goToPrevious": "Zur vorherigen Seite",
+      "goToNext": "Weiter zur nächsten Seite",
+      "all": "Alle Artikel",
+      "entries": "{count, plural, =1 {# Artikel} other {# Artikel}}",
+      "pageSize": "Seitengröße",
+      "showing": "Anzeige",
+      "total": "Gesamt {count, plural, =1 {# Artikel} other {# Artikel}}",
+      "filtered": "gefiltert von",
+      "pageOfPages": "Seite {current} von {total}"
+    },
+    "upload": {
+      "title": "Neues Profilbild hochladen",
+      "description": "Ziehen Sie Ihr Bild per Drag & Drop in die App oder klicken Sie auf die Schaltfläche unten, um eine Datei auszuwählen.",
+      "attachments": {
+        "title": "Anhänge hochladen",
+        "description": "Ziehen Sie Ihre Dateien per Drag & Drop in die App oder klicken Sie auf die Schaltfläche unten, um Dateien auszuwählen.",
+        "selectFiles": "{count, plural, =0 {Dateien auswählen} one {1 ausgewählte Datei} other {Anzahl der ausgewählten Dateien}}",
+        "selectFile": "{count, plural, =0 {Datei auswählen} other {1 Datei ausgewählt}}",
+        "filesSelected": "{count, plural, one {1 Datei ausgewählt} other {Anzahl der ausgewählten Dateien}}",
+        "addMoreFiles": "Weitere Dateien hinzufügen...",
+        "replaceFile": "Datei ersetzen...",
+        "invalidFileType": "Ungültiger Dateityp. Nur {types} -Dateien sind zulässig.",
+        "altText": {
+          "emoji": "Emoji"
+        },
+        "count": "{count, plural, =1 {# Datei} other {# Dateien}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Ziehen Sie eine CSV-Datei zum Importieren der Testfälle.",
+      "dropToImportTestResults": "Datei zum Importieren der Testergebnisse per Drag & Drop ablegen",
+      "supportedCsvFormats": "Unterstütztes Format: .csv",
+      "supportedResultFormats": "Unterstützte Dateiformate: .xml, .trx, .json",
+      "unsupportedFileType": "Nicht unterstützter Dateityp. Erwartet: {expected}",
+      "noFilesDetected": "Im Ordner wurden keine Dateien gefunden."
+    },
+    "editor": {
+      "setColor": "Farbe einstellen",
+      "enterUrl": "Geben Sie die URL einschließlich https:// ein",
+      "uploadFile": "Datei hochladen",
+      "video": {
+        "controls": "Videoplayer-Steuerelemente"
+      },
+      "image": {
+        "alignLeft": "Links ausrichten",
+        "alignCenter": "Zentrieren",
+        "alignRight": "Rechts ausrichten",
+        "sizeSmall": "Kleine Größe",
+        "sizeMedium": "Mittelgroß",
+        "sizeLarge": "Große Größe",
+        "sizeFull": "Volle Breite",
+        "resetSize": "Auf Originalgröße zurücksetzen",
+        "rotate": "Um 90° drehen",
+        "delete": "Bild löschen"
+      },
+      "table": {
+        "insertTable": "Tabelle einfügen",
+        "headerRow": "Kopfzeile",
+        "addColumnBefore": "Spalte vor dem",
+        "addColumnAfter": "Spalte hinzufügen nach",
+        "deleteColumn": "Spalte löschen",
+        "addRowBefore": "Fügen Sie vor der Zeile eine weitere Zeile ein.",
+        "addRowAfter": "Füge nach",
+        "deleteRow": "Zeile löschen",
+        "deleteTable": "Tabelle löschen"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Fügen Sie unten einen Absatz ein.",
+        "clearFormatting": "Klare Formatierung",
+        "copyToClipboard": "In die Zwischenablage kopieren"
+      },
+      "textMenu": {
+        "bold": "Deutlich",
+        "italic": "Kursiv",
+        "underline": "Unterstreichen",
+        "strikethrough": "Durchgestrichen",
+        "code": "Code",
+        "codeBlock": "Codeblock",
+        "highlightText": "Text hervorheben",
+        "textColor": "Textfarbe",
+        "moreOptions": "Mehr Optionen",
+        "subscript": "Index",
+        "superscript": "Hochgestellt",
+        "alignLeft": "Links ausrichten",
+        "alignCenter": "Zentrieren",
+        "alignRight": "Rechts ausrichten",
+        "justify": "Rechtfertigen",
+        "setLink": "Link setzen",
+        "editLink": "Link bearbeiten",
+        "removeLink": "Link entfernen",
+        "resetColorToDefault": "Farbe auf Standard zurücksetzen"
+      }
+    },
+    "ai": {
+      "title": "KI-Schreibassistent",
+      "improveWriting": "Schreiben verbessern",
+      "makeShorter": "Kürzer machen",
+      "makeLonger": "Länger machen",
+      "fixGrammar": "Grammatik korrigieren",
+      "changeTone": "Ton ändern",
+      "professional": "Professional",
+      "casual": "Lässig",
+      "formal": "Formell",
+      "translate": "Übersetzen",
+      "english": "Englisch",
+      "spanish": "Spanisch",
+      "french": "Französisch",
+      "summarize": "Zusammenfassen",
+      "addExamples": "Beispiele hinzufügen",
+      "originalText": "Originaltext",
+      "suggestion": "KI-Vorschlag",
+      "generating": "Generiere Vorschlag...",
+      "noSuggestion": "Es wurden noch keine Vorschläge generiert.",
+      "acceptSuggestion": "Vorschlag annehmen",
+      "errors": {
+        "contentBlocked": "Der Inhalt wurde von Sicherheitsfiltern blockiert. Bitte formulieren Sie Ihre Anfrage anders.",
+        "emptyContent": "Die KI konnte keine Antwort generieren. Bitte formulieren Sie Ihre Anfrage um oder versuchen Sie es später erneut.",
+        "maxTokens": "Die KI-Antwort war zu lang und wurde abgeschnitten. Bitte versuchen Sie eine kürzere Anfrage oder bitten Sie um eine prägnantere Antwort.",
+        "rateLimit": "Der KI-Dienst ist aufgrund von Kapazitätsbeschränkungen vorübergehend nicht verfügbar. Bitte versuchen Sie es in wenigen Minuten erneut.",
+        "accessDenied": "Sie haben keine Berechtigung, KI-Funktionen für dieses Projekt zu verwenden.",
+        "generic": "Leider ist bei der Bearbeitung Ihrer Anfrage ein Fehler aufgetreten."
+      }
+    },
+    "by": "von",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Inhaltsverzeichnis",
+        "emptyMessage": "Beginnen Sie mit dem Hinzufügen von Überschriften zu Ihrem Dokument …"
+      },
+      "carousel": {
+        "previousSlide": "Vorherige Folie",
+        "nextSlide": "Nächste Folie"
+      },
+      "dialog": {
+        "toggleFullScreen": "Vollbildmodus umschalten"
+      },
+      "command": {
+        "title": "Befehlsmenü",
+        "description": "Befehle suchen und ausführen"
+      },
+      "breadcrumb": {
+        "more": "Mehr"
+      },
+      "clickToViewDetails": "Klicken Sie hier, um Details anzuzeigen.",
+      "clickToExpand": "Zum Vergrößern klicken",
+      "clickToCollapse": "Zum Ausblenden klicken",
+      "search": {
+        "filters": "Filter",
+        "noResultsFound": "Keine Ergebnisse gefunden",
+        "loadingProjects": "Projekte werden geladen...",
+        "noProjectsFound": "Keine Projekte gefunden.",
+        "viewAllProjects": "Alle Projekte ansehen",
+        "states": "Staaten",
+        "automationStatus": "Automatisierungsstatus",
+        "parent": "Elternteil"
+      },
+      "issues": {
+        "errorLoadingDetails": "Details zum Ladefehler: ",
+        "updated": "Aktualisiert: ",
+        "openInJira": "In Jira öffnen",
+        "openInExternalSystem": "Öffnen in {provider}",
+        "assignee": "Abtretungsempfänger",
+        "status": "Status: ",
+        "clickToOpenInNewTab": "Zum Öffnen in neuem Tab klicken",
+        "url": "URL: ",
+        "externalId": "Externe ID: ",
+        "viewIn": "Ansehen in",
+        "fieldType": "Feldtyp: ",
+        "richTextContent": "Rich-Text-Inhalte",
+        "invalidContent": "Ungültiger Inhalt",
+        "fieldInformation": "Feldinformationen"
+      },
+      "onboarding": {
+        "skipTour": "Tour überspringen"
+      },
+      "charts": {
+        "resultsDistribution": "Ergebnisverteilung",
+        "statusTimeline": "Status-Zeitleiste",
+        "testDurationHistogram": "Testdauer-Histogramm",
+        "zoomDonutChart": "Zoom Donut-Diagramm",
+        "zoomStatusTimeline": "Zoom-Status-Zeitleiste",
+        "zoomHistogramChart": "Zoom-Histogramm-Diagramm",
+        "duration": "Dauer: {seconds} Sekunden",
+        "durationLabel": "Dauer"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Lade Informationen zum Problem-Tracker...",
+      "enterDocumentation": "Dokumente eingeben...",
+      "noAutomatedTestResults": "Für diesen Durchlauf wurden keine automatisierten Testergebnisse gefunden."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {Minute} other {Minuten}}",
+      "seconds": "{count, plural, =1 {Sekunde} other {Sekunden}}"
+    },
+    "units": {
+      "time": "Zeit"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {Fall} other {Fälle}}",
+      "result": "{count, plural, =1 {Ergebnis} other {Ergebnisse}}",
+      "run": "{count, plural, =1 {run} other {runs}}",
+      "comment": "{count, plural, =1 {{count} Kommentar} other {{count} Kommentare}}"
+    },
+    "success": {
+      "assigned": "Testfall erfolgreich zugewiesen",
+      "unassigned": "Testfall erfolgreich abgemeldet",
+      "bulkAssigned": "{count, plural, one {# Testfall} other {# Testfälle}} erfolgreich zugewiesen",
+      "bulkUnassigned": "{count, plural, one {# Testfall} other {# Testfälle}} erfolgreich nicht zugewiesen"
+    },
+    "tabs": {
+      "general": "Allgemein",
+      "settings": "Einstellungen"
+    },
+    "selectFilter": "Bitte wählen Sie einen Filterwert aus, um Testfälle anzuzeigen.",
+    "invalidProject": "Ungültige Projekt-ID.",
+    "visualization": "Visualisierung",
+    "results": "Ergebnisse",
+    "loading": "Laden..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Neues Konto erstellen",
+      "sso": {
+        "title": "Mit SSO anmelden",
+        "googleOAuth": "Mit Google fortfahren",
+        "apple": "Weiter mit Apple",
+        "microsoft": "Mit Microsoft fortfahren",
+        "samlProvider": "Melden Sie sich mit {name}an.",
+        "magicLink": "Mit Magic Link anmelden",
+        "emailLogin": "Mit der E-Mail fortfahren"
+      },
+      "magicLink": {
+        "description": "Geben Sie Ihre E-Mail-Adresse ein. Wir senden Ihnen dann einen sicheren Link zum Anmelden. Kein Passwort erforderlich. Sie müssen bereits ein Konto besitzen.",
+        "emailPlaceholder": "Geben Sie Ihre E-Mail-Adresse ein",
+        "sendLink": "Magischen Link senden",
+        "sending": "Senden...",
+        "checkEmail": "Überprüfen Sie Ihre E-Mails",
+        "success": "Wir haben Ihnen einen Anmeldelink an {email} gesendet, falls Sie ein Konto besitzen. Klicken Sie auf den Link in der E-Mail, um sich anzumelden.",
+        "error": "Der magische Link konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
+        "backToSignIn": "Zurück zur Anmeldeseite"
+      },
+      "twoFactor": {
+        "title": "Zwei-Faktor-Authentifizierung",
+        "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein oder verwenden Sie einen Ersatzcode."
+      },
+      "troubleSigningIn": "Probleme beim Anmelden?",
+      "contactAdmin": "Wenden Sie sich an den Systemadministrator."
+    },
+    "errors": {
+      "accessDenied": "Zugriff verweigert. Ihr Konto ist möglicherweise inaktiv oder Sie haben keine Berechtigung zum Anmelden.",
+      "configuration": "Es gibt ein Problem mit der Serverkonfiguration.",
+      "verification": "Das Verifizierungstoken ist abgelaufen oder wurde bereits verwendet.",
+      "invalid2FACode": "Ungültiger Bestätigungscode. Bitte versuchen Sie es erneut.",
+      "twoFactorTokenRequired": "Token erforderlich",
+      "verificationCodeRequired": "Ein Bestätigungscode ist erforderlich."
+    },
+    "signup": {
+      "description": "Geben Sie Ihre Daten ein, um sich für ein neues Konto anzumelden.",
+      "signIn": "Melden Sie sich in Ihrem bestehenden Konto an.",
+      "registrationDisabled": "Wenden Sie sich an einen Administrator, um ein Konto zu erstellen.",
+      "errors": {
+        "emailRequired": "E-Mail-Adresse erforderlich",
+        "passwordRequired": "Das Passwort erfüllt nicht die Sicherheitsanforderungen.",
+        "confirmPasswordRequired": "Passwortbestätigung erforderlich",
+        "passwordsDoNotMatch": "Die Passwörter stimmen nicht überein.",
+        "domainRestricted": "Die Registrierung ist auf genehmigte E-Mail-Domänen beschränkt. Bitte kontaktieren Sie Ihren Administrator, falls Sie der Meinung sind, dass dies ein Fehler ist."
+      }
+    },
+    "verifyEmail": {
+      "title": "E-Mail-Adresse bestätigen",
+      "loading": "E-Mail wird überprüft...",
+      "success": "E-Mail-Adresse erfolgreich verifiziert",
+      "error": "E-Mail-Verifizierung fehlgeschlagen",
+      "expired": "Der Bestätigungslink ist abgelaufen.",
+      "invalid": "Ungültiger Verifizierungslink",
+      "alreadyVerified": "E-Mail-Adresse bereits verifiziert",
+      "toast": {
+        "verifySuccess": {
+          "description": "Sie können sich jetzt in Ihr Konto einloggen."
+        },
+        "verifyError": {
+          "description": "Bei der Überprüfung der E-Mail ist ein Fehler aufgetreten."
+        },
+        "resendSuccess": {
+          "title": "E-Mail-Bestätigungslink gesendet",
+          "description": "Bitte prüfen Sie Ihre E-Mails auf den Bestätigungslink."
+        },
+        "resendError": {
+          "title": "E-Mail-Bestätigungslink konnte nicht gesendet werden",
+          "description": "Beim Versenden des E-Mail-Bestätigungslinks ist ein Fehler aufgetreten."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Zwei-Faktor-Authentifizierung einrichten",
+      "description": "Ihre Organisation erfordert eine Zwei-Faktor-Authentifizierung. Richten Sie diese ein, um fortzufahren.",
+      "backupDescription": "Speichern Sie Ihre Backup-Codes, bevor Sie fortfahren.",
+      "required": "Die Sicherheitsrichtlinie Ihrer Organisation schreibt die Zwei-Faktor-Authentifizierung vor.",
+      "loading": "Einrichtung wird vorbereitet...",
+      "manualEntry": "Oder geben Sie diesen Code manuell ein:",
+      "verifyLabel": "Bestätigungscode",
+      "verify": "Überprüfen und Aktivieren",
+      "backupCodesInfo": "Bewahren Sie diese Codes an einem sicheren Ort auf. Sie können sie verwenden, um auf Ihr Konto zuzugreifen, falls Sie Ihr Authentifizierungsgerät verlieren.",
+      "copyCodes": "Alle Codes kopieren",
+      "continue": "Anmelden"
+    },
+    "twoFactorVerify": {
+      "title": "Bestätigen Sie Ihre Identität",
+      "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein, um fortzufahren.",
+      "backupCodeLabel": "Backup-Code",
+      "backupCodeHint": "Sie können auch einen 8-stelligen Backup-Code eingeben.",
+      "useAuthenticator": "Verwenden Sie stattdessen den Authentifizierungscode.",
+      "useBackupCode": "Verwenden Sie stattdessen einen Backup-Code.",
+      "signOut": "Melden Sie sich ab und verwenden Sie ein anderes Konto."
+    },
+    "forceChangePassword": {
+      "title": "Ändern Sie Ihr Passwort",
+      "adminDescription": "Ihr Administrator fordert Sie auf, Ihr Passwort zu ändern.",
+      "expiredDescription": "Ihr Passwort ist abgelaufen. Bitte legen Sie ein neues Passwort fest, um fortzufahren.",
+      "newPasswordLabel": "Neues Passwort",
+      "confirmPasswordLabel": "Neues Passwort bestätigen",
+      "submitButton": "Kennwort ändern",
+      "signOut": "Abmelden",
+      "passwordsMustMatch": "Die Passwörter stimmen nicht überein.",
+      "passwordRequired": "Ein Passwort ist erforderlich.",
+      "genericError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+      "policyTitle": "Passwortanforderungen:",
+      "policyMinLength": "Mindestens {count} Zeichen",
+      "policyUppercase": "Mindestens ein Großbuchstabe",
+      "policyLowercase": "Mindestens ein Kleinbuchstabe",
+      "policyNumbers": "Mindestens eine Zahl",
+      "policySpecialChars": "Mindestens ein Sonderzeichen ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "SSO-Konto verknüpfen",
+      "description": "Verknüpfen Sie Ihr Konto mit einem Single Sign-On-Anbieter.",
+      "availableProviders": "Verfügbare SSO-Anbieter",
+      "linkWithGoogle": "Mit Google verknüpfen",
+      "linkWithSaml": "Verknüpfe mit {name}",
+      "accountLinked": "Konto erfolgreich verknüpft",
+      "linkingFailed": "Konto konnte nicht verknüpft werden",
+      "noProvidersAvailable": "Derzeit sind keine SSO-Anbieter für die Verknüpfung verfügbar.",
+      "linkingInfo": "Durch die Verknüpfung eines SSO-Anbieters können Sie sich mit dessen Hilfe anstelle Ihres Passworts anmelden. Ihre bestehenden Kontodaten bleiben davon unberührt.",
+      "signInWithGoogle": "Mit Google anmelden",
+      "enterpriseSamlSso": "Enterprise SAML SSO",
+      "linkProvider": "Linkanbieter",
+      "linking": "Verknüpfung...",
+      "noProvidersContactAdmin": "Derzeit sind keine SSO-Anbieter verfügbar. Bitte wenden Sie sich an Ihren Administrator."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Armaturenbrett",
+      "admin": "Verwaltung",
+      "profile": "Profil"
+    },
+    "admin": {
+      "crossProjectReports": "Projektübergreifende Berichte"
+    },
+    "projects": {
+      "sections": {
+        "management": "Management"
+      },
+      "menu": {
+        "repository": "Repository",
+        "runs": "Testläufe und Ergebnisse"
+      },
+      "dropdown": {
+        "selectProject": "Wählen Sie ein Projekt aus",
+        "selectProjectAriaLabel": "Projekt auswählen {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "Projekt-ID: {id}",
+      "active": "Das Projekt ist aktiv",
+      "completed": "Projekt abgeschlossen"
+    },
+    "overview": {
+      "title": "Überblick",
+      "currentMilestones": "Aktuelle Meilensteine",
+      "seeAllMilestones": "{count, plural, =1 {Siehe Meilenstein #} other {Alle Meilensteine # anzeigen}}",
+      "seeAllTestCases": "{count, plural, =1 {Siehe Testfall #} other {Siehe alle Testfälle #}}",
+      "latestTestCases": "Neueste Testfälle",
+      "createdOn": "Erstellt am",
+      "seeAllTags": "Alle Schlagwörter anzeigen",
+      "seeAllActiveSessions": "{count, plural, =1 {Aktuelle Sitzung anzeigen} other {Alle aktiven Sitzungen anzeigen}}",
+      "latestSessions": "Neueste Sitzungen",
+      "activeTestRuns": "Aktive Testläufe",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Siehe # Aktive Testläufe} other {Alle # Aktiven Testläufe anzeigen}}",
+      "latestTestRuns": "Neueste Testläufe",
+      "testCaseBreakdown": "Aufschlüsselung der Testfälle",
+      "noTestCases": "Das Projekt-Repository ist leer. Fügen Sie Testfälle mithilfe des Repositorys hinzu.",
+      "noTestCasesPrefix": "Das Projekt-Repository ist leer. Fügen Sie Testfälle mithilfe der",
+      "noTestCasesLink": "Repository"
+    },
+    "icon": {
+      "upload": {
+        "title": "Projekt hochladen-Symbol",
+        "description": "Laden Sie ein quadratisches Bild (Seitenverhältnis 1:1) mit einer Größe von bis zu 4 MB hoch.",
+        "errors": {
+          "invalidFileType": "Es sind nur Bilddateien zulässig.",
+          "fileTooLarge": "Die Datei ist zu groß. Die maximale Größe beträgt {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Einstellungen für {projectName}verwalten",
+      "moreSettingsComingSoon": "Weitere Einstellungen folgen in Kürze.",
+      "moreSettingsDescription": "Weitere Projektkonfigurationsoptionen werden in zukünftigen Updates hier verfügbar sein.",
+      "integrations": {
+        "description": "Verwaltung der Problemintegrationen von Drittanbietern für dieses Projekt",
+        "availableIntegrations": "Verfügbare Problemintegrationen",
+        "availableDescription": "Wählen Sie eine Problemintegration aus, um eine Verbindung zu diesem Projekt herzustellen.",
+        "configuredIntegration": "Konfigurierte Integration",
+        "noIntegrationAssigned": "Keine Problemintegration zugewiesen",
+        "noIntegrationDescription": "Wählen Sie eine Problemintegration aus den verfügbaren Optionen aus, um zu beginnen.",
+        "selectIntegration": "Wählen Sie eine Problemintegration zur Konfiguration aus.",
+        "integration": {
+          "assignError": "Fehler beim Zuweisen der Problemintegration",
+          "updateSuccess": "Integrationseinstellungen aktualisiert",
+          "updateError": "Fehler beim Aktualisieren der Einstellungen für die Problemintegration",
+          "removeError": "Problem beim Entfernen der Integrationsproblematik fehlgeschlagen",
+          "removeIntegration": "Integration entfernen",
+          "confirmRemove": "Entfernen bestätigen",
+          "authDescription": "Sie müssen sich mit {provider} authentifizieren, um diese Problemintegration zu nutzen.",
+          "authenticating": "Authentifizierung läuft...",
+          "authSuccess": "Authentifizierung erfolgreich",
+          "selectProject": "Projekt auswählen {provider}",
+          "selectProjectPlaceholder": "Wählen Sie ein Projekt aus, das verknüpft werden soll.",
+          "linkedProject": "Verknüpftes Projekt",
+          "loadProjectsError": "Projekte konnten nicht geladen werden",
+          "settingsSaved": "Integrationseinstellungen erfolgreich gespeichert",
+          "saveSettingsError": "Fehler beim Speichern der Einstellungen für die Problemintegration",
+          "authorizationRequired": "Autorisierung erforderlich",
+          "authenticationError": "Die Authentifizierung ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+          "authorizationRequiredDescription": "Sie müssen diese Problemintegration autorisieren, um auf externe Projekte zugreifen zu können.",
+          "authorizationMessage": "Bitte genehmigen Sie die Fortsetzung der Problemintegration.",
+          "authorizeIntegration": "Autorisieren {name}",
+          "integrationSettings": "{name} Einstellungen",
+          "integrationSettingsDescription": "Konfigurieren Sie die Einstellungen für die Problemintegration für dieses Projekt.",
+          "selectExternalProject": "Externes Projekt auswählen",
+          "refreshProjects": "Projekte aktualisieren",
+          "defaultIssueType": "Standard-Problemtyp",
+          "selectDefaultIssueType": "Standard-Problemtyp auswählen",
+          "defaultIssueTypeDescription": "Dieser Vorgangstyp wird beim Erstellen neuer Vorgänge vorausgewählt.",
+          "issueTypePlaceholder": "z. B. Bug, Aufgabe, Story",
+          "defaultComponent": "Standardkomponente",
+          "componentPlaceholder": "z. B. Frontend, Backend",
+          "automaticSync": "Automatische Synchronisierung",
+          "automaticSyncDescription": "Automatische Synchronisierung von Problemen zwischen TestPlanIt und dem externen System",
+          "simpleUrlDescription": "Diese Problemintegration verwendet ein einfaches URL-Muster, um auf externe Probleme zu verlinken. Probleme werden in einem neuen Tab mithilfe des konfigurierten URL-Musters geöffnet.",
+          "externalProjectHelp": "Hiermit wird das Standardprojekt für die Erstellung neuer Tickets aus TestPlanIt festgelegt. Tickets aus anderen externen Projekten können weiterhin verknüpft und synchronisiert werden – jedes Ticket verwendet sein eigenes Quellprojekt.",
+          "linkedProjects": "Verknüpfte externe Projekte",
+          "linkedProjectsDescription": "Externe Projekte, die über diese Integration verbunden wurden.",
+          "noLinkedProjects": "Keine externen Projekte verknüpft",
+          "noLinkedProjectsDescription": "Fügen Sie ein externes Projekt hinzu, um die Problemsuche und -synchronisierung zu aktivieren.",
+          "addProjects": "Projekte hinzufügen",
+          "addSelected": "Ausgewählte hinzufügen",
+          "setAsDefault": "Als Standard festlegen",
+          "removeProject": "Projekt entfernen",
+          "removeProjectConfirmation": "Durch das Entfernen dieses Projekts werden keine weiteren Vorgänge mehr synchronisiert. Bereits synchronisierte Vorgänge bleiben erhalten. Fortfahren?",
+          "removeProjectWebhookCascadeBullet": "Der eingehende Webhook für dieses Projekt wird ebenfalls entfernt.",
+          "keepProject": "Projekt beibehalten",
+          "defaultIndicator": "Standard",
+          "syncStatusSyncing": "Synchronisierung",
+          "syncStatusCompleted": "Synchronisiert",
+          "syncStatusError": "Synchronisierungsfehler",
+          "fanOutPartialFailure": "{count} Projekt(e) konnten nicht erreicht werden. Ergebnisse von {successCount} Projekt(en) werden angezeigt.",
+          "projectSelectorLabel": "Projekt",
+          "defaultIssueTypeHelp": "Beim Erstellen neuer Tickets in TestPlanIt wird dieser Tickettyp automatisch ausgewählt. Das spart Zeit, wenn Sie häufig Tickets desselben Typs erstellen.",
+          "automaticSyncHelp": "Wenn diese Funktion aktiviert ist, werden Vorgänge automatisch synchronisiert, sobald Änderungen im externen System erkannt werden (über Webhooks). Eine manuelle Synchronisierung ist jederzeit möglich.",
+          "removeWarningTitle": "Durch das Entfernen dieser Problemintegration wird Folgendes erreicht:",
+          "removeWarning1": "Trennen Sie alle verknüpften Vorgänge von dieser Vorgangsintegration (die Vorgänge bleiben in der Datenbank).",
+          "removeWarning2": "Entfernen Sie alle für die Problemintegration spezifischen Einstellungen für dieses Projekt.",
+          "removeWarning3": "Eine Neukonfiguration ist erforderlich, wenn Sie diese Problemintegration erneut verwenden möchten.",
+          "removeWarning4": "Entfernen Sie den für diese Integration konfigurierten eingehenden Webhook.",
+          "switchIntegration": "Switch-Integration",
+          "switchWarningTitle": "Der Wechsel zu einem anderen KI-Modell wird Folgendes bewirken:",
+          "switchWarning1": "Trennen Sie alle aktuell mit der aktuellen Problemintegration verknüpften Probleme.",
+          "switchWarning2": "Die Einträge in der Datenbank bleiben erhalten (sie werden entkoppelt).",
+          "switchWarning3": "Ersetzen Sie die aktuelle Problemintegrationskonfiguration durch die neue.",
+          "switchWarning4": "Entfernen Sie den für die aktuelle Integration konfigurierten eingehenden Webhook."
+        },
+        "integrationAssigned": "Integration erfolgreich zugewiesen",
+        "integrationAssignError": "Fehler beim Zuordnen der Problemintegration zum Projekt",
+        "integrationRemoved": "Integration erfolgreich entfernt",
+        "integrationRemoveError": "Die Problemintegration konnte nicht aus dem Projekt entfernt werden.",
+        "add": {
+          "jira": {
+            "description": "Verbinden Sie Ihr Jira-Konto, um Probleme direkt in TestPlanIt zu verwalten."
+          },
+          "simple_url": {
+            "description": "Anbindung an ein Drittanbietersystem zur Problemverfolgung."
+          },
+          "github": {
+            "description": "Verbinde dich mit GitHub für die Problemverfolgung und Repository-Verwaltung."
+          },
+          "gitlab": {
+            "description": "Verbinde dich mit GitLab, um Probleme und Merge-Anfragen zu verfolgen."
+          },
+          "gitea": {
+            "description": "Verbinden Sie sich mit einer selbst gehosteten Gitea-, Forgejo- oder Gogs-Instanz, um Probleme zu verfolgen."
+          },
+          "azure_devops": {
+            "description": "Stellen Sie eine Verbindung zu Azure DevOps her, um Arbeitselemente zu verfolgen."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Konfigurieren Sie eingehende Webhooks, um verknüpfte Vorgänge synchron zu halten.",
+        "inboundDescription": "Konfigurieren Sie eingehende Webhooks, um verknüpfte Vorgänge synchron zu halten.",
+        "outboundDescription": "Konfigurieren Sie ausgehende Webhooks, um TestPlanIt-Ereignisse an Slack oder eine beliebige HMAC-signierte URL zu senden.",
+        "directionInbound": "Eingehend",
+        "directionOutbound": "Ausgehend",
+        "inboundAddButtonAllConfigured": "Der eingehende Adapter ist bereits konfiguriert.",
+        "inboundAddButtonNoIntegration": "Weisen Sie diesem Projekt eine Problemintegration zu, bevor Sie einen eingehenden Webhook hinzufügen.",
+        "inboundEmptyWithIntegration": "Es sind keine eingehenden Webhooks konfiguriert. <link>Fügen Sie einen</link> hinzu, um Aktualisierungen zu Ihrem zugewiesenen Issue-Integrationskonto zu erhalten.",
+        "inboundEmptyNoIntegration": "Eine <link>Issue-Integration</link> ist erforderlich, um eingehende Issue-Updates zu empfangen. Weisen Sie Ihrem Projekt eine solche Integration zu, um zu beginnen.",
+        "deliveriesEmptyNoConfigs": "Noch keine Webhook-Zustellungen – erstellen Sie einen eingehenden oder ausgehenden Webhook auf den anderen Registerkarten, um diese zu empfangen.",
+        "noConfig": "Kein Webhook konfiguriert",
+        "createButton": "Webhook erstellen",
+        "url": "Webhook-URL",
+        "urlHelp": "Fügen Sie diese URL in die Webhook-Konfiguration des Issue-Trackers ein.",
+        "secret": "Webhook-Geheimnis",
+        "secretHelp": "Fügen Sie dieses Geheimnis in die Webhook-Konfiguration des Issue-Trackers ein.",
+        "revealedShownOnceWarning": "Kopieren Sie jetzt die unten stehende URL und das Geheimnis – sie werden nur einmal angezeigt und können später nicht abgerufen werden.",
+        "secretMasked": "Ausgeblendet – zum Anzeigen drehen",
+        "rotateSecret": "Geheimnis drehen",
+        "rotateConfirmTitle": "Webhook-Geheimnis rotieren?",
+        "rotateConfirm": "Durch das Ändern des Geheimnisses wird die aktuelle Konfiguration im Issue-Tracker ungültig, bis Sie sie dort aktualisieren. Fortfahren?",
+        "isActive": "Ermöglicht",
+        "deleteConfirmTitle": "Webhook-Konfiguration löschen?",
+        "deleteConfirm": "Wenn Sie diese Webhook-Konfiguration löschen, werden eingehende Lieferungen abgelehnt.",
+        "sendTest": "Test-Webhook senden",
+        "testSuccess": "Webhook-Test akzeptiert (HTTP {statusCode}, Ergebnis: {outcome})",
+        "testFailure": "Test des Webhooks fehlgeschlagen (HTTP {statusCode}): {error}",
+        "saveError": "Webhook-Konfiguration konnte nicht gespeichert werden",
+        "lastReceived": "Zuletzt empfangen: {timestamp}",
+        "lastReceivedLabel": "Zuletzt empfangen:",
+        "lastReceivedNever": "Noch keine Lieferungen",
+        "copyUrl": "Webhook-URL kopieren",
+        "copySecret": "Webhook-Geheimnis kopieren",
+        "urlCopied": "Webhook-URL in die Zwischenablage kopiert",
+        "secretCopied": "Webhook-Geheimnis in die Zwischenablage kopiert",
+        "nextSteps": "Fügen Sie diese Informationen in die Webhook-Konfiguration des Issue-Trackers ein und klicken Sie anschließend unten auf „Test-Webhook senden“, um die Pipeline zu überprüfen. Klicken Sie auf „Fertig“, sobald Sie das Geheimnis gespeichert haben – es kann nicht erneut angezeigt werden.",
+        "revealDone": "Erledigt",
+        "pageTitle": "Webhooks",
+        "inboundTab": "Eingehend",
+        "outboundTab": "Ausgehend",
+        "outboundEmpty": "Es sind keine ausgehenden Webhooks konfiguriert. Fügen Sie einen hinzu, um TestPlanIt-Ereignisse an Slack oder eine beliebige HMAC-signierte URL zu senden.",
+        "outboundAddButton": "Ausgehenden Webhook hinzufügen",
+        "outboundCreateTitle": "Neuer ausgehender Webhook",
+        "outboundCreateName": "Name",
+        "outboundCreateNameHelp": "Eine Bezeichnung für dieses Ziel, z. B. „Engineering Slack“.",
+        "outboundCreateNamePlaceholder": "Engineering Slack",
+        "outboundCreateNameRequired": "Die Angabe des Namens ist erforderlich.",
+        "outboundCreateUrlRequired": "Eine URL ist erforderlich.",
+        "outboundCreateUrlInvalid": "Geben Sie eine gültige URL ein (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "Die URL muss HTTPS verwenden.",
+        "outboundNameLabel": "Name",
+        "outboundUnnamedConfig": "(unbenannter Webhook)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "Die Ziel-URL. Slack-Webhook-URLs werden automatisch erkannt.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Erkannt: Slack",
+        "outboundDetectedHmac": "Erkannt: Generisches HMAC",
+        "adapterLabelSlack": "Locker",
+        "adapterLabelGenericHmac": "Generischer HMAC-Webhook",
+        "outboundCreateSubscriptionsTitle": "Abonnements",
+        "outboundCreateSubscriptionsHelp": "Wählen Sie aus, welche Ereignisse an dieses Ziel gesendet werden sollen. Diese Einstellungen können Sie später ändern.",
+        "outboundSubsTestRunsAndSessions": "Testläufe und Sitzungen",
+        "outboundSubsTestRuns": "Testläufe",
+        "outboundSubsSessions": "Sitzungen",
+        "eventVerbs": {
+          "duplicated": "Dupliziert",
+          "stateChanged": "Status geändert",
+          "resultAdded": "Ergebnis hinzugefügt"
+        },
+        "events": {
+          "testRunCreated": "Testlauf erstellt",
+          "testRunStateChanged": "Testlaufstatus geändert",
+          "testRunCompleted": "Testlauf abgeschlossen",
+          "testRunDuplicated": "Testlauf dupliziert",
+          "testRunResultAdded": "Testlaufergebnis hinzugefügt",
+          "sessionCreated": "Sitzung erstellt",
+          "sessionStateChanged": "Sitzungsstatus geändert",
+          "sessionCompleted": "Sitzung abgeschlossen",
+          "sessionDuplicated": "Sitzung dupliziert",
+          "sessionResultAdded": "Sitzungsergebnis hinzugefügt",
+          "issueCreated": "Problem erstellt",
+          "issueUpdated": "Problem aktualisiert",
+          "issueDeleted": "Problem gelöscht",
+          "caseCreated": "Fall erstellt",
+          "caseUpdated": "Fall aktualisiert",
+          "caseDeleted": "Fall gelöscht",
+          "jiraIssueCreated": "Jira-Ticket erstellt",
+          "jiraIssueUpdated": "Jira-Ticket aktualisiert",
+          "jiraIssueDeleted": "Jira-Vorgang gelöscht",
+          "githubIssues": "GitHub-Probleme-Event",
+          "githubPullRequest": "GitHub-Pull-Anfrage",
+          "githubPush": "GitHub-Push",
+          "githubIssueComment": "GitHub-Issue-Kommentar",
+          "adoWorkitemCreated": "Azure DevOps-Arbeitselement erstellt",
+          "adoWorkitemUpdated": "Azure DevOps-Arbeitselement aktualisiert",
+          "adoWorkitemDeleted": "Azure DevOps-Arbeitselement gelöscht",
+          "webhookTest": "Testereignis"
+        },
+        "outboundSubsIssues": "Probleme",
+        "outboundSubsCases": "Fälle",
+        "outboundSubsSelectAll": "Wählen Sie alle Elemente in diesem Abschnitt aus.",
+        "outboundCreateSubmit": "Webhook erstellen",
+        "outboundCreateCancel": "Stornieren",
+        "outboundCreateSuccess": "Ausgehender Webhook erstellt.",
+        "outboundCreateError": "Fehler beim Erstellen des ausgehenden Webhooks.",
+        "outboundUrlLabel": "Ziel-URL",
+        "outboundActiveToggle": "Aktiv",
+        "outboundSlackHint": "Diese URL ist vertraulich – jeder, der sie besitzt, kann in Ihrem Kanal posten.",
+        "outboundHmacSecretsTitle": "Geheimnisse der Unterschrift",
+        "outboundHmacActiveSecret": "Aktiv",
+        "outboundHmacInactiveSecret": "Inaktiv",
+        "outboundHmacRetiringSecret": "Ruhestand",
+        "outboundHmacAutoRetireIn": "Automatischer Ruhestand in {days} Tagen",
+        "outboundHmacRotateButton": "Geheimnis drehen",
+        "outboundHmacExtendButton": "7 Tage verlängern",
+        "outboundHmacRetireNowButton": "Jetzt in Rente gehen",
+        "outboundRotateConfirmTitle": "Geheime Signatur rotieren?",
+        "outboundRotateConfirm": "Ein neues aktives Geheimnis wird generiert. Das vorherige Geheimnis bleibt 7 Tage lang gültig, während die Verbraucher es aktualisieren.",
+        "outboundRotateSuccess": "Das Geheimnis wurde gedreht. Der neue Klartext wird unten einmal angezeigt.",
+        "outboundRotateError": "Fehler beim Rotieren des Geheimnisses.",
+        "outboundRetireConfirmTitle": "Jetzt das Geheimnis preisgeben?",
+        "outboundRetireConfirm": "Das auslaufende Geheimnis stellt die Signalisierung sofort ein. Verbraucher, die noch das alte Geheimnis verwenden, lehnen neue Datenpakete ab.",
+        "outboundRetireSuccess": "Secret ist im Ruhestand.",
+        "outboundRetireError": "Geheimhaltung nicht sichergestellt.",
+        "outboundExtendSuccess": "Automatischer Ruhestand um 7 Tage verlängert.",
+        "outboundExtendError": "Geheimnis konnte nicht erweitert werden.",
+        "outboundSendTestButton": "Testereignis senden",
+        "outboundSendTestQueued": "Testereignis in der Warteschlange — überprüfen Sie Ihr Ziel auf die Nachricht.",
+        "outboundSendTestError": "Fehler beim Einreihen des Testereignisses.",
+        "outboundDeleteButton": "Webhook löschen",
+        "outboundDeleteConfirmTitle": "Ausgehenden Webhook löschen?",
+        "outboundDeleteConfirm": "Alle weiteren Ereignisse mit diesem Ziel werden sofort eingestellt.",
+        "outboundDeleteSuccess": "Webhook gelöscht.",
+        "outboundDeleteError": "Webhook konnte nicht gelöscht werden.",
+        "outboundSecretCopy": "Geheimnis kopieren",
+        "outboundSecretShownOnce": "Bewahre dieses Geheimnis jetzt auf – es darf nicht wieder enthüllt werden.",
+        "outboundSecretDone": "Erledigt",
+        "inboundAddButton": "Füge einen eingehenden Webhook hinzu.",
+        "inboundChooserTitle": "Adapter auswählen",
+        "inboundChooserDescription": "Wählen Sie den Issue-Tracker aus, der Webhooks an TestPlanIt sendet. Jedes Projekt kann einen Jira-, einen GitHub- und einen Azure DevOps-Webhook für eingehende Anfragen haben.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Bereits konfiguriert",
+        "inboundChooserSubmit": "Weitermachen",
+        "inboundChooserCancel": "Stornieren",
+        "inboundEmpty": "Es sind keine eingehenden Webhooks konfiguriert. Fügen Sie einen hinzu, um Vorgangsaktualisierungen von Jira, GitHub, GitLab, Gitea oder Azure DevOps zu erhalten.",
+        "inboundJiraTitle": "Jira Inbound-Webhook",
+        "inboundGithubTitle": "GitHub-Webhook",
+        "inboundGithubScopeHint": "GitHub <code>issues</code> events update linked TestPlanIt issues. Pull request and issue comment events are accepted but do not update issues yet.",
+        "inboundGitlabTitle": "GitLab-Eingangs-Webhook",
+        "inboundGitlabScopeHint": "GitLab-Ereignisse ( <code>Issue Hook</code> ) aktualisieren verknüpfte TestPlanIt-Vorgänge. Andere Ereignistypen werden zwar akzeptiert, aktualisieren aber keine Vorgänge.",
+        "inboundGiteaTitle": "Gitea Inbound-Webhook",
+        "inboundGiteaScopeHint": "Gitea <code>issues</code> events update linked TestPlanIt issues. Other event types are accepted but do not update issues.",
+        "inboundAdoTitle": "Azure DevOps eingehender Webhook",
+        "inboundAdoScopeHint": "Azure DevOps-Ereignisse <code>workitem.updated</code> aktualisieren verknüpfte TestPlanIt-Vorgänge. Andere Ereignisse werden zwar akzeptiert, aktualisieren aber keine Vorgänge.",
+        "inboundAdoUsername": "Benutzername",
+        "inboundAdoPassword": "Passwort",
+        "inboundAdoUsernamePlaceholder": "Servicekonto",
+        "inboundAdoUsernameHelp": "Die Konfiguration erfolgt auf der Azure DevOps Service Hook-Seite. TestPlanIt überprüft dies über HTTP-Basisauthentifizierung.",
+        "inboundAdoPasswordHelp": "Im Ruhezustand verschlüsselt gespeichert. Speichern Sie diesen Wert auch auf der Azure DevOps Service Hook-Seite.",
+        "inboundAdoResourceDetailsHint": "Bei der Konfiguration des Azure DevOps Service Hooks sollte die Option „Zu sendende Ressourcendetails“ auf „Alle“ gesetzt werden, damit System.State in die Nutzlast aufgenommen wird.",
+        "setupStepsTitle": "Einrichtungsschritte",
+        "setupStepsJiraStep1": "Gehen Sie in Jira zu Einstellungen → System → WebHooks (oder zur Webhook-Konfigurationsseite Ihres Jira-Administrators).",
+        "setupStepsJiraStep2": "Klicken Sie auf „WebHook erstellen“. Fügen Sie die unten stehende URL in das Feld „URL“ und das Geheimnis in das Feld „Geheimnis“ ein.",
+        "setupStepsJiraStep3": "Unter „Problembezogene Ereignisse“ aktivieren Sie die Option „Aktualisiert“, damit Statusänderungen des Problems gesendet werden.",
+        "setupStepsJiraStep4": "Speichern Sie den Webhook. Verwenden Sie unten „Test-Webhook senden“, um die Pipeline zu überprüfen.",
+        "setupStepsGithubStep1": "Gehen Sie in Ihrem GitHub-Repository zu Einstellungen → Webhooks → Webhook hinzufügen.",
+        "setupStepsGithubStep2": "Fügen Sie die unten stehende URL in das Feld „Payload-URL“ ein. Stellen Sie den Inhaltstyp auf „application/json“ ein.",
+        "setupStepsGithubStep3": "Fügen Sie das unten stehende Geheimnis in das Feld „Geheimnis“ ein.",
+        "setupStepsGithubStep4": "Wählen Sie „Einzelne Ereignisse auswählen“ und aktivieren Sie „Probleme“.",
+        "setupStepsGithubStep5": "Klicken Sie auf „Webhook hinzufügen“. Verwenden Sie anschließend „Test-Webhook senden“, um die Pipeline zu überprüfen.",
+        "setupStepsAdoStep1": "Gehen Sie in Ihrem Azure DevOps-Projekt zu Projekteinstellungen → Diensthooks → Abonnement erstellen.",
+        "setupStepsAdoStep2": "Wählen Sie als Dienst „Web Hooks“ aus. Stellen Sie den Auslöser auf „Arbeitselement aktualisiert“ ein.",
+        "setupStepsAdoStep3": "Stellen Sie die zu sendenden Ressourcendetails auf „Alle“ ein, damit auch System.State enthalten ist.",
+        "setupStepsAdoStep4": "Fügen Sie die unten stehende URL in das URL-Feld ein. Legen Sie Benutzername und Passwort für die Basisauthentifizierung auf die oben eingegebenen Werte fest.",
+        "setupStepsAdoStep5": "Speichern Sie das Abonnement. Verwenden Sie unten „Test-Webhook senden“, um die Pipeline zu überprüfen.",
+        "setupStepsGitlabStep1": "In GitLab gehen Sie zu Ihrem Projekt → Einstellungen → Webhooks.",
+        "setupStepsGitlabStep2": "Fügen Sie die unten stehende URL in das Feld „URL“ ein. Fügen Sie den unten stehenden geheimen Token in das Feld „Geheimer Token“ ein.",
+        "setupStepsGitlabStep3": "Aktivieren Sie unter „Trigger“ die Option „Problemereignisse“.",
+        "setupStepsGitlabStep4": "Klicken Sie auf „Webhook hinzufügen“. Verwenden Sie anschließend „Test-Webhook senden“, um die Pipeline zu überprüfen.",
+        "setupStepsGiteaStep1": "In Gitea gehen Sie zu Ihrem Repository → Einstellungen → Webhooks.",
+        "setupStepsGiteaStep2": "Klicken Sie auf „Webhook hinzufügen“ und wählen Sie „Gitea“.",
+        "setupStepsGiteaStep3": "Fügen Sie die unten stehende URL in das Feld „Ziel-URL“ ein. Fügen Sie den unten stehenden Geheimcode in das Feld „Geheimcode“ ein.",
+        "setupStepsGiteaStep4": "Wählen Sie unter „Auslösen bei“ die Option „Probleme“ aus.",
+        "setupStepsGiteaStep5": "Klicken Sie auf „Webhook hinzufügen“. Verwenden Sie unten „Test-Webhook senden“, um die Pipeline zu überprüfen.",
+        "deliveriesTab": "Lieferungen",
+        "filterConfigPlaceholder": "Alle Webhooks",
+        "filterStatusAll": "Alle",
+        "filterStatusFailed": "Fehlgeschlagen",
+        "filterStatusSuccess": "Erfolg",
+        "filterSinceDefault": "Seit…",
+        "filterUntilDefault": "Bis…",
+        "filterReset": "Filter zurücksetzen",
+        "filterBulkReplayButton": "Massenwiedergabe {count} Ausgehende Fehler",
+        "filterBulkReplayHidden": "Alle sichtbaren Fehler sind eingehende Fehler – lösen Sie stattdessen das vorgelagerte Ereignis erneut aus.",
+        "deliveriesEmpty": "Es wurden keine Lieferungen gefunden, die diesen Filtern entsprechen.",
+        "deliveriesResetFilters": "Filter zurücksetzen",
+        "deliveriesLoadMore": "Mehr laden",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Ereignis",
+        "tableHeaderStatus": "Status",
+        "tableHeaderError": "Fehler",
+        "tableHeaderReceivedAt": "Erhalten",
+        "tableHeaderAttempt": "Versuchen",
+        "tableHeaderDirection": "Richtung",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Details anzeigen",
+        "drawerTitle": "Lieferdetails",
+        "drawerLabelEvent": "Ereignis",
+        "drawerLabelDirection": "Richtung",
+        "drawerLabelStatusCode": "Statuscode",
+        "drawerLabelLatency": "Latenz",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Fehler",
+        "drawerLabelPayloadDigest": "Payload-Digest",
+        "drawerLabelEventId": "Ereignis-ID",
+        "drawerLabelAttempt": "Versuchen",
+        "drawerLabelReceivedAt": "Eingegangen bei",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Wiederholung von {id}",
+        "drawerReplayButton": "Diese Sendung erneut abspielen",
+        "drawerInboundReplayNotSupported": "Eingehende Lieferungen können nicht wiederholt werden – lösen Sie stattdessen das vorgelagerte Ereignis erneut aus.",
+        "replayConfirmTitle": "Diese Sendung erneut abspielen?",
+        "replayConfirm": "Dies löst eine echte {direction} {adapterType} Anfrage aus.",
+        "replayAction": "Wiederholung",
+        "bulkReplayConfirmTitle": "Ausgehende Verbindungsfehler erneut abspielen?",
+        "bulkReplayConfirm": "Replay {count} outbound failures to {configName}? This will fire {count} real HTTP requests.",
+        "bulkReplayCapExceeded": "Die Massenwiedergabe ist auf 100 ausgehende Nachrichten gleichzeitig beschränkt. Filtern Sie die Nachrichten ein oder führen Sie die Wiedergabe sequenziell aus. Aktuell würde {count} wiederholt werden.",
+        "bulkReplayAction": "Wiederholung {count}",
+        "healthBadge": {
+          "HEALTHY": "Gesund",
+          "DEGRADED": "Abgebaut",
+          "DISABLED": "Deaktiviert"
+        },
+        "healthTooltipHealthy": "Letzter Erfolg: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} aufeinanderfolgende Fehler · zuletzt bei {lastFailureAt}",
+        "healthTooltipDisabled": "Deaktiviert nach 10 aufeinanderfolgenden Fehlern · {lastFailureAt}",
+        "activityLabel": "Liefertätigkeit",
+        "activityLastDispatched": "Zuletzt versendet",
+        "activityLastSuccess": "Letzter Erfolg",
+        "activityLastFailure": "Letzter Fehlschlag",
+        "activityNever": "Niemals",
+        "reEnable": "erneut aktivieren",
+        "reEnableConfirmTitle": "Diesen Webhook wieder aktivieren?",
+        "reEnableConfirm": "Bitte vergewissern Sie sich, dass das vorgelagerte Problem behoben ist, bevor Sie die Funktion wieder aktivieren. Der Webhook wird dann umgehend wieder versendet.",
+        "toastReplaySuccess": "Wiederholung in der Warteschlange",
+        "toastReplayFailed": "Wiederholung fehlgeschlagen: {error}",
+        "toastReplayInboundNotSupported": "Eingehende Lieferungen können nicht wiederholt werden.",
+        "toastBulkReplaySuccess": "Massenwiedergabe gestartet · Batch {batchId}",
+        "toastBulkReplayFailed": "Massenwiedergabe fehlgeschlagen: {error}",
+        "toastReEnableSuccess": "Webhook wieder aktiviert",
+        "toastReEnableFailed": "Reaktivierung fehlgeschlagen: {error}"
+      },
+      "aiModels": {
+        "description": "KI-Modelle für die intelligente Generierung und Analyse von Testfällen konfigurieren",
+        "availableModels": "Projektstandard",
+        "availableModelsDescription": "Wählen Sie für dieses Projekt ein Standard-KI-Modell aus den von Ihrem Systemadministrator konfigurierten Modellen aus.",
+        "currentModelSettings": "Aktuelle Modelleinstellungen",
+        "currentModelDescription": "Konfigurationsdetails für das aktuell aktive KI-Modell: {name}",
+        "noModelsAvailable": "Es sind derzeit keine KI-Modelle verfügbar. Wenden Sie sich an Ihren Systemadministrator, um KI-Modelle für Ihre Organisation zu konfigurieren.",
+        "monthlyBudget": "Monatliches Budget",
+        "model": "Modell",
+        "budget": "Budget",
+        "streamingTooltip": "Echtzeit-Antwortstreaming aktiviert",
+        "systemDefault": "Systemvorgabe",
+        "setAsDefault": "Als Standard festlegen",
+        "clearDefault": "Standardeinstellungen löschen",
+        "useForProject": "Verwendung für Projekt",
+        "removeModel": "Standardeinstellungen löschen",
+        "removeWarningTitle": "Durch das Löschen des Standard-KI-Modells wird Folgendes bewirkt:",
+        "removeWarning1": "Deaktivieren Sie KI-gestützte Funktionen, es sei denn, es sind individuelle Funktionsüberschreibungen konfiguriert.",
+        "removeWarning2": "Entfernen Sie das für die Testfallgenerierung und -analyse verwendete Ausweichmodell.",
+        "switchModel": "Standardeinstellung ändern",
+        "switchWarningTitle": "Die Änderung des Standard-KI-Modells hat folgende Auswirkungen:",
+        "switchWarning1": "Ändern Sie das Verhalten der KI-Funktionen in diesem Projekt.",
+        "switchWarning2": "Kann die Qualität und den Stil der generierten Inhalte beeinträchtigen.",
+        "modelAssigned": "Standard-KI-Modell für dieses Projekt festgelegt",
+        "modelAssignError": "Fehler beim Festlegen des Standard-KI-Modells",
+        "modelRemoved": "Standard-KI-Modell gelöscht",
+        "modelRemoveError": "Fehler beim Löschen des Standard-KI-Modells",
+        "confirmRemove": "Möchten Sie \"{name}\" wirklich als Standard für dieses Projekt löschen?",
+        "confirmSwitch": "Möchten Sie die Standardeinstellung wirklich von \"{from}\" auf \"{to} \" ändern?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/mo"
+        },
+        "promptConfig": "Eingabeaufforderungskonfiguration",
+        "promptConfigDescription": "Wählen Sie die für dieses Projekt zu verwendende KI-Prompt-Konfiguration aus.",
+        "useSystemDefault": "Systemstandard verwenden",
+        "promptConfigChanged": "Die Konfiguration der Eingabeaufforderung wurde erfolgreich aktualisiert.",
+        "featureOverrides": {
+          "title": "LLM-Überschreibungen pro Funktion",
+          "description": "Die standardmäßige LLM-Integration kann für bestimmte KI-Funktionen überschrieben werden. Überschreibungen haben in der Auflösungshierarchie höchste Priorität.",
+          "feature": "Besonderheit",
+          "override": "Überschreiben",
+          "effectiveLlm": "Effektiver LLM",
+          "source": "Quelle",
+          "noOverride": "Keine Überschreibung",
+          "noLlm": "Kein LLM (behindert)",
+          "disabledOverride": "Deaktiviert (Überschreibung)",
+          "projectOverride": "Projektüberschreibung",
+          "promptConfig": "Prompt-Konfiguration",
+          "noLlmConfigured": "Kein LLM konfiguriert",
+          "selectIntegration": "Integration auswählen...",
+          "overrideSaved": "Funktionsüberschreibung gespeichert",
+          "overrideCleared": "Funktionsüberschreibung gelöscht",
+          "overrideError": "Feature-Überschreibung konnte nicht gespeichert werden"
+        }
+      },
+      "shares": {
+        "title": "Aktien verwalten",
+        "description": "Alle Freigabelinks für dieses Projekt anzeigen und verwalten"
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Aktivieren Sie QuickScript und verbinden Sie ein Code-Repository für die KI-gestützte Testgenerierung.",
+        "enableLabel": "QuickScript aktivieren",
+        "enableDescription": " Erlauben Sie Teammitgliedern, QuickScript zu verwenden, um Testfälle in diesem Projekt in Automatisierungsskripte umzuwandeln.",
+        "enabledToast": "QuickScript aktiviert",
+        "disabledToast": "QuickScript deaktiviert",
+        "noRepos": {
+          "title": "Es sind keine Code-Repositories konfiguriert.",
+          "adminDescription": "Richten Sie eine Repository-Verbindung ein, bevor Sie den Codekontext für dieses Projekt konfigurieren.",
+          "adminLink": "Gehe zu den Code-Repositories",
+          "userDescription": "Wenden Sie sich an Ihren Systemadministrator, um eine Verbindung zum Code-Repository einzurichten."
+        },
+        "repository": {
+          "title": "Code-Repository",
+          "description": "Wählen Sie das Code-Repository aus, das für den KI-Kontext verwendet werden soll.",
+          "placeholder": "Wählen Sie ein Code-Repository aus...",
+          "branchLabel": "Zweig",
+          "branchPlaceholder": "Lassen Sie dieses Feld leer, um den Standardzweig des Repositorys zu verwenden."
+        },
+        "pathPatterns": {
+          "title": "Pfadmuster",
+          "description": "Geben Sie an, welche Dateien einbezogen werden sollen. Jede Zeile kombiniert einen Basispfad und ein Glob-Muster. Beispiele: `path=tests/e2e/pages + pattern=*` schließt alle Dateien direkt in diesem Ordner ein; `path=src + pattern=**/*.test.ts` schließt alle Testdateien rekursiv ein.",
+          "pathLabel": "Weg",
+          "pathPlaceholder": "tests/e2e/pages",
+          "patternLabel": "Muster",
+          "addPath": "Pfad hinzufügen",
+          "previewFiles": "Vorschau der Dateien",
+          "scanningRepo": "Repository-Dateien werden durchsucht… ({seconds}s)",
+          "files": "{count, plural, one {# Datei} other {# Dateien}}",
+          "truncatedBadge": "Die Ergebnisse können unvollständig sein (Anbieterbeschränkung).",
+          "exceedsLimit": "Die Gesamtgröße überschreitet das KI-Kontextlimit um {overflow}. Beim Export werden die Dateien nach ihrer Relevanz für den zu exportierenden Testfall sortiert – die relevantesten Dateien werden zuerst berücksichtigt, und Dateien mit niedrigerer Relevanz werden übersprungen, sobald das Budget erreicht ist. Schränken Sie Ihre Pfadmuster ein, wenn Sie genauer steuern möchten, welche Dateien berücksichtigt werden."
+        },
+        "preview": {
+          "resolvingBranch": "Auflösen des Zweigs…",
+          "scanningFiles": "Dateien werden gescannt in {scope}…",
+          "scanningFilesCount": "Dateien werden in {scope}… durchsucht ({count} gefunden)",
+          "filtering": "Anwenden von Filtern auf {count} Dateien…"
+        },
+        "cache": {
+          "title": "Cache-Einstellungen",
+          "description": "Dateien werden in Valkey zwischengespeichert, um während der KI-Generierung einen schnellen Zugriff zu ermöglichen.",
+          "enableLabel": "Dateizwischenspeicherung aktivieren",
+          "disabledWarning": "Die Dateizwischenspeicherung ist deaktiviert. Repository-Dateien werden beim Export direkt von Ihrem Anbieter abgerufen und nicht in TestPlanIt gespeichert. KI-gestütztes QuickScript enthält weiterhin Codekontext, jedoch wird bei jedem Export eine Live-Anfrage an Ihr Repository gesendet.",
+          "ttlLabel": "Cache-Dauer (Tage)",
+          "statusTitle": "Cache-Status",
+          "refreshButton": "Cache aktualisieren",
+          "listingFiles": "Dateien auflisten…",
+          "cachingFiles": "Zwischenspeicherung {count} Dateien…",
+          "statusNeverFetched": "Nie abgeholt",
+          "statusPending": "Erfrischend...",
+          "lastFetched": "Zuletzt abgerufen",
+          "filesCached": "Zwischengespeicherte Dateien",
+          "totalSize": "Gesamtgröße"
+        },
+        "save": "Konfiguration speichern",
+        "saved": "Codekontextkonfiguration gespeichert",
+        "saveError": "Konfiguration konnte nicht gespeichert werden",
+        "listError": "Fehler beim Auflisten der Repository-Dateien",
+        "contentsError": "Dateiinhalt konnte nicht zwischengespeichert werden",
+        "networkError": "Netzwerkfehler während der Cache-Aktualisierung",
+        "refreshSuccess": "Cache aktualisiert: {fileCount} Dateien ({contentCached} Inhalt zwischengespeichert)",
+        "refreshRateLimited": "Cache aktualisiert: {fileCount} Dateien aufgelistet, {contentCached}/{fileCount} Inhalte zwischengespeichert (Rate begrenzt – erneut aktualisieren, um den Vorgang abzuschließen)",
+        "validation": {
+          "pathRequired": "Pfad erforderlich",
+          "patternRequired": "Ein Schnittmuster ist erforderlich.",
+          "repositoryRequired": "Ein Repository ist erforderlich.",
+          "pathPatternRequired": "Mindestens ein Pfadmuster ist erforderlich."
+        },
+        "exportTemplates": {
+          "title": "Exportvorlagen",
+          "description": "Weisen Sie diesem Projekt Exportvorlagen zu. Nur die zugewiesenen Vorlagen werden im Exportdialog angezeigt.",
+          "noTemplates": "Es sind keine Exportvorlagen aktiviert. Wenden Sie sich an Ihren Systemadministrator.",
+          "assignedLabel": "Zugewiesene Vorlagen",
+          "selectPlaceholder": "Wählen Sie die zuzuweisenden Vorlagen aus...",
+          "defaultLabel": "Standardvorlage",
+          "defaultPlaceholder": "Keine (globalen Standardwert verwenden)",
+          "assigned": "Zugewiesen",
+          "save": "Vorlagenzuweisungen speichern",
+          "saved": "Vorlagenzuweisungen gespeichert",
+          "saveError": "Vorlagenzuweisungen konnten nicht gespeichert werden"
+        },
+        "disconnect": "Repository trennen",
+        "confirmDisconnect": "Möchten Sie \"{name}\" wirklich von diesem Projekt trennen?",
+        "disconnectWarningTitle": "Durch das Trennen dieses Repositorys wird Folgendes bewirkt:",
+        "disconnectWarning1": "Entfernen Sie alle zwischengespeicherten Repository-Dateien.",
+        "disconnectWarning2": "Pfadmuster und Zweigkonfigurationen entfernen",
+        "disconnectWarning3": "Die Einbeziehung des Codekontexts in KI-generierte Exporte sollte eingestellt werden.",
+        "disconnectSuccess": "Code-Repository getrennt",
+        "disconnectError": "Fehler beim Trennen des Code-Repositorys"
+      }
+    }
+  },
+  "milestones": {
+    "title": "Meilenstein-Details",
+    "fields": {
+      "parent": "Meilenstein der Elterngruppe",
+      "dueDate": "Fälligkeitsdatum",
+      "automaticCompletion": "Automatische Vervollständigung am Fälligkeitstag",
+      "notifyDaysBefore": "Benachrichtigen Sie Tage vor dem Fälligkeitstermin",
+      "notifyDaysBeforeValue": "Benachrichtige {count, plural, one {# Tag} other {# Tage}} vor dem Fälligkeitsdatum",
+      "dueDateNotifications": "Benachrichtigungen zum Fälligkeitstermin"
+    },
+    "labels": {
+      "childMilestones": "Meilensteine der Kindheit"
+    },
+    "placeholders": {
+      "description": "Meilensteinbeschreibung eingeben...",
+      "documentation": "Meilensteindokumentation eingeben...",
+      "selectType": "Meilensteintyp auswählen...",
+      "selectParent": "Wählen Sie den übergeordneten Meilenstein aus..."
+    },
+    "empty": {
+      "active": "Keine aktiven Meilensteine",
+      "completed": "Keine Meilensteine abgeschlossen",
+      "description": "Keine Beschreibung vorhanden",
+      "documentation": "Es wurde keine Dokumentation bereitgestellt.",
+      "testRuns": "Keine Testläufe",
+      "forecasts": "Es sind keine Prognosedaten verfügbar."
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Nicht gestartet",
+      "IN_PROGRESS": "Im Gange",
+      "STOPPED": "Angehalten",
+      "BLOCKED": "Blockiert",
+      "CANCELLED": "Abgesagt",
+      "unscheduled": "Ungeplant",
+      "upcoming": "Demnächst",
+      "delayed": "Verzögert",
+      "pastDue": "Überfällig",
+      "started": "Begonnen",
+      "completed": "Vollendet"
+    },
+    "status": {
+      "stop": "Stoppen",
+      "reopen": "Wieder öffnen"
+    },
+    "dates": {
+      "pickStartDate": "Wählen Sie das Startdatum",
+      "pickCompletionDate": "Wählen Sie das Fertigstellungsdatum",
+      "selectDate": "Datum auswählen...",
+      "completionWarning": "Warnung: Dadurch wird dieser Meilenstein als abgeschlossen markiert."
+    },
+    "toast": {
+      "deleted": "Meilenstein {name} gelöscht",
+      "updated": "Meilenstein aktualisiert",
+      "updateFailed": "Meilenstein konnte nicht aktualisiert werden",
+      "completed": "Meilenstein \"{name}\" abgeschlossen.",
+      "completedWithDependencies": "Meilenstein und Abhängigkeiten erfolgreich abgeschlossen."
+    },
+    "errors": {
+      "nameExists": "Ein Meilenstein mit diesem Namen existiert bereits.",
+      "nameRequired": "Meilensteinname erforderlich",
+      "notFound": "Meilenstein nicht gefunden"
+    },
+    "actions": {
+      "add": "Meilenstein hinzufügen"
+    },
+    "delete": {
+      "title": "Meilenstein löschen",
+      "confirmMessage": "Möchten Sie den Meilenstein {name}wirklich löschen?",
+      "warning": "Dieser Meilenstein wird aus dem Projekt entfernt. Die historischen Daten für diesen Meilenstein bleiben jedoch im Projekt erhalten.",
+      "toast": {
+        "loading": "Meilenstein wird gelöscht...",
+        "success": "Meilenstein erfolgreich gelöscht",
+        "error": {
+          "title": "Meilenstein konnte nicht gelöscht werden",
+          "description": "Beim Löschen des Meilensteins ist ein Fehler aufgetreten."
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Meilensteinabschluss bestätigen",
+      "confirmDescription": "Mit dem Erreichen dieses Meilensteins werden auch die folgenden damit verbundenen Punkte erledigt:",
+      "impactActiveTestRuns": "{count, plural, one {# aktiver Testlauf} other {# aktive Testläufe}}",
+      "impactActiveSessions": "{count, plural, one {# aktive Sitzung} other {# aktive Sitzungen}}",
+      "impactDescendantMilestones": "{count, plural, one {# Meilenstein der Nachkommen} other {# Meilensteine der Nachkommen}}",
+      "completeTestRunsLabel": "Zugehörige Testläufe abschließen ({count, plural, one {# aktiv} other {# aktiv}})",
+      "completeSessionsLabel": "Zugehörige Sitzungen abschließen ({count, plural, one {# aktiv} other {# aktiv}})",
+      "testRunStateLabel": "Status des abgeschlossenen Testlaufs",
+      "sessionStateLabel": "Sitzungsabschlussstatus",
+      "itemsRemaining": "Folgende Elemente bleiben aktiv:",
+      "processing": "Verarbeitung...",
+      "confirmAndCompleteAll": "Alle bestätigen und abschließen"
+    },
+    "notifications": {
+      "dueSoon": "Meilenstein \"{name}\" ist fällig am {dueDate}",
+      "overdue": "Der Meilenstein \"{name}\" war am {dueDate} fällig."
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Sitzung} other {Sitzungen}}",
+    "labels": {
+      "totalElapsed": "Zeitaufwand",
+      "remaining": "Verbleibend: {time}",
+      "overtime": "Über die Schätzung um: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Keine abgeschlossenen Sitzungen entsprechen Ihrem Filter."
+    },
+    "filter": {
+      "placeholder": "Sitzungen filtern..."
+    },
+    "actions": {
+      "add": "Sitzung hinzufügen",
+      "create": "Neue Sitzung erstellen",
+      "edit": "Bearbeitungssitzung",
+      "complete": "Sitzung abschließen",
+      "delete": "Sitzung löschen",
+      "viewSessionDetails": "Sitzung ansehen"
+    },
+    "noMilestone": "Kein Meilenstein",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Für dieses Projekt sind keine Abschluss-Workflows konfiguriert. Bitte konfigurieren Sie Workflows in den Administratoreinstellungen, um den Sitzungsabschluss zu aktivieren."
+    },
+    "messages": {
+      "createSuccess": "Sitzung erfolgreich erstellt",
+      "createSuccessMultiple": "{count} Sitzungen erfolgreich erstellt",
+      "duplicateSuccess": "Sitzung erfolgreich dupliziert.",
+      "duplicateSuccessMultiple": "{count} Sitzungen erfolgreich dupliziert"
+    },
+    "duplicateDialog": {
+      "title": "Doppelte Sitzung",
+      "description": "Erstelle eine Kopie der Sitzung <nameStyle>{name}</nameStyle> mit allen Metadaten, aber ohne Ergebnisse."
+    },
+    "errors": {
+      "failedToCreate": "Es konnte keine neue Sitzung erstellt werden.",
+      "failedToCreateVersion": "Sitzungsversion konnte nicht erstellt werden",
+      "nameAlreadyExists": "Dieser Sitzungsname ist bereits vergeben. Bitte wählen Sie einen neuen Namen.",
+      "createFailed": "Sitzung konnte nicht erstellt werden",
+      "duplicateFailed": "Sitzung konnte nicht dupliziert werden"
+    },
+    "validation": {
+      "nameMinLength": "Der Name muss mindestens 2 Zeichen lang sein.",
+      "templateRequired": "Bitte wählen Sie eine Vorlage aus.",
+      "maxDuration": "Die Dauer muss kleiner oder gleich {max}sein."
+    },
+    "placeholders": {
+      "estimate": "Schätzung (z. B. 1 Std. 30 Min.)",
+      "elapsed": "Verstrichene Zeit (z. B. 2 Tage 4 Stunden)",
+      "selectUser": "Benutzer auswählen",
+      "estimateHint": "z. B. 2 Stunden 30 Minuten",
+      "noEstimate": "Keine Schätzung festgelegt"
+    },
+    "delete": {
+      "confirmMessage": "Möchten Sie die Sitzung {name}wirklich löschen?",
+      "warning": "Diese Sitzung wird aus dem Projekt entfernt. Die historischen Daten dieser Sitzung bleiben jedoch im Projekt erhalten.",
+      "toast": {
+        "loading": "Sitzung wird gelöscht...",
+        "success": "Sitzung erfolgreich gelöscht",
+        "error": {
+          "title": "Sitzung konnte nicht gelöscht werden",
+          "description": "Beim Löschen der Sitzung ist ein Fehler aufgetreten."
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Möchten Sie die Sitzung {name}wirklich abschließen?",
+      "warning": "Nach Abschluss der Sitzung wird diese dauerhaft archiviert und kann nicht mehr aktualisiert werden.",
+      "fields": {
+        "completionDate": "Fertigstellungsdatum"
+      },
+      "placeholders": {
+        "pickDate": "Wähle ein Datum"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Geschätzte verbleibende Gesamtzeit:",
+      "recentResultsTitle": "Zusammenfassung der aktuellen Ergebnisse",
+      "recentResultsDescription": "Zusammenfassung der Sitzungsergebnisse.",
+      "noRecentResults": "Es wurden keine aktuellen Sitzungsergebnisse aufgezeichnet.",
+      "completionTrendTitle": "Fertigstellungstrend",
+      "completionTrendDescription": "Abgeschlossene Sitzungen pro Monat.",
+      "noCompletedRuns": "In den letzten 6 Monaten wurden keine abgeschlossenen Durchläufe gefunden.",
+      "completionTrendTitle6Mo": "Fertigstellungstrend (letzte 6 Monate)",
+      "noCompletedSessions6Mo": "In den letzten 6 Monaten wurden keine Sitzungen abgeschlossen."
+    },
+    "version": {
+      "title": "Sitzungsverlauf anzeigen",
+      "notFound": "Sitzungsversion nicht gefunden.",
+      "selectVersion": "Version auswählen",
+      "backToSession": "Zurück zur Sitzung",
+      "backToLatest": "Zurück zur neuesten Version",
+      "versionInfo": {
+        "created": "Version {number} Erstellt",
+        "latestUpdated": "Neueste Version {number} Aktualisiert"
+      },
+      "renderer": {
+        "noEstimate": "Keine Schätzung",
+        "noTimeLogged": "Keine Zeiterfassung",
+        "noContent": "Kein Inhalt",
+        "currentVersion": "Aktuelle Version",
+        "previousVersion": "Vorherige Version"
+      },
+      "diff": {
+        "added": "Hinzugefügt",
+        "removed": "ENTFERNT",
+        "changed": "Geändert"
+      }
+    },
+    "results": {
+      "section": "Sitzungsprotokoll",
+      "add": "Sitzungsergebnis hinzufügen",
+      "edit": "Ergebnis der Bearbeitungssitzung",
+      "editDescription": "Nehmen Sie die gewünschten Änderungen am Sitzungsergebnis vor und klicken Sie anschließend auf Speichern.",
+      "details": "Geben Sie hier Details zum Ergebnis ein...",
+      "noResults": "Es wurden noch keine Ergebnisse hinzugefügt.",
+      "noNotes": "Für dieses Ergebnis wurden keine Anmerkungen hinzugefügt.",
+      "deleteSuccess": "Sitzungsergebnis erfolgreich gelöscht",
+      "deleteError": "Sitzungsergebnis konnte nicht gelöscht werden",
+      "updateSuccess": "Sitzungsergebnis erfolgreich aktualisiert",
+      "updateError": "Aktualisierung des Sitzungsergebnisses fehlgeschlagen",
+      "linkCopied": "Link zum Sitzungsergebnis in die Zwischenablage kopiert",
+      "copyFailed": "Fehler beim Kopieren des Sitzungsergebnisses",
+      "confirmDelete": {
+        "title": "Ergebnis der Sitzungslöschung",
+        "description": "Möchten Sie dieses Sitzungsergebnis wirklich löschen?"
+      }
+    },
+    "notFound": "Sitzung nicht gefunden"
+  },
+  "home": {
+    "dashboard": {
+      "title": "Ihr Dashboard",
+      "users": "Es gibt {count, plural, =1 {# Benutzer} other {sind # Benutzer}}",
+      "yourProjects": "Ihre Projekte",
+      "projects": "Sie haben Zugriff auf {count, plural, =1 {# Projekt} other {# Projekte}}",
+      "loading": "Dashboard wird geladen...",
+      "noItems": "Nichts, was Ihnen zugewiesen ist, erfordert jetzt Ihre Aufmerksamkeit.",
+      "pendingRuns": "Ausstehende Testläufe",
+      "activeSessions": "Aktive Sitzungen",
+      "yourActiveSessions": "{count, plural, =0 {Keine aktiven Sitzungen} =1 {# Aktive Sitzungen} other {# Aktive Sitzungen}}",
+      "yourPendingRuns": "{count, plural, =0 {Keine ausstehenden Testläufe} =1 {# Aktiver Testlauf} other {# Aktive Testläufe}}",
+      "yourAssignments": "Ihre Aufgaben",
+      "totalTime": "Geschätzte Gesamtzeit: ",
+      "totalWorkEffort": "Gesamter Arbeitsaufwand: ",
+      "scheduleSpan": "Zeitplan: "
+    },
+    "initialPreferences": {
+      "title": "Legen Sie Ihre Präferenzen fest",
+      "description": "Wählen Sie die Standardeinstellungen, die am besten zu Ihnen passen. Sie können diese jederzeit in Ihrem Profil ändern.",
+      "dateFormat": "Datumsformat",
+      "timeFormat": "Zeitformat",
+      "timezonePlaceholder": "Zeitzone suchen...",
+      "skip": "Standardeinstellungen beibehalten",
+      "save": "Einstellungen speichern",
+      "success": "Einstellungen aktualisiert",
+      "error": "Beim Speichern Ihrer Einstellungen ist ein Fehler aufgetreten."
+    },
+    "noAccess": {
+      "title": "Kein Projektzugriff",
+      "description": "Sie haben keinen Zugriff auf Projekte in diesem System.",
+      "contact": "Wenden Sie sich an Ihren Systemadministrator, um Zugriff auf Projekte zu beantragen.",
+      "adminAddProject": "Füge dein erstes Projekt hinzu, um loszulegen!",
+      "footer": "Für die Teilnahme an den Testplanungsaktivitäten ist ein Zugriff erforderlich."
+    },
+    "noProjectAccess": {
+      "description": "Sie haben keinen Zugriff auf dieses Projekt.",
+      "contact": "Wenden Sie sich an Ihren Projektadministrator, um Zugriff zu beantragen."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Testfälle} =1 {# Testfall} other {# Testfälle}}",
+      "activeMilestones": "{count, plural, =0 {# Aktive Meilensteine} =1 {# Aktiver Meilenstein} other {# Aktive Meilensteine}}",
+      "activeRuns": "{count, plural, =0 {# Aktive Läufe} =1 {# Aktiver Lauf} other {# Aktive Läufe}}",
+      "activeSessions": "{count, plural, =0 {# Aktive Sitzungen} =1 {# Aktive Sitzung} other {# Aktive Sitzungen}}",
+      "issues": "{count, plural, =0 {# Probleme} =1 {# Problem} other {# Probleme}}"
+    }
+  },
+  "users": {
+    "description": "Benutzerkonten verwalten, Systemzugriffsebenen festlegen und globale Rollen zuweisen.",
+    "filter": "Benutzer filtern...",
+    "profile": {
+      "title": "Benutzerprofil",
+      "edit": {
+        "title": "Profil bearbeiten",
+        "timezonePlaceholder": "Zeitzone auswählen oder suchen...",
+        "timezoneRequired": "Zeitzone erforderlich.",
+        "avatarUpdated": "Avatar erfolgreich aktualisiert.",
+        "avatarUpdateError": "Avatar konnte nicht aktualisiert werden.",
+        "deleteAvatar": "Avatar löschen",
+        "deleteAvatarConfirm": "Möchtest du deinen Avatar wirklich löschen?",
+        "emailDisabledForSso": "Die E-Mail-Adresse kann für SSO-Konten nicht geändert werden. Bitte aktualisieren Sie diese über Ihren Identitätsanbieter.",
+        "emailEditableForBoth": "Sie können sich sowohl mit E-Mail/Passwort als auch mit SSO anmelden. Änderungen der E-Mail-Adresse wirken sich nur auf die Passwortauthentifizierung aus.",
+        "linkSsoProvider": "Link SSO Provider"
+      },
+      "preferences": {
+        "title": "Präferenzen"
+      },
+      "access": {
+        "title": "Zugang"
+      },
+      "notifications": {
+        "title": "Benachrichtigungseinstellungen",
+        "description": "Passen Sie an, wie Sie Benachrichtigungen erhalten",
+        "currentGlobal": "Aktuelle globale Einstellung: {mode}",
+        "mode": {
+          "label": "Benachrichtigungsmodus",
+          "useGlobal": "Globale Einstellungen verwenden"
+        },
+        "options": {
+          "title": "Zusätzliche Optionen",
+          "email": {
+            "label": "E-Mail-Benachrichtigungen",
+            "description": "Benachrichtigungen per E-Mail erhalten"
+          }
+        },
+        "success": {
+          "title": "Einstellungen gespeichert",
+          "description": "Ihre Benachrichtigungseinstellungen wurden aktualisiert"
+        },
+        "error": {
+          "description": "Benachrichtigungseinstellungen konnten nicht gespeichert werden"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Kennwort ändern",
+        "setPasswordButtonText": "Passwort festlegen",
+        "description": "Geben Sie Ihr aktuelles Passwort und ein neues Passwort ein, um Ihr Kontopasswort zu ändern. Dadurch wird nur Ihr intern verwaltetes Passwort geändert. Wenn Sie sich über SSO anmelden, wird dieses Passwort nicht geändert.",
+        "setPasswordDescription": "Sie haben sich per SSO angemeldet und noch kein lokales Passwort festgelegt. Geben Sie ein neues Passwort ein, um die Anmeldung per E-Mail/Passwort für Ihr Konto zu aktivieren.",
+        "currentPasswordLabel": "Aktuelles Passwort",
+        "newPasswordLabel": "Neues Passwort",
+        "confirmPasswordLabel": "Neues Passwort bestätigen",
+        "validation": {
+          "passwordsDoNotMatch": "Die neuen Passwörter stimmen nicht überein.",
+          "newPasswordTooShort": "Das neue Passwort erfüllt nicht die Sicherheitsanforderungen."
+        },
+        "success": {
+          "passwordChanged": "Passwort erfolgreich geändert."
+        }
+      },
+      "mentionedComments": {
+        "title": "In den Kommentaren erwähnt",
+        "description": "Kommentare, in denen Sie erwähnt werden",
+        "noComments": "Du wurdest bisher in keinem Kommentar erwähnt.",
+        "comment": "Kommentar",
+        "showingResults": "Zeigt {start} - {end} von {total}"
+      },
+      "twoFactor": {
+        "enable": "2FA aktivieren",
+        "disable": "Deaktivieren",
+        "disableNotAllowed": "Ihre Organisation verlangt eine Zwei-Faktor-Authentifizierung.",
+        "ssoBypassNotice": "SSO-Anmeldungen umgehen diese 2FA-Einstellung. Wenden Sie sich an Ihren Administrator, um die 2FA für alle Anmeldungen zu erzwingen.",
+        "regenerateCodes": "Neue Codes",
+        "setup": {
+          "description": "Scannen Sie den QR-Code mit Ihrer Authentifizierungs-App (z. B. Google Authenticator oder Authy) und geben Sie den Bestätigungscode ein.",
+          "backupCodesTitle": "Sichern Sie Ihre Backup-Codes",
+          "done": "Ich habe meine Codes gespeichert"
+        },
+        "disableConfirm": {
+          "title": "Zwei-Faktor-Authentifizierung deaktivieren?",
+          "description": "Dadurch wird Ihr Konto weniger sicher. Geben Sie zur Bestätigung Ihren aktuellen 2FA-Code oder einen Ersatzcode ein.",
+          "placeholder": "Geben Sie den Code ein"
+        },
+        "regenerate": {
+          "title": "Backup-Codes neu generieren",
+          "description": "Dadurch werden Ihre bestehenden Backup-Codes ungültig. Geben Sie Ihren aktuellen 2FA-Code ein, um fortzufahren.",
+          "confirm": "Codes neu generieren",
+          "newCodesTitle": "Ihre neuen Backup-Codes",
+          "newCodesDescription": "Ihre alten Codes sind ungültig. Bewahren Sie diese neuen Codes an einem sicheren Ort auf."
+        }
+      },
+      "apiTokens": {
+        "description": "API-Tokens ermöglichen externen Anwendungen und Skripten den Zugriff auf TestPlanIt in Ihrem Namen. Tokens verfügen über dieselben Berechtigungen wie Ihr Konto.",
+        "create": "Token erstellen",
+        "createTitle": "API-Token erstellen",
+        "createDescription": "Erstellen Sie ein neues API-Token zur Authentifizierung externer Tools und Skripte.",
+        "nameLabel": "Token-Name",
+        "namePlaceholder": "z. B. CI/CD-Pipeline, CLI-Tool",
+        "noTokens": "Es wurden noch keine API-Token erstellt.",
+        "expiryLabel": "Ablaufdatum (optional)",
+        "expiryHint": "Lassen Sie das Feld leer, damit kein Verfallsdatum entsteht.",
+        "tokenCreated": "Token erstellt",
+        "tokenCreatedDescription": "Ihr API-Token wurde erfolgreich erstellt.",
+        "copyWarning": "Kopiere diesen Token jetzt. Du wirst ihn nicht wiedersehen!",
+        "yourToken": "Ihr Token",
+        "deleteTitle": "API-Token löschen?",
+        "deleteDescription": "Diese Aktion kann nicht rückgängig gemacht werden. Anwendungen, die dieses Token verwenden, können sich nicht mehr authentifizieren.",
+        "readOnlyLabel": "Nur lesbar",
+        "readOnlyDescription": "Zur Verwendung für KI-Agenten, die Daten lediglich abfragen, aber niemals verändern sollen.",
+        "agentTokenLabel": "Als Agenten-Token markieren",
+        "agentTokenDescription": "Tags audit log entries with metadata.source: \"mcp\", so admins can map agent-driven changes.",
+        "readOnlyBadge": "Nur lesbar",
+        "agentTokenBadge": "Agententoken",
+        "errors": {
+          "nameRequired": "Ein Token-Name ist erforderlich."
+        }
+      }
+    },
+    "access": {
+      "guest": "Gast"
+    },
+    "avatar": {
+      "update": "Avatar aktualisieren",
+      "remove": "Avatar entfernen",
+      "changeProfilePicture": "Profilbild ändern",
+      "notAuthenticated": "Sie müssen angemeldet sein, um einen Avatar hochzuladen."
+    },
+    "deletedUser": "Gelöschter Benutzer"
+  },
+  "userMenu": {
+    "viewProfile": "Profil ansehen",
+    "locale": "Ort",
+    "themes": {
+      "light": "Licht",
+      "dark": "Dunkel",
+      "system": "System",
+      "green": "Grün",
+      "purple": "Lila",
+      "orange": "Orange"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Testfallversion nicht gefunden.",
+      "detailsRegion": "Details zum Testfall",
+      "metadataRegion": "Testfall-Metadaten",
+      "versionCreated": "Version {version} Erstellt",
+      "latestVersionUpdated": "Neueste Version {version} Aktualisiert",
+      "historyView": "Testfallverlauf anzeigen"
+    },
+    "fields": {
+      "optionNotFound": "Option nicht gefunden",
+      "hasValue": "Hat Wert",
+      "noValue": "Kein Wert",
+      "hasDate": "Hat Datum",
+      "noDate": "Kein Datum",
+      "hasText": "Hat Text",
+      "noText": "Kein Text",
+      "hasLink": "Hat Link",
+      "noLink": "Kein Link",
+      "hasSteps": "Hat Schritte",
+      "noSteps": "Keine Stufen",
+      "unchecked": "Ungeprüft",
+      "linkedCases": "Zusammenhängende Fälle",
+      "clickToViewFullContent": "Klicken Sie hier, um den vollständigen Inhalt anzuzeigen."
+    },
+    "steps": {
+      "add": "Schritt hinzufügen",
+      "addSharedSteps": "Gemeinsame Schritte hinzufügen",
+      "delete": "Schritt löschen",
+      "confirmDelete": "Löschvorgang bestätigen Schritt {number}?",
+      "createSharedSteps": "Gemeinsame Schritte erstellen {number, plural, one {Schritt} other {Schritte}}",
+      "sharedStepsName": "Gemeinsame Schritte Name",
+      "sharedStepsDescription": "Geben Sie einen Namen für Ihren neuen gemeinsamen Schritt {number, plural, one {} other {}}ein. Dieser umfasst {number, plural, one {# ausgewählte Schritte} other {# ausgewählte Schritte}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Bitte wählen Sie Schritte aus und geben Sie einen Namen ein, um gemeinsame Schritte zu erstellen.",
+        "failedToCreateSharedStepGroupError": "Die gemeinsamen Schritte konnten nicht erstellt werden. Bitte versuchen Sie es erneut.",
+        "sharedStepGroupCreatedSuccess": "Gemeinsame Schritte erfolgreich erstellt!",
+        "genericSharedStepCreationError": "Beim Erstellen der gemeinsamen Schritte ist ein unbekannter Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+        "errorCreatingSharedGroup": "Es ist fehlgeschlagen, gemeinsame Schritte zu erstellen. Bitte versuchen Sie es erneut.",
+        "sharedGroupCreatedSuccess": "Gemeinsame Schrittgruppe erfolgreich erstellt!"
+      },
+      "selectSharedStepsTitle": "Gemeinsame Schritte auswählen",
+      "selectSharedStepsDescription": "Wählen Sie gemeinsame Schritte aus, die Sie Ihrem Testfall hinzufügen möchten.",
+      "sharedStepsListPlaceholder": "Gemeinsame Schritte werden geladen...",
+      "sharedStepsNamePlaceholder": "Geben Sie einen Namen ein, um die gemeinsamen Schritte zu kennzeichnen.",
+      "noSharedStepsFound": "Für dieses Projekt wurden keine gemeinsamen Schritte gefunden.",
+      "sharedStepGroupTitle": "Gemeinsame Schritte: {name}",
+      "confirmDeleteSharedStepBlock": "Möchten Sie den gemeinsamen Schrittblock \"{name}\" wirklich aus diesem Testfall entfernen? Die gemeinsame Schrittgruppe selbst wird dadurch nicht gelöscht.",
+      "removeBlockButton": "Blockierung entfernen",
+      "loadingSharedStepsItems": "Ladeschritte...",
+      "noStepsInSharedGroup": "Diese gemeinsame Schrittgruppe ist leer.",
+      "searchSharedStepsPlaceholder": "Gemeinsame Schritte auswählen...",
+      "stepsCountLabel": "{count, plural, =0 {# Schritte} =1 {# Schritt} other {# Schritte}}",
+      "reviewSelectedStepsTitle": "Ausgewählte Schritte überprüfen",
+      "noStepsInSelectedGroup": "Die ausgewählte Gruppe enthält keine Schritte.",
+      "sharedGroupSuffix": "(Gemeinsame Schritte)",
+      "unnamedSharedGroup": "Unbenannte gemeinsame Schritte"
+    },
+    "testCase": {
+      "toggleAutomated": "Automatisierte Tests umschalten",
+      "editAttachmentsIndividually": "Anhänge einzeln bearbeiten.",
+      "automatedStatus": "Automatisiertes Testen ist {status}"
+    },
+    "templateNotAssignedWarning": "Dieser Testfall verwendet die Vorlage \"{templateName}\", die dem Projekt \"{projectName}\" derzeit nicht zugewiesen ist. Sie müssen diese Vorlage möglicherweise dem Projekt zuweisen oder den Testfall so ändern, dass er eine andere Vorlage verwendet.",
+    "orphanedStepsWarning": "Dieser Testfall enthält Schritte, aber die aktuelle Vorlage \"{templateName}\" enthält kein Feld für die Schritte. Die Schritte können erst bearbeitet werden, wenn der Testfall eine Vorlage mit einem Feld für die Schritte besitzt.",
+    "orphanedFieldsWarning": "Dieser Testfall enthält {count, plural, =1 {# Feldwert} other {# Feldwerte}} , die {count, plural, =1 {sind,} other {sind,}} nicht in der aktuellen Vorlage enthalten sind \"{templateName}\". {count, plural, =1 {Dieses Feld ist} other {Diese Felder sind}} unten aufgeführt, können aber möglicherweise erst bearbeitet werden, nachdem sie der Vorlage hinzugefügt wurden.",
+    "title": "Testfall-Repository",
+    "folders": "Ordner",
+    "showDescendants": "Alle Nachkommen anzeigen",
+    "addFolder": "Ordner hinzufügen",
+    "emptyFolders": "Klicken Sie oben auf die Schaltfläche „Ordner hinzufügen“, um den ersten Ordner hinzuzufügen.",
+    "selectedAllCases": "{count, plural, =0 {Alle Fälle ausgewählt} one {Anzahl Fälle auf allen Seiten ausgewählt} other {Anzahl Fälle auf allen Seiten ausgewählt}}",
+    "deselectedAllCases": "Alle Fälle auf allen Seiten abgewählt.",
+    "selectAllTooltip": "Alle Fälle auf dieser Seite auswählen/abwählen",
+    "selectAllShiftTooltip": "{count, plural, =0 {Alle Fälle auf allen Seiten auswählen/abwählen} one {# Fälle auf allen Seiten auswählen/abwählen} other {# Fälle auf allen Seiten auswählen/abwählen}}",
+    "deselectAllShiftTooltip": "Alle Fälle auf allen Seiten auswählen/abwählen",
+    "shiftClickHint": "Halten Sie die Umschalttaste gedrückt, um alle Seiten auszuwählen/die Auswahl aufzuheben",
+    "treeView": {
+      "expandAll": "Alle erweitern",
+      "collapseAll": "Alle ausblenden",
+      "altKey": "Halten Sie die Alt-Taste gedrückt, um alle untergeordneten Elemente zu erweitern/auszuklappen."
+    },
+    "dragDrop": {
+      "move": "Bewegen",
+      "copy": "Kopie",
+      "promptTitle": "Was möchten Sie tun?",
+      "copying": "Kopieren…",
+      "copyComplete": "{count, plural, =1 {1 Fall kopiert nach {folder}} other {Anzahl Fälle kopiert nach {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {1 Fall nach {folder}} other {verschoben. Anzahl Fälle nach {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}} verschoben.",
+      "copyError": "{count, plural, =1 {Fehler beim Kopieren von 1 Fall nach {folder}} other {Fehler beim Kopieren von # Fällen nach {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Failed to move 1 case to {folder}} other {Failed to move # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyAlreadyRunning": "Ein weiterer Kopiervorgang ist bereits in Arbeit. Bitte warten Sie, bis er abgeschlossen ist.",
+      "currentSuffix": "(Aktuell)",
+      "moveDisabledSameFolder": "Fälle befinden sich bereits in diesem Ordner",
+      "dragPreviewCase": "Testfall",
+      "dragPreviewCount": "{count, plural, =1 {# Testfall} other {# Testfälle}}",
+      "modifierHintMac": "Halten Sie ⇧ gedrückt, um zu verschieben, oder ⌥, um zu kopieren, während Sie ziehen, um dieses Menü zu überspringen.",
+      "modifierHintWin": "Halten Sie beim Ziehen die Umschalttaste gedrückt, um zu verschieben, oder die Strg-Taste, um zu kopieren, um dieses Menü zu überspringen."
+    },
+    "folderActions": {
+      "edit": "Ordner bearbeiten",
+      "delete": "Ordner löschen",
+      "rename": "Ordner umbenennen"
+    },
+    "cases": {
+      "filter": "Filtergehäuse...",
+      "selectFolder": "Wählen Sie einen Ordner aus, um Testfälle hinzuzufügen oder anzuzeigen.",
+      "selectCases": "Testfälle auswählen",
+      "noTestCases": "Keine Testfälle anzuzeigen.",
+      "addCase": "Fall hinzufügen",
+      "notFound": "Testfall nicht gefunden.",
+      "selectFilter": "Filter auswählen",
+      "testResultHistory": "Testergebnishistorie",
+      "testResultHistoryDescription": "Sehen Sie sich den Verlauf der Testergebnisse für diesen Testfall an.",
+      "noTestResults": "Für diesen Testfall wurden keine Testergebnisse gefunden.",
+      "unknownRun": "Unbekannter Lauf",
+      "attempt": "Versuchen",
+      "invalidProject": "Ungültiges Projekt",
+      "noSearchResults": "Es wurden keine Fälle gefunden, die Ihren Suchkriterien entsprechen.",
+      "bulkEdit": "Massenbearbeitung",
+      "createTestRun": "Testlauf erstellen",
+      "copyMoveToProject": "Kopieren / Verschieben",
+      "export": "Export",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Testfälle können nicht seitenübergreifend neu angeordnet werden. Um die Reihenfolge zu ändern, wählen Sie im Menü „Seitengröße“ die Option „Alle“ aus, um alle Fälle auf einer Seite anzuzeigen, oder deaktivieren Sie die Auswahl von Fällen auf anderen Seiten. Sie können ausgewählte Fälle weiterhin in Ordner verschieben.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Alles im Blickfeld ({count})"
+        },
+        "textLongFormat": {
+          "label": "Rich-Text-Format"
+        },
+        "rowMode": {
+          "label": "Testfallzeilen",
+          "multi": "Eine Reihe pro Schritt"
+        }
+      },
+      "importWizard": {
+        "title": "Import-Testfälle",
+        "fields": {
+          "workflowState": "Workflow-Status",
+          "column": "Spalte {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# Testfall} other {# Testfälle}} erfolgreich importiert"
+        },
+        "errors": {
+          "templateRequired": "Die Auswahl einer Vorlage ist erforderlich.",
+          "folderRequired": "Für diesen Importort ist eine Ordnerauswahl erforderlich.",
+          "fileRequired": "Eine CSV- oder Markdown-Datei ist erforderlich.",
+          "markdownParseFailed": "Fehler beim Parsen der Markdown-Datei",
+          "markdownLlmFailed": "KI-Parsing nicht verfügbar, Standardparser wird verwendet"
+        },
+        "page1": {
+          "fileType": {
+            "label": "Dateityp",
+            "csv": "CSV",
+            "markdown": "Preisnachlass"
+          },
+          "parsingMarkdown": "Markdown-Datei wird analysiert...",
+          "useAiParsing": "Nutzen Sie KI zur Unterstützung der Feldkartierung.",
+          "importLocation": {
+            "label": "Importort",
+            "singleFolder": "Alle Fälle in einen einzigen Ordner einfügen",
+            "rootFolder": "Fügen Sie alle Fälle und Ordner einem Stammordner hinzu (Zuordnung erforderlich).",
+            "topLevel": "Fügen Sie alle Fälle und Ordner der obersten Ebene hinzu (Zuordnung erforderlich)."
+          },
+          "selectFolder": "Ordner auswählen",
+          "selectFolderPlaceholder": "Wählen Sie einen Ordner aus...",
+          "delimiters": {
+            "tab": "Tab"
+          },
+          "hasHeaders": "Die erste Zeile enthält die Spaltennamen.",
+          "template": "Repository-Fallvorlage",
+          "rowMode": {
+            "single": "Jede Zeile stellt einen einzelnen Testfall dar.",
+            "multi": "Testfälle können sich über mehrere Zeilen erstrecken."
+          }
+        },
+        "page2": {
+          "title": "CSV-Spalten Feldern zuordnen",
+          "description": "Ordnen Sie jede CSV-Spalte einem Feld in der Vorlage zu oder wählen Sie, ob sie ignoriert werden soll.",
+          "ignoreColumn": "Spalte ignorieren",
+          "requiredFieldsWarning": "{count, plural, one {# Pflichtfeld ist} other {# Pflichtfelder sind}} nicht zugeordnet"
+        },
+        "page3": {
+          "title": "Zusammenfassung der Feldzuordnung",
+          "mappingSummary": "Kartierungsübersicht",
+          "folderSplitMode": {
+            "label": "Ordnerhierarchiemodus",
+            "plain": "Reiner Text (ohne Aufteilung)",
+            "plainExample": "Beispiel: 'This/is.a>Folder' → Einzelner Ordner mit dem Namen 'This/is.a>Folder'",
+            "slash": "Durch Schrägstrich (/) trennen",
+            "slashExample": "Beispiel: 'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "Durch Punkt (.) trennen",
+            "dotExample": "Beispiel: 'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "Aufteilen durch Größer-als (>)",
+            "greaterThanExample": "Beispiel: 'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "Vorschau Import",
+          "showing": "Anzeige der Fälle {start}-{end} von {total}",
+          "case": "Fall {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Testfall hinzufügen",
+      "name": "Testfallname",
+      "namePlaceholder": "Testfallnamen eingeben",
+      "selectTemplate": "Wählen Sie eine Vorlage aus",
+      "selectState": "Wählen Sie einen Bundesstaat aus",
+      "estimatePlaceholder": "Schätzung eingeben",
+      "create": "Testfall erstellen",
+      "successMessage": "Neuer Testfall hinzugefügt",
+      "errorMessage": "Unbekannter Fehler beim Hinzufügen eines neuen Testfalls"
+    },
+    "columns": {
+      "selectCase": "Fall auswählen",
+      "runOrder": "Ablaufreihenfolge",
+      "lastTestResult": "Letztes Ergebnis",
+      "testedOn": "Zuletzt getestet"
+    },
+    "actions": {
+      "archive": "Archiv"
+    },
+    "parentFolder": "Übergeordneter Ordner",
+    "rootFolder": "Stammverzeichnis",
+    "removeParentFolder": "Übergeordneten Ordner entfernen",
+    "createInSelectedFolder": "Zum übergeordneten Ordner zurückkehren",
+    "deleteCase": {
+      "title": "Testfall löschen",
+      "confirmMessageStart": "Sind Sie sicher, dass Sie den Testfall löschen möchten? ",
+      "confirmMessageEnd": "?",
+      "warning": "Dieser Testfall wird aus dem Projekt entfernt. Die historischen Daten dieses Testfalls, einschließlich der Ergebnisse, bleiben jedoch im Projekt erhalten.",
+      "activeRunWarningMessage": "Dieser Testfall ist Teil von {count, plural, =1 {# aktiver Testlauf} other {# aktive Testläufe}}. Durch das Löschen wird er innerhalb dieser Läufe als gelöscht markiert."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Durch das Löschen dieses Ordners werden auch alle Unterordner gelöscht. Sind Sie sicher?} one {Durch das Löschen dieses Ordners werden auch 1 Testfall in diesem Ordner und allen Unterordnern gelöscht. Sind Sie sicher?} other {Durch das Löschen dieses Ordners werden auch # Testfälle in diesem Ordner und allen Unterordnern gelöscht. Sind Sie sicher?}}",
+      "warning": "Dieser Ordner und alle darin enthaltenen Testfälle werden aus dem Projekt entfernt. Die historischen Daten dieser Testfälle, einschließlich der Ergebnisse, bleiben jedoch im Projekt erhalten.",
+      "confirm": "Ordner löschen bestätigen",
+      "success": "Ordner und alle Unterordner/Fälle wurden erfolgreich gelöscht."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "Dieser Ordnername ist bereits vergeben. Bitte wählen Sie einen anderen Namen."
+      }
+    },
+    "views": {
+      "byAutomation": "Automatisierung",
+      "allTemplates": "Alle Vorlagen",
+      "allStates": "Alle Staaten",
+      "allCreators": "Alle Schöpfer",
+      "allCases": "Alle Fälle",
+      "allAssignees": "Alle Beauftragten",
+      "anyTag": "Beliebiges Tag",
+      "noTags": "Keine Tags",
+      "byTag": "Etikett",
+      "byIssue": "Ausgabe",
+      "anyIssue": "Irgendein Problem",
+      "noIssues": "Keine Probleme"
+    },
+    "noFoldersTitle": "Noch keine Ordner",
+    "noFoldersDescription": "Beginnen Sie damit, Ihren ersten Ordner anzulegen, um Ihre Testfälle zu organisieren.",
+    "noFoldersOrCasesNoPermission": "Es sind keine Ordner oder Testfälle zum Anzeigen vorhanden.",
+    "createFirstFolder": "Erstelle deinen ersten Ordner",
+    "bulkEdit": {
+      "title": "Massenbearbeitung {count, plural, one {# Fall} other {# Fälle}}",
+      "description": "Bearbeiten {count, plural, one {# ausgewählter Fall} other {# ausgewählter Fall}}. Markieren Sie ein Feld, um die Bearbeitung zu aktivieren.",
+      "defineStepsTitle": "Schritte für die Massenaktualisierung definieren",
+      "saveNewSteps": "Neue Schritte speichern",
+      "newStepsDefined": "Neue Schritte definiert ({count}) - Zum Bearbeiten auf die Schaltfläche klicken",
+      "clearExistingStepsWarning": "Die bestehenden Schritte werden entfernt.",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Mehrere Vorlagen ausgewählt",
+          "description": "Nur Standardfelder können bearbeitet werden, wenn Fälle mit unterschiedlichen Vorlagen ausgewählt sind. Dynamische Felder können bearbeitet werden, indem Fälle ausgewählt werden, die dieselbe Vorlage verwenden."
+        },
+        "junitLimitations": {
+          "title": "Einschränkungen bei der automatisierten Bearbeitung von Testfällen",
+          "description": "Die Felder „Schätzung“ und „Automatisiert“ können für Testfälle, die aus automatisierten Testergebnissen importiert wurden, nicht geändert werden."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Fehler beim Laden von Fällen",
+        "fetchErrorDescription": "Die Daten für die ausgewählten Fälle konnten nicht geladen werden. Bitte schließen Sie das Fenster und versuchen Sie es erneut.",
+        "updateErrorTitle": "Aktualisierung fehlgeschlagen",
+        "updateFailed": "Beim Speichern der Änderungen ist ein Fehler aufgetreten. Bitte überprüfen Sie die Daten und versuchen Sie es erneut.",
+        "fetchError": "Fehler beim Abrufen der Falldaten."
+      },
+      "success": {
+        "casesUpdated": "Fälle erfolgreich aktualisiert"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Validierungsfehler",
+      "stepsCannotBeBulkEdited": "Schritte können nicht in großen Mengen bearbeitet werden",
+      "stepsInfoTitle": "Schrittinformationen",
+      "stepsCannotBeBulkEditedInfo": "Schritte können nicht in großen Mengen bearbeitet werden. Bearbeiten Sie die Schritte, indem Sie die einzelnen Fälle bearbeiten.",
+      "confirmDeleteCases": "Möchten Sie wirklich {count, plural, one {# ausgewählte Fälle} other {# ausgewählte Fälle}}löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "replaceAll": "Alle ersetzen",
+      "searchReplace": "Suchen und Ersetzen",
+      "searchFor": "Suchen nach",
+      "replaceWith": "Ersetzen durch",
+      "searchText": "Geben Sie einen Text zum Suchen ein",
+      "replacementText": "Ersetzungstext eingeben",
+      "useRegex": "Regulären Ausdruck verwenden",
+      "caseSensitive": "Groß- und Kleinschreibung beachten",
+      "regexHint": "Verwenden Sie .* für beliebige Zeichen, \\d+ für Zahlen und \\w+ für Wörter. Gruppen erfassen: (Muster) und dann $1, $2 usw. verwenden.",
+      "preview": "Vorschau",
+      "matches": "Spiele",
+      "noMatches": "Keine Treffer gefunden",
+      "invalidRegexPattern": "Ungültiges reguläres Ausdrucksmuster",
+      "searchPatternRequired": "Suchmuster erforderlich",
+      "stepsSearchReplaceInfo": "Die Such- und Ersetzungsfunktion wird sowohl auf die Schrittbeschreibungen als auch auf die erwarteten Ergebnisse angewendet."
+    },
+    "exportModal": {
+      "title": "Export-Testfälle",
+      "description": "Wählen Sie unten Ihre Exportoptionen aus.",
+      "scope": {
+        "selected": "Ausgewählt ({count})",
+        "allFiltered": "Alle (Aktuelle Ansicht) ({count})",
+        "allProject": "Alles im Projekt ({count})"
+      },
+      "format": {
+        "label": "Format",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Preisnachlass"
+      },
+      "columns": {
+        "all": "Alle",
+        "visible": "Sichtbar"
+      },
+      "delimiter": {
+        "label": "Trennzeichen",
+        "placeholder": "Trennzeichen auswählen...",
+        "comma": "Komma (,)",
+        "semicolon": "Semikolon (;)",
+        "colon": "Doppelpunkt (:)",
+        "pipe": "Pipe (|)"
+      },
+      "textLongFormat": {
+        "label": "Text im Langformat"
+      },
+      "attachmentFormat": {
+        "label": "Anhangsformat",
+        "names": "Namen",
+        "json": "JSON",
+        "embedded": "Bilder einbetten"
+      },
+      "stepsFormat": {
+        "label": "Schrittformat",
+        "plainText": "Klartext"
+      },
+      "rowMode": {
+        "label": "Zeilen pro Fall",
+        "single": "Eine Reihe pro Fall",
+        "multi": "Mehrere Zeilen pro Schritt"
+      },
+      "comingSoon": "Demnächst verfügbar",
+      "exporting": "Exportieren...",
+      "exportError": "Der Export ist fehlgeschlagen. Bitte versuchen Sie es erneut."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Konvertieren Sie ausgewählte Testfälle mithilfe einer Vorlage oder KI in Automatisierungsskripte.",
+      "templatePlaceholder": "Wählen Sie eine Vorlage aus...",
+      "searchPlaceholder": "Suchvorlagen...",
+      "noTemplatesFound": "Keine Vorlagen gefunden.",
+      "outputModeLabel": "Ausgabemodus",
+      "outputModeSingle": "Einzeldatei ({count, plural, one {# Fall} other {alle # Fälle}})",
+      "outputModeIndividual": "{count, plural, one {Einzelne Datei (.zip)} other {Einzelne Dateien (.zip)}}",
+      "casesToExport": "{count, plural, one {# Fall} other {# Fälle}} zu exportieren",
+      "exportSuccess": "Export erfolgreich abgeschlossen.",
+      "noAvailableTemplates": "Keine Vorlagen verfügbar. Wenden Sie sich an Ihren Administrator."
+    },
+    "aiExport": {
+      "toggleLabel": "Mit KI generieren",
+      "generating": "Wird generiert...",
+      "generatingProgress": "Erzeuge Fall {current} von {total}...",
+      "generatingBatch": "Generiere {count, plural, one {# Fall} other {# Fälle}} in einer Datei...",
+      "previewTitle": "Exportvorschau",
+      "previewDescription": "{count, plural, one {# Datei} other {# Dateien}} generiert",
+      "copySuccess": "In die Zwischenablage kopiert",
+      "fallbackBadge": "Generiert mithilfe einer Vorlage (KI nicht verfügbar)",
+      "retryButton": "KI-Generierung wiederholen",
+      "aiGenerated": "KI-generiert",
+      "templateGenerated": "Vorlage generiert",
+      "truncatedWarning": "Die Ausgabe wurde abgeschnitten – das Modell hat sein Token-Limit erreicht. Versuchen Sie, die Batchgröße zu verringern oder die maximale Anzahl an Ausgabetokens in Ihrer Eingabeaufforderungskonfiguration zu erhöhen.",
+      "contextFiles": "{count, plural, one {(# Kontextdatei)} other {(# Kontextdateien)}}",
+      "noCodeContextHint": "Es ist kein Code-Repository konfiguriert. Die KI verwendet Standard-Framework-Muster.",
+      "generatingParallelProgress": "Es wurden {done} von {total} Dateien generiert...",
+      "cancelledGeneration": "Abgesagt"
+    },
+    "duplicates": {
+      "findDuplicates": "Duplikate finden",
+      "viewResults": "Ansicht {count, plural, one {# Ergebnis} other {# Ergebnisse}}",
+      "retryScan": "Scan wiederholen",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Ergebnisse durch KI verbessern...",
+      "scanComplete": "Duplikatanalyse abgeschlossen — {count, plural, =0 {Keine Duplikate gefunden} one {# Potenzielle Duplikate gefunden} other {# Potenzielle Duplikate gefunden}}",
+      "scanFailed": "Duplikatanalyse fehlgeschlagen",
+      "scanFailedDescription": "Es ist ein unerwarteter Fehler aufgetreten.",
+      "pageTitle": "Doppelte Kandidaten",
+      "pageDescription": "Überprüfen Sie die beim letzten Scan gefundenen potenziellen Duplikat-Testfälle.",
+      "rescan": "Erneut scannen",
+      "cancelScan": "Scan abbrechen",
+      "loading": "Doppelte Kandidaten werden geladen...",
+      "noDuplicatesFound": "Keine Duplikate gefunden",
+      "noDuplicatesDescription": "Letzter Scan abgeschlossen, keine übereinstimmenden Paare gefunden.",
+      "loadMore": "Mehr laden",
+      "filterPlaceholder": "Duplikate filtern...",
+      "columnConfidence": "Vertrauen",
+      "columnCaseA": "Fall A",
+      "columnCaseB": "Fall B",
+      "columnMatchedFields": "Übereinstimmende Felder",
+      "columnScore": "Punktzahl",
+      "compareButton": "Vergleichen",
+      "viewCaseDetails": "Falldetails anzeigen",
+      "selectAll": "Alle auswählen",
+      "selectRow": "Zeile auswählen",
+      "selected": "{count, plural, one {# ausgewählt} other {# ausgewählt}}",
+      "bulkDismiss": "Keine Duplikate ({count})",
+      "bulkLink": "Link als verwandtes Thema ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# Paar verworfen} other {# Paare verworfen}}",
+      "bulkLinkSuccess": "{count, plural, one {# Paar verknüpft} other {# Paare verknüpft}}",
+      "bulkError": "Es sind einige Vorgänge fehlgeschlagen. Bitte versuchen Sie es erneut.",
+      "tableHint": "Klicken Sie auf eine Zeile oder auf die Schaltfläche „Vergleichen“, um ein Duplikatpaar zu überprüfen und aufzulösen.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "Vergleichen Sie diese potenziellen Duplikate und entscheiden Sie, wie Sie sie auflösen möchten.",
+      "selectPrimary": "Klicken Sie auf einen Fall, um ihn als primären Fall für die Zusammenführung auszuwählen.",
+      "selectedAsPrimary": "Als primär ausgewählt",
+      "mergeButton": "Primäre Funktion beibehalten",
+      "linkButton": "Link als verwandtes",
+      "dismissButton": "Kein Duplikat",
+      "merging": "Zusammenführen...",
+      "linking": "Verknüpfung...",
+      "dismissing": "Entlassen...",
+      "mergeSuccess": "Fälle erfolgreich zusammengeführt. {runsTransferred, plural, =0 {Keine Testläufe übertragen} one {# Testläufe übertragen} other {# Testläufe übertragen}}.",
+      "linkSuccess": "Fälle, die miteinander verknüpft sind.",
+      "dismissSuccess": "Das Paar wurde entlassen. Es wird in zukünftigen Scans nicht mehr angezeigt.",
+      "resolveError": "Das doppelte Paar konnte nicht aufgelöst werden. Bitte versuchen Sie es erneut.",
+      "loadingDetails": "Lade Falldetails...",
+      "caseDetailsError": "Die Falldetails konnten nicht geladen werden.",
+      "sourceLabel": "Quelle",
+      "fieldValuesLabel": "Feldwerte",
+      "lastRunLabel": "Letzter Lauf",
+      "noFieldValues": "Keine Feldwerte",
+      "noLastRun": "Lauf niemals",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Kein Ordner",
+      "duplicateWarning": "Mögliche Duplikate gefunden",
+      "duplicateWarningDescription": "{count, plural, one {# bestehender Fall} other {# bestehende Fälle}} können ähnliche Funktionalitäten abdecken",
+      "duplicateWarningReview": "Rezension",
+      "importWarning": "Mögliches Duplikat",
+      "importWarningTooltip": "Dieser Fallname ähnelt {count, plural, one {# bestehender Fall} other {# bestehende Fälle}}: {names}",
+      "importIntraWarning": "Duplikat innerhalb des Imports",
+      "importIntraWarningTooltip": "Die Zeilen {rows} in diesem Import haben den gleichen oder einen sehr ähnlichen Namen",
+      "checkingDuplicates": "Suche nach Duplikaten..."
+    },
+    "generateTestCases": {
+      "buttonText": "Testfälle generieren",
+      "title": "Testfälle mit KI generieren",
+      "description": "Nutzen Sie KI, um automatisch umfassende Testfälle aus externen Problemen oder Dokumenten zu generieren.",
+      "loadingResults": "Generierte Testfälle werden geladen...",
+      "generatingPreparing": "Anfrage wird vorbereitet...",
+      "generatingCallingAi": "Warten auf die Generierung von Testfällen durch die KI...",
+      "generatingStreaming": "Die KI generiert den Testfall {count}...",
+      "generatingStreamingPage": "KI generiert Testfall {count} — Seite {current} von {total}: {page}",
+      "generatingProcessing": "Generierte Testfälle werden verarbeitet...",
+      "generatingHint": "Dies kann je nach Komplexität Ihres Ausgangsmaterials eine Minute dauern.",
+      "steps": {
+        "selectIssue": "Quelle auswählen",
+        "selectTemplate": "Vorlage auswählen",
+        "reviewGenerated": "Überprüfung & Import"
+      },
+      "selectSource": {
+        "title": "Anforderungsquelle auswählen",
+        "description": "Wählen Sie aus, ob Testfälle aus einem Problem oder einem Anforderungsdokument generiert werden sollen.",
+        "folderContextTip": "Vorhandene Testfälle aus \"{folderName}\" und dessen übergeordneten/untergeordneten Ordnern werden als Kontext verwendet, um Duplikate zu vermeiden. Stellen Sie sicher, dass Sie den richtigen Ordner ausgewählt haben, bevor Sie fortfahren.",
+        "currentFolder": "aktueller Ordner",
+        "fromIssue": "Aus der Ausgabe",
+        "fromDocument": "Aus dem Dokument",
+        "documentTitle": "Dokumenttitel",
+        "documentTitlePlaceholder": "Geben Sie den Titel Ihres Anforderungsdokuments ein.",
+        "documentDescription": "Anforderungsdokument",
+        "documentDescriptionPlaceholder": "Fügen Sie hier den Inhalt Ihres Anforderungsdokuments ein...",
+        "documentPriority": "Priorität (optional)",
+        "selectPriority": "Priorität auswählen",
+        "saveDocument": "Anforderungen an das Speichern von Dokumenten",
+        "fromUrl": "Von der URL",
+        "recentGenerations": "Aktuelle Aufträge zum Generieren von Testfällen aus URLs",
+        "recentJobInfo": "{pages, plural, one {# Seite} other {# Seiten}}{hasTestCases, select, true { · {testCases, plural, one {# Testfall} other {# Testfälle}}} other {}}",
+        "recentJobHasResults": "Bereit zur Überprüfung",
+        "recentJobClickToGenerate": "Klicken Sie hier, um Testfälle zu generieren.",
+        "recentJobCrawling": "Kriechen... {pages, plural, one {# Seite} other {# Seiten}} bisher",
+        "removeJobTitle": "Generation entfernen",
+        "confirmRemoveJob": "Dadurch werden der zwischengespeicherte Crawl und alle generierten Testfälle gelöscht. Sie können jederzeit von derselben URL aus erneut generieren.",
+        "loadingRecentJobs": "Aktuelle Jobs werden geladen...",
+        "urlInput": "Seiten-URL",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "Was enthält diese URL?",
+        "urlModeRequirements": "Anforderungen",
+        "urlModeRequirementsHint": "Auf der Seite wird beschrieben, was zu bauen ist.",
+        "urlModeApplication": "Anwendung",
+        "urlModeApplicationHint": "Page ist die App zum Testen",
+        "urlValidationError": "Bitte geben Sie eine gültige URL ein, die mit http:// oder https:// beginnt.",
+        "followLinks": "Folgen Sie den Links",
+        "followLinksHint": "Es werden nur Seiten gecrawlt, die sich auf derselben Domain wie die eingegebene URL befinden.",
+        "maxDepth": "Maximale Tiefe",
+        "maxPages": "Maximale Seiten",
+        "crawlProgress": "{current, plural, one {Bisher # Seiten abgerufen...} other {Bisher # Seiten abgerufen...}}",
+        "generatingSinglePage": "Generiere Testfälle...",
+        "generatingSetup": "Vorbereitung zur Generierung von Testfällen...",
+        "robotsSkipped": "{count, plural, one {# Seite übersprungen} other {# Seiten übersprungen}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Externes Problem auswählen",
+        "description": "Wählen Sie ein Ticket aus Ihrem externen System (z. B. Jira) aus, um Testfälle zu generieren.",
+        "searchButton": "Ausgaben suchen"
+      },
+      "selectTemplate": {
+        "title": "Testfallvorlage auswählen",
+        "description": "Wählen Sie die Vorlage aus, die zur Generierung von Testfällen verwendet werden soll. Die KI füllt die Felder entsprechend dieser Vorlage aus.",
+        "placeholder": "Wählen Sie eine Vorlage aus...",
+        "fieldsDescription": "Wählen Sie aus, welche Felder die KI ausfüllen soll. Pflichtfelder sind immer enthalten.",
+        "requiredOnly": "Nur erforderlich"
+      },
+      "addNotes": {
+        "title": "Anmerkungen und Hinweise hinzufügen",
+        "description": "Geben Sie zusätzlichen Kontext und Anleitungen, damit die KI bessere Testfälle generieren kann.",
+        "quantity": "Anzahl der zu generierenden Testfälle",
+        "placeholder": "Fügen Sie spezifische Anweisungen zur Testfallgenerierung hinzu...\n\nZum Beispiel:\n• Fokus auf Sicherheitstests\n• Grenzfälle und Randbedingungen einbeziehen\n• Sowohl den Normalfall als auch Fehlerszenarien testen\n• Mobile und Desktop-Szenarien berücksichtigen\n• Fokus auf API-Tests",
+        "suggestions": "Kurzvorschläge:",
+        "quantityOptions": {
+          "justOne": "Nur eins",
+          "couple": "Ein Paar (2)",
+          "few": "Ein paar (2-3)",
+          "several": "Mehrere (4-6)",
+          "many": "Viele (7-10)",
+          "maximum": "Maximal"
+        },
+        "suggestionItems": {
+          "security": "Schwerpunkt Sicherheitstests",
+          "edgeCases": "Berücksichtigen Sie Sonderfälle",
+          "happyPath": "Nur den Normalfall testen",
+          "mobile": "Berücksichtigen Sie mobile Szenarien",
+          "api": "Schwerpunkt API-Tests",
+          "accessibility": "Barrierefreiheitstests einbeziehen"
+        }
+      },
+      "review": {
+        "title": "Generierte Testfälle überprüfen",
+        "description": "Überprüfen Sie die KI-generierten Testfälle, nehmen Sie gegebenenfalls Änderungen vor und wählen Sie die zu importierenden Fälle aus.",
+        "selected": "{count} von {total} ausgewählt",
+        "moreSteps": "... und {count, plural, one {# weiterer Schritt} other {# weitere Schritte}}",
+        "templateFields": "Vorlagenfelder:",
+        "moreFields": "... und {count, plural, one {# weitere Felder} other {# weitere Felder}}",
+        "crawledUrls": "{count, plural, one {# Seite durchsucht} other {# Seiten durchsucht}}",
+        "spaWarning": "Diese Seite erfordert möglicherweise JavaScript-Rendering. Die Ergebnisse sind möglicherweise unvollständig.",
+        "filterByPage": "Nach Seite filtern",
+        "allPages": "Alle Seiten ({pages, plural, one {# Seite} other {# Seiten}}, {cases, plural, one {# Fall} other {# Fälle}})"
+      },
+      "generatingLegacy": "Generierung von Testfällen mit KI...",
+      "expandProgress": "{done} von {total} generiert",
+      "import": "{count, plural, =0 {Testfälle importieren} =1 {1 Testfall importieren} other {# Testfälle importieren}}",
+      "importing": "{count, plural, =0 {Importiere Testfälle...} =1 {Importiere 1 Testfall...} other {Importiere # Testfälle...}}",
+      "openInExternalSystem": "Öffnen in {provider}",
+      "externalSystem": "Externes System",
+      "autoGenerateTags": "Tags für Testfälle automatisch generieren",
+      "success": {
+        "imported": "{count, plural, =1 {1 Testfall erfolgreich importiert} other {# Testfälle erfolgreich importiert}}"
+      },
+      "importData": {
+        "issueDescription": "Externes Problem im Zusammenhang mit der Testfallgenerierung",
+        "generatedFolderName": "Generiert"
+      },
+      "errors": {
+        "generateFailed": "Es konnten keine Testfälle generiert werden. Bitte versuchen Sie es erneut.",
+        "importFailed": "Die Testfälle konnten nicht importiert werden. Bitte versuchen Sie es erneut.",
+        "noTestCasesGenerated": "Es wurden keine Testfälle generiert. Bitte versuchen Sie es erneut mit anderen Eingaben.",
+        "jobNoLongerAvailable": "Diese Generation ist nicht mehr verfügbar. Starten Sie eine neue Generation über den Assistenten zum Generieren von Testfällen.",
+        "noAiModel": "Für dieses Projekt ist kein KI-Modell konfiguriert. Bitte konfigurieren Sie ein KI-Modell in den Projekteinstellungen.",
+        "noIssueSelected": "Bitte wählen Sie ein Problem aus, für das Testfälle generiert werden sollen.",
+        "noDocumentProvided": "Bitte geben Sie die Details der Anforderungsdokumente an.",
+        "noTemplateSelected": "Bitte wählen Sie eine Vorlage für die Testfälle aus.",
+        "noFieldsSelected": "Bitte wählen Sie mindestens ein Feld aus, für das Inhalte generiert werden sollen.",
+        "noTestCasesSelectedForImport": "Bitte wählen Sie mindestens einen Testfall zum Importieren aus.",
+        "templateRequired": "Sie müssen eine Vorlage auswählen. Bitte gehen Sie zurück und wählen Sie eine Vorlage aus.",
+        "repositoryNotFound": "Das Projekt-Repository wurde nicht gefunden. Bitte wenden Sie sich an Ihren Administrator.",
+        "workflowNotConfigured": "Der Projekt-Workflow ist nicht konfiguriert. Bitte überprüfen Sie die Projekteinstellungen.",
+        "authenticationError": "Authentifizierungsfehler. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
+        "caseCreationFailed": "Fehler beim Erstellen des Testfalls: {name}",
+        "caseAlreadyExists": "Der Testfall \"{name}\" existiert bereits in diesem Ordner.",
+        "invalidTemplateConfig": "Ungültige Vorlagenkonfiguration für Testfall \"{name}\".",
+        "nameTooLong": "Der Testfallname \"{name}\" ist zu lang. Bitte verwenden Sie einen kürzeren Namen.",
+        "caseCreationError": "Fehler beim Erstellen von \"{name}\": {error}",
+        "templateNotFound": "Die ausgewählte Vorlage konnte nicht gefunden werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
+        "repositoryConfigError": "Fehler in der Projekt-Repository-Konfiguration. Bitte wenden Sie sich an Ihren Administrator.",
+        "workflowConfigError": "Fehler in der Projektworkflow-Konfiguration. Bitte überprüfen Sie die Projekteinstellungen.",
+        "permissionDenied": "Sie haben keine Berechtigung, in diesem Projekt Testfälle zu erstellen.",
+        "validationFailed": "Die Datenvalidierung ist fehlgeschlagen. Bitte überprüfen Sie den Inhalt des Testfalls und versuchen Sie es erneut.",
+        "databaseError": "Datenbankverbindungsfehler. Bitte versuchen Sie es in Kürze erneut.",
+        "genericImportError": "Import fehlgeschlagen: {error}",
+        "networkRoutingError": "Netzwerkrouting- oder Serverkonfigurationsproblem – anstelle einer API-Antwort wurde eine HTML-Fehlerseite empfangen.",
+        "invalidSourceConfig": "Ungültige Quellkonfiguration",
+        "failedToCreateCaseVersion": "Fallversion konnte nicht erstellt werden",
+        "noUrlProvided": "Bitte geben Sie eine URL ein, um Testfälle zu generieren.",
+        "urlFetchFailed": "Der Inhalt konnte von der angegebenen URL nicht abgerufen werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
+        "llm": {
+          "genericTitle": "KI-Generierungsfehler",
+          "genericMessage": "Beim Generieren der Testfälle mit KI ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder korrigieren Sie Ihre Eingabe.",
+          "overloaded": {
+            "title": "Der Dienst ist vorübergehend nicht verfügbar.",
+            "message": "Der KI-Dienst ist derzeit stark ausgelastet. Bitte versuchen Sie es in wenigen Augenblicken erneut."
+          },
+          "quota": {
+            "title": "Nutzungslimit erreicht",
+            "message": "Sie haben Ihr Nutzungslimit für KI in diesem Zeitraum erreicht. Bitte versuchen Sie es später erneut oder kontaktieren Sie Ihren Administrator."
+          },
+          "timeout": {
+            "title": "Zeitüberschreitung der Anfrage",
+            "message": "Die Bearbeitung der KI-Anfrage dauerte zu lange. Dies kann bei komplexen Anforderungen oder einer großen Anzahl von Testfällen vorkommen."
+          },
+          "network": {
+            "title": "Netzwerkfehler",
+            "message": "Es konnte keine Verbindung zum KI-Dienst hergestellt werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
+          },
+          "unauthorized": {
+            "title": "KI-Dienstauthentifizierung fehlgeschlagen",
+            "message": "Der KI-Dienst hat unsere Anmeldeinformationen abgelehnt. Ein Administrator muss den API-Schlüssel der LLM-Integration in den Administratoreinstellungen überprüfen."
+          },
+          "forbidden": {
+            "title": "Zugriff auf KI-Dienst verweigert",
+            "message": "Der KI-Dienst hat diese Anfrage abgelehnt. Ein Administrator muss die Berechtigungen der LLM-Integration und den Projektzugriff überprüfen."
+          },
+          "projectNotFound": {
+            "title": "Projekt nicht gefunden",
+            "message": "Wir konnten dieses Projekt nicht finden, oder Sie haben keine Berechtigung, hier KI-Generierung zu verwenden."
+          },
+          "noIntegration": {
+            "title": "Keine aktive LLM-Integration",
+            "message": "Für dieses Projekt ist keine aktive LLM-Integration konfiguriert. Ein Administrator muss diese in den Administratoreinstellungen aktivieren."
+          },
+          "invalidRequest": {
+            "title": "Ungültige Anfrage",
+            "message": "Die KI-Generierungsanfrage enthielt nicht alle erforderlichen Informationen. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut."
+          },
+          "retryButton": "Wiederholen",
+          "dismissButton": "Zurückweisen",
+          "suggestionsHeading": "Vorschläge",
+          "suggestions": {
+            "retryLater": "Versuchen Sie es in ein paar Minuten erneut.",
+            "contactAdmin": "Wenden Sie sich an Ihren Administrator, falls das Problem weiterhin besteht.",
+            "checkStatus": "Überprüfen Sie den Status des KI-Dienstes.",
+            "checkNetwork": "Überprüfen Sie Ihre Internetverbindung"
+          },
+          "timestampLabel": "Es ist ein Fehler aufgetreten bei",
+          "showDetails": "Details anzeigen",
+          "hideDetails": "Details ausblenden",
+          "copyDetails": "Kopierdetails",
+          "detailsCopied": "Fehlerdetails in die Zwischenablage kopiert"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Nicht gespeicherte Änderungen",
+        "description": "{count, plural, =1 {Es gibt 1 Testfall mit ungespeicherten Änderungen.} other {Es gibt # Testfälle mit ungespeicherten Änderungen.}}",
+        "warning": "Wenn Sie fortfahren, ohne zu speichern, gehen Ihre Änderungen verloren.",
+        "saveAllAndImport": "Alles speichern & importieren",
+        "discardAndImport": "Änderungen verwerfen & importieren"
+      },
+      "linkedIssuesDroppedTitle": "Einige damit zusammenhängende Probleme wurden nicht berücksichtigt.",
+      "linkedIssuesDropped": "{count, plural, =1 {# verknüpftes Problem wurde verworfen} other {# verknüpfte Probleme wurden verworfen}} aufgrund des Token-Budgets: {keys}.",
+      "linkedIssuesPreviewHeading": "Zugehörige Themen, die berücksichtigt werden"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Tag hinzufügen",
+      "title": "Neuen Tag hinzufügen",
+      "fields": {
+        "name_error": "Ein Tag-Name ist erforderlich."
+      },
+      "errors": {
+        "nameExists": "Ein Tag mit diesem Namen existiert bereits."
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Ein Tag mit diesem Namen existiert bereits."
+      }
+    },
+    "filterPlaceholder": "Filter-Tags...",
+    "defaultName": "Unbenanntes Etikett",
+    "noProject": "Kein Projekt",
+    "description": "Verwalten und organisieren Sie Ihre Testfälle und Sitzungen mit Tags.",
+    "detail": {
+      "title": "Tag-Details",
+      "filterPlaceholder": "Filterelemente...",
+      "noResults": "Keine Artikel gefunden",
+      "noFilterResults": "Es wurden keine Elemente gefunden, die den aktuellen Filtern entsprechen.",
+      "filters": {
+        "hideCompletedSessions": "Abgeschlossene Sitzungen ausblenden",
+        "hideCompletedTestRuns": "Abgeschlossene Testläufe ausblenden",
+        "caseTypeLabel": "Fallart",
+        "allCases": "Alle"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Suchbegriffe...",
+      "searchOrAddPlaceholder": "Tags suchen oder hinzufügen...",
+      "noOptions": "Keine Optionen"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Anhangsanzeige"
+    },
+    "delete": {
+      "confirmMessage": "Möchten Sie diesen Anhang wirklich löschen?",
+      "deferredMessage": "Dieser Anhang wird beim Speichern gelöscht."
+    }
+  },
+  "runs": {
+    "notFound": "Testlauf nicht gefunden.",
+    "add": {
+      "title": "Testlauf hinzufügen",
+      "description": "Füge dem Projekt einen neuen Testlauf hinzu.",
+      "success": {
+        "title": "Testlauf erfolgreich hinzugefügt",
+        "description": "Der Testlauf wurde dem Projekt hinzugefügt.",
+        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for '{name}'"
+      },
+      "estimates": {
+        "manual": "Geschätzte manuelle Zeit",
+        "automated": "Geschätzte automatische Zeit",
+        "mixed": "Geschätzte manuelle/automatisierte Zeit"
+      },
+      "creatingProgress": "Erstelle Testlauf {current} von {total}..."
+    },
+    "magicSelect": {
+      "title": "Magic Select",
+      "description": "KI-gestützte Testfallauswahl basierend auf Ihrem Testlaufkontext",
+      "counting": "Suche nach relevanten Testfällen...",
+      "reasoning": "KI-Schlussfolgerung",
+      "reviewSelection": "Überprüfung der vorgeschlagenen Testfälle",
+      "viewSuggested": "Empfohlene Fälle ansehen",
+      "tokenUsage": "{total} verwendete Tokens",
+      "noLlmIntegration": "Die KI-Funktionen erfordern eine LLM-Integration. Konfigurieren Sie diese in den Projekteinstellungen.",
+      "configure": {
+        "title": "Testfallumfang",
+        "description": "Im Repository wurden folgende Testfälle gefunden: {count, plural, =1 {# Testfälle} other {# Testfälle}}",
+        "descriptionFiltered": "Gefunden: {count, plural, =1 {# möglicherweise relevanter Testfall} other {# möglicherweise relevanter Testfall}} von {total, plural, =1 {# insgesamt} other {# insgesamt}} im Repository",
+        "noMatchesTitle": "Keine passenden Testfälle gefunden",
+        "noMatchesDescription": "Name und Beschreibung des Testlaufs stimmten mit keinem Testfall überein. Gehen Sie zurück zum vorherigen Schritt und fügen Sie genauere Details wie Funktionsnamen, Komponentennamen oder Schlüsselwörter hinzu, die in Ihren Testfällen vorkommen.",
+        "maxResultsTitle": "Maximale Anzahl übereinstimmender Testfälle",
+        "maxResultsDescription": "Die Suchkriterien ergaben eine große Anzahl an Treffern. Um gezieltere Ergebnisse zu erzielen, gehen Sie zurück zum vorherigen Schritt und fügen Sie dem Testlauf weitere spezifische Details hinzu.",
+        "batchSize": "Losgröße",
+        "batchSizeAll": "Alle Fälle (einzelne Anfrage)",
+        "batchSizePercent": "{percent}% ({count} Fälle)",
+        "requestsNeeded": "{count, plural, =1 {# KI-Anfrage wird gestellt} other {# KI-Anfragen werden gestellt}}",
+        "batchNote": "Die Ergebnisse aller Chargen werden zusammengeführt."
+      },
+      "loading": {
+        "batch": "Verarbeitung des Stapels {current} von {total}",
+        "analyzing": "Analyse der Testfälle...",
+        "progress": "Analysierte {analyzed} von {total} Testfällen...",
+        "waitingForAi": "Warte auf KI-Antwort (Batch {batch} von {total})...",
+        "selectedSoFar": "{count, plural, =1 {# Bisher ausgewählte Testfälle} other {# Bisher ausgewählte Testfälle}}",
+        "resolving_integration": "Lösung der KI-Integration...",
+        "fetching_cases": "Testfälle werden abgerufen..."
+      },
+      "success": {
+        "title": "Vorgeschlagene Testfälle",
+        "description": "{count, plural, =1 {# ausgewählter Testfall} other {# ausgewählte Testfälle}} basierend auf Ihrem Testlaufkontext",
+        "linkedCasesAdded": "{count, plural, =1 {# verknüpfte Fälle automatisch eingeschlossen} other {# verknüpfte Fälle automatisch eingeschlossen}}",
+        "truncationWarningTitle": "Teilergebnisse",
+        "truncationWarning": "{count, plural, =1 {# Batch wurde abgeschnitten} other {# Batches wurden abgeschnitten}} durch das KI-Modell — einige Testfälle wurden möglicherweise nicht ausgewertet."
+      },
+      "noSuggestions": {
+        "title": "Keine passenden Testfälle",
+        "description": "Es wurden keine Testfälle gefunden, die den Kriterien entsprachen. Bitte fügen Sie weitere Informationen oder Erläuterungen hinzu."
+      },
+      "clarification": {
+        "label": "Zusätzlicher Kontext (optional)",
+        "placeholder": "Fügen Sie zusätzlichen Kontext hinzu, um die Auswahl relevanter Testfälle zu erleichtern...",
+        "refine": "Auswahl verfeinern"
+      },
+      "actions": {
+        "start": "Testfälle analysieren",
+        "startBatched": "Analysiere Testfälle ({count, plural, one {# Batch} other {# Batches}})",
+        "accept": "Zur Auswahl hinzufügen"
+      },
+      "errors": {
+        "title": "Auswahl fehlgeschlagen",
+        "generic": "Bei der Auswahl der Testfälle ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+        "noTestRunName": "Bitte geben Sie vor der Verwendung von Magic Select einen Namen für den Testlauf ein."
+      }
+    },
+    "delete": {
+      "title": "Testlauf löschen",
+      "description": "Möchten Sie diesen Testlauf wirklich löschen? Die Ergebnisse werden für historische Analysen gespeichert.",
+      "warning": "Diese Handlung kann nicht rückgängig gemacht werden.",
+      "toast": {
+        "loading": "Testlauf wird gelöscht...",
+        "success": "Testlauf erfolgreich gelöscht",
+        "error": {
+          "title": "Testlauf konnte nicht gelöscht werden",
+          "description": "Beim Löschen des Testlaufs ist ein Fehler aufgetreten."
+        }
+      }
+    },
+    "summary": {
+      "title": "Zusammenfassung des Testlaufs",
+      "description": "Sehen Sie sich die Zusammenfassung des Testlaufs an.",
+      "activeRunsAndEstTime": "Aktive Läufe & Geschätzte Zeit",
+      "activeRunsLabel": "Läufe",
+      "totalEstTime": "Geschätzte Gesamtzeit",
+      "responsibleUsers": "Verantwortliche Nutzer",
+      "allActiveRuns": "Alle aktiven Läufe",
+      "recentResultsTitle": "Aktuelle manuelle Ergebnisse",
+      "recentResultsDescription": "Sehen Sie sich die aktuellen Ergebnisse des Testlaufs an.",
+      "recentAutomatedResultsTitle": "Aktuelle automatisierte Ergebnisse",
+      "noRecentAutomatedResults": "Es wurden keine aktuellen automatisierten Ergebnisse gefunden.",
+      "recentResultsDateRange": "Datumsbereich",
+      "recentResultsElapsed": "Vergangen",
+      "noRecentResults": "Keine aktuellen Ergebnisse gefunden.",
+      "completionTrendTitle": "Fertigstellungstrend (letzte 6 Monate)",
+      "workDistributionTitle": "Arbeitsverteilung",
+      "workDistributionDescription": "Geschätzte Arbeitsverteilung nach Aufgabenbereich.",
+      "noWorkDistributionData": "Es sind keine aktiven Sitzungen mit zugewiesenen Personen oder Kostenvoranschlägen anzuzeigen."
+    },
+    "details": {
+      "title": "Details zum Testlauf",
+      "description": "Sehen Sie sich die Details des Testlaufs an."
+    },
+    "duplicateDialog": {
+      "title": "Testlauf duplizieren",
+      "description": "Erstelle eine Kopie des Testlaufs <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Zu duplizierende Testfälle",
+          "allCases": "Alle Testfälle",
+          "specificStatuses": "Testfälle mit spezifischen Status"
+        },
+        "statusesToInclude": {
+          "label": "Zu berücksichtigende Testfälle",
+          "description": "Wählen Sie die Status der Testfälle aus, die Sie in den duplizierten Testlauf einbeziehen möchten.",
+          "noStatuses": "Bei diesem Testlauf wurden keine spezifischen Statuswerte gefunden, oder die Ergebnisse werden noch geladen.",
+          "noStatusesRecorded": "Bei diesem Durchlauf wurden keine spezifischen Status protokolliert. Durch das Duplizieren werden alle Testfälle (in der Regel als „Ungetestet“) eingeschlossen."
+        },
+        "copyAssignments": {
+          "label": "Testfallzuweisungen",
+          "copy": "Vorhandene Testfallzuweisungen kopieren",
+          "assign": "Alle Testfälle im duplizierten Testlauf behalten ihre bestehenden Zuordnungen.",
+          "unassign": "Alle Testfälle im duplizierten Testlauf werden nicht zugewiesen."
+        }
+      },
+      "successMessage": "Der Testlauf '{name}' wurde erfolgreich dupliziert.",
+      "errorMessage": "Fehler beim Duplizieren des Testlaufs. Fehler: {error}"
+    },
+    "filter": {
+      "placeholder": "Filtertestläufe..."
+    },
+    "typeFilter": {
+      "label": "Zeigen",
+      "both": "Manuell & Automatisiert"
+    },
+    "empty": {
+      "noMatchingCompleted": "Es wurden keine abgeschlossenen Testläufe gefunden, die Ihrem Filter entsprechen."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Hauptsächlich",
+      "projects": "Projekte",
+      "templatesAndFields": "Vorlagen & Felder",
+      "fields": "Felder",
+      "workflows": "Arbeitsabläufe",
+      "statuses": "Status",
+      "milestoneTypes": "Meilensteintypen",
+      "configurations": "Konfigurationen",
+      "users": "Benutzer",
+      "groups": "Gruppen",
+      "roles": "Rollen",
+      "tags": "Tags",
+      "issues": "Probleme",
+      "appConfig": "Anwendungskonfiguration",
+      "notifications": "Benachrichtigungen",
+      "imports": "Datenimporte",
+      "integrations": "Problemintegrationen",
+      "webhooks": "Webhooks",
+      "llm": "KI-Modelle",
+      "prompts": "Prompt-Konfigurationen",
+      "exportTemplates": "Exportvorlagen",
+      "codeRepositories": "Code-Repositories",
+      "quickScript": "QuickScript",
+      "sso": "Authentifizierung",
+      "security": "Sicherheit",
+      "trash": "Müll",
+      "reports": "Berichte",
+      "shares": "Aktien verwalten",
+      "elasticsearch": "Suchmaschine",
+      "queues": "Jobwarteschlangen",
+      "auditLogs": "Audit-Protokolle",
+      "apiTokens": "API-Tokens",
+      "quickscriptTemplates": "QuickScript-Vorlagen",
+      "testManagement": "Testmanagement",
+      "peopleAndAccess": "Menschen und Zugang",
+      "toolsAndIntegrations": "Tools & Integrationen",
+      "system": "System"
+    },
+    "imports": {
+      "description": "Daten aus externen Testmanagement-Tools in TestPlanIt importieren.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Laden Sie einen Testmo-JSON-Export hoch, um dessen Inhalt zu analysieren und Ihre Migrationszuordnung vorzubereiten.",
+        "wizard": {
+          "steps": {
+            "upload": "Upload-Export",
+            "analysis": "Analyse der Rezension",
+            "mapping": "Zuordnung konfigurieren",
+            "import": "Monitorimport"
+          },
+          "stepIndicator": "Schritt {step} von {total}"
+        },
+        "fileLabel": "Testmo JSON-Datei",
+        "fileHelp": "Wählen Sie den JSON-Export aus, den Sie von Testmo heruntergeladen haben.",
+        "analyze": "Export analysieren",
+        "analyzing": "Analyse läuft...",
+        "reset": "Klare Ergebnisse",
+        "job": {
+          "discoveringDatasets": "Datensätze entdecken...",
+          "scanningFile": "Testmo-Exportdatei wird gescannt...",
+          "datasetsProcessed": "{processed, number} Datensatz{processed, plural, one {} other {s}} verarbeitet",
+          "datasetsProcessedWithTotal": "{processed, number} von {total, number} Datensatz{total, plural, one {} other {s}} verarbeitet",
+          "rowsProcessed": "{value, number} verarbeitete Zeilen",
+          "itemsProcessed": "{processed, number} von {total, number} verarbeiteten Elementen",
+          "analysisInProgress": "Exportanalyse…",
+          "cancel": "Import abbrechen",
+          "cancelRequested": "Stornierung angefordert",
+          "processingRate": "Rate:",
+          "estimatedTimeRemaining": "Geschätzte verbleibende Zeit:",
+          "datasetsLabel": "Datensätze:",
+          "rowsProcessedLabel": "Zeilen:"
+        },
+        "summaryHeading": "Exportübersicht",
+        "summary": {
+          "datasets": "Datensätze",
+          "fileName": "Dateiname",
+          "fileSize": "Dateigröße",
+          "analysisTime": "Analysezeit"
+        },
+        "datasetTable": {
+          "name": "Datensatz",
+          "rows": "Reihen",
+          "samples": "Entnommene Proben"
+        },
+        "status": {
+          "truncated": "Gekürzt"
+        },
+        "selectDataset": "Datensatz auswählen",
+        "schema": "Schema",
+        "samples": "Beispielzeilen",
+        "noSamples": "Für diesen Datensatz wurden keine Proben erfasst.",
+        "mappingHeading": "Mapping-Konfiguration",
+        "mappingRefresh": "Aktualisierungsanalyse",
+        "mappingDescription": "Überprüfen Sie die Analysedetails und ordnen Sie Testmo-Entitäten bestehenden TestPlanIt-Datensätzen zu oder erstellen Sie neue.",
+        "mappingAnalysisError": "Es konnte keine Kartenanalyse erstellt werden. Bitte versuchen Sie es erneut.",
+        "mappingLoading": "Gebäudekartierungsanalyse…",
+        "mappingSummaryHeading": "Erkannte Entitäten",
+        "mappingSummaryPending": "{count, plural, =1 {# ausstehend} other {# ausstehend}}",
+        "mappingOutstandingTitle": "Offene Zuordnungen auflösen",
+        "mappingOutstandingDescription": "Schließen Sie die restlichen Zuordnungen ab, bevor Sie mit dem Import beginnen.",
+        "mappingOutstandingItem": "{count, plural, =1 {# unaufgelöstes Element} other {# unaufgelöste Elemente}} in {label}",
+        "mappingSummaryTemplateFields": "Vorlagenfelder",
+        "mappingDatasetLabels": {
+          "field_values": "Feldwerte",
+          "repository_case_values": "Repository-Fallwerte",
+          "configs": "Konfigurationseinstellungen",
+          "session_issues": "Sitzungsprobleme",
+          "session_tags": "Sitzungs-Tags",
+          "states": "Workflow-Zustände",
+          "statuses": "Status",
+          "templates": "Vorlagen",
+          "template_fields": "Vorlagenfelder",
+          "milestone_types": "Meilensteintypen",
+          "roles": "Rollen",
+          "users": "Benutzer",
+          "groups": "Gruppen",
+          "user_groups": "Benutzergruppen",
+          "issue_targets": "Problemintegrationen",
+          "tags": "Tags",
+          "sessions": "Sitzungen",
+          "session_results": "Sitzungsergebnisse",
+          "fields": "Felder",
+          "projects": "Projekte",
+          "repositories": "Repositories",
+          "repository_folders": "Repository-Ordner",
+          "repository_cases": "Repository-Fälle",
+          "repository_case_steps": "Schritte im Repository-Fall",
+          "repository_case_tags": "Repository-Falltags",
+          "milestones": "Meilensteine",
+          "runs": "Testläufe",
+          "run_tests": "Testlauffälle",
+          "run_results": "Ergebnisse des Testlaufs",
+          "run_result_steps": "Ergebnisse des Testlaufs",
+          "run_links": "Testlauf-Links",
+          "run_tags": "Testlauf-Tags",
+          "issues": "Probleme",
+          "milestone_issues": "Meilenstein-Probleme",
+          "repository_case_issues": "Repository-Fallprobleme",
+          "run_issues": "Probleme beim Testlauf",
+          "run_result_issues": "Probleme mit den Testergebnissen",
+          "session_result_issues": "Probleme mit den Sitzungsergebnissen",
+          "automation_cases": "Automatisierungsfälle",
+          "automation_runs": "Automatisierung läuft",
+          "automation_run_tests": "Automatisierungstests ausführen",
+          "automation_run_test_fields": "Automatisierungslauf Testfelder",
+          "automation_run_links": "Automatisierungs-Lauf-Links",
+          "automation_run_tags": "Automatisierungslauf-Tags",
+          "session_values": "Sitzungswerte"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Überprüfen Sie die Workflow-Status, um TestPlanIt-Workflows abzubilden oder zu erstellen.",
+          "statuses": "Konfigurieren Sie, wie Testmo-Status den TestPlanIt-Status zugeordnet werden.",
+          "templates": "Überprüfen Sie die aus Testmo importierten Vorlagendefinitionen.",
+          "template_fields": "Überprüfen Sie die im Export enthaltenen Vorlagenfelddefinitionen.",
+          "fields": "Überprüfen Sie die aus Testmo exportierten benutzerdefinierten Felddatensätze.",
+          "field_values": "Überprüfen Sie die im Export erfassten Feldwertdefinitionen.",
+          "milestone_types": "Prüfen Sie die im Export erfassten Meilensteintypdefinitionen.",
+          "roles": "Lesen Sie die Rollendefinitionen, um die Testmo-Berechtigungen zu verstehen.",
+          "users": "Sehen Sie sich die im Testmo-Export erkannten Benutzerkonten an.",
+          "groups": "Überprüfen Sie die Gruppenaufgaben, die aus Testmo übernommen wurden.",
+          "configs": "Ordnen Sie Konfigurationsnamen den TestPlanIt-Kategorien und -Varianten zu.",
+          "tags": "Untersuchen Sie die in den Testmo-Daten vorkommenden Tag-Werte.",
+          "repository_case_values": "Mehrfachauswahl von Werten, die Testfällen zugewiesen sind.",
+          "sessions": "Sitzungen werden immer als neue Sitzungen erstellt.",
+          "session_results": "Die Ergebnisse der Sitzungen sind mit den jeweiligen Sitzungen verknüpft.",
+          "session_issues": "Sitzungsprobleme hängen mit Sitzungen zusammen.",
+          "session_tags": "Session-Tags sind mit Sessions verknüpft.",
+          "issue_targets": "Ordnen Sie Testmo-Problemziele den TestPlanIt-Integrationen (Jira, GitHub usw.) zu."
+        },
+        "mappingDatasetDefaultDescription": "Überprüfung {dataset} im Testmo-Export erkannt.",
+        "mappingDatasetCount": "{count, number} Datensatz{count, plural, one {} other {s}} erkannt",
+        "mappingDatasetNoEntitiesTitle": "Nichts zu kartieren",
+        "mappingDatasetNoEntitiesDescription": "Dieser Datensatz erfordert keine Zuordnung. Fahren Sie mit dem nächsten Datensatz fort, sobald Sie bereit sind.",
+        "mappingDatasetUnsupportedTitle": "Keine Kartierung erforderlich",
+        "mappingDatasetUnsupportedDescription": "Diese Datensätze werden automatisch importiert und mit den zugehörigen Datensätzen in TestPlanIt verknüpft. Eine manuelle Zuordnung ist nicht erforderlich.",
+        "mappingDatasetEmptyTitle": "Keine Datensätze erhalten",
+        "mappingDatasetEmptyDescription": "Die Analyse hat keine Konfigurationsdatensätze gespeichert. Laden Sie einen anderen Export hoch, wenn Sie zusätzliche Daten erwarten.",
+        "importProgressTitle": "Importfortschritt",
+        "importProgressDescription": "{count, plural, =0 {Alle importierten Datensätze aller verfolgten Entitäten.} =1 {1 Datensatz aller verfolgten Entitäten verbleibend.} other {Anzahl der verbleibenden Datensätze aller verfolgten Entitäten.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Keine Datensätze mehr} =1 {1 Datensatz übrig} other {Anzahl der verbleibenden Datensätze}}",
+        "importProgressProcessed": "{processed, number}/{total, number} Datensätze importiert",
+        "importProgressAria": "{percent}% des Imports abgeschlossen",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Gesamtzeit:",
+        "activityLogTitle": "Importaktivität",
+        "activityLogDescription": "Detailliertes Protokoll der Hintergrundimportschritte. Die Zeitstempel basieren auf der Serverzeitzone.",
+        "activitySummaryProcessed": "{count, plural, =1 {# Datensatz verarbeitet} other {# Datensätze verarbeitet}}",
+        "activitySummaryCreated": "{count, plural, =1 {# erstellt} other {# erstellt}}",
+        "activitySummaryMapped": "{count, plural, =1 {# zugeordnet} other {# zugeordnet}}",
+        "activitySummaryUnknown": "Importieren",
+        "activityDefaultMessage": "Importaktualisierung",
+        "previousImportsHeading": "Vorherige Importe prüfen",
+        "previousImportsDescription": "Ergebnisse der Ladeanalyse nach einem abgeschlossenen Import zur Überprüfung der Konfiguration oder der Aktivitätsprotokolle.",
+        "previousImportsRefresh": "Liste aktualisieren",
+        "previousImportsPlaceholder": "Wählen Sie einen vorherigen Import aus.",
+        "previousImportsEmpty": "Für Ihr Konto wurden keine vorherigen Importe gefunden.",
+        "previousImportsCreatedLabel": "Erstellt: ",
+        "previousImportsFileLabel": "Datei: ",
+        "previousImportsNoFilename": "Unbekannte Datei",
+        "jobHistoryLoadFailed": "Zuvor importierte Aufträge konnten nicht geladen werden.",
+        "jobLoadFailed": "Der Importauftrag konnte nicht geladen werden.",
+        "uploadProgressAnalyzing": "Upload abgeschlossen. Datei wird analysiert…",
+        "uploadProgressComplete": "Upload abgeschlossen",
+        "etaLabel": "ETA: {time}",
+        "startImportButton": "Import starten",
+        "workflowCreate": {
+          "nameLabel": "Workflow-Name",
+          "namePlaceholder": "Geben Sie einen Workflow-Namen ein",
+          "scopePlaceholder": "Bereich auswählen",
+          "iconColorLabel": "Symbol & Farbe",
+          "typeLabel": "Workflow-Typ"
+        },
+        "mappingDatasets": "Datensätze, die einer Überprüfung bedürfen",
+        "mappingImportConfiguration": "Importkonfiguration",
+        "mappingExportConfiguration": "Exportkonfiguration",
+        "mappingImportConfigurationFailed": "Die Konfigurationsdatei konnte nicht importiert werden. Bitte überprüfen Sie, ob es sich um gültiges JSON handelt, und versuchen Sie es erneut.",
+        "mappingInvalidConfiguration": "Die Konfiguration muss gültiges JSON sein.",
+        "mappingSaveFailed": "Die Konfiguration konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+        "mappingSaveConfiguration": "Konfiguration speichern",
+        "mappingSavingConfiguration": "Speichern…",
+        "mappingStartImport": "Hintergrundimport starten",
+        "mappingStartingImport": "Import starten…",
+        "mappingImportFailed": "Der Hintergrundimport konnte nicht gestartet werden. Bitte versuchen Sie es erneut.",
+        "mappingImportDisabled": "Speichern Sie eine Konfiguration, bevor Sie den Hintergrundimport starten.",
+        "mappingImportInProgress": "Hintergrundimport läuft",
+        "mappingImportInProgressDescription": "Der Importprozess verarbeitet die Konfiguration. Den Status können Sie oben überwachen.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# Aufnahme} other {# Aufnahmen}} ",
+          "columnSource": "Testmo-Entität",
+          "columnSourceDetails": "Details",
+          "columnSuggestedWorkflowType": "Empfohlener Typ",
+          "columnTarget": "Ziel",
+          "workflowTypeUnknown": "Nicht erkannt",
+          "actionMap": "Zuordnung zu bestehenden",
+          "actionCreate": "Neu erstellen",
+          "workflowTypePlaceholder": "Typ auswählen",
+          "noWorkflowsAvailable": "Es sind keine Workflows verfügbar.",
+          "noStatusesAvailable": "Keine Statusinformationen verfügbar.",
+          "noGroupsAvailable": "Es sind keine Gruppen verfügbar.",
+          "groupSelectPlaceholder": "Gruppe auswählen",
+          "groupNotePlaceholder": "Anmerkungen (optional)",
+          "groupNoteEmpty": "Es wurden keine weiteren Details angegeben.",
+          "noUsersAvailable": "Keine Benutzer verfügbar.",
+          "userNoExistingTargets": "Keine Benutzer zur Zuordnung verfügbar.",
+          "userNamePlaceholder": "Vollständiger Name",
+          "userAccessPlaceholder": "Zugriffsebene auswählen",
+          "userRoleUnavailable": "Es sind keine Rollen zur Zuweisung verfügbar.",
+          "userPasswordPlaceholder": "Temporäres Passwort",
+          "userPasswordHint": "Geben Sie ein temporäres Passwort an. Benutzer können es nach der Anmeldung ändern.",
+          "userActiveLabel": "Aktives Konto",
+          "userDisplayFallback": "Benutzer {id}",
+          "userMissingRequired": "Fehlende erforderliche Angaben",
+          "noConfigurationsAvailable": "Keine Konfigurationen verfügbar.",
+          "configurationNoTokens": "In dieser Konfiguration wurden keine Varianten gefunden.",
+          "configurationNoExistingTargets": "Es sind keine Konfigurationen zum Zuordnen verfügbar.",
+          "configurationNamePlaceholder": "Geben Sie einen Konfigurationsnamen ein",
+          "configurationVariantLabel": "Variante {index}",
+          "configurationVariantActionLabel": "Wie sollte mit dieser Variante umgegangen werden?",
+          "configurationVariantActionPlaceholder": "Wählen Sie eine Option",
+          "configurationVariantMapOption": "Zuordnung zu bestehender Variante",
+          "configurationVariantExistingCategoryOption": "Variante in bestehender Kategorie erstellen",
+          "configurationVariantNewCategoryOption": "Neue Kategorie und Variante erstellen",
+          "configurationVariantSelectLabel": "Variante auswählen",
+          "configurationVariantNoVariants": "Es sind keine Varianten zur Kartierung verfügbar.",
+          "configurationVariantCategoryLabel": "Kategorie",
+          "configurationVariantNameLabel": "Variantenname",
+          "configurationVariantNamePlaceholder": "Geben Sie einen Variantennamen ein",
+          "configurationVariantNoCategories": "Keine Kategorien verfügbar.",
+          "configurationVariantCategoryNameLabel": "Kategoriename",
+          "configurationVariantCategoryNamePlaceholder": "Geben Sie einen Kategorienamen ein",
+          "noTemplateFieldsAvailable": "Es sind keine Vorlagenfelder verfügbar.",
+          "templateFieldDisplayFallback": "Feld {id}",
+          "templateFieldUnknownTemplate": "Unbekannte Vorlage",
+          "templateFieldTargetCase": "Fallfeld",
+          "templateFieldTargetResult": "Ergebnisfeld",
+          "templateFieldSelectPlaceholder": "Auswahlfeld",
+          "templateFieldNoExistingTargets": "Es sind keine Felder zur Zuordnung verfügbar.",
+          "templateFieldTypePlaceholder": "Feldtyp auswählen",
+          "templateFieldRestrictedLabel": "Eingeschränktes Feld",
+          "templateFieldOptionsLabel": "Dropdown-Optionen",
+          "templateFieldOptionsPlaceholder": "Geben Sie pro Zeile eine Option ein.",
+          "templateFieldOptionsHint": "Trennen Sie jede Option durch eine neue Zeile.",
+          "templateFieldOptionsListLabel": "Optionen",
+          "templateFieldOptionsCheckedLabel": "Standardmäßig aktiviert",
+          "templateFieldOptionsMinValueLabel": "Minimalwert",
+          "templateFieldOptionsMaxValueLabel": "Maximalwert",
+          "templateFieldOptionsMinIntegerLabel": "Minimale ganze Zahl",
+          "templateFieldOptionsMaxIntegerLabel": "Maximale ganze Zahl",
+          "templateFieldNewFieldSummaryTitle": "Neue Felddetails",
+          "templateFieldNewFieldSummaryDescription": "Überprüfen Sie die Werte, die zur Erstellung dieses TestPlanIt-Felds verwendet werden.",
+          "templateFieldConfigureFieldButton": "Details konfigurieren",
+          "templateFieldEditFieldButton": "Details bearbeiten",
+          "templateFieldSummaryMissingValue": "Nicht festgelegt",
+          "templateFieldSummaryMissingDetailsHint": "Bitte geben Sie die neuen Felddetails an, bevor Sie fortfahren.",
+          "templateFieldModalSaveButton": "Details speichern",
+          "templateFieldTargetTypeLabel": "Zieltyp",
+          "templateFieldTypeMismatchWarning": "Der ausgewählte Feldtyp {target} stimmt nicht mit dem Testmo-Feldtyp {source}überein.",
+          "templateFieldDuplicateTargetWarning": "Das ausgewählte Ziel ist bereits einem anderen Testmo-Feld zugeordnet. Wählen Sie ein anderes Ziel.",
+          "templateFieldTargetAlreadyUsed": "Bereits kartiert",
+          "templateFieldMappedSummary": "Abgebildet auf {name} ({type})",
+          "templateFieldIssueMissingTarget": "Wählen Sie ein Zielfeld aus.",
+          "templateFieldIssueMissingDetails": "Bitte geben Sie vor dem Fortfahren den Anzeigenamen, den Systemnamen und den Feldtyp an.",
+          "noTemplatesAvailable": "Es sind keine Vorlagen verfügbar.",
+          "templateColumnFields": "Felder",
+          "templateFieldStatusMapped": "Kartiert",
+          "templateFieldStatusCreate": "Neues Feld erstellen",
+          "templateFieldStatusMissing": "Nicht kartiert",
+          "templateFieldStatusMismatch": "Zielabweichung",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# Fallfeld} other {# Fallfelder}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# Ergebnisfeld} other {# Ergebnisfelder}}",
+          "templateMapLabel": "Zuordnung zu bestehender Vorlage",
+          "templateCreateLabel": "Neue Vorlage erstellen",
+          "templateNoMatchingTargets": "Es sind keine passenden Vorlagen verfügbar.",
+          "templateNewNameLabel": "Vorlagenname",
+          "templateMapHintIncomplete": "Ordnen Sie alle Testmo-Felder vorhandenen Fall- und Ergebnisfeldern zu, bevor Sie sie einer bestehenden Vorlage zuordnen.",
+          "templateMapHintDuplicate": "Jedes Testmo-Feld muss einem eindeutigen TestPlanIt-Feld zugeordnet sein.",
+          "templateMapHintNoMatch": "Keine der bestehenden Vorlagen verwendet denselben Satz an Feldern.",
+          "templateMapHintAlreadyMapped": "Alle passenden Vorlagen sind bereits zugeordnet. Löschen Sie die übrigen Zuordnungen, bevor Sie fortfahren.",
+          "templateIssueNoSelection": "Wählen Sie eine vorhandene Vorlage zur Zuordnung aus.",
+          "templateIssueTargetConflict": "Eine andere Vorlage ist diesem Ziel bereits zugeordnet.",
+          "templateIssueFieldErrors": "Lösen Sie die markierten Vorlagenfelder auf.",
+          "templateTargetFieldsMismatch": "Die Felder entsprechen nicht dieser Vorlage.",
+          "templateTargetNoLongerMatching": "Die Felder entsprechen dieser Vorlage nicht mehr.",
+          "noRolesAvailable": "Es sind keine Stellen verfügbar.",
+          "roleSelectPlaceholder": "Rolle auswählen",
+          "roleNameLabel": "Rollenname",
+          "roleNamePlaceholder": "Geben Sie einen Rollennamen ein",
+          "rolePermissionsEmpty": "Keine Berechtigungen zugewiesen",
+          "rolePermissionAddEdit": "Hinzufügen / Bearbeiten",
+          "noMilestoneTypesAvailable": "Es sind keine Meilensteintypen verfügbar.",
+          "milestoneSelectPlaceholder": "Meilensteintyp auswählen",
+          "milestoneNamePlaceholder": "Geben Sie einen Meilenstein-Typnamen ein",
+          "milestoneDefaultLabel": "Standard-Meilensteintyp",
+          "milestoneIconRequired": "Wählen Sie ein Symbol aus",
+          "statusColorPlaceholder": "Farbhex (optional)",
+          "issueTargetSelectPlaceholder": "Integration auswählen...",
+          "noIssueTargetsAvailable": "Keine Integrationen verfügbar",
+          "issueTargetNamePlaceholder": "Integrationsname...",
+          "templateFieldsHeading": "Vorlagenfelder",
+          "roleAreaColumn": "Bereich",
+          "workflowSelectPlaceholder": "Workflow auswählen",
+          "statusSelectPlaceholder": "Status auswählen",
+          "statusNamePlaceholder": "Geben Sie einen Statusnamen ein",
+          "statusSystemNamePlaceholder": "Geben Sie einen Systemnamen ein",
+          "labelSystemName": "Systemname",
+          "groupNamePlaceholder": "Geben Sie einen Gruppennamen ein",
+          "configurationNameLabel": "Konfigurationsname",
+          "userSelectPlaceholder": "Benutzer auswählen",
+          "userApiLabel": "API-Benutzer",
+          "templateCaseFieldsLabel": "Großbuchstaben",
+          "templateResultFieldsLabel": "Ergebnisfelder",
+          "templateNoFieldsPlaceholder": "Für diese Vorlage sind keine Felder konfiguriert.",
+          "templateTargetAlreadyUsed": "Das Ziel ist bereits einer anderen Vorlage zugeordnet.",
+          "templateFieldRequiredLabel": "Pflichtfeld",
+          "templateFieldOptionsDefaultValueLabel": "Standardwert",
+          "templateFieldOptionsInitialHeightLabel": "Anfangshöhe",
+          "templateFieldTemplateLabelSingular": "Vorlage",
+          "templateFieldTemplateLabelPlural": "Vorlagen",
+          "templateFieldTargetGroupCase": "Großbuchstaben",
+          "templateFieldTargetGroupResult": "Ergebnisfelder",
+          "columnAction": "Aktion"
+        },
+        "nextSteps": "Nach Abschluss des Hintergrundimports können Sie die migrierten Daten aus den Zielprojekten überprüfen.",
+        "nextStepsDescription": "Hintergrundimporte werden asynchron ausgeführt. Sie können den Status oben überwachen oder die Seite aktualisieren, um die Aktualisierungen anzuzeigen."
+      },
+      "comingSoon": {
+        "description": "Importe für TestRail, Zephyr und andere Tools sind geplant."
+      },
+      "errors": {
+        "fileRequired": "Bitte wählen Sie vor der Analyse eine Testmo-Export-JSON-Datei aus.",
+        "uploadFailed": "Die Exportdatei konnte nicht im Speicher abgelegt werden. Bitte versuchen Sie es erneut.",
+        "analysisFailed": "Der Export konnte nicht analysiert werden. Bitte überprüfen Sie die Datei und versuchen Sie es erneut."
+      }
+    },
+    "sso": {
+      "description": "Authentifizierungs- und Sicherheitseinstellungen verwalten",
+      "sections": {
+        "providers": {
+          "title": "Anmeldeanbieter",
+          "description": "Konfigurieren Sie, wie sich Benutzer bei Ihrer Anwendung anmelden können."
+        },
+        "security": {
+          "title": "Sicherheit",
+          "description": "Konfigurieren Sie Sicherheitsrichtlinien für die Authentifizierung"
+        }
+      },
+      "globalSettings": {
+        "title": "Globale SSO-Einstellungen",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Google OAuth-Authentifizierung aktivieren oder deaktivieren"
+        },
+        "samlProvider": {
+          "title": "SAML-Anbieter",
+          "description": "SAML-Authentifizierung aktivieren oder deaktivieren"
+        },
+        "apple": {
+          "title": "Apple-Anmeldung",
+          "description": "Apple-Anmeldeauthentifizierung aktivieren oder deaktivieren"
+        },
+        "microsoft": {
+          "title": "Microsoft SSO",
+          "description": "Aktivieren oder deaktivieren Sie die Microsoft-Authentifizierung (Azure AD / Entra ID)."
+        },
+        "magicLink": {
+          "title": "Magic Link-Authentifizierung",
+          "description": "Passwortlose E-Mail-basierte Authentifizierung aktivieren oder deaktivieren"
+        },
+        "forceSso": {
+          "title": "SSO-Anmeldung erzwingen",
+          "description": "Deaktivieren Sie die E-Mail-Anmeldung und verpflichten Sie die Benutzer zur Verwendung von SSO."
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Zwei-Faktor-Authentifizierung für Passwortanmeldungen erzwingen",
+            "description": "Benutzer, die sich mit E-Mail/Passwort anmelden, müssen die Zwei-Faktor-Authentifizierung einrichten und verwenden."
+          },
+          "forceAllLogins": {
+            "title": "Zwei-Faktor-Authentifizierung für alle Anmeldungen erforderlich",
+            "description": "Alle Benutzer müssen sich nach der Anmeldung per Zwei-Faktor-Authentifizierung (2FA) verifizieren, dies gilt auch für SSO-Benutzer."
+          }
+        }
+      },
+      "providers": {
+        "configure": "SAML konfigurieren",
+        "delete": "Anbieter löschen",
+        "entryPoint": "Eingangspunkt: ",
+        "autoProvision": "Automatische Bereitstellung: ",
+        "defaultAccess": "Standardzugriff: ",
+        "configurationMessage": "SAML-Konfiguration nicht eingerichtet. Klicken Sie auf die Schaltfläche „Einstellungen“, um die Konfiguration vorzunehmen."
+      },
+      "samlConfiguration": {
+        "title": "SAML-Anbieter konfigurieren",
+        "backButton": "Zurück zu den SSO-Anbietern",
+        "description": "SAML-Einstellungen für {name}konfigurieren",
+        "samlSettings": {
+          "title": "SAML-Einstellungen",
+          "description": "Konfigurieren Sie Ihre SAML-Identitätsanbietereinstellungen",
+          "ssoUrl": "SSO-URL (Einstiegspunkt)",
+          "entityId": "Entitäts-ID (Aussteller)",
+          "certificate": "X.509-Zertifikat",
+          "callbackUrl": "Callback-URL",
+          "logoutUrl": "Abmelde-URL (optional)"
+        },
+        "userProvisioning": {
+          "title": "Benutzerbereitstellung",
+          "description": "Konfigurieren Sie, wie Benutzer erstellt und zugeordnet werden",
+          "autoProvision": "Automatische Bereitstellung neuer Benutzer",
+          "defaultAccess": "Standard-Systemzugriff für neue Benutzer",
+          "accessDescription": "Neuen Benutzern wird die Standardrolle aus der Datenbank und diese Systemzugriffsebene zugewiesen."
+        },
+        "attributeMapping": {
+          "title": "Attributzuordnung",
+          "description": "SAML-Attribute Benutzerfeldern zuordnen",
+          "email": "E-Mail-Attribut",
+          "displayName": "Anzeigename-Attribut",
+          "userId": "Benutzer-ID-Attribut",
+          "firstName": "Vorname (optional)",
+          "lastName": "Nachname (optional)",
+          "groups": "Gruppenattribut (optional)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Google OAuth aktiviert",
+        "googleDisabled": "Google OAuth deaktiviert",
+        "googleCreated": "Google OAuth-Anbieter erstellt",
+        "googleUpdateFailed": "Google OAuth konnte nicht aktualisiert werden",
+        "samlCreated": "SAML-Anbieter erstellt",
+        "createFailed": "Anbieter konnte nicht erstellt werden",
+        "deleted": "Anbieter gelöscht",
+        "deleteFailed": "Fehler beim Löschen des Anbieters",
+        "enabled": "Anbieter aktiviert",
+        "disabled": "Anbieter deaktiviert",
+        "updateFailed": "Aktualisierung des Anbieters fehlgeschlagen",
+        "forceSsoEnabled": "SSO global erzwingen",
+        "forceSsoDisabled": "SSO erzwingen ist global deaktiviert",
+        "forceSsoUpdateFailed": "Fehler beim Aktualisieren der Einstellung „SSO erzwingen“",
+        "force2FANonSSOEnabled": "Zwei-Faktor-Authentifizierung für Passwortanmeldungen erforderlich",
+        "force2FANonSSODisabled": "Zwei-Faktor-Authentifizierung für Passwortanmeldungen nicht mehr erforderlich.",
+        "force2FAAllLoginsEnabled": "Für alle Anmeldungen ist eine Zwei-Faktor-Authentifizierung erforderlich.",
+        "force2FAAllLoginsDisabled": "Die Zwei-Faktor-Authentifizierung ist nicht mehr für alle Anmeldungen erforderlich.",
+        "force2FAUpdateFailed": "Die Aktualisierung der Zwei-Faktor-Authentifizierungseinstellung ist fehlgeschlagen.",
+        "configUpdated": "SAML-Konfiguration aktualisiert",
+        "configCreated": "SAML-Konfiguration erstellt",
+        "configSaveFailed": "SAML-Konfiguration konnte nicht gespeichert werden",
+        "googleConfigSaved": "Google OAuth-Konfiguration erfolgreich gespeichert",
+        "googleConfigFailed": "Konfiguration konnte nicht gespeichert werden",
+        "appleEnabled": "Apple-Anmeldung aktiviert",
+        "appleDisabled": "Apple-Anmeldung deaktiviert",
+        "appleCreated": "Apple-Anmeldeanbieter erstellt",
+        "appleConfigSaved": "Apple-Anmeldekonfiguration erfolgreich gespeichert",
+        "appleConfigFailed": "Die Apple-Anmeldekonfiguration konnte nicht gespeichert werden.",
+        "appleUpdateFailed": "Fehler beim Aktualisieren des Apple-Anmeldeanbieters",
+        "microsoftEnabled": "Microsoft SSO aktiviert",
+        "microsoftDisabled": "Microsoft SSO deaktiviert",
+        "microsoftCreated": "Microsoft SSO-Anbieter erstellt",
+        "microsoftConfigSaved": "Microsoft SSO-Konfiguration erfolgreich gespeichert",
+        "microsoftConfigFailed": "Microsoft SSO-Konfiguration konnte nicht gespeichert werden",
+        "microsoftUpdateFailed": "Fehler beim Aktualisieren des Microsoft SSO-Anbieters",
+        "magicLinkEnabled": "Magic Link-Authentifizierung aktiviert",
+        "magicLinkDisabled": "Magic Link-Authentifizierung deaktiviert",
+        "magicLinkCreated": "Magic Link-Anbieter erstellt",
+        "magicLinkUpdateFailed": "Aktualisierung des Magic Link-Anbieters fehlgeschlagen",
+        "samlConfigSaved": "SAML-Konfiguration erfolgreich gespeichert",
+        "configureFirst": "Bitte konfigurieren Sie den Provider, bevor Sie ihn aktivieren.",
+        "domainRestrictionEnabled": "E-Mail-Domänenbeschränkung aktiviert",
+        "domainRestrictionDisabled": "E-Mail-Domänenbeschränkung deaktiviert",
+        "domainRestrictionUpdateFailed": "Fehler beim Aktualisieren der Domänenbeschränkungseinstellung",
+        "domainRequired": "Bitte geben Sie eine Domain ein.",
+        "invalidDomain": "Bitte geben Sie eine gültige Domain ein (z. B. example.com).",
+        "domainAdded": "Domain erfolgreich hinzugefügt",
+        "domainExists": "Diese Domain befindet sich bereits in der Liste der zulässigen Domains.",
+        "domainAddFailed": "Domäne konnte nicht hinzugefügt werden",
+        "domainEnabled": "Domäne aktiviert",
+        "domainDisabled": "Domäne deaktiviert",
+        "domainUpdateFailed": "Domäne konnte nicht aktualisiert werden",
+        "domainDeleted": "Domain erfolgreich entfernt",
+        "domainDeleteFailed": "Domäne konnte nicht entfernt werden",
+        "defaultAccessUpdated": "Standardzugriffsebene aktualisiert",
+        "defaultAccessUpdateFailed": "Fehler beim Aktualisieren der Standardzugriffsebene",
+        "emailVerificationEnabled": "Für neue Benutzer ist nun eine E-Mail-Verifizierung erforderlich.",
+        "emailVerificationDisabled": "Eine E-Mail-Verifizierung ist für neue Benutzer nicht mehr erforderlich.",
+        "emailVerificationDisabledAndVerified": "E-Mail-Verifizierung deaktiviert und {count, plural, one {# Benutzerkonto} other {# Benutzerkonten}} verifiziert",
+        "emailVerificationUpdateFailed": "E-Mail-Verifizierungseinstellungen konnten nicht aktualisiert werden",
+        "emailServerNotConfigured": "E-Mail-Verifizierung kann nicht aktiviert werden: Der E-Mail-Server ist nicht konfiguriert.",
+        "openRegistrationEnabled": "Die Selbstregistrierung ist jetzt aktiviert.",
+        "openRegistrationDisabled": "Die Selbstregistrierung ist jetzt deaktiviert.",
+        "openRegistrationUpdateFailed": "Die Aktualisierung der Selbstregistrierungseinstellungen ist fehlgeschlagen."
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Google OAuth konfigurieren",
+          "description": "Richten Sie Ihre Google OAuth-Client-Anmeldeinformationen ein. Diese erhalten Sie in der Google Cloud Console.",
+          "clientIdPlaceholder": "Ihre Google OAuth-Client-ID",
+          "clientSecretPlaceholder": "Ihr Google OAuth-Clientgeheimnis",
+          "instructions": {
+            "title": "Um diese Zugangsdaten zu erhalten:",
+            "step1": "Gehen Sie zur Google Cloud Console.",
+            "step2": "Wählen Sie Ihr Projekt aus oder erstellen Sie ein neues.",
+            "step3": "Aktivieren Sie die Google+ API",
+            "step4": "Gehen Sie zu „Anmeldeinformationen“ und erstellen Sie eine OAuth 2.0-Client-ID.",
+            "step5": "Legen Sie die autorisierte Umleitungs-URI wie folgt fest:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "Sowohl Client-ID als auch Client-Geheimnis werden benötigt."
+          }
+        },
+        "microsoft": {
+          "title": "Microsoft SSO konfigurieren",
+          "description": "Richten Sie Ihre Microsoft Entra ID (Azure AD) Anwendungsanmeldeinformationen ein. Diese erhalten Sie im Azure-Portal.",
+          "clientIdPlaceholder": "Ihre Anwendungs-(Client-)ID",
+          "clientSecretPlaceholder": "Ihr Kundengeheimniswert",
+          "tenantId": "Mieter-ID (optional)",
+          "tenantIdPlaceholder": "Ihre Verzeichnis-(Mandanten-)ID",
+          "tenantIdHint": "Lassen Sie das Feld für Mandantenfähigkeit („gemeinsam“) leer. Geben Sie Ihre spezifische Mandanten-ID ein, um den Zugriff auf Ihre Organisation zu beschränken.",
+          "instructions": {
+            "title": "Um diese Zugangsdaten zu erhalten:",
+            "step1": "Gehen Sie zum Azure-Portal (portal.azure.com).",
+            "step2": "Navigieren Sie zu Microsoft Entra ID > App-Registrierungen",
+            "step3": "Registrieren Sie eine neue Anwendung oder wählen Sie eine bestehende aus",
+            "step4": "Unter „Zertifikate & Geheimnisse“ erstellen Sie ein neues Client-Geheimnis.",
+            "step5": "Fügen Sie unter Authentifizierung die folgende Umleitungs-URI hinzu:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "Sowohl Client-ID als auch Client-Geheimnis werden benötigt."
+          }
+        },
+        "saml": {
+          "description": "Konfigurieren Sie Ihren SAML-Identitätsanbieter. Diese Details erhalten Sie von Ihrem SAML-IdP.",
+          "entryPoint": "SSO-Einstiegspunkt-URL",
+          "issuer": "Aussteller (Unternehmens-ID)",
+          "callbackUrl": "ACS (Callback) URL",
+          "logoutUrl": "SLO-Abmelde-URL (optional)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:your-idp:entity-id",
+          "certPlaceholder": "-----BEGINN DES ZERTIFIKATS-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "So konfigurieren Sie SAML:",
+            "step1": "Wenden Sie sich an Ihren SAML-Identitätsanbieter-Administrator.",
+            "step2": "Fordern Sie die SSO-Einstiegspunkt-URL und die Entitäts-ID an.",
+            "step3": "Laden Sie das X.509-Zertifikat herunter",
+            "step4": "Konfigurieren Sie diese ACS-URL in Ihrem IdP:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "Einstiegspunkt, Aussteller, Zertifikat und Rückruf-URL sind erforderlich."
+          }
+        },
+        "disableEmailVerification": {
+          "title": "E-Mail-Verifizierung deaktivieren?",
+          "description": "Dadurch wird die E-Mail-Verifizierung für neue Benutzeranmeldungen deaktiviert und alle bestehenden, nicht verifizierten Konten werden verifiziert.",
+          "warning": "⚠️ Sicherheitswarnung",
+          "warningPoint1": "Nur für sichere Installationen empfohlen (private Netzwerke, VPNs oder vertrauenswürdige Umgebungen).",
+          "warningPoint2": "Alle bestehenden, nicht verifizierten Konten werden umgehend verifiziert und erhalten Systemzugriff.",
+          "confirmation": "Sind Sie sicher, dass Sie die E-Mail-Verifizierung deaktivieren und alle Konten verifizieren möchten?",
+          "confirm": "Deaktivieren und überprüfen Sie alle",
+          "verifying": "Konten werden überprüft..."
+        }
+      },
+      "status": {
+        "configured": "Konfiguriert",
+        "setup": "Aufstellen"
+      },
+      "registration": {
+        "title": "Registrierungseinstellungen",
+        "description": "Legen Sie fest, wer sich für neue Konten registrieren kann.",
+        "restrictDomains": {
+          "title": "E-Mail-Domänen einschränken",
+          "description": "Nur Registrierungen von bestimmten E-Mail-Domänen zulassen"
+        },
+        "allowedDomains": {
+          "title": "Zulässige E-Mail-Domänen",
+          "placeholder": "example.com",
+          "add": "Domäne hinzufügen",
+          "empty": "Es sind keine zulässigen Domains konfiguriert. Alle Domains werden blockiert, sobald die Einschränkung aktiviert ist."
+        },
+        "defaultAccess": {
+          "title": "Standardzugriffsebene",
+          "description": "Die Systemzugriffsebene, die neuen Benutzern bei der Registrierung zugewiesen wird.",
+          "options": {
+            "NONE": "Kein Zugriff – Benutzer können erst dann auf das System zugreifen, wenn ein Administrator ihnen den Zugriff gewährt.",
+            "USER": "Benutzer – Standardbenutzerzugriff auf zugewiesene Projekte",
+            "PROJECTADMIN": "Projektadministrator – Kann die ihnen zugewiesenen Projekte verwalten",
+            "ADMIN": "Administrator – Vollständiger Systemadministratorzugriff"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "E-Mail-Verifizierung erforderlich",
+          "description": "Benutzer müssen ihre E-Mail-Adresse bestätigen, bevor sie auf das System zugreifen können.",
+          "noEmailServerWarning": "Der E-Mail-Server ist nicht konfiguriert. Die E-Mail-Verifizierung ist automatisch deaktiviert, bis ein E-Mail-Server eingerichtet ist."
+        },
+        "allowOpenRegistration": {
+          "title": "Selbstregistrierung zulassen",
+          "description": "Wenn diese Funktion deaktiviert ist, können sich neue Benutzer weder direkt registrieren noch ein Konto per SSO erstellen. Bestehende Benutzer können sich weiterhin anmelden."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Ungültiger Anbieter oder kein SAML-Anbieter."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Filterprojekte..."
+      },
+      "complete": {
+        "title": "Projekt abschließen",
+        "description": "Mit dieser Aktion wird das Projekt abgeschlossen und das Hinzufügen weiterer Testläufe verhindert."
+      },
+      "add": {
+        "button": "Projekt hinzufügen",
+        "title": "Neues Projekt hinzufügen",
+        "defaultFields": "Standardvorlage, Standard-Meilensteintyp sowie alle Workflows und Status werden dem Projekt bei der Erstellung hinzugefügt.",
+        "selectIssueTracker": "Problemverfolgung auswählen",
+        "issueTrackerRequired": "Ein Issue-Tracker ist erforderlich."
+      },
+      "wizard": {
+        "title": "Neues Projekt erstellen",
+        "description": "Richten Sie ein neues Projekt mit allen erforderlichen Konfigurationen ein.",
+        "steps": {
+          "details": "Projektdetails",
+          "workflows": "Workflows, Status und Meilensteintypen",
+          "integrations": "Integrationen",
+          "permissions": "Benutzer und Berechtigungen"
+        },
+        "labels": {
+          "selected": "Ausgewählt",
+          "statuses": "Teststatus",
+          "issueTrackers": "Problemverfolgung"
+        },
+        "placeholders": {
+          "projectName": "Geben Sie den Projektnamen ein",
+          "selectDefaultAccess": "Standardzugriffstyp auswählen"
+        },
+        "descriptions": {
+          "templates": "Wählen Sie mindestens eine Vorlage aus, um die Struktur der Testfälle in diesem Projekt zu definieren.",
+          "workflows": "Konfigurieren Sie Arbeitsabläufe, Status und Meilensteintypen zur Verwaltung von Projektaktivitäten.",
+          "integrations": "Optional: Verbinden Sie externe Issue-Tracker und KI-Modelle für erweiterte Funktionalität.",
+          "noIntegrations": "Es sind derzeit keine Integrationen konfiguriert. Sie können diesen Schritt überspringen oder die Integrationen später konfigurieren.",
+          "aiModels": "Aktivieren Sie KI-Modelle zur Generierung von Testfällen und intelligenten Vorschlägen.",
+          "permissions": "Konfigurieren Sie Benutzerzugriffs- und Gruppenberechtigungen für dieses Projekt.",
+          "milestoneTypes": "Wählen Sie Meilensteintypen aus, um den Projektfortschritt und die Termine zu verfolgen."
+        },
+        "actions": {
+          "selectDefault": "Standardwert verwenden",
+          "create": "Projekt erstellen",
+          "creating": "Projekt wird erstellt..."
+        },
+        "errors": {
+          "nameRequired": "Projektname erforderlich",
+          "validationFailed": "Der Projektname konnte nicht überprüft werden. Bitte versuchen Sie es erneut.",
+          "templateRequired": "Es muss mindestens eine Vorlage ausgewählt werden.",
+          "workflowRequired": "Mindestens ein Workflow muss ausgewählt werden.",
+          "statusRequired": "Mindestens ein Status muss ausgewählt werden.",
+          "roleRequired": "Bitte wählen Sie eine Rolle aus, wenn Sie den Zugriffstyp „Spezifische Rolle“ verwenden.",
+          "creationFailed": "Das Projekt konnte nicht erstellt werden. Bitte versuchen Sie es erneut."
+        },
+        "success": {
+          "created": "Projekt erfolgreich erstellt"
+        }
+      },
+      "edit": {
+        "title": "Projekt bearbeiten",
+        "labels": {
+          "groupProjectAccess": "Gruppenprojektzugriff",
+          "groupPermissions": "Gruppenberechtigungen",
+          "userPermissions": "Benutzerberechtigungen",
+          "noEffect": "Keine Wirkung",
+          "access": {
+            "groupsGlobalRole": "Globale Rolle der Gruppe",
+            "groupDefault": "Standardgruppe",
+            "groupSpecificRole": "Gruppenspezifische Rolle",
+            "groupProjectDefault": "Standardeinstellungen für Gruppenprojekte",
+            "groupProjectNoAccess": "Gruppenprojekt – Kein Zugriff",
+            "groupProjectSpecificRole": "Gruppenprojektspezifische Rolle",
+            "effectiveAccess": "Effektiver Zugang"
+          },
+          "accessHints": {
+            "noAccess": "Benutzer haben keinen Zugriff auf dieses Projekt, es sei denn, ihnen wird dieser ausdrücklich durch direkte Zuweisung oder Gruppenzugehörigkeit gewährt.",
+            "globalRole": "Alle Benutzer mit Zugriff auf die Website können dieses Projekt einsehen. Ihre Berechtigungen werden durch ihre global zugewiesene Rolle bestimmt.",
+            "specificRole": "Benutzer erhalten nicht automatisch Zugriff. Der Zugriff muss durch direkte Benutzerzuweisung oder Gruppenmitgliedschaft gewährt werden. Benutzer, die über Gruppen zugewiesen wurden, verwenden diese Rolle, sofern sie nicht durch direkte Zuweisung überschrieben werden."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Standardzugriff auswählen",
+          "groupPermissionsUI": "Die Benutzeroberfläche für die Gruppenberechtigungsverwaltung kommt hierher...",
+          "userPermissionsUI": "Die Benutzeroberfläche für die Verwaltung von Benutzerberechtigungen kommt hierher...",
+          "selectAccess": "Zugriff auswählen...",
+          "selectRole": "Rolle auswählen...",
+          "searchUsersToAdd": "Benutzer zum Hinzufügen suchen..."
+        },
+        "tableHeaders": {
+          "globalRole": "Globale Rolle",
+          "projectAccess": "Projektzugang"
+        },
+        "messages": {
+          "noUsersAssigned": "Keinem Benutzer wurden spezifische Berechtigungen zugewiesen.",
+          "noGroupsFound": "Keine Gruppen gefunden."
+        },
+        "actions": {
+          "removeUser": "Benutzer entfernen"
+        },
+        "loadingUserPermissions": "Benutzerberechtigungen werden geladen..."
+      },
+      "delete": {
+        "title": "Projekt löschen",
+        "confirmMessage": "Möchten Sie dieses Projekt wirklich löschen?"
+      }
+    },
+    "templates": {
+      "description": "Testfallvorlagen und Felder verwalten",
+      "help": {
+        "caseFields": "Fallfelder definieren die Eigenschaften und Daten, die für jeden Testfall im Repository erfasst werden können. Sie ermöglichen es Ihnen, die Testfallinformationen über die Standardfelder hinaus anzupassen.",
+        "resultFields": "Ergebnisfelder definieren zusätzliche Daten, die bei der Aufzeichnung von Testergebnissen erfasst werden können. Sie ermöglichen es Ihnen, benutzerdefinierte Informationen zu den Ergebnissen der Testausführung zu verfolgen."
+      },
+      "confirmSetAsDefault": "Als Standardvorlage festlegen",
+      "confirmSetAsDefaultDescription": "Möchten Sie diese Vorlage wirklich als Standard festlegen?",
+      "confirmSetAsDefaultProjects": "Diese Vorlage wird allen Projekten hinzugefügt.",
+      "add": {
+        "button": "Vorlage hinzufügen",
+        "title": "Neue Vorlage hinzufügen",
+        "defaultTemplateHint": "Diese Vorlage wird allen Projekten zugewiesen."
+      },
+      "edit": {
+        "title": "Vorlage bearbeiten"
+      },
+      "delete": {
+        "title": "Vorlage löschen",
+        "confirmMessage": "Möchten Sie die Vorlage <strong>{name}</strong> wirklich löschen?",
+        "warning": "Alle Testfälle und explorativen Sitzungen, die derzeit diese Vorlage verwenden, werden automatisch der Standardvorlage neu zugewiesen.",
+        "errors": {
+          "defaultTemplateNotFound": "Standardvorlage nicht gefunden. Löschvorgang kann nicht fortgesetzt werden.",
+          "unknown": "Beim Löschen der Vorlage ist ein unbekannter Fehler aufgetreten."
+        }
+      },
+      "caseFields": {
+        "description": "Fallfelder verwalten",
+        "add": {
+          "button": "Fall hinzufügen Feld",
+          "title": "Neues Fallfeld hinzufügen"
+        },
+        "edit": {
+          "title": "Feld bearbeiten"
+        },
+        "delete": {
+          "title": "Löschen Sie das Feld „Fall“",
+          "confirmMessage": "Möchten Sie dieses Fallfeld wirklich löschen?",
+          "warning": "Das Feld „Fall“ wird aus allen Vorlagen entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
+        }
+      },
+      "resultFields": {
+        "description": "Ergebnisfelder verwalten",
+        "add": {
+          "button": "Ergebnisfeld hinzufügen",
+          "title": "Neues Ergebnisfeld hinzufügen"
+        },
+        "edit": {
+          "title": "Ergebnis bearbeiten"
+        },
+        "delete": {
+          "title": "Ergebnisfeld löschen",
+          "confirmMessage": "Möchten Sie wirklich <strong>{name}</strong>löschen?",
+          "warning": "Das Ergebnisfeld wird aus allen Vorlagen entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Code-Repositories",
+      "description": "Code-Repository-Verbindungen für den QuickScript-Kontext verwalten.",
+      "addRepository": "Repository hinzufügen",
+      "noRepos": {
+        "title": "Es sind keine Code-Repositories konfiguriert.",
+        "description": "Verbinden Sie ein Git-Repository, um Dateikontext für die KI-gestützte Generierung von Testexporten bereitzustellen."
+      },
+      "delete": {
+        "title": "Repository löschen",
+        "confirmMessage": "Möchten Sie wirklich <strong>{name}</strong>löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "fallbackName": "dieses Repository"
+      },
+      "testConnection": "Testverbindung",
+      "connectionSuccess": "Verbindung erfolgreich",
+      "connectionFailed": "Verbindung fehlgeschlagen",
+      "networkError": "Netzwerkfehler",
+      "editTitle": "Code-Repository bearbeiten",
+      "addTitle": "Code-Repository hinzufügen",
+      "repositoryUpdated": "Repository aktualisiert",
+      "repositoryCreated": "Repository erstellt",
+      "saveFailed": "Repository konnte nicht gespeichert werden",
+      "namePlaceholder": "Mein Repository",
+      "selectProvider": "Anbieter auswählen",
+      "httpWarning": "Diese URL verwendet HTTP. Anmeldeinformationen werden unverschlüsselt übertragen. Verwenden Sie HTTPS für sichere Verbindungen."
+    },
+    "exportTemplates": {
+      "title": "QuickScript-Vorlagen",
+      "description": "Verwalten Sie Vorlagen, die von QuickScript verwendet werden, um Testfälle in Automatisierungsskripte umzuwandeln.",
+      "confirmSetAsDefault": "Als Standardexportvorlage festlegen",
+      "confirmSetAsDefaultDescription": "Möchten Sie diese Vorlage wirklich als Standard festlegen? Sie wird beim Export von Testfällen automatisch vorausgewählt.",
+      "fields": {
+        "category": "Kategorie",
+        "framework": "Rahmen",
+        "fileExtension": "Dateierweiterung",
+        "headerBody": "Header-Vorlage",
+        "templateBody": "Vorlagenkörper",
+        "footerBody": "Fußzeilenvorlage",
+        "validation": {
+          "categoryRequired": "Eine Kategorie ist erforderlich.",
+          "frameworkRequired": "Ein Framework ist erforderlich.",
+          "templateBodyRequired": "Der Vorlagentext ist erforderlich.",
+          "fileExtensionRequired": "Die Dateiendung ist erforderlich.",
+          "languageRequired": "Sprachkenntnisse sind erforderlich."
+        },
+        "placeholders": {
+          "name": "z.B. Dramaturg (TypeScript)",
+          "description": "z.B. Generiert Test-Stubs für den Drehbuchautor",
+          "category": "z. B. Browser E2E",
+          "framework": "z.B. Dramatiker",
+          "fileExtension": "z. B. .spec.ts",
+          "language": "z.B. TypeScript",
+          "headerBody": "Optional. Inhalte, die einmalig am Anfang gerendert werden (z. B. Importanweisungen).",
+          "templateBody": "Mustache-Vorlage eingeben...\n\nVerfügbare Variablen:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSchrittabschnitt:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nBenutzerdefinierte Felder:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Optional. Inhalt, der einmalig am Ende gerendert wird (z. B. der schließende Code)."
+        },
+        "combobox": {
+          "typeNew": "Geben Sie einen neuen Wert ein"
+        }
+      },
+      "add": {
+        "button": "QuickScript-Vorlage hinzufügen",
+        "title": "Neue QuickScript-Vorlage hinzufügen"
+      },
+      "edit": {
+        "title": "QuickScript-Vorlage bearbeiten"
+      },
+      "delete": {
+        "title": "QuickScript-Vorlage löschen",
+        "confirmMessage": "Möchten Sie die QuickScript-Vorlage <strong>{name}</strong> wirklich löschen?"
+      },
+      "preview": {
+        "title": "Vorschau (Beispieldaten)",
+        "empty": "Geben Sie einen Vorlagentext ein, um eine Vorschau anzuzeigen.",
+        "error": "Fehler beim Rendern der Vorlage. Überprüfen Sie Ihre Mustache-Syntax."
+      },
+      "filterPlaceholder": "Filtervorlagen...",
+      "noResults": "Keine Vorlagen entsprechen Ihrem Filter.",
+      "templateCount": "{count, plural, one {# Vorlage} other {# Vorlagen}}",
+      "allFrameworks": "Alle Frameworks",
+      "allFileExtensions": "Alle Erweiterungen",
+      "allLanguages": "Alle Sprachen",
+      "showEnabled": "Nur aktiviert",
+      "showAll": "Alle",
+      "variableInserter": {
+        "placeholder": "Variable einfügen...",
+        "groups": {
+          "customFields": "Benutzerdefinierte Felder"
+        },
+        "stepsBlock": "Schritte blockieren"
+      }
+    },
+    "users": {
+      "showInactive": "Inaktive anzeigen",
+      "add": {
+        "button": "Benutzer hinzufügen",
+        "title": "Neuen Benutzer hinzufügen",
+        "fields": {
+          "email_invalid": "Ungültige E-Mail-Adresse",
+          "password_error": "Passwort erforderlich",
+          "confirmPassword_error": "Passwortbestätigung erforderlich",
+          "passwordOptionalHelp": "Lassen Sie dieses Feld leer, wenn sich der Benutzer über einen magischen Link oder SSO anmelden muss."
+        }
+      },
+      "edit": {
+        "title": "Benutzer bearbeiten"
+      },
+      "delete": {
+        "title": "Benutzer löschen"
+      },
+      "restore": {
+        "title": "Gelöschten Benutzer wiederherstellen",
+        "description": "Ein gelöschter Benutzer mit der E-Mail-Adresse {email} wurde gefunden. Möchten Sie diesen Benutzer wiederherstellen?",
+        "confirm": "Benutzer wiederherstellen"
+      },
+      "forcePasswordChange": "Passwortänderung erzwingen",
+      "revokePassword": "Passwort widerrufen",
+      "forcePasswordChangeDialogTitle": "Passwortänderung erzwingen",
+      "forcePasswordChangeDialogDescription": "Dies erfordert, dass {name} ihr Passwort beim nächsten Login ändern.",
+      "revokePasswordDialogTitle": "Passwort widerrufen",
+      "revokePasswordDialogDescription": "Dadurch wird das Passwort von {name}sofort ungültig. Sie müssen eine andere Anmeldemethode verwenden.",
+      "confirmAction": "Bestätigen",
+      "forcePasswordChangeSuccess": "Passwortänderung erforderlich für {name}",
+      "forcePasswordChangeFailed": "Passwortänderung konnte nicht erzwungen werden",
+      "revokePasswordSuccess": "Passwort für {name} widerrufen",
+      "revokePasswordFailed": "Passwort widerrufen fehlgeschlagen"
+    },
+    "security": {
+      "title": "Sicherheit",
+      "description": "Konfigurieren Sie die Passwortrichtlinie, die Sperreinstellungen und die Durchsetzungsmaßnahmen.",
+      "passwordPolicyTitle": "Passwortrichtlinie",
+      "passwordPolicyDescription": "Anforderungen für Benutzerpasswörter festlegen",
+      "lockoutPolicyTitle": "Aussperrungsrichtlinie",
+      "lockoutPolicyDescription": "Kontosperrung nach fehlgeschlagenen Anmeldeversuchen konfigurieren",
+      "enforcementTitle": "Durchsetzungsmaßnahmen",
+      "enforcementDescription": "Passwortänderungen für Benutzer mit Anmeldeinformationen erzwingen",
+      "minPasswordLengthLabel": "Mindestpasswortlänge",
+      "minPasswordLengthDescription": "Passwörter müssen mindestens so viele Zeichen haben (8-128).",
+      "requireUppercaseLabel": "Großbuchstaben erforderlich",
+      "requireLowercaseLabel": "Kleinbuchstaben erforderlich",
+      "requireNumbersLabel": "Zahlen erforderlich",
+      "requiredSpecialCharsLabel": "Erforderliche Sonderzeichen",
+      "requiredSpecialCharsDescription": "Zum Deaktivieren leer lassen. Geben Sie die Zeichen ein, die angezeigt werden sollen (z. B. !@#$).",
+      "passwordHistoryDepthLabel": "Passwortverlaufstiefe",
+      "passwordHistoryDepthDescription": "Die Wiederverwendung der letzten N Passwörter verhindern (0 = deaktiviert)",
+      "passwordExpirationDaysLabel": "Ablaufdatum des Passworts (Tage)",
+      "passwordExpirationDaysDescription": "Passwortänderung nach N Tagen erzwingen (0 = deaktiviert)",
+      "lockoutThresholdLabel": "Sperrschwelle",
+      "lockoutThresholdDescription": "Anzahl fehlgeschlagener Versuche vor Kontosperrung (mindestens 1)",
+      "lockoutDurationMinutesLabel": "Sperrdauer (Minuten)",
+      "lockoutDurationMinutesDescription": "Wie lange das Konto gesperrt bleibt (mindestens 1)",
+      "saveChanges": "Änderungen speichern",
+      "forceAllUsers": "Alle Benutzer zur Passwortänderung zwingen",
+      "forceAllUsersDialogTitle": "Passwortänderung für alle Benutzer erzwingen",
+      "forceAllUsersDialogDescription": "Dies erfordert, dass {count} Benutzer, die auf Anmeldeinformationen angewiesen sind, ihr Passwort beim nächsten Login ändern.",
+      "forceAllUsersDialogWarning": "Diese Handlung kann nicht rückgängig gemacht werden.",
+      "forceAllUsersDialogConfirm": "Kraftänderung",
+      "saved": "Sicherheitseinstellungen gespeichert",
+      "saveFailed": "Sicherheitseinstellungen konnten nicht gespeichert werden",
+      "forceAllSuccess": "Passwortänderung für {count} Benutzer erforderlich",
+      "forceAllFailed": "Passwortänderung konnte nicht erzwungen werden"
+    },
+    "apiTokens": {
+      "description": "API-Tokens für alle Benutzer anzeigen und verwalten. Tokens widerrufen, wenn Sicherheitsbedenken bestehen.",
+      "filterPlaceholder": "Nach Token-Namen oder Benutzer filtern...",
+      "showInactive": "Show widerrufen",
+      "noTokens": "Es wurden noch keine API-Token erstellt.",
+      "columns": {
+        "lastUsed": "Zuletzt verwendet",
+        "expires": "Läuft ab"
+      },
+      "status": {
+        "revoked": "Widerrufen",
+        "expired": "Abgelaufen"
+      },
+      "noExpiry": "Kein Verfallsdatum",
+      "revokeToken": "Token widerrufen",
+      "revokeConfirmTitle": "API-Token widerrufen",
+      "revokeConfirmMessage": "Sind Sie sicher, dass Sie dieses API-Token widerrufen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "revokeConfirmDescription": "Das Token \"{name}\", das zu {user} gehört, wird sofort widerrufen und kann nicht mehr für den API-Zugriff verwendet werden.",
+      "revokeSuccess": "API-Token erfolgreich widerrufen",
+      "revokeError": "API-Token konnte nicht widerrufen werden.",
+      "revokeAllTokens": "Alle Token widerrufen",
+      "revokeAllTitle": "Alle API-Token widerrufen",
+      "revokeAllDescription": "Dadurch werden ALLE aktiven API-Tokens aller Benutzer sofort widerrufen. Diese Aktion kann nicht rückgängig gemacht werden und kann automatisierte Arbeitsabläufe stören.",
+      "revokeAllConfirm": "Geben Sie „REVOKE ALL“ ein, um zu bestätigen.",
+      "revokeAllPlaceholder": "ALLE WIDERRUF",
+      "revokeAllSuccess": "Alle API-Token wurden widerrufen.",
+      "revokeAllError": "Fehler beim Widerruf aller Token"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Beim Erstellen des Tags ist ein Fehler aufgetreten."
+        }
+      },
+      "delete": {
+        "title": "Tag löschen",
+        "confirmMessage": "Möchten Sie dieses Tag wirklich löschen?",
+        "warning": "Dieses Tag wird aus allen Testfällen und Sitzungen entfernt.",
+        "errors": {
+          "unknown": "Beim Löschen des Tags ist ein Fehler aufgetreten."
+        }
+      },
+      "edit": {
+        "title": "Tag bearbeiten"
+      }
+    },
+    "workflows": {
+      "description": "Testfall-Workflows verwalten",
+      "add": {
+        "button": "Workflow hinzufügen",
+        "title": "Neuen Workflow hinzufügen",
+        "defaultHelp": "Als Standard-Workflow für neue Testfälle festlegen",
+        "scopeLabel": "Workflow-Umfang",
+        "errors": {
+          "nameExists": "Ein Workflow mit diesem Namen existiert bereits."
+        }
+      },
+      "edit": {
+        "title": "Workflow bearbeiten",
+        "lastWorkflowTypeWarning": "Dies ist der letzte Workflow-Typ. Mindestens ein Workflow-Typ muss aktiviert sein.",
+        "errors": {
+          "nameRequired": "Ein Workflow-Name ist erforderlich.",
+          "unknownWorkflow": "Unbekannter Workflow"
+        }
+      },
+      "delete": {
+        "title": "Workflow löschen",
+        "confirmMessage": "Möchten Sie diesen Workflow wirklich löschen?"
+      },
+      "setDefault": {
+        "title": "Standard-Workflow festlegen",
+        "confirmMessage": "Möchten Sie diesen Workflow wirklich als Standard festlegen?",
+        "description": "Dieser Workflow wird allen Projekten hinzugefügt."
+      }
+    },
+    "roles": {
+      "description": "Definieren Sie, welche Aktionen Benutzer ausführen können, indem Sie die Berechtigungen für jeden Anwendungsbereich umschalten.",
+      "filterPlaceholder": "Filterrollen...",
+      "add": {
+        "button": "Rolle hinzufügen",
+        "title": "Neue Rolle hinzufügen",
+        "fields": {
+          "name_error": "Die Angabe des Rollennamens ist erforderlich."
+        },
+        "errors": {
+          "nameExists": "Eine Rolle mit diesem Namen existiert bereits."
+        }
+      },
+      "edit": {
+        "title": "Rolle bearbeiten",
+        "permissionsTitle": "Berechtigungen",
+        "areaHeader": "Anwendungsgebiet"
+      },
+      "delete": {
+        "title": "Rolle löschen",
+        "confirmMessage": "Möchten Sie diese Rolle wirklich löschen?",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden. Benutzer mit dieser Rolle werden der Standardrolle zugewiesen.",
+        "errors": {
+          "defaultNotFound": "Standardrolle kann nicht gelöscht werden"
+        }
+      }
+    },
+    "statuses": {
+      "description": "Teststatus verwalten",
+      "add": {
+        "button": "Status hinzufügen",
+        "title": "Neuen Status hinzufügen",
+        "systemNameHelp": "Der Systemname kennzeichnet diesen Status. Er kann nach der Erstellung nicht mehr geändert werden.",
+        "aliasesHelp": "Durch Kommas getrennte Liste von Aliasen",
+        "errors": {
+          "nameExists": "Ein Status mit diesem Namen existiert bereits.",
+          "systemNameEmpty": "Systemname erforderlich",
+          "systemNameInvalid": "Der Systemname muss alphanumerisch sein.",
+          "aliasesInvalid": "Aliase müssen alphanumerisch sein.",
+          "missingColor": "Die Farbe wurde nicht gefunden. Bitte wählen Sie eine andere Farbe."
+        }
+      },
+      "edit": {
+        "title": "Status bearbeiten",
+        "systemNameHelp": "Der Systemname kennzeichnet diesen Status für automatisierte Prozesse. Er kann nach der Erstellung nicht mehr geändert werden.",
+        "unmodifiableHelp": "Der Status „ungetestet“ ist ein Systemstatus und kann nicht geändert werden.",
+        "untestedHelp": "Die Bezeichnung „ungetestet“ ist für einen Systemstatus reserviert und kann nicht verwendet werden.",
+        "success": "Status erfolgreich aktualisiert"
+      },
+      "delete": {
+        "title": "Löschstatus",
+        "confirmMessage": "Möchten Sie den Status <strong>{name}</strong>wirklich löschen?",
+        "errors": {
+          "inUse": "Dieser Status ist in Verwendung und kann nicht gelöscht werden.",
+          "defaultNotFound": "Standardstatus nicht gefunden"
+        },
+        "success": "Status erfolgreich gelöscht"
+      },
+      "fields": {
+        "final": "Finale",
+        "system": "Systemstatus",
+        "forTestCase": "Für den Testfall",
+        "forTestRun": "Für den Testlauf",
+        "forSession": "Für die Sitzung",
+        "color": "Farbe"
+      }
+    },
+    "appConfig": {
+      "description": "Globale Anwendungskonfigurationen verwalten",
+      "addConfig": "Anwendungskonfiguration hinzufügen",
+      "editConfig": "Anwendungskonfiguration bearbeiten",
+      "keyPlaceholder": "Konfigurationsschlüssel eingeben...",
+      "valuePlaceholder": "Geben Sie einen JSON-Wert ein...",
+      "currentTranslation": "Aktuelle Übersetzung",
+      "filterPlaceholder": "Nach Schlüssel filtern...",
+      "errors": {
+        "keyRequired": "Schlüssel erforderlich",
+        "invalidJson": "Ungültiges JSON-Format"
+      },
+      "configKeys": {
+        "project_docs_default": "Standardeinstellungen für die Projektdokumentation"
+      }
+    },
+    "configurations": {
+      "description": "Konfigurationen sind eine Kombination aus Kategorien und Varianten, die zur Definition einer Testumgebung verwendet werden. Beispiele hierfür sind Betriebssystem/Browser, Testserver, Sprache usw.",
+      "addConfiguration": "Konfiguration hinzufügen",
+      "editConfiguration": "Konfiguration bearbeiten",
+      "filterPlaceholder": "Filterkonfigurationen...",
+      "categories": {
+        "title": "Kategorien",
+        "description": "Globale Kategorien verwalten",
+        "editCategory": "Kategorie bearbeiten",
+        "selectCategory": "Kategorie auswählen",
+        "filterPlaceholder": "Filterkategorien...",
+        "add": {
+          "title": "Neue Kategorie hinzufügen"
+        },
+        "delete": {
+          "confirmMessage": "Möchten Sie diese Kategorie wirklich löschen?",
+          "deleteCategory": "Kategorie löschen",
+          "deleteCategoryConfirm": "Möchten Sie die Kategorie <strong>{name}</strong>wirklich löschen?",
+          "deleteCategoryWarning": "Durch diese Aktion werden die Kategorie und alle zugehörigen Varianten gelöscht."
+        },
+        "disable": {
+          "confirmDisableTitle": "Variante deaktivieren",
+          "confirmDisableDescription": "Sind Sie sicher, dass Sie diese Variante deaktivieren möchten?"
+        }
+      },
+      "combinations": {
+        "title": "Kombinationen",
+        "description": "Globale Kombinationen verwalten",
+        "addCombination": "Kombination hinzufügen",
+        "editCombination": "Bearbeitungskombination",
+        "selectCombination": "Kombination auswählen",
+        "selectCombinationDescription": "Wählen Sie eine Kombination von Varianten aus, die Sie der Konfiguration hinzufügen möchten.",
+        "allExist": "Alle Kombinationen existieren bereits.",
+        "selectAtLeast": "Bitte wählen Sie mindestens eine Kombination aus."
+      },
+      "delete": {
+        "title": "Konfiguration löschen",
+        "message": "Sind Sie sicher, dass Sie die Konfiguration <strong>{name}</strong>löschen möchten?",
+        "confirmMessage": "Möchten Sie diese Konfiguration wirklich löschen?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Bearbeitungsvariante"
+        },
+        "delete": {
+          "title": "Variante löschen",
+          "message": "Sind Sie sicher, dass Sie die Variante <strong>{name}</strong>löschen möchten?",
+          "confirmMessage": "Möchten Sie diese Variante wirklich löschen?",
+          "suggestion": "Erwägen Sie stattdessen, die Variante zu deaktivieren."
+        },
+        "selection": {
+          "title": "Varianten auswählen",
+          "description": "Wählen Sie die Varianten aus, die Sie der Konfiguration hinzufügen möchten."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Organisieren Sie Benutzer in Gruppen, um Projektzugriffe und Rollen in großen Mengen zuzuweisen."
+      },
+      "filterPlaceholder": "Filtergruppen...",
+      "add": {
+        "button": "Gruppe hinzufügen",
+        "title": "Neue Gruppe hinzufügen",
+        "errors": {
+          "nameExists": "Eine Gruppe mit diesem Namen existiert bereits."
+        }
+      },
+      "edit": {
+        "title": "Gruppe bearbeiten"
+      },
+      "delete": {
+        "deleteGroup": "Gruppe löschen",
+        "deleteGroupDescription": "Durch diese Aktion werden die Gruppe und alle zugehörigen Benutzer gelöscht.",
+        "confirmMessage": "Möchtest du diese Gruppe wirklich löschen?"
+      },
+      "noUsersSelected": "Es wurden noch keine Benutzer ausgewählt.",
+      "noUsersAssigned": "Dieser Gruppe sind keine Benutzer zugewiesen."
+    },
+    "milestones": {
+      "description": "Meilensteintypen verwalten",
+      "filterPlaceholder": "Filter-Meilensteintypen...",
+      "addMilestones": "Meilensteine in großen Mengen hinzufügen",
+      "confirmDefault": "Standardwert bestätigen",
+      "confirmDefaultDescription": "Möchten Sie diesen Meilensteintyp wirklich als Standard festlegen?",
+      "warning": "Dieser Meilensteintyp wird allen Projekten hinzugefügt.",
+      "wizard": {
+        "selectProjects": "Projekte auswählen",
+        "projectsSelected": "{count, plural, =0 {Keine Projekte ausgewählt} one {# Projekte ausgewählt} other {# Projekte ausgewählt}}",
+        "createMilestone": "Meilenstein erstellen",
+        "noCommonTypesTitle": "Keine gemeinsamen Meilensteintypen",
+        "noCommonTypesDescription": "Die ausgewählten Projekte weisen keine gemeinsamen Meilensteintypen auf. Bitte stellen Sie sicher, dass alle ausgewählten Projekte mindestens einen gemeinsamen Meilensteintyp haben, oder wählen Sie unterschiedliche Projekte aus."
+      },
+      "add": {
+        "button": "Meilensteintyp hinzufügen",
+        "title": "Neuen Meilensteintyp hinzufügen",
+        "errors": {
+          "nameExists": "Ein Meilensteintyp mit diesem Namen existiert bereits."
+        }
+      },
+      "edit": {
+        "title": "Meilensteintyp bearbeiten"
+      },
+      "delete": {
+        "title": "Meilensteintyp löschen",
+        "confirmMessage": "Möchten Sie diesen Meilensteintyp wirklich löschen?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Link-Problem-Tracker",
+      "link_description": "Konfigurieren Sie die Basis-URL für manuell verknüpfte Vorgänge. Wenn ein Vorgang nur über eine externe ID verknüpft wird, wird diese Basis-URL vorangestellt, um den vollständigen Link zu erstellen.",
+      "filter": {
+        "show_inactive": "Inaktive Konfigurationen anzeigen",
+        "search_placeholder": "Nach Konfigurationsnamen filtern..."
+      },
+      "base_url": "Basis-URL",
+      "link_update_success": "Linkkonfiguration erfolgreich aktualisiert",
+      "link_update_error": "Linkkonfiguration konnte nicht aktualisiert werden",
+      "description": "Konfiguration von Integrationen mit externen Issue-Tracking-Systemen.",
+      "delete": {
+        "title": "Problemkonfiguration löschen",
+        "confirmMessage": "Sind Sie sicher, dass Sie die Konfiguration <bold>{name}</bold>löschen möchten?",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden. Alle Projekte, die diesem Tracker aktuell zugewiesen sind, werden dem Standard-Tracker neu zugewiesen. Erwägen Sie stattdessen, die Konfiguration zu deaktivieren.",
+        "cannotDeleteDefault": "Der Standard-Problemverfolgungs-Tracker kann nicht gelöscht werden.",
+        "noDefaultFound": "Löschen nicht möglich: Es wurde kein Standard-Issue-Tracker gefunden, dem Projekte neu zugewiesen werden können."
+      },
+      "add": {
+        "title": "Problemverfolgung hinzufügen",
+        "description": "Erstellen Sie eine neue Konfiguration für ein Problemverfolgungssystem.",
+        "name": "Konfigurationsname",
+        "name_placeholder": "z. B. Projekt-Jira-Links",
+        "system_type": "Systemtyp",
+        "select_system_type": "Systemtyp auswählen",
+        "base_url": "Basis-URL einschließlich des Problemplatzhalters",
+        "base_url_placeholder": "z. B. https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Problemkonfiguration erfolgreich erstellt",
+        "create_error": "Fehler beim Erstellen der Problemkonfiguration",
+        "setDefaultWarning": "Wenn diese Option als Standard festgelegt wird, wird der Standardstatus aus der aktuellen Standardkonfiguration entfernt."
+      },
+      "edit": {
+        "title": "Problemverfolgung bearbeiten",
+        "description": "Aktualisieren Sie die Details für diese Problemkonfiguration.",
+        "name_placeholder": "Geben Sie den Konfigurationsnamen ein",
+        "select_project": "Projekte auswählen...",
+        "update_success": "Problemkonfiguration erfolgreich aktualisiert",
+        "update_error": "Fehler beim Aktualisieren der Problemkonfiguration",
+        "edit_not_supported": "Die Bearbeitung der Konfiguration für diesen Systemtyp wird derzeit nicht unterstützt."
+      }
+    },
+    "issues": {
+      "description": "Verwalten Sie Probleme für diesen Issue-Tracker",
+      "filterPlaceholder": "Filterprobleme...",
+      "add": {
+        "button": "Problem hinzufügen",
+        "title": "Neues Problem hinzufügen"
+      },
+      "edit": {
+        "title": "Problem bearbeiten"
+      },
+      "delete": {
+        "title": "Problem löschen",
+        "confirmMessage": "Möchten Sie das Problem \"{name}\" wirklich löschen?"
+      },
+      "syncIssue": "Synchronisierungsproblem durch externes System",
+      "syncSuccess": "Problem erfolgreich synchronisiert",
+      "syncSuccessDescription": "Die Ausgabe \"{name}\" wurde mit den neuesten Informationen aus dem externen System aktualisiert.",
+      "syncError": "Synchronisierungsproblem fehlgeschlagen",
+      "syncErrorDescription": "Das Problem konnte nicht synchronisiert werden. Bitte versuchen Sie es später erneut."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Projektlinks",
+        "milestoneLinks": "Meilenstein-Links",
+        "icons": "Symbole",
+        "fieldOptions": "Feldoptionen",
+        "configCategories": "Konfigurationskategorien",
+        "configVariants": "Konfigurationsvarianten",
+        "repositories": "Repositories",
+        "repositoryFolders": "Repository-Ordner",
+        "repositoryCaseLinks": "Repository Case Links",
+        "repositoryCaseVersions": "Repository-Fallversionen",
+        "testRunStepResults": "Ergebnisse des Testlaufs",
+        "issueConfigs": "Problemkonfigurationen",
+        "sharedStepGroups": "Gemeinsame Schrittgruppen"
+      },
+      "table": {
+        "title": "Gelöscht {itemType}",
+        "loading": "Gelöscht wird geladen {itemType}...",
+        "error": "Fehler beim Laden gelöschter Dateien {itemType}: {message}",
+        "noItems": "Es wurden keine gelöschten {itemType} gefunden.",
+        "noResults": "Es wurden keine gelöschten {itemType} gefunden, die Ihrer Suche nach \"{query}\" entsprechen.",
+        "restoreConfirmationMessage": "Sind Sie sicher, dass Sie diese Zeile aus der Tabelle {itemType} wiederherstellen möchten? Zugehörige Daten werden möglicherweise ebenfalls wiederhergestellt.",
+        "purgeConfirmationMessage": "Sind Sie sicher, dass Sie diese Zeile aus der Tabelle {itemType} endgültig löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden und könnte zugehörige Daten löschen."
+      }
+    },
+    "notifications": {
+      "title": "Benachrichtigungsverwaltung",
+      "description": "Legen Sie die Standardeinstellungen für Benachrichtigungen fest (Benutzer können diese überschreiben) und versenden Sie Systembenachrichtigungen.",
+      "defaultMode": {
+        "label": "Standardbenachrichtigungsmodus",
+        "inApp": "Nur in der App",
+        "inAppEmailImmediate": "In-App + E-Mail (sofort)",
+        "inAppEmailDaily": "In-App + E-Mail (tägliche Zusammenfassung)"
+      },
+      "options": {
+        "title": "Verfügbare Benachrichtigungsoptionen",
+        "inApp": {
+          "label": "In-App-Benachrichtigungen",
+          "description": "Benachrichtigungen innerhalb der Anwendung anzeigen"
+        },
+        "emailImmediate": {
+          "label": "Sofortige E-Mail",
+          "description": "Senden Sie sofort E-Mail-Benachrichtigungen, wenn Ereignisse eintreten"
+        },
+        "emailDaily": {
+          "label": "Tägliche E-Mail-Zusammenfassung",
+          "description": "Senden Sie eine tägliche Zusammenfassung der Benachrichtigungen per E-Mail."
+        }
+      },
+      "save": "Einstellungen speichern",
+      "success": {
+        "title": "Einstellungen gespeichert",
+        "description": "Die Benachrichtigungseinstellungen wurden erfolgreich aktualisiert."
+      },
+      "error": {
+        "description": "Benachrichtigungseinstellungen konnten nicht gespeichert werden"
+      },
+      "systemNotification": {
+        "title": "Systembenachrichtigungen",
+        "description": "Wichtige Ankündigungen an alle Benutzer senden",
+        "titlePlaceholder": "Geben Sie einen Benachrichtigungstitel ein...",
+        "messagePlaceholder": "Benachrichtigung eingeben...",
+        "send": "Benachrichtigung senden",
+        "success": {
+          "title": "Benachrichtigung gesendet",
+          "description": "Systembenachrichtigung gesendet an {count, plural, one {# Benutzer} other {# Benutzer}}"
+        },
+        "error": {
+          "description": "Systembenachrichtigung konnte nicht gesendet werden",
+          "emptyFields": "Bitte geben Sie sowohl einen Titel als auch eine Nachricht an."
+        },
+        "history": {
+          "title": "Benachrichtigungsverlauf",
+          "sentBy": "Eingesendet von",
+          "sentAt": "Gesendet an",
+          "empty": "Es wurden noch keine Systembenachrichtigungen versendet."
+        }
+      }
+    },
+    "integrations": {
+      "description": "Verwaltung von Drittanbieterintegrationen für die Problemverfolgung",
+      "list": {
+        "title": "Konfigurierte Problemintegrationen",
+        "description": "Ihre konfigurierten Problemintegrationen anzeigen und verwalten"
+      },
+      "empty": {
+        "message": "Bisher keine Problemintegrationen konfiguriert"
+      },
+      "addIntegration": "Problemintegration hinzufügen",
+      "allIntegrations": "Alle Problemintegrationen",
+      "manageDescription": "Konfigurieren und verwalten Sie Ihre Integrationen für externe Serviceprobleme",
+      "status": {
+        "active": "Aktiv",
+        "inactive": "Inaktiv"
+      },
+      "connectedProjects": "Verbundene Projekte",
+      "noIntegrations": "Keine Probleme bei der Integrationskonfiguration",
+      "testConnection": "Testverbindung",
+      "testSuccess": "Verbindung erfolgreich",
+      "testSuccessDescription": "Die Problemintegration ist ordnungsgemäß konfiguriert und verbunden.",
+      "testFailed": "Verbindung fehlgeschlagen",
+      "testFailedDescription": "Verbindung zum externen Dienst konnte nicht hergestellt werden.",
+      "testError": "Testfehler",
+      "testErrorDescription": "Beim Testen der Verbindung ist ein Fehler aufgetreten.",
+      "syncInProgress": "Synchronisierungsprobleme...",
+      "syncIntegration": "Synchronisieren Sie alle Vorgänge aus der Vorgangsintegration.",
+      "syncSuccess": "Synchronisierung in der Warteschlange",
+      "syncSuccessDescription": "Die Ausgaben von \"{name}\" werden im Hintergrund synchronisiert. Dies kann einige Augenblicke dauern. Die Tabelle wird nach Abschluss automatisch aktualisiert.",
+      "syncError": "Synchronisierung fehlgeschlagen",
+      "syncErrorDescription": "Der Synchronisierungsauftrag für diese Problemintegration konnte nicht in die Warteschlange gestellt werden. Bitte versuchen Sie es später erneut.",
+      "delete": {
+        "confirmMessage": "Möchten Sie die Problemintegration \"{name}\" wirklich löschen?",
+        "warning": "Dadurch wird die Problemintegration entfernt und von allen Projekten getrennt. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "warningTitle": "Diese Maßnahme wird Folgendes bewirken:",
+        "warning1": "Die Problemintegrationskonfiguration und die Anmeldeinformationen werden dauerhaft entfernt.",
+        "warning2": "Trennen Sie alle Benutzerauthentifizierungstoken für diese Problemintegration.",
+        "warning3": "Alle verknüpften Vorgänge in der Datenbank beibehalten (Vorgänge werden entkoppelt)",
+        "warning4": "Zuerst muss die Problemintegration aus allen Projekten entfernt werden."
+      },
+      "deleteSuccess": "Problemintegration gelöscht",
+      "deleteSuccessDescription": "Das Integrationsproblem wurde erfolgreich behoben.",
+      "deleteError": "Löschfehler",
+      "add": {
+        "description": "Konfigurieren einer neuen Problemintegration mit einem externen Dienst",
+        "selectType": "Wählen Sie den Integrationstyp für das Problem aus.",
+        "typeDescription": "Wählen Sie die Art des Dienstes aus, den Sie integrieren möchten.",
+        "successMessage": "Problemintegration erfolgreich erstellt",
+        "successDescription": "Die Problemintegration wurde konfiguriert und ist einsatzbereit.",
+        "simple_url": {
+          "name": "Einfache URL",
+          "description": "Grundlegende Problemverfolgung mit benutzerdefinierten URL-Mustern"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Verbinden Sie sich mit Atlassian Jira für die Problemverfolgung und das Projektmanagement."
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Verbinde dich mit GitHub, um Probleme zu verfolgen."
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Verbinden Sie sich mit GitLab, um Probleme und Merge-Anfragen zu verfolgen."
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Verbinden Sie sich mit einer selbst gehosteten Gitea-, Forgejo- oder Gogs-Instanz zur Problemverfolgung."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Verbinden Sie sich mit Azure DevOps, um Arbeitselemente zu verfolgen."
+        }
+      },
+      "filterPlaceholder": "Filterintegrationen...",
+      "table": {
+        "lastSync": "Letzte Synchronisierung",
+        "empty": "Es wurden keine Integrationsprobleme gefunden.",
+        "loading": "Integrationen werden geladen...",
+        "configure": "Konfigurieren"
+      },
+      "edit": {
+        "description": "Aktualisierung der Problemintegrationseinstellungen und Konfiguration",
+        "successMessage": "Problemintegration erfolgreich aktualisiert",
+        "successDescription": "Die Einstellungen für die Problemintegration wurden gespeichert."
+      },
+      "editIntegration": "Integration von Bearbeitungsproblemen",
+      "saveIntegration": "Speicherproblemintegration",
+      "deleteIntegration": "Problemintegration löschen",
+      "config": {
+        "name": "Name der Problemintegration",
+        "namePlaceholder": "Geben Sie einen Namen für diese Problemintegration ein.",
+        "nameHelp": "Ein beschreibender Name zur Kennzeichnung dieser Problemintegration",
+        "authType": "Authentifizierungstyp",
+        "authTypeHelp": "Wählen Sie aus, wie Sie sich beim externen Dienst authentifizieren möchten.",
+        "emailPlaceholder": "Ihre-E-Mail-Adresse@Beispiel.com",
+        "emailHelp": "Ihre E-Mail-Adresse",
+        "apiToken": "API-Token",
+        "apiTokenPlaceholder": "Geben Sie Ihr API-Token ein.",
+        "apiTokenHelp": "Generieren Sie ein API-Token in Ihren Kontoeinstellungen",
+        "jiraUrl": "Jira-URL",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "Die URL Ihrer Jira-Instanz",
+        "clientId": "Client-ID",
+        "clientIdPlaceholder": "Geben Sie Ihre OAuth-Client-ID ein.",
+        "clientIdHelp": "Die Client-ID aus Ihrer OAuth-Anwendung",
+        "clientSecret": "Kundengeheimnis",
+        "clientSecretPlaceholder": "Geben Sie Ihr OAuth-Clientgeheimnis ein.",
+        "clientSecretHelp": "Der Client-Schlüssel aus Ihrer OAuth-Anwendung",
+        "cloudId": "Cloud-ID",
+        "cloudIdPlaceholder": "Geben Sie Ihre Atlassian Cloud-ID ein.",
+        "cloudIdHelp": "Ihre Atlassian Cloud-Instanz-ID (zu finden in Ihrer Jira-URL)",
+        "apiUrl": "API-URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "Die Basis-URL für die Service-API",
+        "personalAccessTokenPlaceholder": "Geben Sie Ihr persönliches Zugriffstoken ein.",
+        "personalAccessTokenHelp": "Ein persönliches Zugriffstoken mit entsprechenden Berechtigungen",
+        "apiKeyPlaceholder": "Geben Sie Ihren API-Schlüssel ein",
+        "apiKeyHelp": "Der API-Schlüssel zur Authentifizierung",
+        "baseUrl": "URL-Muster",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "URL-Muster für Probleme. Verwenden Sie {issueId} als Platzhalter.",
+        "organizationUrl": "Organisations-URL",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "Ihre Azure DevOps-Organisations-URL",
+        "projectPath": "Projektpfad",
+        "projectPathPlaceholder": "Gruppe/Untergruppe/Projekt",
+        "projectPathHelp": "Der vollständige Pfad Ihres GitLab-Projekts (z. B. mygroup/myproject)",
+        "instanceUrl": "Instanz-URL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "URL Ihrer selbstgehosteten Instanz. Lassen Sie das Feld leer, um gitlab.com zu verwenden.",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Eigentümer",
+        "ownerPlaceholder": "Benutzername oder Organisation",
+        "ownerHelp": "Der Gitea-Benutzer oder die Organisation, der/die das Repository besitzt",
+        "repo": "Repository",
+        "repoPlaceholder": "Repository-Name",
+        "repoHelp": "Der Name des Gitea-Repositorys",
+        "encrypted": "Verschlüsselt",
+        "encryptedHelp": "Dieses Feld ist verschlüsselt und sicher gespeichert.",
+        "changeCredential": "Ändern",
+        "apiKeyWarningTitle": "Hinweis zur API-Schlüsselauthentifizierung",
+        "apiKeyWarningDescription": "Bei Verwendung der API-Schlüsselauthentifizierung werden die Problemmelder automatisch ermittelt:",
+        "apiKeyWarningPoint1": "Wenn Ihre TestPlanIt-E-Mail-Adresse mit der E-Mail-Adresse eines Jira-Benutzers übereinstimmt, werden Sie als Melder festgelegt.",
+        "apiKeyWarningPoint2": "Falls keine E-Mail-Adresse übereinstimmt, wird Ihr TestPlanIt-Name mit den Jira-Anzeigenamen abgeglichen.",
+        "apiKeyWarningPoint3": "Wird keine Übereinstimmung gefunden, wird der Inhaber des API-Schlüssels als Melder festgelegt.",
+        "forgeApiKeyLabel": "Forge API-Schlüssel",
+        "forgeApiKeyDescription": "Wird von der Atlassian Forge-App zur Authentifizierung von Anfragen aus Jira-Vorgangspanels verwendet. Generieren Sie hier einen Schlüssel und fügen Sie ihn in die Einstellungen Ihrer Forge-App ein.",
+        "forgeApiKeyPlaceholder": "Klicken Sie auf Generieren, um einen API-Schlüssel zu erstellen.",
+        "forgeApiKeyGenerate": "Erzeugen",
+        "forgeApiKeyCopy": "Kopie",
+        "forgeApiKeyCopied": "Kopiert",
+        "platform": "Plattform",
+        "platformPlaceholder": "Plattform auswählen...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "API-Schlüssel",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Persönliches Zugriffstoken"
+      },
+      "validation": {
+        "nameRequired": "Der Name der Problemintegration ist erforderlich.",
+        "clientIdRequired": "Die Client-ID ist erforderlich.",
+        "clientSecretRequired": "Clientgeheimnis erforderlich",
+        "cloudIdRequired": "Cloud-ID erforderlich",
+        "apiUrlRequired": "Die API-URL ist erforderlich.",
+        "tokenRequired": "Ein persönlicher Zugriffstoken ist erforderlich.",
+        "apiKeyRequired": "Ein API-Schlüssel ist erforderlich."
+      },
+      "errors": {
+        "updateFailed": "Fehler beim Aktualisieren der Problemintegration",
+        "testFailed": "Verbindungstest fehlgeschlagen",
+        "nameExists": "Es existiert bereits ein Problem mit der Integration unter diesem Namen.",
+        "createFailed": "Fehler beim Erstellen der Problemintegration",
+        "deleteFailed": "Fehler beim Löschen der Problemintegration"
+      },
+      "confirmDelete": {
+        "message": "Sind Sie sicher, dass Sie die Problemintegration \"{name} \" löschen möchten?",
+        "warning": "Dadurch wird die Problemintegration entfernt und von allen Projekten getrennt. Diese Aktion kann nicht rückgängig gemacht werden."
+      },
+      "form": {
+        "success": "Problemintegration erfolgreich gespeichert",
+        "successDescription": "Die Problemintegration wurde konfiguriert und ist einsatzbereit.",
+        "testing": "Verbindung wird getestet..."
+      },
+      "oauth": {
+        "connectAccount": "Konto verbinden",
+        "connected": "Verbunden",
+        "notConnected": "Nicht verbunden",
+        "authDescription": "Sie müssen sich mit {provider} authentifizieren, um diese Integration nutzen zu können.",
+        "authError": "Authentifizierung fehlgeschlagen",
+        "authErrorDescription": "Authentifizierung beim externen Dienst fehlgeschlagen"
+      }
+    },
+    "llm": {
+      "addIntegration": "KI-Modell hinzufügen",
+      "filterPlaceholder": "KI-Filtermodelle...",
+      "testAll": "Alle Verbindungen testen",
+      "connectionTestComplete": "Verbindungstest abgeschlossen",
+      "allIntegrationsTested": "Alle Verbindungen der KI-Modelle wurden getestet.",
+      "failedToTestConnections": "Einige Verbindungen konnten nicht getestet werden.",
+      "notConfigured": "Nicht konfiguriert",
+      "defaultModel": "Ausgewähltes Modell",
+      "budgetUsage": "Nutzung (Diesen Monat)",
+      "noBudget": "Kein Budget festgelegt",
+      "streaming": "Streaming",
+      "add": {
+        "title": "KI-Modellintegration hinzufügen",
+        "description": "Konfigurieren Sie ein neues KI-Modell für Ihre Organisation",
+        "integrationNamePlaceholder": "Geben Sie einen Namen für diese Integration ein...",
+        "selectProvider": "Wählen Sie einen Anbieter aus",
+        "openai": "OpenAI",
+        "anthropic": "Anthropisch",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "customLlm": "Kundenspezifisches LLM",
+        "apiKeyPlaceholder": "Geben Sie Ihren API-Schlüssel ein...",
+        "apiKeyDescription": "Ihr API-Schlüssel zur Authentifizierung beim Anbieter",
+        "endpoint": "Endpunkt-URL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Tipp: Wenn Sie einen Proxy verwenden (z. B. LiteLLM), versuchen Sie, /v1 an das Ende Ihrer Endpunkt-URL anzuhängen.",
+        "deploymentName": "Bereitstellungsname",
+        "deploymentNamePlaceholder": "Geben Sie den Bereitstellungsnamen ein...",
+        "deploymentNameDescription": "Name der Azure OpenAI-Bereitstellung",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, etc.",
+        "defaultModelDescription": "Das standardmäßig zu verwendende Modell",
+        "maxTokensPerRequest": "Maximale Anzahl an Token pro Anfrage",
+        "maxRequestsPerMinute": "Maximale Anfragen pro Minute",
+        "costPerInputToken": "Kosten pro 1 Million Input-Tokens ($)",
+        "costPerOutputToken": "Kosten pro 1 Million Output-Token ($)",
+        "monthlyBudget": "Monatliches Budget ($)",
+        "monthlyBudgetPlaceholder": "100,00",
+        "monthlyBudgetDescription": "Optionales Ausgabenziel für Benachrichtigungen (blockiert die Nutzung nicht)",
+        "billingPeriodStartDay": "Beginn des Abrechnungszeitraums",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "Tag des Monats (1–31), an dem Ihr Abrechnungszeitraum beginnt. Bei den Werten 29–31 wird der letzte Tag kürzerer Monate verwendet.",
+        "defaultTemperature": "Standardtemperatur",
+        "defaultMaxTokens": "Standard-Maximalanzahl an Tokens",
+        "timeout": "Zeitüberschreitung der Anfrage (ms)",
+        "timeoutDescription": "Maximale Wartezeit für die Antwort des KI-Modells (5000–600000 ms). Gilt nicht für Streaming-Anfragen.",
+        "streamingEnabled": "Streaming aktivieren",
+        "streamingEnabledDescription": "Echtzeit-Antwortstreaming ermöglichen",
+        "setAsDefault": "Als Standard festlegen",
+        "setAsDefaultDescription": "Verwenden Sie dies als Standard-KI-Modell für die Organisation.",
+        "fetchingModels": "Modelle werden geladen...",
+        "failedToFetchModels": "Verfügbare Modelle konnten nicht abgerufen werden",
+        "selectModel": "Wählen Sie ein Modell aus",
+        "connectionSuccessfulDescription": "Die Verbindung zum KI-Modell wurde überprüft und funktioniert einwandfrei.",
+        "failedToConnect": "Verbindung zum KI-Modellanbieter fehlgeschlagen",
+        "integrationCreated": "KI-Modellintegration erfolgreich erstellt",
+        "failedToCreate": "Die Integration des KI-Modells ist fehlgeschlagen.",
+        "validation": {
+          "nameRequired": "Die Angabe eines Integrationsnamens ist erforderlich.",
+          "nameUnique": "Eine Integration mit diesem Namen existiert bereits.",
+          "defaultModelRequired": "Standardmodell erforderlich"
+        }
+      },
+      "edit": {
+        "title": "Integration des KI-Modells bearbeiten",
+        "description": "Aktualisieren Sie die Konfiguration für diese KI-Modellintegration.",
+        "statusDescription": "Diese Integration aktivieren oder deaktivieren",
+        "apiKeyPlaceholder": "Geben Sie einen neuen API-Schlüssel ein, um das Update durchzuführen...",
+        "update": "Aktualisieren",
+        "integrationUpdated": "Die Integration des KI-Modells wurde erfolgreich aktualisiert.",
+        "failedToUpdate": "Die Aktualisierung der KI-Modellintegration ist fehlgeschlagen.",
+        "validation": {
+          "nameRequired": "Die Angabe eines Integrationsnamens ist erforderlich.",
+          "nameUnique": "Eine Integration mit diesem Namen existiert bereits.",
+          "defaultModelRequired": "Standardmodell erforderlich"
+        }
+      },
+      "sections": {
+        "provider": "Anbieter",
+        "costAndBudget": "Kosten & Budget",
+        "advanced": "Fortschrittlich"
+      },
+      "delete": {
+        "title": "KI-Modellintegration löschen",
+        "description": "Sind Sie sicher, dass Sie diese KI-Modellintegration löschen möchten? Dadurch wird sie aus allen Projekten entfernt und kann nicht rückgängig gemacht werden.",
+        "integrationDeletedSuccess": "Die Integration des KI-Modells wurde erfolgreich gelöscht.",
+        "failedToDeleteIntegration": "Fehler beim Löschen der KI-Modellintegration",
+        "cannotDeleteDefault": "Das Standard-KI-Modell kann nicht gelöscht werden. Legen Sie zuerst ein anderes als Standard fest."
+      },
+      "validation": {
+        "defaultModelRequired": "Standardmodell erforderlich"
+      },
+      "test": {
+        "title": "Integration des Test-KI-Modells",
+        "description": "Testen Sie die Verbindung und Funktionalität von {name}",
+        "connectionStatus": "Verbindungsstatus",
+        "connectionStatusDescription": "Prüfen Sie, ob das KI-Modell zugänglich ist.",
+        "retest": "Verbindung erneut testen",
+        "connectionSuccessfulDescription": "Das KI-Modell ist zugänglich und reagiert korrekt.",
+        "failedToConnect": "Verbindung zum KI-Modell fehlgeschlagen",
+        "errorTestingConnection": "Beim Testen der Verbindung ist ein Fehler aufgetreten.",
+        "testMessage": "Testnachricht",
+        "testMessagePlaceholder": "Geben Sie eine Nachricht ein, die an das KI-Modell gesendet werden soll...",
+        "sendTestMessage": "Testnachricht senden",
+        "response": "Antwort",
+        "testSuccessful": "Test erfolgreich",
+        "responseReceived": "Antwort erfolgreich empfangen (Kosten: ${cost})",
+        "testFailed": "Test fehlgeschlagen",
+        "failedToGetResponse": "Es wurde keine Antwort vom KI-Modell empfangen.",
+        "failedToSendMessage": "Testnachricht konnte nicht gesendet werden",
+        "defaultTestMessage": "Hallo! Bitte antworten Sie kurz mit einer Bestätigung, dass alles ordnungsgemäß funktioniert."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Die Festlegung eines monatlichen Budgets verhindert nicht, dass die LLM-Nutzung dieses Budget überschreitet. Budgetgrenzen dienen lediglich der Information und unterstützen die Entscheidungsfindung der Verwaltung.",
+        "budgetDisclaimerShort": "Budgetlimits dienen lediglich der Information und schränken die Nutzung nicht ein.",
+        "spendLabel": "Ausgaben im laufenden Monat",
+        "spendOfBudget": "{currentSpend} von {budgetLimit}",
+        "overBudget": "Budgetüberschreitung",
+        "budgetPercentage": "{percentage}% des verwendeten Budgets",
+        "spendReset": "Die Ausgaben des laufenden Monats wurden zurückgesetzt."
+      }
+    },
+    "prompts": {
+      "title": "Eingabeaufforderungskonfigurationen",
+      "description": "KI-Aufforderungsvorlagen für verschiedene Funktionen verwalten",
+      "addPromptConfig": "Eingabeaufforderungskonfiguration hinzufügen",
+      "filterPlaceholder": "Filteraufforderungskonfigurationen...",
+      "features": "Merkmale",
+      "featureCount": "{count, plural, one {# Feature} other {# Features}}",
+      "llmIntegration": "LLM-Integration",
+      "modelOverride": "Modellüberschreibung",
+      "llmIntegrationPlaceholder": "Projektstandard",
+      "modelOverridePlaceholder": "Integrationsstandard",
+      "projectDefault": "Projektstandard (löschen)",
+      "integrationDefault": "Integrationsstandard (löschen)",
+      "systemPrompt": "Systemaufforderung",
+      "userPrompt": "Benutzeraufforderung",
+      "temperature": "Temperatur",
+      "maxOutputTokens": "Maximale Ausgabetoken",
+      "variables": "Variablen",
+      "insertVariable": "Variable einfügen",
+      "noConfigs": "Es wurden keine Konfigurationen gefunden. Fügen Sie Ihre erste Konfiguration hinzu, um zu beginnen.",
+      "add": {
+        "title": "Eingabeaufforderungskonfiguration hinzufügen",
+        "description": "Erstellen Sie eine neue KI-Prompt-Konfiguration mit Prompts für jede Funktion. Standardwerte wurden automatisch angewendet."
+      },
+      "edit": {
+        "title": "Eingabeaufforderung bearbeiten Konfiguration",
+        "description": "Aktualisieren Sie diese KI-Aufforderungskonfiguration"
+      },
+      "delete": {
+        "title": "Konfiguration der Eingabeaufforderung löschen",
+        "confirmMessage": "Möchten Sie wirklich <strong>{name}</strong>löschen? Projekte, die diese Eingabeaufforderung verwenden, greifen auf die Systemstandardeinstellung zurück.",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden. Alle Projekte, die diese Konfiguration verwenden, werden auf die Standardkonfiguration zurückgesetzt."
+      },
+      "llmColumn": "LLM",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "Die Standard-Eingabeaufforderungskonfiguration kann nicht gelöscht werden. Legen Sie zuerst eine andere als Standard fest.",
+      "defaultChanged": "Die Standard-Eingabeaufforderungskonfiguration wurde erfolgreich aktualisiert.",
+      "featureLabels": {
+        "markdown_parsing": "Markdown-Testfallanalyse",
+        "test_case_generation": "Testfallgenerierung",
+        "magic_select_cases": "Intelligente Testfallauswahl",
+        "editor_assistant": "Redaktionsassistent/in",
+        "llm_test": "LLM-Verbindungstest",
+        "export_code_generation": "Exportcode-Generierung",
+        "auto_tag": "KI-Tag-Vorschläge",
+        "duplicate_detection": "Duplikaterkennung",
+        "generate_from_url": "Testfälle aus URL generieren (Anforderungen)",
+        "generate_from_url_app": "Testfälle aus URL generieren (Anwendungstests)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Elasticsearch-Verwaltung",
+      "description": "Suchmaschinenindexierung und -wartung verwalten",
+      "status": {
+        "title": "Elasticsearch-Status",
+        "description": "Aktueller Verbindungs- und Gesundheitsstatus der Suchmaschine",
+        "checking": "Statusprüfung...",
+        "disconnected": "Getrennt",
+        "nodes": "Knoten",
+        "indices": "Indizes",
+        "documents": "Dokumente",
+        "error": {
+          "title": "Verbindungsfehler",
+          "description": "Verbindung zum Elasticsearch-Dienst konnte nicht hergestellt werden."
+        }
+      },
+      "settings": {
+        "description": "Konfigurieren Sie die Elasticsearch-Einstellungen für Ihre Bereitstellung.",
+        "numberOfReplicas": "Anzahl der Repliken",
+        "replicasHelp": "Für Einzelknotencluster auf 0 setzen, für Mehrknotencluster mit Redundanz auf 1+.",
+        "savedDescription": "Die Konfiguration wurde in der Datenbank gespeichert.",
+        "updated": "Indizes aktualisiert",
+        "updatedDescription": "Alle bestehenden Indizes wurden mit den neuen Replikateinstellungen aktualisiert.",
+        "error": "Fehler beim Speichern der Einstellungen",
+        "errorDescription": "Die Konfiguration konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+        "note": {
+          "description": "Änderungen werden sofort auf neue Indizes angewendet. Bestehende Indizes werden beim Speichern aktualisiert. Setzen Sie die Anzahl der Replikate auf 0, um den gelben Status auf Einzelknotenclustern zu beheben."
+        }
+      },
+      "reindex": {
+        "title": "Daten neu indizieren",
+        "description": "Suchindizes neu erstellen, um die Suchleistung zu verbessern",
+        "entities": {
+          "all": "Alle Entitäten"
+        },
+        "button": {
+          "start": "Neuindexierung starten",
+          "indexing": "Indizierung..."
+        },
+        "warning": {
+          "title": "Wichtig",
+          "description": "Die Neuindizierung kann je nach Datenmenge mehrere Minuten dauern. Die Suchfunktion kann während dieses Vorgangs eingeschränkt sein."
+        },
+        "complete": {
+          "title": "Neuindexierung abgeschlossen",
+          "description": "Alle ausgewählten Entitäten wurden erfolgreich neu indiziert."
+        },
+        "success": {
+          "title": "Neuindexierung erfolgreich",
+          "description": "{count, plural, one {# Dokument} other {# Dokumente}} erfolgreich indiziert"
+        },
+        "error": {
+          "title": "Neuindizierung fehlgeschlagen",
+          "description": "Beim Neuindizieren ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+        }
+      }
+    },
+    "queues": {
+      "title": "Hintergrund-Jobwarteschlangen",
+      "description": "Überwachung und Verwaltung der Warteschlangen für die Hintergrundverarbeitung",
+      "queueNames": {
+        "forecast-updates": "Wettervorhersage-Aktualisierungen",
+        "emails": "E-Mail-Warteschlange",
+        "issue-sync": "Problemsynchronisierung",
+        "testmo-imports": "Testmo-Importe",
+        "elasticsearch-reindex": "Elasticsearch-Neuindexierung",
+        "audit-logs": "Audit-Protokolle",
+        "budget-alerts": "Budgetwarnungen",
+        "auto-tag": "KI-Auto-Tag",
+        "repo-cache": "Repository-Cache",
+        "copy-move": "Kopieren & Verschieben",
+        "duplicate-scan": "Duplikatscan",
+        "magic-select": "Magic Select",
+        "step-scan": "Schrittsequenz-Scan"
+      },
+      "status": {
+        "paused": "Angehalten",
+        "idle": "Leerlauf"
+      },
+      "table": {
+        "queue": "Warteschlange",
+        "concurrency": "Gleichzeitigkeit",
+        "waiting": "Warten",
+        "failed": "Fehlgeschlagen"
+      },
+      "concurrency": {
+        "title": "Gleichzeitigkeit der Arbeiter",
+        "description": "Die Parallelität steuert, wie viele Aufträge jeder Worker gleichzeitig bearbeitet. Höhere Werte können den Durchsatz verbessern, beanspruchen aber mehr Systemressourcen (CPU und Arbeitsspeicher).",
+        "configureTitle": "Gleichzeitigkeit konfigurieren",
+        "configureDescription": "Um die Parallelität anzupassen, müssen Umgebungsvariablen gesetzt und die Worker neu gestartet werden. Weitere Informationen finden Sie in der Dokumentation.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo-Importe (Standard: 1, speicherintensiv)",
+          "SYNC_CONCURRENCY": "Ausgabesynchronisierung (Standard: 2, E/A-intensiv)",
+          "EMAIL_CONCURRENCY": "E-Mail-Versand (Standard: 3, E/A-intensiv)",
+          "NOTIFICATION_CONCURRENCY": "Benachrichtigungen (Standard: 5, ressourcenschonend)",
+          "FORECAST_CONCURRENCY": "Wettervorhersageaktualisierungen (Standard: 5, CPU-intensiv)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Warteschlange pausieren",
+          "confirmDescription": "Dadurch wird die Bearbeitung neuer Aufträge verhindert. Laufende Aufträge werden weiterhin bis zum Abschluss bearbeitet."
+        },
+        "resume": {
+          "confirmTitle": "Fortsetzungswarteschlange",
+          "confirmDescription": "Dadurch können die wartenden Aufträge in der Warteschlange abgearbeitet werden."
+        },
+        "clean": {
+          "confirmTitle": "Saubere Warteschlange",
+          "confirmDescription": "Dadurch werden abgeschlossene und fehlgeschlagene Aufträge aus der Warteschlange entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "drain": {
+          "confirmTitle": "Abflussschlange",
+          "confirmDescription": "Dadurch werden alle wartenden Aufträge aus der Warteschlange entfernt. Aktive Aufträge werden weiterhin bis zum Abschluss bearbeitet. Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "obliterate": {
+          "confirmTitle": "Warteschlange löschen",
+          "confirmDescription": "Dadurch wird die Warteschlange vollständig geleert und alle Aufträge unabhängig von ihrem Status entfernt. Diese Aktion kann nicht rückgängig gemacht werden und sollte nur in Notfällen angewendet werden."
+        },
+        "warning": "Warnung",
+        "irreversible": "Diese Aktion kann nicht rückgängig gemacht werden. Bitte bestätigen Sie, dass Sie fortfahren möchten."
+      },
+      "success": {
+        "actionCompleted": "Aktion abgeschlossen",
+        "queuePaused": "Die Warteschlange wurde angehalten.",
+        "queueResumed": "Die Warteschlange wurde wieder in Betrieb genommen.",
+        "queueCleaned": "Die Warteschlange wurde aufgeräumt.",
+        "queueDrained": "Die Warteschlange ist abgearbeitet.",
+        "queueObliterated": "Die Warteschlange wurde gelöscht."
+      },
+      "error": {
+        "loadFailed": "Warteschlangen konnten nicht geladen werden",
+        "actionFailed": "Aktion fehlgeschlagen"
+      },
+      "jobs": {
+        "title": "Jobs in der Warteschlange",
+        "description": "Einzelne Aufträge in der Warteschlange ansehen und verwalten.",
+        "noJobs": "In dieser Warteschlange wurden keine Aufträge gefunden.",
+        "table": {
+          "id": "Job-ID",
+          "name": "Stellenbezeichnung",
+          "attempts": "Versuche"
+        },
+        "details": {
+          "title": "Stellenbeschreibung",
+          "failedReason": "Fehlergrund",
+          "stacktrace": "Stack-Trace",
+          "data": "Jobdaten",
+          "returnValue": "Rückgabewert",
+          "options": "Joboptionen",
+          "processed": "Verarbeitet",
+          "finished": "Fertig"
+        },
+        "success": {
+          "actionCompleted": "Arbeitsvorgang abgeschlossen",
+          "jobRetried": "Der Auftrag wurde erneut versucht.",
+          "jobPromoted": "Job wurde befördert",
+          "jobRemoved": "Die Stelle wurde entfernt"
+        },
+        "error": {
+          "loadFailed": "Jobs konnten nicht geladen werden",
+          "actionFailed": "Jobaktion fehlgeschlagen"
+        },
+        "forceRemove": {
+          "title": "Auftrag erzwingen Entfernen",
+          "question": "Soll dieser Auftrag zwangsweise entfernt werden?",
+          "warning": "Es wird versucht, den Vorgang mehrmals mit Verzögerungen zu beenden. Hinweis: Falls der Auftrag tatsächlich von einem laufenden Prozess blockiert wird, kann der Vorgang dennoch fehlschlagen.",
+          "confirm": "Erzwingen Entfernen"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Systemweites Prüfprotokoll zur Überwachung von Sicherheit und Compliance anzeigen",
+      "filterPlaceholder": "Suche nach Entität, Benutzer oder Aktion...",
+      "filterAction": "Aktion",
+      "filterEntityType": "Entitätstyp",
+      "allActions": "Alle Aktionen",
+      "allEntityTypes": "Alle Entitätstypen",
+      "showing": "Es werden die Einträge {start} bis {end} von {total} angezeigt.",
+      "viewDetails": "Details anzeigen",
+      "detailTitle": "Details zum Audit-Protokoll",
+      "userInfo": "Benutzerinformationen",
+      "changes": "Änderungen",
+      "metadata": "Metadaten",
+      "oldValue": "Alt",
+      "newValue": "Neu",
+      "columns": {
+        "timestamp": "Zeitstempel",
+        "entityId": "Entitäts-ID",
+        "entityName": "Entitätsname",
+        "userId": "Benutzer-ID",
+        "ipAddress": "IP-Adresse",
+        "userAgent": "Benutzeragent"
+      },
+      "exportCsv": "CSV exportieren",
+      "timeRange": "Zeitbereich",
+      "timeRangeOptions": {
+        "last24h": "Letzte 24 Stunden",
+        "last7d": "Letzte 7 Tage",
+        "last30d": "Letzte 30 Tage",
+        "last90d": "Letzte 90 Tage",
+        "allTime": "Alle Zeiten"
+      },
+      "systemActor": "System",
+      "systemActorTooltip": "Die Aktion wurde vom System und nicht von einem angemeldeten Benutzer ausgeführt."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Keine Benachrichtigungen",
+      "aria": {
+        "notifications": "Benachrichtigungen ({count} ungelesen)"
+      },
+      "actions": {
+        "markRead": "Als gelesen markieren",
+        "markUnread": "Als ungelesen markieren",
+        "markAllRead": "Alle als gelesen markieren",
+        "deleteAll": "Alles löschen"
+      },
+      "success": {
+        "deleted": "Benachrichtigung gelöscht",
+        "markedAllRead": "Alle als gelesen markierten Benachrichtigungen",
+        "deletedAll": "Alle Benachrichtigungen gelöscht"
+      },
+      "error": {
+        "markRead": "Fehler beim Markieren als gelesen",
+        "markUnread": "Fehler beim Markieren als ungelesen.",
+        "delete": "Benachrichtigung konnte nicht gelöscht werden",
+        "markAllRead": "Alle Artikel konnten nicht als gelesen markiert werden.",
+        "deleteAll": "Benachrichtigungen konnten nicht gelöscht werden"
+      },
+      "deleteAllDialog": {
+        "title": "Alle Benachrichtigungen löschen?",
+        "description": "Dadurch werden alle Ihre Benachrichtigungen dauerhaft entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Alles löschen"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Neue Testfallzuweisung",
+        "multipleTestCaseAssignmentTitle": "Mehrere Testfälle zugewiesen",
+        "sessionAssignmentTitle": "Neue Sitzungszuweisung",
+        "commentMentionTitle": "Du wurdest in einem Kommentar erwähnt.",
+        "systemAnnouncementTitle": "Systemankündigung",
+        "assignedTestCase": "Ihnen wurde der Testfall zugewiesen",
+        "assignedMultipleTestCases": "dir zugewiesen {count, plural, one {# Testfall} other {# Testfälle}}",
+        "assignedSession": "Sie wurden der Sitzung zugewiesen",
+        "mentionedYouInComment": "Ich habe dich in einem Kommentar erwähnt auf",
+        "inProject": "im Projekt",
+        "testRun": "Probelauf:",
+        "casesInProject": "{count, plural, =1 {# Fall} other {# Fälle}} in",
+        "sentBy": "Gesendet von {name}",
+        "milestoneDueSoonTitle": "Meilenstein bald erreicht",
+        "milestoneOverdueTitle": "Meilenstein überfällig",
+        "milestoneDueSoon": "Der Meilenstein \"{milestoneName}\" im Projekt \"{projectName}\" ist am {dueDate} fällig.",
+        "milestoneOverdue": "Der Meilenstein \"{milestoneName}\" im Projekt \"{projectName}\" war am {dueDate} fällig und ist nun überfällig.",
+        "milestoneNotificationReason": "Sie erhalten diese Benachrichtigung, weil Sie an Arbeiten im Zusammenhang mit diesem Meilenstein teilgenommen haben (Testläufe, Sitzungen oder als Ersteller des Meilensteins).",
+        "milestoneNotificationContinue": "Sie erhalten weiterhin tägliche Erinnerungen, bis dieser Meilenstein als erreicht markiert ist.",
+        "shareLinkAccessedTitle": "Link zum Teilen aufgerufen",
+        "shareLinkAccessedAnonymousViewer": "Jemand",
+        "shareLinkAccessedMessage": "{viewer} hat Ihren freigegebenen Bericht angesehen: \"{shareTitle}\"",
+        "viewedYourSharedLink": "Ich habe Ihren geteilten Link angesehen.",
+        "viewedAt": "Gesehen am",
+        "budgetDisclaimer": "Die Budgetgrenzen dienen lediglich der Information und verhindern die Nutzung nicht.",
+        "llmBudgetExceededTitle": "LLM-Budget überschritten",
+        "llmBudgetThresholdTitle": "LLM-Budget {threshold}% Ausgeschöpft",
+        "llmBudgetExceededMessage": "{providerName} hat sein monatliches Budget überschritten: {spend} hat von {budget} Budget ausgegeben.",
+        "llmBudgetThresholdMessage": "{providerName} hat {threshold}% seines monatlichen Budgets verwendet: {spend} von {budget}.",
+        "userRegisteredTitle": "Neubenutzerregistrierung",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) hat sich über SSO registriert",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) hat sich über das Anmeldeformular registriert",
+        "viewUserList": "Benutzerliste anzeigen",
+        "reviewGeneratedCases": "Generierte Testfälle prüfen",
+        "generateFromUrlCompleteTitle": "Seiten erfolgreich gecrawlt",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# Seite} other {# Seiten}} gecrawlt von {url} im Projekt \"{projectName}\". Klicken Sie hier, um Testfälle zu überprüfen und zu generieren.",
+        "generateFromUrlFailedTitle": "URL-Crawling fehlgeschlagen"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Such- oder Linkprobleme...",
+        "create_label": "Linkproblem \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Problemzusammenfassung eingeben"
+        },
+        "fields": {
+          "name": {
+            "label": "Zusammenfassung"
+          },
+          "description": {
+            "placeholder": "Beschreiben Sie das Problem...",
+            "helper": "Bitte geben Sie detaillierte Informationen zu dem Problem an."
+          },
+          "project": {
+            "helper": "Wählen Sie das Projekt im externen Issue-Tracker aus."
+          }
+        },
+        "loading_metadata": "Integrationseinstellungen werden geladen...",
+        "errors": {
+          "creation_failed": "Das Problem konnte nicht erstellt werden. Bitte versuchen Sie es erneut."
+        },
+        "success": {
+          "created": "Problem erfolgreich erstellt",
+          "external_created": "Problem erstellt und mit externem Tracker verknüpft"
+        },
+        "warnings": {
+          "external_failed": "Das Problem wurde lokal erstellt, konnte aber nicht mit dem externen Tracker synchronisiert werden."
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "Sie müssen Ihr Konto mit {integrationName} verbinden, um Probleme zu erstellen."
+      },
+      "search_issues_dialog": {
+        "title": "Such- und Linkprobleme",
+        "placeholder": "Nach Problemen suchen...",
+        "searching": "Suche...",
+        "searchError": "Suche nach Problemen fehlgeschlagen",
+        "linkButton": "Link",
+        "linkedCount": "{count, plural, one {# Problem} other {# Probleme}} verknüpft"
+      }
+    },
+    "copyMove": {
+      "title": "In Projekt kopieren / verschieben",
+      "step1Desc": "Wählen Sie ein Zielprojekt und einen Zielordner für die Testfälle aus.",
+      "step2Desc": "Wählen Sie die gewünschte Funktion und prüfen Sie die Kompatibilität.",
+      "step3Desc": "Verfolgen Sie den Fortschritt und überprüfen Sie die Ergebnisse.",
+      "targetProject": "Zielprojekt",
+      "searchProjects": "Projekte suchen...",
+      "loadingProjects": "Projekte werden geladen...",
+      "noProjectsFound": "Keine Projekte gefunden.",
+      "completed": "(Vollständig)",
+      "targetFolder": "Zielordner",
+      "newFolderPlaceholder": "Neuer Ordnername...",
+      "operation": "Betrieb",
+      "operationCopy": "Kopie",
+      "operationCopyDesc": "Erstellt eine Kopie des/der ausgewählten Falls/Fälle im Zielprojekt. Die Originale bleiben unverändert.",
+      "operationMove": "Bewegen",
+      "operationMoveDesc": "Verschiebt die ausgewählten Fälle in das Zielprojekt. Die Originale werden aus dem Quellprojekt entfernt.",
+      "checkingCompatibility": "Kompatibilitätsprüfung...",
+      "noTargetWriteAccess": "Sie haben keine Schreibberechtigung für das Zielprojekt.",
+      "noSourceUpdateAccess": "Sie haben keine Bearbeitungsberechtigung für das Quellprojekt, um Fälle zu verschieben.",
+      "templateMismatch": "Vorlagenkonflikt",
+      "autoAssignTemplates": "Fehlende Vorlagen automatisch dem Zielprojekt zuweisen",
+      "templatesMayNotDisplay": "Fehlende Vorlagen stehen im Zielprojekt nicht zur Verfügung. Fälle werden zwar kopiert, aber die Felder aus diesen Vorlagen werden möglicherweise nicht korrekt angezeigt.",
+      "workflowFallback": "Einige Workflow-Zustände sind im Zielprojekt nicht verfügbar. In diesen Fällen wird der Standardzustand des Zielprojekts verwendet.",
+      "default": "(Standard)",
+      "conflicts": "Gilt für alle Konflikte:",
+      "conflictSkip": "Überspringen",
+      "conflictRename": "Umbenennen",
+      "sharedStepGroups": "Wenn im Ziel bereits gemeinsame Schrittgruppen vorhanden sind:",
+      "sharedStepGroupReuse": "Vorhandene wiederverwenden",
+      "sharedStepGroupReuseDesc": "Die Fälle werden auf die bestehende gemeinsame Schrittgruppe Bezug nehmen.",
+      "sharedStepGroupCreateNew": "Neu erstellen",
+      "sharedStepGroupCreateNewDesc": "Es wird eine neue gemeinsame Schrittgruppe erstellt.",
+      "go": "Gehen",
+      "processing": "Verarbeitung...",
+      "progressText": "{processed} von {total} Fällen bearbeitet",
+      "successCount": "{count} Fall(e) {operation}d erfolgreich",
+      "skipped": "Übersprungen: {count}",
+      "droppedLinks": "Projektübergreifende Verknüpfungen entfernt: {count}",
+      "errorCount": "{count} Fall(e) fehlgeschlagen",
+      "viewInTargetProject": "Im Zielprojekt anzeigen",
+      "failed": "Fehlgeschlagen",
+      "folderMode": "Ordner \"{folderName}\" — {caseCount, plural, one {# Fall} other {# Fälle}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Verwandte Themen",
+    "linkedIssuesDescription": "Probleme im Zusammenhang mit diesem Artikel",
+    "refreshed": "Aktualisierte Ausgaben",
+    "refreshedDescription": "Die Liste der verlinkten Probleme wurde aktualisiert.",
+    "unlinked": "Problem nicht verknüpft",
+    "unlinkedDescription": "Das Problem wurde aus diesem Eintrag entfernt.",
+    "linked": "Problem verknüpft",
+    "linkedDescription": "Das Problem steht im Zusammenhang mit diesem Artikel.",
+    "searchAndLink": "Suche und Link",
+    "createAndLink": "Erstellen und Verknüpfen",
+    "noLinkedIssues": "Keine verknüpften Probleme",
+    "viewExternal": "Ansicht in {provider}",
+    "unlink": "Link aufheben",
+    "linkError": "Problem beim Verknüpfen",
+    "linkExternalIssue": "Link {provider} Problem",
+    "linkIssue": "Linkproblem",
+    "addIssue": "Problem hinzufügen",
+    "unlinkError": "Problem konnte nicht gelöst werden",
+    "noIssuesFound": "Es wurden keine Probleme gefunden",
+    "startTypingToSearch": "Beginnen Sie mit der Eingabe, um nach Problemen zu suchen.",
+    "selectedCount": "{count} ausgewählt",
+    "confirmSelection": "Auswahl bestätigen",
+    "alreadyLinked": "Bereits verlinkt",
+    "authenticate": "Authentifizieren",
+    "authenticationRequired": "Authentifizierung erforderlich",
+    "authenticationDescription": "Sie müssen sich mit {provider} authentifizieren, um nach Problemen zu suchen.",
+    "searchIn": "Suche in {provider}",
+    "searchPlaceholder": "Suchprobleme...",
+    "searchIssues": "Suchprobleme",
+    "searchIssuesDescription": "Suchen Sie nach internen Problemen, um einen Link zu diesem Eintrag zu erstellen.",
+    "searchExternalDescription": "Suche nach {provider} Ausgaben, um auf diesen Eintrag zu verlinken.",
+    "error": "Fehler beim Laden",
+    "errorDescription": "Probleme beim Laden. Bitte versuchen Sie es erneut.",
+    "selectIssues": "Themen auswählen",
+    "authRequiredDescription": "Bitte authentifizieren Sie sich mit {provider} , um nach Problemen zu suchen.",
+    "integrationNotConfigured": "Integration nicht konfiguriert",
+    "integrationNotConfiguredDescription": "Diese Integration ist noch nicht vollständig konfiguriert. Bitte wenden Sie sich an Ihren Projektadministrator, um das externe Projekt in den Projekteinstellungen zu konfigurieren.",
+    "createIssue": "Problem erstellen",
+    "createNewIssue": "Neues Problem erstellen",
+    "createIssueDescription": "Neues Problem erstellen",
+    "createIssueDescriptionWithIntegration": "Erstellen Sie ein neues Ticket mit {provider}",
+    "createIssueDescriptionSimpleUrl": "Neues internes Ticket erstellen (Einfache URL-Integration)",
+    "creatingWith": "Problem beim Erstellen von {provider}",
+    "authenticatedAndReady": "Authentifiziert und bereit, Probleme zu erstellen",
+    "created": "Problem erstellt",
+    "createdInExternal": "Problem erstellt in {provider}",
+    "createdInternal": "Problem lokal erstellt",
+    "createdInternalSimpleUrl": "Dieses Ticket wurde intern erstellt und kann über eine einfache URL verlinkt werden.",
+    "createError": "Problem konnte nicht erstellt werden",
+    "useIntegration": "Verwenden Sie {provider}",
+    "useIntegrationDescription": "Problem im externen System erstellen",
+    "externalProject": "Externes Projekt",
+    "selectProject": "Projekt auswählen",
+    "issueType": "Ausgabetyp",
+    "selectIssueType": "Problemtyp auswählen",
+    "noIssueTypes": "Keine Problemtypen verfügbar",
+    "priorityUrgent": "Dringend",
+    "additionalFields": "Zusätzliche Felder",
+    "createIssueInJira": "Vorgang in Jira erstellen",
+    "createIssueInJiraDescription": "Nutzen Sie die Jira-Oberfläche, um ein neues Ticket mit allen verfügbaren Feldern und Optionen zu erstellen.",
+    "createIssueInJiraFallbackDescription": "Öffnen Sie Jira in einem neuen Tab, um ein Ticket mit vorausgefüllten Informationen zu erstellen.",
+    "jiraIframeError": "Die Jira-Oberfläche konnte nicht geladen werden. Bitte versuchen Sie, sie in einem neuen Tab zu öffnen.",
+    "jiraIframeFallback": "Aus Sicherheitsgründen muss Jira in einem neuen Tab geöffnet werden. Klicken Sie auf die Schaltfläche unten, um Ihr Ticket zu erstellen.",
+    "jiraFallbackNote": "Nachdem Sie das Ticket in Jira erstellt haben, kehren Sie hierher zurück, um es mit Ihrem Testfall zu verknüpfen.",
+    "openInNewTab": "In neuem Tab öffnen",
+    "jiraIframeNote": "Nachdem Sie das Ticket in Jira erstellt haben, können Sie diesen Dialog schließen und die Ticketliste aktualisieren.",
+    "fillInRequiredFields": "Füllen Sie die erforderlichen Felder aus, um ein neues Problem zu erstellen.",
+    "failedToFetchFields": "Fehler beim Abrufen der Vorgangsfelder aus Jira",
+    "enterSummary": "Geben Sie eine kurze Zusammenfassung des Problems ein.",
+    "enterDescription": "Geben Sie eine detaillierte Beschreibung des Problems ein.",
+    "failedToCreateIssue": "Es ist fehlgeschlagen, ein Ticket in Jira zu erstellen.",
+    "issueCreatedDescription": "Problem {key} wurde erfolgreich erstellt",
+    "addLabel": "Fügen Sie eine Beschriftung hinzu und drücken Sie die Eingabetaste.",
+    "labelHint": "Leerzeichen werden durch Bindestriche ersetzt.",
+    "labelFormatNote": "Beschriftungen dürfen keine Leerzeichen enthalten. Leerzeichen werden automatisch durch Bindestriche ersetzt.",
+    "enterIssueKey": "Ausgabeschlüssel eingeben (z. B. PROJ-123)",
+    "issueLinkHelp": "Geben Sie den Schlüssel eines bestehenden Vorgangs ein, um ihn zu verknüpfen.",
+    "searchForIssue": "Suche nach einem Problem, das verknüpft werden soll",
+    "searchUsers": "Benutzer suchen",
+    "noTeamsAvailable": "Keine Teams verfügbar",
+    "filterAll": "Alle",
+    "fanOutPartialFailure": "{count} Projekt(e) konnten nicht erreicht werden. Ergebnisse von {successCount} Projekt(en) werden angezeigt.",
+    "projectSelectorLabel": "Projekt",
+    "searchFailedTitle": "Suche fehlgeschlagen"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Alle Ausgaben durchsuchen und verwalten.",
+      "filterPlaceholder": "Probleme nach Namen filtern..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Dokumentation",
+      "Milestones": "Meilensteine",
+      "TestCaseRepository": "Testfall-Repository",
+      "TestCaseRestrictedFields": "Testfall Eingeschränkte Felder",
+      "TestRuns": "Testläufe",
+      "ClosedTestRuns": "Geschlossene Testläufe",
+      "TestRunResults": "Ergebnisse des Testlaufs",
+      "TestRunResultRestrictedFields": "Testlauf-Ergebnis – Eingeschränkte Felder",
+      "Sessions": "Sitzungen",
+      "SessionsRestrictedFields": "Sitzungen – Eingeschränkte Felder",
+      "ClosedSessions": "Geschlossene Sitzungen",
+      "SessionResults": "Sitzungsergebnisse",
+      "Tags": "Tags",
+      "SharedSteps": "Gemeinsame Schritte",
+      "Issues": "Probleme",
+      "IssueIntegration": "Problemintegration",
+      "Forecasting": "Prognose",
+      "Reporting": "Berichterstattung",
+      "Settings": "Einstellungen"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Nicht gestartet",
+      "IN_PROGRESS": "Im Gange",
+      "DONE": "Erledigt"
+    }
+  },
+  "charts": {
+    "average": "Durchschnitt",
+    "count": "Anzahl: {count}",
+    "percent": "Prozent: {percent}%",
+    "completed": "Abgeschlossen: {count}",
+    "durationRange": "Dauer: {from}s - {to}s",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# Testfall} other {# Testfälle}}",
+    "estimate": "Est: {value}",
+    "partOf": "(Teil von {parent})",
+    "status": "Status: {status}"
+  },
+  "linkedCases": {
+    "title": "Verknüpfte Testfälle",
+    "addLink": "Link hinzufügen",
+    "addLinkedTestCase": "Verknüpften Testfall hinzufügen",
+    "testCase": "Testfall",
+    "linkType": "Linktyp",
+    "noLinkedCases": "Keine verknüpften Testfälle.",
+    "linkedBy": "Verlinkt durch",
+    "on": "Verlinkt bei",
+    "alreadyLinked": "Dieser Fall ist bereits verlinkt.",
+    "cannotLinkSelf": "Ein Fall kann nicht mit sich selbst verknüpft werden.",
+    "circularLink": "Kreisförmige Verbindung erkannt.",
+    "failedToCreate": "Link konnte nicht erstellt werden.",
+    "confirmRemoveLink": "Möchten Sie diesen Link wirklich entfernen?",
+    "DEPENDS_ON": "Abhängigkeit",
+    "DUPLICATED_FROM": "Dupliziert von",
+    "SAME_TEST_DIFFERENT_SOURCE": "Gleicher Test (andere Quelle)",
+    "status": "Aktueller Status",
+    "at": "Ausgeführt"
+  },
+  "ganttTooltip": {
+    "task": "Aufgabe",
+    "group": "Ausführung/Sitzung:",
+    "project": "Projekt:",
+    "starts": "Starts:",
+    "scheduledCompletion": "Geplante Fertigstellung:",
+    "estWorkEffort": "Geschätzter Arbeitsaufwand:",
+    "noTasks": "Im Gantt-Diagramm sind keine Aufgaben anzuzeigen."
+  },
+  "help": {
+    "project": {
+      "name": "## Projektname\nDie eindeutige Kennung Ihres Projekts.\n\n- Muss projektübergreifend eindeutig sein.\n- Wird für Navigation und Berichte verwendet.\n- Sollte klar und aussagekräftig sein.\n- Hilft Teammitgliedern, den Projektumfang zu erkennen.",
+      "description": "## Projektbeschreibung\nZusätzliche Details zu Zweck und Umfang des Projekts.\n\n- Optional, aber empfohlen\n- Hilft Teammitgliedern, die Projektziele zu verstehen\n- Kann wichtige Ziele oder Anforderungen enthalten\n- Maximal 256 Zeichen",
+      "icon": "## Projektsymbol\nEin visuelles Symbol für Ihr Projekt.\n\n– Hilft, das Projekt in Listen und Dashboards schnell zu erkennen.\n– Wählen Sie aus einer Vielzahl vordefinierter Symbole.\n– Kann jederzeit geändert werden.\n– Wird in der Projektnavigation und in Berichten angezeigt.",
+      "completed": "## Projektstatus\nZeigt an, ob das Projekt aktiv oder abgeschlossen ist.\n\n- Aktive Projekte stehen für Tests und Aktualisierungen zur Verfügung.\n- Abgeschlossene Projekte sind schreibgeschützt.\n- Beeinflusst die Projektsichtbarkeit in Dashboards.\n- Kann bei Bedarf rückgängig gemacht werden.",
+      "completedAt": "## Abschlussdatum\nDas Datum, an dem das Projekt als abgeschlossen markiert wurde.\n\n- Wird automatisch beim Markieren eines Projekts als abgeschlossen festgelegt.\n- Wird für Berichte und die Nachverfolgung verwendet.\n- Hilft bei der Pflege der Projekthistorie.\n- Kann bei Bedarf geändert werden.",
+      "defaultAccess": "## Standard-Projektzugriff\nDefinieren Sie die Standardzugriffsrechte für Benutzer und Gruppen in diesem Projekt. Diese können für jeden Benutzer oder jede Gruppe einzeln überschrieben werden.",
+      "issueTracker": "## Issue-Tracker-Konfiguration\nWählen Sie die Issue-Tracker-Konfiguration aus, die für die Verwaltung von Problemen im Zusammenhang mit diesem Projekt verwendet werden soll."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Externes Projekt\nWählen Sie das Projekt oder Repository im externen System aus, das mit diesem TestPlanIt-Projekt verknüpft werden soll.\n\n- In TestPlanIt erstellte Tickets werden in diesem Projekt angelegt.\n- Aktiviert die Integration der Ticketverfolgung zwischen Systemen.\n- Erfordert entsprechende Berechtigungen im externen System.",
+          "defaultIssueTypeHelp": "## Standard-Vorgangstyp\nDer Vorgangstyp, der beim Erstellen neuer Vorgänge in TestPlanIt vorausgewählt wird.\n\n- Spart Zeit durch die Verwendung Ihres am häufigsten verwendeten Vorgangstyps.\n- Kann beim Erstellen einzelner Vorgänge überschrieben werden.\n- Muss ein gültiger Vorgangstyp für das ausgewählte externe Projekt sein.\n- Aktualisieren Sie diesen Wert, wenn sich Ihr Workflow ändert.",
+          "automaticSyncHelp": "## Automatische Synchronisierung\nAktiviert die automatische Synchronisierung des Vorgangsstatus zwischen TestPlanIt und dem externen System.\n\n- Mit Testfällen verknüpfte Vorgänge aktualisieren ihren Status automatisch.\n- Trägt zu einer einheitlichen Vorgangsverfolgung in allen Systemen bei.\n- Kann die API-Nutzung des externen Dienstes erhöhen.\n- Kann deaktiviert werden, wenn eine manuelle Steuerung bevorzugt wird."
+        }
+      }
+    },
+    "user": {
+      "name": "## Benutzername\nDer vollständige Name des Benutzers.\n\n- Wird zur systemweiten Identifizierung verwendet.\n- Wird in Aufgaben und Berichten angezeigt.\n- Muss für jeden Benutzer eindeutig sein.",
+      "email": "## E-Mail-Adresse\nDie E-Mail-Adresse des Benutzers für den Kontozugriff.\n\n- Wird für die Systemanmeldung verwendet.\n- Muss für jeden Benutzer eindeutig sein.\n- Wird für Systembenachrichtigungen verwendet.",
+      "password": "## Passwort\nDas Benutzerkontopasswort.\n\n- Optional, wenn eine passwortlose Anmeldemethode konfiguriert ist (Magic Link SSO-Anbieter oder E-Mail-Server) – leer lassen, um die Anmeldung über Magic Link oder SSO zu erzwingen.\n- Falls angegeben, muss es den in **Admin → Sicherheit** festgelegten Passwortrichtlinien entsprechen (Mindestlänge und Zeichenklassen).\n- Wird für den sicheren Kontozugriff verwendet.\n- Sollte vertraulich behandelt werden.",
+      "token": "## Bestätigungstoken\nGeben Sie das Token ein, das Sie per E-Mail erhalten haben, um Ihr Konto zu bestätigen. Falls Sie kein Token besitzen, können Sie ein neues anfordern.",
+      "confirmPassword": "## Passwort bestätigen\nGeben Sie das Passwort erneut ein, um sicherzustellen, dass es korrekt eingegeben wurde.\n\n- Muss exakt mit dem Passwort übereinstimmen.\n- Hilft, Tippfehler zu vermeiden.\n- Nur erforderlich, wenn ein Passwort eingegeben wird – lassen Sie dieses Feld leer, wenn das Passwortfeld leer ist.",
+      "access": "## Systemzugriffsebene\nLegt die systemweiten Berechtigungen des Benutzers fest.\n\n- **Admin:** Voller Systemzugriff und Konfiguration\n- **Projektadministrator:** Kann zugewiesene Projekte verwalten\n- **Benutzer:** Standardzugriff auf zugewiesene Projekte\n- **Keine:** Kann nur das eigene Dashboard anzeigen",
+      "role": "## Systemrolle\nDiese Rolle bestimmt die Standardprojektberechtigungen des Benutzers.\n\n- Definiert Standardzugriffsebenen für Projekte\n- Kann in der Rollenverwaltung angepasst werden\n- Beeinflusst verfügbare Funktionen und Möglichkeiten",
+      "active": "## Aktiver Status\nSteuert, ob ein Benutzer auf das System zugreifen kann.\n\n- Aktive Benutzer können sich anmelden und auf ihre zugewiesenen Ressourcen zugreifen.\n- Inaktive Benutzer können sich nicht anmelden, ihre Daten bleiben jedoch erhalten.\n  - Verwenden Sie diese Option, um den Zugriff vorübergehend zu deaktivieren, ohne das Konto zu löschen.",
+      "api": "## API-Zugriff\nErmöglicht den programmatischen Zugriff auf das System über API-Endpunkte.\n\n- Ermöglicht die Integration mit externen Tools und Automatisierung.\n- Erfordert API-Schlüsselauthentifizierung.\n- Unterliegt Ratenbegrenzung und Zugriffskontrollen.",
+      "projects": "## Projektzuweisung\nWählen Sie aus, auf welche Projekte dieser Benutzer Zugriff hat.\n\n- Steuert, welche Projekte im Dashboard des Benutzers angezeigt werden.\n- Erforderlich für die Projektteilnahme.\n- Kann später von Administratoren geändert werden.\n- Verwenden Sie „Alle auswählen“, um schnell alle verfügbaren Projekte zuzuweisen.",
+      "groups": "## Gruppenzuordnung\nWählen Sie die Gruppen aus, denen dieser Benutzer angehört.\n\n- Gruppen helfen bei der Organisation von Benutzern und Berechtigungen.\n- Benutzer erben Berechtigungen von ihren Gruppen.\n- Vereinfacht die Zugriffsverwaltung.\n- Kann später von Administratoren geändert werden.",
+      "itemsPerPage": "## Elemente pro Seite\nSteuert die Standardanzahl der in Tabellen und Listen angezeigten Elemente.\n\n- Betrifft alle paginierten Ansichten der Anwendung.\n- Kann jederzeit geändert werden.\n- Hilft bei der effizienten Verwaltung großer Datensätze.\n- Verfügbare Optionen: 10, 25, 50 oder 100 Elemente.",
+      "dateFormat": "## Datumsformat\nLegt Ihr bevorzugtes Datumsanzeigeformat fest.\n\n- Wird in der gesamten Anwendung einheitlich angewendet.\n- Trägt zur korrekten Datumsinterpretation bei.\n- Änderungen werden sofort wirksam.\n- Die im Dropdown-Menü angezeigten Beispiele entsprechen dem tatsächlichen Format.",
+      "timeFormat": "## Zeitformat\nLegt Ihr bevorzugtes Zeitanzeigeformat fest.\n\n– Wählen Sie zwischen 12-Stunden- und 24-Stunden-Format.\n– Wird in der gesamten Anwendung einheitlich angewendet.\n– Änderungen werden sofort wirksam.\n– Die im Dropdown-Menü angezeigten Beispiele entsprechen dem tatsächlichen Format.",
+      "timezone": "## Zeitzone\nLegt Ihre bevorzugte Zeitzone für die Datums- und Zeitanzeige fest.\n\n- Wird in der gesamten Anwendung einheitlich angewendet.",
+      "theme": "## Design\nWählen Sie Ihr bevorzugtes visuelles Design für die Anwendung.\n\n- **System:** Passt sich automatisch dem Design Ihres Betriebssystems an.\n- **Hell:** Klare, helle Oberfläche für die Nutzung am Tag.\n- **Dunkel:** Augenschonender Dunkelmodus für Umgebungen mit wenig Licht.\n- **Grün, Orange, Lila:** Ein fröhlicher Farbtupfer!",
+      "locale": "## Sprache\nWählen Sie Ihre bevorzugte Sprache für die Anwendungsoberfläche.\n\n- Ändert alle Texte, Beschriftungen und Meldungen in die gewählte Sprache.\n- Datums- und Zeitformate werden an regionale Konventionen angepasst.\n- Wirkt sofort ohne Seitenaktualisierung.\n- Verfügbare Sprachen hängen von den installierten Übersetzungen ab.",
+      "notificationMode": "## Benachrichtigungseinstellungen\nSteuert, wie Sie Benachrichtigungen für Arbeitsaufträge und Aktualisierungen erhalten.\n\n- **Globale Einstellungen verwenden:** Systemstandardeinstellungen der Administratoren übernehmen\n- **Keine Benachrichtigungen:** Alle Benachrichtigungen deaktivieren\n- **Nur in der App:** Benachrichtigungen nur innerhalb der Anwendung erhalten\n- **In-App + E-Mail (Sofort):** In-App-Benachrichtigungen und sofortige E-Mail-Benachrichtigungen erhalten\n- **In-App + E-Mail (Tägliche Zusammenfassung):** In-App-Benachrichtigungen und eine tägliche E-Mail-Zusammenfassung erhalten\n\nSie können diese Einstellung jederzeit an Ihren Workflow anpassen."
+    },
+    "milestone": {
+      "name": "## Meilensteinname\nEin klarer, aussagekräftiger Name, der diesen Meilenstein in Ihrem Projekt identifiziert.\n\n- Sollte eindeutig und aussagekräftig sein.\n- Hilft Teammitgliedern, den Zweck des Meilensteins schnell zu verstehen.\n- Wird in Berichten und im Projekt-Tracking verwendet.",
+      "type": "## Meilensteintyp\nKategorisiert den Meilenstein und bestimmt sein Erscheinungsbild und Verhalten.\n\n– Unterschiedliche Typen können unterschiedliche Arbeitsabläufe haben.\n– Hilft bei der Organisation und Filterung von Meilensteinen.\n– Kann sich auf Berichterstellung und Nachverfolgung auswirken.",
+      "started": "## Gestarteter Status\nZeigt an, dass die Arbeiten an diesem Meilenstein begonnen haben.\n\n- Markiert den Meilenstein als in Bearbeitung.\n- Aktualisiert das tatsächliche Startdatum automatisch, wenn diese Option aktiviert ist.\n- Beeinflusst die Projektzeitleiste und die Fortschrittsverfolgung.",
+      "completed": "## Abgeschlossener Status\nZeigt an, dass die Arbeiten an diesem Meilenstein abgeschlossen sind.\n\n- Markiert den Meilenstein als erledigt.\n- Aktualisiert automatisch das tatsächliche Fertigstellungsdatum.\n- Wird für die Fortschrittsverfolgung und Berichterstattung verwendet.\n- Beeinflusst abhängige Meilensteine und Projektzeitpläne.",
+      "startDate": "## Geplantes Startdatum\nDas Datum, an dem die Arbeiten an diesem Meilenstein voraussichtlich beginnen.\n\n- Hilft bei der Projektplanung und Terminierung.\n- Wird für Zeitprognosen verwendet.\n- Unterstützt die Ressourcenplanung.",
+      "dueDate": "## Fälligkeitsdatum\nDas Zieldatum für den Abschluss dieses Meilensteins.\n\n- Legt die erwartete Frist fest.\n- Wird für die Projektzeitplanung verwendet.\n- Hilft dabei, den Fortschritt des Meilensteins im Vergleich zum Zeitplan zu verfolgen.",
+      "parent": "## Übergeordneter Meilenstein\nVerknüpft diesen Meilenstein mit einem übergeordneten Meilenstein und erstellt so eine Hierarchie.\n\n- Ordnet Meilensteine in logische Gruppen ein.\n- Zeigt Abhängigkeiten und Beziehungen an.\n- Hilft dabei, den Fortschritt größerer Initiativen zu verfolgen.",
+      "description": "## Beschreibung\nDetaillierte Informationen zu Zweck, Anforderungen und Umfang des Meilensteins.\n\n- Bietet Kontext für Teammitglieder\n- Dokumentiert wichtige Anforderungen und Ziele\n- Unterstützt Zusammenarbeit und Abstimmung",
+      "documentation": "## Dokumentation\nZusätzliche Details, Referenzen und Begleitmaterialien.\n\n- Technische Spezifikationen\n- Konstruktionsdokumente\n- Externe Referenzen\n- Besprechungsprotokolle und Beschlüsse",
+      "automaticCompletion": "## Automatische Fertigstellung am Fälligkeitsdatum\nMarkiert diesen Meilenstein automatisch als abgeschlossen, sobald sein Fälligkeitsdatum erreicht ist.\n\n- Der Meilenstein wird zum geplanten Zeitpunkt am Fälligkeitsdatum abgeschlossen.\n- Nützlich für zeitlich begrenzte Meilensteine, die unabhängig vom Abschlussstatus abgeschlossen werden sollen.\n- Kann durch manuelles Abschließen des Meilensteins vor dem Fälligkeitsdatum überschrieben werden.\n- Erfordert die Festlegung eines Fälligkeitsdatums.",
+      "notifyDaysBefore": "## Benachrichtigung Tage vor dem Fälligkeitsdatum\nBenachrichtigungen an zugewiesene Teammitglieder senden, wenn sich das Fälligkeitsdatum des Meilensteins nähert.\n\n- Aktivieren, um Benachrichtigungen einzuschalten, deaktivieren, um sie zu deaktivieren.\n- Anzahl der Tage vor dem Fälligkeitsdatum eingeben, um Erinnerungen zu versenden.\n- Benachrichtigungen werden an Benutzer gesendet, die Testläufen und Sitzungen innerhalb dieses Meilensteins zugewiesen sind.\n- Überfällige Meilensteine senden weiterhin Erinnerungen, bis sie abgeschlossen sind."
+    },
+    "session": {
+      "name": "## Sitzungsname\nEin klarer, aussagekräftiger Name, der den Zweck Ihrer Testsitzung beschreibt.\n\n- Sollte eindeutig und aussagekräftig sein.\n- Hilft Teammitgliedern zu verstehen, was getestet wird.\n- Wird in Berichten und zur Nachverfolgung verwendet.",
+      "template": "## Vorlage\nVorlagen definieren die Struktur und den Inhalt Ihrer Testsitzung.\n\n- Bietet ein einheitliches Format für die Testdokumentation\n- Enthält vordefinierte Abschnitte und Felder\n- Hilft dabei, Teststandards in Ihrem gesamten Projekt einzuhalten",
+      "configuration": "## Konfiguration\nDie für diese Testsitzung erforderliche spezifische Umgebung oder Einrichtung.\n\n- Testumgebung (z. B. Staging, Produktion)\n- Spezielle Konfigurationen oder Einstellungen\n- Erforderliche Testdaten oder -bedingungen",
+      "milestone": "## Meilenstein\nVerknüpft diese Sitzung mit einem Projektmeilenstein.\n\n– Hilft, den Testfortschritt im Hinblick auf die Projektziele zu verfolgen.\n– Gruppiert zusammengehörige Testsitzungen.\n– Unterstützt die meilensteinbasierte Berichterstellung.",
+      "description": "## Beschreibung\nEin kurzer Überblick über den Inhalt dieser Testsitzung.\n\n- Wichtige Testbereiche oder Funktionen\n- Wichtiger Kontext oder Hintergrund\n- Besondere Überlegungen oder Anforderungen",
+      "mission": "## Mission\nDie Mission definiert die spezifischen Ziele und Vorgaben für diese Testphase.\n\n- Was wird getestet?\n- Worauf liegt der Fokus?\n- Welche Ergebnisse werden erwartet?\n\nEine klare Mission trägt dazu bei, dass das Testen fokussiert und produktiv bleibt.",
+      "estimate": "## Zeitschätzung\nGeschätzte Zeit für diese Testsitzung.\n\nBeispiele:\n- \"30m\" für 30 Minuten\n- \"1h 30m\" für 1 Stunde und 30 Minuten\n- \"2 Tage\" für 2 Tage\n- \"1 Woche\" für 1 Woche",
+      "elapsed": "## Verstrichene Zeit\nDie tatsächlich für diese Testsitzung aufgewendete Zeit.\n\nBeispiele:\n- \"45m\" für 45 Minuten\n- \"2h 15m\" für 2 Stunden und 15 Minuten\n- \"3 days\" für 3 Tage\n\nErfassen Sie die Zeit genau, um zukünftige Schätzungen zu verbessern.",
+      "state": "## Workflow-Status\nDer aktuelle Status dieser Testsitzung in Ihrem Workflow.\n\n- Hilft bei der Nachverfolgung des Sitzungsfortschritts.\n- Unterstützt die Workflow-Verwaltung.\n- Wird für Berichte und die Nachverfolgung verwendet.",
+      "assignedTo": "## Zugewiesen an\nDas Teammitglied, das für die Durchführung dieser Testsitzung verantwortlich ist.\n\n- Identifiziert die Person, die den Test durchführt.\n- Unterstützt das Ressourcenmanagement.\n- Unterstützt die Verantwortlichkeit und Nachverfolgung.",
+      "tags": "## Tags\nSchlüsselwörter oder Bezeichnungen, die helfen, Testsitzungen zu kategorisieren und zu organisieren.\n\n- Erleichtert das Auffinden von Sitzungen.\n- Gruppiert verwandte Testaktivitäten.\n- Unterstützt Filterung und Berichterstellung.",
+      "attachments": "## Anhänge\nDateien, Screenshots oder andere Dokumente, die mit dieser Testsitzung in Zusammenhang stehen.\n\n- Testdatendateien\n- Screenshots oder Aufzeichnungen\n- Begleitende Dokumentation\n- Referenzmaterialien",
+      "issues": "## Probleme\nVerknüpfen Sie relevante Probleme mit dieser Sitzung."
+    },
+    "testRun": {
+      "name": "## Name des Testlaufs\nGeben Sie einen aussagekräftigen Namen für diesen Testlauf ein, um ihn später leichter identifizieren zu können.",
+      "description": "## Beschreibung\nGeben Sie eine kurze Zusammenfassung oder Anmerkungen zu diesem Testlauf an.",
+      "configuration": "## Konfigurationen\nWählen Sie eine oder mehrere Konfigurationen (z. B. Umgebung, Browser, Gerät) aus, unter denen die Testläufe ausgeführt werden sollen. Durch die Auswahl mehrerer Konfigurationen werden für jede Konfiguration separate Testläufe erstellt.",
+      "milestone": "## Meilenstein\nOrdnen Sie diesen Testlauf einem bestimmten Projektmeilenstein zu, um den Fortschritt in Richtung übergeordneter Ziele zu verfolgen.",
+      "docs": "## Dokumentation\nFügen Sie hier alle relevanten Dokumente, Links oder detaillierten Notizen zu diesem Testlauf ein.",
+      "state": "## Status\nGeben Sie den aktuellen Status oder das Ergebnis dieses Testlaufs gemäß dem Workflow Ihres Projekts an.",
+      "tags": "## Tags\nWenden Sie relevante Tags an, um diesen Testlauf zu kategorisieren und zu filtern.",
+      "issues": "## Probleme\nVerknüpfen Sie alle damit zusammenhängenden Probleme (Bugs, Aufgaben usw.) mit diesem Testlauf.",
+      "attachments": "## Anhänge\nLaden Sie alle unterstützenden Dateien, Screenshots oder Protokolle hoch, die mit diesem Testlauf in Zusammenhang stehen.",
+      "duplicate": {
+        "statusesToInclude": "## Einzuschließende Status\nWählen Sie die Status der Testfälle aus, die Sie in den duplizierten Testlauf einbeziehen möchten.",
+        "copyAssignments": "## Zuweisungen kopieren\nWenn diese Option aktiviert ist, werden die Zuweisungen der Testfälle in den duplizierten Testlauf kopiert."
+      }
+    },
+    "appConfig": {
+      "key": "## Schlüssel\nDie eindeutige Kennung für diese Konfiguration.",
+      "value": "## Wert\nDer Wert dieser Konfiguration."
+    },
+    "milestoneType": {
+      "icon": "## Meilenstein-Typ-Symbol\nEine visuelle Kennzeichnung für diesen Meilenstein-Typ.\n\n- Hilft, den Meilenstein-Typ in Listen und Dashboards schnell zu erkennen.\n- Wählen Sie aus einer Vielzahl vordefinierter Symbole.\n- Kann jederzeit geändert werden.\n- Wird in der Projektnavigation und in Berichten angezeigt.",
+      "name": "## Meilensteintyp-Name\nEin klarer, beschreibender Name, der diesen Meilensteintyp in Ihrem Projekt identifiziert.\n\n- Hilft Teammitgliedern, den Zweck des Meilensteintyps schnell zu verstehen.\n- Wird in Berichten und im Projekt-Tracking verwendet.",
+      "isDefault": "## Standard-Meilensteintyp\nGibt an, ob dieser Meilensteintyp für Ihr Projekt standardmäßig ausgewählt ist.\n\n- Der Standard-Meilensteintyp ist für neue Meilensteine vorausgewählt.\n- Kann jederzeit geändert werden.",
+      "projects": "## Zugeordnete Projekte\nWählen Sie aus, für welche Projekte dieser Meilensteintyp verfügbar sein soll.\n\n– Wenn keine Projekte ausgewählt sind, ist der Meilensteintyp global verfügbar.\n– Durch die Zuweisung zu bestimmten Projekten ist die Verwendung auf diese Projekte beschränkt."
+    },
+    "tag": {
+      "name": "## Tag-Name\nEin klarer, prägnanter und beschreibender Name oder ein oder mehrere Schlüsselwörter, die in allen Projekten verwendet werden.\n\n– Hilft Teammitgliedern, schnell verwandte Testfälle, Testläufe und Sitzungen zu finden."
+    },
+    "role": {
+      "name": "## Rollenname\nEin klarer, prägnanter und beschreibender Name oder ein oder mehrere Schlüsselwörter, die in allen Projekten verwendet werden.\n\n– Hilft Teammitgliedern, schnell zugehörige Testfälle, Testläufe und Sitzungen zu finden.",
+      "isDefault": "## Standardrolle\nGibt an, ob diese Rolle die Standardrolle für Ihr Projekt ist.\n\n- Die Standardrolle ist für neue Benutzer vorausgewählt.\n- Kann jederzeit geändert werden.",
+      "permissions": {
+        "canAddEdit": "## Hinzufügen/Bearbeiten\nGibt an, ob diese Rolle den zugehörigen Anwendungsbereich hinzufügen und bearbeiten kann.",
+        "canDelete": "## Löschen\nGibt an, ob diese Rolle den zugehörigen Anwendungsbereich löschen kann.",
+        "canClose": "## Schließen\nGibt an, ob diese Rolle den zugehörigen Anwendungsbereich schließen kann."
+      }
+    },
+    "group": {
+      "name": "## Gruppenname\nEin klarer, prägnanter und beschreibender Name oder ein oder mehrere Schlüsselwörter, die in allen Projekten verwendet werden.\n\n– Hilft Teammitgliedern, schnell verwandte Testfälle, Testläufe und Sitzungen zu finden.",
+      "users": "## Benutzer\nZeigt die Benutzer an, die dieser Gruppe zugeordnet sind."
+    },
+    "template": {
+      "name": "## Template Name\nEin eindeutiger und beschreibender Name für diese Vorlage (z. B. 'Standard Test Case', 'API Test Results').",
+      "isEnabled": "## Aktiviert\nWenn diese Option aktiviert ist, steht diese Vorlage beim Erstellen neuer Testfälle oder beim Definieren von Testablaufstrukturen zur Auswahl. Wenn eine Vorlage als „Standard“ festgelegt ist, muss sie auch auf „Aktiviert“ gesetzt sein.",
+      "isDefault": "## Standard\nWenn diese Option aktiviert ist, wird diese Vorlage automatisch für neue Projekte ausgewählt oder als Standard für alle Projekte festgelegt, falls keine projektspezifische Standardvorlage definiert ist. Nur eine Vorlage kann projektübergreifend als Standard festgelegt sein. Durch Aktivieren dieser Option werden alle anderen aktuell als Standard festgelegten Vorlagen deaktiviert.",
+      "caseFields": "## Testfallfelder\nWählen Sie die benutzerdefinierten Felder aus, die beim Erstellen oder Bearbeiten von Testfällen mit dieser Vorlage verfügbar sein sollen, und ordnen Sie sie an.\n\n- Fügen Sie Felder aus der Dropdown-Liste hinzu, um sie in die Vorlage aufzunehmen.\n- Felder per Drag & Drop neu anordnen.\n- Die Reihenfolge bestimmt, wie die Felder in Formularen angezeigt werden.\n- Nur aktivierte Testfallfelder sind auswählbar.\n- Testfallfelder definieren die Struktur und die für Testfälle erfassten Daten.",
+      "resultFields": "## Ergebnisfelder\nWählen Sie die benutzerdefinierten Felder aus, die beim Hinzufügen von Testergebnissen mit dieser Vorlage verfügbar sein sollen, und ordnen Sie sie an.\n\n- Fügen Sie Felder aus der Dropdown-Liste hinzu, um sie in die Vorlage aufzunehmen.\n- Felder per Drag & Drop neu anordnen.\n- Die Reihenfolge bestimmt, wie die Felder bei der Eingabe von Testergebnissen angezeigt werden.\n- Nur aktivierte Ergebnisfelder stehen zur Auswahl.\n- Ergebnisfelder erfassen zusätzliche Daten, die spezifisch für die Ergebnisse der Testausführung sind.",
+      "projects": "## Zugeordnete Projekte\nWählen Sie aus, für welche Projekte diese Vorlage verfügbar sein soll. Wenn keine Projekte ausgewählt sind, ist die Vorlage global verfügbar. Durch die Zuweisung einer Vorlage zu bestimmten Projekten wird deren Verwendung auf diese Projekte beschränkt."
+    },
+    "llm": {
+      "name": "## Integrationsname\nEine beschreibende Bezeichnung für diese LLM-Integration.\n\n- Wird verwendet, um sie in Listen und Einstellungen zu identifizieren.\n- Beispiel: \"OpenAI GPT-4o\" oder \"Internes Ollama\"",
+      "provider": "## Provider\nDer LLM-Dienst, der diese Integration ermöglicht.\n\n- Bestimmt das API-Protokoll und die verfügbaren Modelle.\n- Kann nach der Erstellung nicht mehr geändert werden.",
+      "apiKey": "## API-Schlüssel\nIhr Authentifizierungsschlüssel für die API des LLM-Anbieters.\n\n- Diesen erhalten Sie in der Entwicklerkonsole Ihres Anbieters.\n- Wird verschlüsselt gespeichert und nach dem Speichern nicht mehr angezeigt.\n- Für Ollama (lokale Bereitstellung) nicht erforderlich.",
+      "endpoint": "## API-Endpunkt\nDie Basis-URL für die API des LLM-Anbieters.\n\n- Für OpenAI, Anthropic und Gemini leer lassen – offizielle URLs werden automatisch verwendet.\n- Erforderlich für Ollama (z. B. `http://localhost:11434`), Azure OpenAI und benutzerdefiniertes LLM.\n- Optional für jeden Anbieter – geben Sie einen OpenAI-kompatiblen Proxy (z. B. LiteLLM) an, indem Sie dessen URL eingeben.\n- **Private/interne Adressen** (localhost, 127.0.0.1, private IPs, Cloud-Metadaten) sind blockiert, sofern sie nicht explizit über die Umgebungsvariable `ALLOWED_PRIVATE_HOSTS` zugelassen werden.",
+      "deploymentName": "## Azure-Bereitstellungsname\nDer Name Ihrer Azure OpenAI-Modellbereitstellung.\n\n- Zu finden in Azure OpenAI Studio unter Bereitstellungen.\n- Unterscheidet sich vom Modellnamen – z. B. wird `my-gpt4-deploy` auf `gpt-4` abgebildet.\n- Nur für Azure OpenAI erforderlich.",
+      "defaultModel": "## Standardmodell\nDas für KI-Anfragen mit dieser Integration verwendete Modell.\n\n- Für OpenAI, Anthropic und Gemini werden verfügbare Modelle automatisch von Ihrem API-Schlüssel abgerufen.\n- Stellen Sie sicher, dass das Modell in Ihrem Anbieterkonto aktiviert ist.\n- Beispiel: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Maximale Token pro Anfrage\nDie **obere Grenze** für die Anzahl der Ausgabetoken pro Anfrage.\n\n- Anfragen, die diesen Wert überschreiten, werden **mit einer Fehlermeldung abgelehnt**, bevor sie das LLM erreichen.\n- Stellen Sie diesen Wert auf die tatsächliche maximale Ausgabetoken-Kapazität Ihres Modells ein.\n- Beispiel: `16384` für GPT-4o, `8192` für Claude 3.5 Sonnet.\n- Ein zu niedriger Wert führt dazu, dass KI-Funktionen fehlschlagen oder eine abgeschnittene Ausgabe erzeugen.",
+      "defaultMaxTokens": "## Standard-Maximalwert für Tokens\nDer **Fallback-Wert** für den Token-Limit, der verwendet wird, wenn eine Anfrage kein eigenes Limit angibt.\n\n- Jede KI-Funktion (Testgenerierung, Codeexport usw.) legt ihr eigenes Limit unter **Admin → Eingabeaufforderungskonfiguration** fest.\n- Dieser Wert dient nur als Fallback für Funktionen ohne konfiguriertes Limit.\n- Sollte ≤ Maximalwert für Tokens pro Anfrage sein.",
+      "maxRequestsPerMinute": "## Maximale Anfragen pro Minute\nBegrenzt die Anzahl der API-Aufrufe, die pro Minute an diesen Anbieter gesendet werden können.\n\n- Entsprechend dem Ratenlimit Ihres Anbietertarifs einstellen.\n- Überschüssige Anfragen werden in eine Warteschlange gestellt, nicht abgelehnt.\n- Informationen zum Limit Ihres Tarifs finden Sie in der Dokumentation Ihres Anbieters.",
+      "costPerInputToken": "## Kosten pro Eingabe-Token (USD)\nDie Kosten in USD für jedes an das Modell gesendete Eingabe-Token (Prompt-Token).\n\n- Wird für die Kostenverfolgung und Budgetwarnungen verwendet.\n- Diesen Wert finden Sie auf der Preisseite Ihres Anbieters.\n- Beispiel: `0,000005` = 5 $ pro Million Eingabe-Token.",
+      "costPerOutputToken": "## Kosten pro Output-Token (USD)\nDie Kosten in USD für jeden vom Modell generierten Output-Token (Abschluss-Token).\n\n- Normalerweise höher als die Kosten des Input-Tokens.\n- Wird zur Kostenverfolgung und für Budgetwarnungen verwendet.\n- Beispiel: `0,000015` = 15 $ pro Million Output-Token.",
+      "monthlyBudget": "## Monatliches Budget (USD)\nEin optionales Ausgabenziel für diese Integration.\n\n- Auf „0“ setzen, um die Budgetverfolgung zu deaktivieren.\n- Das Budget dient **nur zu Informationszwecken** – es schränkt die Nutzung von LLM nicht ein.\n- Sie erhalten Benachrichtigungen bei 80 %, 90 % und 100 % des Budgets.\n- Die Kosten werden anhand der oben genannten Token-Preise berechnet.",
+      "billingPeriodStartDay": "## Beginn des Abrechnungszeitraums\nDer Tag im Monat (1–31), an dem Ihr Abrechnungszeitraum beginnt.\n\n– Standardwert „1“ entspricht dem Kalendermonat.\n– Auf „15“ setzen für einen Zyklus vom 15. bis 15. (z. B. passend zum Rechnungsdatum Ihres Anbieters).\n– Die Werte „29–31“ werden automatisch auf den letzten Tag kürzerer Monate begrenzt (Februar in Nicht-Schaltjahren usw.).\n– Beeinflusst das Ausgabenfenster für das **Monatsbudget** und die Aktion **Ausgaben zurücksetzen**.",
+      "defaultTemperature": "## Standardtemperatur\nSteuert die Zufälligkeit der Modellantworten (0–2).\n\n- **0:** Deterministisch – identische Ausgabe bei gleicher Eingabe\n- **0.3:** Fokussiert – empfohlen für Testgenerierung und Codeausgabe\n- **1+:** Kreativ – vielfältigere Antworten\n- Einzelne Funktionen können dies in der Prompt-Konfiguration überschreiben.",
+      "timeout": "## Anfrage-Timeout (ms)\nWie lange soll auf eine Antwort gewartet werden, bevor die Anfrage abgebrochen wird?\n\n- Wert in Millisekunden (z. B. `30000` = 30 Sekunden)\n- Streaming-Anfragen (z. B. Code-Export-Vorschau) ignorieren dieses Timeout.\n- Für langsame oder große Modelle erhöhen.\n- Bereich: 5.000 – 600.000 ms",
+      "streamingEnabled": "## Streaming aktivieren\nStreamt die Antwort Token für Token, anstatt auf die vollständige Ausgabe zu warten.\n\n– Erforderlich für die Echtzeit-Codevorschau im Export-Modal.\n– Reduziert die gefühlte Latenz bei langen Antworten.\n– Empfohlen für alle unterstützten Anbieter.",
+      "isDefault": "## Als Standardintegration festlegen\nLegt fest, dass diese Integration standardmäßig für alle KI-Funktionen verwendet wird.\n\n– Es kann immer nur eine Integration als Standard festgelegt sein.\n– Funktionen ohne konfigurierten Anbieter verwenden den Standardanbieter.\n– Kann jederzeit geändert werden."
+    },
+    "integration": {
+      "name": "## Integrationsname\nEin beschreibender Name zur systemweiten Identifizierung dieser Integration.\n\n- Muss eindeutig sein, um sie von anderen Integrationen zu unterscheiden.\n- Wird in den Projekteinstellungen und der Konfiguration verwendet.\n- Sollte den Dienst und den Zweck klar angeben.",
+      "authType": "## Authentifizierungstyp\nWählen Sie die Authentifizierungsmethode für den externen Dienst.\n\n- **API-Schlüssel:** Einfache Authentifizierung mit E-Mail-Adresse und API-Token\n- **OAuth 2.0:** Sichere Authentifizierung über den OAuth-Flow\n- **Persönliches Zugriffstoken:** Direkte tokenbasierte Authentifizierung",
+      "email": "## E-Mail-Adresse\nIhre E-Mail-Adresse für den externen Dienst.\n\n- Wird für die API-Schlüsselauthentifizierung verwendet.\n- Muss mit dem Konto übereinstimmen, das das API-Token generiert hat.\n- Erforderlich für Jira und ähnliche Dienste.",
+      "apiToken": "## API-Token\nGenerieren Sie einen API-Token in Ihren Kontoeinstellungen beim externen Dienst.\n\n- Normalerweise zu finden unter Kontoeinstellungen → Sicherheit → API-Tokens\n- Gewährleistet sicheren Zugriff, ohne Ihr Passwort preiszugeben\n- Kann bei Bedarf widerrufen und neu generiert werden",
+      "jiraUrl": "## Jira-URL\nDie Basis-URL Ihrer Jira-Instanz.\n\n- Format: https://your-site.atlassian.net\n- Fügen Sie nicht /browse oder andere Pfade hinzu.\n- Muss von diesem Server aus erreichbar sein.",
+      "clientId": "## OAuth-Client-ID\nDie Client-ID aus Ihrer OAuth-Anwendungskonfiguration.\n\n- Erstellt in der Entwicklerkonsole des externen Dienstes.\n- Wird verwendet, um Ihre Anwendung während des OAuth-Ablaufs zu identifizieren.\n- Kann sicher in Konfigurationsdateien weitergegeben werden.",
+      "clientSecret": "## OAuth-Clientgeheimnis\nDas Clientgeheimnis aus Ihrer OAuth-Anwendungskonfiguration.\n\n- Wird zusammen mit der Client-ID erstellt.\n- Muss vertraulich und sicher aufbewahrt werden.\n- Wird zur Authentifizierung Ihrer Anwendung verwendet.",
+      "personalAccessToken": "## Persönliches Zugriffstoken\nEin persönliches Zugriffstoken mit den entsprechenden Berechtigungen für den externen Dienst.\n\n- Wird in Ihren Kontoeinstellungen generiert.\n- Sollte Lese- und Schreibberechtigungen besitzen.\n- Sicherer als die Passwortauthentifizierung.",
+      "baseUrl": "## URL-Muster\nURL-Muster für die Verlinkung zu externen Vorgängen.\n\n- Verwenden Sie '{issueId}' als Platzhalter für die Vorgangs-ID.\n- Beispiel: https://example.com/issues/'{issueId}'\n- Wird für einfache URL-basierte Integrationen verwendet.",
+      "organizationUrl": "## Organisations-URL\nIhre Azure DevOps-Organisations-URL.\n\n- Format: https://dev.azure.com/your-org\n- Muss von diesem Server aus erreichbar sein\n- Wird für den Zugriff auf die Azure DevOps-APIs verwendet",
+      "apiKey": "## API-Schlüssel\nDer API-Schlüssel zur Authentifizierung beim externen Dienst.\n\n- Wird in den API-Einstellungen des Dienstes generiert.\n- Ermöglicht den programmatischen Zugriff auf den Dienst.\n- Sicher aufbewahren und regelmäßig ändern.",
+      "forgeApiKey": "## Forge-API-Schlüssel\nWird zur Authentifizierung der Atlassian Forge-App verwendet, wenn diese Testdaten aus Ihren Jira-Vorgängen abruft.\n\n– Klicken Sie auf „Generieren“, um einen neuen Schlüssel zu erstellen.\n– Kopieren Sie den Schlüssel und fügen Sie ihn in den Forge-App-Einstellungen in Jira ein (Apps verwalten → TestPlanIt-Einstellungen).\n– Durch das erneute Generieren wird der vorherige Schlüssel ungültig.",
+      "owner": "## Eigentümer / Namensraum\nDer Benutzer oder die Organisation, der/die das Repository besitzt.\n\n- Für GitHub/GitLab: der Benutzername oder Organisationsname.\n- Für Gitea/Forgejo/Gogs: der Benutzer- oder Gruppenname.\n- Beispiel: meine-organisation oder mein-benutzername",
+      "repo": "## Repository-Name\nDer Name des Repositorys, von dem die Issues verlinkt werden sollen.\n\n- Exakter Repository-Name (nicht die vollständige URL).\n- Beispiel: my-project.\n- Muss mit den angegebenen Zugangsdaten zugänglich sein.",
+      "instanceUrl": "## Instanz-URL\nDie Basis-URL Ihrer selbstgehosteten Instanz.\n\n- Format: https://git.example.com\n- Keine abschließenden Schrägstriche oder Pfade einfügen.\n- Muss von diesem Server aus erreichbar sein.",
+      "projectPath": "## Projektpfad\nDer vollständige Pfad zu Ihrem GitLab-Projekt.\n\n- Format: Namespace/Projekt oder Gruppe/Untergruppe/Projekt\n- Beispiel: meine-organisation/mein-projekt\n- In der Projekt-URL zu finden: gitlab.com/Namespace/Projekt",
+      "platform": "## Plattform\nDie selbstgehostete Git-Plattform, mit der Sie sich verbinden.\n\n- **Gitea**: gitea.io-basierte Instanzen\n- **Forgejo**: forgejo.org-basierte Instanzen (Gitea-Fork)\n- **Gogs**: gogs.io-basierte Instanzen\n\nDies steuert, welches Symbol angezeigt wird und kann die API-Kompatibilität beeinflussen."
+    },
+    "config": {
+      "name": "## Konfigurationsname\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Beschreibt die verschiedenen Kombinationen, aus denen sich die Konfiguration zusammensetzt (z. B. \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\" usw.)."
+    },
+    "configCategory": {
+      "name": "## Kategoriename\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Hilft dabei, Varianten (z. B. Chrome, Firefox, Safari, Edge usw.) in Kategorien (z. B. Browser) zu organisieren."
+    },
+    "configVariant": {
+      "name": "## Variantenname\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Beschreibt die Variante, die Teil einer Testumgebung ist (z. B. Chrome, Safari, Windows 10, Windows 11, macOS 15.5 usw.)."
+    },
+    "issueConfig": {
+      "name": "## Name der Vorgangskonfiguration\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Beschreibt die Vorgangskonfiguration (z. B. Jira, GitHub usw.).",
+      "baseUrl": "## Basis-URL\nDie Basis-URL für die Vorgangskonfiguration einschließlich des Vorgangsplatzhalters (z. B. https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Systemtyp\nDer Typ des Issue-Tracking-Systems (z. B. LINK Jira usw.).",
+      "isActive": "## Aktiv\nGibt an, ob diese Problemkonfiguration aktiv ist.",
+      "isDefault": "## Standard\nGibt an, ob diese Vorgangskonfiguration die Standardkonfiguration für Ihr Projekt ist.\n\n- Die Standardkonfiguration ist für neue Vorgänge vorausgewählt.\n- Kann jederzeit geändert werden.",
+      "projects": "## Projekte\nZeigt die Projekte an, die dieser Vorgangskonfiguration zugeordnet sind."
+    },
+    "issue": {
+      "name": "## Problemname\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Hilft bei der Beschreibung des Problems (z. B. \"Problem 123\", \"Bug 456\" usw.).",
+      "title": "## Titel des Problems\nEin lesbarer Titel, der das Problem beschreibt.\n\n- Bietet Kontext zum Thema des Problems.\n- Wird in Listen und Problemübersichten angezeigt.\n- Sollte klar und beschreibend sein.",
+      "externalKey": "## Externer Schlüssel\nDer eindeutige Schlüssel oder die Kennung des externen Problemverfolgungssystems.\n\n- Für JIRA: Problemschlüssel wie \"PROJ-123\"\n- Für GitHub: Problemnummer wie \"456\"\n- Für Azure DevOps: Arbeitselement-ID\n- Wird beim Speichern automatisch die externe URL generiert",
+      "externalId": "## Externe ID\nDie eindeutige Kennung für dieses Problem im Problemverfolgungssystem (z. B. „Problem-123“, „Bug456“ usw.).\n\n– Dies wird als Platzhalter für das Problem in der Basis-URL verwendet.",
+      "description": "## Beschreibung\nEine kurze Übersicht über den Inhalt dieser Ausgabe.\n\n- Wichtige Bereiche oder Funktionen, die getestet werden\n- Wichtiger Kontext oder Hintergrund\n- Besondere Überlegungen oder Anforderungen",
+      "project": "## Projekt\nDas Projekt, dem dieses Problem zugeordnet ist.\n\n- Probleme können mit Testfällen in mehreren Projekten verknüpft werden.\n- Die Festlegung eines Hauptprojekts erleichtert die Organisation von Problemen.\n- Kann für projektübergreifende Probleme leer gelassen werden.",
+      "state": "## Status\nGeben Sie den aktuellen Status oder das Ergebnis dieses Vorgangs gemäß dem Workflow Ihres Projekts an.",
+      "tags": "## Tags\nWenden Sie relevante Tags an, um dieses Problem zu kategorisieren und zu filtern.",
+      "issues": "## Probleme\nVerknüpfen Sie alle damit zusammenhängenden Probleme (Bugs, Aufgaben usw.) mit diesem Problem."
+    },
+    "status": {
+      "name": "## Statusname\nEin klarer, aussagekräftiger Name, der in allen Projekten verwendet wird.\n\n- Beschreibt den Status des Testergebnisses (z. B. Bestanden, Fehlgeschlagen, Blockiert usw.).",
+      "color": "## Farbe\nDie Farbe dieses Status.",
+      "systemName": "## Systemname\nDer Name des Status, der vom Backend-System verwendet wird (z. B. Datenbankabfragen, Berichte usw.).",
+      "aliases": "## Aliase\nZusätzliche Namen oder Synonyme für diesen Status, die verwendet werden können, um externe Systemstatus mit diesem Status zu verknüpfen.",
+      "enabled": "## Aktiviert\nZeigt an, ob dieser Status aktiviert ist.",
+      "isEnabled": "## Aktiviert\nZeigt an, ob dieser Status aktiviert und verfügbar ist.\n\n– Wenn aktiviert, kann dieser Status bei der Aufzeichnung von Testergebnissen ausgewählt werden.\n– Deaktivierte Status sind nicht auswählbar, bleiben aber in den vorhandenen Ergebnissen erhalten.",
+      "success": "## Erfolg\nGibt an, ob es sich bei diesem Status um einen Erfolgsstatus handelt.",
+      "isSuccess": "## Erfolgsstatus\nGibt an, ob dieser Status ein erfolgreiches Testergebnis darstellt.\n\n- Erfolgsstatus tragen zur Berechnung der Bestehensquote bei.\n- Wird in Berichten und Analysen verwendet, um die Testeffektivität zu verfolgen.",
+      "completed": "## Abgeschlossen\nGibt an, ob dieser Status ein abgeschlossener Status ist.",
+      "isCompleted": "## Status „Abgeschlossen“\nGibt an, ob dieser Status eine abgeschlossene Testausführung darstellt.\n\n– Abgeschlossene Status bedeuten, dass der Test beendet wurde.\n– Wird zur Berechnung der Abschlussraten und zur Fortschrittsverfolgung verwendet.",
+      "failure": "## Fehler\nGibt an, ob es sich bei diesem Status um einen Fehlerstatus handelt.",
+      "isFailure": "## Fehlerstatus\nGibt an, ob dieser Status ein fehlgeschlagenes Testergebnis darstellt.\n\n- Fehlerstatus tragen zu den Fehlerratenmetriken bei.\n- Wird in Berichten und Analysen verwendet, um Probleme zu identifizieren.",
+      "scope": "## Scope\nGibt den Gültigkeitsbereich dieses Status an (Testlauf, Sitzung, Automatisierung).",
+      "projects": "## Projekte\nZeigt die Projekte an, die diesen Status verwenden können."
+    },
+    "workflow": {
+      "scope": "## Bereich\nGibt den Bereich dieses Workflows an (Testlauf, Sitzung, Automatisierung).\n\n- Kann nach der Erstellung des Workflows nicht mehr geändert werden.",
+      "iconColor": "## Symbol/Farbe\nDas Symbol und die Farbe für diesen Workflow.",
+      "name": "## Name\nEin klarer, beschreibender Name, der in allen Projekten verwendet wird.\n\n- Hilft dabei, den Workflow zu beschreiben (z. B. \"Entwurf\", \"In Bearbeitung\", \"Aktiv\" usw.).",
+      "workflowType": "## Typ\nDer Workflow-Typ (Nicht gestartet, In Bearbeitung, Abgeschlossen).",
+      "type": "## Workflow-Typ\nDie Kategorie des Workflow-Status (Nicht begonnen, In Bearbeitung, Abgeschlossen).\n\n- Bestimmt, wie sich dieser Status auf die Fortschrittsverfolgung auswirkt.\n- Status „Nicht begonnen“ zeigen an, dass die Arbeit noch nicht begonnen hat.\n- Status „In Bearbeitung“ zeigen aktive Arbeit an.\n- Status „Abgeschlossen“ markiert die abgeschlossene Arbeit.",
+      "isDefault": "## Standard\nGibt an, ob dieser Workflow der Standard-Workflow für Ihr Projekt ist.\n\n– Der Standard-Workflow ist für neue Testläufe, Sitzungen und Automatisierungen vorausgewählt.",
+      "isEnabled": "## Aktiviert\nGibt an, ob dieser Workflow aktiviert ist.",
+      "isActive": "## Aktiv\nZeigt an, ob dieser Workflow-Status aktiv und verfügbar ist.\n\n– Aktive Workflows können beim Aktualisieren von Testläufen, Sitzungen oder Automatisierungen ausgewählt werden.\n– Inaktive Workflows sind nicht auswählbar, bleiben aber in bestehenden Elementen erhalten.",
+      "projects": "## Projekte\nZeigt die Projekte an, die diesen Workflow nutzen können."
+    },
+    "testResult": {
+      "status": "## Status\nWählen Sie den Gesamtstatus der Testausführung. Der gewählte Status kann sich auf Projektkennzahlen und Berichte auswirken.",
+      "elapsedTime": "## Verstrichene Zeit\nGeben Sie die Gesamtzeit ein, die für die Ausführung dieses Testfalls benötigt wurde. Sie können Einheiten wie **s** für Sekunden, **m** für Minuten oder **h** für Stunden verwenden (z. B. 30s, 5m, 1h 20m).",
+      "resultData": "## Ergebnisdetails\nGeben Sie detaillierte Notizen, Beobachtungen oder sonstige relevante Daten zur gesamten Testdurchführung an. Dies können Einrichtungsdetails, Schritte bei Abweichungen vom Plan oder allgemeine Kommentare umfassen.",
+      "evidence": "## Nachweise/Anhänge\nLaden Sie alle Dateien (z. B. Screenshots, Protokolle, Datendateien) hoch, die als Nachweis für dieses Testergebnis dienen. Diese Anhänge werden mit diesem spezifischen Ergebnis verknüpft.",
+      "issues": "## Verknüpfte Probleme\nVerknüpfen Sie alle Probleme aus Ihrem integrierten Problemverfolgungssystem, die mit diesem Testergebnis zusammenhängen. Dies erleichtert die Nachverfolgung von Fehlern oder Aufgaben, die mit dem Ergebnis dieses Tests verbunden sind.",
+      "stepStatus": "## Schrittstatus\nWählen Sie den Status für diesen spezifischen Testschritt aus. Dies ermöglicht die detaillierte Nachverfolgung des Fortschritts innerhalb eines einzelnen Testfalls.",
+      "stepElapsedTime": "## Schrittdauer\nGeben Sie die für diesen Schritt benötigte Zeit ein. Verwenden Sie Einheiten wie **s**, **m**, **h** (z. B. 10s, 2m). Dies ist optional.",
+      "stepNotes": "## Schrittnotizen\nFügen Sie hier Notizen, Beobachtungen oder Daten hinzu, die speziell für die Ausführung dieses Testschritts relevant sind.",
+      "stepIssues": "## Schrittbezogene Probleme\nVerknüpfen Sie Probleme aus Ihrem Problemverfolgungssystem, die speziell mit dem Ergebnis oder den Beobachtungen dieses Testschritts zusammenhängen."
+    },
+    "case": {
+      "name": "## Testfallname\nEin klarer, beschreibender Name für den Testfall.",
+      "state": "## Status\nZeigt den aktuellen Workflow-Status dieses Falls an.",
+      "template": "## Vorlage\nWählen Sie die Vorlage aus, die dieser Fall für seine Fallfelder und Ergebnisfelder verwenden soll.",
+      "estimate": "## Schätzung\nDie manuell eingegebene geschätzte Zeit für die Durchführung dieses Testfalls.",
+      "automated": "## Automatisiert\nGibt an, ob dieser Testfall automatisiert ist oder nicht.",
+      "tags": "## Tags\nWenden Sie relevante Tags an, um diesen Fall zu kategorisieren und zu filtern.",
+      "issues": "## Probleme\nVerknüpfen Sie alle damit zusammenhängenden Probleme (Bugs, Aufgaben usw.) mit diesem Fall."
+    },
+    "folder": {
+      "name": "## Ordnername\nEin klarer, beschreibender Name für den Ordner.",
+      "documentation": "## Dokumentation\nWeitere Details, Referenzen und Begleitmaterialien."
+    },
+    "bulkEdit": {
+      "name": "## Name\nEin klarer, beschreibender Name für die Testfälle.",
+      "state": "## Status\nZeigt den aktuellen Workflow-Status dieser Testfälle an.",
+      "estimate": "## Schätzung\nDie manuell eingegebene geschätzte Zeit für die Durchführung jedes dieser Testfälle.",
+      "automated": "## Automatisiert\nGibt an, ob diese Testfälle automatisiert sind oder nicht.",
+      "tags": "## Tags\nWenden Sie relevante Tags an, um diese Testfälle zu kategorisieren und zu filtern.",
+      "issues": "## Probleme\nVerknüpfen Sie alle zugehörigen Probleme (Bugs, Aufgaben usw.) mit diesen Testfällen."
+    },
+    "caseField": {
+      "displayName": "## Anzeigename\nDies ist der lesbare Name des Feldes, der Benutzern in Formularen und Ansichten angezeigt wird. Wählen Sie einen klaren und aussagekräftigen Namen.",
+      "systemName": "## Systemname\nEin eindeutiger Bezeichner für dieses Feld, der intern vom System verwendet wird (z. B. bei API-Aufrufen und Datenbankabfragen). Er wird automatisch aus dem Anzeigenamen generiert, kann aber angepasst werden. Muss mit einem Buchstaben beginnen. Darf nur Buchstaben, Zahlen und Unterstriche enthalten (keine Leerzeichen oder Sonderzeichen).",
+      "hint": "## Hinweistext (optional)\nGeben Sie eine kurze Anweisung oder ein Beispiel ein, das unterhalb des Feldes angezeigt wird, um die Benutzer zu unterstützen. Dies kann die erwartete Eingabe oder Formatierung verdeutlichen.",
+      "enabled": "## Aktiviert\nLegt fest, ob dieses Feld aktiv und für die Verwendung in Vorlagen und Testfällen verfügbar ist. Deaktivierte Felder werden ausgeblendet, ihre Daten bleiben erhalten, werden aber nicht verwendet.",
+      "required": "## Erforderlich\nWenn diese Option aktiviert ist, müssen Benutzer beim Erstellen oder Bearbeiten eines Testfalls mithilfe einer Vorlage, die dieses Feld enthält, einen Wert für dieses Feld angeben.",
+      "restricted": "## Eingeschränkt\nWenn diese Option aktiviert ist, können nur Benutzer mit speziellen Berechtigungen (z. B. Super-Admins oder Benutzer mit der Berechtigung „Eingeschränkte Felder für Fälle“) den Wert dieses Feldes bearbeiten, sobald ein Fall erstellt wurde. Andere Benutzer sehen es schreibgeschützt. Dies ist nützlich für Felder wie „Geprüft von“ oder „Genehmigungsdatum“, die nach einem bestimmten Stadium nicht mehr von normalen Benutzern geändert werden sollen.",
+      "fieldType": "## Feldtyp\nBestimmt die Art der Daten, die in diesem Feld gespeichert werden, und wie sie angezeigt werden (z. B. Text, Zahl, Datum, Dropdown). Der Feldtyp kann nach der Erstellung nicht mehr geändert werden.",
+      "defaultValue": "## Standardwert (optional)\nLegen Sie einen vordefinierten Wert für dieses Feld fest. Verwenden Sie für den Typ „Kontrollkästchen“ „true“ oder „false“. Bei „Dropdown-Liste“ oder „Mehrfachauswahl“ bezieht sich dies üblicherweise auf die ID(s) der Standardoption(en). Bei anderen Typen ist es der Standardtext bzw. die Standardzahl. Dieser Wert kann beim Hinzufügen des Felds zu einer Vorlage überschrieben werden.",
+      "isChecked": "## Standardzustand (für Kontrollkästchen)\nLegt fest, ob das Kontrollkästchen standardmäßig aktiviert sein soll, wenn ein neues Element (z. B. ein Testfall) erstellt wird.",
+      "minValue": "## Minimalwert (für Zahlen/Ganzzahlen)\nLegt den kleinsten zulässigen numerischen Wert für dieses Feld fest. Sowohl Minimal- als auch Maximalwert müssen festgelegt werden, wenn nur einer verwendet wird.",
+      "maxValue": "## Maximalwert (für Zahl/Ganzzahl)\nLegt den größten zulässigen numerischen Wert für dieses Feld fest. Sowohl Minimal- als auch Maximalwert müssen festgelegt werden, wenn nur einer verwendet wird.",
+      "initialHeight": "## Anfangshöhe (für lange Texte)\nLegen Sie die anfängliche Anzeigehöhe (in Pixeln) für Rich-Text-Editorfelder fest. Dies hilft, das Formularlayout für längere Texteingaben zu steuern.",
+      "dropdownOptions": "## Optionen (für Dropdown-/Mehrfachauswahl)\nDefinieren Sie die Liste der auswählbaren Optionen. Sie können die Reihenfolge der Optionen ändern, eine Standardoption festlegen und einzelne Optionen aktivieren/deaktivieren."
+    },
+    "resultField": {
+      "displayName": "## Anzeigename\nDies ist der lesbare Name für das Feld, der Benutzern bei der Eingabe von Testergebnissen angezeigt wird. Wählen Sie einen klaren und aussagekräftigen Namen.",
+      "systemName": "## Systemname\nEine eindeutige Kennung für dieses Feld, die intern vom System verwendet wird (z. B. bei API-Aufrufen und Datenbankabfragen). Sie wird automatisch aus dem Anzeigenamen generiert, kann aber angepasst werden.\n– Muss mit einem Buchstaben beginnen.\n– Darf nur Buchstaben, Zahlen und Unterstriche enthalten (keine Leerzeichen oder Sonderzeichen).",
+      "hint": "## Hinweistext (optional)\nGeben Sie eine kurze Anweisung oder ein Beispiel ein, das unterhalb des Feldes angezeigt wird, um die Benutzer zu unterstützen. Dies kann die erwartete Eingabe oder Formatierung bei der Eingabe von Ergebnisdaten verdeutlichen.",
+      "enabled": "## Aktiviert\nLegt fest, ob dieses Feld aktiv ist und in Vorlagen zur Eingabe von Testergebnissen verwendet werden kann. Deaktivierte Felder werden ausgeblendet, ihre Daten bleiben erhalten, werden aber nicht verwendet.",
+      "required": "## Erforderlich\nWenn diese Option aktiviert ist, müssen Benutzer beim Hinzufügen eines Testergebnisses mithilfe einer Vorlage, die dieses Feld enthält, einen Wert für dieses Feld angeben.",
+      "restricted": "## Eingeschränkt\nWenn diese Option aktiviert ist, können nur Benutzer mit speziellen Berechtigungen (z. B. Super-Admins oder Benutzer mit der Berechtigung „Eingeschränkte Felder für Testergebnisse“) den Wert dieses Feldes bearbeiten, sobald ein Ergebnis übermittelt wurde. Andere Benutzer sehen es schreibgeschützt.",
+      "fieldType": "## Feldtyp\nBestimmt die Art der Daten, die in diesem Feld gespeichert werden, und wie diese in den Testergebnissen angezeigt werden (z. B. Text, Zahl, Datum, Dropdown-Liste). Der Feldtyp kann nach der Erstellung nicht mehr geändert werden.",
+      "defaultValue": "## Standardwert (Optional)\nLegen Sie beim Hinzufügen eines neuen Testergebnisses einen vordefinierten Wert für dieses Feld fest. Verwenden Sie für den Typ „Kontrollkästchen“ „true“ oder „false“. Bei „Dropdown-Liste“ oder „Mehrfachauswahl“ bezieht sich dies in der Regel auf die ID(s) der Standardoption(en). Bei anderen Typen ist es der Standardtext bzw. die Standardzahl.",
+      "isChecked": "## Standardzustand (für Kontrollkästchen)\nLegt fest, ob das Kontrollkästchen standardmäßig aktiviert sein soll, wenn ein neues Testergebnis hinzugefügt wird.",
+      "minValue": "## Minimalwert (für Zahlen/Ganzzahlen)\nLegt den kleinsten zulässigen numerischen Wert für dieses Feld bei der Eingabe von Ergebnisdaten fest. Sowohl Minimal- als auch Maximalwert müssen festgelegt werden, wenn nur einer verwendet wird.",
+      "maxValue": "## Maximalwert (für Zahlen/Ganzzahlen)\nLegt den größten zulässigen numerischen Wert für dieses Feld bei der Eingabe von Ergebnisdaten fest. Sowohl Minimal- als auch Maximalwert müssen festgelegt werden, wenn nur einer verwendet wird.",
+      "initialHeight": "## Anfangshöhe (für lange Texte)\nLegen Sie die anfängliche Anzeigehöhe (in Pixeln) für Rich-Text-Editorfelder fest, die in den Ergebnissen verwendet werden. Dies hilft, das Formularlayout für längere Texteingaben zu steuern.",
+      "dropdownOptions": "## Optionen (für Dropdown-/Mehrfachauswahl)\nDefinieren Sie die Liste der Auswahlmöglichkeiten bei der Eingabe von Ergebnisdaten. Sie können die Reihenfolge der Optionen ändern, eine Standardeinstellung festlegen und einzelne Optionen aktivieren/deaktivieren."
+    },
+    "exportModal": {
+      "scope": "## Exportumfang\nLegt fest, welche Testfälle exportiert werden:\n- **Ausgewählt:** Exportiert nur die in der Tabelle explizit ausgewählten Testfälle.\n- **Alle gefiltert:** Exportiert alle Testfälle, die den aktuellen Filterkriterien in der Tabelle entsprechen, auch wenn nicht alle aktuell auf der Seite sichtbar sind.\n- **Gesamtes Projekt:** Exportiert alle Testfälle im aktuellen Projekt, unabhängig von Auswahlen oder Filtern.",
+      "format": "## Exportformat\nWählen Sie das Dateiformat für Ihren Export.\n- **CSV (Comma Separated Values):** Eine einfache Textdatei, geeignet für Tabellenkalkulationsprogramme (Excel, Google Sheets) und Datenanalysetools. Der PDF-Export ist für eine zukünftige Version geplant.",
+      "columns": "## Zu exportierende Spalten (nur CSV)\nLegt fest, welche Datenspalten für jeden Testfall exportiert werden:\n- **Alle Spalten:** Exportiert alle verfügbaren Datenfelder der Testfälle, einschließlich benutzerdefinierter Felder aus den Vorlagen.\n- **Sichtbare Spalten:** Exportiert nur die aktuell in der Testfalltabelle sichtbaren Spalten.",
+      "delimiter": "## CSV-Trennzeichen (nur CSV)\nWählen Sie das Zeichen, das zum Trennen der Werte in der CSV-Datei verwendet wird. Am häufigsten wird das Komma verwendet. Verwenden Sie ein anderes Trennzeichen, wenn Ihre Daten Kommas innerhalb von Textfeldern enthalten (z. B. Semikolon).",
+      "textLongFormat": "## Format für lange Textfelder (nur CSV)\nLegt fest, wie Rich-Text-Felder (wie „Beschreibung“ oder benutzerdefinierte „Lange Text“-Felder) exportiert werden:\n– **JSON:** Exportiert den Inhalt als JSON-Zeichenfolge und behält dabei alle Formatierungen (Fett, Listen usw.) bei. Dies eignet sich am besten für den Wiederimport oder die programmgesteuerte Verarbeitung.\n– **Nur-Text:** Exportiert den Inhalt als Nur-Text und entfernt die Formatierung. Dies ist in einfachen Textanzeigeprogrammen besser lesbar.",
+      "stepsFormat": "## Schrittformat (nur CSV)\nLegt fest, wie Testschritte (einschließlich erwarteter Ergebnisse) exportiert werden:\n- **JSON:** Exportiert die Schritte als JSON-Array von Objekten, wobei Struktur und formatierter Text erhalten bleiben. Geeignet für den Reimport oder detaillierte Analysen.\n- **Klartext:** Exportiert die Schritte in einem vereinfachten, lesbaren Klartextformat, wobei jeder Schritt und das erwartete Ergebnis in einer neuen Zeile stehen.",
+      "rowMode": "## Zeilenmodus (nur CSV)\nLegt fest, wie Mehrwertfelder (z. B. Tags oder benutzerdefinierte Mehrfachauswahlfelder) und Schritte dargestellt werden:\n– **Eine Zeile pro Fall:** Jeder Testfall entspricht einer einzelnen Zeile. Mehrwertfelder und Schritte werden in den jeweiligen Zellen zusammengefasst (oft als JSON oder verketteter Text).\n– **Mehrere Zeilen pro Fall:** Ein Testfall kann sich über mehrere Zeilen erstrecken, wenn er mehrere Tags, Mehrfachauswahlwerte oder Schritte enthält. Jeder eindeutige Wert/Schritt für solche Felder erzeugt eine neue Zeile, während andere Falldaten wiederholt werden. Dies ist nützlich für detaillierte Analysen oder Pivot-Tabellen.",
+      "attachmentFormat": "## Format der Anhangsinformationen (nur CSV)\nLegt fest, wie die Informationen zu Anhängen exportiert werden:\n- **JSON:** Exportiert Anhangsdetails (wie Dateiname, URL, Größe) als JSON-Array. Dies ist umfassend, aber in einer CSV-Datei weniger lesbar.\n- **Nur Namen:** Exportiert eine durch Kommas getrennte Liste der Anhangsdateinamen. Einfacher für den schnellen Zugriff."
+    },
+    "reportMetrics": {
+      "count": "## Anzahl der Testergebnisse\nAnzahl der Testlaufergebnisse in dieser Gruppe.",
+      "passRate": "## Bestehensquote\nAnteil der Ergebnisse in dieser Gruppe mit Bestehensstatus.",
+      "avgElapsed": "## Durchschnittliche verstrichene Zeit\nDurchschnittliche verstrichene Zeit für Ergebnisse in dieser Gruppe.",
+      "sumElapsed": "## Gesamte verstrichene Zeit\nSumme der verstrichenen Zeit für Ergebnisse in dieser Gruppe.",
+      "executionCount": "## Testausführungen\nGesamtzahl der durchgeführten Testausführungen.",
+      "testCaseCount": "## Anzahl der Testfälle\nGesamtzahl der Testfälle in dieser Gruppe.",
+      "testRunCount": "## Anzahl der Testläufe\nGesamtzahl der Testläufe in dieser Gruppe.",
+      "automationRate": "## Automatisierungsgrad\nProzentsatz der automatisierten Testfälle.",
+      "averageSteps": "## Durchschnittliche Schritte pro Fall\nDurchschnittliche Anzahl der Schritte pro Testfall.",
+      "automatedCount": "## Automatisierte Fälle\nAnzahl der automatisierten Testfälle.",
+      "manualCount": "## Manuelle Fälle\nAnzahl der manuellen Testfälle.",
+      "totalSteps": "## Gesamtschritte\nGesamtzahl der Testschritte über alle Fälle hinweg.",
+      "createdCaseCount": "## Erstellte Testfälle\nAnzahl der in diesem Zeitraum erstellten Testfälle.",
+      "sessionResultCount": "## Sitzungsergebnisse\nAnzahl der Sitzungstestergebnisse.",
+      "sessionCount": "## Sitzungsanzahl\nGesamtzahl der Testsitzungen.",
+      "activeSessions": "## Aktive Sitzungen\nAnzahl der aktuell aktiven Sitzungen (isActive = true).",
+      "milestoneCompletion": "## Meilenstein-Abschluss\nProzentsatz der in Meilensteinen abgeschlossenen Testfälle. Berechnet als (abgeschlossene Testergebnisse / Gesamtzahl der Testfälle in den Testläufen) × 100.",
+      "averageTimeSpent": "## Durchschnittliche Zeitaufwendung\nDurchschnittliche Zeitaufwendung für Aktivitäten.",
+      "sessionParticipation": "## Sitzungsteilnahme\nGrad der Teilnahme an den Testsitzungen.",
+      "lastActiveDate": "## Letztes Aktivitätsdatum\nLetztes Aktivitätsdatum.",
+      "averageAge": "## Durchschnittsalter\nDurchschnittsalter der Artikel in Tagen.",
+      "issueCount": "## Anzahl der Probleme\nGesamtzahl der erfassten Probleme.",
+      "milestoneCount": "## Meilensteinanzahl\nGesamtzahl der Meilensteine.",
+      "milestoneCompletionRate": "## Meilenstein-Erfüllungsrate\nProzentsatz der abgeschlossenen Meilensteine.",
+      "averageMilestoneDuration": "## Durchschnittliche Meilensteindauer\nDurchschnittliche Dauer der Meilensteine in Tagen."
+    },
+    "reportDimensions": {
+      "user": "## Benutzerdimension\nGruppiert die Ergebnisse nach dem Benutzer, der die Tests ausgeführt hat oder den Elementen zugeordnet ist.",
+      "status": "## Status Dimension\nGruppiert die Ergebnisse nach dem Testausführungsstatus (z. B. Bestanden, Fehlgeschlagen, Blockiert).",
+      "project": "## Projektdimension\nGruppiert Ergebnisse nach Projekt für projektübergreifende Analysen.",
+      "testRun": "## Testlaufdimension\nGruppiert die Ergebnisse nach dem Testlauf, der die ausgeführten Testfälle enthält.",
+      "testCase": "## Testfalldimension\nGruppiert Ergebnisse nach einzelnen Testfällen zur detaillierten Analyse.",
+      "milestone": "## Meilensteindimension\nGruppiert Ergebnisse nach Projektmeilensteinen, um den Fortschritt in Richtung der Ziele zu verfolgen.",
+      "configuration": "## Konfigurationsdimension\nGruppiert Ergebnisse nach Testumgebungskonfiguration (z. B. Browser, Betriebssystem).",
+      "template": "## Template Dimension\nGruppiert Ergebnisse nach der für die Testfallstruktur verwendeten Vorlage.",
+      "creator": "## Creator Dimension\nGruppiert die Ergebnisse nach dem Benutzer, der die Testfälle oder Testläufe erstellt hat.",
+      "state": "## Statusdimension\nGruppiert Ergebnisse nach Workflow-Status (z. B. Entwurf, Aktiv, Abgeschlossen).",
+      "role": "## Rollendimension\nGruppiert Ergebnisse nach Benutzerrollen für die Zugriffs- und Verantwortlichkeitsanalyse.",
+      "group": "## Gruppendimension\nErgebnisse werden nach Benutzergruppen gruppiert. Benutzer können mehreren Gruppen angehören, daher werden Aktivitäten für jede Gruppe gezählt, der der Benutzer angehört.",
+      "folder": "## Ordnerdimension\nGruppiert Ergebnisse nach Repository-Ordnerstruktur für die Organisationsanalyse.",
+      "session": "## Session Dimension\nGruppiert Ergebnisse durch Testen von Sessions für die sitzungsbasierte Analyse.",
+      "assignedTo": "## Zugeordnete Dimension\nGruppiert Ergebnisse nach dem Benutzer, der für die Ausführung oder Verwaltung der Elemente zuständig ist.",
+      "issueType": "## Problemtyp-Dimension\nGruppiert die Ergebnisse nach dem Typ der verfolgten Probleme (z. B. Bug, Task, Story, Enhancement).",
+      "issueTracker": "## Dimension Issue Tracker\nGruppiert die Ergebnisse nach der verwendeten Issue-Tracking-Integration (z. B. Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Problemstatus-Dimension\nGruppiert Ergebnisse nach dem aktuellen Status der Probleme (z. B. Offen, In Bearbeitung, Erledigt, Geschlossen).",
+      "priority": "## Prioritätsdimension\nGruppiert Ergebnisse nach Prioritätsstufe des Problems (z. B. Hoch, Mittel, Niedrig).",
+      "source": "## Source Dimension\nGruppiert die Ergebnisse nach der Quelle der Testausführung (z. B. Manuell, JUnit, API).",
+      "date": "## Datumsdimension\nGruppiert Ergebnisse nach Datum für zeitbasierte Analysen und Trends."
+    },
+    "reportBuilder": {
+      "dimensions": "## Dimensionen\nWählen Sie die Dimensionen aus, die Sie in Ihrem Bericht analysieren möchten. Dimensionen sind Attribute, die Ihre Daten kategorisieren, z. B. Datum, Benutzer, Status usw. Sie können sie per Drag & Drop neu anordnen.",
+      "metrics": "## Kennzahlen\nWählen Sie die Kennzahlen aus, die Sie in Ihrem Bericht messen möchten. Kennzahlen sind quantitative Messwerte, die aus Ihren Daten abgeleitet werden, wie z. B. Anzahl der Testergebnisse, Erfolgsquote, durchschnittliche Bearbeitungszeit usw. Sie können die Reihenfolge per Drag & Drop ändern.",
+      "dateRange": "## Datumsbereich\nFiltern Sie Ihre Berichtsdaten nach einem bestimmten Zeitraum. Sie können aus vordefinierten Bereichen wie „Letzte 7 Tage“ oder „Vormonat“ auswählen oder einen benutzerdefinierten Datumsbereich definieren. Dieser Filter wird auf das jeweilige Datumsfeld für jeden Berichtstyp angewendet (z. B. Ausführungsdatum für Testergebnisse, Erstellungsdatum für Testfälle)."
+    },
+    "codeRepository": {
+      "name": "## Repository-Name\nEin aussagekräftiger Name für diese Repository-Verbindung.\n\n- Wird zur Identifizierung in den Projektcode-Kontexteinstellungen verwendet.\n- Muss nicht mit dem Repository-Namen des Providers übereinstimmen.",
+      "provider": "## Git-Anbieter\nDie Plattform, auf der dieses Repository gehostet wird.\n\n- **GitHub** — github.com (Cloud oder Enterprise)\n- **GitLab** — gitlab.com oder selbst gehostet\n- **Bitbucket Cloud** — bitbucket.org (nur Cloud)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — selbst gehostete Git-Server mit kompatiblen APIs",
+      "githubToken": "## Persönliches Zugriffstoken\nEin GitHub-Token mit der Berechtigung **Inhalt: Lesen**.\n\nGenerieren Sie ein solches Token unter: GitHub → Profileinstellungen → Entwicklereinstellungen → Persönliche Zugriffstoken → Feingranulare Token.",
+      "owner": "## Besitzer\nDie GitHub-Organisation oder das Benutzerkonto, dem das Repository gehört.\n\n- Beispiel: `myorg` oder `myusername`\n- Dies ist der erste Pfadabschnitt Ihrer Repository-URL auf github.com",
+      "repo": "## Repository\nDer Repository-Name ohne das Präfix des Eigentümers.\n\n- Beispiel: `my-repo` (nicht `myorg/my-repo`)\n- Dies ist der zweite Pfadabschnitt Ihrer Repository-URL auf github.com",
+      "gitlabToken": "## Persönliches Zugriffstoken\nEin GitLab-Token mit den Berechtigungen **read_api** und **read_repository**.\n\nGenerieren Sie ein solches Token unter: GitLab → Benutzereinstellungen → Zugriffstoken.",
+      "projectPath": "## Projekt-ID oder Pfad\nDie numerische Projekt-ID oder der vollständige Namespace-Pfad.\n\n- Beispielpfad: `myorg/my-project`\n- Beispiel-ID: `12345678`\n- Zu finden in GitLab unter Einstellungen → Allgemein.",
+      "baseUrl": "## GitLab-URL\nFür gitlab.com leer lassen. Bei selbstgehosteten Instanzen die GitLab-URL eingeben.\n\n- Beispiel: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian-Konto-E-Mail\nDie mit Ihrem Atlassian-Konto verknüpfte E-Mail-Adresse.\n\n- Dies ist die E-Mail-Adresse, mit der Sie sich bei Bitbucket Cloud anmelden.",
+      "bitbucketApiToken": "## API-Token\nEin Bitbucket-API-Token mit **Repositories: Leseberechtigung**.\n\nErstellen Sie einen unter: Bitbucket → Persönliche Einstellungen → API-Token.\n\n> App-Passwörter wurden von Atlassian zugunsten von API-Tokens abgeschafft.",
+      "workspace": "## Arbeitsbereich\nDer Arbeitsbereichs-Slug Ihrer Bitbucket-URL.\n\n- Beispiel: `myworkspace` von `bitbucket.org/myworkspace`",
+      "repoSlug": "## Repository-Slug\nDie Repository-Kennung aus der URL.\n\n- Beispiel: `my-repo` von `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Persönliches Zugriffstoken\nEin Azure DevOps PAT mit **Code (Lesen)**-Berechtigung.\n\nErstellen Sie ein solches Token unter: Azure DevOps → Benutzereinstellungen → Persönliche Zugriffstoken.",
+      "organizationUrl": "## Organisations-URL\nIhre Azure DevOps-Organisations-URL.\n\n- Beispiel: `https://dev.azure.com/myorg`",
+      "project": "## Projektname\nDer Name des Azure DevOps-Projekts, das das Repository enthält.\n\n- Befindet sich als drittes Pfadsegment in Ihrer Azure DevOps-URL nach dem Organisationsnamen.",
+      "azureRepoId": "## Repository-Name oder -ID\nDer Repository-Name oder die GUID innerhalb des Azure DevOps-Projekts.\n\n- Beispiel: `my-repo`",
+      "giteaToken": "## Persönliches Zugriffstoken\nEin Token mit Leseberechtigungen für das Repository.\n\nGenerieren Sie es unter: Website-Administration → Anwendungen oder Benutzereinstellungen → Anwendungen.\n\n– Funktioniert mit Gitea, Forgejo, Gogs und jedem Server mit einer kompatiblen API.",
+      "giteaBaseUrl": "## Server-URL\nDie Basis-URL Ihres selbstgehosteten Git-Servers.\n\n- Beispiel: `https://gitea.example.com`\n- Muss das Protokoll enthalten (https:// empfohlen)\n- Funktioniert mit Gitea, Forgejo, Gogs und anderen Servern mit einer Gitea-kompatiblen `/api/v1/` REST-API",
+      "giteaOwner": "## Eigentümer\nDie Organisation oder das Benutzerkonto, dem das Repository gehört.\n\n- Beispiel: `myorg` oder `myusername`\n- Dies ist das erste Pfadsegment in Ihrer Repository-URL.",
+      "giteaRepo": "## Repository\nDer Repository-Name ohne Eigentümerpräfix.\n\n- Beispiel: `my-repo` (nicht `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Konfigurationsname\nEin eindeutiger, beschreibender Name für diese Eingabeaufforderungskonfiguration.\n\n- Wird verwendet, um die Konfiguration bei der Zuweisung zu einem Projekt zu identifizieren (z. B. „GPT-4o-Eingabeaufforderungen“, „Konservative Eingabeaufforderungen“).",
+      "description": "## Beschreibung\nEine optionale Zusammenfassung der Besonderheiten dieser Konfiguration.\n\n- Hilft Administratoren, den Zweck auf einen Blick zu verstehen (z. B. „Niedrigere Temperaturaufforderungen für deterministische Ausgabe“).",
+      "isActive": "## Aktiv\nWenn diese Konfiguration aktiviert ist, kann sie von Projekten verwendet werden.\n\n- Inaktive Konfigurationen werden in den Dropdown-Menüs zur Projektzuweisung ausgeblendet.\n- Die Standardkonfiguration kann nicht deaktiviert werden.",
+      "isDefault": "## Standardkonfiguration\nWenn diese Konfiguration aktiviert ist, wird sie von allen Projekten verwendet, denen keine spezifische Konfiguration zugewiesen wurde.\n\n– Es kann immer nur eine Konfiguration als Standard festgelegt sein.\n– Durch das Festlegen einer neuen Standardkonfiguration wird die vorherige automatisch überschrieben.",
+      "systemPrompt": "## Systemaufforderung\nAnweisungen, die vor jeder Benutzereingabe an das KI-Modell gesendet werden. Definiert die Rolle, das Ausgabeformat und die Einschränkungen des Modells.\n\n- Unterstützt Platzhalter in doppelten geschweiften Klammern (z. B. FRAMEWORK, LANGUAGE, CASE_NAME), die zur Laufzeit ersetzt werden.\n- Änderungen hier wirken sich auf alle Projekte aus, die diese Konfiguration verwenden.",
+      "userPrompt": "## Benutzereingabe\nDie Nachricht, die im Namen des Benutzers an die KI gesendet wird. Lassen Sie dieses Feld leer, wenn die Funktion die Benutzernachricht vollständig im Code erstellt.\n\n- Unterstützt Platzhalter in doppelten geschweiften Klammern (z. B. ISSUE_TITLE, CASE_NAME, CODE_CONTEXT), die zur Laufzeit ersetzt werden.\n- Die verfügbaren Platzhalter für jede Funktion sind im Abschnitt „Variablen“ unten aufgeführt.",
+      "temperature": "## Temperatur\nSteuert die Zufälligkeit der KI-Ausgabe. Bereich: 0–2.\n\n- **0,0–0,3** — Sehr deterministisch, am besten geeignet für strukturierte Ausgaben (JSON, Code).\n- **0,4–0,7** — Ausgewogen, gut für die Generierung von Testfällen.\n- **0,8–2,0** — Kreativer und abwechslungsreicher, geeignet für offene Texte.",
+      "maxOutputTokens": "## Maximale Anzahl Ausgabetoken\nDie maximale Anzahl an Token, die das Modell in einer einzelnen Antwort generiert.\n\n– Höhere Werte ermöglichen längere Antworten, erhöhen aber Kosten und Latenz.\n– Typische Bereiche: 2048 für kurze Texte, 4096 für Codegenerierung, 6000+ für die Ausgabe mit mehreren Groß-/Kleinschreibung."
+    },
+    "menu": {
+      "startTour": "Geführte Willkommenstour",
+      "startProjectTour": "Projektrundgang",
+      "startAdminTour": "Admin-Tour",
+      "startDemoProjectTour": "Demo-Projekt-Tour"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Willkommen bei TestPlanIt!",
+          "content": "Werfen wir einen kurzen Blick auf die wichtigsten Funktionen von TestPlanIt, um Ihnen den Einstieg in Ihren Test-Workflow zu erleichtern."
+        },
+        "projects": {
+          "content": "Von hier aus können Sie auf alle Ihre Testprojekte zugreifen. Jedes Projekt enthält Testfälle, Testläufe und Funktionen für die Teamzusammenarbeit."
+        },
+        "project": {
+          "title": "Projektkarte",
+          "content": "Klicken Sie auf eine Projektkarte, um deren Details anzuzeigen. Wählen Sie im Hilfemenü „Projekttour“ aus, um eine geführte Tour durch die Projektfunktionen zu erhalten."
+        },
+        "globalFeatures": {
+          "title": "Globale Merkmale",
+          "content": "Tags zur Kategorisierung verwalten, Probleme projektübergreifend verfolgen und Benutzer mit rollenbasierter Zugriffskontrolle verwalten."
+        },
+        "search": {
+          "content": "Kontextbezogene Suche basierend auf Ihrer aktuellen Seite. Finden Sie schnell Testfälle, Testläufe, Probleme oder beliebige Inhalte. Verwenden Sie Cmd+K (oder Strg+K) für den direkten Zugriff."
+        },
+        "help": {
+          "title": "Hilfe & Unterstützung",
+          "content": "Sie können jederzeit auf diese geführte Tour zugreifen oder unsere ausführliche Dokumentation für detaillierte Hilfestellungen besuchen."
+        },
+        "notifications": {
+          "content": "Bleiben Sie über abgeschlossene Testläufe, Aktualisierungen von Problemen und Teamaktivitäten informiert. Konfigurieren Sie Ihre Präferenzen in Ihren Kontoeinstellungen."
+        },
+        "account": {
+          "title": "Kontomenü",
+          "content": "Passen Sie Ihr Profil, Ihre Benachrichtigungseinstellungen und Ihre Kontoeinstellungen an. Wechseln Sie zwischen hellem und dunklem Design."
+        },
+        "assignments": {
+          "content": "Hier sehen Sie die Ihnen zugewiesenen Testfälle und -läufe aus allen Projekten. Dies ist Ihr persönliches Dashboard zur Nachverfolgung Ihrer Testarbeit."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Projektauswahl",
+          "content": "Wechseln Sie mithilfe dieses Dropdown-Menüs schnell zwischen Projekten. Sehen Sie sich Projektdetails an und greifen Sie auf projektweite Einstellungen zu."
+        },
+        "projectSections": {
+          "title": "Projektabschnitte",
+          "content": "Navigieren Sie durch die Übersicht zum Projekt-Dashboard, die Dokumentation zu den Projektleitfäden und die Meilensteine zur Fortschrittsverfolgung."
+        },
+        "repository": {
+          "content": "Verwalten Sie Ihre Testfälle, organisieren Sie sie in Ordnern und erstellen Sie neue Testszenarien für eine umfassende Testabdeckung."
+        },
+        "repositoryPanels": {
+          "title": "Linke Seite des Repositorys",
+          "content": "Im linken Bereich werden Ihre Ordnerstruktur und die Testfallstruktur angezeigt. Verwenden Sie die Ansichtsauswahl, um zwischen verschiedenen Organisationsansichten zu wechseln."
+        },
+        "repositoryRightPanel": {
+          "title": "Rechtes Panel des Repositorys",
+          "content": "Im rechten Bereich werden Details zum Testfall und die Ausführungsergebnisse angezeigt. Außerdem bietet er Funktionen zum Erstellen neuer Testfälle oder zum Importieren vorhandener Testfälle."
+        },
+        "sharedSteps": {
+          "title": "Gemeinsame Schritte",
+          "content": "Definieren Sie wiederverwendbare Schrittgruppen, auf die in mehreren Testfällen verwiesen werden kann. Achten Sie auf konsistente und DRY-Testschritte."
+        },
+        "testRuns": {
+          "content": "Führen Sie geplante Testläufe durch, verfolgen Sie den Fortschritt und verwalten Sie die Testaufgaben innerhalb Ihres Teams. Sehen Sie sich detaillierte Ausführungsergebnisse an."
+        },
+        "testRunsPage": {
+          "title": "Testlauf-Dashboard",
+          "content": "Auf dieser Seite „Testläufe“ können Sie neue Testläufe erstellen, den Ausführungsfortschritt überwachen, Ergebnisse anzeigen und Testzuweisungen verwalten. Verfolgen Sie die Testaktivitäten Ihres Teams zentral."
+        },
+        "sessions": {
+          "title": "Erkundungssitzungen",
+          "content": "Explorative Testsitzungen dokumentieren, Ergebnisse festhalten und den Zeitaufwand für Ad-hoc-Testaktivitäten erfassen."
+        },
+        "sessionsPage": {
+          "title": "Dashboard für explorative Sitzungen",
+          "content": "Auf dieser Seite „Sitzungen“ können Sie explorative Testsitzungen erstellen und verwalten. Dokumentieren Sie Ergebnisse, erfassen Sie die aufgewendete Zeit und protokollieren Sie alle Ad-hoc-Testaktivitäten, um eine bessere Testabdeckung zu gewährleisten."
+        },
+        "tags": {
+          "title": "Tag-Verwaltung",
+          "content": "Organisieren und kategorisieren Sie Ihre Testfälle mithilfe von Tags. Erstellen Sie benutzerdefinierte Tags, um die Organisation und Filterung von Testfällen zu verbessern."
+        },
+        "issues": {
+          "title": "Problemverfolgung",
+          "content": "Während des Testens entdeckte Probleme verfolgen und verwalten. Probleme mit Testfällen verknüpfen und in externe Bug-Tracking-Systeme integrieren."
+        },
+        "reports": {
+          "title": "Berichte & Analysen",
+          "content": "Erstellen Sie umfassende Berichte und Analysen für Ihr Projekt. Sehen Sie die Testabdeckung, Ausführungstrends und Kennzahlen zur Teamleistung ein und erstellen Sie benutzerdefinierte Berichte für Stakeholder."
+        },
+        "settings": {
+          "title": "Projekteinstellungen",
+          "content": "Von hier aus verwalten Sie Integrationen auf Projektebene, KI-Modellkonfigurationen und freigegebene Links."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Willkommen bei den Administrator-Steuerelementen",
+          "content": "Machen Sie eine geführte Tour durch die administrativen Funktionen von TestPlanIt. Verwalten Sie Projekte, Benutzer, Konfigurationen und Systemeinstellungen über dieses zentrale Administrationspanel."
+        },
+        "projects": {
+          "title": "Projektverwaltung",
+          "content": "Verwalten Sie alle Projekte in Ihrem Unternehmen. Erstellen, konfigurieren und archivieren Sie Projekte. Legen Sie projektweite Berechtigungen und Zugriffskontrollen fest."
+        },
+        "templatesAndFields": {
+          "content": "Erstellen und verwalten Sie Testfallvorlagen und benutzerdefinierte Felder. Definieren Sie Feldtypen und Validierungsregeln und organisieren Sie Vorlagen für eine einheitliche Testfallstruktur in allen Projekten."
+        },
+        "workflows": {
+          "title": "Workflow-Management",
+          "content": "Definieren Sie Testfall-Workflows und Statusübergänge. Konfigurieren Sie, wie Testfälle verschiedene Status wie Entwurf, Überprüfung und Genehmigt durchlaufen."
+        },
+        "statuses": {
+          "title": "Testergebnisstatus",
+          "content": "Konfigurieren Sie die verfügbaren Testergebnisstatus wie Bestanden, Nicht bestanden, Blockiert und Übersprungen. Richten Sie benutzerdefinierte Status ein und definieren Sie deren Verhalten und Darstellung."
+        },
+        "milestones": {
+          "content": "Definieren Sie Meilensteintypen für die Projektverfolgung. Konfigurieren Sie Releasetypen, Sprintkategorien und andere Projektmeilensteinklassifizierungen."
+        },
+        "configurations": {
+          "title": "Testkonfigurationen",
+          "content": "Testkonfigurationen und -umgebungen verwalten. Browserkombinationen, Gerätetypen, Betriebssysteme und andere Testausführungskontexte einrichten."
+        },
+        "users": {
+          "title": "Benutzerverwaltung",
+          "content": "Benutzerkonten, Berechtigungen und Zugriffsebenen verwalten. Neue Benutzer erstellen, Rollen zuweisen und Authentifizierungseinstellungen konfigurieren."
+        },
+        "groups": {
+          "title": "Konzernmanagement",
+          "content": "Organisieren Sie Benutzer in Gruppen, um die Berechtigungsverwaltung zu vereinfachen. Erstellen Sie Abteilungs-, Projekt- und rollenbasierte Zugriffsgruppen."
+        },
+        "roles": {
+          "title": "Rollenmanagement",
+          "content": "Definieren Sie Benutzerrollen und Berechtigungen. Konfigurieren Sie, welche Aktionen verschiedene Rollen projekt- und systemadministrationsübergreifend ausführen können."
+        },
+        "tags": {
+          "title": "Globale Tags",
+          "content": "Verwalten Sie unternehmensweite Tags zur Kategorisierung von Testfällen, Projekten und anderen Entitäten. Erstellen Sie Tag-Hierarchien und standardisieren Sie die Tag-Vergabe projektübergreifend."
+        },
+        "reports": {
+          "content": "Erstellen Sie Berichte, die mehrere Projekte umfassen. Analysieren Sie Trends, Leistungskennzahlen und die Effektivität von Organisationstests in Ihrem gesamten Arbeitsbereich."
+        },
+        "notifications": {
+          "title": "Benachrichtigungseinstellungen",
+          "content": "Konfigurieren Sie die systemweiten Benachrichtigungseinstellungen. Richten Sie E-Mail-Vorlagen, Benachrichtigungsregeln und Standardeinstellungen für Benutzerbenachrichtigungen ein."
+        },
+        "integrations": {
+          "title": "Systemintegrationen",
+          "content": "Verwalten Sie Drittanbieterintegrationen und API-Verbindungen. Konfigurieren Sie Jira, GitHub und andere externe Tool-Integrationen für Ihr Unternehmen."
+        },
+        "llm": {
+          "title": "KI-Konfiguration",
+          "content": "Konfigurieren Sie KI-Modelle und -Einstellungen für die automatisierte Testfallgenerierung und intelligente Funktionen. Verwalten Sie API-Schlüssel und Modellpräferenzen."
+        },
+        "sso": {
+          "title": "Single Sign-On",
+          "content": "Konfigurieren Sie SSO-Anbieter und Authentifizierungsmethoden. Richten Sie SAML-, OAuth- und andere Identitätsanbieterintegrationen für einen nahtlosen Benutzerzugriff ein."
+        },
+        "appConfig": {
+          "content": "Verwalten Sie globale Anwendungseinstellungen und Systempräferenzen. Konfigurieren Sie Standardwerte, Funktionsumschalter und systemweite Verhaltensweisen."
+        },
+        "trash": {
+          "title": "Systemmüll",
+          "content": "Gelöschte Elemente projektübergreifend anzeigen und verwalten. Versehentlich gelöschte Inhalte wiederherstellen oder Elemente endgültig aus dem System entfernen."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Willkommen beim Demo-Projekt",
+          "content": "Dieses Projekt enthält bereits Beispieldaten. Lassen Sie uns die wichtigsten Funktionen gemeinsam durchgehen. Über dieses Dropdown-Menü können Sie zwischen Projekten wechseln."
+        },
+        "overview": {
+          "title": "Projektübersicht",
+          "content": "Die Übersicht ist Ihr Projekt-Dashboard. Sie zeigt den Fortschritt der Meilensteine und Zusammenfassungen von Testfällen, aktiven Testläufen, Sitzungen und Tags."
+        },
+        "documentation": {
+          "title": "Dokumentation",
+          "content": "Jedes Projekt verfügt über eine Dokumentationsseite. Nutzen Sie diese für Testpläne, Projektnotizen oder Links zu externen Ressourcen."
+        },
+        "documentationContent": {
+          "title": "Rich-Text-Editor",
+          "content": "Die Dokumentation unterstützt formatierten Text mit Überschriften, Listen, Links und Bildern. Bearbeiten Sie diese Seite, um zu sehen, wie es funktioniert."
+        },
+        "milestones": {
+          "title": "Meilensteine",
+          "content": "Verfolgen Sie Ihre Tests im Hinblick auf Sprints, Releases und andere Ziele. Verknüpfen Sie Testläufe und -sitzungen mit Meilensteinen, um den Fortschritt zu verfolgen."
+        },
+        "milestonesPage": {
+          "title": "Meilenstein-Zeitleiste",
+          "content": "Alle Meilensteine dieses Projekts anzeigen. Jeder Meilenstein zeigt seinen Status und den Fortschritt bis zur Fertigstellung an."
+        },
+        "repository": {
+          "title": "Testfall-Repository",
+          "content": "Organisieren Sie Testfälle in Ordnern mit benutzerdefinierten Feldern, Schritten und Prioritäten. Sehen Sie sich die Beispielordner an, um zu erfahren, wie Testfälle strukturiert sind."
+        },
+        "repositoryPanels": {
+          "title": "Ordner & Hüllen",
+          "content": "Im linken Bereich werden Ordner angezeigt. Klicken Sie auf einen Ordner, um dessen Testfälle anzuzeigen. Jeder Testfall enthält Schritte, Beschreibungen und Verweise auf gemeinsame Schritte."
+        },
+        "repositoryCases": {
+          "title": "Testfälle",
+          "content": "Hier sehen Sie die Testfälle für den ausgewählten Ordner. Jede Zeile enthält den Fallnamen, die Priorität und die benutzerdefinierten Felder. Klicken Sie auf einen Fall, um dessen vollständige Details und Schritte anzuzeigen."
+        },
+        "sharedSteps": {
+          "title": "Gemeinsame Schritte",
+          "content": "Definieren Sie wiederverwendbare Schrittgruppen, auf die in mehreren Testfällen verwiesen werden kann. Dadurch bleiben häufig verwendete Schritte konsistent und leicht zu warten."
+        },
+        "sharedStepsPage": {
+          "title": "Gemeinsame Schrittgruppen",
+          "content": "Jede Gruppe enthält eine Reihe geordneter Schritte. Verwenden Sie diese in jedem Testfall, um Ihre Schritte konsistent und übersichtlich zu halten."
+        },
+        "testRuns": {
+          "title": "Testläufe",
+          "content": "Erstellen Sie Testläufe, um Fälle auszuführen und Ergebnisse zu protokollieren. Weisen Sie die Läufe Meilensteinen zu und verfolgen Sie den Fortschritt (bestanden/nicht bestanden)."
+        },
+        "testRunsPage": {
+          "title": "Testergebnisse",
+          "content": "Testergebnisse und -fortschritt anzeigen. Jeder Testlauf zeigt seinen Status, den zugewiesenen Meilenstein und die Aufschlüsselung nach Erfolg/Misserfolg an."
+        },
+        "sessions": {
+          "title": "Erkundungssitzungen",
+          "content": "Erfassen Sie Ad-hoc-Tests mit sitzungsbasierten Tests. Protokollieren Sie Ergebnisse, weisen Sie Status zu und verfolgen Sie den Zeitaufwand."
+        },
+        "sessionsPage": {
+          "title": "Sitzungsergebnisse",
+          "content": "Jede Sitzung enthält detaillierte Ergebnisse mit Status und Anmerkungen. Klicken Sie auf eine Sitzung, um deren Ergebnisse anzuzeigen."
+        },
+        "tags": {
+          "title": "Tags",
+          "content": "Tags helfen dabei, Testfälle, Testläufe und Sitzungen zu organisieren und zu filtern. Sehen Sie sich die Beispiel-Tags an, um zu erfahren, wie sie Inhalte kategorisieren."
+        },
+        "tagsPage": {
+          "title": "Tag-Verwaltung",
+          "content": "Hier können Sie Tags erstellen, bearbeiten und zuweisen. Verwenden Sie Tags, um Inhalte in Ihrem Projekt zu gruppieren und zu filtern."
+        },
+        "issues": {
+          "title": "Probleme",
+          "content": "Erfassen Sie Fehler und Defekte, die während der Tests gefunden wurden. Probleme können mit fehlgeschlagenen Testlaufergebnissen und Sitzungsergebnissen verknüpft werden, um eine vollständige Nachvollziehbarkeit zu gewährleisten."
+        },
+        "issuesPage": {
+          "title": "Problemverfolgung",
+          "content": "Sehen Sie sich Beispielprobleme an, die mit fehlgeschlagenen Ergebnissen verknüpft sind. Die Probleme lassen sich auf den Testlauf oder die Sitzung zurückführen, in der sie aufgedeckt wurden."
+        },
+        "reports": {
+          "title": "Berichte & Analysen",
+          "content": "Erstellen Sie Berichte zur Testabdeckung, zu Ausführungstrends und zur Teamleistung. Nutzen Sie vorgefertigte Berichte oder erstellen Sie individuelle Berichte für die jeweiligen Stakeholder."
+        },
+        "settings": {
+          "title": "Projekteinstellungen",
+          "content": "Von hier aus verwalten Sie Integrationen auf Projektebene, KI-Modellkonfigurationen und freigegebene Links."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Projektübergreifende Berichte erstellen und verwalten"
+      },
+      "reportsTabDescription": "Vorgefertigte Berichte für Ihr Projekt ansehen und analysieren.",
+      "reportType": "Berichtstyp",
+      "selectReportType": "Berichtstyp auswählen",
+      "selectReport": "Bericht auswählen",
+      "dimensions": "Abmessungen",
+      "dimensionsSubtitle": "Abmessungen (zum Neuanordnen per Drag & Drop, unten hinzufügen)",
+      "metrics": "Kennzahlen",
+      "addDimension": "Dimension hinzufügen...",
+      "addMetric": "Metrik hinzufügen...",
+      "runReport": "Laufbericht",
+      "noResultsFound": "Keine Ergebnisse gefunden.",
+      "selectAtLeastOneDimensionAndMetric": "Wählen Sie mindestens eine Dimension und eine Metrik aus.",
+      "noDataMatchingCriteria": "Es wurden keine Daten gefunden, die den ausgewählten Dimensionen und Metriken entsprechen.",
+      "noDataMatchingCriteriaWithDateFilter": "Es wurden keine Daten gefunden, die den ausgewählten Dimensionen und Metriken entsprechen. Versuchen Sie, Ihren Datumsbereichsfilter anzupassen.",
+      "noDataAvailable": "Für diesen Bericht sind keine Daten verfügbar.",
+      "generatedAt": "Bericht erstellt am",
+      "crossProjectAnalytics": "Projektübergreifende Analysen und Berichte",
+      "unauthorizedAdmin": "Nicht autorisiert: Administratorzugriff erforderlich.",
+      "title": "Berichtsgenerator",
+      "description": "Erstellen Sie individuelle Berichte zur Analyse Ihrer Projektdaten.",
+      "crossProjectDescription": "Analysieren Sie Daten aus allen Projekten in Ihrem Arbeitsbereich.",
+      "selectDimensions": "Dimensionen auswählen...",
+      "selectMetrics": "Kennzahlen auswählen...",
+      "dimensionOrder": "Dimensionsreihenfolge",
+      "metricOrder": "Metrische Ordnung",
+      "filtersDescription": "Filtern Sie die Berichtsdaten nach bestimmten Kriterien",
+      "activeFilters": "Aktive Filter:",
+      "priorityFilterPlaceholder": "Prioritätswerte auswählen (oder für alle leer lassen)",
+      "dateRange": {
+        "selectDateRange": "Datumsbereich auswählen",
+        "chooseStartDate": "Wählen Sie das Startdatum",
+        "chooseEndDate": "Wählen Sie das Enddatum",
+        "categories": {
+          "day": "Tag",
+          "week": "Woche",
+          "month": "Monat",
+          "quarter": "Quartal",
+          "year": "Jahr"
+        },
+        "today": "Heute",
+        "yesterday": "Gestern",
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "thisWeek": "Diese Woche",
+        "lastWeek": "Letzte Woche",
+        "last2Weeks": "Letzte 2 Wochen",
+        "thisMonth": "Diesen Monat",
+        "lastMonth": "Letzten Monat",
+        "last3Months": "Letzte 3 Monate",
+        "thisQuarter": "Dieses Quartal",
+        "lastQuarter": "Letztes Quartal",
+        "thisYear": "Dieses Jahr",
+        "lastYear": "Letztes Jahr",
+        "last12Months": "Letzte 12 Monate",
+        "allTime": "Alle Zeiten",
+        "custom": "Benutzerdefinierter Datumsbereich"
+      },
+      "dateGrouping": {
+        "label": "Gruppieren nach",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich",
+        "quarterly": "Vierteljährlich",
+        "annually": "Jährlich"
+      },
+      "filters": {
+        "selectFilter": "Wählen Sie einen Filtertyp aus",
+        "allProjects": "Alle Projekte"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Fehler beim Laden der Berichtsmetadaten",
+        "failedToRunReport": "Fehler beim Ausführen des Berichts",
+        "atLeastOneDimensionRequired": "Mindestens eine Dimension ist erforderlich.",
+        "atLeastOneMetricRequired": "Mindestens eine Kennzahl muss angegeben werden.",
+        "invalidCombinationDateLastActive": "Die Kennzahl „Datum der letzten Aktivität“ kann nicht mit der Dimension „Aktivitätsdatum“ kombiniert werden.",
+        "lastActiveDateOnlyWithUser": "Die Kennzahl „Datum der letzten Aktivität“ kann nur mit der Dimension „Benutzer“ verwendet werden.",
+        "invalidDimensionCombination": "Die Dimensionen '{dim1}' und '{dim2}' können in Testausführungsberichten nicht zusammen verwendet werden.",
+        "startDateRequiredWithEndDate": "Ein Startdatum ist erforderlich, wenn ein Enddatum angegeben wird.",
+        "endDateMustBeAfterStartDate": "Das Enddatum muss nach oder gleich dem Startdatum liegen."
+      },
+      "chartDataTruncated": {
+        "title": "Diagrammdaten abgeschnitten",
+        "message": "Zur besseren Lesbarkeit werden {shown} von {total} Datenpunkten angezeigt. Verwenden Sie Filter oder Datumsbereiche, um Ihre Ergebnisse einzugrenzen, oder sehen Sie sich die vollständigen Daten in der Ergebnistabelle unten an."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Testausführungsberichte",
+          "description": "Analysieren Sie Testergebnisse, Erfolgsquoten und Ausführungsmetriken."
+        },
+        "repositoryStats": {
+          "label": "Repository-Statistiken",
+          "description": "Testfallstatistiken, Abdeckung und Zustand des Repositorys"
+        },
+        "userEngagement": {
+          "label": "Nutzerbindung",
+          "description": "Analyse von Benutzeraktivität, Produktivität und Arbeitsbelastung"
+        },
+        "projectHealth": {
+          "label": "Projekt Gesundheit",
+          "description": "Projektfortschritt, Meilensteine und Fertigstellungsstatus"
+        },
+        "sessionAnalysis": {
+          "label": "Sitzungsanalyse",
+          "description": "Metriken zu Sitzungsabschluss, -dauer und Aufgabenverteilung"
+        },
+        "issueTracking": {
+          "label": "Problemverfolgung",
+          "description": "Problementstehung, Problemlösung und Folgenabschätzung"
+        },
+        "automationTrends": {
+          "label": "Automatisierungstrends",
+          "description": "Verfolgen Sie den Automatisierungsfortschritt wöchentlich nach Priorität."
+        },
+        "flakyTests": {
+          "label": "Schuppige Tests",
+          "description": "Identifizieren Sie Tests mit inkonsistenten Ergebnissen (bestanden/nicht bestanden)."
+        },
+        "testCaseHealth": {
+          "label": "Testfall Gesundheit",
+          "description": "Identifizieren Sie veraltete, fehlerhafte oder verdächtige Testfälle anhand von Ausführungsmustern"
+        },
+        "issueTestCoverage": {
+          "label": "Problemtestabdeckung",
+          "description": "Probleme mit den zugehörigen Testfällen und dem letzten Ausführungsstatus anzeigen"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Letzte aufeinanderfolgende Läufe",
+        "consecutiveRunsHelp": "Anzahl der zuletzt durchgeführten Testausführungen zur Analyse (5–30). Ergebnisse mit dem Status „ungetestet“ werden ausgeschlossen.",
+        "flipThreshold": "Mindestanzahl an Flips",
+        "flipThresholdHelp": "Mindestanzahl an Übergängen zwischen bestanden und nicht bestanden erforderlich, um als unzuverlässig zu gelten.",
+        "flips": "Überschläge",
+        "lastNResults": "Letztes Ergebnis {count, plural, one {# Ergebnis} other {# Ergebnisse}}",
+        "newest": "Neu",
+        "oldest": "Alt",
+        "noFlakyTests": "Es wurden keine fehlerhaften Tests gefunden, die den Kriterien entsprechen.",
+        "includeFilter": "Enthalten",
+        "testRunDeleted": "Der Testlauf wurde gelöscht",
+        "chart": {
+          "highPriority": "Aufmerksamkeit erforderlich",
+          "lowPriority": "Niedrigere Priorität",
+          "recencyAxis": "Ausfall Aktualität",
+          "flipsAxis": "Flip Count",
+          "oldFailures": "Älter",
+          "recentFailures": "Jüngste",
+          "failureRate": "Ausfallrate",
+          "recency": "Aktualitätswert",
+          "backlogTitle": "Tests mit niedrigerer Priorität",
+          "backlogDescription": "{count, plural, one {# zusätzlicher fehlerhafter Test} other {# zusätzliche fehlerhafte Tests}} nicht angezeigt"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Abgestanden nach (Tagen)",
+        "staleDaysThresholdHelp": "Anzahl der Tage, nach denen ein Test als veraltet gilt, nachdem er nicht ausgeführt wurde (7-90).",
+        "minExecutions": "Mindestausführungen für Rate",
+        "minExecutionsHelp": "Mindestanzahl an Ausführungen, die erforderlich sind, um aussagekräftige Erfolgsquotenstatistiken zu berechnen (3-20).",
+        "lookbackDays": "Betrachtungszeitraum",
+        "lookbackDaysHelp": "Anzahl der Tage zur Analyse der Ausführungshistorie (30-365).",
+        "includeFilter": "Enthalten",
+        "staleFilter": "Abgestandenheit",
+        "stale": "Abgestanden",
+        "notStale": "Nicht abgestanden",
+        "status": "Gesundheitszustand",
+        "healthScore": "Punktzahl",
+        "lastExecuted": "Zuletzt ausgeführt",
+        "executions": "Hinrichtungen",
+        "passRate": "Bestehensquote",
+        "passCount": "Pässe",
+        "failCount": "Ausfälle",
+        "never": "Niemals",
+        "daysSince": "Tage seit der Hinrichtung",
+        "count": "Zählen",
+        "totalTests": "Testfälle",
+        "noData": "Keine Testfälle gefunden",
+        "noExecutedTests": "Keine ausgeführten Tests anzuzeigen",
+        "healthStatus": {
+          "healthy": "Gesund",
+          "stale": "Abgestanden",
+          "neverExecuted": "Nie hingerichtet",
+          "alwaysPassing": "Immer vorbei",
+          "alwaysFailing": "Immer scheitern"
+        },
+        "chart": {
+          "distribution": "Statusverteilung",
+          "healthyRecent": "Gesund und aktuell",
+          "unhealthyStale": "Aufmerksamkeit erforderlich",
+          "daysAxis": "Tage seit der letzten Hinrichtung",
+          "healthScoreAxis": "Gesundheitsbewertung"
+        },
+        "stats": {
+          "totalTests": "Gesamttests",
+          "needsAttention": "Aufmerksamkeit erforderlich",
+          "needsAttentionTooltip": "Immer fehlgeschlagen + Nie ausgeführt + Veraltete Tests",
+          "healthy": "Gesund",
+          "healthyTooltip": "Gesund + Bestehen aller Prüfungen",
+          "avgScore": "Durchschnittlicher Gesundheitswert"
+        },
+        "healthScoreTooltip": {
+          "title": "Die Punktzahl beginnt bei 100, Abzüge:",
+          "neverExecuted": "Nie ausgeführt: -50",
+          "stale90": "Seit über 90 Tagen nicht ausgeführt: -40",
+          "stale60": "Seit über 60 Tagen nicht ausgeführt: -25",
+          "stale30": "Seit über 30 Tagen nicht ausgeführt: -10",
+          "alwaysPassing": "Immer bestanden (100%): -5",
+          "alwaysFailing": "Immer fehlgeschlagen (0%): -30",
+          "lowPassRate": "Niedrige Bestehensquote (<50%): -20",
+          "lowExecutions": "Wenige Hinrichtungen (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Ansichtsmodus",
+        "summaryView": "Zusammenfassung (nach Ausgabe)",
+        "detailView": "Details (nach Testfall)",
+        "issue": "Ausgabe",
+        "testCase": "Testfall",
+        "testCases": "{count, plural, =1 {Testfall} other {Testfälle}}",
+        "issueStatus": "Status",
+        "priority": "Priorität",
+        "linkedTests": "Verknüpfte Tests",
+        "testResults": "Ergebnisse (P/F/U)",
+        "passRate": "Bestehensquote",
+        "passed": "Bestanden",
+        "failed": "Fehlgeschlagen",
+        "lastStatus": "Letzter Status",
+        "lastExecuted": "Zuletzt ausgeführt",
+        "notTested": "Nicht getestet",
+        "noData": "Es wurden keine Probleme mit den verknüpften Testfällen gefunden.",
+        "noIssuesNeedingAttention": "Alle Ausgaben haben die Tests bestanden – hervorragende Arbeit!",
+        "stats": {
+          "totalIssues": "Gesamtzahl der Ausgaben",
+          "issuesWithFailures": "Mit Fehlern",
+          "issuesWithFailuresTooltip": "Probleme mit mindestens einem fehlgeschlagenen Testfall",
+          "issuesWithUntested": "Mit ungetestet",
+          "issuesWithUntestedTooltip": "Probleme mit mindestens einem Testfall, der nicht ausgeführt wurde",
+          "issuesAllPassing": "Alle vorbei",
+          "overallPassRate": "Bestehensquote",
+          "numberOfIssues": "Anzahl der Ausgaben"
+        },
+        "charts": {
+          "passRateDistribution": "Verteilung der Testbestehensquote",
+          "linkedTestCases": "Anzahl der verknüpften Testfälle",
+          "untestedTestCases": "Anzahl der ungetesteten Testfälle",
+          "testCoverageVsExecution": "Testabdeckung vs. Ausführungsstatus"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Projektübergreifende Testausführung",
+          "description": "Analysieren Sie die Testergebnisse, Erfolgsquoten und Ausführungsmetriken aller Projekte."
+        },
+        "repositoryStats": {
+          "label": "projektübergreifende Repository-Statistiken",
+          "description": "Testfallstatistiken, Abdeckung und Repository-Zustand über alle Projekte hinweg"
+        },
+        "userEngagement": {
+          "label": "Projektübergreifende Nutzereinbindung",
+          "description": "Analyse der Benutzeraktivität, Produktivität und Arbeitsbelastung in verschiedenen Projekten"
+        },
+        "issueTracking": {
+          "label": "Projektübergreifende Problemverfolgung",
+          "description": "Problemerkennung, Problemlösung und Folgenabschätzung in verschiedenen Projekten"
+        },
+        "automationTrends": {
+          "label": "Trends in der projektübergreifenden Automatisierung",
+          "description": "Verfolgen Sie den Automatisierungsfortschritt wöchentlich nach Priorität in allen Projekten."
+        },
+        "flakyTests": {
+          "label": "Projektübergreifende, unzuverlässige Tests",
+          "description": "Identifizieren Sie Tests mit inkonsistenten Ergebnissen (bestanden/nicht bestanden) über verschiedene Projekte hinweg."
+        },
+        "testCaseHealth": {
+          "label": "Projektübergreifender Testfallstatus",
+          "description": "Identifizieren Sie veraltete, fehlerhafte oder verdächtige Testfälle in allen Projekten."
+        },
+        "issueTestCoverage": {
+          "label": "Projektübergreifende Testabdeckung",
+          "description": "Probleme mit den zugehörigen Testfällen und dem aktuellen Ausführungsstatus projektübergreifend anzeigen"
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Nur Projektadministratoren und Administratoren haben Zugriff auf Projektberichte.",
+      "projectIdRequired": "Die Projekt-ID ist erforderlich.",
+      "missingRequiredFields": "Fehlende Pflichtfelder",
+      "unsupportedDimension": "Nicht unterstützte Dimension: {dimension}",
+      "unsupportedMetric": "Nicht unterstützte Metrik: {metric}",
+      "atLeastOneDimensionMetricRequired": "Mindestens eine Dimension und eine Metrik erforderlich",
+      "atLeastOneMetricRequired": "Mindestens eine Kennzahl muss angegeben werden.",
+      "projectDimensionsMetricsRequired": "Projekt-ID, Abmessungen und Kennzahlen sind erforderlich.",
+      "unsupportedDimensions": "Nicht unterstützte Dimension(en): {dimensions}",
+      "unsupportedMetrics": "Nicht unterstützte Metrik(en): {metrics}",
+      "unexpectedError": "Es ist ein unerwarteter Fehler aufgetreten."
+    },
+    "dimensions": {
+      "project": "Projekt",
+      "status": "Status",
+      "user": "Benutzer",
+      "executor": "Testamentsvollstrecker",
+      "assignedTo": "Zugewiesen an",
+      "configuration": "Konfiguration",
+      "date": "Datum",
+      "executionDate": "Ausführungsdatum",
+      "creationDate": "Erstellungsdatum",
+      "activityDate": "Aktivitätsdatum",
+      "testRun": "Probelauf",
+      "testCase": "Testfall",
+      "milestone": "Meilenstein",
+      "template": "Vorlage",
+      "creator": "Schöpfer",
+      "state": "Zustand",
+      "source": "Quelle",
+      "folder": "Ordner",
+      "group": "Gruppe",
+      "role": "Rolle",
+      "session": "Sitzung",
+      "weekEnding": "Woche endet",
+      "period": "Zeitraum",
+      "priority": "Priorität",
+      "automationStatus": "Automatisierungsstatus",
+      "issueType": "Ausgabetyp",
+      "issueTracker": "Problemverfolgung",
+      "issueStatus": "Ausgabestatus"
+    },
+    "metrics": {
+      "testResults": "Testergebnisse",
+      "testResultCount": "Testergebnisse zählen",
+      "passRate": "Bestehensquote (%)",
+      "avgElapsed": "Durchschnittliche verstrichene Zeit",
+      "avgElapsedTime": "Durchschnittliche verstrichene Zeit",
+      "totalElapsedTime": "Gesamte verstrichene Zeit",
+      "testRunCount": "Testläufe zählen",
+      "testCaseCount": "Anzahl der Testfälle",
+      "automationRate": "Automatisierungsgrad (%)",
+      "avgStepsPerCase": "Durchschnittliche Schritte pro Fall",
+      "averageSteps": "Durchschnittliche Schritte pro Fall",
+      "automatedCount": "Automatisierte Fälle",
+      "manualCount": "Manuelle Fälle",
+      "totalCount": "Gesamtzahl der Fälle",
+      "totalSteps": "Gesamtschritte",
+      "executionCount": "Testausführungen",
+      "createdCaseCount": "Anzahl der erstellten Testfälle",
+      "sessionResultCount": "Anzahl der Sitzungsergebnisse",
+      "caseCreations": "Erstellte Fälle",
+      "sessionParticipation": "Sitzungsteilnahme",
+      "averageElapsed": "Durchschnittliche Zeit pro Ausführung",
+      "lastActiveDate": "Letztes Aktivitätsdatum",
+      "issueCount": "Ausgabeanzahl",
+      "averageAge": "Durchschnittsalter (Tage)",
+      "sessionCount": "Sitzungsanzahl",
+      "activeSessions": "Aktive Sitzungen",
+      "averageTimeSpent": "Durchschnittliche Bearbeitungszeit (Minuten)",
+      "milestoneCount": "Meilensteinanzahl",
+      "milestoneCompletionRate": "Meilenstein-Abschlussrate (%)",
+      "averageMilestoneDuration": "Durchschnittliche Meilensteindauer (Tage)",
+      "totalMilestones": "Gesamtmeilensteine",
+      "activeMilestones": "Aktive Meilensteine",
+      "milestoneCompletion": "Meilensteinerfüllung (%)",
+      "averageDuration": "Durchschnittliche Dauer",
+      "totalDuration": "Gesamtdauer"
+    },
+    "drillDown": {
+      "title": "Detaillierte Aufzeichnungen",
+      "loading": "Datensätze werden geladen...",
+      "loadingMore": "Weitere Informationen werden geladen...",
+      "noRecords": "Keine Datensätze gefunden",
+      "error": "Datensätze konnten nicht geladen werden",
+      "recordCount": "{count} {count, plural, =1 {Datensatz} other {Datensätze}}",
+      "allRecords": "Alle Datensätze",
+      "allLoaded": "Alle Datensätze geladen"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Aktie",
+      "dialogTitle": "Bericht teilen",
+      "dialogDescription": "Erstellen Sie einen teilbaren Link oder verwalten Sie bestehende freigegebene Berichtslinks.",
+      "tabs": {
+        "create": "Erstellen Teilen",
+        "list": "Meine Aktien"
+      },
+      "shareMode": {
+        "label": "Freigabemodus",
+        "authenticated": {
+          "title": "Authentifiziert (Anmeldung erforderlich)",
+          "description": "Nur angemeldete Benutzer mit Zugriff auf dieses Projekt können es ansehen.",
+          "descriptionCrossProject": "Nur angemeldete Benutzer mit Administratorrechten können diese anzeigen."
+        },
+        "passwordProtected": {
+          "title": "Passwortgeschützt",
+          "description": "Jeder, der den Link und das Passwort hat, kann die Datei einsehen. Angemeldete Benutzer mit Projektzugriff überspringen das Passwort.",
+          "descriptionCrossProject": "Jeder, der den Link und das Passwort hat, kann die Datei einsehen. Angemeldete Benutzer mit Administratorrechten benötigen kein Passwort."
+        },
+        "public": {
+          "title": "Öffentlich (jeder mit Link)",
+          "description": "Jeder, der den Link hat, kann diesen Bericht ohne Anmeldung einsehen."
+        }
+      },
+      "expiration": {
+        "label": "Ablauf",
+        "noExpiration": "Kein Ablaufdatum",
+        "expiresAtMidnight": "Der Link verfällt am Ende des ausgewählten Tages (Ihrer Ortszeit)."
+      },
+      "notifyOnView": {
+        "label": "Benachrichtige mich, wenn jemand diesen Link ansieht.",
+        "description": "Sie erhalten eine Benachrichtigung, wenn auf den Freigabelink zugegriffen wird, entsprechend Ihren Benachrichtigungseinstellungen."
+      },
+      "title": {
+        "placeholder": "z. B. Testausführungsbericht",
+        "leaveEmptyToUse": "Zum Verwenden leer lassen:"
+      },
+      "description": {
+        "placeholder": "Fügen Sie eine Beschreibung für diesen freigegebenen Bericht hinzu..."
+      },
+      "actions": {
+        "createShareLink": "Freigabelink erstellen",
+        "creating": "Wird erstellt..."
+      },
+      "errors": {
+        "loginRequired": "Sie müssen angemeldet sein, um einen Freigabelink zu erstellen.",
+        "createFailed": "Link konnte nicht erstellt werden",
+        "genericError": "Es ist ein unbekannter Fehler aufgetreten."
+      },
+      "status": {
+        "revoked": {
+          "title": "Link zum Teilen widerrufen",
+          "description": "Dieser Freigabelink wurde widerrufen und ist nicht mehr zugänglich."
+        },
+        "expired": {
+          "title": "Link zum Teilen abgelaufen",
+          "description": "Dieser Link zum Teilen ist abgelaufen und nicht mehr erreichbar."
+        }
+      },
+      "footer": {
+        "poweredBy": "Angetrieben von"
+      },
+      "manageShares": {
+        "title": "Aktien verwalten",
+        "description": "Alle Freigabelinks für dieses Projekt anzeigen und verwalten",
+        "adminTitle": "Alle Aktien verwalten",
+        "adminDescription": "Freigabelinks für alle Projekte anzeigen und verwalten"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Modus",
+          "views": "Ansichten",
+          "expires": "Läuft ab"
+        },
+        "status": {
+          "revoked": "Widerrufen",
+          "expired": "Abgelaufen"
+        },
+        "notifications": {
+          "enabled": "An",
+          "disabled": "Aus"
+        },
+        "empty": {
+          "title": "Es wurden noch keine Freigabelinks erstellt.",
+          "description": "Erstellen Sie Ihren ersten Freigabelink, um loszulegen."
+        },
+        "defaultTitle": "{entityType} teilen",
+        "noProject": "Projektübergreifend",
+        "actions": {
+          "copyLink": "Link kopieren",
+          "revoke": "Widerrufen"
+        },
+        "revokeDialog": {
+          "title": "Freigabelink widerrufen?",
+          "description": "Dadurch wird der Freigabelink sofort ungültig. Jeder, der versucht, darauf zuzugreifen, erhält eine Fehlermeldung. Diese Aktion kann nicht rückgängig gemacht werden.",
+          "confirm": "Link widerrufen",
+          "revoking": "Widerruf..."
+        },
+        "deleteDialog": {
+          "title": "Freigabelink löschen?",
+          "description": "Dadurch wird der Freigabelink endgültig gelöscht. Falls der Link aktuell aktiv ist, läuft er sofort ab und ist nicht mehr erreichbar. Diese Aktion kann nicht rückgängig gemacht werden.",
+          "confirm": "Link löschen"
+        },
+        "toast": {
+          "linkCopied": "Link kopiert!",
+          "linkCopiedDescription": "Der Freigabelink wurde in Ihre Zwischenablage kopiert.",
+          "copyFailed": "Kopiervorgang fehlgeschlagen",
+          "copyFailedDescription": "Bitte kopieren Sie den Link manuell.",
+          "linkRevoked": "Link zum Teilen widerrufen",
+          "linkRevokedDescription": "Der Freigabelink wurde widerrufen und ist nicht mehr zugänglich.",
+          "revokeFailed": "Widerruf fehlgeschlagen",
+          "revokeFailedDescription": "Beim Widerrufen des Freigabelinks ist ein Fehler aufgetreten.",
+          "notificationsEnabled": "Benachrichtigungen aktiviert",
+          "notificationsEnabledDescription": "Sie erhalten Benachrichtigungen, wenn jemand diesen Freigabelink ansieht.",
+          "notificationsDisabled": "Benachrichtigungen deaktiviert",
+          "notificationsDisabledDescription": "Sie erhalten keine Benachrichtigungen, wenn jemand diesen Freigabelink ansieht.",
+          "notificationUpdateFailed": "Benachrichtigungen konnten nicht aktualisiert werden",
+          "notificationUpdateFailedDescription": "Beim Aktualisieren der Benachrichtigungseinstellungen ist ein Fehler aufgetreten.",
+          "linkDeleted": "Link zum Teilen gelöscht",
+          "linkDeletedDescription": "Der Teilen-Link wurde gelöscht und wird nicht mehr in Ihrer Liste angezeigt.",
+          "deleteFailed": "Löschen fehlgeschlagen",
+          "deleteFailedDescription": "Beim Löschen des Freigabelinks ist ein Fehler aufgetreten."
+        }
+      },
+      "created": {
+        "title": "Link zum Teilen erstellt!",
+        "description": "Ihr Freigabelink ist einsatzbereit. Kopieren Sie ihn und teilen Sie ihn mit anderen.",
+        "shareLink": "Link teilen",
+        "copy": "Kopie",
+        "openInNewTab": "In neuem Tab öffnen",
+        "metadata": {
+          "mode": "Modus",
+          "expires": "Läuft ab",
+          "views": "Ansichten"
+        },
+        "warnings": {
+          "publicLink": "Öffentlicher Link:",
+          "publicLinkDescription": "Jeder, der diesen Link hat, kann ohne Authentifizierung auf den Bericht zugreifen.",
+          "expiresSoon": "Dieser Link läuft am Ende des"
+        },
+        "actions": {
+          "createAnother": "Erstelle einen weiteren"
+        }
+      },
+      "editDialog": {
+        "title": "Link zum Teilen bearbeiten",
+        "description": "Aktualisieren Sie die Einstellungen für diesen Freigabelink.",
+        "passwordExists": "Dieser Freigabelink ist bereits passwortgeschützt. Lassen Sie das Passwortfeld leer, um das bestehende Passwort beizubehalten.",
+        "passwordPlaceholder": "Lassen Sie dieses Feld leer, um das bestehende Passwort beizubehalten."
+      }
+    },
+    "passwordDialog": {
+      "title": "Passwort erforderlich",
+      "description": "Dieser freigegebene Inhalt von <strong>{projectName}</strong> ist passwortgeschützt. Bitte geben Sie das Passwort ein, um fortzufahren.",
+      "passwordPlaceholder": "Passwort eingeben",
+      "showPassword": "Passwort anzeigen",
+      "hidePassword": "Passwort verbergen",
+      "verifying": "Überprüfung läuft...",
+      "errors": {
+        "emptyPassword": "Bitte geben Sie ein Passwort ein.",
+        "tooManyAttempts": "Zu viele Fehlversuche. Bitte versuchen Sie es später erneut{resetAt, select, null {} other { bei {resetAt}}}.",
+        "genericError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Es sind keine Versuche mehr übrig. Bitte versuchen Sie es später erneut.",
+        "attemptsRemaining": "{count, plural, =1 {1 Versuch} other {# Versuche}} verbleibend."
+      }
+    },
+    "sharedReport": {
+      "loading": "Bericht wird geladen...",
+      "errors": {
+        "onlyReportSharing": "Derzeit ist nur die Berichtsfreigabe implementiert.",
+        "failedToLoad": "Fehler beim Laden der Berichtsdaten"
+      },
+      "defaultTitle": "Gemeinsamer Bericht",
+      "fromProject": "Aus dem Projekt:",
+      "dateRange": "Datumsbereich:",
+      "readOnlyNotice": "Dies ist eine schreibgeschützte, gemeinsam genutzte Ansicht",
+      "viewCount": "{count, plural, =1 {1 Aufruf} other {Anzahl Aufrufe}}",
+      "viewInFullApp": "In der vollständigen App anzeigen",
+      "pagination": {
+        "showing": "Anzeige",
+        "of": "von",
+        "results": "Ergebnisse"
+      }
+    },
+    "authBypass": {
+      "title": "Sie haben Zugriff auf dieses Projekt.",
+      "description": "Anzeige als {userName} mit Zugriff auf {projectName}.",
+      "viewInApp": "In der vollständigen App anzeigen"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Gemeinsame Schritte filtern...",
+    "noGroups": "Es wurden keine gemeinsamen Schritte gefunden.",
+    "noTestCases": "Diese gemeinsame Schrittgruppe wird von keinem Testfall verwendet.",
+    "selectGroupPrompt": "Wählen Sie eine freigegebene Schrittgruppe aus, um deren Schritte anzuzeigen.",
+    "deleteTitle": "Gemeinsame Schrittgruppe löschen?",
+    "deleteDescription": "Möchten Sie diese gemeinsam genutzte Schrittgruppe wirklich löschen? Die Schritte werden aus allen Testfällen entfernt, die sie verwenden.",
+    "saveSuccess": "Die gemeinsamen Schritte wurden erfolgreich aktualisiert.",
+    "saveError": "Beim Speichern der gemeinsamen Schritte ist ein Fehler aufgetreten.",
+    "stepsCount": "{count, plural, one {# Schritt} other {# Schritte}}",
+    "testCasesUsing": "{count, plural, one {# Testfall} other {# Testfälle}}",
+    "importWizard": {
+      "title": "Gemeinsame Schritte importieren",
+      "fields": {
+        "order": "Befehl",
+        "stepNumber": "Schritt #",
+        "stepContent": "Schrittinhalt",
+        "expectedResultContent": "Erwarteter Ergebnisinhalt",
+        "combinedStepData": "Kombinierte Schrittdaten",
+        "stepsData": "Schrittdaten"
+      },
+      "success": {
+        "description": "{count, plural, one {# gemeinsamer Schritt} other {# gemeinsame Schritte}} erfolgreich importiert"
+      },
+      "errors": {
+        "parseFailed": "Fehler beim Parsen der CSV-Datei",
+        "validationFailed": "Validierung fehlgeschlagen",
+        "validationDescription": "{count, plural, one {# Validierungsfehler} other {# Validierungsfehler}} gefunden",
+        "importFailed": "Import fehlgeschlagen",
+        "fileRequired": "Eine CSV-Datei ist erforderlich."
+      },
+      "page1": {
+        "title": "Datei hochladen und Konfiguration",
+        "selectedFile": "Ausgewählte Datei",
+        "delimiter": "Feldtrennzeichen",
+        "delimiters": {
+          "tab": "Tab (\\t)"
+        },
+        "hasHeaders": "Die erste Zeile enthält die Spaltenüberschriften.",
+        "encoding": "Dateikodierung",
+        "rowMode": {
+          "label": "Zeilenmodus",
+          "single": "Eine Zeile pro gemeinsam genutztem Schritt",
+          "multi": "Mehrere Zeilen für komplexe gemeinsame Schritte"
+        }
+      },
+      "page2": {
+        "title": "CSV-Spalten gemeinsamen Schrittfeldern zuordnen",
+        "description": "Ordnen Sie Ihre CSV-Spalten den gemeinsam genutzten Schrittfeldern zu. Pflichtfelder müssen zugeordnet werden.",
+        "ignoreColumn": "Diese Spalte ignorieren",
+        "requiredFieldsWarning": "{count, plural, one {# Pflichtfeld ist} other {# Pflichtfelder sind}} nicht zugeordnet. Bitte ordnen Sie alle Pflichtfelder zu, um fortzufahren."
+      },
+      "page3": {
+        "title": "Vorschau der Importdaten",
+        "showing": "Zeigt {start} bis {end} der {total} gemeinsamen Schritte",
+        "step": "Gemeinsamer Schritt {number}",
+        "noValue": "(leer)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Manuell hinzufügen",
+      "description": "Erstellen Sie eine neue gemeinsame Schrittgruppe mit manueller Eingabe",
+      "groupNamePlaceholder": "Geben Sie einen Namen für diese gemeinsame Schrittgruppe ein.",
+      "success": "Gemeinsame Schritte erfolgreich erstellt",
+      "errors": {
+        "groupNameRequired": "Die Angabe des Gruppennamens ist erforderlich.",
+        "stepsRequired": "Mindestens ein Schritt ist erforderlich",
+        "saveFailed": "Gemeinsame Schritte konnten nicht gespeichert werden"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Schrittsequenz-Duplikate",
+      "pageDescription": "Überprüfen Sie übereinstimmende Schrittsequenzen in den Testfällen. Konvertieren Sie Übereinstimmungen in gemeinsame Schrittgruppen oder verwerfen Sie falsch positive Ergebnisse.",
+      "noResultsFound": "Es wurden keine doppelten Schrittsequenzen gefunden.",
+      "noResultsDescription": "Führen Sie einen Scan durch, um wiederkehrende Schrittsequenzen in Ihren Testfällen zu erkennen.",
+      "filterPlaceholder": "Nach Fallnamen filtern...",
+      "selected": "{count, plural, one {# ausgewählt} other {# ausgewählt}}",
+      "bulkDismiss": "Schließen ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# Spiel abgebrochen} other {# Spiele abgebrochen}}",
+      "bulkError": "Es sind einige Vorgänge fehlgeschlagen. Bitte versuchen Sie es erneut.",
+      "tableHint": "Klicken Sie auf eine Zeile, um die zugehörigen Schritte in der Vorschau anzuzeigen. Markieren Sie Zeilen mit Kontrollkästchen, um Massenaktionen durchzuführen.",
+      "columns": {
+        "matchedSteps": "Passende Schritte",
+        "casesCount": "Fälle",
+        "review": "Rezension"
+      },
+      "scanning": "Scanvorgang läuft...",
+      "scanComplete": "{count, plural, one {# Übereinstimmung gefunden} other {# Übereinstimmungen gefunden}}",
+      "scanFailed": "Scan fehlgeschlagen",
+      "scanFailedDescription": "Beim Scan ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+      "cancelScan": "Scan abbrechen",
+      "findStepDuplicates": "Schrittduplikate finden",
+      "rescan": "Scan",
+      "viewResults": "Ergebnisse anzeigen ({count})",
+      "retryScan": "Scan wiederholen",
+      "dialog": {
+        "title": "In gemeinsame Schritte umwandeln",
+        "previewTitle": "Abgestimmte Schrittfolge",
+        "casesTitle": "Betroffene Testfälle",
+        "casesDescription": "Deaktivieren Sie die Fälle, die Sie von der Konvertierung ausschließen möchten.",
+        "nameLabel": "Name der gemeinsamen Schrittgruppe",
+        "namePlaceholder": "Geben Sie einen Namen für die gemeinsame Schrittgruppe ein...",
+        "converting": "Konvertierung läuft...",
+        "dismissMatch": "Spiel verwerfen",
+        "dismissing": "Entlassen...",
+        "convertSuccess": "Gemeinsame Schrittgruppe erfolgreich erstellt!",
+        "convertError": "Die Konvertierung ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+        "dismissSuccess": "Spiel abgebrochen.",
+        "dismissError": "Fehler beim Schließen. Bitte versuchen Sie es erneut.",
+        "viewSharedStep": "Gemeinsame Schrittgruppe anzeigen",
+        "skippedWarning": "{count, plural, one {# Fall wurde übersprungen} other {# Fälle wurden übersprungen}} (veraltet oder bereits konvertiert).",
+        "noCasesSelected": "Wählen Sie mindestens einen Fall zur Konvertierung aus.",
+        "selectAll": "Alle auswählen"
+      }
+    },
+    "findStepDuplicates": "Duplikate finden"
+  },
+  "search": {
+    "title": "Suchen",
+    "placeholder": {
+      "thisProject": "In diesem Projekt suchen...",
+      "allProjects": "Durchsuchen Sie alle Projekte..."
+    },
+    "currentProjectOnly": "Nur aktuelles Projekt",
+    "allTypes": "Alle Arten",
+    "entityTypes": {
+      "repositoryCase": "Repository-Fälle"
+    },
+    "results": {
+      "tryAdjusting": "Versuchen Sie, Ihre Suchbegriffe oder Filter anzupassen.",
+      "searchingFor": "Suche nach",
+      "within": "innerhalb",
+      "currentProject": "aktuelles Projekt",
+      "page": "Seite"
+    },
+    "errors": {
+      "searchFailed": "Suche fehlgeschlagen. Bitte versuchen Sie es erneut.",
+      "tryAgain": "Versuchen Sie es erneut"
+    },
+    "startTyping": "Beginnen Sie mit der Eingabe, um zu suchen",
+    "typesSelected": "{count, plural, one {# Typ} other {# Typen}}",
+    "customFieldFilters": "Benutzerdefinierte Feldfilter",
+    "customFiltersApplied": "benutzerdefinierte Filter",
+    "customFields": "Benutzerdefinierte Felder",
+    "addFilter": "Filter hinzufügen",
+    "filter": "Filter",
+    "noCustomFilters": "Es wurden keine benutzerdefinierten Feldfilter angewendet.",
+    "selectDate": "Datum auswählen",
+    "selectOption": "Option auswählen",
+    "selectOptions": "Optionen auswählen",
+    "operators": {
+      "equals": "Gleich",
+      "not_equals": "Nicht gleich",
+      "contains": "Enthält",
+      "not_contains": "Enthält nicht",
+      "starts_with": "Beginnt mit",
+      "ends_with": "Endet mit",
+      "gt": "Größer als",
+      "lt": "Weniger als",
+      "gte": "Größer oder gleich",
+      "lte": "Kleiner oder gleich",
+      "between": "Zwischen",
+      "in": "In",
+      "not_in": "Nicht in",
+      "exists": "Existiert",
+      "not_exists": "Existiert nicht"
+    },
+    "help": {
+      "exactPhrases": "Genaue Formulierungen",
+      "exactPhrasesDesc": "Um exakte Formulierungen zu erhalten, sollten Begriffe in Anführungszeichen gesetzt werden:",
+      "proximity": "Nähesuche",
+      "proximityDesc": "Wörter innerhalb von N Positionen voneinander",
+      "booleanOperators": "Boolesche Operatoren",
+      "andDesc": "Beide Begriffe müssen übereinstimmen",
+      "orDesc": "Beide Begriffe können übereinstimmen",
+      "notDesc": "Ergebnisse mit Begriff ausschließen",
+      "prefixDesc": "einen Begriff erfordern oder ausschließen",
+      "groupingDesc": "Gruppierungsbegriffe für komplexe Anfragen",
+      "wildcards": "Wildcards",
+      "wildcardMultiDesc": "Passt zu beliebigen Zeichen",
+      "wildcardSingleDesc": "entspricht einem einzelnen Zeichen",
+      "fuzzyMatching": "Fuzzy-Matching",
+      "fuzzyDesc": "findet ähnliche Begriffe, um bei Tippfehlern zu helfen.",
+      "defaultBehavior": "Mehrere Wörter werden standardmäßig mit ODER verknüpft. Ergebnisse, die dem Namen entsprechen, werden am höchsten eingestuft.",
+      "fullSyntaxLink": "Vollständige Lucene-Abfragesyntaxreferenz"
+    },
+    "filters": {
+      "title": "Erweiterte Filter",
+      "active": "Aktive Filter",
+      "activeCount": "{count, plural, =0 {Keine Filter} one {# Filter} other {# Filter}} aktiv",
+      "apply": "Filter anwenden",
+      "common": "Gängige Filter",
+      "entitySpecific": "Typspezifische Filter",
+      "searchPlaceholder": "Suchfilteroptionen...",
+      "states": "Workflow-Zustände",
+      "createdAt": "Erstellungsdatum",
+      "updatedAt": "Aktualisiertes Datum",
+      "completedAt": "Fertigstellungsdatum",
+      "from": "Aus",
+      "to": "Zu",
+      "testRunType": "Testlauftyp",
+      "regular": "Regulär",
+      "junit": "JUnit",
+      "automatedOnly": "Nur automatisiert",
+      "archivedOnly": "Nur archiviert",
+      "completedOnly": "Nur abgeschlossen",
+      "manualOnly": "Nur Handbuch",
+      "estimateRange": "Schätzbereich",
+      "elapsedRange": "Verstrichener Zeitraum",
+      "minValue": "Min",
+      "maxValue": "Max",
+      "hasExternalId": "Besitzt externe ID",
+      "dueDateRange": "Fälligkeitsdatumsbereich",
+      "hasParent": "Hat einen übergeordneten Meilenstein",
+      "milestoneType": "Meilensteintyp",
+      "minutes": "Minuten",
+      "hours": "Std.",
+      "days": "Tage",
+      "searchingIn": "Suche in",
+      "includeDeleted": "Gelöschte Elemente einschließen",
+      "filterActive": "Filter aktiv:",
+      "applyFilter": "Filter anwenden",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "Der erste Wert muss kleiner als der zweite Wert sein.",
+        "firstDateMustBeBeforeSecond": "Das erste Date muss vor dem zweiten Date stattfinden."
+      },
+      "link": {
+        "domainHelp": "Geben Sie nur die Domain ein (z. B. „github.com“ oder „example.org“)."
+      }
+    }
+  },
+  "email": {
+    "greeting": "Hallo,",
+    "greetingWithName": "Hallo {name},",
+    "notification": {
+      "intro": "Sie haben eine neue Benachrichtigung:",
+      "viewDetails": "Details anzeigen",
+      "viewAll": "Alle Benachrichtigungen anzeigen"
+    },
+    "digest": {
+      "intro": "Hier ist Ihre tägliche Zusammenfassung der Benachrichtigungen von TestPlanIt:",
+      "viewDetails": "Details anzeigen",
+      "viewAll": "Alle Benachrichtigungen anzeigen",
+      "noNotifications": "Sie haben heute keine neuen Benachrichtigungen.",
+      "footer": "Sie erhalten diese E-Mail, weil Sie tägliche Zusammenfassungsbenachrichtigungen aktiviert haben. Sie können Ihre Benachrichtigungseinstellungen in Ihrem Konto ändern.",
+      "profileSettings": "Profileinstellungen"
+    },
+    "footer": {
+      "sentBy": "Diese E-Mail wurde gesendet von",
+      "unsubscribe": "Abbestellen",
+      "managePreferences": "Einstellungen verwalten",
+      "allRightsReserved": "Alle Rechte vorbehalten."
+    },
+    "magicLink": {
+      "subject": "Melden Sie sich bei TestPlanIt an.",
+      "heading": "Melden Sie sich bei TestPlanIt an.",
+      "intro": "Klicken Sie auf die Schaltfläche unten, um sich anzumelden:",
+      "signInButton": "Anmelden",
+      "copyPasteIntro": "Oder kopieren Sie diesen Link und fügen Sie ihn in Ihren Browser ein:",
+      "disclaimer": "Wenn Sie diese E-Mail nicht angefordert haben, können Sie sie getrost ignorieren.",
+      "textBody": "Melden Sie sich bei TestPlanIt an\n\nKlicken Sie auf den unten stehenden Link, um sich anzumelden:\n{url}\n\nWenn Sie diese E-Mail nicht angefordert haben, können Sie sie getrost ignorieren."
+    }
+  },
+  "comments": {
+    "title": "Kommentare",
+    "placeholder": "Schreibe einen Kommentar... (Verwende @, um Nutzer zu erwähnen)",
+    "editPlaceholder": "Bearbeiten Sie Ihren Kommentar...",
+    "postComment": "Kommentar veröffentlichen",
+    "noComments": "Noch keine Kommentare. Sei der Erste, der einen Kommentar hinterlässt!",
+    "edited": "bearbeitet",
+    "confirmDelete": "Sind Sie sicher, dass Sie diesen Kommentar löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "deleteDialog": {
+      "title": "Kommentar löschen"
+    },
+    "errors": {
+      "createFailed": "Kommentar konnte nicht erstellt werden. Bitte versuchen Sie es erneut.",
+      "updateFailed": "Kommentar konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
+      "deleteFailed": "Kommentar konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
+      "loadFailed": "Die Kommentare konnten nicht geladen werden. Bitte versuchen Sie es erneut."
+    },
+    "mentions": {
+      "notAMember": "Kein Projektmitglied",
+      "noUsersFound": "Keine Benutzer gefunden"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "Die Prüfung endet in {count, plural, =1 {1 Tag} other {# Tagen}}",
+    "expiresT oday": "Die Testphase läuft heute ab",
+    "expired": "{count, plural, =1 {Testversion vor 1 Tag abgelaufen} other {Testversion vor # Tagen abgelaufen}}",
+    "contactSales": "Kontaktieren Sie den Vertrieb."
+  },
+  "feedback": {
+    "sheetTitle": "Teilen Sie uns Ihr Feedback mit",
+    "sheetDescription": "Helfen Sie uns, TestPlanIt zu verbessern, indem Sie Ihre Erfahrungen mit uns teilen.",
+    "bannerMessage": "Wie läuft Ihre Testphase? Wir würden uns über Ihr Feedback freuen.",
+    "menuItem": "Feedback teilen"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "KI-Tag",
+      "tagAll": "Alle markieren",
+      "aiAutoTag": "Auto-Tag",
+      "tagActions": "Tag-Aktionen",
+      "startTagging": "Taggen",
+      "selectEntityType": "Entitätstyp auswählen",
+      "selectProject": "Wählen Sie ein Projekt aus",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Testfall} other {Testfälle}}",
+        "testRun": "{count, plural, one {Testlauf} other {Testläufe}}",
+        "session": "{count, plural, one {Sitzung} other {Sitzungen}}"
+      }
+    },
+    "review": {
+      "title": "Vorschläge für Bewertungs-Tags",
+      "description": "Klicken Sie auf die Tags, um die Akzeptanz umzuschalten. Doppelklicken Sie, um einen Tag-Namen zu bearbeiten.",
+      "selectEntity": "Wählen Sie eine Entität aus, um Tag-Vorschläge anzuzeigen.",
+      "noTagsSelected": "Keine Schlagwörter ausgewählt",
+      "footerSummary": "{assignCount, plural, one {# Tag} other {# Tags}} werden zugewiesen, {newCount, plural, one {# neuer Tag} other {# neue Tags}} werden erstellt",
+      "footerAssignCount": "{assignCount, plural, one {# Tag} other {# Tags}} werden zugewiesen",
+      "footerNewCount": "{newCount, plural, one {# neues Tag} other {# neue Tags}} werden erstellt",
+      "newTagsPopoverTitle": "Neue Tags zum Erstellen",
+      "applying": "Bewerbung läuft...",
+      "applySuccess": "{tagCount, plural, one {# Tag} other {# Tags}} angewendet auf {entityCount, plural, one {# Entität} other {# Entitäten}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# Tag} other {# Tags}} angewendet auf {entityCount, plural, one {# Entität} other {# Entitäten}}, {newCount, plural, one {# neuer Tag} other {# neue Tags}} erstellt",
+      "applyError": "Die Tags konnten nicht angewendet werden. Bitte versuchen Sie es erneut.",
+      "suggestedTags": "Vorgeschlagene Tags",
+      "noSuggestions": "Die KI konnte keine Tags generieren.",
+      "alreadyApplied": "Bereits beantragt",
+      "filterEntities": "Entitäten filtern...",
+      "noEntitiesMatch": "Es wurden keine Ergebnisse für Ihre Suche gefunden.",
+      "tagCount": "{count, plural, one {# Tag} other {# Tags}}",
+      "noTags": "keiner",
+      "failed": "Fehlgeschlagen",
+      "analysisFailed": "Diese Entität konnte nicht analysiert werden.",
+      "responseTruncated": "Antwort gekürzt – Erhöhen Sie die maximale Anzahl an Ausgabetoken in den LLM-Einstellungen.",
+      "tooltipExisting": "Vorhandenes Tag",
+      "tooltipNew": "Neues Tag wird erstellt",
+      "tooltipAssign": "Vorhandenes Tag zuweisen",
+      "toggleFailed": "Fehlgeschlagene Entitäten ein-/ausblenden",
+      "showFailed": "Show fehlgeschlagen"
+    },
+    "progress": {
+      "starting": "Analyse wird gestartet...",
+      "analyzed": "Analysierte {analyzed}/{total} Entitäten",
+      "sizing": "Optimale Batchgröße ermitteln (Versuch von {size} Entitäten)...",
+      "streaming": "Empfange KI-Antwort ({analyzed}/{total} Entitäten abgeschlossen)...",
+      "finalizing": "Ergebnisse werden vorbereitet...",
+      "complete": "Analyse abgeschlossen",
+      "reviewSuggestions": "Vorschläge zur Überprüfung",
+      "failed": "Analyse fehlgeschlagen"
+    },
+    "wizard": {
+      "description": "Die KI analysiert alle Testfälle, Testläufe und Sitzungen Ihres Projekts und schlägt basierend auf deren Inhalt relevante Tags vor.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Analyse starten",
+      "untaggedOnly": "Analysiere nur Datensätze ohne vorhandene Tags.",
+      "allowNewTags": "Erstellen neuer Tags zulassen",
+      "noLlmConfigured": "(Kein LLM konfiguriert)",
+      "analyzingDescription": "Die KI analysiert Ihre Entitäten und generiert Tag-Vorschläge. Dies kann einen Moment dauern."
+    },
+    "entityDetail": {
+      "customFields": "Benutzerdefinierte Felder",
+      "noDetails": "Es sind keine weiteren Details verfügbar.",
+      "openInNewTab": "In neuem Tab öffnen"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Sehr schwach",
+    "weak": "Schwach",
+    "fair": "Gerecht",
+    "good": "Gut",
+    "strong": "Stark",
+    "minLength": "Mindestens {count} Zeichen",
+    "uppercase": "Mindestens ein Großbuchstabe",
+    "lowercase": "Mindestens ein Kleinbuchstabe",
+    "numbers": "Mindestens eine Zahl",
+    "specialChars": "Sonderzeichen von: {chars}",
+    "history": "Das Passwort wurde in Ihren letzten {depth} Passwörtern verwendet."
+  },
+  "TrialExpired": {
+    "title": "Ihre Testphase ist abgelaufen.",
+    "description": "Vielen Dank, dass Sie TestPlanIt ausprobiert haben! Ihre Testphase ist abgelaufen und diese Instanz ist nicht mehr zugänglich.",
+    "nextSteps": "Um TestPlanIt weiterhin nutzen und auf Ihre Testdaten zugreifen zu können, wenden Sie sich bitte an unser Vertriebsteam.",
+    "pricingPlans": "Preispläne",
+    "dataRetention": "Ihre Testdaten sind sicher gespeichert und stehen Ihnen nach dem Upgrade Ihres Kontos zur Verfügung."
+  }
+}

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -3030,7 +3030,7 @@
       "system": "System"
     },
     "imports": {
-      "description": "Bring data from external test management tools into Testplanit.",
+      "description": "Bring data from external test management tools into TestPlanIt.",
       "tabs": {
         "testmoJson": "Testmo JSON"
       },

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -3030,7 +3030,7 @@
       "system": "Sistema"
     },
     "imports": {
-      "description": "Traiga datos de herramientas de gestión de pruebas externas a Testplanit.",
+      "description": "Importa datos de herramientas externas de gestión de pruebas a TestPlanIt.",
       "tabs": {
         "testmoJson": "Testmo JSON"
       },

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -3030,7 +3030,7 @@
       "system": "Système"
     },
     "imports": {
-      "description": "Importez les données provenant d'outils de gestion de tests externes dans Testplanit.",
+      "description": "Importez les données provenant d'outils de gestion de tests externes dans TestPlanIt.",
       "tabs": {
         "testmoJson": "Testmo JSON"
       },

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Nome",
+    "cancel": "Cancellare",
+    "dismiss": "Congedare",
+    "of": "Di",
+    "on": "SU",
+    "at": "A",
+    "in": "In",
+    "add": "Aggiungere",
+    "never": "Mai",
+    "select": "Selezionare...",
+    "file": "File",
+    "selectMultiple": "Seleziona più...",
+    "searchUsers": "Cerca utenti...",
+    "searchCases": "{count, plural, =0 {Cerca casi} one {Cerca # caso} other {Cerca # casi}}",
+    "searchProjects": "{count, plural, =0 {Cerca progetti} one {Cerca # progetto} other {Cerca # progetti}}",
+    "searchTags": "Cerca i tag...",
+    "searchRuns": "{count, plural, =0 {Cerca esecuzioni di test} one {Cerca # esecuzione di test} other {Cerca # esecuzione di test}}",
+    "searchSessions": "{count, plural, =0 {Cerca sessioni} one {Cerca # sessione} other {Cerca # sessioni}}",
+    "search": "Ricerca...",
+    "defaultOption": "Opzione predefinita",
+    "yes": "SÌ",
+    "no": "NO",
+    "updated": "Aggiornato",
+    "groupedBy": "raggruppati per",
+    "lastEditedBy": "Ultima modifica di",
+    "actions": {
+      "edit": "Modificare",
+      "save": "Salva",
+      "delete": "Eliminare",
+      "create": "Creare",
+      "submit": "Invia",
+      "close": "Vicino",
+      "done": "Fatto",
+      "verify": "Verificare",
+      "signIn": "Registrazione",
+      "signOut": "Disconnessione",
+      "signUp": "Iscrizione",
+      "resend": "Invia di nuovo",
+      "deleting": "Eliminazione in corso...",
+      "next": "Prossimo",
+      "previous": "Precedente",
+      "finish": "Fine",
+      "download": "Scaricamento",
+      "apply": "Fare domanda a",
+      "confirm": "Confermare",
+      "confirmDelete": "Conferma Elimina",
+      "saveChanges": "Salva le modifiche",
+      "saving": "Risparmio...",
+      "submitting": "Invio in corso...",
+      "start": "Inizio",
+      "pause": "Pausa",
+      "reset": "Reset",
+      "copy": "Copia",
+      "copyLink": "Copia il collegamento",
+      "copied": "Copiato!",
+      "complete": "Completare",
+      "back": "Indietro",
+      "clear": "Chiaro",
+      "expand": "Espandere",
+      "collapse": "Crollo",
+      "addResult": "Aggiungi risultato",
+      "passAndNext": "Passa e Avanti",
+      "viewInRepository": "Visualizza nel repository",
+      "resultAdded": "Risultato del test aggiunto",
+      "resultAddedDescription": "Il risultato del test è stato aggiunto correttamente.",
+      "resultUpdated": "Risultato del test aggiornato",
+      "resultDeleted": "Risultato del test eliminato",
+      "deleteResult": "Elimina il risultato del test",
+      "deleteResultConfirmation": "Vuoi davvero eliminare il risultato di questo test? Questa azione non può essere annullata.",
+      "editResult": "Modifica risultato test",
+      "resultDetails": "Dettagli del risultato",
+      "actionsLabel": "Azioni",
+      "assign": "Assegnare",
+      "assignSelected": "Assegna {count, plural, one {# caso} other {# casi}}",
+      "refresh": "Aggiorna",
+      "addResultSelected": "Aggiungi il risultato a {count, plural, one {# caso} other {# casi}}",
+      "resultsAdded": "{count, plural, one {# Risultato} other {# Risultati}} Aggiunto",
+      "resultsAddedDescription": "{count, plural, one {Il risultato è stato aggiunto al caso di test #} other {I risultati sono stati aggiunti al caso di test #}} con successo",
+      "addingResultsToMultiple": "Aggiunta dei risultati a {count, plural, one {# caso di test} other {# casi di test}}",
+      "addedToTestRun": "Aggiunto al test di esecuzione",
+      "addedToTestRunDescription": "Il caso di test è stato aggiunto al Test Run.",
+      "noAvailableTestRuns": "Tutti i test attivi includono già questo caso di test.",
+      "resultUpdateError": "Impossibile aggiornare il risultato del test",
+      "resultDeleteError": "Impossibile eliminare il risultato del test",
+      "selectStatus": "Seleziona Stato",
+      "addToTestRun": "Aggiungi al test",
+      "status": "Stato",
+      "resultDetailsPlaceholder": "Inserisci i dettagli del risultato...",
+      "selectAll": "Seleziona tutto",
+      "deselectAll": "Deseleziona tutto",
+      "clearAll": "Cancella tutto",
+      "selectFile": "Seleziona file",
+      "restore": "Ripristinare",
+      "purge": "Purga",
+      "previousCase": "Caso precedente",
+      "nextCase": "Caso successivo",
+      "startTesting": "Inizia il test",
+      "expandLeftPanel": "Espandi pannello sinistro",
+      "collapseLeftPanel": "Comprimi pannello sinistro",
+      "expandRightPanel": "Espandi pannello destro",
+      "collapseRightPanel": "Comprimi pannello destro",
+      "createTag": "Crea tag \"{name}\"",
+      "noTagsFound": "Nessun tag trovato",
+      "duplicate": "Duplicato",
+      "exportPdf": "Esporta in PDF",
+      "exportingPdf": "Esportazione...",
+      "change": "Modifica",
+      "viewAll": "Visualizza tutto",
+      "undo": "Disfare",
+      "undoDelete": "Annulla eliminazione",
+      "automated": {
+        "details": "Dettagli del test automatizzato",
+        "message": "Messaggio",
+        "line": "Linea",
+        "testSuite": "Suite di test:"
+      },
+      "junit": {
+        "details": "Dettagli del risultato del test automatizzato",
+        "import": {
+          "title": "Risultati dei test di importazione",
+          "description": "Carica i file dei risultati dei test per importarli in una nuova esecuzione del test. Supporta i formati JUnit, TestNG, xUnit, NUnit, MSTest, Mocha e Cucumber.",
+          "testRun": {
+            "label": "Esecuzione di prova",
+            "placeholder": "Seleziona un test"
+          },
+          "file": {
+            "label": "File dei risultati dei test"
+          },
+          "import": "Importare",
+          "selectFolder": "Seleziona una cartella",
+          "createNewFolder": "crea una nuova cartella",
+          "createNewFolderNamed": "Crea una nuova cartella: {name}",
+          "progress": {
+            "initializing": "Inizializzazione dell'importazione...",
+            "validating": "Convalida dei dati di input...",
+            "creatingRun": "Creazione di un test...",
+            "fetchingTemplate": "Recupero dei dati del modello in corso...",
+            "countingTests": "Elaborazione di {count} casi di test da {files} file...",
+            "parsingFile": "Analisi del file {current} di {total}...",
+            "processingSuite": "Suite di elaborazione: {name}",
+            "processingCase": "Elaborazione del caso di test {current} di {total}...",
+            "finalizing": "Finalizzazione dell'importazione...",
+            "completed": "Importazione completata con successo!",
+            "errorParsing": "Errore durante l'analisi del file {index}: {error}",
+            "skippingFile": "Ignorato il file non valido {index}"
+          },
+          "error": {
+            "title": "Errore di importazione",
+            "importFailed": "Impossibile importare i risultati del test. Riprova."
+          },
+          "success": {
+            "title": "Importazione riuscita",
+            "description": "I risultati dei test sono stati importati correttamente."
+          },
+          "fileRequired": "Si prega di caricare almeno un file con i risultati del test."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Formato del risultato",
+            "placeholder": "Seleziona il formato"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Conferma ripristino",
+      "confirmPurgeTitle": "Conferma eliminazione",
+      "remove": "Rimuovere",
+      "reconfigure": "Riconfigura e riprova"
+    },
+    "permissions": {
+      "addEdit": "Aggiungi/Modifica"
+    },
+    "auth": {
+      "internal": "E-mail/Password",
+      "sso": "Solo SSO",
+      "both": "E-mail e SSO"
+    },
+    "status": {
+      "deleted": "Eliminato",
+      "disabled": "Disabili",
+      "noCustomFieldData": "Nessun dettaglio aggiuntivo.",
+      "pending": "In attesa di",
+      "uploading": "Caricamento in corso...",
+      "notApplicable": "N / A",
+      "redirecting": "Reindirizzamento in corso...",
+      "pendingDelete": "Verrà eliminato",
+      "pendingChanges": "Modifiche in sospeso",
+      "importing": "Importazione...",
+      "addingTestCases": "Aggiunta di casi di test..."
+    },
+    "priority": {
+      "low": "Basso",
+      "medium": "Medio",
+      "high": "Alto"
+    },
+    "filters": {
+      "allStatuses": "Tutti gli stati",
+      "allPriorities": "Tutte le priorità"
+    },
+    "fields": {
+      "groupName": "Nome del gruppo",
+      "users": "Utenti",
+      "mixed": "Tutti i valori",
+      "type": "Tipo",
+      "default": "Predefinito",
+      "enabled": "Abilitato",
+      "projects": "Progetti",
+      "iconColor": "Icona/Colore",
+      "selectWorkflow": "Seleziona flusso di lavoro",
+      "icon": "Icona",
+      "systemName": "Nome del sistema",
+      "aliases": "Alias",
+      "scope": "Ambito",
+      "success": "Successo",
+      "failure": "Fallimento",
+      "completed": "Completato",
+      "elapsed": "Tempo trascorso",
+      "totalElapsed": "Tempo totale trascorso",
+      "totalEstimate": "Tempo stimato rimanente",
+      "completionRate": "Tasso di completamento",
+      "attachments": "Allegati",
+      "documentation": "Documentazione",
+      "state": "Stato",
+      "configuration": "Configurazione",
+      "configurations": "Configurazioni",
+      "milestone": "Pietra miliare",
+      "tags": "Etichette",
+      "createdBy": "Creato da",
+      "description": "Descrizione",
+      "description_placeholder": "Aggiungi una descrizione...",
+      "testCases": "Casi di prova",
+      "sessions": "Sessioni",
+      "sharedSteps": "Passaggi condivisi",
+      "email": "E-mail",
+      "password": "Password",
+      "confirmPassword": "Conferma password",
+      "token": "Gettone",
+      "access": "Accesso",
+      "avatar": "Avatar",
+      "steps": "Passi",
+      "step": "Fare un passo",
+      "expectedResult": "Risultato atteso",
+      "notes": "Note",
+      "estimate": "Stima",
+      "date": "Data",
+      "size": "Misurare",
+      "created": "Creato",
+      "template": "Modello",
+      "mission": "Missione",
+      "assignedTo": "Assegnato a",
+      "executedBy": "Eseguito da",
+      "optional": "Opzionale",
+      "role": "Ruolo",
+      "defaultRole": "Ruolo predefinito",
+      "systemAccess": "Accesso al sistema",
+      "authMethod": "Metodo di autenticazione",
+      "dateCreated": "Data di creazione",
+      "apiUser": "Utente API",
+      "unverified": "Non verificato",
+      "selfRegistered": "Autoregistrato",
+      "role_placeholder": "Seleziona un ruolo",
+      "usersCreated": "Utenti creati",
+      "groups": "Gruppi",
+      "apiAccess": "Accesso API",
+      "requiredForAdmin": "richiesto per l'amministratore",
+      "account": "Account",
+      "accountHistory": "Cronologia dell'account",
+      "activity": "Attività",
+      "lastActive": "Ultimo attivo",
+      "theme": "Tema",
+      "locale": "Lingua",
+      "timezone": "Fuso orario",
+      "itemsPerPage": "Elementi per pagina",
+      "notificationMode": "Notifiche",
+      "value": "Valore",
+      "key": "Chiave",
+      "configurationDetails": "Dettagli di configurazione",
+      "isActive": "Attivo",
+      "members": "Membri",
+      "milestoneTypes": "Tipi di milestone",
+      "milestones": "Pietre miliari",
+      "createdAt": "Creato a",
+      "completedOn": "Completato il",
+      "variants": "Varianti",
+      "emailVerified": "Email verificata",
+      "issueTracker": "Tracker dei problemi",
+      "caseFields": "Campi caso",
+      "resultFields": "Campi risultato",
+      "displayName": "Nome da visualizzare",
+      "hint": "Suggerimento",
+      "required": "Necessario",
+      "restricted": "Limitato",
+      "fieldType": "Tipo di campo",
+      "templates": "Modelli",
+      "started": "Iniziato",
+      "startDate": "Data di inizio",
+      "automated": "Automatizzato",
+      "manual": "Manuale",
+      "notAutomated": "Non automatizzato",
+      "testRuns": "Esecuzioni di prova",
+      "title": "Titolo",
+      "project": "Progetto",
+      "priority": "Priorità",
+      "integration": "Integrazione",
+      "lastSyncedAt": "Ultima sincronizzazione",
+      "externalKey": "Chiave esterna",
+      "initialHeight": "Altezza iniziale",
+      "minValue": "Valore minimo",
+      "maxValue": "Valore massimo",
+      "minIntegerValue": "Valore intero minimo",
+      "maxIntegerValue": "Valore intero massimo",
+      "defaultValue": "Valore predefinito",
+      "checked": "Controllato",
+      "version": "Versione",
+      "issues": "Problemi",
+      "internalIssues": "Problemi interni",
+      "externalIssues": "{provider} Problemi",
+      "data": "Dati",
+      "note": "Nota",
+      "externalId": "ID esterno",
+      "forecast": "Previsione",
+      "forecastManual": "Manuale di previsione",
+      "forecastAutomated": "Previsione automatizzata",
+      "executedAt": "Eseguito a",
+      "className": "Classe",
+      "suiteName": "Suite",
+      "duration": "Durata",
+      "session": "Sessione",
+      "charter": "Carta",
+      "summary": "Riepilogo",
+      "progress": "Progressi",
+      "assertions": "Affermazioni",
+      "properties": "Proprietà",
+      "systemOutput": "Registri dei casi di prova",
+      "systemError": "Errore di sistema",
+      "resultStatus": "Risultato",
+      "links": "Collegamenti",
+      "id": "ID",
+      "JUNIT": "Importazione JUnit",
+      "API": "API",
+      "folder": "Cartella",
+      "parentFolder": "Cartella principale per i nuovi casi",
+      "multipleValues": "Valori multipli",
+      "provider": "Fornitore",
+      "updatedAt": "Aggiornato alle",
+      "tools": "Utensili",
+      "codeRepository": "Repository del codice",
+      "aiModels": "LLM predefinito",
+      "configKeys": {
+        "edit_results_duration": "Modifica durata risultati",
+        "project_docs_default": "Documenti di progetto predefiniti",
+        "notificationSettings": "Impostazione globale di notifica",
+        "elasticsearch_replicas": "Repliche di Elasticsearch"
+      },
+      "options": {
+        "label": "Etichetta",
+        "validation": {
+          "empty": "L'opzione non può essere vuota",
+          "invalidChars": "L'opzione contiene un carattere non valido: \"{char}\"",
+          "duplicate": "L'opzione deve essere univoca",
+          "systemNameError": "Il nome del sistema non è valido",
+          "initialHeightMax": "L'altezza iniziale non può essere maggiore di 600 px.",
+          "displayNameRequiredResult": "Immettere un nome visualizzato per il campo Risultato.",
+          "displayNameRequiredCase": "Immettere un nome visualizzato per il campo caso.",
+          "minValueMaxValue": "Il valore minimo deve essere inferiore al valore massimo e, se ne è impostato uno, devono essere impostati entrambi.",
+          "minMaxValueInteger": "Il valore intero minimo deve essere inferiore al valore intero massimo ed entrambi devono essere impostati se uno è impostato.",
+          "systemNameRequired": "Il nome del sistema non può essere vuoto.",
+          "systemNameRegex": "Il nome del sistema deve iniziare con una lettera e può contenere solo lettere, numeri e trattini bassi.",
+          "fieldTypeRequired": "Il campo Tipo è obbligatorio."
+        }
+      },
+      "placeholders": {
+        "key": "Tasto Invio",
+        "value": "Inserisci il valore",
+        "addVariant": "Aggiungi variante",
+        "addCategory": "Aggiungi categoria",
+        "displayName": "Inserisci il nome visualizzato",
+        "systemName": "Inserisci il nome del sistema",
+        "hint": "Inserisci suggerimento"
+      },
+      "hints": {
+        "systemName": "Il nome del sistema deve essere univoco e contenere solo lettere, numeri e caratteri di sottolineatura",
+        "fieldType": "(Il tipo di campo non può essere modificato una volta creato)"
+      },
+      "validation": {
+        "nameRequired": "Il nome è obbligatorio",
+        "stateRequired": "Lo stato è obbligatorio",
+        "urlRequired": "L'URL è obbligatorio",
+        "invalidUrl": "Formato URL non valido"
+      }
+    },
+    "filter": {
+      "placeholder": "Filtro {item}..."
+    },
+    "access": {
+      "admin": "Amministratore",
+      "projectAdmin": "Amministratore del progetto",
+      "user": "Utente",
+      "none": "Nessuno"
+    },
+    "validation": {
+      "required": "Inserisci {field}",
+      "invalidDuration": "Inserisci una durata valida",
+      "maxDuration": "La durata non può superare {max} minuti",
+      "minLength": "{field} deve essere di almeno {min} caratteri",
+      "emailFormat": "Formato email non valido",
+      "passwordMatch": "Le password devono essere identiche",
+      "unique": "{field} deve essere univoco",
+      "roleRequired": "Il ruolo è obbligatorio",
+      "nameMinLength": "Il nome deve essere composto da almeno 2 caratteri",
+      "invalidDurationFormat": "Formato di durata non valido. Prova qualcosa come 30 minuti, 1 settimana o 1 ora e 25 minuti."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Conferma {action}",
+        "message": "Sei sicuro di voler {action}?"
+      },
+      "confirmDelete": {
+        "description": "Vuoi davvero eliminare questo elemento? Questa azione non può essere annullata."
+      },
+      "assign": {
+        "title": "Assegna caso di prova",
+        "description": "Assegna il caso di test \"{testCase}\" a un utente",
+        "selectUser": "Seleziona un utente"
+      },
+      "assignBulk": {
+        "title": "Assegnazione in blocco dei casi di test",
+        "description": "Assegna {count, plural, one {# caso di test selezionato} other {# casi di test selezionati}} a un utente"
+      },
+      "complete": {
+        "title": "Esecuzione del test completo",
+        "description": "Sei sicuro di voler completare questa prova?",
+        "warning": "Una volta completato, il test non potrà essere modificato.",
+        "apple": {
+          "title": "Configurare l'accesso Apple",
+          "description": "Imposta le tue credenziali di accesso Apple. Puoi ottenerle dall'Apple Developer Portal.",
+          "clientId": "ID del servizio",
+          "clientIdPlaceholder": "com.esempio.servizio",
+          "teamId": "ID squadra",
+          "teamIdPlaceholder": "Il tuo ID squadra di 10 caratteri",
+          "keyId": "ID chiave",
+          "keyIdPlaceholder": "Il tuo ID chiave di 10 caratteri",
+          "privateKey": "Chiave privata",
+          "privateKeyPlaceholder": "Incolla qui il contenuto della tua chiave privata .p8",
+          "instructions": {
+            "title": "Istruzioni per l'installazione:",
+            "step1": "Vai al portale per sviluppatori Apple",
+            "step2": "Crea un ID servizio e configura Accedi con Apple",
+            "step3": "Crea una chiave per l'accesso con Apple",
+            "step4": "Scarica il file della chiave privata .p8",
+            "step5": "Aggiungere il seguente URL di reindirizzamento:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Tutti i campi sono obbligatori"
+          }
+        }
+      },
+      "delete": {
+        "title": "Elimina {item}",
+        "description": "Sei sicuro di voler eliminare {name}?",
+        "warning": "Questa azione non può essere annullata. Eliminerà definitivamente {item}."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Elemento eliminato con successo",
+      "deleteError": "Si è verificato un errore durante l'eliminazione dell'elemento",
+      "moveSuccess": "Elemento spostato con successo",
+      "moveError": "Si è verificato un errore durante lo spostamento dell'elemento",
+      "updateSuccess": "Articolo aggiornato con successo",
+      "updateError": "Si è verificato un errore durante l'aggiornamento dell'elemento",
+      "linkCopied": "Collegamento copiato negli appunti",
+      "copyFailed": "Impossibile copiare il collegamento negli appunti",
+      "created": "Esecuzione del test creata con successo",
+      "createdDescription": "L'esecuzione del test è stata creata ed è ora visibile nell'elenco Esecuzioni del test.",
+      "createError": "Si è verificato un errore sconosciuto. Riprova.",
+      "emptyActive": "Nessun test attivo",
+      "emptyCompleted": "Nessun test completato",
+      "projectUpdated": "Progetto aggiornato con successo",
+      "projectUpdateError": "Si è verificato un errore durante l'aggiornamento del progetto",
+      "noProjects": "Nessun progetto trovato"
+    },
+    "placeholders": {
+      "email": "Indirizzo e-mail",
+      "name": "Inserisci il nome",
+      "mission": "Descrivi la tua missione...",
+      "selectMilestone": "Seleziona Milestone",
+      "selectStatus": "Seleziona uno stato",
+      "selectTemplate": "Seleziona il modello",
+      "duration": "ad esempio 1h 30m o 90m",
+      "docs": "Aggiungi documentazione...",
+      "select": "Selezionare",
+      "selectState": "Seleziona lo stato",
+      "selectConfiguration": "Seleziona la configurazione",
+      "selectConfigurations": "Selezionare le configurazioni",
+      "selectOption": "Seleziona un'opzione",
+      "date": "Seleziona una data",
+      "selectEncoding": "Seleziona la codifica...",
+      "selectATemplate": "Seleziona un modello...",
+      "selectVersion": "Seleziona la versione",
+      "selectAModel": "Seleziona un modello",
+      "selectWorkflowType": "Seleziona il tipo di flusso di lavoro",
+      "addAnOption": "Aggiungi un'opzione",
+      "addADescription": "Aggiungi una descrizione...",
+      "optionalDescription": "Descrizione facoltativa...",
+      "projectNotes": "Note sul progetto...",
+      "filterByName": "Filtra per nome...",
+      "filterByValue": "Filtra per valore...",
+      "selectOperator": "Seleziona l'operatore",
+      "searchIcons": "Icone di ricerca...",
+      "value": "Valore",
+      "stepCount": "conteggio dei passi",
+      "enterText": "Inserisci il testo...",
+      "enterUrl": "Inserisci URL",
+      "issueIdExample": "NUMERO 123",
+      "selectPriorityValuesOrEmpty": "Seleziona i valori di priorità (oppure lascia vuoto per tutte le priorità)"
+    },
+    "errors": {
+      "error": "Errore",
+      "somethingWentWrong": "Si è verificato un errore imprevisto. Riprova più tardi.",
+      "emailRequired": "Inserisci il tuo indirizzo email.",
+      "emailInvalid": "Questo non è un indirizzo email valido.",
+      "passwordRequired": "È richiesta la password.",
+      "confirmPasswordRequired": "Conferma la tua password.",
+      "passwordDoesNotMeetPolicy": "La password non soddisfa i requisiti di sicurezza.",
+      "passwordsDoNotMatch": "Le password non corrispondono",
+      "nameRequired": "Inserisci il tuo nome completo",
+      "duplicate": "Si prega di scegliere un nome univoco.",
+      "userExists": "L'utente esiste già.",
+      "unknown": "Si è verificato un errore sconosciuto.",
+      "invalidCredentials": "Nome utente o password non validi",
+      "projectNotFound": "Progetto non trovato",
+      "projectNotFoundDescription": "Il progetto che stai cercando non esiste o non hai accesso ad esso.",
+      "tokenRequired": "Inserisci il token di verifica della tua email o clicca sul link nella tua email.",
+      "noSuccessStatus": "Nessuno stato di successo selezionato",
+      "missingTestRunCase": "ID del caso di esecuzione del test mancante",
+      "fieldRequired": "Questo campo è obbligatorio",
+      "projectNameExists": "Esiste già un progetto con questo nome",
+      "defaultNotFound": "Valore predefinito non trovato",
+      "emailExists": "Esiste già un utente con questa email",
+      "nameExists": "Esiste già un utente con questo nome",
+      "duplicateValue": "Questo valore è già in uso",
+      "unauthorized": "Non sei autorizzato a eseguire questa azione.",
+      "accessDenied": "Accesso negato",
+      "sessionNotFound": "Sessione non trovata o non valida.",
+      "issueTrackerNotConfigured": "Il tracker dei problemi non è configurato per questo progetto.",
+      "noUserSession": "Nessuna sessione utente trovata",
+      "noProjectId": "Nessun ID progetto trovato",
+      "unknownErrorWithMessage": "Si è verificato un errore sconosciuto. {message}",
+      "unauthenticated": "Utente non autenticato",
+      "fetchFailed": "Impossibile recuperare i dati. Riprova più tardi.",
+      "unsupportedFieldType": "Tipo di campo non supportato",
+      "notAuthenticated": {
+        "title": "Non autenticato",
+        "message": "Devi aver effettuato l'accesso per eseguire questa azione."
+      },
+      "failedToFetchAssignments": {
+        "title": "Impossibile recuperare le assegnazioni",
+        "message": "Impossibile recuperare le assegnazioni. Riprova più tardi."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Problema collegato correttamente",
+        "linkError": "Errore durante il collegamento",
+        "unlinkedSuccess": "Problema scollegato correttamente",
+        "unlinkError": "Errore durante lo scollegamento",
+        "noActiveIntegration": "Nessuna integrazione attiva trovata per questo progetto"
+      },
+      "roleRequiredForSpecificRole": "Il ruolo è obbligatorio quando il tipo di accesso è Ruolo specifico.",
+      "projectCreationFailed": "Creazione del progetto non riuscita, nessun ID restituito.",
+      "invalidRoleId": "ID ruolo non valido",
+      "workflowStateExists": "Lo stato del flusso di lavoro esiste già. Scegli un nuovo nome.",
+      "failedToLoadCaseData": "Impossibile caricare i dati del caso. Impossibile salvare.",
+      "atLeastOneTagRequired": "È richiesto almeno un tag",
+      "atLeastOneIssueRequired": "È richiesto almeno un problema",
+      "atLeastOneOptionRequired": "Deve essere selezionata almeno un'opzione",
+      "valueRequired": "Il valore è obbligatorio",
+      "contentRequired": "Il contenuto è obbligatorio",
+      "invalidContentFormat": "Formato del contenuto non valido",
+      "caseNameRequired": "Inserisci un nome per il caso di test",
+      "caseStateRequired": "Seleziona uno Stato",
+      "caseFolderRequired": "Seleziona una cartella",
+      "estimateTooLarge": "La stima è troppo elevata",
+      "estimateRequiredValid": "È necessario fornire una stima di durata valida (ad esempio, 1 ora e 30 minuti).",
+      "invalidDurationOrExceedsMax": "Formato della durata non valido o supera il limite massimo (ad esempio, 1h 30m)",
+      "configurationNameExists": "Il nome della configurazione esiste già. Scegli un nome diverso.",
+      "variantNameExists": "Il nome della variante esiste già. Scegli un nome diverso.",
+      "categoryNameExists": "Il nome della categoria esiste già. Scegli un nome diverso.",
+      "workflowStateNameExists": "Il nome dello stato del flusso di lavoro esiste già. Scegli un nome diverso.",
+      "folderNameRequired": "Inserisci un nome per la cartella",
+      "folderNameRequiredEnter": "Inserisci un nome per la cartella.",
+      "workflowStateNameRequired": "Inserisci un nome per lo stato del flusso di lavoro",
+      "roleNameEmpty": "Il nome del ruolo non può essere vuoto",
+      "groupNameRequired": "Il nome del gruppo è obbligatorio",
+      "templateNameRequired": "Inserisci un nome per il modello",
+      "caseStateInvalid": "Seleziona uno Stato valido",
+      "caseTemplateRequired": "Seleziona un modello",
+      "invalidContent": "Contenuto non valido",
+      "milestoneNameRequired": "Inserisci un nome per la pietra miliare",
+      "milestoneTypeRequired": "Seleziona un tipo di traguardo",
+      "testRunNameMinLength": "Il nome deve essere composto da almeno 2 caratteri.",
+      "stateRequiredDot": "È richiesto lo stato.",
+      "milestoneTypeNameMinLength": "Il nome del tipo di traguardo deve essere di almeno 2 caratteri.",
+      "projectNameRequired": "Il nome del progetto è obbligatorio",
+      "workflowScopeRequired": "Seleziona un flusso di lavoro per lo Stato",
+      "workflowTypeRequired": "Seleziona un tipo di flusso di lavoro",
+      "newTestCaseAdded": "È stato aggiunto un nuovo caso di test.",
+      "repositoryDeleted": "Repository eliminato",
+      "failedToDeleteRepository": "Impossibile eliminare il repository",
+      "permissionDenied": "Non hai l'autorizzazione per accedere a questa pagina.",
+      "resultSubmitPermissionDenied": "Non puoi inviare i risultati per questo caso. Chiedi a un amministratore di progetto di assegnartelo.",
+      "noModelsFound": "Nessun modello trovato",
+      "failedToFetchModels": "Impossibile recuperare i modelli",
+      "failedToCopyToClipboard": "Impossibile copiare negli appunti",
+      "failedToLoadJobResults": "Impossibile caricare i risultati del lavoro",
+      "failedToUpdateRepositoryStatus": "Impossibile aggiornare lo stato del repository"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "Pannello di controllo",
+      "twoFactorVerification": "Verifica a due fattori",
+      "changePassword": "Cambiare la password",
+      "twoFactorSetup": "Configurazione a due fattori",
+      "signUp": "Iscrizione",
+      "signIn": "Registrazione",
+      "verifyEmail": "Verifica l'indirizzo email",
+      "trialExpired": "Prova scaduta",
+      "linkSsoAccount": "Collegamento dell'account SSO",
+      "userProfile": "Profilo utente",
+      "users": "Utenti",
+      "issues": "Problemi",
+      "tags": "Etichette",
+      "tagDetails": "Dettagli del tag",
+      "aiModels": "Modelli di intelligenza artificiale",
+      "integrations": "Integrazioni",
+      "quickscript": "QuickScript",
+      "webhooks": "webhook",
+      "shares": "Azioni",
+      "repository": "Archivio",
+      "testCaseVersion": "Versione del caso di test",
+      "duplicateTestCases": "Casi di test duplicati",
+      "documentation": "Documentazione",
+      "sharedSteps": "Passaggi condivisi",
+      "stepDuplicates": "Passaggi duplicati",
+      "sessions": "Sessioni",
+      "sessionVersion": "Versione di sessione",
+      "milestones": "Traguardi",
+      "testRuns": "Prove di funzionamento",
+      "reports": "Rapporti",
+      "adminSamlConfig": "Amministratore - Configurazione SAML",
+      "apiDocumentation": "Documentazione API",
+      "sharedContent": "Contenuti condivisi"
+    },
+    "aria": {
+      "userMenu": "Menu utente",
+      "search": "Ricerca",
+      "helpMenu": "Menu Aiuto",
+      "help": "Aiuto",
+      "grouped": "Raggruppati",
+      "group": "Gruppo",
+      "selectAll": "Seleziona tutto",
+      "selectRow": "Seleziona riga",
+      "removeIssue": "Rimuovi il problema",
+      "selectDeselectAllAddEdit": "Seleziona/Deseleziona tutto Aggiungi/Modifica",
+      "selectDeselectAllDelete": "Seleziona/Deseleziona tutto Elimina",
+      "selectDeselectAllClose": "Seleziona/Deseleziona tutto Chiudi",
+      "clearFilter": "Filtro trasparente",
+      "olderVersion": "Versione precedente",
+      "newerVersion": "Versione più recente",
+      "deletedUser": "Utente eliminato",
+      "restrictedField": "Campo riservato",
+      "backToTestCase": "Torna al caso di test"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Progetto} other {# Progetti}}",
+      "templates": "Modelli e campi",
+      "workflows": "Flussi di lavoro",
+      "statuses": "Stati",
+      "roles": "Ruoli",
+      "unknownRole": "Ruolo sconosciuto",
+      "unknownGroup": "Gruppo sconosciuto",
+      "file": "file",
+      "files": "file",
+      "existingAttachments": "Allegati esistenti",
+      "new": "Nuovo",
+      "noElapsedTime": "Nessun tempo registrato",
+      "untested": "Non testato",
+      "noResults": "Nessun risultato",
+      "resultsWithNoElapsedTime": "Nessun tempo registrato per i risultati",
+      "total": "Totale",
+      "noCases": "Nessun caso di prova",
+      "unknown": "Sconosciuto",
+      "selectedTestCases": "Casi di test selezionati",
+      "editToModifyCasesTitle": "Questo elenco non può essere modificato.",
+      "editToModifyCases": "Modificare l'esecuzione del test e fare clic su Casi di test selezionati per modificare l'elenco.",
+      "noTestCasesSelected": "Nessun caso di test selezionato",
+      "editToSelectTestCases": "Modifica l'esecuzione del test per selezionare i casi di test.",
+      "casesInRun": "{count, plural, =0 {Nessun caso di test nell'esecuzione del test} =1 {1 caso di test nell'esecuzione del test} other {# casi di test nell'esecuzione del test}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Caso Unico} other {# Casi Unici}} su {configCount, plural, =1 {1 Configurazione} other {# Configurazioni}} ({totalCount} casi totali)",
+      "viewTestRunDetails": "Visualizza i dettagli dell'esecuzione del test",
+      "sortByStatus": "Raggruppa per stato",
+      "sortByDate": "Ordina per data",
+      "testRuns": "{count, plural, =0 {Nessuna esecuzione di test} =1 {1 esecuzione di test} other {# esecuzioni di test}}",
+      "sessions": "{count, plural, =0 {Nessuna sessione} =1 {1 sessione} other {# sessioni}}",
+      "noOptions": "Nessuna opzione disponibile",
+      "multiConfiguration": "Parte di un gruppo multiconfigurazione",
+      "otherConfigurations": "Altre configurazioni",
+      "selected": "Selezionato: {count}",
+      "defaultProjectAccess": "Accesso predefinito al progetto",
+      "defaultAccessType": "Tipo di accesso predefinito",
+      "assignedUsersCount": "{count, plural, =0 {Nessun utente assegnato} =1 {# Utente assegnato} other {# Utenti assegnati}}",
+      "successRate": "Tasso di successo",
+      "unassigned": "Non assegnato",
+      "testRunName": "Nome dell'esecuzione del test",
+      "estimatesEllipsis": "Stime...",
+      "access": {
+        "noAccess": "Nessun accesso",
+        "globalRole": "Usa ruolo globale",
+        "specificRole": "Ruolo specifico",
+        "projectDefault": "Progetto predefinito",
+        "usersGlobalRole": "Ruolo globale dell'utente"
+      },
+      "unknownUser": "Utente sconosciuto",
+      "unknownProject": "Progetto sconosciuto",
+      "unknownTag": "Tag sconosciuto",
+      "filesSelectedForUpload": "{count, plural, =1 {1 file selezionato per il caricamento} other {# file selezionati per il caricamento}}"
+    },
+    "empty": {
+      "description": "Nessuna descrizione",
+      "documentation": "Nessuna documentazione",
+      "childMilestones": "Nessuna pietra miliare per i bambini",
+      "sessions": "Nessuna sessione",
+      "activeSessions": "Nessuna sessione attiva",
+      "completedSessions": "Nessuna sessione completata",
+      "testCase": "Nessun caso di test trovato",
+      "noTestCasesOrSessions": "Nessun caso di test o sessione trovati",
+      "noTestCasesSessionsOrRuns": "Nessun caso di test, sessione o esecuzione trovati"
+    },
+    "or": "O",
+    "for": "per",
+    "and": "E",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "Logo TestPlanIt",
+      "tagline": "Prova tutto quello che c'è sotto il sole"
+    },
+    "table": {
+      "columns": {
+        "columns": "Colonne",
+        "required": "(necessario)"
+      },
+      "filter": "Elenco filtri...",
+      "selectNone": "Seleziona Nessuno",
+      "sort": "Ordina colonna",
+      "sortAscending": "Ordinato in ordine crescente",
+      "sortDescending": "Ordinato in ordine decrescente",
+      "sortNone": "Non ordinato",
+      "resize": "Ridimensiona colonna"
+    },
+    "pagination": {
+      "selectPage": "Seleziona pagina",
+      "morePages": "Altre pagine",
+      "goToPrevious": "Vai alla pagina precedente",
+      "goToNext": "Vai alla pagina successiva",
+      "all": "Tutti gli articoli",
+      "entries": "{count, plural, =1 {# elemento} other {# elementi}}",
+      "pageSize": "Dimensioni della pagina",
+      "showing": "Mostrando",
+      "total": "totale {count, plural, =1 {# articolo} other {# articoli}}",
+      "filtered": "filtrato da",
+      "pageOfPages": "Pagina {current} di {total}"
+    },
+    "upload": {
+      "title": "Carica una nuova immagine del profilo",
+      "description": "Trascina e rilascia l'immagine oppure clicca sul pulsante qui sotto per selezionare un file.",
+      "attachments": {
+        "title": "Carica allegati",
+        "description": "Trascina e rilascia i tuoi file oppure clicca sul pulsante qui sotto per selezionarli.",
+        "selectFiles": "{count, plural, =0 {Seleziona file} one {1 file selezionato} other {# file selezionati}}",
+        "selectFile": "{count, plural, =0 {Seleziona file} other {1 file selezionato}}",
+        "filesSelected": "{count, plural, one {1 file selezionato} other {# file selezionati}}",
+        "addMoreFiles": "Aggiungi altri file...",
+        "replaceFile": "Sostituisci il file...",
+        "invalidFileType": "Tipo di file non valido. Sono consentiti solo file {types} .",
+        "altText": {
+          "emoji": "emoji"
+        },
+        "count": "{count, plural, =1 {# file} other {# file}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Trascina il file CSV per importare i casi di test",
+      "dropToImportTestResults": "Trascina il file per importare i risultati del test",
+      "supportedCsvFormats": "Formato supportato: .csv",
+      "supportedResultFormats": "Formati supportati: .xml, .trx, .json",
+      "unsupportedFileType": "Tipo di file non supportato. Previsto: {expected}",
+      "noFilesDetected": "Nessun file rilevato nel drop"
+    },
+    "editor": {
+      "setColor": "Imposta colore",
+      "enterUrl": "Inserisci l'URL incluso https://",
+      "uploadFile": "Carica file",
+      "video": {
+        "controls": "Controlli del lettore video"
+      },
+      "image": {
+        "alignLeft": "Allinea a sinistra",
+        "alignCenter": "Allinea il centro",
+        "alignRight": "Allinea a destra",
+        "sizeSmall": "Piccole dimensioni",
+        "sizeMedium": "taglia media",
+        "sizeLarge": "Grandi dimensioni",
+        "sizeFull": "Larghezza intera",
+        "resetSize": "Ripristina le dimensioni originali",
+        "rotate": "Ruota di 90°",
+        "delete": "Elimina immagine"
+      },
+      "table": {
+        "insertTable": "Inserisci tabella",
+        "headerRow": "Riga di intestazione",
+        "addColumnBefore": "Aggiungi colonna prima",
+        "addColumnAfter": "Aggiungi colonna dopo",
+        "deleteColumn": "Elimina colonna",
+        "addRowBefore": "Aggiungi riga prima",
+        "addRowAfter": "Aggiungi riga dopo",
+        "deleteRow": "Elimina riga",
+        "deleteTable": "Elimina tabella"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Aggiungi il paragrafo qui sotto",
+        "clearFormatting": "Formattazione chiara",
+        "copyToClipboard": "Copia negli appunti"
+      },
+      "textMenu": {
+        "bold": "Grassetto",
+        "italic": "Corsivo",
+        "underline": "Sottolineare",
+        "strikethrough": "Barrato",
+        "code": "Codice",
+        "codeBlock": "Blocco di codice",
+        "highlightText": "Evidenzia il testo",
+        "textColor": "Colore del testo",
+        "moreOptions": "Altre opzioni",
+        "subscript": "Abbonamento",
+        "superscript": "Apice",
+        "alignLeft": "Allineare a sinistra",
+        "alignCenter": "Allinea al centro",
+        "alignRight": "Allinea a destra",
+        "justify": "Giustificare",
+        "setLink": "Imposta collegamento",
+        "editLink": "Modifica collegamento",
+        "removeLink": "Rimuovi il collegamento",
+        "resetColorToDefault": "Ripristina il colore predefinito"
+      }
+    },
+    "ai": {
+      "title": "Assistente di scrittura AI",
+      "improveWriting": "Migliorare la scrittura",
+      "makeShorter": "Rendi più breve",
+      "makeLonger": "Rendi più lungo",
+      "fixGrammar": "Correggi la grammatica",
+      "changeTone": "Cambia tono",
+      "professional": "Professionale",
+      "casual": "Casuale",
+      "formal": "Formale",
+      "translate": "Tradurre",
+      "english": "Inglese",
+      "spanish": "spagnolo",
+      "french": "francese",
+      "summarize": "Riassumere",
+      "addExamples": "Aggiungi esempi",
+      "originalText": "Testo originale",
+      "suggestion": "Suggerimento AI",
+      "generating": "Generazione suggerimento in corso...",
+      "noSuggestion": "Nessun suggerimento generato ancora.",
+      "acceptSuggestion": "Accetta suggerimento",
+      "errors": {
+        "contentBlocked": "Il contenuto è stato bloccato dai filtri di sicurezza. Prova a riformulare la tua richiesta con una formulazione diversa.",
+        "emptyContent": "L'IA non è riuscita a generare una risposta. Prova a riformulare la richiesta o riprova più tardi.",
+        "maxTokens": "La risposta dell'IA era troppo lunga ed è stata troncata. Prova una richiesta più breve o chiedi una risposta più concisa.",
+        "rateLimit": "Il servizio AI è temporaneamente non disponibile a causa dei limiti di velocità. Riprova tra qualche minuto.",
+        "accessDenied": "Non hai l'autorizzazione per utilizzare le funzionalità di intelligenza artificiale per questo progetto.",
+        "generic": "Spiacenti, si è verificato un errore durante l'elaborazione della tua richiesta."
+      }
+    },
+    "by": "di",
+    "version": {
+      "prefix": "contro"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Sommario",
+        "emptyMessage": "Inizia ad aggiungere titoli al tuo documento …"
+      },
+      "carousel": {
+        "previousSlide": "Diapositiva precedente",
+        "nextSlide": "Diapositiva successiva"
+      },
+      "dialog": {
+        "toggleFullScreen": "Attiva schermo intero"
+      },
+      "command": {
+        "title": "Menu di comando",
+        "description": "Cerca ed esegui comandi"
+      },
+      "breadcrumb": {
+        "more": "Di più"
+      },
+      "clickToViewDetails": "Clicca per visualizzare i dettagli",
+      "clickToExpand": "Fai clic per espandere",
+      "clickToCollapse": "Fai clic per ridurre",
+      "search": {
+        "filters": "Filtri",
+        "noResultsFound": "Nessun risultato trovato",
+        "loadingProjects": "Caricamento progetti in corso...",
+        "noProjectsFound": "Nessun progetto trovato.",
+        "viewAllProjects": "Visualizza tutti i progetti",
+        "states": "Stati",
+        "automationStatus": "Stato di automazione",
+        "parent": "Genitore"
+      },
+      "issues": {
+        "errorLoadingDetails": "Errore durante il caricamento dei dettagli del problema: ",
+        "updated": "Aggiornato: ",
+        "openInJira": "Apri in Jira",
+        "openInExternalSystem": "Apri in {provider}",
+        "assignee": "Cessionario",
+        "status": "Stato: ",
+        "clickToOpenInNewTab": "Clicca per aprire in una nuova scheda",
+        "url": "URL: ",
+        "externalId": "ID esterno: ",
+        "viewIn": "Visualizza in",
+        "fieldType": "Tipo di campo: ",
+        "richTextContent": "Contenuto di testo avanzato",
+        "invalidContent": "Contenuto non valido",
+        "fieldInformation": "Informazioni sul campo"
+      },
+      "onboarding": {
+        "skipTour": "Salta il tour"
+      },
+      "charts": {
+        "resultsDistribution": "Distribuzione dei risultati",
+        "statusTimeline": "Cronologia dello stato",
+        "testDurationHistogram": "Istogramma della durata del test",
+        "zoomDonutChart": "Grafico a ciambella Zoom",
+        "zoomStatusTimeline": "Cronologia dello stato dello zoom",
+        "zoomHistogramChart": "Grafico istogramma zoom",
+        "duration": "Durata: {seconds} secondi",
+        "durationLabel": "Durata"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Caricamento informazioni sul tracker dei problemi in corso...",
+      "enterDocumentation": "Inserisci la documentazione...",
+      "noAutomatedTestResults": "Nessun risultato di test automatico trovato per questa esecuzione."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {minuto} other {minuti}}",
+      "seconds": "{count, plural, =1 {secondo} other {secondi}}"
+    },
+    "units": {
+      "time": "Tempo"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {caso} other {casi}}",
+      "result": "{count, plural, =1 {risultato} other {risultati}}",
+      "run": "{count, plural, =1 {esegui} other {esegui}}",
+      "comment": "{count, plural, =1 {{count} commento} other {{count} commenti}}"
+    },
+    "success": {
+      "assigned": "Caso di test assegnato con successo",
+      "unassigned": "Caso di test non assegnato correttamente",
+      "bulkAssigned": "{count, plural, one {# caso di test} other {# casi di test}} assegnato con successo",
+      "bulkUnassigned": "{count, plural, one {# caso di test} other {# casi di test}} non assegnato con successo"
+    },
+    "tabs": {
+      "general": "Generale",
+      "settings": "Impostazioni"
+    },
+    "selectFilter": "Selezionare un valore di filtro per visualizzare i casi di prova.",
+    "invalidProject": "ID progetto non valido.",
+    "visualization": "Visualizzazione",
+    "results": "Risultati",
+    "loading": "Caricamento..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Crea un nuovo account",
+      "sso": {
+        "title": "Accedi con SSO",
+        "googleOAuth": "Continua con Google",
+        "apple": "Continua con Apple",
+        "microsoft": "Continua con Microsoft",
+        "samlProvider": "Accedi con {name}",
+        "magicLink": "Accedi con Magic Link",
+        "emailLogin": "Continua con l'email"
+      },
+      "magicLink": {
+        "description": "Inserisci il tuo indirizzo email e ti invieremo un link sicuro per accedere. Non è richiesta alcuna password. Devi già possedere un account.",
+        "emailPlaceholder": "Inserisci la tua email",
+        "sendLink": "Invia collegamento magico",
+        "sending": "Invio in corso...",
+        "checkEmail": "Controlla la tua email",
+        "success": "Abbiamo inviato un link magico a {email} se hai un account. Clicca sul link nell'email per accedere.",
+        "error": "Impossibile inviare il link magico. Riprova.",
+        "backToSignIn": "Torna alla pagina di accesso"
+      },
+      "twoFactor": {
+        "title": "Autenticazione a due fattori",
+        "description": "Inserisci il codice a 6 cifre generato dalla tua app di autenticazione oppure utilizza un codice di backup."
+      },
+      "troubleSigningIn": "Problemi di accesso?",
+      "contactAdmin": "Contattare l'amministratore di sistema"
+    },
+    "errors": {
+      "accessDenied": "Accesso negato. Il tuo account potrebbe essere inattivo o non hai l'autorizzazione per accedere.",
+      "configuration": "Si è verificato un problema con la configurazione del server.",
+      "verification": "Il token di verifica è scaduto o è già stato utilizzato.",
+      "invalid2FACode": "Codice di verifica non valido. Riprova.",
+      "twoFactorTokenRequired": "È necessario il token",
+      "verificationCodeRequired": "È richiesto il codice di verifica"
+    },
+    "signup": {
+      "description": "Inserisci i tuoi dati per creare un nuovo account.",
+      "signIn": "Accedi al tuo account esistente.",
+      "registrationDisabled": "Contatta un amministratore per creare un account.",
+      "errors": {
+        "emailRequired": "L'email è obbligatoria",
+        "passwordRequired": "La password non soddisfa i requisiti di sicurezza",
+        "confirmPasswordRequired": "Conferma la password",
+        "passwordsDoNotMatch": "Le password non corrispondono",
+        "domainRestricted": "La registrazione è limitata ai domini di posta elettronica approvati. Se ritieni che si tratti di un errore, contatta il tuo amministratore."
+      }
+    },
+    "verifyEmail": {
+      "title": "Verifica email",
+      "loading": "Verifica dell'email in corso...",
+      "success": "Email verificata con successo",
+      "error": "Impossibile verificare l'email",
+      "expired": "Il link di verifica è scaduto",
+      "invalid": "Link di verifica non valido",
+      "alreadyVerified": "Email già verificata",
+      "toast": {
+        "verifySuccess": {
+          "description": "Ora puoi accedere al tuo account."
+        },
+        "verifyError": {
+          "description": "Si è verificato un errore durante la verifica dell'email"
+        },
+        "resendSuccess": {
+          "title": "Link di verifica e-mail inviato",
+          "description": "Controlla la tua email per trovare il link di verifica."
+        },
+        "resendError": {
+          "title": "Impossibile inviare il collegamento di verifica e-mail",
+          "description": "Si è verificato un errore durante l'invio del link di verifica via email."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Configura l'autenticazione a due fattori",
+      "description": "La tua organizzazione richiede l'autenticazione a due fattori. Configurala per continuare.",
+      "backupDescription": "Salva i codici di backup prima di continuare",
+      "required": "L'autenticazione a due fattori è richiesta dalle norme di sicurezza della tua organizzazione.",
+      "loading": "Preparazione dell'installazione in corso...",
+      "manualEntry": "Oppure inserisci manualmente questo codice:",
+      "verifyLabel": "Codice di verifica",
+      "verify": "Verifica e abilita",
+      "backupCodesInfo": "Conserva questi codici in un luogo sicuro. Potrai utilizzarli per accedere al tuo account in caso di smarrimento del dispositivo di autenticazione.",
+      "copyCodes": "Copia tutti i codici",
+      "continue": "Continua ad accedere"
+    },
+    "twoFactorVerify": {
+      "title": "Verifica la tua identità",
+      "description": "Inserisci il codice di 6 cifre visualizzato nell'app di autenticazione per continuare.",
+      "backupCodeLabel": "Codice di backup",
+      "backupCodeHint": "È inoltre possibile inserire un codice di backup di 8 caratteri.",
+      "useAuthenticator": "Utilizzare invece il codice di autenticazione",
+      "useBackupCode": "Utilizzare invece un codice di backup",
+      "signOut": "Disconnettiti e usa un altro account."
+    },
+    "forceChangePassword": {
+      "title": "Cambia la tua password",
+      "adminDescription": "L'amministratore ti richiede di cambiare la password.",
+      "expiredDescription": "La tua password è scaduta. Imposta una nuova password per continuare.",
+      "newPasswordLabel": "Nuova password",
+      "confirmPasswordLabel": "Conferma la nuova password",
+      "submitButton": "Cambiare la password",
+      "signOut": "Disconnettiti invece",
+      "passwordsMustMatch": "Le password non corrispondono.",
+      "passwordRequired": "È richiesta la password.",
+      "genericError": "Si è verificato un errore. Riprova.",
+      "policyTitle": "Requisiti della password:",
+      "policyMinLength": "Almeno {count} caratteri",
+      "policyUppercase": "Almeno una lettera maiuscola",
+      "policyLowercase": "Almeno una lettera minuscola",
+      "policyNumbers": "Almeno un numero",
+      "policySpecialChars": "Almeno un carattere speciale ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "Collega account SSO",
+      "description": "Collega il tuo account a un provider Single Sign-On",
+      "availableProviders": "Fornitori SSO disponibili",
+      "linkWithGoogle": "Collegamento con Google",
+      "linkWithSaml": "Collegamento con {name}",
+      "accountLinked": "Account collegato correttamente",
+      "linkingFailed": "Impossibile collegare l'account",
+      "noProvidersAvailable": "Al momento non sono disponibili provider SSO per il collegamento",
+      "linkingInfo": "Collegando un provider SSO puoi accedere utilizzando quel provider anziché la tua password. I dati del tuo account esistente rimarranno invariati.",
+      "signInWithGoogle": "Accedi con Google",
+      "enterpriseSamlSso": "SSO SAML aziendale",
+      "linkProvider": "Fornitore di link",
+      "linking": "Collegamento in corso...",
+      "noProvidersContactAdmin": "Al momento non sono disponibili provider SSO. Contatta l'amministratore."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Pannello di controllo",
+      "admin": "Amministrazione",
+      "profile": "Profilo"
+    },
+    "admin": {
+      "crossProjectReports": "Rapporti tra progetti"
+    },
+    "projects": {
+      "sections": {
+        "management": "Gestione"
+      },
+      "menu": {
+        "repository": "Deposito",
+        "runs": "Test e risultati"
+      },
+      "dropdown": {
+        "selectProject": "Seleziona un progetto",
+        "selectProjectAriaLabel": "Seleziona progetto {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "ID progetto: {id}",
+      "active": "Il progetto è attivo",
+      "completed": "Il progetto è completato"
+    },
+    "overview": {
+      "title": "Panoramica",
+      "currentMilestones": "Traguardi attuali",
+      "seeAllMilestones": "{count, plural, =1 {Vedi # Milestone} other {Vedi tutti i # Milestone}}",
+      "seeAllTestCases": "{count, plural, =1 {Vedi # Caso di prova} other {Vedi tutti i # Casi di prova}}",
+      "latestTestCases": "Ultimi casi di prova",
+      "createdOn": "Creato il",
+      "seeAllTags": "Vedi tutti i tag",
+      "seeAllActiveSessions": "{count, plural, =1 {Vedi # Sessione attiva} other {Vedi tutte le # Sessioni attive}}",
+      "latestSessions": "Ultime sessioni",
+      "activeTestRuns": "Esecuzioni di test attive",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Vedi # Esecuzione test attiva} other {Vedi tutte le # Esecuzioni test attive}}",
+      "latestTestRuns": "Ultimi test eseguiti",
+      "testCaseBreakdown": "Analisi del caso di prova",
+      "noTestCases": "Il repository del progetto è vuoto. Aggiungi casi di test utilizzando il repository.",
+      "noTestCasesPrefix": "Il repository del progetto è vuoto. Aggiungi i casi di test utilizzando",
+      "noTestCasesLink": "Archivio"
+    },
+    "icon": {
+      "upload": {
+        "title": "Icona di caricamento del progetto",
+        "description": "Carica un'immagine quadrata (rapporto d'aspetto 1:1) fino a 4 MB.",
+        "errors": {
+          "invalidFileType": "Sono consentiti solo file immagine.",
+          "fileTooLarge": "Il file è troppo grande. La dimensione massima è {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Gestisci le impostazioni per {projectName}",
+      "moreSettingsComingSoon": "Altre impostazioni in arrivo prossimamente",
+      "moreSettingsDescription": "Ulteriori opzioni di configurazione del progetto saranno disponibili qui nei futuri aggiornamenti",
+      "integrations": {
+        "description": "Gestisci le integrazioni di problemi di terze parti per questo progetto",
+        "availableIntegrations": "Integrazioni di problemi disponibili",
+        "availableDescription": "Seleziona un'integrazione di problemi per connetterti a questo progetto",
+        "configuredIntegration": "Integrazione configurata",
+        "noIntegrationAssigned": "Nessuna integrazione di problemi assegnata",
+        "noIntegrationDescription": "Seleziona un'integrazione di problemi tra le opzioni disponibili per iniziare",
+        "selectIntegration": "Seleziona un'integrazione di problemi da configurare",
+        "integration": {
+          "assignError": "Impossibile assegnare l'integrazione del problema",
+          "updateSuccess": "Impostazioni di integrazione aggiornate",
+          "updateError": "Impossibile aggiornare le impostazioni di integrazione del problema",
+          "removeError": "Impossibile rimuovere l'integrazione del problema",
+          "removeIntegration": "Rimuovi integrazione",
+          "confirmRemove": "Conferma la rimozione",
+          "authDescription": "Devi autenticarti con {provider} per utilizzare questa integrazione dei problemi",
+          "authenticating": "Autenticazione in corso...",
+          "authSuccess": "Autenticazione riuscita",
+          "selectProject": "Seleziona {provider} Progetto",
+          "selectProjectPlaceholder": "Scegli un progetto da collegare",
+          "linkedProject": "Progetto collegato",
+          "loadProjectsError": "Impossibile caricare i progetti",
+          "settingsSaved": "Impostazioni di integrazione salvate correttamente",
+          "saveSettingsError": "Impossibile salvare le impostazioni di integrazione del problema",
+          "authorizationRequired": "Autorizzazione richiesta",
+          "authenticationError": "Autenticazione non riuscita. Riprova.",
+          "authorizationRequiredDescription": "È necessario autorizzare questa integrazione del problema per accedere ai progetti esterni",
+          "authorizationMessage": "Si prega di autorizzare l'integrazione del problema per continuare",
+          "authorizeIntegration": "Autorizza {name}",
+          "integrationSettings": "{name} Impostazioni",
+          "integrationSettingsDescription": "Configura le impostazioni di integrazione dei problemi per questo progetto",
+          "selectExternalProject": "Seleziona progetto esterno",
+          "refreshProjects": "Aggiorna progetti",
+          "defaultIssueType": "Tipo di problema predefinito",
+          "selectDefaultIssueType": "Seleziona il tipo di problema predefinito",
+          "defaultIssueTypeDescription": "Questo tipo di problema verrà preselezionato quando si creano nuovi problemi",
+          "issueTypePlaceholder": "ad esempio, Bug, Attività, Storia",
+          "defaultComponent": "Componente predefinito",
+          "componentPlaceholder": "ad esempio, Frontend, Backend",
+          "automaticSync": "Sincronizzazione automatica",
+          "automaticSyncDescription": "Sincronizza automaticamente i problemi tra TestPlanIt e il sistema esterno",
+          "simpleUrlDescription": "Questa integrazione dei problemi utilizza un semplice modello URL per collegarsi ai problemi esterni. I problemi verranno aperti in una nuova scheda utilizzando il modello URL configurato.",
+          "externalProjectHelp": "Questo imposta il progetto predefinito per la creazione di nuovi problemi da TestPlanIt. È comunque possibile collegare e sincronizzare problemi da altri progetti esterni: ogni problema tiene traccia del proprio progetto sorgente.",
+          "linkedProjects": "Progetti esterni collegati",
+          "linkedProjectsDescription": "Progetti esterni collegati tramite questa integrazione",
+          "noLinkedProjects": "Nessun progetto esterno collegato",
+          "noLinkedProjectsDescription": "Aggiungi un progetto esterno per abilitare la ricerca e la sincronizzazione dei problemi.",
+          "addProjects": "Aggiungi progetti",
+          "addSelected": "Aggiungi selezionati",
+          "setAsDefault": "Imposta come predefinito",
+          "removeProject": "Rimuovi progetto",
+          "removeProjectConfirmation": "Rimuovendo questo progetto, la sincronizzazione dei problemi verrà interrotta. I problemi precedentemente sincronizzati non verranno eliminati. Continuare?",
+          "removeProjectWebhookCascadeBullet": "Anche il webhook in entrata per questo progetto verrà rimosso.",
+          "keepProject": "Mantieni il progetto",
+          "defaultIndicator": "Predefinito",
+          "syncStatusSyncing": "Sincronizzazione",
+          "syncStatusCompleted": "Sincronizzato",
+          "syncStatusError": "Errore di sincronizzazione",
+          "fanOutPartialFailure": "Impossibile raggiungere il/i progetto/i {count} . Vengono visualizzati i risultati del/i progetto/i {successCount}.",
+          "projectSelectorLabel": "Progetto",
+          "defaultIssueTypeHelp": "Quando si creano nuovi problemi da TestPlanIt, questo tipo di problema verrà selezionato automaticamente. Questo consente di risparmiare tempo se si creano solitamente problemi dello stesso tipo.",
+          "automaticSyncHelp": "Se abilitata, la sincronizzazione dei problemi verrà eseguita automaticamente quando vengono rilevate modifiche nel sistema esterno (tramite webhook). La sincronizzazione manuale è sempre disponibile.",
+          "removeWarningTitle": "La rimozione di questa integrazione del problema comporterà:",
+          "removeWarning1": "Disconnetti tutti i problemi collegati da questa integrazione dei problemi (i problemi rimangono nel database)",
+          "removeWarning2": "Rimuovi tutte le impostazioni specifiche dell'integrazione dei problemi per questo progetto",
+          "removeWarning3": "Richiedi una riconfigurazione se vuoi utilizzare nuovamente questa integrazione dei problemi",
+          "removeWarning4": "Rimuovi il webhook in entrata configurato per questa integrazione",
+          "switchIntegration": "Integrazione degli switch",
+          "switchWarningTitle": "Il passaggio a un modello di IA diverso comporterà:",
+          "switchWarning1": "Disconnetti tutti i problemi attualmente collegati all'integrazione del problema corrente",
+          "switchWarning2": "Conserva i problemi nel database (non vengono più collegati)",
+          "switchWarning3": "Sostituisci la configurazione di integrazione del problema corrente con quella nuova",
+          "switchWarning4": "Rimuovere il webhook in entrata configurato per l'integrazione corrente"
+        },
+        "integrationAssigned": "Integrazione assegnata con successo",
+        "integrationAssignError": "Impossibile assegnare l'integrazione del problema al progetto",
+        "integrationRemoved": "Integrazione rimossa con successo",
+        "integrationRemoveError": "Impossibile rimuovere l'integrazione del problema dal progetto",
+        "add": {
+          "jira": {
+            "description": "Collega il tuo account Jira per gestire i problemi direttamente da TestPlanIt."
+          },
+          "simple_url": {
+            "description": "Connettersi a un sistema di terze parti per il monitoraggio dei problemi."
+          },
+          "github": {
+            "description": "Collegati a GitHub per il monitoraggio dei problemi e la gestione del repository."
+          },
+          "gitlab": {
+            "description": "Collegati a GitLab per tenere traccia dei problemi e delle richieste di merge."
+          },
+          "gitea": {
+            "description": "Connettiti a un'istanza self-hosted di Gitea, Forgejo o Gogs per il monitoraggio dei problemi."
+          },
+          "azure_devops": {
+            "description": "Connettiti ad Azure DevOps per il monitoraggio degli elementi di lavoro."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Configura i webhook in entrata per mantenere sincronizzati i ticket collegati.",
+        "inboundDescription": "Configura i webhook in entrata per mantenere sincronizzati i ticket collegati.",
+        "outboundDescription": "Configura i webhook in uscita per inviare gli eventi di TestPlanIt a Slack o a qualsiasi URL firmato da HMAC.",
+        "directionInbound": "In entrata",
+        "directionOutbound": "In uscita",
+        "inboundAddButtonAllConfigured": "L'adattatore in entrata è già configurato.",
+        "inboundAddButtonNoIntegration": "Assegna un'integrazione di tipo Issue a questo progetto prima di aggiungere un webhook in entrata.",
+        "inboundEmptyWithIntegration": "Nessun webhook in entrata configurato. <link>Aggiungine uno</link> per ricevere aggiornamenti sui problemi dall'integrazione dei problemi assegnata.",
+        "inboundEmptyNoIntegration": "Per ricevere aggiornamenti sui problemi in entrata è necessaria un'integrazione <link>Issue Integration</link> . Assegnane una al tuo progetto per iniziare.",
+        "deliveriesEmptyNoConfigs": "Nessuna consegna tramite webhook al momento: crea un webhook in entrata o in uscita nelle altre schede per iniziare a riceverli.",
+        "noConfig": "Nessun webhook configurato",
+        "createButton": "Crea webhook",
+        "url": "URL del webhook",
+        "urlHelp": "Incolla questo URL nella configurazione del webhook del sistema di tracciamento dei problemi.",
+        "secret": "Segreto del webhook",
+        "secretHelp": "Incolla questo segreto nella configurazione del webhook del sistema di tracciamento dei problemi.",
+        "revealedShownOnceWarning": "Copia ora l'URL e la chiave segreta qui sotto: verranno mostrati una sola volta e non potranno essere recuperati in seguito.",
+        "secretMasked": "Nascosto — ruota per visualizzarlo",
+        "rotateSecret": "ruotare segreto",
+        "rotateConfirmTitle": "Ruotare il segreto del webhook?",
+        "rotateConfirm": "La rotazione del segreto invaliderà la configurazione corrente sul sistema di tracciamento dei problemi finché non la aggiornerai. Continuare?",
+        "isActive": "Abilitato",
+        "deleteConfirmTitle": "Eliminare la configurazione del webhook?",
+        "deleteConfirm": "Eliminare questa configurazione del webhook? Le consegne in entrata verranno rifiutate.",
+        "sendTest": "Invia webhook di prova",
+        "testSuccess": "Test webhook accettato (HTTP {statusCode}, risultato: {outcome})",
+        "testFailure": "Test webhook non riuscito (HTTP {statusCode}): {error}",
+        "saveError": "Impossibile salvare la configurazione del webhook",
+        "lastReceived": "Ultimo ricevuto: {timestamp}",
+        "lastReceivedLabel": "Ultimo aggiornamento:",
+        "lastReceivedNever": "Nessuna consegna ancora",
+        "copyUrl": "Copia l'URL del webhook",
+        "copySecret": "Copia il segreto del webhook",
+        "urlCopied": "URL del webhook copiato negli appunti",
+        "secretCopied": "Segreto del webhook copiato negli appunti",
+        "nextSteps": "Successivamente: incolla questi elementi nella configurazione del webhook del sistema di tracciamento dei problemi, quindi fai clic su \"Invia webhook di prova\" qui sotto per verificare la pipeline. Fai clic su \"Fine\" dopo aver salvato il segreto: non potrà essere visualizzato di nuovo.",
+        "revealDone": "Fatto",
+        "pageTitle": "Webhooks",
+        "inboundTab": "In entrata",
+        "outboundTab": "In uscita",
+        "outboundEmpty": "Nessun webhook in uscita configurato. Aggiungine uno per inviare gli eventi di TestPlanIt a Slack o a qualsiasi URL firmato da HMAC.",
+        "outboundAddButton": "Aggiungi webhook in uscita",
+        "outboundCreateTitle": "Nuovo webhook in uscita",
+        "outboundCreateName": "Nome",
+        "outboundCreateNameHelp": "Un'etichetta per questa destinazione, ad esempio \"Engineering Slack\".",
+        "outboundCreateNamePlaceholder": "Engineering Slack",
+        "outboundCreateNameRequired": "Il nome è obbligatorio.",
+        "outboundCreateUrlRequired": "È richiesto l'URL.",
+        "outboundCreateUrlInvalid": "Inserisci un URL valido (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "L'URL deve utilizzare HTTPS",
+        "outboundNameLabel": "Nome",
+        "outboundUnnamedConfig": "(webhook senza nome)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "L'URL di destinazione. Gli URL dei webhook in entrata di Slack vengono rilevati automaticamente.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Rilevato: Slack",
+        "outboundDetectedHmac": "Rilevato: HMAC generico",
+        "adapterLabelSlack": "Slack",
+        "adapterLabelGenericHmac": "Webhook HMAC generico",
+        "outboundCreateSubscriptionsTitle": "Abbonamenti",
+        "outboundCreateSubscriptionsHelp": "Scegli quali eventi vengono inviati a questa destinazione. Potrai modificarli in seguito.",
+        "outboundSubsTestRunsAndSessions": "Prove e sessioni",
+        "outboundSubsTestRuns": "Prove di funzionamento",
+        "outboundSubsSessions": "Sessioni",
+        "eventVerbs": {
+          "duplicated": "Duplicato",
+          "stateChanged": "Lo stato è cambiato",
+          "resultAdded": "Risultato aggiunto"
+        },
+        "events": {
+          "testRunCreated": "Esecuzione di prova creata",
+          "testRunStateChanged": "Lo stato di esecuzione del test è cambiato",
+          "testRunCompleted": "Test completato",
+          "testRunDuplicated": "Esecuzione del test duplicata",
+          "testRunResultAdded": "Risultato del test aggiunto",
+          "sessionCreated": "Sessione creata",
+          "sessionStateChanged": "Stato della sessione modificato",
+          "sessionCompleted": "Sessione completata",
+          "sessionDuplicated": "Sessione duplicata",
+          "sessionResultAdded": "Risultato della sessione aggiunto",
+          "issueCreated": "Problema creato",
+          "issueUpdated": "Problema aggiornato",
+          "issueDeleted": "Problema eliminato",
+          "caseCreated": "Caso creato",
+          "caseUpdated": "Caso aggiornato",
+          "caseDeleted": "Caso eliminato",
+          "jiraIssueCreated": "Problema Jira creato",
+          "jiraIssueUpdated": "Problema Jira aggiornato",
+          "jiraIssueDeleted": "Problema Jira eliminato",
+          "githubIssues": "Evento relativo ai problemi di GitHub",
+          "githubPullRequest": "Richiesta di pull su GitHub",
+          "githubPush": "Push su GitHub",
+          "githubIssueComment": "Commento al problema su GitHub",
+          "adoWorkitemCreated": "Elemento di lavoro Azure DevOps creato",
+          "adoWorkitemUpdated": "Elemento di lavoro di Azure DevOps aggiornato",
+          "adoWorkitemDeleted": "Elemento di lavoro di Azure DevOps eliminato",
+          "webhookTest": "Evento di prova"
+        },
+        "outboundSubsIssues": "Problemi",
+        "outboundSubsCases": "Casi",
+        "outboundSubsSelectAll": "Seleziona tutto in questa sezione",
+        "outboundCreateSubmit": "Crea webhook",
+        "outboundCreateCancel": "Cancellare",
+        "outboundCreateSuccess": "Webhook in uscita creato.",
+        "outboundCreateError": "Impossibile creare il webhook in uscita.",
+        "outboundUrlLabel": "URL di destinazione",
+        "outboundActiveToggle": "Attivo",
+        "outboundSlackHint": "Questo URL è sensibile: chiunque lo possieda può pubblicare sul tuo canale.",
+        "outboundHmacSecretsTitle": "Segreti della firma",
+        "outboundHmacActiveSecret": "Attivo",
+        "outboundHmacInactiveSecret": "Inattivo",
+        "outboundHmacRetiringSecret": "Andare in pensione",
+        "outboundHmacAutoRetireIn": "Si ritira automaticamente tra {days} giorni",
+        "outboundHmacRotateButton": "ruotare segreto",
+        "outboundHmacExtendButton": "Prolunga di 7 giorni",
+        "outboundHmacRetireNowButton": "Vai in pensione ora",
+        "outboundRotateConfirmTitle": "Ruotare il segreto di firma?",
+        "outboundRotateConfirm": "Viene generato un nuovo segreto attivo. Il segreto precedente continua a essere valido per 7 giorni, durante i quali i consumatori si aggiornano.",
+        "outboundRotateSuccess": "Il segreto è stato ruotato. Il nuovo testo in chiaro viene mostrato una volta qui sotto.",
+        "outboundRotateError": "Impossibile ruotare il segreto.",
+        "outboundRetireConfirmTitle": "Ritirare il segreto ora?",
+        "outboundRetireConfirm": "Il segreto in scadenza cessa immediatamente di essere utilizzato per la firma. I consumatori che utilizzano ancora il vecchio segreto rifiuteranno i nuovi payload.",
+        "outboundRetireSuccess": "Segreto ritirato.",
+        "outboundRetireError": "Non è riuscito a ritirare il segreto.",
+        "outboundExtendSuccess": "Il pensionamento automatico è stato prorogato di 7 giorni.",
+        "outboundExtendError": "Impossibile estendere il segreto.",
+        "outboundSendTestButton": "Invia evento di prova",
+        "outboundSendTestQueued": "Evento di prova in coda: controlla la destinazione per il messaggio.",
+        "outboundSendTestError": "Impossibile mettere in coda l'evento di test.",
+        "outboundDeleteButton": "Elimina il webhook",
+        "outboundDeleteConfirmTitle": "Eliminare il webhook in uscita?",
+        "outboundDeleteConfirm": "Tutti gli eventi futuri relativi a questa destinazione vengono interrotti immediatamente.",
+        "outboundDeleteSuccess": "Webhook eliminato.",
+        "outboundDeleteError": "Impossibile eliminare il webhook.",
+        "outboundSecretCopy": "Copia il segreto",
+        "outboundSecretShownOnce": "Custodisci questo segreto ora: non potrà più essere rivelato.",
+        "outboundSecretDone": "Fatto",
+        "inboundAddButton": "Aggiungi webhook in entrata",
+        "inboundChooserTitle": "Scegli l'adattatore",
+        "inboundChooserDescription": "Seleziona il sistema di tracciamento dei problemi che invierà i webhook a TestPlanIt. Ogni progetto può avere un webhook in entrata da Jira, uno da GitHub e uno da Azure DevOps.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Già configurato",
+        "inboundChooserSubmit": "Continuare",
+        "inboundChooserCancel": "Cancellare",
+        "inboundEmpty": "Nessun webhook in entrata configurato. Aggiungine uno per ricevere aggiornamenti sui ticket da Jira, GitHub, GitLab, Gitea o Azure DevOps.",
+        "inboundJiraTitle": "Webhook in entrata di Jira",
+        "inboundGithubTitle": "Webhook in entrata di GitHub",
+        "inboundGithubScopeHint": "GitHub <code>issue</code> eventi aggiornano le issue di TestPlanIt collegate. Gli eventi relativi alle pull request e ai commenti sulle issue sono accettati ma non aggiornano ancora le issue.",
+        "inboundGitlabTitle": "Webhook in entrata di GitLab",
+        "inboundGitlabScopeHint": "Gli eventi di GitLab <code>Issue Hook</code> aggiornano i ticket di TestPlanIt collegati. Altri tipi di eventi sono accettati ma non aggiornano i ticket.",
+        "inboundGiteaTitle": "Webhook in entrata di Gitea",
+        "inboundGiteaScopeHint": "Gitea <code>problemi</code> gli eventi aggiornano i problemi di TestPlanIt collegati. Altri tipi di eventi sono accettati ma non aggiornano i problemi.",
+        "inboundAdoTitle": "Webhook in entrata di Azure DevOps",
+        "inboundAdoScopeHint": "Gli eventi di Azure DevOps <code>workitem.updated</code> aggiornano i ticket di TestPlanIt collegati. Altri eventi sono accettati ma non aggiornano i ticket.",
+        "inboundAdoUsername": "Nome utente",
+        "inboundAdoPassword": "Password",
+        "inboundAdoUsernamePlaceholder": "conto di servizio",
+        "inboundAdoUsernameHelp": "Configurato sul lato Azure DevOps Service Hook. TestPlanIt lo verifica tramite autenticazione HTTP di base.",
+        "inboundAdoPasswordHelp": "Archiviato in forma crittografata a riposo. Salvare questo valore anche sul lato Azure DevOps Service Hook.",
+        "inboundAdoResourceDetailsHint": "Quando si configura l'hook del servizio Azure DevOps, impostare \"Dettagli della risorsa da inviare\" = \"Tutti\" in modo che System.State sia incluso nel payload.",
+        "setupStepsTitle": "Passaggi di configurazione",
+        "setupStepsJiraStep1": "In Jira, vai su Impostazioni → Sistema → Webhook (oppure alla pagina di configurazione dei webhook dell'amministratore di Jira).",
+        "setupStepsJiraStep2": "Fai clic su \"Crea un Webhook\". Incolla l'URL seguente nel campo URL e il segreto nel campo Segreto.",
+        "setupStepsJiraStep3": "Nella sezione \"Eventi relativi al problema\", seleziona \"aggiornato\" affinché le modifiche allo stato del problema vengano inviate.",
+        "setupStepsJiraStep4": "Salva il webhook. Utilizza \"Invia webhook di prova\" qui sotto per verificare la pipeline.",
+        "setupStepsGithubStep1": "Nel tuo repository GitHub, vai su Impostazioni → Webhooks → Aggiungi webhook.",
+        "setupStepsGithubStep2": "Incolla l'URL seguente nel campo URL del payload. Imposta il tipo di contenuto su application/json.",
+        "setupStepsGithubStep3": "Incolla il segreto qui sotto nel campo Segreto.",
+        "setupStepsGithubStep4": "Seleziona \"Consenti la selezione di singoli eventi\" e spunta la casella \"Problemi\".",
+        "setupStepsGithubStep5": "Fai clic su \"Aggiungi webhook\". Utilizza \"Invia webhook di prova\" qui sotto per verificare la pipeline.",
+        "setupStepsAdoStep1": "Nel tuo progetto Azure DevOps, vai a Impostazioni progetto → Hook di servizio → Crea sottoscrizione.",
+        "setupStepsAdoStep2": "Seleziona \"Web Hooks\" come servizio. Imposta il trigger su \"Elemento di lavoro aggiornato\".",
+        "setupStepsAdoStep3": "Imposta i dettagli della risorsa da inviare su Tutti in modo che System.State sia incluso.",
+        "setupStepsAdoStep4": "Incolla l'URL seguente nel campo URL. Imposta nome utente e password per l'autenticazione di base con i valori inseriti in precedenza.",
+        "setupStepsAdoStep5": "Salva l'abbonamento. Utilizza \"Invia webhook di prova\" qui sotto per verificare la pipeline.",
+        "setupStepsGitlabStep1": "In GitLab, vai al tuo progetto → Impostazioni → Webhooks.",
+        "setupStepsGitlabStep2": "Incolla l'URL qui sotto nel campo URL. Incolla il segreto qui sotto nel campo Token segreto.",
+        "setupStepsGitlabStep3": "Nella sezione Trigger, selezionare \"Eventi relativi ai problemi\".",
+        "setupStepsGitlabStep4": "Fai clic su \"Aggiungi webhook\". Utilizza \"Invia webhook di prova\" qui sotto per verificare la pipeline.",
+        "setupStepsGiteaStep1": "In Gitea, vai al tuo repository → Impostazioni → Webhooks.",
+        "setupStepsGiteaStep2": "Fai clic su \"Aggiungi Webhook\" e scegli \"Gitea\".",
+        "setupStepsGiteaStep3": "Incolla l'URL qui sotto nel campo URL di destinazione. Incolla il segreto qui sotto nel campo Segreto.",
+        "setupStepsGiteaStep4": "In \"Attivazione\", selezionare \"Problemi\".",
+        "setupStepsGiteaStep5": "Fai clic su \"Aggiungi Webhook\". Utilizza \"Invia webhook di prova\" qui sotto per verificare la pipeline.",
+        "deliveriesTab": "Consegne",
+        "filterConfigPlaceholder": "Tutti i webhook",
+        "filterStatusAll": "Tutto",
+        "filterStatusFailed": "Fallito",
+        "filterStatusSuccess": "Successo",
+        "filterSinceDefault": "Poiché…",
+        "filterUntilDefault": "Fino a…",
+        "filterReset": "Reimposta i filtri",
+        "filterBulkReplayButton": "Riproduzione in blocco {count} errori in uscita",
+        "filterBulkReplayHidden": "Tutti gli errori visibili sono in entrata: riattivare invece l'evento a monte.",
+        "deliveriesEmpty": "Nessuna consegna corrisponde a questi filtri.",
+        "deliveriesResetFilters": "Reimposta i filtri",
+        "deliveriesLoadMore": "Carica altro",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Evento",
+        "tableHeaderStatus": "Stato",
+        "tableHeaderError": "Errore",
+        "tableHeaderReceivedAt": "Ricevuto",
+        "tableHeaderAttempt": "Tentativo",
+        "tableHeaderDirection": "Direzione",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Visualizza i dettagli",
+        "drawerTitle": "Dettagli di consegna",
+        "drawerLabelEvent": "Evento",
+        "drawerLabelDirection": "Direzione",
+        "drawerLabelStatusCode": "Codice di stato",
+        "drawerLabelLatency": "Latenza",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Errore",
+        "drawerLabelPayloadDigest": "Analisi del carico utile",
+        "drawerLabelEventId": "ID evento",
+        "drawerLabelAttempt": "Tentativo",
+        "drawerLabelReceivedAt": "Ricevuto alle",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Riproduzione di {id}",
+        "drawerReplayButton": "Riproduci questa consegna",
+        "drawerInboundReplayNotSupported": "Le consegne in entrata non possono essere riprodotte: è necessario riattivare l'evento a monte.",
+        "replayConfirmTitle": "Vuoi rigiocare questa consegna?",
+        "replayConfirm": "Questo attiverà una vera richiesta {direction} {adapterType}.",
+        "replayAction": "Rigiocare",
+        "bulkReplayConfirmTitle": "Riproduci gli errori in uscita?",
+        "bulkReplayConfirm": "Riprodurre gli errori in uscita {count} verso {configName}? Questo attiverà {count} richieste HTTP reali.",
+        "bulkReplayCapExceeded": "Riproduzione in blocco limitata a 100 in uscita alla volta. Restringi il filtro o esegui in sequenza. Attualmente {count} verrebbe riprodotto.",
+        "bulkReplayAction": "Riproduci {count}",
+        "healthBadge": {
+          "HEALTHY": "Salutare",
+          "DEGRADED": "Degradato",
+          "DISABLED": "Disabile"
+        },
+        "healthTooltipHealthy": "Ultimo successo: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} fallimenti consecutivi · ultimo a {lastFailureAt}",
+        "healthTooltipDisabled": "Disabilitato dopo 10 errori consecutivi · {lastFailureAt}",
+        "activityLabel": "Attività di consegna",
+        "activityLastDispatched": "Ultimo inviato",
+        "activityLastSuccess": "Ultimo successo",
+        "activityLastFailure": "Ultimo fallimento",
+        "activityNever": "Mai",
+        "reEnable": "Riattiva",
+        "reEnableConfirmTitle": "Riattivare questo webhook?",
+        "reEnableConfirm": "Prima di riattivare il webhook, verifica che il problema a monte sia stato risolto. Il webhook riprenderà immediatamente l'invio.",
+        "toastReplaySuccess": "Riproduzione in coda",
+        "toastReplayFailed": "Riproduzione non riuscita: {error}",
+        "toastReplayInboundNotSupported": "Le consegne in entrata non possono essere riprodotte.",
+        "toastBulkReplaySuccess": "Riproduzione in blocco avviata · batch {batchId}",
+        "toastBulkReplayFailed": "Riproduzione in blocco non riuscita: {error}",
+        "toastReEnableSuccess": "Webhook riattivato",
+        "toastReEnableFailed": "Impossibile riattivare: {error}"
+      },
+      "aiModels": {
+        "description": "Configurare modelli di intelligenza artificiale per la generazione e l'analisi di casi di test intelligenti",
+        "availableModels": "Progetto predefinito",
+        "availableModelsDescription": "Scegli un modello di intelligenza artificiale predefinito per questo progetto tra quelli configurati dall'amministratore di sistema.",
+        "currentModelSettings": "Impostazioni del modello corrente",
+        "currentModelDescription": "Dettagli di configurazione per il modello AI attualmente attivo: {name}",
+        "noModelsAvailable": "Al momento non sono disponibili modelli di intelligenza artificiale. Contatta l'amministratore di sistema per configurare i modelli di intelligenza artificiale per la tua organizzazione.",
+        "monthlyBudget": "Budget mensile",
+        "model": "Modello",
+        "budget": "Bilancio",
+        "streamingTooltip": "Streaming di risposta in tempo reale abilitato",
+        "systemDefault": "Predefinito del sistema",
+        "setAsDefault": "Imposta come predefinito",
+        "clearDefault": "Cancella le impostazioni predefinite",
+        "useForProject": "Utilizzare per il progetto",
+        "removeModel": "Cancella le impostazioni predefinite",
+        "removeWarningTitle": "La cancellazione del modello AI predefinito consentirà di:",
+        "removeWarning1": "Disabilita le funzionalità basate sull'IA a meno che non siano configurate delle eccezioni per ciascuna funzionalità.",
+        "removeWarning2": "Rimuovere il modello di fallback utilizzato per la generazione e l'analisi dei casi di test",
+        "switchModel": "Modifica predefinito",
+        "switchWarningTitle": "La modifica del modello di IA predefinito comporterà:",
+        "switchWarning1": "Cambia il comportamento delle funzionalità AI in questo progetto",
+        "switchWarning2": "Può influenzare la qualità e lo stile del contenuto generato",
+        "modelAssigned": "Modello di intelligenza artificiale predefinito impostato per questo progetto",
+        "modelAssignError": "Impossibile impostare il modello IA predefinito",
+        "modelRemoved": "Modello IA predefinito cancellato",
+        "modelRemoveError": "Impossibile cancellare il modello IA predefinito",
+        "confirmRemove": "Sei sicuro di voler cancellare \"{name}\" come impostazione predefinita per questo progetto?",
+        "confirmSwitch": "Sei sicuro di voler cambiare l'impostazione predefinita da \"{from}\" a \"{to}\"?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/mese"
+        },
+        "promptConfig": "Configurazione rapida",
+        "promptConfigDescription": "Seleziona la configurazione dei prompt di IA da utilizzare per questo progetto.",
+        "useSystemDefault": "Usa le impostazioni predefinite del sistema",
+        "promptConfigChanged": "Configurazione del prompt aggiornata correttamente.",
+        "featureOverrides": {
+          "title": "Sovrascritture LLM per singola funzionalità",
+          "description": "Sovrascrivi l'integrazione LLM predefinita per specifiche funzionalità di intelligenza artificiale. Le sovrascritture hanno la massima priorità nella catena di risoluzione.",
+          "feature": "Caratteristica",
+          "override": "Sovrascrivi",
+          "effectiveLlm": "LLM efficace",
+          "source": "Fonte",
+          "noOverride": "Nooverride",
+          "noLlm": "Nessun LLM (disabilitato)",
+          "disabledOverride": "Disabilitato (Override)",
+          "projectOverride": "Sovrascrittura del progetto",
+          "promptConfig": "Configurazione richiesta",
+          "noLlmConfigured": "Nessun LLM configurato",
+          "selectIntegration": "Seleziona l'integrazione...",
+          "overrideSaved": "Sovrascrittura della funzione salvata",
+          "overrideCleared": "Funzione di override cancellata",
+          "overrideError": "Impossibile salvare la sovrascrittura della funzionalità"
+        }
+      },
+      "shares": {
+        "title": "Gestisci le azioni",
+        "description": "Visualizza e gestisci tutti i link di condivisione per questo progetto"
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Abilita QuickScript e connetti un repository di codice per la generazione di test assistita dall'intelligenza artificiale.",
+        "enableLabel": "Abilita QuickScript",
+        "enableDescription": " Consenti ai membri del team di utilizzare QuickScript per convertire i casi di test in script di automazione in questo progetto.",
+        "enabledToast": "QuickScript abilitato",
+        "disabledToast": "QuickScript disabilitato",
+        "noRepos": {
+          "title": "Nessun repository di codice configurato",
+          "adminDescription": "Configurare una connessione al repository prima di configurare il contesto del codice per questo progetto.",
+          "adminLink": "Vai ai repository del codice",
+          "userDescription": "Contatta l'amministratore di sistema per configurare una connessione al repository del codice."
+        },
+        "repository": {
+          "title": "Repository del codice",
+          "description": "Seleziona il repository di codice da utilizzare per il contesto di IA",
+          "placeholder": "Seleziona un repository di codice...",
+          "branchLabel": "Ramo",
+          "branchPlaceholder": "Lascia vuoto per utilizzare il ramo predefinito del repository"
+        },
+        "pathPatterns": {
+          "title": "Modelli di percorso",
+          "description": "Specifica quali file includere. Ogni riga combina un percorso base e un pattern glob. Esempi: path=tests/e2e/pages + pattern=* include tutti i file direttamente in quella cartella; path=src + pattern=**/*.test.ts include tutti i file di test in modo ricorsivo.",
+          "pathLabel": "Sentiero",
+          "pathPlaceholder": "test/e2e/pagine",
+          "patternLabel": "Modello",
+          "addPath": "Aggiungi percorso",
+          "previewFiles": "Anteprima dei file",
+          "scanningRepo": "Scansione dei file del repository… ({seconds}s)",
+          "files": "{count, plural, one {# file} other {# file}}",
+          "truncatedBadge": "I risultati potrebbero essere incompleti (limite del fornitore).",
+          "exceedsLimit": "La dimensione totale supera il limite del contesto AI di {overflow}. Durante l'esportazione, i file vengono classificati in base alla pertinenza con il caso di test esportato: i file più pertinenti vengono inclusi per primi e quelli con un punteggio inferiore vengono saltati al raggiungimento del budget. Restringi i modelli di percorso se desideri un maggiore controllo sui file inclusi."
+        },
+        "preview": {
+          "resolvingBranch": "Risoluzione del ramo…",
+          "scanningFiles": "Scansione dei file in {scope}…",
+          "scanningFilesCount": "Scansione dei file in {scope}… ({count} trovato)",
+          "filtering": "Applicazione dei filtri ai file {count}…"
+        },
+        "cache": {
+          "title": "Impostazioni della cache",
+          "description": "I file vengono memorizzati nella cache di Valkey per un accesso rapido durante la generazione dell'IA.",
+          "enableLabel": "Abilita la memorizzazione nella cache dei file",
+          "disabledWarning": "La memorizzazione nella cache dei file è disabilitata. I file del repository verranno scaricati direttamente dal tuo provider al momento dell'esportazione e non verranno memorizzati in TestPlanIt. QuickScript, basato sull'intelligenza artificiale, includerà comunque il contesto del codice, ma ogni esportazione effettuerà una richiesta in tempo reale al tuo repository.",
+          "ttlLabel": "Durata della cache (giorni)",
+          "statusTitle": "Stato della cache",
+          "refreshButton": "Aggiorna la cache",
+          "listingFiles": "Elenco dei file…",
+          "cachingFiles": "Memorizzazione nella cache dei file {count} file…",
+          "statusNeverFetched": "Mai recuperato",
+          "statusPending": "Rinfrescante...",
+          "lastFetched": "Ultimo recuperato",
+          "filesCached": "File memorizzati nella cache",
+          "totalSize": "Dimensione totale"
+        },
+        "save": "Salva configurazione",
+        "saved": "Configurazione del contesto del codice salvata",
+        "saveError": "Impossibile salvare la configurazione",
+        "listError": "Impossibile elencare i file del repository",
+        "contentsError": "Impossibile memorizzare nella cache il contenuto del file",
+        "networkError": "Errore di rete durante l'aggiornamento della cache",
+        "refreshSuccess": "Cache aggiornata: {fileCount} file ({contentCached} contenuto memorizzato nella cache)",
+        "refreshRateLimited": "Cache aggiornata: {fileCount} file elencati, {contentCached}/{fileCount} contenuti memorizzati nella cache (frequenza limitata: aggiorna di nuovo per completare)",
+        "validation": {
+          "pathRequired": "Il percorso è richiesto",
+          "patternRequired": "È richiesto un modello",
+          "repositoryRequired": "È richiesto un repository",
+          "pathPatternRequired": "È richiesto almeno uno schema di percorso"
+        },
+        "exportTemplates": {
+          "title": "Esporta modelli",
+          "description": "Assegna i modelli di esportazione a questo progetto. Solo i modelli assegnati verranno visualizzati nella finestra di dialogo di esportazione.",
+          "noTemplates": "Non sono abilitati modelli di esportazione. Contatta l'amministratore di sistema.",
+          "assignedLabel": "Modelli assegnati",
+          "selectPlaceholder": "Seleziona i modelli da assegnare...",
+          "defaultLabel": "Modello predefinito",
+          "defaultPlaceholder": "Nessuno (usa l'impostazione predefinita globale)",
+          "assigned": "Assegnato",
+          "save": "Salva le assegnazioni del modello",
+          "saved": "Assegnazioni modello salvate",
+          "saveError": "Impossibile salvare le assegnazioni del modello."
+        },
+        "disconnect": "Disconnetti il repository",
+        "confirmDisconnect": "Sei sicuro di voler disconnettere \"{name}\" da questo progetto?",
+        "disconnectWarningTitle": "La disconnessione di questo repository comporterà:",
+        "disconnectWarning1": "Rimuovere tutti i file del repository memorizzati nella cache",
+        "disconnectWarning2": "Rimuovi le configurazioni del percorso e del ramo.",
+        "disconnectWarning3": "Smetti di includere il contesto del codice nelle esportazioni generate dall'IA",
+        "disconnectSuccess": "Repository del codice disconnesso",
+        "disconnectError": "Impossibile disconnettere il repository del codice"
+      }
+    }
+  },
+  "milestones": {
+    "title": "Dettagli della pietra miliare",
+    "fields": {
+      "parent": "Traguardo dei genitori",
+      "dueDate": "Scadenza",
+      "automaticCompletion": "Completamento automatico alla data di scadenza",
+      "notifyDaysBefore": "Avvisare con qualche giorno di anticipo rispetto alla data di scadenza.",
+      "notifyDaysBeforeValue": "Avvisami {count, plural, one {# giorni} other {# giorni}} prima della data di scadenza",
+      "dueDateNotifications": "Notifiche di scadenza"
+    },
+    "labels": {
+      "childMilestones": "Tappe fondamentali del bambino"
+    },
+    "placeholders": {
+      "description": "Inserisci la descrizione della pietra miliare...",
+      "documentation": "Inserisci la documentazione relativa alle milestone...",
+      "selectType": "Seleziona il tipo di traguardo...",
+      "selectParent": "Seleziona la pietra miliare principale..."
+    },
+    "empty": {
+      "active": "Nessuna pietra miliare attiva",
+      "completed": "Nessuna pietra miliare completata",
+      "description": "Nessuna descrizione fornita",
+      "documentation": "Nessuna documentazione fornita",
+      "testRuns": "Nessuna prova",
+      "forecasts": "Nessun dato di previsione disponibile"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Non iniziato",
+      "IN_PROGRESS": "In corso",
+      "STOPPED": "Fermato",
+      "BLOCKED": "Bloccato",
+      "CANCELLED": "Annullato",
+      "unscheduled": "Non programmato",
+      "upcoming": "Prossimamente",
+      "delayed": "Ritardato",
+      "pastDue": "Scaduto",
+      "started": "Iniziato",
+      "completed": "Completato"
+    },
+    "status": {
+      "stop": "Fermare",
+      "reopen": "Riaprire"
+    },
+    "dates": {
+      "pickStartDate": "Seleziona la data di inizio",
+      "pickCompletionDate": "Scegli la data di completamento",
+      "selectDate": "Seleziona la data...",
+      "completionWarning": "Attenzione: questo segnerà il traguardo come completato"
+    },
+    "toast": {
+      "deleted": "Milestone {name} eliminato",
+      "updated": "Milestone aggiornato",
+      "updateFailed": "Impossibile aggiornare la milestone",
+      "completed": "Traguardo \"{name}\" completato.",
+      "completedWithDependencies": "Traguardo e dipendenze completati con successo."
+    },
+    "errors": {
+      "nameExists": "Esiste già una pietra miliare con questo nome",
+      "nameRequired": "Il nome della pietra miliare è obbligatorio",
+      "notFound": "Pietra miliare non trovata"
+    },
+    "actions": {
+      "add": "Aggiungi traguardo"
+    },
+    "delete": {
+      "title": "Elimina Milestone",
+      "confirmMessage": "Sei sicuro di voler eliminare la milestone {name}?",
+      "warning": "Questa milestone verrà rimossa dal progetto. I dati storici relativi a questa milestone rimarranno comunque nel progetto.",
+      "toast": {
+        "loading": "Eliminazione della milestone in corso...",
+        "success": "Milestone eliminato con successo",
+        "error": {
+          "title": "Impossibile eliminare la milestone",
+          "description": "Si è verificato un errore durante l'eliminazione della milestone"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Conferma il completamento della milestone",
+      "confirmDescription": "Il completamento di questa pietra miliare comporterà anche il completamento dei seguenti elementi correlati:",
+      "impactActiveTestRuns": "{count, plural, one {# esecuzione test attiva} other {# esecuzioni test attive}}",
+      "impactActiveSessions": "{count, plural, one {# sessione attiva} other {# sessioni attive}}",
+      "impactDescendantMilestones": "{count, plural, one {# milestone discendente} other {# milestone discendenti}}",
+      "completeTestRunsLabel": "Completamento delle esecuzioni di test associate ({count, plural, one {# attivo} other {# attivo}})",
+      "completeSessionsLabel": "Completa le sessioni associate ({count, plural, one {# attive} other {# attive}})",
+      "testRunStateLabel": "Stato di completamento dell'esecuzione del test",
+      "sessionStateLabel": "Stato di completamento della sessione",
+      "itemsRemaining": "I seguenti elementi rimarranno attivi:",
+      "processing": "Elaborazione in corso...",
+      "confirmAndCompleteAll": "Conferma e completa tutto"
+    },
+    "notifications": {
+      "dueSoon": "La tappa \"{name}\" è prevista per il {dueDate}",
+      "overdue": "La tappa \"{name}\" era prevista per il {dueDate}"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Sessione} other {Sessioni}}",
+    "labels": {
+      "totalElapsed": "Tempo trascorso",
+      "remaining": "Rimanenti: {time}",
+      "overtime": "Oltre la stima di: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Nessuna sessione completata corrisponde al tuo filtro."
+    },
+    "filter": {
+      "placeholder": "Filtra sessioni..."
+    },
+    "actions": {
+      "add": "Aggiungi sessione",
+      "create": "Crea nuova sessione",
+      "edit": "Modifica sessione",
+      "complete": "Sessione completa",
+      "delete": "Elimina sessione",
+      "viewSessionDetails": "Visualizza sessione"
+    },
+    "noMilestone": "Nessuna pietra miliare",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Non sono configurati flussi di lavoro di completamento per questo progetto. Configurare i flussi di lavoro nelle impostazioni di amministrazione per abilitare il completamento della sessione."
+    },
+    "messages": {
+      "createSuccess": "Sessione creata con successo",
+      "createSuccessMultiple": "{count} Sessioni create con successo",
+      "duplicateSuccess": "Sessione duplicata con successo",
+      "duplicateSuccessMultiple": "{count} Sessioni duplicate con successo"
+    },
+    "duplicateDialog": {
+      "title": "Sessione duplicata",
+      "description": "Crea una copia della sessione <nameStyle>{name}</nameStyle> con tutti i metadati ma senza risultati."
+    },
+    "errors": {
+      "failedToCreate": "Impossibile creare una nuova sessione",
+      "failedToCreateVersion": "Impossibile creare la versione della sessione",
+      "nameAlreadyExists": "Il nome della sessione esiste già. Scegli un nuovo nome",
+      "createFailed": "Impossibile creare la sessione",
+      "duplicateFailed": "Impossibile duplicare la sessione"
+    },
+    "validation": {
+      "nameMinLength": "Il nome deve essere composto da almeno 2 caratteri.",
+      "templateRequired": "Seleziona un modello",
+      "maxDuration": "La durata deve essere minore o uguale a {max}."
+    },
+    "placeholders": {
+      "estimate": "Stima (ad esempio, 1 ora e 30 minuti)",
+      "elapsed": "Trascorso (ad esempio, 2 giorni e 4 ore)",
+      "selectUser": "Seleziona utente",
+      "estimateHint": "ad esempio, 2h 30m",
+      "noEstimate": "Nessuna stima impostata"
+    },
+    "delete": {
+      "confirmMessage": "Sei sicuro di voler eliminare la sessione {name}?",
+      "warning": "Questa sessione verrà rimossa dal progetto. I dati storici per questa sessione rimarranno comunque nel progetto.",
+      "toast": {
+        "loading": "Eliminazione della sessione...",
+        "success": "Sessione eliminata con successo",
+        "error": {
+          "title": "Impossibile eliminare la sessione",
+          "description": "Si è verificato un errore durante l'eliminazione della sessione"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Sei sicuro di voler completare la sessione {name}?",
+      "warning": "Una volta completata, la sessione verrà archiviata definitivamente e non potrà più essere aggiornata.",
+      "fields": {
+        "completionDate": "Data di completamento"
+      },
+      "placeholders": {
+        "pickDate": "Scegli una data"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Tempo totale stimato rimanente:",
+      "recentResultsTitle": "Riepilogo dei risultati recenti",
+      "recentResultsDescription": "Riepilogo dei risultati della sessione.",
+      "noRecentResults": "Nessun risultato di sessione registrato di recente.",
+      "completionTrendTitle": "Tendenza al completamento",
+      "completionTrendDescription": "Sessioni completate al mese.",
+      "noCompletedRuns": "Nessuna corsa completata trovata negli ultimi 6 mesi.",
+      "completionTrendTitle6Mo": "Tendenza al completamento (ultimi 6 mesi)",
+      "noCompletedSessions6Mo": "Nessuna sessione completata negli ultimi 6 mesi."
+    },
+    "version": {
+      "title": "Visualizzazione cronologia sessione",
+      "notFound": "Versione della sessione non trovata.",
+      "selectVersion": "Seleziona la versione",
+      "backToSession": "Torna alla sessione",
+      "backToLatest": "Torna all'ultima versione",
+      "versionInfo": {
+        "created": "Versione {number} creata",
+        "latestUpdated": "Ultima versione {number} Aggiornata"
+      },
+      "renderer": {
+        "noEstimate": "Nessuna stima",
+        "noTimeLogged": "Nessun tempo registrato",
+        "noContent": "Nessun contenuto",
+        "currentVersion": "Versione corrente",
+        "previousVersion": "Versione precedente"
+      },
+      "diff": {
+        "added": "Aggiunto",
+        "removed": "RIMOSSO",
+        "changed": "Cambiato"
+      }
+    },
+    "results": {
+      "section": "Registro di sessione",
+      "add": "Aggiungi risultato sessione",
+      "edit": "Modifica risultato sessione",
+      "editDescription": "Apportare modifiche al risultato della sessione e fare clic su Salva al termine.",
+      "details": "Inserisci qui i dettagli sul risultato...",
+      "noResults": "Non sono ancora stati aggiunti risultati.",
+      "noNotes": "Nessuna nota aggiunta per questo risultato.",
+      "deleteSuccess": "Risultato della sessione eliminato con successo",
+      "deleteError": "Impossibile eliminare il risultato della sessione",
+      "updateSuccess": "Risultato della sessione aggiornato con successo",
+      "updateError": "Impossibile aggiornare il risultato della sessione",
+      "linkCopied": "Link al risultato della sessione copiato negli appunti",
+      "copyFailed": "Impossibile copiare il collegamento al risultato della sessione",
+      "confirmDelete": {
+        "title": "Elimina risultato sessione",
+        "description": "Sei sicuro di voler eliminare questo risultato della sessione?"
+      }
+    },
+    "notFound": "Sessione non trovata"
+  },
+  "home": {
+    "dashboard": {
+      "title": "La tua dashboard",
+      "users": "Ci sono {count, plural, =1 {# Utente} other {ci sono # Utenti}}",
+      "yourProjects": "I tuoi progetti",
+      "projects": "Hai accesso a {count, plural, =1 {# Progetto} other {# Progetti}}",
+      "loading": "Caricamento dashboard...",
+      "noItems": "In questo momento non ti è stato assegnato nulla che richieda attenzione.",
+      "pendingRuns": "Esecuzioni di test in sospeso",
+      "activeSessions": "Sessioni attive",
+      "yourActiveSessions": "{count, plural, =0 {Nessuna sessione attiva} =1 {# Sessione attiva} other {# Sessioni attive}}",
+      "yourPendingRuns": "{count, plural, =0 {Nessuna esecuzione di test in sospeso} =1 {# Esecuzione di test attiva} other {# Esecuzioni di test attive}}",
+      "yourAssignments": "I tuoi incarichi",
+      "totalTime": "Tempo totale stimato: ",
+      "totalWorkEffort": "Sforzo lavorativo totale: ",
+      "scheduleSpan": "Intervallo di tempo: "
+    },
+    "initialPreferences": {
+      "title": "Imposta le tue preferenze",
+      "description": "Scegli le impostazioni predefinite che meglio si adattano alle tue esigenze. Puoi modificarle in qualsiasi momento dal tuo profilo.",
+      "dateFormat": "Formato data",
+      "timeFormat": "Formato orario",
+      "timezonePlaceholder": "Cerca il fuso orario...",
+      "skip": "Mantieni le impostazioni predefinite",
+      "save": "Salva le preferenze",
+      "success": "Preferenze aggiornate",
+      "error": "Si è verificato un errore durante il salvataggio delle preferenze."
+    },
+    "noAccess": {
+      "title": "Nessun accesso al progetto",
+      "description": "Non hai accesso ad alcun progetto in questo sistema.",
+      "contact": "Contatta l'amministratore di sistema per richiedere l'accesso ai progetti.",
+      "adminAddProject": "Aggiungi il tuo primo progetto per iniziare!",
+      "footer": "L'accesso è necessario per visualizzare e partecipare alle attività di pianificazione dei test."
+    },
+    "noProjectAccess": {
+      "description": "Non hai accesso a questo progetto.",
+      "contact": "Contatta l'amministratore del progetto per richiedere l'accesso."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Casi di test} =1 {# Caso di test} other {# Casi di test}}",
+      "activeMilestones": "{count, plural, =0 {# Traguardi attivi} =1 {# Traguardo attivo} other {# Traguardi attivi}}",
+      "activeRuns": "{count, plural, =0 {# Corse attive} =1 {# Corse attive} other {# Corse attive}}",
+      "activeSessions": "{count, plural, =0 {# Sessioni attive} =1 {# Sessione attiva} other {# Sessioni attive}}",
+      "issues": "{count, plural, =0 {# Problemi} =1 {# Problema} other {# Problemi}}"
+    }
+  },
+  "users": {
+    "description": "Gestisci gli account utente, imposta i livelli di accesso al sistema e assegna i ruoli globali.",
+    "filter": "Filtra utenti...",
+    "profile": {
+      "title": "Profilo utente",
+      "edit": {
+        "title": "Modifica profilo",
+        "timezonePlaceholder": "Seleziona o cerca il fuso orario...",
+        "timezoneRequired": "Il fuso orario è obbligatorio.",
+        "avatarUpdated": "Avatar aggiornato con successo.",
+        "avatarUpdateError": "Impossibile aggiornare l'avatar.",
+        "deleteAvatar": "Elimina Avatar",
+        "deleteAvatarConfirm": "Sei sicuro di voler eliminare il tuo avatar?",
+        "emailDisabledForSso": "L'indirizzo email non può essere modificato per gli account SSO. Aggiornalo tramite il tuo provider di identità.",
+        "emailEditableForBoth": "Puoi accedere sia con email/password che con SSO. Le modifiche all'indirizzo email influiranno solo sull'autenticazione tramite password.",
+        "linkSsoProvider": "Fornitore di collegamento SSO"
+      },
+      "preferences": {
+        "title": "Preferenze"
+      },
+      "access": {
+        "title": "Accesso"
+      },
+      "notifications": {
+        "title": "Preferenze di notifica",
+        "description": "Personalizza il modo in cui ricevi le notifiche",
+        "currentGlobal": "Impostazione globale corrente: {mode}",
+        "mode": {
+          "label": "Modalità di notifica",
+          "useGlobal": "Usa le impostazioni globali"
+        },
+        "options": {
+          "title": "Opzioni aggiuntive",
+          "email": {
+            "label": "Notifiche e-mail",
+            "description": "Ricevi notifiche via email"
+          }
+        },
+        "success": {
+          "title": "Preferenze salvate",
+          "description": "Le tue preferenze di notifica sono state aggiornate"
+        },
+        "error": {
+          "description": "Impossibile salvare le preferenze di notifica"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Cambiare la password",
+        "setPasswordButtonText": "Imposta password",
+        "description": "Inserisci la tua password attuale e una nuova password per modificare la password del tuo account. Questa operazione modificherà solo la password gestita internamente. Se accedi tramite SSO, la password non cambierà.",
+        "setPasswordDescription": "Hai effettuato l'accesso tramite SSO e non hai ancora impostato una password locale. Inserisci una nuova password per abilitare l'accesso tramite email e password per il tuo account.",
+        "currentPasswordLabel": "password attuale",
+        "newPasswordLabel": "Nuova password",
+        "confirmPasswordLabel": "Conferma nuova password",
+        "validation": {
+          "passwordsDoNotMatch": "Le nuove password non corrispondono.",
+          "newPasswordTooShort": "La nuova password non soddisfa i requisiti di sicurezza."
+        },
+        "success": {
+          "passwordChanged": "Password modificata con successo."
+        }
+      },
+      "mentionedComments": {
+        "title": "Citato nei commenti",
+        "description": "Commenti in cui vieni menzionato",
+        "noComments": "Non sei ancora stato menzionato in nessun commento.",
+        "comment": "Commento",
+        "showingResults": "Visualizzazione di {start} - {end} di {total}"
+      },
+      "twoFactor": {
+        "enable": "Abilita l'autenticazione a due fattori",
+        "disable": "Disabilita",
+        "disableNotAllowed": "La tua organizzazione richiede l'autenticazione a due fattori.",
+        "ssoBypassNotice": "Gli accessi SSO aggireranno questa impostazione di autenticazione a due fattori (2FA). Contatta il tuo amministratore per imporre l'autenticazione a due fattori per tutti gli accessi.",
+        "regenerateCodes": "Nuovi codici",
+        "setup": {
+          "description": "Scansiona il codice QR con la tua app di autenticazione (come Google Authenticator o Authy) e inserisci il codice di verifica.",
+          "backupCodesTitle": "Salva i tuoi codici di backup",
+          "done": "Ho salvato i miei codici"
+        },
+        "disableConfirm": {
+          "title": "Disabilitare l'autenticazione a due fattori?",
+          "description": "Questo renderà il tuo account meno sicuro. Inserisci il tuo codice 2FA attuale o un codice di backup per confermare.",
+          "placeholder": "Inserisci il codice"
+        },
+        "regenerate": {
+          "title": "Rigenera i codici di backup",
+          "description": "Questa operazione invaliderà i codici di backup esistenti. Inserisci il tuo codice di autenticazione a due fattori (2FA) attuale per continuare.",
+          "confirm": "Rigenerare i codici",
+          "newCodesTitle": "I tuoi nuovi codici di backup",
+          "newCodesDescription": "I tuoi vecchi codici sono stati invalidati. Conserva questi nuovi codici in un luogo sicuro."
+        }
+      },
+      "apiTokens": {
+        "description": "I token API consentono ad applicazioni e script esterni di accedere a TestPlanIt per tuo conto. I token hanno le stesse autorizzazioni del tuo account.",
+        "create": "Crea token",
+        "createTitle": "Crea un token API",
+        "createDescription": "Crea un nuovo token API per autenticare strumenti e script esterni.",
+        "nameLabel": "Nome del token",
+        "namePlaceholder": "Ad esempio, pipeline CI/CD, strumento CLI",
+        "noTokens": "Nessun token API creato finora.",
+        "expiryLabel": "Data di scadenza (facoltativa)",
+        "expiryHint": "Lasciare vuoto per evitare la scadenza.",
+        "tokenCreated": "Token creato",
+        "tokenCreatedDescription": "Il tuo token API è stato creato con successo.",
+        "copyWarning": "Copia subito questo token. Non potrai più vederlo!",
+        "yourToken": "Il tuo token",
+        "deleteTitle": "Eliminare il token API?",
+        "deleteDescription": "Questa azione è irreversibile. Tutte le applicazioni che utilizzano questo token non saranno più in grado di autenticarsi.",
+        "readOnlyLabel": "Sola lettura",
+        "readOnlyDescription": "Da utilizzare per agenti di intelligenza artificiale che devono solo interrogare i dati, senza mai modificarli.",
+        "agentTokenLabel": "Contrassegna come token agente",
+        "agentTokenDescription": "Aggiunge tag alle voci del registro di controllo con metadata.source: \"mcp\" in modo che gli amministratori possano attribuire le modifiche apportate dall'agente.",
+        "readOnlyBadge": "Sola lettura",
+        "agentTokenBadge": "token agente",
+        "errors": {
+          "nameRequired": "Il nome del token è obbligatorio."
+        }
+      }
+    },
+    "access": {
+      "guest": "Ospite"
+    },
+    "avatar": {
+      "update": "Aggiorna avatar",
+      "remove": "Rimuovi avatar",
+      "changeProfilePicture": "Cambia immagine del profilo",
+      "notAuthenticated": "Devi aver effettuato l'accesso per caricare un avatar."
+    },
+    "deletedUser": "Utente eliminato"
+  },
+  "userMenu": {
+    "viewProfile": "Visualizza profilo",
+    "locale": "Localizzazione",
+    "themes": {
+      "light": "Leggero",
+      "dark": "Buio",
+      "system": "Sistema",
+      "green": "Verde",
+      "purple": "Viola",
+      "orange": "Arancia"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Versione del caso di prova non trovata.",
+      "detailsRegion": "Dettagli del caso di prova",
+      "metadataRegion": "Metadati del caso di prova",
+      "versionCreated": "Versione {version} creata",
+      "latestVersionUpdated": "Ultima versione {version} Aggiornata",
+      "historyView": "Visualizzazione cronologia casi di test"
+    },
+    "fields": {
+      "optionNotFound": "Opzione non trovata",
+      "hasValue": "Ha valore",
+      "noValue": "Nessun valore",
+      "hasDate": "Ha data",
+      "noDate": "Nessuna data",
+      "hasText": "Contiene testo",
+      "noText": "Nessun testo",
+      "hasLink": "Ha un collegamento",
+      "noLink": "Nessun collegamento",
+      "hasSteps": "Ha dei gradini",
+      "noSteps": "Nessun passo",
+      "unchecked": "Non selezionato",
+      "linkedCases": "Casi collegati",
+      "clickToViewFullContent": "Clicca per visualizzare il contenuto completo"
+    },
+    "steps": {
+      "add": "Aggiungi passaggio",
+      "addSharedSteps": "Aggiungi passaggi condivisi",
+      "delete": "Elimina passaggio",
+      "confirmDelete": "Confermare l'eliminazione Passo {number}?",
+      "createSharedSteps": "Crea condiviso {number, plural, one {Passaggio} other {Passaggi}}",
+      "sharedStepsName": "Nome dei passaggi condivisi",
+      "sharedStepsDescription": "Inserisci un nome per il tuo nuovo {number, plural, one {passo condiviso} other {passi}}. Questo includerà {number, plural, one {# passo selezionato} other {# passi selezionati}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Seleziona i passaggi e inserisci un nome per creare passaggi condivisi.",
+        "failedToCreateSharedStepGroupError": "Impossibile creare i passaggi condivisi. Riprova.",
+        "sharedStepGroupCreatedSuccess": "Passaggi condivisi creati con successo!",
+        "genericSharedStepCreationError": "Si è verificato un errore sconosciuto durante la creazione dei passaggi condivisi. Riprova.",
+        "errorCreatingSharedGroup": "Impossibile creare passaggi condivisi. Riprova.",
+        "sharedGroupCreatedSuccess": "Gruppo di passaggi condivisi creato con successo!"
+      },
+      "selectSharedStepsTitle": "Seleziona Passaggi condivisi",
+      "selectSharedStepsDescription": "Scegli i passaggi condivisi da aggiungere al tuo caso di test.",
+      "sharedStepsListPlaceholder": "Caricamento dei passaggi condivisi...",
+      "sharedStepsNamePlaceholder": "Inserisci un nome per identificare i passaggi condivisi",
+      "noSharedStepsFound": "Nessun passaggio condiviso trovato per questo progetto.",
+      "sharedStepGroupTitle": "Passaggi condivisi: {name}",
+      "confirmDeleteSharedStepBlock": "Vuoi davvero rimuovere il blocco di passaggi condivisi \"{name}\" da questo caso di test? Questo non eliminerà il gruppo di passaggi condivisi stesso.",
+      "removeBlockButton": "Rimuovi blocco",
+      "loadingSharedStepsItems": "Caricamento dei passaggi in corso...",
+      "noStepsInSharedGroup": "Questo gruppo di passaggi condivisi è vuoto.",
+      "searchSharedStepsPlaceholder": "Seleziona i passaggi condivisi...",
+      "stepsCountLabel": "{count, plural, =0 {# passaggi} =1 {# passaggio} other {# passaggi}}",
+      "reviewSelectedStepsTitle": "Rivedi i passaggi selezionati",
+      "noStepsInSelectedGroup": "Il gruppo selezionato non ha passaggi.",
+      "sharedGroupSuffix": "(Passaggi condivisi)",
+      "unnamedSharedGroup": "Passaggi condivisi senza nome"
+    },
+    "testCase": {
+      "toggleAutomated": "Attiva/disattiva test automatizzati",
+      "editAttachmentsIndividually": "Modificare gli allegati singolarmente.",
+      "automatedStatus": "I test automatizzati sono {status}"
+    },
+    "templateNotAssignedWarning": "Questo caso di test utilizza il modello \"{templateName}\" che al momento non è assegnato al progetto \"{projectName}\". Potrebbe essere necessario assegnare questo modello al progetto o modificare il caso di test per utilizzare un modello diverso.",
+    "orphanedStepsWarning": "Questo caso di test ha dei passaggi, ma il modello corrente \"{templateName}\" non include il campo Passaggi. I passaggi non possono essere modificati finché il caso di test non avrà un modello con un campo Passaggi.",
+    "orphanedFieldsWarning": "Questo caso di test ha {count, plural, =1 {# valore del campo} other {# valori del campo}} che {count, plural, =1 {è} other {non sono}} inclusi nel modello corrente \"{templateName}\". {count, plural, =1 {Questo campo è} other {Questi campi sono}} mostrati di seguito ma potrebbero non essere modificabili finché non vengono aggiunti al modello.",
+    "title": "Repository dei casi di prova",
+    "folders": "Cartelle",
+    "showDescendants": "Mostra tutti i discendenti",
+    "addFolder": "Aggiungi cartella",
+    "emptyFolders": "Fare clic sul pulsante Aggiungi cartella in alto per aggiungere la prima cartella.",
+    "selectedAllCases": "{count, plural, =0 {Selezionati tutti i casi} one {Selezionato il numero di casi su tutte le pagine} other {Selezionato il numero di casi su tutte le pagine}}",
+    "deselectedAllCases": "Deselezionati tutti i casi in tutte le pagine",
+    "selectAllTooltip": "Seleziona/Deseleziona tutti i casi in questa pagina",
+    "selectAllShiftTooltip": "{count, plural, =0 {Seleziona/Deseleziona tutti i casi in tutte le pagine} one {Seleziona/Deseleziona # casi in tutte le pagine} other {Seleziona/Deseleziona # casi in tutte le pagine}}",
+    "deselectAllShiftTooltip": "Deseleziona/Seleziona tutti i casi in tutte le pagine",
+    "shiftClickHint": "Tieni premuto Maiusc per selezionare/deselezionare tutte le pagine",
+    "treeView": {
+      "expandAll": "Espandi tutto",
+      "collapseAll": "Comprimi tutto",
+      "altKey": "Tieni premuto il tasto Alt per espandere/comprimere tutti i figli"
+    },
+    "dragDrop": {
+      "move": "Mossa",
+      "copy": "Copia",
+      "promptTitle": "Cosa ti piacerebbe fare?",
+      "copying": "Copia…",
+      "copyComplete": "{count, plural, =1 {Copiato 1 caso in {folder}} other {Copiati # casi in {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {Spostato 1 caso in {folder}} other {Spostati # casi in {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Impossibile copiare 1 caso in {folder}} other {Impossibile copiare # casi in {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Impossibile spostare 1 caso in {folder}} other {Impossibile spostare # casi in {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyAlreadyRunning": "Un'altra copia è già in fase di elaborazione. Si prega di attendere il completamento.",
+      "currentSuffix": "(Attuale)",
+      "moveDisabledSameFolder": "I casi sono già presenti in questa cartella",
+      "dragPreviewCase": "Caso di prova",
+      "dragPreviewCount": "{count, plural, =1 {# caso di test} other {# casi di test}}",
+      "modifierHintMac": "Tieni premuto ⇧ per spostare o ⌥ per copiare mentre trascini per saltare questo menu.",
+      "modifierHintWin": "Tieni premuto Maiusc per spostare o Ctrl per copiare mentre trascini per saltare questo menu."
+    },
+    "folderActions": {
+      "edit": "Modifica cartella",
+      "delete": "Elimina cartella",
+      "rename": "Rinomina cartella"
+    },
+    "cases": {
+      "filter": "Filtri...",
+      "selectFolder": "Selezionare una cartella per aggiungere o visualizzare i casi di test.",
+      "selectCases": "Seleziona casi di prova",
+      "noTestCases": "Nessun caso di test da visualizzare.",
+      "addCase": "Aggiungi caso",
+      "notFound": "Caso di prova non trovato.",
+      "selectFilter": "Seleziona filtro",
+      "testResultHistory": "Cronologia dei risultati dei test",
+      "testResultHistoryDescription": "Visualizza la cronologia dei risultati dei test per questo caso di test",
+      "noTestResults": "Nessun risultato di test trovato per questo caso di test",
+      "unknownRun": "Corsa sconosciuta",
+      "attempt": "Tentativo",
+      "invalidProject": "Progetto non valido",
+      "noSearchResults": "Nessun caso corrisponde ai tuoi criteri di ricerca.",
+      "bulkEdit": "Modifica in blocco",
+      "createTestRun": "Crea esecuzione di prova",
+      "copyMoveToProject": "Copia/Sposta",
+      "export": "Esportare",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Non è possibile riordinare i casi di test su più pagine. Per riordinarli, visualizza tutti i casi in una pagina selezionando \"Tutti\" dal menu delle dimensioni della pagina oppure deseleziona i casi dalle altre pagine. Puoi comunque trascinare i casi selezionati nelle cartelle.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Tutto in vista ({count})"
+        },
+        "textLongFormat": {
+          "label": "Formato di testo avanzato"
+        },
+        "rowMode": {
+          "label": "Righe del caso di prova",
+          "multi": "Singola riga per passaggio"
+        }
+      },
+      "importWizard": {
+        "title": "Importa casi di test",
+        "fields": {
+          "workflowState": "Stato del flusso di lavoro",
+          "column": "Colonna {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# caso di test} other {# casi di test}} importato con successo"
+        },
+        "errors": {
+          "templateRequired": "È richiesta la selezione del modello",
+          "folderRequired": "Per questa posizione di importazione è richiesta la selezione della cartella",
+          "fileRequired": "È richiesto un file CSV o Markdown",
+          "markdownParseFailed": "Impossibile analizzare il file Markdown",
+          "markdownLlmFailed": "Analisi sintattica tramite IA non disponibile, utilizzo del parser standard."
+        },
+        "page1": {
+          "fileType": {
+            "label": "Tipo di file",
+            "csv": "CSV",
+            "markdown": "Sconto"
+          },
+          "parsingMarkdown": "Analisi del file markdown in corso...",
+          "useAiParsing": "Utilizzare l'intelligenza artificiale per agevolare la mappatura dei campi.",
+          "importLocation": {
+            "label": "Posizione di importazione",
+            "singleFolder": "Aggiungi tutti i casi a una singola cartella",
+            "rootFolder": "Aggiungere tutti i casi e le cartelle a una cartella principale (è necessaria la mappatura).",
+            "topLevel": "Aggiungere tutti i casi e le cartelle al livello superiore (è necessaria la mappatura)."
+          },
+          "selectFolder": "Seleziona cartella",
+          "selectFolderPlaceholder": "Seleziona una cartella...",
+          "delimiters": {
+            "tab": "Scheda"
+          },
+          "hasHeaders": "La prima riga contiene i nomi delle colonne",
+          "template": "Modello di caso di repository",
+          "rowMode": {
+            "single": "Ogni riga è un singolo caso di test",
+            "multi": "I casi di test possono estendersi su più righe"
+          }
+        },
+        "page2": {
+          "title": "Mappa le colonne CSV sui campi",
+          "description": "Associa ogni colonna CSV a un campo nel modello oppure scegli di ignorarla.",
+          "ignoreColumn": "Ignora colonna",
+          "requiredFieldsWarning": "{count, plural, one {# il campo obbligatorio non è} other {# i campi obbligatori non sono}} mappati"
+        },
+        "page3": {
+          "title": "Riepilogo della mappatura del campo",
+          "mappingSummary": "Riepilogo della mappatura",
+          "folderSplitMode": {
+            "label": "Modalità gerarchia cartelle",
+            "plain": "Testo normale (senza suddivisione)",
+            "plainExample": "Esempio: 'Questa/è.una>Cartella' → Singola cartella denominata 'Questa/è.una>Cartella'",
+            "slash": "Diviso tramite barra (/)",
+            "slashExample": "Esempio: 'Questa/è.una>Cartella' → 'Questo' > 'è.una>Cartella'",
+            "dot": "Dividi per punto (.)",
+            "dotExample": "Esempio: 'Questa/è.una>Cartella' → 'Questa/è' > 'una>Cartella'",
+            "greaterThan": "Dividi per maggiore di (>)",
+            "greaterThanExample": "Esempio: 'Questo/è.una>Cartella' → 'Questo/è.una' > 'Cartella'"
+          }
+        },
+        "page4": {
+          "title": "Anteprima importazione",
+          "showing": "Visualizzazione di {start}-{end} casi su {total}",
+          "case": "Caso {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Aggiungi caso di prova",
+      "name": "Nome del caso di prova",
+      "namePlaceholder": "Inserisci il nome del caso di prova",
+      "selectTemplate": "Seleziona un modello",
+      "selectState": "Seleziona uno stato",
+      "estimatePlaceholder": "Inserisci preventivo",
+      "create": "Crea caso di prova",
+      "successMessage": "Nuovo caso di prova aggiunto",
+      "errorMessage": "Errore sconosciuto durante l'aggiunta di un nuovo caso di test"
+    },
+    "columns": {
+      "selectCase": "Seleziona caso",
+      "runOrder": "Ordine di esecuzione",
+      "lastTestResult": "Risultato rosso",
+      "testedOn": "Ultimo test effettuato"
+    },
+    "actions": {
+      "archive": "Archivio"
+    },
+    "parentFolder": "Cartella padre",
+    "rootFolder": "Cartella principale",
+    "removeParentFolder": "Rimuovere la cartella principale",
+    "createInSelectedFolder": "Ripristina la cartella principale",
+    "deleteCase": {
+      "title": "Elimina caso di prova",
+      "confirmMessageStart": "Sei sicuro di voler eliminare il caso di prova? ",
+      "confirmMessageEnd": "?",
+      "warning": "Questo caso di test verrà rimosso dal progetto. I dati storici per questo caso di test rimarranno comunque nel progetto, inclusi i risultati.",
+      "activeRunWarningMessage": "Questo caso di test fa parte di {count, plural, =1 {# esecuzione di test attiva} other {# esecuzioni di test attive}}. Eliminandolo, verrà contrassegnato come eliminato all'interno di tali esecuzioni."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {L'eliminazione di questa cartella eliminerà anche tutte le sottocartelle. Sei sicuro?} one {L'eliminazione di questa cartella eliminerà anche 1 caso di test in questa cartella e in tutte le sottocartelle. Sei sicuro?} other {L'eliminazione di questa cartella eliminerà anche # casi di test in questa cartella e in tutte le sottocartelle. Sei sicuro?}}",
+      "warning": "Questa cartella e tutti i relativi casi di test verranno rimossi dal progetto. I dati storici per questi casi di test rimarranno comunque nel progetto, inclusi i risultati.",
+      "confirm": "Conferma eliminazione cartella",
+      "success": "Cartella e tutte le sottocartelle/casi eliminati correttamente."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "Il nome della cartella esiste già. Scegli un nome diverso."
+      }
+    },
+    "views": {
+      "byAutomation": "Automazione",
+      "allTemplates": "Tutti i modelli",
+      "allStates": "Tutti gli stati",
+      "allCreators": "Tutti i creatori",
+      "allCases": "Tutti i casi",
+      "allAssignees": "Tutti gli assegnatari",
+      "anyTag": "Qualsiasi tag",
+      "noTags": "Nessun tag",
+      "byTag": "Etichetta",
+      "byIssue": "Problema",
+      "anyIssue": "Qualsiasi problema",
+      "noIssues": "Nessun problema"
+    },
+    "noFoldersTitle": "Nessuna cartella ancora",
+    "noFoldersDescription": "Per iniziare, crea la tua prima cartella per organizzare i tuoi casi di test.",
+    "noFoldersOrCasesNoPermission": "Non ci sono cartelle o casi di test da visualizzare.",
+    "createFirstFolder": "Crea la tua prima cartella",
+    "bulkEdit": {
+      "title": "Modifica in blocco {count, plural, one {# Caso} other {# Casi}}",
+      "description": "Modifica {count, plural, one {# caso selezionato} other {# casi selezionati}}. Seleziona un campo per abilitare la modifica.",
+      "defineStepsTitle": "Definisci i passaggi per l'aggiornamento in blocco",
+      "saveNewSteps": "Salva nuovi passaggi",
+      "newStepsDefined": "Nuovi passaggi definiti ({count}) - Fare clic sul pulsante per modificare",
+      "clearExistingStepsWarning": "I passaggi esistenti verranno rimossi",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Modelli multipli selezionati",
+          "description": "È possibile modificare solo i campi standard quando si selezionano casi con modelli diversi. I campi dinamici possono essere modificati selezionando casi che utilizzano lo stesso modello."
+        },
+        "junitLimitations": {
+          "title": "Limitazioni della modifica automatizzata dei casi di test",
+          "description": "I campi \"Stima\" e \"Automatizzato\" non possono essere modificati per i casi di test importati dai risultati dei test automatizzati."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Errore durante il caricamento dei casi",
+        "fetchErrorDescription": "Impossibile caricare i dati per i casi selezionati. Chiudere la finestra modale e riprovare.",
+        "updateErrorTitle": "Aggiornamento non riuscito",
+        "updateFailed": "Si è verificato un errore durante il salvataggio delle modifiche. Controlla i dati e riprova.",
+        "fetchError": "Errore durante il recupero dei dati del caso."
+      },
+      "success": {
+        "casesUpdated": "Casi aggiornati con successo"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Errore di convalida",
+      "stepsCannotBeBulkEdited": "I passaggi non possono essere modificati in blocco",
+      "stepsInfoTitle": "Informazioni sui passaggi",
+      "stepsCannotBeBulkEditedInfo": "I passaggi non possono essere modificati in blocco. Modifica i passaggi modificando i casi singolarmente.",
+      "confirmDeleteCases": "Sei sicuro di voler eliminare {count, plural, one {# caso selezionato} other {# casi selezionati}}? Questa azione non può essere annullata.",
+      "replaceAll": "Sostituisci tutto",
+      "searchReplace": "Cerca e sostituisci",
+      "searchFor": "Cercare",
+      "replaceWith": "Sostituisci con",
+      "searchText": "Inserisci il testo da cercare",
+      "replacementText": "Inserisci il testo sostitutivo",
+      "useRegex": "Usa l'espressione regolare",
+      "caseSensitive": "Maiuscole e minuscole",
+      "regexHint": "Usa .* per qualsiasi carattere, \\d+ per i numeri, \\w+ per le parole. Cattura gruppi: (modello) quindi usa $1, $2, ecc.",
+      "preview": "Anteprima",
+      "matches": "fiammiferi",
+      "noMatches": "Nessuna corrispondenza trovata",
+      "invalidRegexPattern": "Modello di espressione regolare non valido",
+      "searchPatternRequired": "È richiesto il modello di ricerca",
+      "stepsSearchReplaceInfo": "La funzione Cerca e sostituisci verrà applicata sia alle descrizioni dei passaggi sia ai risultati previsti."
+    },
+    "exportModal": {
+      "title": "Esporta casi di prova",
+      "description": "Seleziona le opzioni di esportazione qui sotto.",
+      "scope": {
+        "selected": "Selezionato ({count})",
+        "allFiltered": "Tutto (Vista corrente) ({count})",
+        "allProject": "Tutto nel progetto ({count})"
+      },
+      "format": {
+        "label": "Formato",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Sconto"
+      },
+      "columns": {
+        "all": "Tutto",
+        "visible": "Visibile"
+      },
+      "delimiter": {
+        "label": "Delimitatore",
+        "placeholder": "Seleziona delimitatore...",
+        "comma": "Virgola (,)",
+        "semicolon": "Punto e virgola (;)",
+        "colon": "Due punti (:)",
+        "pipe": "Tubo (|)"
+      },
+      "textLongFormat": {
+        "label": "Testo in formato lungo"
+      },
+      "attachmentFormat": {
+        "label": "Formato allegato",
+        "names": "nomi",
+        "json": "JSON",
+        "embedded": "Incorpora immagini"
+      },
+      "stepsFormat": {
+        "label": "Formato dei passaggi",
+        "plainText": "Testo normale"
+      },
+      "rowMode": {
+        "label": "Righe per cassa",
+        "single": "Fila singola per cassa",
+        "multi": "Più righe per passaggio"
+      },
+      "comingSoon": "Prossimamente",
+      "exporting": "Esportazione in corso...",
+      "exportError": "Esportazione non riuscita. Riprova."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Converti i casi di test selezionati in script di automazione utilizzando un modello o l'intelligenza artificiale.",
+      "templatePlaceholder": "Seleziona un modello...",
+      "searchPlaceholder": "Modelli di ricerca...",
+      "noTemplatesFound": "Nessun modello trovato.",
+      "outputModeLabel": "Modalità di uscita",
+      "outputModeSingle": "File singolo ({count, plural, one {# caso} other {tutti i # casi}})",
+      "outputModeIndividual": "{count, plural, one {File singolo (.zip)} other {File singoli (.zip)}}",
+      "casesToExport": "{count, plural, one {# caso} other {# casi}} da esportare",
+      "exportSuccess": "Esportazione completata con successo.",
+      "noAvailableTemplates": "Nessun modello disponibile. Contatta l'amministratore."
+    },
+    "aiExport": {
+      "toggleLabel": "Genera con l'IA",
+      "generating": "Generazione in corso...",
+      "generatingProgress": "Generazione del caso {current} di {total}...",
+      "generatingBatch": "Generazione di {count, plural, one {# casi} other {# casi}} in un unico file...",
+      "previewTitle": "Anteprima di esportazione",
+      "previewDescription": "{count, plural, one {# file} other {# file}} generato",
+      "copySuccess": "Copiato negli appunti",
+      "fallbackBadge": "Generato utilizzando un modello (IA non disponibile)",
+      "retryButton": "Riprova la generazione dell'IA",
+      "aiGenerated": "Generato dall'IA",
+      "templateGenerated": "Generazione del modello",
+      "truncatedWarning": "L'output è stato troncato: il modello ha raggiunto il limite di token. Prova a ridurre la dimensione del batch o ad aumentare il numero massimo di token di output nella configurazione del prompt.",
+      "contextFiles": "{count, plural, one {(# file di contesto)} other {(# file di contesto)}}",
+      "noCodeContextHint": "Nessun repository di codice configurato. L'IA utilizzerà modelli di framework standard.",
+      "generatingParallelProgress": "Generati {done} di {total} file...",
+      "cancelledGeneration": "Annullato"
+    },
+    "duplicates": {
+      "findDuplicates": "Trova duplicati",
+      "viewResults": "Visualizza {count, plural, one {# Risultato} other {# Risultati}}",
+      "retryScan": "Riprova la scansione",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Migliorare i risultati con l'intelligenza artificiale...",
+      "scanComplete": "Analisi dei duplicati completata — {count, plural, =0 {nessun duplicato trovato} one {# potenziale duplicato trovato} other {# potenziale duplicato trovato}}",
+      "scanFailed": "Analisi duplicata non riuscita",
+      "scanFailedDescription": "Si è verificato un errore imprevisto",
+      "pageTitle": "Candidati duplicati",
+      "pageDescription": "Esaminare i potenziali casi di test duplicati rilevati durante l'ultima scansione.",
+      "rescan": "Riscansione",
+      "cancelScan": "Annulla scansione",
+      "loading": "Caricamento dei candidati duplicati...",
+      "noDuplicatesFound": "Nessun duplicato trovato",
+      "noDuplicatesDescription": "Ultima scansione completata senza coppie corrispondenti.",
+      "loadMore": "Carica altro",
+      "filterPlaceholder": "Filtra i duplicati...",
+      "columnConfidence": "Fiducia",
+      "columnCaseA": "Caso A",
+      "columnCaseB": "Caso B",
+      "columnMatchedFields": "Campi corrispondenti",
+      "columnScore": "Punto",
+      "compareButton": "Confrontare",
+      "viewCaseDetails": "Visualizza i dettagli del caso",
+      "selectAll": "Seleziona tutto",
+      "selectRow": "Seleziona riga",
+      "selected": "{count, plural, one {# selezionato} other {# selezionato}}",
+      "bulkDismiss": "Non duplicati ({count})",
+      "bulkLink": "Collega come correlato ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# coppia scartata} other {# coppie scartate}}",
+      "bulkLinkSuccess": "{count, plural, one {# coppie collegate} other {# coppie collegate}}",
+      "bulkError": "Alcune operazioni non sono andate a buon fine. Riprova.",
+      "tableHint": "Fai clic su una riga o sul pulsante Confronta per esaminare e risolvere una coppia duplicata.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "Confronta questi potenziali duplicati e scegli come risolverli.",
+      "selectPrimary": "Fai clic su un caso per selezionarlo come principale per l'unione",
+      "selectedAsPrimary": "Selezionato come primario",
+      "mergeButton": "Mantenere primario",
+      "linkButton": "Collegamento come correlato",
+      "dismissButton": "Non è un duplicato",
+      "merging": "Fusione...",
+      "linking": "Collegamento...",
+      "dismissing": "Licenziamento...",
+      "mergeSuccess": "Casi uniti con successo. {runsTransferred, plural, =0 {Nessuna esecuzione di test trasferita} one {# esecuzione di test trasferita} other {# esecuzioni di test trasferite}}.",
+      "linkSuccess": "Casi collegati in quanto correlati.",
+      "dismissSuccess": "Coppia scartata. Non apparirà nelle scansioni future.",
+      "resolveError": "Impossibile risolvere la coppia duplicata. Riprova.",
+      "loadingDetails": "Caricamento dei dettagli del caso in corso...",
+      "caseDetailsError": "Impossibile caricare i dettagli del caso.",
+      "sourceLabel": "Fonte",
+      "fieldValuesLabel": "Valori di campo",
+      "lastRunLabel": "Ultima corsa",
+      "noFieldValues": "Nessun valore di campo",
+      "noLastRun": "Non correre mai",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Nessuna cartella",
+      "duplicateWarning": "Possibili duplicati trovati",
+      "duplicateWarningDescription": "{count, plural, one {# caso esistente} other {# casi esistenti}} potrebbe coprire funzionalità simili",
+      "duplicateWarningReview": "Revisione",
+      "importWarning": "Possibile duplicato",
+      "importWarningTooltip": "Il nome di questo caso è simile a {count, plural, one {# caso esistente} other {# casi esistenti}}: {names}",
+      "importIntraWarning": "Duplicato all'interno dell'importazione",
+      "importIntraWarningTooltip": "Le righe {rows} in questa importazione hanno lo stesso nome o un nome molto simile",
+      "checkingDuplicates": "Verifica della presenza di duplicati in corso..."
+    },
+    "generateTestCases": {
+      "buttonText": "Genera casi di test",
+      "title": "Genera casi di test con l'intelligenza artificiale",
+      "description": "Utilizza l'intelligenza artificiale per generare automaticamente casi di test completi a partire da problematiche o documenti esterni.",
+      "loadingResults": "Caricamento dei casi di test generati...",
+      "generatingPreparing": "Preparazione della richiesta in corso...",
+      "generatingCallingAi": "In attesa che l'IA generi i casi di test...",
+      "generatingStreaming": "L'IA sta generando il caso di test {count}...",
+      "generatingStreamingPage": "L'IA sta generando il caso di test {count} — pagina {current} di {total}: {page}",
+      "generatingProcessing": "Elaborazione dei casi di test generati...",
+      "generatingHint": "Questa operazione potrebbe richiedere un minuto, a seconda della complessità del materiale di partenza.",
+      "steps": {
+        "selectIssue": "Seleziona la fonte",
+        "selectTemplate": "Scegli modello",
+        "reviewGenerated": "Revisione e importazione"
+      },
+      "selectSource": {
+        "title": "Seleziona la fonte dei requisiti",
+        "description": "Scegliere se generare casi di test da un problema o da un documento di requisiti.",
+        "folderContextTip": "I casi di test esistenti in \"{folderName}\" e nelle relative cartelle padre/figlio verranno utilizzati come contesto per evitare duplicati. Assicurati di aver selezionato la cartella corretta prima di procedere.",
+        "currentFolder": "cartella corrente",
+        "fromIssue": "Dal problema",
+        "fromDocument": "Dal documento",
+        "documentTitle": "Titolo del documento",
+        "documentTitlePlaceholder": "Inserisci il titolo del documento dei tuoi requisiti",
+        "documentDescription": "Documento dei requisiti",
+        "documentDescriptionPlaceholder": "Incolla qui il contenuto del documento sui requisiti...",
+        "documentPriority": "Priorità (facoltativo)",
+        "selectPriority": "Seleziona la priorità",
+        "saveDocument": "Salva i requisiti del documento",
+        "fromUrl": "Da URL",
+        "recentGenerations": "Recenti attività di generazione di casi di test da URL",
+        "recentJobInfo": "{pages, plural, one {# pagina} other {# pagine}}{hasTestCases, select, true { · {testCases, plural, one {# caso di test} other {# casi di test}}} other {}}",
+        "recentJobHasResults": "Pronto per la revisione",
+        "recentJobClickToGenerate": "Fare clic per generare casi di test",
+        "recentJobCrawling": "Strisciando... {pages, plural, one {# pagina} other {# pagine}} finora",
+        "removeJobTitle": "Rimuovere la generazione",
+        "confirmRemoveJob": "Questa operazione rimuoverà la scansione memorizzata nella cache e tutti i casi di test generati. È sempre possibile generarli nuovamente dallo stesso URL.",
+        "loadingRecentJobs": "Caricamento delle offerte di lavoro recenti...",
+        "urlInput": "URL della pagina",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "Cosa contiene questo URL?",
+        "urlModeRequirements": "Requisiti",
+        "urlModeRequirementsHint": "La pagina descrive cosa costruire",
+        "urlModeApplication": "Applicazione",
+        "urlModeApplicationHint": "Page è l'app da testare",
+        "urlValidationError": "Inserisci un URL valido che inizi con http:// o https://",
+        "followLinks": "Segui i link",
+        "followLinksHint": "Verranno indicizzate solo le pagine appartenenti allo stesso dominio dell'URL inserito.",
+        "maxDepth": "Profondità massima",
+        "maxPages": "Pagine massime",
+        "crawlProgress": "{current, plural, one {Pagine scaricate finora...} other {Pagine scaricate finora...}}",
+        "generatingSinglePage": "Generazione dei casi di test in corso...",
+        "generatingSetup": "Preparazione alla generazione dei casi di test...",
+        "robotsSkipped": "{count, plural, one {# pagine saltate} other {# pagine saltate}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Seleziona problema esterno",
+        "description": "Scegli un problema dal tuo sistema esterno (come Jira) da cui generare casi di test.",
+        "searchButton": "Cerca problemi"
+      },
+      "selectTemplate": {
+        "title": "Scegli il modello del caso di prova",
+        "description": "Seleziona il modello che verrà utilizzato per generare i casi di test. L'IA compilerà i campi in base a questo modello.",
+        "placeholder": "Seleziona un modello...",
+        "fieldsDescription": "Seleziona i campi che l'IA deve compilare. I campi obbligatori sono sempre inclusi.",
+        "requiredOnly": "Solo richiesto"
+      },
+      "addNotes": {
+        "title": "Aggiungi note e indicazioni",
+        "description": "Fornire ulteriore contesto e indicazioni per aiutare l'IA a generare casi di test migliori.",
+        "quantity": "Numero di casi di test da generare",
+        "placeholder": "Aggiungi istruzioni specifiche per la generazione di casi di test...\n\nAd esempio:\n• Concentrati sui test di sicurezza\n• Includi casi limite e condizioni al contorno\n• Testa sia scenari di percorso felice che di errore\n• Considera scenari mobili e desktop\n• Concentrati sui test API",
+        "suggestions": "Suggerimenti rapidi:",
+        "quantityOptions": {
+          "justOne": "Solo uno",
+          "couple": "Una coppia (2)",
+          "few": "Alcuni (2-3)",
+          "several": "Diversi (4-6)",
+          "many": "Molti (7-10)",
+          "maximum": "Massimo"
+        },
+        "suggestionItems": {
+          "security": "Concentrarsi sui test di sicurezza",
+          "edgeCases": "Includi casi limite",
+          "happyPath": "Prova solo il percorso felice",
+          "mobile": "Considerare scenari mobili",
+          "api": "Concentrarsi sui test API",
+          "accessibility": "Includere test di accessibilità"
+        }
+      },
+      "review": {
+        "title": "Esaminare i casi di test generati",
+        "description": "Esamina i casi di test generati dall'intelligenza artificiale, apporta le modifiche necessarie e seleziona quelli da importare.",
+        "selected": "{count} di {total} selezionati",
+        "moreSteps": "... e {count, plural, one {# altro passaggio} other {# altri passaggi}}",
+        "templateFields": "Campi modello:",
+        "moreFields": "... e {count, plural, one {# altro campo} other {# altro campo}}",
+        "crawledUrls": "{count, plural, one {# pagine scansionate} other {# pagine scansionate}}",
+        "spaWarning": "Questa pagina potrebbe richiedere il rendering tramite JavaScript. I risultati potrebbero essere incompleti.",
+        "filterByPage": "Filtra per pagina",
+        "allPages": "Tutte le pagine ({pages, plural, one {# pagina} other {# pagine}}, {cases, plural, one {# caso} other {# casi}})"
+      },
+      "generatingLegacy": "Generazione di casi di test con l'intelligenza artificiale...",
+      "expandProgress": "{done} di {total} generato",
+      "import": "{count, plural, =0 {Importa casi di test} =1 {Importa 1 caso di test} other {Importa # casi di test}}",
+      "importing": "{count, plural, =0 {Importazione dei casi di test in corso...} =1 {Importazione di 1 caso di test in corso...} other {Importazione di # casi di test in corso...}}",
+      "openInExternalSystem": "Apri in {provider}",
+      "externalSystem": "Sistema esterno",
+      "autoGenerateTags": "Genera automaticamente tag per i casi di test",
+      "success": {
+        "imported": "{count, plural, =1 {Importato con successo 1 caso di test} other {Importati con successo # casi di test}}"
+      },
+      "importData": {
+        "issueDescription": "Problema esterno collegato alla generazione del caso di test",
+        "generatedFolderName": "Generato"
+      },
+      "errors": {
+        "generateFailed": "Impossibile generare i casi di test. Riprova.",
+        "importFailed": "Impossibile importare i casi di test. Riprova.",
+        "noTestCasesGenerated": "Non sono stati generati casi di test. Riprova con input diversi.",
+        "jobNoLongerAvailable": "Questa generazione non è più disponibile. Avviane una nuova tramite la procedura guidata Genera casi di test.",
+        "noAiModel": "Per questo progetto non è configurato alcun modello di intelligenza artificiale. Si prega di configurare un modello di intelligenza artificiale nelle impostazioni del progetto.",
+        "noIssueSelected": "Seleziona un problema da cui generare i casi di test.",
+        "noDocumentProvided": "Si prega di fornire i dettagli del documento dei requisiti.",
+        "noTemplateSelected": "Seleziona un modello per i casi di test.",
+        "noFieldsSelected": "Seleziona almeno un campo per il quale desideri generare contenuti.",
+        "noTestCasesSelectedForImport": "Seleziona almeno un caso di test da importare.",
+        "templateRequired": "È necessario selezionare un modello. Torna indietro e seleziona un modello.",
+        "repositoryNotFound": "Repository del progetto non trovato. Contattare l'amministratore.",
+        "workflowNotConfigured": "Flusso di lavoro del progetto non configurato. Verificare le impostazioni del progetto.",
+        "authenticationError": "Errore di autenticazione. Aggiorna la pagina e riprova.",
+        "caseCreationFailed": "Impossibile creare il caso di test: {name}",
+        "caseAlreadyExists": "Il caso di test \"{name}\" esiste già in questa cartella.",
+        "invalidTemplateConfig": "Configurazione del modello non valida per il caso di test \"{name}\".",
+        "nameTooLong": "Il nome del caso di test \"{name}\" è troppo lungo. Si prega di utilizzare un nome più breve.",
+        "caseCreationError": "Impossibile creare \"{name}\": {error}",
+        "templateNotFound": "Impossibile trovare il modello selezionato. Aggiorna la pagina e riprova.",
+        "repositoryConfigError": "Errore di configurazione del repository del progetto. Contattare l'amministratore.",
+        "workflowConfigError": "Errore di configurazione del flusso di lavoro del progetto. Verificare le impostazioni del progetto.",
+        "permissionDenied": "Non hai l'autorizzazione per creare casi di test in questo progetto.",
+        "validationFailed": "La convalida dei dati non è riuscita. Si prega di verificare il contenuto del caso di test e riprovare.",
+        "databaseError": "Errore di connessione al database. Riprova tra un attimo.",
+        "genericImportError": "Importazione non riuscita: {error}",
+        "networkRoutingError": "Problema di routing di rete o di configurazione del server: è stata ricevuta una pagina di errore HTML anziché una risposta API.",
+        "invalidSourceConfig": "Configurazione sorgente non valida",
+        "failedToCreateCaseVersion": "Impossibile creare la versione del caso",
+        "noUrlProvided": "Inserisci un URL per generare i casi di test da",
+        "urlFetchFailed": "Impossibile recuperare il contenuto dall'URL fornito. Si prega di verificare l'URL e riprovare.",
+        "llm": {
+          "genericTitle": "Errore di generazione dell'IA",
+          "genericMessage": "Si è verificato un errore durante la generazione dei casi di test con l'intelligenza artificiale. Riprova o modifica i dati immessi.",
+          "overloaded": {
+            "title": "Servizio temporaneamente non disponibile",
+            "message": "Il servizio di intelligenza artificiale è attualmente molto richiesto. Riprova tra qualche istante."
+          },
+          "quota": {
+            "title": "Limite di utilizzo raggiunto",
+            "message": "Hai raggiunto il limite di utilizzo dell'IA per questo periodo. Riprova più tardi o contatta l'amministratore."
+          },
+          "timeout": {
+            "title": "Richiesta scaduta",
+            "message": "La richiesta di intelligenza artificiale ha richiesto troppo tempo per essere completata. Questo potrebbe accadere con requisiti complessi o un numero elevato di casi di test."
+          },
+          "network": {
+            "title": "Errore di rete",
+            "message": "Impossibile connettersi al servizio di intelligenza artificiale. Verifica la tua connessione a Internet e riprova."
+          },
+          "unauthorized": {
+            "title": "Autenticazione del servizio AI non riuscita",
+            "message": "Il servizio di intelligenza artificiale ha rifiutato le nostre credenziali. Un amministratore deve verificare la chiave API dell'integrazione LLM nelle impostazioni di amministrazione."
+          },
+          "forbidden": {
+            "title": "Accesso al servizio di intelligenza artificiale negato.",
+            "message": "Il servizio di intelligenza artificiale ha rifiutato la richiesta. È necessario che un amministratore verifichi le autorizzazioni di integrazione di LLM e l'accesso al progetto."
+          },
+          "projectNotFound": {
+            "title": "Progetto non trovato",
+            "message": "Non siamo riusciti a trovare questo progetto, oppure non si dispone dell'autorizzazione per utilizzare la generazione tramite intelligenza artificiale in questo ambiente."
+          },
+          "noIntegration": {
+            "title": "Nessuna integrazione LLM attiva",
+            "message": "Per questo progetto non è configurata alcuna integrazione LLM attiva. Un amministratore deve abilitarne una nelle impostazioni di amministrazione."
+          },
+          "invalidRequest": {
+            "title": "Richiesta non valida",
+            "message": "La richiesta di generazione dell'IA non conteneva tutte le informazioni necessarie. Aggiorna la pagina e riprova."
+          },
+          "retryButton": "Riprova",
+          "dismissButton": "Congedare",
+          "suggestionsHeading": "Suggerimenti",
+          "suggestions": {
+            "retryLater": "Riprova tra qualche minuto.",
+            "contactAdmin": "Se il problema persiste, contatta il tuo amministratore.",
+            "checkStatus": "Verifica lo stato del servizio AI",
+            "checkNetwork": "Verifica la tua connessione internet"
+          },
+          "timestampLabel": "Si è verificato un errore a",
+          "showDetails": "Mostra dettagli",
+          "hideDetails": "Nascondi dettagli",
+          "copyDetails": "Copia dettagli",
+          "detailsCopied": "Dettagli dell'errore copiati negli appunti"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Modifiche non salvate",
+        "description": "{count, plural, =1 {Hai 1 caso di test con modifiche non salvate.} other {Hai # casi di test con modifiche non salvate.}}",
+        "warning": "Se procedi senza salvare, le modifiche andranno perse.",
+        "saveAllAndImport": "Salva tutto e importa",
+        "discardAndImport": "Annulla modifiche e importa"
+      },
+      "linkedIssuesDroppedTitle": "Alcuni problemi correlati non sono stati inclusi",
+      "linkedIssuesDropped": "{count, plural, =1 {# il problema collegato è stato eliminato} other {# i problemi collegati sono stati eliminati}} a causa del budget dei token: {keys}.",
+      "linkedIssuesPreviewHeading": "Problemi correlati che saranno inclusi"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Aggiungi tag",
+      "title": "Aggiungi nuovo tag",
+      "fields": {
+        "name_error": "Il nome del tag è obbligatorio"
+      },
+      "errors": {
+        "nameExists": "Esiste già un tag con questo nome"
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Esiste già un tag con questo nome"
+      }
+    },
+    "filterPlaceholder": "Filtra i tag...",
+    "defaultName": "Tag senza nome",
+    "noProject": "Nessun progetto",
+    "description": "Gestisci e organizza i tuoi casi di test e le sessioni con i tag",
+    "detail": {
+      "title": "Dettagli del tag",
+      "filterPlaceholder": "Filtra gli elementi...",
+      "noResults": "Nessun elemento trovato",
+      "noFilterResults": "Nessun elemento corrisponde ai filtri correnti",
+      "filters": {
+        "hideCompletedSessions": "Nascondi le sessioni completate",
+        "hideCompletedTestRuns": "Nascondi le esecuzioni di prova completate",
+        "caseTypeLabel": "Tipo di caso",
+        "allCases": "Tutto"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Cerca tag...",
+      "searchOrAddPlaceholder": "Cerca o aggiungi tag...",
+      "noOptions": "Nessuna opzione"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Visualizzatore allegati"
+    },
+    "delete": {
+      "confirmMessage": "Sei sicuro di voler eliminare questo allegato?",
+      "deferredMessage": "Questo allegato verrà eliminato al momento del salvataggio."
+    }
+  },
+  "runs": {
+    "notFound": "Esecuzione del test non trovata.",
+    "add": {
+      "title": "Aggiungi esecuzione di prova",
+      "description": "Aggiungi una nuova esecuzione di test al progetto",
+      "success": {
+        "title": "Esecuzione del test aggiunta con successo",
+        "description": "Il test è stato aggiunto al progetto",
+        "descriptionMultiple": "{count, plural, one {# è stata creata una prova} other {# sono state create delle prove}} per '{name}'"
+      },
+      "estimates": {
+        "manual": "Tempo manuale stimato",
+        "automated": "Tempo stimato di automazione",
+        "mixed": "Tempo stimato manuale/automatico"
+      },
+      "creatingProgress": "Creazione dell'esecuzione di prova {current} di {total}..."
+    },
+    "magicSelect": {
+      "title": "Magic Select",
+      "description": "Selezione dei casi di test basata sull'intelligenza artificiale in base al contesto dell'esecuzione del test.",
+      "counting": "Cerchiamo casi di test pertinenti...",
+      "reasoning": "Ragionamento basato sull'IA",
+      "reviewSelection": "Esamina i casi di test suggeriti",
+      "viewSuggested": "Visualizza i casi suggeriti",
+      "tokenUsage": "{total} token utilizzati",
+      "noLlmIntegration": "Le funzionalità di intelligenza artificiale richiedono l'integrazione con LLM. Configurala nelle impostazioni del progetto.",
+      "configure": {
+        "title": "Ambito del caso di test",
+        "description": "Trovato {count, plural, =1 {# caso di test} other {# casi di test}} nel repository",
+        "descriptionFiltered": "Trovato {count, plural, =1 {# casi di test potenzialmente rilevanti} other {# casi di test potenzialmente rilevanti}} da {total, plural, =1 {# totale} other {# totale}} nel repository",
+        "noMatchesTitle": "Nessun caso di test corrispondente trovato",
+        "noMatchesDescription": "Il nome e la descrizione dell'esecuzione del test non corrispondono ad alcun caso di test. Torna al passaggio precedente e aggiungi dettagli più specifici, come i nomi delle funzionalità, i nomi dei componenti o le parole chiave presenti nei tuoi casi di test.",
+        "maxResultsTitle": "Numero massimo di casi di test corrispondenti",
+        "maxResultsDescription": "I criteri di ricerca hanno trovato una corrispondenza con un gran numero di casi di test. Per risultati più mirati, torna al passaggio precedente e aggiungi dettagli più specifici all'esecuzione del test.",
+        "batchSize": "dimensione del lotto",
+        "batchSizeAll": "Tutti i casi (richiesta singola)",
+        "batchSizePercent": "{percent}% ({count} casi)",
+        "requestsNeeded": "{count, plural, =1 {# Verrà effettuata una richiesta AI} other {# Verranno effettuate richieste AI}}",
+        "batchNote": "I risultati di tutti i lotti verranno combinati"
+      },
+      "loading": {
+        "batch": "Elaborazione del lotto {current} di {total}",
+        "analyzing": "Analisi dei casi di test...",
+        "progress": "Sono stati analizzati {analyzed} dei {total} casi di test...",
+        "waitingForAi": "In attesa della risposta dell'IA (lotto {batch} di {total})...",
+        "selectedSoFar": "{count, plural, =1 {# casi di test selezionati finora} other {# casi di test selezionati finora}}",
+        "resolving_integration": "Risoluzione dell'integrazione dell'IA...",
+        "fetching_cases": "Recupero dei casi di test in corso..."
+      },
+      "success": {
+        "title": "Casi di test suggeriti",
+        "description": "{count, plural, =1 {# caso di test selezionato} other {# casi di test selezionati}} in base al contesto dell'esecuzione del test",
+        "linkedCasesAdded": "{count, plural, =1 {# casi collegati inclusi automaticamente} other {# casi collegati inclusi automaticamente}}",
+        "truncationWarningTitle": "Risultati parziali",
+        "truncationWarning": "{count, plural, =1 {# batch troncato} other {# batch troncati}} dal modello AI: alcuni casi di test potrebbero non essere stati valutati."
+      },
+      "noSuggestions": {
+        "title": "Nessun caso di test corrispondente",
+        "description": "Nessun caso di test corrispondeva ai criteri. Prova ad aggiungere maggiori dettagli o chiarimenti."
+      },
+      "clarification": {
+        "label": "Contesto aggiuntivo (facoltativo)",
+        "placeholder": "Aggiungi ulteriori informazioni contestuali per facilitare la selezione dei casi di test pertinenti...",
+        "refine": "Affina la selezione"
+      },
+      "actions": {
+        "start": "Analizzare i casi di test",
+        "startBatched": "Analizza i casi di test ({count, plural, one {# batch} other {# batch}})",
+        "accept": "Aggiungi alla selezione"
+      },
+      "errors": {
+        "title": "Selezione non riuscita",
+        "generic": "Si è verificato un errore durante la selezione dei casi di test. Riprova.",
+        "noTestRunName": "Inserisci un nome per la prova prima di utilizzare Magic Select."
+      }
+    },
+    "delete": {
+      "title": "Elimina esecuzione test",
+      "description": "Sei sicuro di voler eliminare questa esecuzione di prova? I risultati verranno conservati per analisi storiche.",
+      "warning": "Questa azione non può essere annullata.",
+      "toast": {
+        "loading": "Eliminazione dell'esecuzione del test...",
+        "success": "Esecuzione del test eliminata correttamente",
+        "error": {
+          "title": "Impossibile eliminare l'esecuzione del test",
+          "description": "Si è verificato un errore durante l'eliminazione dell'esecuzione del test"
+        }
+      }
+    },
+    "summary": {
+      "title": "Riepilogo dell'esecuzione del test",
+      "description": "Visualizza il riepilogo dell'esecuzione del test",
+      "activeRunsAndEstTime": "Corse attive e tempo stimato",
+      "activeRunsLabel": "Corre",
+      "totalEstTime": "Tempo stimato totale",
+      "responsibleUsers": "Utenti responsabili",
+      "allActiveRuns": "Tutte le corse attive",
+      "recentResultsTitle": "Risultati manuali recenti",
+      "recentResultsDescription": "Visualizza i risultati recenti del test eseguito",
+      "recentAutomatedResultsTitle": "Risultati automatizzati recenti",
+      "noRecentAutomatedResults": "Nessun risultato automatico recente trovato.",
+      "recentResultsDateRange": "Intervallo di date",
+      "recentResultsElapsed": "Trascorso",
+      "noRecentResults": "Nessun risultato recente trovato.",
+      "completionTrendTitle": "Tendenza al completamento (6 mesi precedenti)",
+      "workDistributionTitle": "Distribuzione del lavoro",
+      "workDistributionDescription": "Stima della distribuzione del lavoro per assegnatario.",
+      "noWorkDistributionData": "Nessuna sessione attiva con assegnatari o stime da visualizzare."
+    },
+    "details": {
+      "title": "Dettagli dell'esecuzione del test",
+      "description": "Visualizza i dettagli del test eseguito"
+    },
+    "duplicateDialog": {
+      "title": "Esecuzione di test duplicata",
+      "description": "Crea una copia dell'esecuzione del test <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Casi di test da duplicare",
+          "allCases": "Tutti i casi di prova",
+          "specificStatuses": "Casi di test con stati specifici"
+        },
+        "statusesToInclude": {
+          "label": "Casi di test da includere",
+          "description": "Selezionare gli stati dei casi di test che si desidera includere nell'esecuzione del test duplicato.",
+          "noStatuses": "Non sono stati trovati stati specifici in questa esecuzione del test oppure i risultati sono ancora in fase di caricamento.",
+          "noStatusesRecorded": "Nessuno stato specifico registrato in questa esecuzione. La duplicazione includerà tutti i casi di test (in genere come \"Non testato\")."
+        },
+        "copyAssignments": {
+          "label": "Assegnazioni di casi di prova",
+          "copy": "Copia le assegnazioni dei casi di test esistenti",
+          "assign": "Tutti i casi di test nell'esecuzione del test duplicato manterranno le loro assegnazioni esistenti",
+          "unassign": "Tutti i casi di test nell'esecuzione del test duplicato non saranno assegnati"
+        }
+      },
+      "successMessage": "Esecuzione del test duplicata con successo '{name}'.",
+      "errorMessage": "Impossibile duplicare l'esecuzione del test. Errore: {error}"
+    },
+    "filter": {
+      "placeholder": "Esecuzione del test del filtro..."
+    },
+    "typeFilter": {
+      "label": "Spettacolo",
+      "both": "Manuale e automatizzato"
+    },
+    "empty": {
+      "noMatchingCompleted": "Nessun test completato corrisponde al filtro."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Principale",
+      "projects": "Eventi",
+      "templatesAndFields": "Modelli e campi",
+      "fields": "Campi",
+      "workflows": "Flussi di lavoro",
+      "statuses": "Stati",
+      "milestoneTypes": "Tipi di traguardi",
+      "configurations": "Configurazioni",
+      "users": "Utenti",
+      "groups": "Gruppi",
+      "roles": "Ruoli",
+      "tags": "Etichette",
+      "issues": "Problemi",
+      "appConfig": "Configurazione dell'applicazione",
+      "notifications": "Notifiche",
+      "imports": "Importazioni di dati",
+      "integrations": "Integrazioni dei problemi",
+      "webhooks": "webhook",
+      "llm": "Modelli di intelligenza artificiale",
+      "prompts": "Configurazione richiesta",
+      "exportTemplates": "Esporta modelli",
+      "codeRepositories": "Repository di codice",
+      "quickScript": "QuickScript",
+      "sso": "Autenticazione",
+      "security": "Sicurezza",
+      "trash": "Spazzatura",
+      "reports": "Rapporti",
+      "shares": "Gestisci le azioni",
+      "elasticsearch": "Motore di ricerca",
+      "queues": "Code di lavoro",
+      "auditLogs": "Registri di controllo",
+      "apiTokens": "Token API",
+      "quickscriptTemplates": "Modelli QuickScript",
+      "testManagement": "Gestione dei test",
+      "peopleAndAccess": "Persone e accesso",
+      "toolsAndIntegrations": "Strumenti e integrazioni",
+      "system": "Sistema"
+    },
+    "imports": {
+      "description": "Importa i dati da strumenti esterni di gestione dei test in TestPlanIt.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Carica un'esportazione JSON di Testmo per analizzarne il contenuto e preparare la mappatura della migrazione.",
+        "wizard": {
+          "steps": {
+            "upload": "Carica esportazione",
+            "analysis": "Analisi della recensione",
+            "mapping": "Configura la mappatura",
+            "import": "Importazione del monitor"
+          },
+          "stepIndicator": "Passo {step} di {total}"
+        },
+        "fileLabel": "File JSON di Testmo",
+        "fileHelp": "Seleziona l'esportazione JSON che hai scaricato da Testmo.",
+        "analyze": "Analizza esportazione",
+        "analyzing": "Analisi in corso...",
+        "reset": "Risultati chiari",
+        "job": {
+          "discoveringDatasets": "Alla scoperta dei set di dati...",
+          "scanningFile": "Scansione del file di esportazione testmo in corso...",
+          "datasetsProcessed": "{processed, number} set di dati{processed, plural, one {} other {s}} elaborato",
+          "datasetsProcessedWithTotal": "{processed, number} di {total, number} set di dati{total, plural, one {} other {s}} elaborati",
+          "rowsProcessed": "{value, number} righe elaborate",
+          "itemsProcessed": "{processed, number} di {total, number} elementi elaborati",
+          "analysisInProgress": "Analisi dell'esportazione…",
+          "cancel": "Annulla importazione",
+          "cancelRequested": "Annullamento richiesto",
+          "processingRate": "Valutare:",
+          "estimatedTimeRemaining": "Tempo rimanente stimato:",
+          "datasetsLabel": "Set di dati:",
+          "rowsProcessedLabel": "Righe:"
+        },
+        "summaryHeading": "Riepilogo esportazione",
+        "summary": {
+          "datasets": "Set di dati",
+          "fileName": "Nome del file",
+          "fileSize": "Dimensione del file",
+          "analysisTime": "Tempo di analisi"
+        },
+        "datasetTable": {
+          "name": "Set di dati",
+          "rows": "Righe",
+          "samples": "Campioni catturati"
+        },
+        "status": {
+          "truncated": "Troncato"
+        },
+        "selectDataset": "Seleziona il set di dati",
+        "schema": "Schema",
+        "samples": "Righe di esempio",
+        "noSamples": "Nessun campione catturato per questo set di dati.",
+        "mappingHeading": "Configurazione della mappatura",
+        "mappingRefresh": "Aggiorna analisi",
+        "mappingDescription": "Esamina i dettagli dell'analisi e associa le entità Testmo ai record TestPlanIt esistenti oppure scegli di crearne di nuovi.",
+        "mappingAnalysisError": "Non siamo riusciti a generare l'analisi della mappatura. Riprova.",
+        "mappingLoading": "Analisi della mappatura degli edifici…",
+        "mappingSummaryHeading": "Entità rilevate",
+        "mappingSummaryPending": "{count, plural, =1 {# in attesa} other {# in attesa}}",
+        "mappingOutstandingTitle": "Risolvi le mappature in sospeso",
+        "mappingOutstandingDescription": "Completare le mappature rimanenti prima di avviare l'importazione.",
+        "mappingOutstandingItem": "{count, plural, =1 {# elemento irrisolto} other {# elementi irrisolti}} in {label}",
+        "mappingSummaryTemplateFields": "Campi modello",
+        "mappingDatasetLabels": {
+          "field_values": "Valori di campo",
+          "repository_case_values": "Valori dei casi del repository",
+          "configs": "Impostazioni di configurazione",
+          "session_issues": "Problemi di sessione",
+          "session_tags": "Tag di sessione",
+          "states": "stati del flusso di lavoro",
+          "statuses": "Stati",
+          "templates": "Modelli",
+          "template_fields": "Campi modello",
+          "milestone_types": "Tipi di traguardi",
+          "roles": "Ruoli",
+          "users": "Utenti",
+          "groups": "Gruppi",
+          "user_groups": "Gruppi di utenti",
+          "issue_targets": "Integrazioni dei problemi",
+          "tags": "Etichette",
+          "sessions": "Sessioni",
+          "session_results": "Risultati della sessione",
+          "fields": "Campi",
+          "projects": "Eventi",
+          "repositories": "Repository",
+          "repository_folders": "Cartelle del repository",
+          "repository_cases": "Casi di deposito",
+          "repository_case_steps": "Passaggi del caso del repository",
+          "repository_case_tags": "Tag dei casi del repository",
+          "milestones": "Traguardi",
+          "runs": "Prove di corsa",
+          "run_tests": "Casi di esecuzione del test",
+          "run_results": "Risultati della prova",
+          "run_result_steps": "Risultati della fase di esecuzione del test",
+          "run_links": "collegamenti alle esecuzioni di prova",
+          "run_tags": "Tag di esecuzione del test",
+          "issues": "Problemi",
+          "milestone_issues": "Questioni fondamentali",
+          "repository_case_issues": "Problemi relativi al caso del repository",
+          "run_issues": "Problemi durante l'esecuzione del test",
+          "run_result_issues": "Problemi relativi ai risultati dell'esecuzione del test",
+          "session_result_issues": "Problemi relativi ai risultati della sessione",
+          "automation_cases": "Casi di automazione",
+          "automation_runs": "Esecuzione automatica",
+          "automation_run_tests": "Esecuzione automatizzata dei test",
+          "automation_run_test_fields": "Esecuzione automatica dei test sui campi",
+          "automation_run_links": "Collegamenti di esecuzione dell'automazione",
+          "automation_run_tags": "Tag di esecuzione dell'automazione",
+          "session_values": "valori di sessione"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Esaminare gli stati del flusso di lavoro per mappare o creare flussi di lavoro TestPlanIt.",
+          "statuses": "Configura il modo in cui gli stati di Testmo vengono mappati agli stati di TestPlanIt.",
+          "templates": "Esaminare le definizioni dei modelli importati da Testmo.",
+          "template_fields": "Esaminare le definizioni dei campi modello incluse nell'esportazione.",
+          "fields": "Esamina i record dei campi personalizzati esportati da Testmo.",
+          "field_values": "Esaminare le definizioni dei valori dei campi acquisite nell'esportazione.",
+          "milestone_types": "Esaminare le definizioni dei tipi di milestone acquisite nell'esportazione.",
+          "roles": "Esaminare le definizioni dei ruoli per comprendere le autorizzazioni di Testmo.",
+          "users": "Visualizza gli account utente rilevati nell'esportazione Testmo.",
+          "groups": "Rivedi i compiti di gruppo trasferiti da Testmo.",
+          "configs": "Associare i nomi delle configurazioni alle categorie e alle varianti di TestPlanIt.",
+          "tags": "Esamina i valori dei tag che appaiono nei dati Testmo.",
+          "repository_case_values": "Valori a selezione multipla assegnati ai casi di test.",
+          "sessions": "Le sessioni vengono sempre create come nuove sessioni.",
+          "session_results": "I risultati delle sessioni sono collegati alle sessioni stesse.",
+          "session_issues": "I problemi di sessione sono collegati alle sessioni.",
+          "session_tags": "I tag di sessione sono collegati alle sessioni.",
+          "issue_targets": "Mappare gli obiettivi dei problemi di Testmo sulle integrazioni di TestPlanIt (Jira, GitHub, ecc.)."
+        },
+        "mappingDatasetDefaultDescription": "Revisione {dataset} rilevata nell'esportazione Testmo.",
+        "mappingDatasetCount": "{count, number} record{count, plural, one {} other {s}} rilevato",
+        "mappingDatasetNoEntitiesTitle": "Niente da mappare",
+        "mappingDatasetNoEntitiesDescription": "Questo set di dati non richiede mappatura. Passa al set di dati successivo quando sei pronto.",
+        "mappingDatasetUnsupportedTitle": "Nessuna mappatura richiesta",
+        "mappingDatasetUnsupportedDescription": "Questi record verranno importati automaticamente e collegati ai record correlati in TestPlanIt. Non è richiesta alcuna mappatura manuale.",
+        "mappingDatasetEmptyTitle": "Nessun set di dati conservato",
+        "mappingDatasetEmptyDescription": "L'analisi non ha conservato alcun set di dati per la configurazione. Carica un'esportazione diversa se prevedi dati aggiuntivi.",
+        "importProgressTitle": "Avanzamento dell'importazione",
+        "importProgressDescription": "{count, plural, =0 {Tutti i record importati nelle entità tracciate.} =1 {1 record rimanente nelle entità tracciate.} other {# record rimanenti nelle entità tracciate.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Nessun record rimanente} =1 {1 record rimanente} other {# record rimanenti}}",
+        "importProgressProcessed": "{processed, number}/{total, number} record importati",
+        "importProgressAria": "{percent}% di importazione completata",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Tempo totale:",
+        "activityLogTitle": "Attività di importazione",
+        "activityLogDescription": "Registro dettagliato delle fasi di importazione in background. I timestamp si basano sul fuso orario del server.",
+        "activitySummaryProcessed": "{count, plural, =1 {# record elaborato} other {# record elaborato}}",
+        "activitySummaryCreated": "{count, plural, =1 {# creato} other {# creato}}",
+        "activitySummaryMapped": "{count, plural, =1 {# mappato} other {# mappato}}",
+        "activitySummaryUnknown": "Fase di importazione",
+        "activityDefaultMessage": "Aggiornamento dell'importazione",
+        "previousImportsHeading": "Rivedi le importazioni precedenti",
+        "previousImportsDescription": "Caricare i risultati dell'analisi da un'importazione completata per ispezionare i registri di configurazione o attività.",
+        "previousImportsRefresh": "Aggiorna elenco",
+        "previousImportsPlaceholder": "Seleziona un'importazione precedente",
+        "previousImportsEmpty": "Nessuna importazione precedente trovata per il tuo account.",
+        "previousImportsCreatedLabel": "Creato: ",
+        "previousImportsFileLabel": "File: ",
+        "previousImportsNoFilename": "File sconosciuto",
+        "jobHistoryLoadFailed": "Non è stato possibile caricare i lavori importati in precedenza.",
+        "jobLoadFailed": "Non è stato possibile caricare il processo di importazione.",
+        "uploadProgressAnalyzing": "Caricamento completato. Analisi del file…",
+        "uploadProgressComplete": "Caricamento completato",
+        "etaLabel": "Arrivo previsto: {time}",
+        "startImportButton": "Avvia l'importazione",
+        "workflowCreate": {
+          "nameLabel": "Nome del flusso di lavoro",
+          "namePlaceholder": "Inserisci un nome per il flusso di lavoro",
+          "scopePlaceholder": "Seleziona ambito",
+          "iconColorLabel": "Icona e colore",
+          "typeLabel": "Tipo di flusso di lavoro"
+        },
+        "mappingDatasets": "Set di dati che richiedono revisione",
+        "mappingImportConfiguration": "Importa configurazione",
+        "mappingExportConfiguration": "Configurazione di esportazione",
+        "mappingImportConfigurationFailed": "Non è stato possibile importare il file di configurazione. Verifica che sia un JSON valido e riprova.",
+        "mappingInvalidConfiguration": "La configurazione deve essere un JSON valido.",
+        "mappingSaveFailed": "Non è stato possibile salvare la configurazione. Riprova.",
+        "mappingSaveConfiguration": "Salva la configurazione",
+        "mappingSavingConfiguration": "Salvataggio…",
+        "mappingStartImport": "Avvia l'importazione in background",
+        "mappingStartingImport": "Avvio importazione…",
+        "mappingImportFailed": "Impossibile avviare l'importazione in background. Riprova.",
+        "mappingImportDisabled": "Salvare una configurazione prima di avviare l'importazione in background.",
+        "mappingImportInProgress": "Importazione in background in corso",
+        "mappingImportInProgressDescription": "Il worker di importazione sta elaborando la configurazione. Puoi monitorarne lo stato qui sopra.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# record} other {# record}} ",
+          "columnSource": "Entità Testmo",
+          "columnSourceDetails": "Dettagli",
+          "columnSuggestedWorkflowType": "Tipo suggerito",
+          "columnTarget": "Bersaglio",
+          "workflowTypeUnknown": "Non rilevato",
+          "actionMap": "Mappa esistente",
+          "actionCreate": "Crea nuovo",
+          "workflowTypePlaceholder": "Seleziona il tipo",
+          "noWorkflowsAvailable": "Nessun flusso di lavoro disponibile.",
+          "noStatusesAvailable": "Nessuno stato disponibile.",
+          "noGroupsAvailable": "Nessun gruppo disponibile.",
+          "groupSelectPlaceholder": "Seleziona gruppo",
+          "groupNotePlaceholder": "Note (facoltative)",
+          "groupNoteEmpty": "Non sono stati forniti ulteriori dettagli.",
+          "noUsersAvailable": "Nessun utente disponibile.",
+          "userNoExistingTargets": "Nessun utente disponibile per la mappatura.",
+          "userNamePlaceholder": "Nome e cognome",
+          "userAccessPlaceholder": "Seleziona il livello di accesso",
+          "userRoleUnavailable": "Nessun ruolo disponibile da assegnare.",
+          "userPasswordPlaceholder": "Password temporanea",
+          "userPasswordHint": "Fornisci una password temporanea. Gli utenti potranno modificarla dopo aver effettuato l'accesso.",
+          "userActiveLabel": "Account attivo",
+          "userDisplayFallback": "Utente {id}",
+          "userMissingRequired": "Mancano i dettagli richiesti",
+          "noConfigurationsAvailable": "Nessuna configurazione disponibile.",
+          "configurationNoTokens": "Nessuna variante rilevata in questa configurazione.",
+          "configurationNoExistingTargets": "Nessuna configurazione disponibile per la mappatura.",
+          "configurationNamePlaceholder": "Inserisci un nome di configurazione",
+          "configurationVariantLabel": "Variante {index}",
+          "configurationVariantActionLabel": "Come dovrebbe essere gestita questa variante?",
+          "configurationVariantActionPlaceholder": "Scegli un'opzione",
+          "configurationVariantMapOption": "Mappa alla variante esistente",
+          "configurationVariantExistingCategoryOption": "Crea variante nella categoria esistente",
+          "configurationVariantNewCategoryOption": "Crea una nuova categoria e variante",
+          "configurationVariantSelectLabel": "Seleziona variante",
+          "configurationVariantNoVariants": "Nessuna variante disponibile da mappare.",
+          "configurationVariantCategoryLabel": "Categoria",
+          "configurationVariantNameLabel": "Nome variante",
+          "configurationVariantNamePlaceholder": "Inserisci un nome variante",
+          "configurationVariantNoCategories": "Nessuna categoria disponibile.",
+          "configurationVariantCategoryNameLabel": "Nome della categoria",
+          "configurationVariantCategoryNamePlaceholder": "Inserisci un nome di categoria",
+          "noTemplateFieldsAvailable": "Nessun campo modello disponibile.",
+          "templateFieldDisplayFallback": "Campo {id}",
+          "templateFieldUnknownTemplate": "Modello sconosciuto",
+          "templateFieldTargetCase": "Campo caso",
+          "templateFieldTargetResult": "Campo risultato",
+          "templateFieldSelectPlaceholder": "Seleziona campo",
+          "templateFieldNoExistingTargets": "Nessun campo disponibile per la mappatura.",
+          "templateFieldTypePlaceholder": "Seleziona il tipo di campo",
+          "templateFieldRestrictedLabel": "Campo riservato",
+          "templateFieldOptionsLabel": "Opzioni a discesa",
+          "templateFieldOptionsPlaceholder": "Inserisci un'opzione per riga",
+          "templateFieldOptionsHint": "Separare ogni opzione con una nuova riga.",
+          "templateFieldOptionsListLabel": "Opzioni",
+          "templateFieldOptionsCheckedLabel": "Selezionato per impostazione predefinita",
+          "templateFieldOptionsMinValueLabel": "Valore minimo",
+          "templateFieldOptionsMaxValueLabel": "Valore massimo",
+          "templateFieldOptionsMinIntegerLabel": "Intero minimo",
+          "templateFieldOptionsMaxIntegerLabel": "Numero intero massimo",
+          "templateFieldNewFieldSummaryTitle": "Nuovi dettagli del campo",
+          "templateFieldNewFieldSummaryDescription": "Esaminare i valori che verranno utilizzati per creare questo campo TestPlanIt.",
+          "templateFieldConfigureFieldButton": "Configura i dettagli",
+          "templateFieldEditFieldButton": "Modifica dettagli",
+          "templateFieldSummaryMissingValue": "Non impostato",
+          "templateFieldSummaryMissingDetailsHint": "Prima di continuare, fornisci i dettagli del nuovo campo.",
+          "templateFieldModalSaveButton": "Salva i dettagli",
+          "templateFieldTargetTypeLabel": "Tipo di bersaglio",
+          "templateFieldTypeMismatchWarning": "Il tipo di campo selezionato {target} non corrisponde al tipo di campo Testmo {source}.",
+          "templateFieldDuplicateTargetWarning": "Il target selezionato è già mappato su un altro campo Testmo. Scegli un target diverso.",
+          "templateFieldTargetAlreadyUsed": "Già mappato",
+          "templateFieldMappedSummary": "Mappato su {name} ({type})",
+          "templateFieldIssueMissingTarget": "Seleziona un campo di destinazione.",
+          "templateFieldIssueMissingDetails": "Prima di continuare, specificare il nome visualizzato, il nome del sistema e il tipo di campo.",
+          "noTemplatesAvailable": "Nessun modello disponibile.",
+          "templateColumnFields": "Campi",
+          "templateFieldStatusMapped": "Mappato",
+          "templateFieldStatusCreate": "Crea nuovo campo",
+          "templateFieldStatusMissing": "Non mappato",
+          "templateFieldStatusMismatch": "Mancata corrispondenza dell'obiettivo",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# campo caso} other {# campi caso}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# campo risultato} other {# campi risultato}}",
+          "templateMapLabel": "Mappa sul modello esistente",
+          "templateCreateLabel": "Crea un nuovo modello",
+          "templateNoMatchingTargets": "Nessun modello corrispondente disponibile.",
+          "templateNewNameLabel": "Nome del modello",
+          "templateMapHintIncomplete": "Mappare tutti i campi Testmo sui campi caso e risultato esistenti prima di mapparli su un modello esistente.",
+          "templateMapHintDuplicate": "Ogni campo Testmo deve essere mappato a un campo TestPlanIt univoco.",
+          "templateMapHintNoMatch": "Nessun modello esistente utilizza lo stesso set di campi.",
+          "templateMapHintAlreadyMapped": "Tutti i modelli corrispondenti sono già mappati. Cancella l'altra mappatura prima di continuare.",
+          "templateIssueNoSelection": "Seleziona un modello esistente da mappare.",
+          "templateIssueTargetConflict": "Un altro modello è già mappato su questa destinazione.",
+          "templateIssueFieldErrors": "Risolvi i campi del modello evidenziati.",
+          "templateTargetFieldsMismatch": "I campi non corrispondono a questo modello.",
+          "templateTargetNoLongerMatching": "I campi non corrispondono più a questo modello.",
+          "noRolesAvailable": "Nessun ruolo disponibile.",
+          "roleSelectPlaceholder": "Seleziona il ruolo",
+          "roleNameLabel": "Nome del ruolo",
+          "roleNamePlaceholder": "Inserisci un nome per il ruolo",
+          "rolePermissionsEmpty": "Nessuna autorizzazione assegnata",
+          "rolePermissionAddEdit": "Aggiungi / Modifica",
+          "noMilestoneTypesAvailable": "Nessun tipo di traguardo disponibile.",
+          "milestoneSelectPlaceholder": "Seleziona il tipo di traguardo",
+          "milestoneNamePlaceholder": "Inserisci un nome per il tipo di traguardo",
+          "milestoneDefaultLabel": "Tipo di traguardo predefinito",
+          "milestoneIconRequired": "Seleziona un'icona",
+          "statusColorPlaceholder": "Colore esadecimale (facoltativo)",
+          "issueTargetSelectPlaceholder": "Seleziona integrazione...",
+          "noIssueTargetsAvailable": "Nessuna integrazione disponibile",
+          "issueTargetNamePlaceholder": "Nome dell'integrazione...",
+          "templateFieldsHeading": "Campi modello",
+          "roleAreaColumn": "Zona",
+          "workflowSelectPlaceholder": "Seleziona il flusso di lavoro",
+          "statusSelectPlaceholder": "Seleziona lo stato",
+          "statusNamePlaceholder": "Inserisci un nome di stato",
+          "statusSystemNamePlaceholder": "Inserisci il nome del sistema",
+          "labelSystemName": "Nome del sistema",
+          "groupNamePlaceholder": "Inserisci il nome del gruppo",
+          "configurationNameLabel": "Nome della configurazione",
+          "userSelectPlaceholder": "Seleziona utente",
+          "userApiLabel": "utente API",
+          "templateCaseFieldsLabel": "Casi di studio",
+          "templateResultFieldsLabel": "Campi di risultato",
+          "templateNoFieldsPlaceholder": "Nessun campo configurato per questo modello.",
+          "templateTargetAlreadyUsed": "L'obiettivo è già mappato a un altro modello.",
+          "templateFieldRequiredLabel": "Campo obbligatorio",
+          "templateFieldOptionsDefaultValueLabel": "Valore predefinito",
+          "templateFieldOptionsInitialHeightLabel": "altezza iniziale",
+          "templateFieldTemplateLabelSingular": "modello",
+          "templateFieldTemplateLabelPlural": "modelli",
+          "templateFieldTargetGroupCase": "Casi di studio",
+          "templateFieldTargetGroupResult": "Campi di risultato",
+          "columnAction": "Azione"
+        },
+        "nextSteps": "Una volta completata l'importazione in background, è possibile rivedere i dati migrati dai progetti di destinazione.",
+        "nextStepsDescription": "Le importazioni in background vengono eseguite in modo asincrono. Puoi monitorare lo stato qui sopra o aggiornare la pagina per visualizzare gli aggiornamenti."
+      },
+      "comingSoon": {
+        "description": "Sono previste importazioni per TestRail, Zephyr e altri strumenti."
+      },
+      "errors": {
+        "fileRequired": "Si prega di scegliere un file JSON di esportazione Testmo prima dell'analisi.",
+        "uploadFailed": "Non è stato possibile caricare l'esportazione nell'archivio. Riprova.",
+        "analysisFailed": "Non è stato possibile analizzare l'esportazione. Verifica il file e riprova."
+      }
+    },
+    "sso": {
+      "description": "Gestisci le impostazioni di autenticazione e sicurezza",
+      "sections": {
+        "providers": {
+          "title": "Fornitori di accesso",
+          "description": "Configura le modalità di accesso degli utenti alla tua applicazione."
+        },
+        "security": {
+          "title": "Sicurezza",
+          "description": "Configurare le politiche di sicurezza per l'autenticazione"
+        }
+      },
+      "globalSettings": {
+        "title": "Impostazioni SSO globali",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Abilita o disabilita l'autenticazione Google OAuth"
+        },
+        "samlProvider": {
+          "title": "Fornitore SAML",
+          "description": "Abilita o disabilita l'autenticazione SAML"
+        },
+        "apple": {
+          "title": "Accedi ad Apple",
+          "description": "Abilita o disabilita l'autenticazione Apple Sign In"
+        },
+        "microsoft": {
+          "title": "Accesso Single Sign-On (SSO) di Microsoft",
+          "description": "Abilita o disabilita l'autenticazione Microsoft (Azure AD / Entra ID)"
+        },
+        "magicLink": {
+          "title": "Autenticazione Magic Link",
+          "description": "Attiva o disattiva l'autenticazione senza password basata sull'email"
+        },
+        "forceSso": {
+          "title": "Forza l'accesso SSO",
+          "description": "Disabilita l'accesso tramite e-mail e richiedi agli utenti di utilizzare SSO"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Richiedi l'autenticazione a due fattori per l'accesso tramite password",
+            "description": "Gli utenti che accedono con email/password devono configurare e utilizzare l'autenticazione a due fattori."
+          },
+          "forceAllLogins": {
+            "title": "Richiedi l'autenticazione a due fattori per tutti gli accessi.",
+            "description": "Tutti gli utenti devono verificare l'identità tramite 2FA dopo aver effettuato l'accesso, inclusi gli utenti SSO."
+          }
+        }
+      },
+      "providers": {
+        "configure": "Configurare SAML",
+        "delete": "Elimina fornitore",
+        "entryPoint": "Punto di ingresso: ",
+        "autoProvision": "Provisioning automatico: ",
+        "defaultAccess": "Accesso predefinito: ",
+        "configurationMessage": "Configurazione SAML non impostata. Fare clic sul pulsante Impostazioni per configurarla."
+      },
+      "samlConfiguration": {
+        "title": "Configurare il provider SAML",
+        "backButton": "Torna ai provider SSO",
+        "description": "Configura le impostazioni SAML per {name}",
+        "samlSettings": {
+          "title": "Impostazioni SAML",
+          "description": "Configura le impostazioni del tuo provider di identità SAML",
+          "ssoUrl": "URL SSO (punto di ingresso)",
+          "entityId": "ID entità (emittente)",
+          "certificate": "Certificato X.509",
+          "callbackUrl": "URL di richiamata",
+          "logoutUrl": "URL di disconnessione (facoltativo)"
+        },
+        "userProvisioning": {
+          "title": "Provisioning degli utenti",
+          "description": "Configurare come gli utenti vengono creati e mappati",
+          "autoProvision": "Provisioning automatico di nuovi utenti",
+          "defaultAccess": "Accesso predefinito al sistema per i nuovi utenti",
+          "accessDescription": "Ai nuovi utenti verrà assegnato il ruolo predefinito del database e questo livello di accesso al sistema."
+        },
+        "attributeMapping": {
+          "title": "Mappatura degli attributi",
+          "description": "Mappare gli attributi SAML sui campi utente",
+          "email": "Attributo e-mail",
+          "displayName": "Attributo Nome visualizzato",
+          "userId": "Attributo ID utente",
+          "firstName": "Attributo Nome (facoltativo)",
+          "lastName": "Attributo Cognome (facoltativo)",
+          "groups": "Attributo Gruppi (facoltativo)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Google OAuth abilitato",
+        "googleDisabled": "Google OAuth disabilitato",
+        "googleCreated": "Provider Google OAuth creato",
+        "googleUpdateFailed": "Impossibile aggiornare Google OAuth",
+        "samlCreated": "Fornitore SAML creato",
+        "createFailed": "Impossibile creare il provider",
+        "deleted": "Fornitore eliminato",
+        "deleteFailed": "Impossibile eliminare il provider",
+        "enabled": "Provider abilitato",
+        "disabled": "Provider disabilitato",
+        "updateFailed": "Impossibile aggiornare il provider",
+        "forceSsoEnabled": "Forza l'abilitazione dell'SSO a livello globale",
+        "forceSsoDisabled": "Forza la disattivazione globale dell'SSO",
+        "forceSsoUpdateFailed": "Impossibile aggiornare l'impostazione SSO forzata",
+        "force2FANonSSOEnabled": "Autenticazione a due fattori richiesta per l'accesso tramite password",
+        "force2FANonSSODisabled": "L'autenticazione a due fattori non è più richiesta per l'accesso tramite password.",
+        "force2FAAllLoginsEnabled": "Autenticazione a due fattori richiesta per tutti gli accessi.",
+        "force2FAAllLoginsDisabled": "L'autenticazione a due fattori non è più richiesta per tutti gli accessi.",
+        "force2FAUpdateFailed": "Impossibile aggiornare l'impostazione dell'autenticazione a due fattori",
+        "configUpdated": "Configurazione SAML aggiornata",
+        "configCreated": "Configurazione SAML creata",
+        "configSaveFailed": "Impossibile salvare la configurazione SAML",
+        "googleConfigSaved": "Configurazione Google OAuth salvata correttamente",
+        "googleConfigFailed": "Impossibile salvare la configurazione",
+        "appleEnabled": "Accesso Apple abilitato",
+        "appleDisabled": "Accesso Apple disabilitato",
+        "appleCreated": "Provider di accesso Apple creato",
+        "appleConfigSaved": "Configurazione di Apple Sign In salvata correttamente",
+        "appleConfigFailed": "Impossibile salvare la configurazione di Apple Sign In",
+        "appleUpdateFailed": "Impossibile aggiornare il provider di accesso Apple",
+        "microsoftEnabled": "Accesso SSO abilitato per Microsoft",
+        "microsoftDisabled": "Accesso Single Sign-On (SSO) di Microsoft disabilitato",
+        "microsoftCreated": "Provider SSO Microsoft creato",
+        "microsoftConfigSaved": "Configurazione SSO di Microsoft salvata correttamente.",
+        "microsoftConfigFailed": "Impossibile salvare la configurazione di Microsoft SSO.",
+        "microsoftUpdateFailed": "Impossibile aggiornare il provider SSO di Microsoft.",
+        "magicLinkEnabled": "Autenticazione Magic Link abilitata",
+        "magicLinkDisabled": "Autenticazione Magic Link disabilitata",
+        "magicLinkCreated": "Fornitore di Magic Link creato",
+        "magicLinkUpdateFailed": "Impossibile aggiornare il provider Magic Link",
+        "samlConfigSaved": "Configurazione SAML salvata correttamente",
+        "configureFirst": "Si prega di configurare il provider prima di abilitarlo",
+        "domainRestrictionEnabled": "Restrizione del dominio e-mail abilitata",
+        "domainRestrictionDisabled": "Restrizione del dominio e-mail disabilitata",
+        "domainRestrictionUpdateFailed": "Impossibile aggiornare l'impostazione di restrizione del dominio",
+        "domainRequired": "Inserisci un dominio",
+        "invalidDomain": "Inserisci un dominio valido (ad esempio, example.com)",
+        "domainAdded": "Dominio aggiunto con successo",
+        "domainExists": "Questo dominio è già nell'elenco consentito",
+        "domainAddFailed": "Impossibile aggiungere il dominio",
+        "domainEnabled": "Dominio abilitato",
+        "domainDisabled": "Dominio disabilitato",
+        "domainUpdateFailed": "Impossibile aggiornare il dominio",
+        "domainDeleted": "Dominio rimosso con successo",
+        "domainDeleteFailed": "Impossibile rimuovere il dominio",
+        "defaultAccessUpdated": "Livello di accesso predefinito aggiornato",
+        "defaultAccessUpdateFailed": "Impossibile aggiornare il livello di accesso predefinito",
+        "emailVerificationEnabled": "Ora è richiesta la verifica dell'indirizzo email per i nuovi utenti.",
+        "emailVerificationDisabled": "La verifica dell'indirizzo email non è più richiesta per i nuovi utenti.",
+        "emailVerificationDisabledAndVerified": "Verifica dell'email disabilitata e {count, plural, one {# account utente} other {# account utente}} verificato",
+        "emailVerificationUpdateFailed": "Impossibile aggiornare le impostazioni di verifica dell'email.",
+        "emailServerNotConfigured": "Impossibile abilitare la verifica dell'e-mail: il server di posta elettronica non è configurato.",
+        "openRegistrationEnabled": "La registrazione autonoma è ora abilitata.",
+        "openRegistrationDisabled": "La registrazione autonoma è ora disabilitata.",
+        "openRegistrationUpdateFailed": "Impossibile aggiornare le impostazioni di autoregistrazione"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Configurare Google OAuth",
+          "description": "Imposta le credenziali del client Google OAuth. Puoi ottenerle dalla Google Cloud Console.",
+          "clientIdPlaceholder": "Il tuo ID client Google OAuth",
+          "clientSecretPlaceholder": "Il segreto del tuo client Google OAuth",
+          "instructions": {
+            "title": "Per ottenere queste credenziali:",
+            "step1": "Vai alla Google Cloud Console",
+            "step2": "Seleziona il tuo progetto o creane uno nuovo",
+            "step3": "Abilita l'API di Google+",
+            "step4": "Vai a Credenziali e crea un ID client OAuth 2.0",
+            "step5": "Imposta l'URI di reindirizzamento autorizzato su:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "Sono richiesti sia l'ID client che il segreto client"
+          }
+        },
+        "microsoft": {
+          "title": "Configurare l'SSO di Microsoft",
+          "description": "Configura le credenziali dell'applicazione Microsoft Entra ID (Azure AD). Puoi ottenerle dal portale di Azure.",
+          "clientIdPlaceholder": "Il tuo ID applicazione (client)",
+          "clientSecretPlaceholder": "Il valore segreto del tuo cliente",
+          "tenantId": "ID inquilino (facoltativo)",
+          "tenantIdPlaceholder": "Il tuo ID di directory (tenant)",
+          "tenantIdHint": "Lascia vuoto per la modalità multi-tenant (\"comune\"). Imposta l'ID del tuo tenant specifico per limitare l'accesso alla tua organizzazione.",
+          "instructions": {
+            "title": "Per ottenere queste credenziali:",
+            "step1": "Accedi al portale di Azure (portal.azure.com)",
+            "step2": "Accedere a Microsoft Entra ID > Registrazioni app.",
+            "step3": "Registra una nuova candidatura o selezionane una esistente.",
+            "step4": "Nella sezione Certificati e segreti, crea un nuovo segreto client.",
+            "step5": "Aggiungi il seguente URI di reindirizzamento nella sezione Autenticazione:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "Sono richiesti sia l'ID client che il segreto client."
+          }
+        },
+        "saml": {
+          "description": "Imposta la configurazione del tuo SAML Identity Provider. Puoi ottenere questi dettagli dal tuo SAML Identity Provider.",
+          "entryPoint": "URL del punto di ingresso SSO",
+          "issuer": "Emittente (ID entità)",
+          "callbackUrl": "URL ACS (richiamata)",
+          "logoutUrl": "URL di disconnessione SLO (facoltativo)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:your-idp:entity-id",
+          "certPlaceholder": "-----INIZIO CERTIFICATO-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "Per configurare SAML:",
+            "step1": "Contatta l'amministratore del tuo provider di identità SAML",
+            "step2": "Richiedi l'URL del punto di ingresso SSO e l'ID entità",
+            "step3": "Scarica il certificato X.509",
+            "step4": "Configura questo URL ACS nel tuo IdP:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "Sono richiesti il punto di ingresso, l'emittente, il certificato e l'URL di callback"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "Disabilitare la verifica dell'indirizzo email?",
+          "description": "Questa operazione disabiliterà la verifica dell'indirizzo email per le nuove registrazioni e verificherà tutti gli account esistenti non verificati.",
+          "warning": "⚠️ Avviso di sicurezza",
+          "warningPoint1": "Consigliato solo per installazioni protette (reti private, VPN o ambienti affidabili).",
+          "warningPoint2": "Tutti gli account esistenti non verificati verranno verificati immediatamente e riceveranno l'accesso al sistema.",
+          "confirmation": "Sei sicuro di voler disattivare la verifica dell'email e verificare tutti gli account?",
+          "confirm": "Disabilita e verifica tutto",
+          "verifying": "Verifica degli account in corso..."
+        }
+      },
+      "status": {
+        "configured": "Configurato",
+        "setup": "Impostare"
+      },
+      "registration": {
+        "title": "Impostazioni di registrazione",
+        "description": "Controlla chi può registrarsi per nuovi account",
+        "restrictDomains": {
+          "title": "Limita i domini di posta elettronica",
+          "description": "Consenti la registrazione solo da domini di posta elettronica specifici"
+        },
+        "allowedDomains": {
+          "title": "Domini di posta elettronica consentiti",
+          "placeholder": "esempio.com",
+          "add": "Aggiungi dominio",
+          "empty": "Nessun dominio consentito configurato. Tutti i domini saranno bloccati quando la restrizione è abilitata."
+        },
+        "defaultAccess": {
+          "title": "Livello di accesso predefinito",
+          "description": "Il livello di accesso al sistema assegnato ai nuovi utenti al momento della registrazione.",
+          "options": {
+            "NONE": "Accesso negato - Gli utenti non possono accedere al sistema finché un amministratore non concede l'accesso.",
+            "USER": "Utente - Accesso utente standard ai progetti assegnati",
+            "PROJECTADMIN": "Amministratore di progetto - Può gestire i progetti a cui è assegnato",
+            "ADMIN": "Amministratore - Accesso completo all'amministrazione del sistema."
+          }
+        },
+        "requireEmailVerification": {
+          "title": "È richiesta la verifica dell'indirizzo email.",
+          "description": "Gli utenti devono verificare il proprio indirizzo email prima di accedere al sistema.",
+          "noEmailServerWarning": "Il server di posta elettronica non è configurato. La verifica dell'indirizzo email viene disabilitata automaticamente fino alla configurazione di un server di posta elettronica."
+        },
+        "allowOpenRegistration": {
+          "title": "Consenti l'auto-registrazione",
+          "description": "Quando questa opzione è disabilitata, i nuovi utenti non possono registrarsi direttamente né creare un account tramite SSO. Gli utenti già registrati possono comunque accedere."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Provider non valido o non è un provider SAML."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Filtra progetti..."
+      },
+      "complete": {
+        "title": "Progetto completo",
+        "description": "Questa azione completerà il progetto e impedirà l'aggiunta di ulteriori test."
+      },
+      "add": {
+        "button": "Aggiungi progetto",
+        "title": "Aggiungi nuovo progetto",
+        "defaultFields": "Il modello predefinito, il tipo di milestone predefinito e tutti i flussi di lavoro e gli stati verranno aggiunti al progetto al momento della sua creazione.",
+        "selectIssueTracker": "Seleziona Issue Tracker",
+        "issueTrackerRequired": "È richiesto Issue Tracker"
+      },
+      "wizard": {
+        "title": "Crea nuovo progetto",
+        "description": "Imposta un nuovo progetto con tutte le configurazioni necessarie",
+        "steps": {
+          "details": "Dettagli del progetto",
+          "workflows": "Flussi di lavoro, stati e tipi di milestone",
+          "integrations": "Integrazioni",
+          "permissions": "Utenti e permessi"
+        },
+        "labels": {
+          "selected": "Selezionato",
+          "statuses": "Stati dei test",
+          "issueTrackers": "Tracker dei problemi"
+        },
+        "placeholders": {
+          "projectName": "Inserisci il nome del progetto",
+          "selectDefaultAccess": "Seleziona il tipo di accesso predefinito"
+        },
+        "descriptions": {
+          "templates": "Selezionare almeno un modello per definire la struttura dei casi di test in questo progetto.",
+          "workflows": "Configura flussi di lavoro, stati e tipi di milestone per la gestione delle attività del progetto.",
+          "integrations": "Facoltativo: collega tracker di problemi esterni e modelli di intelligenza artificiale per funzionalità avanzate.",
+          "noIntegrations": "Al momento non è configurata alcuna integrazione. Puoi saltare questo passaggio o configurare le integrazioni in seguito.",
+          "aiModels": "Abilita modelli di intelligenza artificiale per la generazione di casi di test e suggerimenti intelligenti.",
+          "permissions": "Configura l'accesso utente e le autorizzazioni di gruppo per questo progetto.",
+          "milestoneTypes": "Seleziona i tipi di milestone per monitorare l'avanzamento e le scadenze del progetto."
+        },
+        "actions": {
+          "selectDefault": "Usa predefinito",
+          "create": "Crea progetto",
+          "creating": "Creazione del progetto..."
+        },
+        "errors": {
+          "nameRequired": "Il nome del progetto è obbligatorio",
+          "validationFailed": "Impossibile convalidare il nome del progetto. Riprova.",
+          "templateRequired": "Deve essere selezionato almeno un modello",
+          "workflowRequired": "È necessario selezionare almeno un flusso di lavoro",
+          "statusRequired": "Deve essere selezionato almeno uno stato",
+          "roleRequired": "Selezionare un ruolo quando si utilizza il tipo di accesso \"Ruolo specifico\"",
+          "creationFailed": "Impossibile creare il progetto. Riprova."
+        },
+        "success": {
+          "created": "Progetto creato con successo"
+        }
+      },
+      "edit": {
+        "title": "Modifica progetto",
+        "labels": {
+          "groupProjectAccess": "Accesso al progetto di gruppo",
+          "groupPermissions": "Autorizzazioni di gruppo",
+          "userPermissions": "Autorizzazioni utente",
+          "noEffect": "Nessun effetto",
+          "access": {
+            "groupsGlobalRole": "Ruolo globale del gruppo",
+            "groupDefault": "Gruppo predefinito",
+            "groupSpecificRole": "Ruolo specifico del gruppo",
+            "groupProjectDefault": "Progetto di gruppo predefinito",
+            "groupProjectNoAccess": "Progetto di gruppo senza accesso",
+            "groupProjectSpecificRole": "Ruolo specifico del progetto di gruppo",
+            "effectiveAccess": "Accesso efficace"
+          },
+          "accessHints": {
+            "noAccess": "Gli utenti non avranno accesso a questo progetto a meno che non venga loro esplicitamente concesso l'accesso tramite assegnazione diretta o appartenenza al gruppo.",
+            "globalRole": "Tutti gli utenti con accesso al sito possono visualizzare questo progetto. Le loro autorizzazioni sono determinate dal ruolo assegnato a livello globale.",
+            "specificRole": "L'accesso non viene concesso automaticamente agli utenti. L'accesso deve essere concesso tramite assegnazione diretta dell'utente o appartenenza a un gruppo. Gli utenti assegnati tramite gruppi utilizzeranno questo ruolo, a meno che non venga sovrascritto da un'assegnazione diretta."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Seleziona Accesso predefinito",
+          "groupPermissionsUI": "Qui va inserita l'interfaccia utente di gestione delle autorizzazioni di gruppo...",
+          "userPermissionsUI": "Qui va inserita l'interfaccia utente per la gestione delle autorizzazioni utente...",
+          "selectAccess": "Seleziona l'accesso...",
+          "selectRole": "Seleziona il ruolo...",
+          "searchUsersToAdd": "Cerca utenti da aggiungere..."
+        },
+        "tableHeaders": {
+          "globalRole": "Ruolo globale",
+          "projectAccess": "Accesso al progetto"
+        },
+        "messages": {
+          "noUsersAssigned": "Nessun utente ha ricevuto autorizzazioni specifiche.",
+          "noGroupsFound": "Nessun gruppo trovato."
+        },
+        "actions": {
+          "removeUser": "Rimuovi utente"
+        },
+        "loadingUserPermissions": "Caricamento autorizzazioni utente..."
+      },
+      "delete": {
+        "title": "Elimina progetto",
+        "confirmMessage": "Sei sicuro di voler eliminare questo progetto?"
+      }
+    },
+    "templates": {
+      "description": "Gestisci modelli e campi dei casi di test",
+      "help": {
+        "caseFields": "I campi Case definiscono le proprietà e i dati che possono essere acquisiti per ciascun caso di test nel repository. Consentono di personalizzare le informazioni relative al caso di test oltre i campi standard.",
+        "resultFields": "I campi dei risultati definiscono dati aggiuntivi che possono essere acquisiti durante la registrazione dei risultati dei test. Consentono di tenere traccia di informazioni personalizzate specifiche per gli esiti dell'esecuzione dei test."
+      },
+      "confirmSetAsDefault": "Imposta come modello predefinito",
+      "confirmSetAsDefaultDescription": "Sei sicuro di voler impostare questo modello come predefinito?",
+      "confirmSetAsDefaultProjects": "Questo modello verrà aggiunto a tutti i progetti.",
+      "add": {
+        "button": "Aggiungi modello",
+        "title": "Aggiungi nuovo modello",
+        "defaultTemplateHint": "Questo modello verrà assegnato a tutti i progetti."
+      },
+      "edit": {
+        "title": "Modifica modello"
+      },
+      "delete": {
+        "title": "Elimina modello",
+        "confirmMessage": "Sei sicuro di voler eliminare il modello <strong>{name}</strong>?",
+        "warning": "Tutti i casi di test e le sessioni esplorative che attualmente utilizzano questo modello verranno automaticamente riassegnati al modello predefinito.",
+        "errors": {
+          "defaultTemplateNotFound": "Modello predefinito non trovato. Impossibile procedere con l'eliminazione.",
+          "unknown": "Si è verificato un errore sconosciuto durante l'eliminazione del modello."
+        }
+      },
+      "caseFields": {
+        "description": "Gestisci i campi del caso",
+        "add": {
+          "button": "Aggiungi campo caso",
+          "title": "Aggiungi nuovo campo caso"
+        },
+        "edit": {
+          "title": "Modifica campo caso"
+        },
+        "delete": {
+          "title": "Elimina campo caso",
+          "confirmMessage": "Sei sicuro di voler eliminare questo campo caso?",
+          "warning": "Il campo Caso verrà rimosso da tutti i modelli. Questa azione non può essere annullata."
+        }
+      },
+      "resultFields": {
+        "description": "Gestisci i campi dei risultati",
+        "add": {
+          "button": "Aggiungi campo risultato",
+          "title": "Aggiungi nuovo campo risultato"
+        },
+        "edit": {
+          "title": "Modifica campo risultato"
+        },
+        "delete": {
+          "title": "Elimina campo risultato",
+          "confirmMessage": "Sei sicuro di voler eliminare <strong>{name}</strong>?",
+          "warning": "Il campo Risultato verrà rimosso da tutti i modelli. Questa azione non può essere annullata."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Repository di codice",
+      "description": "Gestisci le connessioni al repository del codice per il contesto QuickScript.",
+      "addRepository": "Aggiungi repository",
+      "noRepos": {
+        "title": "Nessun repository di codice configurato",
+        "description": "Collega un repository Git per fornire il contesto dei file per la generazione di esportazioni di test basate sull'intelligenza artificiale."
+      },
+      "delete": {
+        "title": "Elimina il repository",
+        "confirmMessage": "Sei sicuro di voler eliminare <strong>{name}</strong>? Questa azione non può essere annullata.",
+        "fallbackName": "questo repository"
+      },
+      "testConnection": "Connessione di prova",
+      "connectionSuccess": "Connessione riuscita",
+      "connectionFailed": "Connessione fallita",
+      "networkError": "Errore di rete",
+      "editTitle": "Modifica il repository del codice",
+      "addTitle": "Aggiungi repository di codice",
+      "repositoryUpdated": "Repository aggiornato",
+      "repositoryCreated": "Repository creato",
+      "saveFailed": "Impossibile salvare il repository",
+      "namePlaceholder": "Il mio repository",
+      "selectProvider": "Seleziona i fornitori",
+      "httpWarning": "Questo URL utilizza HTTP. Le credenziali verranno inviate in chiaro. Per connessioni sicure, utilizzare HTTPS."
+    },
+    "exportTemplates": {
+      "title": "Modelli QuickScript",
+      "description": "Gestisci i modelli utilizzati da QuickScript per convertire i casi di test in script di automazione.",
+      "confirmSetAsDefault": "Imposta come modello di esportazione predefinito",
+      "confirmSetAsDefaultDescription": "Sei sicuro di voler impostare questo modello come predefinito? Verrà preselezionato automaticamente quando gli utenti esporteranno i casi di test.",
+      "fields": {
+        "category": "Categoria",
+        "framework": "Struttura",
+        "fileExtension": "Estensione del file",
+        "headerBody": "Modello di intestazione",
+        "templateBody": "Corpo del modello",
+        "footerBody": "Modello di piè di pagina",
+        "validation": {
+          "categoryRequired": "La categoria è obbligatoria.",
+          "frameworkRequired": "È necessaria una struttura di base.",
+          "templateBodyRequired": "Il corpo del template è obbligatorio.",
+          "fileExtensionRequired": "È necessaria un'estensione del file.",
+          "languageRequired": "È richiesta la conoscenza della lingua."
+        },
+        "placeholders": {
+          "name": "Ad esempio, Drammaturgo (TypeScript)",
+          "description": "Ad esempio, genera stub di prova per drammaturghi",
+          "category": "ad esempio, Browser E2E",
+          "framework": "ad esempio, drammaturgo",
+          "fileExtension": "ad esempio, .spec.ts",
+          "language": "ad esempio, Typescript",
+          "headerBody": "Opzionale. Il contenuto viene visualizzato una sola volta in alto (ad esempio, le istruzioni di importazione).",
+          "templateBody": "Inserisci il modello Baffi...\n\nVariabili disponibili:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSezione Passaggi:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nCampi personalizzati:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Opzionale. Il contenuto viene visualizzato una sola volta in fondo (ad esempio, il codice di chiusura)."
+        },
+        "combobox": {
+          "typeNew": "Digita per inserire un nuovo valore"
+        }
+      },
+      "add": {
+        "button": "Aggiungi modello QuickScript",
+        "title": "Aggiungi un nuovo modello QuickScript"
+      },
+      "edit": {
+        "title": "Modifica il modello QuickScript"
+      },
+      "delete": {
+        "title": "Elimina modello QuickScript",
+        "confirmMessage": "Sei sicuro di voler eliminare il modello QuickScript <strong>{name}</strong>?"
+      },
+      "preview": {
+        "title": "Anteprima (dati fittizi)",
+        "empty": "Inserisci il corpo del modello per visualizzarne un'anteprima.",
+        "error": "Errore durante il rendering del template. Controlla la sintassi di Mustache."
+      },
+      "filterPlaceholder": "Modelli di filtro...",
+      "noResults": "Nessun modello corrisponde al filtro selezionato.",
+      "templateCount": "{count, plural, one {# template} other {# template}}",
+      "allFrameworks": "Tutti i framework",
+      "allFileExtensions": "Tutte le estensioni",
+      "allLanguages": "Tutte le lingue",
+      "showEnabled": "Solo abilitato",
+      "showAll": "Tutto",
+      "variableInserter": {
+        "placeholder": "Inserisci variabile...",
+        "groups": {
+          "customFields": "Campi personalizzati"
+        },
+        "stepsBlock": "Blocco dei gradini"
+      }
+    },
+    "users": {
+      "showInactive": "Mostra inattivo",
+      "add": {
+        "button": "Aggiungi utente",
+        "title": "Aggiungi nuovo utente",
+        "fields": {
+          "email_invalid": "Indirizzo email non valido",
+          "password_error": "La password è obbligatoria",
+          "confirmPassword_error": "La conferma della password è obbligatoria",
+          "passwordOptionalHelp": "Lascia vuoto per richiedere all'utente di accedere tramite link magico o SSO."
+        }
+      },
+      "edit": {
+        "title": "Modifica utente"
+      },
+      "delete": {
+        "title": "Elimina utente"
+      },
+      "restore": {
+        "title": "Ripristina utente eliminato",
+        "description": "È stato trovato un utente eliminato con l'indirizzo email {email} . Desideri ripristinare questo utente?",
+        "confirm": "Ripristina utente"
+      },
+      "forcePasswordChange": "Cambio forzato della password",
+      "revokePassword": "Revoca password",
+      "forcePasswordChangeDialogTitle": "Cambio forzato della password",
+      "forcePasswordChangeDialogDescription": "Ciò richiederà a {name} di cambiare la propria password al prossimo accesso.",
+      "revokePasswordDialogTitle": "Revoca password",
+      "revokePasswordDialogDescription": "Questo invaliderà immediatamente la password di {name}. Dovranno utilizzare un altro metodo di accesso.",
+      "confirmAction": "Confermare",
+      "forcePasswordChangeSuccess": "È necessario cambiare la password per {name}",
+      "forcePasswordChangeFailed": "Impossibile forzare il cambio password",
+      "revokePasswordSuccess": "Password revocata per {name}",
+      "revokePasswordFailed": "Impossibile revocare la password"
+    },
+    "security": {
+      "title": "Sicurezza",
+      "description": "Configura i criteri per le password, le impostazioni di blocco e le azioni di applicazione.",
+      "passwordPolicyTitle": "Politica sulle password",
+      "passwordPolicyDescription": "Definisci i requisiti per le password degli utenti",
+      "lockoutPolicyTitle": "Politica di blocco",
+      "lockoutPolicyDescription": "Configura il blocco dell'account dopo tentativi di accesso non riusciti.",
+      "enforcementTitle": "Provvedimenti esecutivi",
+      "enforcementDescription": "Forza la modifica della password per gli utenti basati su credenziali",
+      "minPasswordLengthLabel": "Lunghezza minima della password",
+      "minPasswordLengthDescription": "Le password devono avere un numero di caratteri compreso tra 8 e 128.",
+      "requireUppercaseLabel": "Sono richieste lettere maiuscole.",
+      "requireLowercaseLabel": "Sono richieste lettere minuscole",
+      "requireNumbersLabel": "Numeri richiesti",
+      "requiredSpecialCharsLabel": "Caratteri speciali richiesti",
+      "requiredSpecialCharsDescription": "Lascia vuoto per disabilitare. Inserisci i caratteri che devono apparire (es. !@#$)",
+      "passwordHistoryDepthLabel": "Cronologia password Profondità",
+      "passwordHistoryDepthDescription": "Impedisci il riutilizzo delle ultime N password (0 = disabilitato)",
+      "passwordExpirationDaysLabel": "Scadenza della password (giorni)",
+      "passwordExpirationDaysDescription": "Forza il cambio password dopo N giorni (0 = disabilitato)",
+      "lockoutThresholdLabel": "Soglia di blocco",
+      "lockoutThresholdDescription": "Numero di tentativi falliti prima del blocco dell'account (minimo 1)",
+      "lockoutDurationMinutesLabel": "Durata del blocco (minuti)",
+      "lockoutDurationMinutesDescription": "Per quanto tempo l'account rimane bloccato (minimo 1)",
+      "saveChanges": "Salva le modifiche",
+      "forceAllUsers": "Obbliga tutti gli utenti a cambiare la password",
+      "forceAllUsersDialogTitle": "Forza la modifica della password per tutti gli utenti",
+      "forceAllUsersDialogDescription": "Ciò richiederà agli utenti che utilizzano le credenziali {count} di cambiare la password al prossimo accesso.",
+      "forceAllUsersDialogWarning": "Questa azione non può essere annullata.",
+      "forceAllUsersDialogConfirm": "Cambio forzato",
+      "saved": "Impostazioni di sicurezza salvate",
+      "saveFailed": "Impossibile salvare le impostazioni di sicurezza",
+      "forceAllSuccess": "È necessario cambiare la password per gli utenti {count}",
+      "forceAllFailed": "Impossibile forzare il cambio password"
+    },
+    "apiTokens": {
+      "description": "Visualizza e gestisci i token API di tutti gli utenti. Revoca i token in caso di problemi di sicurezza.",
+      "filterPlaceholder": "Filtra per nome del token o per utente...",
+      "showInactive": "Mostra revocato",
+      "noTokens": "Non è stato ancora creato alcun token API.",
+      "columns": {
+        "lastUsed": "Ultimo utilizzo",
+        "expires": "Scade"
+      },
+      "status": {
+        "revoked": "Revocato",
+        "expired": "Scaduto"
+      },
+      "noExpiry": "Nessuna scadenza",
+      "revokeToken": "Revoca il token",
+      "revokeConfirmTitle": "Revoca il token API",
+      "revokeConfirmMessage": "Sei sicuro di voler revocare questo token API? Questa azione non può essere annullata.",
+      "revokeConfirmDescription": "Il token \"{name}\" appartenente a {user} verrà immediatamente revocato e non potrà più essere utilizzato per l'accesso all'API.",
+      "revokeSuccess": "Token API revocato con successo",
+      "revokeError": "Impossibile revocare il token API",
+      "revokeAllTokens": "Revoca tutti i token",
+      "revokeAllTitle": "Revoca tutti i token API",
+      "revokeAllDescription": "Questa operazione revocherà immediatamente TUTTI i token API attivi per tutti gli utenti. Tale azione è irreversibile e potrebbe interrompere i flussi di lavoro automatizzati.",
+      "revokeAllConfirm": "Digita \"REVOCA TUTTO\" per confermare",
+      "revokeAllPlaceholder": "REVOCA TUTTO",
+      "revokeAllSuccess": "Tutti i token API sono stati revocati.",
+      "revokeAllError": "Impossibile revocare tutti i token"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Si è verificato un errore durante la creazione del tag"
+        }
+      },
+      "delete": {
+        "title": "Elimina tag",
+        "confirmMessage": "Sei sicuro di voler eliminare questo tag?",
+        "warning": "Questo tag verrà rimosso da tutti i casi di test e dalle sessioni.",
+        "errors": {
+          "unknown": "Si è verificato un errore durante l'eliminazione del tag"
+        }
+      },
+      "edit": {
+        "title": "Modifica tag"
+      }
+    },
+    "workflows": {
+      "description": "Gestire i flussi di lavoro dei casi di prova",
+      "add": {
+        "button": "Aggiungi flusso di lavoro",
+        "title": "Aggiungi nuovo flusso di lavoro",
+        "defaultHelp": "Imposta come flusso di lavoro predefinito per i nuovi casi di test",
+        "scopeLabel": "Ambito del flusso di lavoro",
+        "errors": {
+          "nameExists": "Esiste già un flusso di lavoro con questo nome"
+        }
+      },
+      "edit": {
+        "title": "Modifica flusso di lavoro",
+        "lastWorkflowTypeWarning": "Questo è l'ultimo tipo di flusso di lavoro. È necessario abilitare almeno un tipo di flusso di lavoro.",
+        "errors": {
+          "nameRequired": "Il nome del flusso di lavoro è obbligatorio",
+          "unknownWorkflow": "Flusso di lavoro sconosciuto"
+        }
+      },
+      "delete": {
+        "title": "Elimina flusso di lavoro",
+        "confirmMessage": "Sei sicuro di voler eliminare questo flusso di lavoro?"
+      },
+      "setDefault": {
+        "title": "Imposta flusso di lavoro predefinito",
+        "confirmMessage": "Vuoi davvero impostare questo flusso di lavoro come predefinito?",
+        "description": "Questo flusso di lavoro verrà aggiunto a tutti i progetti."
+      }
+    },
+    "roles": {
+      "description": "Definisci quali azioni gli utenti possono eseguire attivando o disattivando le autorizzazioni per ciascuna area dell'applicazione.",
+      "filterPlaceholder": "Filtra i ruoli...",
+      "add": {
+        "button": "Aggiungi ruolo",
+        "title": "Aggiungi nuovo ruolo",
+        "fields": {
+          "name_error": "Il nome del ruolo è obbligatorio"
+        },
+        "errors": {
+          "nameExists": "Esiste già un ruolo con questo nome"
+        }
+      },
+      "edit": {
+        "title": "Modifica ruolo",
+        "permissionsTitle": "Permessi",
+        "areaHeader": "Area di applicazione"
+      },
+      "delete": {
+        "title": "Elimina ruolo",
+        "confirmMessage": "Sei sicuro di voler eliminare questo ruolo?",
+        "warning": "Questa azione non può essere annullata. Agli utenti con questo ruolo verrà assegnato il ruolo predefinito.",
+        "errors": {
+          "defaultNotFound": "Impossibile eliminare il ruolo predefinito"
+        }
+      }
+    },
+    "statuses": {
+      "description": "Gestire gli stati dei test",
+      "add": {
+        "button": "Aggiungi stato",
+        "title": "Aggiungi nuovo stato",
+        "systemNameHelp": "Il nome del sistema identifica questo stato. Non può essere modificato dopo la creazione.",
+        "aliasesHelp": "Elenco di alias separati da virgole",
+        "errors": {
+          "nameExists": "Esiste già uno stato con questo nome",
+          "systemNameEmpty": "Il nome del sistema è obbligatorio",
+          "systemNameInvalid": "Il nome del sistema deve essere alfanumerico",
+          "aliasesInvalid": "Gli alias devono essere alfanumerici",
+          "missingColor": "Il colore non è stato trovato. Seleziona un colore diverso."
+        }
+      },
+      "edit": {
+        "title": "Modifica stato",
+        "systemNameHelp": "Il nome del sistema identifica questo stato per i processi automatizzati. Non può essere modificato dopo la creazione.",
+        "unmodifiableHelp": "Lo stato \"non testato\" è uno stato del sistema e non può essere modificato.",
+        "untestedHelp": "Il nome \"non testato\" è riservato allo stato del sistema e non può essere utilizzato.",
+        "success": "Stato aggiornato con successo"
+      },
+      "delete": {
+        "title": "Elimina stato",
+        "confirmMessage": "Sei sicuro di voler eliminare lo stato <strong>{name}</strong>?",
+        "errors": {
+          "inUse": "Questo stato è in uso e non può essere eliminato",
+          "defaultNotFound": "Stato predefinito non trovato"
+        },
+        "success": "Stato eliminato con successo"
+      },
+      "fields": {
+        "final": "Finale",
+        "system": "Stato del sistema",
+        "forTestCase": "Per il caso di prova",
+        "forTestRun": "Per la prova di funzionamento",
+        "forSession": "Per la sessione",
+        "color": "Colore"
+      }
+    },
+    "appConfig": {
+      "description": "Gestire le configurazioni globali delle applicazioni",
+      "addConfig": "Aggiungi configurazione applicazione",
+      "editConfig": "Modifica la configurazione dell'applicazione",
+      "keyPlaceholder": "Inserisci la chiave di configurazione...",
+      "valuePlaceholder": "Inserisci il valore JSON...",
+      "currentTranslation": "Traduzione attuale",
+      "filterPlaceholder": "Filtra per chiave...",
+      "errors": {
+        "keyRequired": "La chiave è richiesta",
+        "invalidJson": "Formato JSON non valido"
+      },
+      "configKeys": {
+        "project_docs_default": "Documentazione del progetto predefinita"
+      }
+    },
+    "configurations": {
+      "description": "Le configurazioni sono una combinazione di categorie e varianti utilizzate per definire un ambiente di test. Ad esempio, sistema operativo/browser, server di test, lingua, ecc.",
+      "addConfiguration": "Aggiungi configurazione",
+      "editConfiguration": "Modifica configurazione",
+      "filterPlaceholder": "Configurazioni del filtro...",
+      "categories": {
+        "title": "Categorie",
+        "description": "Gestisci categorie globali",
+        "editCategory": "Modifica categoria",
+        "selectCategory": "Seleziona categoria",
+        "filterPlaceholder": "Filtra categorie...",
+        "add": {
+          "title": "Aggiungi nuova categoria"
+        },
+        "delete": {
+          "confirmMessage": "Sei sicuro di voler eliminare questa categoria?",
+          "deleteCategory": "Elimina categoria",
+          "deleteCategoryConfirm": "Sei sicuro di voler eliminare la categoria <strong>{name}</strong>?",
+          "deleteCategoryWarning": "Questa azione eliminerà la categoria e tutte le varianti associate."
+        },
+        "disable": {
+          "confirmDisableTitle": "Disabilita variante",
+          "confirmDisableDescription": "Sei sicuro di voler disattivare questa variante?"
+        }
+      },
+      "combinations": {
+        "title": "Combinazioni",
+        "description": "Gestisci combinazioni globali",
+        "addCombination": "Aggiungi combinazione",
+        "editCombination": "Modifica combinazione",
+        "selectCombination": "Seleziona combinazione",
+        "selectCombinationDescription": "Seleziona una combinazione di varianti da aggiungere alla configurazione.",
+        "allExist": "Tutte le combinazioni esistono già.",
+        "selectAtLeast": "Seleziona almeno una combinazione."
+      },
+      "delete": {
+        "title": "Elimina configurazione",
+        "message": "Sei sicuro di voler eliminare la configurazione <strong>{name}</strong>?",
+        "confirmMessage": "Sei sicuro di voler eliminare questa configurazione?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Modifica variante"
+        },
+        "delete": {
+          "title": "Elimina variante",
+          "message": "Sei sicuro di voler eliminare la variante <strong>{name}</strong>?",
+          "confirmMessage": "Sei sicuro di voler eliminare questa variante?",
+          "suggestion": "Si consiglia invece di disabilitare la variante."
+        },
+        "selection": {
+          "title": "Seleziona varianti",
+          "description": "Seleziona le varianti che vuoi aggiungere alla configurazione."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Organizza gli utenti in gruppi per assegnare in blocco l'accesso ai progetti e i ruoli."
+      },
+      "filterPlaceholder": "Filtra gruppi...",
+      "add": {
+        "button": "Aggiungi gruppo",
+        "title": "Aggiungi nuovo gruppo",
+        "errors": {
+          "nameExists": "Esiste già un gruppo con questo nome"
+        }
+      },
+      "edit": {
+        "title": "Modifica gruppo"
+      },
+      "delete": {
+        "deleteGroup": "Elimina gruppo",
+        "deleteGroupDescription": "Questa azione eliminerà il gruppo e tutti gli utenti associati.",
+        "confirmMessage": "Sei sicuro di voler eliminare questo gruppo?"
+      },
+      "noUsersSelected": "Nessun utente selezionato ancora.",
+      "noUsersAssigned": "Nessun utente assegnato a questo gruppo."
+    },
+    "milestones": {
+      "description": "Gestisci i tipi di milestone",
+      "filterPlaceholder": "Filtra tipi di milestone...",
+      "addMilestones": "Aggiungi traguardi in blocco",
+      "confirmDefault": "Conferma predefinito",
+      "confirmDefaultDescription": "Vuoi davvero impostare questo tipo di traguardo come predefinito?",
+      "warning": "Questo tipo di traguardo verrà aggiunto a tutti i progetti.",
+      "wizard": {
+        "selectProjects": "Seleziona progetti",
+        "projectsSelected": "{count, plural, =0 {Nessun progetto selezionato} one {# progetto selezionato} other {# progetti selezionati}}",
+        "createMilestone": "Crea traguardo",
+        "noCommonTypesTitle": "Nessun tipo di traguardo comune",
+        "noCommonTypesDescription": "I progetti selezionati non hanno alcun tipo di milestone in comune. Assicurati che tutti i progetti selezionati abbiano almeno un tipo di milestone in comune, oppure seleziona progetti diversi."
+      },
+      "add": {
+        "button": "Aggiungi tipo di traguardo",
+        "title": "Aggiungi nuovo tipo di traguardo",
+        "errors": {
+          "nameExists": "Esiste già un tipo di Milestone con questo nome"
+        }
+      },
+      "edit": {
+        "title": "Modifica tipo di traguardo"
+      },
+      "delete": {
+        "title": "Elimina tipo di traguardo",
+        "confirmMessage": "Sei sicuro di voler eliminare questo tipo di traguardo?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Tracker dei problemi dei link",
+      "link_description": "Configura l'URL di base per i problemi collegati manualmente. Quando si collega un problema utilizzando solo un ID esterno, questo URL di base verrà anteposto per creare il collegamento completo.",
+      "filter": {
+        "show_inactive": "Mostra configurazioni inattive",
+        "search_placeholder": "Filtra per nome della configurazione..."
+      },
+      "base_url": "URL di base",
+      "link_update_success": "Configurazione del collegamento aggiornata correttamente",
+      "link_update_error": "Impossibile aggiornare la configurazione del collegamento",
+      "description": "Configurare le integrazioni con sistemi di monitoraggio dei problemi esterni.",
+      "delete": {
+        "title": "Elimina la configurazione del problema",
+        "confirmMessage": "Sei sicuro di voler eliminare la configurazione <bold>{name}</bold>?",
+        "warning": "Questa azione non può essere annullata. Tutti i progetti attualmente assegnati a questo tracker verranno riassegnati al tracker predefinito. Si consiglia di disattivare la configurazione.",
+        "cannotDeleteDefault": "Il tracker dei problemi predefinito non può essere eliminato.",
+        "noDefaultFound": "Impossibile eliminare: non è stato trovato alcun issue tracker predefinito a cui riassegnare i progetti."
+      },
+      "add": {
+        "title": "Aggiungi Issue Tracker",
+        "description": "Crea una nuova configurazione per un sistema di monitoraggio dei problemi.",
+        "name": "Nome della configurazione",
+        "name_placeholder": "ad esempio, collegamenti al progetto Jira",
+        "system_type": "Tipo di sistema",
+        "select_system_type": "Seleziona il tipo di sistema",
+        "base_url": "URL di base incluso il segnaposto del problema",
+        "base_url_placeholder": "ad esempio, https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Configurazione del problema creata correttamente",
+        "create_error": "Errore durante la creazione della configurazione del problema",
+        "setDefaultWarning": "Impostando questa opzione come predefinita, lo stato predefinito verrà rimosso dalla configurazione predefinita corrente."
+      },
+      "edit": {
+        "title": "Modifica Issue Tracker",
+        "description": "Aggiorna i dettagli per questa configurazione del problema.",
+        "name_placeholder": "Inserisci il nome della configurazione",
+        "select_project": "Seleziona progetti...",
+        "update_success": "Configurazione del problema aggiornata correttamente",
+        "update_error": "Impossibile aggiornare la configurazione del problema",
+        "edit_not_supported": "La modifica della configurazione per questo tipo di sistema non è attualmente supportata."
+      }
+    },
+    "issues": {
+      "description": "Gestisci i problemi per questo tracker dei problemi",
+      "filterPlaceholder": "Problemi con il filtro...",
+      "add": {
+        "button": "Aggiungi problema",
+        "title": "Aggiungi nuovo problema"
+      },
+      "edit": {
+        "title": "Modifica problema"
+      },
+      "delete": {
+        "title": "Elimina problema",
+        "confirmMessage": "Sei sicuro di voler eliminare il problema \"{name}\"?"
+      },
+      "syncIssue": "Problema di sincronizzazione dal sistema esterno",
+      "syncSuccess": "Problema sincronizzato correttamente",
+      "syncSuccessDescription": "Il problema \"{name}\" è stato aggiornato con le ultime informazioni provenienti dal sistema esterno.",
+      "syncError": "Problema di sincronizzazione non riuscito",
+      "syncErrorDescription": "Impossibile sincronizzare il problema. Riprova più tardi."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Link al progetto",
+        "milestoneLinks": "Link importanti",
+        "icons": "Icone",
+        "fieldOptions": "Opzioni campo",
+        "configCategories": "Categorie di configurazione",
+        "configVariants": "Varianti di configurazione",
+        "repositories": "Depositi",
+        "repositoryFolders": "Cartelle del repository",
+        "repositoryCaseLinks": "Collegamenti ai casi del repository",
+        "repositoryCaseVersions": "Versioni del caso del repository",
+        "testRunStepResults": "Risultati della fase di esecuzione del test",
+        "issueConfigs": "Configurazioni dei problemi",
+        "sharedStepGroups": "Gruppi di passi condivisi"
+      },
+      "table": {
+        "title": "Eliminato {itemType}",
+        "loading": "Caricamento eliminato {itemType}...",
+        "error": "Errore durante il caricamento dell'elemento eliminato {itemType}: {message}",
+        "noItems": "Nessun {itemType} eliminato trovato.",
+        "noResults": "Nessun {itemType} eliminato trovato corrispondente alla tua ricerca per \"{query}\".",
+        "restoreConfirmationMessage": "Vuoi davvero ripristinare questa riga dalla tabella {itemType} ? Potrebbero essere ripristinati anche i dati associati.",
+        "purgeConfirmationMessage": "Vuoi davvero eliminare definitivamente questa riga dalla tabella {itemType} ? Questa azione non può essere annullata e potrebbe rimuovere i dati associati."
+      }
+    },
+    "notifications": {
+      "title": "Amministrazione delle notifiche",
+      "description": "Imposta le preferenze di notifica predefinite (che gli utenti possono modificare) e invia notifiche di sistema.",
+      "defaultMode": {
+        "label": "Modalità di notifica predefinita",
+        "inApp": "Solo in-app",
+        "inAppEmailImmediate": "In-App + Email (Immediato)",
+        "inAppEmailDaily": "In-App + Email (Riepilogo giornaliero)"
+      },
+      "options": {
+        "title": "Opzioni di notifica disponibili",
+        "inApp": {
+          "label": "Notifiche in-app",
+          "description": "Mostra le notifiche all'interno dell'applicazione"
+        },
+        "emailImmediate": {
+          "label": "Email immediata",
+          "description": "Invia notifiche e-mail immediatamente quando si verificano eventi"
+        },
+        "emailDaily": {
+          "label": "Riepilogo giornaliero via e-mail",
+          "description": "Invia un riepilogo giornaliero delle notifiche tramite e-mail"
+        }
+      },
+      "save": "Salva impostazioni",
+      "success": {
+        "title": "Impostazioni salvate",
+        "description": "Le impostazioni di notifica sono state aggiornate correttamente"
+      },
+      "error": {
+        "description": "Impossibile salvare le impostazioni di notifica"
+      },
+      "systemNotification": {
+        "title": "Notifiche di sistema",
+        "description": "Invia annunci importanti a tutti gli utenti",
+        "titlePlaceholder": "Inserisci il titolo della notifica...",
+        "messagePlaceholder": "Inserisci il messaggio di notifica...",
+        "send": "Invia notifica",
+        "success": {
+          "title": "Notifica inviata",
+          "description": "Notifica di sistema inviata a {count, plural, one {# utente} other {# utenti}}"
+        },
+        "error": {
+          "description": "Impossibile inviare la notifica di sistema",
+          "emptyFields": "Si prega di fornire sia il titolo che il messaggio"
+        },
+        "history": {
+          "title": "Cronologia delle notifiche",
+          "sentBy": "Inviato da",
+          "sentAt": "Inviato a",
+          "empty": "Nessuna notifica di sistema è stata ancora inviata"
+        }
+      }
+    },
+    "integrations": {
+      "description": "Gestire le integrazioni di terze parti per il monitoraggio dei problemi",
+      "list": {
+        "title": "Integrazioni dei problemi configurate",
+        "description": "Visualizza e gestisci le integrazioni dei problemi configurati"
+      },
+      "empty": {
+        "message": "Nessuna integrazione di problemi configurata ancora"
+      },
+      "addIntegration": "Aggiungi integrazione problema",
+      "allIntegrations": "Tutte le integrazioni dei problemi",
+      "manageDescription": "Configura e gestisci le integrazioni dei problemi dei servizi esterni",
+      "status": {
+        "active": "Attivo",
+        "inactive": "Inattivo"
+      },
+      "connectedProjects": "Progetti connessi",
+      "noIntegrations": "Nessuna integrazione di problemi configurata",
+      "testConnection": "Prova di connessione",
+      "testSuccess": "Connessione riuscita",
+      "testSuccessDescription": "L'integrazione del problema è configurata e connessa correttamente",
+      "testFailed": "Connessione fallita",
+      "testFailedDescription": "Impossibile connettersi al servizio esterno",
+      "testError": "Errore di prova",
+      "testErrorDescription": "Si è verificato un errore durante il test della connessione",
+      "syncInProgress": "Problemi di sincronizzazione...",
+      "syncIntegration": "Sincronizza tutti i problemi dall'integrazione dei problemi",
+      "syncSuccess": "Sincronizzazione in coda",
+      "syncSuccessDescription": "I problemi di \"{name}\" vengono sincronizzati in background. L'operazione potrebbe richiedere alcuni minuti. La tabella verrà aggiornata automaticamente al termine.",
+      "syncError": "Sincronizzazione non riuscita",
+      "syncErrorDescription": "Impossibile mettere in coda il processo di sincronizzazione per l'integrazione di questo problema. Riprova più tardi.",
+      "delete": {
+        "confirmMessage": "Sei sicuro di voler eliminare l'integrazione del problema \"{name}\"?",
+        "warning": "Questa operazione rimuoverà l'integrazione del problema e la disconnetterà da tutti i progetti. Questa azione non può essere annullata.",
+        "warningTitle": "Questa azione:",
+        "warning1": "Rimuovere definitivamente la configurazione e le credenziali di integrazione del problema",
+        "warning2": "Disconnetti tutti i token di autenticazione utente per questa integrazione del problema",
+        "warning3": "Conserva tutti i problemi collegati nel database (i problemi diventano non collegati)",
+        "warning4": "Richiedere prima la rimozione dell'integrazione del problema da tutti i progetti"
+      },
+      "deleteSuccess": "Problema di integrazione eliminato",
+      "deleteSuccessDescription": "L'integrazione del problema è stata rimossa correttamente",
+      "deleteError": "Elimina errore",
+      "add": {
+        "description": "Configurare una nuova integrazione dei problemi con un servizio esterno",
+        "selectType": "Seleziona il tipo di integrazione del problema",
+        "typeDescription": "Scegli il tipo di servizio che vuoi integrare",
+        "successMessage": "Problema di integrazione creato con successo",
+        "successDescription": "L'integrazione del problema è stata configurata ed è pronta per l'uso",
+        "simple_url": {
+          "name": "URL semplice",
+          "description": "Monitoraggio di base dei problemi con modelli URL personalizzati"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Connettiti ad Atlassian Jira per il monitoraggio dei problemi e la gestione dei progetti"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Connettiti a GitHub per il monitoraggio dei problemi"
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Collegati a GitLab per tenere traccia di problemi e richieste di merge."
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Connettiti a un'istanza self-hosted di Gitea, Forgejo o Gogs per il monitoraggio dei problemi."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Connettiti ad Azure DevOps per il monitoraggio degli elementi di lavoro"
+        }
+      },
+      "filterPlaceholder": "Integrazioni di filtri...",
+      "table": {
+        "lastSync": "Ultima sincronizzazione",
+        "empty": "Nessuna integrazione di problemi trovata",
+        "loading": "Caricamento delle integrazioni dei problemi...",
+        "configure": "Configurare"
+      },
+      "edit": {
+        "description": "Aggiorna le impostazioni e la configurazione dell'integrazione dei problemi",
+        "successMessage": "Problema Integrazione aggiornata con successo",
+        "successDescription": "Le impostazioni di integrazione del problema sono state salvate"
+      },
+      "editIntegration": "Modifica problema Integrazione",
+      "saveIntegration": "Integrazione del salvataggio del problema",
+      "deleteIntegration": "Eliminazione dell'integrazione dei problemi",
+      "config": {
+        "name": "Nome dell'integrazione del problema",
+        "namePlaceholder": "Inserisci un nome per l'integrazione di questo problema",
+        "nameHelp": "Un nome descrittivo per identificare l'integrazione di questo problema",
+        "authType": "Tipo di autenticazione",
+        "authTypeHelp": "Scegli come autenticarti con il servizio esterno",
+        "emailPlaceholder": "la-tua-email@esempio.com",
+        "emailHelp": "L'indirizzo email del tuo account",
+        "apiToken": "Token API",
+        "apiTokenPlaceholder": "Inserisci il tuo token API",
+        "apiTokenHelp": "Genera un token API dalle impostazioni del tuo account",
+        "jiraUrl": "URL di Jira",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "L'URL della tua istanza Jira",
+        "clientId": "ID cliente",
+        "clientIdPlaceholder": "Inserisci il tuo ID client OAuth",
+        "clientIdHelp": "L'ID client della tua applicazione OAuth",
+        "clientSecret": "Segreto del cliente",
+        "clientSecretPlaceholder": "Inserisci il tuo segreto client OAuth",
+        "clientSecretHelp": "Il segreto client della tua applicazione OAuth",
+        "cloudId": "ID cloud",
+        "cloudIdPlaceholder": "Inserisci il tuo ID Atlassian Cloud",
+        "cloudIdHelp": "ID dell'istanza Atlassian Cloud (disponibile nell'URL Jira)",
+        "apiUrl": "URL dell'API",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "L'URL di base per l'API del servizio",
+        "personalAccessTokenPlaceholder": "Inserisci il tuo token di accesso personale",
+        "personalAccessTokenHelp": "Un token di accesso personale con autorizzazioni appropriate",
+        "apiKeyPlaceholder": "Inserisci la tua chiave API",
+        "apiKeyHelp": "La chiave API per l'autenticazione",
+        "baseUrl": "Modello URL",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "Modello URL per i problemi. Usa {issueId} come segnaposto",
+        "organizationUrl": "URL dell'organizzazione",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "URL dell'organizzazione Azure DevOps",
+        "projectPath": "Percorso del progetto",
+        "projectPathPlaceholder": "gruppo/sottogruppo/progetto",
+        "projectPathHelp": "Il percorso completo del tuo progetto GitLab (ad esempio mygroup/myproject)",
+        "instanceUrl": "URL dell'istanza",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "URL della tua istanza self-hosted. Lascia vuoto per utilizzare gitlab.com",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Proprietario",
+        "ownerPlaceholder": "nome utente o organizzazione",
+        "ownerHelp": "L'utente o l'organizzazione Gitea proprietaria del repository",
+        "repo": "Archivio",
+        "repoPlaceholder": "nome del repository",
+        "repoHelp": "Il nome del repository Gitea",
+        "encrypted": "Criptato",
+        "encryptedHelp": "Questo campo è crittografato e archiviato in modo sicuro",
+        "changeCredential": "Modifica",
+        "apiKeyWarningTitle": "Avviso di autenticazione della chiave API",
+        "apiKeyWarningDescription": "Quando si utilizza l'autenticazione tramite chiave API, i segnalatori dei problemi vengono determinati automaticamente:",
+        "apiKeyWarningPoint1": "Se la tua email di TestPlanIt corrisponde a un'email di un utente Jira, verrai impostato come reporter",
+        "apiKeyWarningPoint2": "Se non esiste alcuna corrispondenza e-mail, il nome TestPlanIt verrà abbinato ai nomi visualizzati di Jira",
+        "apiKeyWarningPoint3": "Se non viene trovata alcuna corrispondenza, il proprietario della chiave API verrà impostato come reporter",
+        "forgeApiKeyLabel": "Chiave API Forge",
+        "forgeApiKeyDescription": "Utilizzato dall'app Atlassian Forge per autenticare le richieste provenienti dai pannelli dei ticket Jira. Genera una chiave qui e incollala nelle impostazioni dell'app Forge.",
+        "forgeApiKeyPlaceholder": "Fai clic su Genera per creare una chiave API",
+        "forgeApiKeyGenerate": "Generare",
+        "forgeApiKeyCopy": "Copia",
+        "forgeApiKeyCopied": "Copiato",
+        "platform": "Piattaforma",
+        "platformPlaceholder": "Seleziona la piattaforma...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "Chiave API",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Token di accesso personale"
+      },
+      "validation": {
+        "nameRequired": "Il nome dell'integrazione del problema è obbligatorio",
+        "clientIdRequired": "È richiesto l'ID cliente",
+        "clientSecretRequired": "Il segreto del client è obbligatorio",
+        "cloudIdRequired": "È richiesto l'ID cloud",
+        "apiUrlRequired": "L'URL dell'API è obbligatorio",
+        "tokenRequired": "È richiesto il token di accesso personale",
+        "apiKeyRequired": "È richiesta la chiave API"
+      },
+      "errors": {
+        "updateFailed": "Impossibile aggiornare l'integrazione del problema",
+        "testFailed": "Test di connessione fallito",
+        "nameExists": "Esiste già un'integrazione di problema con questo nome",
+        "createFailed": "Impossibile creare l'integrazione del problema",
+        "deleteFailed": "Impossibile eliminare l'integrazione del problema"
+      },
+      "confirmDelete": {
+        "message": "Sei sicuro di voler eliminare l'integrazione del problema \"{name}\"?",
+        "warning": "Questa operazione rimuoverà l'integrazione del problema e la disconnetterà da tutti i progetti. Questa azione è irreversibile."
+      },
+      "form": {
+        "success": "Problema: Integrazione salvata correttamente",
+        "successDescription": "L'integrazione dei problemi è stata configurata ed è pronta per l'uso.",
+        "testing": "Test di connessione in corso..."
+      },
+      "oauth": {
+        "connectAccount": "Connetti account",
+        "connected": "Collegato",
+        "notConnected": "Non connesso",
+        "authDescription": "Devi autenticarti con {provider} per utilizzare questa integrazione",
+        "authError": "Autenticazione fallita",
+        "authErrorDescription": "Impossibile autenticarsi con il servizio esterno"
+      }
+    },
+    "llm": {
+      "addIntegration": "Aggiungi modello AI",
+      "filterPlaceholder": "Filtra i modelli di IA...",
+      "testAll": "Testa tutte le connessioni",
+      "connectionTestComplete": "Test di connessione completato",
+      "allIntegrationsTested": "Sono state testate tutte le connessioni del modello AI",
+      "failedToTestConnections": "Impossibile testare alcune connessioni",
+      "notConfigured": "Non configurato",
+      "defaultModel": "Modello selezionato",
+      "budgetUsage": "Utilizzo (questo mese)",
+      "noBudget": "Nessun budget impostato",
+      "streaming": "Streaming",
+      "add": {
+        "title": "Aggiungi integrazione modello AI",
+        "description": "Configura un nuovo modello di intelligenza artificiale per la tua organizzazione",
+        "integrationNamePlaceholder": "Inserisci un nome per questa integrazione...",
+        "selectProvider": "Seleziona un fornitore",
+        "openai": "OpenAI",
+        "anthropic": "Antropico",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemelli",
+        "ollama": "Ollama",
+        "customLlm": "LLM personalizzato",
+        "apiKeyPlaceholder": "Inserisci la tua chiave API...",
+        "apiKeyDescription": "La tua chiave API per l'autenticazione con il provider",
+        "endpoint": "URL dell'endpoint",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Suggerimento: se si utilizza un proxy (ad esempio LiteLLM), provare ad aggiungere /v1 alla fine dell'URL dell'endpoint.",
+        "deploymentName": "Nome della distribuzione",
+        "deploymentNamePlaceholder": "Inserisci il nome della distribuzione...",
+        "deploymentNameDescription": "Nome della distribuzione di Azure OpenAI",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, ecc.",
+        "defaultModelDescription": "Il modello da utilizzare di default",
+        "maxTokensPerRequest": "Numero massimo di token per richiesta",
+        "maxRequestsPerMinute": "Numero massimo di richieste al minuto",
+        "costPerInputToken": "Costo per 1 milione di token di input ($)",
+        "costPerOutputToken": "Costo per 1 milione di token prodotti ($)",
+        "monthlyBudget": "Budget mensile ($)",
+        "monthlyBudgetPlaceholder": "100,00",
+        "monthlyBudgetDescription": "Obiettivo di spesa facoltativo per le notifiche (non blocca l'utilizzo)",
+        "billingPeriodStartDay": "Giorno di inizio del periodo di fatturazione",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "Giorno del mese (1-31) in cui inizia il periodo di fatturazione. I valori dal 29 al 31 utilizzano l'ultimo giorno dei mesi più brevi.",
+        "defaultTemperature": "Temperatura predefinita",
+        "defaultMaxTokens": "Token massimi predefiniti",
+        "timeout": "Timeout della richiesta (ms)",
+        "timeoutDescription": "Tempo massimo di attesa per la risposta del modello AI (5000-600000 ms). Non si applica alle richieste in streaming.",
+        "streamingEnabled": "Abilita lo streaming",
+        "streamingEnabledDescription": "Consenti lo streaming di risposta in tempo reale",
+        "setAsDefault": "Imposta come predefinito",
+        "setAsDefaultDescription": "Utilizza questo come modello di intelligenza artificiale predefinito per l'organizzazione",
+        "fetchingModels": "Recupero modelli in corso...",
+        "failedToFetchModels": "Impossibile recuperare i modelli disponibili",
+        "selectModel": "Seleziona un modello",
+        "connectionSuccessfulDescription": "La connessione del modello AI è stata verificata e funziona correttamente",
+        "failedToConnect": "Impossibile connettersi al provider del modello AI",
+        "integrationCreated": "Integrazione del modello AI creata con successo",
+        "failedToCreate": "Impossibile creare l'integrazione del modello AI",
+        "validation": {
+          "nameRequired": "Il nome dell'integrazione è obbligatorio",
+          "nameUnique": "Esiste già un'integrazione con questo nome",
+          "defaultModelRequired": "È richiesto il modello predefinito"
+        }
+      },
+      "edit": {
+        "title": "Modifica l'integrazione del modello AI",
+        "description": "Aggiorna la configurazione per questa integrazione del modello AI",
+        "statusDescription": "Abilita o disabilita questa integrazione",
+        "apiKeyPlaceholder": "Inserisci una nuova chiave API per aggiornare...",
+        "update": "Aggiornamento",
+        "integrationUpdated": "Integrazione del modello AI aggiornata con successo",
+        "failedToUpdate": "Impossibile aggiornare l'integrazione del modello AI",
+        "validation": {
+          "nameRequired": "Il nome dell'integrazione è obbligatorio",
+          "nameUnique": "Esiste già un'integrazione con questo nome",
+          "defaultModelRequired": "È richiesto il modello predefinito"
+        }
+      },
+      "sections": {
+        "provider": "Fornitore",
+        "costAndBudget": "Costi e budget",
+        "advanced": "Avanzato"
+      },
+      "delete": {
+        "title": "Elimina l'integrazione del modello AI",
+        "description": "Vuoi davvero eliminare questa integrazione del modello AI? Questa operazione la rimuoverà da tutti i progetti e non potrà essere annullata.",
+        "integrationDeletedSuccess": "Integrazione del modello AI eliminata correttamente",
+        "failedToDeleteIntegration": "Impossibile eliminare l'integrazione del modello AI",
+        "cannotDeleteDefault": "Impossibile eliminare il modello IA predefinito. Impostane prima un altro come predefinito."
+      },
+      "validation": {
+        "defaultModelRequired": "È richiesto il modello predefinito"
+      },
+      "test": {
+        "title": "Test di integrazione del modello AI",
+        "description": "Testare la connessione e la funzionalità di {name}",
+        "connectionStatus": "Stato della connessione",
+        "connectionStatusDescription": "Verificare se il modello AI è accessibile",
+        "retest": "Riprova la connessione",
+        "connectionSuccessfulDescription": "Il modello di intelligenza artificiale è accessibile e risponde correttamente",
+        "failedToConnect": "Impossibile connettersi al modello AI",
+        "errorTestingConnection": "Si è verificato un errore durante il test della connessione",
+        "testMessage": "Messaggio di prova",
+        "testMessagePlaceholder": "Inserisci un messaggio da inviare al modello AI...",
+        "sendTestMessage": "Invia messaggio di prova",
+        "response": "Risposta",
+        "testSuccessful": "Test riuscito",
+        "responseReceived": "Risposta ricevuta con successo (Costo: ${cost})",
+        "testFailed": "Test fallito",
+        "failedToGetResponse": "Impossibile ottenere risposta dal modello AI",
+        "failedToSendMessage": "Impossibile inviare il messaggio di prova",
+        "defaultTestMessage": "Ciao! Ti preghiamo di rispondere brevemente confermando che stai lavorando correttamente."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Impostare un budget mensile non impedisce che l'utilizzo di LLM lo superi. I limiti di budget sono forniti solo a titolo informativo per le decisioni amministrative.",
+        "budgetDisclaimerShort": "I limiti di budget sono puramente informativi e non bloccano l'utilizzo.",
+        "spendLabel": "Spesa del mese corrente",
+        "spendOfBudget": "{currentSpend} di {budgetLimit}",
+        "overBudget": "sforamento del budget",
+        "budgetPercentage": "{percentage}% del budget utilizzato",
+        "spendReset": "La spesa del mese corrente è stata azzerata"
+      }
+    },
+    "prompts": {
+      "title": "Configurazioni richieste",
+      "description": "Gestisci i modelli di prompt AI per diverse funzionalità",
+      "addPromptConfig": "Aggiungi la configurazione del prompt",
+      "filterPlaceholder": "Configurazioni dei prompt dei filtri...",
+      "features": "Caratteristiche",
+      "featureCount": "{count, plural, one {# funzionalità} other {# funzionalità}}",
+      "llmIntegration": "Integrazione LLM",
+      "modelOverride": "Sovrascrittura del modello",
+      "llmIntegrationPlaceholder": "Progetto predefinito",
+      "modelOverridePlaceholder": "Integrazione predefinita",
+      "projectDefault": "Progetto predefinito (cancella)",
+      "integrationDefault": "Integrazione predefinita (cancella)",
+      "systemPrompt": "Prompt di sistema",
+      "userPrompt": "Richiesta all'utente",
+      "temperature": "Temperatura",
+      "maxOutputTokens": "Numero massimo di token di output",
+      "variables": "Variabili",
+      "insertVariable": "Inserire variabile",
+      "noConfigs": "Nessuna configurazione di prompt trovata. Aggiungi la tua prima configurazione per iniziare.",
+      "add": {
+        "title": "Aggiungi la configurazione del prompt",
+        "description": "Crea una nuova configurazione di prompt AI con prompt per ogni funzionalità. Le impostazioni predefinite sono state applicate automaticamente."
+      },
+      "edit": {
+        "title": "Modifica la configurazione del prompt",
+        "description": "Aggiorna questa configurazione del prompt AI"
+      },
+      "delete": {
+        "title": "Elimina la configurazione del prompt",
+        "confirmMessage": "Sei sicuro di voler eliminare <strong>{name}</strong>? I progetti che utilizzano questo prompt torneranno all'impostazione predefinita del sistema.",
+        "warning": "Questa azione non può essere annullata. Tutti i progetti che utilizzano questa configurazione torneranno alla configurazione predefinita del prompt."
+      },
+      "llmColumn": "LLM",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "Impossibile eliminare la configurazione predefinita del prompt. Impostane prima un'altra come predefinita.",
+      "defaultChanged": "Configurazione predefinita dei prompt aggiornata correttamente.",
+      "featureLabels": {
+        "markdown_parsing": "Analisi dei casi di test Markdown",
+        "test_case_generation": "Generazione di casi di test",
+        "magic_select_cases": "Selezione intelligente dei casi di test",
+        "editor_assistant": "Assistente alla redazione",
+        "llm_test": "Test di connessione LLM",
+        "export_code_generation": "Generazione del codice di esportazione",
+        "auto_tag": "Suggerimenti di tag basati sull'IA",
+        "duplicate_detection": "Rilevamento duplicati",
+        "generate_from_url": "Genera casi di test da URL (requisiti)",
+        "generate_from_url_app": "Genera casi di test da URL (test dell'applicazione)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Gestione Elasticsearch",
+      "description": "Gestire l'indicizzazione e la manutenzione dei motori di ricerca",
+      "status": {
+        "title": "Stato di Elasticsearch",
+        "description": "Connessione attuale e stato di salute del motore di ricerca",
+        "checking": "Verifica dello stato...",
+        "disconnected": "Disconnesso",
+        "nodes": "Nodi",
+        "indices": "Indici",
+        "documents": "documenti",
+        "error": {
+          "title": "Errore di connessione",
+          "description": "Impossibile connettersi al servizio Elasticsearch"
+        }
+      },
+      "settings": {
+        "description": "Configura le impostazioni di Elasticsearch per la tua distribuzione",
+        "numberOfReplicas": "Numero di repliche",
+        "replicasHelp": "Impostare su 0 per cluster a nodo singolo, 1+ per cluster a più nodi con ridondanza",
+        "savedDescription": "La configurazione è stata salvata nel database",
+        "updated": "Indici aggiornati",
+        "updatedDescription": "Tutti gli indici esistenti sono stati aggiornati con le nuove impostazioni di replica",
+        "error": "Errore durante il salvataggio delle impostazioni",
+        "errorDescription": "Impossibile salvare la configurazione. Riprova.",
+        "note": {
+          "description": "Le modifiche si applicano immediatamente ai nuovi indici. Gli indici esistenti vengono aggiornati al momento del salvataggio. Impostare le repliche su 0 per risolvere lo stato GIALLO nei cluster a nodo singolo."
+        }
+      },
+      "reindex": {
+        "title": "Reindicizzazione dei dati",
+        "description": "Ricostruisci gli indici di ricerca per migliorare le prestazioni di ricerca",
+        "entities": {
+          "all": "Tutte le entità"
+        },
+        "button": {
+          "start": "Avvia reindicizzazione",
+          "indexing": "Indicizzazione in corso..."
+        },
+        "warning": {
+          "title": "Importante",
+          "description": "La reindicizzazione potrebbe richiedere diversi minuti a seconda del volume di dati. Durante questo processo, la funzionalità di ricerca potrebbe essere limitata."
+        },
+        "complete": {
+          "title": "Reindicizzazione completa",
+          "description": "Tutte le entità selezionate sono state reindicizzate correttamente"
+        },
+        "success": {
+          "title": "Reindicizzazione riuscita",
+          "description": "{count, plural, one {# documento} other {# documenti}} indicizzato con successo"
+        },
+        "error": {
+          "title": "Reindicizzazione non riuscita",
+          "description": "Si è verificato un errore durante la reindicizzazione. Riprova."
+        }
+      }
+    },
+    "queues": {
+      "title": "Code di lavoro in background",
+      "description": "Monitorare e gestire le code di elaborazione dei lavori in background",
+      "queueNames": {
+        "forecast-updates": "Aggiornamenti delle previsioni",
+        "emails": "Coda di posta elettronica",
+        "issue-sync": "Sincronizzazione dei problemi",
+        "testmo-imports": "Importazioni Testmo",
+        "elasticsearch-reindex": "Reindicizzazione di Elasticsearch",
+        "audit-logs": "Registri di controllo",
+        "budget-alerts": "Avvisi di bilancio",
+        "auto-tag": "Etichettatura automatica tramite IA",
+        "repo-cache": "Cache del repository",
+        "copy-move": "Copia e sposta",
+        "duplicate-scan": "Scansione duplicata",
+        "magic-select": "Magic Select",
+        "step-scan": "Scansione della sequenza dei passaggi"
+      },
+      "status": {
+        "paused": "In pausa",
+        "idle": "Oziare"
+      },
+      "table": {
+        "queue": "Coda",
+        "concurrency": "Concorrenza",
+        "waiting": "In attesa",
+        "failed": "Fallito"
+      },
+      "concurrency": {
+        "title": "Concorrenza dei lavoratori",
+        "description": "La concorrenza controlla quanti processi ogni worker elabora simultaneamente. Valori più elevati possono migliorare la produttività, ma utilizzano più risorse di sistema (CPU e memoria).",
+        "configureTitle": "Configurazione della concorrenza",
+        "configureDescription": "Per regolare la concorrenza, impostare le variabili di ambiente e riavviare i worker. Consultare la documentazione per i dettagli.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Importazioni Testmo (predefinito: 1, ad alta intensità di memoria)",
+          "SYNC_CONCURRENCY": "Sincronizzazione dei problemi (predefinito: 2, I/O intensivo)",
+          "EMAIL_CONCURRENCY": "Invio di e-mail (predefinito: 3, I/O intensivo)",
+          "NOTIFICATION_CONCURRENCY": "Notifiche (predefinito: 5, leggero)",
+          "FORECAST_CONCURRENCY": "Aggiornamenti delle previsioni (predefinito: 5, ad alta intensità di CPU)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Coda di pausa",
+          "confirmDescription": "Ciò impedirà l'elaborazione di nuovi lavori. I lavori attivi continueranno fino al completamento."
+        },
+        "resume": {
+          "confirmTitle": "Coda di ripresa",
+          "confirmDescription": "Ciò consentirà alla coda di elaborare i lavori in attesa."
+        },
+        "clean": {
+          "confirmTitle": "Coda pulita",
+          "confirmDescription": "Questa operazione rimuoverà dalla coda i lavori completati e non riusciti. Questa azione non può essere annullata."
+        },
+        "drain": {
+          "confirmTitle": "Coda di scarico",
+          "confirmDescription": "Questa operazione rimuoverà tutti i lavori in attesa dalla coda. I lavori attivi proseguiranno fino al completamento. Questa azione non può essere annullata."
+        },
+        "obliterate": {
+          "confirmTitle": "Elimina coda",
+          "confirmDescription": "Questa operazione cancellerà completamente la coda, rimuovendo tutti i lavori indipendentemente dal loro stato. Questa azione non può essere annullata e dovrebbe essere utilizzata solo in situazioni di emergenza."
+        },
+        "warning": "Avvertimento",
+        "irreversible": "Questa azione non può essere annullata. Conferma di voler procedere."
+      },
+      "success": {
+        "actionCompleted": "Azione completata",
+        "queuePaused": "La coda è stata messa in pausa",
+        "queueResumed": "La coda è stata ripresa",
+        "queueCleaned": "La coda è stata pulita",
+        "queueDrained": "La coda è stata svuotata",
+        "queueObliterated": "La coda è stata cancellata"
+      },
+      "error": {
+        "loadFailed": "Impossibile caricare le code",
+        "actionFailed": "Azione fallita"
+      },
+      "jobs": {
+        "title": "Lavori in coda",
+        "description": "Visualizza e gestisci i singoli lavori nella coda",
+        "noJobs": "Nessun lavoro trovato in questa coda",
+        "table": {
+          "id": "ID lavoro",
+          "name": "Nome del lavoro",
+          "attempts": "Tentativi"
+        },
+        "details": {
+          "title": "Dettagli del lavoro",
+          "failedReason": "Motivo del fallimento",
+          "stacktrace": "Stack Trace",
+          "data": "Dati di lavoro",
+          "returnValue": "Valore di ritorno",
+          "options": "Opzioni di lavoro",
+          "processed": "Elaborato",
+          "finished": "Finito"
+        },
+        "success": {
+          "actionCompleted": "Azione di lavoro completata",
+          "jobRetried": "Il lavoro è stato riprovato",
+          "jobPromoted": "Il lavoro è stato promosso",
+          "jobRemoved": "Il lavoro è stato rimosso"
+        },
+        "error": {
+          "loadFailed": "Impossibile caricare i lavori",
+          "actionFailed": "Azione di lavoro non riuscita"
+        },
+        "forceRemove": {
+          "title": "Forza la rimozione del lavoro",
+          "question": "Vuoi forzare la rimozione di questo lavoro?",
+          "warning": "Questo tenterà di rimuoverlo più volte, con ritardi. Nota: se il processo è effettivamente bloccato da un worker in esecuzione, potrebbe comunque non riuscire.",
+          "confirm": "Forza la rimozione"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Visualizza il registro di controllo a livello di sistema per il monitoraggio della sicurezza e della conformità.",
+      "filterPlaceholder": "Cerca per entità, utente o azione...",
+      "filterAction": "Azione",
+      "filterEntityType": "Tipo di entità",
+      "allActions": "Tutte le azioni",
+      "allEntityTypes": "Tutti i tipi di entità",
+      "showing": "Visualizzazione delle voci da {start} a {end} di {total}",
+      "viewDetails": "Visualizza i dettagli",
+      "detailTitle": "Dettagli del registro di controllo",
+      "userInfo": "Informazioni utente",
+      "changes": "Modifiche",
+      "metadata": "Metadati",
+      "oldValue": "Vecchio",
+      "newValue": "Nuovo",
+      "columns": {
+        "timestamp": "Timestamp",
+        "entityId": "ID entità",
+        "entityName": "Nome dell'entità",
+        "userId": "ID utente",
+        "ipAddress": "Indirizzo IP",
+        "userAgent": "Agente utente"
+      },
+      "exportCsv": "Esporta in formato CSV",
+      "timeRange": "Intervallo di tempo",
+      "timeRangeOptions": {
+        "last24h": "Ultime 24 ore",
+        "last7d": "Ultimi 7 giorni",
+        "last30d": "Ultimi 30 giorni",
+        "last90d": "Ultimi 90 giorni",
+        "allTime": "Di tutti i tempi"
+      },
+      "systemActor": "Sistema",
+      "systemActorTooltip": "Azione eseguita dal sistema, non da un utente autenticato."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Nessuna notifica",
+      "aria": {
+        "notifications": "Notifiche ({count} non lette)"
+      },
+      "actions": {
+        "markRead": "Segna come letto",
+        "markUnread": "Segna come non letto",
+        "markAllRead": "Segna tutto come letto",
+        "deleteAll": "Elimina tutto"
+      },
+      "success": {
+        "deleted": "Notifica eliminata",
+        "markedAllRead": "Tutte le notifiche contrassegnate come lette",
+        "deletedAll": "Tutte le notifiche eliminate"
+      },
+      "error": {
+        "markRead": "Impossibile contrassegnare come letto",
+        "markUnread": "Impossibile contrassegnare come non letto",
+        "delete": "Impossibile eliminare la notifica",
+        "markAllRead": "Impossibile contrassegnare tutto come letto",
+        "deleteAll": "Impossibile eliminare le notifiche"
+      },
+      "deleteAllDialog": {
+        "title": "Eliminare tutte le notifiche?",
+        "description": "Questa operazione rimuoverà definitivamente tutte le tue notifiche. Tale azione non può essere annullata.",
+        "confirm": "Elimina tutto"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Nuovo incarico di caso di prova",
+        "multipleTestCaseAssignmentTitle": "Assegnati più casi di test",
+        "sessionAssignmentTitle": "Nuova assegnazione della sessione",
+        "commentMentionTitle": "Sei stato menzionato in un commento",
+        "systemAnnouncementTitle": "Annuncio di sistema",
+        "assignedTestCase": "ti è stato assegnato il caso di prova",
+        "assignedMultipleTestCases": "ti ho assegnato {count, plural, one {# caso di test} other {# casi di test}}",
+        "assignedSession": "ti ha assegnato alla sessione",
+        "mentionedYouInComment": "ti ha menzionato in un commento su",
+        "inProject": "nel progetto",
+        "testRun": "Esecuzione di prova:",
+        "casesInProject": "{count, plural, =1 {# caso} other {# casi}} in",
+        "sentBy": "Inviato da {name}",
+        "milestoneDueSoonTitle": "Traguardo in arrivo a breve",
+        "milestoneOverdueTitle": "Traguardo in ritardo",
+        "milestoneDueSoon": "La pietra miliare \"{milestoneName}\" nel progetto \"{projectName}\" è prevista per il {dueDate}.",
+        "milestoneOverdue": "La tappa fondamentale \"{milestoneName}\" nel progetto \"{projectName}\" era prevista per il {dueDate} ed è ora in ritardo.",
+        "milestoneNotificationReason": "Ricevi questa notifica perché hai partecipato ad attività associate a questa tappa (prove, sessioni o in qualità di creatore della tappa).",
+        "milestoneNotificationContinue": "Continuerai a ricevere promemoria giornalieri fino a quando questo traguardo non sarà contrassegnato come completato.",
+        "shareLinkAccessedTitle": "Link di condivisione accessibile",
+        "shareLinkAccessedAnonymousViewer": "Qualcuno",
+        "shareLinkAccessedMessage": "{viewer} ha visualizzato il tuo report condiviso: \"{shareTitle}\"",
+        "viewedYourSharedLink": "ho visualizzato il tuo link condiviso",
+        "viewedAt": "Visualizzato a",
+        "budgetDisclaimer": "I limiti di budget sono puramente informativi e non impediscono l'utilizzo.",
+        "llmBudgetExceededTitle": "Il budget del programma LLM è stato superato.",
+        "llmBudgetThresholdTitle": "Budget LLM {threshold}% Utilizzato",
+        "llmBudgetExceededMessage": "{providerName} ha superato il suo budget mensile: {spend} ha speso del budget {budget}.",
+        "llmBudgetThresholdMessage": "{providerName} ha utilizzato {threshold}% del suo budget mensile: {spend} di {budget}.",
+        "userRegisteredTitle": "Registrazione nuovo utente",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) si è registrato tramite SSO",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) si è registrato tramite il modulo di registrazione",
+        "viewUserList": "Visualizza l'elenco degli utenti",
+        "reviewGeneratedCases": "Esamina i casi di test generati",
+        "generateFromUrlCompleteTitle": "Pagine indicizzate con successo",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# pagina} other {# pagine}} indicizzato da {url} nel progetto \"{projectName}\". Fare clic per rivedere e generare casi di test.",
+        "generateFromUrlFailedTitle": "Scansione URL fallita"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Problemi di ricerca o collegamento...",
+        "create_label": "Problema di collegamento \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Inserisci il riepilogo del problema"
+        },
+        "fields": {
+          "name": {
+            "label": "Riepilogo"
+          },
+          "description": {
+            "placeholder": "Descrivi il problema...",
+            "helper": "Fornire informazioni dettagliate sul problema"
+          },
+          "project": {
+            "helper": "Seleziona il progetto nel tracker dei problemi esterno"
+          }
+        },
+        "loading_metadata": "Caricamento delle impostazioni di integrazione in corso...",
+        "errors": {
+          "creation_failed": "Impossibile creare il problema. Riprova."
+        },
+        "success": {
+          "created": "Problema creato con successo",
+          "external_created": "Problema creato e collegato al tracker esterno"
+        },
+        "warnings": {
+          "external_failed": "Problema creato localmente ma non è stato possibile sincronizzarlo con il tracker esterno"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "Devi collegare il tuo account a {integrationName} per creare problemi."
+      },
+      "search_issues_dialog": {
+        "title": "Problemi di ricerca e collegamento",
+        "placeholder": "Cerca problemi...",
+        "searching": "Ricerca in corso...",
+        "searchError": "Problemi di ricerca non riusciti",
+        "linkButton": "Collegamento",
+        "linkedCount": "{count, plural, one {# problema} other {# problemi}} collegato"
+      }
+    },
+    "copyMove": {
+      "title": "Copia / Sposta nel progetto",
+      "step1Desc": "Selezionare un progetto e una cartella di destinazione per i casi di test.",
+      "step2Desc": "Seleziona l'operazione e verifica la compatibilità.",
+      "step3Desc": "Monitorare i progressi e rivedere i risultati.",
+      "targetProject": "Progetto obiettivo",
+      "searchProjects": "Cerca progetti...",
+      "loadingProjects": "Caricamento dei progetti in corso...",
+      "noProjectsFound": "Nessun progetto trovato.",
+      "completed": "(Completare)",
+      "targetFolder": "Cartella di destinazione",
+      "newFolderPlaceholder": "Nuovo nome della cartella...",
+      "operation": "Operazione",
+      "operationCopy": "Copia",
+      "operationCopyDesc": "Crea una copia del/dei caso/i selezionato/i nel progetto di destinazione. Gli originali rimangono invariati.",
+      "operationMove": "Mossa",
+      "operationMoveDesc": "Sposta il/i caso/i selezionato/i nel progetto di destinazione. Gli originali verranno rimossi dalla sorgente.",
+      "checkingCompatibility": "Verifica della compatibilità...",
+      "noTargetWriteAccess": "Non si dispone dei permessi di scrittura per il progetto di destinazione.",
+      "noSourceUpdateAccess": "Non si dispone dell'autorizzazione di modifica sul progetto sorgente per spostare i casi.",
+      "templateMismatch": "Mancata corrispondenza del modello",
+      "autoAssignTemplates": "Assegna automaticamente i modelli mancanti al progetto di destinazione",
+      "templatesMayNotDisplay": "I modelli mancanti non saranno disponibili nel progetto di destinazione. I casi verranno copiati, ma i campi di tali modelli potrebbero non essere visualizzati correttamente.",
+      "workflowFallback": "Alcuni stati del flusso di lavoro non sono disponibili nel progetto di destinazione. In questi casi verrà utilizzato lo stato predefinito del progetto di destinazione.",
+      "default": "(predefinito)",
+      "conflicts": "Applicabile a tutti i conflitti:",
+      "conflictSkip": "Saltare",
+      "conflictRename": "Rinominare",
+      "sharedStepGroups": "Quando nel sistema di destinazione esistono già gruppi di passaggi condivisi:",
+      "sharedStepGroupReuse": "Riutilizzare quello esistente",
+      "sharedStepGroupReuseDesc": "I casi faranno riferimento al gruppo di passaggi condivisi esistente.",
+      "sharedStepGroupCreateNew": "Crea nuovo",
+      "sharedStepGroupCreateNewDesc": "Verrà creato un nuovo gruppo di passaggi condivisi.",
+      "go": "Andare",
+      "processing": "Elaborazione in corso...",
+      "progressText": "{processed} di {total} casi elaborati",
+      "successCount": "{count} caso(i) {operation}d riuscito",
+      "skipped": "Saltato: {count}",
+      "droppedLinks": "Collegamenti tra progetti interrotti: {count}",
+      "errorCount": "{count} caso(i) fallito(i)",
+      "viewInTargetProject": "Visualizza nel progetto di destinazione",
+      "failed": "Fallito",
+      "folderMode": "Cartella \"{folderName}\" — {caseCount, plural, one {# caso} other {# casi}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Problemi collegati",
+    "linkedIssuesDescription": "Problemi associati a questo articolo",
+    "refreshed": "Problemi aggiornati",
+    "refreshedDescription": "L'elenco dei problemi collegati è stato aggiornato",
+    "unlinked": "Problema non collegato",
+    "unlinkedDescription": "Il problema è stato rimosso da questo elemento",
+    "linked": "Problema collegato",
+    "linkedDescription": "Il problema è stato collegato a questo elemento",
+    "searchAndLink": "Cerca e collega",
+    "createAndLink": "Crea e collega",
+    "noLinkedIssues": "Nessun problema collegato",
+    "viewExternal": "Visualizza in {provider}",
+    "unlink": "Scollega",
+    "linkError": "Problema di collegamento non riuscito",
+    "linkExternalIssue": "Collegamento {provider} Problema",
+    "linkIssue": "Problema di collegamento",
+    "addIssue": "Aggiungi problema",
+    "unlinkError": "Problema di scollegamento non riuscito",
+    "noIssuesFound": "Nessun problema trovato",
+    "startTypingToSearch": "Inizia a digitare per cercare i problemi",
+    "selectedCount": "{count} selezionato",
+    "confirmSelection": "Conferma selezione",
+    "alreadyLinked": "Già collegato",
+    "authenticate": "Autenticare",
+    "authenticationRequired": "Autenticazione richiesta",
+    "authenticationDescription": "Per cercare i problemi è necessario autenticarsi con {provider} .",
+    "searchIn": "Cerca in {provider}",
+    "searchPlaceholder": "Problemi di ricerca...",
+    "searchIssues": "Problemi di ricerca",
+    "searchIssuesDescription": "Cerca problemi interni da collegare a questo elemento.",
+    "searchExternalDescription": "Cerca {provider} numeri da collegare a questo elemento.",
+    "error": "Errore durante il caricamento dei problemi",
+    "errorDescription": "Impossibile caricare i problemi. Riprova.",
+    "selectIssues": "Seleziona problemi",
+    "authRequiredDescription": "Si prega di autenticarsi con {provider} per cercare i problemi",
+    "integrationNotConfigured": "Integrazione non configurata",
+    "integrationNotConfiguredDescription": "Questa integrazione non è stata completamente configurata. Contatta l'amministratore del progetto per configurare il progetto esterno nelle impostazioni del progetto.",
+    "createIssue": "Crea problema",
+    "createNewIssue": "Crea un nuovo problema",
+    "createIssueDescription": "Crea un nuovo problema",
+    "createIssueDescriptionWithIntegration": "Crea un nuovo problema utilizzando {provider}",
+    "createIssueDescriptionSimpleUrl": "Crea un nuovo problema interno (integrazione URL semplice)",
+    "creatingWith": "Creazione di un problema con {provider}",
+    "authenticatedAndReady": "Autenticato e pronto per creare problemi",
+    "created": "Problema creato",
+    "createdInExternal": "Problema creato in {provider}",
+    "createdInternal": "Problema creato localmente",
+    "createdInternalSimpleUrl": "Problema creato internamente e può essere collegato tramite URL semplice",
+    "createError": "Impossibile creare il problema",
+    "useIntegration": "Usa {provider}",
+    "useIntegrationDescription": "Crea un problema nel sistema esterno",
+    "externalProject": "Progetto esterno",
+    "selectProject": "Seleziona progetto",
+    "issueType": "Tipo di problema",
+    "selectIssueType": "Seleziona il tipo di problema",
+    "noIssueTypes": "Nessun tipo di problema disponibile",
+    "priorityUrgent": "Urgente",
+    "additionalFields": "Campi aggiuntivi",
+    "createIssueInJira": "Crea un problema in Jira",
+    "createIssueInJiraDescription": "Utilizza l'interfaccia di Jira per creare un nuovo problema con tutti i campi e le opzioni disponibili",
+    "createIssueInJiraFallbackDescription": "Apri Jira in una nuova scheda per creare un problema con informazioni precompilate",
+    "jiraIframeError": "Impossibile caricare l'interfaccia di Jira. Prova ad aprirla in una nuova scheda.",
+    "jiraIframeFallback": "Per motivi di sicurezza, Jira richiede l'apertura in una nuova scheda. Clicca sul pulsante qui sotto per segnalare la tua segnalazione.",
+    "jiraFallbackNote": "Dopo aver creato il problema in Jira, torna qui per continuare a collegarlo al tuo caso di test.",
+    "openInNewTab": "Apri in una nuova scheda",
+    "jiraIframeNote": "Dopo aver creato il problema in Jira, puoi chiudere questa finestra di dialogo e aggiornare l'elenco dei problemi.",
+    "fillInRequiredFields": "Compila i campi richiesti per creare un nuovo problema",
+    "failedToFetchFields": "Impossibile recuperare i campi del problema da Jira",
+    "enterSummary": "Inserisci un breve riepilogo del problema",
+    "enterDescription": "Inserisci una descrizione dettagliata del problema",
+    "failedToCreateIssue": "Impossibile creare il problema in Jira",
+    "issueCreatedDescription": "Il problema {key} è stato creato correttamente",
+    "addLabel": "Aggiungi un'etichetta e premi Invio",
+    "labelHint": "Gli spazi saranno sostituiti con trattini",
+    "labelFormatNote": "Le etichette non possono contenere spazi. Gli spazi verranno automaticamente sostituiti da trattini.",
+    "enterIssueKey": "Inserisci la chiave del problema (ad esempio, PROJ-123)",
+    "issueLinkHelp": "Inserisci la chiave di un problema esistente da collegare",
+    "searchForIssue": "Cerca un problema da collegare",
+    "searchUsers": "Cerca utenti",
+    "noTeamsAvailable": "Nessuna squadra disponibile",
+    "filterAll": "Tutto",
+    "fanOutPartialFailure": "Impossibile raggiungere il/i progetto/i {count} . Vengono visualizzati i risultati del/i progetto/i {successCount}.",
+    "projectSelectorLabel": "Progetto",
+    "searchFailedTitle": "Ricerca non riuscita"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Sfoglia e gestisci tutti i problemi.",
+      "filterPlaceholder": "Filtra i problemi per nome..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Documentazione",
+      "Milestones": "Traguardi",
+      "TestCaseRepository": "Archivio dei casi di test",
+      "TestCaseRestrictedFields": "Campi riservati del caso di prova",
+      "TestRuns": "Prove di funzionamento",
+      "ClosedTestRuns": "Esecuzioni di test chiuse",
+      "TestRunResults": "Risultati del test",
+      "TestRunResultRestrictedFields": "Campi riservati del risultato dell'esecuzione del test",
+      "Sessions": "Sessioni",
+      "SessionsRestrictedFields": "Campi riservati alle sessioni",
+      "ClosedSessions": "Sessioni chiuse",
+      "SessionResults": "Risultati della sessione",
+      "Tags": "Etichette",
+      "SharedSteps": "Passaggi condivisi",
+      "Issues": "Problemi",
+      "IssueIntegration": "Integrazione dei problemi",
+      "Forecasting": "Previsione",
+      "Reporting": "Segnalazione",
+      "Settings": "Impostazioni"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Non avviato",
+      "IN_PROGRESS": "In corso",
+      "DONE": "Fatto"
+    }
+  },
+  "charts": {
+    "average": "Media",
+    "count": "Conteggio: {count}",
+    "percent": "Percentuale: {percent}%",
+    "completed": "Completato: {count}",
+    "durationRange": "Durata: {from}s - {to}s",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# caso di test} other {# casi di test}}",
+    "estimate": "Previsione: {value}",
+    "partOf": "(Parte di {parent})",
+    "status": "Stato: {status}"
+  },
+  "linkedCases": {
+    "title": "Casi di test collegati",
+    "addLink": "Aggiungi collegamento",
+    "addLinkedTestCase": "Aggiungi caso di test collegato",
+    "testCase": "Caso di prova",
+    "linkType": "Tipo di collegamento",
+    "noLinkedCases": "Nessun caso di test collegato.",
+    "linkedBy": "Collegato da",
+    "on": "Collegato a",
+    "alreadyLinked": "Questo caso è già collegato.",
+    "cannotLinkSelf": "Non è possibile collegare un caso a se stesso.",
+    "circularLink": "Rilevato collegamento circolare.",
+    "failedToCreate": "Impossibile creare il collegamento.",
+    "confirmRemoveLink": "Sei sicuro di voler rimuovere questo collegamento?",
+    "DEPENDS_ON": "Dipendenza",
+    "DUPLICATED_FROM": "Duplicato da",
+    "SAME_TEST_DIFFERENT_SOURCE": "Stesso test (fonte diversa)",
+    "status": "Stato più recente",
+    "at": "Eseguito"
+  },
+  "ganttTooltip": {
+    "task": "Compito",
+    "group": "Esecuzione/Sessione:",
+    "project": "Progetto:",
+    "starts": "Inizio:",
+    "scheduledCompletion": "Completamento programmato:",
+    "estWorkEffort": "Sforzo lavorativo stimato:",
+    "noTasks": "Nessuna attività da visualizzare nel diagramma di Gantt."
+  },
+  "help": {
+    "project": {
+      "name": "## Nome del progetto\nL'identificatore univoco per il tuo progetto.\n\n- Deve essere univoco in tutti i progetti\n- Utilizzato nella navigazione e nei report\n- Deve essere chiaro e descrittivo\n- Aiuta i membri del team a identificare l'ambito del progetto",
+      "description": "## Descrizione del progetto\nDettagli aggiuntivi sullo scopo e l'ambito del progetto.\n\n- Facoltativo ma consigliato\n- Aiuta i membri del team a comprendere gli obiettivi del progetto\n- Può includere obiettivi o requisiti chiave\n- Limitato a 256 caratteri",
+      "icon": "## Icona del progetto\nUn identificatore visivo per il tuo progetto.\n\n- Aiuta a identificare rapidamente il progetto in elenchi e dashboard\n- Scegli tra una varietà di icone predefinite\n- Può essere modificata in qualsiasi momento\n- Appare nella navigazione del progetto e nei report",
+      "completed": "## Stato del progetto\nIndica se il progetto è attivo o completato.\n\n- I progetti attivi sono disponibili per test e aggiornamenti\n- I progetti completati sono di sola lettura\n- Influisce sulla visibilità del progetto nelle dashboard\n- Può essere annullato se necessario",
+      "completedAt": "## Data di completamento\nData in cui il progetto è stato contrassegnato come completato.\n\n- Impostata automaticamente quando si contrassegna un progetto come completato\n- Utilizzata per la creazione di report e il monitoraggio\n- Aiuta a mantenere la cronologia del progetto\n- Può essere modificata se necessario",
+      "defaultAccess": "## Accesso predefinito al progetto\nDefinisce le autorizzazioni di accesso predefinite per utenti e gruppi in questo progetto. Queste impostazioni possono essere modificate per utente o per gruppo.",
+      "issueTracker": "## Configurazione del tracker dei problemi\nSeleziona la configurazione del tracker dei problemi da utilizzare per gestire i problemi relativi a questo progetto."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Progetto esterno\nSeleziona il progetto o il repository nel sistema esterno da collegare a questo progetto TestPlanIt.\n\n- I problemi creati da TestPlanIt verranno creati in questo progetto\n- Abilita l'integrazione del tracciamento dei problemi tra i sistemi\n- Deve disporre delle autorizzazioni appropriate nel sistema esterno",
+          "defaultIssueTypeHelp": "## Tipo di problema predefinito\nIl tipo di problema che verrà preselezionato quando si creano nuovi problemi da TestPlanIt.\n\n- Risparmia tempo impostando come predefinito il tipo di problema più comune\n- Può essere sovrascritto quando si creano singoli problemi\n- Deve essere un tipo di problema valido per il progetto esterno selezionato\n- Aggiorna questo se il flusso di lavoro cambia",
+          "automaticSyncHelp": "## Sincronizzazione automatica\nAbilita la sincronizzazione automatica dello stato dei problemi tra TestPlanIt e il sistema esterno.\n\n- I problemi collegati ai casi di test aggiorneranno automaticamente il loro stato\n- Aiuta a mantenere il monitoraggio dei problemi coerente tra i sistemi\n- Può aumentare l'utilizzo dell'API con il servizio esterno\n- Può essere disabilitato se si preferisce il controllo manuale"
+        }
+      }
+    },
+    "user": {
+      "name": "## Nome utente\nIl nome completo dell'utente.\n\n- Utilizzato per l'identificazione nel sistema\n- Visualizzato in assegnazioni e report\n- Deve essere univoco per ciascun utente",
+      "email": "## Indirizzo email\nIndirizzo email dell'utente per l'accesso all'account.\n\n- Utilizzato per l'accesso al sistema\n- Deve essere univoco per ciascun utente\n- Utilizzato per le notifiche di sistema",
+      "password": "## Password\nLa password dell'account dell'utente.\n\n- Facoltativo quando è configurato un metodo di accesso senza password (provider SSO Magic Link o server di posta elettronica) — lasciare vuoto per richiedere l'accesso tramite Magic Link o SSO\n- Se fornita, deve soddisfare i criteri password impostati in **Amministrazione → Sicurezza** (lunghezza minima e classi di caratteri)\n- Utilizzata per l'accesso sicuro all'account\n- Deve essere mantenuta riservata",
+      "token": "## Token di verifica\nInserisci il token che hai ricevuto via email per verificare il tuo account. Se non hai un token, puoi richiederne uno nuovo.",
+      "confirmPassword": "## Conferma password\nReinserisci la password per assicurarti che sia stata digitata correttamente.\n\n- Deve corrispondere esattamente alla password\n- Aiuta a prevenire errori di digitazione\n- Richiesto solo quando viene inserita una password: lascia vuoto se il campo password è vuoto",
+      "access": "## Livello di accesso al sistema\nDetermina le autorizzazioni dell'utente a livello di sistema.\n\n- **Amministratore:** Accesso completo al sistema e configurazione\n- **Amministratore del progetto:** Può gestire i progetti assegnati\n- **Utente:** Accesso standard ai progetti assegnati\n- **Nessuno:** Può solo visualizzare la propria dashboard",
+      "role": "## Ruolo di sistema\nQuesto ruolo determina le autorizzazioni predefinite dell'utente per il progetto.\n\n- Definisce i livelli di accesso predefiniti per i progetti\n- Può essere personalizzato in Amministrazione ruoli\n- Influisce sulle funzionalità e sulle capacità disponibili",
+      "active": "## Stato attivo\nControlla se un utente può accedere al sistema.\n\n- Gli utenti attivi possono accedere e accedere alle risorse assegnate\n- Gli utenti inattivi non possono accedere ma i loro dati vengono conservati\n  - Usalo per disabilitare temporaneamente l'accesso senza eliminare l'account",
+      "api": "## Accesso API\nConsente l'accesso programmatico al sistema tramite endpoint API.\n\n- Consente l'integrazione con strumenti esterni e automazione\n- Richiede l'autenticazione tramite chiave API\n- Soggetto a limitazione della velocità e controlli di accesso",
+      "projects": "## Assegnazione progetto\nSeleziona a quali progetti può accedere questo utente.\n\n- Controlla quali progetti vengono visualizzati nella dashboard dell'utente\n- Richiesto per la partecipazione al progetto\n- Può essere modificato in seguito dagli amministratori\n- Usa \"Seleziona tutto\" per assegnare rapidamente tutti i progetti disponibili",
+      "groups": "## Assegnazione gruppo\nSeleziona a quali gruppi appartiene questo utente.\n\n- I gruppi aiutano a organizzare utenti e permessi\n- Gli utenti ereditano i permessi dai loro gruppi\n- Semplifica la gestione degli accessi\n- Possono essere modificati in seguito dagli amministratori",
+      "itemsPerPage": "## Elementi per pagina\nControlla il numero predefinito di elementi mostrati nelle tabelle e negli elenchi.\n\n- Influisce su tutte le viste impaginate nell'applicazione\n- Può essere modificato in qualsiasi momento\n- Aiuta a gestire in modo efficiente grandi set di dati\n- Opzioni disponibili: 10, 25, 50 o 100 elementi",
+      "dateFormat": "## Formato data\nImposta il formato di visualizzazione della data preferito.\n\n- Applicato in modo coerente in tutta l'applicazione\n- Aiuta a garantire l'accuratezza dell'interpretazione della data\n- Le modifiche hanno effetto immediato\n- Gli esempi mostrati nel menu a discesa riflettono il formato effettivo",
+      "timeFormat": "## Formato ora\nImposta il formato di visualizzazione dell'ora preferito.\n\n- Scegli tra i formati a 12 e 24 ore\n- Applicato in modo coerente in tutta l'applicazione\n- Le modifiche hanno effetto immediato\n- Gli esempi mostrati nel menu a discesa riflettono il formato effettivo",
+      "timezone": "## Fuso orario\nImposta il fuso orario preferito per la visualizzazione di data e ora.\n\n- Applicato in modo coerente in tutta l'applicazione",
+      "theme": "## Tema\nScegli il tema visivo che preferisci per l'applicazione.\n\n- **Sistema:** Corrisponde automaticamente al tema del tuo sistema operativo\n- **Chiaro:** Interfaccia pulita e luminosa per l'uso diurno\n- **Scuro:** Modalità scura adatta agli occhi per ambienti scarsamente illuminati\n- **Verde, Arancione, Viola:** Un divertente tocco di colore!",
+      "locale": "## Lingua\nSeleziona la lingua preferita per l'interfaccia dell'applicazione.\n\n- Modifica tutto il testo, le etichette e i messaggi nella lingua scelta\n- I formati di data e ora si adattano alle convenzioni regionali\n- Ha effetto immediato senza richiedere l'aggiornamento della pagina\n- Le lingue disponibili dipendono dalle traduzioni installate",
+      "notificationMode": "## Preferenze di notifica\nControlla come ricevi le notifiche per gli incarichi di lavoro e gli aggiornamenti.\n\n- **Usa impostazioni globali:** Segui le impostazioni predefinite di sistema impostate dagli amministratori\n- **Nessuna notifica:** Disattiva tutte le notifiche\n- **Solo in-app:** Ricevi notifiche solo all'interno dell'applicazione\n- **In-app + e-mail (immediato):** Ricevi sia notifiche in-app che avvisi e-mail immediati\n- **In-app + e-mail (riepilogo giornaliero):** Ricevi notifiche in-app e un riepilogo e-mail giornaliero\n\nPuoi modificare questa preferenza in qualsiasi momento per adattarla al tuo flusso di lavoro."
+    },
+    "milestone": {
+      "name": "## Nome della milestone\nUn nome chiaro e descrittivo che identifichi questa milestone nel tuo progetto.\n\n- Deve essere univoco e significativo\n- Aiuta i membri del team a comprendere rapidamente lo scopo della milestone\n- Utilizzato nei report e nel monitoraggio del progetto",
+      "type": "## Tipo di milestone\nCategorizza la milestone e ne determina l'aspetto e il comportamento.\n\n- Tipi diversi possono avere flussi di lavoro diversi\n- Aiuta a organizzare e filtrare le milestone\n- Può influire sulla creazione di report e sul monitoraggio",
+      "started": "## Stato di avvio\nIndica che il lavoro su questa milestone è iniziato.\n\n- Contrassegna la milestone come in corso\n- Aggiorna automaticamente la data di inizio effettiva quando viene attivata\n- Influisce sulla cronologia del progetto e sul monitoraggio dei progressi",
+      "completed": "## Stato completato\nIndica che il lavoro su questa milestone è terminato.\n\n- Contrassegna la milestone come completata\n- Aggiorna automaticamente la data di completamento effettiva\n- Utilizzato per il monitoraggio e la segnalazione dei progressi\n- Influisce sulle milestone dipendenti e sulle tempistiche del progetto",
+      "startDate": "## Data di inizio pianificata\nData in cui si prevede che inizi il lavoro su questa milestone.\n\n- Aiuta nella pianificazione e programmazione del progetto\n- Utilizzato per le proiezioni della sequenza temporale\n- Supporta la pianificazione dell'allocazione delle risorse",
+      "dueDate": "## Data di scadenza\nLa data target per il completamento di questa milestone.\n\n- Imposta le aspettative di scadenza\n- Utilizzato per la pianificazione della sequenza temporale del progetto\n- Aiuta a monitorare i progressi della milestone rispetto alla pianificazione",
+      "parent": "## Milestone padre\nCollega questa milestone a una milestone padre, creando una gerarchia.\n\n- Organizza le milestone in gruppi logici\n- Mostra dipendenze e relazioni\n- Aiuta a monitorare i progressi di iniziative più grandi",
+      "description": "## Descrizione\nInformazioni dettagliate sullo scopo, i requisiti e l'ambito della milestone.\n\n- Fornisce il contesto per i membri del team\n- Documenta i requisiti e gli obiettivi chiave\n- Supporta la collaborazione e l'allineamento",
+      "documentation": "## Documentazione\nDettagli aggiuntivi, riferimenti e materiali di supporto.\n\n- Specifiche tecniche\n- Documenti di progettazione\n- Riferimenti esterni\n- Appunti e decisioni delle riunioni",
+      "automaticCompletion": "## Completamento automatico alla data di scadenza\nContrassegna automaticamente questa milestone come completata al raggiungimento della data di scadenza.\n\n- La milestone verrà completata all'ora programmata alla data di scadenza\n- Utile per milestone a tempo limitato che devono essere chiuse indipendentemente dallo stato di completamento\n- Può essere sovrascritto completando manualmente la milestone prima della data di scadenza\n- Richiede l'impostazione di una data di scadenza",
+      "notifyDaysBefore": "## Notifica giorni prima della data di scadenza\nInvia notifiche ai membri del team assegnati quando si avvicina la data di scadenza della milestone.\n\n- Attiva per abilitare le notifiche, disattiva per disabilitarle\n- Inserisci il numero di giorni prima della data di scadenza per iniziare a inviare promemoria\n- Le notifiche vengono inviate agli utenti assegnati alle esecuzioni di test e alle sessioni all'interno di questa milestone\n- Le milestone in ritardo continueranno a inviare promemoria fino al completamento"
+    },
+    "session": {
+      "name": "## Nome sessione\nUn nome chiaro e descrittivo che identifichi lo scopo della sessione di test.\n\n- Deve essere univoco e significativo\n- Aiuta i membri del team a capire cosa viene testato\n- Utilizzato nei report e nel monitoraggio",
+      "template": "## Template\nI template definiscono la struttura e il contenuto della sessione di test.\n\n- Fornisce un formato coerente per la documentazione dei test\n- Include sezioni e campi predefiniti\n- Aiuta a mantenere gli standard di test in tutto il progetto",
+      "configuration": "## Configurazione\nL'ambiente o la configurazione specifici richiesti per questa sessione di test.\n\n- Ambiente di test (ad esempio, Staging, Produzione)\n- Configurazioni o impostazioni speciali\n- Dati o condizioni di test richiesti",
+      "milestone": "## Milestone\nAssocia questa sessione a una milestone del progetto.\n\n- Aiuta a monitorare i progressi dei test verso gli obiettivi del progetto\n- Raggruppa le sessioni di test correlate\n- Supporta la creazione di report basati su milestone",
+      "description": "## Descrizione\nUna breve panoramica di ciò che copre questa sessione di test.\n\n- Aree o funzionalità chiave sottoposte a test\n- Contesto o background importante\n- Considerazioni o requisiti speciali",
+      "mission": "## Missione\nLa missione definisce gli obiettivi e le finalità specifiche per questa sessione di test.\n\n- Cosa stai testando?\n- Quali sono le aree chiave su cui concentrarti?\n- Quali sono i risultati attesi?\n\nUna missione chiara aiuta a mantenere i test concentrati e produttivi.",
+      "estimate": "## Tempo stimato\nTempo stimato per completare questa sessione di test.\n\nEsempi:\n- \"30m\" per 30 minuti\n- \"1h 30m\" per 1 ora e 30 minuti\n- \"2 giorni\" per 2 giorni\n- \"1 settimana\" per 1 settimana",
+      "elapsed": "## Tempo trascorso\nIl tempo effettivo impiegato in questa sessione di test.\n\nEsempi:\n- \"45m\" per 45 minuti\n- \"2h 15m\" per 2 ore e 15 minuti\n- \"3 giorni\" per 3 giorni\n\nTieni traccia del tempo in modo accurato per migliorare le stime future.",
+      "state": "## Stato del flusso di lavoro\nLo stato attuale di questa sessione di test nel flusso di lavoro.\n\n- Aiuta a monitorare l'avanzamento della sessione\n- Supporta la gestione del flusso di lavoro\n- Utilizzato per la creazione di report e il monitoraggio",
+      "assignedTo": "## Assegnato a\nIl membro del team responsabile della conduzione di questa sessione di test.\n\n- Identifica chi sta eseguendo il test\n- Aiuta nella gestione delle risorse\n- Supporta la responsabilità e il monitoraggio",
+      "tags": "## Tag\nParole chiave o etichette che aiutano a categorizzare e organizzare le sessioni di test.\n\n- Rende le sessioni più facili da trovare\n- Raggruppa le attività di test correlate\n- Supporta il filtraggio e la creazione di report",
+      "attachments": "## Allegati\nFile, screenshot o altri documenti relativi a questa sessione di test.\n\n- File di dati di test\n- Screenshot o registrazioni\n- Documentazione di supporto\n- Materiali di riferimento",
+      "issues": "## Problemi\nCollega i problemi rilevanti a questa sessione."
+    },
+    "testRun": {
+      "name": "## Nome esecuzione test\nInserisci un nome descrittivo per questa esecuzione test per identificarla facilmente in seguito.",
+      "description": "## Descrizione\nFornisci un breve riepilogo o delle note su questa esecuzione del test.",
+      "configuration": "## Configurazioni\nSeleziona una o più configurazioni (ad esempio, ambiente, browser, dispositivo) in base alle quali verranno eseguite le prove. Selezionando più configurazioni, verranno create prove separate per ciascuna.",
+      "milestone": "## Milestone\nAssocia questa esecuzione di test a una specifica milestone del progetto per monitorare i progressi verso obiettivi più ampi.",
+      "docs": "## Documentazione\nIncludere qualsiasi documentazione pertinente, link o note dettagliate per questa esecuzione del test.",
+      "state": "## Stato\nIndica lo stato attuale o il risultato di questa esecuzione del test in base al flusso di lavoro del tuo progetto.",
+      "tags": "## Tag\nApplica tag pertinenti per categorizzare e filtrare questa esecuzione del test.",
+      "issues": "## Problemi\nCollega eventuali problemi correlati (bug, attività, ecc.) a questa esecuzione di test.",
+      "attachments": "## Allegati\nCarica eventuali file di supporto, screenshot o registri relativi a questa esecuzione del test.",
+      "duplicate": {
+        "statusesToInclude": "## Stati da includere\nSeleziona gli stati dei casi di test che desideri includere nell'esecuzione del test duplicato.",
+        "copyAssignments": "## Copia assegnazioni\nSe abilitata, le assegnazioni dei casi di test verranno copiate nell'esecuzione del test duplicata."
+      }
+    },
+    "appConfig": {
+      "key": "## Chiave\nIdentificatore univoco per questa configurazione.",
+      "value": "## Valore\nIl valore di questa configurazione."
+    },
+    "milestoneType": {
+      "icon": "## Icona tipo milestone\nUn identificatore visivo per questo tipo di milestone.\n\n- Aiuta a identificare rapidamente il tipo di milestone in elenchi e dashboard\n- Scegli tra una varietà di icone predefinite\n- Può essere modificata in qualsiasi momento\n- Appare nella navigazione del progetto e nei report",
+      "name": "## Nome del tipo di milestone\nUn nome chiaro e descrittivo che identifica questo tipo di milestone nel tuo progetto.\n\n- Aiuta i membri del team a comprendere rapidamente lo scopo del tipo di milestone\n- Utilizzato nei report e nel monitoraggio del progetto",
+      "isDefault": "## Tipo di milestone predefinito\nIndica se questo tipo di milestone è quello predefinito per il tuo progetto.\n\n- Il tipo di milestone predefinito è preselezionato per le nuove milestone\n- Può essere modificato in qualsiasi momento",
+      "projects": "## Progetti associati\nSeleziona i progetti per i quali sarà disponibile questo tipo di traguardo.\n\n- Se non viene selezionato alcun progetto, il tipo di traguardo sarà disponibile a livello globale.\n- L'assegnazione a progetti specifici ne limita l'utilizzo solo a quei progetti."
+    },
+    "tag": {
+      "name": "## Nome tag\nUn nome o una o più parole chiave chiare, concise e descrittive, utilizzate in tutti i progetti.\n\n- Aiuta i membri del team a trovare rapidamente casi di test, esecuzioni di test e sessioni correlate."
+    },
+    "role": {
+      "name": "## Nome ruolo\nUn nome o una o più parole chiave chiare, concise e descrittive, utilizzate in tutti i progetti.\n\n- Aiuta i membri del team a trovare rapidamente casi di test, esecuzioni di test e sessioni correlate.",
+      "isDefault": "## Ruolo predefinito\nIndica se questo ruolo è quello predefinito per il tuo progetto.\n\n- Il ruolo predefinito è preselezionato per i nuovi utenti\n- Può essere modificato in qualsiasi momento",
+      "permissions": {
+        "canAddEdit": "## Aggiungi/Modifica\nIndica se questo ruolo può aggiungere e modificare l'area di applicazione correlata.",
+        "canDelete": "## Elimina\nIndica se questo ruolo può eliminare l'area di applicazione correlata.",
+        "canClose": "## Chiudi\nIndica se questo ruolo può chiudere l'area dell'applicazione correlata."
+      }
+    },
+    "group": {
+      "name": "## Nome del gruppo\nUn nome o una o più parole chiave chiare, concise e descrittive, utilizzate in tutti i progetti.\n\n- Aiuta i membri del team a trovare rapidamente casi di test, esecuzioni di test e sessioni correlate.",
+      "users": "## Utenti\nIndica gli utenti assegnati a questo gruppo."
+    },
+    "template": {
+      "name": "## Nome modello\nUn nome univoco e descrittivo per questo modello (ad esempio, 'Caso di test standard', 'Risultati del test API').",
+      "isEnabled": "## Abilitato\nSe selezionato, questo modello sarà disponibile per la selezione durante la creazione di nuovi casi di test o la definizione di strutture di esecuzione dei test. Se un modello è impostato come \"Predefinito\", deve essere anche \"Abilitato\".",
+      "isDefault": "## Predefinito\nSe selezionato, questo modello verrà selezionato automaticamente per i nuovi progetti o come predefinito per tutti i progetti se non è impostato alcun valore predefinito specifico per il progetto. Solo un modello può essere predefinito per tutti i progetti. Abilitando questa opzione, verranno disabilitati tutti gli altri modelli attualmente impostati come predefiniti.",
+      "caseFields": "## Campi del caso\nSeleziona e ordina i campi personalizzati che saranno disponibili durante la creazione o la modifica dei casi di test utilizzando questo modello.\n\n- Aggiungi campi dal menu a tendina per includerli nel modello\n- Trascina e rilascia per riordinare i campi\n- L'ordine determina come i campi vengono visualizzati nei moduli\n- Solo i campi del caso abilitati sono disponibili per la selezione\n- I campi del caso definiscono la struttura e i dati acquisiti per i casi di test",
+      "resultFields": "## Campi dei risultati\nSeleziona e ordina i campi personalizzati che saranno disponibili quando aggiungi i risultati dei test utilizzando questo modello.\n\n- Aggiungi i campi dal menu a tendina per includerli nel modello\n- Trascina e rilascia per riordinare i campi\n- L'ordine determina come appaiono i campi quando inserisci i risultati dei test\n- Solo i campi dei risultati abilitati sono disponibili per la selezione\n- I campi dei risultati acquisiscono dati aggiuntivi specifici per gli esiti dell'esecuzione dei test",
+      "projects": "## Progetti associati\nSeleziona per quali progetti sarà disponibile questo modello. Se non viene selezionato alcun progetto, il modello sarà disponibile a livello globale. L'assegnazione di un modello a progetti specifici ne limita l'utilizzo solo a tali progetti."
+    },
+    "llm": {
+      "name": "## Nome dell'integrazione\nUn'etichetta descrittiva per questa integrazione LLM.\n\n- Utilizzato per identificarla in elenchi e impostazioni\n- Esempio: \"OpenAI GPT-4o\" o \"Ollama interno\"",
+      "provider": "## Provider\nIl servizio LLM che alimenta questa integrazione.\n\n- Determina il protocollo API e i modelli disponibili\n- Non può essere modificato dopo la creazione",
+      "apiKey": "## Chiave API\nLa tua chiave di autenticazione per l'API del provider LLM.\n\n- Ottienila dalla console per sviluppatori del tuo provider\n- Mantenuta crittografata e mai visualizzata dopo il salvataggio\n- Non richiesta per Ollama (distribuzione locale)",
+      "endpoint": "## Endpoint API\nL'URL di base per l'API del provider LLM.\n\n- Lasciare vuoto per OpenAI, Anthropic e Gemini: gli URL ufficiali vengono utilizzati automaticamente\n- Obbligatorio per Ollama (ad esempio `http://localhost:11434`), Azure OpenAI e LLM personalizzato\n- Facoltativo per qualsiasi provider: puntare a un proxy compatibile con OpenAI (ad esempio LiteLLM) inserendo il suo URL\n- **Gli indirizzi privati/interni** (localhost, 127.0.0.1, IP privati, metadati cloud) sono bloccati a meno che non siano esplicitamente consentiti tramite la variabile di ambiente `ALLOWED_PRIVATE_HOSTS`",
+      "deploymentName": "## Nome della distribuzione di Azure\nIl nome della distribuzione del modello Azure OpenAI.\n\n- Si trova in Azure OpenAI Studio in Distribuzioni\n- Diverso dal nome del modello, ad esempio `my-gpt4-deploy` corrisponde a `gpt-4`\n- Richiesto solo per Azure OpenAI",
+      "defaultModel": "## Modello predefinito\nIl modello utilizzato per le richieste AI con questa integrazione.\n\n- Per OpenAI, Anthropic e Gemini: i modelli disponibili vengono recuperati automaticamente dalla tua chiave API\n- Assicurati che il modello sia abilitato nel tuo account provider\n- Esempio: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Numero massimo di token per richiesta\nIl **limite massimo** di token di output per ogni singola richiesta.\n\n- Le richieste che superano questo limite vengono **rifiutate con un errore** prima di raggiungere l'LLM\n- Imposta questo valore sulla capacità massima effettiva di token di output del tuo modello\n- Esempio: `16384` per GPT-4o, `8192` per Claude 3.5 Sonnet\n- Impostare questo valore troppo basso causa il fallimento delle funzionalità AI o la produzione di output troncato",
+      "defaultMaxTokens": "## Token massimi predefiniti\nIl limite di token di output **di ripiego** utilizzato quando una richiesta non specifica il proprio.\n\n- Ogni funzionalità AI (generazione di test, esportazione del codice, ecc.) imposta il proprio limite in **Amministrazione → Configurazione prompt**\n- Questo valore viene utilizzato solo come ripiego per le funzionalità senza un limite specifico configurato\n- Dovrebbe essere ≤ Token massimi per richiesta",
+      "maxRequestsPerMinute": "## Richieste massime al minuto\nLimita il numero di chiamate API che possono essere effettuate a questo provider al minuto.\n\n- Imposta in modo che corrisponda al limite di frequenza del tuo piano provider\n- Le richieste in eccesso vengono messe in coda, non rifiutate\n- Controlla la documentazione del tuo provider per il limite del tuo piano",
+      "costPerInputToken": "## Costo per token di input (USD)\nIl costo in USD per ogni token di input (prompt) inviato al modello.\n\n- Utilizzato per il monitoraggio dei costi e gli avvisi di budget\n- Trova questo nella pagina dei prezzi del tuo fornitore\n- Esempio: `0,000005` = $5 per milione di token di input",
+      "costPerOutputToken": "## Costo per token di output (USD)\nIl costo in USD per ogni token di output (completamento) generato dal modello.\n\n- Solitamente superiore al costo del token di input\n- Utilizzato per il monitoraggio dei costi e gli avvisi di budget\n- Esempio: `0,000015` = $15 per milione di token di output",
+      "monthlyBudget": "## Budget mensile (USD)\nUn obiettivo di spesa facoltativo per questa integrazione.\n\n- Imposta su `0` per disabilitare il monitoraggio del budget\n- Il budget è **solo informativo** — non blocca l'utilizzo di LLM\n- Riceverai notifiche all'80%, al 90% e al 100% del budget\n- I costi vengono calcolati utilizzando le tariffe per token sopra indicate",
+      "billingPeriodStartDay": "## Giorno di inizio del periodo di fatturazione\nIl giorno del mese (1–31) in cui inizia il periodo di fatturazione.\n\n- Il valore predefinito `1` si allinea con il mese del calendario\n- Impostare su `15` per un ciclo dal 15 al 15 (ad esempio, per corrispondere alla data di fattura del fornitore)\n- I valori `29–31` vengono automaticamente impostati sull'ultimo giorno dei mesi più corti (febbraio negli anni non bisestili, ecc.)\n- Influisce sulla finestra di spesa del **Budget mensile** e sull'azione **Reimposta spesa**",
+      "defaultTemperature": "## Temperatura predefinita\nControlla la casualità delle risposte del modello (0–2).\n\n- **0:** Deterministico — output identico per lo stesso input\n- **0.3:** Focalizzato — consigliato per la generazione di test e l'output del codice\n- **1+:** Creativo — risposte più varie\n- Le singole funzionalità possono sovrascrivere questo valore in Prompt Config",
+      "timeout": "## Timeout della richiesta (ms)\nQuanto tempo attendere per una risposta prima che la richiesta venga annullata.\n\n- Il valore è in millisecondi (es. `30000` = 30 secondi)\n- Le richieste di streaming (es. anteprima dell'esportazione del codice) ignorano questo timeout\n- Aumentare per modelli lenti o di grandi dimensioni\n- Intervallo: 5.000 – 600.000 ms",
+      "streamingEnabled": "## Abilita lo streaming\nTrasmette in streaming la risposta token per token invece di attendere l'output completo.\n\n- Necessario per l'anteprima del codice in tempo reale nella finestra modale di esportazione\n- Riduce la latenza percepita per le risposte lunghe\n- Consigliato per tutti i provider supportati",
+      "isDefault": "## Imposta come integrazione predefinita\nImposta questa integrazione come predefinita per tutte le funzionalità AI.\n\n- Solo un'integrazione può essere predefinita alla volta\n- Le funzionalità senza un provider specifico configurato utilizzeranno l'integrazione predefinita\n- Può essere modificata in qualsiasi momento"
+    },
+    "integration": {
+      "name": "## Nome integrazione\nUn nome descrittivo per identificare questa integrazione nel sistema.\n\n- Deve essere univoco per distinguerla da altre integrazioni\n- Utilizzato nelle impostazioni e nella configurazione del progetto\n- Dovrebbe indicare chiaramente il servizio e lo scopo",
+      "authType": "## Tipo di autenticazione\nScegli come autenticarti con il servizio esterno.\n\n- **Chiave API:** Autenticazione semplice tramite e-mail e token API\n- **OAuth 2.0:** Autenticazione sicura tramite flusso OAuth\n- **Token di accesso personale:** Autenticazione diretta basata su token",
+      "email": "## Indirizzo email\nL'indirizzo email del tuo account per il servizio esterno.\n\n- Utilizzato per l'autenticazione tramite chiave API\n- Deve corrispondere all'account che ha generato il token API\n- Obbligatorio per Jira e servizi simili",
+      "apiToken": "## Token API\nGenera un token API dalle impostazioni del tuo account nel servizio esterno.\n\n- Solitamente si trova in Impostazioni account → Sicurezza → Token API\n- Fornisce un accesso sicuro senza esporre la tua password\n- Può essere revocato e rigenerato secondo necessità",
+      "jiraUrl": "## URL Jira\nL'URL di base della tua istanza Jira.\n\n- Formato: https://your-site.atlassian.net\n- Non includere /browse o altri percorsi\n- Deve essere accessibile da questo server",
+      "clientId": "## ID client OAuth\nID client dalla configurazione dell'applicazione OAuth.\n\n- Creato nella console per sviluppatori del servizio esterno\n- Utilizzato per identificare l'applicazione durante il flusso OAuth\n- Sicuro da condividere nei file di configurazione",
+      "clientSecret": "## Segreto client OAuth\nIl segreto client dalla configurazione dell'applicazione OAuth.\n\n- Creato insieme all'ID client\n- Deve essere mantenuto riservato e sicuro\n- Utilizzato per autenticare l'applicazione",
+      "personalAccessToken": "## Token di accesso personale\nUn token di accesso personale con autorizzazioni appropriate per il servizio esterno.\n\n- Generato nelle impostazioni del tuo account\n- Dovrebbe avere autorizzazioni per problemi di lettura e scrittura\n- Più sicuro dell'autenticazione tramite password",
+      "baseUrl": "## Modello URL\nModello URL per il collegamento a problemi esterni.\n\n- Usa '{issueId}' come segnaposto per l'identificatore del problema\n- Esempio: https://example.com/issues/'{issueId}'\n- Usato per semplici integrazioni basate su URL",
+      "organizationUrl": "## URL organizzazione\nURL della tua organizzazione Azure DevOps.\n\n- Formato: https://dev.azure.com/your-org\n- Deve essere accessibile da questo server\n- Utilizzato per accedere alle API di Azure DevOps",
+      "apiKey": "## Chiave API\nLa chiave API per l'autenticazione con il servizio esterno.\n\n- Generata nelle impostazioni API del servizio\n- Fornisce accesso programmatico al servizio\n- Mantieni la sicurezza e ruota regolarmente",
+      "forgeApiKey": "## Chiave API Forge\nUtilizzata per autenticare l'app Atlassian Forge quando recupera i dati di test dai tuoi ticket Jira.\n\n- Fai clic su Genera per creare una nuova chiave\n- Copia la chiave e incollala nelle impostazioni dell'app Forge in Jira (Gestisci app → Impostazioni TestPlanIt)\n- La rigenerazione invaliderà la chiave precedente",
+      "owner": "## Proprietario / Namespace\nL'utente o l'organizzazione proprietaria del repository.\n\n- Per GitHub/GitLab: il nome utente o il nome dell'organizzazione\n- Per Gitea/Forgejo/Gogs: il nome utente o del gruppo\n- Esempio: my-org o my-username",
+      "repo": "## Nome del repository\nIl nome del repository da cui collegare i problemi.\n\n- Nome esatto del repository (non l'URL completo)\n- Esempio: my-project\n- Deve essere accessibile con le credenziali fornite",
+      "instanceUrl": "## URL dell'istanza\nL'URL di base della tua istanza self-hosted.\n\n- Formato: https://git.example.com\n- Non includere barre finali o percorsi\n- Deve essere accessibile da questo server",
+      "projectPath": "## Percorso del progetto\nIl percorso completo del tuo progetto GitLab.\n\n- Formato: namespace/project o group/subgroup/project\n- Esempio: my-org/my-project\n- Si trova nell'URL del progetto: gitlab.com/namespace/project",
+      "platform": "## Piattaforma\nLa piattaforma Git self-hosted a cui ti stai connettendo.\n\n- **Gitea**: istanze basate su gitea.io\n- **Forgejo**: istanze basate su forgejo.org (fork di Gitea)\n- **Gogs**: istanze basate su gogs.io\n\nQuesto controlla quale icona viene mostrata e potrebbe influire sulla compatibilità API."
+    },
+    "config": {
+      "name": "## Nome configurazione\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere le varianti che compongono la configurazione (ad esempio \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", ecc.)."
+    },
+    "configCategory": {
+      "name": "## Nome categoria\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a organizzare le varianti (ad esempio Chrome, Firefox, Safari, Edge, ecc.) in categorie (ad esempio Browser)."
+    },
+    "configVariant": {
+      "name": "## Nome variante\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere la variante che fa parte di un ambiente di test (ad esempio Chrome, Safari, Windows 10, Windows 11, macOS 15.5, ecc.)."
+    },
+    "issueConfig": {
+      "name": "## Nome configurazione problema\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere la configurazione del problema (ad esempio Jira, GitHub, ecc.).",
+      "baseUrl": "## URL di base\nL'URL di base per la configurazione del problema, incluso il segnaposto del problema (ad esempio https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Tipo di sistema\nIl tipo di sistema di monitoraggio dei problemi (ad esempio LINK Jira, ecc.).",
+      "isActive": "## Attivo\nIndica se questa configurazione del problema è attiva.",
+      "isDefault": "## Predefinito\nIndica se questa configurazione del problema è quella predefinita per il tuo progetto.\n\n- La configurazione predefinita del problema è preselezionata per i nuovi problemi\n- Può essere modificata in qualsiasi momento",
+      "projects": "## Progetti\nIndica i progetti assegnati a questa configurazione del problema."
+    },
+    "issue": {
+      "name": "## Nome del problema\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere il problema (ad esempio \"Problema 123\", \"Bug 456\", ecc.).",
+      "title": "## Titolo del problema\nUn titolo leggibile che descrive il problema.\n\n- Fornisce il contesto su cosa riguarda il problema\n- Visualizzato negli elenchi e nelle visualizzazioni dei problemi\n- Deve essere chiaro e descrittivo",
+      "externalKey": "## Chiave esterna\nChiave o identificatore univoco del sistema di monitoraggio dei problemi esterno.\n\n- Per JIRA: chiave del problema come \"PROJ-123\"\n- Per GitHub: numero del problema come \"456\"\n- Per Azure DevOps: ID elemento di lavoro\n- Genera automaticamente l'URL esterno al momento del salvataggio",
+      "externalId": "## ID esterno\nIdentificatore univoco per questo problema nel sistema di monitoraggio dei problemi (ad esempio \"Issue-123\", \"Bug456\", ecc.).\n\n- Viene utilizzato come segnaposto del problema nell'URL di base.",
+      "description": "## Descrizione\nUna breve panoramica di ciò che riguarda questo problema.\n\n- Aree o funzionalità chiave sottoposte a test\n- Contesto o background importante\n- Considerazioni o requisiti speciali",
+      "project": "## Progetto\nIl progetto a cui è associato questo problema.\n\n- I problemi possono essere collegati a casi di test su più progetti\n- L'impostazione di un progetto primario aiuta a organizzare i problemi\n- Può essere lasciato vuoto per problemi tra progetti",
+      "state": "## Stato\nIndica lo stato attuale o l'esito di questo problema in base al flusso di lavoro del tuo progetto.",
+      "tags": "## Tag\nApplica tag pertinenti per categorizzare e filtrare questo problema.",
+      "issues": "## Problemi\nCollega eventuali problemi correlati (bug, attività, ecc.) a questo problema."
+    },
+    "status": {
+      "name": "## Nome stato\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere lo stato del risultato del test (ad esempio Superato, Non superato, Bloccato, ecc.).",
+      "color": "## Colore\nIl colore di questo stato.",
+      "systemName": "## Nome del sistema\nIl nome dello stato utilizzato dal sistema backend (ad esempio query del database, report, ecc.).",
+      "aliases": "## Alias\nNomi aggiuntivi o sinonimi per questo stato che possono essere utilizzati per collegare stati di sistema esterni a questo stato.",
+      "enabled": "## Abilitato\nIndica se questo stato è abilitato.",
+      "isEnabled": "## Abilitato\nIndica se questo stato è abilitato e disponibile per l'uso.\n\n- Quando abilitato, questo stato può essere selezionato durante la registrazione dei risultati del test.\n- Gli stati disabilitati sono nascosti dalla selezione ma conservati nei risultati esistenti.",
+      "success": "## Successo\nIndica se questo stato è uno stato di successo.",
+      "isSuccess": "## Stato di successo\nIndica se questo stato rappresenta un esito positivo del test.\n\n- Gli stati di successo contribuiscono alle metriche del tasso di superamento\n- Utilizzato nella reportistica e nell'analisi per monitorare l'efficacia del test",
+      "completed": "## Completato\nIndica se questo stato è uno stato completato.",
+      "isCompleted": "## Stato Completato\nIndica se questo stato rappresenta un'esecuzione del test completata.\n\n- Gli stati Completato indicano che il test ha terminato l'esecuzione.\n- Utilizzato per calcolare i tassi di completamento e il monitoraggio dei progressi.",
+      "failure": "## Errore\nIndica se questo stato è uno stato di errore.",
+      "isFailure": "## Stato di errore\nIndica se questo stato rappresenta un esito del test non riuscito.\n\n- Gli stati di errore contribuiscono alle metriche del tasso di errore\n- Utilizzato nella creazione di report e nell'analisi per identificare i problemi",
+      "scope": "## Ambito\nIndica l'ambito di questo stato (Esecuzione test, Sessione, Automazione).",
+      "projects": "## Progetti\nIndica i progetti che possono utilizzare questo stato."
+    },
+    "workflow": {
+      "scope": "## Ambito\nIndica l'ambito di questo flusso di lavoro (esecuzione di test, sessione, automazione).\n\n- Non può essere modificato una volta creato il flusso di lavoro.",
+      "iconColor": "## Icona/Colore\nL'icona e il colore per questo flusso di lavoro.",
+      "name": "## Nome\nUn nome chiaro e descrittivo che viene utilizzato in tutti i progetti.\n\n- Aiuta a descrivere il flusso di lavoro (ad esempio \"Bozza\", \"In fase di revisione\", \"Attivo\", ecc.).",
+      "workflowType": "## Tipo\nIl tipo di flusso di lavoro (Non iniziato, In corso, Completato).",
+      "type": "## Tipo di flusso di lavoro\nLa categoria dello stato del flusso di lavoro (Non avviato, In corso, Completato).\n\n- Determina in che modo questo stato influisce sul monitoraggio dei progressi\n- Gli stati Non avviato indicano che il lavoro non è iniziato\n- Gli stati In corso mostrano il lavoro attivo\n- Gli stati Completato contrassegnano il lavoro terminato",
+      "isDefault": "## Predefinito\nIndica se questo flusso di lavoro è quello predefinito per il tuo progetto.\n\n- Il flusso di lavoro predefinito è preselezionato per nuove esecuzioni di test, sessioni e automazioni.",
+      "isEnabled": "## Abilitato\nIndica se questo flusso di lavoro è abilitato.",
+      "isActive": "## Attivo\nIndica se questo stato del flusso di lavoro è attivo e disponibile per l'uso.\n\n- I flussi di lavoro attivi possono essere selezionati durante l'aggiornamento di esecuzioni di test, sessioni o automazioni.\n- I flussi di lavoro inattivi sono nascosti dalla selezione ma conservati negli elementi esistenti.",
+      "projects": "## Progetti\nIndica i progetti che possono utilizzare questo flusso di lavoro."
+    },
+    "testResult": {
+      "status": "## Stato\nSeleziona lo stato generale dell'esecuzione del test. Lo stato scelto può influire sulle metriche e sui report del progetto.",
+      "elapsedTime": "## Tempo trascorso\nInserisci il tempo totale impiegato per eseguire questo caso di test. Puoi usare unità come **s** per secondi, **m** per minuti, **h** per ore (ad esempio, 30 s, 5 m, 1 ora e 20 minuti).",
+      "resultData": "## Dettagli del risultato\nFornire note dettagliate, osservazioni o altri dati rilevanti sull'esecuzione complessiva del test. Possono includere dettagli di configurazione, passaggi seguiti in caso di deviazione dal piano o commenti generali.",
+      "evidence": "## Prove/Allegati\nCarica tutti i file (ad esempio, screenshot, log, file di dati) che servono come prova per questo risultato del test. Questi allegati saranno collegati a questo risultato specifico.",
+      "issues": "## Problemi collegati\nCollega tutti i problemi presenti nel tuo sistema di tracciamento integrato correlati al risultato di questo test. Questo aiuta a monitorare difetti o attività associati al risultato di questo test.",
+      "stepStatus": "## Stato del passaggio\nSeleziona lo stato per questo specifico passaggio di test. Ciò consente un monitoraggio dettagliato dei progressi all'interno di un singolo caso di test.",
+      "stepElapsedTime": "## Tempo trascorso del passaggio\nInserisci il tempo impiegato per eseguire questo passaggio specifico. Utilizza unità come **s**, **m**, **h** (ad esempio, 10 s, 2 m). Questo è facoltativo.",
+      "stepNotes": "## Note sul passaggio\nAggiungi eventuali note, osservazioni o dati specifici per l'esecuzione di questo passaggio di test.",
+      "stepIssues": "## Problemi collegati al passaggio\nCollega i problemi dal tuo tracker dei problemi che sono specificamente correlati al risultato o alle osservazioni di questo passaggio del test."
+    },
+    "case": {
+      "name": "## Nome del caso di test\nUn nome chiaro e descrittivo per il caso di test.",
+      "state": "## Stato\nIndica lo stato corrente del flusso di lavoro di questo caso.",
+      "template": "## Modello\nSeleziona il modello che questo caso utilizzerà per i suoi campi caso e campi risultato.",
+      "estimate": "## Stima\nIl tempo stimato inserito manualmente per completare questo caso di test.",
+      "automated": "## Automatizzato\nIndica se questo caso di test è automatizzato o meno.",
+      "tags": "## Tag\nApplica tag pertinenti per categorizzare e filtrare questo caso.",
+      "issues": "## Problemi\nCollega eventuali problemi correlati (bug, attività, ecc.) a questo caso."
+    },
+    "folder": {
+      "name": "## Nome cartella\nUn nome chiaro e descrittivo per la cartella.",
+      "documentation": "## Documentazione\nUlteriori dettagli, riferimenti e materiali di supporto."
+    },
+    "bulkEdit": {
+      "name": "## Nome\nUn nome chiaro e descrittivo per i casi di test.",
+      "state": "## Stato\nIndica lo stato corrente del flusso di lavoro di questi casi di test.",
+      "estimate": "## Stima\nIl tempo stimato inserito manualmente per completare ciascuno di questi casi di test.",
+      "automated": "## Automatizzato\nIndica se questi casi di test sono automatizzati o meno.",
+      "tags": "## Tag\nApplica tag pertinenti per categorizzare e filtrare questi casi di test.",
+      "issues": "## Problemi\nCollega eventuali problemi correlati (bug, attività, ecc.) a questi casi di test."
+    },
+    "caseField": {
+      "displayName": "## Nome visualizzato\nQuesto è il nome leggibile per il campo che verrà mostrato agli utenti nei moduli e nelle viste. Rendilo chiaro e descrittivo.",
+      "systemName": "## Nome del sistema\nIdentificatore univoco per questo campo utilizzato internamente dal sistema (ad esempio, nelle chiamate API, nelle query del database). Verrà generato automaticamente dal Nome visualizzato, ma può essere personalizzato. Deve iniziare con una lettera. Può contenere solo lettere, numeri e caratteri di sottolineatura (nessuno spazio o carattere speciale).",
+      "hint": "## Testo suggerimento (facoltativo)\nFornisci una breve istruzione o un esempio che apparirà sotto il campo per guidare gli utenti. Questo può chiarire l'input o la formattazione previsti.",
+      "enabled": "## Abilitato\nDetermina se questo campo è attivo e disponibile per l'uso in modelli e casi di test. I campi disabilitati sono nascosti e i relativi dati vengono conservati ma non utilizzati.",
+      "required": "## Obbligatorio\nSe selezionato, gli utenti devono fornire un valore per questo campo quando creano o modificano un caso di test utilizzando un modello che include questo campo.",
+      "restricted": "## Limitato\nSe selezionato, solo gli utenti con autorizzazioni speciali (ad esempio, Super Admin o coloro che dispongono dell'autorizzazione \"Campi con restrizioni caso\") possono modificare il valore di questo campo una volta creato un caso. Gli altri utenti lo vedranno come di sola lettura. Questa opzione è utile per campi come \"Revisionato da\" o \"Data di approvazione\" che non devono essere modificati dagli utenti generici dopo una certa fase.",
+      "fieldType": "## Tipo di campo\nDetermina il tipo di dati che questo campo memorizzerà e come verranno visualizzati (ad esempio, Testo, Numero, Data, Elenco a discesa). Il tipo di campo non può essere modificato dopo la creazione.",
+      "defaultValue": "## Valore predefinito (facoltativo)\nImposta un valore precompilato per questo campo. Per il tipo \"Casella di controllo\", usa \"true\" o \"false\". Per \"Elenco a discesa\" o \"Selezione multipla\", questo di solito si riferisce all'ID delle opzioni predefinite. Per altri tipi, è il testo/numero predefinito letterale. Questo può essere sovrascritto quando il campo viene aggiunto a un modello.",
+      "isChecked": "## Stato predefinito (per la casella di controllo)\nDetermina se la casella di controllo deve essere selezionata per impostazione predefinita quando viene creato un nuovo elemento (ad esempio, un caso di test).",
+      "minValue": "## Valore minimo (per numero/intero)\nImposta il valore numerico più piccolo consentito per questo campo. È necessario impostare sia il valore minimo che quello massimo, se ne viene utilizzato uno.",
+      "maxValue": "## Valore massimo (per numero/intero)\nImposta il valore numerico massimo consentito per questo campo. È necessario impostare sia il valore minimo che quello massimo, se ne viene utilizzato uno.",
+      "initialHeight": "## Altezza iniziale (per testo lungo)\nSpecifica l'altezza iniziale di visualizzazione (in pixel) per i campi dell'editor di testo avanzato. Ciò aiuta a controllare il layout del modulo per input di testo più lunghi.",
+      "dropdownOptions": "## Opzioni (per menu a discesa/selezione multipla)\nDefinisce l'elenco delle opzioni disponibili per la selezione. È possibile riordinare le opzioni, impostare un valore predefinito e abilitare/disabilitare singole opzioni."
+    },
+    "resultField": {
+      "displayName": "## Nome visualizzato\nQuesto è il nome leggibile per il campo che verrà mostrato agli utenti quando inseriscono i risultati del test. Rendilo chiaro e descrittivo.",
+      "systemName": "## Nome del sistema\nIdentificatore univoco per questo campo utilizzato internamente dal sistema (ad esempio, nelle chiamate API, nelle query del database). Verrà generato automaticamente dal nome visualizzato, ma può essere personalizzato.\n- Deve iniziare con una lettera.\n- Può contenere solo lettere, numeri e caratteri di sottolineatura (nessuno spazio o carattere speciale).",
+      "hint": "## Testo suggerimento (facoltativo)\nFornisci una breve istruzione o un esempio che apparirà sotto il campo per guidare gli utenti. Questo può chiarire l'input o la formattazione previsti quando si inseriscono i dati dei risultati.",
+      "enabled": "## Abilitato\nDetermina se questo campo è attivo e disponibile per l'uso nei modelli durante l'inserimento dei risultati dei test. I campi disabilitati sono nascosti e i relativi dati vengono conservati ma non utilizzati.",
+      "required": "## Obbligatorio\nSe selezionato, gli utenti devono fornire un valore per questo campo quando aggiungono un risultato del test utilizzando un modello che include questo campo.",
+      "restricted": "## Limitato\nSe selezionato, solo gli utenti con autorizzazioni speciali (ad esempio, Super Admin o coloro che dispongono dell'autorizzazione \"Campi riservati per i risultati dei test\") possono modificare il valore di questo campo una volta inviato un risultato. Gli altri utenti lo vedranno come di sola lettura.",
+      "fieldType": "## Tipo di campo\nDetermina il tipo di dati che questo campo memorizzerà e come verranno visualizzati nei risultati del test (ad esempio, Testo, Numero, Data, Elenco a discesa). Il tipo di campo non può essere modificato dopo la creazione.",
+      "defaultValue": "## Valore predefinito (facoltativo)\nImposta un valore precompilato per questo campo quando aggiungi un nuovo risultato del test. Per il tipo \"Casella di controllo\", usa \"vero\" o \"falso\". Per \"Elenco a discesa\" o \"Selezione multipla\", questo di solito si riferisce all'ID delle opzioni predefinite. Per altri tipi, è il testo/numero predefinito letterale.",
+      "isChecked": "## Stato predefinito (per la casella di controllo)\nDetermina se la casella di controllo deve essere selezionata per impostazione predefinita quando viene aggiunto un nuovo risultato del test.",
+      "minValue": "## Valore minimo (per numero/intero)\nImposta il valore numerico più piccolo consentito per questo campo quando si inseriscono i dati dei risultati. È necessario impostare sia il valore minimo che quello massimo, se ne viene utilizzato uno.",
+      "maxValue": "## Valore massimo (per numero/intero)\nImposta il valore numerico massimo consentito per questo campo quando si inseriscono i dati dei risultati. È necessario impostare sia il valore minimo che quello massimo, se ne viene utilizzato uno.",
+      "initialHeight": "## Altezza iniziale (per testo lungo)\nSpecifica l'altezza iniziale di visualizzazione (in pixel) per i campi dell'editor di testo avanzato utilizzati nei risultati. Ciò aiuta a controllare il layout del modulo per input di testo più lunghi.",
+      "dropdownOptions": "## Opzioni (per menu a discesa/selezione multipla)\nDefinisce l'elenco delle opzioni disponibili per la selezione durante l'inserimento dei dati dei risultati. È possibile riordinare le opzioni, impostare un valore predefinito e abilitare/disabilitare singole opzioni."
+    },
+    "exportModal": {
+      "scope": "## Ambito di esportazione\nDetermina quali casi di test saranno inclusi nell'esportazione:\n- **Selezionato:** Esporta solo i casi di test selezionati esplicitamente nella tabella.\n- **Tutti filtrati:** Esporta tutti i casi di test che corrispondono ai criteri di filtro correnti nella tabella, anche se non tutti sono attualmente visibili sulla pagina.\n- **Tutti i progetti:** Esporta tutti i casi di test nel progetto corrente, ignorando eventuali selezioni o filtri.",
+      "format": "## Formato di esportazione\nScegli il formato di file per l'esportazione.\n- **CSV (valori separati da virgola):** un file di testo normale adatto per fogli di calcolo (Excel, Google Sheets) e strumenti di analisi dei dati. L'esportazione in PDF è prevista per una versione futura.",
+      "columns": "## Colonne da esportare (solo CSV)\nDetermina quali colonne di dati saranno incluse per ciascun caso di test:\n- **Tutte le colonne:** Esporta tutti i campi di dati disponibili per i casi di test, inclusi i campi personalizzati dai relativi modelli.\n- **Colonne visibili:** Esporta solo le colonne attualmente visibili nella tabella dei casi di test.",
+      "delimiter": "## Delimitatore CSV (solo CSV)\nScegli il carattere utilizzato per separare i valori nel file CSV. Il più comune è la virgola. Utilizza un delimitatore diverso se i tuoi dati contengono virgole nei campi di testo (ad esempio, punto e virgola).",
+      "textLongFormat": "## Formato campo testo lungo (solo CSV)\nDetermina come vengono esportati i campi di testo avanzato (come i campi \"Descrizione\" o \"Testo lungo\" personalizzati):\n- **JSON:** Esporta il contenuto come stringa JSON, mantenendo tutta la formattazione (grassetto, elenchi, ecc.). Questa è la soluzione ideale per la reimportazione o l'elaborazione programmatica.\n- **Testo normale:** Esporta il contenuto come testo normale, eliminando la formattazione. Questa soluzione è più leggibile nei visualizzatori di testo semplice.",
+      "stepsFormat": "## Formato dei passaggi (solo CSV)\nDetermina come vengono esportati i passaggi del test (inclusi i risultati previsti):\n- **JSON:** Esporta i passaggi come un array JSON di oggetti, preservando la struttura e il testo avanzato. Adatto per la reimportazione o l'analisi dettagliata.\n- **Testo normale:** Esporta i passaggi in un formato di testo normale semplificato e leggibile, con ogni passaggio e il risultato previsto su una nuova riga.",
+      "rowMode": "## Modalità riga (solo CSV)\nDetermina come vengono rappresentati i campi multivalore (come tag o campi personalizzati a selezione multipla) e i passaggi:\n- **Riga singola per caso:** Ogni caso di test è una singola riga. I campi multivalore e i passaggi saranno condensati nelle rispettive celle (spesso come JSON o testo concatenato).\n- **Righe multiple per caso:** Un caso di test può estendersi su più righe se ha più tag, valori a selezione multipla o passaggi. Ogni valore/passaggio univoco per tali campi creerà una nuova riga, con altri dati del caso ripetuti. Questo è utile per analisi dettagliate o pivot.",
+      "attachmentFormat": "## Formato informazioni allegato (solo CSV)\nDetermina come vengono esportate le informazioni sugli allegati:\n- **JSON:** Esporta i dettagli dell'allegato (come nome file, URL, dimensione) come array JSON. Questo è completo ma meno leggibile direttamente in un CSV.\n- **Solo nomi:** Esporta un elenco separato da virgole dei nomi dei file degli allegati. Più semplice per una consultazione rapida."
+    },
+    "reportMetrics": {
+      "count": "## Conteggio risultati test\nNumero di risultati di esecuzione test in questo gruppo.",
+      "passRate": "## Tasso di superamento\nFrazione di risultati in questo gruppo con stato di superamento.",
+      "avgElapsed": "## Tempo medio trascorso\nTempo medio trascorso per i risultati in questo gruppo.",
+      "sumElapsed": "## Tempo totale trascorso\nSomma del tempo trascorso per i risultati in questo gruppo.",
+      "executionCount": "## Esecuzioni test\nNumero totale di esecuzioni test eseguite.",
+      "testCaseCount": "## Conteggio casi di test\nNumero totale di casi di test in questo gruppo.",
+      "testRunCount": "## Numero di esecuzioni di test\nNumero totale di esecuzioni di test in questo gruppo.",
+      "automationRate": "## Tasso di automazione\nPercentuale di casi di test automatizzati.",
+      "averageSteps": "## Passaggi medi per caso\nNumero medio di passaggi per caso di test.",
+      "automatedCount": "## Casi automatizzati\nNumero di casi di test automatizzati.",
+      "manualCount": "## Casi manuali\nNumero di casi di test manuali.",
+      "totalSteps": "## Passaggi totali\nNumero totale di passaggi di test in tutti i casi.",
+      "createdCaseCount": "## Casi di test creati\nNumero di casi di test creati in questo periodo.",
+      "sessionResultCount": "## Risultati della sessione\nNumero di risultati dei test della sessione.",
+      "sessionCount": "## Conteggio sessioni\nNumero totale di sessioni di test.",
+      "activeSessions": "## Sessioni attive\nNumero di sessioni attualmente attive (isActive = true).",
+      "milestoneCompletion": "## Completamento della milestone\nPercentuale di casi di test completati nelle milestone. Calcolato come (risultati dei test completati / casi di test totali nelle esecuzioni di test) × 100.",
+      "averageTimeSpent": "## Tempo medio trascorso\nTempo medio trascorso in attività.",
+      "sessionParticipation": "## Partecipazione alla sessione\nLivello di partecipazione alle sessioni di test.",
+      "lastActiveDate": "## Data ultima attività\nData di attività più recente.",
+      "averageAge": "## Età media\nEtà media degli articoli in giorni.",
+      "issueCount": "## Numero di problemi\nNumero totale di problemi monitorati.",
+      "milestoneCount": "## Conteggio traguardi\nNumero totale di traguardi.",
+      "milestoneCompletionRate": "## Tasso di completamento delle pietre miliari\nPercentuale di pietre miliari completate.",
+      "averageMilestoneDuration": "## Durata media delle pietre miliari\nDurata media delle pietre miliari in giorni."
+    },
+    "reportDimensions": {
+      "user": "## Dimensione utente\nRaggruppa i risultati in base all'utente che ha eseguito i test o a cui sono assegnati gli elementi.",
+      "status": "## Dimensione Stato\nRaggruppa i risultati in base allo stato di esecuzione del test (ad esempio, Superato, Non superato, Bloccato).",
+      "project": "## Dimensione del progetto\nRaggruppa i risultati per progetto per l'analisi interprogetto.",
+      "testRun": "## Dimensione esecuzione test\nRaggruppa i risultati in base all'esecuzione del test che contiene i casi di test eseguiti.",
+      "testCase": "## Dimensione del caso di test\nRaggruppa i risultati per singoli casi di test per un'analisi dettagliata.",
+      "milestone": "## Milestone Dimension\nRaggruppa i risultati in base alle milestone del progetto per monitorare i progressi verso gli obiettivi.",
+      "configuration": "## Dimensione di configurazione\nRaggruppa i risultati in base alla configurazione dell'ambiente di test (ad esempio, browser, sistema operativo).",
+      "template": "## Dimensione modello\nRaggruppa i risultati in base al modello utilizzato per la struttura del caso di test.",
+      "creator": "## Dimensione Creatore\nRaggruppa i risultati in base all'utente che ha creato i casi di test o le esecuzioni dei test.",
+      "state": "## Dimensione Stato\nRaggruppa i risultati in base allo stato del flusso di lavoro (ad esempio, Bozza, Attivo, Completato).",
+      "role": "## Dimensione ruolo\nRaggruppa i risultati in base ai ruoli utente per l'analisi di accesso e responsabilità.",
+      "group": "## Dimensione Gruppo\nRaggruppa i risultati per gruppi di utenti. Gli utenti possono appartenere a più gruppi, quindi le attività verranno conteggiate per ogni gruppo a cui appartiene l'utente.",
+      "folder": "## Dimensione cartella\nRaggruppa i risultati in base alla struttura delle cartelle del repository per l'analisi organizzativa.",
+      "session": "## Dimensione sessione\nRaggruppa i risultati in base alle sessioni di test per l'analisi basata sulle sessioni.",
+      "assignedTo": "## Assegnato alla dimensione\nRaggruppa i risultati in base all'utente assegnato all'esecuzione o alla gestione degli elementi.",
+      "issueType": "## Dimensione Tipo di problema\nRaggruppa i risultati in base al tipo di problemi monitorati (ad esempio, Bug, Attività, Storia, Miglioramento).",
+      "issueTracker": "## Dimensione di tracciamento dei problemi\nRaggruppa i risultati in base all'integrazione di tracciamento dei problemi utilizzata (ad esempio, Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Dimensione Stato Problema\nRaggruppa i risultati in base allo stato attuale dei problemi (ad esempio, Aperto, In corso, Risolto, Chiuso).",
+      "priority": "## Dimensione priorità\nRaggruppa i risultati in base al livello di priorità del problema (ad esempio, Alta, Media, Bassa).",
+      "source": "## Dimensione sorgente\nRaggruppa i risultati in base alla sorgente di esecuzione del test (ad esempio, Manuale, JUnit, API).",
+      "date": "## Dimensione data\nRaggruppa i risultati per data per analisi e tendenze basate sul tempo."
+    },
+    "reportBuilder": {
+      "dimensions": "## Dimensioni\nSeleziona le dimensioni che desideri analizzare nel tuo report. Le dimensioni sono attributi che categorizzano i dati, come Data, Utente, Stato, ecc. Puoi trascinarle per riordinarle.",
+      "metrics": "## Metriche\nSeleziona le metriche che desideri misurare nel tuo report. Le metriche sono misurazioni quantitative derivate dai tuoi dati, come il conteggio dei risultati dei test, il tasso di superamento, il tempo medio trascorso, ecc. Puoi trascinarle per riordinarle.",
+      "dateRange": "## Intervallo di date\nFiltra i dati del report in base a un periodo di tempo specifico. Puoi selezionare intervalli predefiniti come \"Ultimi 7 giorni\" o \"Mese precedente\", oppure definire un intervallo di date personalizzato. Questo filtro si applica al campo data pertinente per ciascun tipo di report (ad esempio, data di esecuzione per i risultati dei test, data di creazione per i casi di test)."
+    },
+    "codeRepository": {
+      "name": "## Nome del repository\nUn nome visualizzato descrittivo per questa connessione al repository.\n\n- Utilizzato per identificarlo nelle impostazioni del contesto del codice del progetto.\n- Non deve necessariamente corrispondere al nome del repository sul provider.",
+      "provider": "## Provider Git\nLa piattaforma che ospita questo repository.\n\n- **GitHub** — github.com (cloud o Enterprise)\n- **GitLab** — gitlab.com o self-hosted\n- **Bitbucket Cloud** — bitbucket.org (solo cloud)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — server Git self-hosted con API compatibili",
+      "githubToken": "## Token di accesso personale\nUn token GitHub con autorizzazione **Contenuto: Lettura**.\n\nGenerane uno in: GitHub → Impostazioni del profilo → Impostazioni sviluppatore → Token di accesso personali → Token granulari.",
+      "owner": "## Proprietario\nL'organizzazione GitHub o l'account utente proprietario del repository.\n\n- Esempio: `myorg` o `myusername`\n- Questo è il primo segmento del percorso nell'URL del repository su github.com",
+      "repo": "## Repository\nIl nome del repository, senza il prefisso del proprietario.\n\n- Esempio: `my-repo` (non `myorg/my-repo`)\n- Questo è il secondo segmento del percorso nell'URL del tuo repository su github.com",
+      "gitlabToken": "## Token di accesso personale\nUn token GitLab con ambiti **read_api** e **read_repository**.\n\nGenerane uno in: GitLab → Impostazioni utente → Token di accesso.",
+      "projectPath": "## ID o percorso del progetto\nL'ID numerico del progetto o il percorso completo dello spazio dei nomi.\n\n- Esempio di percorso: `myorg/my-project`\n- Esempio di ID: `12345678`\n- Si trova in GitLab in Impostazioni → Generale.",
+      "baseUrl": "## URL di GitLab\nLascia vuoto per gitlab.com. Per le istanze self-hosted, inserisci l'URL di GitLab.\n\n- Esempio: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Indirizzo email dell'account Atlassian\nL'indirizzo email associato al tuo account Atlassian.\n\n- Questo è l'indirizzo email che usi per accedere a Bitbucket Cloud.",
+      "bitbucketApiToken": "## Token API\nUn token API di Bitbucket con ambito **Repository: Read**.\n\nCreane uno in: Bitbucket → Impostazioni personali → Token API.\n\n> Le password delle app sono state deprecate da Atlassian a favore dei token API.",
+      "workspace": "## Area di lavoro\nLo slug dell'area di lavoro dall'URL di Bitbucket.\n\n- Esempio: `myworkspace` da `bitbucket.org/myworkspace`",
+      "repoSlug": "## Slug del repository\nL'identificativo del repository dal suo URL.\n\n- Esempio: `my-repo` da `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Token di accesso personale\nUn PAT di Azure DevOps con autorizzazione **Codice (Lettura)**.\n\nCreane uno in: Azure DevOps → Impostazioni utente → Token di accesso personali.",
+      "organizationUrl": "## URL dell'organizzazione\nURL della tua organizzazione Azure DevOps.\n\n- Esempio: `https://dev.azure.com/myorg`",
+      "project": "## Nome del progetto\nIl nome del progetto Azure DevOps che contiene il repository.\n\n- Si trova come terzo segmento del percorso nell'URL di Azure DevOps dopo il nome dell'organizzazione",
+      "azureRepoId": "## Nome o ID del repository\nIl nome o il GUID del repository all'interno del progetto Azure DevOps.\n\n- Esempio: `my-repo`",
+      "giteaToken": "## Token di accesso personale\nUn token con permessi di lettura del repository.\n\nGenerane uno in: Amministrazione del sito → Applicazioni, oppure Impostazioni utente → Applicazioni.\n\n- Funziona con Gitea, Forgejo, Gogs e qualsiasi server che esponga un'API compatibile.",
+      "giteaBaseUrl": "## URL del server\nL'URL di base del tuo server Git self-hosted.\n\n- Esempio: `https://gitea.example.com`\n- Deve includere il protocollo (https:// consigliato)\n- Funziona con Gitea, Forgejo, Gogs e altri server con un'API REST `/api/v1/` compatibile con Gitea.",
+      "giteaOwner": "## Proprietario\nL'organizzazione o l'account utente proprietario del repository.\n\n- Esempio: `myorg` o `myusername`\n- Questo è il primo segmento del percorso nell'URL del repository",
+      "giteaRepo": "## Repository\nIl nome del repository, senza il prefisso del proprietario.\n\n- Esempio: `my-repo` (non `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Nome della configurazione\nUn nome univoco e descrittivo per questa configurazione di prompt.\n\n- Utilizzato per identificare la configurazione quando la si assegna a un progetto (ad esempio \"Prompt GPT-4o\", \"Prompt conservativi\").",
+      "description": "## Descrizione\nUn riepilogo facoltativo di ciò che rende questa configurazione particolare.\n\n- Aiuta gli amministratori a comprendere lo scopo a colpo d'occhio (ad esempio \"Richiedi impostazioni di temperatura più basse per un output deterministico\").",
+      "isActive": "## Attiva\nQuando abilitata, questa configurazione è disponibile per l'uso da parte dei progetti.\n\n- Le configurazioni inattive sono nascoste dai menu a tendina di assegnazione dei progetti.\n- La configurazione predefinita non può essere disattivata.",
+      "isDefault": "## Configurazione predefinita\nQuando abilitata, questa configurazione viene utilizzata da qualsiasi progetto a cui non è stata assegnata una configurazione specifica.\n\n- Solo una configurazione può essere predefinita alla volta.\n- L'impostazione di una nuova configurazione predefinita annulla automaticamente quella precedente.",
+      "systemPrompt": "## Richiesta di sistema\nIstruzioni inviate al modello AI prima di qualsiasi input dell'utente. Definisce il ruolo del modello, il formato di output e i vincoli.\n\n- Supporta segnaposto con doppie parentesi graffe (ad es. FRAMEWORK, LANGUAGE, CASE_NAME) che vengono sostituiti in fase di esecuzione.\n- Le modifiche qui apportate influiscono su ogni progetto che utilizza questa configurazione.",
+      "userPrompt": "## Richiesta utente\nIl messaggio inviato all'IA per conto dell'utente. Lasciare vuoto se la funzionalità costruisce il messaggio utente interamente tramite codice.\n\n- Supporta segnaposto con doppie parentesi graffe (ad es. ISSUE_TITLE, CASE_NAME, CODE_CONTEXT) che vengono sostituiti in fase di esecuzione.\n- I segnaposto disponibili per ciascuna funzionalità sono elencati nella sezione Variabili qui sotto.",
+      "temperature": "## Temperatura\nControlla la casualità dell'output dell'IA. Intervallo: 0–2.\n\n- **0,0–0,3** — Altamente deterministico, ideale per output strutturati (JSON, codice).\n- **0,4–0,7** — Bilanciato, adatto per la generazione di casi di test.\n- **0,8–2,0** — Più creativo e vario, adatto per testi aperti.",
+      "maxOutputTokens": "## Numero massimo di token di output\nIl numero massimo di token che il modello genererà in una singola risposta.\n\n- Valori più alti consentono risposte più lunghe ma aumentano i costi e la latenza.\n- Intervalli tipici: 2048 per testo breve, 4096 per la generazione di codice, 6000+ per output multi-caso."
+    },
+    "menu": {
+      "startTour": "Visita guidata di benvenuto",
+      "startProjectTour": "Tour del progetto",
+      "startAdminTour": "Tour amministrativo",
+      "startDemoProjectTour": "Tour dimostrativo del progetto"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Benvenuti su TestPlanIt!",
+          "content": "Diamo un'occhiata veloce alle funzionalità principali di TestPlanIt per aiutarti a iniziare a utilizzare il tuo flusso di lavoro di test."
+        },
+        "projects": {
+          "content": "Accedi a tutti i tuoi progetti di test da qui. Ogni progetto contiene casi di test, esecuzioni e funzionalità di collaborazione in team."
+        },
+        "project": {
+          "title": "Scheda Progetto",
+          "content": "Fai clic sulla scheda di un progetto per visualizzarne i dettagli. Seleziona \"Tour del progetto\" dal menu \"Aiuto\" per una panoramica guidata delle funzionalità del progetto."
+        },
+        "globalFeatures": {
+          "title": "Caratteristiche globali",
+          "content": "Gestisci i tag per la categorizzazione, monitora i problemi nei progetti e gestisci gli utenti con il controllo degli accessi basato sui ruoli."
+        },
+        "search": {
+          "content": "Ricerca contestuale basata sulla pagina corrente. Trova rapidamente casi di test, esecuzioni, problemi o qualsiasi contenuto. Usa Cmd+K (o Ctrl+K) per un accesso immediato."
+        },
+        "help": {
+          "title": "Aiuto e supporto",
+          "content": "Accedi a questa visita guidata in qualsiasi momento oppure consulta la nostra documentazione completa per un aiuto dettagliato."
+        },
+        "notifications": {
+          "content": "Rimani informato sul completamento dei test, sugli aggiornamenti dei problemi e sulle attività del team. Configura le preferenze nelle impostazioni del tuo account."
+        },
+        "account": {
+          "title": "Menu Account",
+          "content": "Personalizza il tuo profilo, le preferenze di notifica e le impostazioni dell'account. Passa dal tema chiaro a quello scuro."
+        },
+        "assignments": {
+          "content": "Visualizza i casi di test e le esecuzioni assegnate a te in tutti i progetti. Questa è la tua dashboard personale per monitorare il tuo lavoro di testing."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Selettore di progetto",
+          "content": "Passa rapidamente da un progetto all'altro utilizzando questo menu a discesa. Visualizza i dettagli del progetto e accedi alle impostazioni generali."
+        },
+        "projectSections": {
+          "title": "Sezioni del progetto",
+          "content": "Naviga attraverso la Panoramica per la dashboard del progetto, la Documentazione per le guide del progetto e le Pietre miliari per monitorare i progressi."
+        },
+        "repository": {
+          "content": "Gestisci i tuoi casi di test, organizzali in cartelle e crea nuovi scenari di test per una copertura di test completa."
+        },
+        "repositoryPanels": {
+          "title": "Pannello sinistro del repository",
+          "content": "Il pannello di sinistra mostra la struttura delle cartelle e l'albero dei casi di test. Utilizza il selettore di visualizzazione per passare da una vista organizzativa all'altra."
+        },
+        "repositoryRightPanel": {
+          "title": "Pannello destro del repository",
+          "content": "Il pannello di destra mostra i dettagli del caso di test, i risultati dell'esecuzione e fornisce azioni per creare nuovi casi di test o importare quelli esistenti."
+        },
+        "sharedSteps": {
+          "title": "Passaggi condivisi",
+          "content": "Definisci gruppi di passaggi riutilizzabili a cui fare riferimento da più casi di test. Mantieni i passaggi di test DRY (Don't Repeat Yourself, ovvero non ripetere mai le stesse regole) e coerenti."
+        },
+        "testRuns": {
+          "content": "Esegui test pianificati, monitora i progressi e gestisci le assegnazioni dei test all'interno del tuo team. Visualizza i risultati dettagliati dell'esecuzione."
+        },
+        "testRunsPage": {
+          "title": "Dashboard delle esecuzioni di prova",
+          "content": "Questa è la pagina \"Test Run\" dove puoi creare nuovi test run, monitorare l'avanzamento dell'esecuzione, visualizzare i risultati e gestire le assegnazioni dei test. Monitora le attività di test del tuo team da un'unica posizione centrale."
+        },
+        "sessions": {
+          "title": "Sessioni esplorative",
+          "content": "Documentare le sessioni di test esplorativi, acquisire i risultati e tenere traccia del tempo impiegato in attività di test ad hoc."
+        },
+        "sessionsPage": {
+          "title": "Dashboard delle sessioni esplorative",
+          "content": "Questa è la pagina Sessioni, dove puoi creare e gestire sessioni di test esplorativi. Documenta i risultati, monitora il tempo impiegato e conserva un registro di tutte le attività di test ad hoc per una migliore copertura dei test."
+        },
+        "tags": {
+          "title": "Gestione dei tag",
+          "content": "Organizza e categorizza i tuoi casi di test utilizzando i tag. Crea tag personalizzati per migliorare l'organizzazione e il filtraggio dei casi di test."
+        },
+        "issues": {
+          "title": "Monitoraggio dei problemi",
+          "content": "Monitora e gestisci i problemi rilevati durante i test. Collega i problemi ai casi di test e integrali con sistemi di tracciamento dei bug esterni."
+        },
+        "reports": {
+          "title": "Report e analisi",
+          "content": "Genera report e analisi complete per il tuo progetto. Visualizza la copertura dei test, i trend di esecuzione, le metriche delle prestazioni del team e crea report personalizzati per gli stakeholder."
+        },
+        "settings": {
+          "title": "Impostazioni del progetto",
+          "content": "Da qui è possibile gestire le integrazioni a livello di progetto, le configurazioni dei modelli di intelligenza artificiale e i link condivisi."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Benvenuti ai controlli amministrativi",
+          "content": "Partecipa a un tour guidato delle funzionalità amministrative di TestPlanIt. Gestisci progetti, utenti, configurazioni e impostazioni di sistema da questo pannello di amministrazione centrale."
+        },
+        "projects": {
+          "title": "Amministrazione del progetto",
+          "content": "Gestisci tutti i progetti della tua organizzazione. Crea, configura e archivia progetti. Imposta autorizzazioni e controlli di accesso a livello di progetto."
+        },
+        "templatesAndFields": {
+          "content": "Crea e gestisci modelli di casi di test e campi personalizzati. Definisci tipi di campo, regole di convalida e organizza i modelli per una struttura coerente dei casi di test in tutti i progetti."
+        },
+        "workflows": {
+          "title": "Gestione del flusso di lavoro",
+          "content": "Definisci i flussi di lavoro dei casi di test e le transizioni di stato. Configura il modo in cui i casi di test passano attraverso diversi stati, come Bozza, Revisione e Approvato."
+        },
+        "statuses": {
+          "title": "Stati dei risultati dei test",
+          "content": "Configura gli stati dei risultati dei test disponibili, come Superato, Non superato, Bloccato e Ignorato. Imposta stati personalizzati e definisci il loro comportamento e aspetto."
+        },
+        "milestones": {
+          "content": "Definisci i tipi di milestone per il monitoraggio del progetto. Configura i tipi di release, le categorie di sprint e altre classificazioni delle milestone del progetto."
+        },
+        "configurations": {
+          "title": "Configurazioni di prova",
+          "content": "Gestisci configurazioni e ambienti di test. Imposta combinazioni di browser, tipi di dispositivi, sistemi operativi e altri contesti di esecuzione dei test."
+        },
+        "users": {
+          "title": "Gestione degli utenti",
+          "content": "Gestisci account utente, autorizzazioni e livelli di accesso. Crea nuovi utenti, assegna ruoli e configura le impostazioni di autenticazione."
+        },
+        "groups": {
+          "title": "Gestione del gruppo",
+          "content": "Organizza gli utenti in gruppi per una gestione più semplice delle autorizzazioni. Crea gruppi di reparto, team di progetto e gruppi di accesso basati sui ruoli."
+        },
+        "roles": {
+          "title": "Gestione dei ruoli",
+          "content": "Definisci ruoli e permessi utente. Configura quali azioni possono essere eseguite dai diversi ruoli nei progetti e nell'amministrazione del sistema."
+        },
+        "tags": {
+          "title": "Tag globali",
+          "content": "Gestisci i tag a livello di organizzazione per categorizzare casi di test, progetti e altre entità. Crea gerarchie di tag e standardizza il tagging tra i progetti."
+        },
+        "reports": {
+          "content": "Genera report che coprono più progetti. Analizza tendenze, parametri di performance ed efficacia dei test organizzativi in tutto il tuo spazio di lavoro."
+        },
+        "notifications": {
+          "title": "Impostazioni di notifica",
+          "content": "Configura le preferenze di notifica a livello di sistema. Imposta modelli di email, regole di notifica e impostazioni predefinite per le notifiche utente."
+        },
+        "integrations": {
+          "title": "Integrazioni di sistema",
+          "content": "Gestisci integrazioni di terze parti e connessioni API. Configura Jira, GitHub e altre integrazioni di strumenti esterni per la tua organizzazione."
+        },
+        "llm": {
+          "title": "Configurazione AI",
+          "content": "Configura modelli e impostazioni di intelligenza artificiale per la generazione automatizzata di casi di test e funzionalità intelligenti. Gestisci le chiavi API e le preferenze del modello."
+        },
+        "sso": {
+          "title": "Accesso unico",
+          "content": "Configura i provider SSO e i metodi di autenticazione. Imposta SAML, OAuth e altre integrazioni con provider di identità per un accesso utente senza interruzioni."
+        },
+        "appConfig": {
+          "content": "Gestisci le impostazioni globali delle applicazioni e le preferenze di sistema. Configura i valori predefiniti, le opzioni di attivazione/disattivazione delle funzionalità e i comportamenti a livello di sistema."
+        },
+        "trash": {
+          "title": "Cestino di sistema",
+          "content": "Visualizza e gestisci gli elementi eliminati in tutti i progetti. Ripristina i contenuti eliminati accidentalmente o rimuovi definitivamente gli elementi dal sistema."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Benvenuti al progetto dimostrativo.",
+          "content": "Questo progetto è precaricato con dati di esempio. Analizziamo insieme le sue caratteristiche principali. Utilizza il menu a tendina per passare da un progetto all'altro."
+        },
+        "overview": {
+          "title": "Panoramica del progetto",
+          "content": "La panoramica è la dashboard del tuo progetto. Mostra l'avanzamento delle tappe fondamentali e i riepiloghi dei casi di test, delle esecuzioni attive, delle sessioni e dei tag."
+        },
+        "documentation": {
+          "title": "Documentazione",
+          "content": "Ogni progetto ha una pagina di documentazione. Utilizzala per i piani di test, le note di progetto o i link a risorse esterne."
+        },
+        "documentationContent": {
+          "title": "Editor di testo avanzato",
+          "content": "La documentazione supporta il testo formattato con titoli, elenchi, link e immagini. Prova a modificare questa pagina per vedere come funziona."
+        },
+        "milestones": {
+          "title": "Traguardi",
+          "content": "Monitora i tuoi test rispetto a sprint, release e altri obiettivi. Collega le esecuzioni e le sessioni di test alle milestone per tenere traccia dei progressi."
+        },
+        "milestonesPage": {
+          "title": "Cronologia delle tappe fondamentali",
+          "content": "Visualizza tutte le tappe fondamentali di questo progetto. Ogni tappa fondamentale mostra il suo stato e i progressi verso il completamento."
+        },
+        "repository": {
+          "title": "Archivio dei casi di test",
+          "content": "Organizza i casi di test in cartelle con campi, passaggi e priorità personalizzati. Esplora le cartelle di esempio per vedere come sono strutturati i casi."
+        },
+        "repositoryPanels": {
+          "title": "Cartelle e custodie",
+          "content": "Il pannello di sinistra mostra le cartelle. Fai clic su una cartella per visualizzare i relativi casi di test. Ogni caso contiene passaggi, descrizioni e riferimenti a passaggi condivisi."
+        },
+        "repositoryCases": {
+          "title": "Casi di test",
+          "content": "Qui puoi visualizzare i casi di test per la cartella selezionata. Ogni riga mostra il nome del caso, la priorità e i campi personalizzati. Fai clic su un caso per visualizzarne i dettagli completi e i passaggi."
+        },
+        "sharedSteps": {
+          "title": "Passaggi condivisi",
+          "content": "Definisci gruppi di passaggi riutilizzabili a cui fare riferimento da più casi di test. Questo mantiene i passaggi comuni coerenti e di facile manutenzione."
+        },
+        "sharedStepsPage": {
+          "title": "Gruppi di passi condivisi",
+          "content": "Ogni gruppo contiene una serie di passaggi ordinati. Fate riferimento a questi passaggi in qualsiasi caso di test per mantenerli coerenti e conformi al principio DRY (Don't Repeat Yourself)."
+        },
+        "testRuns": {
+          "title": "Prove di funzionamento",
+          "content": "Crea delle sessioni di test per eseguire i casi e registra i risultati. Assegna le sessioni alle tappe fondamentali e monitora l'andamento (superato/non superato)."
+        },
+        "testRunsPage": {
+          "title": "Risultati della prova",
+          "content": "Visualizza i risultati e l'avanzamento delle prove. Ogni prova mostra il suo stato, la milestone assegnata e la ripartizione tra successo e fallimento."
+        },
+        "sessions": {
+          "title": "Sessioni esplorative",
+          "content": "Cattura i risultati dei test ad hoc con i test basati su sessioni. Registra i risultati, assegna stati e tieni traccia del tempo impiegato."
+        },
+        "sessionsPage": {
+          "title": "Risultati della sessione",
+          "content": "Ogni sessione include risultati dettagliati con stato di avanzamento e note. Clicca su una sessione per visualizzarne i risultati."
+        },
+        "tags": {
+          "title": "Etichette",
+          "content": "I tag aiutano a organizzare e filtrare casi di test, esecuzioni e sessioni. Esplora i tag di esempio per vedere come categori i contenuti."
+        },
+        "tagsPage": {
+          "title": "Gestione dei tag",
+          "content": "Da qui puoi creare, modificare e assegnare tag. Utilizza i tag per raggruppare e filtrare i contenuti all'interno del tuo progetto."
+        },
+        "issues": {
+          "title": "Problemi",
+          "content": "Tieni traccia dei bug e dei difetti riscontrati durante i test. I problemi possono essere collegati ai risultati dei test falliti e ai dati delle sessioni per una tracciabilità completa."
+        },
+        "issuesPage": {
+          "title": "Strumento di tracciamento dei problemi",
+          "content": "Visualizza esempi di problemi collegati a risultati non riusciti. I problemi possono essere ricondotti all'esecuzione del test o alla sessione di test che li ha rilevati."
+        },
+        "reports": {
+          "title": "Report e analisi",
+          "content": "Genera report sulla copertura dei test, sull'andamento dell'esecuzione e sulle prestazioni del team. Utilizza report predefiniti o creane di personalizzati per le parti interessate."
+        },
+        "settings": {
+          "title": "Impostazioni del progetto",
+          "content": "Da qui è possibile gestire le integrazioni a livello di progetto, le configurazioni dei modelli di intelligenza artificiale e i link condivisi."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Creare e gestire report interprogetto"
+      },
+      "reportsTabDescription": "Visualizza e analizza i report predefiniti per il tuo progetto",
+      "reportType": "Tipo di rapporto",
+      "selectReportType": "Seleziona il tipo di rapporto",
+      "selectReport": "Seleziona il report",
+      "dimensions": "Dimensioni",
+      "dimensionsSubtitle": "Dimensioni (trascina per riordinare, aggiungi sotto)",
+      "metrics": "Metrica",
+      "addDimension": "Aggiungi dimensione...",
+      "addMetric": "Aggiungi metrica...",
+      "runReport": "Esegui rapporto",
+      "noResultsFound": "Nessun risultato trovato.",
+      "selectAtLeastOneDimensionAndMetric": "Selezionare almeno una dimensione e una metrica.",
+      "noDataMatchingCriteria": "Nessun dato trovato corrispondente alle dimensioni e alle metriche selezionate.",
+      "noDataMatchingCriteriaWithDateFilter": "Nessun dato trovato corrispondente alle dimensioni e alle metriche selezionate. Prova a modificare il filtro dell'intervallo di date.",
+      "noDataAvailable": "Nessun dato disponibile per questo rapporto.",
+      "generatedAt": "Rapporto generato alle",
+      "crossProjectAnalytics": "Analisi e reporting interprogettuali",
+      "unauthorizedAdmin": "Non autorizzato: è richiesto l'accesso amministratore.",
+      "title": "Generatore di report",
+      "description": "Crea report personalizzati per analizzare i dati del tuo progetto",
+      "crossProjectDescription": "Analizza i dati di tutti i progetti nel tuo spazio di lavoro",
+      "selectDimensions": "Seleziona le dimensioni...",
+      "selectMetrics": "Seleziona le metriche...",
+      "dimensionOrder": "Ordine dimensionale",
+      "metricOrder": "Ordine metrico",
+      "filtersDescription": "Filtra i dati del report in base a criteri specifici",
+      "activeFilters": "Filtri attivi:",
+      "priorityFilterPlaceholder": "Seleziona i valori di priorità (oppure lascia vuoto per tutte le priorità)",
+      "dateRange": {
+        "selectDateRange": "Seleziona intervallo di date",
+        "chooseStartDate": "Scegli la data di inizio",
+        "chooseEndDate": "Seleziona la data di fine",
+        "categories": {
+          "day": "Giorno",
+          "week": "Settimana",
+          "month": "Mese",
+          "quarter": "Trimestre",
+          "year": "Anno"
+        },
+        "today": "Oggi",
+        "yesterday": "Ieri",
+        "last7Days": "Ultimi 7 giorni",
+        "last30Days": "Ultimi 30 giorni",
+        "thisWeek": "Questa settimana",
+        "lastWeek": "La settimana scorsa",
+        "last2Weeks": "Ultime 2 settimane",
+        "thisMonth": "Questo mese",
+        "lastMonth": "Il mese scorso",
+        "last3Months": "Ultimi 3 mesi",
+        "thisQuarter": "Questo trimestre",
+        "lastQuarter": "Ultimo trimestre",
+        "thisYear": "Quest'anno",
+        "lastYear": "L'anno scorso",
+        "last12Months": "Ultimi 12 mesi",
+        "allTime": "Di tutti i tempi",
+        "custom": "Intervallo di date personalizzato"
+      },
+      "dateGrouping": {
+        "label": "Raggruppa per",
+        "daily": "Quotidiano",
+        "weekly": "Settimanale",
+        "monthly": "Mensile",
+        "quarterly": "Trimestrale",
+        "annually": "Annualmente"
+      },
+      "filters": {
+        "selectFilter": "Seleziona un tipo di filtro",
+        "allProjects": "Tutti i progetti"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Impossibile caricare i metadati del report",
+        "failedToRunReport": "Impossibile eseguire il report",
+        "atLeastOneDimensionRequired": "È richiesta almeno una dimensione.",
+        "atLeastOneMetricRequired": "È necessario specificare almeno una metrica.",
+        "invalidCombinationDateLastActive": "La metrica \"Data ultima attività\" non può essere combinata con la dimensione \"Data attività\".",
+        "lastActiveDateOnlyWithUser": "La metrica \"Data ultima attività\" può essere utilizzata solo con la dimensione \"Utente\".",
+        "invalidDimensionCombination": "Le dimensioni '{dim1}' e '{dim2}' non possono essere utilizzate insieme nei report di esecuzione dei test.",
+        "startDateRequiredWithEndDate": "La data di inizio è obbligatoria quando è specificata la data di fine.",
+        "endDateMustBeAfterStartDate": "La data di fine deve essere successiva o uguale alla data di inizio."
+      },
+      "chartDataTruncated": {
+        "title": "Dati del grafico troncati",
+        "message": "Vengono visualizzati {shown} punti dati su {total} per una migliore leggibilità. Utilizza filtri o intervalli di date per restringere i risultati oppure visualizza i dati completi nella tabella dei risultati qui sotto."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Rapporti di esecuzione dei test",
+          "description": "Analizza i risultati dei test, i tassi di superamento e le metriche di esecuzione"
+        },
+        "repositoryStats": {
+          "label": "Statistiche del repository",
+          "description": "Statistiche dei casi di prova, copertura e stato del repository"
+        },
+        "userEngagement": {
+          "label": "Coinvolgimento dell'utente",
+          "description": "Analisi dell'attività, della produttività e del carico di lavoro dell'utente"
+        },
+        "projectHealth": {
+          "label": "Progetto Salute",
+          "description": "Avanzamento del progetto, traguardi e stato di completamento"
+        },
+        "sessionAnalysis": {
+          "label": "Analisi della sessione",
+          "description": "Metriche di completamento, durata e assegnazione della sessione"
+        },
+        "issueTracking": {
+          "label": "Tracciamento dei problemi",
+          "description": "Creazione, risoluzione e analisi dell'impatto dei problemi"
+        },
+        "automationTrends": {
+          "label": "Tendenze dell'automazione",
+          "description": "Monitora i progressi dell'automazione settimana dopo settimana, in base alla priorità."
+        },
+        "flakyTests": {
+          "label": "Test instabili",
+          "description": "Identificare i test con risultati di superamento/non superamento incoerenti"
+        },
+        "testCaseHealth": {
+          "label": "Caso di prova Salute",
+          "description": "Identifica i casi di test obsoleti, danneggiati o sospetti in base ai modelli di esecuzione"
+        },
+        "issueTestCoverage": {
+          "label": "Copertura dei test dei problemi",
+          "description": "Visualizza i problemi con i relativi casi di test collegati e lo stato di esecuzione più recente"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Ultime corse consecutive",
+        "consecutiveRunsHelp": "Numero di esecuzioni di test recenti da analizzare (5-30). I risultati con stato \"non testato\" sono esclusi.",
+        "flipThreshold": "Ribaltazioni minime",
+        "flipThresholdHelp": "Numero minimo di transizioni di successo/fallimento richiesto per essere considerato inaffidabile.",
+        "flips": "Flips",
+        "lastNResults": "Ultimo {count, plural, one {# Risultato} other {# Risultati}}",
+        "newest": "Nuovo",
+        "oldest": "Vecchio",
+        "noFlakyTests": "Nessun test instabile trovato corrispondente ai criteri",
+        "includeFilter": "Includi",
+        "testRunDeleted": "La prova è stata eliminata",
+        "chart": {
+          "highPriority": "Necessita di attenzione",
+          "lowPriority": "Priorità inferiore",
+          "recencyAxis": "Recentità del guasto",
+          "flipsAxis": "Conteggio dei capovolgimenti",
+          "oldFailures": "Più vecchio",
+          "recentFailures": "Recente",
+          "failureRate": "Tasso di guasto",
+          "recency": "Punteggio di recenza",
+          "backlogTitle": "Test a priorità inferiore",
+          "backlogDescription": "{count, plural, one {# test instabile aggiuntivo} other {# test instabili aggiuntivi}} non mostrato"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Raffermo dopo (giorni)",
+        "staleDaysThresholdHelp": "Numero di giorni senza esecuzione prima che un test venga considerato obsoleto (7-90).",
+        "minExecutions": "Esecuzioni minime per tasso",
+        "minExecutionsHelp": "Numero minimo di esecuzioni necessarie per calcolare statistiche significative sul tasso di successo (3-20).",
+        "lookbackDays": "Periodo di riferimento",
+        "lookbackDaysHelp": "Numero di giorni per analizzare la cronologia delle esecuzioni (30-365).",
+        "includeFilter": "Includi",
+        "staleFilter": "Stagionato",
+        "stale": "Stagionato",
+        "notStale": "Non stantio",
+        "status": "stato di salute",
+        "healthScore": "Punto",
+        "lastExecuted": "Ultima esecuzione",
+        "executions": "Esecuzioni",
+        "passRate": "Tasso di superamento",
+        "passCount": "Pass",
+        "failCount": "Fallimenti",
+        "never": "Mai",
+        "daysSince": "Giorni trascorsi dall'esecuzione",
+        "count": "Contare",
+        "totalTests": "casi di test",
+        "noData": "Nessun caso di test trovato",
+        "noExecutedTests": "Nessun test eseguito da visualizzare",
+        "healthStatus": {
+          "healthy": "Salutare",
+          "stale": "Stagionato",
+          "neverExecuted": "Mai eseguito",
+          "alwaysPassing": "Sempre di passaggio",
+          "alwaysFailing": "Sempre fallimentare"
+        },
+        "chart": {
+          "distribution": "Distribuzione dello stato",
+          "healthyRecent": "Sano e recente",
+          "unhealthyStale": "Necessita di attenzione",
+          "daysAxis": "Giorni trascorsi dall'ultima esecuzione",
+          "healthScoreAxis": "Punteggio di salute"
+        },
+        "stats": {
+          "totalTests": "Test totali",
+          "needsAttention": "Necessita di attenzione",
+          "needsAttentionTooltip": "Sempre fallimentari + Mai eseguiti + Test obsoleti",
+          "healthy": "Salutare",
+          "healthyTooltip": "Sano e con test sempre superati.",
+          "avgScore": "Punteggio medio di salute"
+        },
+        "healthScoreTooltip": {
+          "title": "Il punteggio iniziale è 100, con le seguenti penalità:",
+          "neverExecuted": "Mai eseguito: -50",
+          "stale90": "Non eseguito negli ultimi 90 giorni: -40",
+          "stale60": "Non eseguito negli ultimi 60 giorni: -25",
+          "stale30": "Non eseguito negli ultimi 30 giorni: -10",
+          "alwaysPassing": "Sempre superato (100%): -5",
+          "alwaysFailing": "Sempre fallito (0%): -30",
+          "lowPassRate": "Bassa percentuale di superamento (<50%): -20",
+          "lowExecutions": "Poche esecuzioni (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Modalità di visualizzazione",
+        "summaryView": "Riepilogo (per numero)",
+        "detailView": "Dettagli (per caso di test)",
+        "issue": "Problema",
+        "testCase": "Caso di prova",
+        "testCases": "{count, plural, =1 {Caso di test} other {Casi di test}}",
+        "issueStatus": "Stato",
+        "priority": "Priorità",
+        "linkedTests": "Test collegati",
+        "testResults": "Risultati (P/F/U)",
+        "passRate": "Tasso di superamento",
+        "passed": "Superato",
+        "failed": "Fallito",
+        "lastStatus": "Stato attuale",
+        "lastExecuted": "Ultima esecuzione",
+        "notTested": "Non testato",
+        "noData": "Nessun problema riscontrato con i casi di test collegati",
+        "noIssuesNeedingAttention": "Tutti i problemi sono stati testati con successo: ottimo lavoro!",
+        "stats": {
+          "totalIssues": "Numero totale di emissioni",
+          "issuesWithFailures": "Con guasti",
+          "issuesWithFailuresTooltip": "Problemi con almeno un caso di test fallito",
+          "issuesWithUntested": "Con non testato",
+          "issuesWithUntestedTooltip": "Problemi con almeno un caso di test che non è stato eseguito",
+          "issuesAllPassing": "Tutti i passaggi",
+          "overallPassRate": "Tasso di superamento",
+          "numberOfIssues": "Numero di problemi"
+        },
+        "charts": {
+          "passRateDistribution": "Distribuzione dei tassi di superamento del test",
+          "linkedTestCases": "Numero di casi di test collegati",
+          "untestedTestCases": "Numero di casi di test non ancora testati",
+          "testCoverageVsExecution": "Copertura dei test vs. stato di esecuzione"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Esecuzione di test tra progetti",
+          "description": "Analizza i risultati dei test, i tassi di superamento e le metriche di esecuzione in tutti i progetti"
+        },
+        "repositoryStats": {
+          "label": "Statistiche del repository interprogetto",
+          "description": "Statistiche dei casi di test, copertura e stato del repository nei vari progetti"
+        },
+        "userEngagement": {
+          "label": "Coinvolgimento degli utenti tra progetti",
+          "description": "Analisi dell'attività, della produttività e del carico di lavoro degli utenti nei vari progetti"
+        },
+        "issueTracking": {
+          "label": "Monitoraggio dei problemi tra progetti",
+          "description": "Creazione di problemi, risoluzione e analisi dell'impatto nei progetti"
+        },
+        "automationTrends": {
+          "label": "Tendenze dell'automazione interprogetto",
+          "description": "Monitora i progressi dell'automazione settimana dopo settimana, in base alla priorità, per tutti i progetti."
+        },
+        "flakyTests": {
+          "label": "Test instabili tra progetti",
+          "description": "Identificare i test con risultati di superamento/fallimento incoerenti tra i diversi progetti"
+        },
+        "testCaseHealth": {
+          "label": "Salute dei casi di test interprogetto",
+          "description": "Identificare i casi di test obsoleti, danneggiati o sospetti nei vari progetti."
+        },
+        "issueTestCoverage": {
+          "label": "Copertura dei test dei problemi tra progetti",
+          "description": "Visualizza i problemi con i relativi casi di test collegati e lo stato di esecuzione più recente nei progetti."
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Solo gli amministratori del progetto e gli amministratori possono accedere ai report del progetto.",
+      "projectIdRequired": "L'ID del progetto è obbligatorio",
+      "missingRequiredFields": "Campi obbligatori mancanti",
+      "unsupportedDimension": "Dimensione non supportata: {dimension}",
+      "unsupportedMetric": "Metrica non supportata: {metric}",
+      "atLeastOneDimensionMetricRequired": "Sono richieste almeno una dimensione e una metrica",
+      "atLeastOneMetricRequired": "È necessario specificare almeno una metrica",
+      "projectDimensionsMetricsRequired": "Sono richiesti ID progetto, dimensioni e metriche",
+      "unsupportedDimensions": "Dimensioni non supportate: {dimensions}",
+      "unsupportedMetrics": "Metriche non supportate: {metrics}",
+      "unexpectedError": "Si è verificato un errore imprevisto."
+    },
+    "dimensions": {
+      "project": "Progetto",
+      "status": "Stato",
+      "user": "Utente",
+      "executor": "Esecutore",
+      "assignedTo": "Assegnato a",
+      "configuration": "Configurazione",
+      "date": "Data",
+      "executionDate": "Data di esecuzione",
+      "creationDate": "Data di creazione",
+      "activityDate": "Data dell'attività",
+      "testRun": "Esecuzione del test",
+      "testCase": "Caso di prova",
+      "milestone": "Pietra miliare",
+      "template": "Modello",
+      "creator": "Creatore",
+      "state": "Stato",
+      "source": "Fonte",
+      "folder": "Cartella",
+      "group": "Gruppo",
+      "role": "Ruolo",
+      "session": "Sessione",
+      "weekEnding": "Fine settimana",
+      "period": "Periodo",
+      "priority": "Priorità",
+      "automationStatus": "Stato dell'automazione",
+      "issueType": "Tipo di problema",
+      "issueTracker": "Strumento di tracciamento dei problemi",
+      "issueStatus": "Stato del problema"
+    },
+    "metrics": {
+      "testResults": "Risultati del test",
+      "testResultCount": "Conteggio dei risultati dei test",
+      "passRate": "Tasso di superamento (%)",
+      "avgElapsed": "Tempo medio trascorso",
+      "avgElapsedTime": "Tempo medio trascorso",
+      "totalElapsedTime": "Tempo totale trascorso",
+      "testRunCount": "Numero di esecuzioni dei test",
+      "testCaseCount": "Conteggio dei casi di test",
+      "automationRate": "Tasso di automazione (%)",
+      "avgStepsPerCase": "Media dei passaggi per caso",
+      "averageSteps": "Passaggi medi per caso",
+      "automatedCount": "Casi automatizzati",
+      "manualCount": "Casi manuali",
+      "totalCount": "Casi totali",
+      "totalSteps": "Passi totali",
+      "executionCount": "Esecuzioni di test",
+      "createdCaseCount": "Conteggio dei casi di test creati",
+      "sessionResultCount": "Conteggio dei risultati della sessione",
+      "caseCreations": "Casi creati",
+      "sessionParticipation": "Partecipazione alla sessione",
+      "averageElapsed": "Tempo medio per esecuzione",
+      "lastActiveDate": "Ultima data attiva",
+      "issueCount": "Numero di problemi",
+      "averageAge": "Età media (giorni)",
+      "sessionCount": "Conteggio delle sessioni",
+      "activeSessions": "Sessioni attive",
+      "averageTimeSpent": "Tempo medio trascorso (minuti)",
+      "milestoneCount": "Conteggio delle pietre miliari",
+      "milestoneCompletionRate": "Tasso di completamento delle pietre miliari (%)",
+      "averageMilestoneDuration": "Durata media del traguardo (giorni)",
+      "totalMilestones": "Traguardi totali",
+      "activeMilestones": "Traguardi attivi",
+      "milestoneCompletion": "Completamento della tappa (%)",
+      "averageDuration": "Durata media",
+      "totalDuration": "Durata totale"
+    },
+    "drillDown": {
+      "title": "Registri dettagliati",
+      "loading": "Caricamento dei record in corso...",
+      "loadingMore": "Caricamento in corso...",
+      "noRecords": "Nessun risultato trovato",
+      "error": "Impossibile caricare i record",
+      "recordCount": "{count} {count, plural, =1 {record} other {record}}",
+      "allRecords": "Tutti i record",
+      "allLoaded": "Tutti i record caricati"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Condividere",
+      "dialogTitle": "Condividi il rapporto",
+      "dialogDescription": "Crea un link condivisibile o gestisci i link di report condivisi esistenti.",
+      "tabs": {
+        "create": "Crea Condividi",
+        "list": "Le mie azioni"
+      },
+      "shareMode": {
+        "label": "Modalità di condivisione",
+        "authenticated": {
+          "title": "Autenticato (richiede l'accesso)",
+          "description": "Solo gli utenti autenticati e autorizzati ad accedere a questo progetto possono visualizzarlo.",
+          "descriptionCrossProject": "Solo gli utenti autenticati con accesso di amministratore possono visualizzare."
+        },
+        "passwordProtected": {
+          "title": "Protetto da password",
+          "description": "Chiunque abbia il link e la password può visualizzare il contenuto. Gli utenti registrati con accesso al progetto non devono inserire la password.",
+          "descriptionCrossProject": "Chiunque abbia il link e la password può visualizzare il contenuto. Gli utenti registrati con accesso di amministratore non devono inserire la password."
+        },
+        "public": {
+          "title": "Pubblico (chiunque abbia il link)",
+          "description": "Chiunque abbia il link può visualizzare questo report senza dover effettuare l'accesso."
+        }
+      },
+      "expiration": {
+        "label": "Scadenza",
+        "noExpiration": "Nessuna scadenza",
+        "expiresAtMidnight": "Il link scadrà al termine della giornata selezionata (ora locale)."
+      },
+      "notifyOnView": {
+        "label": "Avvisami quando qualcuno visualizza questo link",
+        "description": "In base alle tue preferenze di notifica, riceverai una notifica quando qualcuno accederà al link di condivisione."
+      },
+      "title": {
+        "placeholder": "Ad esempio, rapporto di esecuzione del test",
+        "leaveEmptyToUse": "Lasciare vuoto per utilizzare:"
+      },
+      "description": {
+        "placeholder": "Aggiungi una descrizione per questo report condiviso..."
+      },
+      "actions": {
+        "createShareLink": "Crea un link di condivisione",
+        "creating": "Creazione..."
+      },
+      "errors": {
+        "loginRequired": "È necessario aver effettuato l'accesso per creare un link di condivisione.",
+        "createFailed": "Impossibile creare il link di condivisione",
+        "genericError": "Si è verificato un errore sconosciuto"
+      },
+      "status": {
+        "revoked": {
+          "title": "Link di condivisione revocato",
+          "description": "Questo link di condivisione è stato revocato e non è più accessibile."
+        },
+        "expired": {
+          "title": "Link di condivisione scaduto",
+          "description": "Questo link di condivisione è scaduto e non è più accessibile."
+        }
+      },
+      "footer": {
+        "poweredBy": "Offerto da"
+      },
+      "manageShares": {
+        "title": "Gestisci le azioni",
+        "description": "Visualizza e gestisci tutti i link di condivisione per questo progetto",
+        "adminTitle": "Gestisci tutte le azioni",
+        "adminDescription": "Visualizza e gestisci i link di condivisione in tutti i progetti"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Modalità",
+          "views": "Punti di vista",
+          "expires": "Scade"
+        },
+        "status": {
+          "revoked": "Revocato",
+          "expired": "Scaduto"
+        },
+        "notifications": {
+          "enabled": "SU",
+          "disabled": "Spento"
+        },
+        "empty": {
+          "title": "Non sono ancora stati creati link di condivisione.",
+          "description": "Per iniziare, crea il tuo primo link di condivisione."
+        },
+        "defaultTitle": "{entityType} condividi",
+        "noProject": "Progetto trasversale",
+        "actions": {
+          "copyLink": "Copia collegamento",
+          "revoke": "Revocare"
+        },
+        "revokeDialog": {
+          "title": "Revocare il link di condivisione?",
+          "description": "Questa operazione revocherà immediatamente il link di condivisione. Chiunque tenti di accedervi visualizzerà un messaggio di errore. Questa azione è irreversibile.",
+          "confirm": "Revoca il collegamento",
+          "revoking": "Revoca..."
+        },
+        "deleteDialog": {
+          "title": "Eliminare il link di condivisione?",
+          "description": "Questa operazione eliminerà definitivamente il link di condivisione. Se il link è attualmente attivo, scadrà immediatamente e non sarà più accessibile. Questa azione è irreversibile.",
+          "confirm": "Elimina collegamento"
+        },
+        "toast": {
+          "linkCopied": "Link copiato!",
+          "linkCopiedDescription": "Il link di condivisione è stato copiato negli appunti.",
+          "copyFailed": "Impossibile copiare",
+          "copyFailedDescription": "Si prega di copiare il link manualmente.",
+          "linkRevoked": "Link di condivisione revocato",
+          "linkRevokedDescription": "Il link di condivisione è stato revocato e non è più accessibile.",
+          "revokeFailed": "Non è stata effettuata la revoca",
+          "revokeFailedDescription": "Si è verificato un errore durante la revoca del link di condivisione.",
+          "notificationsEnabled": "Notifiche abilitate",
+          "notificationsEnabledDescription": "Riceverai una notifica quando qualcuno visualizzerà questo link di condivisione.",
+          "notificationsDisabled": "Notifiche disattivate",
+          "notificationsDisabledDescription": "Non riceverai notifiche quando qualcuno visualizzerà questo link di condivisione.",
+          "notificationUpdateFailed": "Impossibile aggiornare le notifiche.",
+          "notificationUpdateFailedDescription": "Si è verificato un errore durante l'aggiornamento delle impostazioni di notifica.",
+          "linkDeleted": "Link di condivisione eliminato",
+          "linkDeletedDescription": "Il link di condivisione è stato eliminato e non apparirà più nel tuo elenco.",
+          "deleteFailed": "Impossibile eliminare",
+          "deleteFailedDescription": "Si è verificato un errore durante l'eliminazione del link di condivisione."
+        }
+      },
+      "created": {
+        "title": "Link di condivisione creato!",
+        "description": "Il tuo link di condivisione è pronto all'uso. Copialo e condividilo con altri.",
+        "shareLink": "Condividi il link",
+        "copy": "Copia",
+        "openInNewTab": "Apri in una nuova scheda",
+        "metadata": {
+          "mode": "Modalità",
+          "expires": "Scade",
+          "views": "Punti di vista"
+        },
+        "warnings": {
+          "publicLink": "Link pubblico:",
+          "publicLinkDescription": "Chiunque abbia questo link può accedere al report senza autenticazione.",
+          "expiresSoon": "Questo link scadrà alla fine di"
+        },
+        "actions": {
+          "createAnother": "Creane un altro"
+        }
+      },
+      "editDialog": {
+        "title": "Modifica il link di condivisione",
+        "description": "Aggiorna le impostazioni per questo link di condivisione.",
+        "passwordExists": "Questo link di condivisione è già protetto da password. Lascia vuoto il campo della password per mantenerla.",
+        "passwordPlaceholder": "Lascia vuoto per mantenere la password esistente"
+      }
+    },
+    "passwordDialog": {
+      "title": "Password richiesta",
+      "description": "Questo contenuto condiviso da <strong>{projectName}</strong> è protetto da password. Inserisci la password per continuare.",
+      "passwordPlaceholder": "Inserisci la password",
+      "showPassword": "Mostra password",
+      "hidePassword": "Nascondi password",
+      "verifying": "Verifica in corso...",
+      "errors": {
+        "emptyPassword": "Inserisci una password",
+        "tooManyAttempts": "Troppi tentativi falliti. Riprova più tardi{resetAt, select, null {} other { a {resetAt}}}.",
+        "genericError": "Si è verificato un errore. Riprova."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Nessun tentativo rimasto. Riprova più tardi.",
+        "attemptsRemaining": "{count, plural, =1 {1 tentativo} other {# tentativi}} rimanenti."
+      }
+    },
+    "sharedReport": {
+      "loading": "Caricamento del report in corso...",
+      "errors": {
+        "onlyReportSharing": "Al momento è implementata solo la condivisione dei report.",
+        "failedToLoad": "Impossibile caricare i dati del report"
+      },
+      "defaultTitle": "Condividi il report",
+      "fromProject": "Dal progetto:",
+      "dateRange": "Intervallo di date:",
+      "readOnlyNotice": "Questa è una vista condivisa di sola lettura",
+      "viewCount": "{count, plural, =1 {1 visualizzazione} other {# visualizzazioni}}",
+      "viewInFullApp": "Visualizza l'app completa",
+      "pagination": {
+        "showing": "Mostrando",
+        "of": "Di",
+        "results": "risultati"
+      }
+    },
+    "authBypass": {
+      "title": "Hai accesso a questo progetto",
+      "description": "Visualizzazione come {userName} con accesso a {projectName}.",
+      "viewInApp": "Visualizza l'app completa"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Filtra i passaggi condivisi...",
+    "noGroups": "Nessun passaggio condiviso trovato.",
+    "noTestCases": "Nessun caso di test utilizza questo gruppo di passaggi condiviso.",
+    "selectGroupPrompt": "Seleziona un gruppo di passaggi condiviso per visualizzarne i passaggi.",
+    "deleteTitle": "Eliminare il gruppo di passaggi condivisi?",
+    "deleteDescription": "Vuoi davvero eliminare questo gruppo di passaggi condivisi? I passaggi verranno rimossi da tutti i casi di test che li utilizzano.",
+    "saveSuccess": "Passaggi condivisi aggiornati correttamente.",
+    "saveError": "Si è verificato un errore durante il salvataggio dei passaggi condivisi.",
+    "stepsCount": "{count, plural, one {# passo} other {# passi}}",
+    "testCasesUsing": "{count, plural, one {# caso di test} other {# casi di test}}",
+    "importWizard": {
+      "title": "Importa passaggi condivisi",
+      "fields": {
+        "order": "Ordine",
+        "stepNumber": "Fare un passo #",
+        "stepContent": "Contenuto del passaggio",
+        "expectedResultContent": "Contenuto del risultato atteso",
+        "combinedStepData": "Dati combinati dei passaggi",
+        "stepsData": "Dati sui passaggi"
+      },
+      "success": {
+        "description": "{count, plural, one {# passaggio condiviso} other {# passaggi condivisi}} importato con successo"
+      },
+      "errors": {
+        "parseFailed": "Impossibile analizzare il file CSV",
+        "validationFailed": "Convalida fallita",
+        "validationDescription": "{count, plural, one {# errore di convalida} other {# errori di convalida}} trovati",
+        "importFailed": "Importazione non riuscita",
+        "fileRequired": "È richiesto un file CSV"
+      },
+      "page1": {
+        "title": "Carica file e configurazione",
+        "selectedFile": "File selezionato",
+        "delimiter": "Delimitatore di campo",
+        "delimiters": {
+          "tab": "Tabulazione (\\t)"
+        },
+        "hasHeaders": "La prima riga contiene le intestazioni delle colonne",
+        "encoding": "Codifica dei file",
+        "rowMode": {
+          "label": "Modalità riga",
+          "single": "Singola riga per passaggio condiviso",
+          "multi": "Più righe per passaggi condivisi complessi"
+        }
+      },
+      "page2": {
+        "title": "Mappa le colonne CSV sui campi dei passaggi condivisi",
+        "description": "Mappa le colonne CSV ai campi condivisi dei passaggi. I campi obbligatori devono essere mappati.",
+        "ignoreColumn": "Ignora questa colonna",
+        "requiredFieldsWarning": "{count, plural, one {# il campo obbligatorio è} other {# i campi obbligatori sono}} non mappati. Mappa tutti i campi obbligatori per continuare."
+      },
+      "page3": {
+        "title": "Anteprima dati di importazione",
+        "showing": "Visualizzazione di {start} a {end} di {total} passaggi condivisi",
+        "step": "Passo condiviso {number}",
+        "noValue": "(vuoto)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Aggiungi manualmente",
+      "description": "Crea un nuovo gruppo di passaggi condivisi con inserimento manuale",
+      "groupNamePlaceholder": "Inserisci un nome per questo gruppo di passaggi condivisi",
+      "success": "Passaggi condivisi creati con successo",
+      "errors": {
+        "groupNameRequired": "Il nome del gruppo è obbligatorio",
+        "stepsRequired": "È richiesto almeno un passaggio",
+        "saveFailed": "Impossibile salvare i passaggi condivisi"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Sequenza dei passaggi Duplicati",
+      "pageDescription": "Esamina le sequenze di passaggi corrispondenti nei vari casi di test. Converti le corrispondenze in gruppi di passaggi condivisi o scarta i falsi positivi.",
+      "noResultsFound": "Non sono state trovate sequenze di passaggi duplicate.",
+      "noResultsDescription": "Esegui una scansione per rilevare sequenze di passaggi ripetute nei tuoi casi di test.",
+      "filterPlaceholder": "Filtra per nome del caso...",
+      "selected": "{count, plural, one {# selezionato} other {# selezionato}}",
+      "bulkDismiss": "Ignora ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# partita annullata} other {# partite annullate}}",
+      "bulkError": "Alcune operazioni non sono andate a buon fine. Riprova.",
+      "tableHint": "Fai clic su una riga per visualizzare in anteprima i passaggi corrispondenti. Seleziona le righe con le caselle di controllo per eseguire azioni in blocco.",
+      "columns": {
+        "matchedSteps": "Passi abbinati",
+        "casesCount": "Casi",
+        "review": "Revisione"
+      },
+      "scanning": "Scansione in corso...",
+      "scanComplete": "{count, plural, one {# corrispondenza trovata} other {# corrispondenze trovate}}",
+      "scanFailed": "Scansione non riuscita",
+      "scanFailedDescription": "Si è verificato un errore durante la scansione. Riprova.",
+      "cancelScan": "Annulla scansione",
+      "findStepDuplicates": "Trova i passaggi duplicati",
+      "rescan": "Scansione",
+      "viewResults": "Visualizza i risultati ({count})",
+      "retryScan": "Riprova la scansione",
+      "dialog": {
+        "title": "Converti in passaggi condivisi",
+        "previewTitle": "Sequenza di passi corrispondente",
+        "casesTitle": "Casi di test interessati",
+        "casesDescription": "Deseleziona i casi che desideri escludere dalla conversione.",
+        "nameLabel": "Nome del gruppo di passi condiviso",
+        "namePlaceholder": "Inserisci un nome per il gruppo di passaggi condiviso...",
+        "converting": "Conversione...",
+        "dismissMatch": "Ignora la partita",
+        "dismissing": "Licenziamento...",
+        "convertSuccess": "Gruppo di passaggi condivisi creato con successo!",
+        "convertError": "Conversione non riuscita. Riprova.",
+        "dismissSuccess": "Partita annullata.",
+        "dismissError": "Impossibile chiudere l'operazione. Riprova.",
+        "viewSharedStep": "Visualizza il gruppo di passi condivisi",
+        "skippedWarning": "{count, plural, one {# caso saltato} other {# casi saltati}} (obsoleto o già convertito).",
+        "noCasesSelected": "Seleziona almeno un caso da convertire.",
+        "selectAll": "Seleziona tutto"
+      }
+    },
+    "findStepDuplicates": "Trova duplicati"
+  },
+  "search": {
+    "title": "Ricerca",
+    "placeholder": {
+      "thisProject": "Cerca in questo progetto...",
+      "allProjects": "Cerca in tutti i progetti..."
+    },
+    "currentProjectOnly": "Solo progetto attuale",
+    "allTypes": "Tutti i tipi",
+    "entityTypes": {
+      "repositoryCase": "Casi di repository"
+    },
+    "results": {
+      "tryAdjusting": "Prova a modificare i termini di ricerca o i filtri",
+      "searchingFor": "Alla ricerca di",
+      "within": "entro",
+      "currentProject": "progetto attuale",
+      "page": "Pagina"
+    },
+    "errors": {
+      "searchFailed": "Ricerca non riuscita. Riprova.",
+      "tryAgain": "Riprova"
+    },
+    "startTyping": "Inizia a digitare per cercare",
+    "typesSelected": "{count, plural, one {# tipo} other {# tipi}}",
+    "customFieldFilters": "Filtri di campo personalizzati",
+    "customFiltersApplied": "filtri personalizzati",
+    "customFields": "Campi personalizzati",
+    "addFilter": "Aggiungi filtro",
+    "filter": "Filtro",
+    "noCustomFilters": "Nessun filtro di campo personalizzato applicato",
+    "selectDate": "Seleziona la data",
+    "selectOption": "Seleziona l'opzione",
+    "selectOptions": "Seleziona le opzioni",
+    "operators": {
+      "equals": "Uguali",
+      "not_equals": "Non uguali",
+      "contains": "Contiene",
+      "not_contains": "Non contiene",
+      "starts_with": "Inizia con",
+      "ends_with": "Termina con",
+      "gt": "Maggiore di",
+      "lt": "Meno di",
+      "gte": "Maggiore o uguale",
+      "lte": "Minore o uguale",
+      "between": "Fra",
+      "in": "In",
+      "not_in": "Non in",
+      "exists": "Esiste",
+      "not_exists": "Non esiste"
+    },
+    "help": {
+      "exactPhrases": "Frasi esatte",
+      "exactPhrasesDesc": "Per far corrispondere i termini alle frasi esatte, racchiudili tra virgolette:",
+      "proximity": "Ricerca di prossimità",
+      "proximityDesc": "parole entro N posizioni l'una dall'altra",
+      "booleanOperators": "Operatori booleani",
+      "andDesc": "entrambi i termini devono corrispondere",
+      "orDesc": "entrambi i termini possono corrispondere",
+      "notDesc": "escludi i risultati con termine",
+      "prefixDesc": "richiedere o escludere un termine",
+      "groupingDesc": "termini di gruppo per query complesse",
+      "wildcards": "Jolly",
+      "wildcardMultiDesc": "corrisponde a qualsiasi carattere",
+      "wildcardSingleDesc": "corrisponde a un singolo carattere",
+      "fuzzyMatching": "Corrispondenza approssimativa",
+      "fuzzyDesc": "trova termini simili per aiutarti con gli errori di battitura",
+      "defaultBehavior": "L'operatore OR viene utilizzato per impostazione predefinita quando si utilizzano più parole. I risultati corrispondenti al nome vengono classificati più in alto.",
+      "fullSyntaxLink": "Riferimento completo alla sintassi delle query Lucene"
+    },
+    "filters": {
+      "title": "Filtri avanzati",
+      "active": "filtri attivi",
+      "activeCount": "{count, plural, =0 {Nessun filtro} one {# filtro} other {# filtri}} attivi",
+      "apply": "Applica filtri",
+      "common": "Filtri comuni",
+      "entitySpecific": "Filtri specifici per tipo",
+      "searchPlaceholder": "Opzioni del filtro di ricerca...",
+      "states": "Stati del flusso di lavoro",
+      "createdAt": "Data di creazione",
+      "updatedAt": "Data di aggiornamento",
+      "completedAt": "Data di completamento",
+      "from": "Da",
+      "to": "A",
+      "testRunType": "Tipo di esecuzione del test",
+      "regular": "Regolare",
+      "junit": "JUnit",
+      "automatedOnly": "Solo automatizzato",
+      "archivedOnly": "Solo archiviato",
+      "completedOnly": "Completato solo",
+      "manualOnly": "Solo manuale",
+      "estimateRange": "Intervallo di stima",
+      "elapsedRange": "Intervallo di tempo trascorso",
+      "minValue": "Minimo",
+      "maxValue": "Massimo",
+      "hasExternalId": "Ha un ID esterno",
+      "dueDateRange": "Intervallo di date di scadenza",
+      "hasParent": "Ha raggiunto il traguardo genitoriale",
+      "milestoneType": "Tipo di traguardo",
+      "minutes": "minuti",
+      "hours": "ore",
+      "days": "giorni",
+      "searchingIn": "Ricerca in",
+      "includeDeleted": "Includi elementi eliminati",
+      "filterActive": "Filtro attivo:",
+      "applyFilter": "Applica filtro",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "Il primo valore deve essere minore del secondo valore",
+        "firstDateMustBeBeforeSecond": "Il primo appuntamento deve essere precedente al secondo appuntamento."
+      },
+      "link": {
+        "domainHelp": "Inserisci solo il dominio (ad esempio, \"github.com\" o \"example.org\")"
+      }
+    }
+  },
+  "email": {
+    "greeting": "Ciao,",
+    "greetingWithName": "Ciao {name},",
+    "notification": {
+      "intro": "Hai una nuova notifica:",
+      "viewDetails": "Visualizza i dettagli",
+      "viewAll": "Visualizza tutte le notifiche"
+    },
+    "digest": {
+      "intro": "Ecco il riepilogo giornaliero delle notifiche di TestPlanIt:",
+      "viewDetails": "Visualizza i dettagli",
+      "viewAll": "Visualizza tutte le notifiche",
+      "noNotifications": "Oggi non hai nuove notifiche.",
+      "footer": "Ricevi questa email perché hai abilitato le notifiche di riepilogo giornaliero. Puoi modificare le preferenze di notifica nel tuo",
+      "profileSettings": "impostazioni del profilo"
+    },
+    "footer": {
+      "sentBy": "Questa e-mail è stata inviata da",
+      "unsubscribe": "Annulla iscrizione",
+      "managePreferences": "Gestisci preferenze",
+      "allRightsReserved": "Tutti i diritti riservati."
+    },
+    "magicLink": {
+      "subject": "Accedi a TestPlanIt",
+      "heading": "Accedi a TestPlanIt",
+      "intro": "Fai clic sul pulsante qui sotto per accedere:",
+      "signInButton": "Registrazione",
+      "copyPasteIntro": "Oppure copia e incolla questo link nel tuo browser:",
+      "disclaimer": "Se non hai richiesto questa email, puoi tranquillamente ignorarla.",
+      "textBody": "Accedi a TestPlanIt\n\nFai clic sul link qui sotto per accedere:\n{url}\n\nSe non hai richiesto questa email, puoi tranquillamente ignorarla."
+    }
+  },
+  "comments": {
+    "title": "Commenti",
+    "placeholder": "Scrivi un commento... (usa @ per menzionare gli utenti)",
+    "editPlaceholder": "Modifica il tuo commento...",
+    "postComment": "Pubblica commento",
+    "noComments": "Nessun commento ancora. Sii il primo a commentare!",
+    "edited": "modificato",
+    "confirmDelete": "Vuoi davvero eliminare questo commento? Questa azione non può essere annullata.",
+    "deleteDialog": {
+      "title": "Elimina commento"
+    },
+    "errors": {
+      "createFailed": "Impossibile creare il commento. Riprova.",
+      "updateFailed": "Impossibile aggiornare il commento. Riprova.",
+      "deleteFailed": "Impossibile eliminare il commento. Riprova.",
+      "loadFailed": "Impossibile caricare i commenti. Riprova."
+    },
+    "mentions": {
+      "notAMember": "Non un membro del progetto",
+      "noUsersFound": "Nessun utente trovato"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "La prova termina tra {count, plural, =1 {1 giorno} other {# giorni}}",
+    "expiresT oday": "La prova scade oggi",
+    "expired": "{count, plural, =1 {Prova scaduta 1 giorno fa} other {Prova scaduta # giorni fa}}",
+    "contactSales": "Contatta il reparto vendite"
+  },
+  "feedback": {
+    "sheetTitle": "Condividi il tuo feedback",
+    "sheetDescription": "Aiutaci a migliorare TestPlanIt condividendo la tua esperienza.",
+    "bannerMessage": "Come sta andando il tuo processo? Ci piacerebbe conoscere la tua opinione.",
+    "menuItem": "Condividi il tuo feedback"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "Tag AI",
+      "tagAll": "Etichetta tutto",
+      "aiAutoTag": "Etichetta automatica",
+      "tagActions": "Azioni dei tag",
+      "startTagging": "Inizia a taggare",
+      "selectEntityType": "Seleziona il tipo di entità",
+      "selectProject": "Seleziona un progetto",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Caso di test} other {Casi di test}}",
+        "testRun": "{count, plural, one {Esecuzione di prova} other {Esecuzioni di prova}}",
+        "session": "{count, plural, one {Sessione} other {Sessioni}}"
+      }
+    },
+    "review": {
+      "title": "Suggerimenti per i tag di recensione",
+      "description": "Fai clic sui tag per attivarli o disattivarli. Fai doppio clic per modificare il nome di un tag.",
+      "selectEntity": "Seleziona un'entità per visualizzare i suggerimenti di tag.",
+      "noTagsSelected": "Nessun tag selezionato",
+      "footerSummary": "{assignCount, plural, one {# tag} other {# tag}} verranno assegnati, {newCount, plural, one {# nuovo tag} other {# nuovi tag}} verranno creati",
+      "footerAssignCount": "{assignCount, plural, one {# tag} other {# tag}} verranno assegnati",
+      "footerNewCount": "{newCount, plural, one {# nuovo tag} other {# nuovi tag}} verranno creati",
+      "newTagsPopoverTitle": "Nuovi tag da creare",
+      "applying": "Applicazione in corso...",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tag}} applicati a {entityCount, plural, one {# entità} other {# entità}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tag}} applicati a {entityCount, plural, one {# entità} other {# entità}}, {newCount, plural, one {# nuovo tag} other {# nuovi tag}} creati",
+      "applyError": "Impossibile applicare i tag. Riprova.",
+      "suggestedTags": "Tag suggeriti",
+      "noSuggestions": "L'IA non è stata in grado di generare alcun tag.",
+      "alreadyApplied": "Già inviato",
+      "filterEntities": "Filtra le entità...",
+      "noEntitiesMatch": "Nessuna entità corrisponde alla tua ricerca.",
+      "tagCount": "{count, plural, one {# tag} other {# tag}}",
+      "noTags": "nessuno",
+      "failed": "Fallito",
+      "analysisFailed": "Impossibile analizzare questa entità",
+      "responseTruncated": "Risposta troncata: aumentare il numero massimo di token di output nelle impostazioni LLM.",
+      "tooltipExisting": "Tag esistente",
+      "tooltipNew": "Nuovo tag — verrà creato",
+      "tooltipAssign": "Assegna tag esistente",
+      "toggleFailed": "Mostra/nascondi le entità non riuscite",
+      "showFailed": "Spettacolo fallito"
+    },
+    "progress": {
+      "starting": "Inizio dell'analisi...",
+      "analyzed": "Entità analizzate {analyzed}/{total}",
+      "sizing": "Ricerca della dimensione ottimale del batch (prova con {size} entità)...",
+      "streaming": "Ricezione della risposta AI ({analyzed}/{total} entità completate)...",
+      "finalizing": "Preparazione dei risultati...",
+      "complete": "Analisi completata",
+      "reviewSuggestions": "Suggerimenti per la revisione",
+      "failed": "Analisi fallita"
+    },
+    "wizard": {
+      "description": "L'intelligenza artificiale analizzerà tutti i casi di test, le esecuzioni di test e le sessioni del tuo progetto per suggerire tag pertinenti in base al loro contenuto.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Avvia l'analisi",
+      "untaggedOnly": "Analizza solo i record senza tag esistenti",
+      "allowNewTags": "Consenti la creazione di nuovi tag",
+      "noLlmConfigured": "(Nessun LLM configurato)",
+      "analyzingDescription": "L'intelligenza artificiale sta analizzando le tue entità e generando suggerimenti di tag. Questa operazione potrebbe richiedere qualche istante."
+    },
+    "entityDetail": {
+      "customFields": "Campi personalizzati",
+      "noDetails": "Non sono disponibili ulteriori dettagli.",
+      "openInNewTab": "Apri in una nuova scheda"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Molto debole",
+    "weak": "Debole",
+    "fair": "Giusto",
+    "good": "Bene",
+    "strong": "Forte",
+    "minLength": "Almeno {count} caratteri",
+    "uppercase": "Almeno una lettera maiuscola",
+    "lowercase": "Almeno una lettera minuscola",
+    "numbers": "Almeno un numero",
+    "specialChars": "Carattere speciale da: {chars}",
+    "history": "La password è stata utilizzata nelle tue ultime {depth} password"
+  },
+  "TrialExpired": {
+    "title": "La tua prova è scaduta.",
+    "description": "Grazie per aver provato TestPlanIt! Il periodo di prova è terminato e questa istanza non è più accessibile.",
+    "nextSteps": "Per continuare a utilizzare TestPlanIt e accedere ai dati dei test, contatta il nostro team di vendita.",
+    "pricingPlans": "Piani tariffari",
+    "dataRetention": "I tuoi dati di prova sono archiviati in modo sicuro e saranno disponibili quando effettuerai l'upgrade del tuo account."
+  }
+}

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "名前",
+    "cancel": "キャンセル",
+    "dismiss": "却下する",
+    "of": "の",
+    "on": "の上",
+    "at": "で",
+    "in": "で",
+    "add": "追加",
+    "never": "一度もない",
+    "select": "選択...",
+    "file": "ファイル",
+    "selectMultiple": "複数選択...",
+    "searchUsers": "ユーザーを検索...",
+    "searchCases": "{count, plural, =0 {症例を検索} one {症例を検索 #} other {症例を検索 #}}",
+    "searchProjects": "{count, plural, =0 {プロジェクトを検索} one {プロジェクト番号を検索} other {プロジェクト番号を検索}}",
+    "searchTags": "タグを検索...",
+    "searchRuns": "{count, plural, =0 {テスト実行を検索} one {テスト実行番号を検索} other {テスト実行番号を検索}}",
+    "searchSessions": "{count, plural, =0 {セッションを検索} one {セッション番号を検索} other {セッション番号を検索}}",
+    "search": "検索...",
+    "defaultOption": "デフォルトオプション",
+    "yes": "はい",
+    "no": "いいえ",
+    "updated": "更新",
+    "groupedBy": "グループ化",
+    "lastEditedBy": "最終編集者",
+    "actions": {
+      "edit": "編集",
+      "save": "保存",
+      "delete": "消去",
+      "create": "作成する",
+      "submit": "提出する",
+      "close": "近い",
+      "done": "終わり",
+      "verify": "確認する",
+      "signIn": "サインイン",
+      "signOut": "サインアウト",
+      "signUp": "サインアップ",
+      "resend": "再送信",
+      "deleting": "削除しています...",
+      "next": "次",
+      "previous": "前の",
+      "finish": "仕上げる",
+      "download": "ダウンロード",
+      "apply": "適用する",
+      "confirm": "確認する",
+      "confirmDelete": "削除を確認",
+      "saveChanges": "変更を保存",
+      "saving": "保存中...",
+      "submitting": "送信中...",
+      "start": "始める",
+      "pause": "一時停止",
+      "reset": "リセット",
+      "copy": "コピー",
+      "copyLink": "リンクをコピー",
+      "copied": "コピーしました！",
+      "complete": "完了",
+      "back": "戻る",
+      "clear": "クリア",
+      "expand": "拡大する",
+      "collapse": "崩壊",
+      "addResult": "結果を追加",
+      "passAndNext": "パス＆次へ",
+      "viewInRepository": "リポジトリで表示",
+      "resultAdded": "テスト結果を追加しました",
+      "resultAddedDescription": "テスト結果が正常に追加されました。",
+      "resultUpdated": "テスト結果が更新されました",
+      "resultDeleted": "テスト結果を削除しました",
+      "deleteResult": "テスト結果を削除",
+      "deleteResultConfirmation": "このテスト結果を削除してもよろしいですか? この操作は元に戻せません。",
+      "editResult": "テスト結果を編集",
+      "resultDetails": "結果の詳細",
+      "actionsLabel": "アクション",
+      "assign": "割り当てる",
+      "assignSelected": "割り当て {count, plural, one {# ケース} other {# ケース}}",
+      "refresh": "リフレッシュ",
+      "addResultSelected": "結果を {count, plural, one {# ケース} other {# ケース}} に追加します",
+      "resultsAdded": "{count, plural, one {# 結果} other {# 結果}} 追加済み",
+      "resultsAddedDescription": "{count, plural, one {結果が # テストケースに追加されました} other {結果が # テストケースに追加されました}} 正常に",
+      "addingResultsToMultiple": "結果を {count, plural, one {# テストケース} other {# テストケース}} に追加しています。",
+      "addedToTestRun": "テスト実行に追加されました",
+      "addedToTestRunDescription": "テスト ケースがテスト実行に追加されました。",
+      "noAvailableTestRuns": "すべてのアクティブなテスト実行には、このテスト ケースがすでに含まれています。",
+      "resultUpdateError": "テスト結果の更新に失敗しました",
+      "resultDeleteError": "テスト結果を削除できませんでした",
+      "selectStatus": "ステータスを選択",
+      "addToTestRun": "テスト実行に追加",
+      "status": "状態",
+      "resultDetailsPlaceholder": "結果の詳細を入力してください...",
+      "selectAll": "すべて選択",
+      "deselectAll": "すべて選択解除",
+      "clearAll": "すべてクリア",
+      "selectFile": "ファイルを選択",
+      "restore": "復元する",
+      "purge": "パージ",
+      "previousCase": "前回の事例",
+      "nextCase": "次のケース",
+      "startTesting": "テストを開始する",
+      "expandLeftPanel": "左パネルを展開",
+      "collapseLeftPanel": "左パネルを折りたたむ",
+      "expandRightPanel": "右パネルを展開",
+      "collapseRightPanel": "右パネルを折りたたむ",
+      "createTag": "タグ「{name}」を作成",
+      "noTagsFound": "タグが見つかりません",
+      "duplicate": "重複",
+      "exportPdf": "PDFをエクスポート",
+      "exportingPdf": "エクスポート中...",
+      "change": "変化",
+      "viewAll": "すべて表示",
+      "undo": "元に戻す",
+      "undoDelete": "削除を元に戻す",
+      "automated": {
+        "details": "自動テストの詳細",
+        "message": "メッセージ",
+        "line": "ライン",
+        "testSuite": "テストスイート:"
+      },
+      "junit": {
+        "details": "自動テスト結果の詳細",
+        "import": {
+          "title": "輸入テスト結果",
+          "description": "テスト結果ファイルをアップロードして、新しいテスト実行にインポートします。JUnit、TestNG、xUnit、NUnit、MSTest、Mocha、Cucumberのフォーマットに対応しています。",
+          "testRun": {
+            "label": "試運転",
+            "placeholder": "テスト実行を選択"
+          },
+          "file": {
+            "label": "テスト結果ファイル"
+          },
+          "import": "輸入",
+          "selectFolder": "フォルダを選択",
+          "createNewFolder": "新しいフォルダーを作成する",
+          "createNewFolderNamed": "新しいフォルダを作成します: {name}",
+          "progress": {
+            "initializing": "インポートを初期化しています...",
+            "validating": "入力データを検証しています...",
+            "creatingRun": "テスト実行を作成しています...",
+            "fetchingTemplate": "テンプレートデータを取得しています...",
+            "countingTests": "{files} ファイルから {count} テストケースを処理中...",
+            "parsingFile": "ファイル {current} / {total}を解析しています...",
+            "processingSuite": "処理スイート: {name}",
+            "processingCase": "{total}のうちテストケース {current} を処理中...",
+            "finalizing": "インポートを終了しています...",
+            "completed": "インポートが正常に完了しました。",
+            "errorParsing": "ファイル {index}の解析中にエラーが発生しました: {error}",
+            "skippingFile": "無効なファイルをスキップしています {index}"
+          },
+          "error": {
+            "title": "インポートエラー",
+            "importFailed": "テスト結果のインポートに失敗しました。もう一度お試しください。"
+          },
+          "success": {
+            "title": "インポート成功",
+            "description": "試験結果が正常にインポートされました。"
+          },
+          "fileRequired": "少なくとも1つのテスト結果ファイルをアップロードしてください。"
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "結果形式",
+            "placeholder": "フォーマットを選択"
+          }
+        }
+      },
+      "confirmRestoreTitle": "復元を確認",
+      "confirmPurgeTitle": "パージの確認",
+      "remove": "取り除く",
+      "reconfigure": "再設定して再試行"
+    },
+    "permissions": {
+      "addEdit": "追加/編集"
+    },
+    "auth": {
+      "internal": "メールアドレス/パスワード",
+      "sso": "SSOのみ",
+      "both": "メールとSSO"
+    },
+    "status": {
+      "deleted": "削除済み",
+      "disabled": "無効",
+      "noCustomFieldData": "追加の詳細はありません。",
+      "pending": "保留中",
+      "uploading": "アップロード中...",
+      "notApplicable": "該当なし",
+      "redirecting": "リダイレクト中...",
+      "pendingDelete": "削除されます",
+      "pendingChanges": "保留中の変更",
+      "importing": "インポート中...",
+      "addingTestCases": "テストケースを追加しています..."
+    },
+    "priority": {
+      "low": "低い",
+      "medium": "中くらい",
+      "high": "高い"
+    },
+    "filters": {
+      "allStatuses": "すべてのステータス",
+      "allPriorities": "すべての優先事項"
+    },
+    "fields": {
+      "groupName": "グループ名",
+      "users": "ユーザー",
+      "mixed": "すべての値",
+      "type": "タイプ",
+      "default": "デフォルト",
+      "enabled": "有効",
+      "projects": "プロジェクト",
+      "iconColor": "アイコン/色",
+      "selectWorkflow": "ワークフローを選択",
+      "icon": "アイコン",
+      "systemName": "システム名",
+      "aliases": "エイリアス",
+      "scope": "範囲",
+      "success": "成功",
+      "failure": "失敗",
+      "completed": "完了",
+      "elapsed": "経過時間",
+      "totalElapsed": "合計経過時間",
+      "totalEstimate": "残り時間の見積もり",
+      "completionRate": "完了率",
+      "attachments": "添付ファイル",
+      "documentation": "ドキュメント",
+      "state": "州",
+      "configuration": "構成",
+      "configurations": "構成",
+      "milestone": "マイルストーン",
+      "tags": "タグ",
+      "createdBy": "作成者",
+      "description": "説明",
+      "description_placeholder": "説明を追加...",
+      "testCases": "テストケース",
+      "sessions": "セッション",
+      "sharedSteps": "共有ステップ",
+      "email": "メール",
+      "password": "パスワード",
+      "confirmPassword": "パスワードを認証する",
+      "token": "トークン",
+      "access": "アクセス",
+      "avatar": "アバター",
+      "steps": "手順",
+      "step": "ステップ",
+      "expectedResult": "期待される結果",
+      "notes": "注記",
+      "estimate": "見積もり",
+      "date": "日付",
+      "size": "サイズ",
+      "created": "作成",
+      "template": "テンプレート",
+      "mission": "ミッション",
+      "assignedTo": "割り当て先",
+      "executedBy": "実行者",
+      "optional": "オプション",
+      "role": "役割",
+      "defaultRole": "デフォルトロール",
+      "systemAccess": "システムアクセス",
+      "authMethod": "認証方法",
+      "dateCreated": "作成日",
+      "apiUser": "APIユーザー",
+      "unverified": "未確認",
+      "selfRegistered": "自己登録",
+      "role_placeholder": "役割を選択",
+      "usersCreated": "作成されたユーザー",
+      "groups": "グループ",
+      "apiAccess": "APIアクセス",
+      "requiredForAdmin": "管理者に必須",
+      "account": "アカウント",
+      "accountHistory": "アカウント履歴",
+      "activity": "活動",
+      "lastActive": "最終アクティブ",
+      "theme": "テーマ",
+      "locale": "言語",
+      "timezone": "タイムゾーン",
+      "itemsPerPage": "ページあたりの項目数",
+      "notificationMode": "通知",
+      "value": "価値",
+      "key": "鍵",
+      "configurationDetails": "構成の詳細",
+      "isActive": "アクティブ",
+      "members": "メンバー",
+      "milestoneTypes": "マイルストーンの種類",
+      "milestones": "マイルストーン",
+      "createdAt": "作成日",
+      "completedOn": "完了日",
+      "variants": "変種",
+      "emailVerified": "メール認証済み",
+      "issueTracker": "問題トラッカー",
+      "caseFields": "ケースフィールド",
+      "resultFields": "結果フィールド",
+      "displayName": "表示名",
+      "hint": "ヒント",
+      "required": "必須",
+      "restricted": "制限付き",
+      "fieldType": "フィールドタイプ",
+      "templates": "テンプレート",
+      "started": "開始",
+      "startDate": "開始日",
+      "automated": "自動化",
+      "manual": "マニュアル",
+      "notAutomated": "自動化されていない",
+      "testRuns": "テスト実行",
+      "title": "タイトル",
+      "project": "プロジェクト",
+      "priority": "優先度",
+      "integration": "統合",
+      "lastSyncedAt": "最終同期",
+      "externalKey": "外部キー",
+      "initialHeight": "初期高さ",
+      "minValue": "最小値",
+      "maxValue": "最大値",
+      "minIntegerValue": "最小整数値",
+      "maxIntegerValue": "最大整数値",
+      "defaultValue": "デフォルト値",
+      "checked": "チェック済み",
+      "version": "バージョン",
+      "issues": "問題",
+      "internalIssues": "内部問題",
+      "externalIssues": "{provider} 問題",
+      "data": "データ",
+      "note": "注記",
+      "externalId": "外部ID",
+      "forecast": "予報",
+      "forecastManual": "予測マニュアル",
+      "forecastAutomated": "予測自動化",
+      "executedAt": "実行場所",
+      "className": "クラス",
+      "suiteName": "スイート",
+      "duration": "間隔",
+      "session": "セッション",
+      "charter": "チャーター",
+      "summary": "まとめ",
+      "progress": "進捗",
+      "assertions": "アサーション",
+      "properties": "プロパティ",
+      "systemOutput": "テストケースログ",
+      "systemError": "システムエラー",
+      "resultStatus": "結果",
+      "links": "リンク",
+      "id": "ID",
+      "JUNIT": "JUnitインポート",
+      "API": "API",
+      "folder": "フォルダ",
+      "parentFolder": "新規ケースの親フォルダ",
+      "multipleValues": "複数の値",
+      "provider": "プロバイダー",
+      "updatedAt": "更新日時",
+      "tools": "ツール",
+      "codeRepository": "コードリポジトリ",
+      "aiModels": "デフォルトLLM",
+      "configKeys": {
+        "edit_results_duration": "結果の期間を編集",
+        "project_docs_default": "プロジェクトドキュメントのデフォルト",
+        "notificationSettings": "通知のグローバル設定",
+        "elasticsearch_replicas": "Elasticsearchレプリカ"
+      },
+      "options": {
+        "label": "ラベル",
+        "validation": {
+          "empty": "オプションは空にできません",
+          "invalidChars": "オプションに無効な文字が含まれています: \"{char}\"",
+          "duplicate": "オプションは一意である必要があります",
+          "systemNameError": "システム名が無効です",
+          "initialHeightMax": "初期の高さは 600 ピクセルより大きくできません。",
+          "displayNameRequiredResult": "結果フィールドの表示名を入力します。",
+          "displayNameRequiredCase": "ケース フィールドの表示名を入力します。",
+          "minValueMaxValue": "最小値は最大値より小さくする必要があり、一方が設定されている場合は両方を設定する必要があります。",
+          "minMaxValueInteger": "最小整数値は最大整数値より小さくする必要があり、一方が設定されている場合は両方を設定する必要があります。",
+          "systemNameRequired": "システム名は空欄にできません。",
+          "systemNameRegex": "システム名は文字で始まり、文字、数字、アンダースコアのみを含めることができます。",
+          "fieldTypeRequired": "フィールドタイプは必須です。"
+        }
+      },
+      "placeholders": {
+        "key": "Enterキー",
+        "value": "値を入力",
+        "addVariant": "バリエーションを追加",
+        "addCategory": "カテゴリを追加",
+        "displayName": "表示名を入力",
+        "systemName": "システム名を入力してください",
+        "hint": "ヒントを入力"
+      },
+      "hints": {
+        "systemName": "システム名は一意で、文字、数字、アンダースコアのみで構成されている必要があります",
+        "fieldType": "（フィールドタイプは作成後は変更できません）"
+      },
+      "validation": {
+        "nameRequired": "名前は必須です",
+        "stateRequired": "州は必須です",
+        "urlRequired": "URLは必須です",
+        "invalidUrl": "無効なURL形式"
+      }
+    },
+    "filter": {
+      "placeholder": "フィルター {item}..."
+    },
+    "access": {
+      "admin": "管理者",
+      "projectAdmin": "プロジェクト管理者",
+      "user": "ユーザー",
+      "none": "なし"
+    },
+    "validation": {
+      "required": "{field}を入力してください",
+      "invalidDuration": "有効な期間を入力してください",
+      "maxDuration": "期間は {max} 分を超えることはできません",
+      "minLength": "{field} は少なくとも {min} 文字である必要があります",
+      "emailFormat": "無効なメール形式",
+      "passwordMatch": "パスワードが一致する必要があります",
+      "unique": "{field} は一意である必要があります",
+      "roleRequired": "役割は必須です",
+      "nameMinLength": "名前は2文字以上でなければなりません",
+      "invalidDurationFormat": "期間の形式が正しくありません。30分、1週間、1時間25分などの形式をお試しください。"
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "確認 {action}",
+        "message": "本当に {action}しますか?"
+      },
+      "confirmDelete": {
+        "description": "このアイテムを削除してもよろしいですか? この操作は元に戻せません。"
+      },
+      "assign": {
+        "title": "テストケースの割り当て",
+        "description": "テストケース「{testCase}」をユーザーに割り当てる",
+        "selectUser": "ユーザーを選択"
+      },
+      "assignBulk": {
+        "title": "テストケースの一括割り当て",
+        "description": "{count, plural, one {# 選択されたテストケース} other {# 選択されたテストケース}} をユーザーに割り当てます。"
+      },
+      "complete": {
+        "title": "完全なテスト実行",
+        "description": "このテスト実行を完了してもよろしいですか?",
+        "warning": "完了すると、テスト実行を変更できなくなります。",
+        "apple": {
+          "title": "Appleサインインを設定する",
+          "description": "Apple サインイン認証情報を設定します。これらは Apple Developer Portal から取得できます。",
+          "clientId": "サービスID",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "チームID",
+          "teamIdPlaceholder": "10文字のチームID",
+          "keyId": "キーID",
+          "keyIdPlaceholder": "10文字のキーID",
+          "privateKey": "秘密鍵",
+          "privateKeyPlaceholder": ".p8秘密鍵の内容をここに貼り付けます",
+          "instructions": {
+            "title": "セットアップ手順:",
+            "step1": "Apple開発者ポータルへアクセス",
+            "step2": "サービスIDを作成し、Appleでサインインを設定する",
+            "step3": "Appleでサインインするためのキーを作成する",
+            "step4": ".p8秘密鍵ファイルをダウンロードする",
+            "step5": "次のリダイレクト URL を追加します。"
+          },
+          "redirectUri": "/api/auth/コールバック/アップル",
+          "validation": {
+            "allRequired": "すべてのフィールドは必須です"
+          }
+        }
+      },
+      "delete": {
+        "title": "削除 {item}",
+        "description": "{name}を削除してもよろしいですか?",
+        "warning": "この操作は元に戻せません。 {item}は完全に削除されます。"
+      }
+    },
+    "messages": {
+      "deleteSuccess": "アイテムは正常に削除されました",
+      "deleteError": "アイテムの削除中にエラーが発生しました",
+      "moveSuccess": "アイテムは正常に移動されました",
+      "moveError": "アイテムの移動中にエラーが発生しました",
+      "updateSuccess": "アイテムが正常に更新されました",
+      "updateError": "アイテムの更新中にエラーが発生しました",
+      "linkCopied": "リンクをクリップボードにコピーしました",
+      "copyFailed": "リンクをクリップボードにコピーできませんでした",
+      "created": "テスト実行が正常に作成されました",
+      "createdDescription": "テスト実行が作成され、テスト実行リストに表示されるようになりました。",
+      "createError": "不明なエラーが発生しました。もう一度お試しください。",
+      "emptyActive": "アクティブなテスト実行はありません",
+      "emptyCompleted": "完了したテスト実行はありません",
+      "projectUpdated": "プロジェクトが正常に更新されました",
+      "projectUpdateError": "プロジェクトの更新中にエラーが発生しました",
+      "noProjects": "プロジェクトが見つかりません"
+    },
+    "placeholders": {
+      "email": "電子メールアドレス",
+      "name": "名前を入力",
+      "mission": "あなたの使命を説明してください...",
+      "selectMilestone": "マイルストーンを選択",
+      "selectStatus": "ステータスを選択",
+      "selectTemplate": "テンプレートを選択",
+      "duration": "例：1時間30分または90分",
+      "docs": "ドキュメントを追加...",
+      "select": "選択",
+      "selectState": "州を選択",
+      "selectConfiguration": "構成を選択",
+      "selectConfigurations": "構成を選択",
+      "selectOption": "オプションを選択",
+      "date": "日付を選択",
+      "selectEncoding": "エンコードを選択してください...",
+      "selectATemplate": "テンプレートを選択してください...",
+      "selectVersion": "バージョンを選択",
+      "selectAModel": "モデルを選択してください",
+      "selectWorkflowType": "ワークフローの種類を選択してください",
+      "addAnOption": "オプションを追加する",
+      "addADescription": "説明を追加してください...",
+      "optionalDescription": "任意での説明...",
+      "projectNotes": "プロジェクトノート…",
+      "filterByName": "名前で絞り込む...",
+      "filterByValue": "値で絞り込む...",
+      "selectOperator": "演算子を選択",
+      "searchIcons": "アイコンを検索...",
+      "value": "価値",
+      "stepCount": "歩数",
+      "enterText": "テキストを入力してください...",
+      "enterUrl": "URLを入力してください",
+      "issueIdExample": "第123号",
+      "selectPriorityValuesOrEmpty": "優先度を選択してください（すべて選択する場合は空欄のままにしてください）。"
+    },
+    "errors": {
+      "error": "エラー",
+      "somethingWentWrong": "予期しないエラーが発生しました。しばらくしてからもう一度お試しください。",
+      "emailRequired": "メールアドレスを入力してください。",
+      "emailInvalid": "このメールアドレスは有効ではありません。",
+      "passwordRequired": "パスワードが必要です。",
+      "confirmPasswordRequired": "パスワードを確認してください。",
+      "passwordDoesNotMeetPolicy": "パスワードがセキュリティ要件を満たしていません。",
+      "passwordsDoNotMatch": "パスワードが一致しません",
+      "nameRequired": "氏名を入力してください",
+      "duplicate": "一意の名前を選択してください。",
+      "userExists": "ユーザーは既に存在します。",
+      "unknown": "不明なエラーが発生しました。",
+      "invalidCredentials": "ユーザー名またはパスワードが無効です",
+      "projectNotFound": "プロジェクトが見つかりません",
+      "projectNotFoundDescription": "探しているプロジェクトは存在しないか、アクセス権がありません。",
+      "tokenRequired": "メール確認トークンを入力するか、メール内のリンクをクリックしてください。",
+      "noSuccessStatus": "成功ステータスが選択されていません",
+      "missingTestRunCase": "テスト実行ケースIDがありません",
+      "fieldRequired": "この項目は必須です",
+      "projectNameExists": "この名前のプロジェクトは既に存在します",
+      "defaultNotFound": "デフォルト値が見つかりません",
+      "emailExists": "このメールアドレスを持つユーザーは既に存在します",
+      "nameExists": "この名前のユーザーは既に存在します",
+      "duplicateValue": "この値はすでに使用されています",
+      "unauthorized": "この操作を実行する権限がありません。",
+      "accessDenied": "アクセスが拒否されました",
+      "sessionNotFound": "セッションが見つからないか無効です。",
+      "issueTrackerNotConfigured": "このプロジェクトでは問題追跡が設定されていません。",
+      "noUserSession": "ユーザーセッションが見つかりません",
+      "noProjectId": "プロジェクトIDが見つかりません",
+      "unknownErrorWithMessage": "不明なエラーが発生しました。 {message}",
+      "unauthenticated": "ユーザーが認証されていません",
+      "fetchFailed": "データの取得に失敗しました。しばらくしてからもう一度お試しください。",
+      "unsupportedFieldType": "サポートされていないフィールドタイプ",
+      "notAuthenticated": {
+        "title": "認証されていません",
+        "message": "この操作を実行するにはログインする必要があります。"
+      },
+      "failedToFetchAssignments": {
+        "title": "割り当てを取得できませんでした",
+        "message": "課題を取得できませんでした。しばらくしてからもう一度お試しください。"
+      },
+      "issueManagement": {
+        "linkedSuccess": "問題が正常にリンクされました",
+        "linkError": "リンクエラーの問題",
+        "unlinkedSuccess": "問題のリンクが正常に解除されました",
+        "unlinkError": "リンク解除エラー",
+        "noActiveIntegration": "このプロジェクトにアクティブな統合が見つかりません"
+      },
+      "roleRequiredForSpecificRole": "アクセス タイプが特定のロールの場合、ロールが必要です。",
+      "projectCreationFailed": "プロジェクトの作成に失敗しました。ID が返されませんでした。",
+      "invalidRoleId": "無効なロールID",
+      "workflowStateExists": "ワークフロー状態は既に存在します。新しい名前を選択してください。",
+      "failedToLoadCaseData": "ケースデータの読み込みに失敗しました。保存できません。",
+      "atLeastOneTagRequired": "少なくとも1つのタグが必要です",
+      "atLeastOneIssueRequired": "少なくとも1つの問題が必要です",
+      "atLeastOneOptionRequired": "少なくとも1つのオプションを選択する必要があります",
+      "valueRequired": "値は必須です",
+      "contentRequired": "コンテンツは必須です",
+      "invalidContentFormat": "無効なコンテンツ形式",
+      "caseNameRequired": "テストケースの名前を入力してください",
+      "caseStateRequired": "州を選択してください",
+      "caseFolderRequired": "フォルダを選択してください",
+      "estimateTooLarge": "見積もりが大きすぎる",
+      "estimateRequiredValid": "見積もりは必須であり、有効な期間（例：1時間30分）でなければなりません。",
+      "invalidDurationOrExceedsMax": "無効な期間形式、または最大制限を超えています（例：1時間30分）。",
+      "configurationNameExists": "設定名は既に存在します。別の名前を選択してください。",
+      "variantNameExists": "バリアント名は既に存在します。別の名前を選択してください。",
+      "categoryNameExists": "既に同じカテゴリ名が存在します。別の名前を選択してください。",
+      "workflowStateNameExists": "ワークフロー状態名は既に存在します。別の名前を選択してください。",
+      "folderNameRequired": "フォルダ名を入力してください",
+      "folderNameRequiredEnter": "フォルダの名前を入力してください。",
+      "workflowStateNameRequired": "ワークフロー状態の名前を入力してください",
+      "roleNameEmpty": "役割名は空欄にできません",
+      "groupNameRequired": "グループ名は必須です。",
+      "templateNameRequired": "テンプレートの名前を入力してください",
+      "caseStateInvalid": "有効な州を選択してください",
+      "caseTemplateRequired": "テンプレートを選択してください",
+      "invalidContent": "無効なコンテンツ",
+      "milestoneNameRequired": "マイルストーンの名前を入力してください",
+      "milestoneTypeRequired": "マイルストーンの種類を選択してください",
+      "testRunNameMinLength": "名前は2文字以上でなければなりません。",
+      "stateRequiredDot": "州の情報は必須です。",
+      "milestoneTypeNameMinLength": "マイルストーンタイプの名称は、少なくとも2文字以上である必要があります。",
+      "projectNameRequired": "プロジェクト名は必須です。",
+      "workflowScopeRequired": "州のワークフローを選択してください",
+      "workflowTypeRequired": "ワークフローの種類を選択してください",
+      "newTestCaseAdded": "新しいテストケースが追加されました",
+      "repositoryDeleted": "リポジトリが削除されました",
+      "failedToDeleteRepository": "リポジトリの削除に失敗しました",
+      "permissionDenied": "このページにアクセスする権限がありません。",
+      "resultSubmitPermissionDenied": "この案件については、結果を提出できません。プロジェクト管理者に依頼して、あなたに割り当ててもらってください。",
+      "noModelsFound": "モデルが見つかりません",
+      "failedToFetchModels": "モデルの取得に失敗しました",
+      "failedToCopyToClipboard": "クリップボードへのコピーに失敗しました",
+      "failedToLoadJobResults": "ジョブ結果の読み込みに失敗しました",
+      "failedToUpdateRepositoryStatus": "リポジトリの状態の更新に失敗しました"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "ダッシュボード",
+      "twoFactorVerification": "二要素認証",
+      "changePassword": "パスワードを変更する",
+      "twoFactorSetup": "二段階認証の設定",
+      "signUp": "サインアップ",
+      "signIn": "サインイン",
+      "verifyEmail": "メールアドレスを確認する",
+      "trialExpired": "試用期間が終了しました",
+      "linkSsoAccount": "SSOアカウントをリンクする",
+      "userProfile": "ユーザープロフィール",
+      "users": "ユーザー",
+      "issues": "問題",
+      "tags": "タグ",
+      "tagDetails": "タグの詳細",
+      "aiModels": "AIモデル",
+      "integrations": "統合",
+      "quickscript": "クイックスクリプト",
+      "webhooks": "ウェブフック",
+      "shares": "株式",
+      "repository": "リポジトリ",
+      "testCaseVersion": "テストケースバージョン",
+      "duplicateTestCases": "重複したテストケース",
+      "documentation": "文書",
+      "sharedSteps": "共有ステップ",
+      "stepDuplicates": "ステップの重複",
+      "sessions": "セッション",
+      "sessionVersion": "セッションバージョン",
+      "milestones": "マイルストーン",
+      "testRuns": "テスト実行",
+      "reports": "報告書",
+      "adminSamlConfig": "管理者 - SAML設定",
+      "apiDocumentation": "APIドキュメント",
+      "sharedContent": "共有コンテンツ"
+    },
+    "aria": {
+      "userMenu": "ユーザーメニュー",
+      "search": "検索",
+      "helpMenu": "ヘルプメニュー",
+      "help": "ヘルプ",
+      "grouped": "グループ化された",
+      "group": "グループ",
+      "selectAll": "すべて選択",
+      "selectRow": "行を選択",
+      "removeIssue": "問題を削除する",
+      "selectDeselectAllAddEdit": "すべて選択/選択解除 追加/編集",
+      "selectDeselectAllDelete": "すべて選択/選択解除 すべて削除",
+      "selectDeselectAllClose": "すべて選択/選択解除 閉じる",
+      "clearFilter": "フィルターをクリア",
+      "olderVersion": "旧バージョン",
+      "newerVersion": "最新バージョン",
+      "deletedUser": "削除されたユーザー",
+      "restrictedField": "制限付きフィールド",
+      "backToTestCase": "テストケースに戻る"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# プロジェクト} other {# プロジェクト}}",
+      "templates": "テンプレートとフィールド",
+      "workflows": "ワークフロー",
+      "statuses": "ステータス",
+      "roles": "役割",
+      "unknownRole": "役割不明",
+      "unknownGroup": "不明なグループ",
+      "file": "ファイル",
+      "files": "ファイル",
+      "existingAttachments": "既存の添付ファイル",
+      "new": "新しい",
+      "noElapsedTime": "時間は記録されていません",
+      "untested": "未テスト",
+      "noResults": "結果なし",
+      "resultsWithNoElapsedTime": "結果の時間は記録されません",
+      "total": "合計",
+      "noCases": "テストケースなし",
+      "unknown": "未知",
+      "selectedTestCases": "選択されたテストケース",
+      "editToModifyCasesTitle": "このリストは変更できません。",
+      "editToModifyCases": "テスト実行を編集し、「選択したテスト ケース」をクリックしてリストを変更します。",
+      "noTestCasesSelected": "テストケースが選択されていません",
+      "editToSelectTestCases": "テスト実行を編集してテストケースを選択します。",
+      "casesInRun": "{count, plural, =0 {テスト実行にテストケースはありません} =1 {テスト実行にテストケースが 1 つあります} other {テスト実行にテストケースの数があります}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 つのユニークなケース} other {# つのユニークなケース}} 全体 {configCount, plural, =1 {1 つの構成} other {# つの構成}} (合計{totalCount} 件のケース)",
+      "viewTestRunDetails": "テスト実行の詳細を表示",
+      "sortByStatus": "ステータス別にグループ化",
+      "sortByDate": "日付順に並べ替え",
+      "testRuns": "{count, plural, =0 {テスト実行なし} =1 {テスト実行 1 回} other {テスト実行回数}}",
+      "sessions": "{count, plural, =0 {セッションなし} =1 {セッション 1 件} other {セッション数}}",
+      "noOptions": "利用可能なオプションはありません",
+      "multiConfiguration": "複数構成グループの一部",
+      "otherConfigurations": "その他の構成",
+      "selected": "選択済み: {count}",
+      "defaultProjectAccess": "デフォルトのプロジェクトアクセス",
+      "defaultAccessType": "デフォルトのアクセスタイプ",
+      "assignedUsersCount": "{count, plural, =0 {割り当てられたユーザーなし} =1 {割り当てられたユーザー数} other {割り当てられたユーザー数}}",
+      "successRate": "成功率",
+      "unassigned": "未割り当て",
+      "testRunName": "テスト実行名",
+      "estimatesEllipsis": "見積もり...",
+      "access": {
+        "noAccess": "アクセス不可",
+        "globalRole": "グローバルロールを使用する",
+        "specificRole": "特定の役割",
+        "projectDefault": "プロジェクトのデフォルト",
+        "usersGlobalRole": "ユーザーのグローバルロール"
+      },
+      "unknownUser": "不明なユーザー",
+      "unknownProject": "不明なプロジェクト",
+      "unknownTag": "不明なタグ",
+      "filesSelectedForUpload": "{count, plural, =1 {アップロード対象として 1 つのファイルを選択しました} other {アップロード対象として # つのファイルを選択しました}}"
+    },
+    "empty": {
+      "description": "説明なし",
+      "documentation": "文書化なし",
+      "childMilestones": "子どもの成長の節目がない",
+      "sessions": "セッションなし",
+      "activeSessions": "アクティブなセッションはありません",
+      "completedSessions": "完了したセッションはありません",
+      "testCase": "テストケースが見つかりません",
+      "noTestCasesOrSessions": "テストケースまたはセッションが見つかりません",
+      "noTestCasesSessionsOrRuns": "テストケース、セッション、実行が見つかりません"
+    },
+    "or": "または",
+    "for": "のために",
+    "and": "そして",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt ロゴ",
+      "tagline": "あらゆるものをテストする"
+    },
+    "table": {
+      "columns": {
+        "columns": "列",
+        "required": "（必須）"
+      },
+      "filter": "フィルター リスト...",
+      "selectNone": "すべてを選択",
+      "sort": "列の並べ替え",
+      "sortAscending": "昇順でソート",
+      "sortDescending": "降順でソート",
+      "sortNone": "ソートされていません",
+      "resize": "列のサイズを変更する"
+    },
+    "pagination": {
+      "selectPage": "ページを選択",
+      "morePages": "その他のページ",
+      "goToPrevious": "前のページへ",
+      "goToNext": "次のページへ",
+      "all": "すべての商品",
+      "entries": "{count, plural, =1 {# アイテム} other {# アイテム}}",
+      "pageSize": "ページサイズ",
+      "showing": "表示中",
+      "total": "合計 {count, plural, =1 {# アイテム} other {# アイテム}}",
+      "filtered": "フィルタリング",
+      "pageOfPages": "{current} / {total}ページ"
+    },
+    "upload": {
+      "title": "新しいプロフィール写真をアップロード",
+      "description": "画像をドラッグアンドドロップするか、下のボタンをクリックしてファイルを選択してください。",
+      "attachments": {
+        "title": "添付ファイルをアップロード",
+        "description": "ファイルをドラッグ アンド ドロップするか、下のボタンをクリックしてファイルを選択してください。",
+        "selectFiles": "{count, plural, =0 {ファイルを選択} one {選択したファイル 1 個} other {選択したファイル # 個}}",
+        "selectFile": "{count, plural, =0 {ファイルを選択} other {選択されたファイル 1 件}}",
+        "filesSelected": "{count, plural, one {1 ファイルが選択されました} other {# ファイルが選択されました}}",
+        "addMoreFiles": "ファイルを追加...",
+        "replaceFile": "ファイルを置き換えます...",
+        "invalidFileType": "無効なファイルタイプです。許可されるのは {types} ファイルだけです。",
+        "altText": {
+          "emoji": "絵文字"
+        },
+        "count": "{count, plural, =1 {# ファイル} other {# ファイル}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "テストケースをインポートするCSVファイルをドロップしてください",
+      "dropToImportTestResults": "ファイルをドロップしてテスト結果をインポートします",
+      "supportedCsvFormats": "対応ファイル形式: .csv",
+      "supportedResultFormats": "対応ファイル形式：.xml、.trx、.json",
+      "unsupportedFileType": "サポートされていないファイル形式です。期待される形式: {expected}",
+      "noFilesDetected": "ドロップでファイルが検出されませんでした"
+    },
+    "editor": {
+      "setColor": "色を設定する",
+      "enterUrl": "https://を含むURLを入力してください",
+      "uploadFile": "ファイルをアップロード",
+      "video": {
+        "controls": "ビデオプレーヤーのコントロール"
+      },
+      "image": {
+        "alignLeft": "左揃え",
+        "alignCenter": "中央揃え",
+        "alignRight": "右揃え",
+        "sizeSmall": "小型",
+        "sizeMedium": "中サイズ",
+        "sizeLarge": "大きいサイズ",
+        "sizeFull": "全幅",
+        "resetSize": "元のサイズにリセット",
+        "rotate": "90°回転",
+        "delete": "画像を削除"
+      },
+      "table": {
+        "insertTable": "テーブルを挿入",
+        "headerRow": "ヘッダー行",
+        "addColumnBefore": "列を追加する前に",
+        "addColumnAfter": "列を追加",
+        "deleteColumn": "列を削除",
+        "addRowBefore": "行を追加する前に",
+        "addRowAfter": "行を追加",
+        "deleteRow": "行を削除",
+        "deleteTable": "テーブルを削除"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "下に段落を追加してください",
+        "clearFormatting": "明確な書式設定",
+        "copyToClipboard": "クリップボードにコピー"
+      },
+      "textMenu": {
+        "bold": "大胆な",
+        "italic": "イタリック",
+        "underline": "下線",
+        "strikethrough": "取り消し線",
+        "code": "コード",
+        "codeBlock": "コードブロック",
+        "highlightText": "テキストをハイライト表示",
+        "textColor": "テキストの色",
+        "moreOptions": "その他のオプション",
+        "subscript": "添字",
+        "superscript": "上付き文字",
+        "alignLeft": "左揃え",
+        "alignCenter": "中央揃え",
+        "alignRight": "右揃え",
+        "justify": "正当化する",
+        "setLink": "リンクを設定",
+        "editLink": "リンクを編集",
+        "removeLink": "リンクを削除",
+        "resetColorToDefault": "色をデフォルトに戻す"
+      }
+    },
+    "ai": {
+      "title": "AIライティングアシスタント",
+      "improveWriting": "ライティング力を向上させる",
+      "makeShorter": "短くする",
+      "makeLonger": "長くする",
+      "fixGrammar": "文法を修正する",
+      "changeTone": "トーンを変える",
+      "professional": "プロ",
+      "casual": "カジュアル",
+      "formal": "フォーマル",
+      "translate": "翻訳する",
+      "english": "英語",
+      "spanish": "スペイン語",
+      "french": "フランス語",
+      "summarize": "要約",
+      "addExamples": "例を追加",
+      "originalText": "原文",
+      "suggestion": "AIによる提案",
+      "generating": "提案を生成しています...",
+      "noSuggestion": "まだ提案は生成されていません。",
+      "acceptSuggestion": "提案を受け入れる",
+      "errors": {
+        "contentBlocked": "コンテンツは安全フィルターによってブロックされました。リクエストを別の言葉で言い換えてください。",
+        "emptyContent": "AIは応答を生成できませんでした。リクエストを言い換えるか、しばらくしてからもう一度お試しください。",
+        "maxTokens": "AIの応答が長すぎたため、途中で切れてしまいました。リクエストを短くするか、より簡潔な応答を求めてください。",
+        "rateLimit": "レート制限のため、AIサービスは一時的にご利用いただけません。数分後にもう一度お試しください。",
+        "accessDenied": "このプロジェクトで AI 機能を使用する権限がありません。",
+        "generic": "申し訳ございませんが、リクエストの処理中にエラーが発生しました。"
+      }
+    },
+    "by": "による",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "目次",
+        "emptyMessage": "ドキュメントに見出しを追加し始めましょう …"
+      },
+      "carousel": {
+        "previousSlide": "前のスライド",
+        "nextSlide": "次のスライド"
+      },
+      "dialog": {
+        "toggleFullScreen": "全画面表示を切り替える"
+      },
+      "command": {
+        "title": "コマンドメニュー",
+        "description": "コマンドの検索と実行"
+      },
+      "breadcrumb": {
+        "more": "もっと"
+      },
+      "clickToViewDetails": "詳細を表示するにはクリックしてください",
+      "clickToExpand": "クリックして展開",
+      "clickToCollapse": "クリックして折りたたむ",
+      "search": {
+        "filters": "フィルター",
+        "noResultsFound": "結果が見つかりませんでした",
+        "loadingProjects": "プロジェクトを読み込んでいます...",
+        "noProjectsFound": "プロジェクトが見つかりません。",
+        "viewAllProjects": "すべてのプロジェクトを見る",
+        "states": "州",
+        "automationStatus": "自動化ステータス",
+        "parent": "親"
+      },
+      "issues": {
+        "errorLoadingDetails": "問題の詳細の読み込み中にエラーが発生しました: ",
+        "updated": "更新日: ",
+        "openInJira": "Jiraで開く",
+        "openInExternalSystem": "{provider}で開く",
+        "assignee": "譲受人",
+        "status": "状態： ",
+        "clickToOpenInNewTab": "クリックして新しいタブで開く",
+        "url": "URL: ",
+        "externalId": "外部ID: ",
+        "viewIn": "表示",
+        "fieldType": "フィールドタイプ: ",
+        "richTextContent": "リッチテキストコンテンツ",
+        "invalidContent": "無効なコンテンツ",
+        "fieldInformation": "フィールド情報"
+      },
+      "onboarding": {
+        "skipTour": "ツアーをスキップ"
+      },
+      "charts": {
+        "resultsDistribution": "結果の分布",
+        "statusTimeline": "ステータスタイムライン",
+        "testDurationHistogram": "テスト期間ヒストグラム",
+        "zoomDonutChart": "ズームドーナツチャート",
+        "zoomStatusTimeline": "Zoomステータスタイムライン",
+        "zoomHistogramChart": "ズームヒストグラムチャート",
+        "duration": "持続時間: {seconds} 秒",
+        "durationLabel": "間隔"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "問題追跡情報を読み込んでいます...",
+      "enterDocumentation": "ドキュメントを入力してください...",
+      "noAutomatedTestResults": "この実行では自動テストの結果が見つかりません。"
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {分} other {分}}",
+      "seconds": "{count, plural, =1 {秒} other {秒}}"
+    },
+    "units": {
+      "time": "時間"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {ケース} other {ケース}}",
+      "result": "{count, plural, =1 {結果} other {結果}}",
+      "run": "{count, plural, =1 {実行} other {実行}}",
+      "comment": "{count, plural, =1 {{count} コメント} other {{count} コメント}}"
+    },
+    "success": {
+      "assigned": "テストケースが正常に割り当てられました",
+      "unassigned": "テストケースの割り当てが正常に解除されました",
+      "bulkAssigned": "{count, plural, one {# テストケース} other {# テストケース}} 正常に割り当てられました",
+      "bulkUnassigned": "{count, plural, one {# テストケース} other {# テストケース}} 正常に割り当て解除されました"
+    },
+    "tabs": {
+      "general": "一般的な",
+      "settings": "設定"
+    },
+    "selectFilter": "テストケースを表示するにはフィルター値を選択してください。",
+    "invalidProject": "プロジェクト ID が無効です。",
+    "visualization": "視覚化",
+    "results": "結果",
+    "loading": "読み込み中..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "新しいアカウントを作成する",
+      "sso": {
+        "title": "SSOでサインイン",
+        "googleOAuth": "Googleで続行",
+        "apple": "Appleで続ける",
+        "microsoft": "Microsoft で続行",
+        "samlProvider": "{name}でサインイン",
+        "magicLink": "マジックリンクでサインイン",
+        "emailLogin": "メールで続行"
+      },
+      "magicLink": {
+        "description": "メールアドレスを入力すると、安全なログインリンクが送信されます。パスワードは不要です。アカウントをお持ちである必要があります。",
+        "emailPlaceholder": "メールアドレスを入力してください",
+        "sendLink": "マジックリンクを送信",
+        "sending": "送信中...",
+        "checkEmail": "メールを確認してください",
+        "success": "アカウントをお持ちの場合は、 {email} 宛にマジックリンクを送信しました。メール内のリンクをクリックしてサインインしてください。",
+        "error": "マジックリンクの送信に失敗しました。もう一度お試しください。",
+        "backToSignIn": "サインインに戻る"
+      },
+      "twoFactor": {
+        "title": "二要素認証",
+        "description": "認証アプリからの 6 桁のコードを入力するか、バックアップ コードを使用します。"
+      },
+      "troubleSigningIn": "サインインに問題がありますか?",
+      "contactAdmin": "システム管理者に問い合わせる"
+    },
+    "errors": {
+      "accessDenied": "アクセスが拒否されました。アカウントが非アクティブであるか、サインインする権限がない可能性があります。",
+      "configuration": "サーバー構成に問題があります。",
+      "verification": "検証トークンの有効期限が切れているか、すでに使用されています。",
+      "invalid2FACode": "認証コードが無効です。もう一度お試しください。",
+      "twoFactorTokenRequired": "トークンが必要です",
+      "verificationCodeRequired": "認証コードが必要です"
+    },
+    "signup": {
+      "description": "新しいアカウントにサインアップするには、情報を入力してください。",
+      "signIn": "既存のアカウントにサインインします。",
+      "registrationDisabled": "アカウントを作成するには、管理者にお問い合わせください。",
+      "errors": {
+        "emailRequired": "メールアドレスは必須です",
+        "passwordRequired": "パスワードがセキュリティ要件を満たしていません",
+        "confirmPasswordRequired": "パスワードの確認が必要です",
+        "passwordsDoNotMatch": "パスワードが一致しません",
+        "domainRestricted": "登録は承認されたメールドメインのみに制限されています。エラーと思われる場合は、管理者にお問い合わせください。"
+      }
+    },
+    "verifyEmail": {
+      "title": "メールを確認する",
+      "loading": "メールを確認しています...",
+      "success": "メールの確認に成功しました",
+      "error": "メールの確認に失敗しました",
+      "expired": "確認リンクの有効期限が切れました",
+      "invalid": "無効な確認リンク",
+      "alreadyVerified": "メールアドレスはすでに確認済みです",
+      "toast": {
+        "verifySuccess": {
+          "description": "これでアカウントにサインインできます。"
+        },
+        "verifyError": {
+          "description": "メールの確認中にエラーが発生しました"
+        },
+        "resendSuccess": {
+          "title": "メール確認リンクを送信しました",
+          "description": "確認リンクをメールで確認してください。"
+        },
+        "resendError": {
+          "title": "メール確認リンクの送信に失敗しました",
+          "description": "メール確認リンクの送信中にエラーが発生しました。"
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "2要素認証を設定する",
+      "description": "組織では2要素認証が必要です。続行するには設定してください。",
+      "backupDescription": "続行する前にバックアップコードを保存してください",
+      "required": "組織のセキュリティ ポリシーにより、2 要素認証が必須です。",
+      "loading": "セットアップを準備しています...",
+      "manualEntry": "または、このコードを手動で入力します:",
+      "verifyLabel": "検証コード",
+      "verify": "確認して有効化",
+      "backupCodesInfo": "これらのコードは安全な場所に保管してください。認証デバイスを紛失した場合でも、これらのコードを使用してアカウントにアクセスできます。",
+      "copyCodes": "すべてのコードをコピー",
+      "continue": "サインインを続ける"
+    },
+    "twoFactorVerify": {
+      "title": "本人確認",
+      "description": "続行するには、認証アプリからの 6 桁のコードを入力してください。",
+      "backupCodeLabel": "バックアップコード",
+      "backupCodeHint": "8文字のバックアップコードを入力することもできます",
+      "useAuthenticator": "代わりに認証コードを使用する",
+      "useBackupCode": "代わりにバックアップコードを使用してください",
+      "signOut": "ログアウトして別のアカウントを使用する"
+    },
+    "forceChangePassword": {
+      "title": "パスワードを変更する",
+      "adminDescription": "管理者からパスワードの変更を求められています。",
+      "expiredDescription": "パスワードの有効期限が切れています。続行するには、新しいパスワードを設定してください。",
+      "newPasswordLabel": "新しいパスワード",
+      "confirmPasswordLabel": "新しいパスワードを確認する",
+      "submitButton": "パスワードを変更する",
+      "signOut": "代わりにログアウトしてください",
+      "passwordsMustMatch": "パスワードが一致しません。",
+      "passwordRequired": "パスワードが必要です。",
+      "genericError": "エラーが発生しました。もう一度お試しください。",
+      "policyTitle": "パスワード要件:",
+      "policyMinLength": "少なくとも {count} 文字",
+      "policyUppercase": "少なくとも1文字は大文字",
+      "policyLowercase": "少なくとも1文字は小文字",
+      "policyNumbers": "少なくとも1つの数字",
+      "policySpecialChars": "少なくとも1つの特殊文字（{chars}）"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "SSOアカウントをリンク",
+      "description": "アカウントをシングルサインオンプロバイダーにリンクする",
+      "availableProviders": "利用可能なSSOプロバイダー",
+      "linkWithGoogle": "Googleとリンク",
+      "linkWithSaml": "{name}とリンク",
+      "accountLinked": "アカウントが正常にリンクされました",
+      "linkingFailed": "アカウントのリンクに失敗しました",
+      "noProvidersAvailable": "現在、リンクできるSSOプロバイダはありません",
+      "linkingInfo": "SSOプロバイダをリンクすると、パスワードの代わりにそのプロバイダを使用してサインインできるようになります。既存のアカウントデータは変更されません。",
+      "signInWithGoogle": "Googleでログイン",
+      "enterpriseSamlSso": "エンタープライズSAML SSO",
+      "linkProvider": "リンクプロバイダー",
+      "linking": "リンクしています...",
+      "noProvidersContactAdmin": "現在利用できるSSOプロバイダはありません。管理者にお問い合わせください。"
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "ダッシュボード",
+      "admin": "管理",
+      "profile": "プロフィール"
+    },
+    "admin": {
+      "crossProjectReports": "プロジェクト間レポート"
+    },
+    "projects": {
+      "sections": {
+        "management": "管理"
+      },
+      "menu": {
+        "repository": "リポジトリ",
+        "runs": "テスト実行と結果"
+      },
+      "dropdown": {
+        "selectProject": "プロジェクトを選択",
+        "selectProjectAriaLabel": "プロジェクトを選択 {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "プロジェクトID: {id}",
+      "active": "プロジェクトはアクティブです",
+      "completed": "プロジェクトが完了しました"
+    },
+    "overview": {
+      "title": "概要",
+      "currentMilestones": "現在のマイルストーン",
+      "seeAllMilestones": "{count, plural, =1 {マイルストーン # を見る} other {すべてのマイルストーン # を見る}}",
+      "seeAllTestCases": "{count, plural, =1 {# テストケースを参照} other {すべての # テストケースを参照}}",
+      "latestTestCases": "最新のテストケース",
+      "createdOn": "作成日",
+      "seeAllTags": "すべてのタグを見る",
+      "seeAllActiveSessions": "{count, plural, =1 {アクティブセッション数を表示} other {すべてのアクティブセッション数を表示}}",
+      "latestSessions": "最新のセッション",
+      "activeTestRuns": "アクティブテスト実行",
+      "seeAllActiveTestRuns": "{count, plural, =1 {アクティブなテスト実行 # を参照} other {すべてのアクティブなテスト実行 # を参照}}",
+      "latestTestRuns": "最新のテスト実行",
+      "testCaseBreakdown": "テストケースの内訳",
+      "noTestCases": "プロジェクトリポジトリが空です。リポジトリを使用してテストケースを追加してください。",
+      "noTestCasesPrefix": "プロジェクトリポジトリは空です。テストケースを追加するには、",
+      "noTestCasesLink": "リポジトリ"
+    },
+    "icon": {
+      "upload": {
+        "title": "プロジェクトアイコンのアップロード",
+        "description": "最大 4MB の正方形画像 (アスペクト比 1:1) をアップロードします。",
+        "errors": {
+          "invalidFileType": "画像ファイルのみが許可されます。",
+          "fileTooLarge": "ファイルが大きすぎます。最大サイズは {size}です。"
+        }
+      }
+    },
+    "settings": {
+      "description": "{projectName}の設定を管理する",
+      "moreSettingsComingSoon": "その他の設定は近日公開予定です",
+      "moreSettingsDescription": "追加のプロジェクト設定オプションは、今後のアップデートで利用可能になります。",
+      "integrations": {
+        "description": "このプロジェクトのサードパーティの問題統合を管理する",
+        "availableIntegrations": "利用可能な問題統合",
+        "availableDescription": "このプロジェクトに接続する問題統合を選択してください",
+        "configuredIntegration": "構成された統合",
+        "noIntegrationAssigned": "問題統合が割り当てられていません",
+        "noIntegrationDescription": "利用可能なオプションから問題の統合を選択して開始します",
+        "selectIntegration": "設定する問題統合を選択してください",
+        "integration": {
+          "assignError": "問題統合の割り当てに失敗しました",
+          "updateSuccess": "統合設定が更新されました",
+          "updateError": "問題統合設定の更新に失敗しました",
+          "removeError": "問題の統合を削除できませんでした",
+          "removeIntegration": "統合を削除",
+          "confirmRemove": "削除を確認する",
+          "authDescription": "この問題統合を使用するには、 {provider} で認証する必要があります",
+          "authenticating": "認証中...",
+          "authSuccess": "認証成功",
+          "selectProject": "{provider} プロジェクトを選択",
+          "selectProjectPlaceholder": "リンクするプロジェクトを選択してください",
+          "linkedProject": "関連プロジェクト",
+          "loadProjectsError": "プロジェクトの読み込みに失敗しました",
+          "settingsSaved": "統合設定が正常に保存されました",
+          "saveSettingsError": "問題統合設定を保存できませんでした",
+          "authorizationRequired": "承認が必要です",
+          "authenticationError": "認証に失敗しました。もう一度お試しください。",
+          "authorizationRequiredDescription": "外部プロジェクトにアクセスするには、この問題の統合を承認する必要があります",
+          "authorizationMessage": "問題統合を続行するには承認してください",
+          "authorizeIntegration": "承認 {name}",
+          "integrationSettings": "{name} 設定",
+          "integrationSettingsDescription": "このプロジェクトの問題統合設定を構成する",
+          "selectExternalProject": "外部プロジェクトを選択",
+          "refreshProjects": "プロジェクトの更新",
+          "defaultIssueType": "デフォルトの問題タイプ",
+          "selectDefaultIssueType": "デフォルトの問題タイプを選択",
+          "defaultIssueTypeDescription": "この問題タイプは、新しい問題を作成するときに事前に選択されます",
+          "issueTypePlaceholder": "例：バグ、タスク、ストーリー",
+          "defaultComponent": "デフォルトコンポーネント",
+          "componentPlaceholder": "例：フロントエンド、バックエンド",
+          "automaticSync": "自動同期",
+          "automaticSyncDescription": "TestPlanItと外部システム間で問題を自動的に同期します",
+          "simpleUrlDescription": "この問題統合では、シンプルなURLパターンを使用して外部の問題にリンクします。設定されたURLパターンを使用して、新しいタブで問題が開きます。",
+          "externalProjectHelp": "これにより、TestPlanIt から新しい課題を作成する際のデフォルトプロジェクトが設定されます。他の外部プロジェクトから課題をリンクして同期することは可能です。各課題は独自のソースプロジェクトを追跡します。",
+          "linkedProjects": "関連外部プロジェクト",
+          "linkedProjectsDescription": "この統合を通じて接続される外部プロジェクト",
+          "noLinkedProjects": "リンクされた外部プロジェクトはありません",
+          "noLinkedProjectsDescription": "課題の検索と同期を有効にするには、外部プロジェクトを追加してください。",
+          "addProjects": "プロジェクトを追加する",
+          "addSelected": "選択した項目を追加",
+          "setAsDefault": "デフォルトとして設定",
+          "removeProject": "プロジェクトを削除する",
+          "removeProjectConfirmation": "このプロジェクトを削除すると、そこからの課題の同期が停止します。既に同期された課題は削除されません。続行しますか？",
+          "removeProjectWebhookCascadeBullet": "このプロジェクトの受信ウェブフックも削除されます。",
+          "keepProject": "プロジェクトを維持する",
+          "defaultIndicator": "デフォルト",
+          "syncStatusSyncing": "同期中",
+          "syncStatusCompleted": "同期済み",
+          "syncStatusError": "同期エラー",
+          "fanOutPartialFailure": "{count} 個のプロジェクトにアクセスできませんでした。 {successCount} 個のプロジェクトの結果を表示します。",
+          "projectSelectorLabel": "プロジェクト",
+          "defaultIssueTypeHelp": "TestPlanIt から新しい問題を作成する際、この問題タイプが自動的に選択されます。同じタイプの問題を頻繁に作成する場合、これにより時間を節約できます。",
+          "automaticSyncHelp": "有効にすると、外部システム（Webhook経由）で変更が検出されると、課題が自動的に同期されます。手動同期はいつでも利用可能です。",
+          "removeWarningTitle": "この問題の統合を削除すると、次のようになります。",
+          "removeWarning1": "この問題統合からリンクされたすべての問題を切断します（問題はデータベースに残ります）",
+          "removeWarning2": "このプロジェクトのすべての問題統合固有の設定を削除します",
+          "removeWarning3": "この問題の統合を再度使用する場合は再設定が必要です",
+          "removeWarning4": "この統合用に設定されている受信ウェブフックを削除します。",
+          "switchIntegration": "スイッチ統合",
+          "switchWarningTitle": "別の AI モデルに切り替えると、次のようになります。",
+          "switchWarning1": "現在の問題統合に現在リンクされているすべての問題を切断します",
+          "switchWarning2": "データベース内の問題を保存します（リンクが解除されます）",
+          "switchWarning3": "現在の問題統合設定を新しいものに置き換えます",
+          "switchWarning4": "現在の統合用に設定されている受信ウェブフックを削除します。"
+        },
+        "integrationAssigned": "統合が正常に割り当てられました",
+        "integrationAssignError": "問題統合をプロジェクトに割り当てることができませんでした",
+        "integrationRemoved": "統合が正常に削除されました",
+        "integrationRemoveError": "プロジェクトから問題統合を削除できませんでした",
+        "add": {
+          "jira": {
+            "description": "Jira アカウントを接続して、TestPlanIt から直接問題を管理します。"
+          },
+          "simple_url": {
+            "description": "問題追跡のためにサードパーティ システムに接続します。"
+          },
+          "github": {
+            "description": "問題追跡とリポジトリ管理のために GitHub に接続します。"
+          },
+          "gitlab": {
+            "description": "課題やマージリクエストの追跡には、GitLabに接続してください。"
+          },
+          "gitea": {
+            "description": "課題追跡のために、自己ホスト型のGitea、Forgejo、またはGogsインスタンスに接続します。"
+          },
+          "azure_devops": {
+            "description": "作業項目の追跡には、Azure DevOpsに接続してください。"
+          }
+        }
+      },
+      "webhooks": {
+        "description": "関連する課題を同期させるために、受信ウェブフックを設定します。",
+        "inboundDescription": "関連する課題を同期させるために、受信ウェブフックを設定します。",
+        "outboundDescription": "TestPlanItイベントをSlackまたは任意のHMAC署名付きURLに送信するように、アウトバウンドWebhookを設定します。",
+        "directionInbound": "受信",
+        "directionOutbound": "発信",
+        "inboundAddButtonAllConfigured": "インバウンドアダプタは既に設定済みです。",
+        "inboundAddButtonNoIntegration": "インバウンドWebhookを追加する前に、このプロジェクトに課題統合を割り当ててください。",
+        "inboundEmptyWithIntegration": "受信ウェブフックが設定されていません。 <link>割り当てられた課題統合から課題の更新情報を受け取るには、</link> を 1 つ追加してください。",
+        "inboundEmptyNoIntegration": "受信した課題更新情報を受け取るには、課題統合 <link>が必要です。開始するには、プロジェクトに課題統合</link> を割り当ててください。",
+        "deliveriesEmptyNoConfigs": "まだWebhookによる配信は開始されていません。受信を開始するには、他のタブで受信または送信のWebhookを作成してください。",
+        "noConfig": "ウェブフックが設定されていません",
+        "createButton": "ウェブフックを作成する",
+        "url": "Webhook URL",
+        "urlHelp": "このURLを課題追跡システムのWebhook設定に貼り付けてください。",
+        "secret": "Webhook シークレット",
+        "secretHelp": "このシークレットを課題追跡システムのウェブフック設定に貼り付けてください。",
+        "revealedShownOnceWarning": "以下のURLとシークレットを今すぐコピーしてください。これらは一度しか表示されず、後で取得することはできません。",
+        "secretMasked": "非表示 — 回転させて表示",
+        "rotateSecret": "秘密を回転させる",
+        "rotateConfirmTitle": "ウェブフックのシークレットをローテーションしますか？",
+        "rotateConfirm": "シークレットをローテーションすると、課題追跡システム側で設定を更新するまで、現在の設定が無効になります。続行しますか？",
+        "isActive": "有効",
+        "deleteConfirmTitle": "ウェブフックの設定を削除しますか？",
+        "deleteConfirm": "このWebhook設定を削除しますか？受信する配信が拒否されます。",
+        "sendTest": "テスト用ウェブフックを送信",
+        "testSuccess": "テストWebhookが受け入れられました（HTTP {statusCode}、結果： {outcome}）",
+        "testFailure": "テストウェブフックが失敗しました (HTTP {statusCode}): {error}",
+        "saveError": "ウェブフック設定の保存に失敗しました",
+        "lastReceived": "最終受信日時: {timestamp}",
+        "lastReceivedLabel": "最終受信日時:",
+        "lastReceivedNever": "まだ配達はありません",
+        "copyUrl": "ウェブフックURLをコピー",
+        "copySecret": "ウェブフックシークレットをコピー",
+        "urlCopied": "Webhook URLがクリップボードにコピーされました",
+        "secretCopied": "Webhook シークレットがクリップボードにコピーされました",
+        "nextSteps": "次に、これらの情報を課題トラッカーのWebhook設定に貼り付け、下の「テストWebhookを送信」をクリックしてパイプラインを確認してください。シークレットを保存したら「完了」をクリックしてください。シークレットは再度表示されません。",
+        "revealDone": "終わり",
+        "pageTitle": "ウェブフック",
+        "inboundTab": "受信",
+        "outboundTab": "発信",
+        "outboundEmpty": "送信ウェブフックが設定されていません。TestPlanItイベントをSlackまたはHMAC署名付きURLに送信するには、ウェブフックを追加してください。",
+        "outboundAddButton": "アウトバウンドWebhookを追加する",
+        "outboundCreateTitle": "新しいアウトバウンドウェブフック",
+        "outboundCreateName": "名前",
+        "outboundCreateNameHelp": "この宛先のラベル。例：「エンジニアリングSlack」。",
+        "outboundCreateNamePlaceholder": "エンジニアリングの余裕",
+        "outboundCreateNameRequired": "名前は必須です。",
+        "outboundCreateUrlRequired": "URLは必須です。",
+        "outboundCreateUrlInvalid": "有効なURLを入力してください（例：https://example.com/...）。",
+        "outboundCreateUrlMustUseHttps": "URLはHTTPSを使用する必要があります",
+        "outboundNameLabel": "名前",
+        "outboundUnnamedConfig": "（名前のないウェブフック）",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "宛先URL。Slackの受信Webhook URLは自動的に検出されます。",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "検出されました: Slack",
+        "outboundDetectedHmac": "検出されました：汎用HMAC",
+        "adapterLabelSlack": "スラック",
+        "adapterLabelGenericHmac": "汎用HMACウェブフック",
+        "outboundCreateSubscriptionsTitle": "購読",
+        "outboundCreateSubscriptionsHelp": "この宛先に送信されるイベントを選択してください。これらの設定は後で変更できます。",
+        "outboundSubsTestRunsAndSessions": "テスト実行とセッション",
+        "outboundSubsTestRuns": "テスト実行",
+        "outboundSubsSessions": "セッション",
+        "eventVerbs": {
+          "duplicated": "複製",
+          "stateChanged": "状態が変更されました",
+          "resultAdded": "結果を追加しました"
+        },
+        "events": {
+          "testRunCreated": "テスト実行が作成されました",
+          "testRunStateChanged": "テスト実行状態が変更されました",
+          "testRunCompleted": "テスト実行が完了しました",
+          "testRunDuplicated": "テスト実行を複製しました",
+          "testRunResultAdded": "テスト実行結果を追加しました",
+          "sessionCreated": "セッションが作成されました",
+          "sessionStateChanged": "セッションの状態が変更されました",
+          "sessionCompleted": "セッションが完了しました",
+          "sessionDuplicated": "セッションが複製されました",
+          "sessionResultAdded": "セッション結果が追加されました",
+          "issueCreated": "問題が作成されました",
+          "issueUpdated": "問題が更新されました",
+          "issueDeleted": "問題は削除されました",
+          "caseCreated": "ケースが作成されました",
+          "caseUpdated": "ケースの更新",
+          "caseDeleted": "ケースは削除されました",
+          "jiraIssueCreated": "Jira課題が作成されました",
+          "jiraIssueUpdated": "Jira課題が更新されました",
+          "jiraIssueDeleted": "Jira課題が削除されました",
+          "githubIssues": "GitHubイシューイベント",
+          "githubPullRequest": "GitHub プルリクエスト",
+          "githubPush": "GitHub プッシュ",
+          "githubIssueComment": "GitHubのイシューコメント",
+          "adoWorkitemCreated": "Azure DevOps 作業項目が作成されました",
+          "adoWorkitemUpdated": "Azure DevOps の作業項目が更新されました",
+          "adoWorkitemDeleted": "Azure DevOps の作業項目が削除されました",
+          "webhookTest": "テストイベント"
+        },
+        "outboundSubsIssues": "問題",
+        "outboundSubsCases": "事例",
+        "outboundSubsSelectAll": "このセクションのすべてを選択してください",
+        "outboundCreateSubmit": "ウェブフックを作成する",
+        "outboundCreateCancel": "キャンセル",
+        "outboundCreateSuccess": "送信用ウェブフックが作成されました。",
+        "outboundCreateError": "送信ウェブフックの作成に失敗しました。",
+        "outboundUrlLabel": "宛先URL",
+        "outboundActiveToggle": "アクティブ",
+        "outboundSlackHint": "このURLは機密情報です。このURLを知っている人は誰でもあなたのチャンネルに投稿できます。",
+        "outboundHmacSecretsTitle": "秘密の署名",
+        "outboundHmacActiveSecret": "アクティブ",
+        "outboundHmacInactiveSecret": "非アクティブ",
+        "outboundHmacRetiringSecret": "退職",
+        "outboundHmacAutoRetireIn": "{days} 日後に自動退職します",
+        "outboundHmacRotateButton": "秘密を回転させる",
+        "outboundHmacExtendButton": "7日間延長",
+        "outboundHmacRetireNowButton": "今すぐ退職する",
+        "outboundRotateConfirmTitle": "署名秘密を回転させる？",
+        "outboundRotateConfirm": "新しい有効な秘密鍵が生成されます。以前の秘密鍵は、消費者がアップデートを行う間、7日間署名を継続します。",
+        "outboundRotateSuccess": "秘密鍵が回転されました。新しい平文は以下に一度だけ表示されます。",
+        "outboundRotateError": "シークレットの回転に失敗しました。",
+        "outboundRetireConfirmTitle": "秘密を今すぐ解散する？",
+        "outboundRetireConfirm": "廃止される秘密通信は直ちに署名を停止します。旧秘密通信を使用しているユーザーは、新しいペイロードを拒否します。",
+        "outboundRetireSuccess": "シークレットは引退した。",
+        "outboundRetireError": "秘密裏に退去することに失敗した。",
+        "outboundExtendSuccess": "自動退職期間が7日間延長されました。",
+        "outboundExtendError": "シークレットの拡張に失敗しました。",
+        "outboundSendTestButton": "テストイベントを送信",
+        "outboundSendTestQueued": "テストイベントがキューに追加されました。メッセージが届いているか、送信先を確認してください。",
+        "outboundSendTestError": "テストイベントのキューイングに失敗しました。",
+        "outboundDeleteButton": "ウェブフックを削除する",
+        "outboundDeleteConfirmTitle": "送信ウェブフックを削除しますか？",
+        "outboundDeleteConfirm": "この目的地への今後のすべてのイベントは、直ちに発火を停止します。",
+        "outboundDeleteSuccess": "ウェブフックが削除されました。",
+        "outboundDeleteError": "ウェブフックの削除に失敗しました。",
+        "outboundSecretCopy": "コピーシークレット",
+        "outboundSecretShownOnce": "この秘密は今すぐ守ってください。二度と明かすことはできません。",
+        "outboundSecretDone": "終わり",
+        "inboundAddButton": "インバウンドウェブフックを追加する",
+        "inboundChooserTitle": "アダプターを選択してください",
+        "inboundChooserDescription": "TestPlanItにWebhookを送信する課題追跡システムを選択してください。各プロジェクトには、Jira、GitHub、Azure DevOpsの受信Webhookをそれぞれ1つずつ設定できます。",
+        "inboundChooserJira": "ジラ",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "ギテア",
+        "inboundChooserAlreadyConfigured": "既に設定済み",
+        "inboundChooserSubmit": "続く",
+        "inboundChooserCancel": "キャンセル",
+        "inboundEmpty": "受信Webhookが設定されていません。Jira、GitHub、GitLab、Gitea、またはAzure DevOpsからの課題更新情報を受信するには、受信Webhookを追加してください。",
+        "inboundJiraTitle": "JiraインバウンドWebhook",
+        "inboundGithubTitle": "GitHubの受信Webhook",
+        "inboundGithubScopeHint": "GitHub <code>の課題</code> のイベントは、リンクされた TestPlanIt の課題を更新します。プル リクエストと課題コメントのイベントは受け付けられますが、課題はまだ更新されません。",
+        "inboundGitlabTitle": "GitLabの受信Webhook",
+        "inboundGitlabScopeHint": "GitLab <code>Issue Hook</code> イベントは、リンクされた TestPlanIt の課題を更新します。他のイベントタイプも受け入れられますが、課題は更新されません。",
+        "inboundGiteaTitle": "Giteaの受信Webhook",
+        "inboundGiteaScopeHint": "Gitea <code>の課題</code> イベントは、リンクされた TestPlanIt の課題を更新します。その他のイベントタイプも受け入れられますが、課題は更新されません。",
+        "inboundAdoTitle": "Azure DevOps インバウンド Webhook",
+        "inboundAdoScopeHint": "Azure DevOps <code>workitem.updated</code> イベントは、リンクされた TestPlanIt の課題を更新します。その他のイベントも受け付けますが、課題は更新されません。",
+        "inboundAdoUsername": "ユーザー名",
+        "inboundAdoPassword": "パスワード",
+        "inboundAdoUsernamePlaceholder": "サービスアカウント",
+        "inboundAdoUsernameHelp": "Azure DevOps Service Hook側で設定されています。TestPlanItはHTTP基本認証を使用してこれを検証します。",
+        "inboundAdoPasswordHelp": "保存時は暗号化されます。この値はAzure DevOps Service Hook側にも保存してください。",
+        "inboundAdoResourceDetailsHint": "Azure DevOps Service Hook を構成する際は、「送信するリソースの詳細」を「すべて」に設定して、System.State がペイロードに含まれるようにしてください。",
+        "setupStepsTitle": "セットアップ手順",
+        "setupStepsJiraStep1": "Jiraでは、[設定] → [システム] → [WebHooks]（またはJira管理者のWebhook設定ページ）に移動します。",
+        "setupStepsJiraStep2": "「WebHookを作成」をクリックします。以下のURLをURLフィールドに、シークレットをシークレットフィールドに貼り付けてください。",
+        "setupStepsJiraStep3": "「課題関連イベント」で「更新済み」にチェックを入れると、課題ステータスの変更が送信されます。",
+        "setupStepsJiraStep4": "ウェブフックを保存します。パイプラインを確認するには、以下の「テストウェブフックを送信」を使用してください。",
+        "setupStepsGithubStep1": "GitHubリポジトリで、[設定] → [Webhook] → [Webhookを追加] に移動します。",
+        "setupStepsGithubStep2": "以下のURLをペイロードURLフィールドに貼り付けてください。コンテンツタイプをapplication/jsonに設定してください。",
+        "setupStepsGithubStep3": "以下の秘密情報を「秘密情報」欄に貼り付けてください。",
+        "setupStepsGithubStep4": "「個々のイベントを選択する」を選択し、「問題」にチェックを入れます。",
+        "setupStepsGithubStep5": "「Webhookを追加」をクリックしてください。パイプラインを確認するには、下の「テストWebhookを送信」を使用してください。",
+        "setupStepsAdoStep1": "Azure DevOps プロジェクトで、[プロジェクト設定] → [サービス フック] → [サブスクリプションの作成] に移動します。",
+        "setupStepsAdoStep2": "サービスとして「Webフック」を選択します。トリガーを「作業項目が更新されました」に設定します。",
+        "setupStepsAdoStep3": "送信するリソースの詳細を「すべて」に設定すると、System.State が含まれます。",
+        "setupStepsAdoStep4": "以下のURLをURL欄に貼り付けてください。基本認証のユーザー名とパスワードは、上記で入力した値に設定してください。",
+        "setupStepsAdoStep5": "購読を保存してください。パイプラインを確認するには、以下の「テストWebhookを送信」を使用してください。",
+        "setupStepsGitlabStep1": "GitLabで、プロジェクト→設定→Webhooksに移動します。",
+        "setupStepsGitlabStep2": "以下のURLをURL欄に貼り付けてください。以下のシークレットをシークレットトークン欄に貼り付けてください。",
+        "setupStepsGitlabStep3": "「トリガー」で「問題発生イベント」にチェックを入れます。",
+        "setupStepsGitlabStep4": "「Webhookを追加」をクリックしてください。パイプラインを確認するには、下の「テストWebhookを送信」を使用してください。",
+        "setupStepsGiteaStep1": "Giteaでは、リポジトリ→設定→Webhooksに移動します。",
+        "setupStepsGiteaStep2": "「Webhookを追加」をクリックし、「Gitea」を選択してください。",
+        "setupStepsGiteaStep3": "以下のURLを「ターゲットURL」欄に貼り付けてください。以下の秘密情報を「秘密情報」欄に貼り付けてください。",
+        "setupStepsGiteaStep4": "「トリガー」で「問題」を選択します。",
+        "setupStepsGiteaStep5": "「Webhookを追加」をクリックしてください。パイプラインを確認するには、下の「テストWebhookを送信」を使用してください。",
+        "deliveriesTab": "配達",
+        "filterConfigPlaceholder": "すべてのウェブフック",
+        "filterStatusAll": "全て",
+        "filterStatusFailed": "失敗した",
+        "filterStatusSuccess": "成功",
+        "filterSinceDefault": "…以来",
+        "filterUntilDefault": "…まで",
+        "filterReset": "フィルターをリセット",
+        "filterBulkReplayButton": "一括リプレイ {count} 送信失敗",
+        "filterBulkReplayHidden": "目に見える障害はすべて受信側からのものです。代わりに、上流側のイベントを再トリガーしてください。",
+        "deliveriesEmpty": "これらの条件に一致する配達はありません。",
+        "deliveriesResetFilters": "フィルターをリセット",
+        "deliveriesLoadMore": "もっと読み込む",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "イベント",
+        "tableHeaderStatus": "状態",
+        "tableHeaderError": "エラー",
+        "tableHeaderReceivedAt": "受け取った",
+        "tableHeaderAttempt": "試み",
+        "tableHeaderDirection": "方向",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "詳細を見る",
+        "drawerTitle": "配送の詳細",
+        "drawerLabelEvent": "イベント",
+        "drawerLabelDirection": "方向",
+        "drawerLabelStatusCode": "ステータスコード",
+        "drawerLabelLatency": "遅延",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "エラー",
+        "drawerLabelPayloadDigest": "ペイロード概要",
+        "drawerLabelEventId": "イベントID",
+        "drawerLabelAttempt": "試み",
+        "drawerLabelReceivedAt": "受信場所",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "{id} のリプレイ",
+        "drawerReplayButton": "この配達を再生する",
+        "drawerInboundReplayNotSupported": "受信配信は再生できません。代わりに、上流のイベントを再トリガーしてください。",
+        "replayConfirmTitle": "この配達をもう一度再生しますか？",
+        "replayConfirm": "これにより、実際の {direction} {adapterType} リクエストが送信されます。",
+        "replayAction": "リプレイ",
+        "bulkReplayConfirmTitle": "送信エラーを再生しますか？",
+        "bulkReplayConfirm": "{count} の送信失敗を {configName}にリプレイしますか？これにより、 {count} の実際の HTTP リクエストが送信されます。",
+        "bulkReplayCapExceeded": "一括再生は一度に100件の送信に制限されています。フィルタを絞り込むか、順番に実行してください。現在、 {count} が再生されます。",
+        "bulkReplayAction": "リプレイ {count}",
+        "healthBadge": {
+          "HEALTHY": "健康",
+          "DEGRADED": "劣化",
+          "DISABLED": "無効"
+        },
+        "healthTooltipHealthy": "最後の成功: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} 連続失敗 · 最終失敗 {lastFailureAt}",
+        "healthTooltipDisabled": "10回連続で失敗すると無効になります · {lastFailureAt}",
+        "activityLabel": "配送活動",
+        "activityLastDispatched": "最終発送",
+        "activityLastSuccess": "最後の成功",
+        "activityLastFailure": "最後の失敗",
+        "activityNever": "一度もない",
+        "reEnable": "再度有効にする",
+        "reEnableConfirmTitle": "このウェブフックを再度有効にしますか？",
+        "reEnableConfirm": "再度有効化する前に、上流の問題が解決されていることを確認してください。Webhookは直ちに配信を再開します。",
+        "toastReplaySuccess": "リプレイがキューに追加されました",
+        "toastReplayFailed": "リプレイ失敗: {error}",
+        "toastReplayInboundNotSupported": "到着した配送はやり直すことができません。",
+        "toastBulkReplaySuccess": "一括再生開始 · バッチ {batchId}",
+        "toastBulkReplayFailed": "一括再生に失敗しました: {error}",
+        "toastReEnableSuccess": "Webhookが再び有効化されました",
+        "toastReEnableFailed": "再有効化に失敗しました: {error}"
+      },
+      "aiModels": {
+        "description": "インテリジェントなテストケース生成と分析のための AI モデルを構成する",
+        "availableModels": "プロジェクトデフォルト",
+        "availableModelsDescription": "システム管理者が設定したAIモデルの中から、このプロジェクトのデフォルトAIモデルを選択してください。",
+        "currentModelSettings": "現在のモデル設定",
+        "currentModelDescription": "現在アクティブなAIモデルの構成の詳細: {name}",
+        "noModelsAvailable": "現在利用可能な AI モデルはありません。組織の AI モデルを構成するには、システム管理者にお問い合わせください。",
+        "monthlyBudget": "月間予算",
+        "model": "モデル",
+        "budget": "予算",
+        "streamingTooltip": "リアルタイム応答ストリーミングが有効",
+        "systemDefault": "システムのデフォルト",
+        "setAsDefault": "デフォルトとして設定",
+        "clearDefault": "デフォルトをクリア",
+        "useForProject": "プロジェクトに使用",
+        "removeModel": "デフォルトをクリア",
+        "removeWarningTitle": "デフォルトのAIモデルをクリアすると、以下のようになります。",
+        "removeWarning1": "機能ごとのオーバーライドが設定されていない限り、AI搭載機能は無効にします。",
+        "removeWarning2": "テストケースの生成と分析に使用されるフォールバックモデルを削除します。",
+        "switchModel": "デフォルトを変更する",
+        "switchWarningTitle": "デフォルトのAIモデルを変更すると、次のようになります。",
+        "switchWarning1": "このプロジェクトでの AI 機能の動作を変更する",
+        "switchWarning2": "生成されるコンテンツの品質とスタイルに影響を与える可能性があります",
+        "modelAssigned": "このプロジェクトに設定されているデフォルトのAIモデル",
+        "modelAssignError": "デフォルトのAIモデルの設定に失敗しました",
+        "modelRemoved": "デフォルトのAIモデルがクリアされました",
+        "modelRemoveError": "デフォルトのAIモデルをクリアできませんでした",
+        "confirmRemove": "このプロジェクトのデフォルト設定を「{name}」から解除してもよろしいですか？",
+        "confirmSwitch": "デフォルトを「{from}」から「{to}」に変更してもよろしいですか？",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/月"
+        },
+        "promptConfig": "プロンプト設定",
+        "promptConfigDescription": "このプロジェクトで使用するAIプロンプト構成を選択してください。",
+        "useSystemDefault": "システムデフォルトを使用する",
+        "promptConfigChanged": "プロンプトの設定が正常に更新されました。",
+        "featureOverrides": {
+          "title": "機能ごとのLLMオーバーライド",
+          "description": "特定のAI機能に対して、デフォルトのLLM統合を上書きします。上書きされた設定は、解決チェーンにおいて最も高い優先順位を持ちます。",
+          "feature": "特徴",
+          "override": "オーバーライド",
+          "effectiveLlm": "効果的なLLM",
+          "source": "ソース",
+          "noOverride": "オーバーライドなし",
+          "noLlm": "LLMなし（無効）",
+          "disabledOverride": "無効化（上書き）",
+          "projectOverride": "プロジェクトオーバーライド",
+          "promptConfig": "プロンプト設定",
+          "noLlmConfigured": "LLMが設定されていません",
+          "selectIntegration": "統合を選択してください...",
+          "overrideSaved": "機能の上書きが保存されました",
+          "overrideCleared": "機能オーバーライドがクリアされました",
+          "overrideError": "機能オーバーライドの保存に失敗しました"
+        }
+      },
+      "shares": {
+        "title": "株式の管理",
+        "description": "このプロジェクトのすべての共有リンクを表示および管理します。"
+      },
+      "quickScript": {
+        "title": "クイックスクリプト",
+        "description": "QuickScriptを有効にし、AIによるテスト生成のためのコードリポジトリを接続します。",
+        "enableLabel": "QuickScriptを有効にする",
+        "enableDescription": " このプロジェクトでは、チームメンバーがQuickScriptを使用してテストケースを自動化スクリプトに変換できるようにします。",
+        "enabledToast": "QuickScriptが有効になっています",
+        "disabledToast": "QuickScriptが無効になっています",
+        "noRepos": {
+          "title": "コードリポジトリは設定されていません",
+          "adminDescription": "このプロジェクトのコードコンテキストを設定する前に、リポジトリへの接続を確立してください。",
+          "adminLink": "コードリポジトリへ移動",
+          "userDescription": "コードリポジトリへの接続を設定するには、システム管理者に連絡してください。"
+        },
+        "repository": {
+          "title": "コードリポジトリ",
+          "description": "AIコンテキストで使用するコードリポジトリを選択してください。",
+          "placeholder": "コードリポジトリを選択してください...",
+          "branchLabel": "支店",
+          "branchPlaceholder": "リポジトリのデフォルトブランチを使用する場合は、空白のままにしてください。"
+        },
+        "pathPatterns": {
+          "title": "パスパターン",
+          "description": "含めるファイルを指定します。各行は、ベースパスとグロブパターンを組み合わせたものです。例：path=tests/e2e/pages + pattern=* は、そのフォルダ内のすべてのファイルを直接含めます。path=src + pattern=**/*.test.ts は、すべてのテストファイルを再帰的に含めます。",
+          "pathLabel": "パス",
+          "pathPlaceholder": "テスト/e2e/ページ",
+          "patternLabel": "パターン",
+          "addPath": "パスを追加",
+          "previewFiles": "プレビューファイル",
+          "scanningRepo": "リポジトリファイルをスキャンしています… ({seconds}秒)",
+          "files": "{count, plural, one {# ファイル} other {# ファイル}}",
+          "truncatedBadge": "結果は不完全な場合があります（プロバイダーの制限による）。",
+          "exceedsLimit": "合計サイズがAIコンテキストの制限を {overflow}だけ超過しています。エクスポート中、ファイルはエクスポート対象のテストケースとの関連性に基づいてランク付けされます。最も関連性の高いファイルが最初に含まれ、制限に達するとランクの低いファイルはスキップされます。含めるファイルをより細かく制御したい場合は、パスパターンを絞り込んでください。"
+        },
+        "preview": {
+          "resolvingBranch": "ブランチ… を解決しています",
+          "scanningFiles": "{scope}… のファイルをスキャンしています。",
+          "scanningFilesCount": "{scope}… 内のファイルをスキャンしています ({count} が見つかりました)",
+          "filtering": "{count} 個のファイル…にフィルタを適用しています。"
+        },
+        "cache": {
+          "title": "キャッシュ設定",
+          "description": "AI生成時の高速アクセスを確保するため、ファイルはValkeyにキャッシュされます。",
+          "enableLabel": "ファイルキャッシュを有効にする",
+          "disabledWarning": "ファイルキャッシュは無効になっています。リポジトリファイルはエクスポート時にプロバイダから直接取得され、TestPlanItには保存されません。AI搭載のQuickScriptにはコードコンテキストが含まれますが、エクスポートのたびにリポジトリへのリアルタイムリクエストが行われます。",
+          "ttlLabel": "キャッシュの有効期間（日数）",
+          "statusTitle": "キャッシュの状態",
+          "refreshButton": "キャッシュを更新",
+          "listingFiles": "ファイル一覧…",
+          "cachingFiles": "{count} 個のファイルをキャッシュしています…",
+          "statusNeverFetched": "一度も取りに来なかった",
+          "statusPending": "爽快…",
+          "lastFetched": "最後に取得したデータ",
+          "filesCached": "キャッシュされたファイル",
+          "totalSize": "総サイズ"
+        },
+        "save": "設定を保存",
+        "saved": "コードコンテキスト構成が保存されました",
+        "saveError": "設定の保存に失敗しました",
+        "listError": "リポジトリファイルの一覧表示に失敗しました",
+        "contentsError": "ファイルコンテンツのキャッシュに失敗しました",
+        "networkError": "キャッシュ更新中にネットワークエラーが発生しました",
+        "refreshSuccess": "キャッシュが更新されました: {fileCount} 個のファイル ({contentCached} 個のコンテンツがキャッシュされました)",
+        "refreshRateLimited": "キャッシュが更新されました: {fileCount} 個のファイルが一覧表示され、 {contentCached}/{fileCount} 個のコンテンツがキャッシュされました (レート制限あり - 完了するには再度更新してください)",
+        "validation": {
+          "pathRequired": "パスが必要です",
+          "patternRequired": "型紙が必要です",
+          "repositoryRequired": "リポジトリが必要です",
+          "pathPatternRequired": "少なくとも1つのパスパターンが必要です"
+        },
+        "exportTemplates": {
+          "title": "エクスポートテンプレート",
+          "description": "このプロジェクトにエクスポートテンプレートを割り当ててください。割り当てられたテンプレートのみがエクスポートダイアログに表示されます。",
+          "noTemplates": "エクスポートテンプレートが有効になっていません。システム管理者にお問い合わせください。",
+          "assignedLabel": "割り当てられたテンプレート",
+          "selectPlaceholder": "割り当てるテンプレートを選択してください...",
+          "defaultLabel": "デフォルトテンプレート",
+          "defaultPlaceholder": "なし（グローバルデフォルトを使用）",
+          "assigned": "割り当てられた",
+          "save": "テンプレート割り当てを保存する",
+          "saved": "テンプレートの割り当てが保存されました",
+          "saveError": "テンプレート割り当ての保存に失敗しました"
+        },
+        "disconnect": "リポジトリの接続を解除します",
+        "confirmDisconnect": "「{name}」をこのプロジェクトから切断してもよろしいですか？",
+        "disconnectWarningTitle": "このリポジトリの接続を解除すると、以下のようになります。",
+        "disconnectWarning1": "キャッシュされたリポジトリファイルをすべて削除します",
+        "disconnectWarning2": "パスパターンとブランチ構成を削除します",
+        "disconnectWarning3": "AI生成エクスポートにコードコンテキストを含めないようにする",
+        "disconnectSuccess": "コードリポジトリとの接続が切断されました",
+        "disconnectError": "コードリポジトリの接続解除に失敗しました"
+      }
+    }
+  },
+  "milestones": {
+    "title": "マイルストーンの詳細",
+    "fields": {
+      "parent": "親のマイルストーン",
+      "dueDate": "期日",
+      "automaticCompletion": "期日を自動で完了",
+      "notifyDaysBefore": "期日の数日前に通知",
+      "notifyDaysBeforeValue": "期日前 {count, plural, one {# 日} other {# 日}} に通知する",
+      "dueDateNotifications": "期日通知"
+    },
+    "labels": {
+      "childMilestones": "子どもの成長の節目"
+    },
+    "placeholders": {
+      "description": "マイルストーンの説明を入力してください...",
+      "documentation": "マイルストーンドキュメントを入力してください...",
+      "selectType": "マイルストーンの種類を選択...",
+      "selectParent": "親マイルストーンを選択..."
+    },
+    "empty": {
+      "active": "アクティブなマイルストーンはありません",
+      "completed": "完了したマイルストーンはありません",
+      "description": "説明なし",
+      "documentation": "文書は提供されていません",
+      "testRuns": "テスト実行なし",
+      "forecasts": "予測データはありません"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "開始されていません",
+      "IN_PROGRESS": "進行中",
+      "STOPPED": "停止",
+      "BLOCKED": "ブロックされました",
+      "CANCELLED": "キャンセル",
+      "unscheduled": "予定外",
+      "upcoming": "今後の予定",
+      "delayed": "遅延",
+      "pastDue": "支払期限超過",
+      "started": "開始",
+      "completed": "完了"
+    },
+    "status": {
+      "stop": "停止",
+      "reopen": "再開"
+    },
+    "dates": {
+      "pickStartDate": "開始日を選択",
+      "pickCompletionDate": "完了日を選択",
+      "selectDate": "日付を選択...",
+      "completionWarning": "警告: これにより、マイルストーンは完了としてマークされます"
+    },
+    "toast": {
+      "deleted": "マイルストーン {name} が削除されました",
+      "updated": "マイルストーンを更新しました",
+      "updateFailed": "マイルストーンの更新に失敗しました",
+      "completed": "マイルストーン「{name}」が完了しました。",
+      "completedWithDependencies": "マイルストーンと依存関係は正常に完了しました。"
+    },
+    "errors": {
+      "nameExists": "この名前のマイルストーンは既に存在します",
+      "nameRequired": "マイルストーン名は必須です",
+      "notFound": "マイルストーンが見つかりません"
+    },
+    "actions": {
+      "add": "マイルストーンを追加"
+    },
+    "delete": {
+      "title": "マイルストーンを削除",
+      "confirmMessage": "マイルストーン {name}を削除してもよろしいですか?",
+      "warning": "このマイルストーンはプロジェクトから削除されます。このマイルストーンの履歴データはプロジェクト内に残ります。",
+      "toast": {
+        "loading": "マイルストーンを削除しています...",
+        "success": "マイルストーンが正常に削除されました",
+        "error": {
+          "title": "マイルストーンの削除に失敗しました",
+          "description": "マイルストーンの削除中にエラーが発生しました"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "マイルストーンの完了を確認する",
+      "confirmDescription": "このマイルストーンを完了すると、次の関連項目も完了します。",
+      "impactActiveTestRuns": "{count, plural, one {# アクティブなテスト実行} other {# アクティブなテスト実行}}",
+      "impactActiveSessions": "{count, plural, one {# アクティブセッション} other {# アクティブセッション}}",
+      "impactDescendantMilestones": "{count, plural, one {# 子孫マイルストーン} other {# 子孫マイルストーン}}",
+      "completeTestRunsLabel": "関連テスト実行を完了します ({count, plural, one {# アクティブ} other {# アクティブ}})",
+      "completeSessionsLabel": "関連セッションを完了します ({count, plural, one {# アクティブ} other {# アクティブ}})",
+      "testRunStateLabel": "テスト実行完了状態",
+      "sessionStateLabel": "セッション完了状態",
+      "itemsRemaining": "以下の項目は引き続き有効です。",
+      "processing": "処理...",
+      "confirmAndCompleteAll": "すべて確認して完了"
+    },
+    "notifications": {
+      "dueSoon": "マイルストーン「{name}」は {dueDate}に期限が到来します",
+      "overdue": "マイルストーン「{name}」の期限は {dueDate}でした"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {セッション} other {セッション}}",
+    "labels": {
+      "totalElapsed": "費やした時間",
+      "remaining": "残り: {time}",
+      "overtime": "予想を上回った人: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "完了したセッションがフィルターに一致しません。"
+    },
+    "filter": {
+      "placeholder": "セッションをフィルタリング..."
+    },
+    "actions": {
+      "add": "セッションを追加",
+      "create": "新しいセッションを作成",
+      "edit": "編集セッション",
+      "complete": "セッションを完了する",
+      "delete": "セッションを削除",
+      "viewSessionDetails": "セッションを見る"
+    },
+    "noMilestone": "マイルストーンなし",
+    "completeDialog": {
+      "noWorkflowsConfigured": "このプロジェクトには完了ワークフローが設定されていません。セッションの完了を有効にするには、管理設定でワークフローを設定してください。"
+    },
+    "messages": {
+      "createSuccess": "セッションが正常に作成されました",
+      "createSuccessMultiple": "{count} セッションが正常に作成されました",
+      "duplicateSuccess": "セッションの複製に成功しました",
+      "duplicateSuccessMultiple": "{count} セッションの複製に成功しました"
+    },
+    "duplicateDialog": {
+      "title": "セッションの重複",
+      "description": "すべてのメタデータを含み、結果を含まないセッション <nameStyle>{name}</nameStyle> のコピーを作成します。"
+    },
+    "errors": {
+      "failedToCreate": "新しいセッションを作成できませんでした",
+      "failedToCreateVersion": "セッションバージョンの作成に失敗しました",
+      "nameAlreadyExists": "セッション名が既に存在します。新しい名前を選択してください。",
+      "createFailed": "セッションの作成に失敗しました",
+      "duplicateFailed": "セッションの複製に失敗しました"
+    },
+    "validation": {
+      "nameMinLength": "名前は 2 文字以上でなければなりません。",
+      "templateRequired": "テンプレートを選択してください",
+      "maxDuration": "期間は {max}以下でなければなりません。"
+    },
+    "placeholders": {
+      "estimate": "推定時間（例：1時間30分）",
+      "elapsed": "経過時間（例：2日4時間）",
+      "selectUser": "ユーザーを選択",
+      "estimateHint": "例：2時間30分",
+      "noEstimate": "見積りが設定されていません"
+    },
+    "delete": {
+      "confirmMessage": "セッション {name}を削除してもよろしいですか?",
+      "warning": "このセッションはプロジェクトから削除されます。このセッションの履歴データはプロジェクト内に残ります。",
+      "toast": {
+        "loading": "セッションを削除しています...",
+        "success": "セッションが正常に削除されました",
+        "error": {
+          "title": "セッションの削除に失敗しました",
+          "description": "セッションの削除中にエラーが発生しました"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "セッション {name}を完了してもよろしいですか?",
+      "warning": "完了すると、セッションは永久にアーカイブされ、更新できなくなります。",
+      "fields": {
+        "completionDate": "完了日"
+      },
+      "placeholders": {
+        "pickDate": "日付を選択"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "残り推定時間:",
+      "recentResultsTitle": "最近の結果の概要",
+      "recentResultsDescription": "セッション結果の要約。",
+      "noRecentResults": "最近セッション結果が記録されていません。",
+      "completionTrendTitle": "完了傾向",
+      "completionTrendDescription": "月ごとに完了したセッション数。",
+      "noCompletedRuns": "過去 6 か月間に完了した実行は見つかりませんでした。",
+      "completionTrendTitle6Mo": "完了傾向（過去6か月）",
+      "noCompletedSessions6Mo": "過去 6 か月間に完了したセッションはありません。"
+    },
+    "version": {
+      "title": "セッション履歴ビュー",
+      "notFound": "セッション バージョンが見つかりません。",
+      "selectVersion": "バージョンを選択",
+      "backToSession": "セッションに戻る",
+      "backToLatest": "最新バージョンに戻る",
+      "versionInfo": {
+        "created": "バージョン {number} が作成されました",
+        "latestUpdated": "最新バージョン {number} 更新"
+      },
+      "renderer": {
+        "noEstimate": "見積もりなし",
+        "noTimeLogged": "記録された時間はありません",
+        "noContent": "コンテンツなし",
+        "currentVersion": "現在のバージョン",
+        "previousVersion": "以前のバージョン"
+      },
+      "diff": {
+        "added": "追加した",
+        "removed": "削除されました",
+        "changed": "変更"
+      }
+    },
+    "results": {
+      "section": "セッションログ",
+      "add": "セッション結果を追加",
+      "edit": "セッション結果の編集",
+      "editDescription": "セッション結果に変更を加え、完了したら「保存」をクリックします。",
+      "details": "結果の詳細をここに入力してください...",
+      "noResults": "まだ結果が追加されていません。",
+      "noNotes": "この結果に対してメモは追加されていません。",
+      "deleteSuccess": "セッション結果が正常に削除されました",
+      "deleteError": "セッション結果の削除に失敗しました",
+      "updateSuccess": "セッション結果が正常に更新されました",
+      "updateError": "セッション結果の更新に失敗しました",
+      "linkCopied": "セッション結果のリンクがクリップボードにコピーされました",
+      "copyFailed": "セッション結果リンクのコピーに失敗しました",
+      "confirmDelete": {
+        "title": "セッション結果を削除",
+        "description": "このセッション結果を削除してもよろしいですか?"
+      }
+    },
+    "notFound": "セッションが見つかりません"
+  },
+  "home": {
+    "dashboard": {
+      "title": "ダッシュボード",
+      "users": "ユーザーは {count, plural, =1 {# 人、ユーザーは} other {# 人、ユーザーは}}",
+      "yourProjects": "あなたのプロジェクト",
+      "projects": "{count, plural, =1 {# プロジェクト} other {# プロジェクト}}にアクセスできます",
+      "loading": "ダッシュボードを読み込んでいます...",
+      "noItems": "現時点では、あなたに割り当てられているものには注意を払う必要はありません。",
+      "pendingRuns": "保留中のテスト実行",
+      "activeSessions": "アクティブセッション",
+      "yourActiveSessions": "{count, plural, =0 {アクティブセッションなし} =1 {アクティブセッション数} other {アクティブセッション数}}",
+      "yourPendingRuns": "{count, plural, =0 {保留中のテスト実行はありません} =1 {アクティブなテスト実行の数} other {アクティブなテスト実行の数}}",
+      "yourAssignments": "あなたの課題",
+      "totalTime": "合計推定時間: ",
+      "totalWorkEffort": "総作業量: ",
+      "scheduleSpan": "スケジュール期間: "
+    },
+    "initialPreferences": {
+      "title": "設定する",
+      "description": "自分に最適なデフォルト設定を選択してください。プロフィールからいつでも変更できます。",
+      "dateFormat": "日付形式",
+      "timeFormat": "時刻形式",
+      "timezonePlaceholder": "タイムゾーンを検索...",
+      "skip": "デフォルトのままにする",
+      "save": "設定を保存",
+      "success": "設定が更新されました",
+      "error": "設定の保存中に問題が発生しました"
+    },
+    "noAccess": {
+      "title": "プロジェクトへのアクセスなし",
+      "description": "このシステム内のどのプロジェクトにもアクセスできません。",
+      "contact": "プロジェクトへのアクセスを要求するには、システム管理者に連絡してください。",
+      "adminAddProject": "始めるには最初のプロジェクトを追加してください。",
+      "footer": "テスト計画アクティビティを表示および参加するにはアクセスが必要です。"
+    },
+    "noProjectAccess": {
+      "description": "このプロジェクトへのアクセス権がありません。",
+      "contact": "アクセスをリクエストするには、プロジェクト管理者に連絡してください。"
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# テストケース} =1 {# テストケース} other {# テストケース}}",
+      "activeMilestones": "{count, plural, =0 {# アクティブなマイルストーン} =1 {# アクティブなマイルストーン} other {# アクティブなマイルストーン}}",
+      "activeRuns": "{count, plural, =0 {アクティブな実行回数} =1 {アクティブな実行回数} other {アクティブな実行回数}}",
+      "activeSessions": "{count, plural, =0 {アクティブセッション数} =1 {アクティブセッション数} other {アクティブセッション数}}",
+      "issues": "{count, plural, =0 {# 問題} =1 {# 問題} other {# 問題}}"
+    }
+  },
+  "users": {
+    "description": "ユーザーアカウントの管理、システムアクセスレベルの設定、グローバルロールの割り当てを行います。",
+    "filter": "ユーザーをフィルタリング...",
+    "profile": {
+      "title": "ユーザープロフィール",
+      "edit": {
+        "title": "プロフィールを編集",
+        "timezonePlaceholder": "タイムゾーンを選択または検索...",
+        "timezoneRequired": "タイムゾーンは必須です。",
+        "avatarUpdated": "アバターが正常に更新されました。",
+        "avatarUpdateError": "アバターの更新に失敗しました。",
+        "deleteAvatar": "アバターを削除",
+        "deleteAvatarConfirm": "本当にアバターを削除してもよろしいですか?",
+        "emailDisabledForSso": "SSOアカウントのメールアドレスは変更できません。IDプロバイダーを通じて更新してください。",
+        "emailEditableForBoth": "メールアドレス/パスワードとSSOの両方でサインインできます。メールアドレスの変更はパスワード認証にのみ影響します。",
+        "linkSsoProvider": "SSOプロバイダーへのリンク"
+      },
+      "preferences": {
+        "title": "設定"
+      },
+      "access": {
+        "title": "アクセス"
+      },
+      "notifications": {
+        "title": "通知設定",
+        "description": "通知の受信方法をカスタマイズする",
+        "currentGlobal": "現在のグローバル設定: {mode}",
+        "mode": {
+          "label": "通知モード",
+          "useGlobal": "グローバル設定を使用する"
+        },
+        "options": {
+          "title": "追加オプション",
+          "email": {
+            "label": "メール通知",
+            "description": "メールで通知を受け取る"
+          }
+        },
+        "success": {
+          "title": "設定を保存しました",
+          "description": "通知設定が更新されました"
+        },
+        "error": {
+          "description": "通知設定を保存できませんでした"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "パスワードを変更する",
+        "setPasswordButtonText": "パスワードを設定",
+        "description": "アカウントのパスワードを変更するには、現在のパスワードと新しいパスワードを入力してください。これにより、社内で管理されているパスワードのみが変更されます。SSO経由でログインした場合、そのパスワードは変更されません。",
+        "setPasswordDescription": "SSO経由でサインインしましたが、ローカルパスワードはまだ設定されていません。アカウントへのメールアドレス/パスワードログインを有効にするには、新しいパスワードを入力してください。",
+        "currentPasswordLabel": "現在のパスワード",
+        "newPasswordLabel": "新しいパスワード",
+        "confirmPasswordLabel": "新しいパスワードの確認",
+        "validation": {
+          "passwordsDoNotMatch": "新しいパスワードが一致しません。",
+          "newPasswordTooShort": "新しいパスワードはセキュリティ要件を満たしていません。"
+        },
+        "success": {
+          "passwordChanged": "パスワードが正常に変更されました。"
+        }
+      },
+      "mentionedComments": {
+        "title": "コメントで言及",
+        "description": "あなたが言及されているコメント",
+        "noComments": "あなたはまだコメントで言及されていません。",
+        "comment": "コメント",
+        "showingResults": "{start} - {end} / {total}を表示"
+      },
+      "twoFactor": {
+        "enable": "2FAを有効にする",
+        "disable": "無効にする",
+        "disableNotAllowed": "組織では2要素認証が必要です",
+        "ssoBypassNotice": "SSOログインではこの2FA設定は無視されます。すべてのログインに2FAを適用するには、管理者にご連絡ください。",
+        "regenerateCodes": "新しいコード",
+        "setup": {
+          "description": "認証アプリ（Google Authenticator や Authy など）で QR コードをスキャンし、確認コードを入力します。",
+          "backupCodesTitle": "バックアップコードを保存する",
+          "done": "コードを保存しました"
+        },
+        "disableConfirm": {
+          "title": "二要素認証を無効にしますか?",
+          "description": "これにより、アカウントのセキュリティが低下します。現在の2FAコードまたはバックアップコードを入力して確認してください。",
+          "placeholder": "コードを入力"
+        },
+        "regenerate": {
+          "title": "バックアップコードの再生成",
+          "description": "これにより、既存のバックアップコードが無効になります。続行するには、現在の2FAコードを入力してください。",
+          "confirm": "コードを再生成",
+          "newCodesTitle": "新しいバックアップコード",
+          "newCodesDescription": "古いコードは無効になりました。新しいコードは安全な場所に保管してください。"
+        }
+      },
+      "apiTokens": {
+        "description": "APIトークンを使用すると、外部アプリケーションやスクリプトがお客様に代わってTestPlanItにアクセスできるようになります。トークンには、お客様のアカウントと同じ権限が付与されます。",
+        "create": "トークンを作成",
+        "createTitle": "APIトークンを作成する",
+        "createDescription": "外部ツールとスクリプトを認証するための新しい API トークンを作成します。",
+        "nameLabel": "トークン名",
+        "namePlaceholder": "例: CI/CD パイプライン、CLI ツール",
+        "noTokens": "API トークンはまだ作成されていません。",
+        "expiryLabel": "有効期限（オプション）",
+        "expiryHint": "有効期限がない場合は空白のままにします。",
+        "tokenCreated": "トークンが作成されました",
+        "tokenCreatedDescription": "API トークンが正常に作成されました。",
+        "copyWarning": "このトークンを今すぐコピーしてください。二度と表示されなくなります。",
+        "yourToken": "あなたのトークン",
+        "deleteTitle": "API トークンを削除しますか?",
+        "deleteDescription": "この操作は元に戻せません。このトークンを使用しているアプリケーションは認証できなくなります。",
+        "readOnlyLabel": "読み取り専用",
+        "readOnlyDescription": "データ照会のみを行い、決してデータを変更しないAIエージェントに使用します。",
+        "agentTokenLabel": "エージェントトークンとしてマークする",
+        "agentTokenDescription": "管理者がエージェントによる変更を関連付けられるように、metadata.source: \"mcp\" で監査ログエントリにタグを付けます。",
+        "readOnlyBadge": "読み取り専用",
+        "agentTokenBadge": "エージェントトークン",
+        "errors": {
+          "nameRequired": "トークン名は必須です。"
+        }
+      }
+    },
+    "access": {
+      "guest": "ゲスト"
+    },
+    "avatar": {
+      "update": "アバターを更新",
+      "remove": "アバターを削除",
+      "changeProfilePicture": "プロフィール写真を変更する",
+      "notAuthenticated": "アバターをアップロードするにはログインする必要があります。"
+    },
+    "deletedUser": "削除されたユーザー"
+  },
+  "userMenu": {
+    "viewProfile": "プロフィールを見る",
+    "locale": "ロケール",
+    "themes": {
+      "light": "ライト",
+      "dark": "暗い",
+      "system": "システム",
+      "green": "緑",
+      "purple": "紫",
+      "orange": "オレンジ"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "テストケースのバージョンが見つかりません。",
+      "detailsRegion": "テストケースの詳細",
+      "metadataRegion": "テストケースのメタデータ",
+      "versionCreated": "バージョン {version} が作成されました",
+      "latestVersionUpdated": "最新バージョン {version} 更新",
+      "historyView": "テストケース履歴ビュー"
+    },
+    "fields": {
+      "optionNotFound": "オプションが見つかりません",
+      "hasValue": "価値がある",
+      "noValue": "価値なし",
+      "hasDate": "日付がある",
+      "noDate": "日付なし",
+      "hasText": "テキストあり",
+      "noText": "テキストなし",
+      "hasLink": "リンクあり",
+      "noLink": "リンクなし",
+      "hasSteps": "階段あり",
+      "noSteps": "ステップなし",
+      "unchecked": "未チェック",
+      "linkedCases": "関連症例",
+      "clickToViewFullContent": "全文を見るにはクリックしてください"
+    },
+    "steps": {
+      "add": "ステップを追加",
+      "addSharedSteps": "共有ステップを追加する",
+      "delete": "ステップを削除",
+      "confirmDelete": "ステップ {number}の削除を確認しますか?",
+      "createSharedSteps": "共有を作成 {number, plural, one {ステップ} other {ステップ}}",
+      "sharedStepsName": "共有ステップ名",
+      "sharedStepsDescription": "新しい共有ステップ {number, plural, one {ステップ} other {ステップ}}の名前を入力します。これには、選択したステップ {number, plural, one {個、選択したステップ} other {個、選択したステップ}}が含まれます。",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "共有ステップを作成するには、ステップを選択して名前を入力してください。",
+        "failedToCreateSharedStepGroupError": "共有ステップの作成に失敗しました。もう一度お試しください。",
+        "sharedStepGroupCreatedSuccess": "共有手順が正常に作成されました。",
+        "genericSharedStepCreationError": "共有ステップの作成中に不明なエラーが発生しました。もう一度お試しください。",
+        "errorCreatingSharedGroup": "共有ステップの作成に失敗しました。もう一度お試しください。",
+        "sharedGroupCreatedSuccess": "共有ステップ グループが正常に作成されました。"
+      },
+      "selectSharedStepsTitle": "共有ステップを選択",
+      "selectSharedStepsDescription": "テスト ケースに追加する共有ステップを選択します。",
+      "sharedStepsListPlaceholder": "共有手順を読み込んでいます...",
+      "sharedStepsNamePlaceholder": "共有ステップを識別するための名前を入力します",
+      "noSharedStepsFound": "このプロジェクトに共有ステップが見つかりません。",
+      "sharedStepGroupTitle": "共有ステップ: {name}",
+      "confirmDeleteSharedStepBlock": "このテストケースから共有ステップブロック「{name}」を削除してもよろしいですか? これによって共有ステップグループ自体は削除されません。",
+      "removeBlockButton": "ブロックを削除",
+      "loadingSharedStepsItems": "手順を読み込んでいます...",
+      "noStepsInSharedGroup": "この共有ステップ グループは空です。",
+      "searchSharedStepsPlaceholder": "共有ステップを選択...",
+      "stepsCountLabel": "{count, plural, =0 {# ステップ} =1 {# ステップ} other {# ステップ}}",
+      "reviewSelectedStepsTitle": "選択した手順を確認する",
+      "noStepsInSelectedGroup": "選択したグループにはステップがありません。",
+      "sharedGroupSuffix": "（共有ステップ）",
+      "unnamedSharedGroup": "名前のない共有ステップ"
+    },
+    "testCase": {
+      "toggleAutomated": "自動テストを切り替える",
+      "editAttachmentsIndividually": "添付ファイルを個別に編集します。",
+      "automatedStatus": "自動テストは {status}"
+    },
+    "templateNotAssignedWarning": "このテストケースでは、テンプレート「{templateName}」を使用していますが、このテンプレートは現在プロジェクト「{projectName}」に割り当てられていません。このテンプレートをプロジェクトに割り当てるか、テストケースを変更して別のテンプレートを使用するようにする必要があるかもしれません。",
+    "orphanedStepsWarning": "このテストケースにはステップが含まれていますが、現在のテンプレート「{templateName}」にはステップフィールドが含まれていません。テストケースにステップフィールドを含むテンプレートが追加されるまで、ステップを編集することはできません。",
+    "orphanedFieldsWarning": "このテスト ケースには、 {count, plural, =1 {# フィールド値} other {# フィールド値}} があり、 {count, plural, =1 {} other {は、}} 現在のテンプレート \"{templateName}\" に含まれていません。 {count, plural, =1 {このフィールドは} other {これらのフィールドは}} 以下に表示されていますが、テンプレートに追加されるまで編集できない場合があります。",
+    "title": "テストケースリポジトリ",
+    "folders": "フォルダ",
+    "showDescendants": "すべての子孫を表示",
+    "addFolder": "フォルダを追加",
+    "emptyFolders": "最初のフォルダーを追加するには、上の「フォルダーの追加」ボタンをクリックします。",
+    "selectedAllCases": "{count, plural, =0 {すべてのケースを選択しました} one {すべてのページでケースを選択しました} other {すべてのページでケースを選択しました}}",
+    "deselectedAllCases": "すべてのページのすべてのケースの選択を解除しました",
+    "selectAllTooltip": "このページのすべてのケースを選択/選択解除",
+    "selectAllShiftTooltip": "{count, plural, =0 {すべてのページのすべてのケースを選択/選択解除します} one {すべてのページのケースを # 件選択/選択解除します} other {すべてのページのケースを # 件選択/選択解除します}}",
+    "deselectAllShiftTooltip": "すべてのページのすべてのケースを選択/選択解除",
+    "shiftClickHint": "Shift キーを押しながらすべてのページを選択/選択解除します",
+    "treeView": {
+      "expandAll": "すべて展開",
+      "collapseAll": "すべて折りたたむ",
+      "altKey": "Altキーを押すとすべての子を展開/折りたたむことができます"
+    },
+    "dragDrop": {
+      "move": "動く",
+      "copy": "コピー",
+      "promptTitle": "何をしたいですか？",
+      "copying": "… をコピーしています",
+      "copyComplete": "{count, plural, =1 {1件のケースを {folder}にコピーしました} other {#件のケースを {folder}にコピーしました}}{dest, select, samename {} crossProject { を {projectName}} other {}} にコピーしました",
+      "moveComplete": "{count, plural, =1 {1件のケースを {folder}に移動しました。} other {#件のケースを {folder}に移動しました。}}{dest, select, samename {} crossProject { を {projectName}} other {}}に移動しました。",
+      "copyError": "{count, plural, =1 {1 つのケースを {folder}にコピーできませんでした} other {# つのケースを {folder}}}{dest, select, samename {} crossProject { にコピーできませんでした {projectName}} other {}} にコピーできませんでした",
+      "moveError": "{count, plural, =1 {1件のケースを {folder}} other {に移動できませんでした。#件のケースを {folder}}}{dest, select, samename {} crossProject { に {projectName}} other {}} に移動できませんでした。",
+      "copyAlreadyRunning": "別のコピーの作成が既に始まっています。完成までしばらくお待ちください。",
+      "currentSuffix": "（現在）",
+      "moveDisabledSameFolder": "ケースは既にこのフォルダにあります",
+      "dragPreviewCase": "テストケース",
+      "dragPreviewCount": "{count, plural, =1 {# テストケース} other {# テストケース}}",
+      "modifierHintMac": "⇧キーを押しながらドラッグすると移動、⌥キーを押しながらドラッグするとコピーできます。このメニューをスキップするには、⇧キーを押しながらドラッグしてください。",
+      "modifierHintWin": "このメニューをスキップするには、ドラッグ中にShiftキーを押しながら移動するか、Ctrlキーを押しながらドラッグしてコピーしてください。"
+    },
+    "folderActions": {
+      "edit": "フォルダを編集",
+      "delete": "フォルダを削除",
+      "rename": "フォルダ名の変更"
+    },
+    "cases": {
+      "filter": "フィルターケース...",
+      "selectFolder": "テストケースを追加または表示するフォルダーを選択します。",
+      "selectCases": "テストケースを選択",
+      "noTestCases": "表示するテストケースはありません。",
+      "addCase": "ケースを追加",
+      "notFound": "テストケースが見つかりません。",
+      "selectFilter": "フィルターを選択",
+      "testResultHistory": "テスト結果履歴",
+      "testResultHistoryDescription": "このテストケースのテスト結果の履歴を表示する",
+      "noTestResults": "このテストケースのテスト結果は見つかりませんでした",
+      "unknownRun": "不明な実行",
+      "attempt": "試み",
+      "invalidProject": "無効なプロジェクト",
+      "noSearchResults": "検索条件に一致するケースはありません。",
+      "bulkEdit": "一括編集",
+      "createTestRun": "テスト実行の作成",
+      "copyMoveToProject": "コピー／移動",
+      "export": "輸出",
+      "quickScript": "クイックスクリプト",
+      "cannotReorderAcrossPages": "複数ページにまたがるテストケースの順序を変更することはできません。順序を変更するには、ページサイズメニューから「すべて」を選択してすべてのケースを1ページに表示するか、他のページでケースの選択を解除してください。選択したケースをフォルダにドラッグすることは可能です。",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "すべて表示 ({count})"
+        },
+        "textLongFormat": {
+          "label": "リッチテキスト形式"
+        },
+        "rowMode": {
+          "label": "テストケース行",
+          "multi": "ステップごとに1行"
+        }
+      },
+      "importWizard": {
+        "title": "テストケースのインポート",
+        "fields": {
+          "workflowState": "ワークフロー状態",
+          "column": "列 {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# テストケース} other {# テストケース}} 正常にインポートされました"
+        },
+        "errors": {
+          "templateRequired": "テンプレートの選択は必須です",
+          "folderRequired": "このインポート場所にはフォルダの選択が必要です",
+          "fileRequired": "CSVまたはMarkdownファイルが必要です",
+          "markdownParseFailed": "Markdownファイルの解析に失敗しました",
+          "markdownLlmFailed": "AI解析は利用できません。標準パーサーを使用します。"
+        },
+        "page1": {
+          "fileType": {
+            "label": "ファイルの種類",
+            "csv": "CSV",
+            "markdown": "マークダウン"
+          },
+          "parsingMarkdown": "マークダウンファイルを解析しています...",
+          "useAiParsing": "AIを活用してフィールドマッピングを支援する",
+          "importLocation": {
+            "label": "インポート場所",
+            "singleFolder": "すべてのケースを1つのフォルダに追加する",
+            "rootFolder": "すべてのケースとフォルダをルートフォルダに追加します（マッピングが必要です）。",
+            "topLevel": "すべてのケースとフォルダを最上位レベルに追加する（マッピングが必要）"
+          },
+          "selectFolder": "フォルダを選択",
+          "selectFolderPlaceholder": "フォルダーを選択...",
+          "delimiters": {
+            "tab": "タブ"
+          },
+          "hasHeaders": "最初の行には列名が含まれています",
+          "template": "リポジトリケーステンプレート",
+          "rowMode": {
+            "single": "各行は1つのテストケースです",
+            "multi": "テストケースは複数の行にまたがることができる"
+          }
+        },
+        "page2": {
+          "title": "CSV列をフィールドにマッピングする",
+          "description": "各 CSV 列をテンプレートのフィールドにマップするか、無視することを選択します。",
+          "ignoreColumn": "列を無視",
+          "requiredFieldsWarning": "{count, plural, one {# 必須フィールドは} other {# 必須フィールドは}} マッピングされていません"
+        },
+        "page3": {
+          "title": "フィールドマッピングの概要",
+          "mappingSummary": "マッピングの概要",
+          "folderSplitMode": {
+            "label": "フォルダ階層モード",
+            "plain": "プレーンテキスト（分割なし）",
+            "plainExample": "例: 'This/is.a>Folder' → 'This/is.a>Folder' という名前の単一のフォルダー",
+            "slash": "スラッシュ（/）で分割",
+            "slashExample": "例: 'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "ドット (.) で分割",
+            "dotExample": "例: 'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "より大きい (>) で分割",
+            "greaterThanExample": "例: 'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "プレビューインポート",
+          "showing": "{total} 件中 {start}-{end} 件を表示",
+          "case": "ケース {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "テストケースを追加",
+      "name": "テストケース名",
+      "namePlaceholder": "テストケース名を入力してください",
+      "selectTemplate": "テンプレートを選択",
+      "selectState": "州を選択",
+      "estimatePlaceholder": "見積りを入力",
+      "create": "テストケースを作成する",
+      "successMessage": "新しいテストケースが追加されました",
+      "errorMessage": "新しいテストケースの追加中に不明なエラーが発生しました"
+    },
+    "columns": {
+      "selectCase": "ケースを選択",
+      "runOrder": "実行順序",
+      "lastTestResult": "最終結果",
+      "testedOn": "最終テスト"
+    },
+    "actions": {
+      "archive": "アーカイブ"
+    },
+    "parentFolder": "親フォルダ",
+    "rootFolder": "ルートフォルダ",
+    "removeParentFolder": "親フォルダを削除する",
+    "createInSelectedFolder": "親フォルダに戻る",
+    "deleteCase": {
+      "title": "テストケースを削除",
+      "confirmMessageStart": "テストケースを削除してもよろしいですか? ",
+      "confirmMessageEnd": "?",
+      "warning": "このテストケースはプロジェクトから削除されます。このテストケースの履歴データ（結果を含む）はプロジェクト内に残ります。",
+      "activeRunWarningMessage": "このテストケースは、 {count, plural, =1 {# アクティブなテスト実行} other {# アクティブなテスト実行}}の一部です。削除すると、これらの実行内で削除済みとしてマークされます。"
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {このフォルダを削除すると、サブフォルダもすべて削除されます。よろしいですか?} one {このフォルダを削除すると、このフォルダとすべてのサブフォルダ内のテストケースが 1 つ削除されます。よろしいですか?} other {このフォルダを削除すると、このフォルダとすべてのサブフォルダ内のテストケースが # つ削除されます。よろしいですか?}}",
+      "warning": "このフォルダとすべてのテストケースはプロジェクトから削除されます。これらのテストケースの履歴データ（結果を含む）はプロジェクト内に残ります。",
+      "confirm": "フォルダの削除を確認",
+      "success": "フォルダーとすべてのサブフォルダー/ケースが正常に削除されました。"
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "フォルダ名は既に存在します。別の名前を選択してください。"
+      }
+    },
+    "views": {
+      "byAutomation": "オートメーション",
+      "allTemplates": "すべてのテンプレート",
+      "allStates": "すべての州",
+      "allCreators": "すべてのクリエイター",
+      "allCases": "すべてのケース",
+      "allAssignees": "すべての譲受人",
+      "anyTag": "任意のタグ",
+      "noTags": "タグなし",
+      "byTag": "タグ",
+      "byIssue": "問題",
+      "anyIssue": "何か問題がありますか？",
+      "noIssues": "問題なし"
+    },
+    "noFoldersTitle": "フォルダはまだありません",
+    "noFoldersDescription": "まず、テストケースを整理するための最初のフォルダーを作成します。",
+    "noFoldersOrCasesNoPermission": "表示するフォルダーまたはテスト ケースはありません。",
+    "createFirstFolder": "最初のフォルダを作成する",
+    "bulkEdit": {
+      "title": "一括編集 {count, plural, one {# ケース} other {# ケース}}",
+      "description": "{count, plural, one {# 選択されたケース} other {# 選択されたケース}}を編集しています。編集を有効にするには、フィールドをチェックしてください。",
+      "defineStepsTitle": "一括更新の手順を定義する",
+      "saveNewSteps": "新しいステップを保存",
+      "newStepsDefined": "新しいステップが定義されました ({count}) - ボタンをクリックして編集します",
+      "clearExistingStepsWarning": "既存のステップは削除されます",
+      "warnings": {
+        "templateMismatch": {
+          "title": "複数のテンプレートが選択されました",
+          "description": "異なるテンプレートを使用するケースを選択した場合、編集できるのは標準フィールドのみです。同じテンプレートを使用するケースを選択すると、動的フィールドを編集できます。"
+        },
+        "junitLimitations": {
+          "title": "自動テストケース編集の制限事項",
+          "description": "自動テスト結果からインポートされたテストケースでは、見積もりフィールドと自動化フィールドを変更することはできません。"
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "ケースの読み込み中にエラーが発生しました",
+        "fetchErrorDescription": "選択したケースのデータを読み込めませんでした。モーダルを閉じてもう一度お試しください。",
+        "updateErrorTitle": "更新に失敗しました",
+        "updateFailed": "変更の保存中にエラーが発生しました。データを確認してもう一度お試しください。",
+        "fetchError": "ケースデータの取得中にエラーが発生しました。"
+      },
+      "success": {
+        "casesUpdated": "ケースが正常に更新されました"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "検証エラー",
+      "stepsCannotBeBulkEdited": "ステップは一括編集できません",
+      "stepsInfoTitle": "ステップ情報",
+      "stepsCannotBeBulkEditedInfo": "ステップは一括編集できません。ケースを個別に編集してステップを編集してください。",
+      "confirmDeleteCases": "{count, plural, one {# 選択したケース} other {# 選択したケース}}を削除してもよろしいですか? この操作は元に戻せません。",
+      "replaceAll": "すべて置換",
+      "searchReplace": "検索と置換",
+      "searchFor": "検索する",
+      "replaceWith": "置換",
+      "searchText": "検索するテキストを入力してください",
+      "replacementText": "置換テキストを入力",
+      "useRegex": "正規表現を使用する",
+      "caseSensitive": "大文字と小文字を区別",
+      "regexHint": "任意の文字には .* 、数字には \\d+ 、単語には \\w+ を使用します。グループをキャプチャするには、(パターン) の後に $1、$2 などを使用します。",
+      "preview": "プレビュー",
+      "matches": "マッチ",
+      "noMatches": "一致するものが見つかりません",
+      "invalidRegexPattern": "無効な正規表現パターン",
+      "searchPatternRequired": "検索パターンが必要です",
+      "stepsSearchReplaceInfo": "検索と置換は、ステップの説明と予想される結果の両方に適用されます。"
+    },
+    "exportModal": {
+      "title": "テストケースのエクスポート",
+      "description": "以下のエクスポート オプションを選択してください。",
+      "scope": {
+        "selected": "選択済み ({count})",
+        "allFiltered": "すべて（現在のビュー）（{count}）",
+        "allProject": "プロジェクト内のすべて ({count})"
+      },
+      "format": {
+        "label": "形式",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "マークダウン"
+      },
+      "columns": {
+        "all": "全て",
+        "visible": "見える"
+      },
+      "delimiter": {
+        "label": "デリミタ",
+        "placeholder": "区切り文字を選択...",
+        "comma": "カンマ（,）",
+        "semicolon": "セミコロン（;）",
+        "colon": "コロン（:)",
+        "pipe": "パイプ（|）"
+      },
+      "textLongFormat": {
+        "label": "テキストの長い形式"
+      },
+      "attachmentFormat": {
+        "label": "添付ファイルの形式",
+        "names": "名前",
+        "json": "JSON",
+        "embedded": "画像を埋め込む"
+      },
+      "stepsFormat": {
+        "label": "ステップ形式",
+        "plainText": "プレーンテキスト"
+      },
+      "rowMode": {
+        "label": "ケースあたりの行数",
+        "single": "ケースごとに1行",
+        "multi": "ステップごとに複数行"
+      },
+      "comingSoon": "近日公開",
+      "exporting": "エクスポート中...",
+      "exportError": "エクスポートに失敗しました。もう一度お試しください。"
+    },
+    "quickScript": {
+      "title": "クイックスクリプト",
+      "description": "テンプレートまたはAIを使用して、選択したテストケースを自動化スクリプトに変換します。",
+      "templatePlaceholder": "テンプレートを選択してください...",
+      "searchPlaceholder": "テンプレートを検索...",
+      "noTemplatesFound": "テンプレートが見つかりませんでした。",
+      "outputModeLabel": "出力モード",
+      "outputModeSingle": "単一ファイル ({count, plural, one {# ケース} other {すべて # ケース}})",
+      "outputModeIndividual": "{count, plural, one {個別ファイル (.zip)} other {個別ファイル (.zip)}}",
+      "casesToExport": "{count, plural, one {# ケース} other {# ケース}} エクスポートする",
+      "exportSuccess": "エクスポートが正常に完了しました。",
+      "noAvailableTemplates": "利用可能なテンプレートがありません。管理者にお問い合わせください。"
+    },
+    "aiExport": {
+      "toggleLabel": "AIで生成",
+      "generating": "生成中...",
+      "generatingProgress": "{total} のケース {current} を生成しています...",
+      "generatingBatch": "{count, plural, one {# ケース} other {# ケース}} を 1 つのファイルに生成しています...",
+      "previewTitle": "エクスポートプレビュー",
+      "previewDescription": "{count, plural, one {# ファイル} other {# ファイル}} 生成されました",
+      "copySuccess": "クリップボードにコピーされました",
+      "fallbackBadge": "テンプレートを使用して生成されました（AIは利用できません）",
+      "retryButton": "AI生成を再試行",
+      "aiGenerated": "AI生成",
+      "templateGenerated": "テンプレートが生成されました",
+      "truncatedWarning": "出力が途中で途切れました。モデルがトークン数の上限に達したためです。バッチサイズを小さくするか、プロンプト設定で最大出力トークン数を増やしてみてください。",
+      "contextFiles": "{count, plural, one {(# コンテキスト ファイル)} other {(# コンテキスト ファイル)}}",
+      "noCodeContextHint": "コードリポジトリが設定されていません。AIは標準的なフレームワークパターンを使用します。",
+      "generatingParallelProgress": "{done} 個のファイルのうち、 {total} 個のファイルが生成されました...",
+      "cancelledGeneration": "キャンセル"
+    },
+    "duplicates": {
+      "findDuplicates": "重複データの検索",
+      "viewResults": "表示 {count, plural, one {# 結果} other {# 結果}}",
+      "retryScan": "スキャンを再試行",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "AIを活用して成果を向上させる…",
+      "scanComplete": "重複分析完了 — {count, plural, =0 {重複なし} one {# 重複の可能性あり} other {# 重複の可能性あり}}",
+      "scanFailed": "重複分析に失敗しました",
+      "scanFailedDescription": "予期せぬエラーが発生しました",
+      "pageTitle": "重複候補者",
+      "pageDescription": "前回のスキャンで検出された、重複の可能性のあるテストケースを確認してください。",
+      "rescan": "再スキャン",
+      "cancelScan": "スキャンをキャンセル",
+      "loading": "重複候補を読み込んでいます...",
+      "noDuplicatesFound": "重複は見つかりませんでした",
+      "noDuplicatesDescription": "最後のスキャンが完了しましたが、一致するペアは見つかりませんでした。",
+      "loadMore": "もっと読み込む",
+      "filterPlaceholder": "重複をフィルタリング...",
+      "columnConfidence": "自信",
+      "columnCaseA": "ケースA",
+      "columnCaseB": "ケースB",
+      "columnMatchedFields": "一致するフィールド",
+      "columnScore": "スコア",
+      "compareButton": "比較する",
+      "viewCaseDetails": "事件の詳細を見る",
+      "selectAll": "すべて選択",
+      "selectRow": "行を選択",
+      "selected": "{count, plural, one {# 選択済み} other {# 選択済み}}",
+      "bulkDismiss": "重複なし ({count})",
+      "bulkLink": "関連リンク ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# ペアが削除されました} other {# ペアが削除されました}}",
+      "bulkLinkSuccess": "{count, plural, one {# ペアがリンクされています} other {# ペアがリンクされています}}",
+      "bulkError": "一部の操作が失敗しました。もう一度お試しください。",
+      "tableHint": "行をクリックするか、「比較」ボタンをクリックして、重複するペアを確認し、解決してください。",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "これらの重複の可能性のあるものを比較し、解決方法を選択してください。",
+      "selectPrimary": "ケースをクリックして、マージのプライマリとして選択します。",
+      "selectedAsPrimary": "プライマリとして選択",
+      "mergeButton": "プライマリーを維持する",
+      "linkButton": "関連リンク",
+      "dismissButton": "重複ではありません",
+      "merging": "統合中...",
+      "linking": "リンク中...",
+      "dismissing": "却下中...",
+      "mergeSuccess": "ケースは正常にマージされました。 {runsTransferred, plural, =0 {テスト実行は転送されませんでした} one {# テスト実行が転送されました} other {# テスト実行が転送されました}}。",
+      "linkSuccess": "関連する事例としてリンクされています。",
+      "dismissSuccess": "該当ペアは除外されました。今後のスキャンには表示されません。",
+      "resolveError": "重複するペアの解決に失敗しました。もう一度お試しください。",
+      "loadingDetails": "事件の詳細を読み込んでいます...",
+      "caseDetailsError": "事件の詳細の読み込みに失敗しました。",
+      "sourceLabel": "ソース",
+      "fieldValuesLabel": "フィールド値",
+      "lastRunLabel": "ラストラン",
+      "noFieldValues": "フィールド値なし",
+      "noLastRun": "決して走ってはいけない",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "フォルダなし",
+      "duplicateWarning": "重複の可能性のあるデータが見つかりました",
+      "duplicateWarningDescription": "{count, plural, one {# 既存のケース} other {# 既存のケース}} は同様の機能をカバーする可能性があります",
+      "duplicateWarningReview": "レビュー",
+      "importWarning": "重複の可能性あり",
+      "importWarningTooltip": "このケース名は、 {count, plural, one {# 既存のケース} other {# 既存のケース}}: {names} と類似しています。",
+      "importIntraWarning": "インポート内で重複",
+      "importIntraWarningTooltip": "このインポート内の行 {rows} は、同じまたは非常に似た名前を持っています",
+      "checkingDuplicates": "重複をチェックしています..."
+    },
+    "generateTestCases": {
+      "buttonText": "テストケースを生成する",
+      "title": "AIでテストケースを生成する",
+      "description": "AI を使用して、外部の問題やドキュメントから包括的なテスト ケースを自動的に生成します。",
+      "loadingResults": "生成されたテストケースを読み込んでいます...",
+      "generatingPreparing": "リクエストを準備しています...",
+      "generatingCallingAi": "AIがテストケースを生成するのを待っています...",
+      "generatingStreaming": "AI がテストケース {count} を生成しています...",
+      "generatingStreamingPage": "AI がテストケース {count} を生成しています — {current} / {total}: {page}",
+      "generatingProcessing": "生成されたテストケースを処理しています...",
+      "generatingHint": "資料の複雑さによっては、1分ほどかかる場合があります。",
+      "steps": {
+        "selectIssue": "ソースを選択",
+        "selectTemplate": "テンプレートを選択",
+        "reviewGenerated": "レビューとインポート"
+      },
+      "selectSource": {
+        "title": "要件ソースを選択",
+        "description": "問題からテスト ケースを生成するか、要件ドキュメントから生成するかを選択します。",
+        "folderContextTip": "重複を避けるため、「{folderName}」およびその親/子フォルダにある既存のテストケースがコンテキストとして使用されます。続行する前に、正しいフォルダを選択していることを確認してください。",
+        "currentFolder": "現在のフォルダ",
+        "fromIssue": "発行元",
+        "fromDocument": "文書から",
+        "documentTitle": "文書タイトル",
+        "documentTitlePlaceholder": "要件ドキュメントのタイトルを入力してください",
+        "documentDescription": "要件ドキュメント",
+        "documentDescriptionPlaceholder": "要件ドキュメントの内容をここに貼り付けます...",
+        "documentPriority": "優先度（オプション）",
+        "selectPriority": "優先順位を選択",
+        "saveDocument": "ドキュメントの要件を保存",
+        "fromUrl": "URLから",
+        "recentGenerations": "最近発生したURLからのテストケース生成ジョブ",
+        "recentJobInfo": "{pages, plural, one {# ページ} other {# ページ}}{hasTestCases, select, true { · {testCases, plural, one {# テスト ケース} other {# テスト ケース}}} other {}}",
+        "recentJobHasResults": "レビューの準備ができました",
+        "recentJobClickToGenerate": "クリックしてテストケースを生成",
+        "recentJobCrawling": "クロール中... {pages, plural, one {# ページ} other {# ページ}} これまでのところ",
+        "removeJobTitle": "世代を取り除く",
+        "confirmRemoveJob": "これにより、キャッシュされたクロールと生成されたテストケースがすべて削除されます。同じURLからいつでも再度生成できます。",
+        "loadingRecentJobs": "最近の求人情報を読み込んでいます...",
+        "urlInput": "ページURL",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "このURLには何が含まれていますか？",
+        "urlModeRequirements": "要件",
+        "urlModeRequirementsHint": "このページでは、何を作るべきかを説明しています。",
+        "urlModeApplication": "応用",
+        "urlModeApplicationHint": "Pageはテストするアプリです",
+        "urlValidationError": "http:// または https:// で始まる有効な URL を入力してください",
+        "followLinks": "リンクをたどる",
+        "followLinksHint": "入力したURLと同じドメインにあるページのみがクロールされます。",
+        "maxDepth": "最大深度",
+        "maxPages": "最大ページ数",
+        "crawlProgress": "{current, plural, one {これまでに#ページを取得しました...} other {これまでに#ページを取得しました...}}",
+        "generatingSinglePage": "テストケースを生成しています...",
+        "generatingSetup": "テストケース生成の準備中...",
+        "robotsSkipped": "{count, plural, one {# ページスキップ} other {# ページスキップ}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "外部の問題を選択",
+        "description": "テスト ケースを生成する外部システム (Jira など) から問題を選択します。",
+        "searchButton": "問題の検索"
+      },
+      "selectTemplate": {
+        "title": "テストケーステンプレートを選択",
+        "description": "テストケースの生成に使用するテンプレートを選択します。AIはこのテンプレートに従ってフィールドにデータを入力します。",
+        "placeholder": "テンプレートを選択...",
+        "fieldsDescription": "AIが入力するフィールドを選択します。必須フィールドは常に含まれます。",
+        "requiredOnly": "必須のみ"
+      },
+      "addNotes": {
+        "title": "メモとガイダンスを追加する",
+        "description": "AI がより良いテスト ケースを生成できるように、追加のコンテキストとガイダンスを提供します。",
+        "quantity": "生成するテストケースの数",
+        "placeholder": "テストケース生成のための具体的な指示を追加します...\n\n例:\n• セキュリティテストに重点を置く\n• エッジケースと境界条件を含める\n• ハッピーパスとエラーシナリオの両方をテストする\n• モバイルとデスクトップのシナリオを考慮する\n• APIテストに重点を置く",
+        "suggestions": "簡単な提案:",
+        "quantityOptions": {
+          "justOne": "たった一つ",
+          "couple": "カップル（2）",
+          "few": "少数（2〜3）",
+          "several": "いくつか（4-6）",
+          "many": "多数（7～10）",
+          "maximum": "最大"
+        },
+        "suggestionItems": {
+          "security": "セキュリティテストに重点を置く",
+          "edgeCases": "エッジケースを含める",
+          "happyPath": "ハッピーパスのみをテスト",
+          "mobile": "モバイルシナリオを検討する",
+          "api": "APIテストに重点を置く",
+          "accessibility": "アクセシビリティテストを含める"
+        }
+      },
+      "review": {
+        "title": "生成されたテストケースを確認する",
+        "description": "AI によって生成されたテスト ケースを確認し、必要な編集を行って、インポートするテスト ケースを選択します。",
+        "selected": "{total} 件中 {count} 件を選択",
+        "moreSteps": "...そして {count, plural, one {# さらなるステップ} other {# さらなるステップ}}",
+        "templateFields": "テンプレートフィールド:",
+        "moreFields": "...そして {count, plural, one {# その他のフィールド} other {# その他のフィールド}}",
+        "crawledUrls": "{count, plural, one {# クロールされたページ} other {# クロールされたページ}}",
+        "spaWarning": "このページはJavaScriptによる表示が必要な場合があります。結果が不完全な場合があります。",
+        "filterByPage": "ページごとに絞り込む",
+        "allPages": "すべてのページ ({pages, plural, one {# ページ} other {# ページ}}、 {cases, plural, one {# ケース} other {# ケース}})"
+      },
+      "generatingLegacy": "AIによるテストケースの生成...",
+      "expandProgress": "{done} のうち {total} が生成しました",
+      "import": "{count, plural, =0 {テストケースをインポート} =1 {1 つのテストケースをインポート} other {# つのテストケースをインポート}}",
+      "importing": "{count, plural, =0 {テストケースをインポートしています...} =1 {1 つのテストケースをインポートしています...} other {# つのテストケースをインポートしています...}}",
+      "openInExternalSystem": "{provider}で開く",
+      "externalSystem": "外部システム",
+      "autoGenerateTags": "テストケースのタグを自動生成する",
+      "success": {
+        "imported": "{count, plural, =1 {1 つのテストケースを正常にインポートしました} other {# つのテストケースを正常にインポートしました}}"
+      },
+      "importData": {
+        "issueDescription": "テストケース生成からリンクされた外部問題",
+        "generatedFolderName": "生成された"
+      },
+      "errors": {
+        "generateFailed": "テストケースを生成できませんでした。もう一度お試しください。",
+        "importFailed": "テストケースのインポートに失敗しました。もう一度お試しください。",
+        "noTestCasesGenerated": "テストケースが生成されませんでした。別の入力でもう一度お試しください。",
+        "jobNoLongerAvailable": "この生成方法は現在利用できません。テストケース生成ウィザードから新しい生成を開始してください。",
+        "noAiModel": "このプロジェクトにはAIモデルが設定されていません。プロジェクト設定でAIモデルを設定してください。",
+        "noIssueSelected": "テストケースを生成する対象となる課題を選択してください。",
+        "noDocumentProvided": "要件定義書の詳細をご提供ください。",
+        "noTemplateSelected": "テストケースのテンプレートを選択してください。",
+        "noFieldsSelected": "コンテンツを生成するフィールドを少なくとも1つ選択してください。",
+        "noTestCasesSelectedForImport": "インポートするテストケースを少なくとも1つ選択してください。",
+        "templateRequired": "テンプレートの選択が必要です。戻ってテンプレートを選択してください。",
+        "repositoryNotFound": "プロジェクトリポジトリが見つかりません。管理者にお問い合わせください。",
+        "workflowNotConfigured": "プロジェクトのワークフローが設定されていません。プロジェクト設定を確認してください。",
+        "authenticationError": "認証エラーが発生しました。ページを更新してもう一度お試しください。",
+        "caseCreationFailed": "テストケースの作成に失敗しました: {name}",
+        "caseAlreadyExists": "テストケース \"{name}\" は既にこのフォルダに存在します。",
+        "invalidTemplateConfig": "テストケース \"{name} \" のテンプレート構成が無効です。",
+        "nameTooLong": "テストケース名「{name}」は長すぎます。もっと短い名前を使用してください。",
+        "caseCreationError": "\"{name}\"の作成に失敗しました: {error}",
+        "templateNotFound": "選択したテンプレートが見つかりませんでした。ページを更新してもう一度お試しください。",
+        "repositoryConfigError": "プロジェクトリポジトリの設定エラーが発生しました。システム管理者にお問い合わせください。",
+        "workflowConfigError": "プロジェクトワークフローの設定エラーが発生しました。プロジェクト設定を確認してください。",
+        "permissionDenied": "このプロジェクトでは、テストケースを作成する権限がありません。",
+        "validationFailed": "データ検証に失敗しました。テストケースの内容を確認して、もう一度お試しください。",
+        "databaseError": "データベース接続エラーが発生しました。しばらくしてからもう一度お試しください。",
+        "genericImportError": "インポートに失敗しました: {error}",
+        "networkRoutingError": "ネットワークルーティングまたはサーバー構成の問題 - API応答の代わりにHTMLエラーページを受信しました",
+        "invalidSourceConfig": "無効なソース構成",
+        "failedToCreateCaseVersion": "ケースバージョンの作成に失敗しました",
+        "noUrlProvided": "テストケースを生成するURLを入力してください",
+        "urlFetchFailed": "指定されたURLからコンテンツを取得できませんでした。URLを確認して、もう一度お試しください。",
+        "llm": {
+          "genericTitle": "AI生成エラー",
+          "genericMessage": "AIを使用したテストケースの生成中にエラーが発生しました。もう一度お試しいただくか、入力内容を調整してください。",
+          "overloaded": {
+            "title": "サービスは一時的に利用できません",
+            "message": "現在、AIサービスの需要が高まっています。しばらくしてからもう一度お試しください。"
+          },
+          "quota": {
+            "title": "使用制限に達しました",
+            "message": "この期間のAI使用制限に達しました。しばらくしてからもう一度お試しいただくか、管理者にお問い合わせください。"
+          },
+          "timeout": {
+            "title": "リクエストがタイムアウトしました",
+            "message": "AIリクエストの完了に時間がかかりすぎました。これは、要件が複雑であったり、テストケースの数が多い場合に発生する可能性があります。"
+          },
+          "network": {
+            "title": "ネットワークエラー",
+            "message": "AIサービスに接続できませんでした。インターネット接続を確認して、もう一度お試しください。"
+          },
+          "unauthorized": {
+            "title": "AIサービス認証に失敗しました",
+            "message": "AIサービスが認証情報を拒否しました。管理者は、管理設定でLLM連携のAPIキーを確認する必要があります。"
+          },
+          "forbidden": {
+            "title": "AIサービスへのアクセスが拒否されました",
+            "message": "AIサービスはこのリクエストを拒否しました。管理者は、LLM統合の権限とプロジェクトへのアクセス権限を確認する必要があります。"
+          },
+          "projectNotFound": {
+            "title": "プロジェクトが見つかりません",
+            "message": "このプロジェクトが見つからないか、または、このプロジェクトでAI生成機能を使用する許可があなたにはないようです。"
+          },
+          "noIntegration": {
+            "title": "アクティブなLLM統合はありません",
+            "message": "このプロジェクトには、アクティブなLLM連携が設定されていません。管理者が管理設定で有効にする必要があります。"
+          },
+          "invalidRequest": {
+            "title": "無効なリクエスト",
+            "message": "AI生成リクエストに必要な情報が不足しています。ページを更新してもう一度お試しください。"
+          },
+          "retryButton": "リトライ",
+          "dismissButton": "却下する",
+          "suggestionsHeading": "提案",
+          "suggestions": {
+            "retryLater": "数分後にもう一度お試しください。",
+            "contactAdmin": "問題が解決しない場合は、管理者にお問い合わせください。",
+            "checkStatus": "AIサービスのステータスを確認してください",
+            "checkNetwork": "インターネット接続を確認してください"
+          },
+          "timestampLabel": "エラーが発生しました",
+          "showDetails": "詳細を表示",
+          "hideDetails": "詳細を非表示",
+          "copyDetails": "詳細をコピー",
+          "detailsCopied": "エラーの詳細がクリップボードにコピーされました"
+        }
+      },
+      "unsavedEdits": {
+        "title": "保存されていない編集",
+        "description": "{count, plural, =1 {保存されていない編集のあるテストケースが 1 件あります。} other {保存されていない編集のあるテストケースが # 件あります。}}",
+        "warning": "保存せずに続行すると、変更内容は失われます。",
+        "saveAllAndImport": "すべて保存してインポート",
+        "discardAndImport": "編集を破棄してインポート"
+      },
+      "linkedIssuesDroppedTitle": "関連する問題の一部は含まれていません",
+      "linkedIssuesDropped": "{count, plural, =1 {# リンクされた問題は削除されました} other {# リンクされた問題は削除されました}} トークン予算のため: {keys}。",
+      "linkedIssuesPreviewHeading": "関連する問題には以下が含まれます"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "タグを追加",
+      "title": "新しいタグを追加",
+      "fields": {
+        "name_error": "タグ名は必須です"
+      },
+      "errors": {
+        "nameExists": "この名前のタグは既に存在します"
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "この名前のタグは既に存在します"
+      }
+    },
+    "filterPlaceholder": "タグをフィルター...",
+    "defaultName": "名前のないタグ",
+    "noProject": "プロジェクトなし",
+    "description": "タグを使用してテストケースとセッションを管理および整理します",
+    "detail": {
+      "title": "タグの詳細",
+      "filterPlaceholder": "アイテムをフィルター...",
+      "noResults": "アイテムが見つかりません",
+      "noFilterResults": "現在のフィルターに一致するアイテムはありません",
+      "filters": {
+        "hideCompletedSessions": "完了したセッションを非表示にする",
+        "hideCompletedTestRuns": "完了したテスト実行を非表示にする",
+        "caseTypeLabel": "ケースの種類",
+        "allCases": "全て"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "タグを検索...",
+      "searchOrAddPlaceholder": "タグを検索または追加...",
+      "noOptions": "オプションなし"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "添付ファイルビューア"
+    },
+    "delete": {
+      "confirmMessage": "この添付ファイルを削除してもよろしいですか?",
+      "deferredMessage": "この添付ファイルは保存すると削除されます。"
+    }
+  },
+  "runs": {
+    "notFound": "テスト実行が見つかりません。",
+    "add": {
+      "title": "テスト実行を追加",
+      "description": "プロジェクトに新しいテスト実行を追加する",
+      "success": {
+        "title": "テスト実行が正常に追加されました",
+        "description": "テスト実行がプロジェクトに追加されました",
+        "descriptionMultiple": "{count, plural, one {# テスト実行は} other {# テスト実行は}} '{name} ' 用に作成されました"
+      },
+      "estimates": {
+        "manual": "推定手動時間",
+        "automated": "推定自動所要時間",
+        "mixed": "推定手動/自動時間"
+      },
+      "creatingProgress": "{total}件中のテスト実行 {current} を作成しています..."
+    },
+    "magicSelect": {
+      "title": "マジックセレクト",
+      "description": "テスト実行コンテキストに基づいた AI によるテストケース選択",
+      "counting": "関連するテストケースを探しています...",
+      "reasoning": "AI推論",
+      "reviewSelection": "提案されたテストケースを確認する",
+      "viewSuggested": "提案されたケースを見る",
+      "tokenUsage": "{total} トークン使用",
+      "noLlmIntegration": "AI機能を使用するにはLLM統合が必要です。プロジェクト設定で設定してください。",
+      "configure": {
+        "title": "テストケースの範囲",
+        "description": "リポジトリ内に {count, plural, =1 {# テストケース} other {# テストケース}} が見つかりました",
+        "descriptionFiltered": "リポジトリ内の {count, plural, =1 {# 件の関連がある可能性のあるテスト ケース} other {# 件の関連がある可能性のあるテスト ケース}} が、 {total, plural, =1 {から合計} other {# 件の合計}} に見つかりました",
+        "noMatchesTitle": "一致するテストケースが見つかりません",
+        "noMatchesDescription": "テスト実行名と説明がどのテストケースにも一致しませんでした。前の手順に戻り、機能名、コンポーネント名、テストケースに表示されるキーワードなど、より具体的な詳細を追加してください。",
+        "maxResultsTitle": "テストケースの最大一致数",
+        "maxResultsDescription": "検索条件に一致するテストケースが多数ありました。より的確な結果を得るには、前の手順に戻り、テスト実行にさらに具体的な詳細を追加してください。",
+        "batchSize": "バッチサイズ",
+        "batchSizeAll": "すべてのケース（単一のリクエスト）",
+        "batchSizePercent": "{percent}% ({count} 件)",
+        "requestsNeeded": "{count, plural, =1 {# AIリクエストが行われます} other {# AIリクエストが行われます}}",
+        "batchNote": "すべてのバッチの結果が統合されます"
+      },
+      "loading": {
+        "batch": "{total}のバッチ {current} を処理中",
+        "analyzing": "テストケースを分析しています...",
+        "progress": "Analyzed {analyzed} of {total} test cases...",
+        "waitingForAi": "AIからの応答を待っています（バッチ {batch} / {total}）...",
+        "selectedSoFar": "{count, plural, =1 {# これまでに選択されたテストケース} other {# これまでに選択されたテストケース}}",
+        "resolving_integration": "AI統合の課題解決…",
+        "fetching_cases": "テストケースを取得しています..."
+      },
+      "success": {
+        "title": "推奨テストケース",
+        "description": "{count, plural, =1 {# テストケースが選択されました} other {# テストケースが選択されました}} テスト実行コンテキストに基づいて",
+        "linkedCasesAdded": "{count, plural, =1 {リンクされたケースが自動的に含まれるケースの数} other {リンクされたケースが自動的に含まれるケースの数}}",
+        "truncationWarningTitle": "部分的な結果",
+        "truncationWarning": "{count, plural, =1 {# バッチが切り捨てられました} other {# バッチが切り捨てられました}} AI モデルにより、一部のテスト ケースが評価されなかった可能性があります。"
+      },
+      "noSuggestions": {
+        "title": "一致するテストケースがありません",
+        "description": "条件に一致するテストケースが見つかりませんでした。コンテキストや説明を追加してください。"
+      },
+      "clarification": {
+        "label": "追加のコンテキスト（オプション）",
+        "placeholder": "関連するテスト ケースを選択できるように追加のコンテキストを追加します...",
+        "refine": "選択範囲を絞り込む"
+      },
+      "actions": {
+        "start": "テストケースを分析する",
+        "startBatched": "テストケースの分析 ({count, plural, one {# バッチ} other {# バッチ}})",
+        "accept": "選択に追加"
+      },
+      "errors": {
+        "title": "選択に失敗しました",
+        "generic": "テストケースの選択中にエラーが発生しました。もう一度お試しください。",
+        "noTestRunName": "Magic Select を使用する前に、テスト実行名を入力してください。"
+      }
+    },
+    "delete": {
+      "title": "テスト実行を削除",
+      "description": "このテスト実行を削除してもよろしいですか? 結果は履歴分析のために保持されます。",
+      "warning": "この操作は元に戻せません。",
+      "toast": {
+        "loading": "テスト実行を削除しています...",
+        "success": "テスト実行が正常に削除されました",
+        "error": {
+          "title": "テスト実行の削除に失敗しました",
+          "description": "テスト実行の削除中にエラーが発生しました"
+        }
+      }
+    },
+    "summary": {
+      "title": "テスト実行の概要",
+      "description": "テスト実行の概要を表示する",
+      "activeRunsAndEstTime": "アクティブランと推定時間",
+      "activeRunsLabel": "ラン",
+      "totalEstTime": "合計推定時間",
+      "responsibleUsers": "責任あるユーザー",
+      "allActiveRuns": "すべてのアクティブな実行",
+      "recentResultsTitle": "最近の手動結果",
+      "recentResultsDescription": "テスト実行の最新の結果を表示する",
+      "recentAutomatedResultsTitle": "最近の自動結果",
+      "noRecentAutomatedResults": "最近の自動結果が見つかりません。",
+      "recentResultsDateRange": "日付範囲",
+      "recentResultsElapsed": "経過",
+      "noRecentResults": "最近の結果は見つかりませんでした。",
+      "completionTrendTitle": "完了傾向（過去6か月）",
+      "workDistributionTitle": "仕事の配分",
+      "workDistributionDescription": "担当者別の作業配分の見積もり。",
+      "noWorkDistributionData": "表示する割り当て先または見積りのあるアクティブなセッションはありません。"
+    },
+    "details": {
+      "title": "テスト実行の詳細",
+      "description": "テスト実行の詳細を表示する"
+    },
+    "duplicateDialog": {
+      "title": "重複したテスト実行",
+      "description": "テスト実行 <nameStyle>{name}</nameStyle>のコピーを作成します。",
+      "fields": {
+        "duplicateScope": {
+          "label": "複製するテストケース",
+          "allCases": "すべてのテストケース",
+          "specificStatuses": "特定のステータスを持つテストケース"
+        },
+        "statusesToInclude": {
+          "label": "含めるテストケース",
+          "description": "複製されたテスト実行に含めるテスト ケースのステータスを選択します。",
+          "noStatuses": "このテスト実行では特定のステータスが見つからないか、結果がまだ読み込まれています。",
+          "noStatusesRecorded": "この実行では特定のステータスは記録されませんでした。複製にはすべてのテストケースが含まれます（通常は「未テスト」として表示されます）。"
+        },
+        "copyAssignments": {
+          "label": "テストケースの割り当て",
+          "copy": "既存のテストケースの割り当てをコピーする",
+          "assign": "複製されたテスト実行内のすべてのテストケースは、既存の割り当てを保持します。",
+          "unassign": "複製されたテスト実行内のすべてのテストケースは割り当て解除されます"
+        }
+      },
+      "successMessage": "テスト実行 '{name}' が正常に複製されました。",
+      "errorMessage": "テスト実行の複製に失敗しました。エラー: {error}"
+    },
+    "filter": {
+      "placeholder": "フィルターテストが実行されます..."
+    },
+    "typeFilter": {
+      "label": "見せる",
+      "both": "手動と自動"
+    },
+    "empty": {
+      "noMatchingCompleted": "完了したテスト実行の中にフィルターに一致するものはありません。"
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "主要",
+      "projects": "プロジェクト",
+      "templatesAndFields": "テンプレートとフィールド",
+      "fields": "フィールド",
+      "workflows": "ワークフロー",
+      "statuses": "ステータス",
+      "milestoneTypes": "マイルストーンの種類",
+      "configurations": "構成",
+      "users": "ユーザー",
+      "groups": "グループ",
+      "roles": "役割",
+      "tags": "タグ",
+      "issues": "問題",
+      "appConfig": "アプリケーション構成",
+      "notifications": "通知",
+      "imports": "データのインポート",
+      "integrations": "問題の統合",
+      "webhooks": "ウェブフック",
+      "llm": "AIモデル",
+      "prompts": "プロンプト設定",
+      "exportTemplates": "エクスポートテンプレート",
+      "codeRepositories": "コードリポジトリ",
+      "quickScript": "クイックスクリプト",
+      "sso": "認証",
+      "security": "安全",
+      "trash": "ごみ",
+      "reports": "レポート",
+      "shares": "株式の管理",
+      "elasticsearch": "検索エンジン",
+      "queues": "ジョブキュー",
+      "auditLogs": "監査ログ",
+      "apiTokens": "APIトークン",
+      "quickscriptTemplates": "QuickScriptテンプレート",
+      "testManagement": "テスト管理",
+      "peopleAndAccess": "人材とアクセス",
+      "toolsAndIntegrations": "ツールと連携機能",
+      "system": "システム"
+    },
+    "imports": {
+      "description": "外部のテスト管理ツールからデータをTestPlanItに取り込む。",
+      "tabs": {
+        "testmoJson": "テストモ JSON"
+      },
+      "testmo": {
+        "intro": "Testmo JSON エクスポートをアップロードしてその内容を分析し、移行マッピングを準備します。",
+        "wizard": {
+          "steps": {
+            "upload": "アップロードエクスポート",
+            "analysis": "レビュー分析",
+            "mapping": "マッピングを構成する",
+            "import": "インポートを監視する"
+          },
+          "stepIndicator": "ステップ {step} / {total}"
+        },
+        "fileLabel": "Testmo JSONファイル",
+        "fileHelp": "Testmo からダウンロードした JSON エクスポートを選択します。",
+        "analyze": "エクスポートを分析",
+        "analyzing": "分析中...",
+        "reset": "明確な結果",
+        "job": {
+          "discoveringDatasets": "データセットを検出しています...",
+          "scanningFile": "testmo エクスポート ファイルをスキャンしています...",
+          "datasetsProcessed": "{processed, number} データセット{processed, plural, one {} other {s}} が処理されました",
+          "datasetsProcessedWithTotal": "{processed, number} のうち {total, number} データセット{total, plural, one {} other {秒}} が処理されました",
+          "rowsProcessed": "{value, number} 行が処理されました",
+          "itemsProcessed": "{total, number} 件中 {processed, number} 件のアイテムが処理されました",
+          "analysisInProgress": "エクスポートの分析…",
+          "cancel": "インポートをキャンセル",
+          "cancelRequested": "キャンセル要求",
+          "processingRate": "レート：",
+          "estimatedTimeRemaining": "残り時間の目安:",
+          "datasetsLabel": "データセット:",
+          "rowsProcessedLabel": "行数:"
+        },
+        "summaryHeading": "エクスポートの概要",
+        "summary": {
+          "datasets": "データセット",
+          "fileName": "ファイル名",
+          "fileSize": "ファイルサイズ",
+          "analysisTime": "分析時間"
+        },
+        "datasetTable": {
+          "name": "データセット",
+          "rows": "行",
+          "samples": "採取したサンプル"
+        },
+        "status": {
+          "truncated": "切り捨て"
+        },
+        "selectDataset": "データセットを選択",
+        "schema": "スキーマ",
+        "samples": "サンプル行",
+        "noSamples": "このデータセットではサンプルがキャプチャされませんでした。",
+        "mappingHeading": "マッピング構成",
+        "mappingRefresh": "分析を更新",
+        "mappingDescription": "分析の詳細を確認し、Testmo エンティティを既存の TestPlanIt レコードにマッピングするか、新しいエンティティを作成することを選択します。",
+        "mappingAnalysisError": "マッピング分析を生成できませんでした。もう一度お試しください。",
+        "mappingLoading": "建物マッピング分析…",
+        "mappingSummaryHeading": "検出されたエンティティ",
+        "mappingSummaryPending": "{count, plural, =1 {# 保留中} other {# 保留中}}",
+        "mappingOutstandingTitle": "未解決のマッピングを解決する",
+        "mappingOutstandingDescription": "インポートを開始する前に、残りのマッピングを完了してください。",
+        "mappingOutstandingItem": "{count, plural, =1 {# 未解決の項目} other {# 未解決の項目}} {label}内",
+        "mappingSummaryTemplateFields": "テンプレートフィールド",
+        "mappingDatasetLabels": {
+          "field_values": "フィールド値",
+          "repository_case_values": "リポジトリケースの値",
+          "configs": "構成設定",
+          "session_issues": "セッションの問題",
+          "session_tags": "セッションタグ",
+          "states": "ワークフローの状態",
+          "statuses": "ステータス",
+          "templates": "テンプレート",
+          "template_fields": "テンプレートフィールド",
+          "milestone_types": "マイルストーンの種類",
+          "roles": "役割",
+          "users": "ユーザー",
+          "groups": "グループ",
+          "user_groups": "ユーザーグループ",
+          "issue_targets": "課題統合",
+          "tags": "タグ",
+          "sessions": "セッション",
+          "session_results": "セッション結果",
+          "fields": "フィールズ",
+          "projects": "プロジェクト",
+          "repositories": "リポジトリ",
+          "repository_folders": "リポジトリフォルダ",
+          "repository_cases": "リポジトリのケース",
+          "repository_case_steps": "リポジトリケースの手順",
+          "repository_case_tags": "リポジトリケースタグ",
+          "milestones": "マイルストーン",
+          "runs": "テスト実行",
+          "run_tests": "テスト実行ケース",
+          "run_results": "テスト実行結果",
+          "run_result_steps": "テスト実行ステップの結果",
+          "run_links": "テスト実行リンク",
+          "run_tags": "テスト実行タグ",
+          "issues": "問題",
+          "milestone_issues": "マイルストーンの問題",
+          "repository_case_issues": "リポジトリのケースに関する問題",
+          "run_issues": "テスト実行時の問題点",
+          "run_result_issues": "テスト実行結果の問題",
+          "session_result_issues": "セッション結果の問題",
+          "automation_cases": "自動化ケース",
+          "automation_runs": "自動化を実行する",
+          "automation_run_tests": "自動化実行テスト",
+          "automation_run_test_fields": "自動化実行テストフィールド",
+          "automation_run_links": "自動化実行リンク",
+          "automation_run_tags": "自動化実行タグ",
+          "session_values": "セッション値"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "ワークフローの状態を確認して、TestPlanIt ワークフローをマップまたは作成します。",
+          "statuses": "Testmo ステータスを TestPlanIt ステータスにマップする方法を構成します。",
+          "templates": "Testmo からインポートされたテンプレート定義を確認します。",
+          "template_fields": "エクスポートに含まれるテンプレート フィールド定義を検査します。",
+          "fields": "Testmo からエクスポートされたカスタム フィールド レコードを確認します。",
+          "field_values": "エクスポートでキャプチャされたフィールド値の定義を検査します。",
+          "milestone_types": "エクスポートでキャプチャされたマイルストーン タイプの定義を検査します。",
+          "roles": "ロールの定義を確認して、Testmo の権限を理解します。",
+          "users": "Testmo エクスポートで検出されたユーザー アカウントを確認します。",
+          "groups": "Testmo から引き継がれたグループの割り当てを確認します。",
+          "configs": "構成名を TestPlanIt のカテゴリとバリアントにマップします。",
+          "tags": "Testmo データに表示されるタグ値を検査します。",
+          "repository_case_values": "テスト ケースに割り当てられた値を複数選択します。",
+          "sessions": "セッションは常に新しいセッションとして作成されます。",
+          "session_results": "セッション結果はセッションに接続されます。",
+          "session_issues": "セッションの問題はセッションに関連しています。",
+          "session_tags": "セッション タグはセッションに接続されます。",
+          "issue_targets": "Testmo の問題ターゲットを TestPlanIt 統合 (Jira、GitHub など) にマップします。"
+        },
+        "mappingDatasetDefaultDescription": "Testmo エクスポートでレビュー {dataset} が検出されました。",
+        "mappingDatasetCount": "{count, number} 記録{count, plural, one {} other {s}} 検出",
+        "mappingDatasetNoEntitiesTitle": "マップするものがありません",
+        "mappingDatasetNoEntitiesDescription": "このデータセットはマッピングを必要としません。準備ができたら次のデータセットに進んでください。",
+        "mappingDatasetUnsupportedTitle": "マッピングは不要",
+        "mappingDatasetUnsupportedDescription": "これらのレコードは自動的にインポートされ、TestPlanIt 内の関連レコードに接続されます。手動でのマッピングは必要ありません。",
+        "mappingDatasetEmptyTitle": "データセットは保存されません",
+        "mappingDatasetEmptyDescription": "分析では設定用のデータセットが保存されませんでした。追加データが必要な場合は、別のエクスポートをアップロードしてください。",
+        "importProgressTitle": "インポートの進行状況",
+        "importProgressDescription": "{count, plural, =0 {追跡対象のエンティティ全体ですべてのレコードがインポートされました。} =1 {追跡対象のエンティティ全体で 1 レコードが残っています。} other {追跡対象のエンティティ全体で # レコードが残っています。}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {残りレコードなし} =1 {残り 1 レコード} other {残りレコード数}}",
+        "importProgressProcessed": "{processed, number}/{total, number} レコードがインポートされました",
+        "importProgressAria": "{percent}インポート完了率",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "合計時間:",
+        "activityLogTitle": "輸入活動",
+        "activityLogDescription": "バックグラウンドインポート手順の詳細なログ。タイムスタンプはサーバーのタイムゾーンに基づきます。",
+        "activitySummaryProcessed": "{count, plural, =1 {処理されたレコード数} other {処理されたレコード数}}",
+        "activitySummaryCreated": "{count, plural, =1 {# 作成済み} other {# 作成済み}}",
+        "activitySummaryMapped": "{count, plural, =1 {# マッピング済み} other {# マッピング済み}}",
+        "activitySummaryUnknown": "インポート手順",
+        "activityDefaultMessage": "インポートの更新",
+        "previousImportsHeading": "以前のインポートを確認する",
+        "previousImportsDescription": "完了したインポートから分析結果を読み込み、構成またはアクティビティ ログを検査します。",
+        "previousImportsRefresh": "リストを更新",
+        "previousImportsPlaceholder": "以前のインポートを選択",
+        "previousImportsEmpty": "あなたのアカウントに以前のインポートは見つかりませんでした。",
+        "previousImportsCreatedLabel": "作成日: ",
+        "previousImportsFileLabel": "ファイル： ",
+        "previousImportsNoFilename": "不明なファイル",
+        "jobHistoryLoadFailed": "以前にインポートしたジョブを読み込めませんでした。",
+        "jobLoadFailed": "そのインポートジョブを読み込むことができませんでした。",
+        "uploadProgressAnalyzing": "アップロードが完了しました。ファイル…を分析中です",
+        "uploadProgressComplete": "アップロード完了",
+        "etaLabel": "到着予定時刻: {time}",
+        "startImportButton": "インポートを開始",
+        "workflowCreate": {
+          "nameLabel": "ワークフロー名",
+          "namePlaceholder": "ワークフロー名を入力してください",
+          "scopePlaceholder": "範囲を選択",
+          "iconColorLabel": "アイコンと色",
+          "typeLabel": "ワークフロータイプ"
+        },
+        "mappingDatasets": "レビューが必要なデータセット",
+        "mappingImportConfiguration": "インポート構成",
+        "mappingExportConfiguration": "エクスポート設定",
+        "mappingImportConfigurationFailed": "設定ファイルをインポートできませんでした。有効なJSONであることを確認して、もう一度お試しください。",
+        "mappingInvalidConfiguration": "構成は有効な JSON である必要があります。",
+        "mappingSaveFailed": "設定を保存できませんでした。もう一度お試しください。",
+        "mappingSaveConfiguration": "設定を保存",
+        "mappingSavingConfiguration": "保存中…",
+        "mappingStartImport": "バックグラウンドインポートを開始",
+        "mappingStartingImport": "インポートを開始しています…",
+        "mappingImportFailed": "バックグラウンドインポートを開始できませんでした。もう一度お試しください。",
+        "mappingImportDisabled": "バックグラウンドインポートを開始する前に構成を保存します。",
+        "mappingImportInProgress": "バックグラウンドインポートが進行中",
+        "mappingImportInProgressDescription": "インポートワーカーが構成を処理中です。上記のステータスを監視できます。",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# レコード} other {# レコード}} ",
+          "columnSource": "Testmoエンティティ",
+          "columnSourceDetails": "詳細",
+          "columnSuggestedWorkflowType": "推奨タイプ",
+          "columnTarget": "ターゲット",
+          "workflowTypeUnknown": "検出されませんでした",
+          "actionMap": "既存のマップ",
+          "actionCreate": "新規作成",
+          "workflowTypePlaceholder": "タイプを選択",
+          "noWorkflowsAvailable": "利用できるワークフローはありません。",
+          "noStatusesAvailable": "利用可能なステータスはありません。",
+          "noGroupsAvailable": "利用可能なグループはありません。",
+          "groupSelectPlaceholder": "グループを選択",
+          "groupNotePlaceholder": "メモ（オプション）",
+          "groupNoteEmpty": "追加の詳細は提供されていません。",
+          "noUsersAvailable": "利用可能なユーザーがいません。",
+          "userNoExistingTargets": "マップできるユーザーがいません。",
+          "userNamePlaceholder": "フルネーム",
+          "userAccessPlaceholder": "アクセスレベルを選択",
+          "userRoleUnavailable": "割り当てられるロールがありません。",
+          "userPasswordPlaceholder": "一時パスワード",
+          "userPasswordHint": "仮パスワードを入力してください。ユーザーはサインイン後にパスワードを変更できます。",
+          "userActiveLabel": "アクティブアカウント",
+          "userDisplayFallback": "ユーザー {id}",
+          "userMissingRequired": "必要な詳細が不足しています",
+          "noConfigurationsAvailable": "利用可能な構成はありません。",
+          "configurationNoTokens": "この構成ではバリアントは検出されませんでした。",
+          "configurationNoExistingTargets": "マップできる構成がありません。",
+          "configurationNamePlaceholder": "設定名を入力してください",
+          "configurationVariantLabel": "バリアント {index}",
+          "configurationVariantActionLabel": "このバリアントはどのように処理する必要がありますか?",
+          "configurationVariantActionPlaceholder": "オプションを選択",
+          "configurationVariantMapOption": "既存のバリアントにマップする",
+          "configurationVariantExistingCategoryOption": "既存のカテゴリにバリアントを作成する",
+          "configurationVariantNewCategoryOption": "新しいカテゴリとバリアントを作成する",
+          "configurationVariantSelectLabel": "バリエーションを選択",
+          "configurationVariantNoVariants": "マップできるバリアントがありません。",
+          "configurationVariantCategoryLabel": "カテゴリ",
+          "configurationVariantNameLabel": "バリアント名",
+          "configurationVariantNamePlaceholder": "バリアント名を入力してください",
+          "configurationVariantNoCategories": "利用可能なカテゴリはありません。",
+          "configurationVariantCategoryNameLabel": "カテゴリ名",
+          "configurationVariantCategoryNamePlaceholder": "カテゴリ名を入力してください",
+          "noTemplateFieldsAvailable": "使用できるテンプレート フィールドがありません。",
+          "templateFieldDisplayFallback": "フィールド {id}",
+          "templateFieldUnknownTemplate": "不明なテンプレート",
+          "templateFieldTargetCase": "ケースフィールド",
+          "templateFieldTargetResult": "結果フィールド",
+          "templateFieldSelectPlaceholder": "フィールドを選択",
+          "templateFieldNoExistingTargets": "マップできるフィールドがありません。",
+          "templateFieldTypePlaceholder": "フィールドタイプを選択",
+          "templateFieldRestrictedLabel": "制限フィールド",
+          "templateFieldOptionsLabel": "ドロップダウンオプション",
+          "templateFieldOptionsPlaceholder": "1行に1つのオプションを入力してください",
+          "templateFieldOptionsHint": "各オプションを新しい行で区切ります。",
+          "templateFieldOptionsListLabel": "オプション",
+          "templateFieldOptionsCheckedLabel": "デフォルトでチェックされています",
+          "templateFieldOptionsMinValueLabel": "最小値",
+          "templateFieldOptionsMaxValueLabel": "最大値",
+          "templateFieldOptionsMinIntegerLabel": "最小整数",
+          "templateFieldOptionsMaxIntegerLabel": "最大整数",
+          "templateFieldNewFieldSummaryTitle": "新しいフィールドの詳細",
+          "templateFieldNewFieldSummaryDescription": "この TestPlanIt フィールドを作成するために使用される値を確認します。",
+          "templateFieldConfigureFieldButton": "詳細を設定する",
+          "templateFieldEditFieldButton": "詳細を編集",
+          "templateFieldSummaryMissingValue": "設定されていません",
+          "templateFieldSummaryMissingDetailsHint": "続行する前に、新しいフィールドの詳細を入力してください。",
+          "templateFieldModalSaveButton": "詳細を保存",
+          "templateFieldTargetTypeLabel": "ターゲットタイプ",
+          "templateFieldTypeMismatchWarning": "選択されたフィールド タイプ {target} は、Testmo フィールド タイプ {source}と一致しません。",
+          "templateFieldDuplicateTargetWarning": "選択したターゲットは既に別のTestmoフィールドにマッピングされています。別のターゲットを選択してください。",
+          "templateFieldTargetAlreadyUsed": "すでにマッピング済み",
+          "templateFieldMappedSummary": "{name} ({type}) にマッピングされます",
+          "templateFieldIssueMissingTarget": "対象フィールドを選択します。",
+          "templateFieldIssueMissingDetails": "続行する前に、表示名、システム名、フィールド タイプを入力してください。",
+          "noTemplatesAvailable": "利用できるテンプレートはありません。",
+          "templateColumnFields": "フィールド",
+          "templateFieldStatusMapped": "マッピング",
+          "templateFieldStatusCreate": "新しいフィールドを作成",
+          "templateFieldStatusMissing": "マッピングされていません",
+          "templateFieldStatusMismatch": "ターゲットの不一致",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# ケースフィールド} other {# ケースフィールド}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# 結果フィールド} other {# 結果フィールド}}",
+          "templateMapLabel": "既存のテンプレートにマップする",
+          "templateCreateLabel": "新しいテンプレートを作成する",
+          "templateNoMatchingTargets": "一致するテンプレートはありません。",
+          "templateNewNameLabel": "テンプレート名",
+          "templateMapHintIncomplete": "既存のテンプレートにマッピングする前に、すべての Testmo フィールドを既存のケース フィールドと結果フィールドにマッピングします。",
+          "templateMapHintDuplicate": "各 Testmo フィールドは、一意の TestPlanIt フィールドにマップする必要があります。",
+          "templateMapHintNoMatch": "既存のテンプレートでは同じフィールド セットは使用されません。",
+          "templateMapHintAlreadyMapped": "一致するテンプレートはすべて既にマッピングされています。続行する前に、他のマッピングをクリアしてください。",
+          "templateIssueNoSelection": "マップする既存のテンプレートを選択します。",
+          "templateIssueTargetConflict": "このターゲットには別のテンプレートがすでにマップされています。",
+          "templateIssueFieldErrors": "強調表示されたテンプレート フィールドを解決します。",
+          "templateTargetFieldsMismatch": "フィールドはこのテンプレートと一致しません。",
+          "templateTargetNoLongerMatching": "フィールドはこのテンプレートと一致しなくなりました。",
+          "noRolesAvailable": "利用できる役割がありません。",
+          "roleSelectPlaceholder": "役割を選択",
+          "roleNameLabel": "役割名",
+          "roleNamePlaceholder": "役割名を入力してください",
+          "rolePermissionsEmpty": "権限が割り当てられていません",
+          "rolePermissionAddEdit": "追加/編集",
+          "noMilestoneTypesAvailable": "使用できるマイルストーン タイプはありません。",
+          "milestoneSelectPlaceholder": "マイルストーンの種類を選択",
+          "milestoneNamePlaceholder": "マイルストーンの種類名を入力してください",
+          "milestoneDefaultLabel": "デフォルトのマイルストーンの種類",
+          "milestoneIconRequired": "アイコンを選択",
+          "statusColorPlaceholder": "色の16進数（オプション）",
+          "issueTargetSelectPlaceholder": "統合を選択...",
+          "noIssueTargetsAvailable": "問題の統合は利用できません",
+          "issueTargetNamePlaceholder": "統合名...",
+          "templateFieldsHeading": "テンプレートフィールド",
+          "roleAreaColumn": "エリア",
+          "workflowSelectPlaceholder": "ワークフローを選択",
+          "statusSelectPlaceholder": "ステータスを選択",
+          "statusNamePlaceholder": "ステータス名を入力してください",
+          "statusSystemNamePlaceholder": "システム名を入力してください",
+          "labelSystemName": "システム名",
+          "groupNamePlaceholder": "グループ名を入力してください",
+          "configurationNameLabel": "設定名",
+          "userSelectPlaceholder": "ユーザーを選択",
+          "userApiLabel": "APIユーザー",
+          "templateCaseFieldsLabel": "ケースフィールド",
+          "templateResultFieldsLabel": "結果フィールド",
+          "templateNoFieldsPlaceholder": "このテンプレートにはフィールドが設定されていません。",
+          "templateTargetAlreadyUsed": "対象は既に別のテンプレートにマッピングされています。",
+          "templateFieldRequiredLabel": "必須項目",
+          "templateFieldOptionsDefaultValueLabel": "デフォルト値",
+          "templateFieldOptionsInitialHeightLabel": "初期高さ",
+          "templateFieldTemplateLabelSingular": "テンプレート",
+          "templateFieldTemplateLabelPlural": "テンプレート",
+          "templateFieldTargetGroupCase": "ケースフィールド",
+          "templateFieldTargetGroupResult": "結果フィールド",
+          "columnAction": "アクション"
+        },
+        "nextSteps": "バックグラウンド インポートが完了したら、ターゲット プロジェクトから移行されたデータを確認できます。",
+        "nextStepsDescription": "バックグラウンドインポートは非同期で実行されます。上記のステータスを監視するか、ページを更新して更新内容を確認できます。"
+      },
+      "comingSoon": {
+        "description": "TestRail、Zephyr、その他のツールのインポートはロードマップに含まれています。"
+      },
+      "errors": {
+        "fileRequired": "分析する前に、Testmo エクスポート JSON ファイルを選択してください。",
+        "uploadFailed": "エクスポートをストレージにアップロードできませんでした。もう一度お試しください。",
+        "analysisFailed": "エクスポートを分析できませんでした。ファイルを確認してもう一度お試しください。"
+      }
+    },
+    "sso": {
+      "description": "認証とセキュリティ設定を管理する",
+      "sections": {
+        "providers": {
+          "title": "サインインプロバイダー",
+          "description": "ユーザーがアプリケーションにサインインする方法を設定します。"
+        },
+        "security": {
+          "title": "安全",
+          "description": "認証のためのセキュリティポリシーを設定する"
+        }
+      },
+      "globalSettings": {
+        "title": "グローバルSSO設定",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Google OAuth 認証を有効または無効にする"
+        },
+        "samlProvider": {
+          "title": "SAMLプロバイダー",
+          "description": "SAML認証を有効または無効にする"
+        },
+        "apple": {
+          "title": "Appleサインイン",
+          "description": "Apple サインイン認証を有効または無効にする"
+        },
+        "microsoft": {
+          "title": "Microsoft SSO",
+          "description": "Microsoft (Azure AD / Entra ID) 認証を有効または無効にする"
+        },
+        "magicLink": {
+          "title": "マジックリンク認証",
+          "description": "パスワードなしのメールベースの認証を有効または無効にする"
+        },
+        "forceSso": {
+          "title": "SSOログインを強制する",
+          "description": "メールログインを無効にし、ユーザーにSSOの使用を要求する"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "パスワードログインに2FAを要求する",
+            "description": "メールアドレス/パスワードでサインインするユーザーは、2要素認証を設定して使用する必要があります。"
+          },
+          "forceAllLogins": {
+            "title": "すべてのログインに2FAを要求する",
+            "description": "SSOユーザーを含むすべてのユーザーは、サインイン後に2FAで認証する必要があります。"
+          }
+        }
+      },
+      "providers": {
+        "configure": "SAMLを構成する",
+        "delete": "プロバイダーを削除",
+        "entryPoint": "エントリポイント: ",
+        "autoProvision": "自動プロビジョニング: ",
+        "defaultAccess": "デフォルトのアクセス: ",
+        "configurationMessage": "SAML設定が設定されていません。設定ボタンをクリックして設定してください。"
+      },
+      "samlConfiguration": {
+        "title": "SAMLプロバイダーを構成する",
+        "backButton": "SSOプロバイダーに戻る",
+        "description": "{name}のSAML設定を構成する",
+        "samlSettings": {
+          "title": "SAML設定",
+          "description": "SAML IDプロバイダーの設定を構成する",
+          "ssoUrl": "SSO URL (エントリ ポイント)",
+          "entityId": "エンティティID（発行者）",
+          "certificate": "X.509証明書",
+          "callbackUrl": "コールバックURL",
+          "logoutUrl": "ログアウトURL（オプション）"
+        },
+        "userProvisioning": {
+          "title": "ユーザープロビジョニング",
+          "description": "ユーザーの作成とマッピング方法を構成する",
+          "autoProvision": "新規ユーザーの自動プロビジョニング",
+          "defaultAccess": "新規ユーザーのデフォルトのシステムアクセス",
+          "accessDescription": "新しいユーザーには、データベースからのデフォルトのロールとこのシステム アクセス レベルが割り当てられます。"
+        },
+        "attributeMapping": {
+          "title": "属性マッピング",
+          "description": "SAML属性をユーザーフィールドにマッピングする",
+          "email": "メール属性",
+          "displayName": "表示名属性",
+          "userId": "ユーザーID属性",
+          "firstName": "名属性（オプション）",
+          "lastName": "姓属性（オプション）",
+          "groups": "グループ属性（オプション）"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Google OAuth 対応",
+        "googleDisabled": "Google OAuth が無効になっています",
+        "googleCreated": "Google OAuth プロバイダが作成されました",
+        "googleUpdateFailed": "Google OAuth の更新に失敗しました",
+        "samlCreated": "SAMLプロバイダーが作成されました",
+        "createFailed": "プロバイダーの作成に失敗しました",
+        "deleted": "プロバイダーを削除しました",
+        "deleteFailed": "プロバイダの削除に失敗しました",
+        "enabled": "プロバイダーが有効",
+        "disabled": "プロバイダーが無効です",
+        "updateFailed": "プロバイダーの更新に失敗しました",
+        "forceSsoEnabled": "SSO をグローバルに強制的に有効化",
+        "forceSsoDisabled": "SSO をグローバルに強制的に無効にする",
+        "forceSsoUpdateFailed": "強制SSO設定の更新に失敗しました",
+        "force2FANonSSOEnabled": "パスワードログインには2要素認証が必要",
+        "force2FANonSSODisabled": "パスワードログインに2要素認証は不要になりました",
+        "force2FAAllLoginsEnabled": "すべてのログインに2要素認証が必要",
+        "force2FAAllLoginsDisabled": "すべてのログインに2要素認証は不要になりました",
+        "force2FAUpdateFailed": "2要素認証設定の更新に失敗しました",
+        "configUpdated": "SAML設定が更新されました",
+        "configCreated": "SAML設定が作成されました",
+        "configSaveFailed": "SAML設定を保存できませんでした",
+        "googleConfigSaved": "Google OAuth 設定が正常に保存されました",
+        "googleConfigFailed": "設定を保存できませんでした",
+        "appleEnabled": "Appleサインインが有効",
+        "appleDisabled": "Appleサインインが無効になっています",
+        "appleCreated": "Apple サインイン プロバイダが作成されました",
+        "appleConfigSaved": "Apple サインイン設定が正常に保存されました",
+        "appleConfigFailed": "Apple サインイン設定を保存できませんでした",
+        "appleUpdateFailed": "Apple サインイン プロバイダの更新に失敗しました",
+        "microsoftEnabled": "Microsoft SSOが有効になっています",
+        "microsoftDisabled": "Microsoft SSO が無効になっています",
+        "microsoftCreated": "Microsoft SSO プロバイダーが作成されました",
+        "microsoftConfigSaved": "Microsoft SSO の設定が正常に保存されました",
+        "microsoftConfigFailed": "Microsoft SSO構成の保存に失敗しました",
+        "microsoftUpdateFailed": "Microsoft SSO プロバイダーの更新に失敗しました",
+        "magicLinkEnabled": "マジックリンク認証が有効",
+        "magicLinkDisabled": "Magic Link認証が無効です",
+        "magicLinkCreated": "マジックリンクプロバイダーが作成されました",
+        "magicLinkUpdateFailed": "Magic Link プロバイダーの更新に失敗しました",
+        "samlConfigSaved": "SAML 構成が正常に保存されました",
+        "configureFirst": "有効にする前にプロバイダーを設定してください",
+        "domainRestrictionEnabled": "メールドメイン制限が有効",
+        "domainRestrictionDisabled": "メールドメイン制限が無効になっています",
+        "domainRestrictionUpdateFailed": "ドメイン制限設定の更新に失敗しました",
+        "domainRequired": "ドメインを入力してください",
+        "invalidDomain": "有効なドメインを入力してください（例：example.com）",
+        "domainAdded": "ドメインが正常に追加されました",
+        "domainExists": "このドメインはすでに許可リストに含まれています",
+        "domainAddFailed": "ドメインの追加に失敗しました",
+        "domainEnabled": "ドメインが有効",
+        "domainDisabled": "ドメインが無効です",
+        "domainUpdateFailed": "ドメインの更新に失敗しました",
+        "domainDeleted": "ドメインが正常に削除されました",
+        "domainDeleteFailed": "ドメインの削除に失敗しました",
+        "defaultAccessUpdated": "デフォルトのアクセスレベルが更新されました",
+        "defaultAccessUpdateFailed": "デフォルトのアクセス レベルの更新に失敗しました",
+        "emailVerificationEnabled": "新規ユーザーにはメールアドレスの認証が必須になりました。",
+        "emailVerificationDisabled": "新規ユーザーのメールアドレス認証は不要になりました。",
+        "emailVerificationDisabledAndVerified": "メール認証は無効になっており、 {count, plural, one {# ユーザー アカウント} other {# ユーザー アカウント}} が検証されています。",
+        "emailVerificationUpdateFailed": "メール認証設定の更新に失敗しました",
+        "emailServerNotConfigured": "メール認証を有効にできません: メールサーバーが設定されていません",
+        "openRegistrationEnabled": "自己登録が可能になりました",
+        "openRegistrationDisabled": "自己登録は現在無効になっています",
+        "openRegistrationUpdateFailed": "自己登録設定の更新に失敗しました"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Google OAuth を設定する",
+          "description": "Google OAuth クライアントの認証情報を設定します。認証情報は Google Cloud Console から取得できます。",
+          "clientIdPlaceholder": "Google OAuth クライアント ID",
+          "clientSecretPlaceholder": "Google OAuth クライアント シークレット",
+          "instructions": {
+            "title": "これらの資格情報を取得するには:",
+            "step1": "Google Cloud Console にアクセスします",
+            "step2": "プロジェクトを選択するか、新しいプロジェクトを作成してください",
+            "step3": "Google+ APIを有効にする",
+            "step4": "認証情報に移動してOAuth 2.0クライアントIDを作成します",
+            "step5": "承認済みリダイレクト URI を次のように設定します。"
+          },
+          "redirectUri": "/api/auth/コールバック/google",
+          "validation": {
+            "bothRequired": "クライアントIDとクライアントシークレットの両方が必要です"
+          }
+        },
+        "microsoft": {
+          "title": "Microsoft SSO を構成する",
+          "description": "Microsoft Entra ID (Azure AD) アプリケーションの認証情報を設定してください。これらの認証情報は、Azure ポータルから取得できます。",
+          "clientIdPlaceholder": "あなたのアプリケーション（クライアント）ID",
+          "clientSecretPlaceholder": "顧客にとっての秘密の価値",
+          "tenantId": "テナントID（任意）",
+          "tenantIdPlaceholder": "ディレクトリ（テナント）ID",
+          "tenantIdHint": "複数テナント（「共通」）の場合は空欄のままにしてください。組織のみに制限する場合は、特定のテナントIDを設定してください。",
+          "instructions": {
+            "title": "これらの認証情報を取得するには：",
+            "step1": "Azureポータル（portal.azure.com）にアクセスしてください。",
+            "step2": "Microsoft Entra ID > アプリ登録 に移動してください。",
+            "step3": "新規申請を登録するか、既存の申請を選択してください。",
+            "step4": "「証明書とシークレット」で、新しいクライアントシークレットを作成します。",
+            "step5": "認証設定に以下のリダイレクトURIを追加してください。"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "クライアントIDとクライアントシークレットの両方が必要です"
+          }
+        },
+        "saml": {
+          "description": "SAML IDプロバイダーの設定を行います。これらの詳細はSAML IdPから取得できます。",
+          "entryPoint": "SSO エントリ ポイント URL",
+          "issuer": "発行者（エンティティID）",
+          "callbackUrl": "ACS（コールバック）URL",
+          "logoutUrl": "SLO ログアウト URL (オプション)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:あなたのIDP:エンティティID",
+          "certPlaceholder": "-----証明書の開始-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "SAML を構成するには:",
+            "step1": "SAML IDプロバイダの管理者に問い合わせてください",
+            "step2": "SSOエントリポイントURLとエンティティIDを要求する",
+            "step3": "X.509証明書をダウンロードする",
+            "step4": "IdP でこの ACS URL を設定します。"
+          },
+          "redirectUri": "/api/auth/コールバック/saml",
+          "validation": {
+            "allRequired": "エントリポイント、発行者、証明書、コールバックURLは必須です"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "メール認証を無効にしますか？",
+          "description": "これにより、新規ユーザー登録時のメール認証が無効になり、既存の未認証アカウントはすべて認証されます。",
+          "warning": "⚠️セキュリティ警告",
+          "warningPoint1": "セキュリティが確保された環境（プライベートネットワーク、VPN、または信頼できる環境）でのみ推奨されます。",
+          "warningPoint2": "既存の未認証アカウントはすべて即座に認証され、システムへのアクセス権が付与されます。",
+          "confirmation": "メール認証を無効にして、すべてのアカウントを認証してもよろしいですか？",
+          "confirm": "無効化してすべてを確認する",
+          "verifying": "アカウントを確認しています..."
+        }
+      },
+      "status": {
+        "configured": "構成済み",
+        "setup": "設定"
+      },
+      "registration": {
+        "title": "登録設定",
+        "description": "新規アカウントを登録できるユーザーを制御する",
+        "restrictDomains": {
+          "title": "メールドメインを制限する",
+          "description": "特定のメールドメインからの登録のみを許可する"
+        },
+        "allowedDomains": {
+          "title": "許可されたメールドメイン",
+          "placeholder": "example.com",
+          "add": "ドメインを追加",
+          "empty": "許可されたドメインが設定されていません。制限を有効にすると、すべてのドメインがブロックされます。"
+        },
+        "defaultAccess": {
+          "title": "デフォルトのアクセスレベル",
+          "description": "新規ユーザーの登録時に割り当てられるシステムアクセスレベル",
+          "options": {
+            "NONE": "アクセス不可 - 管理者がアクセスを許可するまでユーザーはシステムにアクセスできません",
+            "USER": "ユーザー - 割り当てられたプロジェクトへの標準ユーザーアクセス",
+            "PROJECTADMIN": "プロジェクト管理者 - 割り当てられたプロジェクトを管理できます",
+            "ADMIN": "管理者 - 完全なシステム管理アクセス"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "メール認証が必要",
+          "description": "ユーザーはシステムにアクセスする前にメールアドレスを確認する必要があります。",
+          "noEmailServerWarning": "メールサーバーが設定されていません。メールサーバーが設定されるまで、メール認証は自動的に無効になります。"
+        },
+        "allowOpenRegistration": {
+          "title": "自己登録を許可する",
+          "description": "無効化されている場合、新規ユーザーは直接登録することも、SSO経由でアカウントを作成することもできません。既存ユーザーは引き続きログインできます。"
+        }
+      },
+      "errors": {
+        "invalidProvider": "プロバイダーが無効であるか、SAML プロバイダーではありません。"
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "プロジェクトをフィルタリング..."
+      },
+      "complete": {
+        "title": "プロジェクトの完了",
+        "description": "このアクションによりプロジェクトが完了し、これ以上のテスト実行が追加されなくなります。"
+      },
+      "add": {
+        "button": "プロジェクトを追加",
+        "title": "新しいプロジェクトを追加",
+        "defaultFields": "デフォルトのテンプレート、デフォルトのマイルストーン タイプ、およびすべてのワークフローとステータスは、プロジェクトの作成時にプロジェクトに追加されます。",
+        "selectIssueTracker": "問題追跡ツールを選択",
+        "issueTrackerRequired": "問題トラッカーが必要です"
+      },
+      "wizard": {
+        "title": "新しいプロジェクトを作成する",
+        "description": "必要なすべての設定を含む新しいプロジェクトをセットアップする",
+        "steps": {
+          "details": "プロジェクトの詳細",
+          "workflows": "ワークフロー、ステータス、マイルストーンの種類",
+          "integrations": "統合",
+          "permissions": "ユーザーと権限"
+        },
+        "labels": {
+          "selected": "選択済み",
+          "statuses": "テストステータス",
+          "issueTrackers": "問題追跡"
+        },
+        "placeholders": {
+          "projectName": "プロジェクト名を入力してください",
+          "selectDefaultAccess": "デフォルトのアクセスタイプを選択"
+        },
+        "descriptions": {
+          "templates": "このプロジェクトのテスト ケースの構造を定義するには、少なくとも 1 つのテンプレートを選択します。",
+          "workflows": "プロジェクト アクティビティを管理するためのワークフロー、ステータス、マイルストーンの種類を構成します。",
+          "integrations": "オプション: 外部の問題追跡ツールと AI モデルを接続して機能を強化します。",
+          "noIntegrations": "現在、統合が設定されていません。この手順をスキップするか、後で統合を設定することもできます。",
+          "aiModels": "テストケースの生成とインテリジェントな提案のための AI モデルを有効にします。",
+          "permissions": "このプロジェクトのユーザー アクセスとグループ権限を構成します。",
+          "milestoneTypes": "プロジェクトの進捗状況と期限を追跡するには、マイルストーンの種類を選択します。"
+        },
+        "actions": {
+          "selectDefault": "デフォルトを使用する",
+          "create": "プロジェクトを作成",
+          "creating": "プロジェクトを作成しています..."
+        },
+        "errors": {
+          "nameRequired": "プロジェクト名は必須です",
+          "validationFailed": "プロジェクト名の検証に失敗しました。もう一度お試しください。",
+          "templateRequired": "少なくとも1つのテンプレートを選択する必要があります",
+          "workflowRequired": "少なくとも1つのワークフローを選択する必要があります",
+          "statusRequired": "少なくとも1つのステータスを選択する必要があります",
+          "roleRequired": "「特定の役割」アクセスタイプを使用する場合は役割を選択してください",
+          "creationFailed": "プロジェクトの作成に失敗しました。もう一度お試しください。"
+        },
+        "success": {
+          "created": "プロジェクトが正常に作成されました"
+        }
+      },
+      "edit": {
+        "title": "プロジェクトの編集",
+        "labels": {
+          "groupProjectAccess": "グループプロジェクトアクセス",
+          "groupPermissions": "グループ権限",
+          "userPermissions": "ユーザー権限",
+          "noEffect": "効果なし",
+          "access": {
+            "groupsGlobalRole": "グループのグローバルな役割",
+            "groupDefault": "グループのデフォルト",
+            "groupSpecificRole": "グループ固有の役割",
+            "groupProjectDefault": "グループプロジェクトのデフォルト",
+            "groupProjectNoAccess": "グループプロジェクトアクセス不可",
+            "groupProjectSpecificRole": "グループプロジェクト固有の役割",
+            "effectiveAccess": "効果的なアクセス"
+          },
+          "accessHints": {
+            "noAccess": "直接割り当てまたはグループ メンバーシップを通じて明示的に許可されない限り、ユーザーはこのプロジェクトにアクセスできません。",
+            "globalRole": "サイトアクセス権を持つすべてのユーザーがこのプロジェクトを閲覧できます。権限は、グローバルに割り当てられたロールによって決まります。",
+            "specificRole": "ユーザーには自動的にアクセス権限が付与されません。アクセス権限は、ユーザーへの直接割り当てまたはグループメンバーシップを通じて付与する必要があります。グループ経由で割り当てられたユーザーは、直接割り当てによって上書きされない限り、このロールを使用します。"
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "デフォルトのアクセスを選択",
+          "groupPermissionsUI": "グループ権限管理 UI はここにあります...",
+          "userPermissionsUI": "ユーザー権限管理 UI はここにあります...",
+          "selectAccess": "アクセスを選択...",
+          "selectRole": "役割を選択...",
+          "searchUsersToAdd": "追加するユーザーを検索..."
+        },
+        "tableHeaders": {
+          "globalRole": "グローバルな役割",
+          "projectAccess": "プロジェクトアクセス"
+        },
+        "messages": {
+          "noUsersAssigned": "特定の権限を割り当てられたユーザーはいません。",
+          "noGroupsFound": "グループが見つかりません。"
+        },
+        "actions": {
+          "removeUser": "ユーザーを削除"
+        },
+        "loadingUserPermissions": "ユーザー権限を読み込んでいます..."
+      },
+      "delete": {
+        "title": "プロジェクトを削除",
+        "confirmMessage": "このプロジェクトを削除してもよろしいですか?"
+      }
+    },
+    "templates": {
+      "description": "テストケースのテンプレートとフィールドを管理する",
+      "help": {
+        "caseFields": "ケースフィールドは、リポジトリ内の各テストケースで取得できるプロパティとデータを定義します。これにより、標準フィールド以外のテストケース情報をカスタマイズできます。",
+        "resultFields": "結果フィールドは、テスト結果の記録時に取得できる追加データを定義します。これにより、テスト実行結果に固有のカスタム情報を追跡できます。"
+      },
+      "confirmSetAsDefault": "デフォルトのテンプレートとして設定",
+      "confirmSetAsDefaultDescription": "このテンプレートをデフォルトとして設定してもよろしいですか?",
+      "confirmSetAsDefaultProjects": "このテンプレートはすべてのプロジェクトに追加されます。",
+      "add": {
+        "button": "テンプレートを追加",
+        "title": "新しいテンプレートを追加",
+        "defaultTemplateHint": "このテンプレートはすべてのプロジェクトに割り当てられます。"
+      },
+      "edit": {
+        "title": "テンプレートを編集"
+      },
+      "delete": {
+        "title": "テンプレートを削除",
+        "confirmMessage": "<strong>{name}</strong> テンプレートを削除してもよろしいですか?",
+        "warning": "現在このテンプレートを使用しているすべてのテスト ケースと探索セッションは、自動的にデフォルトのテンプレートに再割り当てされます。",
+        "errors": {
+          "defaultTemplateNotFound": "デフォルトのテンプレートが見つかりません。削除を続行できません。",
+          "unknown": "テンプレートの削除中に不明なエラーが発生しました。"
+        }
+      },
+      "caseFields": {
+        "description": "ケースフィールドの管理",
+        "add": {
+          "button": "ケースフィールドを追加",
+          "title": "新しいケースフィールドを追加"
+        },
+        "edit": {
+          "title": "ケースフィールドの編集"
+        },
+        "delete": {
+          "title": "ケースフィールドの削除",
+          "confirmMessage": "このケースフィールドを削除してもよろしいですか?",
+          "warning": "ケースフィールドはすべてのテンプレートから削除されます。この操作は元に戻せません。"
+        }
+      },
+      "resultFields": {
+        "description": "結果フィールドを管理する",
+        "add": {
+          "button": "結果フィールドを追加",
+          "title": "新しい結果フィールドを追加"
+        },
+        "edit": {
+          "title": "結果フィールドを編集"
+        },
+        "delete": {
+          "title": "結果フィールドを削除",
+          "confirmMessage": "<strong>{name}</strong>を削除してもよろしいですか?",
+          "warning": "結果フィールドはすべてのテンプレートから削除されます。この操作は元に戻せません。"
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "コードリポジトリ",
+      "description": "QuickScriptコンテキストのコードリポジトリ接続を管理します。",
+      "addRepository": "リポジトリを追加",
+      "noRepos": {
+        "title": "コードリポジトリは設定されていません",
+        "description": "Gitリポジトリを接続して、AIを活用したテストエクスポート生成のためのファイルコンテキストを提供します。"
+      },
+      "delete": {
+        "title": "リポジトリを削除する",
+        "confirmMessage": "<strong>{name}</strong>を削除してもよろしいですか？この操作は元に戻せません。",
+        "fallbackName": "このリポジトリ"
+      },
+      "testConnection": "接続テスト",
+      "connectionSuccess": "接続に成功しました",
+      "connectionFailed": "接続に失敗しました",
+      "networkError": "ネットワークエラー",
+      "editTitle": "コードリポジトリを編集する",
+      "addTitle": "コードリポジトリを追加する",
+      "repositoryUpdated": "リポジトリが更新されました",
+      "repositoryCreated": "リポジトリが作成されました",
+      "saveFailed": "リポジトリの保存に失敗しました",
+      "namePlaceholder": "私のリポジトリ",
+      "selectProvider": "プロバイダーを選択してください",
+      "httpWarning": "このURLはHTTPを使用しています。認証情報は平文で送信されます。安全な接続にはHTTPSを使用してください。"
+    },
+    "exportTemplates": {
+      "title": "QuickScriptテンプレート",
+      "description": "QuickScriptがテストケースを自動化スクリプトに変換するために使用するテンプレートを管理します。",
+      "confirmSetAsDefault": "デフォルトのエクスポートテンプレートとして設定",
+      "confirmSetAsDefaultDescription": "このテンプレートをデフォルトとして設定してもよろしいですか？ユーザーがテストケースをエクスポートする際に、このテンプレートがデフォルトで選択されます。",
+      "fields": {
+        "category": "カテゴリ",
+        "framework": "フレームワーク",
+        "fileExtension": "ファイル拡張子",
+        "headerBody": "ヘッダーテンプレート",
+        "templateBody": "テンプレート本体",
+        "footerBody": "フッターテンプレート",
+        "validation": {
+          "categoryRequired": "カテゴリは必須です。",
+          "frameworkRequired": "フレームワークが必要です。",
+          "templateBodyRequired": "テンプレート本文は必須です。",
+          "fileExtensionRequired": "ファイル拡張子が必要です。",
+          "languageRequired": "言語能力は必須です。"
+        },
+        "placeholders": {
+          "name": "例：Playwright（TypeScript）",
+          "description": "例：Playwrightのテストスタブを生成する",
+          "category": "例：ブラウザE2E",
+          "framework": "例：劇作家",
+          "fileExtension": "例：.spec.ts",
+          "language": "例：タイプスクリプト",
+          "headerBody": "オプション。先頭に一度だけ表示されるコンテンツ（例：インポート文）。",
+          "templateBody": "Mustacheテンプレートを入力してください...\n\n使用可能な変数:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nステップセクション:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nカスタムフィールド:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "オプション。一番下に一度だけ表示されるコンテンツ（例：閉じコード）。"
+        },
+        "combobox": {
+          "typeNew": "新しい値を入力するには、入力してください。"
+        }
+      },
+      "add": {
+        "button": "QuickScriptテンプレートを追加する",
+        "title": "新しい QuickScript テンプレートを追加する"
+      },
+      "edit": {
+        "title": "QuickScriptテンプレートを編集する"
+      },
+      "delete": {
+        "title": "QuickScriptテンプレートを削除する",
+        "confirmMessage": "<strong>{name}</strong> QuickScript テンプレートを削除してもよろしいですか？"
+      },
+      "preview": {
+        "title": "プレビュー（模擬データ）",
+        "empty": "テンプレート本文を入力するとプレビューが表示されます。",
+        "error": "テンプレートのレンダリング中にエラーが発生しました。Mustache構文を確認してください。"
+      },
+      "filterPlaceholder": "テンプレートをフィルタリング...",
+      "noResults": "フィルター条件に一致するテンプレートはありません。",
+      "templateCount": "{count, plural, one {# テンプレート} other {# テンプレート}}",
+      "allFrameworks": "すべてのフレームワーク",
+      "allFileExtensions": "すべての拡張機能",
+      "allLanguages": "すべての言語",
+      "showEnabled": "有効のみ",
+      "showAll": "全て",
+      "variableInserter": {
+        "placeholder": "変数を挿入します...",
+        "groups": {
+          "customFields": "カスタムフィールド"
+        },
+        "stepsBlock": "ステップブロック"
+      }
+    },
+    "users": {
+      "showInactive": "非アクティブを表示",
+      "add": {
+        "button": "ユーザーを追加",
+        "title": "新しいユーザーを追加",
+        "fields": {
+          "email_invalid": "無効なメールアドレス",
+          "password_error": "パスワードが必要です",
+          "confirmPassword_error": "パスワードの確認が必要です",
+          "passwordOptionalHelp": "空白のままにすると、ユーザーはマジックリンクまたはSSO経由でサインインする必要があります。"
+        }
+      },
+      "edit": {
+        "title": "ユーザーを編集"
+      },
+      "delete": {
+        "title": "ユーザーの削除"
+      },
+      "restore": {
+        "title": "削除されたユーザーを復元する",
+        "description": "メールアドレス {email} を持つ削除済みユーザーが見つかりました。このユーザーを復元しますか？",
+        "confirm": "ユーザーを復元"
+      },
+      "forcePasswordChange": "強制パスワード変更",
+      "revokePassword": "パスワードの取り消し",
+      "forcePasswordChangeDialogTitle": "強制パスワード変更",
+      "forcePasswordChangeDialogDescription": "これにより、 {name} は次回のログイン時にパスワードを変更する必要があります。",
+      "revokePasswordDialogTitle": "パスワードの取り消し",
+      "revokePasswordDialogDescription": "これにより、 {name}のパスワードは即座に無効になります。別のログイン方法を使用する必要があります。",
+      "confirmAction": "確認する",
+      "forcePasswordChangeSuccess": "{name} のパスワード変更が必要です。",
+      "forcePasswordChangeFailed": "パスワード変更の強制に失敗しました",
+      "revokePasswordSuccess": "{name} のパスワードが取り消されました",
+      "revokePasswordFailed": "パスワードの取り消しに失敗しました"
+    },
+    "security": {
+      "title": "安全",
+      "description": "パスワードポリシー、ロックアウト設定、および強制措置を設定します。",
+      "passwordPolicyTitle": "パスワードポリシー",
+      "passwordPolicyDescription": "ユーザーパスワードの要件を設定する",
+      "lockoutPolicyTitle": "ロックアウトポリシー",
+      "lockoutPolicyDescription": "ログイン失敗後のアカウントロックアウトを設定する",
+      "enforcementTitle": "執行措置",
+      "enforcementDescription": "認証情報ベースのユーザーのパスワード変更を強制する",
+      "minPasswordLengthLabel": "パスワードの最小文字数",
+      "minPasswordLengthDescription": "パスワードは少なくともこの文字数（8～128文字）以上である必要があります。",
+      "requireUppercaseLabel": "大文字のみ入力可",
+      "requireLowercaseLabel": "小文字を必須とする",
+      "requireNumbersLabel": "数値が必要",
+      "requiredSpecialCharsLabel": "必須の特殊文字",
+      "requiredSpecialCharsDescription": "無効にするには空白のままにしてください。表示させる文字を入力してください（例：!@#$）",
+      "passwordHistoryDepthLabel": "パスワード履歴の詳細度",
+      "passwordHistoryDepthDescription": "過去N個のパスワードの再利用を防止する（0＝無効）",
+      "passwordExpirationDaysLabel": "パスワードの有効期限（日数）",
+      "passwordExpirationDaysDescription": "N日後にパスワード変更を強制する（0＝無効）",
+      "lockoutThresholdLabel": "ロックアウトしきい値",
+      "lockoutThresholdDescription": "アカウントロックアウトまでの失敗回数（最低1回）",
+      "lockoutDurationMinutesLabel": "ロックアウト期間（分）",
+      "lockoutDurationMinutesDescription": "アカウントがロックされる期間（最低1年）",
+      "saveChanges": "変更を保存",
+      "forceAllUsers": "全ユーザーにパスワードの変更を強制する",
+      "forceAllUsersDialogTitle": "全ユーザーのパスワード変更を強制する",
+      "forceAllUsersDialogDescription": "これにより、 {count} 認証情報ベースのユーザーは次回のログイン時にパスワードを変更する必要があります。",
+      "forceAllUsersDialogWarning": "この操作は取り消すことができません。",
+      "forceAllUsersDialogConfirm": "変化を強制する",
+      "saved": "セキュリティ設定が保存されました",
+      "saveFailed": "セキュリティ設定の保存に失敗しました",
+      "forceAllSuccess": "{count} ユーザーのパスワード変更が必要です",
+      "forceAllFailed": "パスワード変更の強制に失敗しました"
+    },
+    "apiTokens": {
+      "description": "すべてのユーザーのAPIトークンを表示および管理します。セキュリティ上の懸念がある場合はトークンを取り消します。",
+      "filterPlaceholder": "トークン名またはユーザーでフィルタリングします...",
+      "showInactive": "表示取り消し",
+      "noTokens": "API トークンはまだ作成されていません。",
+      "columns": {
+        "lastUsed": "最後に使用したもの",
+        "expires": "有効期限"
+      },
+      "status": {
+        "revoked": "取り消されました",
+        "expired": "期限切れ"
+      },
+      "noExpiry": "有効期限なし",
+      "revokeToken": "トークンを取り消す",
+      "revokeConfirmTitle": "APIトークンを取り消す",
+      "revokeConfirmMessage": "この API トークンを取り消してもよろしいですか? この操作は元に戻せません。",
+      "revokeConfirmDescription": "{user} に属するトークン「{name}」は直ちに取り消され、API アクセスに使用できなくなります。",
+      "revokeSuccess": "APIトークンが正常に取り消されました",
+      "revokeError": "APIトークンの取り消しに失敗しました",
+      "revokeAllTokens": "すべてのトークンを取り消す",
+      "revokeAllTitle": "すべてのAPIトークンを取り消す",
+      "revokeAllDescription": "これにより、すべてのユーザーのアクティブなAPIトークンがすべて直ちに取り消されます。この操作は元に戻すことができず、自動化されたワークフローに支障をきたす可能性があります。",
+      "revokeAllConfirm": "確認するには「REVOKE ALL」と入力してください",
+      "revokeAllPlaceholder": "すべて取り消す",
+      "revokeAllSuccess": "すべてのAPIトークンが取り消されました",
+      "revokeAllError": "すべてのトークンを取り消すことができませんでした"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "タグの作成中にエラーが発生しました"
+        }
+      },
+      "delete": {
+        "title": "タグを削除",
+        "confirmMessage": "このタグを削除してもよろしいですか?",
+        "warning": "このタグはすべてのテストケースとセッションから削除されます。",
+        "errors": {
+          "unknown": "タグの削除中にエラーが発生しました"
+        }
+      },
+      "edit": {
+        "title": "タグを編集"
+      }
+    },
+    "workflows": {
+      "description": "テストケースワークフローを管理する",
+      "add": {
+        "button": "ワークフローを追加",
+        "title": "新しいワークフローを追加",
+        "defaultHelp": "新しいテストケースのデフォルトのワークフローとして設定する",
+        "scopeLabel": "ワークフロースコープ",
+        "errors": {
+          "nameExists": "この名前のワークフローは既に存在します"
+        }
+      },
+      "edit": {
+        "title": "ワークフローの編集",
+        "lastWorkflowTypeWarning": "これは最後のワークフロータイプです。少なくとも 1 つのワークフロータイプを有効にする必要があります。",
+        "errors": {
+          "nameRequired": "ワークフロー名は必須です",
+          "unknownWorkflow": "不明なワークフロー"
+        }
+      },
+      "delete": {
+        "title": "ワークフローの削除",
+        "confirmMessage": "このワークフローを削除してもよろしいですか?"
+      },
+      "setDefault": {
+        "title": "デフォルトのワークフローを設定する",
+        "confirmMessage": "このワークフローをデフォルトとして設定してもよろしいですか?",
+        "description": "このワークフローはすべてのプロジェクトに追加されます。"
+      }
+    },
+    "roles": {
+      "description": "各アプリケーション領域の権限を切り替えることで、ユーザーが実行できる操作を定義します。",
+      "filterPlaceholder": "役割をフィルター...",
+      "add": {
+        "button": "役割を追加",
+        "title": "新しい役割を追加",
+        "fields": {
+          "name_error": "ロール名は必須です"
+        },
+        "errors": {
+          "nameExists": "この名前のロールは既に存在します"
+        }
+      },
+      "edit": {
+        "title": "役割を編集",
+        "permissionsTitle": "権限",
+        "areaHeader": "応用分野"
+      },
+      "delete": {
+        "title": "ロールを削除",
+        "confirmMessage": "このロールを削除してもよろしいですか?",
+        "warning": "この操作は元に戻せません。このロールを持つユーザーにはデフォルトのロールが割り当てられます。",
+        "errors": {
+          "defaultNotFound": "デフォルトロールを削除できません"
+        }
+      }
+    },
+    "statuses": {
+      "description": "テストステータスの管理",
+      "add": {
+        "button": "ステータスを追加",
+        "title": "新しいステータスを追加",
+        "systemNameHelp": "このステータスはシステム名によって識別されます。作成後は変更できません。",
+        "aliasesHelp": "カンマ区切りのエイリアスリスト",
+        "errors": {
+          "nameExists": "この名前のステータスは既に存在します",
+          "systemNameEmpty": "システム名は必須です",
+          "systemNameInvalid": "システム名は英数字でなければなりません",
+          "aliasesInvalid": "エイリアスは英数字でなければなりません",
+          "missingColor": "色が見つかりません。別の色を選択してください。"
+        }
+      },
+      "edit": {
+        "title": "編集ステータス",
+        "systemNameHelp": "システム名は、自動プロセスのこのステータスを識別します。作成後は変更できません。",
+        "unmodifiableHelp": "「未テスト」ステータスはシステム ステータスであり、変更できません。",
+        "untestedHelp": "「未テスト」という名前はシステム ステータス用に予約されており、使用できません。",
+        "success": "ステータスが正常に更新されました"
+      },
+      "delete": {
+        "title": "削除ステータス",
+        "confirmMessage": "ステータス <strong>{name}</strong>を削除してもよろしいですか?",
+        "errors": {
+          "inUse": "このステータスは使用中なので削除できません",
+          "defaultNotFound": "デフォルトのステータスが見つかりません"
+        },
+        "success": "ステータスが正常に削除されました"
+      },
+      "fields": {
+        "final": "ファイナル",
+        "system": "システムステータス",
+        "forTestCase": "テストケースの場合",
+        "forTestRun": "テスト実行用",
+        "forSession": "セッション用",
+        "color": "色"
+      }
+    },
+    "appConfig": {
+      "description": "グローバルアプリケーション構成を管理する",
+      "addConfig": "アプリケーション構成を追加する",
+      "editConfig": "アプリケーション構成の編集",
+      "keyPlaceholder": "構成キーを入力してください...",
+      "valuePlaceholder": "JSON 値を入力してください...",
+      "currentTranslation": "現在の翻訳",
+      "filterPlaceholder": "キーでフィルタリング...",
+      "errors": {
+        "keyRequired": "キーが必要です",
+        "invalidJson": "無効なJSON形式"
+      },
+      "configKeys": {
+        "project_docs_default": "プロジェクトドキュメントのデフォルト"
+      }
+    },
+    "configurations": {
+      "description": "構成とは、テスト環境を定義するために使用されるカテゴリとバリアントの組み合わせです。例えば、OS/ブラウザ、テストサーバー、言語などです。",
+      "addConfiguration": "設定を追加する",
+      "editConfiguration": "設定を編集する",
+      "filterPlaceholder": "フィルター構成...",
+      "categories": {
+        "title": "カテゴリー",
+        "description": "グローバルカテゴリを管理する",
+        "editCategory": "カテゴリを編集",
+        "selectCategory": "カテゴリーを選択",
+        "filterPlaceholder": "カテゴリをフィルター...",
+        "add": {
+          "title": "新しいカテゴリを追加"
+        },
+        "delete": {
+          "confirmMessage": "このカテゴリを削除してもよろしいですか?",
+          "deleteCategory": "カテゴリを削除",
+          "deleteCategoryConfirm": "カテゴリー <strong>{name}</strong>を削除してもよろしいですか?",
+          "deleteCategoryWarning": "このアクションにより、カテゴリとそれに関連付けられているすべてのバリアントが削除されます。"
+        },
+        "disable": {
+          "confirmDisableTitle": "バリアントを無効にする",
+          "confirmDisableDescription": "このバリアントを無効にしてもよろしいですか?"
+        }
+      },
+      "combinations": {
+        "title": "組み合わせ",
+        "description": "グローバルな組み合わせを管理する",
+        "addCombination": "組み合わせを追加",
+        "editCombination": "組み合わせを編集",
+        "selectCombination": "組み合わせを選択",
+        "selectCombinationDescription": "構成に追加するバリアントの組み合わせを選択します。",
+        "allExist": "すべての組み合わせはすでに存在します。",
+        "selectAtLeast": "少なくとも 1 つの組み合わせを選択してください。"
+      },
+      "delete": {
+        "title": "設定を削除",
+        "message": "設定 <strong>{name}</strong>を削除してもよろしいですか?",
+        "confirmMessage": "この設定を削除してもよろしいですか?"
+      },
+      "variants": {
+        "edit": {
+          "title": "バリエーションを編集"
+        },
+        "delete": {
+          "title": "バリアントを削除",
+          "message": "バリアント <strong>{name}</strong>を削除してもよろしいですか?",
+          "confirmMessage": "このバリアントを削除してもよろしいですか?",
+          "suggestion": "代わりにバリアントを無効にすることを検討してください。"
+        },
+        "selection": {
+          "title": "バリエーションを選択",
+          "description": "構成に追加するバリアントを選択します。"
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "ユーザーをグループに編成することで、プロジェクトへのアクセス権限や役割を一括で割り当てることができます。"
+      },
+      "filterPlaceholder": "フィルター グループ...",
+      "add": {
+        "button": "グループを追加",
+        "title": "新しいグループを追加",
+        "errors": {
+          "nameExists": "この名前のグループは既に存在します"
+        }
+      },
+      "edit": {
+        "title": "グループを編集"
+      },
+      "delete": {
+        "deleteGroup": "グループを削除",
+        "deleteGroupDescription": "このアクションにより、グループとそれに関連付けられているすべてのユーザーが削除されます。",
+        "confirmMessage": "このグループを削除してもよろしいですか?"
+      },
+      "noUsersSelected": "まだユーザーは選択されていません。",
+      "noUsersAssigned": "このグループにはユーザーが割り当てられていません。"
+    },
+    "milestones": {
+      "description": "マイルストーンの種類を管理する",
+      "filterPlaceholder": "マイルストーンの種類をフィルター...",
+      "addMilestones": "マイルストーンの一括追加",
+      "confirmDefault": "デフォルトを確認",
+      "confirmDefaultDescription": "このマイルストーン タイプをデフォルトとして設定してもよろしいですか?",
+      "warning": "このマイルストーン タイプはすべてのプロジェクトに追加されます。",
+      "wizard": {
+        "selectProjects": "プロジェクトを選択",
+        "projectsSelected": "{count, plural, =0 {プロジェクトが選択されていません} one {プロジェクトが選択されました} other {プロジェクトが選択されました}}",
+        "createMilestone": "マイルストーンを作成",
+        "noCommonTypesTitle": "共通のマイルストーンタイプはありません",
+        "noCommonTypesDescription": "選択したプロジェクトには共通のマイルストーンタイプがありません。選択したすべてのプロジェクトに少なくとも1つの共通のマイルストーンタイプがあることを確認するか、別のプロジェクトを選択してください。"
+      },
+      "add": {
+        "button": "マイルストーンの種類を追加",
+        "title": "新しいマイルストーンタイプを追加",
+        "errors": {
+          "nameExists": "この名前のマイルストーンタイプは既に存在します"
+        }
+      },
+      "edit": {
+        "title": "マイルストーンタイプの編集"
+      },
+      "delete": {
+        "title": "マイルストーンタイプの削除",
+        "confirmMessage": "このマイルストーン タイプを削除してもよろしいですか?"
+      }
+    },
+    "issue_config": {
+      "link_title": "リンク問題トラッカー",
+      "link_description": "手動でリンクされた課題のベースURLを設定します。外部IDのみを使用して課題をリンクする場合、このベースURLが先頭に追加され、完全なリンクが作成されます。",
+      "filter": {
+        "show_inactive": "非アクティブな構成を表示",
+        "search_placeholder": "構成名でフィルタリング..."
+      },
+      "base_url": "ベースURL",
+      "link_update_success": "リンク設定が正常に更新されました",
+      "link_update_error": "リンク設定の更新に失敗しました",
+      "description": "外部の問題追跡システムとの統合を構成します。",
+      "delete": {
+        "title": "問題設定の削除",
+        "confirmMessage": "構成 <bold>{name}</bold>を削除してもよろしいですか?",
+        "warning": "この操作は元に戻せません。現在このトラッカーに割り当てられているプロジェクトはすべて、デフォルトのトラッカーに再割り当てされます。代わりに、設定を無効化することを検討してください。",
+        "cannotDeleteDefault": "デフォルトの問題追跡ツールは削除できません。",
+        "noDefaultFound": "削除できません: プロジェクトを再割り当てするデフォルトの問題追跡ツールが見つかりません。"
+      },
+      "add": {
+        "title": "問題追跡ツールを追加",
+        "description": "問題追跡システムの新しい構成を作成します。",
+        "name": "構成名",
+        "name_placeholder": "例: プロジェクト Jira リンク",
+        "system_type": "システムタイプ",
+        "select_system_type": "システムタイプを選択",
+        "base_url": "問題のプレースホルダーを含むベース URL",
+        "base_url_placeholder": "例: https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "問題設定が正常に作成されました",
+        "create_error": "問題設定の作成中にエラーが発生しました",
+        "setDefaultWarning": "これをデフォルトに設定すると、現在のデフォルト構成からデフォルト ステータスが削除されます。"
+      },
+      "edit": {
+        "title": "問題トラッカーを編集",
+        "description": "この問題の構成の詳細を更新します。",
+        "name_placeholder": "設定名を入力",
+        "select_project": "プロジェクトを選択...",
+        "update_success": "問題の設定が正常に更新されました",
+        "update_error": "問題の設定を更新できませんでした",
+        "edit_not_supported": "このシステム タイプの構成の編集は現在サポートされていません。"
+      }
+    },
+    "issues": {
+      "description": "この問題トラッカーの問題を管理する",
+      "filterPlaceholder": "フィルターの問題...",
+      "add": {
+        "button": "問題を追加",
+        "title": "新しい問題を追加"
+      },
+      "edit": {
+        "title": "問題を編集"
+      },
+      "delete": {
+        "title": "問題を削除",
+        "confirmMessage": "問題「{name}」を削除してもよろしいですか?"
+      },
+      "syncIssue": "外部システムからの同期の問題",
+      "syncSuccess": "問題は正常に同期されました",
+      "syncSuccessDescription": "問題「{name}」は外部システムからの最新情報で更新されました。",
+      "syncError": "同期に失敗した問題",
+      "syncErrorDescription": "問題を同期できませんでした。しばらくしてからもう一度お試しください。"
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "プロジェクトリンク",
+        "milestoneLinks": "マイルストーンリンク",
+        "icons": "アイコン",
+        "fieldOptions": "フィールドオプション",
+        "configCategories": "設定カテゴリ",
+        "configVariants": "設定バリアント",
+        "repositories": "リポジトリ",
+        "repositoryFolders": "リポジトリフォルダ",
+        "repositoryCaseLinks": "リポジトリケースリンク",
+        "repositoryCaseVersions": "リポジトリケースのバージョン",
+        "testRunStepResults": "テスト実行ステップの結果",
+        "issueConfigs": "問題構成",
+        "sharedStepGroups": "共有ステップグループ"
+      },
+      "table": {
+        "title": "削除されました {itemType}",
+        "loading": "削除された {itemType}を読み込んでいます...",
+        "error": "削除された {itemType}の読み込み中にエラーが発生しました : {message}",
+        "noItems": "削除された {itemType} は見つかりません。",
+        "noResults": "「{query}」の検索に一致する削除済みの {itemType} は見つかりませんでした。",
+        "restoreConfirmationMessage": "{itemType} テーブルからこの行を復元してもよろしいですか? 関連データも復元される可能性があります。",
+        "purgeConfirmationMessage": "{itemType} テーブルからこの行を完全に削除してもよろしいですか? この操作は元に戻すことができず、関連データが削除される可能性があります。"
+      }
+    },
+    "notifications": {
+      "title": "通知管理",
+      "description": "デフォルトの通知設定（ユーザーが上書き可能）を設定し、システム通知を送信します。",
+      "defaultMode": {
+        "label": "デフォルトの通知モード",
+        "inApp": "アプリ内限定",
+        "inAppEmailImmediate": "アプリ内 + メール（即時）",
+        "inAppEmailDaily": "アプリ内 + メール（デイリーダイジェスト）"
+      },
+      "options": {
+        "title": "利用可能な通知オプション",
+        "inApp": {
+          "label": "アプリ内通知",
+          "description": "アプリケーション内で通知を表示する"
+        },
+        "emailImmediate": {
+          "label": "即時メール",
+          "description": "イベントが発生したらすぐにメール通知を送信する"
+        },
+        "emailDaily": {
+          "label": "毎日のメールダイジェスト",
+          "description": "毎日の通知の概要をメールで送信"
+        }
+      },
+      "save": "設定を保存",
+      "success": {
+        "title": "設定を保存しました",
+        "description": "通知設定が正常に更新されました"
+      },
+      "error": {
+        "description": "通知設定を保存できませんでした"
+      },
+      "systemNotification": {
+        "title": "システム通知",
+        "description": "重要なお知らせを全ユーザーに送信する",
+        "titlePlaceholder": "通知のタイトルを入力してください...",
+        "messagePlaceholder": "通知メッセージを入力してください...",
+        "send": "通知を送信",
+        "success": {
+          "title": "通知を送信しました",
+          "description": "システム通知が {count, plural, one {# ユーザー} other {# ユーザー}} に送信されました。"
+        },
+        "error": {
+          "description": "システム通知の送信に失敗しました",
+          "emptyFields": "タイトルとメッセージの両方を入力してください"
+        },
+        "history": {
+          "title": "通知履歴",
+          "sentBy": "送信者",
+          "sentAt": "送信先",
+          "empty": "システム通知はまだ送信されていません"
+        }
+      }
+    },
+    "integrations": {
+      "description": "課題追跡のためのサードパーティ統合を管理する",
+      "list": {
+        "title": "設定済みの課題統合",
+        "description": "構成された問題統合を表示および管理する"
+      },
+      "empty": {
+        "message": "問題統合はまだ設定されていません"
+      },
+      "addIntegration": "課題統合の追加",
+      "allIntegrations": "すべての課題統合",
+      "manageDescription": "外部サービスの問題統合を構成および管理する",
+      "status": {
+        "active": "アクティブ",
+        "inactive": "非アクティブ"
+      },
+      "connectedProjects": "関連プロジェクト",
+      "noIntegrations": "問題統合が設定されていません",
+      "testConnection": "テスト接続",
+      "testSuccess": "接続成功",
+      "testSuccessDescription": "問題統合は適切に構成され、接続されています",
+      "testFailed": "接続に失敗しました",
+      "testFailedDescription": "外部サービスに接続できません",
+      "testError": "テストエラー",
+      "testErrorDescription": "接続テスト中にエラーが発生しました",
+      "syncInProgress": "同期の問題...",
+      "syncIntegration": "課題統合からすべての課題を同期します",
+      "syncSuccess": "同期キュー",
+      "syncSuccessDescription": "「{name}」の課題をバックグラウンドで同期しています。これには少し時間がかかる場合があります。完了すると、表は自動的に更新されます。",
+      "syncError": "同期に失敗しました",
+      "syncErrorDescription": "この問題の統合に関する同期ジョブをキューに追加できませんでした。しばらくしてからもう一度お試しください。",
+      "delete": {
+        "confirmMessage": "問題統合「{name}」を削除してもよろしいですか?",
+        "warning": "これにより、課題の統合が削除され、すべてのプロジェクトから切断されます。この操作は元に戻せません。",
+        "warningTitle": "このアクションにより次のことが起こります:",
+        "warning1": "問題の統合構成と資格情報を完全に削除します",
+        "warning2": "この問題の統合のすべてのユーザー認証トークンを切断します",
+        "warning3": "データベース内のリンクされたすべての問題を保存します（問題はリンク解除されます）",
+        "warning4": "まずすべてのプロジェクトから問題の統合を削除する必要があります"
+      },
+      "deleteSuccess": "課題統合が削除されました",
+      "deleteSuccessDescription": "問題の統合が正常に削除されました",
+      "deleteError": "削除エラー",
+      "add": {
+        "description": "外部サービスとの新しい問題統合を構成する",
+        "selectType": "課題統合タイプを選択してください",
+        "typeDescription": "統合したいサービスの種類を選択してください",
+        "successMessage": "課題統合が正常に作成されました",
+        "successDescription": "問題統合が設定され、使用準備が整いました",
+        "simple_url": {
+          "name": "シンプルなURL",
+          "description": "カスタム URL パターンを使用した基本的な問題追跡"
+        },
+        "jira": {
+          "name": "ジラ",
+          "description": "問題追跡とプロジェクト管理のために Atlassian Jira に接続します"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "問題追跡のためにGitHubに接続する"
+        },
+        "gitlab": {
+          "name": "ギットラボ",
+          "description": "課題とマージリクエストの追跡にはGitLabに接続してください。"
+        },
+        "gitea": {
+          "name": "ギテア / フォルヘホ / ゴグス",
+          "description": "自己ホスト型のGitea、Forgejo、またはGogsインスタンスに接続して課題を追跡します。"
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "作業項目の追跡のために Azure DevOps に接続する"
+        }
+      },
+      "filterPlaceholder": "フィルター統合...",
+      "table": {
+        "lastSync": "最終同期",
+        "empty": "問題のある統合は見つかりませんでした",
+        "loading": "課題統合を読み込んでいます...",
+        "configure": "設定"
+      },
+      "edit": {
+        "description": "課題統合設定と構成を更新する",
+        "successMessage": "課題統合が正常に更新されました",
+        "successDescription": "課題統合設定が保存されました"
+      },
+      "editIntegration": "課題編集機能の統合",
+      "saveIntegration": "課題保存機能の統合",
+      "deleteIntegration": "課題削除統合",
+      "config": {
+        "name": "課題統合名",
+        "namePlaceholder": "この問題統合の名前を入力してください",
+        "nameHelp": "この問題の統合を識別するための説明的な名前",
+        "authType": "認証タイプ",
+        "authTypeHelp": "外部サービスでの認証方法を選択する",
+        "emailPlaceholder": "あなたのメールアドレス@example.com",
+        "emailHelp": "アカウントのメールアドレス",
+        "apiToken": "APIトークン",
+        "apiTokenPlaceholder": "APIトークンを入力してください",
+        "apiTokenHelp": "アカウント設定からAPIトークンを生成する",
+        "jiraUrl": "Jira URL",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "JiraインスタンスのURL",
+        "clientId": "クライアントID",
+        "clientIdPlaceholder": "OAuthクライアントIDを入力してください",
+        "clientIdHelp": "OAuthアプリケーションのクライアントID",
+        "clientSecret": "クライアントシークレット",
+        "clientSecretPlaceholder": "OAuthクライアントシークレットを入力してください",
+        "clientSecretHelp": "OAuthアプリケーションのクライアントシークレット",
+        "cloudId": "クラウドID",
+        "cloudIdPlaceholder": "Atlassian Cloud IDを入力してください",
+        "cloudIdHelp": "Atlassian Cloud インスタンス ID (Jira URL に記載)",
+        "apiUrl": "API URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "サービスAPIのベースURL",
+        "personalAccessTokenPlaceholder": "個人アクセストークンを入力してください",
+        "personalAccessTokenHelp": "適切な権限を持つ個人アクセストークン",
+        "apiKeyPlaceholder": "APIキーを入力してください",
+        "apiKeyHelp": "認証用のAPIキー",
+        "baseUrl": "URLパターン",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "問題のURLパターン。プレースホルダーとして {issueId} を使用してください。",
+        "organizationUrl": "組織のURL",
+        "organizationUrlPlaceholder": "https://dev.azure.com/あなたの組織",
+        "organizationUrlHelp": "Azure DevOps 組織の URL",
+        "projectPath": "プロジェクトパス",
+        "projectPathPlaceholder": "グループ／サブグループ／プロジェクト",
+        "projectPathHelp": "GitLabプロジェクトの完全なパス（例：mygroup/myproject）",
+        "instanceUrl": "インスタンスURL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "セルフホスト型インスタンスのURL。gitlab.comを使用する場合は空欄のままにしてください。",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "所有者",
+        "ownerPlaceholder": "ユーザー名または組織",
+        "ownerHelp": "リポジトリを所有するGiteaユーザーまたは組織",
+        "repo": "リポジトリ",
+        "repoPlaceholder": "リポジトリ名",
+        "repoHelp": "Giteaリポジトリの名前",
+        "encrypted": "暗号化された",
+        "encryptedHelp": "このフィールドは暗号化され、安全に保存されます",
+        "changeCredential": "変化",
+        "apiKeyWarningTitle": "APIキー認証に関するお知らせ",
+        "apiKeyWarningDescription": "API キー認証を使用する場合、問題報告者は自動的に決定されます。",
+        "apiKeyWarningPoint1": "TestPlanItのメールアドレスがJiraのユーザーのメールアドレスと一致する場合、報告者として設定されます。",
+        "apiKeyWarningPoint2": "メールアドレスが一致しない場合は、TestPlanIt の名前が Jira の表示名と一致します。",
+        "apiKeyWarningPoint3": "一致するものが見つからない場合は、APIキーの所有者が報告者として設定されます。",
+        "forgeApiKeyLabel": "Forge APIキー",
+        "forgeApiKeyDescription": "Atlassian ForgeアプリがJira課題パネルからのリクエストを認証するために使用します。ここでキーを生成し、Forgeアプリの設定に貼り付けてください。",
+        "forgeApiKeyPlaceholder": "「生成」をクリックしてAPIキーを作成します。",
+        "forgeApiKeyGenerate": "生成する",
+        "forgeApiKeyCopy": "コピー",
+        "forgeApiKeyCopied": "コピーしました",
+        "platform": "プラットフォーム",
+        "platformPlaceholder": "プラットフォームを選択してください...",
+        "platformGitea": "ギテア",
+        "platformForgejo": "フォルジェホ",
+        "platformGogs": "ゴグス"
+      },
+      "authType": {
+        "api_key": "APIキー",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "個人アクセストークン"
+      },
+      "validation": {
+        "nameRequired": "課題統合名は必須です",
+        "clientIdRequired": "クライアントIDが必要です",
+        "clientSecretRequired": "クライアントシークレットが必要です",
+        "cloudIdRequired": "クラウドIDが必要です",
+        "apiUrlRequired": "API URLは必須です",
+        "tokenRequired": "個人アクセストークンが必要です",
+        "apiKeyRequired": "APIキーが必要です"
+      },
+      "errors": {
+        "updateFailed": "問題統合の更新に失敗しました",
+        "testFailed": "接続テストに失敗しました",
+        "nameExists": "この名前の課題統合は既に存在します",
+        "createFailed": "課題統合の作成に失敗しました",
+        "deleteFailed": "課題統合の削除に失敗しました"
+      },
+      "confirmDelete": {
+        "message": "課題統合「{name}」を削除してもよろしいですか？",
+        "warning": "これにより、課題統合機能が削除され、すべてのプロジェクトから切り離されます。この操作は元に戻せません。"
+      },
+      "form": {
+        "success": "課題統合が正常に保存されました",
+        "successDescription": "課題統合の設定が完了し、使用準備が整いました。",
+        "testing": "接続をテストしています..."
+      },
+      "oauth": {
+        "connectAccount": "アカウントを接続",
+        "connected": "接続",
+        "notConnected": "接続されていません",
+        "authDescription": "この統合を使用するには、 {provider} で認証する必要があります",
+        "authError": "認証に失敗しました",
+        "authErrorDescription": "外部サービスで認証できません"
+      }
+    },
+    "llm": {
+      "addIntegration": "AIモデルを追加",
+      "filterPlaceholder": "AI モデルをフィルタリング...",
+      "testAll": "すべての接続をテストする",
+      "connectionTestComplete": "接続テストが完了しました",
+      "allIntegrationsTested": "すべてのAIモデルの接続がテスト済み",
+      "failedToTestConnections": "一部の接続のテストに失敗しました",
+      "notConfigured": "構成されていません",
+      "defaultModel": "選択されたモデル",
+      "budgetUsage": "利用状況（今月）",
+      "noBudget": "予算設定なし",
+      "streaming": "ストリーミング",
+      "add": {
+        "title": "AIモデル統合を追加する",
+        "description": "組織向けに新しい AI モデルを構成する",
+        "integrationNamePlaceholder": "この統合の名前を入力してください...",
+        "selectProvider": "プロバイダーを選択",
+        "openai": "オープンAI",
+        "anthropic": "人類学的",
+        "azureOpenai": "Azure オープンAI",
+        "gemini": "Google ジェミニ",
+        "ollama": "オラマ",
+        "customLlm": "カスタムLLM",
+        "apiKeyPlaceholder": "API キーを入力してください...",
+        "apiKeyDescription": "プロバイダー認証用のAPIキー",
+        "endpoint": "エンドポイントURL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "ヒント：プロキシ（例：LiteLLM）を使用している場合は、エンドポイントURLの末尾に/v1を追加してみてください。",
+        "deploymentName": "デプロイメント名",
+        "deploymentNamePlaceholder": "デプロイメント名を入力してください...",
+        "deploymentNameDescription": "Azure OpenAI デプロイメント名",
+        "defaultModelPlaceholder": "gpt-4o、claude-3-5-sonnet-20241022 など。",
+        "defaultModelDescription": "デフォルトで使用するモデル",
+        "maxTokensPerRequest": "リクエストあたりの最大トークン数",
+        "maxRequestsPerMinute": "1分あたりの最大リクエスト数",
+        "costPerInputToken": "100万トークンあたりのコスト（ドル）",
+        "costPerOutputToken": "100万トークンあたりのコスト（ドル）",
+        "monthlyBudget": "月間予算（$）",
+        "monthlyBudgetPlaceholder": "100.00",
+        "monthlyBudgetDescription": "通知に関するオプションの支出目標（利用を妨げません）",
+        "billingPeriodStartDay": "請求期間開始日",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "請求期間の開始日（1～31日）。29～31の値は、日数の少ない月の最終日を使用します。",
+        "defaultTemperature": "デフォルト温度",
+        "defaultMaxTokens": "デフォルトの最大トークン数",
+        "timeout": "リクエストタイムアウト（ミリ秒）",
+        "timeoutDescription": "AIモデルからの応答を待つ最大時間（5000～600000ミリ秒）。ストリーミングリクエストには適用されません。",
+        "streamingEnabled": "ストリーミングを有効にする",
+        "streamingEnabledDescription": "リアルタイム応答ストリーミングを許可する",
+        "setAsDefault": "デフォルトとして設定",
+        "setAsDefaultDescription": "これを組織のデフォルトのAIモデルとして使用します",
+        "fetchingModels": "モデルを取得しています...",
+        "failedToFetchModels": "利用可能なモデルを取得できませんでした",
+        "selectModel": "モデルを選択",
+        "connectionSuccessfulDescription": "AIモデルの接続は検証済みで、正常に動作しています",
+        "failedToConnect": "AIモデルプロバイダーへの接続に失敗しました",
+        "integrationCreated": "AIモデルの統合が正常に作成されました",
+        "failedToCreate": "AIモデル統合の作成に失敗しました",
+        "validation": {
+          "nameRequired": "統合名は必須です。",
+          "nameUnique": "この名前の統合は既に存在します",
+          "defaultModelRequired": "デフォルトモデルが必要です"
+        }
+      },
+      "edit": {
+        "title": "AIモデルの統合を編集する",
+        "description": "このAIモデル統合の設定を更新します",
+        "statusDescription": "この統合を有効または無効にする",
+        "apiKeyPlaceholder": "更新するには新しい API キーを入力してください...",
+        "update": "アップデート",
+        "integrationUpdated": "AIモデルの統合が正常に更新されました",
+        "failedToUpdate": "AIモデルの統合を更新できませんでした",
+        "validation": {
+          "nameRequired": "統合名は必須です。",
+          "nameUnique": "この名前の統合は既に存在します",
+          "defaultModelRequired": "デフォルトモデルが必要です"
+        }
+      },
+      "sections": {
+        "provider": "プロバイダー",
+        "costAndBudget": "費用と予算",
+        "advanced": "高度な"
+      },
+      "delete": {
+        "title": "AIモデル統合の削除",
+        "description": "この AI モデル統合を削除してもよろしいですか? すべてのプロジェクトから削除され、元に戻すことはできません。",
+        "integrationDeletedSuccess": "AIモデルの統合が正常に削除されました",
+        "failedToDeleteIntegration": "AIモデル統合の削除に失敗しました",
+        "cannotDeleteDefault": "デフォルトのAIモデルは削除できません。まず別のモデルをデフォルトに設定してください。"
+      },
+      "validation": {
+        "defaultModelRequired": "デフォルトモデルが必要です"
+      },
+      "test": {
+        "title": "AIモデルの統合をテストする",
+        "description": "{name}の接続と機能をテストします",
+        "connectionStatus": "接続ステータス",
+        "connectionStatusDescription": "AIモデルにアクセスできるかどうかを確認する",
+        "retest": "接続を再テスト",
+        "connectionSuccessfulDescription": "AIモデルはアクセス可能であり、正しく応答します",
+        "failedToConnect": "AIモデルへの接続に失敗しました",
+        "errorTestingConnection": "接続テスト中にエラーが発生しました",
+        "testMessage": "テストメッセージ",
+        "testMessagePlaceholder": "AI モデルに送信するメッセージを入力してください...",
+        "sendTestMessage": "テストメッセージを送信",
+        "response": "応答",
+        "testSuccessful": "テスト成功",
+        "responseReceived": "応答を正常に受信しました (コスト: ${cost})",
+        "testFailed": "テストに失敗しました",
+        "failedToGetResponse": "AIモデルからの応答を取得できませんでした",
+        "failedToSendMessage": "テストメッセージの送信に失敗しました",
+        "defaultTestMessage": "こんにちは！正常に動作していることを簡単に確認してご返信ください。"
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "月間予算を設定しても、LLMの利用が予算を超えることを防ぐことはできません。予算制限は、管理者の意思決定のための参考情報としてのみ使用されます。",
+        "budgetDisclaimerShort": "予算制限は情報提供のみを目的としており、利用を制限するものではありません。",
+        "spendLabel": "当月の支出",
+        "spendOfBudget": "{currentSpend} / {budgetLimit}",
+        "overBudget": "予算超過",
+        "budgetPercentage": "{percentage}予算使用率（％）",
+        "spendReset": "今月の支出がリセットされました"
+      }
+    },
+    "prompts": {
+      "title": "プロンプト設定",
+      "description": "さまざまな機能に対応したAIプロンプトテンプレートを管理する",
+      "addPromptConfig": "プロンプト設定の追加",
+      "filterPlaceholder": "フィルタープロンプトの設定...",
+      "features": "特徴",
+      "featureCount": "{count, plural, one {# 機能} other {# 機能}}",
+      "llmIntegration": "LLM統合",
+      "modelOverride": "モデルのオーバーライド",
+      "llmIntegrationPlaceholder": "プロジェクトデフォルト",
+      "modelOverridePlaceholder": "統合デフォルト",
+      "projectDefault": "プロジェクトのデフォルト設定（クリア）",
+      "integrationDefault": "統合デフォルト（クリア）",
+      "systemPrompt": "システムプロンプト",
+      "userPrompt": "ユーザープロンプト",
+      "temperature": "温度",
+      "maxOutputTokens": "最大出力トークン数",
+      "variables": "変数",
+      "insertVariable": "変数を挿入する",
+      "noConfigs": "プロンプト設定が見つかりませんでした。開始するには、最初の設定を追加してください。",
+      "add": {
+        "title": "プロンプト設定の追加",
+        "description": "各機能に対応するプロンプトを含む、新しいAIプロンプト設定を作成します。デフォルト設定は自動的に適用されています。"
+      },
+      "edit": {
+        "title": "プロンプト設定の編集",
+        "description": "このAIプロンプトの設定を更新してください"
+      },
+      "delete": {
+        "title": "削除プロンプト設定",
+        "confirmMessage": "<strong>{name}</strong>を削除してもよろしいですか？このプロンプトを使用するプロジェクトは、システムのデフォルト設定に戻ります。",
+        "warning": "この操作は元に戻せません。この設定を使用しているすべてのプロジェクトは、デフォルトのプロンプト設定に戻ります。"
+      },
+      "llmColumn": "法学修士",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "デフォルトのプロンプト設定を削除できません。まず別の設定をデフォルトにしてください。",
+      "defaultChanged": "デフォルトのプロンプト設定が正常に更新されました。",
+      "featureLabels": {
+        "markdown_parsing": "Markdownテストケースの解析",
+        "test_case_generation": "テストケース生成",
+        "magic_select_cases": "スマートなテストケース選択",
+        "editor_assistant": "編集者兼ライティングアシスタント",
+        "llm_test": "LLM接続テスト",
+        "export_code_generation": "エクスポートコード生成",
+        "auto_tag": "AIによるタグ提案",
+        "duplicate_detection": "重複検出",
+        "generate_from_url": "URLからテストケースを生成する（要件）",
+        "generate_from_url_app": "URLからテストケースを生成する（アプリケーションテスト）"
+      }
+    },
+    "elasticsearch": {
+      "title": "Elasticsearch管理",
+      "description": "検索エンジンのインデックス作成とメンテナンスを管理する",
+      "status": {
+        "title": "Elasticsearch ステータス",
+        "description": "検索エンジンの現在の接続と健全性状態",
+        "checking": "ステータスを確認しています...",
+        "disconnected": "切断",
+        "nodes": "ノード",
+        "indices": "インデックス",
+        "documents": "ドキュメント",
+        "error": {
+          "title": "接続エラー",
+          "description": "Elasticsearch サービスに接続できません"
+        }
+      },
+      "settings": {
+        "description": "デプロイメントに合わせてElasticsearch設定を構成する",
+        "numberOfReplicas": "レプリカの数",
+        "replicasHelp": "単一ノードクラスタの場合は0に設定し、冗長性のある複数ノードクラスタの場合は1+に設定します。",
+        "savedDescription": "設定がデータベースに保存されました",
+        "updated": "インデックスの更新",
+        "updatedDescription": "既存のインデックスはすべて新しいレプリカ設定で更新されました",
+        "error": "設定の保存中にエラーが発生しました",
+        "errorDescription": "設定を保存できませんでした。もう一度お試しください。",
+        "note": {
+          "description": "変更は新しいインデックスにすぐに適用されます。既存のインデックスは保存時に更新されます。単一ノードクラスタのYELLOWステータスを解決するには、レプリカ数を0に設定してください。"
+        }
+      },
+      "reindex": {
+        "title": "データの再インデックス",
+        "description": "検索パフォーマンスを向上させるために検索インデックスを再構築する",
+        "entities": {
+          "all": "すべてのエンティティ"
+        },
+        "button": {
+          "start": "再インデックスを開始",
+          "indexing": "インデックスを作成しています..."
+        },
+        "warning": {
+          "title": "重要",
+          "description": "インデックスの再作成には、データ量に応じて数分かかる場合があります。この処理中は検索機能が制限される場合があります。"
+        },
+        "complete": {
+          "title": "再インデックス完了",
+          "description": "選択したすべてのエンティティの再インデックスが正常に完了しました"
+        },
+        "success": {
+          "title": "再インデックスが成功しました",
+          "description": "{count, plural, one {# ドキュメント} other {# ドキュメント}} インデックス作成に成功しました"
+        },
+        "error": {
+          "title": "再インデックスに失敗しました",
+          "description": "インデックスの再作成中にエラーが発生しました。もう一度お試しください。"
+        }
+      }
+    },
+    "queues": {
+      "title": "バックグラウンドジョブキュー",
+      "description": "バックグラウンドジョブ処理キューの監視と管理",
+      "queueNames": {
+        "forecast-updates": "予報の更新",
+        "emails": "メールキュー",
+        "issue-sync": "問題の同期",
+        "testmo-imports": "テストモインポート",
+        "elasticsearch-reindex": "Elasticsearch の再インデックス",
+        "audit-logs": "監査ログ",
+        "budget-alerts": "予算アラート",
+        "auto-tag": "AI自動タグ付け",
+        "repo-cache": "リポジトリキャッシュ",
+        "copy-move": "コピー＆移動",
+        "duplicate-scan": "重複スキャン",
+        "magic-select": "マジックセレクト",
+        "step-scan": "ステップシーケンススキャン"
+      },
+      "status": {
+        "paused": "一時停止",
+        "idle": "アイドル"
+      },
+      "table": {
+        "queue": "列",
+        "concurrency": "同時実行性",
+        "waiting": "待っている",
+        "failed": "失敗した"
+      },
+      "concurrency": {
+        "title": "ワーカーの同時実行",
+        "description": "同時実行性は、各ワーカーが同時に処理するジョブの数を制御します。値を大きくするとスループットが向上しますが、システムリソース（CPUとメモリ）の消費量も増加します。",
+        "configureTitle": "同時実行の設定",
+        "configureDescription": "同時実行性を調整するには、環境変数を設定し、ワーカーを再起動してください。詳細はドキュメントをご覧ください。",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo インポート (デフォルト: 1、メモリを大量に消費)",
+          "SYNC_CONCURRENCY": "問題の同期（デフォルト：2、I/O集中型）",
+          "EMAIL_CONCURRENCY": "メール送信（デフォルト: 3、I/O 集中型）",
+          "NOTIFICATION_CONCURRENCY": "通知（デフォルト：5、軽量）",
+          "FORECAST_CONCURRENCY": "予測の更新（デフォルト: 5、CPU を集中的に使用）"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "一時停止キュー",
+          "confirmDescription": "これにより、新しいジョブは処理されなくなります。アクティブなジョブは完了するまで処理を続行します。"
+        },
+        "resume": {
+          "confirmTitle": "キューを再開",
+          "confirmDescription": "これにより、キューは待機中のジョブを処理できるようになります。"
+        },
+        "clean": {
+          "confirmTitle": "クリーンキュー",
+          "confirmDescription": "これにより、完了したジョブと失敗したジョブがキューから削除されます。この操作は元に戻せません。"
+        },
+        "drain": {
+          "confirmTitle": "ドレインキュー",
+          "confirmDescription": "これにより、キューから待機中のジョブがすべて削除されます。アクティブなジョブは完了するまで処理が続行されます。この操作は元に戻せません。"
+        },
+        "obliterate": {
+          "confirmTitle": "抹消キュー",
+          "confirmDescription": "これによりキューが完全に消去され、状態に関係なくすべてのジョブが削除されます。このアクションは元に戻すことはできません。緊急時のみ使用してください。"
+        },
+        "warning": "警告",
+        "irreversible": "この操作は元に戻せません。続行することを確認してください。"
+      },
+      "success": {
+        "actionCompleted": "アクションが完了しました",
+        "queuePaused": "キューは一時停止されました",
+        "queueResumed": "キューが再開されました",
+        "queueCleaned": "キューがクリーンアップされました",
+        "queueDrained": "キューが空になりました",
+        "queueObliterated": "キューは消滅しました"
+      },
+      "error": {
+        "loadFailed": "キューの読み込みに失敗しました",
+        "actionFailed": "アクションに失敗しました"
+      },
+      "jobs": {
+        "title": "キュージョブ",
+        "description": "キュー内の個々のジョブを表示および管理する",
+        "noJobs": "このキューにジョブが見つかりません",
+        "table": {
+          "id": "ジョブID",
+          "name": "職名",
+          "attempts": "試み"
+        },
+        "details": {
+          "title": "仕事の詳細",
+          "failedReason": "失敗理由",
+          "stacktrace": "スタックトレース",
+          "data": "求人データ",
+          "returnValue": "戻り値",
+          "options": "仕事の選択肢",
+          "processed": "処理済み",
+          "finished": "終了した"
+        },
+        "success": {
+          "actionCompleted": "ジョブアクションが完了しました",
+          "jobRetried": "ジョブは再試行されました",
+          "jobPromoted": "仕事が昇進しました",
+          "jobRemoved": "求人は削除されました"
+        },
+        "error": {
+          "loadFailed": "ジョブの読み込みに失敗しました",
+          "actionFailed": "ジョブアクションが失敗しました"
+        },
+        "forceRemove": {
+          "title": "ジョブの強制削除",
+          "question": "このジョブを強制的に削除しますか?",
+          "warning": "これにより、遅延を伴い複数回削除が試行されます。注: ジョブが実行中のワーカーによって実際にロックされている場合、削除は失敗する可能性があります。",
+          "confirm": "強制削除"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "セキュリティとコンプライアンスの追跡のためのシステム全体の監査証跡を表示する",
+      "filterPlaceholder": "エンティティ、ユーザー、またはアクションで検索...",
+      "filterAction": "アクション",
+      "filterEntityType": "エンティティタイプ",
+      "allActions": "すべてのアクション",
+      "allEntityTypes": "すべてのエンティティタイプ",
+      "showing": "{total} 件中 {start} ～ {end} 件を表示しています",
+      "viewDetails": "詳細を表示",
+      "detailTitle": "監査ログの詳細",
+      "userInfo": "ユーザー情報",
+      "changes": "変更点",
+      "metadata": "メタデータ",
+      "oldValue": "古い",
+      "newValue": "新しい",
+      "columns": {
+        "timestamp": "タイムスタンプ",
+        "entityId": "エンティティID",
+        "entityName": "エンティティ名",
+        "userId": "ユーザーID",
+        "ipAddress": "IPアドレス",
+        "userAgent": "ユーザーエージェント"
+      },
+      "exportCsv": "CSVエクスポート",
+      "timeRange": "期間",
+      "timeRangeOptions": {
+        "last24h": "過去24時間",
+        "last7d": "過去7日間",
+        "last30d": "過去30日間",
+        "last90d": "過去90日間",
+        "allTime": "歴代"
+      },
+      "systemActor": "システム",
+      "systemActorTooltip": "ログインユーザーではなく、システムによって実行された操作"
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "通知なし",
+      "aria": {
+        "notifications": "通知（{count} 件未読）"
+      },
+      "actions": {
+        "markRead": "既読にする",
+        "markUnread": "未読としてマーク",
+        "markAllRead": "すべてを既読にする",
+        "deleteAll": "すべて削除"
+      },
+      "success": {
+        "deleted": "通知を削除しました",
+        "markedAllRead": "すべての通知を既読としてマーク",
+        "deletedAll": "すべての通知が削除されました"
+      },
+      "error": {
+        "markRead": "既読にできませんでした",
+        "markUnread": "未読としてマークできませんでした",
+        "delete": "通知を削除できませんでした",
+        "markAllRead": "すべてを既読にできませんでした",
+        "deleteAll": "通知の削除に失敗しました"
+      },
+      "deleteAllDialog": {
+        "title": "通知をすべて削除しますか？",
+        "description": "これにより、すべての通知が完全に削除されます。この操作は元に戻せません。",
+        "confirm": "すべて削除"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "新しいテストケースの割り当て",
+        "multipleTestCaseAssignmentTitle": "複数のテストケースが割り当てられている",
+        "sessionAssignmentTitle": "新しいセッションの割り当て",
+        "commentMentionTitle": "コメントで言及されました",
+        "systemAnnouncementTitle": "システムアナウンス",
+        "assignedTestCase": "テストケースに割り当てられた",
+        "assignedMultipleTestCases": "あなたに割り当てられたテストケース {count, plural, one {# テストケース} other {# テストケース}}",
+        "assignedSession": "セッションに割り当てました",
+        "mentionedYouInComment": "コメントであなたに言及しました",
+        "inProject": "プロジェクト中",
+        "testRun": "試運転：",
+        "casesInProject": "{count, plural, =1 {# 件} other {# 件}} 内",
+        "sentBy": "{name}から送信",
+        "milestoneDueSoonTitle": "マイルストーンは間もなく達成",
+        "milestoneOverdueTitle": "マイルストーンの期限超過",
+        "milestoneDueSoon": "プロジェクト \"{projectName}\" のマイルストーン \"{milestoneName}\" は、 {dueDate}に完了予定です。",
+        "milestoneOverdue": "プロジェクト「{projectName}」のマイルストーン「{milestoneName}」は、期限が {dueDate} でしたが、現在は期限を過ぎています。",
+        "milestoneNotificationReason": "この通知は、このマイルストーンに関連付けられた作業 (テスト実行、セッション、またはマイルストーンの作成者) に参加したために送信されています。",
+        "milestoneNotificationContinue": "このマイルストーンが完了としてマークされるまで、毎日リマインダーが届き続けます。",
+        "shareLinkAccessedTitle": "共有リンクにアクセスしました",
+        "shareLinkAccessedAnonymousViewer": "誰か",
+        "shareLinkAccessedMessage": "{viewer} があなたの共有レポートを閲覧しました: \"{shareTitle}\"",
+        "viewedYourSharedLink": "共有されたリンクを確認しました",
+        "viewedAt": "閲覧場所",
+        "budgetDisclaimer": "予算制限はあくまで参考情報であり、利用を妨げるものではありません。",
+        "llmBudgetExceededTitle": "LLMの予算を超過",
+        "llmBudgetThresholdTitle": "LLM予算 {threshold}使用率 %",
+        "llmBudgetExceededMessage": "{providerName} は月間予算を超過しました: {spend} が {budget} の予算を消費しました。",
+        "llmBudgetThresholdMessage": "{providerName} は月間予算の {threshold}% を使用しました: {spend} / {budget}。",
+        "userRegisteredTitle": "新規ユーザー登録",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) は SSO 経由で登録されました",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) が登録フォームから登録しました",
+        "viewUserList": "ユーザーリストを表示",
+        "reviewGeneratedCases": "生成されたテストケースを確認する",
+        "generateFromUrlCompleteTitle": "ページのクロールは正常に完了しました。",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# ページ} other {# ページ}} はプロジェクト \"{projectName}\" の {url} からクロールされました。クリックして確認し、テストケースを生成してください。",
+        "generateFromUrlFailedTitle": "URLクロールに失敗しました"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "検索またはリンクの問題...",
+        "create_label": "リンクの問題 \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "問題の概要を入力"
+        },
+        "fields": {
+          "name": {
+            "label": "まとめ"
+          },
+          "description": {
+            "placeholder": "問題を説明してください...",
+            "helper": "問題に関する詳細な情報を提供する"
+          },
+          "project": {
+            "helper": "外部の問題追跡ツールでプロジェクトを選択する"
+          }
+        },
+        "loading_metadata": "統合設定を読み込んでいます...",
+        "errors": {
+          "creation_failed": "問題の作成に失敗しました。もう一度お試しください。"
+        },
+        "success": {
+          "created": "問題が正常に作成されました",
+          "external_created": "問題が作成され、外部トラッカーにリンクされました"
+        },
+        "warnings": {
+          "external_failed": "問題はローカルで作成されましたが、外部トラッカーと同期できませんでした"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "問題を作成するには、アカウントを {integrationName} に接続する必要があります。"
+      },
+      "search_issues_dialog": {
+        "title": "検索とリンクの問題",
+        "placeholder": "問題を検索...",
+        "searching": "検索中...",
+        "searchError": "問題の検索に失敗しました",
+        "linkButton": "リンク",
+        "linkedCount": "{count, plural, one {# 問題} other {# 問題}} リンク済み"
+      }
+    },
+    "copyMove": {
+      "title": "プロジェクトにコピー/移動",
+      "step1Desc": "テストケースの対象となるプロジェクトとフォルダを選択してください。",
+      "step2Desc": "操作を選択し、互換性を確認してください。",
+      "step3Desc": "進捗状況を追跡し、結果を確認する。",
+      "targetProject": "対象プロジェクト",
+      "searchProjects": "プロジェクトを検索...",
+      "loadingProjects": "プロジェクトを読み込んでいます...",
+      "noProjectsFound": "プロジェクトが見つかりませんでした。",
+      "completed": "（完了）",
+      "targetFolder": "対象フォルダ",
+      "newFolderPlaceholder": "新しいフォルダ名...",
+      "operation": "手術",
+      "operationCopy": "コピー",
+      "operationCopyDesc": "選択したケースのコピーをターゲットプロジェクトに作成します。オリジナルは変更されません。",
+      "operationMove": "動く",
+      "operationMoveDesc": "選択したケースをターゲットプロジェクトに移動します。元のファイルはソースから削除されます。",
+      "checkingCompatibility": "互換性を確認中...",
+      "noTargetWriteAccess": "対象プロジェクトへの書き込み権限がありません。",
+      "noSourceUpdateAccess": "ケースを移動するためのソースプロジェクトに対する編集権限がありません。",
+      "templateMismatch": "テンプレートの不一致",
+      "autoAssignTemplates": "不足しているテンプレートを対象プロジェクトに自動割り当てする",
+      "templatesMayNotDisplay": "不足しているテンプレートは、対象プロジェクトでは利用できません。ケースはコピーされますが、それらのテンプレートのフィールドが正しく表示されない場合があります。",
+      "workflowFallback": "ワークフローの状態の中には、対象プロジェクトで利用できないものがあります。そのような場合は、対象プロジェクトのデフォルトの状態が使用されます。",
+      "default": "（デフォルト）",
+      "conflicts": "すべての紛争に適用：",
+      "conflictSkip": "スキップ",
+      "conflictRename": "名前を変更する",
+      "sharedStepGroups": "ターゲットに共有ステップグループが既に存在する場合：",
+      "sharedStepGroupReuse": "既存のものを再利用する",
+      "sharedStepGroupReuseDesc": "事例は、既存の共有ステップグループを参照します。",
+      "sharedStepGroupCreateNew": "新規作成",
+      "sharedStepGroupCreateNewDesc": "新しい共有ステップグループが作成されます。",
+      "go": "行く",
+      "processing": "処理...",
+      "progressText": "{processed} 件のうち {total} 件が処理されました",
+      "successCount": "{count} ケース {operation}d 成功",
+      "skipped": "スキップ: {count}",
+      "droppedLinks": "プロジェクト間のリンクが削除されました: {count}",
+      "errorCount": "{count} ケースが失敗しました",
+      "viewInTargetProject": "対象プロジェクトで表示",
+      "failed": "失敗した",
+      "folderMode": "フォルダ \"{folderName}\" — {caseCount, plural, one {# ケース} other {# ケース}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "関連する問題",
+    "linkedIssuesDescription": "このアイテムに関連する問題",
+    "refreshed": "問題の更新",
+    "refreshedDescription": "リンクされた問題のリストが更新されました",
+    "unlinked": "問題がリンク解除されました",
+    "unlinkedDescription": "この問題はこのアイテムから削除されました",
+    "linked": "問題がリンクされました",
+    "linkedDescription": "この問題はこのアイテムにリンクされています",
+    "searchAndLink": "検索とリンク",
+    "createAndLink": "作成してリンクする",
+    "noLinkedIssues": "関連する問題はありません",
+    "viewExternal": "{provider}で表示",
+    "unlink": "リンクを解除",
+    "linkError": "リンクに失敗しました",
+    "linkExternalIssue": "リンク {provider} 問題",
+    "linkIssue": "リンクの問題",
+    "addIssue": "課題を追加する",
+    "unlinkError": "問題のリンクを解除できませんでした",
+    "noIssuesFound": "問題は見つかりませんでした",
+    "startTypingToSearch": "問題を検索するには入力を開始してください",
+    "selectedCount": "{count} 選択済み",
+    "confirmSelection": "選択を確認",
+    "alreadyLinked": "すでにリンクされています",
+    "authenticate": "認証",
+    "authenticationRequired": "認証が必要です",
+    "authenticationDescription": "問題を検索するには、 {provider} で認証する必要があります。",
+    "searchIn": "{provider}で検索",
+    "searchPlaceholder": "検索に関する問題...",
+    "searchIssues": "検索に関する問題",
+    "searchIssuesDescription": "このアイテムにリンクする内部の問題を検索します。",
+    "searchExternalDescription": "このアイテムにリンクするには、 {provider} 件の問題を検索してください。",
+    "error": "読み込みエラーの問題",
+    "errorDescription": "問題を読み込めませんでした。もう一度お試しください。",
+    "selectIssues": "問題を選択",
+    "authRequiredDescription": "問題を検索するには、 {provider} で認証してください",
+    "integrationNotConfigured": "統合が設定されていません",
+    "integrationNotConfiguredDescription": "この統合はまだ完全に設定されていません。プロジェクト管理者に連絡して、プロジェクト設定で外部プロジェクトを設定してください。",
+    "createIssue": "問題を作成",
+    "createNewIssue": "新しい問題を作成する",
+    "createIssueDescription": "新しい問題を作成する",
+    "createIssueDescriptionWithIntegration": "{provider}を使用して新しい問題を作成します",
+    "createIssueDescriptionSimpleUrl": "新しい内部問題を作成する（シンプル URL 統合）",
+    "creatingWith": "{provider}で問題を作成しています",
+    "authenticatedAndReady": "認証され、問題を作成する準備ができました",
+    "created": "問題が作成されました",
+    "createdInExternal": "{provider}で問題が作成されました",
+    "createdInternal": "ローカルで作成された問題",
+    "createdInternalSimpleUrl": "問題は内部的に作成され、シンプルな URL 経由でリンクできます",
+    "createError": "問題の作成に失敗しました",
+    "useIntegration": "{provider}を使用する",
+    "useIntegrationDescription": "外部システムに問題を作成する",
+    "externalProject": "外部プロジェクト",
+    "selectProject": "プロジェクトを選択",
+    "issueType": "問題の種類",
+    "selectIssueType": "問題の種類を選択",
+    "noIssueTypes": "利用可能な問題タイプはありません",
+    "priorityUrgent": "緊急",
+    "additionalFields": "追加フィールド",
+    "createIssueInJira": "Jiraで課題を作成する",
+    "createIssueInJiraDescription": "Jira のインターフェースを使用して、利用可能なすべてのフィールドとオプションを含む新しい課題を作成します。",
+    "createIssueInJiraFallbackDescription": "新しいタブで Jira を開き、事前に入力された情報を使用して課題を作成します。",
+    "jiraIframeError": "Jiraインターフェースを読み込めません。新しいタブで開いてみてください。",
+    "jiraIframeFallback": "セキュリティ上の理由により、Jira は新しいタブで開く必要があります。以下のボタンをクリックして課題を作成してください。",
+    "jiraFallbackNote": "Jira で問題を作成した後、ここに戻ってテスト ケースへのリンクを続行します。",
+    "openInNewTab": "新しいタブで開く",
+    "jiraIframeNote": "Jira で問題を作成した後、このダイアログを閉じて問題リストを更新できます。",
+    "fillInRequiredFields": "新しい問題を作成するには、必須フィールドに入力してください",
+    "failedToFetchFields": "Jira から課題フィールドを取得できませんでした",
+    "enterSummary": "問題の簡単な概要を入力してください",
+    "enterDescription": "問題の詳細な説明を入力してください",
+    "failedToCreateIssue": "Jira で問題を作成できませんでした",
+    "issueCreatedDescription": "問題 {key} が正常に作成されました",
+    "addLabel": "ラベルを追加してEnterキーを押します",
+    "labelHint": "スペースはハイフンに置き換えられます",
+    "labelFormatNote": "ラベルにはスペースを含めることはできません。スペースは自動的にハイフンに置き換えられます。",
+    "enterIssueKey": "問題キーを入力してください（例：PROJ-123）",
+    "issueLinkHelp": "リンクする既存の問題のキーを入力してください",
+    "searchForIssue": "リンクする問題を検索する",
+    "searchUsers": "ユーザーを検索",
+    "noTeamsAvailable": "利用可能なチームはありません",
+    "filterAll": "全て",
+    "fanOutPartialFailure": "{count} 個のプロジェクトにアクセスできませんでした。 {successCount} 個のプロジェクトの結果を表示します。",
+    "projectSelectorLabel": "プロジェクト",
+    "searchFailedTitle": "検索に失敗しました"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "すべての問題を参照および管理します。",
+      "filterPlaceholder": "名前で問題をフィルタリング..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "ドキュメント",
+      "Milestones": "マイルストーン",
+      "TestCaseRepository": "テストケースリポジトリ",
+      "TestCaseRestrictedFields": "テストケースの制限フィールド",
+      "TestRuns": "テスト実行",
+      "ClosedTestRuns": "クローズドテスト実行",
+      "TestRunResults": "テスト実行結果",
+      "TestRunResultRestrictedFields": "テスト実行結果の制限フィールド",
+      "Sessions": "セッション",
+      "SessionsRestrictedFields": "セッション制限フィールド",
+      "ClosedSessions": "クローズドセッション",
+      "SessionResults": "セッション結果",
+      "Tags": "タグ",
+      "SharedSteps": "共有ステップ",
+      "Issues": "問題",
+      "IssueIntegration": "問題の統合",
+      "Forecasting": "予測",
+      "Reporting": "報告",
+      "Settings": "設定"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "開始されていません",
+      "IN_PROGRESS": "進行中",
+      "DONE": "終わり"
+    }
+  },
+  "charts": {
+    "average": "平均",
+    "count": "カウント: {count}",
+    "percent": "パーセント: {percent}%",
+    "completed": "完了: {count}",
+    "durationRange": "持続時間: {from}秒 - {to}秒",
+    "seconds": "{seconds}秒",
+    "testCases": "{count, plural, one {# テストケース} other {# テストケース}}",
+    "estimate": "推定: {value}",
+    "partOf": "（ {parent}の一部）",
+    "status": "ステータス: {status}"
+  },
+  "linkedCases": {
+    "title": "リンクされたテストケース",
+    "addLink": "リンクを追加",
+    "addLinkedTestCase": "リンクされたテストケースを追加",
+    "testCase": "テストケース",
+    "linkType": "リンクタイプ",
+    "noLinkedCases": "リンクされたテストケースはありません。",
+    "linkedBy": "リンク",
+    "on": "リンク先",
+    "alreadyLinked": "このケースはすでにリンクされています。",
+    "cannotLinkSelf": "ケースをそれ自身にリンクすることはできません。",
+    "circularLink": "循環リンクが検出されました。",
+    "failedToCreate": "リンクの作成に失敗しました。",
+    "confirmRemoveLink": "このリンクを削除してもよろしいですか?",
+    "DEPENDS_ON": "依存",
+    "DUPLICATED_FROM": "複製元",
+    "SAME_TEST_DIFFERENT_SOURCE": "同じテスト（異なるソース）",
+    "status": "最新の状況",
+    "at": "処刑された"
+  },
+  "ganttTooltip": {
+    "task": "タスク",
+    "group": "実行/セッション:",
+    "project": "プロジェクト：",
+    "starts": "開始:",
+    "scheduledCompletion": "完了予定日:",
+    "estWorkEffort": "推定作業量:",
+    "noTasks": "ガントチャートに表示するタスクがありません。"
+  },
+  "help": {
+    "project": {
+      "name": "## プロジェクト名\nプロジェクトの一意の識別子。\n\n- すべてのプロジェクトで一意である必要があります\n- ナビゲーションとレポートで使用されます\n- 明確で説明的なものである必要があります\n- チームメンバーがプロジェクトの範囲を識別するのに役立ちます",
+      "description": "## プロジェクトの説明\nプロジェクトの目的と範囲に関する追加の詳細。\n\n- オプションですが推奨されます\n- チームメンバーがプロジェクトの目標を理解するのに役立ちます\n- 主要な目標や要件を含めることができます\n- 256文字に制限されています",
+      "icon": "## プロジェクトアイコン\nプロジェクトの視覚的な識別子。\n\n- リストやダッシュボードでプロジェクトをすばやく識別するのに役立ちます\n- さまざまな定義済みアイコンから選択します\n- いつでも変更できます\n- プロジェクトナビゲーションとレポートに表示されます",
+      "completed": "## プロジェクトステータス\nプロジェクトがアクティブか完了しているかを示します。\n\n- アクティブなプロジェクトはテストと更新に使用できます\n- 完了したプロジェクトは読み取り専用です\n- ダッシュボードでのプロジェクトの表示に影響します\n- 必要に応じて元に戻すことができます",
+      "completedAt": "## 完了日\nプロジェクトが完了としてマークされた日付。\n\n- プロジェクトを完了としてマークすると自動的に設定されます\n- 報告と追跡に使用されます\n- プロジェクト履歴の管理に役立ちます\n- 必要に応じて変更できます",
+      "defaultAccess": "## デフォルトのプロジェクトアクセス\nこのプロジェクトにおけるユーザーとグループのデフォルトのアクセス権限を定義します。これはユーザーごとまたはグループごとに上書きできます。",
+      "issueTracker": "## 問題追跡設定\nこのプロジェクトに関連する問題を管理するために使用される問題追跡設定を選択します。"
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## 外部プロジェクト\nこの TestPlanIt プロジェクトにリンクする外部システムのプロジェクトまたはリポジトリを選択します。\n\n- TestPlanIt から作成された問題は、このプロジェクトに作成されます\n- システム間の問題追跡統合を有効にします\n- 外部システムで適切な権限を持っている必要があります",
+          "defaultIssueTypeHelp": "## デフォルトの問題タイプ\nTestPlanIt から新しい問題を作成するときに事前に選択される問題タイプ。\n\n- 最も一般的な問題タイプをデフォルトに設定することで時間を節約します\n- 個々の問題を作成するときに上書きできます\n- 選択した外部プロジェクトで有効な問題タイプである必要があります\n- ワークフローが変更された場合はこれを更新します",
+          "automaticSyncHelp": "## 自動同期\nTestPlanIt と外部システム間の問題ステータスの自動同期を有効にします。\n\n- テストケースにリンクされた問題はステータスを自動的に更新します\n- システム間で問題追跡の一貫性を保つのに役立ちます\n- 外部サービスでの API 使用量が増加する可能性があります\n- 手動制御を優先する場合は無効にできます"
+        }
+      }
+    },
+    "user": {
+      "name": "## ユーザー名\nユーザーのフルネーム。\n\n- システム全体での識別に使用されます\n- 課題やレポートに表示されます\n- ユーザーごとに一意である必要があります",
+      "email": "## メールアドレス\nアカウントアクセス用のユーザーのメールアドレス。\n\n- システムログインに使用\n- ユーザーごとに一意である必要があります\n- システム通知に使用",
+      "password": "## パスワード\nユーザーアカウントのパスワード。\n\n- パスワードなしのログイン方法が設定されている場合はオプションです (Magic Link SSO プロバイダーまたはメールサーバー) — Magic Link または SSO 経由でのサインインを要求する場合は空白のままにします。\n- 入力する場合は、**管理者 → セキュリティ** で設定されているパスワードポリシー (最小長と文字クラス) を満たす必要があります。\n- 安全なアカウントアクセスに使用されます。\n- 機密情報として保持する必要があります。",
+      "token": "## 認証トークン\nメールで受け取ったトークンを入力してアカウントを認証してください。トークンをお持ちでない場合は、新しいトークンをリクエストできます。",
+      "confirmPassword": "## パスワードの確認\nパスワードを再入力して、正しく入力されたことを確認してください。\n\n- パスワードと完全に一致する必要があります\n- 入力ミスを防ぐのに役立ちます\n- パスワードを入力する場合のみ必要です。パスワードフィールドが空白の場合は空白のままにしてください",
+      "access": "## システムアクセスレベル\nユーザーのシステム全体の権限を決定します。\n\n- **管理者:** 完全なシステムアクセスと構成\n- **プロジェクト管理者:** 割り当てられたプロジェクトを管理できます\n- **ユーザー:** 割り当てられたプロジェクトへの標準アクセス\n- **なし:** ダッシュボードの表示のみ可能です",
+      "role": "## システムロール\nこのロールは、ユーザーのデフォルトのプロジェクト権限を決定します。\n\n- プロジェクトのデフォルトのアクセスレベルを定義します\n- ロール管理でカスタマイズできます\n- 利用可能な機能に影響します",
+      "active": "## アクティブステータス\nユーザーがシステムにアクセスできるかどうかを制御します。\n\n- アクティブなユーザーはサインインして割り当てられたリソースにアクセスできます\n- 非アクティブなユーザーはサインインできませんが、データは保持されます\n  - アカウントを削除せずに一時的にアクセスを無効にするには、これを使用します",
+      "api": "## APIアクセス\nAPIエンドポイントを介してシステムへのプログラムアクセスを可能にします。\n\n- 外部ツールや自動化との統合を可能にします\n- APIキー認証が必要です\n- レート制限とアクセス制御の対象となります",
+      "projects": "## プロジェクトの割り当て\nこのユーザーがアクセスできるプロジェクトを選択します。\n\n- ユーザーのダッシュボードに表示されるプロジェクトを制御します\n- プロジェクトへの参加に必須です\n- 管理者が後で変更できます\n- 「すべて選択」を使用して、利用可能なすべてのプロジェクトをすばやく割り当てます",
+      "groups": "## グループの割り当て\nこのユーザーが所属するグループを選択します。\n\n- グループはユーザーと権限を整理するのに役立ちます\n- ユーザーはグループから権限を継承します\n- アクセス管理が簡素化されます\n- 管理者が後で変更できます",
+      "itemsPerPage": "## 1ページあたりのアイテム数\nテーブルやリストに表示されるデフォルトのアイテム数を制御します。\n\n- アプリケーション内のすべてのページ分割されたビューに影響します\n- いつでも変更できます\n- 大規模なデータセットを効率的に管理するのに役立ちます\n- 使用可能なオプション: 10、25、50、または100アイテム",
+      "dateFormat": "## 日付形式\n日付の表示形式を設定します。\n\n- アプリケーション全体で一貫して適用されます\n- 日付の解釈の正確性を確保するのに役立ちます\n- 変更はすぐに有効になります\n- ドロップダウンに表示される例は実際の形式を反映しています",
+      "timeFormat": "## 時刻形式\n希望する時刻表示形式を設定します。\n\n- 12時間形式と24時間形式から選択します\n- アプリケーション全体で一貫して適用されます\n- 変更はすぐに有効になります\n- ドロップダウンに表示される例は実際の形式を反映しています",
+      "timezone": "## タイムゾーン\n日付と時刻の表示に使用するタイムゾーンを設定します。\n\n- アプリケーション全体で一貫して適用されます",
+      "theme": "## テーマ\nアプリケーションの好みのビジュアル テーマを選択します。\n\n- **システム:** オペレーティング システムのテーマと自動的に一致します\n- **ライト:** 日中の使用に適した、クリーンで明るいインターフェイス\n- **ダーク:** 暗い環境向けの、目に優しいダーク モード\n- **緑、オレンジ、紫:** 楽しいポップ カラー!",
+      "locale": "## 言語\nアプリケーションインターフェースで使用する言語を選択してください。\n\n- すべてのテキスト、ラベル、メッセージが選択した言語に変更されます\n- 日付と時刻の形式が地域の慣習に合わせて調整されます\n- ページを更新せずにすぐに有効になります\n- 利用可能な言語はインストールされている翻訳によって異なります",
+      "notificationMode": "## 通知設定\n作業割り当てや更新に関する通知の受信方法を制御します。\n\n- **グローバル設定を使用:** 管理者が設定したシステムのデフォルトに従います\n- **通知なし:** すべての通知を無効にします\n- **アプリ内のみ:** アプリケーション内のみで通知を受信します\n- **アプリ内 + メール (即時):** アプリ内通知と即時メール アラートの両方を取得します\n- **アプリ内 + メール (日次ダイジェスト):** アプリ内通知と毎日のメール サマリーを取得します\n\nこの設定は、ワークフローに合わせていつでも変更できます。"
+    },
+    "milestone": {
+      "name": "## マイルストーン名\nプロジェクト内のこのマイルストーンを識別するための明確で説明的な名前。\n\n- 一意で意味のあるものにする必要があります\n- チームメンバーがマイルストーンの目的をすぐに理解できるようにします\n- レポートやプロジェクト追跡で使用されます",
+      "type": "## マイルストーンの種類\nマイルストーンを分類し、その外観と動作を決定します。\n\n- タイプによってワークフローが異なる場合があります\n- マイルストーンの整理とフィルタリングに役立ちます\n- レポートと追跡に影響する場合があります",
+      "started": "## 開始ステータス\nこのマイルストーンの作業が開始されたことを示します。\n\n- マイルストーンを進行中としてマークします\n- 切り替えると実際の開始日が自動的に更新されます\n- プロジェクトのタイムラインと進捗状況の追跡に影響します",
+      "completed": "## 完了ステータス\nこのマイルストーンの作業が完了したことを示します。\n\n- マイルストーンを完了としてマークします\n- 実際の完了日を自動的に更新します\n- 進捗状況の追跡とレポートに使用されます\n- 依存するマイルストーンとプロジェクトのタイムラインに影響します",
+      "startDate": "## 計画開始日\nこのマイルストーンの作業が開始される予定日。\n\n- プロジェクトの計画とスケジュールに役立ちます\n- タイムラインの予測に使用されます\n- リソース割り当て計画をサポートします",
+      "dueDate": "## 期日\nこのマイルストーンを完了するための目標日。\n\n- 期限の期待値を設定します\n- プロジェクトのタイムライン計画に使用されます\n- スケジュールに対するマイルストーンの進捗状況を追跡するのに役立ちます",
+      "parent": "## 親マイルストーン\nこのマイルストーンを親マイルストーンにリンクして階層を作成します。\n\n- マイルストーンを論理グループに整理します\n- 依存関係と関係を表示します\n- 大規模なイニシアチブの進捗状況を追跡するのに役立ちます",
+      "description": "## 説明\nマイルストーンの目的、要件、範囲に関する詳細情報。\n\n- チームメンバーにコンテキストを提供します\n- 主要な要件と目標を文書化します\n- コラボレーションと調整をサポートします",
+      "documentation": "## ドキュメント\n追加の詳細、参考資料、およびサポート資料。\n\n- 技術仕様\n- 設計ドキュメント\n- 外部参照\n- 会議の議事録と決定事項",
+      "automaticCompletion": "## 期日自動完了\n期日が来ると、このマイルストーンを自動的に完了としてマークします。\n\n- マイルストーンは期日の予定時刻に完了します\n- 完了ステータスに関係なく閉じる必要がある時間指定のマイルストーンに役立ちます\n- 期日前にマイルストーンを手動で完了することで上書きできます\n- 期日を設定する必要があります",
+      "notifyDaysBefore": "## 期日前に通知\nマイルストーンの期日が近づくと、割り当てられたチームメンバーに通知を送信します。\n\n- 通知を有効にするにはオンに切り替え、無効にするにはオフにします\n- 期日の何日前にリマインダーの送信を開始するかを入力します\n- 通知は、このマイルストーン内のテスト実行とセッションに割り当てられたユーザーに送信されます\n- 期限を過ぎたマイルストーンは、完了するまでリマインダーを送信し続けます"
+    },
+    "session": {
+      "name": "## セッション名\nテストセッションの目的を明確に示す説明的な名前。\n\n- ユニークで意味のあるものにする必要があります\n- チームメンバーがテスト対象を理解するのに役立ちます\n- レポートや追跡で使用されます",
+      "template": "## テンプレート\nテンプレートはテストセッションの構造と内容を定義します。\n\n- テストドキュメントに一貫した形式を提供します\n- 定義済みのセクションとフィールドが含まれています\n- プロジェクト全体でテスト標準を維持するのに役立ちます",
+      "configuration": "## 構成\nこのテストセッションに必要な特定の環境または設定。\n\n- テスト環境（例：ステージング、本番）\n- 特別な構成または設定\n- 必要なテストデータまたは条件",
+      "milestone": "## マイルストーン\nこのセッションをプロジェクトのマイルストーンに関連付けます。\n\n- プロジェクトの目標に向けたテストの進捗状況を追跡するのに役立ちます\n- 関連するテストセッションをグループ化します\n- マイルストーンベースのレポートをサポートします",
+      "description": "## 説明\nこのテストセッションでカバーされる内容の簡単な概要。\n\n- テストされる主要な領域または機能\n- 重要なコンテキストまたは背景\n- 特別な考慮事項または要件",
+      "mission": "## ミッション\nミッションは、このテスト セッションの具体的な目的と目標を定義します。\n\n- 何をテストしますか?\n- 重点的に取り組むべき主要な領域は何ですか?\n- 期待される成果は何ですか?\n\n明確なミッションがあると、テストの焦点を絞った生産的な状態を維持できます。",
+      "estimate": "## 推定時間\nこのテストセッションを完了するのにかかる推定時間。\n\n例:\n- 30 分の場合は「30m」\n- 1 時間 30 分の場合は「1h 30m」\n- 2 日間の場合は「2 days」\n- 1 週間の場合は「1 week」",
+      "elapsed": "## 経過時間\nこのテスト セッションに費やされた実際の時間。\n\n例:\n- 45 分の場合は「45m」\n- 2 時間 15 分の場合は「2h 15m」\n- 3 日間の場合は「3 days」\n\n将来の見積りを改善するために時間を正確に追跡します。",
+      "state": "## ワークフロー状態\nワークフロー内のこのテストセッションの現在の状態。\n\n- セッションの進行状況を追跡するのに役立ちます\n- ワークフロー管理をサポートします\n- レポートと追跡に使用されます",
+      "assignedTo": "## 担当者\nこのテストセッションの実施を担当するチームメンバー。\n\n- テストを実行するユーザーを特定します\n- リソース管理を支援します\n- 説明責任と追跡をサポートします",
+      "tags": "## タグ\nテストセッションを分類および整理するのに役立つキーワードまたはラベル。\n\n- セッションを見つけやすくします\n- 関連するテスト活動をグループ化します\n- フィルタリングとレポートをサポートします",
+      "attachments": "## 添付ファイル\nこのテストセッションに関連するファイル、スクリーンショット、またはその他のドキュメント。\n\n- テストデータファイル\n- スクリーンショットまたは録画\n- サポートドキュメント\n- 参考資料",
+      "issues": "## 問題\n関連する問題をこのセッションにリンクします。"
+    },
+    "testRun": {
+      "name": "## テスト実行名\n後で簡単に識別できるように、このテスト実行にわかりやすい名前を入力します。",
+      "description": "## 説明\nこのテスト実行に関する簡単な概要またはメモを入力します。",
+      "configuration": "## 構成\nテスト実行を実行する構成（環境、ブラウザ、デバイスなど）を1つ以上選択します。複数の構成を選択した場合、それぞれに個別のテスト実行が作成されます。",
+      "milestone": "## マイルストーン\nこのテスト実行を特定のプロジェクト マイルストーンに関連付けて、より大きな目標に向けた進捗状況を追跡します。",
+      "docs": "## ドキュメント\nこのテスト実行に関連するドキュメント、リンク、または詳細なメモを含めます。",
+      "state": "## 状態\nプロジェクトのワークフローに従って、このテスト実行の現在のステータスまたは結果を示します。",
+      "tags": "## タグ\n関連するタグを適用して、このテスト実行を分類およびフィルタリングします。",
+      "issues": "## 問題\n関連する問題 (バグ、タスクなど) をこのテスト実行にリンクします。",
+      "attachments": "## 添付ファイル\nこのテスト実行に関連するサポート ファイル、スクリーンショット、またはログをアップロードします。",
+      "duplicate": {
+        "statusesToInclude": "## 含めるステータス\n複製されたテスト実行に含めるテストケースのステータスを選択します。",
+        "copyAssignments": "## 割り当てのコピー\n有効にすると、テストケースの割り当てが複製されたテスト実行にコピーされます。"
+      }
+    },
+    "appConfig": {
+      "key": "## キー\nこの構成の一意の識別子。",
+      "value": "## 値\nこの構成の値。"
+    },
+    "milestoneType": {
+      "icon": "## マイルストーンタイプアイコン\nこのマイルストーンタイプの視覚的な識別子。\n\n- リストやダッシュボードでマイルストーンタイプをすばやく識別するのに役立ちます\n- さまざまな定義済みアイコンから選択します\n- いつでも変更できます\n- プロジェクトナビゲーションとレポートに表示されます",
+      "name": "## マイルストーンタイプ名\nプロジェクト内でこのマイルストーンタイプを識別するための、明確でわかりやすい名前。\n\n- チームメンバーがマイルストーンタイプの目的をすぐに理解するのに役立ちます\n- レポートやプロジェクト追跡で使用されます",
+      "isDefault": "## デフォルトのマイルストーンタイプ\nこのマイルストーンタイプがプロジェクトのデフォルトかどうかを示します。\n\n- 新しいマイルストーンにはデフォルトのマイルストーンタイプが事前に選択されています\n- いつでも変更できます",
+      "projects": "## 関連プロジェクト\nこのマイルストーンタイプを利用できるプロジェクトを選択します。\n\n- プロジェクトが選択されていない場合、マイルストーンタイプはグローバルに利用できます。\n- 特定のプロジェクトに割り当てると、そのプロジェクトのみでの使用が制限されます。"
+    },
+    "tag": {
+      "name": "## タグ名\nすべてのプロジェクトで使用される、明確で簡潔な説明的な名前またはキーワード。\n\n- チームメンバーが関連するテストケース、テスト実行、およびセッションをすばやく見つけるのに役立ちます。"
+    },
+    "role": {
+      "name": "## ロール名\nすべてのプロジェクトで使用される、明確で簡潔な説明的な名前またはキーワード。\n\n- チームメンバーが関連するテストケース、テスト実行、およびセッションをすばやく見つけるのに役立ちます。",
+      "isDefault": "## デフォルトのロール\nこのロールがプロジェクトのデフォルトかどうかを示します。\n\n- デフォルトのロールは新しいユーザーには事前に選択されています\n- いつでも変更できます",
+      "permissions": {
+        "canAddEdit": "## 追加/編集\nこのロールが関連するアプリケーション領域を追加および編集できるかどうかを示します。",
+        "canDelete": "## 削除\nこのロールが関連するアプリケーション領域を削除できるかどうかを示します。",
+        "canClose": "## 閉じる\nこのロールが関連するアプリケーション領域を閉じることができるかどうかを示します。"
+      }
+    },
+    "group": {
+      "name": "## グループ名\nすべてのプロジェクトで使用される、明確で簡潔な説明的な名前またはキーワード。\n\n- チームメンバーが関連するテストケース、テスト実行、およびセッションをすばやく見つけるのに役立ちます。",
+      "users": "## ユーザー\nこのグループに割り当てられているユーザーを示します。"
+    },
+    "template": {
+      "name": "## テンプレート名\nこのテンプレートの一意の説明的な名前 (例: '標準テスト ケース'、'API テスト結果')。",
+      "isEnabled": "## 有効化\nチェックを入れると、新しいテストケースの作成時やテスト実行構造の定義時に、このテンプレートを選択できるようになります。テンプレートを「デフォルト」に設定する場合は、「有効化」も設定する必要があります。",
+      "isDefault": "## デフォルト\nチェックを入れると、このテンプレートは新規プロジェクトで自動的に選択されます。プロジェクト固有のデフォルトが設定されていない場合は、すべてのプロジェクトのデフォルトとして選択されます。すべてのプロジェクトでデフォルトとして設定できるテンプレートは1つだけです。これを有効にすると、現在デフォルトとして設定されている他のテンプレートは無効になります。",
+      "caseFields": "## ケース フィールド\nこのテンプレートを使用してテスト ケースを作成または編集するときに使用できるカスタム フィールドを選択して順序付けます。\n\n- ドロップダウンからフィールドを追加してテンプレートに含めます\n- ドラッグ アンド ドロップでフィールドを並べ替えます\n- 順序によって、フォームでのフィールドの表示方法が決定されます\n- 有効なケース フィールドのみ選択できます\n- ケース フィールドは、テスト ケースの構造とキャプチャされたデータを定義します",
+      "resultFields": "## 結果フィールド\nこのテンプレートを使用してテスト結果を追加するときに使用できるカスタムフィールドを選択して順序付けます。\n\n- ドロップダウンからフィールドを追加してテンプレートに含めます\n- ドラッグアンドドロップでフィールドを並べ替えます\n- 順序は、テスト結果を入力したときにフィールドがどのように表示されるかを決定します\n- 有効な結果フィールドのみを選択できます\n- 結果フィールドは、テスト実行結果に固有の追加データを取得します",
+      "projects": "## 関連プロジェクト\nこのテンプレートをどのプロジェクトで利用できるかを選択します。プロジェクトが選択されていない場合、テンプレートはグローバルで利用可能になります。特定のプロジェクトにテンプレートを割り当てると、そのプロジェクトでのみ利用できるようになります。"
+    },
+    "llm": {
+      "name": "## 統合名\nこの LLM 統合の説明ラベル。\n\n- リストや設定で識別するために使用されます。\n- 例: \"OpenAI GPT-4o\" または \"Internal Ollama\"",
+      "provider": "## プロバイダー\nこの統合を支えるLLMサービス。\n\n- APIプロトコルと利用可能なモデルを決定します。\n- 作成後に変更することはできません。",
+      "apiKey": "## API キー\nLLM プロバイダーの API の認証キー。\n\n- プロバイダーの開発者コンソールから取得します。\n- 保存後は暗号化され、表示されません。\n- Ollama (ローカル展開) では不要です。",
+      "endpoint": "## APIエンドポイント\nLLMプロバイダーのAPIのベースURL。\n\n- OpenAI、Anthropic、Geminiの場合は空白のままにしてください。公式URLが自動的に使用されます。\n- Ollama（例：`http://localhost:11434`）、Azure OpenAI、カスタムLLMには必須です。\n- どのプロバイダーでもオプションです。OpenAI互換プロキシ（例：LiteLLM）を指定するには、そのURLを入力します。\n- **プライベート/内部アドレス**（localhost、127.0.0.1、プライベートIP、クラウドメタデータ）は、`ALLOWED_PRIVATE_HOSTS`環境変数で明示的に許可されていない限りブロックされます。",
+      "deploymentName": "## Azure デプロイメント名\nAzure OpenAI モデルデプロイメントの名前。\n\n- Azure OpenAI Studio の「デプロイメント」に表示されます。\n- モデル名とは異なります。例: `my-gpt4-deploy` は `gpt-4` にマッピングされます。\n- Azure OpenAI でのみ必要です。",
+      "defaultModel": "## デフォルトモデル\nこの統合でAIリクエストに使用されるモデル。\n\n- OpenAI、Anthropic、Geminiの場合、利用可能なモデルはAPIキーから自動的に取得されます。\n- プロバイダーアカウントでモデルが有効になっていることを確認してください。\n- 例: `gpt-4o`、`claude-3-5-sonnet-20241022`、`gemini-1.5-pro`",
+      "maxTokensPerRequest": "## リクエストあたりの最大トークン数\n単一のリクエストにおける出力トークンの**上限**。\n\n- これを超えるリクエストは、LLMに到達する前に**エラーで拒否**されます。\n- モデルの実際の最大出力トークン容量に設定してください。\n- 例: GPT-4o の場合は `16384`、Claude 3.5 Sonnet の場合は `8192`\n- 低く設定しすぎると、AI 機能が失敗したり、出力が切り詰められたりします。",
+      "defaultMaxTokens": "## デフォルトの最大トークン数\nリクエストで独自の制限が指定されていない場合に使用される**フォールバック**出力トークン制限。\n\n- 各AI機能（テスト生成、コードエクスポートなど）は、**管理画面 → プロンプト設定**で独自の制限を設定します。\n- この値は、特定の制限が設定されていない機能のフォールバックとしてのみ使用されます。\n- リクエストあたりの最大トークン数以下である必要があります。",
+      "maxRequestsPerMinute": "## 1分あたりの最大リクエスト数\nこのプロバイダに対して1分あたりに実行できるAPI呼び出しの数を制限します。\n\n- プロバイダプランのレート制限に合わせて設定します。\n- 超過リクエストは拒否されず、キューに格納されます。\n- プランの制限については、プロバイダのドキュメントを確認してください。",
+      "costPerInputToken": "## 入力トークンあたりのコスト (USD)\nモデルに送信される入力 (プロンプト) トークンごとのコスト (USD)。\n\n- コスト追跡と予算アラートに使用されます。\n- プロバイダーの料金ページで確認できます。\n- 例: `0.000005` = 100万入力トークンあたり5ドル",
+      "costPerOutputToken": "## 出力トークンあたりのコスト (USD)\nモデルによって生成される出力 (完了) トークンごとのコスト (USD)。\n\n- 通常は入力トークンのコストよりも高くなります。\n- コスト追跡と予算アラートに使用されます。\n- 例: `0.000015` = 100万出力トークンあたり 15 ドル",
+      "monthlyBudget": "## 月間予算 (USD)\nこの統合におけるオプションの支出目標です。\n\n- 予算追跡を無効にするには「0」に設定します。\n- 予算は**情報提供のみ**であり、LLMの使用をブロックするものではありません。\n- 予算の80%、90%、100%に達した時点で通知を受け取ります。\n- コストは上記のトークンごとのレートを使用して計算されます。",
+      "billingPeriodStartDay": "## 請求期間開始日\n請求期間が始まる月の日 (1～31)。\n\n- デフォルト値の「1」はカレンダーの月と一致します。\n- 15日から15日までのサイクルにするには「15」に設定します (例: プロバイダーの請求書の日付に合わせるため)。\n- 値「29～31」は、短い月の最終日 (閏年でない年の2月など) に自動的に固定されます。\n- **月間予算**の支出期間と**支出のリセット**アクションに影響します。",
+      "defaultTemperature": "## デフォルト温度\nモデル応答のランダム性を制御します (0～2)。\n\n- **0:** 決定論的 — 同じ入力に対して同一の出力\n- **0.3:** 集中的 — テスト生成とコード出力に推奨\n- **1+:** 創造的 — より多様な応答\n- 個々の機能はプロンプト設定でこれを上書きできます",
+      "timeout": "## リクエストタイムアウト (ms)\nリクエストがキャンセルされるまでの応答待ち時間。\n\n- 値はミリ秒単位です (例: `30000` = 30 秒)\n- ストリーミングリクエスト (例: コードのエクスポートプレビュー) はこのタイムアウトを無視します\n- 処理が遅い場合や大規模なモデルの場合は値を増やしてください\n- 範囲: 5,000 ～ 600,000 ms",
+      "streamingEnabled": "## ストリーミングを有効にする\n完全な出力を待つのではなく、応答をトークンごとにストリーミングします。\n\n- エクスポートモーダルでのリアルタイムコードプレビューに必要です。\n- 長い応答の体感遅延を軽減します。\n- サポートされているすべてのプロバイダーに推奨されます。",
+      "isDefault": "## デフォルトの統合として設定\nすべてのAI機能でデフォルトでこの統合が使用されます。\n\n- 一度にデフォルトに設定できる統合は1つだけです。\n- 特定のプロバイダーが設定されていない機能は、デフォルトを使用します。\n- いつでも変更できます。"
+    },
+    "integration": {
+      "name": "## 統合名\nシステム全体でこの統合を識別するための説明的な名前。\n\n- 他の統合と区別するために一意である必要があります\n- プロジェクトの設定と構成で使用されます\n- サービスと目的を明確に示す必要があります",
+      "authType": "## 認証タイプ\n外部サービスでの認証方法を選択します。\n\n- **APIキー:** メールとAPIトークンを使用したシンプルな認証\n- **OAuth 2.0:** OAuthフローを使用した安全な認証\n- **個人アクセストークン:** トークンベースの直接認証",
+      "email": "## メールアドレス\n外部サービス用のアカウントのメールアドレス。\n\n- APIキー認証に使用されます\n- APIトークンを生成したアカウントと一致する必要があります\n- Jiraなどのサービスに必要です",
+      "apiToken": "## APIトークン\n外部サービスのアカウント設定からAPIトークンを生成します。\n\n- 通常はアカウント設定 → セキュリティ → APIトークンにあります\n- パスワードを公開することなく安全なアクセスを提供します\n- 必要に応じて取り消しや再生成が可能です",
+      "jiraUrl": "## Jira URL\nJiraインスタンスのベースURL。\n\n- 形式: https://your-site.atlassian.net\n- /browseやその他のパスを含めないでください\n- このサーバーからアクセスできる必要があります",
+      "clientId": "## OAuthクライアントID\nOAuthアプリケーション構成からのクライアントID。\n\n- 外部サービスの開発者コンソールで作成されます\n- OAuthフロー中にアプリケーションを識別するために使用されます\n- 構成ファイルで安全に共有できます",
+      "clientSecret": "## OAuthクライアントシークレット\nOAuthアプリケーション構成からのクライアントシークレット。\n\n- クライアントIDと一緒に作成されます\n- 機密性と安全性を保つ必要があります\n- アプリケーションの認証に使用されます",
+      "personalAccessToken": "## 個人アクセストークン\n外部サービスへの適切な権限を持つ個人アクセストークン。\n\n- アカウント設定で生成されます\n- 読み取りと書き込みの問題に対する権限が必要です\n- パスワード認証よりも安全です",
+      "baseUrl": "## URLパターン\n外部の問題にリンクするためのURLパターン。\n\n- 問題識別子のプレースホルダーとして '{issueId}' を使用します。\n- 例: https://example.com/issues/'{issueId}'\n- シンプルなURLベースの統合に使用されます。",
+      "organizationUrl": "## 組織 URL\nAzure DevOps 組織の URL。\n\n- 形式: https://dev.azure.com/your-org\n- このサーバーからアクセスできる必要があります\n- Azure DevOps API へのアクセスに使用されます",
+      "apiKey": "## APIキー\n外部サービス認証用のAPIキー。\n\n- サービスのAPI設定で生成されます\n- サービスへのプログラムアクセスを提供します\n- 安全に保管し、定期的にローテーションします",
+      "forgeApiKey": "## Forge APIキー\nJira課題からテストデータを取得する際に、Atlassian Forgeアプリの認証に使用されます。\n\n- [生成]をクリックして新しいキーを作成します。\n- キーをコピーして、JiraのForgeアプリ設定（アプリの管理 → TestPlanIt設定）に貼り付けます。\n- 再生成すると、以前のキーは無効になります。",
+      "owner": "## 所有者 / 名前空間\nリポジトリを所有するユーザーまたは組織。\n\n- GitHub/GitLab の場合: ユーザー名または組織名\n- Gitea/Forgejo/Gogs の場合: ユーザー名またはグループ名\n- 例: my-org または my-username",
+      "repo": "## リポジトリ名\n課題をリンクするリポジトリの名前。\n\n- 正確なリポジトリ名（完全な URL ではない）\n- 例: my-project\n- 指定された認証情報でアクセスできる必要があります",
+      "instanceUrl": "## インスタンス URL\nセルフホスト型インスタンスのベース URL。\n\n- 形式: https://git.example.com\n- 末尾のスラッシュやパスを含めないでください。\n- このサーバーからアクセス可能である必要があります。",
+      "projectPath": "## プロジェクトパス\nGitLabプロジェクトへのフルパス。\n\n- 形式: namespace/project または group/subgroup/project\n- 例: my-org/my-project\n- プロジェクトURL: gitlab.com/namespace/project で確認できます。",
+      "platform": "## プラットフォーム\n接続先の自己ホスト型 Git プラットフォーム。\n\n- **Gitea**: gitea.io ベースのインスタンス\n- **Forgejo**: forgejo.org ベースのインスタンス (Gitea フォーク)\n- **Gogs**: gogs.io ベースのインスタンス\n\nこれにより、表示されるアイコンが制御され、API の互換性に影響する場合があります。"
+    },
+    "config": {
+      "name": "## 構成名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- 構成を構成するバリアントの組み合わせを説明するのに役立ちます (例: 「Chrome、Windows 10」、「Safari/macOS 15.5」、「Edge/Windows 11」など)。"
+    },
+    "configCategory": {
+      "name": "## カテゴリ名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- バリアント (例: Chrome、Firefox、Safari、Edge など) をカテゴリ (例: ブラウザー) に整理するのに役立ちます。"
+    },
+    "configVariant": {
+      "name": "## バリアント名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- テスト環境の一部であるバリアントを説明するのに役立ちます (例: Chrome、Safari、Windows 10、Windows 11、macOS 15.5 など)。"
+    },
+    "issueConfig": {
+      "name": "## 問題設定名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- 問題設定を説明するのに役立ちます (例: Jira、GitHub など)。",
+      "baseUrl": "## ベース URL\n課題プレースホルダーを含む課題設定のベース URL (例: https://your-jira-instance.atlassian.net/browse/'{issueId}')。",
+      "systemType": "## システム タイプ\n問題追跡システムのタイプ (例: LINK Jira など)。",
+      "isActive": "## アクティブ\nこの問題の構成がアクティブかどうかを示します。",
+      "isDefault": "## デフォルト\nこの問題設定がプロジェクトのデフォルトかどうかを示します。\n\n- デフォルトの問題設定は、新しい問題に対して事前に選択されています\n- いつでも変更できます",
+      "projects": "## プロジェクト\nこの問題構成に割り当てられているプロジェクトを示します。"
+    },
+    "issue": {
+      "name": "## 問題名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- 問題を説明するのに役立ちます (例: 「問題 123」、「バグ 456」など)。",
+      "title": "## 問題のタイトル\n問題を説明する、人間が読めるタイトル。\n\n- 問題の内容についてのコンテキストを提供します\n- リストや問題の表示に表示されます\n- 明確で説明的なものにする必要があります",
+      "externalKey": "## 外部キー\n外部の問題追跡システムからの一意のキーまたは識別子。\n\n- JIRAの場合: \"PROJ-123\"のような問題キー\n- GitHubの場合: \"456\"のような問題番号\n- Azure DevOpsの場合: 作業項目ID\n- 保存時に外部URLを自動的に生成します",
+      "externalId": "## 外部 ID\n問題追跡システムにおけるこの問題の一意の識別子 (例: 「Issue-123」、「Bug456」など)。\n\n- これはベース URL の問題プレースホルダーとして使用されます。",
+      "description": "## 説明\nこの問題がカバーする内容の簡単な概要。\n\n- テスト対象の主要な領域または機能\n- 重要なコンテキストまたは背景\n- 特別な考慮事項または要件",
+      "project": "## プロジェクト\nこの問題が関連付けられているプロジェクト。\n\n- 問題は複数のプロジェクトにまたがるテストケースにリンクできます\n- プライマリプロジェクトを設定すると、問題を整理しやすくなります\n- プロジェクト間の問題の場合は空白のままにすることができます",
+      "state": "## 状態\nプロジェクトのワークフローに従って、この問題の現在のステータスまたは結果を示します。",
+      "tags": "## タグ\n関連するタグを適用して、この問題を分類およびフィルタリングします。",
+      "issues": "## 問題\n関連する問題 (バグ、タスクなど) をこの問題にリンクします。"
+    },
+    "status": {
+      "name": "## ステータス名\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- テスト結果のステータス (合格、不合格、ブロックなど) を説明するのに役立ちます。",
+      "color": "## 色\nこのステータスの色。",
+      "systemName": "## システム名\nバックエンド システムで使用されるステータスの名前 (例: データベース クエリ、レポートなど)。",
+      "aliases": "## エイリアス\n外部システムのステータスをこのステータスにリンクするために使用できる、このステータスの追加の名前または同義語。",
+      "enabled": "## 有効\nこのステータスが有効かどうかを示します。",
+      "isEnabled": "## 有効\nこのステータスが有効で使用可能かどうかを示します。\n\n- 有効にすると、テスト結果を記録するときにこのステータスを選択できます\n- 無効のステータスは選択できませんが、既存の結果には保持されます",
+      "success": "## 成功\nこのステータスが成功ステータスかどうかを示します。",
+      "isSuccess": "## 成功ステータス\nこのステータスがテストの成功結果を表すかどうかを示します。\n\n- 成功ステータスは合格率の指標に貢献します\n- テストの有効性を追跡するためのレポートと分析で使用されます",
+      "completed": "## 完了\nこのステータスが完了ステータスであるかどうかを示します。",
+      "isCompleted": "## 完了ステータス\nこのステータスが完了したテスト実行を表しているかどうかを示します。\n\n- 完了ステータスは、テストの実行が終了したことを示します\n- 完了率と進捗状況の追跡を計算するために使用されます",
+      "failure": "## 失敗\nこのステータスが失敗ステータスであるかどうかを示します。",
+      "isFailure": "## 失敗ステータス\nこのステータスが失敗したテスト結果を表すかどうかを示します。\n\n- 失敗ステータスは失敗率の指標に貢献します\n- レポートと分析で問題を特定するために使用されます",
+      "scope": "## スコープ\nこのステータスのスコープ (テスト実行、セッション、自動化) を示します。",
+      "projects": "## プロジェクト\nこのステータスを使用できるプロジェクトを示します。"
+    },
+    "workflow": {
+      "scope": "## スコープ\nこのワークフローのスコープ (テスト実行、セッション、自動化) を示します。\n\n- ワークフローを作成した後は変更できません。",
+      "iconColor": "## アイコン/色\nこのワークフローのアイコンと色。",
+      "name": "## 名前\nすべてのプロジェクトで使用される、明確で説明的な名前。\n\n- ワークフローの説明に役立ちます (例:「ドラフト」、「レビュー中」、「アクティブ」など)。",
+      "workflowType": "## タイプ\nワークフローのタイプ (未開始、進行中、完了)。",
+      "type": "## ワークフロータイプ\nワークフロー状態のカテゴリ（未開始、進行中、完了）。\n\n- この状態が進捗状況の追跡にどのように影響するかを決定します\n- 未開始状態は作業が開始されていないことを示します\n- 進行中状態はアクティブな作業を示します\n- 完了状態は作業が完了したことを示します",
+      "isDefault": "## デフォルト\nこのワークフローがプロジェクトのデフォルトかどうかを示します。\n\n- 新しいテスト実行、セッション、および自動化では、デフォルトのワークフローが事前に選択されています。",
+      "isEnabled": "## 有効\nこのワークフローが有効かどうかを示します。",
+      "isActive": "## アクティブ\nこのワークフローの状態がアクティブで使用可能かどうかを示します。\n\n- アクティブなワークフローは、テスト実行、セッション、または自動化を更新するときに選択できます。\n- 非アクティブなワークフローは選択から非表示になりますが、既存の項目に保持されます。",
+      "projects": "## プロジェクト\nこのワークフローを使用できるプロジェクトを示します。"
+    },
+    "testResult": {
+      "status": "## ステータス\nテスト実行の全体的なステータスを選択します。選択したステータスは、プロジェクトのメトリクスとレポートに影響を与える可能性があります。",
+      "elapsedTime": "## 経過時間\nこのテストケースの実行にかかった合計時間を入力します。秒は**s**、分は**m**、時間は**h**などの単位を使用できます（例：30s、5m、1h 20m）。",
+      "resultData": "## 結果の詳細\nテスト実行全体に関する詳細なメモ、観察結果、その他の関連データを提供します。これには、セットアップの詳細、計画から逸脱した場合の手順、一般的なコメントなどが含まれます。",
+      "evidence": "## 証拠/添付ファイル\nこのテスト結果の証拠となるファイル（スクリーンショット、ログ、データファイルなど）をアップロードしてください。これらの添付ファイルは、この特定の結果にリンクされます。",
+      "issues": "## リンクされた問題\n統合された問題トラッカーから、このテスト結果に関連する問題をリンクします。これにより、このテストの結果に関連する不具合やタスクを追跡しやすくなります。",
+      "stepStatus": "## ステップステータス\nこの特定のテストステップのステータスを選択します。これにより、単一のテストケース内の進捗状況を詳細に追跡できます。",
+      "stepElapsedTime": "## ステップ経過時間\nこのステップの実行にかかった時間を入力します。単位は **s**、**m**、**h** など（例：10s、2m）を使用してください。これはオプションです。",
+      "stepNotes": "## ステップ ノート\nこのテスト ステップの実行に固有のメモ、観察結果、またはデータを追加します。",
+      "stepIssues": "## ステップにリンクされた問題\nこのテスト ステップの結果または観察に特に関連する問題トラッカーからの問題をリンクします。"
+    },
+    "case": {
+      "name": "## テストケース名\nテストケースのわかりやすい名前。",
+      "state": "## 状態\nこのケースの現在のワークフロー状態を示します。",
+      "template": "## テンプレート\nこのケースのケース フィールドと結果フィールドに使用するテンプレートを選択します。",
+      "estimate": "## 見積もり\nこのテストケースを完了するのにかかる手動で入力された推定時間。",
+      "automated": "## 自動化\nこのテストケースが自動化されているかどうかを示します。",
+      "tags": "## タグ\n関連するタグを適用して、このケースを分類およびフィルタリングします。",
+      "issues": "## 問題\n関連する問題 (バグ、タスクなど) をこのケースにリンクします。"
+    },
+    "folder": {
+      "name": "## フォルダー名\nフォルダーのわかりやすい名前。",
+      "documentation": "## ドキュメント\n追加の詳細、参照、およびサポート資料。"
+    },
+    "bulkEdit": {
+      "name": "## 名前\nテストケースのわかりやすい名前。",
+      "state": "## 状態\nこれらのテストケースの現在のワークフロー状態を示します。",
+      "estimate": "## 見積もり\n各テストケースを完了するのにかかる手動で入力された推定時間。",
+      "automated": "## 自動化\nこれらのテストケースが自動化されているかどうかを示します。",
+      "tags": "## タグ\n関連するタグを適用して、これらのテストケースを分類およびフィルタリングします。",
+      "issues": "## 問題\n関連する問題 (バグ、タスクなど) をこれらのテスト ケースにリンクします。"
+    },
+    "caseField": {
+      "displayName": "## 表示名\nこれは、フォームやビューでユーザーに表示されるフィールドの、人間が読める名前です。明確で説明的な名前にしてください。",
+      "systemName": "## システム名\nシステム内部（API呼び出し、データベースクエリなど）で使用される、このフィールドの一意の識別子です。表示名から自動生成されますが、カスタマイズも可能です。先頭は文字でなければなりません。文字、数字、アンダースコアのみを使用できます（スペースや特殊文字は使用できません）。",
+      "hint": "## ヒントテキスト（オプション）\nユーザーを誘導するために、フィールドの下に表示される短い説明または例を入力します。これにより、想定される入力内容や書式を明確にすることができます。",
+      "enabled": "## 有効\nこのフィールドがアクティブで、テンプレートやテストケースで使用できるかどうかを決定します。無効なフィールドは非表示になり、データは保持されますが使用されません。",
+      "required": "## 必須\nチェックされている場合、このフィールドを含むテンプレートを使用してテストケースを作成または編集するときに、ユーザーはこのフィールドに値を入力する必要があります。",
+      "restricted": "## 制限\nチェックを入れると、ケース作成後、特別な権限を持つユーザー（例：スーパー管理者または「ケース制限フィールド」権限を持つユーザー）のみがこのフィールドの値を編集できます。他のユーザーには読み取り専用として表示されます。これは、「レビュー担当者」や「承認日」など、特定の段階以降は一般ユーザーが変更できないフィールドに役立ちます。",
+      "fieldType": "## フィールドタイプ\nこのフィールドに格納されるデータの種類と表示方法（例：テキスト、数値、日付、ドロップダウン）を決定します。フィールドタイプは作成後に変更できません。",
+      "defaultValue": "## デフォルト値（オプション）\nこのフィールドに事前入力される値を設定します。「チェックボックス」タイプの場合は「true」または「false」を使用します。「ドロップダウン」または「複数選択」タイプの場合は、通常、デフォルトの選択肢のIDを参照します。その他のタイプの場合は、デフォルトのテキストまたは数値がそのまま使用されます。この値は、フィールドをテンプレートに追加する際に上書きできます。",
+      "isChecked": "## デフォルトの状態 (チェックボックスの場合)\n新しい項目 (テスト ケースなど) を作成するときに、チェックボックスをデフォルトでオンにするかどうかを決定します。",
+      "minValue": "## 最小値（数値/整数）\nこのフィールドで許容される最小の数値を設定します。最小値と最大値のいずれかを使用する場合は、両方を設定する必要があります。",
+      "maxValue": "## 最大値（数値/整数）\nこのフィールドで許容される最大の数値を設定します。最小値と最大値のいずれかを使用する場合は、両方を設定する必要があります。",
+      "initialHeight": "## 初期高さ（長文テキスト用）\nリッチテキストエディターのフィールドの初期表示高さ（ピクセル単位）を指定します。これにより、長文テキスト入力時のフォームレイアウトを制御できます。",
+      "dropdownOptions": "## オプション（ドロップダウン/複数選択用）\n選択可能な選択肢のリストを定義します。選択肢の順序を変更したり、デフォルトの設定を行ったり、個々の選択肢を有効/無効にしたりできます。"
+    },
+    "resultField": {
+      "displayName": "## 表示名\nこれは、ユーザーがテスト結果を入力する際に表示される、人間が判読できるフィールド名です。明確でわかりやすい名前にしてください。",
+      "systemName": "## システム名\nシステム内部（API呼び出し、データベースクエリなど）で使用される、このフィールドの一意の識別子です。表示名から自動生成されますが、カスタマイズも可能です。\n- 先頭は文字である必要があります。\n- 文字、数字、アンダースコアのみを使用できます（スペースや特殊文字は使用できません）。",
+      "hint": "## ヒントテキスト（オプション）\nフィールドの下に表示される、ユーザーを誘導するための短い説明または例を入力します。これにより、結果データの入力時に期待される入力内容やフォーマットを明確にすることができます。",
+      "enabled": "## 有効\nこのフィールドをアクティブにして、テスト結果を入力する際のテンプレートで使用可能にするかどうかを決定します。無効なフィールドは非表示になり、データは保持されますが使用されません。",
+      "required": "## 必須\nチェックした場合、このフィールドを含むテンプレートを使用してテスト結果を追加するときに、ユーザーはこのフィールドに値を入力する必要があります。",
+      "restricted": "## 制限\nチェックを入れると、結果の送信後、特別な権限を持つユーザー（例：スーパー管理者または「テスト実行結果の制限フィールド」権限を持つユーザー）のみがこのフィールドの値を編集できます。他のユーザーには読み取り専用として表示されます。",
+      "fieldType": "## フィールドタイプ\nこのフィールドに格納されるデータの種類と、テスト結果での表示方法を決定します（例：テキスト、数値、日付、ドロップダウン）。フィールドタイプは作成後に変更できません。",
+      "defaultValue": "## デフォルト値（オプション）\n新しいテスト結果を追加するときに、このフィールドに事前入力される値を設定します。「チェックボックス」タイプの場合は「true」または「false」を使用します。「ドロップダウン」または「複数選択」タイプの場合は、通常、デフォルトオプションのIDを参照します。その他のタイプの場合は、デフォルトのテキストまたは数値がそのまま使用されます。",
+      "isChecked": "## デフォルトの状態 (チェックボックスの場合)\n新しいテスト結果が追加されるときに、チェックボックスをデフォルトでオンにするかどうかを決定します。",
+      "minValue": "## 最小値（数値/整数）\n結果データを入力する際に、このフィールドに入力できる最小の数値を設定します。最小値と最大値のいずれかを使用する場合は、両方を設定する必要があります。",
+      "maxValue": "## 最大値（数値/整数）\n結果データを入力する際に、このフィールドに許容される最大の数値を設定します。最小値と最大値のいずれかを使用する場合は、両方を設定する必要があります。",
+      "initialHeight": "## 初期高さ（長文テキスト用）\n結果に表示されるリッチテキストエディターフィールドの初期表示高さ（ピクセル単位）を指定します。これにより、長文テキスト入力時のフォームレイアウトを制御できます。",
+      "dropdownOptions": "## オプション（ドロップダウン/複数選択用）\n結果データを入力する際に選択可能な選択肢のリストを定義します。選択肢の順序を変更したり、デフォルトの設定を行ったり、個々の選択肢を有効/無効にしたりできます。"
+    },
+    "exportModal": {
+      "scope": "## エクスポート範囲\nエクスポートに含めるテスト ケースを決定します。\n- **選択済み:** テーブルで明示的に選択したテスト ケースのみをエクスポートします。\n- **すべてフィルター済み:** テーブル内の現在のフィルター基準に一致するすべてのテスト ケースをエクスポートします (ページに現在すべてのテスト ケースが表示されていない場合でも)。\n- **すべてのプロジェクト:** 選択やフィルターを無視して、現在のプロジェクト内のすべてのテスト ケースをエクスポートします。",
+      "format": "## エクスポート形式\nエクスポートするファイル形式を選択します。\n- **CSV（カンマ区切り値）:** スプレッドシート（Excel、Googleスプレッドシート）やデータ分析ツールに適したプレーンテキストファイルです。PDFエクスポートは今後のリリースで予定されています。",
+      "columns": "## エクスポートする列 (CSV のみ)\n各テスト ケースに含めるデータ列を決定します。\n- **すべての列:** テンプレートのカスタム フィールドを含む、テスト ケースで使用可能なすべてのデータ フィールドをエクスポートします。\n- **表示されている列:** テスト ケース テーブルに現在表示されている列のみをエクスポートします。",
+      "delimiter": "## CSV 区切り文字 (CSV のみ)\nCSV ファイル内の値を区切る文字を選択します。最も一般的なのはカンマです。テキストフィールド内にカンマが含まれている場合は、別の区切り文字（例：セミコロン）を使用してください。",
+      "textLongFormat": "## ロングテキストフィールド形式（CSVのみ）\nリッチテキストフィールド（「説明」やカスタムの「ロングテキスト」フィールドなど）のエクスポート方法を決定します。\n- **JSON:** すべての書式（太字、リストなど）を保持したまま、コンテンツをJSON文字列としてエクスポートします。これは、再インポートやプログラムによる処理に最適です。\n- **プレーンテキスト:** 書式を削除し、コンテンツをプレーンテキストとしてエクスポートします。シンプルなテキストビューアで読みやすくなります。",
+      "stepsFormat": "## ステップ形式（CSVのみ）\nテストステップ（期待される結果を含む）のエクスポート方法を決定します。\n- **JSON:** ステップをオブジェクトのJSON配列としてエクスポートし、構造とリッチテキストを維持します。再インポートや詳細な分析に適しています。\n- **プレーンテキスト:** ステップを簡略化された読みやすいプレーンテキスト形式でエクスポートし、各ステップと期待される結果を新しい行に記述します。",
+      "rowMode": "## 行モード (CSV のみ)\n複数値フィールド (タグや複数選択カスタム フィールドなど) とステップの表示方法を決定します。\n- **ケースごとに 1 行:** 各テスト ケースは 1 行です。複数値フィールドとステップは、それぞれのセルに圧縮されます (多くの場合、JSON または連結されたテキストとして)。\n- **ケースごとに複数行:** テスト ケースは、複数のタグ、複数選択値、またはステップがある場合、複数の行にまたがることができます。このようなフィールドの一意の値/ステップごとに新しい行が作成され、他のケース データが繰り返されます。これは、詳細な分析やピボットに便利です。",
+      "attachmentFormat": "## 添付ファイル情報のフォーマット（CSVのみ）\n添付ファイルに関する情報のエクスポート方法を指定します。\n- **JSON:** 添付ファイルの詳細（ファイル名、URL、サイズなど）をJSON配列としてエクスポートします。これは包括的な情報ですが、CSV形式で直接保存すると人間が読みにくくなります。\n- **名前のみ:** 添付ファイル名をカンマ区切りのリストとしてエクスポートします。より簡潔なため、すぐに参照できます。"
+    },
+    "reportMetrics": {
+      "count": "## テスト結果数\nこのグループ内のテスト実行結果の数。",
+      "passRate": "## 合格率\nこのグループ内で合格ステータスとなった結果の割合。",
+      "avgElapsed": "## 平均経過時間\nこのグループの結果の平均経過時間。",
+      "sumElapsed": "## 合計経過時間\nこのグループの結果の経過時間の合計。",
+      "executionCount": "## テスト実行\n実行されたテスト実行の合計数。",
+      "testCaseCount": "## テストケース数\nこのグループ内のテストケースの合計数。",
+      "testRunCount": "## テスト実行数\nこのグループ内のテスト実行の合計数。",
+      "automationRate": "## 自動化率\n自動化されているテストケースの割合。",
+      "averageSteps": "## ケースあたりの平均ステップ数\nテストケースあたりのステップ数の平均。",
+      "automatedCount": "## 自動化されたケース\n自動化されたテストケースの数。",
+      "manualCount": "## 手動ケース\n手動テストケースの数。",
+      "totalSteps": "## 合計ステップ数\nすべてのケースにおけるテストステップの合計数。",
+      "createdCaseCount": "## 作成されたテストケース\nこの期間に作成されたテストケースの数。",
+      "sessionResultCount": "## セッション結果\nセッションテスト結果の数。",
+      "sessionCount": "## セッション数\nテストセッションの合計数。",
+      "activeSessions": "## アクティブセッション\n現在アクティブなセッションの数 (isActive = true)。",
+      "milestoneCompletion": "## マイルストーン完了\nマイルストーンで完了したテストケースの割合。(完了したテスト結果 / テスト実行の合計テストケース数) × 100 として計算されます。",
+      "averageTimeSpent": "## 平均所要時間\nアクティビティに費やされた平均時間。",
+      "sessionParticipation": "## セッション参加\nテストセッションへの参加レベル。",
+      "lastActiveDate": "## 最終アクティブ日\n最新のアクティビティの日付。",
+      "averageAge": "## 平均年齢\nアイテムの平均年齢（日数）。",
+      "issueCount": "## 問題数\n追跡された問題の合計数。",
+      "milestoneCount": "## マイルストーン数\nマイルストーンの合計数。",
+      "milestoneCompletionRate": "## マイルストーン完了率\n完了したマイルストーンの割合。",
+      "averageMilestoneDuration": "## 平均マイルストーン期間\nマイルストーンの平均期間（日数）。"
+    },
+    "reportDimensions": {
+      "user": "## ユーザー ディメンション\nテストを実行したユーザーまたはアイテムに割り当てられているユーザーごとに結果をグループ化します。",
+      "status": "## ステータス ディメンション\nテスト実行ステータス (合格、不合格、ブロックなど) 別に結果をグループ化します。",
+      "project": "## プロジェクト ディメンション\nプロジェクト間の分析のために結果をプロジェクトごとにグループ化します。",
+      "testRun": "## テスト実行ディメンション\n実行されたテストケースを含むテスト実行ごとに結果をグループ化します。",
+      "testCase": "## テスト ケース ディメンション\n詳細な分析のために、結果を個々のテスト ケースごとにグループ化します。",
+      "milestone": "## マイルストーン ディメンション\nプロジェクトのマイルストーンごとに結果をグループ化し、目標に向けた進捗状況を追跡します。",
+      "configuration": "## 構成ディメンション\nテスト環境の構成 (ブラウザー、OS など) ごとに結果をグループ化します。",
+      "template": "## テンプレート ディメンション\nテスト ケース構造に使用されるテンプレートごとに結果をグループ化します。",
+      "creator": "## 作成者ディメンション\nテストケースまたはテスト実行を作成したユーザーごとに結果をグループ化します。",
+      "state": "## 状態ディメンション\n結果をワークフローの状態 (下書き、アクティブ、完了など) 別にグループ化します。",
+      "role": "## ロール ディメンション\nアクセスと責任の分析のために、結果をユーザー ロール別にグループ化します。",
+      "group": "## グループディメンション\n結果をユーザーグループごとにグループ化します。ユーザーは複数のグループに所属できるため、アクティビティはユーザーが所属するグループごとにカウントされます。",
+      "folder": "## フォルダー ディメンション\n組織分析のために、リポジトリ フォルダー構造ごとに結果をグループ化します。",
+      "session": "## セッション ディメンション\nセッションベースの分析のために、結果をテスト セッションごとにグループ化します。",
+      "assignedTo": "## ディメンションに割り当て\nアイテムを実行または管理するために割り当てられたユーザーごとに結果をグループ化します。",
+      "issueType": "## 課題タイプディメンション\n追跡対象の課題タイプ（例：バグ、タスク、ストーリー、機能強化）ごとに結果をグループ化します。",
+      "issueTracker": "## 課題追跡ディメンション\n使用されている課題追跡統合 (例: Jira、GitHub Issues、Azure DevOps) ごとに結果をグループ化します。",
+      "issueStatus": "## 課題ステータスディメンション\n課題の現在のステータス (例: オープン、進行中、解決済み、クローズ済み) で結果をグループ化します。",
+      "priority": "## 優先度ディメンション\n問題の優先度レベル (高、中、低など) で結果をグループ化します。",
+      "source": "## ソース ディメンション\nテスト実行のソース (手動、JUnit、API など) ごとに結果をグループ化します。",
+      "date": "## 日付ディメンション\n時間ベースの分析と傾向のために、結果を日付別にグループ化します。"
+    },
+    "reportBuilder": {
+      "dimensions": "## ディメンション\nレポートで分析したいディメンションを選択します。ディメンションとは、日付、ユーザー、ステータスなど、データを分類する属性です。ドラッグして順序を変更できます。",
+      "metrics": "## メトリクス\nレポートで測定するメトリクスを選択します。メトリクスとは、テスト結果数、合格率、平均経過時間など、データから得られる定量的な測定値です。ドラッグして順序を変更できます。",
+      "dateRange": "## 日付範囲\n特定の期間でレポートデータをフィルタリングします。「過去7日間」や「前月」などの定義済み範囲から選択するか、カスタムの日付範囲を定義することができます。このフィルターは、各レポートタイプの関連する日付フィールド（例：テスト結果の実行日、テストケースの作成日）に適用されます。"
+    },
+    "codeRepository": {
+      "name": "## リポジトリ名\nこのリポジトリ接続の分かりやすい表示名。\n\n- プロジェクトコードコンテキスト設定で識別するために使用されます。\n- プロバイダのリポジトリ名と一致する必要はありません。",
+      "provider": "## Git プロバイダー\nこのリポジトリをホストするプラットフォーム。\n\n- **GitHub** — github.com (クラウドまたはエンタープライズ)\n- **GitLab** — gitlab.com またはセルフホスト\n- **Bitbucket Cloud** — bitbucket.org (クラウドのみ)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — 互換性のある API を備えたセルフホスト型 Git サーバー",
+      "githubToken": "## 個人アクセストークン\n**Contents: Read** 権限を持つ GitHub トークン。\n\nGitHub → プロファイル設定 → 開発者設定 → 個人アクセストークン → 細かいトークンで生成します。",
+      "owner": "## 所有者\nリポジトリを所有する GitHub 組織またはユーザー アカウント。\n\n- 例: `myorg` または `myusername`\n- これは、github.com 上のリポジトリ URL の最初のパス セグメントです。",
+      "repo": "## リポジトリ\nオーナープレフィックスを除いたリポジトリ名。\n\n- 例: `my-repo` (`myorg/my-repo` ではありません)\n- これは、github.com 上のリポジトリ URL の 2 番目のパス部分です。",
+      "gitlabToken": "## 個人アクセストークン\n**read_api** および **read_repository** スコープを持つ GitLab トークン。\n\nGitLab → ユーザー設定 → アクセストークンで生成します。",
+      "projectPath": "## プロジェクト ID またはパス\n数値のプロジェクト ID または完全な名前空間パス。\n\n- パスの例: `myorg/my-project`\n- ID の例: `12345678`\n- GitLab の [設定] → [一般] で確認できます。",
+      "baseUrl": "## GitLab URL\ngitlab.com の場合は空欄のままにしてください。セルフホスト型インスタンスの場合は、GitLab URL を入力してください。\n\n- 例: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian アカウントのメールアドレス\nAtlassian アカウントに関連付けられているメールアドレス。\n\n- これは Bitbucket Cloud にログインするために使用するメールアドレスです。",
+      "bitbucketApiToken": "## APIトークン\n**リポジトリ: 読み取り** スコープを持つBitbucket APIトークン。\n\nBitbucket → 個人設定 → APIトークンで作成します。\n\n> アプリパスワードは、APIトークンを優先するため、Atlassianによって非推奨になりました。",
+      "workspace": "## ワークスペース\nBitbucket URL のワークスペーススラッグ。\n\n- 例: `bitbucket.org/myworkspace` の `myworkspace`",
+      "repoSlug": "## リポジトリスラッグ\nURL から取得したリポジトリ識別子。\n\n- 例: `bitbucket.org/myworkspace/my-repo` の `my-repo`",
+      "azureToken": "## 個人アクセストークン\n**コード (読み取り)** 権限を持つ Azure DevOps PAT。\n\nAzure DevOps → ユーザー設定 → 個人アクセストークンで作成します。",
+      "organizationUrl": "## 組織URL\nAzure DevOps組織のURL。\n\n- 例: `https://dev.azure.com/myorg`",
+      "project": "## プロジェクト名\nリポジトリを含む Azure DevOps プロジェクトの名前。\n\n- Azure DevOps URL の組織名の後の 3 番目のパスセグメントとして見つかります。",
+      "azureRepoId": "## リポジトリ名またはID\nAzure DevOpsプロジェクト内のリポジトリ名またはGUID。\n\n- 例: `my-repo`",
+      "giteaToken": "## 個人アクセストークン\nリポジトリの読み取り権限を持つトークン。\n\nサイト管理 → アプリケーション、またはユーザー設定 → アプリケーションで生成します。\n\n- Gitea、Forgejo、Gogs、および互換性のある API を公開する任意のサーバーで動作します。",
+      "giteaBaseUrl": "## サーバーURL\nセルフホスト型GitサーバーのベースURL。\n\n- 例: `https://gitea.example.com`\n- プロトコルを含める必要があります（https:// を推奨）\n- Gitea、Forgejo、Gogs、およびGitea互換の`/api/v1/` REST APIを備えたその他のサーバーで動作します",
+      "giteaOwner": "## 所有者\nリポジトリを所有する組織またはユーザーアカウント。\n\n- 例: `myorg` または `myusername`\n- これはリポジトリ URL の最初のパスセグメントです",
+      "giteaRepo": "## リポジトリ\nオーナープレフィックスを除いたリポジトリ名。\n\n- 例: `my-repo` (`myorg/my-repo` ではありません)"
+    },
+    "promptConfig": {
+      "name": "## 設定名\nこのプロンプト設定の一意で分かりやすい名前。\n\n- プロジェクトに割り当てる際に設定を識別するために使用されます (例: \"GPT-4o プロンプト\"、\"保守的なプロンプト\")。",
+      "description": "## 説明\nこの設定の特徴を簡潔にまとめたオプションの要約。\n\n- 管理者が目的を一目で理解するのに役立ちます（例：「温度が低いほど、決定論的な出力が求められます」）。",
+      "isActive": "## アクティブ\n有効にすると、この構成はプロジェクトで使用できるようになります。\n\n- 非アクティブな構成は、プロジェクト割り当てのドロップダウンから非表示になります。\n- デフォルトの構成は非アクティブ化できません。",
+      "isDefault": "## デフォルト設定\n有効にすると、この設定は特定の設定が割り当てられていないすべてのプロジェクトで使用されます。\n\n- 一度にデフォルトにできる設定は 1 つだけです。\n- 新しいデフォルトを設定すると、以前のデフォルトは自動的に解除されます。",
+      "systemPrompt": "## システムプロンプト\nユーザー入力の前に AI モデルに送信される指示。モデルの役割、出力形式、制約を定義します。\n\n- 実行時に置換される二重中括弧プレースホルダー (FRAMEWORK、LANGUAGE、CASE_NAME など) をサポートします。\n- ここでの変更は、この構成を使用するすべてのプロジェクトに影響します。",
+      "userPrompt": "## ユーザープロンプト\nユーザーに代わって AI に送信されるメッセージ。機能でユーザーメッセージを完全にコードで構築する場合は、空白のままにします。\n\n- 実行時に置換される二重中括弧のプレースホルダー (例: ISSUE_TITLE、CASE_NAME、CODE_CONTEXT) をサポートします。\n- 各機能で使用可能なプレースホルダーは、以下の変数セクションに記載されています。",
+      "temperature": "## 温度\nAI 出力のランダム性を制御します。範囲: 0–2。\n\n- **0.0–0.3** — 決定論性が高く、構造化された出力 (JSON、コード) に最適です。\n- **0.4–0.7** — バランスが取れており、テスト ケースの生成に適しています。\n- **0.8–2.0** — より創造的で多様であり、自由形式のテキストに適しています。",
+      "maxOutputTokens": "## 最大出力トークン数\nモデルが単一の応答で生成するトークンの最大数。\n\n- 値が大きいほど応答は長くなりますが、コストとレイテンシが増加します。\n- 一般的な範囲: 短いテキストの場合は 2048、コード生成の場合は 4096、複数ケース出力の場合は 6000 以上。"
+    },
+    "menu": {
+      "startTour": "ガイド付きウェルカムツアー",
+      "startProjectTour": "プロジェクトツアー",
+      "startAdminTour": "管理者ツアー",
+      "startDemoProjectTour": "デモプロジェクトツアー"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "TestPlanIt へようこそ!",
+          "content": "テスト ワークフローを開始するのに役立つ TestPlanIt の主な機能を簡単に見てみましょう。"
+        },
+        "projects": {
+          "content": "ここからすべてのテストプロジェクトにアクセスできます。各プロジェクトには、テストケース、実行、チームコラボレーション機能が含まれています。"
+        },
+        "project": {
+          "title": "プロジェクトカード",
+          "content": "プロジェクトカードをクリックすると詳細が表示されます。ヘルプメニューから「プロジェクトツアー」を選択すると、プロジェクト機能のガイドツアーが表示されます。"
+        },
+        "globalFeatures": {
+          "title": "グローバル機能",
+          "content": "分類のためのタグを管理し、プロジェクト全体の問題を追跡し、ロールベースのアクセス制御を使用してユーザーを管理します。"
+        },
+        "search": {
+          "content": "現在のページに基づいたコンテキスト検索。テストケース、実行、問題、その他のコンテンツを素早く検索できます。Cmd+K（またはCtrl+K）ですぐにアクセスできます。"
+        },
+        "help": {
+          "title": "ヘルプとサポート",
+          "content": "いつでもこのガイド ツアーにアクセスしたり、詳細なヘルプについては包括的なドキュメントをご覧ください。"
+        },
+        "notifications": {
+          "content": "テスト実行の完了、問題の更新、チームの活動に関する最新情報を入手できます。アカウント設定で設定を行ってください。"
+        },
+        "account": {
+          "title": "アカウントメニュー",
+          "content": "プロフィール、通知設定、アカウント設定をカスタマイズできます。ライトテーマとダークテーマを切り替えられます。"
+        },
+        "assignments": {
+          "content": "すべてのプロジェクトで割り当てられたテストケースと実行を表示します。これは、テスト作業を追跡するための個人用ダッシュボードです。"
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "プロジェクトセレクター",
+          "content": "このドロップダウンを使ってプロジェクト間を素早く切り替えることができます。プロジェクトの詳細を表示したり、プロジェクト全体の設定にアクセスしたりできます。"
+        },
+        "projectSections": {
+          "title": "プロジェクトセクション",
+          "content": "プロジェクト ダッシュボードの概要、プロジェクト ガイドのドキュメント、進捗状況を追跡するためのマイルストーンをナビゲートします。"
+        },
+        "repository": {
+          "content": "テスト ケースを管理し、フォルダーに整理して、徹底したテスト範囲をカバーする新しいテスト シナリオを作成します。"
+        },
+        "repositoryPanels": {
+          "title": "リポジトリの左パネル",
+          "content": "左側のパネルには、フォルダ構造とテストケースツリーが表示されます。ビューセレクターを使用して、異なる組織ビューを切り替えます。"
+        },
+        "repositoryRightPanel": {
+          "title": "リポジトリの右パネル",
+          "content": "右側のパネルには、テスト ケースの詳細、実行結果が表示され、新しいテスト ケースを作成したり、既存のテスト ケースをインポートしたりするためのアクションが提供されます。"
+        },
+        "sharedSteps": {
+          "title": "共有ステップ",
+          "content": "複数のテストケースから参照できる、再利用可能なステップグループを定義します。テストステップは、DRY（Don't Repeat Yourself）原則に従い、一貫性を保つようにしてください。"
+        },
+        "testRuns": {
+          "content": "計画されたテスト実行、進捗状況の追跡、チーム全体のテスト割り当ての管理を行います。詳細な実行結果を表示します。"
+        },
+        "testRunsPage": {
+          "title": "テスト実行ダッシュボード",
+          "content": "これは「テスト実行」ページです。ここでは、新しいテスト実行の作成、実行の進捗状況の監視、結果の表示、テスト割り当ての管理を行うことができます。チームのテスト活動を一元的に追跡できます。"
+        },
+        "sessions": {
+          "title": "探索セッション",
+          "content": "探索的テスト セッションを文書化し、調査結果を取得し、アドホック テスト アクティビティに費やされた時間を追跡します。"
+        },
+        "sessionsPage": {
+          "title": "探索セッションダッシュボード",
+          "content": "こちらは「セッション」ページで、探索的テストセッションを作成・管理できます。調査結果を文書化し、所要時間を追跡し、すべてのアドホックテスト活動の記録を維持することで、テストカバレッジの向上を図ります。"
+        },
+        "tags": {
+          "title": "タグ管理",
+          "content": "タグを使用してテストケースを整理および分類します。カスタムタグを作成して、テストケースの整理とフィルタリングを改善します。"
+        },
+        "issues": {
+          "title": "問題追跡",
+          "content": "テスト中に発見された問題を追跡および管理します。問題をテストケースにリンクし、外部のバグ追跡システムと統合します。"
+        },
+        "reports": {
+          "title": "レポートと分析",
+          "content": "プロジェクトの包括的なレポートと分析を生成します。テストカバレッジ、実行傾向、チームのパフォーマンス指標を確認し、関係者向けのカスタムレポートを作成します。"
+        },
+        "settings": {
+          "title": "プロジェクト設定",
+          "content": "ここから、プロジェクトレベルの統合、AIモデルの設定、共有リンクを管理できます。"
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "管理者コントロールへようこそ",
+          "content": "TestPlanIt の管理機能のガイドツアーをご覧ください。この集中管理パネルから、プロジェクト、ユーザー、構成、システム設定を管理できます。"
+        },
+        "projects": {
+          "title": "プロジェクト管理",
+          "content": "組織内のすべてのプロジェクトを管理します。プロジェクトを作成、設定、アーカイブし、プロジェクト全体の権限とアクセス制御を設定します。"
+        },
+        "templatesAndFields": {
+          "content": "テストケーステンプレートとカスタムフィールドを作成および管理します。フィールドタイプ、検証ルールを定義し、テンプレートを整理することで、プロジェクト間で一貫したテストケース構造を実現します。"
+        },
+        "workflows": {
+          "title": "ワークフロー管理",
+          "content": "テストケースのワークフローと状態遷移を定義します。ドラフト、レビュー、承認などのさまざまな状態を経てテストケースがどのように進行するかを構成します。"
+        },
+        "statuses": {
+          "title": "テスト結果のステータス",
+          "content": "合格、不合格、ブロック、スキップなどの利用可能なテスト結果ステータスを設定します。カスタムステータスを設定し、その動作と外観を定義します。"
+        },
+        "milestones": {
+          "content": "プロジェクト追跡のためのマイルストーンの種類を定義します。リリースタイプ、スプリントのカテゴリー、その他のプロジェクトマイルストーンの分類を設定します。"
+        },
+        "configurations": {
+          "title": "テスト構成",
+          "content": "テスト構成と環境を管理します。ブラウザの組み合わせ、デバイスの種類、オペレーティングシステム、その他のテスト実行コンテキストを設定します。"
+        },
+        "users": {
+          "title": "ユーザー管理",
+          "content": "ユーザーアカウント、権限、アクセスレベルを管理します。新しいユーザーを作成し、ロールを割り当て、認証設定を構成します。"
+        },
+        "groups": {
+          "title": "グループマネジメント",
+          "content": "ユーザーをグループにまとめることで、権限管理が容易になります。部門グループ、プロジェクトチーム、役割ベースのアクセスグループを作成できます。"
+        },
+        "roles": {
+          "title": "役割管理",
+          "content": "ユーザーの役割と権限を定義します。プロジェクトやシステム管理全体で、異なる役割が実行できるアクションを設定します。"
+        },
+        "tags": {
+          "title": "グローバルタグ",
+          "content": "テストケース、プロジェクト、その他のエンティティを分類するための組織全体のタグを管理します。タグ階層を作成し、プロジェクト間でタグ付けを標準化します。"
+        },
+        "reports": {
+          "content": "複数のプロジェクトにまたがるレポートを生成し、ワークスペース全体の傾向、パフォーマンス指標、組織的なテストの有効性を分析します。"
+        },
+        "notifications": {
+          "title": "通知設定",
+          "content": "システム全体の通知設定を構成します。メールテンプレート、通知ルール、ユーザー通知のデフォルト設定を設定します。"
+        },
+        "integrations": {
+          "title": "システム統合",
+          "content": "サードパーティとの統合とAPI接続を管理します。組織向けにJira、GitHub、その他の外部ツールとの統合を設定します。"
+        },
+        "llm": {
+          "title": "AI構成",
+          "content": "自動テストケース生成とインテリジェント機能のためのAIモデルと設定を構成します。APIキーとモデル設定を管理します。"
+        },
+        "sso": {
+          "title": "シングルサインオン",
+          "content": "SSOプロバイダーと認証方法を設定します。SAML、OAuth、その他のIDプロバイダーとの統合を設定して、シームレスなユーザーアクセスを実現します。"
+        },
+        "appConfig": {
+          "content": "グローバルアプリケーション設定とシステム環境設定を管理します。デフォルト値、機能の切り替え、システム全体の動作を設定します。"
+        },
+        "trash": {
+          "title": "システムゴミ箱",
+          "content": "すべてのプロジェクトで削除されたアイテムを表示および管理します。誤って削除したコンテンツを復元したり、システムからアイテムを完全に削除したりできます。"
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "デモプロジェクトへようこそ",
+          "content": "このプロジェクトにはサンプルデータがあらかじめ読み込まれています。それでは、主な機能を見ていきましょう。このドロップダウンメニューを使ってプロジェクトを切り替えることができます。"
+        },
+        "overview": {
+          "title": "プロジェクト概要",
+          "content": "概要はプロジェクトのダッシュボードです。マイルストーンの進捗状況、テストケースの概要、アクティブな実行状況、セッション、タグなどが表示されます。"
+        },
+        "documentation": {
+          "title": "文書",
+          "content": "すべてのプロジェクトにはドキュメントページがあります。テスト計画、プロジェクトに関するメモ、外部リソースへのリンクなどを記載するのに活用してください。"
+        },
+        "documentationContent": {
+          "title": "リッチテキストエディタ",
+          "content": "ドキュメントは、見出し、リスト、リンク、画像を含むリッチテキストをサポートしています。このページを編集して、その動作を確認してみてください。"
+        },
+        "milestones": {
+          "title": "マイルストーン",
+          "content": "スプリント、リリース、その他の目標に対してテストの進捗状況を追跡します。テスト実行とセッションをマイルストーンにリンクして、進捗状況を追跡できます。"
+        },
+        "milestonesPage": {
+          "title": "マイルストーンタイムライン",
+          "content": "このプロジェクトのすべてのマイルストーンを表示します。各マイルストーンには、そのステータスと完了までの進捗状況が表示されます。"
+        },
+        "repository": {
+          "title": "テストケースリポジトリ",
+          "content": "テストケースを、カスタムフィールド、ステップ、優先度を設定したフォルダに整理します。サンプルフォルダを参照して、ケースの構造を確認してください。"
+        },
+        "repositoryPanels": {
+          "title": "ファイル＆ケース",
+          "content": "左側のパネルにはフォルダが表示されます。フォルダをクリックすると、そのフォルダ内のテストケースが表示されます。各テストケースには、手順、説明、および共通の手順参照が含まれています。"
+        },
+        "repositoryCases": {
+          "title": "テストケース",
+          "content": "ここでは、選択したフォルダーのテストケースを確認できます。各行には、ケース名、優先度、およびカスタムフィールドが表示されます。ケースをクリックすると、詳細と手順が表示されます。"
+        },
+        "sharedSteps": {
+          "title": "共有ステップ",
+          "content": "複数のテストケースから参照できる、再利用可能なステップグループを定義します。これにより、共通のステップの一貫性が保たれ、保守が容易になります。"
+        },
+        "sharedStepsPage": {
+          "title": "共有ステップグループ",
+          "content": "各グループには、順序付けられた一連の手順が含まれています。どのテストケースからでもこれらの手順を参照することで、手順をDRY（Don't Repeat Yourself）かつ一貫性のあるものにすることができます。"
+        },
+        "testRuns": {
+          "title": "テスト実行",
+          "content": "テスト実行を作成してケースを実行し、結果を記録します。実行をマイルストーンに割り当て、合否の進捗状況を追跡します。"
+        },
+        "testRunsPage": {
+          "title": "テスト実行結果",
+          "content": "テスト実行結果と進捗状況を確認できます。各実行結果には、ステータス、割り当てられたマイルストーン、合否の内訳が表示されます。"
+        },
+        "sessions": {
+          "title": "探索セッション",
+          "content": "セッションベースのテストで、アドホックなテストを効率的に実行できます。テスト結果を記録し、ステータスを割り当て、所要時間を追跡します。"
+        },
+        "sessionsPage": {
+          "title": "セッション結果",
+          "content": "各セッションには、詳細な調査結果、ステータス、およびメモが含まれています。セッションをクリックすると、その結果が表示されます。"
+        },
+        "tags": {
+          "title": "タグ",
+          "content": "タグは、テストケース、テスト実行、テストセッションを整理・フィルタリングするのに役立ちます。サンプルタグを参照して、コンテンツがどのように分類されるかを確認してください。"
+        },
+        "tagsPage": {
+          "title": "タグ管理",
+          "content": "ここからタグを作成、編集、割り当てることができます。タグを使用して、プロジェクト全体のコンテンツをグループ化およびフィルタリングできます。"
+        },
+        "issues": {
+          "title": "問題",
+          "content": "テスト中に発見されたバグや不具合を追跡します。問題は、失敗したテスト実行結果やセッションの調査結果と関連付けることができ、完全なトレーサビリティを確保できます。"
+        },
+        "issuesPage": {
+          "title": "課題追跡システム",
+          "content": "失敗した結果に関連するサンプル問題を表示します。問題は、それらを発見したテスト実行またはセッションの検出結果まで遡って追跡できます。"
+        },
+        "reports": {
+          "title": "レポートと分析",
+          "content": "テストカバレッジ、実行傾向、チームパフォーマンスに関するレポートを生成します。あらかじめ用意されたレポートを使用することも、関係者向けにカスタムレポートを作成することもできます。"
+        },
+        "settings": {
+          "title": "プロジェクト設定",
+          "content": "ここから、プロジェクトレベルの統合、AIモデルの設定、共有リンクを管理できます。"
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "プロジェクト間レポートの作成と管理"
+      },
+      "reportsTabDescription": "プロジェクトの事前構築されたレポートを表示および分析します",
+      "reportType": "レポートの種類",
+      "selectReportType": "レポートの種類を選択",
+      "selectReport": "レポートを選択",
+      "dimensions": "寸法",
+      "dimensionsSubtitle": "寸法（ドラッグして順序を変更し、下に追加します）",
+      "metrics": "メトリクス",
+      "addDimension": "次元を追加...",
+      "addMetric": "メトリックを追加...",
+      "runReport": "レポートを実行",
+      "noResultsFound": "結果が見つかりませんでした。",
+      "selectAtLeastOneDimensionAndMetric": "少なくとも 1 つのディメンションと 1 つの指標を選択してください。",
+      "noDataMatchingCriteria": "選択したディメンションと指標に一致するデータが見つかりません。",
+      "noDataMatchingCriteriaWithDateFilter": "選択したディメンションと指標に一致するデータが見つかりません。日付範囲フィルタを調整してみてください。",
+      "noDataAvailable": "このレポートに利用できるデータはありません。",
+      "generatedAt": "レポートは以下で生成されました",
+      "crossProjectAnalytics": "プロジェクト間の分析とレポート",
+      "unauthorizedAdmin": "権限がありません: 管理者アクセスが必要です。",
+      "title": "レポートビルダー",
+      "description": "プロジェクトデータを分析するためのカスタムレポートを作成する",
+      "crossProjectDescription": "ワークスペース内のすべてのプロジェクトのデータを分析する",
+      "selectDimensions": "寸法を選択...",
+      "selectMetrics": "メトリックを選択...",
+      "dimensionOrder": "次元順序",
+      "metricOrder": "メートル法",
+      "filtersDescription": "特定の基準でレポートデータをフィルタリングする",
+      "activeFilters": "アクティブフィルター:",
+      "priorityFilterPlaceholder": "優先度の値を選択する（またはすべて空白のままにする）",
+      "dateRange": {
+        "selectDateRange": "日付範囲を選択",
+        "chooseStartDate": "開始日を選択",
+        "chooseEndDate": "終了日を選択",
+        "categories": {
+          "day": "日",
+          "week": "週",
+          "month": "月",
+          "quarter": "四半期",
+          "year": "年"
+        },
+        "today": "今日",
+        "yesterday": "昨日",
+        "last7Days": "過去7日間",
+        "last30Days": "過去30日間",
+        "thisWeek": "今週",
+        "lastWeek": "先週",
+        "last2Weeks": "過去2週間",
+        "thisMonth": "今月",
+        "lastMonth": "先月",
+        "last3Months": "過去3か月",
+        "thisQuarter": "今四半期",
+        "lastQuarter": "前四半期",
+        "thisYear": "今年",
+        "lastYear": "去年",
+        "last12Months": "過去12か月",
+        "allTime": "オールタイム",
+        "custom": "カスタム日付範囲"
+      },
+      "dateGrouping": {
+        "label": "グループ化",
+        "daily": "毎日",
+        "weekly": "週刊",
+        "monthly": "毎月",
+        "quarterly": "四半期ごと",
+        "annually": "毎年"
+      },
+      "filters": {
+        "selectFilter": "フィルターの種類を選択",
+        "allProjects": "すべてのプロジェクト"
+      },
+      "errors": {
+        "failedToLoadMetadata": "レポートのメタデータを読み込めませんでした",
+        "failedToRunReport": "レポートの実行に失敗しました",
+        "atLeastOneDimensionRequired": "少なくとも 1 つのディメンションが必要です。",
+        "atLeastOneMetricRequired": "少なくとも 1 つのメトリックを指定する必要があります。",
+        "invalidCombinationDateLastActive": "「最終アクティブ日」メトリックは、「アクティビティ日」ディメンションと組み合わせることはできません。",
+        "lastActiveDateOnlyWithUser": "「最終アクティブ日」メトリックは、「ユーザー」ディメンションでのみ使用できます。",
+        "invalidDimensionCombination": "テスト実行レポートでは、 '{dim1}' ディメンションと '{dim2}' ディメンションを一緒に使用することはできません。",
+        "startDateRequiredWithEndDate": "終了日を指定する場合、開始日が必要です。",
+        "endDateMustBeAfterStartDate": "終了日は開始日以降である必要があります。"
+      },
+      "chartDataTruncated": {
+        "title": "グラフデータが切り捨てられました",
+        "message": "読みやすさを考慮し、 {shown} 件中 {total} 件のデータを表示しています。フィルターまたは日付範囲を使用して結果を絞り込むか、以下の結果表で全データをご覧ください。"
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "テスト実行レポート",
+          "description": "テスト結果、合格率、実行メトリックを分析する"
+        },
+        "repositoryStats": {
+          "label": "リポジトリ統計",
+          "description": "テストケースの統計、カバレッジ、リポジトリの健全性"
+        },
+        "userEngagement": {
+          "label": "ユーザーエンゲージメント",
+          "description": "ユーザーアクティビティ、生産性、ワークロード分析"
+        },
+        "projectHealth": {
+          "label": "プロジェクトヘルス",
+          "description": "プロジェクトの進捗状況、マイルストーン、完了状況"
+        },
+        "sessionAnalysis": {
+          "label": "セッション分析",
+          "description": "セッションの完了、期間、および割り当ての指標"
+        },
+        "issueTracking": {
+          "label": "課題追跡",
+          "description": "問題の作成、解決、影響分析"
+        },
+        "automationTrends": {
+          "label": "自動化のトレンド",
+          "description": "優先順位ごとに自動化の進捗状況を週ごとに追跡"
+        },
+        "flakyTests": {
+          "label": "不安定なテスト",
+          "description": "合否判定結果に矛盾があるテストを特定する"
+        },
+        "testCaseHealth": {
+          "label": "テストケースの健全性",
+          "description": "実行パターンに基づいて、古くなった、壊れた、または疑わしいテストケースを特定する"
+        },
+        "issueTestCoverage": {
+          "label": "問題テストの網羅性",
+          "description": "関連するテストケースと最新の実行状況とともに問題を表示します。"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "直近の連続記録",
+        "consecutiveRunsHelp": "分析対象となる最近のテスト実行回数（5～30）。「未テスト」ステータスの結果は除外されます。",
+        "flipThreshold": "最小フリップ数",
+        "flipThresholdHelp": "不安定とみなされるために必要な合格／不合格の遷移の最小回数。",
+        "flips": "フリップ",
+        "lastNResults": "最後の {count, plural, one {# 結果} other {# 結果}}",
+        "newest": "新しい",
+        "oldest": "古い",
+        "noFlakyTests": "基準に合致する不安定なテストは見つかりませんでした",
+        "includeFilter": "含む",
+        "testRunDeleted": "テスト実行は削除されました",
+        "chart": {
+          "highPriority": "注意が必要",
+          "lowPriority": "優先度が低い",
+          "recencyAxis": "故障発生時期",
+          "flipsAxis": "フリップカウント",
+          "oldFailures": "年配の方",
+          "recentFailures": "最近の",
+          "failureRate": "故障率",
+          "recency": "最近性スコア",
+          "backlogTitle": "優先度の低い検査",
+          "backlogDescription": "{count, plural, one {# 追加の不安定なテスト} other {# 追加の不安定なテスト}} 表示されません"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "賞味期限（日数）",
+        "staleDaysThresholdHelp": "テストが実行されなかった日数（7～90日）。",
+        "minExecutions": "レートの最小実行回数",
+        "minExecutionsHelp": "意味のある合格率統計を計算するために必要な最小実行回数（3～20回）。",
+        "lookbackDays": "遡及期間",
+        "lookbackDaysHelp": "実行履歴を分析する日数（30～365日）。",
+        "includeFilter": "含む",
+        "staleFilter": "陳腐さ",
+        "stale": "古くなった",
+        "notStale": "鮮度が落ちていない",
+        "status": "健康状態",
+        "healthScore": "スコア",
+        "lastExecuted": "最後に処刑された",
+        "executions": "処刑",
+        "passRate": "合格率",
+        "passCount": "パス",
+        "failCount": "失敗",
+        "never": "一度もない",
+        "daysSince": "処刑からの日数",
+        "count": "カウント",
+        "totalTests": "テストケース",
+        "noData": "テストケースが見つかりませんでした",
+        "noExecutedTests": "表示する実行済みテストはありません",
+        "healthStatus": {
+          "healthy": "健康",
+          "stale": "古くなった",
+          "neverExecuted": "処刑されなかった",
+          "alwaysPassing": "常に過ぎ去っていく",
+          "alwaysFailing": "常に失敗している"
+        },
+        "chart": {
+          "distribution": "ステータス分布",
+          "healthyRecent": "健康で最新の",
+          "unhealthyStale": "注意が必要",
+          "daysAxis": "前回の処刑からの日数",
+          "healthScoreAxis": "健康スコア"
+        },
+        "stats": {
+          "totalTests": "総検査数",
+          "needsAttention": "注意が必要",
+          "needsAttentionTooltip": "常に失敗する + 実行されない + 古くなったテスト",
+          "healthy": "健康",
+          "healthyTooltip": "健康で、常にテストに合格する",
+          "avgScore": "平均健康スコア"
+        },
+        "healthScoreTooltip": {
+          "title": "得点は100点から始まり、減点は以下の通りです。",
+          "neverExecuted": "実行されなかった: -50",
+          "stale90": "90日以上実行されていない：-40",
+          "stale60": "60日以上実行されていない：-25",
+          "stale30": "30日以上実行されていない：-10",
+          "alwaysPassing": "常に合格（100％）：-5",
+          "alwaysFailing": "常に失敗（0％）：-30",
+          "lowPassRate": "合格率が低い（50%未満）：-20",
+          "lowExecutions": "処刑回数が少ない（3回未満）：-10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "表示モード",
+        "summaryView": "概要（号別）",
+        "detailView": "詳細（テストケース別）",
+        "issue": "問題",
+        "testCase": "テストケース",
+        "testCases": "{count, plural, =1 {テストケース} other {テストケース}}",
+        "issueStatus": "状態",
+        "priority": "優先度",
+        "linkedTests": "関連テスト",
+        "testResults": "結果（合格／不合格／追跡調査）",
+        "passRate": "合格率",
+        "passed": "合格した",
+        "failed": "失敗した",
+        "lastStatus": "最終ステータス",
+        "lastExecuted": "最後に処刑された",
+        "notTested": "未テスト",
+        "noData": "関連付けられたテストケースに問題は見つかりませんでした。",
+        "noIssuesNeedingAttention": "すべての問題がテストに合格しました。素晴らしい！",
+        "stats": {
+          "totalIssues": "総発行号数",
+          "issuesWithFailures": "失敗と共に",
+          "issuesWithFailuresTooltip": "少なくとも1つのテストケースが失敗するという問題",
+          "issuesWithUntested": "未検証",
+          "issuesWithUntestedTooltip": "少なくとも1つのテストケースが実行されていないという問題があります。",
+          "issuesAllPassing": "通過するすべての人",
+          "overallPassRate": "合格率",
+          "numberOfIssues": "発行件数"
+        },
+        "charts": {
+          "passRateDistribution": "テスト合格率分布",
+          "linkedTestCases": "関連付けられたテストケースの数",
+          "untestedTestCases": "未テストのテストケース数",
+          "testCoverageVsExecution": "テストカバレッジと実行状況の比較"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "プロジェクト間テスト実行",
+          "description": "すべてのプロジェクトにわたってテスト結果、合格率、実行指標を分析する"
+        },
+        "repositoryStats": {
+          "label": "プロジェクト間リポジトリ統計",
+          "description": "プロジェクト全体のテストケース統計、カバレッジ、リポジトリの健全性"
+        },
+        "userEngagement": {
+          "label": "プロジェクト間のユーザーエンゲージメント",
+          "description": "プロジェクト全体のユーザーアクティビティ、生産性、ワークロード分析"
+        },
+        "issueTracking": {
+          "label": "プロジェクト間の問題追跡",
+          "description": "プロジェクト全体にわたる問題の作成、解決、影響分析"
+        },
+        "automationTrends": {
+          "label": "プロジェクト間自動化のトレンド",
+          "description": "プロジェクト全体の優先度別に自動化の進捗状況を週ごとに追跡"
+        },
+        "flakyTests": {
+          "label": "プロジェクト横断的な不安定なテスト",
+          "description": "プロジェクト間で合否結果に一貫性のないテストを特定する"
+        },
+        "testCaseHealth": {
+          "label": "プロジェクト横断型テストケースの健全性",
+          "description": "プロジェクト全体で、古くなった、壊れた、または疑わしいテストケースを特定する"
+        },
+        "issueTestCoverage": {
+          "label": "プロジェクト横断的な課題テストカバレッジ",
+          "description": "プロジェクト全体にわたる、関連するテストケースと最新の実行状況とともに課題を表示します。"
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "プロジェクト管理者と管理者のみがプロジェクト レポートにアクセスできます。",
+      "projectIdRequired": "プロジェクトIDが必要です",
+      "missingRequiredFields": "必須フィールドがありません",
+      "unsupportedDimension": "サポートされていない寸法: {dimension}",
+      "unsupportedMetric": "サポートされていないメトリック: {metric}",
+      "atLeastOneDimensionMetricRequired": "少なくとも 1 つのディメンションと 1 つの指標が必要です",
+      "atLeastOneMetricRequired": "少なくとも1つのメトリックを指定する必要があります",
+      "projectDimensionsMetricsRequired": "プロジェクトID、ディメンション、指標は必須です",
+      "unsupportedDimensions": "サポートされていない寸法: {dimensions}",
+      "unsupportedMetrics": "サポートされていないメトリック: {metrics}",
+      "unexpectedError": "予期しないエラーが発生しました。"
+    },
+    "dimensions": {
+      "project": "プロジェクト",
+      "status": "状態",
+      "user": "ユーザー",
+      "executor": "執行者",
+      "assignedTo": "担当者",
+      "configuration": "構成",
+      "date": "日付",
+      "executionDate": "実行日",
+      "creationDate": "作成日",
+      "activityDate": "活動日",
+      "testRun": "試運転",
+      "testCase": "テストケース",
+      "milestone": "マイルストーン",
+      "template": "テンプレート",
+      "creator": "クリエイター",
+      "state": "州",
+      "source": "ソース",
+      "folder": "フォルダ",
+      "group": "グループ",
+      "role": "役割",
+      "session": "セッション",
+      "weekEnding": "週末",
+      "period": "期間",
+      "priority": "優先度",
+      "automationStatus": "自動化ステータス",
+      "issueType": "問題の種類",
+      "issueTracker": "課題追跡システム",
+      "issueStatus": "問題ステータス"
+    },
+    "metrics": {
+      "testResults": "検査結果",
+      "testResultCount": "テスト結果の数",
+      "passRate": "合格率（％）",
+      "avgElapsed": "平均経過時間",
+      "avgElapsedTime": "平均経過時間",
+      "totalElapsedTime": "経過時間合計",
+      "testRunCount": "テスト実行回数",
+      "testCaseCount": "テストケース数",
+      "automationRate": "自動化率（％）",
+      "avgStepsPerCase": "ケースあたりの平均ステップ数",
+      "averageSteps": "ケースあたりの平均ステップ数",
+      "automatedCount": "自動化されたケース",
+      "manualCount": "マニュアルケース",
+      "totalCount": "合計症例数",
+      "totalSteps": "合計歩数",
+      "executionCount": "テスト実行",
+      "createdCaseCount": "作成されたテストケース数",
+      "sessionResultCount": "セッション結果数",
+      "caseCreations": "作成されたケース",
+      "sessionParticipation": "セッション参加",
+      "averageElapsed": "実行あたりの平均時間",
+      "lastActiveDate": "最終アクティブ日",
+      "issueCount": "発行数",
+      "averageAge": "平均年齢（日数）",
+      "sessionCount": "セッション数",
+      "activeSessions": "アクティブなセッション",
+      "averageTimeSpent": "平均所要時間（分）",
+      "milestoneCount": "マイルストーン数",
+      "milestoneCompletionRate": "マイルストーン完了率（％）",
+      "averageMilestoneDuration": "平均マイルストーン期間（日数）",
+      "totalMilestones": "合計マイルストーン",
+      "activeMilestones": "アクティブなマイルストーン",
+      "milestoneCompletion": "マイルストーンの完了率（％）",
+      "averageDuration": "平均期間",
+      "totalDuration": "合計期間"
+    },
+    "drillDown": {
+      "title": "詳細な記録",
+      "loading": "レコードを読み込んでいます...",
+      "loadingMore": "さらに読み込み中...",
+      "noRecords": "記録が見つかりません",
+      "error": "レコードの読み込みに失敗しました",
+      "recordCount": "{count} {count, plural, =1 {記録} other {記録}}",
+      "allRecords": "すべての記録",
+      "allLoaded": "すべてのレコードがロードされました"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "共有",
+      "dialogTitle": "レポートを共有する",
+      "dialogDescription": "共有可能なリンクを作成するか、既存の共有レポートリンクを管理します。",
+      "tabs": {
+        "create": "作成・共有",
+        "list": "私の保有株"
+      },
+      "shareMode": {
+        "label": "シェアモード",
+        "authenticated": {
+          "title": "認証済み（ログインが必要です）",
+          "description": "このプロジェクトへのアクセス権を持つログインユーザーのみが閲覧できます。",
+          "descriptionCrossProject": "管理者権限を持つログインユーザーのみが閲覧できます。"
+        },
+        "passwordProtected": {
+          "title": "パスワードで保護されています",
+          "description": "リンクとパスワードを知っている人なら誰でも閲覧できます。プロジェクトへのアクセス権を持つログインユーザーはパスワード入力不要です。",
+          "descriptionCrossProject": "リンクとパスワードを知っている人なら誰でも閲覧できます。管理者権限を持つログインユーザーはパスワード入力不要です。"
+        },
+        "public": {
+          "title": "公開（リンクを知っている人なら誰でも）",
+          "description": "リンクを知っている人なら誰でも、ログインせずにこのレポートを閲覧できます。"
+        }
+      },
+      "expiration": {
+        "label": "有効期限",
+        "noExpiration": "有効期限なし",
+        "expiresAtMidnight": "リンクは選択した日の終わり（現地時間）に期限切れとなります。"
+      },
+      "notifyOnView": {
+        "label": "このリンクが閲覧されたら通知を受け取る",
+        "description": "通知設定に応じて、共有リンクがアクセスされた際に通知が届きます。"
+      },
+      "title": {
+        "placeholder": "例：テスト実行レポート",
+        "leaveEmptyToUse": "空欄のまま使用する:"
+      },
+      "description": {
+        "placeholder": "この共有レポートの説明を追加してください..."
+      },
+      "actions": {
+        "createShareLink": "共有リンクを作成する",
+        "creating": "作成..."
+      },
+      "errors": {
+        "loginRequired": "共有リンクを作成するにはログインする必要があります",
+        "createFailed": "共有リンクの作成に失敗しました",
+        "genericError": "不明なエラーが発生しました"
+      },
+      "status": {
+        "revoked": {
+          "title": "共有リンクは取り消されました",
+          "description": "この共有リンクは無効になっており、アクセスできなくなりました。"
+        },
+        "expired": {
+          "title": "共有リンクの有効期限が切れました",
+          "description": "この共有リンクは有効期限が切れており、アクセスできなくなりました。"
+        }
+      },
+      "footer": {
+        "poweredBy": "搭載"
+      },
+      "manageShares": {
+        "title": "株式の管理",
+        "description": "このプロジェクトのすべての共有リンクを表示および管理します。",
+        "adminTitle": "すべてのシェアを管理",
+        "adminDescription": "すべてのプロジェクトにわたる共有リンクの表示と管理"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "モード",
+          "views": "閲覧数",
+          "expires": "有効期限切れ"
+        },
+        "status": {
+          "revoked": "取り消された",
+          "expired": "期限切れ"
+        },
+        "notifications": {
+          "enabled": "の上",
+          "disabled": "オフ"
+        },
+        "empty": {
+          "title": "共有リンクはまだ作成されていません。",
+          "description": "まずは最初の共有リンクを作成しましょう。"
+        },
+        "defaultTitle": "{entityType} シェア",
+        "noProject": "プロジェクト横断型",
+        "actions": {
+          "copyLink": "リンクをコピー",
+          "revoke": "取り消す"
+        },
+        "revokeDialog": {
+          "title": "共有リンクを取り消しますか？",
+          "description": "これにより、共有リンクは即座に無効になります。リンクにアクセスしようとすると、エラーメッセージが表示されます。この操作は元に戻すことはできません。",
+          "confirm": "リンクを取り消す",
+          "revoking": "取り消し..."
+        },
+        "deleteDialog": {
+          "title": "共有リンクを削除しますか？",
+          "description": "これにより、共有リンクは完全に削除されます。リンクが現在有効な場合、即座に期限切れとなり、アクセスできなくなります。この操作は元に戻すことはできません。",
+          "confirm": "リンクを削除"
+        },
+        "toast": {
+          "linkCopied": "リンクをコピーしました！",
+          "linkCopiedDescription": "共有リンクがクリップボードにコピーされました。",
+          "copyFailed": "コピーに失敗しました",
+          "copyFailedDescription": "リンクを手動でコピーしてください。",
+          "linkRevoked": "共有リンクは無効になりました",
+          "linkRevokedDescription": "共有リンクは無効になっており、アクセスできなくなりました。",
+          "revokeFailed": "取り消しに失敗しました",
+          "revokeFailedDescription": "共有リンクの取り消し中にエラーが発生しました。",
+          "notificationsEnabled": "通知が有効になっています",
+          "notificationsEnabledDescription": "誰かがこの共有リンクを閲覧すると、通知が届きます。",
+          "notificationsDisabled": "通知は無効になっています",
+          "notificationsDisabledDescription": "誰かがこの共有リンクを閲覧しても、通知は届きません。",
+          "notificationUpdateFailed": "通知の更新に失敗しました",
+          "notificationUpdateFailedDescription": "通知設定の更新中にエラーが発生しました。",
+          "linkDeleted": "共有リンクは削除されました",
+          "linkDeletedDescription": "共有リンクは削除されましたので、リストには表示されなくなります。",
+          "deleteFailed": "削除に失敗しました",
+          "deleteFailedDescription": "共有リンクの削除中にエラーが発生しました。"
+        }
+      },
+      "created": {
+        "title": "共有リンクが作成されました！",
+        "description": "共有リンクの準備ができました。コピーして他の人と共有してください。",
+        "shareLink": "共有リンク",
+        "copy": "コピー",
+        "openInNewTab": "新しいタブで開く",
+        "metadata": {
+          "mode": "モード",
+          "expires": "有効期限切れ",
+          "views": "閲覧数"
+        },
+        "warnings": {
+          "publicLink": "公開リンク:",
+          "publicLinkDescription": "このリンクを知っている人なら誰でも、認証なしでレポートにアクセスできます。",
+          "expiresSoon": "このリンクは、"
+        },
+        "actions": {
+          "createAnother": "別のものを作成する"
+        }
+      },
+      "editDialog": {
+        "title": "編集 共有リンク",
+        "description": "この共有リンクの設定を更新してください。",
+        "passwordExists": "この共有リンクには既にパスワードが設定されています。既存のパスワードを維持するには、パスワード欄を空欄のままにしてください。",
+        "passwordPlaceholder": "既存のパスワードを保持するには空欄のままにしてください。"
+      }
+    },
+    "passwordDialog": {
+      "title": "パスワードが必要です",
+      "description": "<strong>{projectName}</strong> から共有されたこのコンテンツはパスワードで保護されています。続行するにはパスワードを入力してください。",
+      "passwordPlaceholder": "パスワードを入力してください",
+      "showPassword": "パスワードを表示",
+      "hidePassword": "パスワードを隠す",
+      "verifying": "確認中...",
+      "errors": {
+        "emptyPassword": "パスワードを入力してください",
+        "tooManyAttempts": "試行回数が多すぎます。後でもう一度お試しください{resetAt, select, null {} other { {resetAt}}}。",
+        "genericError": "エラーが発生しました。もう一度お試しください。"
+      },
+      "attempts": {
+        "noAttemptsRemaining": "試行回数が残りなくなりました。しばらくしてからもう一度お試しください。",
+        "attemptsRemaining": "{count, plural, =1 {1 回} other {残り # 回}}"
+      }
+    },
+    "sharedReport": {
+      "loading": "レポートを読み込んでいます...",
+      "errors": {
+        "onlyReportSharing": "現在実装されているのはレポート共有機能のみです。",
+        "failedToLoad": "レポートデータの読み込みに失敗しました"
+      },
+      "defaultTitle": "共有レポート",
+      "fromProject": "プロジェクトより:",
+      "dateRange": "日付範囲:",
+      "readOnlyNotice": "これは読み取り専用の共有ビューです",
+      "viewCount": "{count, plural, =1 {1ビュー} other {#ビュー}}",
+      "viewInFullApp": "フルアプリで表示",
+      "pagination": {
+        "showing": "表示中",
+        "of": "の",
+        "results": "結果"
+      }
+    },
+    "authBypass": {
+      "title": "このプロジェクトへのアクセス権があります",
+      "description": "{userName} として表示され、 {projectName}にアクセスできます。",
+      "viewInApp": "アプリ全体を表示"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "共有ステップをフィルター...",
+    "noGroups": "共有ステップが見つかりません。",
+    "noTestCases": "この共有ステップ グループを使用するテスト ケースはありません。",
+    "selectGroupPrompt": "共有ステップ グループを選択して、そのステップを表示します。",
+    "deleteTitle": "共有ステップ グループを削除しますか?",
+    "deleteDescription": "この共有ステップ グループを削除してもよろしいですか? これらのステップは、それらを使用するすべてのテスト ケースから削除されます。",
+    "saveSuccess": "共有手順が正常に更新されました。",
+    "saveError": "共有ステップの保存中にエラーが発生しました。",
+    "stepsCount": "{count, plural, one {# ステップ} other {# ステップ}}",
+    "testCasesUsing": "{count, plural, one {# テストケース} other {# テストケース}}",
+    "importWizard": {
+      "title": "共有ステップのインポート",
+      "fields": {
+        "order": "注文",
+        "stepNumber": "ステップ ＃",
+        "stepContent": "ステップ内容",
+        "expectedResultContent": "期待される結果の内容",
+        "combinedStepData": "統合された歩数データ",
+        "stepsData": "歩数データ"
+      },
+      "success": {
+        "description": "{count, plural, one {# 共有ステップ} other {# 共有ステップ}} 正常にインポートされました"
+      },
+      "errors": {
+        "parseFailed": "CSVファイルの解析に失敗しました",
+        "validationFailed": "検証に失敗しました",
+        "validationDescription": "{count, plural, one {# 検証エラー} other {# 検証エラー}} が見つかりました",
+        "importFailed": "インポートに失敗しました",
+        "fileRequired": "CSVファイルが必要です"
+      },
+      "page1": {
+        "title": "ファイルと設定をアップロードする",
+        "selectedFile": "選択したファイル",
+        "delimiter": "フィールド区切り文字",
+        "delimiters": {
+          "tab": "タブ (\\t)"
+        },
+        "hasHeaders": "最初の行には列ヘッダーが含まれています",
+        "encoding": "ファイルのエンコーディング",
+        "rowMode": {
+          "label": "行モード",
+          "single": "共有ステップごとに 1 行",
+          "multi": "複雑な共有手順の複数行"
+        }
+      },
+      "page2": {
+        "title": "CSV列を共有ステップフィールドにマッピングする",
+        "description": "CSV 列を共有ステップフィールドにマッピングします。必須フィールドは必ずマッピングしてください。",
+        "ignoreColumn": "この列を無視",
+        "requiredFieldsWarning": "{count, plural, one {# 必須フィールドが} other {# 必須フィールドが}} マッピングされていません。続行するには、すべての必須フィールドをマッピングしてください。"
+      },
+      "page3": {
+        "title": "インポートデータのプレビュー",
+        "showing": "{total} 件の共有ステップのうち {start} ～ {end} 件を表示しています",
+        "step": "共有ステップ {number}",
+        "noValue": "（空の）"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "手動で追加",
+      "description": "手動入力で新しい共有ステップグループを作成する",
+      "groupNamePlaceholder": "この共有ステップグループの名前を入力してください",
+      "success": "共有ステップが正常に作成されました",
+      "errors": {
+        "groupNameRequired": "グループ名は必須です",
+        "stepsRequired": "少なくとも1つのステップが必要です",
+        "saveFailed": "共有ステップを保存できませんでした"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "ステップシーケンスの重複",
+      "pageDescription": "テストケース全体で一致するステップシーケンスを確認します。一致するものを共有ステップグループに変換するか、誤検出を除外します。",
+      "noResultsFound": "ステップシーケンスの重複は見つかりませんでした",
+      "noResultsDescription": "スキャンを実行して、テストケース全体で繰り返される手順シーケンスを検出します。",
+      "filterPlaceholder": "ケース名で絞り込む...",
+      "selected": "{count, plural, one {# 選択済み} other {# 選択済み}}",
+      "bulkDismiss": "閉じる ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# 試合が却下されました} other {# 試合が却下されました}}",
+      "bulkError": "一部の操作が失敗しました。もう一度お試しください。",
+      "tableHint": "該当する行をクリックすると、一致する手順をプレビューできます。チェックボックスが付いている行を選択すると、一括操作を実行できます。",
+      "columns": {
+        "matchedSteps": "一致するステップ",
+        "casesCount": "事例",
+        "review": "レビュー"
+      },
+      "scanning": "走査...",
+      "scanComplete": "{count, plural, one {# 一致が見つかりました} other {# 一致が見つかりました}}",
+      "scanFailed": "スキャンに失敗しました",
+      "scanFailedDescription": "スキャン中にエラーが発生しました。もう一度お試しください。",
+      "cancelScan": "スキャンをキャンセル",
+      "findStepDuplicates": "重複する手順を検索",
+      "rescan": "スキャン",
+      "viewResults": "結果を表示（{count}）",
+      "retryScan": "スキャンを再試行",
+      "dialog": {
+        "title": "共有ステップに変換する",
+        "previewTitle": "一致するステップシーケンス",
+        "casesTitle": "影響を受けるテストケース",
+        "casesDescription": "変換対象から除外したいケースのチェックを外してください。",
+        "nameLabel": "共有ステップグループ名",
+        "namePlaceholder": "共有ステップグループの名前を入力してください...",
+        "converting": "変換中...",
+        "dismissMatch": "マッチを却下",
+        "dismissing": "却下中...",
+        "convertSuccess": "共有ステップグループが正常に作成されました！",
+        "convertError": "変換に失敗しました。もう一度お試しください。",
+        "dismissSuccess": "試合は終了しました。",
+        "dismissError": "削除に失敗しました。もう一度お試しください。",
+        "viewSharedStep": "共有ステップグループを表示",
+        "skippedWarning": "{count, plural, one {# ケースがスキップされました} other {# ケースがスキップされました}} (古いか、既に変換済み)。",
+        "noCasesSelected": "変換するケースを少なくとも1つ選択してください。",
+        "selectAll": "すべて選択"
+      }
+    },
+    "findStepDuplicates": "重複データの検索"
+  },
+  "search": {
+    "title": "検索",
+    "placeholder": {
+      "thisProject": "このプロジェクト内を検索...",
+      "allProjects": "すべてのプロジェクトを検索..."
+    },
+    "currentProjectOnly": "現在のプロジェクトのみ",
+    "allTypes": "すべてのタイプ",
+    "entityTypes": {
+      "repositoryCase": "リポジトリケース"
+    },
+    "results": {
+      "tryAdjusting": "検索語句やフィルターを調整してみてください",
+      "searchingFor": "検索中",
+      "within": "内で",
+      "currentProject": "現在のプロジェクト",
+      "page": "ページ"
+    },
+    "errors": {
+      "searchFailed": "検索に失敗しました。もう一度お試しください。",
+      "tryAgain": "もう一度やり直してください"
+    },
+    "startTyping": "入力して検索を開始",
+    "typesSelected": "{count, plural, one {# タイプ} other {# タイプ}}",
+    "customFieldFilters": "カスタムフィールドフィルター",
+    "customFiltersApplied": "カスタムフィルター",
+    "customFields": "カスタムフィールド",
+    "addFilter": "フィルターを追加",
+    "filter": "フィルター",
+    "noCustomFilters": "カスタムフィールドフィルターは適用されていません",
+    "selectDate": "日付を選択",
+    "selectOption": "オプションを選択",
+    "selectOptions": "オプションを選択",
+    "operators": {
+      "equals": "等しい",
+      "not_equals": "等しくない",
+      "contains": "含む",
+      "not_contains": "含まれていない",
+      "starts_with": "始まりは",
+      "ends_with": "終わり",
+      "gt": "より大きい",
+      "lt": "未満",
+      "gte": "より大きいか等しい",
+      "lte": "以下",
+      "between": "間",
+      "in": "で",
+      "not_in": "含まれていない",
+      "exists": "存在する",
+      "not_exists": "存在しない"
+    },
+    "help": {
+      "exactPhrases": "正確なフレーズ",
+      "exactPhrasesDesc": "正確なフレーズに一致させるには、用語を引用符で囲んでください。",
+      "proximity": "近接検索",
+      "proximityDesc": "互いにN文字以内の単語",
+      "booleanOperators": "ブール演算子",
+      "andDesc": "両方の条件が一致する必要があります",
+      "orDesc": "どちらの用語も一致します",
+      "notDesc": "用語を含む結果を除外する",
+      "prefixDesc": "条件を必須または除外する",
+      "groupingDesc": "複雑なクエリのグループ用語",
+      "wildcards": "ワイルドカード",
+      "wildcardMultiDesc": "任意の文字に一致する",
+      "wildcardSingleDesc": "1文字に一致する",
+      "fuzzyMatching": "ファジーマッチング",
+      "fuzzyDesc": "類似語を検索してタイプミスを修正します",
+      "defaultBehavior": "複数の単語はデフォルトで「OR」演算子で処理されます。名前と一致する結果が最も上位に表示されます。",
+      "fullSyntaxLink": "Luceneクエリ構文の完全なリファレンス"
+    },
+    "filters": {
+      "title": "高度なフィルター",
+      "active": "フィルターがアクティブ",
+      "activeCount": "{count, plural, =0 {フィルターなし} one {フィルター数 #} other {フィルター数 #}} アクティブ",
+      "apply": "フィルターを適用する",
+      "common": "一般的なフィルター",
+      "entitySpecific": "タイプ固有のフィルター",
+      "searchPlaceholder": "検索フィルター オプション...",
+      "states": "ワークフローの状態",
+      "createdAt": "作成日",
+      "updatedAt": "更新日",
+      "completedAt": "完了日",
+      "from": "から",
+      "to": "に",
+      "testRunType": "テスト実行タイプ",
+      "regular": "通常",
+      "junit": "ジュニット",
+      "automatedOnly": "自動のみ",
+      "archivedOnly": "アーカイブのみ",
+      "completedOnly": "完了のみ",
+      "manualOnly": "手動のみ",
+      "estimateRange": "推定範囲",
+      "elapsedRange": "経過時間範囲",
+      "minValue": "分",
+      "maxValue": "マックス",
+      "hasExternalId": "外部IDあり",
+      "dueDateRange": "期日範囲",
+      "hasParent": "親マイルストーンあり",
+      "milestoneType": "マイルストーンの種類",
+      "minutes": "分",
+      "hours": "時間",
+      "days": "日",
+      "searchingIn": "検索中",
+      "includeDeleted": "削除されたアイテムを含める",
+      "filterActive": "フィルター有効:",
+      "applyFilter": "フィルターを適用",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "最初の値は2番目の値より小さくなければならない",
+        "firstDateMustBeBeforeSecond": "最初のデートは2回目のデートより前に行わなければならない"
+      },
+      "link": {
+        "domainHelp": "ドメイン名のみを入力してください（例：「github.com」または「example.org」）"
+      }
+    }
+  },
+  "email": {
+    "greeting": "こんにちは、",
+    "greetingWithName": "こんにちは {name}さん、",
+    "notification": {
+      "intro": "新しい通知があります:",
+      "viewDetails": "詳細を見る",
+      "viewAll": "すべての通知を表示"
+    },
+    "digest": {
+      "intro": "TestPlanIt からの毎日の通知ダイジェストは次のとおりです。",
+      "viewDetails": "詳細を見る",
+      "viewAll": "すべての通知を表示",
+      "noNotifications": "今日は新しい通知はありません。",
+      "footer": "このメールは、毎日のダイジェスト通知が有効になっているため送信されています。通知設定は、",
+      "profileSettings": "プロフィール設定"
+    },
+    "footer": {
+      "sentBy": "このメールは",
+      "unsubscribe": "購読解除",
+      "managePreferences": "設定を管理する",
+      "allRightsReserved": "無断転載を禁じます。"
+    },
+    "magicLink": {
+      "subject": "TestPlanItにサインインしてください",
+      "heading": "TestPlanItにサインインしてください",
+      "intro": "下のボタンをクリックしてログインしてください。",
+      "signInButton": "サインイン",
+      "copyPasteIntro": "または、このリンクをコピーしてブラウザに貼り付けてください。",
+      "disclaimer": "このメールをリクエストしていない場合は、無視していただいて構いません。",
+      "textBody": "TestPlanIt にサインインしてください\n\nサインインするには、以下のリンクをクリックしてください:\n{url}\n\nこのメールをリクエストしていない場合は、無視しても問題ありません。"
+    }
+  },
+  "comments": {
+    "title": "コメント",
+    "placeholder": "コメントを書く... (ユーザーをメンションするには @ を使用します)",
+    "editPlaceholder": "コメントを編集...",
+    "postComment": "コメントを投稿",
+    "noComments": "まだコメントはありません。最初にコメントしてください！",
+    "edited": "編集済み",
+    "confirmDelete": "このコメントを削除してもよろしいですか? この操作は元に戻せません。",
+    "deleteDialog": {
+      "title": "コメントを削除"
+    },
+    "errors": {
+      "createFailed": "コメントを作成できませんでした。もう一度お試しください。",
+      "updateFailed": "コメントを更新できませんでした。もう一度お試しください。",
+      "deleteFailed": "コメントを削除できませんでした。もう一度お試しください。",
+      "loadFailed": "コメントを読み込めませんでした。もう一度お試しください。"
+    },
+    "mentions": {
+      "notAMember": "プロジェクトメンバーではない",
+      "noUsersFound": "ユーザーが見つかりません"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "トライアル終了まであと {count, plural, =1 {1 日} other {# 日}}",
+    "expiresT oday": "トライアルは本日終了します",
+    "expired": "{count, plural, =1 {試用期間は 1 日前に終了しました} other {試用期間は # 日前に終了しました}}",
+    "contactSales": "営業担当者へのお問い合わせ"
+  },
+  "feedback": {
+    "sheetTitle": "ご意見をお聞かせください",
+    "sheetDescription": "TestPlanItの改善にご協力いただくため、ぜひご経験を共有してください。",
+    "bannerMessage": "治験の進捗状況はいかがですか？ぜひご意見をお聞かせください。",
+    "menuItem": "フィードバックを共有する"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "AIタグ",
+      "tagAll": "すべてにタグを付ける",
+      "aiAutoTag": "自動タグ",
+      "tagActions": "タグアクション",
+      "startTagging": "タグ付けを開始",
+      "selectEntityType": "エンティティタイプを選択してください",
+      "selectProject": "プロジェクトを選択してください",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {テストケース} other {テストケース}}",
+        "testRun": "{count, plural, one {テスト実行} other {テスト実行}}",
+        "session": "{count, plural, one {セッション} other {セッション}}"
+      }
+    },
+    "review": {
+      "title": "レビュータグの提案",
+      "description": "タグをクリックすると、承認のオン/オフを切り替えられます。ダブルクリックすると、タグ名を編集できます。",
+      "selectEntity": "タグ候補を表示するには、エンティティを選択してください。",
+      "noTagsSelected": "タグが選択されていません",
+      "footerSummary": "{assignCount, plural, one {# タグ} other {# タグ}} が割り当てられ、 {newCount, plural, one {# 新しいタグ} other {# 新しいタグ}} が作成されます",
+      "footerAssignCount": "{assignCount, plural, one {# タグ} other {# タグ}} が割り当てられます",
+      "footerNewCount": "{newCount, plural, one {# 新しいタグ} other {# 新しいタグ}} が作成されます",
+      "newTagsPopoverTitle": "作成する新しいタグ",
+      "applying": "適用中...",
+      "applySuccess": "{tagCount, plural, one {# タグ} other {# タグ}} 適用先 {entityCount, plural, one {# エンティティ} other {# エンティティ}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# タグ} other {# タグ}} 適用先 {entityCount, plural, one {# エンティティ} other {# エンティティ}}、 {newCount, plural, one {# 新しいタグ} other {# 新しいタグ}} 作成されました",
+      "applyError": "タグの適用に失敗しました。もう一度お試しください。",
+      "suggestedTags": "推奨タグ",
+      "noSuggestions": "AIはタグを生成できませんでした。",
+      "alreadyApplied": "既に申請済み",
+      "filterEntities": "エンティティをフィルタリング...",
+      "noEntitiesMatch": "検索条件に一致するエンティティは見つかりませんでした。",
+      "tagCount": "{count, plural, one {# タグ} other {# タグ}}",
+      "noTags": "なし",
+      "failed": "失敗した",
+      "analysisFailed": "このエンティティを分析できませんでした",
+      "responseTruncated": "応答が途中で途切れています — LLM設定で最大出力トークン数を増やしてください",
+      "tooltipExisting": "既存のタグ",
+      "tooltipNew": "新しいタグが作成されます",
+      "tooltipAssign": "既存のタグを割り当てる",
+      "toggleFailed": "失敗したエンティティを表示/非表示",
+      "showFailed": "ショーが失敗しました"
+    },
+    "progress": {
+      "starting": "分析を開始します...",
+      "analyzed": "{analyzed}/{total} エンティティを解析しました。",
+      "sizing": "最適なバッチサイズを見つける（ {size} 個のエンティティを試行）...",
+      "streaming": "AIからの応答を受信しました（{analyzed}/{total} エンティティ完了）...",
+      "finalizing": "結果を準備中...",
+      "complete": "分析完了",
+      "reviewSuggestions": "レビューの提案",
+      "failed": "分析に失敗しました"
+    },
+    "wizard": {
+      "description": "AIは、プロジェクト全体のテストケース、テスト実行、およびセッションを分析し、その内容に基づいて関連するタグを提案します。",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "分析を開始",
+      "untaggedOnly": "既存のタグがないレコードのみを分析する",
+      "allowNewTags": "新しいタグの作成を許可する",
+      "noLlmConfigured": "(LLMが設定されていません)",
+      "analyzingDescription": "AIがエンティティを分析し、タグ候補を生成しています。少々お時間をいただく場合がございます。"
+    },
+    "entityDetail": {
+      "customFields": "カスタムフィールド",
+      "noDetails": "これ以上の情報は入手できません。",
+      "openInNewTab": "新しいタブで開く"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "非常に弱い",
+    "weak": "弱い",
+    "fair": "公平",
+    "good": "良い",
+    "strong": "強い",
+    "minLength": "少なくとも {count} 文字",
+    "uppercase": "少なくとも1文字は大文字",
+    "lowercase": "少なくとも1文字は小文字",
+    "numbers": "少なくとも1つの数字",
+    "specialChars": "特殊文字: {chars}",
+    "history": "このパスワードは、あなたの最後の {depth} 個のパスワードで使用されました。"
+  },
+  "TrialExpired": {
+    "title": "トライアル期間が終了しました",
+    "description": "TestPlanIt をお試しいただきありがとうございます。試用期間が終了しており、このインスタンスにはアクセスできなくなりました。",
+    "nextSteps": "TestPlanIt を引き続き使用し、テスト データにアクセスするには、弊社の営業チームにお問い合わせください。",
+    "pricingPlans": "料金プラン",
+    "dataRetention": "テスト データは安全に保存され、アカウントをアップグレードすると利用できるようになります。"
+  }
+}

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "이름",
+    "cancel": "취소",
+    "dismiss": "해고하다",
+    "of": "~의",
+    "on": "~에",
+    "at": "~에",
+    "in": "~에",
+    "add": "추가하다",
+    "never": "절대",
+    "select": "선택하다...",
+    "file": "파일",
+    "selectMultiple": "여러 개를 선택하세요...",
+    "searchUsers": "사용자를 검색하세요...",
+    "searchCases": "{count, plural, =0 {검색 사례} one {검색 사례 수} other {검색 사례 수}}",
+    "searchProjects": "{count, plural, =0 {프로젝트 검색} one {프로젝트 수 검색} other {프로젝트 수 검색}}",
+    "searchTags": "태그를 검색하세요...",
+    "searchRuns": "{count, plural, =0 {테스트 실행 횟수 검색} one {테스트 실행 횟수 검색} other {테스트 실행 횟수 검색}}",
+    "searchSessions": "{count, plural, =0 {검색 세션} one {검색 # 세션} other {검색 # 세션}}",
+    "search": "찾다...",
+    "defaultOption": "기본 옵션",
+    "yes": "예",
+    "no": "아니요",
+    "updated": "업데이트됨",
+    "groupedBy": "그룹화됨",
+    "lastEditedBy": "최종 수정자:",
+    "actions": {
+      "edit": "편집하다",
+      "save": "구하다",
+      "delete": "삭제",
+      "create": "만들다",
+      "submit": "제출하다",
+      "close": "닫다",
+      "done": "완료",
+      "verify": "확인하다",
+      "signIn": "로그인",
+      "signOut": "로그아웃",
+      "signUp": "회원가입",
+      "resend": "다시 보내기",
+      "deleting": "삭제 중...",
+      "next": "다음",
+      "previous": "이전의",
+      "finish": "마치다",
+      "download": "다운로드",
+      "apply": "적용하다",
+      "confirm": "확인하다",
+      "confirmDelete": "삭제 확인",
+      "saveChanges": "변경 사항 저장",
+      "saving": "절약...",
+      "submitting": "제출 중...",
+      "start": "시작",
+      "pause": "정지시키다",
+      "reset": "다시 놓기",
+      "copy": "복사",
+      "copyLink": "링크 복사",
+      "copied": "복사했어요!",
+      "complete": "완벽한",
+      "back": "뒤쪽에",
+      "clear": "분명한",
+      "expand": "확장하다",
+      "collapse": "무너지다",
+      "addResult": "결과 추가",
+      "passAndNext": "패스 & 다음",
+      "viewInRepository": "저장소에서 보기",
+      "resultAdded": "테스트 결과가 추가되었습니다",
+      "resultAddedDescription": "테스트 결과가 성공적으로 추가되었습니다.",
+      "resultUpdated": "테스트 결과가 업데이트되었습니다.",
+      "resultDeleted": "테스트 결과가 삭제되었습니다",
+      "deleteResult": "시험 결과 삭제",
+      "deleteResultConfirmation": "이 시험 결과를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "editResult": "테스트 결과 수정",
+      "resultDetails": "결과 상세 정보",
+      "actionsLabel": "행위",
+      "assign": "양수인",
+      "assignSelected": "할당 {count, plural, one {# 경우} other {# 경우}}",
+      "refresh": "새로 고치다",
+      "addResultSelected": "결과를 {count, plural, one {에 추가합니다. # 경우} other {# 경우}}",
+      "resultsAdded": "{count, plural, one {# 결과} other {# 결과}} 추가됨",
+      "resultsAddedDescription": "{count, plural, one {테스트 케이스에 결과가 추가되었습니다.} other {테스트 케이스에 결과가 성공적으로 추가되었습니다.}}",
+      "addingResultsToMultiple": "{count, plural, one {에 결과를 추가합니다. # 테스트 케이스} other {# 테스트 케이스}}",
+      "addedToTestRun": "테스트 실행에 추가되었습니다",
+      "addedToTestRunDescription": "테스트 케이스가 테스트 실행에 추가되었습니다.",
+      "noAvailableTestRuns": "현재 실행 중인 모든 테스트 실행에 이 테스트 케이스가 이미 포함되어 있습니다.",
+      "resultUpdateError": "테스트 결과 업데이트에 실패했습니다.",
+      "resultDeleteError": "테스트 결과를 삭제하는 데 실패했습니다.",
+      "selectStatus": "상태 선택",
+      "addToTestRun": "테스트 실행에 추가",
+      "status": "상태",
+      "resultDetailsPlaceholder": "결과 세부 정보를 입력하세요...",
+      "selectAll": "모두 선택",
+      "deselectAll": "모두 선택 해제",
+      "clearAll": "모두 지우기",
+      "selectFile": "파일을 선택하세요",
+      "restore": "복원하다",
+      "purge": "숙청",
+      "previousCase": "이전 사례",
+      "nextCase": "다음 사례",
+      "startTesting": "테스트 시작",
+      "expandLeftPanel": "왼쪽 패널 펼치기",
+      "collapseLeftPanel": "왼쪽 패널 접기",
+      "expandRightPanel": "오른쪽 패널 펼치기",
+      "collapseRightPanel": "오른쪽 패널 접기",
+      "createTag": "태그 \"{name} \" 생성",
+      "noTagsFound": "태그를 찾을 수 없습니다.",
+      "duplicate": "복제하다",
+      "exportPdf": "PDF 내보내기",
+      "exportingPdf": "수출 중...",
+      "change": "변화",
+      "viewAll": "모두 보기",
+      "undo": "끄르다",
+      "undoDelete": "삭제 취소",
+      "automated": {
+        "details": "자동화 테스트 세부 정보",
+        "message": "메시지",
+        "line": "선",
+        "testSuite": "테스트 스위트:"
+      },
+      "junit": {
+        "details": "자동화 테스트 결과 세부 정보",
+        "import": {
+          "title": "가져오기 테스트 결과",
+          "description": "테스트 결과 파일을 업로드하여 새 테스트 실행에 가져오세요. JUnit, TestNG, xUnit, NUnit, MSTest, Mocha 및 Cucumber 형식을 지원합니다.",
+          "testRun": {
+            "label": "테스트 실행",
+            "placeholder": "테스트 실행을 선택하세요"
+          },
+          "file": {
+            "label": "테스트 결과 파일"
+          },
+          "import": "수입",
+          "selectFolder": "폴더를 선택하세요",
+          "createNewFolder": "새 폴더 만들기",
+          "createNewFolderNamed": "새 폴더 만들기: {name}",
+          "progress": {
+            "initializing": "가져오기 초기화 중...",
+            "validating": "입력 데이터 유효성 검사 중...",
+            "creatingRun": "테스트 실행을 생성하는 중...",
+            "fetchingTemplate": "템플릿 데이터를 가져오는 중...",
+            "countingTests": "{count} 개의 테스트 케이스를 {files} 파일에서 처리 중...",
+            "parsingFile": "파일 {current} 의 {total}를 파싱하는 중...",
+            "processingSuite": "처리 제품군: {name}",
+            "processingCase": "{total}의 테스트 케이스 {current} 를 처리 중...",
+            "finalizing": "가져오기를 완료하는 중...",
+            "completed": "가져오기가 성공적으로 완료되었습니다!",
+            "errorParsing": "파일 {index}구문 분석 오류 : {error}",
+            "skippingFile": "잘못된 파일 {index}을 건너뜁니다."
+          },
+          "error": {
+            "title": "가져오기 오류",
+            "importFailed": "테스트 결과를 가져오는 데 실패했습니다. 다시 시도해 주세요."
+          },
+          "success": {
+            "title": "가져오기 성공",
+            "description": "테스트 결과가 성공적으로 불러와졌습니다."
+          },
+          "fileRequired": "시험 결과 파일을 최소 하나 이상 업로드해 주세요."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "결과 형식",
+            "placeholder": "형식을 선택하세요"
+          }
+        }
+      },
+      "confirmRestoreTitle": "복원 확인",
+      "confirmPurgeTitle": "삭제 확인",
+      "remove": "제거하다",
+      "reconfigure": "재구성 후 다시 시도"
+    },
+    "permissions": {
+      "addEdit": "추가/편집"
+    },
+    "auth": {
+      "internal": "이메일/비밀번호",
+      "sso": "SSO 전용",
+      "both": "이메일 및 SSO"
+    },
+    "status": {
+      "deleted": "삭제됨",
+      "disabled": "장애가 있는",
+      "noCustomFieldData": "추가 정보는 없습니다.",
+      "pending": "보류 중",
+      "uploading": "업로드 중...",
+      "notApplicable": "해당 사항 없음",
+      "redirecting": "리디렉션 중...",
+      "pendingDelete": "삭제될 예정입니다",
+      "pendingChanges": "보류 중인 변경 사항",
+      "importing": "가져오는 중...",
+      "addingTestCases": "테스트 케이스를 추가하는 중..."
+    },
+    "priority": {
+      "low": "낮은",
+      "medium": "중간",
+      "high": "높은"
+    },
+    "filters": {
+      "allStatuses": "모든 상태",
+      "allPriorities": "모든 우선순위"
+    },
+    "fields": {
+      "groupName": "그룹 이름",
+      "users": "사용자",
+      "mixed": "모든 값",
+      "type": "유형",
+      "default": "기본",
+      "enabled": "활성화됨",
+      "projects": "프로젝트",
+      "iconColor": "아이콘/색상",
+      "selectWorkflow": "워크플로우를 선택하세요",
+      "icon": "상",
+      "systemName": "시스템 이름",
+      "aliases": "별칭",
+      "scope": "범위",
+      "success": "성공",
+      "failure": "실패",
+      "completed": "완전한",
+      "elapsed": "경과 시간",
+      "totalElapsed": "총 경과 시간",
+      "totalEstimate": "남은 예상 시간",
+      "completionRate": "완료율",
+      "attachments": "첨부파일",
+      "documentation": "선적 서류 비치",
+      "state": "상태",
+      "configuration": "구성",
+      "configurations": "구성",
+      "milestone": "중요한 단계",
+      "tags": "태그",
+      "createdBy": "제작자:",
+      "description": "설명",
+      "description_placeholder": "설명을 추가하세요...",
+      "testCases": "테스트 케이스",
+      "sessions": "세션",
+      "sharedSteps": "공유된 단계",
+      "email": "이메일",
+      "password": "비밀번호",
+      "confirmPassword": "비밀번호 확인",
+      "token": "토큰",
+      "access": "입장",
+      "avatar": "화신",
+      "steps": "단계",
+      "step": "단계",
+      "expectedResult": "예상 결과",
+      "notes": "메모",
+      "estimate": "추정",
+      "date": "날짜",
+      "size": "크기",
+      "created": "생성됨",
+      "template": "주형",
+      "mission": "사명",
+      "assignedTo": "담당자에게 배정됨",
+      "executedBy": "실행자:",
+      "optional": "선택 과목",
+      "role": "역할",
+      "defaultRole": "기본 역할",
+      "systemAccess": "시스템 접근",
+      "authMethod": "인증 방법",
+      "dateCreated": "생성일",
+      "apiUser": "API 사용자",
+      "unverified": "미확인",
+      "selfRegistered": "자체 등록",
+      "role_placeholder": "역할을 선택하세요",
+      "usersCreated": "사용자 생성",
+      "groups": "여러 떼",
+      "apiAccess": "API 액세스",
+      "requiredForAdmin": "관리자에게 필수 사항",
+      "account": "계정",
+      "accountHistory": "계정 내역",
+      "activity": "활동",
+      "lastActive": "최근 활동",
+      "theme": "주제",
+      "locale": "언어",
+      "timezone": "시간대",
+      "itemsPerPage": "페이지당 항목 수",
+      "notificationMode": "알림",
+      "value": "값",
+      "key": "열쇠",
+      "configurationDetails": "구성 세부 정보",
+      "isActive": "활동적인",
+      "members": "회원들",
+      "milestoneTypes": "마일스톤 유형",
+      "milestones": "주요 이정표",
+      "createdAt": "제작일:",
+      "completedOn": "완료일",
+      "variants": "변형",
+      "emailVerified": "이메일 인증 완료",
+      "issueTracker": "이슈 트래커",
+      "caseFields": "케이스 필드",
+      "resultFields": "결과 필드",
+      "displayName": "표시 이름",
+      "hint": "힌트",
+      "required": "필수의",
+      "restricted": "제한된",
+      "fieldType": "필드 유형",
+      "templates": "템플릿",
+      "started": "시작됨",
+      "startDate": "시작일",
+      "automated": "자동화된",
+      "manual": "수동",
+      "notAutomated": "자동화되지 않음",
+      "testRuns": "테스트 실행",
+      "title": "제목",
+      "project": "프로젝트",
+      "priority": "우선 사항",
+      "integration": "완성",
+      "lastSyncedAt": "마지막 동기화",
+      "externalKey": "외부 키",
+      "initialHeight": "초기 높이",
+      "minValue": "최소값",
+      "maxValue": "최대값",
+      "minIntegerValue": "최소 정수 값",
+      "maxIntegerValue": "최대 정수 값",
+      "defaultValue": "기본값",
+      "checked": "확인됨",
+      "version": "버전",
+      "issues": "문제점",
+      "internalIssues": "내부 문제",
+      "externalIssues": "{provider} 문제",
+      "data": "데이터",
+      "note": "메모",
+      "externalId": "외부 ID",
+      "forecast": "예측",
+      "forecastManual": "예측 매뉴얼",
+      "forecastAutomated": "예측 자동화",
+      "executedAt": "실행됨",
+      "className": "수업",
+      "suiteName": "모음곡",
+      "duration": "지속",
+      "session": "세션",
+      "charter": "전세",
+      "summary": "요약",
+      "progress": "진전",
+      "assertions": "주장",
+      "properties": "속성",
+      "systemOutput": "테스트 케이스 로그",
+      "systemError": "시스템 오류",
+      "resultStatus": "결과",
+      "links": "모래밭",
+      "id": "ID",
+      "JUNIT": "JUnit 가져오기",
+      "API": "API",
+      "folder": "접는 사람",
+      "parentFolder": "새 사건용 상위 폴더",
+      "multipleValues": "다중 값",
+      "provider": "공급자",
+      "updatedAt": "업데이트됨",
+      "tools": "도구",
+      "codeRepository": "코드 저장소",
+      "aiModels": "기본 LLM",
+      "configKeys": {
+        "edit_results_duration": "편집 결과 기간",
+        "project_docs_default": "프로젝트 문서 기본값",
+        "notificationSettings": "알림 전역 설정",
+        "elasticsearch_replicas": "엘라스틱서치 복제본"
+      },
+      "options": {
+        "label": "상표",
+        "validation": {
+          "empty": "해당 옵션은 비워둘 수 없습니다.",
+          "invalidChars": "옵션에 유효하지 않은 문자가 포함되어 있습니다: \"{char}\"",
+          "duplicate": "옵션은 고유해야 합니다.",
+          "systemNameError": "시스템 이름이 잘못되었습니다.",
+          "initialHeightMax": "초기 높이는 600px를 초과할 수 없습니다.",
+          "displayNameRequiredResult": "결과 필드에 표시할 이름을 입력하세요.",
+          "displayNameRequiredCase": "케이스 필드에 표시할 이름을 입력하세요.",
+          "minValueMaxValue": "최소값은 최대값보다 작아야 하며, 하나가 설정된 경우 둘 다 설정되어야 합니다.",
+          "minMaxValueInteger": "최소 정수 값은 최대 정수 값보다 작아야 하며, 둘 중 하나가 설정되어 있으면 둘 다 설정되어 있어야 합니다.",
+          "systemNameRequired": "시스템 이름은 비워둘 수 없습니다.",
+          "systemNameRegex": "시스템 이름은 문자로 시작해야 하며 문자, 숫자 및 밑줄만 포함할 수 있습니다.",
+          "fieldTypeRequired": "필드 유형은 필수 입력 사항입니다."
+        }
+      },
+      "placeholders": {
+        "key": "엔터 키",
+        "value": "값을 입력하세요",
+        "addVariant": "변형 추가",
+        "addCategory": "카테고리 추가",
+        "displayName": "표시 이름을 입력하세요",
+        "systemName": "시스템 이름을 입력하세요",
+        "hint": "힌트를 입력하세요"
+      },
+      "hints": {
+        "systemName": "시스템 이름은 고유해야 하며 문자, 숫자 및 밑줄만 포함해야 합니다.",
+        "fieldType": "(필드 유형은 생성 후 변경할 수 없습니다.)"
+      },
+      "validation": {
+        "nameRequired": "이름은 필수 입력 사항입니다.",
+        "stateRequired": "주정부가 요구합니다",
+        "urlRequired": "URL이 필요합니다.",
+        "invalidUrl": "잘못된 URL 형식입니다"
+      }
+    },
+    "filter": {
+      "placeholder": "필터 {item}..."
+    },
+    "access": {
+      "admin": "관리자",
+      "projectAdmin": "프로젝트 관리자",
+      "user": "사용자",
+      "none": "없음"
+    },
+    "validation": {
+      "required": "{field}를 입력하세요.",
+      "invalidDuration": "유효한 기간을 입력해 주세요.",
+      "maxDuration": "지속 시간은 {max} 분을 초과할 수 없습니다.",
+      "minLength": "{field} 는 최소 {min} 자 이상이어야 합니다.",
+      "emailFormat": "잘못된 이메일 형식입니다",
+      "passwordMatch": "비밀번호는 일치해야 합니다.",
+      "unique": "{field} 는 고유해야 합니다.",
+      "roleRequired": "해당 역할이 필요합니다.",
+      "nameMinLength": "이름은 최소 2자 이상이어야 합니다.",
+      "invalidDurationFormat": "기간 형식이 잘못되었습니다. 30분, 1주 또는 1시간 25분과 같은 형식을 사용해 보세요."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "확인 {action}",
+        "message": "정말 {action} 하시겠습니까?"
+      },
+      "confirmDelete": {
+        "description": "이 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+      },
+      "assign": {
+        "title": "테스트 케이스 할당",
+        "description": "테스트 케이스 \"{testCase}\"를 사용자에게 할당합니다.",
+        "selectUser": "사용자를 선택하세요"
+      },
+      "assignBulk": {
+        "title": "테스트 케이스 일괄 할당",
+        "description": "{count, plural, one {# 선택된 테스트 케이스} other {# 선택된 테스트 케이스}} 를 사용자에게 할당"
+      },
+      "complete": {
+        "title": "전체 테스트 실행",
+        "description": "이 테스트를 완료하시겠습니까?",
+        "warning": "테스트 실행이 완료되면 수정할 수 없습니다.",
+        "apple": {
+          "title": "Apple 로그인 설정",
+          "description": "Apple Sign In 자격 증명을 설정하세요. 이 자격 증명은 Apple 개발자 포털에서 얻을 수 있습니다.",
+          "clientId": "서비스 ID",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "팀 ID",
+          "teamIdPlaceholder": "10자리 팀 ID",
+          "keyId": "키 ID",
+          "keyIdPlaceholder": "10자리 키 ID",
+          "privateKey": "개인 키",
+          "privateKeyPlaceholder": ".p8 개인 키 내용을 여기에 붙여넣으세요",
+          "instructions": {
+            "title": "설치 방법:",
+            "step1": "애플 개발자 포털로 이동하세요.",
+            "step2": "서비스 ID를 생성하고 Apple로 로그인 기능을 구성하세요.",
+            "step3": "Apple로 로그인하기 위한 키를 생성하세요",
+            "step4": ".p8 개인 키 파일을 다운로드하세요.",
+            "step5": "다음 리디렉션 URL을 추가하세요:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "모든 항목은 필수 입력 사항입니다."
+          }
+        }
+      },
+      "delete": {
+        "title": "삭제 {item}",
+        "description": "{name}를 정말로 삭제하시겠습니까?",
+        "warning": "이 작업은 되돌릴 수 없습니다. {item}를 영구적으로 삭제합니다."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "항목이 성공적으로 삭제되었습니다.",
+      "deleteError": "항목을 삭제하는 동안 오류가 발생했습니다.",
+      "moveSuccess": "물품이 성공적으로 이동되었습니다.",
+      "moveError": "물품을 이동하는 동안 오류가 발생했습니다.",
+      "updateSuccess": "항목이 성공적으로 업데이트되었습니다.",
+      "updateError": "항목을 업데이트하는 동안 오류가 발생했습니다.",
+      "linkCopied": "링크가 클립보드에 복사되었습니다",
+      "copyFailed": "링크를 클립보드에 복사하는 데 실패했습니다.",
+      "created": "테스트 실행이 성공적으로 완료되었습니다.",
+      "createdDescription": "테스트 실행이 생성되었으며 이제 테스트 실행 목록에서 확인할 수 있습니다.",
+      "createError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.",
+      "emptyActive": "현재 실행 중인 테스트가 없습니다.",
+      "emptyCompleted": "완료된 테스트 실행이 없습니다.",
+      "projectUpdated": "프로젝트가 성공적으로 업데이트되었습니다.",
+      "projectUpdateError": "프로젝트 업데이트 중 오류가 발생했습니다.",
+      "noProjects": "프로젝트를 찾을 수 없습니다."
+    },
+    "placeholders": {
+      "email": "이메일 주소",
+      "name": "이름을 입력하세요",
+      "mission": "당신의 임무에 대해 설명해 주세요...",
+      "selectMilestone": "마일스톤을 선택하세요",
+      "selectStatus": "상태를 선택하세요",
+      "selectTemplate": "템플릿을 선택하세요",
+      "duration": "예: 1시간 30분 또는 90분",
+      "docs": "문서 추가...",
+      "select": "선택하다",
+      "selectState": "주를 선택하세요",
+      "selectConfiguration": "구성 선택",
+      "selectConfigurations": "구성 선택",
+      "selectOption": "옵션을 선택하세요",
+      "date": "날짜를 선택하세요",
+      "selectEncoding": "인코딩을 선택하세요...",
+      "selectATemplate": "템플릿을 선택하세요...",
+      "selectVersion": "버전 선택",
+      "selectAModel": "모델을 선택하세요",
+      "selectWorkflowType": "워크플로 유형을 선택하세요",
+      "addAnOption": "옵션을 추가하세요",
+      "addADescription": "설명을 추가하세요...",
+      "optionalDescription": "선택 사항 설명...",
+      "projectNotes": "프로젝트 노트...",
+      "filterByName": "이름으로 필터링...",
+      "filterByValue": "값으로 필터링...",
+      "selectOperator": "연산자를 선택하세요",
+      "searchIcons": "검색 아이콘...",
+      "value": "값",
+      "stepCount": "걸음 수",
+      "enterText": "텍스트를 입력하세요...",
+      "enterUrl": "URL을 입력하세요",
+      "issueIdExample": "제123호",
+      "selectPriorityValuesOrEmpty": "우선순위 값을 선택하세요 (모두 선택하려면 비워 두세요)."
+    },
+    "errors": {
+      "error": "오류",
+      "somethingWentWrong": "예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요.",
+      "emailRequired": "이메일 주소를 입력하세요.",
+      "emailInvalid": "이 이메일 주소는 유효하지 않습니다.",
+      "passwordRequired": "비밀번호를 입력해야 합니다.",
+      "confirmPasswordRequired": "비밀번호를 확인하세요.",
+      "passwordDoesNotMeetPolicy": "비밀번호가 보안 요구 사항을 충족하지 않습니다.",
+      "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
+      "nameRequired": "성명을 모두 입력해 주세요.",
+      "duplicate": "고유한 이름을 선택해 주세요.",
+      "userExists": "이미 사용자가 존재합니다.",
+      "unknown": "알 수 없는 오류가 발생했습니다.",
+      "invalidCredentials": "잘못된 사용자 이름 또는 비밀번호입니다.",
+      "projectNotFound": "프로젝트를 찾을 수 없습니다.",
+      "projectNotFoundDescription": "찾으시는 프로젝트가 존재하지 않거나 접근 권한이 없습니다.",
+      "tokenRequired": "이메일 인증 토큰을 입력하거나 이메일에 있는 링크를 클릭하세요.",
+      "noSuccessStatus": "성공 상태가 선택되지 않았습니다.",
+      "missingTestRunCase": "테스트 실행 케이스 ID가 누락되었습니다.",
+      "fieldRequired": "이 항목은 필수 입력 사항입니다.",
+      "projectNameExists": "이미 동일한 이름의 프로젝트가 존재합니다.",
+      "defaultNotFound": "기본값을 찾을 수 없습니다.",
+      "emailExists": "이 이메일 주소를 가진 사용자가 이미 존재합니다.",
+      "nameExists": "이미 동일한 이름을 가진 사용자가 존재합니다.",
+      "duplicateValue": "이 값은 이미 사용 중입니다.",
+      "unauthorized": "귀하는 이 작업을 수행할 권한이 없습니다.",
+      "accessDenied": "접근 불가",
+      "sessionNotFound": "세션을 찾을 수 없거나 유효하지 않습니다.",
+      "issueTrackerNotConfigured": "이 프로젝트에는 이슈 트래커가 설정되어 있지 않습니다.",
+      "noUserSession": "사용자 세션을 찾을 수 없습니다.",
+      "noProjectId": "프로젝트 ID를 찾을 수 없습니다.",
+      "unknownErrorWithMessage": "알 수 없는 오류가 발생했습니다. {message}",
+      "unauthenticated": "사용자가 인증되지 않았습니다.",
+      "fetchFailed": "데이터를 가져오는 데 실패했습니다. 나중에 다시 시도해 주세요.",
+      "unsupportedFieldType": "지원되지 않는 필드 유형",
+      "notAuthenticated": {
+        "title": "인증되지 않음",
+        "message": "이 작업을 수행하려면 로그인해야 합니다."
+      },
+      "failedToFetchAssignments": {
+        "title": "과제 가져오기 실패",
+        "message": "과제 정보를 가져오는 데 실패했습니다. 나중에 다시 시도해 주세요."
+      },
+      "issueManagement": {
+        "linkedSuccess": "문제가 성공적으로 연결되었습니다.",
+        "linkError": "오류 연결 문제",
+        "unlinkedSuccess": "문제가 성공적으로 연결 해제되었습니다.",
+        "unlinkError": "연결 해제 오류",
+        "noActiveIntegration": "이 프로젝트에 대한 활성 통합 기능을 찾을 수 없습니다."
+      },
+      "roleRequiredForSpecificRole": "접근 유형이 특정 역할인 경우 역할이 필수입니다.",
+      "projectCreationFailed": "프로젝트 생성에 실패했습니다. ID가 반환되지 않았습니다.",
+      "invalidRoleId": "잘못된 역할 ID",
+      "workflowStateExists": "워크플로 상태가 이미 존재합니다. 새 이름을 선택하세요.",
+      "failedToLoadCaseData": "사건 데이터를 불러오는 데 실패했습니다. 저장할 수 없습니다.",
+      "atLeastOneTagRequired": "최소 하나의 태그가 필요합니다.",
+      "atLeastOneIssueRequired": "최소 한 가지 이슈가 필요합니다.",
+      "atLeastOneOptionRequired": "최소한 하나의 옵션을 선택해야 합니다.",
+      "valueRequired": "값은 필수입니다.",
+      "contentRequired": "콘텐츠는 필수 입력 사항입니다.",
+      "invalidContentFormat": "잘못된 콘텐츠 형식입니다",
+      "caseNameRequired": "테스트 케이스의 이름을 입력해 주세요.",
+      "caseStateRequired": "주를 선택해 주세요.",
+      "caseFolderRequired": "폴더를 선택해 주세요",
+      "estimateTooLarge": "추정치가 너무 큽니다",
+      "estimateRequiredValid": "예상 소요 시간을 입력해야 하며, 유효한 시간이어야 합니다 (예: 1시간 30분).",
+      "invalidDurationOrExceedsMax": "시간 형식이 잘못되었거나 최대 제한을 초과했습니다(예: 1시간 30분).",
+      "configurationNameExists": "구성 이름이 이미 존재합니다. 다른 이름을 선택하십시오.",
+      "variantNameExists": "이미 동일한 이름의 변형이 존재합니다. 다른 이름을 선택해 주세요.",
+      "categoryNameExists": "해당 카테고리 이름이 이미 존재합니다. 다른 이름을 선택해 주세요.",
+      "workflowStateNameExists": "워크플로 상태 이름이 이미 존재합니다. 다른 이름을 선택해 주세요.",
+      "folderNameRequired": "폴더 이름을 입력해 주세요.",
+      "folderNameRequiredEnter": "폴더 이름을 입력하세요.",
+      "workflowStateNameRequired": "워크플로 상태에 대한 이름을 입력해 주세요.",
+      "roleNameEmpty": "역할 이름은 비워둘 수 없습니다.",
+      "groupNameRequired": "그룹 이름은 필수 입력 사항입니다.",
+      "templateNameRequired": "템플릿에 사용할 이름을 입력해 주세요.",
+      "caseStateInvalid": "유효한 주를 선택하십시오.",
+      "caseTemplateRequired": "템플릿을 선택해 주세요.",
+      "invalidContent": "유효하지 않은 콘텐츠",
+      "milestoneNameRequired": "마일스톤에 사용할 이름을 입력해 주세요.",
+      "milestoneTypeRequired": "마일스톤 유형을 선택해 주세요.",
+      "testRunNameMinLength": "이름은 최소 2자 이상이어야 합니다.",
+      "stateRequiredDot": "주정부 정보가 필요합니다.",
+      "milestoneTypeNameMinLength": "마일스톤 유형 이름은 최소 2자 이상이어야 합니다.",
+      "projectNameRequired": "프로젝트 이름은 필수 입력 사항입니다.",
+      "workflowScopeRequired": "해당 주에 맞는 워크플로우를 선택해 주세요.",
+      "workflowTypeRequired": "워크플로 유형을 선택해 주세요.",
+      "newTestCaseAdded": "새로운 테스트 케이스가 추가되었습니다.",
+      "repositoryDeleted": "저장소가 삭제되었습니다",
+      "failedToDeleteRepository": "저장소를 삭제하는 데 실패했습니다.",
+      "permissionDenied": "이 페이지에 접근할 권한이 없습니다.",
+      "resultSubmitPermissionDenied": "이 사례에 대한 결과를 제출할 수 없습니다. 프로젝트 관리자에게 배정해 달라고 요청하세요.",
+      "noModelsFound": "모델을 찾을 수 없습니다.",
+      "failedToFetchModels": "모델을 가져오는 데 실패했습니다.",
+      "failedToCopyToClipboard": "클립보드에 복사하는 데 실패했습니다.",
+      "failedToLoadJobResults": "작업 결과를 불러오는 데 실패했습니다.",
+      "failedToUpdateRepositoryStatus": "저장소 상태 업데이트에 실패했습니다."
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "계기반",
+      "twoFactorVerification": "2단계 인증",
+      "changePassword": "비밀번호 변경",
+      "twoFactorSetup": "2단계 인증 설정",
+      "signUp": "회원가입",
+      "signIn": "로그인",
+      "verifyEmail": "이메일 인증",
+      "trialExpired": "체험 기간 만료",
+      "linkSsoAccount": "SSO 계정 연결",
+      "userProfile": "사용자 프로필",
+      "users": "사용자",
+      "issues": "문제점",
+      "tags": "태그",
+      "tagDetails": "태그 세부 정보",
+      "aiModels": "AI 모델",
+      "integrations": "통합",
+      "quickscript": "퀵스크립트",
+      "webhooks": "웹훅",
+      "shares": "주식",
+      "repository": "저장소",
+      "testCaseVersion": "테스트 케이스 버전",
+      "duplicateTestCases": "중복 테스트 케이스",
+      "documentation": "선적 서류 비치",
+      "sharedSteps": "공유된 단계",
+      "stepDuplicates": "단계 중복",
+      "sessions": "세션",
+      "sessionVersion": "세션 버전",
+      "milestones": "주요 이정표",
+      "testRuns": "테스트 실행",
+      "reports": "보고서",
+      "adminSamlConfig": "관리자 - SAML 구성",
+      "apiDocumentation": "API 문서",
+      "sharedContent": "공유 콘텐츠"
+    },
+    "aria": {
+      "userMenu": "사용자 메뉴",
+      "search": "찾다",
+      "helpMenu": "도움말 메뉴",
+      "help": "돕다",
+      "grouped": "그룹화된",
+      "group": "그룹",
+      "selectAll": "모두 선택하세요",
+      "selectRow": "행을 선택하세요",
+      "removeIssue": "문제를 해결합니다",
+      "selectDeselectAllAddEdit": "모두 선택/선택 해제 추가/편집",
+      "selectDeselectAllDelete": "모두 선택/선택 해제 삭제",
+      "selectDeselectAllClose": "모두 선택/선택 해제 닫기",
+      "clearFilter": "필터 지우기",
+      "olderVersion": "이전 버전",
+      "newerVersion": "최신 버전",
+      "deletedUser": "삭제된 사용자",
+      "restrictedField": "제한된 필드",
+      "backToTestCase": "테스트 케이스로 돌아가기"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# 프로젝트} other {# 프로젝트}}",
+      "templates": "템플릿 및 필드",
+      "workflows": "워크플로",
+      "statuses": "상태",
+      "roles": "역할",
+      "unknownRole": "알 수 없는 역할",
+      "unknownGroup": "알 수 없는 그룹",
+      "file": "파일",
+      "files": "파일",
+      "existingAttachments": "기존 첨부파일",
+      "new": "새로운",
+      "noElapsedTime": "시간 기록 없음",
+      "untested": "테스트되지 않음",
+      "noResults": "검색 결과 없음",
+      "resultsWithNoElapsedTime": "결과에 소요된 시간은 기록되지 않았습니다.",
+      "total": "총",
+      "noCases": "테스트 케이스 없음",
+      "unknown": "알려지지 않은",
+      "selectedTestCases": "선택된 테스트 케이스",
+      "editToModifyCasesTitle": "이 목록은 수정할 수 없습니다.",
+      "editToModifyCases": "테스트 실행을 편집하고 선택한 테스트 케이스를 클릭하여 목록을 수정하세요.",
+      "noTestCasesSelected": "선택된 테스트 케이스가 없습니다.",
+      "editToSelectTestCases": "테스트 실행을 편집하여 테스트 케이스를 선택하세요.",
+      "casesInRun": "{count, plural, =0 {테스트 실행에 테스트 케이스가 없습니다} =1 {테스트 실행에 테스트 케이스가 1개 있습니다} other {테스트 실행에 테스트 케이스가 있습니다}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {고유 사례 1개} other {고유 사례 수}} {configCount, plural, =1 {구성 1개} other {구성 수}} (총 사례 수{totalCount} 개)",
+      "viewTestRunDetails": "테스트 실행 세부 정보 보기",
+      "sortByStatus": "상태별로 그룹화",
+      "sortByDate": "날짜순으로 정렬",
+      "testRuns": "{count, plural, =0 {테스트 실행 없음} =1 {테스트 실행 1회} other {테스트 실행 횟수}}",
+      "sessions": "{count, plural, =0 {세션 없음} =1 {세션 1개} other {세션 수}}",
+      "noOptions": "사용 가능한 옵션이 없습니다",
+      "multiConfiguration": "다중 구성 그룹의 일부",
+      "otherConfigurations": "기타 구성",
+      "selected": "선택됨: {count}",
+      "defaultProjectAccess": "기본 프로젝트 액세스",
+      "defaultAccessType": "기본 액세스 유형",
+      "assignedUsersCount": "{count, plural, =0 {할당된 사용자 없음} =1 {할당된 사용자 수} other {할당된 사용자 수}}",
+      "successRate": "성공률",
+      "unassigned": "미지정",
+      "testRunName": "테스트 실행 이름",
+      "estimatesEllipsis": "추정치...",
+      "access": {
+        "noAccess": "접근 금지",
+        "globalRole": "글로벌 역할 사용",
+        "specificRole": "구체적인 역할",
+        "projectDefault": "프로젝트 기본값",
+        "usersGlobalRole": "사용자의 글로벌 역할"
+      },
+      "unknownUser": "알 수 없는 사용자",
+      "unknownProject": "알 수 없는 프로젝트",
+      "unknownTag": "알 수 없는 태그",
+      "filesSelectedForUpload": "{count, plural, =1 {업로드할 파일 1개가 선택되었습니다} other {업로드할 파일 개수}}"
+    },
+    "empty": {
+      "description": "설명 없음",
+      "documentation": "문서 없음",
+      "childMilestones": "아이의 발달 단계는 없습니다.",
+      "sessions": "세션 없음",
+      "activeSessions": "현재 진행 중인 세션이 없습니다.",
+      "completedSessions": "완료된 세션 없음",
+      "testCase": "테스트 케이스를 찾을 수 없습니다.",
+      "noTestCasesOrSessions": "테스트 케이스 또는 세션을 찾을 수 없습니다.",
+      "noTestCasesSessionsOrRuns": "테스트 케이스, 세션 또는 실행을 찾을 수 없습니다."
+    },
+    "or": "또는",
+    "for": "~을 위한",
+    "and": "그리고",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt 로고",
+      "tagline": "세상의 모든 것을 시험해 보세요"
+    },
+    "table": {
+      "columns": {
+        "columns": "컬럼",
+        "required": "(필수의)"
+      },
+      "filter": "필터 목록...",
+      "selectNone": "없음을 선택하세요",
+      "sort": "정렬 열",
+      "sortAscending": "오름차순 정렬",
+      "sortDescending": "내림차순 정렬",
+      "sortNone": "정렬되지 않음",
+      "resize": "열 크기 조정"
+    },
+    "pagination": {
+      "selectPage": "페이지를 선택하세요",
+      "morePages": "더 많은 페이지",
+      "goToPrevious": "이전 페이지로 이동",
+      "goToNext": "다음 페이지로 이동",
+      "all": "모든 품목",
+      "entries": "{count, plural, =1 {# 아이템} other {# 아이템}}",
+      "pageSize": "페이지 크기",
+      "showing": "전시",
+      "total": "총 {count, plural, =1 {항목 수} other {항목 수}}",
+      "filtered": "필터링됨",
+      "pageOfPages": "{total}의 페이지 {current}"
+    },
+    "upload": {
+      "title": "새 프로필 사진 업로드",
+      "description": "이미지를 드래그 앤 드롭하거나 아래 버튼을 클릭하여 파일을 선택하세요.",
+      "attachments": {
+        "title": "첨부파일 업로드",
+        "description": "파일을 드래그 앤 드롭하거나 아래 버튼을 클릭하여 파일을 선택하세요.",
+        "selectFiles": "{count, plural, =0 {파일 선택} one {선택된 파일 1개} other {선택된 파일 수}}",
+        "selectFile": "{count, plural, =0 {파일 선택} other {파일 1개 선택됨}}",
+        "filesSelected": "{count, plural, one {파일 1개 선택됨} other {선택된 파일 수}}",
+        "addMoreFiles": "파일을 더 추가하세요...",
+        "replaceFile": "파일을 교체하세요...",
+        "invalidFileType": "잘못된 파일 형식입니다. {types} 파일만 허용됩니다.",
+        "altText": {
+          "emoji": "이모지"
+        },
+        "count": "{count, plural, =1 {# 파일} other {# 파일들}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "테스트 케이스를 가져오려면 CSV 파일을 드롭하세요.",
+      "dropToImportTestResults": "테스트 결과를 가져오려면 파일을 드래그하세요.",
+      "supportedCsvFormats": "지원 파일 형식: .csv",
+      "supportedResultFormats": "지원되는 파일 형식: .xml, .trx, .json",
+      "unsupportedFileType": "지원되지 않는 파일 형식입니다. 예상되는 파일 형식은 {expected}입니다.",
+      "noFilesDetected": "드롭에서 파일이 감지되지 않았습니다."
+    },
+    "editor": {
+      "setColor": "색상 설정",
+      "enterUrl": "https://를 포함한 URL을 입력하세요.",
+      "uploadFile": "파일 업로드",
+      "video": {
+        "controls": "비디오 플레이어 컨트롤"
+      },
+      "image": {
+        "alignLeft": "왼쪽 정렬",
+        "alignCenter": "중앙 정렬",
+        "alignRight": "오른쪽 정렬",
+        "sizeSmall": "소형 사이즈",
+        "sizeMedium": "엠",
+        "sizeLarge": "대판",
+        "sizeFull": "전폭",
+        "resetSize": "원래 크기로 복원",
+        "rotate": "90도 회전",
+        "delete": "이미지 삭제"
+      },
+      "table": {
+        "insertTable": "테이블 삽입",
+        "headerRow": "헤더 행",
+        "addColumnBefore": "열을 앞에 추가하세요",
+        "addColumnAfter": "열을 추가합니다",
+        "deleteColumn": "열을 삭제합니다.",
+        "addRowBefore": "행을 앞에 추가하세요",
+        "addRowAfter": "행을 추가합니다",
+        "deleteRow": "행 삭제",
+        "deleteTable": "테이블 삭제"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "아래에 단락을 추가하세요",
+        "clearFormatting": "서식 지우기",
+        "copyToClipboard": "클립보드에 복사"
+      },
+      "textMenu": {
+        "bold": "용감한",
+        "italic": "이탤릭체",
+        "underline": "밑줄",
+        "strikethrough": "취소선",
+        "code": "암호",
+        "codeBlock": "코드 블록",
+        "highlightText": "텍스트를 강조 표시합니다",
+        "textColor": "텍스트 색상",
+        "moreOptions": "더 많은 옵션",
+        "subscript": "아래첨자",
+        "superscript": "어깨 기호",
+        "alignLeft": "왼쪽 정렬",
+        "alignCenter": "중앙 정렬",
+        "alignRight": "오른쪽 정렬",
+        "justify": "신이 옳다고 하다",
+        "setLink": "링크 설정",
+        "editLink": "링크 수정",
+        "removeLink": "링크 제거",
+        "resetColorToDefault": "색상을 기본값으로 재설정"
+      }
+    },
+    "ai": {
+      "title": "AI 글쓰기 도우미",
+      "improveWriting": "글쓰기 실력 향상",
+      "makeShorter": "더 짧게 만들기",
+      "makeLonger": "더 길게 만들기",
+      "fixGrammar": "문법 수정",
+      "changeTone": "어조 바꾸기",
+      "professional": "전문적인",
+      "casual": "평상복",
+      "formal": "공식적인",
+      "translate": "번역하다",
+      "english": "영어",
+      "spanish": "스페인 사람",
+      "french": "프랑스 국민",
+      "summarize": "요약하다",
+      "addExamples": "예시를 추가하세요",
+      "originalText": "원문",
+      "suggestion": "AI 추천",
+      "generating": "제안 생성 중...",
+      "noSuggestion": "아직 제안이 생성되지 않았습니다.",
+      "acceptSuggestion": "제안 수락",
+      "errors": {
+        "contentBlocked": "콘텐츠가 보안 필터에 의해 차단되었습니다. 다른 표현으로 요청을 다시 작성해 주세요.",
+        "emptyContent": "AI가 응답을 생성할 수 없습니다. 요청을 다시 작성하거나 나중에 다시 시도해 주세요.",
+        "maxTokens": "AI 응답이 너무 길어서 잘렸습니다. 더 짧은 요청을 하시거나 간결한 응답을 요청해 주세요.",
+        "rateLimit": "AI 서비스는 사용량 제한으로 인해 일시적으로 이용할 수 없습니다. 몇 분 후에 다시 시도해 주세요.",
+        "accessDenied": "이 프로젝트에서는 AI 기능을 사용할 권한이 없습니다.",
+        "generic": "죄송합니다. 요청 처리 중 오류가 발생했습니다."
+      }
+    },
+    "by": "~에 의해",
+    "version": {
+      "prefix": "다섯"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "목차",
+        "emptyMessage": "문서에 제목을 추가해 보세요 …"
+      },
+      "carousel": {
+        "previousSlide": "이전 슬라이드",
+        "nextSlide": "다음 슬라이드"
+      },
+      "dialog": {
+        "toggleFullScreen": "전체 화면 전환"
+      },
+      "command": {
+        "title": "명령 메뉴",
+        "description": "검색 및 명령 실행"
+      },
+      "breadcrumb": {
+        "more": "더"
+      },
+      "clickToViewDetails": "클릭하여 세부 정보를 확인하세요.",
+      "clickToExpand": "클릭하여 펼치기",
+      "clickToCollapse": "클릭하면 접힙니다",
+      "search": {
+        "filters": "필터",
+        "noResultsFound": "검색 결과가 없습니다.",
+        "loadingProjects": "프로젝트를 불러오는 중...",
+        "noProjectsFound": "프로젝트를 찾을 수 없습니다.",
+        "viewAllProjects": "모든 프로젝트 보기",
+        "states": "주",
+        "automationStatus": "자동화 상태",
+        "parent": "조상"
+      },
+      "issues": {
+        "errorLoadingDetails": "오류 발생 시 상세 정보: ",
+        "updated": "업데이트됨: ",
+        "openInJira": "Jira에서 열기",
+        "openInExternalSystem": "{provider}에서 열기",
+        "assignee": "양수인",
+        "status": "상태: ",
+        "clickToOpenInNewTab": "클릭하면 새 탭에서 열립니다.",
+        "url": "URL: ",
+        "externalId": "외부 ID: ",
+        "viewIn": "보기",
+        "fieldType": "필드 유형: ",
+        "richTextContent": "풍부한 텍스트 콘텐츠",
+        "invalidContent": "유효하지 않은 콘텐츠",
+        "fieldInformation": "필드 정보"
+      },
+      "onboarding": {
+        "skipTour": "투어 건너뛰기"
+      },
+      "charts": {
+        "resultsDistribution": "결과 분포",
+        "statusTimeline": "상태 타임라인",
+        "testDurationHistogram": "테스트 지속 시간 히스토그램",
+        "zoomDonutChart": "줌 도넛 차트",
+        "zoomStatusTimeline": "줌 상태 타임라인",
+        "zoomHistogramChart": "확대 히스토그램 차트",
+        "duration": "지속 시간: {seconds} 초",
+        "durationLabel": "지속"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "윈도우-1252"
+        }
+      },
+      "loadingIssueTracker": "이슈 트래커 정보를 불러오는 중...",
+      "enterDocumentation": "문서를 입력하세요...",
+      "noAutomatedTestResults": "이번 실행에 대한 자동 테스트 결과가 없습니다."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {분} other {분}}",
+      "seconds": "{count, plural, =1 {초} other {초}}"
+    },
+    "units": {
+      "time": "시간"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {경우} other {경우}}",
+      "result": "{count, plural, =1 {결과} other {결과}}",
+      "run": "{count, plural, =1 {실행} other {실행}}",
+      "comment": "{count, plural, =1 {{count} 댓글} other {{count} 댓글}}"
+    },
+    "success": {
+      "assigned": "테스트 케이스가 성공적으로 할당되었습니다.",
+      "unassigned": "테스트 케이스가 성공적으로 할당되지 않았습니다.",
+      "bulkAssigned": "{count, plural, one {# 테스트 케이스} other {# 테스트 케이스}} 성공적으로 할당됨",
+      "bulkUnassigned": "{count, plural, one {# 테스트 케이스} other {# 테스트 케이스}} 할당 해제 성공"
+    },
+    "tabs": {
+      "general": "일반적인",
+      "settings": "설정"
+    },
+    "selectFilter": "테스트 케이스를 보려면 필터 값을 선택하세요.",
+    "invalidProject": "잘못된 프로젝트 ID입니다.",
+    "visualization": "심상",
+    "results": "결과",
+    "loading": "로딩 중..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "새 계정을 만드세요",
+      "sso": {
+        "title": "SSO로 로그인",
+        "googleOAuth": "Google에서 계속 진행",
+        "apple": "Apple에서 계속 진행하세요",
+        "microsoft": "Microsoft에서 계속 진행하세요",
+        "samlProvider": "{name}로 로그인하세요",
+        "magicLink": "매직링크로 로그인",
+        "emailLogin": "이메일로 계속 진행"
+      },
+      "magicLink": {
+        "description": "이메일 주소를 입력하시면 로그인용 보안 링크를 보내드립니다. 비밀번호는 필요하지 않습니다. 이미 계정이 있으셔야 합니다.",
+        "emailPlaceholder": "이메일 주소를 입력하세요",
+        "sendLink": "매직링크 보내기",
+        "sending": "배상...",
+        "checkEmail": "이메일을 확인하세요",
+        "success": "계정이 있으시면 {email} 로 연결되는 링크를 보내드렸습니다. 이메일에 있는 링크를 클릭하여 로그인하세요.",
+        "error": "매직링크 전송에 실패했습니다. 다시 시도해 주세요.",
+        "backToSignIn": "로그인 페이지로 돌아가기"
+      },
+      "twoFactor": {
+        "title": "2단계 인증",
+        "description": "인증 앱에서 6자리 코드를 입력하거나 백업 코드를 사용하세요."
+      },
+      "troubleSigningIn": "로그인에 문제가 있으신가요?",
+      "contactAdmin": "시스템 관리자에게 문의하십시오."
+    },
+    "errors": {
+      "accessDenied": "접근이 거부되었습니다. 계정이 비활성화되었거나 로그인 권한이 없을 수 있습니다.",
+      "configuration": "서버 구성에 문제가 있습니다.",
+      "verification": "인증 토큰이 만료되었거나 이미 사용되었습니다.",
+      "invalid2FACode": "인증 코드가 잘못되었습니다. 다시 시도해 주세요.",
+      "twoFactorTokenRequired": "토큰이 필요합니다",
+      "verificationCodeRequired": "인증 코드가 필요합니다."
+    },
+    "signup": {
+      "description": "새 계정을 만들려면 정보를 입력하세요.",
+      "signIn": "기존 계정으로 로그인하세요.",
+      "registrationDisabled": "계정을 만들려면 관리자에게 문의하세요.",
+      "errors": {
+        "emailRequired": "이메일 주소는 필수입니다.",
+        "passwordRequired": "비밀번호가 보안 요구 사항을 충족하지 않습니다.",
+        "confirmPasswordRequired": "비밀번호 확인이 필요합니다",
+        "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
+        "domainRestricted": "등록은 승인된 이메일 도메인으로 제한됩니다. 오류라고 생각되시면 관리자에게 문의하십시오."
+      }
+    },
+    "verifyEmail": {
+      "title": "이메일 인증",
+      "loading": "이메일을 확인하는 중...",
+      "success": "이메일 인증이 완료되었습니다.",
+      "error": "이메일 인증에 실패했습니다.",
+      "expired": "인증 링크가 만료되었습니다.",
+      "invalid": "잘못된 인증 링크입니다",
+      "alreadyVerified": "이메일 인증 완료",
+      "toast": {
+        "verifySuccess": {
+          "description": "이제 계정에 로그인할 수 있습니다."
+        },
+        "verifyError": {
+          "description": "이메일 인증 중 오류가 발생했습니다."
+        },
+        "resendSuccess": {
+          "title": "이메일 인증 링크가 전송되었습니다.",
+          "description": "인증 링크가 포함된 이메일을 확인해 주세요."
+        },
+        "resendError": {
+          "title": "이메일 인증 링크 전송에 실패했습니다.",
+          "description": "이메일 인증 링크를 전송하는 동안 오류가 발생했습니다."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "2단계 인증을 설정하세요",
+      "description": "귀 기관에서는 2단계 인증이 필요합니다. 설정 후 계속 진행하세요.",
+      "backupDescription": "계속하기 전에 백업 코드를 저장하세요.",
+      "required": "귀사의 보안 정책에 따라 2단계 인증이 필수입니다.",
+      "loading": "설정 준비 중...",
+      "manualEntry": "또는 이 코드를 수동으로 입력하세요.",
+      "verifyLabel": "인증 코드",
+      "verify": "확인 및 활성화",
+      "backupCodesInfo": "이 코드를 안전한 곳에 보관하세요. 인증 기기를 분실했을 경우 이 코드를 사용하여 계정에 접속할 수 있습니다.",
+      "copyCodes": "모든 코드 복사",
+      "continue": "로그인 계속하기"
+    },
+    "twoFactorVerify": {
+      "title": "본인 인증을 완료하세요",
+      "description": "인증 앱에서 받은 6자리 코드를 입력하여 계속 진행하세요.",
+      "backupCodeLabel": "백업 코드",
+      "backupCodeHint": "8자리 백업 코드를 입력할 수도 있습니다.",
+      "useAuthenticator": "인증 코드를 사용하세요",
+      "useBackupCode": "대신 백업 코드를 사용하세요",
+      "signOut": "로그아웃하고 다른 계정을 사용하세요."
+    },
+    "forceChangePassword": {
+      "title": "비밀번호를 변경하세요",
+      "adminDescription": "관리자가 비밀번호를 변경하라고 요구했습니다.",
+      "expiredDescription": "비밀번호가 만료되었습니다. 계속하려면 새 비밀번호를 설정하세요.",
+      "newPasswordLabel": "새 비밀번호",
+      "confirmPasswordLabel": "새 비밀번호를 확인하세요",
+      "submitButton": "비밀번호 변경",
+      "signOut": "로그아웃하세요.",
+      "passwordsMustMatch": "비밀번호가 일치하지 않습니다.",
+      "passwordRequired": "비밀번호를 입력해야 합니다.",
+      "genericError": "오류가 발생했습니다. 다시 시도해 주세요.",
+      "policyTitle": "비밀번호 요구 사항:",
+      "policyMinLength": "최소 {count} 문자",
+      "policyUppercase": "적어도 하나의 대문자",
+      "policyLowercase": "적어도 하나의 소문자",
+      "policyNumbers": "적어도 하나의 숫자",
+      "policySpecialChars": "특수 문자({chars} ) 하나 이상"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "SSO 계정 연결",
+      "description": "계정을 싱글 사인온(SSO) 제공업체와 연결하세요",
+      "availableProviders": "사용 가능한 SSO 제공업체",
+      "linkWithGoogle": "구글과 연결하기",
+      "linkWithSaml": "{name}와 연결",
+      "accountLinked": "계정이 성공적으로 연결되었습니다.",
+      "linkingFailed": "계정 연결에 실패했습니다",
+      "noProvidersAvailable": "현재 연결에 사용할 수 있는 SSO 제공업체가 없습니다.",
+      "linkingInfo": "SSO 제공업체를 연결하면 비밀번호 대신 해당 제공업체를 사용하여 로그인할 수 있습니다. 기존 계정 정보는 변경되지 않습니다.",
+      "signInWithGoogle": "Google 계정으로 로그인",
+      "enterpriseSamlSso": "엔터프라이즈 SAML SSO",
+      "linkProvider": "링크 제공자",
+      "linking": "연결 중...",
+      "noProvidersContactAdmin": "현재 사용 가능한 SSO 제공업체가 없습니다. 관리자에게 문의하십시오."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "계기반",
+      "admin": "관리",
+      "profile": "윤곽"
+    },
+    "admin": {
+      "crossProjectReports": "프로젝트 간 보고서"
+    },
+    "projects": {
+      "sections": {
+        "management": "관리"
+      },
+      "menu": {
+        "repository": "저장소",
+        "runs": "시험 실행 및 결과"
+      },
+      "dropdown": {
+        "selectProject": "프로젝트를 선택하세요",
+        "selectProjectAriaLabel": "프로젝트 선택 {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "프로젝트 ID: {id}",
+      "active": "프로젝트가 진행 중입니다",
+      "completed": "프로젝트가 완료되었습니다"
+    },
+    "overview": {
+      "title": "개요",
+      "currentMilestones": "현재 주요 성과",
+      "seeAllMilestones": "{count, plural, =1 {# 마일스톤 보기} other {모든 # 마일스톤 보기}}",
+      "seeAllTestCases": "{count, plural, =1 {테스트 케이스 보기} other {모든 테스트 케이스 보기}}",
+      "latestTestCases": "최신 테스트 사례",
+      "createdOn": "생성일:",
+      "seeAllTags": "모든 태그 보기",
+      "seeAllActiveSessions": "{count, plural, =1 {활성 세션 보기} other {모든 활성 세션 보기}}",
+      "latestSessions": "최신 세션",
+      "activeTestRuns": "활성 테스트 실행",
+      "seeAllActiveTestRuns": "{count, plural, =1 {활성 테스트 실행 보기} other {모든 활성 테스트 실행 보기}}",
+      "latestTestRuns": "최근 테스트 실행 결과",
+      "testCaseBreakdown": "테스트 케이스 분석",
+      "noTestCases": "프로젝트 저장소가 비어 있습니다. 저장소를 사용하여 테스트 케이스를 추가하세요.",
+      "noTestCasesPrefix": "프로젝트 저장소가 비어 있습니다. 다음을 사용하여 테스트 케이스를 추가하세요.",
+      "noTestCasesLink": "저장소"
+    },
+    "icon": {
+      "upload": {
+        "title": "프로젝트 업로드 아이콘",
+        "description": "최대 4MB 크기의 정사각형 이미지(1:1 비율)를 업로드하세요.",
+        "errors": {
+          "invalidFileType": "이미지 파일만 허용됩니다.",
+          "fileTooLarge": "파일 크기가 너무 큽니다. 최대 크기는 {size} 입니다."
+        }
+      }
+    },
+    "settings": {
+      "description": "{projectName}에 대한 설정을 관리합니다.",
+      "moreSettingsComingSoon": "추가 설정 기능이 곧 제공될 예정입니다.",
+      "moreSettingsDescription": "향후 업데이트에서 추가적인 프로젝트 구성 옵션이 여기에 제공될 예정입니다.",
+      "integrations": {
+        "description": "이 프로젝트에 대한 타사 이슈 통합을 관리합니다.",
+        "availableIntegrations": "사용 가능한 이슈 통합 기능",
+        "availableDescription": "이 프로젝트에 연결할 이슈 통합 방식을 선택하세요.",
+        "configuredIntegration": "구성된 통합",
+        "noIntegrationAssigned": "문제 통합이 할당되지 않았습니다.",
+        "noIntegrationDescription": "시작하려면 제공되는 옵션 중에서 문제 통합을 선택하세요.",
+        "selectIntegration": "구성할 이슈 통합을 선택하세요.",
+        "integration": {
+          "assignError": "이슈 통합 할당에 실패했습니다.",
+          "updateSuccess": "통합 설정이 업데이트되었습니다.",
+          "updateError": "이슈 통합 설정 업데이트에 실패했습니다.",
+          "removeError": "이슈 통합 제거에 실패했습니다.",
+          "removeIntegration": "통합 제거",
+          "confirmRemove": "확인 제거",
+          "authDescription": "이슈 통합 기능을 사용하려면 {provider} 로 인증해야 합니다.",
+          "authenticating": "인증 중...",
+          "authSuccess": "인증 성공",
+          "selectProject": "{provider} 프로젝트를 선택하세요",
+          "selectProjectPlaceholder": "연결할 프로젝트를 선택하세요",
+          "linkedProject": "링크된 프로젝트",
+          "loadProjectsError": "프로젝트를 불러오는 데 실패했습니다.",
+          "settingsSaved": "통합 설정이 성공적으로 저장되었습니다.",
+          "saveSettingsError": "이슈 통합 설정을 저장하는 데 실패했습니다.",
+          "authorizationRequired": "승인 필요",
+          "authenticationError": "인증에 실패했습니다. 다시 시도해 주세요.",
+          "authorizationRequiredDescription": "외부 프로젝트에 접근하려면 이 이슈 통합에 대한 승인이 필요합니다.",
+          "authorizationMessage": "이슈 통합을 계속 진행하려면 승인해 주세요.",
+          "authorizeIntegration": "{name}를 승인하세요",
+          "integrationSettings": "{name} 설정",
+          "integrationSettingsDescription": "이 프로젝트에 대한 이슈 통합 설정을 구성합니다.",
+          "selectExternalProject": "외부 프로젝트 선택",
+          "refreshProjects": "리프레시 프로젝트",
+          "defaultIssueType": "기본 문제 유형",
+          "selectDefaultIssueType": "기본 문제 유형을 선택하세요",
+          "defaultIssueTypeDescription": "새로운 이슈를 생성할 때 이 이슈 유형이 미리 선택됩니다.",
+          "issueTypePlaceholder": "예: 버그, 작업, 스토리",
+          "defaultComponent": "기본 구성 요소",
+          "componentPlaceholder": "예: 프런트엔드, 백엔드",
+          "automaticSync": "자동 동기화",
+          "automaticSyncDescription": "TestPlanIt과 외부 시스템 간의 이슈를 자동으로 동기화합니다.",
+          "simpleUrlDescription": "이슈 연동 기능은 간단한 URL 패턴을 사용하여 외부 이슈에 연결합니다. 설정된 URL 패턴을 사용하면 새 탭에서 이슈가 열립니다.",
+          "externalProjectHelp": "이 설정은 TestPlanIt에서 새 이슈를 생성할 때 사용할 기본 프로젝트를 지정합니다. 다른 외부 프로젝트의 이슈를 연결하고 동기화할 수도 있으며, 각 이슈는 자체 소스 프로젝트를 추적합니다.",
+          "linkedProjects": "연결된 외부 프로젝트",
+          "linkedProjectsDescription": "이 통합을 통해 연결된 외부 프로젝트",
+          "noLinkedProjects": "외부 프로젝트 링크 없음",
+          "noLinkedProjectsDescription": "이슈 검색 및 동기화를 활성화하려면 외부 프로젝트를 추가하세요.",
+          "addProjects": "프로젝트 추가",
+          "addSelected": "선택 항목 추가",
+          "setAsDefault": "기본값으로 설정",
+          "removeProject": "프로젝트 제거",
+          "removeProjectConfirmation": "이 프로젝트를 삭제하면 해당 프로젝트와 관련된 이슈 동기화가 중지됩니다. 이전에 동기화된 이슈는 삭제되지 않습니다. 계속하시겠습니까?",
+          "removeProjectWebhookCascadeBullet": "이 프로젝트에 대한 인바운드 웹훅도 제거될 예정입니다.",
+          "keepProject": "프로젝트 유지",
+          "defaultIndicator": "기본",
+          "syncStatusSyncing": "동기화",
+          "syncStatusCompleted": "동기화됨",
+          "syncStatusError": "동기화 오류",
+          "fanOutPartialFailure": "{count} 프로젝트에 연결할 수 없습니다. {successCount} 프로젝트의 결과를 표시합니다.",
+          "projectSelectorLabel": "프로젝트",
+          "defaultIssueTypeHelp": "TestPlanIt에서 새 이슈를 생성할 때 이 이슈 유형이 자동으로 선택됩니다. 따라서 동일한 유형의 이슈를 자주 생성하는 경우 시간을 절약할 수 있습니다.",
+          "automaticSyncHelp": "이 기능을 활성화하면 외부 시스템에서 변경 사항이 감지될 때(웹훅을 통해) 이슈가 자동으로 동기화됩니다. 수동 동기화도 항상 가능합니다.",
+          "removeWarningTitle": "이 문제 통합을 제거하면 다음과 같은 결과가 나타납니다.",
+          "removeWarning1": "이슈 통합에서 연결된 모든 이슈를 연결 해제합니다(이슈는 데이터베이스에 그대로 유지됩니다).",
+          "removeWarning2": "이 프로젝트에 대한 모든 이슈 통합 관련 설정을 제거하세요.",
+          "removeWarning3": "이슈 통합 기능을 다시 사용하려면 재구성이 필요합니다.",
+          "removeWarning4": "이 통합에 대해 구성된 인바운드 웹훅을 제거합니다.",
+          "switchIntegration": "스위치 통합",
+          "switchWarningTitle": "다른 AI 모델로 전환하면 다음과 같은 이점이 있습니다.",
+          "switchWarning1": "현재 이슈 통합에 연결된 모든 이슈 연결을 해제합니다.",
+          "switchWarning2": "데이터베이스에 이슈 정보를 보존합니다(연결 해제됨).",
+          "switchWarning3": "현재 문제 통합 구성을 새 구성으로 교체하십시오.",
+          "switchWarning4": "현재 통합에 대해 구성된 인바운드 웹훅을 제거합니다."
+        },
+        "integrationAssigned": "통합 작업이 성공적으로 완료되었습니다.",
+        "integrationAssignError": "이슈 통합을 프로젝트에 할당하는 데 실패했습니다.",
+        "integrationRemoved": "통합 기능이 성공적으로 제거되었습니다.",
+        "integrationRemoveError": "프로젝트에서 이슈 통합을 제거하는 데 실패했습니다.",
+        "add": {
+          "jira": {
+            "description": "TestPlanIt에서 직접 이슈를 관리하려면 Jira 계정을 연결하세요."
+          },
+          "simple_url": {
+            "description": "이슈 추적을 위해 타사 시스템에 연결하세요."
+          },
+          "github": {
+            "description": "이슈 추적 및 저장소 관리를 위해 GitHub에 연결하세요."
+          },
+          "gitlab": {
+            "description": "이슈 및 병합 요청 추적을 위해 GitLab에 연결하세요."
+          },
+          "gitea": {
+            "description": "이슈 추적을 위해 자체 호스팅 Gitea, Forgejo 또는 Gogs 인스턴스에 연결하세요."
+          },
+          "azure_devops": {
+            "description": "작업 항목 추적을 위해 Azure DevOps에 연결하세요."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "연결된 이슈를 동기화 상태로 유지하려면 수신 웹훅을 구성하세요.",
+        "inboundDescription": "연결된 이슈를 동기화 상태로 유지하려면 수신 웹훅을 구성하세요.",
+        "outboundDescription": "TestPlanIt 이벤트를 Slack 또는 HMAC로 서명된 URL로 전송하도록 아웃바운드 웹훅을 구성합니다.",
+        "directionInbound": "인바운드",
+        "directionOutbound": "배 밖으로",
+        "inboundAddButtonAllConfigured": "인바운드 어댑터가 이미 구성되었습니다.",
+        "inboundAddButtonNoIntegration": "인바운드 웹훅을 추가하기 전에 이 프로젝트에 이슈 통합을 할당하세요.",
+        "inboundEmptyWithIntegration": "구성된 인바운드 웹훅이 없습니다. <link>할당된 이슈 통합에서 이슈 업데이트를 받으려면</link> 하나를 추가하세요.",
+        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "deliveriesEmptyNoConfigs": "아직 웹훅 전송이 없습니다. 수신 또는 발신 웹훅을 다른 탭에서 생성하여 웹훅 수신을 시작하세요.",
+        "noConfig": "웹훅이 구성되지 않았습니다.",
+        "createButton": "웹훅 생성",
+        "url": "웹훅 URL",
+        "urlHelp": "이 URL을 이슈 트래커의 웹훅 설정에 붙여넣으세요.",
+        "secret": "웹훅 비밀",
+        "secretHelp": "이 비밀 키를 이슈 트래커의 웹훅 설정에 붙여넣으세요.",
+        "revealedShownOnceWarning": "아래 URL과 비밀번호를 지금 복사하세요. 이 정보는 한 번만 표시되며 나중에 다시 가져올 수 없습니다.",
+        "secretMasked": "숨겨져 있음 — 돌려서 보기",
+        "rotateSecret": "비밀을 회전시키세요",
+        "rotateConfirmTitle": "웹훅 비밀 키를 회전시키시겠습니까?",
+        "rotateConfirm": "비밀 키를 변경하면 이슈 트래커 측의 현재 구성이 무효화되며, 이슈 트래커에서 구성을 업데이트하기 전까지는 유지됩니다. 계속하시겠습니까?",
+        "isActive": "활성화됨",
+        "deleteConfirmTitle": "웹훅 설정을 삭제하시겠습니까?",
+        "deleteConfirm": "이 웹훅 설정을 삭제하시겠습니까? 그러면 수신 요청이 거부됩니다.",
+        "sendTest": "테스트 웹훅 전송",
+        "testSuccess": "테스트 웹훅 수락됨(HTTP {statusCode}, 결과: {outcome})",
+        "testFailure": "웹훅 테스트 실패(HTTP {statusCode}): {error}",
+        "saveError": "웹훅 설정을 저장하는 데 실패했습니다.",
+        "lastReceived": "마지막 수신: {timestamp}",
+        "lastReceivedLabel": "최종 수신일:",
+        "lastReceivedNever": "아직 배송된 상품이 없습니다.",
+        "copyUrl": "웹훅 URL 복사",
+        "copySecret": "웹훅 비밀 키를 복사하세요",
+        "urlCopied": "웹훅 URL이 클립보드에 복사되었습니다.",
+        "secretCopied": "웹훅 비밀 키가 클립보드에 복사되었습니다.",
+        "nextSteps": "다음으로, 이 내용을 이슈 트래커의 웹훅 구성에 붙여넣고 아래의 \"테스트 웹훅 보내기\"를 클릭하여 파이프라인을 확인하세요. 비밀 키를 저장한 후 \"완료\"를 클릭하면 비밀 키가 다시 표시되지 않습니다.",
+        "revealDone": "완료",
+        "pageTitle": "웹훅",
+        "inboundTab": "인바운드",
+        "outboundTab": "배 밖으로",
+        "outboundEmpty": "구성된 아웃바운드 웹훅이 없습니다. TestPlanIt 이벤트를 Slack 또는 HMAC로 서명된 URL로 보내려면 웹훅을 추가하세요.",
+        "outboundAddButton": "아웃바운드 웹훅 추가",
+        "outboundCreateTitle": "새로운 아웃바운드 웹훅",
+        "outboundCreateName": "이름",
+        "outboundCreateNameHelp": "이 목적지에 대한 레이블(예: \"Engineering Slack\")을 지정합니다.",
+        "outboundCreateNamePlaceholder": "엔지니어링 슬랙",
+        "outboundCreateNameRequired": "이름은 필수 입력 사항입니다.",
+        "outboundCreateUrlRequired": "URL은 필수 입력 사항입니다.",
+        "outboundCreateUrlInvalid": "유효한 URL을 입력하세요(https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "URL은 HTTPS를 사용해야 합니다.",
+        "outboundNameLabel": "이름",
+        "outboundUnnamedConfig": "(이름 없는 웹훅)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "목적지 URL입니다. Slack 수신 웹훅 URL은 자동으로 감지됩니다.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "감지됨: 슬랙",
+        "outboundDetectedHmac": "감지됨: 일반 HMAC",
+        "adapterLabelSlack": "느슨하게",
+        "adapterLabelGenericHmac": "일반 HMAC 웹훅",
+        "outboundCreateSubscriptionsTitle": "구독",
+        "outboundCreateSubscriptionsHelp": "이 대상으로 전송될 이벤트를 선택하세요. 이 설정은 나중에 변경할 수 있습니다.",
+        "outboundSubsTestRunsAndSessions": "테스트 실행 및 세션",
+        "outboundSubsTestRuns": "테스트 실행",
+        "outboundSubsSessions": "세션",
+        "eventVerbs": {
+          "duplicated": "복제됨",
+          "stateChanged": "상태가 변경되었습니다",
+          "resultAdded": "결과가 추가되었습니다"
+        },
+        "events": {
+          "testRunCreated": "테스트 실행이 생성되었습니다.",
+          "testRunStateChanged": "테스트 실행 상태가 변경되었습니다.",
+          "testRunCompleted": "테스트 실행이 완료되었습니다.",
+          "testRunDuplicated": "테스트 실행이 중복되었습니다.",
+          "testRunResultAdded": "테스트 실행 결과가 추가되었습니다.",
+          "sessionCreated": "세션이 생성되었습니다",
+          "sessionStateChanged": "세션 상태가 변경되었습니다",
+          "sessionCompleted": "세션이 완료되었습니다",
+          "sessionDuplicated": "세션이 복제되었습니다",
+          "sessionResultAdded": "세션 결과가 추가되었습니다",
+          "issueCreated": "이슈가 생성되었습니다",
+          "issueUpdated": "이슈가 업데이트되었습니다.",
+          "issueDeleted": "문제가 삭제되었습니다.",
+          "caseCreated": "케이스 생성됨",
+          "caseUpdated": "사건 업데이트됨",
+          "caseDeleted": "사건 삭제됨",
+          "jiraIssueCreated": "Jira 이슈가 생성되었습니다.",
+          "jiraIssueUpdated": "Jira 이슈가 업데이트되었습니다.",
+          "jiraIssueDeleted": "Jira 이슈가 삭제되었습니다.",
+          "githubIssues": "GitHub 이슈 이벤트",
+          "githubPullRequest": "GitHub 풀 요청",
+          "githubPush": "GitHub 푸시",
+          "githubIssueComment": "GitHub 이슈 댓글",
+          "adoWorkitemCreated": "Azure DevOps 작업 항목이 생성되었습니다.",
+          "adoWorkitemUpdated": "Azure DevOps 작업 항목이 업데이트되었습니다.",
+          "adoWorkitemDeleted": "Azure DevOps 작업 항목이 삭제되었습니다.",
+          "webhookTest": "테스트 이벤트"
+        },
+        "outboundSubsIssues": "문제점",
+        "outboundSubsCases": "사례",
+        "outboundSubsSelectAll": "이 섹션에서 모두 선택하세요",
+        "outboundCreateSubmit": "웹훅 생성",
+        "outboundCreateCancel": "취소",
+        "outboundCreateSuccess": "아웃바운드 웹훅이 생성되었습니다.",
+        "outboundCreateError": "아웃바운드 웹훅 생성에 실패했습니다.",
+        "outboundUrlLabel": "목적지 URL",
+        "outboundActiveToggle": "활동적인",
+        "outboundSlackHint": "이 URL은 민감한 정보입니다. 이 URL을 아는 사람은 누구나 당신의 채널에 게시물을 올릴 수 있습니다.",
+        "outboundHmacSecretsTitle": "서명 비밀",
+        "outboundHmacActiveSecret": "활동적인",
+        "outboundHmacInactiveSecret": "비활성화됨",
+        "outboundHmacRetiringSecret": "암띤",
+        "outboundHmacAutoRetireIn": "자동 은퇴 ( {days} 일 소요)",
+        "outboundHmacRotateButton": "비밀을 회전시키세요",
+        "outboundHmacExtendButton": "7일 연장",
+        "outboundHmacRetireNowButton": "지금 은퇴하세요",
+        "outboundRotateConfirmTitle": "서명 비밀번호를 변경하시겠습니까?",
+        "outboundRotateConfirm": "새로운 활성 비밀 키가 생성됩니다. 이전 비밀 키는 소비자가 업데이트하는 동안 7일 동안 계속 서명에 사용됩니다.",
+        "outboundRotateSuccess": "비밀 키가 회전되었습니다. 새로운 평문은 아래에 한 번 표시됩니다.",
+        "outboundRotateError": "비밀 키를 회전하는 데 실패했습니다.",
+        "outboundRetireConfirmTitle": "이제 비밀을 은퇴하시겠습니까?",
+        "outboundRetireConfirm": "사용 중지되는 비밀 키는 즉시 서명을 중지합니다. 이전 비밀 키를 사용하는 사용자는 새로운 페이로드를 거부합니다.",
+        "outboundRetireSuccess": "비밀은 은퇴했다.",
+        "outboundRetireError": "비밀 해제에 실패했습니다.",
+        "outboundExtendSuccess": "자동 은퇴 기간이 7일 연장되었습니다.",
+        "outboundExtendError": "비밀 키 확장에 실패했습니다.",
+        "outboundSendTestButton": "테스트 이벤트 전송",
+        "outboundSendTestQueued": "테스트 이벤트가 대기열에 추가되었습니다. 메시지를 확인하려면 수신처를 확인하세요.",
+        "outboundSendTestError": "테스트 이벤트 대기열에 추가하는 데 실패했습니다.",
+        "outboundDeleteButton": "웹훅 삭제",
+        "outboundDeleteConfirmTitle": "발신 웹훅을 삭제하시겠습니까?",
+        "outboundDeleteConfirm": "이 목적지로 향하는 모든 향후 항공편은 즉시 발사를 중단합니다.",
+        "outboundDeleteSuccess": "웹훅이 삭제되었습니다.",
+        "outboundDeleteError": "웹훅 삭제에 실패했습니다.",
+        "outboundSecretCopy": "비밀을 복사하세요",
+        "outboundSecretShownOnce": "이 비밀을 지금 저장하세요. 다시는 공개될 수 없습니다.",
+        "outboundSecretDone": "완료",
+        "inboundAddButton": "인바운드 웹훅 추가",
+        "inboundChooserTitle": "어댑터를 선택하세요",
+        "inboundChooserDescription": "TestPlanIt으로 웹훅을 전송할 이슈 트래커를 선택하세요. 각 프로젝트는 Jira, GitHub, Azure DevOps에서 각각 하나씩의 인바운드 웹훅을 설정할 수 있습니다.",
+        "inboundChooserJira": "지라",
+        "inboundChooserGithub": "깃허브",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "깃랩",
+        "inboundChooserGitea": "기테아",
+        "inboundChooserAlreadyConfigured": "이미 구성됨",
+        "inboundChooserSubmit": "계속하다",
+        "inboundChooserCancel": "취소",
+        "inboundEmpty": "구성된 인바운드 웹훅이 없습니다. Jira, GitHub, GitLab, Gitea 또는 Azure DevOps에서 이슈 업데이트를 수신하려면 웹훅을 추가하세요.",
+        "inboundJiraTitle": "Jira 인바운드 웹훅",
+        "inboundGithubTitle": "GitHub 인바운드 웹훅",
+        "inboundGithubScopeHint": "GitHub <code>이슈</code> 이벤트는 연결된 TestPlanIt 이슈를 업데이트합니다. 풀 리퀘스트 및 이슈 댓글 이벤트는 허용되지만 아직 이슈를 업데이트하지는 않습니다.",
+        "inboundGitlabTitle": "GitLab 인바운드 웹훅",
+        "inboundGitlabScopeHint": "GitLab <code>이슈 훅</code> 이벤트는 연결된 TestPlanIt 이슈를 업데이트합니다. 다른 이벤트 유형도 허용되지만 이슈는 업데이트되지 않습니다.",
+        "inboundGiteaTitle": "Gitea 인바운드 웹훅",
+        "inboundGiteaScopeHint": "Gitea <code>이슈</code> 이벤트는 연결된 TestPlanIt 이슈를 업데이트합니다. 다른 이벤트 유형도 허용되지만 이슈는 업데이트되지 않습니다.",
+        "inboundAdoTitle": "Azure DevOps 인바운드 웹훅",
+        "inboundAdoScopeHint": "Azure DevOps <code>작업 항목 업데이트</code> 이벤트는 연결된 TestPlanIt 이슈를 업데이트합니다. 다른 이벤트도 허용되지만 이슈는 업데이트되지 않습니다.",
+        "inboundAdoUsername": "사용자 이름",
+        "inboundAdoPassword": "비밀번호",
+        "inboundAdoUsernamePlaceholder": "서비스 계정",
+        "inboundAdoUsernameHelp": "Azure DevOps 서비스 후크 측에서 구성됩니다. TestPlanIt은 HTTP 기본 인증을 통해 이를 검증합니다.",
+        "inboundAdoPasswordHelp": "저장된 데이터는 암호화됩니다. 이 값은 Azure DevOps 서비스 후크 측에도 저장해야 합니다.",
+        "inboundAdoResourceDetailsHint": "Azure DevOps 서비스 후크를 구성할 때 '전송할 리소스 세부 정보'를 '모두'로 설정하여 System.State가 페이로드에 포함되도록 하십시오.",
+        "setupStepsTitle": "설정 단계",
+        "setupStepsJiraStep1": "Jira에서 설정 → 시스템 → 웹훅(또는 Jira 관리자 웹훅 구성 페이지)으로 이동합니다.",
+        "setupStepsJiraStep2": "\"웹훅 생성\"을 클릭하세요. 아래 URL을 URL 필드에 붙여넣고, 비밀 키를 비밀 키 필드에 붙여넣으세요.",
+        "setupStepsJiraStep3": "\"문제 관련 이벤트\"에서 \"업데이트됨\"을 선택하여 문제 상태 변경 사항이 전송되도록 하세요.",
+        "setupStepsJiraStep4": "웹훅을 저장하세요. 아래의 \"테스트 웹훅 보내기\"를 사용하여 파이프라인을 확인하세요.",
+        "setupStepsGithubStep1": "GitHub 저장소에서 설정 → 웹훅 → 웹훅 추가로 이동하세요.",
+        "setupStepsGithubStep2": "아래 URL을 페이로드 URL 필드에 붙여넣으세요. 콘텐츠 유형을 application/json으로 설정하세요.",
+        "setupStepsGithubStep3": "아래의 비밀을 비밀 입력란에 붙여넣으세요.",
+        "setupStepsGithubStep4": "\"개별 이벤트를 직접 선택\"을 선택하고 \"문제\"를 체크하세요.",
+        "setupStepsGithubStep5": "\"웹훅 추가\"를 클릭하세요. 아래의 \"테스트 웹훅 보내기\"를 사용하여 파이프라인을 확인하세요.",
+        "setupStepsAdoStep1": "Azure DevOps 프로젝트에서 프로젝트 설정 → 서비스 후크 → 구독 만들기로 이동합니다.",
+        "setupStepsAdoStep2": "서비스로 \"웹훅\"을 선택하세요. 트리거를 \"작업 항목 업데이트됨\"으로 설정하세요.",
+        "setupStepsAdoStep3": "리소스 세부 정보를 '모두'로 설정하여 System.State가 포함되도록 합니다.",
+        "setupStepsAdoStep4": "아래 URL을 URL 필드에 붙여넣으세요. 기본 인증 사용자 이름과 비밀번호는 위에서 입력한 값으로 설정하세요.",
+        "setupStepsAdoStep5": "구독을 저장하세요. 아래의 \"테스트 웹훅 보내기\"를 사용하여 파이프라인을 확인하세요.",
+        "setupStepsGitlabStep1": "GitLab에서 프로젝트 → 설정 → 웹훅으로 이동하세요.",
+        "setupStepsGitlabStep2": "아래 URL을 URL 필드에 붙여넣으세요. 아래 비밀 키를 비밀 토큰 필드에 붙여넣으세요.",
+        "setupStepsGitlabStep3": "트리거 항목에서 \"이벤트 발생\"을 선택하세요.",
+        "setupStepsGitlabStep4": "\"웹훅 추가\"를 클릭하세요. 아래의 \"테스트 웹훅 보내기\"를 사용하여 파이프라인을 확인하세요.",
+        "setupStepsGiteaStep1": "Gitea에서 저장소 → 설정 → 웹훅으로 이동하세요.",
+        "setupStepsGiteaStep2": "\"웹훅 추가\"를 클릭하고 \"Gitea\"를 선택하세요.",
+        "setupStepsGiteaStep3": "아래 URL을 '대상 URL' 필드에 붙여넣으세요. 아래 비밀 키를 '비밀 키' 필드에 붙여넣으세요.",
+        "setupStepsGiteaStep4": "\"트리거 조건\"에서 \"문제\"를 선택하세요.",
+        "setupStepsGiteaStep5": "\"웹훅 추가\"를 클릭하세요. 아래의 \"테스트 웹훅 보내기\"를 사용하여 파이프라인을 확인하세요.",
+        "deliveriesTab": "배송",
+        "filterConfigPlaceholder": "모든 웹훅",
+        "filterStatusAll": "모두",
+        "filterStatusFailed": "실패한",
+        "filterStatusSuccess": "성공",
+        "filterSinceDefault": "… 이후로",
+        "filterUntilDefault": "…까지",
+        "filterReset": "필터 초기화",
+        "filterBulkReplayButton": "대량 재생 {count} 아웃바운드 실패",
+        "filterBulkReplayHidden": "모든 가시적인 오류는 인바운드 오류이므로, 상위 이벤트 트리거를 다시 실행하십시오.",
+        "deliveriesEmpty": "이 필터 조건에 맞는 배송 건이 없습니다.",
+        "deliveriesResetFilters": "필터 초기화",
+        "deliveriesLoadMore": "더 보기",
+        "tableHeaderConfig": "웹훅",
+        "tableHeaderEvent": "이벤트",
+        "tableHeaderStatus": "상태",
+        "tableHeaderError": "오류",
+        "tableHeaderReceivedAt": "받았다",
+        "tableHeaderAttempt": "시도",
+        "tableHeaderDirection": "방향",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "자세히 보기",
+        "drawerTitle": "배송 정보",
+        "drawerLabelEvent": "이벤트",
+        "drawerLabelDirection": "방향",
+        "drawerLabelStatusCode": "상태 코드",
+        "drawerLabelLatency": "숨어 있음",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "오류",
+        "drawerLabelPayloadDigest": "페이로드 다이제스트",
+        "drawerLabelEventId": "이벤트 ID",
+        "drawerLabelAttempt": "시도",
+        "drawerLabelReceivedAt": "수신처",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "{id} 재생",
+        "drawerReplayButton": "이 방송을 다시 재생하세요",
+        "drawerInboundReplayNotSupported": "수신된 전달은 다시 재생할 수 없습니다. 대신 상위 이벤트를 다시 트리거하십시오.",
+        "replayConfirmTitle": "이 방송을 다시 재생하시겠습니까?",
+        "replayConfirm": "이렇게 하면 실제 {direction} {adapterType} 요청이 발생합니다.",
+        "replayAction": "다시 하다",
+        "bulkReplayConfirmTitle": "발신 실패를 다시 실행하시겠습니까?",
+        "bulkReplayConfirm": "{count} 아웃바운드 실패를 {configName}로 다시 재생하시겠습니까? 이렇게 하면 {count} 실제 HTTP 요청이 실행됩니다.",
+        "bulkReplayCapExceeded": "대량 재생은 한 번에 최대 100개의 발신으로 제한됩니다. 필터를 좁히거나 순차적으로 실행하세요. 현재 {count} 이 재생됩니다.",
+        "bulkReplayAction": "재생 {count}",
+        "healthBadge": {
+          "HEALTHY": "건강한",
+          "DEGRADED": "타락한",
+          "DISABLED": "장애가 있는"
+        },
+        "healthTooltipHealthy": "마지막 성공: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} 연속 실패 · 마지막 실패 시간: {lastFailureAt}",
+        "healthTooltipDisabled": "10회 연속 실패 후 비활성화됨 · {lastFailureAt}",
+        "activityLabel": "배송 활동",
+        "activityLastDispatched": "마지막으로 발송됨",
+        "activityLastSuccess": "마지막 성공",
+        "activityLastFailure": "마지막 실패",
+        "activityNever": "절대",
+        "reEnable": "다시 활성화",
+        "reEnableConfirmTitle": "이 웹훅을 다시 활성화하시겠습니까?",
+        "reEnableConfirm": "상위 문제 해결 여부를 확인한 후 다시 활성화하십시오. 웹훅은 즉시 전송을 재개합니다.",
+        "toastReplaySuccess": "재생 대기 중",
+        "toastReplayFailed": "재생 실패: {error}",
+        "toastReplayInboundNotSupported": "수신된 배송물은 다시 재생할 수 없습니다.",
+        "toastBulkReplaySuccess": "대량 재생 시작됨 · 배치 {batchId}",
+        "toastBulkReplayFailed": "대량 재생 실패: {error}",
+        "toastReEnableSuccess": "웹훅이 다시 활성화되었습니다",
+        "toastReEnableFailed": "재활성화에 실패했습니다: {error}"
+      },
+      "aiModels": {
+        "description": "지능형 테스트 케이스 생성 및 분석을 위한 AI 모델 구성",
+        "availableModels": "프로젝트 기본값",
+        "availableModelsDescription": "시스템 관리자가 구성한 기본 AI 모델 중에서 이 프로젝트에 사용할 모델을 선택하세요.",
+        "currentModelSettings": "현재 모델 설정",
+        "currentModelDescription": "현재 활성화된 AI 모델의 구성 세부 정보: {name}",
+        "noModelsAvailable": "현재 사용 가능한 AI 모델이 없습니다. 조직에 맞는 AI 모델을 구성하려면 시스템 관리자에게 문의하십시오.",
+        "monthlyBudget": "월간 예산",
+        "model": "모델",
+        "budget": "예산",
+        "streamingTooltip": "실시간 응답 스트리밍 가능",
+        "systemDefault": "시스템 기본값",
+        "setAsDefault": "기본값으로 설정",
+        "clearDefault": "기본값 지우기",
+        "useForProject": "프로젝트에 사용",
+        "removeModel": "기본값 지우기",
+        "removeWarningTitle": "기본 AI 모델을 초기화하면 다음과 같은 결과가 나타납니다.",
+        "removeWarning1": "기능별 재정의 설정이 되어 있지 않으면 AI 기반 기능을 비활성화하십시오.",
+        "removeWarning2": "테스트 케이스 생성 및 분석에 사용되는 대체 모델을 제거합니다.",
+        "switchModel": "기본값 변경",
+        "switchWarningTitle": "기본 AI 모델을 변경하면 다음과 같은 결과가 나타납니다.",
+        "switchWarning1": "이 프로젝트에서 AI 기능의 동작 방식을 변경합니다.",
+        "switchWarning2": "생성된 콘텐츠의 품질 및 스타일에 영향을 미칠 수 있습니다.",
+        "modelAssigned": "이 프로젝트에 설정된 기본 AI 모델",
+        "modelAssignError": "기본 AI 모델 설정에 실패했습니다.",
+        "modelRemoved": "기본 AI 모델이 초기화되었습니다.",
+        "modelRemoveError": "기본 AI 모델을 지우는 데 실패했습니다.",
+        "confirmRemove": "이 프로젝트의 기본값으로 \"{name}\"을 지우시겠습니까?",
+        "confirmSwitch": "기본값을 \"{from}\"에서 \"{to} \"로 변경하시겠습니까?",
+        "currency": {
+          "dollar": "달러",
+          "perMonth": "월"
+        },
+        "promptConfig": "프롬프트 구성",
+        "promptConfigDescription": "이 프로젝트에 사용할 AI 프롬프트 구성을 선택하세요.",
+        "useSystemDefault": "시스템 기본값을 사용합니다",
+        "promptConfigChanged": "프롬프트 구성이 성공적으로 업데이트되었습니다.",
+        "featureOverrides": {
+          "title": "기능별 LLM 재정의",
+          "description": "특정 AI 기능에 대한 기본 LLM 통합을 재정의합니다. 재정의된 내용은 문제 해결 과정에서 가장 높은 우선순위를 갖습니다.",
+          "feature": "특징",
+          "override": "보수",
+          "effectiveLlm": "효과적인 LLM",
+          "source": "원천",
+          "noOverride": "재정의 없음",
+          "noLlm": "LLM 없음(비활성화됨)",
+          "disabledOverride": "비활성화됨(재정의)",
+          "projectOverride": "프로젝트 재정의",
+          "promptConfig": "프롬프트 구성",
+          "noLlmConfigured": "LLM이 구성되지 않았습니다.",
+          "selectIntegration": "통합 방식을 선택하세요...",
+          "overrideSaved": "기능 재정의가 저장되었습니다",
+          "overrideCleared": "기능 재정의가 해제되었습니다.",
+          "overrideError": "기능 재정의를 저장하는 데 실패했습니다."
+        }
+      },
+      "shares": {
+        "title": "주식 관리",
+        "description": "이 프로젝트의 모든 공유 링크를 보고 관리하세요."
+      },
+      "quickScript": {
+        "title": "퀵스크립트",
+        "description": "QuickScript를 활성화하고 AI 기반 테스트 생성을 위한 코드 저장소를 연결하세요.",
+        "enableLabel": "QuickScript 활성화",
+        "enableDescription": " 이 프로젝트에서 팀 구성원이 QuickScript를 사용하여 테스트 케이스를 자동화 스크립트로 변환할 수 있도록 허용합니다.",
+        "enabledToast": "QuickScript 사용 가능",
+        "disabledToast": "QuickScript가 비활성화되었습니다.",
+        "noRepos": {
+          "title": "구성된 코드 저장소가 없습니다.",
+          "adminDescription": "이 프로젝트의 코드 컨텍스트를 구성하기 전에 저장소 연결을 설정하십시오.",
+          "adminLink": "코드 저장소로 이동",
+          "userDescription": "코드 저장소 연결을 설정하려면 시스템 관리자에게 문의하십시오."
+        },
+        "repository": {
+          "title": "코드 저장소",
+          "description": "AI 컨텍스트에 사용할 코드 저장소를 선택하세요.",
+          "placeholder": "코드 저장소를 선택하세요...",
+          "branchLabel": "나뭇가지",
+          "branchPlaceholder": "기본 저장소 분기를 사용하려면 비워 두십시오."
+        },
+        "pathPatterns": {
+          "title": "경로 패턴",
+          "description": "포함할 파일을 지정합니다. 각 행은 기본 경로와 글로브 패턴을 조합합니다. 예: path=tests/e2e/pages + pattern=*는 해당 폴더의 모든 파일을 직접 포함하고, path=src + pattern=**/*.test.ts는 모든 테스트 파일을 재귀적으로 포함합니다.",
+          "pathLabel": "길",
+          "pathPlaceholder": "테스트/e2e/페이지",
+          "patternLabel": "무늬",
+          "addPath": "경로 추가",
+          "previewFiles": "미리보기 파일",
+          "scanningRepo": "저장소 파일 스캔 중… ({seconds}s)",
+          "files": "{count, plural, one {# 파일} other {# 파일들}}",
+          "truncatedBadge": "결과가 불완전할 수 있습니다(제공업체 제한).",
+          "exceedsLimit": "총 크기가 AI 컨텍스트 제한을 {overflow}만큼 초과했습니다. 내보내기 과정에서 파일은 내보내는 테스트 케이스와의 관련성에 따라 순위가 매겨집니다. 관련성이 가장 높은 파일이 먼저 포함되고, 예산이 초과되면 순위가 낮은 파일은 건너뛰어집니다. 포함할 파일을 더 세밀하게 제어하려면 경로 패턴을 좁히세요."
+        },
+        "preview": {
+          "resolvingBranch": "분기…를 해결 중",
+          "scanningFiles": "{scope}…에서 파일을 스캔합니다.",
+          "scanningFilesCount": "{scope}… 에서 파일을 스캔하는 중입니다 ({count} 이 발견되었습니다)",
+          "filtering": "{count} 파일…에 필터 적용"
+        },
+        "cache": {
+          "title": "캐시 설정",
+          "description": "AI 생성 중 빠른 접근을 위해 파일이 Valkey에 캐시됩니다.",
+          "enableLabel": "파일 캐싱을 활성화합니다.",
+          "disabledWarning": "파일 캐싱이 비활성화되었습니다. 저장소 파일은 내보내기 시점에 공급자로부터 직접 가져오며 TestPlanIt에 저장되지 않습니다. AI 기반 QuickScript는 코드 컨텍스트를 계속 포함하지만, 각 내보내기 시 저장소에 실시간 요청을 보냅니다.",
+          "ttlLabel": "캐시 지속 시간(일)",
+          "statusTitle": "캐시 상태",
+          "refreshButton": "캐시 새로 고침",
+          "listingFiles": "파일 목록…",
+          "cachingFiles": "{count} 파일… 캐싱 중",
+          "statusNeverFetched": "절대 가져오지 않음",
+          "statusPending": "상쾌한...",
+          "lastFetched": "마지막으로 가져온",
+          "filesCached": "캐시된 파일",
+          "totalSize": "전체 크기"
+        },
+        "save": "설정 저장",
+        "saved": "코드 컨텍스트 구성이 저장되었습니다.",
+        "saveError": "설정을 저장하는 데 실패했습니다.",
+        "listError": "저장소 파일 목록을 가져오는 데 실패했습니다.",
+        "contentsError": "파일 내용 캐시 실패",
+        "networkError": "캐시 새로 고침 중 네트워크 오류 발생",
+        "refreshSuccess": "캐시 새로 고침됨: {fileCount} 개 파일 ({contentCached} 개 콘텐츠 캐시됨)",
+        "refreshRateLimited": "캐시 새로 고침됨: {fileCount} 개의 파일이 나열되었고, {contentCached}/{fileCount} 개의 콘텐츠가 캐시되었습니다(호출 속도 제한됨 - 완료하려면 다시 새로 고침하세요).",
+        "validation": {
+          "pathRequired": "경로가 필요합니다",
+          "patternRequired": "패턴이 필요합니다",
+          "repositoryRequired": "저장소가 필요합니다",
+          "pathPatternRequired": "최소 하나의 경로 패턴이 필요합니다."
+        },
+        "exportTemplates": {
+          "title": "내보내기 템플릿",
+          "description": "이 프로젝트에 내보내기 템플릿을 지정하세요. 지정된 템플릿만 내보내기 대화 상자에 표시됩니다.",
+          "noTemplates": "내보내기 템플릿이 활성화되어 있지 않습니다. 시스템 관리자에게 문의하십시오.",
+          "assignedLabel": "할당된 템플릿",
+          "selectPlaceholder": "할당할 템플릿을 선택하세요...",
+          "defaultLabel": "기본 템플릿",
+          "defaultPlaceholder": "없음(전역 기본값 사용)",
+          "assigned": "할당된",
+          "save": "템플릿 할당 저장",
+          "saved": "템플릿 할당이 저장되었습니다",
+          "saveError": "템플릿 할당을 저장하는 데 실패했습니다."
+        },
+        "disconnect": "저장소 연결 해제",
+        "confirmDisconnect": "\"{name}\"를 이 프로젝트에서 연결 해제하시겠습니까?",
+        "disconnectWarningTitle": "이 저장소 연결을 해제하면 다음과 같은 결과가 발생합니다.",
+        "disconnectWarning1": "캐시된 저장소 파일을 모두 제거합니다.",
+        "disconnectWarning2": "경로 패턴 및 분기 구성을 제거합니다.",
+        "disconnectWarning3": "AI가 생성한 내보내기에 코드 컨텍스트를 포함하지 마세요.",
+        "disconnectSuccess": "코드 저장소 연결이 끊어졌습니다.",
+        "disconnectError": "코드 저장소 연결 해제에 실패했습니다."
+      }
+    }
+  },
+  "milestones": {
+    "title": "주요 단계 세부 정보",
+    "fields": {
+      "parent": "부모의 중요한 순간",
+      "dueDate": "마감일",
+      "automaticCompletion": "마감일 자동 완성",
+      "notifyDaysBefore": "마감일 며칠 전에 알려주세요",
+      "notifyDaysBeforeValue": "마감일 {count, plural, one {#일} other {#일}} 전에 알림",
+      "dueDateNotifications": "마감일 알림"
+    },
+    "labels": {
+      "childMilestones": "아동 발달 단계"
+    },
+    "placeholders": {
+      "description": "주요 단계 설명을 입력하세요...",
+      "documentation": "주요 단계별 문서를 입력하세요...",
+      "selectType": "마일스톤 유형을 선택하세요...",
+      "selectParent": "상위 단계 선택..."
+    },
+    "empty": {
+      "active": "진행 중인 마일스톤이 없습니다.",
+      "completed": "완료된 마일스톤 없음",
+      "description": "설명 없음",
+      "documentation": "제공된 서류 없음",
+      "testRuns": "테스트 실행 없음",
+      "forecasts": "예측 데이터가 없습니다."
+    },
+    "statusLabels": {
+      "NOT_STARTED": "시작 안 함",
+      "IN_PROGRESS": "진행 중",
+      "STOPPED": "멈췄습니다",
+      "BLOCKED": "막힌",
+      "CANCELLED": "취소",
+      "unscheduled": "예정되지 않은",
+      "upcoming": "다가오는",
+      "delayed": "지연",
+      "pastDue": "연체",
+      "started": "시작됨",
+      "completed": "완전한"
+    },
+    "status": {
+      "stop": "멈추다",
+      "reopen": "다시 열다"
+    },
+    "dates": {
+      "pickStartDate": "시작 날짜를 선택하세요",
+      "pickCompletionDate": "선택 완료일",
+      "selectDate": "날짜를 선택하세요...",
+      "completionWarning": "경고: 이렇게 하면 해당 단계가 완료된 것으로 표시됩니다."
+    },
+    "toast": {
+      "deleted": "마일스톤 {name} 삭제됨",
+      "updated": "마일스톤 업데이트됨",
+      "updateFailed": "마일스톤 업데이트에 실패했습니다.",
+      "completed": "마일스톤 \"{name}\"이 완료되었습니다.",
+      "completedWithDependencies": "마일스톤 및 관련 작업이 성공적으로 완료되었습니다."
+    },
+    "errors": {
+      "nameExists": "이미 같은 이름을 가진 이정표가 존재합니다.",
+      "nameRequired": "마일스톤 이름은 필수 입력 사항입니다.",
+      "notFound": "마일스톤을 찾을 수 없습니다."
+    },
+    "actions": {
+      "add": "마일스톤 추가"
+    },
+    "delete": {
+      "title": "마일스톤 삭제",
+      "confirmMessage": "마일스톤 {name}을 정말로 삭제하시겠습니까?",
+      "warning": "이 마일스톤은 프로젝트에서 삭제됩니다. 하지만 이 마일스톤에 대한 과거 데이터는 프로젝트에 계속 남아 있습니다.",
+      "toast": {
+        "loading": "마일스톤 삭제 중...",
+        "success": "마일스톤이 성공적으로 삭제되었습니다.",
+        "error": {
+          "title": "마일스톤 삭제에 실패했습니다",
+          "description": "마일스톤을 삭제하는 동안 오류가 발생했습니다."
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "마일스톤 완료 확인",
+      "confirmDescription": "이 단계를 완료하면 다음과 같은 관련 항목도 함께 완료됩니다.",
+      "impactActiveTestRuns": "{count, plural, one {# 활성 테스트 실행} other {# 활성 테스트 실행}}",
+      "impactActiveSessions": "{count, plural, one {# 활성 세션} other {# 활성 세션}}",
+      "impactDescendantMilestones": "{count, plural, one {# 후손 마일스톤} other {# 후손 마일스톤}}",
+      "completeTestRunsLabel": "관련 테스트 실행 완료 ({count, plural, one {# 활성} other {# 활성}})",
+      "completeSessionsLabel": "관련 세션 완료 ({count, plural, one {# 활성} other {# 활성}})",
+      "testRunStateLabel": "테스트 실행 완료 상태",
+      "sessionStateLabel": "세션 완료 상태",
+      "itemsRemaining": "다음 항목들은 계속 활성화 상태로 유지됩니다:",
+      "processing": "처리 중...",
+      "confirmAndCompleteAll": "모두 확인하고 완료하세요"
+    },
+    "notifications": {
+      "dueSoon": "마일스톤 \"{name}\"은 {dueDate}에 완료될 예정입니다.",
+      "overdue": "마일스톤 \"{name}\"은 {dueDate}에 완료될 예정이었습니다."
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {세션} other {세션들}}",
+    "labels": {
+      "totalElapsed": "소요 시간",
+      "remaining": "남은 값: {time}",
+      "overtime": "예상치 초과: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "필터 조건에 맞는 완료된 세션이 없습니다."
+    },
+    "filter": {
+      "placeholder": "세션을 필터링하세요..."
+    },
+    "actions": {
+      "add": "세션 추가",
+      "create": "새 세션 만들기",
+      "edit": "편집 세션",
+      "complete": "전체 세션",
+      "delete": "세션 삭제",
+      "viewSessionDetails": "세션 보기"
+    },
+    "noMilestone": "이정표 없음",
+    "completeDialog": {
+      "noWorkflowsConfigured": "이 프로젝트에는 완료 워크플로가 구성되어 있지 않습니다. 세션 완료 기능을 활성화하려면 관리자 설정에서 워크플로를 구성하십시오."
+    },
+    "messages": {
+      "createSuccess": "세션이 성공적으로 생성되었습니다.",
+      "createSuccessMultiple": "{count} 세션이 성공적으로 생성되었습니다",
+      "duplicateSuccess": "세션이 성공적으로 복제되었습니다.",
+      "duplicateSuccessMultiple": "{count} 세션이 성공적으로 복제되었습니다"
+    },
+    "duplicateDialog": {
+      "title": "중복 세션",
+      "description": "모든 메타데이터는 포함하되 결과는 포함하지 않는 세션 <nameStyle>{name}</nameStyle> 의 복사본을 생성합니다."
+    },
+    "errors": {
+      "failedToCreate": "새 세션을 생성하는 데 실패했습니다.",
+      "failedToCreateVersion": "세션 버전을 생성하는 데 실패했습니다.",
+      "nameAlreadyExists": "세션 이름이 이미 존재합니다. 새 이름을 선택해 주세요.",
+      "createFailed": "세션 생성에 실패했습니다.",
+      "duplicateFailed": "세션 복제에 실패했습니다."
+    },
+    "validation": {
+      "nameMinLength": "이름은 최소 2자 이상이어야 합니다.",
+      "templateRequired": "템플릿을 선택해 주세요.",
+      "maxDuration": "지속 시간은 {max} 이하이어야 합니다."
+    },
+    "placeholders": {
+      "estimate": "예상 소요 시간 (예: 1시간 30분)",
+      "elapsed": "경과 시간 (예: 2일 4시간)",
+      "selectUser": "사용자 선택",
+      "estimateHint": "예: 2시간 30분",
+      "noEstimate": "예상 비용이 설정되지 않았습니다."
+    },
+    "delete": {
+      "confirmMessage": "세션 {name}을 삭제하시겠습니까?",
+      "warning": "이 세션은 프로젝트에서 삭제됩니다. 하지만 이 세션의 과거 데이터는 프로젝트에 계속 남아 있습니다.",
+      "toast": {
+        "loading": "세션을 삭제하는 중...",
+        "success": "세션이 성공적으로 삭제되었습니다.",
+        "error": {
+          "title": "세션 삭제에 실패했습니다.",
+          "description": "세션을 삭제하는 동안 오류가 발생했습니다."
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "세션 {name}을 완료하시겠습니까?",
+      "warning": "세션이 완료되면 해당 세션은 영구적으로 보관되며 더 이상 업데이트할 수 없습니다.",
+      "fields": {
+        "completionDate": "완료일"
+      },
+      "placeholders": {
+        "pickDate": "날짜를 정하세요"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "남은 예상 시간:",
+      "recentResultsTitle": "최근 결과 요약",
+      "recentResultsDescription": "세션 결과 요약.",
+      "noRecentResults": "최근 세션 결과가 기록되지 않았습니다.",
+      "completionTrendTitle": "완료 추세",
+      "completionTrendDescription": "월별 완료된 세션 수.",
+      "noCompletedRuns": "지난 6개월 동안 완료된 실행 기록이 없습니다.",
+      "completionTrendTitle6Mo": "완료 추세 (지난 6개월)",
+      "noCompletedSessions6Mo": "지난 6개월 동안 완료된 세션이 없습니다."
+    },
+    "version": {
+      "title": "세션 기록 보기",
+      "notFound": "세션 버전을 찾을 수 없습니다.",
+      "selectVersion": "버전 선택",
+      "backToSession": "세션으로 돌아가기",
+      "backToLatest": "최신 버전으로 돌아가기",
+      "versionInfo": {
+        "created": "버전 {number} 생성됨",
+        "latestUpdated": "최신 버전 {number} 업데이트됨"
+      },
+      "renderer": {
+        "noEstimate": "견적 없음",
+        "noTimeLogged": "시간 기록 없음",
+        "noContent": "콘텐츠 없음",
+        "currentVersion": "현재 버전",
+        "previousVersion": "이전 버전"
+      },
+      "diff": {
+        "added": "추가됨",
+        "removed": "제거됨",
+        "changed": "변경됨"
+      }
+    },
+    "results": {
+      "section": "세션 로그",
+      "add": "세션 결과 추가",
+      "edit": "편집 세션 결과",
+      "editDescription": "세션 결과를 변경하고 완료되면 저장을 클릭하십시오.",
+      "details": "결과에 대한 자세한 내용을 여기에 입력하세요...",
+      "noResults": "아직 검색 결과가 추가되지 않았습니다.",
+      "noNotes": "이 결과에 대한 추가 메모는 없습니다.",
+      "deleteSuccess": "세션 결과가 성공적으로 삭제되었습니다.",
+      "deleteError": "세션 결과 삭제 실패",
+      "updateSuccess": "세션 결과가 성공적으로 업데이트되었습니다.",
+      "updateError": "세션 결과 업데이트에 실패했습니다.",
+      "linkCopied": "세션 결과 링크가 클립보드에 복사되었습니다.",
+      "copyFailed": "세션 결과 링크 복사에 실패했습니다.",
+      "confirmDelete": {
+        "title": "세션 결과 삭제",
+        "description": "이 세션 결과를 삭제하시겠습니까?"
+      }
+    },
+    "notFound": "세션을 찾을 수 없습니다."
+  },
+  "home": {
+    "dashboard": {
+      "title": "내 대시보드",
+      "users": "사용자 수는 {count, plural, =1 {명입니다. 사용자 수는} other {명입니다. 사용자 수는}}명입니다.",
+      "yourProjects": "여러분의 프로젝트",
+      "projects": "다음 항목에 접근할 수 있습니다: {count, plural, =1 {# 프로젝트} other {# 프로젝트}}",
+      "loading": "대시보드를 불러오는 중...",
+      "noItems": "지금 당신에게 맡겨진 일 중 당장 처리해야 할 일은 없습니다.",
+      "pendingRuns": "보류 중인 테스트 실행",
+      "activeSessions": "활성 세션",
+      "yourActiveSessions": "{count, plural, =0 {활성 세션 없음} =1 {활성 세션 수} other {활성 세션 수}}",
+      "yourPendingRuns": "{count, plural, =0 {보류 중인 테스트 실행 없음} =1 {활성 테스트 실행 수} other {활성 테스트 실행 수}}",
+      "yourAssignments": "여러분의 과제",
+      "totalTime": "총 예상 소요 시간: ",
+      "totalWorkEffort": "총 작업량: ",
+      "scheduleSpan": "일정 기간: "
+    },
+    "initialPreferences": {
+      "title": "설정을 변경하세요",
+      "description": "본인에게 가장 잘 맞는 기본 설정을 선택하세요. 프로필에서 언제든지 설정을 변경할 수 있습니다.",
+      "dateFormat": "날짜 형식",
+      "timeFormat": "시간 형식",
+      "timezonePlaceholder": "시간대를 검색하세요...",
+      "skip": "기본 설정 유지",
+      "save": "환경설정 저장",
+      "success": "환경설정이 업데이트되었습니다",
+      "error": "환경설정을 저장하는 동안 오류가 발생했습니다."
+    },
+    "noAccess": {
+      "title": "프로젝트 접근 권한 없음",
+      "description": "이 시스템의 어떤 프로젝트에도 접근할 수 없습니다.",
+      "contact": "프로젝트 접근 권한을 요청하려면 시스템 관리자에게 문의하십시오.",
+      "adminAddProject": "지금 바로 첫 번째 프로젝트를 추가하여 시작해 보세요!",
+      "footer": "테스트 계획 활동을 보고 참여하려면 접근 권한이 필요합니다."
+    },
+    "noProjectAccess": {
+      "description": "이 프로젝트에 대한 접근 권한이 없습니다.",
+      "contact": "프로젝트 관리자에게 연락하여 접근 권한을 요청하세요."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# 테스트 케이스} =1 {# 테스트 케이스} other {# 테스트 케이스}}",
+      "activeMilestones": "{count, plural, =0 {# 활성 마일스톤} =1 {# 활성 마일스톤} other {# 활성 마일스톤}}",
+      "activeRuns": "{count, plural, =0 {# 활성 실행} =1 {# 활성 실행} other {# 활성 실행}}",
+      "activeSessions": "{count, plural, =0 {# 활성 세션} =1 {# 활성 세션} other {# 활성 세션}}",
+      "issues": "{count, plural, =0 {# 문제} =1 {# 문제} other {# 문제}}"
+    }
+  },
+  "users": {
+    "description": "사용자 계정을 관리하고, 시스템 접근 수준을 설정하고, 전역 역할을 할당할 수 있습니다.",
+    "filter": "사용자 필터링...",
+    "profile": {
+      "title": "사용자 프로필",
+      "edit": {
+        "title": "프로필 수정",
+        "timezonePlaceholder": "시간대를 선택하거나 검색하세요...",
+        "timezoneRequired": "시간대 정보는 필수입니다.",
+        "avatarUpdated": "아바타가 성공적으로 업데이트되었습니다.",
+        "avatarUpdateError": "아바타 업데이트에 실패했습니다.",
+        "deleteAvatar": "아바타 삭제",
+        "deleteAvatarConfirm": "아바타를 정말로 삭제하시겠습니까?",
+        "emailDisabledForSso": "SSO 계정의 경우 이메일 주소를 변경할 수 없습니다. ID 제공업체를 통해 이메일 주소를 업데이트하십시오.",
+        "emailEditableForBoth": "이메일/비밀번호 로그인과 SSO(싱글 사인온) 로그인 모두 가능합니다. 이메일 주소 변경은 비밀번호 인증에만 영향을 미칩니다.",
+        "linkSsoProvider": "SSO 제공업체 링크"
+      },
+      "preferences": {
+        "title": "환경설정"
+      },
+      "access": {
+        "title": "입장"
+      },
+      "notifications": {
+        "title": "알림 설정",
+        "description": "알림 수신 방식을 맞춤 설정하세요",
+        "currentGlobal": "현재 전역 설정: {mode}",
+        "mode": {
+          "label": "알림 모드",
+          "useGlobal": "전역 설정을 사용하세요"
+        },
+        "options": {
+          "title": "추가 옵션",
+          "email": {
+            "label": "이메일 알림",
+            "description": "이메일을 통해 알림을 받으세요"
+          }
+        },
+        "success": {
+          "title": "설정이 저장되었습니다",
+          "description": "알림 설정이 업데이트되었습니다."
+        },
+        "error": {
+          "description": "알림 설정을 저장하는 데 실패했습니다."
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "비밀번호 변경",
+        "setPasswordButtonText": "비밀번호 설정",
+        "description": "현재 비밀번호와 새 비밀번호를 입력하여 계정 비밀번호를 변경하세요. 이 작업은 내부적으로 관리되는 비밀번호만 변경합니다. SSO(단일 로그인)를 통해 로그인하는 경우 해당 비밀번호는 변경되지 않습니다.",
+        "setPasswordDescription": "SSO를 통해 로그인하셨으며 아직 로컬 암호를 설정하지 않으셨습니다. 이메일/암호 로그인을 활성화하려면 새 암호를 입력하세요.",
+        "currentPasswordLabel": "현재 비밀번호",
+        "newPasswordLabel": "새 비밀번호",
+        "confirmPasswordLabel": "새 비밀번호를 확인하세요",
+        "validation": {
+          "passwordsDoNotMatch": "새 비밀번호가 일치하지 않습니다.",
+          "newPasswordTooShort": "새 비밀번호가 보안 요구 사항을 충족하지 않습니다."
+        },
+        "success": {
+          "passwordChanged": "비밀번호가 성공적으로 변경되었습니다."
+        }
+      },
+      "mentionedComments": {
+        "title": "댓글에서 언급됨",
+        "description": "당신이 언급된 댓글",
+        "noComments": "아직 댓글에서 당신의 이름이 언급되지 않았습니다.",
+        "comment": "논평",
+        "showingResults": "{start} - {end} 의 {total}를 표시합니다."
+      },
+      "twoFactor": {
+        "enable": "2단계 인증을 활성화하세요",
+        "disable": "장애를 입히다",
+        "disableNotAllowed": "귀사에서는 2단계 인증을 요구합니다.",
+        "ssoBypassNotice": "SSO 로그인은 이 2단계 인증 설정을 우회합니다. 모든 로그인에 2단계 인증을 적용하려면 관리자에게 문의하십시오.",
+        "regenerateCodes": "새로운 코드",
+        "setup": {
+          "description": "인증 앱(예: Google Authenticator 또는 Authy)으로 QR 코드를 스캔하고 인증 코드를 입력하세요.",
+          "backupCodesTitle": "백업 코드를 저장하세요",
+          "done": "코드를 저장했어요"
+        },
+        "disableConfirm": {
+          "title": "2단계 인증을 비활성화하시겠습니까?",
+          "description": "이렇게 하면 계정 보안이 약해집니다. 현재 사용 중인 2단계 인증 코드 또는 백업 코드를 입력하여 확인하세요.",
+          "placeholder": "코드를 입력하세요"
+        },
+        "regenerate": {
+          "title": "백업 코드 재생성",
+          "description": "이렇게 하면 기존 백업 코드가 무효화됩니다. 계속하려면 현재 사용 중인 2FA 코드를 입력하세요.",
+          "confirm": "코드 재생성",
+          "newCodesTitle": "새로운 백업 코드",
+          "newCodesDescription": "기존 코드는 더 이상 유효하지 않습니다. 새 코드를 안전한 곳에 저장해 두세요."
+        }
+      },
+      "apiTokens": {
+        "description": "API 토큰을 사용하면 외부 애플리케이션 및 스크립트가 사용자를 대신하여 TestPlanIt에 액세스할 수 있습니다. 토큰은 사용자 계정과 동일한 권한을 가집니다.",
+        "create": "토큰 생성",
+        "createTitle": "API 토큰 생성",
+        "createDescription": "외부 도구 및 스크립트를 인증하기 위한 새 API 토큰을 생성합니다.",
+        "nameLabel": "토큰 이름",
+        "namePlaceholder": "예: CI/CD 파이프라인, CLI 도구",
+        "noTokens": "아직 API 토큰이 생성되지 않았습니다.",
+        "expiryLabel": "만료일 (선택 사항)",
+        "expiryHint": "유통기한이 없는 경우 빈칸으로 두십시오.",
+        "tokenCreated": "토큰이 생성되었습니다",
+        "tokenCreatedDescription": "API 토큰이 성공적으로 생성되었습니다.",
+        "copyWarning": "지금 이 토큰을 복사하세요. 다시는 볼 수 없을 겁니다!",
+        "yourToken": "토큰",
+        "deleteTitle": "API 토큰을 삭제하시겠습니까?",
+        "deleteDescription": "이 작업은 되돌릴 수 없습니다. 이 토큰을 사용하는 모든 애플리케이션은 더 이상 인증할 수 없습니다.",
+        "readOnlyLabel": "읽기 전용",
+        "readOnlyDescription": "데이터를 조회만 하고 절대 수정하지 않아야 하는 AI 에이전트에 사용하십시오.",
+        "agentTokenLabel": "에이전트 토큰으로 표시",
+        "agentTokenDescription": "관리자가 에이전트 기반 변경 사항을 파악할 수 있도록 감사 로그 항목에 metadata.source: \"mcp\" 태그를 추가합니다.",
+        "readOnlyBadge": "읽기 전용",
+        "agentTokenBadge": "에이전트 토큰",
+        "errors": {
+          "nameRequired": "토큰 이름은 필수 입력 사항입니다."
+        }
+      }
+    },
+    "access": {
+      "guest": "손님"
+    },
+    "avatar": {
+      "update": "아바타 업데이트",
+      "remove": "아바타 제거",
+      "changeProfilePicture": "프로필 사진 변경",
+      "notAuthenticated": "아바타를 업로드하려면 로그인해야 합니다."
+    },
+    "deletedUser": "삭제된 사용자"
+  },
+  "userMenu": {
+    "viewProfile": "프로필 보기",
+    "locale": "장소",
+    "themes": {
+      "light": "빛",
+      "dark": "어두운",
+      "system": "체계",
+      "green": "녹색",
+      "purple": "보라",
+      "orange": "주황색"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "테스트 케이스 버전을 찾을 수 없습니다.",
+      "detailsRegion": "테스트 케이스 세부 정보",
+      "metadataRegion": "테스트 케이스 메타데이터",
+      "versionCreated": "버전 {version} 생성됨",
+      "latestVersionUpdated": "최신 버전 {version} 업데이트됨",
+      "historyView": "테스트 케이스 기록 보기"
+    },
+    "fields": {
+      "optionNotFound": "옵션을 찾을 수 없습니다",
+      "hasValue": "가치가 있다",
+      "noValue": "값 없음",
+      "hasDate": "날짜가 있습니다",
+      "noDate": "날짜 없음",
+      "hasText": "텍스트가 있습니다",
+      "noText": "텍스트 없음",
+      "hasLink": "링크가 있습니다",
+      "noLink": "링크 없음",
+      "hasSteps": "단계가 있습니다",
+      "noSteps": "단계 없음",
+      "unchecked": "확인되지 않음",
+      "linkedCases": "연관 사례",
+      "clickToViewFullContent": "전체 내용을 보려면 클릭하세요"
+    },
+    "steps": {
+      "add": "단계 추가",
+      "addSharedSteps": "공유 단계 추가",
+      "delete": "삭제 단계",
+      "confirmDelete": "삭제 단계 {number}를 확인하시겠습니까?",
+      "createSharedSteps": "공유 생성 {number, plural, one {단계} other {단계}}",
+      "sharedStepsName": "공유 단계 이름",
+      "sharedStepsDescription": "Enter a name for your new shared {number, plural, one {step} other {steps}}. This will include {number, plural, one {# selected step} other {# selected steps}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "공유 단계를 생성하려면 단계를 선택하고 이름을 입력하세요.",
+        "failedToCreateSharedStepGroupError": "공유 단계를 생성하는 데 실패했습니다. 다시 시도해 주세요.",
+        "sharedStepGroupCreatedSuccess": "공유 단계가 성공적으로 생성되었습니다!",
+        "genericSharedStepCreationError": "공유 단계를 생성하는 동안 알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.",
+        "errorCreatingSharedGroup": "공유 단계를 생성하는 데 실패했습니다. 다시 시도해 주세요.",
+        "sharedGroupCreatedSuccess": "공유 스텝 그룹이 성공적으로 생성되었습니다!"
+      },
+      "selectSharedStepsTitle": "공유 단계를 선택하세요",
+      "selectSharedStepsDescription": "테스트 케이스에 추가할 공유 단계를 선택하세요.",
+      "sharedStepsListPlaceholder": "공유 단계를 불러오는 중...",
+      "sharedStepsNamePlaceholder": "공유되는 단계를 식별할 이름을 입력하세요.",
+      "noSharedStepsFound": "이 프로젝트에 대한 공유 단계가 없습니다.",
+      "sharedStepGroupTitle": "공유 단계: {name}",
+      "confirmDeleteSharedStepBlock": "이 테스트 케이스에서 공유 스텝 블록 \"{name}\"을 제거하시겠습니까? 이렇게 해도 공유 스텝 그룹 자체는 삭제되지 않습니다.",
+      "removeBlockButton": "블록 제거",
+      "loadingSharedStepsItems": "로딩 단계...",
+      "noStepsInSharedGroup": "이 공유 스텝 그룹이 비어 있습니다.",
+      "searchSharedStepsPlaceholder": "공유 단계를 선택하세요...",
+      "stepsCountLabel": "{count, plural, =0 {단계 수} =1 {단계 수} other {단계 수}}",
+      "reviewSelectedStepsTitle": "선택한 단계 검토",
+      "noStepsInSelectedGroup": "선택된 그룹에는 단계가 없습니다.",
+      "sharedGroupSuffix": "(공통 단계)",
+      "unnamedSharedGroup": "이름 없는 공유 단계"
+    },
+    "testCase": {
+      "toggleAutomated": "자동 테스트 토글",
+      "editAttachmentsIndividually": "첨부 파일을 개별적으로 편집하세요.",
+      "automatedStatus": "자동화 테스트는 {status}입니다."
+    },
+    "templateNotAssignedWarning": "이 테스트 케이스는 현재 프로젝트 \"{projectName}\"에 할당되지 않은 템플릿 \"{templateName}\"을 사용합니다. 이 템플릿을 프로젝트에 할당하거나 테스트 케이스에서 다른 템플릿을 사용하도록 변경해야 할 수 있습니다.",
+    "orphanedStepsWarning": "이 테스트 케이스에는 단계가 있지만 현재 템플릿 \"{templateName}\"에는 단계 필드가 포함되어 있지 않습니다. 테스트 케이스에 단계 필드가 포함된 템플릿이 추가될 때까지 단계를 편집할 수 없습니다.",
+    "orphanedFieldsWarning": "이 테스트 케이스에는 {count, plural, =1 {# 필드 값} other {# 필드 값}} 이 있으며, {count, plural, =1 {은} other {이고}} 은 현재 템플릿 \"{templateName}\"에 포함되어 있지 않습니다. {count, plural, =1 {이 필드는} other {입니다. 이 필드들은}} 아래에 표시되지만 템플릿에 추가될 때까지 편집할 수 없을 수 있습니다.",
+    "title": "테스트 케이스 저장소",
+    "folders": "폴더",
+    "showDescendants": "모든 후손을 표시합니다",
+    "addFolder": "폴더 추가",
+    "emptyFolders": "위의 '폴더 추가' 버튼을 클릭하여 첫 번째 폴더를 추가하세요.",
+    "selectedAllCases": "{count, plural, =0 {모든 케이스 선택됨} one {모든 페이지에서 #개의 케이스 선택됨} other {모든 페이지에서 #개의 케이스 선택됨}}",
+    "deselectedAllCases": "모든 페이지에서 모든 사례를 선택 해제했습니다.",
+    "selectAllTooltip": "이 페이지의 모든 사례를 선택/선택 해제하세요.",
+    "selectAllShiftTooltip": "{count, plural, =0 {모든 페이지의 모든 사례 선택/선택 해제} one {모든 페이지의 #개 사례 선택/선택 해제} other {모든 페이지의 #개 사례 선택/선택 해제}}",
+    "deselectAllShiftTooltip": "모든 페이지에서 모든 사례를 선택/선택 해제합니다.",
+    "shiftClickHint": "Shift 키를 누른 상태로 모든 페이지를 선택/선택 해제하세요.",
+    "treeView": {
+      "expandAll": "모두 펼치기",
+      "collapseAll": "모두 접기",
+      "altKey": "Alt 키를 누른 상태로 하위 자식 노드를 모두 펼치거나 접으세요."
+    },
+    "dragDrop": {
+      "move": "이동하다",
+      "copy": "복사",
+      "promptTitle": "무엇을 하고 싶으세요?",
+      "copying": "… 복사 중",
+      "copyComplete": "{count, plural, =1 {케이스 1개를 {folder}} other {에 복사했습니다. #개의 케이스를 {folder}}}{dest, select, samename {} crossProject { 에 {projectName}} other {}}에 복사했습니다.",
+      "moveComplete": "{count, plural, =1 {1개의 케이스를 {folder}} other {로 이동했습니다. #개의 케이스를 {folder}}}{dest, select, samename {} crossProject { {projectName}} other {}}로 이동했습니다.",
+      "copyError": "{count, plural, =1 {{folder}} other {{folder}}}{dest, select, samename {} crossProject { {projectName}} other {}} 에 케이스 1개를 복사하는 데 실패했습니다.",
+      "moveError": "{count, plural, =1 {1개의 케이스를 {folder}} other {로 이동하는 데 실패했습니다. #개의 케이스를 {folder}}}{dest, select, samename {} crossProject { 로 이동하는 데 실패했습니다. {projectName}} other {}}",
+      "copyAlreadyRunning": "다른 복사본 제작이 이미 진행 중입니다. 완료될 때까지 잠시 기다려 주십시오.",
+      "currentSuffix": "(현재의)",
+      "moveDisabledSameFolder": "사건들은 이미 이 폴더에 있습니다.",
+      "dragPreviewCase": "테스트 케이스",
+      "dragPreviewCount": "{count, plural, =1 {# 테스트 케이스} other {# 테스트 케이스}}",
+      "modifierHintMac": "드래그하는 동안 ⇧ 키를 누른 상태로 이동하거나 ⌥ 키를 누른 상태로 복사하면 이 메뉴를 건너뛸 수 있습니다.",
+      "modifierHintWin": "드래그하는 동안 Shift 키를 누른 상태로 이동하거나 Ctrl 키를 누른 상태로 복사하면 이 메뉴를 건너뛸 수 있습니다."
+    },
+    "folderActions": {
+      "edit": "폴더 편집",
+      "delete": "폴더 삭제",
+      "rename": "폴더 이름 변경"
+    },
+    "cases": {
+      "filter": "필터 케이스...",
+      "selectFolder": "테스트 케이스를 추가하거나 표시할 폴더를 선택하세요.",
+      "selectCases": "테스트 케이스 선택",
+      "noTestCases": "표시할 테스트 케이스가 없습니다.",
+      "addCase": "케이스 추가",
+      "notFound": "테스트 케이스를 찾을 수 없습니다.",
+      "selectFilter": "필터 선택",
+      "testResultHistory": "시험 결과 내역",
+      "testResultHistoryDescription": "이 테스트 케이스에 대한 테스트 결과 기록을 확인하세요.",
+      "noTestResults": "이 테스트 케이스에 대한 테스트 결과를 찾을 수 없습니다.",
+      "unknownRun": "알 수 없는 실행",
+      "attempt": "시도",
+      "invalidProject": "잘못된 프로젝트입니다",
+      "noSearchResults": "검색 조건과 일치하는 사례가 없습니다.",
+      "bulkEdit": "일괄 편집",
+      "createTestRun": "테스트 실행 생성",
+      "copyMoveToProject": "복사/이동",
+      "export": "내보내다",
+      "quickScript": "퀵스크립트",
+      "cannotReorderAcrossPages": "여러 페이지에 걸쳐 있는 테스트 케이스의 순서를 변경할 수 없습니다. 순서를 변경하려면 페이지 크기 메뉴에서 '모두'를 선택하여 모든 케이스를 한 페이지에 표시하거나 다른 페이지에서 케이스 선택을 해제하세요. 선택한 케이스는 폴더로 드래그하여 이동할 수 있습니다.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "모두 보기 ({count})"
+        },
+        "textLongFormat": {
+          "label": "서식 있는 텍스트 형식"
+        },
+        "rowMode": {
+          "label": "테스트 케이스 행",
+          "multi": "단계별로 한 줄씩"
+        }
+      },
+      "importWizard": {
+        "title": "테스트 케이스 가져오기",
+        "fields": {
+          "workflowState": "워크플로우 상태",
+          "column": "컬럼 {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# 테스트 케이스} other {# 테스트 케이스}} 성공적으로 가져왔습니다"
+        },
+        "errors": {
+          "templateRequired": "템플릿 선택이 필요합니다.",
+          "folderRequired": "이 가져오기 위치를 선택하려면 폴더를 지정해야 합니다.",
+          "fileRequired": "CSV 또는 Markdown 파일이 필요합니다.",
+          "markdownParseFailed": "마크다운 파일을 구문 분석하는 데 실패했습니다.",
+          "markdownLlmFailed": "AI 구문 분석 기능을 사용할 수 없으므로 표준 구문 분석기를 사용합니다."
+        },
+        "page1": {
+          "fileType": {
+            "label": "파일 형식",
+            "csv": "CSV",
+            "markdown": "가격 인하"
+          },
+          "parsingMarkdown": "마크다운 파일을 파싱하는 중...",
+          "useAiParsing": "AI를 활용하여 현장 지도를 작성하세요",
+          "importLocation": {
+            "label": "수입 위치",
+            "singleFolder": "모든 사례를 하나의 폴더에 추가하세요",
+            "rootFolder": "모든 케이스와 폴더를 루트 폴더에 추가합니다(매핑 필요).",
+            "topLevel": "모든 케이스와 폴더를 최상위 레벨에 추가합니다(매핑 필요)."
+          },
+          "selectFolder": "폴더를 선택하세요",
+          "selectFolderPlaceholder": "폴더를 선택하세요...",
+          "delimiters": {
+            "tab": "꼬리표"
+          },
+          "hasHeaders": "첫 번째 행에는 열 이름이 포함되어 있습니다.",
+          "template": "저장소 사례 템플릿",
+          "rowMode": {
+            "single": "각 행은 하나의 테스트 케이스입니다.",
+            "multi": "테스트 케이스는 여러 행에 걸쳐 있을 수 있습니다."
+          }
+        },
+        "page2": {
+          "title": "CSV 열을 필드에 매핑",
+          "description": "CSV 파일의 각 열을 템플릿의 필드에 매핑하거나 무시하도록 선택할 수 있습니다.",
+          "ignoreColumn": "무시할 열",
+          "requiredFieldsWarning": "{count, plural, one {# 필수 입력 필드는} other {# 필수 입력 필드는}} 매핑되지 않았습니다"
+        },
+        "page3": {
+          "title": "현장 지도 작성 요약",
+          "mappingSummary": "지도 요약",
+          "folderSplitMode": {
+            "label": "폴더 계층 모드",
+            "plain": "텍스트 (분할 없음)",
+            "plainExample": "예시: 'This/is.a>Folder' → 'This/is.a>Folder'라는 이름의 단일 폴더",
+            "slash": "슬래시(/)로 구분",
+            "slashExample": "예시: 'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "점(.)으로 분할",
+            "dotExample": "예시: 'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "보다 큼(>)으로 나누기",
+            "greaterThanExample": "예시: 'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "미리보기 가져오기",
+          "showing": "Showing {start}-{end} of {total} cases",
+          "case": "케이스 {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "테스트 케이스 추가",
+      "name": "테스트 케이스 이름",
+      "namePlaceholder": "테스트 케이스 이름을 입력하세요",
+      "selectTemplate": "템플릿을 선택하세요",
+      "selectState": "주를 선택하세요",
+      "estimatePlaceholder": "예상 금액을 입력하세요",
+      "create": "테스트 케이스 생성",
+      "successMessage": "새로운 테스트 케이스가 추가되었습니다.",
+      "errorMessage": "새 테스트 케이스를 추가하는 중 알 수 없는 오류가 발생했습니다."
+    },
+    "columns": {
+      "selectCase": "케이스를 선택하세요",
+      "runOrder": "실행 순서",
+      "lastTestResult": "최종 결과",
+      "testedOn": "최근 테스트됨"
+    },
+    "actions": {
+      "archive": "보관소"
+    },
+    "parentFolder": "상위 폴더",
+    "rootFolder": "루트 폴더",
+    "removeParentFolder": "상위 폴더 삭제",
+    "createInSelectedFolder": "상위 폴더로 되돌리기",
+    "deleteCase": {
+      "title": "테스트 케이스 삭제",
+      "confirmMessageStart": "테스트 케이스를 삭제하시겠습니까? ",
+      "confirmMessageEnd": "?",
+      "warning": "이 테스트 케이스는 프로젝트에서 제거될 예정입니다. 하지만 이 테스트 케이스와 관련된 과거 데이터(결과 포함)는 프로젝트에 계속 남아 있습니다.",
+      "activeRunWarningMessage": "이 테스트 케이스는 {count, plural, =1 {# 활성 테스트 실행} other {# 활성 테스트 실행}}의 일부입니다. 이 테스트 케이스를 삭제하면 해당 실행 내에서 삭제된 것으로 표시됩니다."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {이 폴더를 삭제하면 모든 하위 폴더도 삭제됩니다. 삭제하시겠습니까?} one {이 폴더를 삭제하면 이 폴더와 모든 하위 폴더에 있는 테스트 케이스 1개도 삭제됩니다. 삭제하시겠습니까?} other {이 폴더를 삭제하면 이 폴더와 모든 하위 폴더에 있는 테스트 케이스 #개도 삭제됩니다. 삭제하시겠습니까?}}",
+      "warning": "이 폴더와 그 안에 있는 모든 테스트 케이스는 프로젝트에서 삭제됩니다. 하지만 해당 테스트 케이스의 과거 데이터(결과 포함)는 프로젝트에 계속 남아 있습니다.",
+      "confirm": "폴더 삭제를 확인하세요",
+      "success": "폴더와 모든 하위 폴더/케이스가 성공적으로 삭제되었습니다."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "해당 폴더 이름이 이미 존재합니다. 다른 이름을 선택해 주세요."
+      }
+    },
+    "views": {
+      "byAutomation": "오토메이션",
+      "allTemplates": "모든 템플릿",
+      "allStates": "모든 주",
+      "allCreators": "모든 크리에이터",
+      "allCases": "모든 사건",
+      "allAssignees": "모든 양수인",
+      "anyTag": "모든 태그",
+      "noTags": "태그 없음",
+      "byTag": "꼬리표",
+      "byIssue": "문제",
+      "anyIssue": "어떤 문제든",
+      "noIssues": "문제 없음"
+    },
+    "noFoldersTitle": "아직 폴더가 없습니다",
+    "noFoldersDescription": "먼저 테스트 케이스를 정리할 첫 번째 폴더를 만드세요.",
+    "noFoldersOrCasesNoPermission": "표시할 폴더나 테스트 케이스가 없습니다.",
+    "createFirstFolder": "첫 번째 폴더를 만드세요",
+    "bulkEdit": {
+      "title": "일괄 편집 {count, plural, one {# 케이스} other {# 케이스}}",
+      "description": "편집 중 {count, plural, one {# 선택된 사례} other {# 선택된 사례}}. 편집을 활성화하려면 필드를 선택하세요.",
+      "defineStepsTitle": "일괄 업데이트를 위한 단계 정의",
+      "saveNewSteps": "새로운 단계 저장",
+      "newStepsDefined": "새로운 단계가 정의되었습니다({count}) - 편집하려면 버튼을 클릭하세요",
+      "clearExistingStepsWarning": "기존 단계는 삭제됩니다.",
+      "warnings": {
+        "templateMismatch": {
+          "title": "여러 템플릿이 선택됨",
+          "description": "서로 다른 템플릿을 사용하는 케이스를 선택하면 표준 필드만 편집할 수 있습니다. 동일한 템플릿을 사용하는 케이스를 선택하면 동적 필드를 편집할 수 있습니다."
+        },
+        "junitLimitations": {
+          "title": "자동화된 테스트 케이스 편집의 제한 사항",
+          "description": "자동화된 테스트 결과에서 가져온 테스트 케이스의 경우, 예상 및 자동화 필드를 수정할 수 없습니다."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "오류 발생 사례",
+        "fetchErrorDescription": "선택한 사례에 대한 데이터를 불러올 수 없습니다. 모달 창을 닫고 다시 시도해 주세요.",
+        "updateErrorTitle": "업데이트 실패",
+        "updateFailed": "변경 사항을 저장하는 동안 오류가 발생했습니다. 데이터를 확인하고 다시 시도해 주세요.",
+        "fetchError": "사례 데이터를 가져오는 중 오류가 발생했습니다."
+      },
+      "success": {
+        "casesUpdated": "사례 정보가 성공적으로 업데이트되었습니다."
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "유효성 검사 오류",
+      "stepsCannotBeBulkEdited": "단계는 일괄 편집할 수 없습니다.",
+      "stepsInfoTitle": "단계 정보",
+      "stepsCannotBeBulkEditedInfo": "단계는 일괄 편집할 수 없습니다. 각 사례를 개별적으로 편집하여 단계를 수정하십시오.",
+      "confirmDeleteCases": "{count, plural, one {# 선택된 사례} other {# 선택된 사례}}를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "replaceAll": "모두 교체",
+      "searchReplace": "검색 및 바꾸기",
+      "searchFor": "검색",
+      "replaceWith": "다음으로 교체하세요",
+      "searchText": "검색할 텍스트를 입력하세요",
+      "replacementText": "대체 텍스트를 입력하세요",
+      "useRegex": "정규 표현식을 사용하세요",
+      "caseSensitive": "대소문자 구분",
+      "regexHint": "모든 문자는 .*로, 숫자는 \\d+로, 단어는 \\w+로 입력하세요. 그룹을 캡처하려면 (패턴)을 사용한 다음 $1, $2 등으로 표시하세요.",
+      "preview": "시사",
+      "matches": "성냥",
+      "noMatches": "일치하는 항목이 없습니다.",
+      "invalidRegexPattern": "잘못된 정규 표현식 패턴",
+      "searchPatternRequired": "검색 패턴이 필요합니다.",
+      "stepsSearchReplaceInfo": "찾기 및 바꾸기 기능은 단계 설명과 예상 결과 모두에 적용됩니다."
+    },
+    "exportModal": {
+      "title": "내보내기 테스트 케이스",
+      "description": "아래에서 내보내기 옵션을 선택하세요.",
+      "scope": {
+        "selected": "선택됨 ({count})",
+        "allFiltered": "전체 (현재 보기) ({count})",
+        "allProject": "프로젝트의 모든 것 ({count})"
+      },
+      "format": {
+        "label": "체재",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "가격 인하"
+      },
+      "columns": {
+        "all": "모두",
+        "visible": "보이는"
+      },
+      "delimiter": {
+        "label": "구분 기호",
+        "placeholder": "구분 기호를 선택하세요...",
+        "comma": "쉼표(,)",
+        "semicolon": "세미콜론(;)",
+        "colon": "콜론(:)",
+        "pipe": "파이프(|)"
+      },
+      "textLongFormat": {
+        "label": "텍스트 장문 형식"
+      },
+      "attachmentFormat": {
+        "label": "첨부 파일 형식",
+        "names": "이름",
+        "json": "JSON",
+        "embedded": "이미지 삽입"
+      },
+      "stepsFormat": {
+        "label": "단계 형식",
+        "plainText": "일반 텍스트"
+      },
+      "rowMode": {
+        "label": "케이스당 행 수",
+        "single": "케이스당 한 줄씩",
+        "multi": "단계별로 여러 행"
+      },
+      "comingSoon": "곧 출시 예정",
+      "exporting": "수출 중...",
+      "exportError": "내보내기에 실패했습니다. 다시 시도해 주세요."
+    },
+    "quickScript": {
+      "title": "퀵스크립트",
+      "description": "선택한 테스트 케이스를 템플릿 또는 AI를 사용하여 자동화 스크립트로 변환합니다.",
+      "templatePlaceholder": "템플릿을 선택하세요...",
+      "searchPlaceholder": "템플릿을 검색하세요...",
+      "noTemplatesFound": "템플릿을 찾을 수 없습니다.",
+      "outputModeLabel": "출력 모드",
+      "outputModeSingle": "단일 파일 ({count, plural, one {# 경우} other {모든 # 경우}})",
+      "outputModeIndividual": "{count, plural, one {개별 파일(.zip)} other {개별 파일(.zip)}}",
+      "casesToExport": "{count, plural, one {# 경우} other {# 경우}} 내보내기",
+      "exportSuccess": "내보내기가 성공적으로 완료되었습니다.",
+      "noAvailableTemplates": "사용 가능한 템플릿이 없습니다. 관리자에게 문의하세요."
+    },
+    "aiExport": {
+      "toggleLabel": "AI로 생성",
+      "generating": "생성 중...",
+      "generatingProgress": "{current} 의 {total} 생성 중...",
+      "generatingBatch": "하나의 파일에 {count, plural, one {# 케이스} other {# 케이스}} 를 생성하는 중...",
+      "previewTitle": "내보내기 미리보기",
+      "previewDescription": "{count, plural, one {# 파일} other {# 파일}} 생성됨",
+      "copySuccess": "클립보드에 복사됨",
+      "fallbackBadge": "템플릿을 사용하여 생성되었습니다(AI 사용 불가).",
+      "retryButton": "AI 생성 재시도",
+      "aiGenerated": "AI가 생성함",
+      "templateGenerated": "템플릿 생성됨",
+      "truncatedWarning": "출력이 잘렸습니다. 모델이 토큰 제한에 도달했습니다. 배치 크기를 줄이거나 프롬프트 구성에서 최대 출력 토큰 수를 늘려 보세요.",
+      "contextFiles": "{count, plural, one {(# 컨텍스트 파일)} other {(# 컨텍스트 파일)}}",
+      "noCodeContextHint": "코드 저장소가 구성되지 않았습니다. AI는 표준 프레임워크 패턴을 사용합니다.",
+      "generatingParallelProgress": "{done} 개의 {total} 개의 파일이 생성되었습니다...",
+      "cancelledGeneration": "취소"
+    },
+    "duplicates": {
+      "findDuplicates": "중복 항목 찾기",
+      "viewResults": "보기 {count, plural, one {# 결과} other {# 결과}}",
+      "retryScan": "스캔 재시도",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "AI를 활용하여 결과 향상...",
+      "scanComplete": "중복 분석 완료 — {count, plural, =0 {중복 항목 없음} one {잠재적 중복 항목 수} other {잠재적 중복 항목 수}}",
+      "scanFailed": "중복 분석에 실패했습니다.",
+      "scanFailedDescription": "예기치 않은 오류가 발생했습니다",
+      "pageTitle": "중복 후보자",
+      "pageDescription": "최근 검사에서 발견된 중복 테스트 케이스를 검토하십시오.",
+      "rescan": "재스캔",
+      "cancelScan": "스캔 취소",
+      "loading": "중복 후보를 불러오는 중...",
+      "noDuplicatesFound": "중복된 항목이 없습니다.",
+      "noDuplicatesDescription": "마지막 스캔이 완료되었지만 일치하는 쌍이 없습니다.",
+      "loadMore": "더 보기",
+      "filterPlaceholder": "중복 항목을 필터링합니다...",
+      "columnConfidence": "신뢰",
+      "columnCaseA": "사례 A",
+      "columnCaseB": "사례 B",
+      "columnMatchedFields": "일치하는 필드",
+      "columnScore": "점수",
+      "compareButton": "비교하다",
+      "viewCaseDetails": "사건 상세 정보를 확인하세요",
+      "selectAll": "모두 선택하세요",
+      "selectRow": "행을 선택하세요",
+      "selected": "{count, plural, one {# 선택됨} other {# 선택됨}}",
+      "bulkDismiss": "중복되지 않음 ({count})",
+      "bulkLink": "관련 링크 ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# 쌍 해제됨} other {# 쌍 해제됨}}",
+      "bulkLinkSuccess": "{count, plural, one {# 연결된 쌍} other {# 연결된 쌍}}",
+      "bulkError": "일부 작업에 실패했습니다. 다시 시도해 주세요.",
+      "tableHint": "행을 클릭하거나 비교 버튼을 클릭하여 중복된 쌍을 검토하고 해결하세요.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "이러한 잠재적 중복 항목을 비교하고 해결 방법을 선택하십시오.",
+      "selectPrimary": "병합을 위한 기본 사례로 선택하려면 해당 사례를 클릭하십시오.",
+      "selectedAsPrimary": "기본으로 선택됨",
+      "mergeButton": "기본 유지",
+      "linkButton": "관련 링크",
+      "dismissButton": "중복이 아닙니다",
+      "merging": "병합 중...",
+      "linking": "연결 중...",
+      "dismissing": "해고합니다...",
+      "mergeSuccess": "케이스가 성공적으로 병합되었습니다. {runsTransferred, plural, =0 {전송된 테스트 실행 없음} one {전송된 테스트 실행 수} other {전송된 테스트 실행 수}}.",
+      "linkSuccess": "관련 사건으로 연결되었습니다.",
+      "dismissSuccess": "해당 쌍은 삭제되었습니다. 향후 스캔에서 나타나지 않습니다.",
+      "resolveError": "중복된 항목을 찾지 못했습니다. 다시 시도해 주세요.",
+      "loadingDetails": "사건 상세 정보를 불러오는 중...",
+      "caseDetailsError": "사건 세부 정보를 불러오는 데 실패했습니다.",
+      "sourceLabel": "원천",
+      "fieldValuesLabel": "필드 값",
+      "lastRunLabel": "마지막 달리기",
+      "noFieldValues": "필드 값이 없습니다",
+      "noLastRun": "절대 뛰지 마세요",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "폴더 없음",
+      "duplicateWarning": "중복 가능성이 있는 항목이 발견되었습니다.",
+      "duplicateWarningDescription": "{count, plural, one {# 기존 사례} other {# 기존 사례}} 는 유사한 기능을 포함할 수 있습니다.",
+      "duplicateWarningReview": "검토",
+      "importWarning": "중복일 가능성이 있습니다.",
+      "importWarningTooltip": "이 사건명은 {count, plural, one {# 기존 사건} other {# 기존 사건}}: {names}와 유사합니다.",
+      "importIntraWarning": "가져오기 내 중복",
+      "importIntraWarningTooltip": "이 가져오기의 행 {rows} 은 이름이 같거나 매우 유사합니다.",
+      "checkingDuplicates": "중복 항목을 확인하는 중..."
+    },
+    "generateTestCases": {
+      "buttonText": "테스트 케이스 생성",
+      "title": "AI를 사용하여 테스트 케이스를 생성하세요",
+      "description": "AI를 활용하여 외부 이슈 또는 문서를 기반으로 포괄적인 테스트 케이스를 자동으로 생성하세요.",
+      "loadingResults": "생성된 테스트 케이스를 불러오는 중...",
+      "generatingPreparing": "요청 준비 중...",
+      "generatingCallingAi": "AI가 테스트 케이스를 생성하기를 기다리는 중...",
+      "generatingStreaming": "AI가 테스트 케이스 {count}를 생성하고 있습니다...",
+      "generatingStreamingPage": "AI가 테스트 케이스 {count} 를 생성하고 있습니다. — {total}의 {current} 페이지 : {page}",
+      "generatingProcessing": "생성된 테스트 케이스를 처리 중...",
+      "generatingHint": "원본 자료의 복잡성에 따라 다소 시간이 걸릴 수 있습니다.",
+      "steps": {
+        "selectIssue": "소스 선택",
+        "selectTemplate": "템플릿을 선택하세요",
+        "reviewGenerated": "검토 및 가져오기"
+      },
+      "selectSource": {
+        "title": "요구사항 소스를 선택하세요",
+        "description": "테스트 케이스를 이슈 또는 요구사항 문서에서 생성할지 여부를 선택하세요.",
+        "folderContextTip": "\"{folderName}\" 및 상위/하위 폴더의 기존 테스트 케이스가 중복을 방지하기 위한 컨텍스트로 사용됩니다. 진행하기 전에 올바른 폴더를 선택했는지 확인하십시오.",
+        "currentFolder": "현재 폴더",
+        "fromIssue": "문제에서",
+        "fromDocument": "문서에서",
+        "documentTitle": "문서 제목",
+        "documentTitlePlaceholder": "요구사항 문서의 제목을 입력하세요",
+        "documentDescription": "요구사항 문서",
+        "documentDescriptionPlaceholder": "요구사항 문서의 내용을 여기에 붙여넣으세요...",
+        "documentPriority": "우선순위 (선택 사항)",
+        "selectPriority": "우선순위를 선택하세요",
+        "saveDocument": "문서 저장 요구 사항",
+        "fromUrl": "URL에서",
+        "recentGenerations": "최근 URL에서 테스트 케이스 생성 작업",
+        "recentJobInfo": "{pages, plural, one {# 페이지} other {# 페이지}}{hasTestCases, select, true { · {testCases, plural, one {# 테스트 케이스} other {# 테스트 케이스}}} other {}}",
+        "recentJobHasResults": "검토할 준비가 되었습니다",
+        "recentJobClickToGenerate": "클릭하여 테스트 케이스를 생성하세요",
+        "recentJobCrawling": "기어가는 중... {pages, plural, one {# 페이지} other {# 페이지}} 현재까지",
+        "removeJobTitle": "세대 제거",
+        "confirmRemoveJob": "이렇게 하면 캐시된 크롤링 결과와 생성된 테스트 케이스가 모두 삭제됩니다. 동일한 URL에서 언제든지 다시 생성할 수 있습니다.",
+        "loadingRecentJobs": "최근 채용 공고 불러오는 중...",
+        "urlInput": "페이지 URL",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "이 URL에는 무엇이 포함되어 있습니까?",
+        "urlModeRequirements": "요구 사항",
+        "urlModeRequirementsHint": "이 페이지는 무엇을 만들어야 하는지 설명합니다.",
+        "urlModeApplication": "애플리케이션",
+        "urlModeApplicationHint": "Page는 테스트할 앱입니다.",
+        "urlValidationError": "http:// 또는 https://로 시작하는 유효한 URL을 입력하세요.",
+        "followLinks": "링크를 따라가세요",
+        "followLinksHint": "입력한 URL과 동일한 도메인에 있는 페이지만 크롤링됩니다.",
+        "maxDepth": "최대 깊이",
+        "maxPages": "최대 페이지 수",
+        "crawlProgress": "{current, plural, one {지금까지 가져온 페이지 수...} other {지금까지 가져온 페이지 수...}}",
+        "generatingSinglePage": "테스트 케이스를 생성하는 중...",
+        "generatingSetup": "테스트 케이스 생성을 준비 중...",
+        "robotsSkipped": "{count, plural, one {# 건너뛴 페이지 수} other {# 건너뛴 페이지 수}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "외부 이슈를 선택하세요",
+        "description": "외부 시스템(예: Jira)에서 테스트 케이스를 생성할 이슈를 선택하세요.",
+        "searchButton": "이슈 검색"
+      },
+      "selectTemplate": {
+        "title": "테스트 케이스 템플릿을 선택하세요",
+        "description": "테스트 케이스 생성에 사용할 템플릿을 선택하세요. AI는 선택한 템플릿에 따라 필드를 채웁니다.",
+        "placeholder": "템플릿을 선택하세요...",
+        "fieldsDescription": "AI가 자동으로 입력할 필드를 선택하세요. 필수 필드는 항상 포함됩니다.",
+        "requiredOnly": "필수 항목만 해당"
+      },
+      "addNotes": {
+        "title": "메모 및 안내 추가",
+        "description": "AI가 더 나은 테스트 케이스를 생성할 수 있도록 추가적인 맥락과 지침을 제공하세요.",
+        "quantity": "생성할 테스트 케이스 수",
+        "placeholder": "테스트 케이스 생성에 대한 구체적인 지침을 추가하세요...\n\n예시:\n• 보안 테스트에 집중\n• 예외 상황 및 경계 조건 포함\n• 정상 경로 및 오류 시나리오 모두 테스트\n• 모바일 및 데스크톱 시나리오 고려\n• API 테스트에 집중",
+        "suggestions": "빠른 제안:",
+        "quantityOptions": {
+          "justOne": "단 하나",
+          "couple": "커플(2)",
+          "few": "몇 개(2-3개)",
+          "several": "여러 개(4-6개)",
+          "many": "많은 (7-10)",
+          "maximum": "최고"
+        },
+        "suggestionItems": {
+          "security": "보안 테스트에 집중하세요",
+          "edgeCases": "예외적인 경우를 포함시키세요",
+          "happyPath": "정상 경로만 테스트하세요.",
+          "mobile": "모바일 환경을 고려하십시오.",
+          "api": "API 테스트에 집중하세요",
+          "accessibility": "접근성 테스트를 포함하세요"
+        }
+      },
+      "review": {
+        "title": "생성된 테스트 케이스를 검토하세요",
+        "description": "AI가 생성한 테스트 케이스를 검토하고 필요한 수정을 거쳐 가져올 케이스를 선택합니다.",
+        "selected": "{count} > {total} 이 선택되었습니다.",
+        "moreSteps": "... 그리고 {count, plural, one {# 추가 단계} other {# 추가 단계}}",
+        "templateFields": "템플릿 필드:",
+        "moreFields": "... 그리고 {count, plural, one {# 추가 필드} other {# 추가 필드}}",
+        "crawledUrls": "{count, plural, one {# 크롤링된 페이지 수} other {# 크롤링된 페이지 수}}",
+        "spaWarning": "이 페이지는 JavaScript 렌더링이 필요할 수 있습니다. 검색 결과가 불완전할 수 있습니다.",
+        "filterByPage": "페이지별 필터링",
+        "allPages": "모든 페이지 ({pages, plural, one {# 페이지} other {# 페이지}}, {cases, plural, one {# 사례} other {# 사례}})"
+      },
+      "generatingLegacy": "AI를 이용한 테스트 케이스 생성...",
+      "expandProgress": "{done} {total} 이 생성되었습니다.",
+      "import": "{count, plural, =0 {테스트 케이스 가져오기} =1 {테스트 케이스 1개 가져오기} other {테스트 케이스 #개 가져오기}}",
+      "importing": "{count, plural, =0 {테스트 케이스를 가져오는 중...} =1 {테스트 케이스 1개를 가져오는 중...} other {테스트 케이스 #개를 가져오는 중...}}",
+      "openInExternalSystem": "{provider}에서 열기",
+      "externalSystem": "외부 시스템",
+      "autoGenerateTags": "테스트 케이스에 대한 태그를 자동으로 생성합니다.",
+      "success": {
+        "imported": "{count, plural, =1 {테스트 케이스 1개를 성공적으로 가져왔습니다.} other {테스트 케이스 #개를 성공적으로 가져왔습니다.}}"
+      },
+      "importData": {
+        "issueDescription": "테스트 케이스 생성과 관련된 외부 문제",
+        "generatedFolderName": "생성됨"
+      },
+      "errors": {
+        "generateFailed": "테스트 케이스 생성에 실패했습니다. 다시 시도해 주세요.",
+        "importFailed": "테스트 케이스를 가져오는 데 실패했습니다. 다시 시도해 주세요.",
+        "noTestCasesGenerated": "테스트 케이스가 생성되지 않았습니다. 다른 입력값을 사용하여 다시 시도해 주세요.",
+        "jobNoLongerAvailable": "이 생성 기능은 더 이상 사용할 수 없습니다. 테스트 케이스 생성 마법사를 사용하여 새 생성을 시작하십시오.",
+        "noAiModel": "이 프로젝트에는 AI 모델이 설정되어 있지 않습니다. 프로젝트 설정에서 AI 모델을 설정해 주세요.",
+        "noIssueSelected": "테스트 케이스를 생성할 이슈를 선택하세요.",
+        "noDocumentProvided": "요구 문서에 대한 세부 정보를 제공해 주십시오.",
+        "noTemplateSelected": "테스트 케이스에 사용할 템플릿을 선택해 주세요.",
+        "noFieldsSelected": "콘텐츠를 생성할 필드를 하나 이상 선택해 주세요.",
+        "noTestCasesSelectedForImport": "가져올 테스트 케이스를 최소 하나 이상 선택하십시오.",
+        "templateRequired": "템플릿 선택이 필요합니다. 뒤로 돌아가서 템플릿을 선택하세요.",
+        "repositoryNotFound": "프로젝트 저장소를 찾을 수 없습니다. 관리자에게 문의하십시오.",
+        "workflowNotConfigured": "프로젝트 워크플로가 구성되지 않았습니다. 프로젝트 설정을 확인하십시오.",
+        "authenticationError": "인증 오류가 발생했습니다. 페이지를 새로고침하고 다시 시도해 주세요.",
+        "caseCreationFailed": "테스트 케이스 생성에 실패했습니다: {name}",
+        "caseAlreadyExists": "테스트 케이스 \"{name}\"이 폴더에 이미 존재합니다.",
+        "invalidTemplateConfig": "테스트 케이스 \"{name} \"에 대한 템플릿 구성이 잘못되었습니다.",
+        "nameTooLong": "테스트 케이스 이름 \"{name}\"이 너무 깁니다. 더 짧은 이름을 사용해 주세요.",
+        "caseCreationError": "\"{name}\" 생성 실패: {error}",
+        "templateNotFound": "선택한 템플릿을 찾을 수 없습니다. 페이지를 새로고침하고 다시 시도해 주세요.",
+        "repositoryConfigError": "프로젝트 저장소 구성 오류입니다. 관리자에게 문의하십시오.",
+        "workflowConfigError": "프로젝트 워크플로 구성 오류입니다. 프로젝트 설정을 확인하십시오.",
+        "permissionDenied": "이 프로젝트에서는 테스트 케이스를 생성할 권한이 없습니다.",
+        "validationFailed": "데이터 유효성 검사에 실패했습니다. 테스트 케이스 내용을 확인하고 다시 시도해 주세요.",
+        "databaseError": "데이터베이스 연결 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+        "genericImportError": "가져오기 실패: {error}",
+        "networkRoutingError": "네트워크 라우팅 또는 서버 구성 문제 - API 응답 대신 HTML 오류 페이지가 수신되었습니다.",
+        "invalidSourceConfig": "잘못된 소스 구성입니다",
+        "failedToCreateCaseVersion": "케이스 버전 생성에 실패했습니다.",
+        "noUrlProvided": "테스트 케이스를 생성할 URL을 입력하세요.",
+        "urlFetchFailed": "제공된 URL에서 콘텐츠를 가져오는 데 실패했습니다. URL을 확인하고 다시 시도해 주세요.",
+        "llm": {
+          "genericTitle": "AI 생성 오류",
+          "genericMessage": "AI를 이용한 테스트 케이스 생성 중 오류가 발생했습니다. 다시 시도하거나 입력값을 조정해 주세요.",
+          "overloaded": {
+            "title": "서비스가 일시적으로 이용 불가합니다.",
+            "message": "현재 AI 서비스에 접속자가 많아 속도가 느립니다. 잠시 후 다시 시도해 주세요."
+          },
+          "quota": {
+            "title": "사용 한도에 도달했습니다",
+            "message": "해당 기간 동안 AI 사용 한도에 도달했습니다. 나중에 다시 시도하거나 관리자에게 문의하십시오."
+          },
+          "timeout": {
+            "title": "요청 시간 초과",
+            "message": "AI 요청 완료에 너무 오랜 시간이 걸렸습니다. 이는 요구 사항이 복잡하거나 테스트 케이스 수가 많은 경우에 발생할 수 있습니다."
+          },
+          "network": {
+            "title": "네트워크 오류",
+            "message": "AI 서비스에 연결할 수 없습니다. 인터넷 연결 상태를 확인하고 다시 시도해 주세요."
+          },
+          "unauthorized": {
+            "title": "AI 서비스 인증 실패",
+            "message": "AI 서비스에서 저희 자격 증명을 거부했습니다. 관리자는 관리자 설정에서 LLM 통합의 API 키를 검토해야 합니다."
+          },
+          "forbidden": {
+            "title": "AI 서비스 접근이 거부되었습니다",
+            "message": "AI 서비스에서 이 요청을 거부했습니다. 관리자가 LLM 통합의 권한과 프로젝트 접근 권한을 확인해야 합니다."
+          },
+          "projectNotFound": {
+            "title": "프로젝트를 찾을 수 없습니다.",
+            "message": "해당 프로젝트를 찾을 수 없거나, 여기에서 AI 생성 기능을 사용할 권한이 없습니다."
+          },
+          "noIntegration": {
+            "title": "LLM 통합이 활성화되어 있지 않습니다.",
+            "message": "이 프로젝트에는 활성화된 LLM 통합 기능이 구성되어 있지 않습니다. 관리자가 관리자 설정에서 통합 기능을 활성화해야 합니다."
+          },
+          "invalidRequest": {
+            "title": "잘못된 요청입니다",
+            "message": "AI 생성 요청에 필요한 정보가 누락되었습니다. 페이지를 새로고침하고 다시 시도해 주세요."
+          },
+          "retryButton": "다시 해 보다",
+          "dismissButton": "해고하다",
+          "suggestionsHeading": "제안",
+          "suggestions": {
+            "retryLater": "몇 분 후에 다시 시도해 보세요.",
+            "contactAdmin": "문제가 지속되면 관리자에게 문의하십시오.",
+            "checkStatus": "AI 서비스 상태를 확인하세요",
+            "checkNetwork": "인터넷 연결 상태를 확인하세요."
+          },
+          "timestampLabel": "오류가 발생했습니다.",
+          "showDetails": "세부 정보 보기",
+          "hideDetails": "세부 정보 숨기기",
+          "copyDetails": "복사 세부 정보",
+          "detailsCopied": "오류 세부 정보가 클립보드에 복사되었습니다."
+        }
+      },
+      "unsavedEdits": {
+        "title": "저장되지 않은 편집 내용",
+        "description": "{count, plural, =1 {저장되지 않은 편집 내용이 있는 테스트 케이스가 1개 있습니다.} other {저장되지 않은 편집 내용이 있는 테스트 케이스가 #개 있습니다.}}",
+        "warning": "저장하지 않고 진행하면 변경 내용이 손실됩니다.",
+        "saveAllAndImport": "모두 저장 및 가져오기",
+        "discardAndImport": "수정 내용 삭제 및 가져오기"
+      },
+      "linkedIssuesDroppedTitle": "일부 연관된 문제가 포함되지 않았습니다.",
+      "linkedIssuesDropped": "{count, plural, =1 {# 연결된 이슈가 삭제되었습니다} other {# 연결된 이슈가 삭제되었습니다}} 토큰 예산 부족으로 인해: {keys}.",
+      "linkedIssuesPreviewHeading": "포함될 관련 이슈"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "태그 추가",
+      "title": "새 태그 추가",
+      "fields": {
+        "name_error": "태그 이름은 필수입니다."
+      },
+      "errors": {
+        "nameExists": "이 이름의 태그가 이미 존재합니다."
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "이 이름의 태그가 이미 존재합니다."
+      }
+    },
+    "filterPlaceholder": "필터 태그...",
+    "defaultName": "이름 없는 태그",
+    "noProject": "프로젝트 없음",
+    "description": "태그를 사용하여 테스트 케이스와 세션을 관리하고 정리하세요.",
+    "detail": {
+      "title": "태그 세부 정보",
+      "filterPlaceholder": "항목을 필터링하세요...",
+      "noResults": "항목을 찾을 수 없습니다.",
+      "noFilterResults": "현재 필터 조건에 맞는 항목이 없습니다.",
+      "filters": {
+        "hideCompletedSessions": "완료된 세션 숨기기",
+        "hideCompletedTestRuns": "완료된 테스트 실행 숨기기",
+        "caseTypeLabel": "케이스 유형",
+        "allCases": "모두"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "검색 태그...",
+      "searchOrAddPlaceholder": "검색 또는 태그 추가...",
+      "noOptions": "옵션 없음"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "첨부파일 뷰어"
+    },
+    "delete": {
+      "confirmMessage": "이 첨부 파일을 정말로 삭제하시겠습니까?",
+      "deferredMessage": "이 첨부 파일은 저장하면 삭제됩니다."
+    }
+  },
+  "runs": {
+    "notFound": "테스트 실행을 찾을 수 없습니다.",
+    "add": {
+      "title": "테스트 실행 추가",
+      "description": "프로젝트에 새 테스트 실행을 추가합니다.",
+      "success": {
+        "title": "테스트 실행이 성공적으로 추가되었습니다.",
+        "description": "테스트 실행 기능이 프로젝트에 추가되었습니다.",
+        "descriptionMultiple": "{count, plural, one {# 테스트 실행 횟수} other {# 테스트 실행 횟수}} '{name} '에 대해 테스트 실행이 생성되었습니다."
+      },
+      "estimates": {
+        "manual": "예상 수동 작업 시간",
+        "automated": "예상 자동 처리 시간",
+        "mixed": "예상 수동/자동 처리 시간"
+      },
+      "creatingProgress": "{total}의 테스트 실행 {current} 을 생성하는 중..."
+    },
+    "magicSelect": {
+      "title": "매직 셀렉트",
+      "description": "테스트 실행 컨텍스트에 기반한 AI 기반 테스트 케이스 선택",
+      "counting": "관련 테스트 케이스를 찾고 있습니다...",
+      "reasoning": "AI 추론",
+      "reviewSelection": "제안된 테스트 케이스를 검토하세요.",
+      "viewSuggested": "추천 사례 보기",
+      "tokenUsage": "{total} 토큰 사용됨",
+      "noLlmIntegration": "AI 기능을 사용하려면 LLM 통합이 필요합니다. 프로젝트 설정에서 LLM 통합을 구성하십시오.",
+      "configure": {
+        "title": "테스트 케이스 범위",
+        "description": "저장소에서 {count, plural, =1 {# 테스트 케이스} other {# 테스트 케이스}} 를 찾았습니다.",
+        "descriptionFiltered": "저장소에서 {count, plural, =1 {# 관련 가능성이 있는 테스트 케이스} other {# 관련 가능성이 있는 테스트 케이스}} 를 찾았습니다. {total, plural, =1 {에서 찾은 총 개수는} other {# 총 개수는}} 입니다.",
+        "noMatchesTitle": "일치하는 테스트 케이스를 찾을 수 없습니다.",
+        "noMatchesDescription": "테스트 실행 이름과 설명이 어떤 테스트 케이스와도 일치하지 않습니다. 이전 단계로 돌아가서 기능 이름, 구성 요소 이름 또는 테스트 케이스에 나타나는 키워드와 같은 더 구체적인 세부 정보를 추가하세요.",
+        "maxResultsTitle": "최대 테스트 케이스 일치 수",
+        "maxResultsDescription": "검색 조건이 많은 테스트 케이스와 일치했습니다. 보다 구체적인 결과를 얻으려면 이전 단계로 돌아가 테스트 실행에 더 구체적인 세부 정보를 추가하십시오.",
+        "batchSize": "배치 크기",
+        "batchSizeAll": "모든 경우 (단일 요청)",
+        "batchSizePercent": "{percent}% ({count} 경우)",
+        "requestsNeeded": "{count, plural, =1 {# AI 요청이 이루어집니다} other {# AI 요청이 이루어집니다}}",
+        "batchNote": "모든 배치의 결과가 합산됩니다."
+      },
+      "loading": {
+        "batch": "{current} 배치 처리 중 {total}",
+        "analyzing": "테스트 케이스 분석 중...",
+        "progress": "{analyzed} 개 테스트 케이스 중 {total} 개를 분석했습니다...",
+        "waitingForAi": "AI 응답을 기다리는 중 (배치 {batch} of {total})...",
+        "selectedSoFar": "{count, plural, =1 {# 지금까지 선택된 테스트 케이스} other {# 지금까지 선택된 테스트 케이스}}",
+        "resolving_integration": "AI 통합 문제 해결 중...",
+        "fetching_cases": "테스트 케이스를 가져오는 중..."
+      },
+      "success": {
+        "title": "제안된 테스트 사례",
+        "description": "{count, plural, =1 {# 테스트 실행 컨텍스트에 따라 선택된 테스트 케이스} other {# 테스트 케이스}}",
+        "linkedCasesAdded": "{count, plural, =1 {# 연결된 경우 자동으로 포함됨} other {# 연결된 경우 자동으로 포함됨}}",
+        "truncationWarningTitle": "부분 결과",
+        "truncationWarning": "{count, plural, =1 {# 배치가 잘렸습니다} other {# 배치가 잘렸습니다}} AI 모델에 의해 일부 테스트 케이스가 평가되지 않았을 수 있습니다."
+      },
+      "noSuggestions": {
+        "title": "일치하는 테스트 케이스가 없습니다.",
+        "description": "기준에 맞는 테스트 케이스가 없습니다. 더 자세한 맥락이나 설명을 추가해 보세요."
+      },
+      "clarification": {
+        "label": "추가적인 맥락 설명 (선택 사항)",
+        "placeholder": "적절한 테스트 케이스를 선택하는 데 도움이 되도록 추가적인 맥락 정보를 제공하세요...",
+        "refine": "선택 항목 세분화"
+      },
+      "actions": {
+        "start": "테스트 케이스 분석",
+        "startBatched": "테스트 케이스 분석 ({count, plural, one {# 배치} other {# 배치}})",
+        "accept": "선택 항목에 추가"
+      },
+      "errors": {
+        "title": "선택 실패",
+        "generic": "테스트 케이스를 선택하는 동안 오류가 발생했습니다. 다시 시도해 주세요.",
+        "noTestRunName": "Magic Select를 사용하기 전에 테스트 실행 이름을 입력하십시오."
+      }
+    },
+    "delete": {
+      "title": "테스트 실행 삭제",
+      "description": "이 테스트 실행 기록을 삭제하시겠습니까? 결과는 기록 분석을 위해 보존됩니다.",
+      "warning": "이 작업은 되돌릴 수 없습니다.",
+      "toast": {
+        "loading": "테스트 실행을 삭제하는 중...",
+        "success": "테스트 실행이 성공적으로 삭제되었습니다.",
+        "error": {
+          "title": "테스트 실행을 삭제하는 데 실패했습니다.",
+          "description": "테스트 실행을 삭제하는 동안 오류가 발생했습니다."
+        }
+      }
+    },
+    "summary": {
+      "title": "테스트 실행 요약",
+      "description": "테스트 실행 요약을 확인하세요",
+      "activeRunsAndEstTime": "진행 중인 달리기 및 예상 시간",
+      "activeRunsLabel": "실행",
+      "totalEstTime": "총 예상 소요 시간",
+      "responsibleUsers": "책임감 있는 사용자",
+      "allActiveRuns": "모든 활성 실행",
+      "recentResultsTitle": "최근 수동 검색 결과",
+      "recentResultsDescription": "최근 테스트 실행 결과를 확인하세요",
+      "recentAutomatedResultsTitle": "최근 자동 검색 결과",
+      "noRecentAutomatedResults": "최근 자동화된 검색 결과가 없습니다.",
+      "recentResultsDateRange": "날짜 범위",
+      "recentResultsElapsed": "경과 시간",
+      "noRecentResults": "최근 검색 결과가 없습니다.",
+      "completionTrendTitle": "완료 추세 (지난 6개월)",
+      "workDistributionTitle": "업무 분배",
+      "workDistributionDescription": "담당자별 예상 업무 분담.",
+      "noWorkDistributionData": "표시할 담당자 또는 예상 일정이 있는 활성 세션이 없습니다."
+    },
+    "details": {
+      "title": "테스트 실행 세부 정보",
+      "description": "테스트 실행 세부 정보를 확인하세요"
+    },
+    "duplicateDialog": {
+      "title": "중복 테스트 실행",
+      "description": "테스트 실행 <nameStyle>{name}</nameStyle>의 복사본을 생성합니다.",
+      "fields": {
+        "duplicateScope": {
+          "label": "복제할 테스트 케이스",
+          "allCases": "모든 테스트 케이스",
+          "specificStatuses": "특정 상태를 포함하는 테스트 케이스"
+        },
+        "statusesToInclude": {
+          "label": "포함할 테스트 케이스",
+          "description": "복제된 테스트 실행에 포함할 테스트 케이스의 상태를 선택하십시오.",
+          "noStatuses": "이번 테스트 실행에서는 특정 상태를 찾을 수 없거나 결과가 아직 로드 중입니다.",
+          "noStatusesRecorded": "이번 실행에서는 특정 상태가 기록되지 않았습니다. 복제본에는 모든 테스트 케이스가 포함됩니다(일반적으로 '테스트되지 않음'으로 표시됨)."
+        },
+        "copyAssignments": {
+          "label": "테스트 케이스 과제",
+          "copy": "기존 테스트 케이스 할당을 복사합니다.",
+          "assign": "복제된 테스트 실행의 모든 테스트 케이스는 기존 할당을 유지합니다.",
+          "unassign": "중복 테스트 실행에 포함된 모든 테스트 케이스는 할당되지 않습니다."
+        }
+      },
+      "successMessage": "테스트 실행 '{name} '을 성공적으로 복제했습니다.",
+      "errorMessage": "테스트 실행을 재현하는 데 실패했습니다. 오류: {error}"
+    },
+    "filter": {
+      "placeholder": "필터 테스트 실행..."
+    },
+    "typeFilter": {
+      "label": "보여주다",
+      "both": "수동 및 자동"
+    },
+    "empty": {
+      "noMatchingCompleted": "필터 조건과 일치하는 완료된 테스트 실행이 없습니다."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "기본",
+      "projects": "프로젝트",
+      "templatesAndFields": "템플릿 및 필드",
+      "fields": "전지",
+      "workflows": "워크플로",
+      "statuses": "상태",
+      "milestoneTypes": "마일스톤 유형",
+      "configurations": "구성",
+      "users": "사용자",
+      "groups": "여러 떼",
+      "roles": "역할",
+      "tags": "태그",
+      "issues": "문제점",
+      "appConfig": "애플리케이션 구성",
+      "notifications": "알림",
+      "imports": "데이터 가져오기",
+      "integrations": "이슈 통합",
+      "webhooks": "웹훅",
+      "llm": "AI 모델",
+      "prompts": "프롬프트 구성",
+      "exportTemplates": "내보내기 템플릿",
+      "codeRepositories": "코드 저장소",
+      "quickScript": "퀵스크립트",
+      "sso": "입증",
+      "security": "보안",
+      "trash": "쓰레기",
+      "reports": "보고서",
+      "shares": "주식 관리",
+      "elasticsearch": "검색 엔진",
+      "queues": "작업 대기열",
+      "auditLogs": "감사 로그",
+      "apiTokens": "API 토큰",
+      "quickscriptTemplates": "QuickScript 템플릿",
+      "testManagement": "테스트 관리",
+      "peopleAndAccess": "사람 및 접근성",
+      "toolsAndIntegrations": "도구 및 통합",
+      "system": "체계"
+    },
+    "imports": {
+      "description": "외부 테스트 관리 도구의 데이터를 TestPlanIt으로 가져옵니다.",
+      "tabs": {
+        "testmoJson": "테스트모 JSON"
+      },
+      "testmo": {
+        "intro": "Testmo JSON 내보내기 파일을 업로드하여 내용을 분석하고 마이그레이션 매핑을 준비하세요.",
+        "wizard": {
+          "steps": {
+            "upload": "업로드 내보내기",
+            "analysis": "분석 검토",
+            "mapping": "매핑 구성",
+            "import": "모니터 가져오기"
+          },
+          "stepIndicator": "{step} 단계 {total}"
+        },
+        "fileLabel": "테스트모 JSON 파일",
+        "fileHelp": "Testmo에서 다운로드한 JSON 내보내기 파일을 선택하세요.",
+        "analyze": "수출 분석",
+        "analyzing": "분석 중...",
+        "reset": "명확한 결과",
+        "job": {
+          "discoveringDatasets": "데이터셋 탐색...",
+          "scanningFile": "testmo 내보내기 파일을 스캔하는 중...",
+          "datasetsProcessed": "{processed, number} 데이터셋{processed, plural, one {} other {s}} 처리됨",
+          "datasetsProcessedWithTotal": "{processed, number} {total, number} 데이터셋{total, plural, one {} other {s}} 처리됨",
+          "rowsProcessed": "{value, number} 처리된 행 수",
+          "itemsProcessed": "{processed, number} {total, number} 항목 처리됨",
+          "analysisInProgress": "수출 분석…",
+          "cancel": "가져오기 취소",
+          "cancelRequested": "취소 요청됨",
+          "processingRate": "비율:",
+          "estimatedTimeRemaining": "예상 남은 시간:",
+          "datasetsLabel": "데이터 세트:",
+          "rowsProcessedLabel": "행:"
+        },
+        "summaryHeading": "수출 요약",
+        "summary": {
+          "datasets": "데이터 세트",
+          "fileName": "파일 이름",
+          "fileSize": "파일 크기",
+          "analysisTime": "분석 시간"
+        },
+        "datasetTable": {
+          "name": "데이터셋",
+          "rows": "행",
+          "samples": "채취된 샘플"
+        },
+        "status": {
+          "truncated": "잘린"
+        },
+        "selectDataset": "데이터셋을 선택하세요",
+        "schema": "개요",
+        "samples": "샘플 행",
+        "noSamples": "이 데이터 세트에 대해 수집된 샘플이 없습니다.",
+        "mappingHeading": "매핑 구성",
+        "mappingRefresh": "분석 새로 고침",
+        "mappingDescription": "분석 세부 정보를 검토하고 Testmo 엔티티를 기존 TestPlanIt 레코드에 매핑하거나 새 레코드를 생성하도록 선택하십시오.",
+        "mappingAnalysisError": "지도 분석을 생성할 수 없습니다. 다시 시도해 주세요.",
+        "mappingLoading": "건물 매핑 분석…",
+        "mappingSummaryHeading": "감지된 개체",
+        "mappingSummaryPending": "{count, plural, =1 {# 대기 중} other {# 대기 중}}",
+        "mappingOutstandingTitle": "미해결 매핑 문제를 해결하세요",
+        "mappingOutstandingDescription": "가져오기를 시작하기 전에 나머지 매핑을 완료하십시오.",
+        "mappingOutstandingItem": "{count, plural, =1 {# 미해결 항목} other {# 미해결 항목}} {label} 내",
+        "mappingSummaryTemplateFields": "템플릿 필드",
+        "mappingDatasetLabels": {
+          "field_values": "필드 값",
+          "repository_case_values": "저장소 케이스 값",
+          "configs": "구성 설정",
+          "session_issues": "세션 문제",
+          "session_tags": "세션 태그",
+          "states": "워크플로 상태",
+          "statuses": "상태",
+          "templates": "템플릿",
+          "template_fields": "템플릿 필드",
+          "milestone_types": "마일스톤 유형",
+          "roles": "역할",
+          "users": "사용자",
+          "groups": "여러 떼",
+          "user_groups": "사용자 그룹",
+          "issue_targets": "이슈 통합",
+          "tags": "태그",
+          "sessions": "세션",
+          "session_results": "세션 결과",
+          "fields": "전지",
+          "projects": "프로젝트",
+          "repositories": "저장소",
+          "repository_folders": "저장소 폴더",
+          "repository_cases": "저장소 사례",
+          "repository_case_steps": "리포지토리 케이스 단계",
+          "repository_case_tags": "저장소 케이스 태그",
+          "milestones": "주요 이정표",
+          "runs": "테스트 실행",
+          "run_tests": "테스트 실행 사례",
+          "run_results": "테스트 실행 결과",
+          "run_result_steps": "테스트 실행 단계 결과",
+          "run_links": "테스트 실행 링크",
+          "run_tags": "테스트 실행 태그",
+          "issues": "문제점",
+          "milestone_issues": "주요 이슈",
+          "repository_case_issues": "저장소 사례 문제",
+          "run_issues": "테스트 실행 문제",
+          "run_result_issues": "테스트 실행 결과 문제",
+          "session_result_issues": "세션 결과 문제",
+          "automation_cases": "자동화 사례",
+          "automation_runs": "자동화 실행",
+          "automation_run_tests": "자동화 실행 테스트",
+          "automation_run_test_fields": "자동화 실행 테스트 필드",
+          "automation_run_links": "자동화 실행 링크",
+          "automation_run_tags": "자동화 실행 태그",
+          "session_values": "세션 값"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "TestPlanIt 워크플로를 매핑하거나 생성하려면 워크플로 상태를 검토하세요.",
+          "statuses": "Testmo 상태가 TestPlanIt 상태에 어떻게 매핑되는지 구성합니다.",
+          "templates": "Testmo에서 가져온 검토 템플릿 정의입니다.",
+          "template_fields": "내보내기에 포함된 템플릿 필드 정의를 검사합니다.",
+          "fields": "Testmo에서 내보낸 사용자 정의 필드 레코드를 검토합니다.",
+          "field_values": "내보내기 파일에 포함된 필드 값 정의를 검사합니다.",
+          "milestone_types": "내보내기 파일에 포함된 마일스톤 유형 정의를 검토합니다.",
+          "roles": "Testmo의 권한을 이해하려면 역할 정의를 검토하십시오.",
+          "users": "Testmo 내보내기에서 감지된 사용자 계정을 확인하세요.",
+          "groups": "Testmo에서 이월된 그룹 과제를 검토하세요.",
+          "configs": "구성 이름을 TestPlanIt 범주 및 변형에 매핑합니다.",
+          "tags": "Testmo 데이터에 나타나는 태그 값을 검사합니다.",
+          "repository_case_values": "테스트 케이스에 할당된 다중 선택 값입니다.",
+          "sessions": "세션은 항상 새로운 세션으로 생성됩니다.",
+          "session_results": "세션 결과는 세션과 연결되어 있습니다.",
+          "session_issues": "세션 관련 문제는 세션과 연관되어 있습니다.",
+          "session_tags": "세션 태그는 세션과 연결됩니다.",
+          "issue_targets": "Testmo 이슈 대상을 TestPlanIt 통합(Jira, GitHub 등)에 매핑합니다."
+        },
+        "mappingDatasetDefaultDescription": "Testmo 내보내기에서 {dataset} 리뷰가 감지되었습니다.",
+        "mappingDatasetCount": "{count, number} 기록{count, plural, one {} other {s}} 감지됨",
+        "mappingDatasetNoEntitiesTitle": "지도에 표시할 내용이 없습니다",
+        "mappingDatasetNoEntitiesDescription": "이 데이터 세트는 매핑이 필요하지 않습니다. 준비가 되면 다음 데이터 세트로 이동하세요.",
+        "mappingDatasetUnsupportedTitle": "지도가 필요 없습니다.",
+        "mappingDatasetUnsupportedDescription": "이러한 기록은 자동으로 가져와 TestPlanIt의 관련 기록에 연결됩니다. 수동 매핑은 필요하지 않습니다.",
+        "mappingDatasetEmptyTitle": "보존된 데이터 세트가 없습니다.",
+        "mappingDatasetEmptyDescription": "분석 과정에서 구성에 필요한 데이터 세트가 보존되지 않았습니다. 추가 데이터가 필요한 경우 다른 내보내기 파일을 업로드하십시오.",
+        "importProgressTitle": "가져오기 진행 상황",
+        "importProgressDescription": "{count, plural, =0 {추적된 엔티티 전체에서 가져온 모든 레코드입니다.} =1 {추적된 엔티티 전체에 1개의 레코드가 남아 있습니다.} other {추적된 엔티티 전체에 남은 레코드 수입니다.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {남은 레코드 없음} =1 {레코드 1개 남음} other {남은 레코드 수}}",
+        "importProgressProcessed": "{processed, number}/{total, number} 레코드가 가져왔습니다",
+        "importProgressAria": "{percent}가져오기 완료율",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "총 소요 시간:",
+        "activityLogTitle": "가져오기 활동",
+        "activityLogDescription": "백그라운드 가져오기 단계에 대한 자세한 로그입니다. 타임스탬프는 서버 시간대를 기준으로 합니다.",
+        "activitySummaryProcessed": "{count, plural, =1 {처리된 레코드 수} other {처리된 레코드 수}}",
+        "activitySummaryCreated": "{count, plural, =1 {# 생성됨} other {# 생성됨}}",
+        "activitySummaryMapped": "{count, plural, =1 {# 매핑됨} other {# 매핑됨}}",
+        "activitySummaryUnknown": "가져오기 단계",
+        "activityDefaultMessage": "가져오기 업데이트",
+        "previousImportsHeading": "이전 수입 내역을 검토하세요",
+        "previousImportsDescription": "구성 또는 활동 로그를 검사하기 위해 가져오기가 완료된 후 로드 분석 결과를 보여줍니다.",
+        "previousImportsRefresh": "목록 새로 고침",
+        "previousImportsPlaceholder": "이전 가져오기를 선택하세요",
+        "previousImportsEmpty": "계정에 대한 이전 가져오기 항목이 없습니다.",
+        "previousImportsCreatedLabel": "생성일: ",
+        "previousImportsFileLabel": "파일: ",
+        "previousImportsNoFilename": "알 수 없는 파일",
+        "jobHistoryLoadFailed": "이전에 가져온 작업을 불러올 수 없습니다.",
+        "jobLoadFailed": "해당 가져오기 작업을 로드할 수 없습니다.",
+        "uploadProgressAnalyzing": "업로드 완료. 파일… 분석 중",
+        "uploadProgressComplete": "업로드 완료",
+        "etaLabel": "예상 도착 시간: {time}",
+        "startImportButton": "가져오기 시작",
+        "workflowCreate": {
+          "nameLabel": "워크플로 이름",
+          "namePlaceholder": "워크플로 이름을 입력하세요",
+          "scopePlaceholder": "범위를 선택하세요",
+          "iconColorLabel": "아이콘 및 색상",
+          "typeLabel": "워크플로 유형"
+        },
+        "mappingDatasets": "검토가 필요한 데이터 세트",
+        "mappingImportConfiguration": "가져오기 구성",
+        "mappingExportConfiguration": "내보내기 구성",
+        "mappingImportConfigurationFailed": "해당 구성 파일을 가져올 수 없습니다. 유효한 JSON 형식인지 확인하고 다시 시도해 주세요.",
+        "mappingInvalidConfiguration": "설정 파일 형식은 유효한 JSON이어야 합니다.",
+        "mappingSaveFailed": "설정을 저장할 수 없습니다. 다시 시도해 주세요.",
+        "mappingSaveConfiguration": "설정 저장",
+        "mappingSavingConfiguration": "저장 중…",
+        "mappingStartImport": "백그라운드 가져오기 시작",
+        "mappingStartingImport": "… 가져오기 시작",
+        "mappingImportFailed": "백그라운드 가져오기를 시작할 수 없습니다. 다시 시도해 주세요.",
+        "mappingImportDisabled": "백그라운드 가져오기를 시작하기 전에 구성을 저장하십시오.",
+        "mappingImportInProgress": "백그라운드 가져오기 진행 중",
+        "mappingImportInProgressDescription": "가져오기 작업자가 구성을 처리 중입니다. 위에서 상태를 확인할 수 있습니다.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# 레코드} other {# 레코드}} ",
+          "columnSource": "테스트모 엔티티",
+          "columnSourceDetails": "세부",
+          "columnSuggestedWorkflowType": "제안된 유형",
+          "columnTarget": "목표",
+          "workflowTypeUnknown": "감지되지 않음",
+          "actionMap": "기존 지도에 매핑",
+          "actionCreate": "새 항목 생성",
+          "workflowTypePlaceholder": "유형을 선택하세요",
+          "noWorkflowsAvailable": "사용 가능한 워크플로가 없습니다.",
+          "noStatusesAvailable": "사용 가능한 상태가 없습니다.",
+          "noGroupsAvailable": "이용 가능한 그룹이 없습니다.",
+          "groupSelectPlaceholder": "그룹을 선택하세요",
+          "groupNotePlaceholder": "참고 (선택 사항)",
+          "groupNoteEmpty": "추가적인 세부 정보는 제공되지 않았습니다.",
+          "noUsersAvailable": "사용 가능한 사용자가 없습니다.",
+          "userNoExistingTargets": "지도에 표시할 수 있는 사용자가 없습니다.",
+          "userNamePlaceholder": "성명",
+          "userAccessPlaceholder": "접근 수준을 선택하세요",
+          "userRoleUnavailable": "할당할 역할이 없습니다.",
+          "userPasswordPlaceholder": "임시 비밀번호",
+          "userPasswordHint": "임시 비밀번호를 제공하세요. 사용자는 로그인 후 비밀번호를 변경할 수 있습니다.",
+          "userActiveLabel": "활성 계정",
+          "userDisplayFallback": "사용자 {id}",
+          "userMissingRequired": "필수 정보가 누락되었습니다",
+          "noConfigurationsAvailable": "사용 가능한 구성이 없습니다.",
+          "configurationNoTokens": "이 구성에서는 변이체가 발견되지 않았습니다.",
+          "configurationNoExistingTargets": "매핑할 수 있는 구성이 없습니다.",
+          "configurationNamePlaceholder": "구성 이름을 입력하세요",
+          "configurationVariantLabel": "변형 {index}",
+          "configurationVariantActionLabel": "이 변형은 어떻게 처리해야 할까요?",
+          "configurationVariantActionPlaceholder": "옵션을 선택하세요",
+          "configurationVariantMapOption": "기존 변형에 매핑",
+          "configurationVariantExistingCategoryOption": "기존 카테고리에 변형 상품 생성",
+          "configurationVariantNewCategoryOption": "새로운 카테고리와 상품 옵션을 생성하세요.",
+          "configurationVariantSelectLabel": "옵션을 선택하세요",
+          "configurationVariantNoVariants": "매핑할 수 있는 변형이 없습니다.",
+          "configurationVariantCategoryLabel": "범주",
+          "configurationVariantNameLabel": "변형 이름",
+          "configurationVariantNamePlaceholder": "변형 이름을 입력하세요",
+          "configurationVariantNoCategories": "이용 가능한 카테고리가 없습니다.",
+          "configurationVariantCategoryNameLabel": "카테고리 이름",
+          "configurationVariantCategoryNamePlaceholder": "카테고리 이름을 입력하세요",
+          "noTemplateFieldsAvailable": "사용 가능한 템플릿 필드가 없습니다.",
+          "templateFieldDisplayFallback": "필드 {id}",
+          "templateFieldUnknownTemplate": "알 수 없는 템플릿",
+          "templateFieldTargetCase": "케이스 필드",
+          "templateFieldTargetResult": "결과 필드",
+          "templateFieldSelectPlaceholder": "필드를 선택하세요",
+          "templateFieldNoExistingTargets": "매핑할 수 있는 필드가 없습니다.",
+          "templateFieldTypePlaceholder": "필드 유형을 선택하세요",
+          "templateFieldRestrictedLabel": "제한된 필드",
+          "templateFieldOptionsLabel": "드롭다운 옵션",
+          "templateFieldOptionsPlaceholder": "한 줄에 하나의 옵션만 입력하세요",
+          "templateFieldOptionsHint": "각 옵션을 새 줄로 구분하세요.",
+          "templateFieldOptionsListLabel": "옵션",
+          "templateFieldOptionsCheckedLabel": "기본적으로 선택됨",
+          "templateFieldOptionsMinValueLabel": "최소값",
+          "templateFieldOptionsMaxValueLabel": "최대값",
+          "templateFieldOptionsMinIntegerLabel": "최소 정수",
+          "templateFieldOptionsMaxIntegerLabel": "최대 정수",
+          "templateFieldNewFieldSummaryTitle": "새로운 필드 세부 정보",
+          "templateFieldNewFieldSummaryDescription": "TestPlanIt 필드를 생성하는 데 사용될 값을 검토하십시오.",
+          "templateFieldConfigureFieldButton": "설정 세부 정보",
+          "templateFieldEditFieldButton": "세부 정보 수정",
+          "templateFieldSummaryMissingValue": "설정되지 않음",
+          "templateFieldSummaryMissingDetailsHint": "계속 진행하기 전에 새 필드 세부 정보를 입력하십시오.",
+          "templateFieldModalSaveButton": "저장 세부 정보",
+          "templateFieldTargetTypeLabel": "대상 유형",
+          "templateFieldTypeMismatchWarning": "선택한 필드 유형 {target} 이 Testmo 필드 유형 {source}과 일치하지 않습니다.",
+          "templateFieldDuplicateTargetWarning": "선택한 대상이 이미 다른 Testmo 필드에 매핑되어 있습니다. 다른 대상을 선택하세요.",
+          "templateFieldTargetAlreadyUsed": "이미 지도에 표시됨",
+          "templateFieldMappedSummary": "{name} ({type} )에 매핑됨",
+          "templateFieldIssueMissingTarget": "대상 필드를 선택하세요.",
+          "templateFieldIssueMissingDetails": "계속하기 전에 표시 이름, 시스템 이름 및 필드 유형을 입력하십시오.",
+          "noTemplatesAvailable": "사용 가능한 템플릿이 없습니다.",
+          "templateColumnFields": "전지",
+          "templateFieldStatusMapped": "지도화됨",
+          "templateFieldStatusCreate": "새 필드 생성",
+          "templateFieldStatusMissing": "지도에 표시되지 않음",
+          "templateFieldStatusMismatch": "대상 불일치",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# 케이스 필드} other {# 케이스 필드}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# 결과 필드} other {# 결과 필드}}",
+          "templateMapLabel": "기존 템플릿에 매핑",
+          "templateCreateLabel": "새 템플릿 만들기",
+          "templateNoMatchingTargets": "일치하는 템플릿이 없습니다.",
+          "templateNewNameLabel": "템플릿 이름",
+          "templateMapHintIncomplete": "기존 템플릿에 매핑하기 전에 모든 Testmo 필드를 기존 사례 및 결과 필드에 매핑하십시오.",
+          "templateMapHintDuplicate": "각 Testmo 필드는 고유한 TestPlanIt 필드에 매핑되어야 합니다.",
+          "templateMapHintNoMatch": "기존 템플릿 중 동일한 필드 세트를 사용하는 템플릿은 없습니다.",
+          "templateMapHintAlreadyMapped": "일치하는 템플릿이 모두 매핑되었습니다. 계속하기 전에 다른 매핑을 지우십시오.",
+          "templateIssueNoSelection": "매핑할 기존 템플릿을 선택하세요.",
+          "templateIssueTargetConflict": "이미 다른 템플릿이 이 대상에 매핑되어 있습니다.",
+          "templateIssueFieldErrors": "강조 표시된 템플릿 필드를 해결하세요.",
+          "templateTargetFieldsMismatch": "입력 필드가 이 템플릿과 일치하지 않습니다.",
+          "templateTargetNoLongerMatching": "해당 필드가 더 이상 이 템플릿과 일치하지 않습니다.",
+          "noRolesAvailable": "현재 채용 가능한 직책이 없습니다.",
+          "roleSelectPlaceholder": "역할을 선택하세요",
+          "roleNameLabel": "역할 이름",
+          "roleNamePlaceholder": "역할 이름을 입력하세요",
+          "rolePermissionsEmpty": "권한이 할당되지 않았습니다.",
+          "rolePermissionAddEdit": "추가/수정",
+          "noMilestoneTypesAvailable": "사용 가능한 마일스톤 유형이 없습니다.",
+          "milestoneSelectPlaceholder": "마일스톤 유형을 선택하세요",
+          "milestoneNamePlaceholder": "마일스톤 유형 이름을 입력하세요",
+          "milestoneDefaultLabel": "기본 마일스톤 유형",
+          "milestoneIconRequired": "아이콘을 선택하세요",
+          "statusColorPlaceholder": "색상 헥스 코드 (선택 사항)",
+          "issueTargetSelectPlaceholder": "통합 방식을 선택하세요...",
+          "noIssueTargetsAvailable": "문제 없는 통합 기능 사용 가능",
+          "issueTargetNamePlaceholder": "통합 이름...",
+          "templateFieldsHeading": "템플릿 필드",
+          "roleAreaColumn": "영역",
+          "workflowSelectPlaceholder": "워크플로우를 선택하세요",
+          "statusSelectPlaceholder": "상태를 선택하세요",
+          "statusNamePlaceholder": "상태 이름을 입력하세요",
+          "statusSystemNamePlaceholder": "시스템 이름을 입력하세요",
+          "labelSystemName": "시스템 이름",
+          "groupNamePlaceholder": "그룹 이름을 입력하세요",
+          "configurationNameLabel": "구성 이름",
+          "userSelectPlaceholder": "사용자를 선택하세요",
+          "userApiLabel": "API 사용자",
+          "templateCaseFieldsLabel": "케이스 필드",
+          "templateResultFieldsLabel": "결과 필드",
+          "templateNoFieldsPlaceholder": "이 템플릿에 대해 구성된 필드가 없습니다.",
+          "templateTargetAlreadyUsed": "대상이 이미 다른 템플릿에 매핑되었습니다.",
+          "templateFieldRequiredLabel": "필수 입력 항목",
+          "templateFieldOptionsDefaultValueLabel": "기본값",
+          "templateFieldOptionsInitialHeightLabel": "초기 높이",
+          "templateFieldTemplateLabelSingular": "주형",
+          "templateFieldTemplateLabelPlural": "템플릿",
+          "templateFieldTargetGroupCase": "케이스 필드",
+          "templateFieldTargetGroupResult": "결과 필드",
+          "columnAction": "행동"
+        },
+        "nextSteps": "백그라운드 가져오기가 완료되면 대상 프로젝트에서 마이그레이션된 데이터를 검토할 수 있습니다.",
+        "nextStepsDescription": "백그라운드 가져오기는 비동기적으로 실행됩니다. 위에서 상태를 모니터링하거나 페이지를 새로 고침하여 업데이트를 확인할 수 있습니다."
+      },
+      "comingSoon": {
+        "description": "TestRail, Zephyr 및 기타 도구와의 연동 기능은 향후 개발 계획에 포함되어 있습니다."
+      },
+      "errors": {
+        "fileRequired": "분석하기 전에 Testmo에서 JSON 형식으로 내보내기 파일을 선택하십시오.",
+        "uploadFailed": "내보내기 파일을 저장소에 업로드할 수 없습니다. 다시 시도해 주세요.",
+        "analysisFailed": "해당 내보내기 파일을 분석할 수 없습니다. 파일을 확인한 후 다시 시도해 주세요."
+      }
+    },
+    "sso": {
+      "description": "인증 및 보안 설정을 관리합니다.",
+      "sections": {
+        "providers": {
+          "title": "로그인 제공업체",
+          "description": "사용자가 애플리케이션에 로그인하는 방법을 구성하세요."
+        },
+        "security": {
+          "title": "보안",
+          "description": "인증을 위한 보안 정책을 구성합니다."
+        }
+      },
+      "globalSettings": {
+        "title": "글로벌 SSO 설정",
+        "googleOAuth": {
+          "title": "구글 OAuth",
+          "description": "Google OAuth 인증을 활성화 또는 비활성화합니다."
+        },
+        "samlProvider": {
+          "title": "SAML 제공업체",
+          "description": "SAML 인증을 활성화 또는 비활성화합니다."
+        },
+        "apple": {
+          "title": "애플 로그인",
+          "description": "Apple Sign In 인증을 활성화 또는 비활성화합니다."
+        },
+        "microsoft": {
+          "title": "마이크로소프트 SSO",
+          "description": "Microsoft(Azure AD/Entra ID) 인증을 활성화 또는 비활성화합니다."
+        },
+        "magicLink": {
+          "title": "매직 링크 인증",
+          "description": "비밀번호 없이 이메일 기반 인증을 활성화 또는 비활성화합니다."
+        },
+        "forceSso": {
+          "title": "SSO 강제 로그인",
+          "description": "이메일 로그인을 비활성화하고 사용자에게 SSO 사용을 요구합니다."
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "비밀번호 로그인에 2단계 인증(2FA)을 요구하세요",
+            "description": "이메일/비밀번호로 로그인하는 사용자는 2단계 인증을 설정하고 사용해야 합니다."
+          },
+          "forceAllLogins": {
+            "title": "모든 로그인에 2단계 인증(2FA)을 요구하세요",
+            "description": "모든 사용자(SSO 사용자 포함)는 로그인 후 2단계 인증(2FA)을 통해 본인 인증을 해야 합니다."
+          }
+        }
+      },
+      "providers": {
+        "configure": "SAML 구성",
+        "delete": "제공자 삭제",
+        "entryPoint": "진입점: ",
+        "autoProvision": "자동 프로비저닝: ",
+        "defaultAccess": "기본 접근 권한: ",
+        "configurationMessage": "SAML 구성이 설정되지 않았습니다. 설정 버튼을 클릭하여 구성하십시오."
+      },
+      "samlConfiguration": {
+        "title": "SAML 공급자 구성",
+        "backButton": "SSO 제공업체 목록으로 돌아가기",
+        "description": "{name}에 대한 SAML 설정을 구성합니다.",
+        "samlSettings": {
+          "title": "SAML 설정",
+          "description": "SAML ID 공급자 설정을 구성하세요",
+          "ssoUrl": "SSO URL(진입점)",
+          "entityId": "엔티티 ID(발급자)",
+          "certificate": "X.509 인증서",
+          "callbackUrl": "콜백 URL",
+          "logoutUrl": "로그아웃 URL (선택 사항)"
+        },
+        "userProvisioning": {
+          "title": "사용자 프로비저닝",
+          "description": "사용자 생성 및 매핑 방식을 구성합니다.",
+          "autoProvision": "신규 사용자 자동 프로비저닝",
+          "defaultAccess": "신규 사용자를 위한 기본 시스템 액세스 권한",
+          "accessDescription": "신규 사용자는 데이터베이스에서 기본 역할을 할당받고 시스템 접근 권한을 갖게 됩니다."
+        },
+        "attributeMapping": {
+          "title": "속성 매핑",
+          "description": "SAML 속성을 사용자 필드에 매핑합니다.",
+          "email": "이메일 속성",
+          "displayName": "표시 이름 속성",
+          "userId": "사용자 ID 속성",
+          "firstName": "이름 속성 (선택 사항)",
+          "lastName": "성(姓) 속성 (선택 사항)",
+          "groups": "그룹 속성(선택 사항)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Google OAuth가 활성화되었습니다.",
+        "googleDisabled": "Google OAuth가 비활성화되었습니다.",
+        "googleCreated": "Google OAuth 제공업체가 생성되었습니다.",
+        "googleUpdateFailed": "Google OAuth 업데이트에 실패했습니다.",
+        "samlCreated": "SAML 공급자가 생성되었습니다.",
+        "createFailed": "공급자를 생성하는 데 실패했습니다.",
+        "deleted": "제공자가 삭제했습니다",
+        "deleteFailed": "공급자 삭제에 실패했습니다",
+        "enabled": "공급자 활성화됨",
+        "disabled": "제공자가 비활성화됨",
+        "updateFailed": "공급자 업데이트에 실패했습니다",
+        "forceSsoEnabled": "SSO를 전 세계적으로 강제 활성화",
+        "forceSsoDisabled": "SSO를 전 세계적으로 강제 비활성화합니다.",
+        "forceSsoUpdateFailed": "강제 SSO 설정 업데이트에 실패했습니다.",
+        "force2FANonSSOEnabled": "비밀번호 로그인에는 2단계 인증이 필요합니다.",
+        "force2FANonSSODisabled": "비밀번호 로그인 시 2단계 인증이 더 이상 필요하지 않습니다.",
+        "force2FAAllLoginsEnabled": "모든 로그인에는 2단계 인증이 필요합니다.",
+        "force2FAAllLoginsDisabled": "모든 로그인에 2단계 인증이 더 이상 필요하지 않습니다.",
+        "force2FAUpdateFailed": "2단계 인증 설정 업데이트에 실패했습니다.",
+        "configUpdated": "SAML 구성이 업데이트되었습니다.",
+        "configCreated": "SAML 구성이 생성되었습니다.",
+        "configSaveFailed": "SAML 구성 저장에 실패했습니다.",
+        "googleConfigSaved": "Google OAuth 구성이 성공적으로 저장되었습니다.",
+        "googleConfigFailed": "설정을 저장하는 데 실패했습니다.",
+        "appleEnabled": "Apple 로그인 활성화됨",
+        "appleDisabled": "Apple 로그인 비활성화됨",
+        "appleCreated": "Apple Sign In 제공업체가 생성되었습니다",
+        "appleConfigSaved": "Apple 로그인 설정이 성공적으로 저장되었습니다.",
+        "appleConfigFailed": "Apple 로그인 설정을 저장하는 데 실패했습니다.",
+        "appleUpdateFailed": "Apple Sign In 제공업체 업데이트에 실패했습니다.",
+        "microsoftEnabled": "Microsoft SSO 활성화됨",
+        "microsoftDisabled": "Microsoft SSO가 비활성화되었습니다.",
+        "microsoftCreated": "Microsoft SSO 공급자가 생성되었습니다.",
+        "microsoftConfigSaved": "Microsoft SSO 구성이 성공적으로 저장되었습니다.",
+        "microsoftConfigFailed": "Microsoft SSO 구성을 저장하는 데 실패했습니다.",
+        "microsoftUpdateFailed": "Microsoft SSO 공급자 업데이트에 실패했습니다.",
+        "magicLinkEnabled": "매직링크 인증이 활성화되었습니다.",
+        "magicLinkDisabled": "매직링크 인증이 비활성화되었습니다.",
+        "magicLinkCreated": "매직 링크 제공업체가 생성했습니다.",
+        "magicLinkUpdateFailed": "매직링크 공급자 업데이트에 실패했습니다.",
+        "samlConfigSaved": "SAML 구성이 성공적으로 저장되었습니다.",
+        "configureFirst": "활성화하기 전에 공급자를 구성하십시오.",
+        "domainRestrictionEnabled": "이메일 도메인 제한이 활성화되었습니다.",
+        "domainRestrictionDisabled": "이메일 도메인 제한이 해제되었습니다.",
+        "domainRestrictionUpdateFailed": "도메인 제한 설정 업데이트에 실패했습니다.",
+        "domainRequired": "도메인을 입력하세요",
+        "invalidDomain": "유효한 도메인을 입력하세요 (예: example.com).",
+        "domainAdded": "도메인이 성공적으로 추가되었습니다.",
+        "domainExists": "이 도메인은 이미 허용 목록에 있습니다.",
+        "domainAddFailed": "도메인 추가에 실패했습니다",
+        "domainEnabled": "도메인 활성화됨",
+        "domainDisabled": "도메인 비활성화됨",
+        "domainUpdateFailed": "도메인 업데이트에 실패했습니다.",
+        "domainDeleted": "도메인이 성공적으로 삭제되었습니다.",
+        "domainDeleteFailed": "도메인을 삭제하는 데 실패했습니다.",
+        "defaultAccessUpdated": "기본 접근 수준이 업데이트되었습니다.",
+        "defaultAccessUpdateFailed": "기본 액세스 수준 업데이트에 실패했습니다.",
+        "emailVerificationEnabled": "이제 신규 사용자는 이메일 인증이 필수입니다.",
+        "emailVerificationDisabled": "신규 사용자는 더 이상 이메일 인증을 받을 필요가 없습니다.",
+        "emailVerificationDisabledAndVerified": "이메일 인증이 비활성화되었으며 {count, plural, one {# 사용자 계정} other {# 사용자 계정}} 이 인증되었습니다.",
+        "emailVerificationUpdateFailed": "이메일 인증 설정 업데이트에 실패했습니다.",
+        "emailServerNotConfigured": "이메일 인증을 활성화할 수 없습니다: 이메일 서버가 구성되지 않았습니다.",
+        "openRegistrationEnabled": "이제 셀프 등록이 가능합니다.",
+        "openRegistrationDisabled": "셀프 등록 기능이 현재 비활성화되었습니다.",
+        "openRegistrationUpdateFailed": "자체 등록 설정 업데이트에 실패했습니다."
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Google OAuth 구성",
+          "description": "Google OAuth 클라이언트 자격 증명을 설정하세요. 이 자격 증명은 Google 클라우드 콘솔에서 얻을 수 있습니다.",
+          "clientIdPlaceholder": "Google OAuth 클라이언트 ID",
+          "clientSecretPlaceholder": "Google OAuth 클라이언트 비밀 키",
+          "instructions": {
+            "title": "이러한 자격 증명을 얻으려면:",
+            "step1": "Google 클라우드 콘솔로 이동하세요.",
+            "step2": "프로젝트를 선택하거나 새 프로젝트를 만드세요.",
+            "step3": "Google+ API를 활성화하세요",
+            "step4": "자격 증명으로 이동하여 OAuth 2.0 클라이언트 ID를 생성하세요.",
+            "step5": "승인된 리디렉션 URI를 다음과 같이 설정하십시오."
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "클라이언트 ID와 클라이언트 시크릿 모두 필수입니다."
+          }
+        },
+        "microsoft": {
+          "title": "Microsoft SSO 구성",
+          "description": "Microsoft Entra ID(Azure AD) 애플리케이션 자격 증명을 설정하세요. 이 자격 증명은 Azure 포털에서 얻을 수 있습니다.",
+          "clientIdPlaceholder": "귀하의 애플리케이션(클라이언트) ID",
+          "clientSecretPlaceholder": "고객 비밀 가치",
+          "tenantId": "임차인 ID (선택 사항)",
+          "tenantIdPlaceholder": "사용자 디렉터리(테넌트) ID",
+          "tenantIdHint": "다중 테넌트(\"공용\")를 사용하려면 비워 두십시오. 조직에서만 사용하도록 제한하려면 특정 테넌트 ID를 설정하십시오.",
+          "instructions": {
+            "title": "이러한 자격 증명을 얻으려면:",
+            "step1": "Azure 포털(portal.azure.com)로 이동하세요.",
+            "step2": "Microsoft Entra ID > 앱 등록으로 이동하세요.",
+            "step3": "새 애플리케이션을 등록하거나 기존 애플리케이션을 선택하세요.",
+            "step4": "인증서 및 비밀 항목에서 새 클라이언트 비밀을 생성하세요.",
+            "step5": "인증 항목에 다음 리디렉션 URI를 추가하십시오."
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "클라이언트 ID와 클라이언트 시크릿 모두 필수입니다."
+          }
+        },
+        "saml": {
+          "description": "SAML ID 공급자 구성을 설정하세요. 이러한 세부 정보는 SAML IdP에서 얻을 수 있습니다.",
+          "entryPoint": "SSO 진입점 URL",
+          "issuer": "발급자(엔티티 ID)",
+          "callbackUrl": "ACS(콜백) URL",
+          "logoutUrl": "SLO 로그아웃 URL (선택 사항)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:your-idp:entity-id",
+          "certPlaceholder": "-----시작 인증서-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "SAML을 구성하려면 다음 단계를 따르세요.",
+            "step1": "SAML ID 공급자 관리자에게 문의하십시오.",
+            "step2": "SSO 진입점 URL 및 엔티티 ID를 요청하세요.",
+            "step3": "X.509 인증서를 다운로드하십시오.",
+            "step4": "IdP에서 이 ACS URL을 구성하십시오."
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "진입점, 발급자, 인증서 및 콜백 URL은 필수입니다."
+          }
+        },
+        "disableEmailVerification": {
+          "title": "이메일 인증을 비활성화하시겠습니까?",
+          "description": "이렇게 하면 신규 사용자 가입 시 이메일 인증이 비활성화되고, 인증되지 않은 기존 계정은 모두 인증됩니다.",
+          "warning": "⚠️ 보안 경고",
+          "warningPoint1": "보안 설치(개인 네트워크, VPN 또는 신뢰할 수 있는 환경)에만 권장됩니다.",
+          "warningPoint2": "기존의 모든 미인증 계정은 즉시 인증되어 시스템 접근 권한이 부여됩니다.",
+          "confirmation": "이메일 인증을 비활성화하고 모든 계정을 인증하시겠습니까?",
+          "confirm": "모두 비활성화 및 확인",
+          "verifying": "계정 확인 중..."
+        }
+      },
+      "status": {
+        "configured": "구성됨",
+        "setup": "설정"
+      },
+      "registration": {
+        "title": "등록 설정",
+        "description": "새 계정 등록 권한을 관리하세요.",
+        "restrictDomains": {
+          "title": "이메일 도메인 제한",
+          "description": "특정 이메일 도메인에서만 가입을 허용합니다."
+        },
+        "allowedDomains": {
+          "title": "허용된 이메일 도메인",
+          "placeholder": "example.com",
+          "add": "도메인 추가",
+          "empty": "허용된 도메인이 설정되어 있지 않습니다. 제한 기능을 활성화하면 모든 도메인이 차단됩니다."
+        },
+        "defaultAccess": {
+          "title": "기본 액세스 수준",
+          "description": "신규 사용자가 등록할 때 할당되는 시스템 접근 수준",
+          "options": {
+            "NONE": "접근 불가 - 관리자가 접근 권한을 부여할 때까지 사용자는 시스템에 접근할 수 없습니다.",
+            "USER": "사용자 - 할당된 프로젝트에 대한 표준 사용자 액세스 권한",
+            "PROJECTADMIN": "프로젝트 관리자 - 자신에게 할당된 프로젝트를 관리할 수 있습니다.",
+            "ADMIN": "관리자 - 시스템 전체 관리자 권한"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "이메일 인증 필수",
+          "description": "사용자는 시스템에 접속하기 전에 이메일 주소를 인증해야 합니다.",
+          "noEmailServerWarning": "이메일 서버가 구성되지 않았습니다. 이메일 서버가 설정될 때까지 이메일 인증이 자동으로 비활성화됩니다."
+        },
+        "allowOpenRegistration": {
+          "title": "셀프 등록 허용",
+          "description": "이 기능이 비활성화되면 신규 사용자는 직접 가입하거나 SSO를 통해 계정을 생성할 수 없습니다. 기존 사용자는 계속 로그인할 수 있습니다."
+        }
+      },
+      "errors": {
+        "invalidProvider": "유효하지 않은 공급자이거나 SAML 공급자가 아닙니다."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "프로젝트 필터링..."
+      },
+      "complete": {
+        "title": "프로젝트 완료",
+        "description": "이 작업을 수행하면 프로젝트가 완료되고 더 이상 테스트 실행이 추가되지 않습니다."
+      },
+      "add": {
+        "button": "프로젝트 추가",
+        "title": "새 프로젝트 추가",
+        "defaultFields": "프로젝트 생성 시 기본 템플릿, 기본 마일스톤 유형, 모든 워크플로 및 상태가 추가됩니다.",
+        "selectIssueTracker": "이슈 트래커를 선택하세요",
+        "issueTrackerRequired": "이슈 트래커가 필요합니다."
+      },
+      "wizard": {
+        "title": "새 프로젝트 생성",
+        "description": "필요한 모든 설정을 완료하여 새 프로젝트를 설정하세요.",
+        "steps": {
+          "details": "프로젝트 세부 정보",
+          "workflows": "워크플로, 상태 및 마일스톤 유형",
+          "integrations": "통합",
+          "permissions": "사용자 및 권한"
+        },
+        "labels": {
+          "selected": "선택된",
+          "statuses": "테스트 상태",
+          "issueTrackers": "이슈 트래커"
+        },
+        "placeholders": {
+          "projectName": "프로젝트 이름을 입력하세요",
+          "selectDefaultAccess": "기본 액세스 유형을 선택하세요"
+        },
+        "descriptions": {
+          "templates": "이 프로젝트에서 테스트 케이스 구조를 정의하는 데 사용할 템플릿을 하나 이상 선택하세요.",
+          "workflows": "프로젝트 활동 관리를 위한 워크플로, 상태 및 마일스톤 유형을 구성합니다.",
+          "integrations": "선택 사항: 기능 향상을 위해 외부 이슈 추적 도구 및 AI 모델을 연결할 수 있습니다.",
+          "noIntegrations": "현재 구성된 연동 기능이 없습니다. 이 단계를 건너뛰거나 나중에 연동 기능을 구성할 수 있습니다.",
+          "aiModels": "테스트 케이스 생성 및 지능형 제안을 위해 AI 모델을 활성화하세요.",
+          "permissions": "이 프로젝트에 대한 사용자 액세스 및 그룹 권한을 구성하십시오.",
+          "milestoneTypes": "프로젝트 진행 상황 및 마감일을 추적하려면 마일스톤 유형을 선택하세요."
+        },
+        "actions": {
+          "selectDefault": "기본값 사용",
+          "create": "프로젝트 생성",
+          "creating": "프로젝트 생성 중..."
+        },
+        "errors": {
+          "nameRequired": "프로젝트 이름은 필수 입력 사항입니다.",
+          "validationFailed": "프로젝트 이름 유효성 검사에 실패했습니다. 다시 시도해 주세요.",
+          "templateRequired": "최소 하나의 템플릿을 선택해야 합니다.",
+          "workflowRequired": "최소 하나의 워크플로우를 선택해야 합니다.",
+          "statusRequired": "최소한 하나의 상태를 선택해야 합니다.",
+          "roleRequired": "'특정 역할' 접근 유형을 사용할 때는 역할을 선택하십시오.",
+          "creationFailed": "프로젝트 생성에 실패했습니다. 다시 시도해 주세요."
+        },
+        "success": {
+          "created": "프로젝트가 성공적으로 생성되었습니다."
+        }
+      },
+      "edit": {
+        "title": "프로젝트 편집",
+        "labels": {
+          "groupProjectAccess": "그룹 프로젝트 액세스",
+          "groupPermissions": "그룹 권한",
+          "userPermissions": "사용자 권한",
+          "noEffect": "효과 없음",
+          "access": {
+            "groupsGlobalRole": "그룹의 글로벌 역할",
+            "groupDefault": "그룹 기본값",
+            "groupSpecificRole": "그룹별 역할",
+            "groupProjectDefault": "그룹 프로젝트 기본값",
+            "groupProjectNoAccess": "그룹 프로젝트 접근 권한 없음",
+            "groupProjectSpecificRole": "그룹 프로젝트 특정 역할",
+            "effectiveAccess": "효과적인 접근"
+          },
+          "accessHints": {
+            "noAccess": "사용자는 직접 배정 또는 그룹 멤버십을 통해 명시적으로 권한이 부여되지 않는 한 이 프로젝트에 접근할 수 없습니다.",
+            "globalRole": "사이트 접근 권한이 있는 모든 사용자는 이 프로젝트를 볼 수 있습니다. 사용자 권한은 전역적으로 할당된 역할에 따라 결정됩니다.",
+            "specificRole": "사용자에게 접근 권한이 자동으로 부여되는 것은 아닙니다. 접근 권한은 직접 사용자 지정 또는 그룹 멤버십을 통해 부여해야 합니다. 그룹을 통해 지정된 사용자는 직접 지정하지 않는 한 해당 역할을 사용하게 됩니다."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "기본 액세스 선택",
+          "groupPermissionsUI": "그룹 권한 관리 UI가 여기에 들어갑니다...",
+          "userPermissionsUI": "사용자 권한 관리 UI가 여기에 들어갑니다...",
+          "selectAccess": "접근 권한을 선택하세요...",
+          "selectRole": "역할을 선택하세요...",
+          "searchUsersToAdd": "추가할 사용자를 검색하세요..."
+        },
+        "tableHeaders": {
+          "globalRole": "글로벌 역할",
+          "projectAccess": "프로젝트 접근 권한"
+        },
+        "messages": {
+          "noUsersAssigned": "특정 권한이 부여된 사용자가 없습니다.",
+          "noGroupsFound": "그룹을 찾을 수 없습니다."
+        },
+        "actions": {
+          "removeUser": "사용자 제거"
+        },
+        "loadingUserPermissions": "사용자 권한을 불러오는 중..."
+      },
+      "delete": {
+        "title": "프로젝트 삭제",
+        "confirmMessage": "이 프로젝트를 정말로 삭제하시겠습니까?"
+      }
+    },
+    "templates": {
+      "description": "테스트 케이스 템플릿 및 필드 관리",
+      "help": {
+        "caseFields": "테스트 케이스 필드는 저장소의 각 테스트 케이스에 대해 캡처할 수 있는 속성과 데이터를 정의합니다. 이를 통해 표준 필드 외에도 테스트 케이스 정보를 사용자 지정할 수 있습니다.",
+        "resultFields": "결과 필드는 테스트 결과를 기록할 때 캡처할 수 있는 추가 데이터를 정의합니다. 이를 통해 테스트 실행 결과에 특정한 사용자 지정 정보를 추적할 수 있습니다."
+      },
+      "confirmSetAsDefault": "기본 템플릿으로 설정",
+      "confirmSetAsDefaultDescription": "이 템플릿을 기본값으로 설정하시겠습니까?",
+      "confirmSetAsDefaultProjects": "이 템플릿은 모든 프로젝트에 추가됩니다.",
+      "add": {
+        "button": "템플릿 추가",
+        "title": "새 템플릿 추가",
+        "defaultTemplateHint": "이 템플릿은 모든 프로젝트에 적용됩니다."
+      },
+      "edit": {
+        "title": "템플릿 편집"
+      },
+      "delete": {
+        "title": "템플릿 삭제",
+        "confirmMessage": "<strong>{name}</strong> 템플릿을 삭제하시겠습니까?",
+        "warning": "현재 이 템플릿을 사용하고 있는 모든 테스트 케이스와 탐색적 세션은 자동으로 기본 템플릿으로 다시 할당됩니다.",
+        "errors": {
+          "defaultTemplateNotFound": "기본 템플릿을 찾을 수 없습니다. 삭제를 진행할 수 없습니다.",
+          "unknown": "템플릿을 삭제하는 동안 알 수 없는 오류가 발생했습니다."
+        }
+      },
+      "caseFields": {
+        "description": "사례 필드 관리",
+        "add": {
+          "button": "케이스 필드 추가",
+          "title": "새 사례 필드 추가"
+        },
+        "edit": {
+          "title": "사례 필드 편집"
+        },
+        "delete": {
+          "title": "케이스 필드 삭제",
+          "confirmMessage": "이 사례 필드를 삭제하시겠습니까?",
+          "warning": "케이스 필드는 모든 템플릿에서 제거됩니다. 이 작업은 되돌릴 수 없습니다."
+        }
+      },
+      "resultFields": {
+        "description": "결과 필드 관리",
+        "add": {
+          "button": "결과 필드 추가",
+          "title": "새로운 결과 필드 추가"
+        },
+        "edit": {
+          "title": "결과 필드 편집"
+        },
+        "delete": {
+          "title": "결과 필드 삭제",
+          "confirmMessage": "<strong>{name}</strong>를 정말로 삭제하시겠습니까?",
+          "warning": "결과 필드는 모든 템플릿에서 제거됩니다. 이 작업은 되돌릴 수 없습니다."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "코드 저장소",
+      "description": "QuickScript 컨텍스트에 대한 코드 저장소 연결을 관리합니다.",
+      "addRepository": "저장소 추가",
+      "noRepos": {
+        "title": "구성된 코드 저장소가 없습니다.",
+        "description": "AI 기반 테스트 내보내기 생성을 위한 파일 컨텍스트를 제공하려면 Git 저장소를 연결하세요."
+      },
+      "delete": {
+        "title": "저장소 삭제",
+        "confirmMessage": "<strong>{name}</strong>를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        "fallbackName": "이 저장소"
+      },
+      "testConnection": "테스트 연결",
+      "connectionSuccess": "연결 성공",
+      "connectionFailed": "연결 실패",
+      "networkError": "네트워크 오류",
+      "editTitle": "코드 저장소 편집",
+      "addTitle": "코드 저장소 추가",
+      "repositoryUpdated": "저장소가 업데이트되었습니다",
+      "repositoryCreated": "저장소가 생성되었습니다",
+      "saveFailed": "저장소를 저장하는 데 실패했습니다.",
+      "namePlaceholder": "내 저장소",
+      "selectProvider": "제공업체를 선택하세요",
+      "httpWarning": "이 URL은 HTTP를 사용합니다. 자격 증명은 평문으로 전송됩니다. 안전한 연결을 위해서는 HTTPS를 사용하십시오."
+    },
+    "exportTemplates": {
+      "title": "QuickScript 템플릿",
+      "description": "QuickScript에서 테스트 케이스를 자동화 스크립트로 변환하는 데 사용되는 템플릿을 관리합니다.",
+      "confirmSetAsDefault": "기본 내보내기 템플릿으로 설정",
+      "confirmSetAsDefaultDescription": "이 템플릿을 기본값으로 설정하시겠습니까? 사용자가 테스트 케이스를 내보낼 때 이 템플릿이 기본적으로 선택됩니다.",
+      "fields": {
+        "category": "범주",
+        "framework": "뼈대",
+        "fileExtension": "파일 확장자",
+        "headerBody": "헤더 템플릿",
+        "templateBody": "템플릿 본문",
+        "footerBody": "푸터 템플릿",
+        "validation": {
+          "categoryRequired": "카테고리는 필수 입력 사항입니다.",
+          "frameworkRequired": "프레임워크가 필요합니다.",
+          "templateBodyRequired": "템플릿 본문은 필수입니다.",
+          "fileExtensionRequired": "파일 확장자는 필수 입력 사항입니다.",
+          "languageRequired": "언어 능력이 필요합니다."
+        },
+        "placeholders": {
+          "name": "예: Playwright(TypeScript)",
+          "description": "예: Playwright 테스트 스텁 생성",
+          "category": "예: 브라우저 E2E",
+          "framework": "예: 극작가",
+          "fileExtension": "예: .spec.ts",
+          "language": "예: 타입스크립트",
+          "headerBody": "선택 사항입니다. 콘텐츠는 상단에 한 번만 표시됩니다(예: 가져오기 문).",
+          "templateBody": "콧수염 템플릿 입력...\n\n사용 가능한 변수:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\n단계 섹션:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\n사용자 정의 필드:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "선택 사항입니다. 콘텐츠는 하단에 한 번만 렌더링됩니다(예: 종료 코드)."
+        },
+        "combobox": {
+          "typeNew": "새 값을 입력하려면 입력하세요."
+        }
+      },
+      "add": {
+        "button": "QuickScript 템플릿 추가",
+        "title": "새 QuickScript 템플릿 추가"
+      },
+      "edit": {
+        "title": "QuickScript 템플릿 편집"
+      },
+      "delete": {
+        "title": "QuickScript 템플릿 삭제",
+        "confirmMessage": "<strong>{name}</strong> QuickScript 템플릿을 삭제하시겠습니까?"
+      },
+      "preview": {
+        "title": "미리보기 (모의 데이터)",
+        "empty": "미리보기를 보려면 템플릿 본문을 입력하세요.",
+        "error": "템플릿 렌더링 오류입니다. Mustache 구문을 확인하세요."
+      },
+      "filterPlaceholder": "필터 템플릿...",
+      "noResults": "필터 조건에 맞는 템플릿이 없습니다.",
+      "templateCount": "{count, plural, one {# 템플릿} other {# 템플릿}}",
+      "allFrameworks": "모든 프레임워크",
+      "allFileExtensions": "모든 확장 프로그램",
+      "allLanguages": "모든 언어",
+      "showEnabled": "활성화됨",
+      "showAll": "모두",
+      "variableInserter": {
+        "placeholder": "변수를 삽입하세요...",
+        "groups": {
+          "customFields": "사용자 정의 필드"
+        },
+        "stepsBlock": "단계 차단"
+      }
+    },
+    "users": {
+      "showInactive": "비활성 상태 표시",
+      "add": {
+        "button": "사용자 추가",
+        "title": "새 사용자 추가",
+        "fields": {
+          "email_invalid": "잘못된 이메일 주소입니다.",
+          "password_error": "비밀번호가 필요합니다",
+          "confirmPassword_error": "비밀번호 확인이 필요합니다",
+          "passwordOptionalHelp": "매직링크 또는 SSO를 통해 로그인하도록 하려면 이 필드를 비워 두십시오."
+        }
+      },
+      "edit": {
+        "title": "사용자 편집"
+      },
+      "delete": {
+        "title": "사용자 삭제"
+      },
+      "restore": {
+        "title": "삭제된 사용자 복원",
+        "description": "삭제된 사용자 중 {email} 라는 이메일 주소를 가진 사용자가 발견되었습니다. 이 사용자를 복원하시겠습니까?",
+        "confirm": "사용자 복원"
+      },
+      "forcePasswordChange": "강제 비밀번호 변경",
+      "revokePassword": "비밀번호 취소",
+      "forcePasswordChangeDialogTitle": "강제 비밀번호 변경",
+      "forcePasswordChangeDialogDescription": "이렇게 하려면 {name} 님이 다음 로그인 시 비밀번호를 변경해야 합니다.",
+      "revokePasswordDialogTitle": "비밀번호 취소",
+      "revokePasswordDialogDescription": "이렇게 하면 {name}의 비밀번호가 즉시 무효화됩니다. 다른 로그인 방법을 사용해야 합니다.",
+      "confirmAction": "확인하다",
+      "forcePasswordChangeSuccess": "{name}의 비밀번호를 변경해야 합니다.",
+      "forcePasswordChangeFailed": "비밀번호 변경 강제 실행에 실패했습니다.",
+      "revokePasswordSuccess": "{name}의 비밀번호가 취소되었습니다.",
+      "revokePasswordFailed": "비밀번호 취소에 실패했습니다"
+    },
+    "security": {
+      "title": "보안",
+      "description": "암호 정책, 잠금 설정 및 시행 조치를 구성합니다.",
+      "passwordPolicyTitle": "비밀번호 정책",
+      "passwordPolicyDescription": "사용자 암호에 대한 요구 사항을 설정하세요",
+      "lockoutPolicyTitle": "잠금 정책",
+      "lockoutPolicyDescription": "로그인 시도 실패 후 계정 잠금 설정을 구성합니다.",
+      "enforcementTitle": "집행 조치",
+      "enforcementDescription": "자격 증명 기반 사용자의 암호 변경을 강제합니다.",
+      "minPasswordLengthLabel": "최소 비밀번호 길이",
+      "minPasswordLengthDescription": "비밀번호는 최소 8~128자 이상이어야 합니다.",
+      "requireUppercaseLabel": "대문자 필수",
+      "requireLowercaseLabel": "소문자 필수",
+      "requireNumbersLabel": "숫자가 필요합니다",
+      "requiredSpecialCharsLabel": "필수 특수 문자",
+      "requiredSpecialCharsDescription": "비활성화하려면 비워 두세요. 반드시 표시되어야 하는 문자를 입력하세요(예: !@#$).",
+      "passwordHistoryDepthLabel": "비밀번호 기록 깊이",
+      "passwordHistoryDepthDescription": "최근 N개의 비밀번호 재사용을 방지합니다(0 = 비활성화).",
+      "passwordExpirationDaysLabel": "비밀번호 만료 기간(일)",
+      "passwordExpirationDaysDescription": "N일 후 비밀번호 변경 강제 설정 (0 = 비활성화)",
+      "lockoutThresholdLabel": "잠금 임계값",
+      "lockoutThresholdDescription": "계정 잠금 전 실패 시도 횟수 (최소 1회)",
+      "lockoutDurationMinutesLabel": "잠금 시간(분)",
+      "lockoutDurationMinutesDescription": "계정 잠금 기간 (최소 1일)",
+      "saveChanges": "변경 사항 저장",
+      "forceAllUsers": "모든 사용자에게 비밀번호 변경 강제 적용",
+      "forceAllUsersDialogTitle": "모든 사용자에 대한 비밀번호 강제 변경",
+      "forceAllUsersDialogDescription": "이렇게 하면 {count} 자격 증명 기반 사용자는 다음 로그인 시 비밀번호를 변경해야 합니다.",
+      "forceAllUsersDialogWarning": "이 작업은 되돌릴 수 없습니다.",
+      "forceAllUsersDialogConfirm": "강제 변화",
+      "saved": "보안 설정이 저장되었습니다",
+      "saveFailed": "보안 설정을 저장하는 데 실패했습니다.",
+      "forceAllSuccess": "{count} 사용자의 비밀번호 변경이 필요합니다.",
+      "forceAllFailed": "비밀번호 변경 강제 실행에 실패했습니다."
+    },
+    "apiTokens": {
+      "description": "모든 사용자의 API 토큰을 확인하고 관리할 수 있습니다. 보안상의 문제가 있는 경우 토큰을 취소할 수 있습니다.",
+      "filterPlaceholder": "토큰 이름 또는 사용자로 필터링...",
+      "showInactive": "쇼 취소됨",
+      "noTokens": "아직 API 토큰이 생성되지 않았습니다.",
+      "columns": {
+        "lastUsed": "최근 사용",
+        "expires": "만료됨"
+      },
+      "status": {
+        "revoked": "취소됨",
+        "expired": "만료됨"
+      },
+      "noExpiry": "유효기간 없음",
+      "revokeToken": "토큰 취소",
+      "revokeConfirmTitle": "API 토큰 취소",
+      "revokeConfirmMessage": "이 API 토큰을 취소하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "revokeConfirmDescription": "{user} 에 속한 토큰 \"{name}\"은 즉시 취소되며 더 이상 API 접근에 사용할 수 없습니다.",
+      "revokeSuccess": "API 토큰이 성공적으로 취소되었습니다.",
+      "revokeError": "API 토큰 취소에 실패했습니다.",
+      "revokeAllTokens": "모든 토큰을 취소합니다",
+      "revokeAllTitle": "모든 API 토큰을 취소합니다",
+      "revokeAllDescription": "이렇게 하면 모든 사용자의 활성 API 토큰이 즉시 모두 취소됩니다. 이 작업은 되돌릴 수 없으며 자동화된 워크플로에 지장을 줄 수 있습니다.",
+      "revokeAllConfirm": "확인하려면 \"REVOKE ALL\"을 입력하세요.",
+      "revokeAllPlaceholder": "모두 취소",
+      "revokeAllSuccess": "모든 API 토큰이 취소되었습니다.",
+      "revokeAllError": "모든 토큰을 취소하는 데 실패했습니다."
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "태그를 생성하는 동안 오류가 발생했습니다."
+        }
+      },
+      "delete": {
+        "title": "태그 삭제",
+        "confirmMessage": "이 태그를 정말로 삭제하시겠습니까?",
+        "warning": "이 태그는 모든 테스트 케이스와 세션에서 제거될 예정입니다.",
+        "errors": {
+          "unknown": "태그를 삭제하는 동안 오류가 발생했습니다."
+        }
+      },
+      "edit": {
+        "title": "태그 수정"
+      }
+    },
+    "workflows": {
+      "description": "테스트 케이스 워크플로우 관리",
+      "add": {
+        "button": "워크플로 추가",
+        "title": "새 워크플로 추가",
+        "defaultHelp": "새로운 테스트 케이스에 대한 기본 워크플로로 설정합니다.",
+        "scopeLabel": "워크플로 범위",
+        "errors": {
+          "nameExists": "이미 동일한 이름의 워크플로가 존재합니다."
+        }
+      },
+      "edit": {
+        "title": "워크플로 편집",
+        "lastWorkflowTypeWarning": "이것이 마지막 워크플로 유형입니다. 최소한 하나의 워크플로 유형이 활성화되어 있어야 합니다.",
+        "errors": {
+          "nameRequired": "워크플로 이름은 필수 입력 사항입니다.",
+          "unknownWorkflow": "알 수 없는 워크플로"
+        }
+      },
+      "delete": {
+        "title": "워크플로 삭제",
+        "confirmMessage": "이 워크플로를 정말로 삭제하시겠습니까?"
+      },
+      "setDefault": {
+        "title": "기본 워크플로 설정",
+        "confirmMessage": "이 워크플로를 기본값으로 설정하시겠습니까?",
+        "description": "이 워크플로는 모든 프로젝트에 추가됩니다."
+      }
+    },
+    "roles": {
+      "description": "각 애플리케이션 영역에 대한 권한을 설정하여 사용자가 수행할 수 있는 작업을 정의하십시오.",
+      "filterPlaceholder": "역할 필터링...",
+      "add": {
+        "button": "역할 추가",
+        "title": "새 역할 추가",
+        "fields": {
+          "name_error": "역할 이름은 필수 입력 사항입니다."
+        },
+        "errors": {
+          "nameExists": "이 이름의 역할이 이미 존재합니다."
+        }
+      },
+      "edit": {
+        "title": "역할 편집",
+        "permissionsTitle": "권한",
+        "areaHeader": "적용 분야"
+      },
+      "delete": {
+        "title": "역할 삭제",
+        "confirmMessage": "이 역할을 정말로 삭제하시겠습니까?",
+        "warning": "이 작업은 되돌릴 수 없습니다. 이 역할을 가진 사용자는 기본 역할로 할당됩니다.",
+        "errors": {
+          "defaultNotFound": "기본 역할을 삭제할 수 없습니다"
+        }
+      }
+    },
+    "statuses": {
+      "description": "테스트 상태 관리",
+      "add": {
+        "button": "상태 추가",
+        "title": "새 상태 추가",
+        "systemNameHelp": "시스템 이름은 이 상태를 식별합니다. 생성 후에는 변경할 수 없습니다.",
+        "aliasesHelp": "별칭 목록을 쉼표로 구분하여 나열합니다.",
+        "errors": {
+          "nameExists": "이미 동일한 이름의 상태가 존재합니다.",
+          "systemNameEmpty": "시스템 이름은 필수 입력 사항입니다.",
+          "systemNameInvalid": "시스템 이름은 영숫자여야 합니다.",
+          "aliasesInvalid": "별칭은 영숫자여야 합니다.",
+          "missingColor": "원하는 색상을 찾을 수 없습니다. 다른 색상을 선택해 주세요."
+        }
+      },
+      "edit": {
+        "title": "상태 수정",
+        "systemNameHelp": "시스템 이름은 자동화된 프로세스의 상태를 식별하는 데 사용됩니다. 생성 후에는 변경할 수 없습니다.",
+        "unmodifiableHelp": "'테스트되지 않음' 상태는 시스템 상태이며 수정할 수 없습니다.",
+        "untestedHelp": "'테스트되지 않음'이라는 이름은 시스템 상태에 대해 예약되어 있으므로 사용할 수 없습니다.",
+        "success": "상태가 성공적으로 업데이트되었습니다."
+      },
+      "delete": {
+        "title": "삭제 상태",
+        "confirmMessage": "<strong>{name}</strong> 상태를 삭제하시겠습니까?",
+        "errors": {
+          "inUse": "이 상태는 사용 중이므로 삭제할 수 없습니다.",
+          "defaultNotFound": "기본 상태를 찾을 수 없음"
+        },
+        "success": "상태가 성공적으로 삭제되었습니다."
+      },
+      "fields": {
+        "final": "결정적인",
+        "system": "시스템 상태",
+        "forTestCase": "테스트 케이스용",
+        "forTestRun": "테스트 실행용",
+        "forSession": "세션용",
+        "color": "색상"
+      }
+    },
+    "appConfig": {
+      "description": "글로벌 애플리케이션 구성을 관리합니다.",
+      "addConfig": "애플리케이션 구성 추가",
+      "editConfig": "애플리케이션 구성 편집",
+      "keyPlaceholder": "구성 키를 입력하세요...",
+      "valuePlaceholder": "JSON 값을 입력하세요...",
+      "currentTranslation": "현재 번역",
+      "filterPlaceholder": "주요 키워드로 필터링...",
+      "errors": {
+        "keyRequired": "키가 필요합니다.",
+        "invalidJson": "잘못된 JSON 형식입니다."
+      },
+      "configKeys": {
+        "project_docs_default": "프로젝트 문서 기본값"
+      }
+    },
+    "configurations": {
+      "description": "구성은 테스트 환경을 정의하는 데 사용되는 범주와 변형의 조합입니다. 예를 들어 운영 체제/브라우저, 테스트 서버, 언어 등이 있습니다.",
+      "addConfiguration": "추가 구성",
+      "editConfiguration": "편집 구성",
+      "filterPlaceholder": "필터 구성...",
+      "categories": {
+        "title": "카테고리",
+        "description": "글로벌 카테고리 관리",
+        "editCategory": "카테고리 편집",
+        "selectCategory": "카테고리를 선택하세요",
+        "filterPlaceholder": "카테고리 필터링...",
+        "add": {
+          "title": "새 카테고리 추가"
+        },
+        "delete": {
+          "confirmMessage": "이 카테고리를 정말로 삭제하시겠습니까?",
+          "deleteCategory": "카테고리 삭제",
+          "deleteCategoryConfirm": "카테고리 <strong>{name}</strong>를 삭제하시겠습니까?",
+          "deleteCategoryWarning": "이 작업을 수행하면 해당 카테고리와 관련된 모든 변형이 삭제됩니다."
+        },
+        "disable": {
+          "confirmDisableTitle": "변형 비활성화",
+          "confirmDisableDescription": "이 변형을 비활성화하시겠습니까?"
+        }
+      },
+      "combinations": {
+        "title": "조합",
+        "description": "글로벌 조합 관리",
+        "addCombination": "조합을 추가하세요",
+        "editCombination": "조합 편집",
+        "selectCombination": "조합을 선택하세요",
+        "selectCombinationDescription": "구성에 추가할 변형 조합을 선택하십시오.",
+        "allExist": "모든 조합이 이미 존재합니다.",
+        "selectAtLeast": "최소 한 가지 조합을 선택해 주세요."
+      },
+      "delete": {
+        "title": "삭제 구성",
+        "message": "구성 <strong>{name}</strong>을 삭제하시겠습니까?",
+        "confirmMessage": "이 설정을 삭제하시겠습니까?"
+      },
+      "variants": {
+        "edit": {
+          "title": "변형 편집"
+        },
+        "delete": {
+          "title": "변형 삭제",
+          "message": "<strong>{name}</strong> 변형을 삭제하시겠습니까?",
+          "confirmMessage": "이 버전을 삭제하시겠습니까?",
+          "suggestion": "해당 변형을 비활성화하는 것을 고려해 보세요."
+        },
+        "selection": {
+          "title": "변형 선택",
+          "description": "구성에 추가할 변형을 선택하십시오."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "사용자들을 그룹으로 구성하여 프로젝트 접근 권한과 역할을 일괄적으로 할당할 수 있습니다."
+      },
+      "filterPlaceholder": "필터 그룹...",
+      "add": {
+        "button": "그룹 추가",
+        "title": "새 그룹 추가",
+        "errors": {
+          "nameExists": "이미 동일한 이름의 그룹이 존재합니다."
+        }
+      },
+      "edit": {
+        "title": "편집 그룹"
+      },
+      "delete": {
+        "deleteGroup": "그룹 삭제",
+        "deleteGroupDescription": "이 작업을 수행하면 그룹과 해당 그룹에 속한 모든 사용자가 삭제됩니다.",
+        "confirmMessage": "이 그룹을 정말로 삭제하시겠습니까?"
+      },
+      "noUsersSelected": "아직 선택된 사용자가 없습니다.",
+      "noUsersAssigned": "이 그룹에 할당된 사용자가 없습니다."
+    },
+    "milestones": {
+      "description": "마일스톤 유형 관리",
+      "filterPlaceholder": "마일스톤 유형 필터링...",
+      "addMilestones": "마일스톤 일괄 추가",
+      "confirmDefault": "기본값 확인",
+      "confirmDefaultDescription": "이 마일스톤 유형을 기본값으로 설정하시겠습니까?",
+      "warning": "이 마일스톤 유형은 모든 프로젝트에 추가됩니다.",
+      "wizard": {
+        "selectProjects": "프로젝트 선택",
+        "projectsSelected": "{count, plural, =0 {선택된 프로젝트 없음} one {선택된 프로젝트 수} other {선택된 프로젝트 수}}",
+        "createMilestone": "마일스톤 생성",
+        "noCommonTypesTitle": "공통된 마일스톤 유형 없음",
+        "noCommonTypesDescription": "선택한 프로젝트에는 공통된 마일스톤 유형이 없습니다. 선택한 모든 프로젝트에 최소 하나 이상의 공통 마일스톤 유형이 있는지 확인하거나, 다른 프로젝트를 선택하십시오."
+      },
+      "add": {
+        "button": "마일스톤 유형 추가",
+        "title": "새로운 마일스톤 유형 추가",
+        "errors": {
+          "nameExists": "이 이름으로 된 마일스톤 유형이 이미 존재합니다."
+        }
+      },
+      "edit": {
+        "title": "마일스톤 유형 편집"
+      },
+      "delete": {
+        "title": "마일스톤 유형 삭제",
+        "confirmMessage": "이 마일스톤 유형을 정말로 삭제하시겠습니까?"
+      }
+    },
+    "issue_config": {
+      "link_title": "링크 문제 추적기",
+      "link_description": "수동으로 연결된 이슈에 대한 기본 URL을 구성합니다. 외부 ID만 사용하여 이슈를 연결할 경우, 이 기본 URL이 앞에 추가되어 전체 링크가 생성됩니다.",
+      "filter": {
+        "show_inactive": "비활성 구성 표시",
+        "search_placeholder": "구성 이름으로 필터링..."
+      },
+      "base_url": "기본 URL",
+      "link_update_success": "링크 구성이 성공적으로 업데이트되었습니다.",
+      "link_update_error": "링크 구성 업데이트에 실패했습니다.",
+      "description": "외부 이슈 추적 시스템과의 통합을 구성합니다.",
+      "delete": {
+        "title": "문제 구성 삭제",
+        "confirmMessage": "구성 <bold>{name}</bold>을 삭제하시겠습니까?",
+        "warning": "이 작업은 되돌릴 수 없습니다. 현재 이 추적기에 할당된 모든 프로젝트는 기본 추적기로 다시 할당됩니다. 대신 구성을 비활성화하는 것을 고려하십시오.",
+        "cannotDeleteDefault": "기본 이슈 트래커는 삭제할 수 없습니다.",
+        "noDefaultFound": "삭제할 수 없습니다. 프로젝트를 다시 할당할 기본 이슈 트래커를 찾을 수 없습니다."
+      },
+      "add": {
+        "title": "이슈 트래커 추가",
+        "description": "이슈 추적 시스템에 대한 새 구성을 생성합니다.",
+        "name": "구성 이름",
+        "name_placeholder": "예: 프로젝트 Jira 링크",
+        "system_type": "시스템 유형",
+        "select_system_type": "시스템 유형을 선택하세요",
+        "base_url": "이슈 자리 표시자를 포함한 기본 URL",
+        "base_url_placeholder": "예: https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "이슈 구성이 성공적으로 생성되었습니다.",
+        "create_error": "이슈 구성 생성 오류",
+        "setDefaultWarning": "이 값을 기본값으로 설정하면 현재 기본 구성에서 기본 상태가 제거됩니다."
+      },
+      "edit": {
+        "title": "이슈 트래커 편집",
+        "description": "이 문제 구성에 대한 세부 정보를 업데이트하세요.",
+        "name_placeholder": "구성 이름을 입력하십시오",
+        "select_project": "프로젝트를 선택하세요...",
+        "update_success": "문제 구성이 성공적으로 업데이트되었습니다.",
+        "update_error": "이슈 구성 업데이트에 실패했습니다.",
+        "edit_not_supported": "현재 이 시스템 유형에 대한 구성 편집은 지원되지 않습니다."
+      }
+    },
+    "issues": {
+      "description": "이 이슈 트래커의 이슈를 관리하세요",
+      "filterPlaceholder": "필터 문제...",
+      "add": {
+        "button": "이슈 추가",
+        "title": "새로운 이슈 추가"
+      },
+      "edit": {
+        "title": "문제 수정"
+      },
+      "delete": {
+        "title": "삭제 문제",
+        "confirmMessage": "\"{name} \" 이슈를 삭제하시겠습니까?"
+      },
+      "syncIssue": "외부 시스템과의 동기화 문제",
+      "syncSuccess": "이슈가 성공적으로 동기화되었습니다.",
+      "syncSuccessDescription": "이슈 \"{name}\"가 외부 시스템의 최신 정보로 업데이트되었습니다.",
+      "syncError": "동기화 실패 문제",
+      "syncErrorDescription": "동기화에 실패했습니다. 나중에 다시 시도해 주세요."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "프로젝트 링크",
+        "milestoneLinks": "주요 링크",
+        "icons": "아이콘",
+        "fieldOptions": "필드 옵션",
+        "configCategories": "구성 카테고리",
+        "configVariants": "구성 변형",
+        "repositories": "저장소",
+        "repositoryFolders": "저장소 폴더",
+        "repositoryCaseLinks": "저장소 사례 링크",
+        "repositoryCaseVersions": "저장소 케이스 버전",
+        "testRunStepResults": "테스트 실행 단계 결과",
+        "issueConfigs": "문제 구성",
+        "sharedStepGroups": "공유 스텝 그룹"
+      },
+      "table": {
+        "title": "삭제됨 {itemType}",
+        "loading": "삭제된 {itemType} 로딩 중...",
+        "error": "삭제된 {itemType}: {message} 로드 오류",
+        "noItems": "삭제된 {itemType} 항목이 없습니다.",
+        "noResults": "삭제된 {itemType} 이 \"{query} \"와 일치하는 항목이 없습니다.",
+        "restoreConfirmationMessage": "{itemType} 테이블에서 이 행을 복원하시겠습니까? 관련 데이터도 함께 복원될 수 있습니다.",
+        "purgeConfirmationMessage": "{itemType} 테이블에서 이 행을 영구적으로 삭제하시겠습니까? 이 작업은 되돌릴 수 없으며 관련 데이터도 삭제될 수 있습니다."
+      }
+    },
+    "notifications": {
+      "title": "알림 관리",
+      "description": "기본 알림 설정을 지정하고(사용자가 재정의할 수 있음) 시스템 알림을 전송합니다.",
+      "defaultMode": {
+        "label": "기본 알림 모드",
+        "inApp": "앱 내에서만 사용 가능",
+        "inAppEmailImmediate": "앱 내 알림 + 이메일 알림 (즉시)",
+        "inAppEmailDaily": "앱 내 알림 + 이메일 (일일 요약)"
+      },
+      "options": {
+        "title": "사용 가능한 알림 옵션",
+        "inApp": {
+          "label": "앱 내 알림",
+          "description": "애플리케이션 내에서 알림을 표시합니다."
+        },
+        "emailImmediate": {
+          "label": "즉시 이메일 발송",
+          "description": "이벤트 발생 시 즉시 이메일 알림을 보냅니다."
+        },
+        "emailDaily": {
+          "label": "일일 이메일 요약",
+          "description": "매일 알림 요약을 이메일로 보내드립니다."
+        }
+      },
+      "save": "설정 저장",
+      "success": {
+        "title": "설정이 저장되었습니다",
+        "description": "알림 설정이 성공적으로 업데이트되었습니다."
+      },
+      "error": {
+        "description": "알림 설정을 저장하는 데 실패했습니다."
+      },
+      "systemNotification": {
+        "title": "시스템 알림",
+        "description": "모든 사용자에게 중요 공지사항을 전송합니다.",
+        "titlePlaceholder": "알림 제목을 입력하세요...",
+        "messagePlaceholder": "알림 메시지를 입력하세요...",
+        "send": "알림 보내기",
+        "success": {
+          "title": "알림이 전송되었습니다",
+          "description": "시스템 알림이 {count, plural, one {# 사용자} other {# 사용자}}에게 전송되었습니다."
+        },
+        "error": {
+          "description": "시스템 알림 전송에 실패했습니다.",
+          "emptyFields": "제목과 메시지를 모두 제공해 주세요."
+        },
+        "history": {
+          "title": "알림 내역",
+          "sentBy": "보낸 사람",
+          "sentAt": "보낸 날짜",
+          "empty": "아직 시스템 알림이 전송되지 않았습니다."
+        }
+      }
+    },
+    "integrations": {
+      "description": "이슈 추적을 위한 타사 통합 관리",
+      "list": {
+        "title": "구성된 이슈 통합",
+        "description": "구성된 이슈 통합을 보고 관리하세요."
+      },
+      "empty": {
+        "message": "아직 문제 통합이 구성되지 않았습니다."
+      },
+      "addIntegration": "이슈 추가 통합",
+      "allIntegrations": "모든 이슈 통합",
+      "manageDescription": "외부 서비스 문제 통합을 구성하고 관리하세요.",
+      "status": {
+        "active": "활동적인",
+        "inactive": "비활성화됨"
+      },
+      "connectedProjects": "연결된 프로젝트",
+      "noIntegrations": "문제 없는 통합 구성 완료",
+      "testConnection": "테스트 연결",
+      "testSuccess": "연결 성공",
+      "testSuccessDescription": "이슈 통합이 올바르게 구성되고 연결되었습니다.",
+      "testFailed": "연결 실패",
+      "testFailedDescription": "외부 서비스에 연결할 수 없습니다.",
+      "testError": "테스트 오류",
+      "testErrorDescription": "연결 테스트 중 오류가 발생했습니다.",
+      "syncInProgress": "동기화 문제...",
+      "syncIntegration": "이슈 통합에서 모든 이슈를 동기화합니다.",
+      "syncSuccess": "동기화 대기 중",
+      "syncSuccessDescription": "\"{name}\"의 이슈가 백그라운드에서 동기화되고 있습니다. 몇 분 정도 소요될 수 있습니다. 완료되면 테이블이 자동으로 업데이트됩니다.",
+      "syncError": "동기화 실패",
+      "syncErrorDescription": "이 문제 통합에 대한 동기화 작업을 대기열에 추가할 수 없습니다. 나중에 다시 시도해 주세요.",
+      "delete": {
+        "confirmMessage": "이슈 통합 \"{name} \"을 삭제하시겠습니까?",
+        "warning": "이렇게 하면 이슈 통합이 제거되고 모든 프로젝트에서 연결이 끊어집니다. 이 작업은 되돌릴 수 없습니다.",
+        "warningTitle": "이 작업은 다음과 같은 결과를 가져올 것입니다:",
+        "warning1": "이슈 통합 구성 및 자격 증명을 영구적으로 제거합니다.",
+        "warning2": "이 문제 통합을 위해 모든 사용자 인증 토큰 연결을 해제하세요.",
+        "warning3": "데이터베이스에 연결된 모든 이슈를 유지합니다(이슈의 연결은 해제됩니다).",
+        "warning4": "모든 프로젝트에서 이슈 통합 기능을 먼저 제거해야 합니다."
+      },
+      "deleteSuccess": "이슈 통합 삭제됨",
+      "deleteSuccessDescription": "문제 통합이 성공적으로 제거되었습니다.",
+      "deleteError": "삭제 오류",
+      "add": {
+        "description": "외부 서비스와의 새로운 이슈 통합을 구성합니다.",
+        "selectType": "이슈 통합 유형을 선택하세요",
+        "typeDescription": "통합할 서비스 유형을 선택하세요",
+        "successMessage": "이슈 통합이 성공적으로 완료되었습니다.",
+        "successDescription": "이슈 통합 설정이 완료되어 사용 준비가 되었습니다.",
+        "simple_url": {
+          "name": "간단한 URL",
+          "description": "사용자 지정 URL 패턴을 사용한 기본 문제 추적"
+        },
+        "jira": {
+          "name": "지라",
+          "description": "이슈 추적 및 프로젝트 관리를 위해 Atlassian Jira에 연결하세요."
+        },
+        "github": {
+          "name": "깃허브",
+          "description": "문제 추적을 위해 GitHub에 연결하세요."
+        },
+        "gitlab": {
+          "name": "깃랩",
+          "description": "이슈 및 병합 요청 추적을 위해 GitLab에 연결하세요."
+        },
+        "gitea": {
+          "name": "기테아 / 포르게호 / 고그스",
+          "description": "이슈 추적을 위해 자체 호스팅 Gitea, Forgejo 또는 Gogs 인스턴스에 연결하세요."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Azure DevOps에 연결하여 작업 항목을 추적하세요."
+        }
+      },
+      "filterPlaceholder": "필터 통합...",
+      "table": {
+        "lastSync": "마지막 동기화",
+        "empty": "문제 통합 사항이 발견되지 않았습니다.",
+        "loading": "이슈 통합을 불러오는 중...",
+        "configure": "구성"
+      },
+      "edit": {
+        "description": "문제 통합 설정 및 구성 업데이트",
+        "successMessage": "이슈 통합이 성공적으로 업데이트되었습니다.",
+        "successDescription": "이슈 통합 설정이 저장되었습니다."
+      },
+      "editIntegration": "문제 편집 통합",
+      "saveIntegration": "문제 저장 통합",
+      "deleteIntegration": "문제 삭제 통합",
+      "config": {
+        "name": "문제 통합 이름",
+        "namePlaceholder": "이 문제 통합에 대한 이름을 입력하세요",
+        "nameHelp": "이 문제 통합을 식별하기 위한 설명적인 이름",
+        "authType": "인증 유형",
+        "authTypeHelp": "외부 서비스와의 인증 방법을 선택하세요",
+        "emailPlaceholder": "your-email@example.com",
+        "emailHelp": "귀하의 계정 이메일 주소",
+        "apiToken": "API 토큰",
+        "apiTokenPlaceholder": "API 토큰을 입력하세요",
+        "apiTokenHelp": "계정 설정에서 API 토큰을 생성하세요.",
+        "jiraUrl": "지라 URL",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "Jira 인스턴스의 URL",
+        "clientId": "클라이언트 ID",
+        "clientIdPlaceholder": "OAuth 클라이언트 ID를 입력하세요.",
+        "clientIdHelp": "OAuth 애플리케이션의 클라이언트 ID",
+        "clientSecret": "고객 비밀",
+        "clientSecretPlaceholder": "OAuth 클라이언트 암호를 입력하세요.",
+        "clientSecretHelp": "OAuth 애플리케이션의 클라이언트 시크릿",
+        "cloudId": "클라우드 ID",
+        "cloudIdPlaceholder": "Atlassian Cloud ID를 입력하세요.",
+        "cloudIdHelp": "Atlassian Cloud 인스턴스 ID(Jira URL에서 확인 가능)",
+        "apiUrl": "API URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "서비스 API의 기본 URL",
+        "personalAccessTokenPlaceholder": "개인 액세스 토큰을 입력하세요",
+        "personalAccessTokenHelp": "적절한 권한이 있는 개인 액세스 토큰",
+        "apiKeyPlaceholder": "API 키를 입력하세요",
+        "apiKeyHelp": "인증용 API 키",
+        "baseUrl": "URL 패턴",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "이슈에 대한 URL 패턴입니다. {issueId} 를 플레이스홀더로 사용하세요.",
+        "organizationUrl": "조직 URL",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "Azure DevOps 조직 URL",
+        "projectPath": "프로젝트 경로",
+        "projectPathPlaceholder": "그룹/하위그룹/프로젝트",
+        "projectPathHelp": "GitLab 프로젝트의 전체 경로(예: mygroup/myproject)",
+        "instanceUrl": "인스턴스 URL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "자체 호스팅 인스턴스의 URL입니다. gitlab.com을 사용하려면 비워 두세요.",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "소유자",
+        "ownerPlaceholder": "사용자 이름 또는 조직",
+        "ownerHelp": "리포지토리를 소유한 Gitea 사용자 또는 조직",
+        "repo": "저장소",
+        "repoPlaceholder": "저장소 이름",
+        "repoHelp": "Gitea 저장소의 이름",
+        "encrypted": "암호화됨",
+        "encryptedHelp": "이 필드는 암호화되어 안전하게 저장됩니다.",
+        "changeCredential": "변화",
+        "apiKeyWarningTitle": "API 키 인증 알림",
+        "apiKeyWarningDescription": "API 키 인증을 사용하는 경우, 문제 보고자는 자동으로 결정됩니다.",
+        "apiKeyWarningPoint1": "TestPlanIt 이메일 주소가 Jira 사용자 이메일 주소와 일치하면 보고자로 지정됩니다.",
+        "apiKeyWarningPoint2": "이메일 주소가 일치하지 않으면 TestPlanIt에서 사용하는 이름이 Jira 표시 이름과 일치하게 됩니다.",
+        "apiKeyWarningPoint3": "일치하는 항목이 없으면 API 키 소유자가 리포터로 설정됩니다.",
+        "forgeApiKeyLabel": "Forge API 키",
+        "forgeApiKeyDescription": "Atlassian Forge 앱에서 Jira 이슈 패널의 요청을 인증하는 데 사용됩니다. 여기에서 키를 생성하고 Forge 앱 설정에 붙여넣으세요.",
+        "forgeApiKeyPlaceholder": "API 키를 생성하려면 '생성'을 클릭하세요.",
+        "forgeApiKeyGenerate": "생성하다",
+        "forgeApiKeyCopy": "복사",
+        "forgeApiKeyCopied": "복사됨",
+        "platform": "플랫폼",
+        "platformPlaceholder": "플랫폼을 선택하세요...",
+        "platformGitea": "기테아",
+        "platformForgejo": "포르제호",
+        "platformGogs": "고그스"
+      },
+      "authType": {
+        "api_key": "API 키",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "개인 액세스 토큰"
+      },
+      "validation": {
+        "nameRequired": "이슈 통합 이름은 필수 입력 사항입니다.",
+        "clientIdRequired": "고객 ID가 필요합니다.",
+        "clientSecretRequired": "클라이언트 시크릿이 필요합니다.",
+        "cloudIdRequired": "클라우드 ID가 필요합니다.",
+        "apiUrlRequired": "API URL은 필수 입력 사항입니다.",
+        "tokenRequired": "개인 액세스 토큰이 필요합니다.",
+        "apiKeyRequired": "API 키가 필요합니다."
+      },
+      "errors": {
+        "updateFailed": "이슈 통합 업데이트에 실패했습니다.",
+        "testFailed": "연결 테스트 실패",
+        "nameExists": "이 이름으로 된 이슈 통합이 이미 존재합니다.",
+        "createFailed": "이슈 통합 생성에 실패했습니다.",
+        "deleteFailed": "이슈 통합 삭제 실패"
+      },
+      "confirmDelete": {
+        "message": "이슈 통합 \"{name} \"을 삭제하시겠습니까?",
+        "warning": "이렇게 하면 이슈 통합이 제거되고 모든 프로젝트에서 연결이 끊어집니다. 이 작업은 되돌릴 수 없습니다."
+      },
+      "form": {
+        "success": "이슈 통합이 성공적으로 저장되었습니다.",
+        "successDescription": "이슈 통합 설정이 완료되어 사용 준비가 되었습니다.",
+        "testing": "연결 테스트 중..."
+      },
+      "oauth": {
+        "connectAccount": "계정 연결",
+        "connected": "연결됨",
+        "notConnected": "연결되지 않음",
+        "authDescription": "이 연동 기능을 사용하려면 {provider} 로 인증해야 합니다.",
+        "authError": "인증 실패",
+        "authErrorDescription": "외부 서비스에 인증할 수 없습니다."
+      }
+    },
+    "llm": {
+      "addIntegration": "AI 모델 추가",
+      "filterPlaceholder": "AI 모델 필터링...",
+      "testAll": "모든 연결을 테스트하세요",
+      "connectionTestComplete": "연결 테스트 완료",
+      "allIntegrationsTested": "모든 AI 모델 연결이 테스트되었습니다.",
+      "failedToTestConnections": "일부 연결 테스트에 실패했습니다.",
+      "notConfigured": "구성되지 않음",
+      "defaultModel": "선택된 모델",
+      "budgetUsage": "(이번 달) 사용량",
+      "noBudget": "예산 설정 안 함",
+      "streaming": "스트리밍",
+      "add": {
+        "title": "AI 모델 통합 추가",
+        "description": "조직에 맞는 새로운 AI 모델을 구성하세요.",
+        "integrationNamePlaceholder": "이 통합 기능에 대한 이름을 입력하세요...",
+        "selectProvider": "제공업체를 선택하세요",
+        "openai": "오픈아이",
+        "anthropic": "인류",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "구글 제미니",
+        "ollama": "올라마",
+        "customLlm": "맞춤형 LLM",
+        "apiKeyPlaceholder": "API 키를 입력하세요...",
+        "apiKeyDescription": "제공업체와의 인증에 사용되는 API 키입니다.",
+        "endpoint": "엔드포인트 URL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "팁: 프록시(예: LiteLLM)를 사용하는 경우 엔드포인트 URL 끝에 /v1을 추가해 보세요.",
+        "deploymentName": "배포 이름",
+        "deploymentNamePlaceholder": "배포 이름을 입력하세요...",
+        "deploymentNameDescription": "Azure OpenAI 배포 이름",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022 등",
+        "defaultModelDescription": "기본적으로 사용할 모델",
+        "maxTokensPerRequest": "요청당 최대 토큰 수",
+        "maxRequestsPerMinute": "분당 최대 요청 수",
+        "costPerInputToken": "입력 토큰 100만 개당 비용($)",
+        "costPerOutputToken": "100만 출력 토큰당 비용($)",
+        "monthlyBudget": "월 예산($)",
+        "monthlyBudgetPlaceholder": "100.00",
+        "monthlyBudgetDescription": "알림에 대한 선택적 지출 목표 설정 (사용 차단은 아님)",
+        "billingPeriodStartDay": "청구 기간 시작일",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "청구 기간이 시작되는 날짜(1~31일)를 입력합니다. 29~31일의 경우 청구 기간이 더 짧은 달의 마지막 날을 사용합니다.",
+        "defaultTemperature": "기본 온도",
+        "defaultMaxTokens": "기본 최대 토큰",
+        "timeout": "요청 시간 초과(밀리초)",
+        "timeoutDescription": "AI 모델 응답 대기 최대 시간(5000~600000ms). 스트리밍 요청에는 적용되지 않습니다.",
+        "streamingEnabled": "스트리밍 활성화",
+        "streamingEnabledDescription": "실시간 응답 스트리밍을 허용합니다",
+        "setAsDefault": "기본값으로 설정",
+        "setAsDefaultDescription": "이 모델을 조직의 기본 AI 모델로 사용하십시오.",
+        "fetchingModels": "모델을 불러오는 중...",
+        "failedToFetchModels": "사용 가능한 모델을 가져오는 데 실패했습니다.",
+        "selectModel": "모델을 선택하세요",
+        "connectionSuccessfulDescription": "AI 모델 연결이 검증되었으며 정상적으로 작동하고 있습니다.",
+        "failedToConnect": "AI 모델 제공업체에 연결하지 못했습니다.",
+        "integrationCreated": "AI 모델 통합이 성공적으로 완료되었습니다.",
+        "failedToCreate": "AI 모델 통합 생성에 실패했습니다.",
+        "validation": {
+          "nameRequired": "통합 이름은 필수 입력 사항입니다.",
+          "nameUnique": "이미 동일한 이름의 통합 기능이 존재합니다.",
+          "defaultModelRequired": "기본 모델이 필요합니다."
+        }
+      },
+      "edit": {
+        "title": "AI 모델 통합 편집",
+        "description": "이 AI 모델 통합에 대한 구성을 업데이트하세요.",
+        "statusDescription": "이 통합 기능을 활성화 또는 비활성화합니다.",
+        "apiKeyPlaceholder": "업데이트하려면 새 API 키를 입력하세요...",
+        "update": "업데이트",
+        "integrationUpdated": "AI 모델 통합이 성공적으로 업데이트되었습니다.",
+        "failedToUpdate": "AI 모델 통합 업데이트에 실패했습니다.",
+        "validation": {
+          "nameRequired": "통합 이름은 필수 입력 사항입니다.",
+          "nameUnique": "이미 동일한 이름의 통합 기능이 존재합니다.",
+          "defaultModelRequired": "기본 모델이 필요합니다."
+        }
+      },
+      "sections": {
+        "provider": "공급자",
+        "costAndBudget": "비용 및 예산",
+        "advanced": "고급의"
+      },
+      "delete": {
+        "title": "AI 모델 통합 삭제",
+        "description": "이 AI 모델 통합을 삭제하시겠습니까? 삭제하면 모든 프로젝트에서 제거되며 되돌릴 수 없습니다.",
+        "integrationDeletedSuccess": "AI 모델 통합이 성공적으로 삭제되었습니다.",
+        "failedToDeleteIntegration": "AI 모델 통합 삭제에 실패했습니다.",
+        "cannotDeleteDefault": "기본 AI 모델을 삭제할 수 없습니다. 먼저 다른 AI 모델을 기본값으로 설정하십시오."
+      },
+      "validation": {
+        "defaultModelRequired": "기본 모델이 필요합니다."
+      },
+      "test": {
+        "title": "AI 모델 통합 테스트",
+        "description": "{name}의 연결 및 기능을 테스트하세요.",
+        "connectionStatus": "연결 상태",
+        "connectionStatusDescription": "AI 모델에 접근 가능한지 확인하세요",
+        "retest": "연결 재테스트",
+        "connectionSuccessfulDescription": "AI 모델은 접근 가능하며 올바르게 응답합니다.",
+        "failedToConnect": "AI 모델에 연결하지 못했습니다.",
+        "errorTestingConnection": "연결 테스트 중 오류가 발생했습니다.",
+        "testMessage": "테스트 메시지",
+        "testMessagePlaceholder": "인공지능 모델에게 보낼 메시지를 입력하세요...",
+        "sendTestMessage": "테스트 메시지 전송",
+        "response": "응답",
+        "testSuccessful": "테스트 성공",
+        "responseReceived": "응답을 성공적으로 수신했습니다 (비용: ${cost})",
+        "testFailed": "테스트 실패",
+        "failedToGetResponse": "AI 모델로부터 응답을 받지 못했습니다.",
+        "failedToSendMessage": "테스트 메시지 전송에 실패했습니다.",
+        "defaultTestMessage": "안녕하세요! 정상적으로 작동하는지 간단히 확인해 주시면 감사하겠습니다."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "월별 예산을 설정한다고 해서 LLM 사용량이 예산을 초과하는 것을 막을 수는 없습니다. 예산 한도는 관리자의 의사 결정에 참고 자료로만 활용해야 합니다.",
+        "budgetDisclaimerShort": "예산 한도는 참고용일 뿐이며 사용을 차단하는 것은 아닙니다.",
+        "spendLabel": "이번 달 지출",
+        "spendOfBudget": "{currentSpend} {budgetLimit}",
+        "overBudget": "예산 초과",
+        "budgetPercentage": "{percentage}예산 사용률",
+        "spendReset": "이번 달 지출액이 초기화되었습니다."
+      }
+    },
+    "prompts": {
+      "title": "프롬프트 구성",
+      "description": "다양한 기능에 대한 AI 프롬프트 템플릿을 관리하세요.",
+      "addPromptConfig": "프롬프트 구성 추가",
+      "filterPlaceholder": "필터 프롬프트 구성...",
+      "features": "특징",
+      "featureCount": "{count, plural, one {# 기능} other {# 기능}}",
+      "llmIntegration": "LLM 통합",
+      "modelOverride": "모델 오버라이드",
+      "llmIntegrationPlaceholder": "프로젝트 기본값",
+      "modelOverridePlaceholder": "통합 기본값",
+      "projectDefault": "프로젝트 기본값(지우기)",
+      "integrationDefault": "통합 기본값(지우기)",
+      "systemPrompt": "시스템 프롬프트",
+      "userPrompt": "사용자 프롬프트",
+      "temperature": "온도",
+      "maxOutputTokens": "최대 출력 토큰",
+      "variables": "변수",
+      "insertVariable": "변수 삽입",
+      "noConfigs": "프롬프트 구성이 없습니다. 시작하려면 첫 번째 구성을 추가하세요.",
+      "add": {
+        "title": "프롬프트 구성 추가",
+        "description": "각 기능에 대한 프롬프트를 포함하는 새로운 AI 프롬프트 구성을 생성합니다. 기본값이 자동으로 적용되었습니다."
+      },
+      "edit": {
+        "title": "프롬프트 구성 편집",
+        "description": "이 AI 프롬프트 구성을 업데이트하세요."
+      },
+      "delete": {
+        "title": "프롬프트 구성 삭제",
+        "confirmMessage": "<strong>{name}</strong>를 삭제하시겠습니까? 이 메시지를 사용하는 프로젝트는 시스템 기본값으로 되돌아갑니다.",
+        "warning": "이 작업은 되돌릴 수 없습니다. 이 설정을 사용하는 모든 프로젝트는 기본 프롬프트 설정으로 되돌아갑니다."
+      },
+      "llmColumn": "법학 석사",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "기본 프롬프트 구성을 삭제할 수 없습니다. 먼저 다른 설정을 기본값으로 지정하십시오.",
+      "defaultChanged": "기본 프롬프트 구성이 성공적으로 업데이트되었습니다.",
+      "featureLabels": {
+        "markdown_parsing": "마크다운 테스트 케이스 구문 분석",
+        "test_case_generation": "테스트 케이스 생성",
+        "magic_select_cases": "스마트 테스트 케이스 선택",
+        "editor_assistant": "편집 보조",
+        "llm_test": "LLM 연결 테스트",
+        "export_code_generation": "수출 코드 생성",
+        "auto_tag": "AI 태그 제안",
+        "duplicate_detection": "중복 감지",
+        "generate_from_url": "URL(요구사항)에서 테스트 케이스 생성",
+        "generate_from_url_app": "URL에서 테스트 케이스 생성 (애플리케이션 테스트)"
+      }
+    },
+    "elasticsearch": {
+      "title": "엘라스틱서치 관리",
+      "description": "검색 엔진 색인 생성 및 유지 관리를 담당합니다.",
+      "status": {
+        "title": "Elasticsearch 상태",
+        "description": "검색 엔진의 현재 연결 상태 및 건강 상태",
+        "checking": "상태 확인 중...",
+        "disconnected": "연결이 끊어졌습니다",
+        "nodes": "노드",
+        "indices": "지수",
+        "documents": "문서",
+        "error": {
+          "title": "연결 오류",
+          "description": "Elasticsearch 서비스에 연결할 수 없습니다."
+        }
+      },
+      "settings": {
+        "description": "배포 환경에 맞게 Elasticsearch 설정을 구성하세요.",
+        "numberOfReplicas": "복제본 수",
+        "replicasHelp": "단일 노드 클러스터의 경우 0으로 설정하고, 이중화된 다중 노드 클러스터의 경우 1 이상으로 설정합니다.",
+        "savedDescription": "설정 내용이 데이터베이스에 저장되었습니다.",
+        "updated": "지수 업데이트됨",
+        "updatedDescription": "기존의 모든 인덱스가 새로운 복제 설정으로 업데이트되었습니다.",
+        "error": "설정 저장 오류",
+        "errorDescription": "설정을 저장하는 데 실패했습니다. 다시 시도해 주세요.",
+        "note": {
+          "description": "새 인덱스에는 변경 사항이 즉시 적용됩니다. 기존 인덱스는 저장할 때 업데이트됩니다. 단일 노드 클러스터에서 노란색(YELLOW) 상태가 발생하는 경우 복제본 수를 0으로 설정하십시오."
+        }
+      },
+      "reindex": {
+        "title": "데이터 재색인",
+        "description": "검색 성능 향상을 위해 검색 인덱스를 재구축합니다.",
+        "entities": {
+          "all": "모든 개체"
+        },
+        "button": {
+          "start": "재색인 시작",
+          "indexing": "인덱싱 중..."
+        },
+        "warning": {
+          "title": "중요한",
+          "description": "데이터 양에 따라 재색인 작업은 몇 분 정도 소요될 수 있습니다. 이 과정 동안 검색 기능이 제한될 수 있습니다."
+        },
+        "complete": {
+          "title": "재색인 완료",
+          "description": "선택된 모든 엔티티의 재색인 작업이 성공적으로 완료되었습니다."
+        },
+        "success": {
+          "title": "재색인 성공",
+          "description": "{count, plural, one {# 문서} other {# 문서}} 색인이 성공적으로 생성되었습니다."
+        },
+        "error": {
+          "title": "재색인 실패",
+          "description": "색인 재구축 중 오류가 발생했습니다. 다시 시도해 주세요."
+        }
+      }
+    },
+    "queues": {
+      "title": "백그라운드 작업 큐",
+      "description": "백그라운드 작업 처리 대기열을 모니터링하고 관리합니다.",
+      "queueNames": {
+        "forecast-updates": "일기예보 업데이트",
+        "emails": "이메일 대기열",
+        "issue-sync": "이슈 동기화",
+        "testmo-imports": "테스트모 임포트",
+        "elasticsearch-reindex": "Elasticsearch 재인덱싱",
+        "audit-logs": "감사 로그",
+        "budget-alerts": "예산 알림",
+        "auto-tag": "AI 자동 태그",
+        "repo-cache": "저장소 캐시",
+        "copy-move": "복사 및 이동",
+        "duplicate-scan": "중복 스캔",
+        "magic-select": "매직 셀렉트",
+        "step-scan": "단계 순서 스캔"
+      },
+      "status": {
+        "paused": "일시 중지됨",
+        "idle": "게으른"
+      },
+      "table": {
+        "queue": "대기줄",
+        "concurrency": "동시성",
+        "waiting": "대기 중",
+        "failed": "실패한"
+      },
+      "concurrency": {
+        "title": "작업자 동시성",
+        "description": "동시성 제어는 각 워커가 동시에 처리하는 작업 수를 조절합니다. 값이 높을수록 처리량은 향상되지만 시스템 리소스(CPU 및 메모리) 사용량이 증가합니다.",
+        "configureTitle": "동시성 구성",
+        "configureDescription": "동시 실행 수를 조정하려면 환경 변수를 설정하고 워커를 다시 시작하십시오. 자세한 내용은 설명서를 참조하십시오.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo 가져오기(기본값: 1, 메모리 사용량 많음)",
+          "SYNC_CONCURRENCY": "이슈 동기화(기본값: 2, I/O 집약적)",
+          "EMAIL_CONCURRENCY": "이메일 전송(기본값: 3, 입출력 작업 집중)",
+          "NOTIFICATION_CONCURRENCY": "알림 (기본값: 5, 경량)",
+          "FORECAST_CONCURRENCY": "예보 업데이트 (기본값: 5, CPU 사용량 높음)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "대기열 일시 정지",
+          "confirmDescription": "이렇게 하면 새로운 작업 처리가 중단됩니다. 진행 중인 작업은 완료될 때까지 계속 진행됩니다."
+        },
+        "resume": {
+          "confirmTitle": "재개 대기열",
+          "confirmDescription": "이렇게 하면 대기 중인 작업을 처리할 수 있습니다."
+        },
+        "clean": {
+          "confirmTitle": "깨끗한 대기열",
+          "confirmDescription": "이렇게 하면 완료된 작업과 실패한 작업이 대기열에서 제거됩니다. 이 작업은 되돌릴 수 없습니다."
+        },
+        "drain": {
+          "confirmTitle": "배수 대기열",
+          "confirmDescription": "이렇게 하면 대기 중인 모든 작업이 큐에서 제거됩니다. 활성 작업은 완료될 때까지 계속 진행됩니다. 이 작업은 되돌릴 수 없습니다."
+        },
+        "obliterate": {
+          "confirmTitle": "대기열을 없애다",
+          "confirmDescription": "이렇게 하면 대기열이 완전히 초기화되어 상태와 관계없이 모든 작업이 제거됩니다. 이 작업은 되돌릴 수 없으므로 긴급 상황에서만 사용해야 합니다."
+        },
+        "warning": "경고",
+        "irreversible": "이 작업은 되돌릴 수 없습니다. 계속 진행하시겠습니까?"
+      },
+      "success": {
+        "actionCompleted": "작업 완료",
+        "queuePaused": "대기열이 일시 중지되었습니다.",
+        "queueResumed": "대기열이 재개되었습니다",
+        "queueCleaned": "대기열이 정리되었습니다",
+        "queueDrained": "대기열이 비워졌습니다",
+        "queueObliterated": "대기열이 완전히 사라졌습니다."
+      },
+      "error": {
+        "loadFailed": "큐를 불러오는 데 실패했습니다.",
+        "actionFailed": "작업이 실패했습니다"
+      },
+      "jobs": {
+        "title": "큐 작업",
+        "description": "대기열에 있는 개별 작업을 보고 관리하세요.",
+        "noJobs": "이 대기열에서 작업을 찾을 수 없습니다.",
+        "table": {
+          "id": "작업 ID",
+          "name": "직무명",
+          "attempts": "시도"
+        },
+        "details": {
+          "title": "채용 정보",
+          "failedReason": "실패 원인",
+          "stacktrace": "스택 트레이스",
+          "data": "직무 데이터",
+          "returnValue": "반환 값",
+          "options": "직업 선택",
+          "processed": "처리됨",
+          "finished": "완성된"
+        },
+        "success": {
+          "actionCompleted": "업무 조치 완료",
+          "jobRetried": "Job이 재시도되었습니다",
+          "jobPromoted": "Job이 승진했습니다.",
+          "jobRemoved": "해당 채용 공고가 삭제되었습니다."
+        },
+        "error": {
+          "loadFailed": "작업을 불러오는 데 실패했습니다.",
+          "actionFailed": "업무 조치 실패"
+        },
+        "forceRemove": {
+          "title": "강제로 작업 삭제",
+          "question": "이 작업을 강제로 삭제하시겠습니까?",
+          "warning": "이렇게 하면 지연 시간을 두고 여러 번 제거를 시도합니다. 참고: 실행 중인 워커에 의해 작업이 실제로 잠겨 있는 경우 실패할 수 있습니다.",
+          "confirm": "강제 제거"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "보안 및 규정 준수 추적을 위한 시스템 전반의 감사 기록을 확인하세요.",
+      "filterPlaceholder": "개체, 사용자 또는 작업으로 검색...",
+      "filterAction": "행동",
+      "filterEntityType": "엔티티 유형",
+      "allActions": "모든 작업",
+      "allEntityTypes": "모든 엔티티 유형",
+      "showing": "{start} 부터 {end} 까지의 {total} 개 항목을 표시합니다.",
+      "viewDetails": "상세 정보 보기",
+      "detailTitle": "감사 로그 세부 정보",
+      "userInfo": "사용자 정보",
+      "changes": "변경 사항",
+      "metadata": "메타데이터",
+      "oldValue": "오래된",
+      "newValue": "새로운",
+      "columns": {
+        "timestamp": "타임스탬프",
+        "entityId": "엔티티 ID",
+        "entityName": "엔티티 이름",
+        "userId": "사용자 ID",
+        "ipAddress": "IP 주소",
+        "userAgent": "사용자 에이전트"
+      },
+      "exportCsv": "CSV 내보내기",
+      "timeRange": "시간 범위",
+      "timeRangeOptions": {
+        "last24h": "지난 24시간",
+        "last7d": "지난 7일",
+        "last30d": "지난 30일",
+        "last90d": "지난 90일",
+        "allTime": "역대"
+      },
+      "systemActor": "체계",
+      "systemActorTooltip": "로그인한 사용자가 아닌 시스템에서 수행한 작업입니다."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "알림 없음",
+      "aria": {
+        "notifications": "알림 ({count} 읽지 않음)"
+      },
+      "actions": {
+        "markRead": "읽음으로 표시",
+        "markUnread": "읽지 않음으로 표시",
+        "markAllRead": "모두 읽음으로 표시",
+        "deleteAll": "모두 삭제"
+      },
+      "success": {
+        "deleted": "알림이 삭제되었습니다",
+        "markedAllRead": "읽음으로 표시된 모든 알림",
+        "deletedAll": "모든 알림이 삭제되었습니다."
+      },
+      "error": {
+        "markRead": "읽음 표시를 하는 데 실패했습니다.",
+        "markUnread": "읽지 않음으로 표시하는 데 실패했습니다.",
+        "delete": "알림 삭제에 실패했습니다",
+        "markAllRead": "모두 읽음으로 표시하는 데 실패했습니다.",
+        "deleteAll": "알림 삭제에 실패했습니다"
+      },
+      "deleteAllDialog": {
+        "title": "모든 알림을 삭제하시겠습니까?",
+        "description": "이렇게 하면 모든 알림이 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+        "confirm": "모두 삭제"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "새로운 테스트 케이스 할당",
+        "multipleTestCaseAssignmentTitle": "여러 테스트 케이스가 할당되었습니다.",
+        "sessionAssignmentTitle": "새로운 세션 과제",
+        "commentMentionTitle": "댓글에서 당신이 언급되었습니다.",
+        "systemAnnouncementTitle": "시스템 공지",
+        "assignedTestCase": "테스트 케이스를 배정받았습니다.",
+        "assignedMultipleTestCases": "당신에게 할당되었습니다 {count, plural, one {# 테스트 케이스} other {# 테스트 케이스}}",
+        "assignedSession": "당신을 세션에 배정했습니다.",
+        "mentionedYouInComment": "댓글에서 당신을 언급했습니다.",
+        "inProject": "프로젝트에서",
+        "testRun": "테스트 실행:",
+        "casesInProject": "{count, plural, =1 {# 경우} other {# 경우}}",
+        "sentBy": "{name}님이 보냈습니다.",
+        "milestoneDueSoonTitle": "곧 중요한 일정이 예정되어 있습니다.",
+        "milestoneOverdueTitle": "주요 일정 기한 초과",
+        "milestoneDueSoon": "프로젝트 \"{projectName}\"의 마일스톤 \"{milestoneName}\"은 {dueDate} 에 완료될 예정입니다.",
+        "milestoneOverdue": "프로젝트 \"{projectName}\"의 마일스톤 \"{milestoneName}\"은 {dueDate} 에 완료 예정이었으나 현재 기한이 지났습니다.",
+        "milestoneNotificationReason": "이 알림은 귀하께서 해당 마일스톤과 관련된 작업(테스트 실행, 세션 참여 또는 마일스톤 생성)에 참여하셨기 때문에 발송되었습니다.",
+        "milestoneNotificationContinue": "이 단계가 완료로 표시될 때까지 매일 알림을 계속 받게 됩니다.",
+        "shareLinkAccessedTitle": "공유 링크 접속됨",
+        "shareLinkAccessedAnonymousViewer": "누구",
+        "shareLinkAccessedMessage": "{viewer} 님이 공유하신 보고서를 확인했습니다: \"{shareTitle}\"",
+        "viewedYourSharedLink": "공유하신 링크를 확인했습니다.",
+        "viewedAt": "다음에서 볼 수 있습니다",
+        "budgetDisclaimer": "예산 한도는 참고용일 뿐이며 사용을 제한하는 것은 아닙니다.",
+        "llmBudgetExceededTitle": "LLM 예산 초과",
+        "llmBudgetThresholdTitle": "LLM 예산 {threshold}사용률",
+        "llmBudgetExceededMessage": "{providerName} 이 월간 예산을 초과했습니다. {spend} 이 {budget} 의 예산을 사용했습니다.",
+        "llmBudgetThresholdMessage": "{providerName} 는 월 예산의 {threshold}%를 사용했습니다: {spend} (총 {budget} 중).",
+        "userRegisteredTitle": "신규 사용자 등록",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) 님이 SSO를 통해 등록했습니다.",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) 님이 등록 양식을 통해 등록했습니다.",
+        "viewUserList": "사용자 목록 보기",
+        "reviewGeneratedCases": "생성된 테스트 케이스를 검토합니다.",
+        "generateFromUrlCompleteTitle": "페이지 크롤링이 성공적으로 완료되었습니다.",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# 페이지} other {# 페이지}} 프로젝트 \"{projectName}\"의 {url} 에서 크롤링되었습니다. 클릭하여 검토하고 테스트 케이스를 생성하세요.",
+        "generateFromUrlFailedTitle": "URL 크롤링 실패"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "검색 또는 링크 문제...",
+        "create_label": "링크 문제 \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "문제 요약을 입력하세요"
+        },
+        "fields": {
+          "name": {
+            "label": "요약"
+          },
+          "description": {
+            "placeholder": "문제를 설명해 주세요...",
+            "helper": "해당 문제에 대한 자세한 정보를 제공하십시오."
+          },
+          "project": {
+            "helper": "외부 이슈 트래커에서 프로젝트를 선택하세요"
+          }
+        },
+        "loading_metadata": "통합 설정 불러오는 중...",
+        "errors": {
+          "creation_failed": "이슈 생성에 실패했습니다. 다시 시도해 주세요."
+        },
+        "success": {
+          "created": "이슈가 성공적으로 생성되었습니다.",
+          "external_created": "이슈가 생성되어 외부 추적기에 연결되었습니다."
+        },
+        "warnings": {
+          "external_failed": "로컬에서 이슈가 생성되었지만 외부 추적기와 동기화되지 않았습니다."
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "이슈를 생성하려면 계정을 {integrationName} 에 연결해야 합니다."
+      },
+      "search_issues_dialog": {
+        "title": "검색 및 링크 문제",
+        "placeholder": "문제를 검색하세요...",
+        "searching": "수색...",
+        "searchError": "검색 실패 문제",
+        "linkButton": "링크",
+        "linkedCount": "{count, plural, one {# 이슈} other {# 이슈}} 링크됨"
+      }
+    },
+    "copyMove": {
+      "title": "복사/이동하여 프로젝트에 붙여넣기",
+      "step1Desc": "테스트 케이스를 저장할 대상 프로젝트와 폴더를 선택하세요.",
+      "step2Desc": "작동 방식을 선택하고 호환성을 확인하세요.",
+      "step3Desc": "진행 상황을 추적하고 결과를 검토하세요.",
+      "targetProject": "목표 프로젝트",
+      "searchProjects": "프로젝트를 검색하세요...",
+      "loadingProjects": "프로젝트를 불러오는 중...",
+      "noProjectsFound": "프로젝트를 찾을 수 없습니다.",
+      "completed": "(완벽한)",
+      "targetFolder": "대상 폴더",
+      "newFolderPlaceholder": "새 폴더 이름...",
+      "operation": "작업",
+      "operationCopy": "복사",
+      "operationCopyDesc": "선택한 사례의 사본을 대상 프로젝트에 생성합니다. 원본은 변경되지 않습니다.",
+      "operationMove": "이동하다",
+      "operationMoveDesc": "선택한 케이스를 대상 프로젝트로 이동합니다. 원본 파일은 소스 프로젝트에서 삭제됩니다.",
+      "checkingCompatibility": "호환성을 확인하는 중...",
+      "noTargetWriteAccess": "대상 프로젝트에 대한 쓰기 권한이 없습니다.",
+      "noSourceUpdateAccess": "원본 프로젝트에 대한 편집 권한이 없어 케이스를 이동할 수 없습니다.",
+      "templateMismatch": "템플릿 불일치",
+      "autoAssignTemplates": "누락된 템플릿을 대상 프로젝트에 자동 할당",
+      "templatesMayNotDisplay": "누락된 템플릿은 대상 프로젝트에서 사용할 수 없습니다. 케이스는 복사되지만 해당 템플릿의 필드가 올바르게 표시되지 않을 수 있습니다.",
+      "workflowFallback": "대상 프로젝트에서 일부 워크플로 상태를 사용할 수 없습니다. 이러한 경우에는 대상 프로젝트의 기본 상태가 사용됩니다.",
+      "default": "(기본)",
+      "conflicts": "모든 분쟁에 적용:",
+      "conflictSkip": "건너뛰다",
+      "conflictRename": "이름 변경",
+      "sharedStepGroups": "대상에 공유 단계 그룹이 이미 있는 경우:",
+      "sharedStepGroupReuse": "기존 것을 재사용하세요",
+      "sharedStepGroupReuseDesc": "사례는 기존의 공유 단계 그룹을 참조합니다.",
+      "sharedStepGroupCreateNew": "새 항목 생성",
+      "sharedStepGroupCreateNewDesc": "새로운 공유 단계 그룹이 생성됩니다.",
+      "go": "가다",
+      "processing": "처리 중...",
+      "progressText": "{processed} {total} 건이 처리되었습니다.",
+      "successCount": "{count} 사례 {operation}d 성공적으로 완료",
+      "skipped": "건너뛴 항목: {count}",
+      "droppedLinks": "프로젝트 간 링크 삭제됨: {count}",
+      "errorCount": "{count} 케이스(들)가 실패했습니다",
+      "viewInTargetProject": "대상 프로젝트에서 보기",
+      "failed": "실패한",
+      "folderMode": "폴더 \"{folderName}\" — {caseCount, plural, one {# 경우} other {# 경우}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "관련 이슈",
+    "linkedIssuesDescription": "이 항목과 관련된 문제점",
+    "refreshed": "이슈가 새로워졌습니다",
+    "refreshedDescription": "관련 이슈 목록이 업데이트되었습니다.",
+    "unlinked": "문제가 연결되지 않았습니다",
+    "unlinkedDescription": "해당 항목에서 문제가 해결되었습니다.",
+    "linked": "문제 관련됨",
+    "linkedDescription": "해당 문제는 이 항목과 관련이 있습니다.",
+    "searchAndLink": "검색 및 링크",
+    "createAndLink": "생성 및 연결",
+    "noLinkedIssues": "연결된 문제 없음",
+    "viewExternal": "{provider}에서 보기",
+    "unlink": "풀리다",
+    "linkError": "링크 오류 발생",
+    "linkExternalIssue": "링크 {provider} 문제",
+    "linkIssue": "링크 문제",
+    "addIssue": "이슈 추가",
+    "unlinkError": "연결 해제 실패 문제",
+    "noIssuesFound": "문제가 발견되지 않았습니다.",
+    "startTypingToSearch": "검색하려면 입력을 시작하세요.",
+    "selectedCount": "{count} 선택됨",
+    "confirmSelection": "선택 확인",
+    "alreadyLinked": "이미 연결됨",
+    "authenticate": "인증하다",
+    "authenticationRequired": "인증 필요",
+    "authenticationDescription": "이슈를 검색하려면 {provider} 로 인증해야 합니다.",
+    "searchIn": "{provider}에서 검색",
+    "searchPlaceholder": "검색 문제...",
+    "searchIssues": "검색 문제",
+    "searchIssuesDescription": "이 항목과 관련된 내부 문제를 검색하세요.",
+    "searchExternalDescription": "이 항목에 연결하려면 {provider} 이슈를 검색하세요.",
+    "error": "오류 로딩 문제",
+    "errorDescription": "페이지를 불러오는 데 실패했습니다. 다시 시도해 주세요.",
+    "selectIssues": "이슈 선택",
+    "authRequiredDescription": "이슈를 검색하려면 {provider} 로 인증하세요.",
+    "integrationNotConfigured": "통합이 구성되지 않았습니다.",
+    "integrationNotConfiguredDescription": "이 통합은 아직 완전히 구성되지 않았습니다. 프로젝트 관리자에게 문의하여 프로젝트 설정에서 외부 프로젝트를 구성하십시오.",
+    "createIssue": "이슈 생성",
+    "createNewIssue": "새로운 이슈 생성",
+    "createIssueDescription": "새로운 이슈를 생성하세요",
+    "createIssueDescriptionWithIntegration": "{provider}를 사용하여 새 이슈를 생성하세요.",
+    "createIssueDescriptionSimpleUrl": "새로운 내부 이슈 생성 (간단한 URL 통합)",
+    "creatingWith": "{provider}에 이슈를 생성하고 있습니다.",
+    "authenticatedAndReady": "인증 완료, 문제 생성 준비 완료",
+    "created": "문제 발생",
+    "createdInExternal": "이슈가 {provider}에 생성되었습니다.",
+    "createdInternal": "로컬에서 생성된 문제",
+    "createdInternalSimpleUrl": "내부적으로 생성된 이슈이며, 간단한 URL을 통해 연결할 수 있습니다.",
+    "createError": "이슈 생성에 실패했습니다",
+    "useIntegration": "{provider}를 사용하세요",
+    "useIntegrationDescription": "외부 시스템에 문제를 발생시키세요",
+    "externalProject": "외부 프로젝트",
+    "selectProject": "프로젝트를 선택하세요",
+    "issueType": "문제 유형",
+    "selectIssueType": "문제 유형을 선택하세요",
+    "noIssueTypes": "사용 가능한 문제 유형이 없습니다.",
+    "priorityUrgent": "긴급한",
+    "additionalFields": "추가 필드",
+    "createIssueInJira": "Jira에 이슈 생성",
+    "createIssueInJiraDescription": "Jira의 인터페이스를 사용하여 사용 가능한 모든 필드와 옵션을 활용해 새 이슈를 생성하세요.",
+    "createIssueInJiraFallbackDescription": "Jira를 새 탭에서 열어 미리 입력된 정보로 이슈를 생성하세요.",
+    "jiraIframeError": "Jira 인터페이스를 불러올 수 없습니다. 새 탭에서 열어보세요.",
+    "jiraIframeFallback": "보안상의 이유로 Jira는 새 탭에서 열어야 합니다. 아래 버튼을 클릭하여 이슈를 생성하세요.",
+    "jiraFallbackNote": "Jira에서 이슈를 생성한 후, 여기로 돌아와서 해당 이슈를 테스트 케이스에 연결하는 작업을 계속하세요.",
+    "openInNewTab": "새 탭에서 열기",
+    "jiraIframeNote": "Jira에서 이슈를 생성한 후 이 대화 상자를 닫고 이슈 목록을 새로 고칠 수 있습니다.",
+    "fillInRequiredFields": "새로운 이슈를 생성하려면 필수 입력란을 작성하세요.",
+    "failedToFetchFields": "Jira에서 이슈 필드를 가져오는 데 실패했습니다.",
+    "enterSummary": "문제에 대한 간략한 요약을 입력하세요.",
+    "enterDescription": "문제에 대한 자세한 설명을 입력하세요.",
+    "failedToCreateIssue": "Jira에서 이슈를 생성하는 데 실패했습니다.",
+    "issueCreatedDescription": "이슈 {key} 가 성공적으로 생성되었습니다.",
+    "addLabel": "레이블을 추가하고 Enter 키를 누르세요.",
+    "labelHint": "공백은 하이픈으로 대체됩니다.",
+    "labelFormatNote": "레이블에는 공백을 포함할 수 없습니다. 공백은 자동으로 하이픈으로 대체됩니다.",
+    "enterIssueKey": "발급 코드를 입력하십시오(예: PROJ-123).",
+    "issueLinkHelp": "기존 이슈의 키를 입력하여 연결하세요.",
+    "searchForIssue": "연결할 문제를 검색하세요",
+    "searchUsers": "사용자 검색",
+    "noTeamsAvailable": "이용 가능한 팀이 없습니다.",
+    "filterAll": "모두",
+    "fanOutPartialFailure": "{count} 프로젝트에 연결할 수 없습니다. {successCount} 프로젝트의 결과를 표시합니다.",
+    "projectSelectorLabel": "프로젝트",
+    "searchFailedTitle": "검색 실패"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "모든 이슈를 찾아보고 관리하세요.",
+      "filterPlaceholder": "이슈를 이름으로 필터링하세요..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "선적 서류 비치",
+      "Milestones": "주요 이정표",
+      "TestCaseRepository": "테스트 케이스 저장소",
+      "TestCaseRestrictedFields": "테스트 케이스 제한 필드",
+      "TestRuns": "테스트 실행",
+      "ClosedTestRuns": "폐쇄형 테스트 실행",
+      "TestRunResults": "테스트 실행 결과",
+      "TestRunResultRestrictedFields": "테스트 실행 결과 제한된 필드",
+      "Sessions": "세션",
+      "SessionsRestrictedFields": "세션 제한 필드",
+      "ClosedSessions": "비공개 세션",
+      "SessionResults": "세션 결과",
+      "Tags": "태그",
+      "SharedSteps": "공유된 단계",
+      "Issues": "문제점",
+      "IssueIntegration": "이슈 통합",
+      "Forecasting": "예측",
+      "Reporting": "보고",
+      "Settings": "설정"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "시작 안 함",
+      "IN_PROGRESS": "진행 중",
+      "DONE": "완료"
+    }
+  },
+  "charts": {
+    "average": "평균",
+    "count": "개수: {count}",
+    "percent": "백분율: {percent}%",
+    "completed": "완료됨: {count}",
+    "durationRange": "지속 시간: {from}초 - {to}초",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# 테스트 케이스} other {# 테스트 케이스}}",
+    "estimate": "추정: {value}",
+    "partOf": "( {parent}의 일부)",
+    "status": "상태: {status}"
+  },
+  "linkedCases": {
+    "title": "연결된 테스트 케이스",
+    "addLink": "링크 추가",
+    "addLinkedTestCase": "연결된 테스트 케이스 추가",
+    "testCase": "테스트 케이스",
+    "linkType": "링크 유형",
+    "noLinkedCases": "연결된 테스트 케이스가 없습니다.",
+    "linkedBy": "연결됨",
+    "on": "링크드인",
+    "alreadyLinked": "이 사건은 이미 연관되어 있습니다.",
+    "cannotLinkSelf": "사건 자체를 연결할 수 없습니다.",
+    "circularLink": "순환 링크가 감지되었습니다.",
+    "failedToCreate": "링크를 생성하는 데 실패했습니다.",
+    "confirmRemoveLink": "이 링크를 정말로 삭제하시겠습니까?",
+    "DEPENDS_ON": "의존",
+    "DUPLICATED_FROM": "복제됨",
+    "SAME_TEST_DIFFERENT_SOURCE": "동일한 테스트 (다른 출처)",
+    "status": "최신 상태",
+    "at": "실행됨"
+  },
+  "ganttTooltip": {
+    "task": "일",
+    "group": "실행/세션:",
+    "project": "프로젝트:",
+    "starts": "시작:",
+    "scheduledCompletion": "예정 완료일:",
+    "estWorkEffort": "예상 작업량:",
+    "noTasks": "간트 차트에 표시할 작업이 없습니다."
+  },
+  "help": {
+    "project": {
+      "name": "## 프로젝트 이름\n프로젝트의 고유 식별자입니다.\n\n- 모든 프로젝트에서 고유해야 합니다.\n- 탐색 및 보고서에 사용됩니다.\n- 명확하고 설명적이어야 합니다.\n- 팀 구성원이 프로젝트 범위를 파악하는 데 도움이 됩니다.",
+      "description": "## 프로젝트 설명\n프로젝트의 목적과 범위에 대한 추가 정보입니다.\n\n- 선택 사항이지만 권장합니다.\n- 팀 구성원이 프로젝트 목표를 이해하는 데 도움이 됩니다.\n- 주요 목표 또는 요구 사항을 포함할 수 있습니다.\n- 256자 이내로 제한됩니다.",
+      "icon": "## 프로젝트 아이콘\n프로젝트를 시각적으로 식별하는 아이콘입니다.\n\n- 목록 및 대시보드에서 프로젝트를 빠르게 찾을 수 있도록 도와줍니다.\n- 다양한 사전 정의된 아이콘 중에서 선택할 수 있습니다.\n- 언제든지 변경할 수 있습니다.\n- 프로젝트 탐색 및 보고서에 표시됩니다.",
+      "completed": "## 프로젝트 상태\n프로젝트가 활성 상태인지 완료된 상태인지 나타냅니다.\n\n- 활성 프로젝트는 테스트 및 업데이트가 가능합니다.\n- 완료된 프로젝트는 읽기 전용입니다.\n- 대시보드에서 프로젝트 표시 여부에 영향을 미칩니다.\n- 필요한 경우 되돌릴 수 있습니다.",
+      "completedAt": "## 완료일\n프로젝트가 완료로 표시된 날짜입니다.\n\n- 프로젝트를 완료로 표시할 때 자동으로 설정됩니다.\n- 보고 및 추적에 사용됩니다.\n- 프로젝트 이력 관리에 도움이 됩니다.\n- 필요한 경우 수정할 수 있습니다.",
+      "defaultAccess": "## 기본 프로젝트 접근 권한\n이 프로젝트에서 사용자 및 그룹에 대한 기본 접근 권한을 정의합니다. 이 설정은 사용자별 또는 그룹별로 재정의할 수 있습니다.",
+      "issueTracker": "## 이슈 트래커 구성\n이 프로젝트와 관련된 이슈 관리에 사용할 이슈 트래커 구성을 선택하세요."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## 외부 프로젝트\n이 TestPlanIt 프로젝트와 연결할 외부 시스템의 프로젝트 또는 저장소를 선택하세요.\n\n- TestPlanIt에서 생성된 이슈는 이 프로젝트에 생성됩니다.\n- 시스템 간 이슈 추적 통합을 활성화합니다.\n- 외부 시스템에서 적절한 권한이 있어야 합니다.",
+          "defaultIssueTypeHelp": "## 기본 이슈 유형\nTestPlanIt에서 새 이슈를 생성할 때 미리 선택될 이슈 유형입니다.\n\n- 가장 자주 사용하는 이슈 유형을 기본값으로 설정하여 시간을 절약합니다.\n- 개별 이슈를 생성할 때 재정의할 수 있습니다.\n- 선택한 외부 프로젝트에 대해 유효한 이슈 유형이어야 합니다.\n- 워크플로가 변경되면 이 값을 업데이트하세요.",
+          "automaticSyncHelp": "## 자동 동기화\nTestPlanIt과 외부 시스템 간의 이슈 상태 자동 동기화를 활성화합니다.\n\n- 테스트 케이스에 연결된 이슈의 상태가 자동으로 업데이트됩니다.\n- 시스템 간 이슈 추적의 일관성을 유지하는 데 도움이 됩니다.\n- 외부 서비스의 API 사용량이 증가할 수 있습니다.\n- 수동 제어를 선호하는 경우 비활성화할 수 있습니다."
+        }
+      }
+    },
+    "user": {
+      "name": "## 사용자 이름\n사용자의 전체 이름입니다.\n\n- 시스템 전체에서 사용자를 식별하는 데 사용됩니다.\n- 과제 및 보고서에 표시됩니다.\n- 사용자마다 고유해야 합니다.",
+      "email": "## 이메일 주소\n계정 접속을 위한 사용자 이메일 주소입니다.\n\n- 시스템 로그인에 사용됩니다.\n- 사용자마다 고유해야 합니다.\n- 시스템 알림에 사용됩니다.",
+      "password": "## 비밀번호\n사용자 계정 비밀번호입니다.\n\n- 비밀번호 없이 로그인하는 방법(매직링크 SSO 제공업체 또는 이메일 서버)이 구성된 경우 선택 사항입니다. 매직링크 또는 SSO를 통한 로그인이 필수인 경우 비워 두십시오.\n- 제공되는 경우, **관리 → 보안**에서 설정된 비밀번호 정책(최소 길이 및 문자 종류)을 충족해야 합니다.\n- 안전한 계정 접근에 사용됩니다.\n- 기밀로 유지해야 합니다.",
+      "token": "## 인증 토큰\n이메일로 받은 토큰을 입력하여 계정을 인증하세요. 토큰이 없는 경우 새 토큰을 요청할 수 있습니다.",
+      "confirmPassword": "## 비밀번호 확인\n비밀번호를 다시 입력하여 정확하게 입력했는지 확인하세요.\n\n- 비밀번호와 정확히 일치해야 합니다.\n- 오타 방지에 도움이 됩니다.\n- 비밀번호를 입력한 경우에만 필요합니다. 비밀번호 입력란이 비어 있는 경우 비워 두세요.",
+      "access": "## 시스템 접근 수준\n사용자의 시스템 전체 권한을 결정합니다.\n\n- **관리자:** 시스템 전체 접근 및 구성 권한\n- **프로젝트 관리자:** 할당된 프로젝트 관리 가능\n- **사용자:** 할당된 프로젝트에 대한 표준 접근 권한\n- **없음:** 대시보드만 보기 가능",
+      "role": "## 시스템 역할\n이 역할은 사용자의 기본 프로젝트 권한을 결정합니다.\n\n- 프로젝트에 대한 기본 액세스 수준을 정의합니다.\n- 역할 관리에서 사용자 지정할 수 있습니다.\n- 사용 가능한 기능 및 역량에 영향을 미칩니다.",
+      "active": "## 활성 상태\n사용자의 시스템 접근 권한을 제어합니다.\n\n- 활성 사용자는 로그인하여 할당된 리소스에 접근할 수 있습니다.\n- 비활성 사용자는 로그인할 수 없지만 데이터는 보존됩니다.\n  - 계정을 삭제하지 않고 일시적으로 접근을 차단하는 데 사용합니다.",
+      "api": "## API 접근\nAPI 엔드포인트를 통해 시스템에 대한 프로그래밍 방식 접근을 허용합니다.\n\n- 외부 도구 및 자동화와의 통합을 지원합니다.\n- API 키 인증이 필요합니다.\n- 속도 제한 및 접근 제어가 적용됩니다.",
+      "projects": "## 프로젝트 할당\n이 사용자가 접근할 수 있는 프로젝트를 선택하세요.\n\n- 사용자 대시보드에 표시되는 프로젝트를 제어합니다.\n- 프로젝트 참여에 필수입니다.\n- 관리자가 나중에 수정할 수 있습니다.\n- \"모두 선택\"을 사용하여 사용 가능한 모든 프로젝트를 빠르게 할당할 수 있습니다.",
+      "groups": "## 그룹 할당\n이 사용자가 속할 그룹을 선택하세요.\n\n- 그룹은 사용자와 권한을 체계적으로 관리하는 데 도움이 됩니다.\n- 사용자는 소속 그룹의 권한을 상속받습니다.\n- 접근 관리가 간편해집니다.\n- 관리자는 나중에 수정할 수 있습니다.",
+      "itemsPerPage": "## 페이지당 항목 수\n표와 목록에 표시되는 기본 항목 수를 제어합니다.\n\n- 애플리케이션의 모든 페이지 매김 보기에 영향을 미칩니다.\n- 언제든지 변경할 수 있습니다.\n- 대규모 데이터 세트를 효율적으로 관리하는 데 도움이 됩니다.\n- 사용 가능한 옵션: 10, 25, 50 또는 100개 항목",
+      "dateFormat": "## 날짜 형식\n원하는 날짜 표시 형식을 설정합니다.\n\n- 애플리케이션 전체에 일관되게 적용됩니다.\n- 날짜 해석의 정확성을 높이는 데 도움이 됩니다.\n- 변경 사항이 즉시 적용됩니다.\n- 드롭다운 메뉴에 표시된 예시는 실제 형식을 반영합니다.",
+      "timeFormat": "## 시간 형식\n원하는 시간 표시 형식을 설정합니다.\n\n- 12시간제 또는 24시간제 중에서 선택하세요.\n- 애플리케이션 전체에 일관되게 적용됩니다.\n- 변경 사항이 즉시 적용됩니다.\n- 드롭다운 메뉴에 표시된 예시는 실제 형식을 반영합니다.",
+      "timezone": "## 시간대\n날짜 및 시간 표시를 위한 기본 시간대를 설정합니다.\n\n- 애플리케이션 전체에 일관되게 적용됩니다.",
+      "theme": "## 테마\n애플리케이션에 사용할 원하는 시각적 테마를 선택하세요.\n\n- **시스템:** 운영 체제 테마와 자동으로 일치합니다.\n- **밝은:** 낮에 사용하기 좋은 깔끔하고 밝은 인터페이스입니다.\n- **어두운:** 어두운 환경에서 사용하기 좋은 눈 편한 다크 모드입니다.\n- **녹색, 주황색, 보라색:** 재미있는 색상으로 포인트를 주세요!",
+      "locale": "## 언어\n애플리케이션 인터페이스에 사용할 언어를 선택하세요.\n\n- 모든 텍스트, 레이블 및 메시지가 선택한 언어로 변경됩니다.\n- 날짜 및 시간 형식이 지역별 관습에 맞게 조정됩니다.\n- 페이지를 새로 고침할 필요 없이 즉시 적용됩니다.\n- 사용 가능한 언어는 설치된 번역에 따라 다릅니다.",
+      "notificationMode": "## 알림 설정\n업무 배정 및 업데이트에 대한 알림 수신 방식을 제어합니다.\n\n- **전역 설정 사용:** 관리자가 설정한 시스템 기본값을 따릅니다.\n- **알림 없음:** 모든 알림을 비활성화합니다.\n- **앱 내에서만:** 앱 내에서만 알림을 받습니다.\n- **앱 내 + 이메일(즉시):** 앱 내 알림과 이메일 알림을 모두 받습니다.\n- **앱 내 + 이메일(일일 요약):** 앱 내 알림과 일일 이메일 요약을 받습니다.\n\n작업 흐름에 맞게 언제든지 이 설정을 변경할 수 있습니다."
+    },
+    "milestone": {
+      "name": "## 마일스톤 이름\n프로젝트에서 이 마일스톤을 명확하고 설명적으로 식별하는 이름입니다.\n\n- 고유하고 의미 있는 이름이어야 합니다.\n- 팀 구성원이 마일스톤의 목적을 빠르게 이해하는 데 도움이 됩니다.\n- 보고서 및 프로젝트 추적에 사용됩니다.",
+      "type": "## 마일스톤 유형\n마일스톤을 분류하고 표시 방식과 동작을 결정합니다.\n\n- 유형별로 워크플로가 다를 수 있습니다.\n- 마일스톤을 정리하고 필터링하는 데 도움이 됩니다.\n- 보고 및 추적에 영향을 줄 수 있습니다.",
+      "started": "## 시작 상태\n이 마일스톤 작업이 시작되었음을 나타냅니다.\n\n- 마일스톤이 진행 중임을 표시합니다.\n- 토글 시 실제 시작 날짜가 자동으로 업데이트됩니다.\n- 프로젝트 타임라인 및 진행 상황 추적에 영향을 미칩니다.",
+      "completed": "## 완료 상태\n이 마일스톤의 작업이 완료되었음을 나타냅니다.\n\n- 마일스톤을 완료로 표시합니다.\n- 실제 완료 날짜를 자동으로 업데이트합니다.\n- 진행 상황 추적 및 보고에 사용됩니다.\n- 종속 마일스톤 및 프로젝트 일정에 영향을 미칩니다.",
+      "startDate": "## 계획된 시작일\n이 마일스톤 작업이 시작될 것으로 예상되는 날짜입니다.\n\n- 프로젝트 계획 및 일정 수립에 도움이 됩니다.\n- 타임라인 예측에 사용됩니다.\n- 자원 배분 계획을 지원합니다.",
+      "dueDate": "## 마감일\n이 마일스톤을 완료하기 위한 목표 날짜입니다.\n\n- 마감일 기대치를 설정합니다.\n- 프로젝트 일정 계획에 사용됩니다.\n- 일정 대비 마일스톤 진행 상황을 추적하는 데 도움이 됩니다.",
+      "parent": "## 상위 마일스톤\n이 마일스톤을 상위 마일스톤에 연결하여 계층 구조를 만듭니다.\n\n- 마일스톤을 논리적인 그룹으로 구성합니다.\n- 종속성 및 관계를 보여줍니다.\n- 더 큰 규모의 프로젝트 진행 상황을 추적하는 데 도움이 됩니다.",
+      "description": "## 설명\n마일스톤의 목적, 요구사항 및 범위에 대한 자세한 정보입니다.\n\n- 팀 구성원에게 맥락을 제공합니다.\n- 주요 요구사항 및 목표를 문서화합니다.\n- 협업 및 조율을 지원합니다.",
+      "documentation": "## 문서\n추가 정보, 참고 자료 및 보충 자료.\n\n- 기술 사양\n- 설계 문서\n- 외부 참고 자료\n- 회의록 및 결정 사항",
+      "automaticCompletion": "## 마감일 자동 완료\n마감일이 되면 이 마일스톤을 자동으로 완료로 표시합니다.\n\n- 마일스톤은 마감일의 예정된 시간에 완료됩니다.\n- 완료 여부와 관계없이 마감되어야 하는 시간 제한 마일스톤에 유용합니다.\n- 마감일 전에 수동으로 마일스톤을 완료하면 이 설정을 무시할 수 있습니다.\n- 마감일을 설정해야 합니다.",
+      "notifyDaysBefore": "## 마감일 며칠 전 알림\n마일스톤 마감일이 다가오면 지정된 팀원에게 알림을 보냅니다.\n\n- 알림을 활성화하려면 켜고, 비활성화하려면 끄세요.\n- 마감일 며칠 전부터 알림을 보낼지 입력하세요.\n- 이 마일스톤 내의 테스트 실행 및 세션에 지정된 사용자에게 알림이 전송됩니다.\n- 마감일이 지난 마일스톤은 완료될 때까지 알림이 계속 전송됩니다."
+    },
+    "session": {
+      "name": "## 세션 이름\n테스트 세션의 목적을 명확하고 설명적으로 나타내는 이름입니다.\n\n- 고유하고 의미 있는 이름이어야 합니다.\n- 팀 구성원이 테스트 대상을 이해하는 데 도움이 됩니다.\n- 보고서 및 추적에 사용됩니다.",
+      "template": "## 템플릿\n템플릿은 테스트 세션의 구조와 내용을 정의합니다.\n\n- 테스트 문서에 일관된 형식을 제공합니다.\n- 미리 정의된 섹션과 필드를 포함합니다.\n- 프로젝트 전체의 테스트 표준을 유지하는 데 도움이 됩니다.",
+      "configuration": "## 구성\n이 테스트 세션에 필요한 특정 환경 또는 설정입니다.\n\n- 테스트 환경(예: 스테이징, 프로덕션)\n- 특수 구성 또는 설정\n- 필수 테스트 데이터 또는 조건",
+      "milestone": "## 마일스톤\n이 세션을 프로젝트 마일스톤과 연결합니다.\n\n- 프로젝트 목표 달성을 위한 테스트 진행 상황 추적에 도움이 됩니다.\n- 관련 테스트 세션을 그룹화합니다.\n- 마일스톤 기반 보고를 지원합니다.",
+      "description": "## 설명\n이 테스트 세션에서 다루는 내용에 대한 간략한 개요입니다.\n\n- 테스트 대상 주요 영역 또는 기능\n- 중요한 맥락 또는 배경\n- 특별 고려 사항 또는 요구 사항",
+      "mission": "## 미션\n미션은 이번 테스트 세션의 구체적인 목표와 목적을 정의합니다.\n\n- 무엇을 테스트하는가?\n- 주요 초점 영역은 무엇인가?\n- 예상되는 결과는 무엇인가?\n\n명확한 미션은 테스트의 집중도와 생산성을 유지하는 데 도움이 됩니다.",
+      "estimate": "## 예상 소요 시간\n이 테스트 세션을 완료하는 데 예상되는 시간입니다.\n\n예시:\n- \"30m\": 30분\n- \"1h 30m\": 1시간 30분\n- \"2 days\": 2일\n- \"1 week\": 1주일",
+      "elapsed": "## 경과 시간\n이 테스트 세션에 실제로 소요된 시간입니다.\n\n예시:\n- \"45m\": 45분\n- \"2h 15m\": 2시간 15분\n- \"3 days\": 3일\n\n향후 예측 정확도를 높이기 위해 시간을 정확하게 기록하십시오.",
+      "state": "## 워크플로 상태\n워크플로에서 이 테스트 세션의 현재 상태입니다.\n\n- 세션 진행 상황 추적에 도움이 됩니다.\n- 워크플로 관리를 지원합니다.\n- 보고 및 추적에 사용됩니다.",
+      "assignedTo": "## 담당자\n이 테스트 세션을 진행할 팀원입니다.\n\n- 테스트 수행자를 파악합니다.\n- 리소스 관리를 지원합니다.\n- 책임 소재 파악 및 진행 상황 추적을 지원합니다.",
+      "tags": "## 태그\n테스트 세션을 분류하고 정리하는 데 도움이 되는 키워드 또는 레이블입니다.\n\n- 세션을 더 쉽게 찾을 수 있도록 합니다.\n- 관련 테스트 활동을 그룹화합니다.\n- 필터링 및 보고 기능을 지원합니다.",
+      "attachments": "## 첨부파일\n이 테스트 세션과 관련된 파일, 스크린샷 또는 기타 문서입니다.\n\n- 테스트 데이터 파일\n- 스크린샷 또는 녹화 파일\n- 지원 문서\n- 참고 자료",
+      "issues": "## 이슈\n이 세션에 관련된 이슈를 연결하세요."
+    },
+    "testRun": {
+      "name": "## 테스트 실행 이름\n나중에 쉽게 식별할 수 있도록 이 테스트 실행에 대한 설명적인 이름을 입력하십시오.",
+      "description": "## 설명\n이 테스트 실행에 대한 간략한 요약 또는 메모를 제공하십시오.",
+      "configuration": "## 구성\n테스트 실행을 수행할 구성(예: 환경, 브라우저, 장치)을 하나 이상 선택하십시오. 여러 구성을 선택하면 각 구성에 대해 별도의 테스트 실행이 생성됩니다.",
+      "milestone": "## 마일스톤\n더 큰 목표 달성을 위한 진행 상황을 추적하려면 이 테스트 실행을 특정 프로젝트 마일스톤과 연결하세요.",
+      "docs": "## 문서화\n이 테스트 실행과 관련된 모든 문서, 링크 또는 자세한 메모를 포함하세요.",
+      "state": "## 상태\n프로젝트 워크플로에 따라 이 테스트 실행의 현재 상태 또는 결과를 나타냅니다.",
+      "tags": "## 태그\n이 테스트 실행을 분류하고 필터링하려면 관련 태그를 적용하세요.",
+      "issues": "## 문제점\n이 테스트 실행과 관련된 문제점(버그, 작업 등)을 연결하세요.",
+      "attachments": "## 첨부파일\n이 테스트 실행과 관련된 지원 파일, 스크린샷 또는 로그를 업로드하십시오.",
+      "duplicate": {
+        "statusesToInclude": "## 포함할 상태\n복제된 테스트 실행에 포함할 테스트 케이스의 상태를 선택하세요.",
+        "copyAssignments": "## 할당 복사\n이 옵션을 활성화하면 테스트 케이스의 할당이 복제된 테스트 실행에 복사됩니다."
+      }
+    },
+    "appConfig": {
+      "key": "## 키\n이 구성에 대한 고유 식별자입니다.",
+      "value": "## 값\n이 구성의 값입니다."
+    },
+    "milestoneType": {
+      "icon": "## 마일스톤 유형 아이콘\n이 마일스톤 유형을 시각적으로 식별하는 아이콘입니다.\n\n- 목록 및 대시보드에서 마일스톤 유형을 빠르게 식별하는 데 도움이 됩니다.\n- 다양한 사전 정의된 아이콘 중에서 선택할 수 있습니다.\n- 언제든지 변경할 수 있습니다.\n- 프로젝트 탐색 및 보고서에 표시됩니다.",
+      "name": "## 마일스톤 유형 이름\n프로젝트에서 이 마일스톤 유형을 명확하고 설명적으로 식별하는 이름입니다.\n\n- 팀 구성원이 마일스톤 유형의 목적을 빠르게 이해하는 데 도움이 됩니다.\n- 보고서 및 프로젝트 추적에 사용됩니다.",
+      "isDefault": "## 기본 마일스톤 유형\n이 마일스톤 유형이 프로젝트의 기본 유형인지 여부를 나타냅니다.\n\n- 새 마일스톤에 대해 기본 마일스톤 유형이 미리 선택됩니다.\n- 언제든지 변경할 수 있습니다.",
+      "projects": "## 관련 프로젝트\n이 마일스톤 유형을 사용할 프로젝트를 선택하세요.\n\n- 프로젝트를 선택하지 않으면 마일스톤 유형이 전체 프로젝트에서 사용 가능합니다.\n- 특정 프로젝트에 할당하면 해당 프로젝트에서만 사용할 수 있습니다."
+    },
+    "tag": {
+      "name": "## 태그 이름\n모든 프로젝트에서 사용되는 명확하고 간결하며 설명적인 이름 또는 키워드입니다.\n\n- 팀 구성원이 관련 테스트 케이스, 테스트 실행 및 세션을 빠르게 찾을 수 있도록 도와줍니다."
+    },
+    "role": {
+      "name": "## 역할 이름\n모든 프로젝트에서 사용되는 명확하고 간결하며 설명적인 이름 또는 키워드입니다.\n\n- 팀 구성원이 관련 테스트 케이스, 테스트 실행 및 세션을 빠르게 찾을 수 있도록 도와줍니다.",
+      "isDefault": "## 기본 역할\n이 역할이 프로젝트의 기본 역할인지 여부를 나타냅니다.\n\n- 신규 사용자의 경우 기본 역할이 미리 선택됩니다.\n- 언제든지 변경할 수 있습니다.",
+      "permissions": {
+        "canAddEdit": "## 추가/편집\n이 역할이 관련 애플리케이션 영역을 추가하고 편집할 수 있는지 여부를 나타냅니다.",
+        "canDelete": "## 삭제\n이 역할이 관련 애플리케이션 영역을 삭제할 수 있는지 여부를 나타냅니다.",
+        "canClose": "## 닫기\n이 역할이 관련 애플리케이션 영역을 닫을 수 있는지 여부를 나타냅니다."
+      }
+    },
+    "group": {
+      "name": "## 그룹 이름\n모든 프로젝트에서 사용되는 명확하고 간결하며 설명적인 이름 또는 키워드입니다.\n\n- 팀 구성원이 관련 테스트 케이스, 테스트 실행 및 세션을 빠르게 찾을 수 있도록 도와줍니다.",
+      "users": "## 사용자\n이 그룹에 할당된 사용자를 나타냅니다."
+    },
+    "template": {
+      "name": "## 템플릿 이름\n이 템플릿에 대한 고유하고 설명적인 이름입니다(예: '표준 테스트 케이스', 'API 테스트 결과').",
+      "isEnabled": "## 활성화됨\n이 옵션을 선택하면 새 테스트 케이스를 생성하거나 테스트 실행 구조를 정의할 때 이 템플릿을 선택할 수 있습니다. 템플릿이 '기본값'으로 설정된 경우 '활성화됨'으로도 설정해야 합니다.",
+      "isDefault": "## 기본값\n이 옵션을 선택하면 새 프로젝트에 자동으로 선택되거나, 프로젝트별 기본값이 설정되지 않은 경우 모든 프로젝트의 기본값으로 설정됩니다. 모든 프로젝트의 기본값으로 설정할 수 있는 템플릿은 하나뿐입니다. 이 옵션을 활성화하면 현재 기본값으로 설정된 다른 템플릿은 모두 비활성화됩니다.",
+      "caseFields": "## 테스트 케이스 필드\n이 템플릿을 사용하여 테스트 케이스를 생성하거나 편집할 때 사용할 수 있는 사용자 지정 필드를 선택하고 순서를 지정합니다.\n\n- 드롭다운에서 필드를 추가하여 템플릿에 포함합니다.\n- 드래그 앤 드롭으로 필드 순서를 변경합니다.\n- 순서에 따라 양식에 필드가 표시됩니다.\n- 활성화된 테스트 케이스 필드만 선택할 수 있습니다.\n- 테스트 케이스 필드는 테스트 케이스의 구조와 캡처되는 데이터를 정의합니다.",
+      "resultFields": "## 결과 필드\n이 템플릿을 사용하여 테스트 결과를 추가할 때 사용할 수 있는 사용자 지정 필드를 선택하고 순서를 지정합니다.\n\n- 드롭다운에서 필드를 선택하여 템플릿에 추가합니다.\n- 드래그 앤 드롭으로 필드 순서를 변경합니다.\n- 순서에 따라 테스트 결과를 입력할 때 필드가 표시됩니다.\n- 활성화된 결과 필드만 선택할 수 있습니다.\n- 결과 필드는 테스트 실행 결과에 특정한 추가 데이터를 캡처합니다.",
+      "projects": "## 관련 프로젝트\n이 템플릿을 사용할 프로젝트를 선택하세요. 프로젝트를 선택하지 않으면 템플릿은 모든 프로젝트에서 사용할 수 있습니다. 특정 프로젝트에 템플릿을 지정하면 해당 프로젝트에서만 사용할 수 있습니다."
+    },
+    "llm": {
+      "name": "## 통합 이름\n이 LLM 통합에 대한 설명 레이블입니다.\n\n- 목록 및 설정에서 식별하는 데 사용됩니다.\n- 예: \"OpenAI GPT-4o\" 또는 \"Internal Ollama\"",
+      "provider": "## 공급자\n이 통합을 지원하는 LLM 서비스입니다.\n\n- API 프로토콜 및 사용 가능한 모델을 결정합니다.\n- 생성 후에는 변경할 수 없습니다.",
+      "apiKey": "## API 키\nLLM 제공업체 API에 대한 인증 키입니다.\n\n- 제공업체 개발자 콘솔에서 얻을 수 있습니다.\n- 저장 후에는 암호화되어 표시되지 않습니다.\n- Ollama(로컬 배포)에는 필요하지 않습니다.",
+      "endpoint": "## API 엔드포인트\nLLM 공급자 API의 기본 URL입니다.\n\n- OpenAI, Anthropic, Gemini의 경우 비워 두세요. 공식 URL이 자동으로 사용됩니다.\n- Ollama(예: `http://localhost:11434`), Azure OpenAI, Custom LLM의 경우 필수입니다.\n- 모든 공급자의 경우 선택 사항입니다. OpenAI 호환 프록시(예: LiteLLM)의 URL을 입력하여 해당 프록시를 가리키도록 설정할 수 있습니다.\n- **개인/내부 주소**(localhost, 127.0.0.1, 개인 IP, 클라우드 메타데이터)는 `ALLOWED_PRIVATE_HOSTS` 환경 변수를 통해 명시적으로 허용하지 않는 한 차단됩니다.",
+      "deploymentName": "## Azure 배포 이름\nAzure OpenAI 모델 배포의 이름입니다.\n\n- Azure OpenAI Studio의 배포에서 찾을 수 있습니다.\n- 모델 이름과 다릅니다. 예: `my-gpt4-deploy`는 `gpt-4`에 해당합니다.\n- Azure OpenAI에만 필요합니다.",
+      "defaultModel": "## 기본 모델\n이 통합을 통해 AI 요청에 사용되는 모델입니다.\n\n- OpenAI, Anthropic, Gemini의 경우 사용 가능한 모델이 API 키에서 자동으로 가져와집니다.\n- 공급자 계정에서 모델이 활성화되어 있는지 확인하세요.\n- 예시: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## 요청당 최대 토큰 수\n단일 요청에 대한 출력 토큰의 **최대 허용치**입니다.\n\n- 이 값을 초과하는 요청은 LLM에 도달하기 전에 **오류와 함께 거부**됩니다.\n- 모델의 실제 최대 출력 토큰 용량으로 설정하십시오.\n- 예: GPT-4o의 경우 `16384`, Claude 3.5 Sonnet의 경우 `8192`\n- 이 값을 너무 낮게 설정하면 AI 기능이 제대로 작동하지 않거나 출력이 잘릴 수 있습니다.",
+      "defaultMaxTokens": "## 기본 최대 토큰\n요청에서 자체 토큰 제한을 지정하지 않은 경우 사용되는 **대체** 출력 토큰 제한입니다.\n\n- 각 AI 기능(테스트 생성, 코드 내보내기 등)은 **관리자 → 프롬프트 구성**에서 자체 제한을 설정합니다.\n- 이 값은 특정 제한이 구성되지 않은 기능에 대한 대체 값으로만 사용됩니다.\n- 요청당 최대 토큰 수 이하여야 합니다.",
+      "maxRequestsPerMinute": "## 분당 최대 요청 수\n이 공급자에게 분당 할 수 있는 API 호출 횟수를 제한합니다.\n\n- 공급자 요금제의 요청 제한에 맞춰 설정하세요.\n- 초과 요청은 거부되지 않고 대기열에 저장됩니다.\n- 요금제별 제한 사항은 공급자 문서를 확인하세요.",
+      "costPerInputToken": "## 입력 토큰당 비용(USD)\n모델에 전송되는 각 입력(프롬프트) 토큰에 대한 비용(USD)입니다.\n\n- 비용 추적 및 예산 알림에 사용됩니다.\n- 서비스 제공업체의 가격 페이지에서 확인할 수 있습니다.\n- 예: `0.000005` = 입력 토큰 백만 개당 5달러",
+      "costPerOutputToken": "## 출력 토큰당 비용(USD)\n모델에서 생성된 각 출력(완료) 토큰의 비용(USD)입니다.\n\n- 일반적으로 입력 토큰 비용보다 높습니다.\n- 비용 추적 및 예산 알림에 사용됩니다.\n- 예: `0.000015` = 출력 토큰 백만 개당 15달러",
+      "monthlyBudget": "## 월별 예산(USD)\n이 연동을 위한 선택적 지출 목표입니다.\n\n- 예산 추적을 비활성화하려면 `0`으로 설정하세요.\n- 예산은 **정보 제공용**이며 LLM 사용을 차단하지 않습니다.\n- 예산의 80%, 90%, 100%에 도달하면 알림을 받게 됩니다.\n- 비용은 위의 토큰당 요율을 사용하여 계산됩니다.",
+      "billingPeriodStartDay": "## 청구 기간 시작일\n청구 기간이 시작되는 날짜(1~31일)입니다.\n\n- 기본값 `1`은 달력상의 월과 일치합니다.\n- 15일부터 15일까지의 주기를 설정하려면 `15`로 설정합니다(예: 서비스 제공업체 청구서 날짜와 일치).\n- `29~31` 값은 월이 짧은 경우(윤년이 아닌 해의 경우 2월 등) 자동으로 마지막 날짜로 고정됩니다.\n- **월별 예산** 지출 기간 및 **지출 재설정** 작업에 영향을 미칩니다.",
+      "defaultTemperature": "## 기본 온도\n모델 응답의 무작위성을 제어합니다(0~2).\n\n- **0:** 결정론적 — 동일한 입력에 대해 동일한 출력\n- **0.3:** 집중적 — 테스트 생성 및 코드 출력에 권장\n- **1+:** 창의적 — 더 다양한 응답\n- 개별 기능은 프롬프트 구성에서 이 값을 재정의할 수 있습니다.",
+      "timeout": "## 요청 시간 초과(밀리초)\n요청이 취소되기 전에 응답을 기다리는 시간입니다.\n\n- 값은 밀리초 단위입니다(예: `30000` = 30초).\n- 스트리밍 요청(예: 코드 내보내기 미리보기)은 이 시간 초과를 무시합니다.\n- 느리거나 큰 모델의 경우 값을 늘립니다.\n- 범위: 5,000 ~ 600,000ms",
+      "streamingEnabled": "## 스트리밍 활성화\n전체 출력을 기다리지 않고 응답 토큰을 하나씩 스트리밍합니다.\n\n- 내보내기 모달에서 실시간 코드 미리보기를 위해 필요합니다.\n- 긴 응답에 대한 체감 지연 시간을 줄입니다.\n- 지원되는 모든 공급자에게 권장됩니다.",
+      "isDefault": "## 기본 통합 설정\n모든 AI 기능에 기본적으로 사용되는 통합으로 설정합니다.\n\n- 한 번에 하나의 통합만 기본값으로 설정할 수 있습니다.\n- 특정 공급자가 구성되지 않은 기능은 기본값을 사용합니다.\n- 언제든지 변경할 수 있습니다."
+    },
+    "integration": {
+      "name": "## 통합 이름\n시스템 전체에서 이 통합을 식별하는 데 사용되는 설명적인 이름입니다.\n\n- 다른 통합과 구별하기 위해 고유해야 합니다.\n- 프로젝트 설정 및 구성에 사용됩니다.\n- 서비스 및 목적을 명확하게 나타내야 합니다.",
+      "authType": "## 인증 유형\n외부 서비스와의 인증 방법을 선택하세요.\n\n- **API 키:** 이메일과 API 토큰을 사용한 간편 인증\n- **OAuth 2.0:** OAuth 흐름을 사용한 보안 인증\n- **개인 액세스 토큰:** 토큰 기반의 직접 인증",
+      "email": "## 이메일 주소\n외부 서비스 계정의 이메일 주소입니다.\n\n- API 키 인증에 사용됩니다.\n- API 토큰을 생성한 계정과 일치해야 합니다.\n- Jira 및 유사 서비스에 필수입니다.",
+      "apiToken": "## API 토큰\n외부 서비스의 계정 설정에서 API 토큰을 생성하세요.\n\n- 일반적으로 계정 설정 → 보안 → API 토큰에서 찾을 수 있습니다.\n- 비밀번호를 노출하지 않고 안전하게 액세스할 수 있습니다.\n- 필요에 따라 취소하고 다시 생성할 수 있습니다.",
+      "jiraUrl": "## Jira URL\nJira 인스턴스의 기본 URL입니다.\n\n- 형식: https://your-site.atlassian.net\n- /browse 또는 기타 경로를 포함하지 마세요.\n- 이 서버에서 접근 가능해야 합니다.",
+      "clientId": "## OAuth 클라이언트 ID\nOAuth 애플리케이션 구성에서 가져온 클라이언트 ID입니다.\n\n- 외부 서비스 개발자 콘솔에서 생성\n- OAuth 흐름 중에 애플리케이션을 식별하는 데 사용\n- 구성 파일에서 공유해도 안전함",
+      "clientSecret": "## OAuth 클라이언트 시크릿\nOAuth 애플리케이션 구성에서 생성된 클라이언트 시크릿입니다.\n\n- 클라이언트 ID와 함께 생성됩니다.\n- 기밀로 안전하게 보관해야 합니다.\n- 애플리케이션 인증에 사용됩니다.",
+      "personalAccessToken": "## 개인 액세스 토큰\n외부 서비스에 대한 적절한 권한이 있는 개인 액세스 토큰입니다.\n\n- 계정 설정에서 생성됩니다.\n- 읽기 및 쓰기 권한이 있어야 합니다.\n- 비밀번호 인증보다 안전합니다.",
+      "baseUrl": "## URL 패턴\n외부 이슈 링크용 URL 패턴입니다.\n\n- 이슈 식별자의 자리 표시자로 '{issueId}'를 사용합니다.\n- 예: https://example.com/issues/'{issueId}'\n- 간단한 URL 기반 통합에 사용됩니다.",
+      "organizationUrl": "## 조직 URL\nAzure DevOps 조직 URL입니다.\n\n- 형식: https://dev.azure.com/your-org\n- 이 서버에서 액세스 가능해야 합니다.\n- Azure DevOps API에 액세스하는 데 사용됩니다.",
+      "apiKey": "## API 키\n외부 서비스 인증에 사용되는 API 키입니다.\n\n- 서비스의 API 설정에서 생성됩니다.\n- 서비스에 대한 프로그래밍 방식 접근을 제공합니다.\n- 안전하게 보관하고 정기적으로 갱신하십시오.",
+      "forgeApiKey": "## Forge API 키\nAtlassian Forge 앱이 Jira 이슈에서 테스트 데이터를 가져올 때 인증에 사용됩니다.\n\n- '생성'을 클릭하여 새 키를 생성합니다.\n- 키를 복사하여 Jira의 Forge 앱 설정(앱 관리 → TestPlanIt 설정)에 붙여넣습니다.\n- 키를 다시 생성하면 이전 키가 무효화됩니다.",
+      "owner": "## 소유자 / 네임스페이스\n저장소를 소유하는 사용자 또는 조직입니다.\n\n- GitHub/GitLab의 경우: 사용자 이름 또는 조직 이름\n- Gitea/Forgejo/Gogs의 경우: 사용자 또는 그룹 이름\n- 예: my-org 또는 my-username",
+      "repo": "## 저장소 이름\n이슈를 연결할 저장소의 이름입니다.\n\n- 정확한 저장소 이름 (전체 URL이 아님)\n- 예: my-project\n- 제공된 자격 증명으로 접근 가능해야 합니다.",
+      "instanceUrl": "## 인스턴스 URL\n자체 호스팅 인스턴스의 기본 URL입니다.\n\n- 형식: https://git.example.com\n- 끝에 슬래시나 경로를 포함하지 마세요.\n- 이 서버에서 접근 가능해야 합니다.",
+      "projectPath": "## 프로젝트 경로\nGitLab 프로젝트의 전체 경로입니다.\n\n- 형식: 네임스페이스/프로젝트 또는 그룹/하위그룹/프로젝트\n- 예시: my-org/my-project\n- 프로젝트 URL에서 찾을 수 있습니다: gitlab.com/namespace/project",
+      "platform": "## 플랫폼\n연결할 자체 호스팅 Git 플랫폼입니다.\n\n- **Gitea**: gitea.io 기반 인스턴스\n- **Forgejo**: forgejo.org 기반 인스턴스(Gitea 포크)\n- **Gogs**: gogs.io 기반 인스턴스\n\n이 설정은 표시되는 아이콘을 제어하며 API 호환성에 영향을 줄 수 있습니다."
+    },
+    "config": {
+      "name": "## 구성 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 구성을 이루는 다양한 조합을 설명하는 데 도움이 됩니다(예: \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\" 등)."
+    },
+    "configCategory": {
+      "name": "## 카테고리 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 변형(예: Chrome, Firefox, Safari, Edge 등)을 카테고리(예: 브라우저)로 정리하는 데 도움이 됩니다."
+    },
+    "configVariant": {
+      "name": "## 변형 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 테스트 환경의 일부인 변형을 설명하는 데 도움이 됩니다(예: Chrome, Safari, Windows 10, Windows 11, macOS 15.5 등)."
+    },
+    "issueConfig": {
+      "name": "## 이슈 구성 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 이슈 구성(예: Jira, GitHub 등)을 설명하는 데 도움이 됩니다.",
+      "baseUrl": "## 기본 URL\n이슈 자리 표시자를 포함한 이슈 구성의 기본 URL입니다(예: https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## 시스템 유형\n이슈 추적 시스템의 유형(예: LINK Jira 등).",
+      "isActive": "## 활성\n이 문제 구성이 활성화되어 있는지 여부를 나타냅니다.",
+      "isDefault": "## 기본값\n이 이슈 구성이 프로젝트의 기본값인지 여부를 나타냅니다.\n\n- 새 이슈에 대해 기본 이슈 구성이 미리 선택됩니다.\n- 언제든지 변경할 수 있습니다.",
+      "projects": "## 프로젝트\n이 이슈 구성에 할당된 프로젝트를 나타냅니다."
+    },
+    "issue": {
+      "name": "## 이슈 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 이슈를 설명하는 데 도움이 됩니다(예: \"이슈 123\", \"버그 456\" 등).",
+      "title": "## 문제 제목\n문제를 설명하는 사람이 읽기 쉬운 제목입니다.\n\n- 문제에 대한 맥락을 제공합니다.\n- 목록 및 문제 표시 화면에 표시됩니다.\n- 명확하고 설명적이어야 합니다.",
+      "externalKey": "## 외부 키\n외부 이슈 추적 시스템의 고유 키 또는 식별자입니다.\n\n- JIRA의 경우: \"PROJ-123\"과 같은 이슈 키\n- GitHub의 경우: \"456\"과 같은 이슈 번호\n- Azure DevOps의 경우: 작업 항목 ID\n- 저장 시 외부 URL이 자동으로 생성됩니다.",
+      "externalId": "## 외부 ID\n이슈 추적 시스템에서 이 이슈를 식별하는 고유 식별자입니다(예: \"Issue-123\", \"Bug456\" 등).\n\n- 기본 URL에서 이슈 자리 표시자로 사용됩니다.",
+      "description": "## 설명\n이 이슈에서 다루는 내용에 대한 간략한 개요입니다.\n\n- 테스트 대상 주요 영역 또는 기능\n- 중요한 맥락 또는 배경\n- 특별 고려 사항 또는 요구 사항",
+      "project": "## 프로젝트\n이 이슈와 관련된 프로젝트입니다.\n\n- 이슈는 여러 프로젝트의 테스트 케이스와 연결될 수 있습니다.\n- 기본 프로젝트를 설정하면 이슈를 체계적으로 관리하는 데 도움이 됩니다.\n- 여러 프로젝트에 걸친 이슈의 경우 비워둘 수 있습니다.",
+      "state": "## 상태\n프로젝트 워크플로에 따라 이 문제의 현재 상태 또는 결과를 표시하십시오.",
+      "tags": "## 태그\n이 문제를 분류하고 필터링하려면 관련 태그를 적용하세요.",
+      "issues": "## 이슈\n관련 이슈(버그, 작업 등)를 이 이슈에 연결하세요."
+    },
+    "status": {
+      "name": "## 상태 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 테스트 결과 상태를 설명하는 데 도움이 됩니다(예: 통과, 실패, 차단 등).",
+      "color": "## 색상\n이 상태의 색상입니다.",
+      "systemName": "## 시스템 이름\n백엔드 시스템(예: 데이터베이스 쿼리, 보고서 등)에서 사용하는 상태 이름입니다.",
+      "aliases": "## 별칭\n외부 시스템 상태를 이 상태에 연결하는 데 사용할 수 있는 이 상태에 대한 추가 이름 또는 동의어입니다.",
+      "enabled": "## 활성화됨\n이 상태가 활성화되었는지 여부를 나타냅니다.",
+      "isEnabled": "## 활성화됨\n이 상태가 활성화되어 사용 가능한지 여부를 나타냅니다.\n\n- 활성화된 경우, 테스트 결과를 기록할 때 이 상태를 선택할 수 있습니다.\n- 비활성화된 상태는 선택 항목에서 숨겨지지만 기존 결과에는 유지됩니다.",
+      "success": "## 성공\n이 상태가 성공 상태인지 여부를 나타냅니다.",
+      "isSuccess": "## 성공 상태\n이 상태가 테스트의 성공적인 결과를 나타내는지 여부를 표시합니다.\n\n- 성공 상태는 합격률 지표에 반영됩니다.\n- 테스트 효과를 추적하기 위한 보고 및 분석에 사용됩니다.",
+      "completed": "## 완료됨\n이 상태가 완료된 상태인지 여부를 나타냅니다.",
+      "isCompleted": "## 완료 상태\n이 상태는 테스트 실행이 완료되었는지 여부를 나타냅니다.\n\n- 완료 상태는 테스트 실행이 완료되었음을 나타냅니다.\n- 완료율 및 진행 상황 추적 계산에 사용됩니다.",
+      "failure": "## 실패\n이 상태가 실패 상태인지 여부를 나타냅니다.",
+      "isFailure": "## 실패 상태\n이 상태가 테스트 실패 결과를 나타내는지 여부를 표시합니다.\n\n- 실패 상태는 실패율 지표에 반영됩니다.\n- 보고 및 분석에서 문제를 식별하는 데 사용됩니다.",
+      "scope": "## 범위\n이 상태의 범위(테스트 실행, 세션, 자동화)를 나타냅니다.",
+      "projects": "## 프로젝트\n이 상태를 사용할 수 있는 프로젝트를 나타냅니다."
+    },
+    "workflow": {
+      "scope": "## 범위\n이 워크플로의 범위(테스트 실행, 세션, 자동화)를 나타냅니다.\n\n- 워크플로가 생성된 후에는 변경할 수 없습니다.",
+      "iconColor": "## 아이콘/색상\n이 워크플로에 사용할 아이콘과 색상입니다.",
+      "name": "## 이름\n모든 프로젝트에서 사용되는 명확하고 설명적인 이름입니다.\n\n- 워크플로를 설명하는 데 도움이 됩니다(예: \"초안\", \"검토 중\", \"진행 중\" 등).",
+      "workflowType": "## 워크플로 유형(시작 안 함, 진행 중, 완료됨)을 입력하세요.\n",
+      "type": "## 워크플로 유형\n워크플로 상태의 범주(시작 안 함, 진행 중, 완료됨).\n\n- 이 상태가 진행 상황 추적에 미치는 영향을 결정합니다.\n- 시작 안 함 상태는 작업이 아직 시작되지 않았음을 나타냅니다.\n- 진행 중 상태는 활성 작업을 나타냅니다.\n- 완료됨 상태는 작업이 완료되었음을 나타냅니다.",
+      "isDefault": "## 기본값\n이 워크플로가 프로젝트의 기본값인지 여부를 나타냅니다.\n\n- 새 테스트 실행, 세션 및 자동화에 대해 기본 워크플로가 미리 선택됩니다.",
+      "isEnabled": "## 활성화됨\n이 워크플로가 활성화되었는지 여부를 나타냅니다.",
+      "isActive": "## 활성\n이 워크플로 상태가 활성화되어 사용 가능한지 여부를 나타냅니다.\n\n- 활성 워크플로는 테스트 실행, 세션 또는 자동화를 업데이트할 때 선택할 수 있습니다.\n- 비활성 워크플로는 선택 항목에서 숨겨지지만 기존 항목에는 유지됩니다.",
+      "projects": "## 프로젝트\n이 워크플로를 사용할 수 있는 프로젝트를 나타냅니다."
+    },
+    "testResult": {
+      "status": "## 상태\n테스트 실행의 전체 상태를 선택하세요. 선택한 상태는 프로젝트 지표 및 보고서에 영향을 줄 수 있습니다.",
+      "elapsedTime": "## 경과 시간\n이 테스트 케이스를 실행하는 데 걸린 총 시간을 입력하세요. 초는 **s**, 분은 **m**, 시간은 **h**와 같은 단위를 사용할 수 있습니다(예: 30s, 5m, 1h 20m).",
+      "resultData": "## 결과 세부 정보\n전체 테스트 실행에 대한 자세한 메모, 관찰 내용 또는 기타 관련 데이터를 제공하십시오. 여기에는 설정 세부 정보, 계획에서 벗어난 경우 수행한 단계 또는 일반적인 의견이 포함될 수 있습니다.",
+      "evidence": "## 증거/첨부파일\n이 테스트 결과에 대한 증거로 사용할 수 있는 파일(예: 스크린샷, 로그, 데이터 파일)을 업로드하세요. 이러한 첨부파일은 해당 결과에 연결됩니다.",
+      "issues": "## 연결된 이슈\n통합 이슈 트래커에서 이 테스트 결과와 관련된 이슈를 연결하세요. 이렇게 하면 이 테스트 결과와 관련된 결함이나 작업을 추적하는 데 도움이 됩니다.",
+      "stepStatus": "## 단계 상태\n이 특정 테스트 단계에 대한 상태를 선택합니다. 이를 통해 단일 테스트 케이스 내에서 진행 상황을 세부적으로 추적할 수 있습니다.",
+      "stepElapsedTime": "## 단계별 경과 시간\n이 특정 단계를 실행하는 데 걸린 시간을 입력하십시오. **s**, **m**, **h**와 같은 단위를 사용하십시오(예: 10s, 2m). 이 항목은 선택 사항입니다.",
+      "stepNotes": "## 단계 참고 사항\n이 테스트 단계 실행과 관련된 메모, 관찰 내용 또는 데이터를 추가하십시오.",
+      "stepIssues": "## 단계별 연결된 이슈\n이 테스트 단계의 결과 또는 관찰 내용과 특별히 관련된 이슈 트래커의 이슈를 연결하세요."
+    },
+    "case": {
+      "name": "## 테스트 케이스 이름\n테스트 케이스에 대한 명확하고 설명적인 이름입니다.",
+      "state": "## 상태\n이 케이스의 현재 워크플로 상태를 나타냅니다.",
+      "template": "## 템플릿\n이 케이스의 케이스 필드와 결과 필드에 사용할 템플릿을 선택하세요.",
+      "estimate": "## 예상 시간\n이 테스트 케이스를 완료하는 데 필요한 예상 시간을 수동으로 입력합니다.",
+      "automated": "## 자동화 여부\n이 테스트 케이스가 자동화되었는지 여부를 나타냅니다.",
+      "tags": "## 태그\n이 사례를 분류하고 필터링하려면 관련 태그를 적용하세요.",
+      "issues": "## 이슈\n관련 이슈(버그, 작업 등)를 이 케이스에 연결하세요."
+    },
+    "folder": {
+      "name": "## 폴더 이름\n폴더에 대한 명확하고 설명적인 이름입니다.",
+      "documentation": "## 문서\n추가 정보, 참고 자료 및 지원 자료."
+    },
+    "bulkEdit": {
+      "name": "## 이름\n테스트 케이스에 대한 명확하고 설명적인 이름입니다.",
+      "state": "## 상태\n이 테스트 케이스의 현재 워크플로 상태를 나타냅니다.",
+      "estimate": "## 예상 시간\n각 테스트 케이스를 완료하는 데 필요한 예상 시간을 수동으로 입력합니다.",
+      "automated": "## 자동화 여부\n이 테스트 케이스가 자동화되었는지 여부를 나타냅니다.",
+      "tags": "## 태그\n관련 태그를 적용하여 이러한 테스트 케이스를 분류하고 필터링하세요.",
+      "issues": "## 이슈\n관련 이슈(버그, 작업 등)를 이 테스트 케이스에 연결하세요."
+    },
+    "caseField": {
+      "displayName": "## 표시 이름\n이 이름은 양식 및 보기에서 사용자에게 표시될 필드의 사람이 읽기 쉬운 이름입니다. 명확하고 설명적인 이름으로 지정하세요.",
+      "systemName": "## 시스템 이름\n시스템 내부에서 사용되는 고유 식별자입니다(예: API 호출, 데이터베이스 쿼리). 표시 이름에서 자동으로 생성되지만 사용자 지정할 수 있습니다. 문자로 시작해야 하며, 문자, 숫자, 밑줄만 사용할 수 있습니다(공백이나 특수 문자는 사용할 수 없음).",
+      "hint": "## 힌트 텍스트 (선택 사항)\n입력란 아래에 표시될 간단한 안내 또는 예시를 제공하여 사용자를 안내합니다. 이를 통해 예상 입력값이나 형식을 명확히 할 수 있습니다.",
+      "enabled": "## 활성화 여부\n이 필드가 템플릿 및 테스트 케이스에서 사용 가능한지 여부를 결정합니다. 비활성화된 필드는 숨겨지고 데이터는 보존되지만 사용되지 않습니다.",
+      "required": "## 필수 항목\n이 항목을 선택하면 사용자는 이 필드가 포함된 템플릿을 사용하여 테스트 케이스를 생성하거나 편집할 때 이 필드에 값을 입력해야 합니다.",
+      "restricted": "## 제한됨\n이 옵션을 선택하면 특별 권한(예: 슈퍼 관리자 또는 '케이스 제한 필드' 권한 보유자)이 있는 사용자만 케이스 생성 후 이 필드 값을 편집할 수 있습니다. 다른 사용자는 읽기 전용으로 표시됩니다. 이는 '검토자' 또는 '승인일'과 같이 특정 단계 이후에는 일반 사용자가 변경해서는 안 되는 필드에 유용합니다.",
+      "fieldType": "## 필드 유형\n이 필드에 저장될 데이터의 종류와 표시 방식을 결정합니다(예: 텍스트, 숫자, 날짜, 드롭다운). 필드 유형은 생성 후 변경할 수 없습니다.",
+      "defaultValue": "## 기본값 (선택 사항)\n이 필드에 미리 채워진 값을 설정합니다. '체크박스' 유형의 경우 'true' 또는 'false'를 사용합니다. '드롭다운' 또는 '다중 선택'의 경우 일반적으로 기본 옵션의 ID를 나타냅니다. 다른 유형의 경우 기본 텍스트/숫자를 그대로 사용합니다. 이 값은 필드를 템플릿에 추가할 때 재정의할 수 있습니다.",
+      "isChecked": "## 기본 상태(체크박스용)\n새 항목(예: 테스트 케이스)을 생성할 때 체크박스가 기본적으로 선택되어야 하는지 여부를 결정합니다.",
+      "minValue": "## 최소값 (숫자/정수)\n이 필드에 허용되는 가장 작은 숫자 값을 설정합니다. 최소값과 최대값을 모두 설정해야 합니다.",
+      "maxValue": "## 최대값 (숫자/정수)\n이 필드에 허용되는 최대 숫자 값을 설정합니다. 최소값과 최대값을 모두 설정해야 합니다.",
+      "initialHeight": "## 초기 높이 (긴 텍스트 입력용)\n서식 있는 텍스트 편집기 필드의 초기 표시 높이(픽셀 단위)를 지정합니다. 이는 긴 텍스트 입력란의 폼 레이아웃을 제어하는 데 도움이 됩니다.",
+      "dropdownOptions": "## 옵션 (드롭다운/다중 선택용)\n선택 가능한 항목 목록을 정의합니다. 옵션 순서를 변경하거나, 기본값을 설정하거나, 개별 옵션을 활성화/비활성화할 수 있습니다."
+    },
+    "resultField": {
+      "displayName": "## 표시 이름\n이 이름은 사용자가 시험 결과를 입력할 때 표시될 필드의 읽기 쉬운 이름입니다. 명확하고 설명적인 이름으로 지정하세요.",
+      "systemName": "## 시스템 이름\n시스템 내부에서 사용되는 고유 식별자입니다(예: API 호출, 데이터베이스 쿼리). 표시 이름에서 자동으로 생성되지만 사용자 지정할 수 있습니다.\n- 문자로 시작해야 합니다.\n- 문자, 숫자 및 밑줄만 포함할 수 있습니다(공백 또는 특수 문자는 사용할 수 없음).",
+      "hint": "## 힌트 텍스트 (선택 사항)\n입력란 아래에 표시될 간단한 안내 또는 예시를 제공하여 사용자를 안내합니다. 이를 통해 결과 데이터를 입력할 때 예상되는 입력값이나 형식을 명확히 할 수 있습니다.",
+      "enabled": "## 활성화\n이 필드가 활성화되어 시험 결과를 입력할 때 템플릿에서 사용할 수 있는지 여부를 결정합니다. 비활성화된 필드는 숨겨지고 데이터는 보존되지만 사용되지 않습니다.",
+      "required": "## 필수 항목\n이 항목을 선택하면, 사용자는 이 필드가 포함된 템플릿을 사용하여 테스트 결과를 추가할 때 이 필드에 값을 입력해야 합니다.",
+      "restricted": "## 제한됨\n이 옵션을 선택하면 특별 권한(예: 슈퍼 관리자 또는 '테스트 실행 결과 제한 필드' 권한 보유자)이 있는 사용자만 결과 제출 후 이 필드의 값을 편집할 수 있습니다. 다른 사용자는 읽기 전용으로 표시됩니다.",
+      "fieldType": "## 필드 유형\n이 필드에 저장될 데이터의 종류와 테스트 결과에 표시되는 방식을 결정합니다(예: 텍스트, 숫자, 날짜, 드롭다운). 필드 유형은 생성 후 변경할 수 없습니다.",
+      "defaultValue": "## 기본값 (선택 사항)\n새 검사 결과를 추가할 때 이 필드에 미리 입력될 값을 설정합니다. '체크박스' 유형의 경우 'true' 또는 'false'를 사용합니다. '드롭다운' 또는 '다중 선택'의 경우 일반적으로 기본 옵션의 ID를 나타냅니다. 다른 유형의 경우 기본값(텍스트/숫자)을 그대로 사용합니다.",
+      "isChecked": "## 기본 상태(체크박스용)\n새 테스트 결과가 추가될 때 체크박스가 기본적으로 선택되어야 하는지 여부를 결정합니다.",
+      "minValue": "## 최소값 (숫자/정수)\n결과 데이터를 입력할 때 이 필드에 허용되는 가장 작은 숫자 값을 설정합니다. 최소값과 최대값을 모두 설정해야 합니다.",
+      "maxValue": "## 최대값 (숫자/정수)\n결과 데이터를 입력할 때 이 필드에 허용되는 최대 숫자 값을 설정합니다. 최소값과 최대값을 모두 설정해야 합니다.",
+      "initialHeight": "## 초기 높이 (긴 텍스트 입력용)\n결과에 사용되는 서식 있는 텍스트 편집기 필드의 초기 표시 높이(픽셀 단위)를 지정합니다. 이는 긴 텍스트 입력란의 폼 레이아웃을 제어하는 데 도움이 됩니다.",
+      "dropdownOptions": "## 옵션 (드롭다운/다중 선택용)\n결과 데이터를 입력할 때 선택할 수 있는 항목 목록을 정의합니다. 옵션 순서를 변경하거나, 기본값을 설정하거나, 개별 옵션을 활성화/비활성화할 수 있습니다."
+    },
+    "exportModal": {
+      "scope": "## 내보내기 범위\n내보내기에 포함할 테스트 케이스를 결정합니다.\n- **선택됨:** 표에서 명시적으로 선택한 테스트 케이스만 내보냅니다.\n- **필터링된 모든 테스트 케이스:** 현재 페이지에 표시되지 않더라도 표에서 현재 필터 기준과 일치하는 모든 테스트 케이스를 내보냅니다.\n- **프로젝트 전체:** 선택이나 필터를 무시하고 현재 프로젝트의 모든 테스트 케이스를 내보냅니다.",
+      "format": "## 내보내기 형식\n내보낼 파일 형식을 선택하세요.\n- **CSV(쉼표로 구분된 값):** 스프레드시트(Excel, Google Sheets) 및 데이터 분석 도구에 적합한 일반 텍스트 파일입니다. PDF 내보내기 기능은 향후 릴리스에서 지원될 예정입니다.",
+      "columns": "## 내보낼 열 (CSV 형식만 해당)\n각 테스트 케이스에 포함할 데이터 열을 결정합니다.\n- **모든 열:** 템플릿의 사용자 지정 필드를 포함하여 테스트 케이스에서 사용 가능한 모든 데이터 필드를 내보냅니다.\n- **표시되는 열:** 테스트 케이스 표에 현재 표시되는 열만 내보냅니다.",
+      "delimiter": "## CSV 구분 기호 (CSV 파일에만 해당)\nCSV 파일에서 값을 구분하는 데 사용할 문자를 선택하세요. 가장 일반적인 구분 기호는 쉼표입니다. 텍스트 필드 내에 쉼표가 포함된 경우 다른 구분 기호(예: 세미콜론)를 사용하세요.",
+      "textLongFormat": "## 긴 텍스트 필드 형식 (CSV 전용)\n서식 있는 텍스트 필드(예: '설명' 또는 사용자 지정 '긴 텍스트' 필드)를 내보내는 방식을 결정합니다.\n- **JSON:** 모든 서식(굵게, 목록 등)을 유지하면서 콘텐츠를 JSON 문자열로 내보냅니다. 재가져오기 또는 프로그램 처리에 가장 적합합니다.\n- **일반 텍스트:** 서식을 제거하고 콘텐츠를 일반 텍스트로 내보냅니다. 간단한 텍스트 뷰어에서 읽기 쉽습니다.",
+      "stepsFormat": "## 단계 형식 (CSV만 해당)\n테스트 단계(예상 결과 포함)를 내보내는 방식을 결정합니다.\n- **JSON:** 구조와 서식 있는 텍스트를 유지하면서 단계를 객체 배열인 JSON 형식으로 내보냅니다. 재가져오기 또는 상세 분석에 적합합니다.\n- **일반 텍스트:** 각 단계와 예상 결과를 새 줄에 표시하여 단계를 간소화되고 읽기 쉬운 일반 텍스트 형식으로 내보냅니다.",
+      "rowMode": "## 행 모드(CSV 전용)\n태그 또는 다중 선택 사용자 지정 필드와 같은 다중 값 필드 및 단계의 표현 방식을 결정합니다.\n- **테스트 케이스당 한 행:** 각 테스트 케이스는 한 행으로 표시됩니다. 다중 값 필드와 단계는 해당 셀에 압축되어 표시됩니다(대부분 JSON 또는 연결된 텍스트 형식).\n- **테스트 케이스당 여러 행:** 테스트 케이스에 여러 태그, 다중 선택 값 또는 단계가 있는 경우 여러 행에 걸쳐 표시될 수 있습니다. 이러한 필드의 각 고유 값/단계는 새 행을 생성하고 다른 케이스 데이터는 반복됩니다. 이는 상세 분석 또는 피벗팅에 유용합니다.",
+      "attachmentFormat": "## 첨부 파일 정보 형식 (CSV만 해당)\n첨부 파일 정보 내보내기 방식을 지정합니다.\n- **JSON:** 첨부 파일 세부 정보(파일 이름, URL, 크기 등)를 JSON 배열로 내보냅니다. 이 형식은 포괄적이지만 CSV 파일에 직접 저장하면 가독성이 떨어집니다.\n- **파일 이름만:** 첨부 파일 이름을 쉼표로 구분한 목록으로 내보냅니다. 간편하게 참조할 수 있습니다."
+    },
+    "reportMetrics": {
+      "count": "## 테스트 결과 개수\n이 그룹에 포함된 테스트 실행 결과의 개수입니다.",
+      "passRate": "## 합격률\n이 그룹에서 합격 상태인 결과의 비율입니다.",
+      "avgElapsed": "## 평균 경과 시간\n이 그룹의 결과에 대한 평균 경과 시간입니다.",
+      "sumElapsed": "## 총 경과 시간\n이 그룹의 결과에 대한 경과 시간의 합계입니다.",
+      "executionCount": "## 테스트 실행 횟수\n수행된 테스트의 총 실행 횟수입니다.",
+      "testCaseCount": "## 테스트 케이스 개수\n이 그룹의 총 테스트 케이스 수입니다.",
+      "testRunCount": "## 테스트 실행 횟수\n이 그룹의 총 테스트 실행 횟수입니다.",
+      "automationRate": "## 자동화율\n자동화된 테스트 케이스의 비율입니다.",
+      "averageSteps": "## 테스트 케이스당 평균 단계 수\n테스트 케이스당 평균 단계 수입니다.",
+      "automatedCount": "## 자동화된 테스트 케이스\n자동화된 테스트 케이스 수입니다.",
+      "manualCount": "## 수동 테스트 케이스\n수동 테스트 케이스 수입니다.",
+      "totalSteps": "## 총 단계 수\n모든 테스트 케이스에 걸친 총 테스트 단계 수입니다.",
+      "createdCaseCount": "## 생성된 테스트 케이스 수\n이 기간 동안 생성된 테스트 케이스 수입니다.",
+      "sessionResultCount": "## 세션 결과\n세션 테스트 결과 수입니다.",
+      "sessionCount": "## 세션 수\n총 테스트 세션 수입니다.",
+      "activeSessions": "## 활성 세션\n현재 활성화된 세션 수(isActive = true).",
+      "milestoneCompletion": "## 마일스톤 완료율\n마일스톤별 테스트 케이스 완료율. 계산식: (완료된 테스트 결과 / 전체 테스트 실행 케이스 수) × 100.",
+      "averageTimeSpent": "## 평균 소요 시간\n활동에 소요된 평균 시간입니다.",
+      "sessionParticipation": "## 세션 참여\n테스트 세션 참여 수준.",
+      "lastActiveDate": "## 마지막 활동 날짜\n가장 최근 활동 날짜입니다.",
+      "averageAge": "## 평균 연령\n항목의 평균 연령(일).",
+      "issueCount": "## 이슈 개수\n추적된 이슈의 총 개수입니다.",
+      "milestoneCount": "## 마일스톤 개수\n총 마일스톤 수입니다.",
+      "milestoneCompletionRate": "## 마일스톤 완료율\n완료된 마일스톤의 비율입니다.",
+      "averageMilestoneDuration": "## 평균 마일스톤 기간\n마일스톤의 평균 기간(일)."
+    },
+    "reportDimensions": {
+      "user": "## 사용자 차원\n테스트를 실행한 사용자 또는 항목에 할당된 사용자를 기준으로 결과를 그룹화합니다.",
+      "status": "## 상태 차원\n테스트 실행 상태(예: 통과, 실패, 차단됨)별로 결과를 그룹화합니다.",
+      "project": "## 프로젝트 차원\n프로젝트 간 분석을 위해 결과를 프로젝트별로 그룹화합니다.",
+      "testRun": "## 테스트 실행 차원\n실행된 테스트 케이스가 포함된 테스트 실행별로 결과를 그룹화합니다.",
+      "testCase": "## 테스트 케이스 차원\n개별 테스트 케이스별로 결과를 그룹화하여 자세한 분석을 할 수 있습니다.",
+      "milestone": "## 마일스톤 차원\n프로젝트 마일스톤별로 결과를 그룹화하여 목표 달성 진행 상황을 추적합니다.",
+      "configuration": "## 구성 차원\n테스트 환경 구성(예: 브라우저, 운영 체제)별로 결과를 그룹화합니다.",
+      "template": "## 템플릿 차원\n테스트 케이스 구조에 사용된 템플릿별로 결과를 그룹화합니다.",
+      "creator": "## 생성자 차원\n테스트 케이스 또는 테스트 실행을 생성한 사용자별로 결과를 그룹화합니다.",
+      "state": "## 상태 차원\n워크플로 상태(예: 초안, 활성, 완료)별로 결과를 그룹화합니다.",
+      "role": "## 역할 차원\n접근 및 책임 분석을 위해 사용자 역할별로 결과를 그룹화합니다.",
+      "group": "## 그룹 차원\n사용자 그룹별로 결과를 그룹화합니다. 사용자는 여러 그룹에 속할 수 있으므로 사용자가 속한 각 그룹에 대한 활동이 집계됩니다.",
+      "folder": "## 폴더 차원\n조직 분석을 위해 저장소 폴더 구조별로 결과를 그룹화합니다.",
+      "session": "## 세션 차원\n세션 기반 분석을 위해 테스트 세션별로 결과를 그룹화합니다.",
+      "assignedTo": "## 할당 대상 차원\n항목을 실행하거나 관리하도록 할당된 사용자별로 결과를 그룹화합니다.",
+      "issueType": "## 이슈 유형 차원\n추적되는 이슈 유형(예: 버그, 작업, 스토리, 개선 사항)별로 결과를 그룹화합니다.",
+      "issueTracker": "## 이슈 트래커 차원\n사용된 이슈 트래킹 통합(예: Jira, GitHub Issues, Azure DevOps)별로 결과를 그룹화합니다.",
+      "issueStatus": "## 이슈 상태 차원\n이슈의 현재 상태(예: 열림, 진행 중, 해결됨, 닫힘)별로 결과를 그룹화합니다.",
+      "priority": "## 우선순위 차원\n이슈의 우선순위 수준(예: 높음, 중간, 낮음)별로 결과를 그룹화합니다.",
+      "source": "## 소스 차원\n테스트 실행 소스(예: 수동, JUnit, API)별로 결과를 그룹화합니다.",
+      "date": "## 날짜 차원\n시간 기반 분석 및 추세 분석을 위해 결과를 날짜별로 그룹화합니다."
+    },
+    "reportBuilder": {
+      "dimensions": "## 차원\n보고서에서 분석할 차원을 선택하세요. 차원은 날짜, 사용자, 상태 등과 같이 데이터를 분류하는 속성입니다. 드래그하여 순서를 변경할 수 있습니다.",
+      "metrics": "## 측정항목\n보고서에서 측정할 측정항목을 선택하세요. 측정항목은 시험 결과 개수, 합격률, 평균 소요 시간 등과 같이 데이터에서 도출된 정량적 측정값입니다. 드래그하여 순서를 변경할 수 있습니다.",
+      "dateRange": "## 날짜 범위\n특정 기간으로 보고서 데이터를 필터링하세요. '지난 7일' 또는 '지난달'과 같은 미리 정의된 범위를 선택하거나 사용자 지정 날짜 범위를 정의할 수 있습니다. 이 필터는 각 보고서 유형의 관련 날짜 필드(예: 테스트 결과의 실행 날짜, 테스트 케이스의 생성 날짜)에 적용됩니다."
+    },
+    "codeRepository": {
+      "name": "## 저장소 이름\n이 저장소 연결에 대한 보기 쉬운 표시 이름입니다.\n\n- 프로젝트 코드 컨텍스트 설정에서 식별하는 데 사용됩니다.\n- 공급자의 저장소 이름과 일치할 필요는 없습니다.",
+      "provider": "## Git 제공업체\n이 저장소를 호스팅하는 플랫폼입니다.\n\n- **GitHub** — github.com (클라우드 또는 엔터프라이즈)\n- **GitLab** — gitlab.com 또는 자체 호스팅\n- **Bitbucket Cloud** — bitbucket.org (클라우드 전용)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — 호환 가능한 API를 제공하는 자체 호스팅 Git 서버",
+      "githubToken": "## 개인 액세스 토큰\n**콘텐츠: 읽기** 권한이 있는 GitHub 토큰입니다.\n\n다음 경로에서 생성하세요: GitHub → 프로필 설정 → 개발자 설정 → 개인 액세스 토큰 → 세부 토큰.",
+      "owner": "## 소유자\n저장소를 소유하는 GitHub 조직 또는 사용자 계정입니다.\n\n- 예: `myorg` 또는 `myusername`\n- 이는 github.com의 저장소 URL에서 첫 번째 경로 부분입니다.",
+      "repo": "## 저장소\n소유자 접두사를 제외한 저장소 이름입니다.\n\n- 예: `my-repo` (`myorg/my-repo`가 아님)\n- 이는 github.com의 저장소 URL에서 두 번째 경로 부분입니다.",
+      "gitlabToken": "## 개인 액세스 토큰\n**read_api** 및 **read_repository** 스코프가 있는 GitLab 토큰입니다.\n\nGitLab → 사용자 설정 → 액세스 토큰에서 생성하세요.",
+      "projectPath": "## 프로젝트 ID 또는 경로\n숫자 프로젝트 ID 또는 전체 네임스페이스 경로입니다.\n\n- 경로 예시: `myorg/my-project`\n- ID 예시: `12345678`\n- GitLab의 설정 → 일반에서 찾을 수 있습니다.",
+      "baseUrl": "## GitLab URL\ngitlab.com을 사용하는 경우 비워 두세요. 자체 호스팅 인스턴스의 경우 GitLab URL을 입력하세요.\n\n- 예: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian 계정 이메일\nAtlassian 계정과 연결된 이메일 주소입니다.\n\n- Bitbucket Cloud에 로그인할 때 사용하는 이메일 주소입니다.",
+      "bitbucketApiToken": "## API 토큰\n**저장소: 읽기** 범위의 Bitbucket API 토큰입니다.\n\nBitbucket → 개인 설정 → API 토큰에서 생성할 수 있습니다.\n\nAtlassian은 앱 암호 대신 API 토큰을 사용하도록 권장하고 있습니다.",
+      "workspace": "## 워크스페이스\nBitbucket URL에서 가져온 워크스페이스 슬러그입니다.\n\n- 예: `bitbucket.org/myworkspace`의 `myworkspace`",
+      "repoSlug": "## 저장소 슬러그\nURL에서 가져온 저장소 식별자입니다.\n\n- 예: `bitbucket.org/myworkspace/my-repo`의 `my-repo`",
+      "azureToken": "## 개인 액세스 토큰\n**코드(읽기)** 권한이 있는 Azure DevOps PAT입니다.\n\nAzure DevOps → 사용자 설정 → 개인 액세스 토큰에서 생성하세요.",
+      "organizationUrl": "## 조직 URL\nAzure DevOps 조직 URL입니다.\n\n- 예: `https://dev.azure.com/myorg`",
+      "project": "## 프로젝트 이름\n리포지토리가 포함된 Azure DevOps 프로젝트의 이름입니다.\n\n- Azure DevOps URL에서 조직 이름 다음에 나오는 세 번째 경로 부분으로 찾을 수 있습니다.",
+      "azureRepoId": "## 리포지토리 이름 또는 ID\nAzure DevOps 프로젝트 내의 리포지토리 이름 또는 GUID입니다.\n\n- 예: `my-repo`",
+      "giteaToken": "## 개인 액세스 토큰\n저장소 읽기 권한이 있는 토큰입니다.\n\n사이트 관리 → 애플리케이션 또는 사용자 설정 → 애플리케이션에서 생성할 수 있습니다.\n\n- Gitea, Forgejo, Gogs 및 호환되는 API를 제공하는 모든 서버에서 작동합니다.",
+      "giteaBaseUrl": "## 서버 URL\n자체 호스팅 Git 서버의 기본 URL입니다.\n\n- 예: `https://gitea.example.com`\n- 프로토콜을 포함해야 합니다(https:// 권장).\n- Gitea, Forgejo, Gogs 및 Gitea와 호환되는 `/api/v1/` REST API를 사용하는 기타 서버와 함께 작동합니다.",
+      "giteaOwner": "## 소유자\n저장소를 소유하는 조직 또는 사용자 계정입니다.\n\n- 예: `myorg` 또는 `myusername`\n- 저장소 URL의 첫 번째 경로 부분입니다.",
+      "giteaRepo": "## 저장소\n소유자 접두사를 제외한 저장소 이름입니다.\n\n- 예: `my-repo` (`myorg/my-repo`가 아님)"
+    },
+    "promptConfig": {
+      "name": "## 구성 이름\n이 프롬프트 구성에 대한 고유하고 설명적인 이름입니다.\n\n- 프로젝트에 구성을 할당할 때 구성을 식별하는 데 사용됩니다(예: \"GPT-4o 프롬프트\", \"보수적 프롬프트\").",
+      "description": "## 설명\n이 구성이 다른 구성과 구별되는 점에 대한 선택적 요약입니다.\n\n- 관리자가 목적을 한눈에 이해하는 데 도움이 됩니다(예: \"낮은 온도에서 확정적 출력을 위한 프롬프트 표시\").",
+      "isActive": "## 활성\n이 구성이 활성화되면 프로젝트에서 사용할 수 있습니다.\n\n- 비활성화된 구성은 프로젝트 할당 드롭다운 메뉴에서 숨겨집니다.\n- 기본 구성은 비활성화할 수 없습니다.",
+      "isDefault": "## 기본 구성\n이 구성을 활성화하면 특정 구성이 지정되지 않은 모든 프로젝트에서 이 구성이 사용됩니다.\n\n- 한 번에 하나의 구성만 기본값으로 설정할 수 있습니다.\n- 새 기본값을 설정하면 이전 기본값이 자동으로 해제됩니다.",
+      "systemPrompt": "## 시스템 프롬프트\n사용자 입력 전에 AI 모델에 전송되는 지침입니다. 모델의 역할, 출력 형식 및 제약 조건을 정의합니다.\n\n- 런타임에 대체되는 이중 중괄호 자리 표시자(예: FRAMEWORK, LANGUAGE, CASE_NAME)를 지원합니다.\n- 여기에 대한 변경 사항은 이 구성을 사용하는 모든 프로젝트에 영향을 미칩니다.",
+      "userPrompt": "## 사용자 프롬프트\n사용자를 대신하여 AI에 전송되는 메시지입니다. 기능이 사용자 메시지를 코드로 완전히 구성하는 경우 비워 두십시오.\n\n- 런타임에 대체되는 이중 중괄호 자리 표시자(예: ISSUE_TITLE, CASE_NAME, CODE_CONTEXT)를 지원합니다.\n- 각 기능에 사용할 수 있는 자리 표시자는 아래 변수 섹션에 나열되어 있습니다.",
+      "temperature": "## 온도\nAI 출력의 무작위성을 제어합니다. 범위: 0–2.\n\n- **0.0–0.3** — 매우 결정적이며, 구조화된 출력(JSON, 코드)에 가장 적합합니다.\n- **0.4–0.7** — 균형 잡힌 출력으로, 테스트 케이스 생성에 적합합니다.\n- **0.8–2.0** — 더 창의적이고 다양한 출력을 제공하며, 자유로운 형식의 텍스트에 적합합니다.",
+      "maxOutputTokens": "## 최대 출력 토큰\n모델이 단일 응답에서 생성할 최대 토큰 수입니다.\n\n- 값이 높을수록 응답 시간이 길어지지만 비용과 지연 시간이 증가합니다.\n- 일반적인 범위: 짧은 텍스트의 경우 2048개, 코드 생성의 경우 4096개, 여러 경우 출력의 경우 6000개 이상."
+    },
+    "menu": {
+      "startTour": "가이드가 동행하는 환영 투어",
+      "startProjectTour": "프로젝트 투어",
+      "startAdminTour": "관리자 투어",
+      "startDemoProjectTour": "데모 프로젝트 투어"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "TestPlanIt에 오신 것을 환영합니다!",
+          "content": "TestPlanIt의 주요 기능을 간단히 살펴보면서 테스트 워크플로를 시작하는 데 도움을 드리겠습니다."
+        },
+        "projects": {
+          "content": "여기에서 모든 테스트 프로젝트에 액세스할 수 있습니다. 각 프로젝트에는 테스트 케이스, 실행 결과 및 팀 협업 기능이 포함되어 있습니다."
+        },
+        "project": {
+          "title": "프로젝트 카드",
+          "content": "프로젝트 카드를 클릭하여 세부 정보를 확인하세요. 도움말 메뉴에서 '프로젝트 둘러보기'를 선택하면 프로젝트 기능에 대한 안내 투어를 이용할 수 있습니다."
+        },
+        "globalFeatures": {
+          "title": "글로벌 특징",
+          "content": "분류를 위한 태그를 관리하고, 프로젝트 전반의 문제를 추적하며, 역할 기반 접근 제어를 통해 사용자를 관리할 수 있습니다."
+        },
+        "search": {
+          "content": "현재 페이지를 기반으로 컨텍스트 검색을 제공합니다. 테스트 케이스, 실행 결과, 문제 또는 기타 콘텐츠를 빠르게 찾을 수 있습니다. Cmd+K(또는 Ctrl+K)를 눌러 즉시 액세스할 수 있습니다."
+        },
+        "help": {
+          "title": "도움 및 지원",
+          "content": "언제든지 이 가이드 투어를 이용하거나 자세한 도움을 받으려면 종합 안내 자료를 참조하세요."
+        },
+        "notifications": {
+          "content": "테스트 실행 완료, 문제 업데이트 및 팀 활동에 대한 최신 정보를 받아보세요. 계정 설정에서 환경 설정을 구성할 수 있습니다."
+        },
+        "account": {
+          "title": "계정 메뉴",
+          "content": "프로필, 알림 설정 및 계정 설정을 맞춤 설정하세요. 밝은 테마와 어두운 테마 중에서 선택할 수 있습니다."
+        },
+        "assignments": {
+          "content": "모든 프로젝트에서 본인에게 할당된 테스트 케이스와 실행 결과를 확인하세요. 이 개인 대시보드를 통해 테스트 업무를 추적할 수 있습니다."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "프로젝트 선택기",
+          "content": "이 드롭다운 메뉴를 사용하여 프로젝트 간에 빠르게 전환할 수 있습니다. 프로젝트 세부 정보를 확인하고 프로젝트 전체 설정에 액세스할 수 있습니다."
+        },
+        "projectSections": {
+          "title": "프로젝트 섹션",
+          "content": "개요에서 프로젝트 대시보드를, 문서에서 프로젝트 가이드를, 마일스톤에서 진행 상황을 확인하세요."
+        },
+        "repository": {
+          "content": "테스트 케이스를 관리하고, 폴더로 정리하고, 철저한 테스트 범위를 확보하기 위해 새로운 테스트 시나리오를 생성하세요."
+        },
+        "repositoryPanels": {
+          "title": "저장소 왼쪽 패널",
+          "content": "왼쪽 패널에는 폴더 구조와 테스트 케이스 트리가 표시됩니다. 보기 선택기를 사용하여 다양한 구성 보기 간에 전환할 수 있습니다."
+        },
+        "repositoryRightPanel": {
+          "title": "저장소 오른쪽 패널",
+          "content": "오른쪽 패널에는 테스트 케이스 세부 정보, 실행 결과가 표시되며 새 테스트 케이스를 생성하거나 기존 테스트 케이스를 가져오는 작업이 제공됩니다."
+        },
+        "sharedSteps": {
+          "title": "공유된 단계",
+          "content": "여러 테스트 케이스에서 참조할 수 있는 재사용 가능한 단계 그룹을 정의하세요. 테스트 단계는 DRY 원칙을 준수하고 일관성을 유지하세요."
+        },
+        "testRuns": {
+          "content": "계획된 테스트를 실행하고, 진행 상황을 추적하며, 팀 전체의 테스트 할당을 관리하세요. 자세한 실행 결과를 확인할 수 있습니다."
+        },
+        "testRunsPage": {
+          "title": "테스트 실행 대시보드",
+          "content": "이 페이지는 테스트 실행 페이지로, 새로운 테스트 실행을 생성하고, 실행 진행 상황을 모니터링하고, 결과를 확인하고, 테스트 담당자를 관리할 수 있습니다. 팀의 테스트 활동을 한 곳에서 편리하게 추적하세요."
+        },
+        "sessions": {
+          "title": "탐색 세션",
+          "content": "탐색적 테스트 세션을 문서화하고, 결과를 기록하고, 임시 테스트 활동에 소요된 시간을 추적합니다."
+        },
+        "sessionsPage": {
+          "title": "탐색 세션 대시보드",
+          "content": "이 페이지는 탐색적 테스트 세션을 생성하고 관리할 수 있는 세션 페이지입니다. 테스트 결과를 문서화하고, 소요 시간을 추적하며, 모든 임시 테스트 활동 기록을 유지하여 테스트 범위를 확대할 수 있습니다."
+        },
+        "tags": {
+          "title": "태그 관리",
+          "content": "태그를 사용하여 테스트 케이스를 정리하고 분류하세요. 사용자 지정 태그를 생성하여 테스트 케이스 정리 및 필터링 기능을 향상시킬 수 있습니다."
+        },
+        "issues": {
+          "title": "이슈 추적",
+          "content": "테스트 중에 발견된 문제를 추적하고 관리합니다. 문제를 테스트 케이스와 연결하고 외부 버그 추적 시스템과 통합합니다."
+        },
+        "reports": {
+          "title": "보고서 및 분석",
+          "content": "프로젝트에 대한 종합적인 보고서와 분석 자료를 생성하세요. 테스트 범위, 실행 추세, 팀 성과 지표를 확인하고 이해관계자를 위한 맞춤형 보고서를 만들 수 있습니다."
+        },
+        "settings": {
+          "title": "프로젝트 설정",
+          "content": "여기에서 프로젝트 수준 통합, AI 모델 구성 및 공유 링크를 관리할 수 있습니다."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "관리자 제어에 오신 것을 환영합니다",
+          "content": "TestPlanIt의 관리 기능을 단계별로 살펴보세요. 이 중앙 관리 패널에서 프로젝트, 사용자, 구성 및 시스템 설정을 관리할 수 있습니다."
+        },
+        "projects": {
+          "title": "프로젝트 관리",
+          "content": "조직 내 모든 프로젝트를 관리하세요. 프로젝트를 생성, 구성 및 보관할 수 있습니다. 프로젝트 전체에 대한 권한 및 접근 제어를 설정하세요."
+        },
+        "templatesAndFields": {
+          "content": "테스트 케이스 템플릿과 사용자 정의 필드를 생성하고 관리하세요. 필드 유형, 유효성 검사 규칙을 정의하고, 템플릿을 구성하여 프로젝트 전반에 걸쳐 일관된 테스트 케이스 구조를 유지하세요."
+        },
+        "workflows": {
+          "title": "워크플로우 관리",
+          "content": "테스트 케이스 워크플로 및 상태 전환을 정의합니다. 초안, 검토, 승인과 같은 다양한 상태를 거치는 테스트 케이스의 진행 방식을 구성합니다."
+        },
+        "statuses": {
+          "title": "테스트 결과 상태",
+          "content": "합격, 불합격, 차단, 건너뛰기 등 사용 가능한 테스트 결과 상태를 구성합니다. 사용자 지정 상태를 설정하고 해당 동작 및 표시 방식을 정의할 수 있습니다."
+        },
+        "milestones": {
+          "content": "프로젝트 추적을 위한 마일스톤 유형을 정의합니다. 릴리스 유형, 스프린트 범주 및 기타 프로젝트 마일스톤 분류를 구성합니다."
+        },
+        "configurations": {
+          "title": "테스트 구성",
+          "content": "테스트 구성 및 환경을 관리합니다. 브라우저 조합, 장치 유형, 운영 체제 및 기타 테스트 실행 환경을 설정합니다."
+        },
+        "users": {
+          "title": "사용자 관리",
+          "content": "사용자 계정, 권한 및 접근 수준을 관리하세요. 새 사용자를 생성하고, 역할을 할당하고, 인증 설정을 구성하세요."
+        },
+        "groups": {
+          "title": "그룹 관리",
+          "content": "권한 관리를 간소화하기 위해 사용자를 그룹으로 구성하세요. 부서 그룹, 프로젝트 팀 및 역할 기반 액세스 그룹을 생성할 수 있습니다."
+        },
+        "roles": {
+          "title": "역할 관리",
+          "content": "사용자 역할 및 권한을 정의합니다. 프로젝트 및 시스템 관리 전반에 걸쳐 각 역할이 수행할 수 있는 작업을 구성합니다."
+        },
+        "tags": {
+          "title": "글로벌 태그",
+          "content": "조직 전체에서 테스트 케이스, 프로젝트 및 기타 엔티티를 분류하기 위한 태그를 관리합니다. 태그 계층 구조를 생성하고 프로젝트 전반에 걸쳐 태그 지정을 표준화합니다."
+        },
+        "reports": {
+          "content": "여러 프로젝트에 걸쳐 보고서를 생성하세요. 전체 작업 공간에서 추세, 성과 지표 및 조직 테스트 효과를 분석하세요."
+        },
+        "notifications": {
+          "title": "알림 설정",
+          "content": "시스템 전체 알림 기본 설정을 구성합니다. 이메일 템플릿, 알림 규칙 및 사용자 알림의 기본 설정을 지정합니다."
+        },
+        "integrations": {
+          "title": "시스템 통합",
+          "content": "타사 통합 및 API 연결을 관리하세요. Jira, GitHub 및 기타 외부 도구 통합을 조직에 맞게 구성하세요."
+        },
+        "llm": {
+          "title": "AI 구성",
+          "content": "자동 테스트 케이스 생성 및 지능형 기능을 위한 AI 모델과 설정을 구성하세요. API 키와 모델 기본 설정을 관리하세요."
+        },
+        "sso": {
+          "title": "싱글 사인온",
+          "content": "SSO 공급자 및 인증 방법을 구성합니다. 원활한 사용자 액세스를 위해 SAML, OAuth 및 기타 ID 공급자 통합을 설정합니다."
+        },
+        "appConfig": {
+          "content": "전역 애플리케이션 설정 및 시스템 환경설정을 관리합니다. 기본값, 기능 토글 및 시스템 전체 동작을 구성할 수 있습니다."
+        },
+        "trash": {
+          "title": "시스템 휴지통",
+          "content": "모든 프로젝트에서 삭제된 항목을 보고 관리할 수 있습니다. 실수로 삭제한 콘텐츠를 복원하거나 시스템에서 항목을 영구적으로 삭제할 수 있습니다."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "데모 프로젝트에 오신 것을 환영합니다",
+          "content": "이 프로젝트에는 샘플 데이터가 미리 로드되어 있습니다. 주요 기능을 함께 살펴보겠습니다. 이 드롭다운 메뉴를 사용하여 프로젝트를 전환할 수 있습니다."
+        },
+        "overview": {
+          "title": "프로젝트 개요",
+          "content": "개요는 프로젝트 대시보드입니다. 여기에는 마일스톤 진행 상황과 테스트 케이스 요약, 활성 실행, 세션 및 태그가 표시됩니다."
+        },
+        "documentation": {
+          "title": "선적 서류 비치",
+          "content": "모든 프로젝트에는 문서 페이지가 있습니다. 테스트 계획, 프로젝트 노트 또는 외부 자료 링크를 저장하는 데 활용하세요."
+        },
+        "documentationContent": {
+          "title": "서식 있는 텍스트 편집기",
+          "content": "문서에는 제목, 목록, 링크 및 이미지가 포함된 서식 있는 텍스트가 지원됩니다. 이 페이지를 편집하여 어떻게 작동하는지 확인해 보세요."
+        },
+        "milestones": {
+          "title": "주요 이정표",
+          "content": "스프린트, 릴리스 및 기타 목표에 맞춰 테스트 진행 상황을 추적하세요. 테스트 실행 및 세션을 마일스톤에 연결하여 진행 상황을 관리할 수 있습니다."
+        },
+        "milestonesPage": {
+          "title": "주요 단계별 일정",
+          "content": "이 프로젝트의 모든 마일스톤을 확인하세요. 각 마일스톤은 진행 상황과 완료를 향한 진척도를 보여줍니다."
+        },
+        "repository": {
+          "title": "테스트 케이스 저장소",
+          "content": "사용자 지정 필드, 단계 및 우선순위를 사용하여 테스트 케이스를 폴더로 구성하세요. 샘플 폴더를 살펴보면 테스트 케이스가 어떻게 구성되는지 확인할 수 있습니다."
+        },
+        "repositoryPanels": {
+          "title": "폴더 및 케이스",
+          "content": "왼쪽 패널에는 폴더가 표시됩니다. 폴더를 클릭하면 해당 폴더에 포함된 테스트 케이스를 볼 수 있습니다. 각 케이스에는 단계, 설명 및 공유 단계 참조가 있습니다."
+        },
+        "repositoryCases": {
+          "title": "테스트 케이스",
+          "content": "여기에서 선택한 폴더에 대한 테스트 케이스를 볼 수 있습니다. 각 행에는 케이스 이름, 우선순위 및 사용자 지정 필드가 표시됩니다. 케이스를 클릭하면 전체 세부 정보와 단계를 볼 수 있습니다."
+        },
+        "sharedSteps": {
+          "title": "공유된 단계",
+          "content": "여러 테스트 케이스에서 참조할 수 있는 재사용 가능한 단계 그룹을 정의하세요. 이렇게 하면 공통 단계의 일관성을 유지하고 관리하기 쉬워집니다."
+        },
+        "sharedStepsPage": {
+          "title": "공유 스텝 그룹",
+          "content": "각 그룹에는 순서대로 나열된 단계들이 포함되어 있습니다. 모든 테스트 케이스에서 이러한 단계들을 참조하여 단계들을 간결하고 일관성 있게 유지하세요."
+        },
+        "testRuns": {
+          "title": "테스트 실행",
+          "content": "테스트 실행을 생성하여 테스트 케이스를 실행하고 결과를 기록합니다. 실행 결과를 마일스톤에 할당하고 합격/불합격 진행 상황을 추적합니다."
+        },
+        "testRunsPage": {
+          "title": "테스트 실행 결과",
+          "content": "테스트 실행 결과 및 진행 상황을 확인하세요. 각 실행에는 상태, 할당된 마일스톤, 합격/불합격 여부가 표시됩니다."
+        },
+        "sessions": {
+          "title": "탐색 세션",
+          "content": "세션 기반 테스트를 통해 임시 테스트를 캡처하세요. 결과를 기록하고, 상태를 지정하고, 소요 시간을 추적하세요."
+        },
+        "sessionsPage": {
+          "title": "세션 결과",
+          "content": "각 세션에는 진행 상황 및 메모를 포함한 자세한 결과가 나와 있습니다. 세션을 클릭하여 결과를 확인하세요."
+        },
+        "tags": {
+          "title": "태그",
+          "content": "태그는 테스트 케이스, 실행 및 세션을 정리하고 필터링하는 데 도움이 됩니다. 샘플 태그를 살펴보면 콘텐츠를 분류하는 방법을 확인할 수 있습니다."
+        },
+        "tagsPage": {
+          "title": "태그 관리",
+          "content": "여기에서 태그를 생성, 편집 및 할당할 수 있습니다. 태그를 사용하여 프로젝트 전체의 콘텐츠를 그룹화하고 필터링하세요."
+        },
+        "issues": {
+          "title": "문제점",
+          "content": "테스트 중에 발견된 버그와 결함을 추적하세요. 문제를 테스트 실행 실패 결과 및 세션 결과와 연결하여 완벽한 추적성을 확보할 수 있습니다."
+        },
+        "issuesPage": {
+          "title": "이슈 트래커",
+          "content": "테스트 실패와 관련된 샘플 문제를 확인하세요. 문제는 해당 문제를 발견한 테스트 실행 또는 세션에서 추적할 수 있습니다."
+        },
+        "reports": {
+          "title": "보고서 및 분석",
+          "content": "테스트 범위, 실행 추세 및 팀 성과에 대한 보고서를 생성합니다. 미리 만들어진 보고서를 사용하거나 이해 관계자를 위해 사용자 지정 보고서를 만들 수 있습니다."
+        },
+        "settings": {
+          "title": "프로젝트 설정",
+          "content": "여기에서 프로젝트 수준 통합, AI 모델 구성 및 공유 링크를 관리할 수 있습니다."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "프로젝트 간 보고서를 생성하고 관리합니다."
+      },
+      "reportsTabDescription": "프로젝트에 대한 사전 제작된 보고서를 보고 분석하세요.",
+      "reportType": "보고서 유형",
+      "selectReportType": "보고서 유형을 선택하세요",
+      "selectReport": "보고서 선택",
+      "dimensions": "치수",
+      "dimensionsSubtitle": "치수 (드래그하여 순서를 변경하고 아래에 추가하세요)",
+      "metrics": "측정 기준",
+      "addDimension": "차원을 더하다...",
+      "addMetric": "측정항목을 추가하세요...",
+      "runReport": "실행 보고서",
+      "noResultsFound": "검색 결과가 없습니다.",
+      "selectAtLeastOneDimensionAndMetric": "최소한 하나의 차원과 하나의 측정 기준을 선택하십시오.",
+      "noDataMatchingCriteria": "선택한 차원 및 측정항목과 일치하는 데이터를 찾을 수 없습니다.",
+      "noDataMatchingCriteriaWithDateFilter": "선택한 차원 및 측정항목과 일치하는 데이터가 없습니다. 날짜 범위 필터를 조정해 보세요.",
+      "noDataAvailable": "이 보고서에 대한 데이터가 없습니다.",
+      "generatedAt": "보고서 생성 시간",
+      "crossProjectAnalytics": "프로젝트 간 분석 및 보고",
+      "unauthorizedAdmin": "권한이 없습니다. 관리자 권한이 필요합니다.",
+      "title": "보고서 작성기",
+      "description": "프로젝트 데이터를 분석하기 위한 맞춤형 보고서를 작성하세요.",
+      "crossProjectDescription": "워크스페이스의 모든 프로젝트 데이터를 분석하세요",
+      "selectDimensions": "크기를 선택하세요...",
+      "selectMetrics": "측정항목을 선택하세요...",
+      "dimensionOrder": "차원 순서",
+      "metricOrder": "미터법 순서",
+      "filtersDescription": "특정 기준에 따라 보고서 데이터를 필터링합니다.",
+      "activeFilters": "활성 필터:",
+      "priorityFilterPlaceholder": "우선순위 값을 선택하세요 (모두 선택하려면 비워 두세요).",
+      "dateRange": {
+        "selectDateRange": "날짜 범위를 선택하세요",
+        "chooseStartDate": "시작일을 선택하세요",
+        "chooseEndDate": "종료일을 선택하세요",
+        "categories": {
+          "day": "낮",
+          "week": "주",
+          "month": "월",
+          "quarter": "4분의 1",
+          "year": "년도"
+        },
+        "today": "오늘",
+        "yesterday": "어제",
+        "last7Days": "지난 7일",
+        "last30Days": "지난 30일",
+        "thisWeek": "이번 주",
+        "lastWeek": "지난주",
+        "last2Weeks": "지난 2주",
+        "thisMonth": "이번 달",
+        "lastMonth": "전달",
+        "last3Months": "지난 3개월",
+        "thisQuarter": "이번 분기",
+        "lastQuarter": "지난 분기",
+        "thisYear": "올해",
+        "lastYear": "작년",
+        "last12Months": "지난 12개월",
+        "allTime": "역대 최고",
+        "custom": "사용자 지정 날짜 범위"
+      },
+      "dateGrouping": {
+        "label": "그룹화 기준",
+        "daily": "일일",
+        "weekly": "주간",
+        "monthly": "월간 간행물",
+        "quarterly": "계간지",
+        "annually": "매년"
+      },
+      "filters": {
+        "selectFilter": "필터 유형을 선택하세요",
+        "allProjects": "모든 프로젝트"
+      },
+      "errors": {
+        "failedToLoadMetadata": "보고서 메타데이터를 불러오는 데 실패했습니다.",
+        "failedToRunReport": "보고서 실행에 실패했습니다",
+        "atLeastOneDimensionRequired": "최소한 하나의 차원이 필요합니다.",
+        "atLeastOneMetricRequired": "최소한 하나의 측정 기준을 지정해야 합니다.",
+        "invalidCombinationDateLastActive": "'마지막 활동 날짜' 측정항목은 '활동 날짜' 차원과 결합할 수 없습니다.",
+        "lastActiveDateOnlyWithUser": "'마지막 활동 날짜' 측정항목은 '사용자' 차원과 함께만 사용할 수 있습니다.",
+        "invalidDimensionCombination": "테스트 실행 보고서에서 '{dim1}' 및 '{dim2}' 차원을 함께 사용할 수 없습니다.",
+        "startDateRequiredWithEndDate": "종료일을 지정할 경우 시작일은 필수 입력 사항입니다.",
+        "endDateMustBeAfterStartDate": "종료일은 시작일 이후이거나 시작일과 같아야 합니다."
+      },
+      "chartDataTruncated": {
+        "title": "차트 데이터가 잘렸습니다.",
+        "message": "가독성을 위해 {shown} 개의 데이터 포인트(총 {total} 개)를 표시합니다. 필터 또는 날짜 범위를 사용하여 결과를 좁히거나 아래 결과 표에서 전체 데이터를 볼 수 있습니다."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "테스트 실행 보고서",
+          "description": "시험 결과, 합격률 및 실행 지표를 분석합니다."
+        },
+        "repositoryStats": {
+          "label": "저장소 통계",
+          "description": "테스트 케이스 통계, 테스트 범위 및 저장소 상태"
+        },
+        "userEngagement": {
+          "label": "사용자 참여",
+          "description": "사용자 활동, 생산성 및 작업량 분석"
+        },
+        "projectHealth": {
+          "label": "프로젝트 헬스",
+          "description": "프로젝트 진행 상황, 주요 일정 및 완료 현황"
+        },
+        "sessionAnalysis": {
+          "label": "세션 분석",
+          "description": "수업 완료율, 소요 시간 및 과제 관련 지표"
+        },
+        "issueTracking": {
+          "label": "이슈 추적",
+          "description": "문제 발생, 해결 및 영향 분석"
+        },
+        "automationTrends": {
+          "label": "자동화 트렌드",
+          "description": "우선순위에 따라 자동화 진행 상황을 매주 추적하세요."
+        },
+        "flakyTests": {
+          "label": "플레이키 테스트",
+          "description": "합격/불합격 결과가 일관되지 않은 테스트를 식별합니다."
+        },
+        "testCaseHealth": {
+          "label": "테스트 케이스 상태",
+          "description": "실행 패턴을 기반으로 오래되었거나, 오류가 있거나, 의심스러운 테스트 케이스를 식별합니다."
+        },
+        "issueTestCoverage": {
+          "label": "이슈 테스트 커버리지",
+          "description": "연결된 테스트 케이스 및 최신 실행 상태와 함께 문제를 확인하세요."
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "최근 연속 실행",
+        "consecutiveRunsHelp": "분석할 최근 테스트 실행 횟수(5~30회). '테스트되지 않음' 상태의 결과는 제외됩니다.",
+        "flipThreshold": "최소 플립",
+        "flipThresholdHelp": "불안정하다고 간주되기 위해 필요한 최소 합격/불합격 전환 횟수.",
+        "flips": "뒤집기",
+        "lastNResults": "마지막 {count, plural, one {# 결과} other {# 결과}}",
+        "newest": "새로운",
+        "oldest": "오래된",
+        "noFlakyTests": "해당 기준에 맞는 불안정한 테스트는 발견되지 않았습니다.",
+        "includeFilter": "포함하다",
+        "testRunDeleted": "테스트 실행이 삭제되었습니다.",
+        "chart": {
+          "highPriority": "주의가 필요합니다",
+          "lowPriority": "우선순위 낮음",
+          "recencyAxis": "실패 최근",
+          "flipsAxis": "뒤집기 횟수",
+          "oldFailures": "나이든",
+          "recentFailures": "최근의",
+          "failureRate": "실패율",
+          "recency": "최근 점수",
+          "backlogTitle": "우선순위가 낮은 테스트",
+          "backlogDescription": "{count, plural, one {# 추가적인 플레이키 테스트} other {# 추가적인 플레이키 테스트}} 표시되지 않음"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "(일) 후 변질됨",
+        "staleDaysThresholdHelp": "테스트가 만료된 것으로 간주되기 전까지 실행되지 않은 일수(7-90일).",
+        "minExecutions": "금리에 대한 최소 실행 횟수",
+        "minExecutionsHelp": "의미 있는 합격률 통계를 계산하는 데 필요한 최소 실행 횟수(3~20회).",
+        "lookbackDays": "회고 기간",
+        "lookbackDaysHelp": "실행 내역 분석 기간(일수: 30~365일).",
+        "includeFilter": "포함하다",
+        "staleFilter": "진부함",
+        "stale": "탁한",
+        "notStale": "신선하지 않음",
+        "status": "건강 상태",
+        "healthScore": "점수",
+        "lastExecuted": "마지막 실행",
+        "executions": "처형",
+        "passRate": "합격률",
+        "passCount": "패스",
+        "failCount": "실패",
+        "never": "절대",
+        "daysSince": "사형 집행 후 경과 일수",
+        "count": "세다",
+        "totalTests": "테스트 케이스",
+        "noData": "테스트 케이스를 찾을 수 없습니다.",
+        "noExecutedTests": "표시할 실행된 테스트가 없습니다.",
+        "healthStatus": {
+          "healthy": "건강한",
+          "stale": "탁한",
+          "neverExecuted": "절대 집행되지 않음",
+          "alwaysPassing": "항상 지나가는",
+          "alwaysFailing": "항상 실패하는"
+        },
+        "chart": {
+          "distribution": "상태 분포",
+          "healthyRecent": "건강하고 최근",
+          "unhealthyStale": "주의가 필요합니다",
+          "daysAxis": "마지막 실행 이후 경과 일수",
+          "healthScoreAxis": "건강 점수"
+        },
+        "stats": {
+          "totalTests": "총 테스트 수",
+          "needsAttention": "주의가 필요합니다",
+          "needsAttentionTooltip": "항상 실패하고, 실행되지 않으며, 오래된 테스트",
+          "healthy": "건강한",
+          "healthyTooltip": "건강하고 항상 시험에 합격하는",
+          "avgScore": "평균 건강 점수"
+        },
+        "healthScoreTooltip": {
+          "title": "점수는 100점에서 시작하며, 감점 항목은 다음과 같습니다.",
+          "neverExecuted": "실행되지 않음: -50",
+          "stale90": "90일 이상 실행 안 함: -40",
+          "stale60": "60일 이상 실행되지 않음: -25",
+          "stale30": "30일 이상 실행 안 함: -10",
+          "alwaysPassing": "항상 통과(100%): -5",
+          "alwaysFailing": "항상 실패함(0%): -30",
+          "lowPassRate": "낮은 합격률(<50%): -20",
+          "lowExecutions": "실행 횟수 적음(<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "보기 모드",
+        "summaryView": "요약 (쟁점별)",
+        "detailView": "상세 정보 (테스트 케이스별)",
+        "issue": "문제",
+        "testCase": "테스트 케이스",
+        "testCases": "{count, plural, =1 {테스트 케이스} other {테스트 케이스}}",
+        "issueStatus": "상태",
+        "priority": "우선 사항",
+        "linkedTests": "연동 테스트",
+        "testResults": "결과 (P/F/U)",
+        "passRate": "합격률",
+        "passed": "통과됨",
+        "failed": "실패한",
+        "lastStatus": "최종 상태",
+        "lastExecuted": "마지막 실행",
+        "notTested": "테스트되지 않음",
+        "noData": "연결된 테스트 케이스에서 문제가 발견되지 않았습니다.",
+        "noIssuesNeedingAttention": "모든 문제가 테스트를 통과했습니다. 훌륭합니다!",
+        "stats": {
+          "totalIssues": "총 발행 건수",
+          "issuesWithFailures": "실패와 함께",
+          "issuesWithFailuresTooltip": "하나 이상의 테스트 케이스가 실패하는 문제가 있습니다.",
+          "issuesWithUntested": "검증되지 않은 것과 함께",
+          "issuesWithUntestedTooltip": "실행되지 않은 테스트 케이스 중 하나 이상에 문제가 있습니다.",
+          "issuesAllPassing": "모든 통과",
+          "overallPassRate": "합격률",
+          "numberOfIssues": "문제 수"
+        },
+        "charts": {
+          "passRateDistribution": "시험 합격률 분포",
+          "linkedTestCases": "연결된 테스트 케이스 수",
+          "untestedTestCases": "테스트되지 않은 테스트 케이스 수",
+          "testCoverageVsExecution": "테스트 커버리지와 실행 상태"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "프로젝트 간 테스트 실행",
+          "description": "모든 프로젝트의 테스트 결과, 합격률 및 실행 지표를 분석합니다."
+        },
+        "repositoryStats": {
+          "label": "프로젝트 간 저장소 통계",
+          "description": "프로젝트 전반에 걸친 테스트 케이스 통계, 테스트 범위 및 저장소 상태"
+        },
+        "userEngagement": {
+          "label": "프로젝트 간 사용자 참여",
+          "description": "프로젝트 전반에 걸친 사용자 활동, 생산성 및 작업량 분석"
+        },
+        "issueTracking": {
+          "label": "프로젝트 간 이슈 추적",
+          "description": "프로젝트 전반에 걸친 문제 발생, 해결 및 영향 분석"
+        },
+        "automationTrends": {
+          "label": "프로젝트 간 자동화 트렌드",
+          "description": "프로젝트별 우선순위에 따라 자동화 진행 상황을 매주 추적하세요."
+        },
+        "flakyTests": {
+          "label": "프로젝트 간 불안정한 테스트",
+          "description": "프로젝트 전반에 걸쳐 합격/불합격 결과가 일관되지 않은 테스트를 식별합니다."
+        },
+        "testCaseHealth": {
+          "label": "프로젝트 간 테스트 케이스 상태",
+          "description": "프로젝트 전반에 걸쳐 오래되었거나, 오류가 있거나, 의심스러운 테스트 케이스를 식별합니다."
+        },
+        "issueTestCoverage": {
+          "label": "프로젝트 간 이슈 테스트 범위",
+          "description": "프로젝트 전반에 걸쳐 연결된 테스트 케이스 및 최신 실행 상태와 함께 문제를 확인하세요."
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "프로젝트 보고서에는 프로젝트 관리자 및 관리자만 접근할 수 있습니다.",
+      "projectIdRequired": "프로젝트 ID는 필수 입력 사항입니다.",
+      "missingRequiredFields": "필수 입력 항목이 누락되었습니다",
+      "unsupportedDimension": "지원되지 않는 차원: {dimension}",
+      "unsupportedMetric": "지원되지 않는 메트릭: {metric}",
+      "atLeastOneDimensionMetricRequired": "최소한 하나의 차원과 하나의 측정 기준이 필요합니다.",
+      "atLeastOneMetricRequired": "최소한 하나의 측정 기준을 지정해야 합니다.",
+      "projectDimensionsMetricsRequired": "프로젝트 ID, 크기 및 측정항목이 필요합니다.",
+      "unsupportedDimensions": "지원되지 않는 차원: {dimensions}",
+      "unsupportedMetrics": "지원되지 않는 메트릭: {metrics}",
+      "unexpectedError": "예기치 않은 오류가 발생했습니다."
+    },
+    "dimensions": {
+      "project": "프로젝트",
+      "status": "상태",
+      "user": "사용자",
+      "executor": "집행자",
+      "assignedTo": "담당자에게 배정됨",
+      "configuration": "구성",
+      "date": "날짜",
+      "executionDate": "실행일",
+      "creationDate": "생성일",
+      "activityDate": "활동 날짜",
+      "testRun": "테스트 실행",
+      "testCase": "테스트 케이스",
+      "milestone": "중요한 단계",
+      "template": "주형",
+      "creator": "창조자",
+      "state": "상태",
+      "source": "원천",
+      "folder": "접는 사람",
+      "group": "그룹",
+      "role": "역할",
+      "session": "세션",
+      "weekEnding": "주말",
+      "period": "기간",
+      "priority": "우선 사항",
+      "automationStatus": "자동화 상태",
+      "issueType": "문제 유형",
+      "issueTracker": "이슈 트래커",
+      "issueStatus": "문제 상태"
+    },
+    "metrics": {
+      "testResults": "시험 결과",
+      "testResultCount": "테스트 결과 집계",
+      "passRate": "합격률(%)",
+      "avgElapsed": "평균 경과 시간",
+      "avgElapsedTime": "평균 경과 시간",
+      "totalElapsedTime": "총 경과 시간",
+      "testRunCount": "테스트 실행 횟수",
+      "testCaseCount": "테스트 케이스 수",
+      "automationRate": "자동화율(%)",
+      "avgStepsPerCase": "사례당 평균 단계 수",
+      "averageSteps": "사례당 평균 단계 수",
+      "automatedCount": "자동화된 사례",
+      "manualCount": "수동 케이스",
+      "totalCount": "총 확진자 수",
+      "totalSteps": "총 걸음 수",
+      "executionCount": "테스트 실행",
+      "createdCaseCount": "생성된 테스트 케이스 수",
+      "sessionResultCount": "세션 결과 개수",
+      "caseCreations": "생성된 사례",
+      "sessionParticipation": "세션 참여",
+      "averageElapsed": "실행당 평균 시간",
+      "lastActiveDate": "마지막 활동 날짜",
+      "issueCount": "문제 수",
+      "averageAge": "평균 연령(일)",
+      "sessionCount": "세션 수",
+      "activeSessions": "활성 세션",
+      "averageTimeSpent": "평균 소요 시간(분)",
+      "milestoneCount": "마일스톤 개수",
+      "milestoneCompletionRate": "주요 단계 완료율(%)",
+      "averageMilestoneDuration": "평균 마일스톤 소요 기간(일)",
+      "totalMilestones": "총 마일스톤 수",
+      "activeMilestones": "활성 마일스톤",
+      "milestoneCompletion": "주요 단계 완료율(%)",
+      "averageDuration": "평균 소요 시간",
+      "totalDuration": "총 소요 시간"
+    },
+    "drillDown": {
+      "title": "상세 기록",
+      "loading": "레코드를 불러오는 중...",
+      "loadingMore": "더 많은 내용을 불러오는 중...",
+      "noRecords": "검색된 기록이 없습니다.",
+      "error": "레코드를 불러오는 데 실패했습니다.",
+      "recordCount": "{count} {count, plural, =1 {레코드} other {레코드}}",
+      "allRecords": "모든 기록",
+      "allLoaded": "모든 레코드가 로드되었습니다."
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "공유하다",
+      "dialogTitle": "공유 보고서",
+      "dialogDescription": "공유 가능한 링크를 생성하거나 기존 공유 보고서 링크를 관리하세요.",
+      "tabs": {
+        "create": "공유하기",
+        "list": "내 주식"
+      },
+      "shareMode": {
+        "label": "공유 모드",
+        "authenticated": {
+          "title": "인증됨(로그인 필요)",
+          "description": "이 프로젝트에 접근 권한이 있는 로그인 사용자만 볼 수 있습니다.",
+          "descriptionCrossProject": "관리자 권한이 있는 로그인 사용자만 볼 수 있습니다."
+        },
+        "passwordProtected": {
+          "title": "비밀번호로 보호됨",
+          "description": "링크와 비밀번호만 있으면 누구나 볼 수 있습니다. 프로젝트 접근 권한이 있는 로그인 사용자는 비밀번호를 건너뛸 수 있습니다.",
+          "descriptionCrossProject": "링크와 비밀번호만 있으면 누구나 볼 수 있습니다. 관리자 권한이 있는 로그인 사용자는 비밀번호를 건너뛸 수 있습니다."
+        },
+        "public": {
+          "title": "공개 (링크를 가진 모든 사람)",
+          "description": "링크만 있으면 로그인 없이도 이 보고서를 볼 수 있습니다."
+        }
+      },
+      "expiration": {
+        "label": "만료",
+        "noExpiration": "유효기간 없음",
+        "expiresAtMidnight": "링크는 선택하신 날짜(현지 시간) 자정에 만료됩니다."
+      },
+      "notifyOnView": {
+        "label": "이 링크를 누군가 조회하면 알려주세요",
+        "description": "공유 링크에 접속하면 설정하신 알림 환경에 따라 알림을 받게 됩니다."
+      },
+      "title": {
+        "placeholder": "예: 테스트 실행 보고서",
+        "leaveEmptyToUse": "사용하려면 비워 두세요:"
+      },
+      "description": {
+        "placeholder": "이 공유 보고서에 대한 설명을 추가하세요..."
+      },
+      "actions": {
+        "createShareLink": "공유 링크 생성",
+        "creating": "생성 중..."
+      },
+      "errors": {
+        "loginRequired": "공유 링크를 만들려면 로그인해야 합니다.",
+        "createFailed": "공유 링크 생성에 실패했습니다.",
+        "genericError": "알 수 없는 오류가 발생했습니다."
+      },
+      "status": {
+        "revoked": {
+          "title": "공유 링크가 취소되었습니다",
+          "description": "이 공유 링크는 취소되어 더 이상 접속할 수 없습니다."
+        },
+        "expired": {
+          "title": "공유 링크 만료됨",
+          "description": "이 공유 링크는 만료되어 더 이상 접속할 수 없습니다."
+        }
+      },
+      "footer": {
+        "poweredBy": "Powered by"
+      },
+      "manageShares": {
+        "title": "주식 관리",
+        "description": "이 프로젝트의 모든 공유 링크를 보고 관리하세요.",
+        "adminTitle": "모든 주식 관리",
+        "adminDescription": "모든 프로젝트의 공유 링크를 보고 관리하세요."
+      },
+      "shareList": {
+        "columns": {
+          "mode": "방법",
+          "views": "조회수",
+          "expires": "만료됨"
+        },
+        "status": {
+          "revoked": "취소됨",
+          "expired": "만료됨"
+        },
+        "notifications": {
+          "enabled": "~에",
+          "disabled": "끄다"
+        },
+        "empty": {
+          "title": "아직 공유 링크가 생성되지 않았습니다.",
+          "description": "시작하려면 첫 번째 공유 링크를 만드세요."
+        },
+        "defaultTitle": "{entityType} 공유",
+        "noProject": "프로젝트 간",
+        "actions": {
+          "copyLink": "링크 복사",
+          "revoke": "취소"
+        },
+        "revokeDialog": {
+          "title": "공유 링크를 취소하시겠습니까?",
+          "description": "이렇게 하면 공유 링크가 즉시 취소됩니다. 해당 링크에 액세스하려는 사람은 오류 메시지를 보게 됩니다. 이 작업은 되돌릴 수 없습니다.",
+          "confirm": "링크 취소",
+          "revoking": "취소 중..."
+        },
+        "deleteDialog": {
+          "title": "공유 링크를 삭제하시겠습니까?",
+          "description": "이렇게 하면 공유 링크가 영구적으로 삭제됩니다. 링크가 현재 활성화된 경우 즉시 만료되어 더 이상 액세스할 수 없습니다. 이 작업은 되돌릴 수 없습니다.",
+          "confirm": "링크 삭제"
+        },
+        "toast": {
+          "linkCopied": "링크 복사 완료!",
+          "linkCopiedDescription": "공유 링크가 클립보드에 복사되었습니다.",
+          "copyFailed": "복사에 실패했습니다",
+          "copyFailedDescription": "링크를 직접 복사해 주세요.",
+          "linkRevoked": "공유 링크가 취소되었습니다",
+          "linkRevokedDescription": "공유 링크가 취소되어 더 이상 접속할 수 없습니다.",
+          "revokeFailed": "취소에 실패했습니다",
+          "revokeFailedDescription": "공유 링크를 취소하는 동안 오류가 발생했습니다.",
+          "notificationsEnabled": "알림 활성화됨",
+          "notificationsEnabledDescription": "이 공유 링크를 누군가 조회하면 알림을 받게 됩니다.",
+          "notificationsDisabled": "알림이 비활성화됨",
+          "notificationsDisabledDescription": "이 공유 링크를 누군가 조회해도 알림을 받지 못합니다.",
+          "notificationUpdateFailed": "알림 업데이트에 실패했습니다.",
+          "notificationUpdateFailedDescription": "알림 설정 업데이트 중 오류가 발생했습니다.",
+          "linkDeleted": "공유 링크가 삭제되었습니다.",
+          "linkDeletedDescription": "공유 링크가 삭제되어 더 이상 목록에 표시되지 않습니다.",
+          "deleteFailed": "삭제에 실패했습니다",
+          "deleteFailedDescription": "공유 링크를 삭제하는 동안 오류가 발생했습니다."
+        }
+      },
+      "created": {
+        "title": "공유 링크가 생성되었습니다!",
+        "description": "공유 링크가 준비되었습니다. 복사해서 다른 사람들과 공유하세요.",
+        "shareLink": "공유 링크",
+        "copy": "복사",
+        "openInNewTab": "새 탭에서 열기",
+        "metadata": {
+          "mode": "방법",
+          "expires": "만료됨",
+          "views": "조회수"
+        },
+        "warnings": {
+          "publicLink": "공개 링크:",
+          "publicLinkDescription": "이 링크만 있으면 누구나 인증 절차 없이 보고서에 접근할 수 있습니다.",
+          "expiresSoon": "이 링크는 일정 기간이 지나면 만료됩니다."
+        },
+        "actions": {
+          "createAnother": "다른 것을 만드세요"
+        }
+      },
+      "editDialog": {
+        "title": "공유 링크 편집",
+        "description": "이 공유 링크의 설정을 업데이트하세요.",
+        "passwordExists": "이 공유 링크에는 이미 암호가 설정되어 있습니다. 기존 암호를 유지하려면 암호 입력란을 비워 두세요.",
+        "passwordPlaceholder": "기존 비밀번호를 유지하려면 비워 두십시오."
+      }
+    },
+    "passwordDialog": {
+      "title": "비밀번호가 필요합니다",
+      "description": "<strong>{projectName}</strong> 에서 공유된 이 콘텐츠는 비밀번호로 보호되어 있습니다. 계속하려면 비밀번호를 입력하세요.",
+      "passwordPlaceholder": "비밀번호를 입력하세요",
+      "showPassword": "비밀번호 표시",
+      "hidePassword": "비밀번호 숨기기",
+      "verifying": "확인 중...",
+      "errors": {
+        "emptyPassword": "비밀번호를 입력하세요",
+        "tooManyAttempts": "너무 많은 시도 실패가 있었습니다. 나중에 다시 시도해 주세요.{resetAt, select, null {} other { {resetAt}}}.",
+        "genericError": "오류가 발생했습니다. 다시 시도해 주세요."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "남은 시도 횟수가 없습니다. 나중에 다시 시도해 주세요.",
+        "attemptsRemaining": "{count, plural, =1 {시도 1회} other {시도 횟수}} 남음."
+      }
+    },
+    "sharedReport": {
+      "loading": "보고서 불러오는 중...",
+      "errors": {
+        "onlyReportSharing": "현재는 보고서 공유 기능만 구현되어 있습니다.",
+        "failedToLoad": "보고서 데이터를 불러오는 데 실패했습니다."
+      },
+      "defaultTitle": "공유 보고서",
+      "fromProject": "프로젝트에서:",
+      "dateRange": "기간:",
+      "readOnlyNotice": "이것은 읽기 전용 공유 뷰입니다.",
+      "viewCount": "{count, plural, =1 {조회수 1회} other {조회수}}",
+      "viewInFullApp": "전체 화면에서 보기",
+      "pagination": {
+        "showing": "전시",
+        "of": "~의",
+        "results": "결과"
+      }
+    },
+    "authBypass": {
+      "title": "이 프로젝트에 대한 접근 권한이 있습니다.",
+      "description": "{userName} 로 보고 있으며 {projectName}에 접근할 수 있습니다.",
+      "viewInApp": "전체 앱에서 보기"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "공유된 단계를 필터링합니다...",
+    "noGroups": "공통된 단계를 찾을 수 없습니다.",
+    "noTestCases": "이 공유 스텝 그룹을 사용하는 테스트 케이스는 없습니다.",
+    "selectGroupPrompt": "공유 단계 그룹을 선택하여 해당 단계를 확인하세요.",
+    "deleteTitle": "공유 단계 그룹을 삭제하시겠습니까?",
+    "deleteDescription": "공유 단계 그룹을 삭제하시겠습니까? 해당 단계를 사용하는 모든 테스트 케이스에서 단계가 제거됩니다.",
+    "saveSuccess": "공유 단계가 성공적으로 업데이트되었습니다.",
+    "saveError": "공유 단계를 저장하는 동안 오류가 발생했습니다.",
+    "stepsCount": "{count, plural, one {# 단계} other {# 단계}}",
+    "testCasesUsing": "{count, plural, one {# 테스트 케이스} other {# 테스트 케이스}}",
+    "importWizard": {
+      "title": "공유 단계 가져오기",
+      "fields": {
+        "order": "주문하다",
+        "stepNumber": "단계 #",
+        "stepContent": "단계 내용",
+        "expectedResultContent": "예상 결과 내용",
+        "combinedStepData": "결합된 단계 데이터",
+        "stepsData": "단계 데이터"
+      },
+      "success": {
+        "description": "{count, plural, one {# 공유 단계} other {# 공유 단계}} 성공적으로 가져왔습니다"
+      },
+      "errors": {
+        "parseFailed": "CSV 파일 구문 분석에 실패했습니다.",
+        "validationFailed": "유효성 검사 실패",
+        "validationDescription": "{count, plural, one {# 유효성 검사 오류} other {# 유효성 검사 오류}} 발견됨",
+        "importFailed": "가져오기 실패",
+        "fileRequired": "CSV 파일이 필요합니다."
+      },
+      "page1": {
+        "title": "파일 업로드 및 구성",
+        "selectedFile": "선택된 파일",
+        "delimiter": "필드 구분 기호",
+        "delimiters": {
+          "tab": "탭(\\t)"
+        },
+        "hasHeaders": "첫 번째 행에는 열 헤더가 포함되어 있습니다.",
+        "encoding": "파일 인코딩",
+        "rowMode": {
+          "label": "행 모드",
+          "single": "공유 단계당 한 행",
+          "multi": "복잡한 공유 단계를 위한 여러 행"
+        }
+      },
+      "page2": {
+        "title": "CSV 열을 공유 단계 필드에 매핑",
+        "description": "CSV 파일의 열을 공유 단계 필드에 매핑하세요. 필수 필드는 반드시 매핑해야 합니다.",
+        "ignoreColumn": "이 열은 무시하세요",
+        "requiredFieldsWarning": "{count, plural, one {# 필수 입력란은} other {# 필수 입력란은}} 매핑되지 않았습니다. 계속하려면 모든 필수 입력란을 매핑하십시오."
+      },
+      "page3": {
+        "title": "미리보기 가져오기 데이터",
+        "showing": "{start} 부터 {end} 까지 {total} 개의 공유된 단계를 표시합니다.",
+        "step": "공유 단계 {number}",
+        "noValue": "(비어 있는)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "수동으로 추가",
+      "description": "수동 입력을 사용하여 새 공유 단계 그룹을 만듭니다.",
+      "groupNamePlaceholder": "이 공유 스텝 그룹의 이름을 입력하세요.",
+      "success": "공유 단계가 성공적으로 생성되었습니다.",
+      "errors": {
+        "groupNameRequired": "그룹 이름은 필수 입력 사항입니다.",
+        "stepsRequired": "최소 한 단계 이상 필요합니다.",
+        "saveFailed": "공유 단계를 저장하는 데 실패했습니다."
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "단계 순서 중복",
+      "pageDescription": "테스트 케이스 전반에 걸쳐 일치하는 단계 순서를 검토합니다. 일치하는 항목을 공유 단계 그룹으로 변환하거나 오탐을 제거합니다.",
+      "noResultsFound": "단계 순서 중복이 발견되지 않았습니다.",
+      "noResultsDescription": "테스트 케이스 전체에서 반복되는 단계 순서를 감지하기 위해 스캔을 실행하세요.",
+      "filterPlaceholder": "사건명으로 필터링...",
+      "selected": "{count, plural, one {# 선택됨} other {# 선택됨}}",
+      "bulkDismiss": "닫기({count})",
+      "bulkDismissSuccess": "{count, plural, one {# 일치 항목 해제됨} other {# 일치 항목 해제됨}}",
+      "bulkError": "일부 작업에 실패했습니다. 다시 시도해 주세요.",
+      "tableHint": "일치하는 단계를 미리 보려면 행을 클릭하세요. 일괄 작업을 하려면 확인란이 있는 행을 선택하세요.",
+      "columns": {
+        "matchedSteps": "일치하는 단계",
+        "casesCount": "사례",
+        "review": "검토"
+      },
+      "scanning": "스캐닝...",
+      "scanComplete": "{count, plural, one {# 일치하는 항목 발견됨} other {# 일치하는 항목 발견됨}}",
+      "scanFailed": "스캔 실패",
+      "scanFailedDescription": "스캔 도중 오류가 발생했습니다. 다시 시도해 주세요.",
+      "cancelScan": "스캔 취소",
+      "findStepDuplicates": "단계 중복 찾기",
+      "rescan": "주사",
+      "viewResults": "결과 보기 ({count})",
+      "retryScan": "스캔 재시도",
+      "dialog": {
+        "title": "공유 단계로 변환",
+        "previewTitle": "일치하는 단계 순서",
+        "casesTitle": "영향을 받는 테스트 케이스",
+        "casesDescription": "변환에서 제외할 경우는 체크를 해제하세요.",
+        "nameLabel": "공유 단계 그룹 이름",
+        "namePlaceholder": "공유 스텝 그룹의 이름을 입력하세요...",
+        "converting": "변환 중...",
+        "dismissMatch": "매치 해제",
+        "dismissing": "해고합니다...",
+        "convertSuccess": "공유 스텝 그룹이 성공적으로 생성되었습니다!",
+        "convertError": "변환에 실패했습니다. 다시 시도해 주세요.",
+        "dismissSuccess": "경기 종료.",
+        "dismissError": "닫기에 실패했습니다. 다시 시도해 주세요.",
+        "viewSharedStep": "공유 스텝 그룹 보기",
+        "skippedWarning": "{count, plural, one {# 해당 사례는 건너뛰었습니다.} other {# 해당 사례는 건너뛰었습니다.}} (오래되었거나 이미 변환되었습니다).",
+        "noCasesSelected": "변환할 사례를 하나 이상 선택하세요.",
+        "selectAll": "모두 선택하세요"
+      }
+    },
+    "findStepDuplicates": "중복 항목 찾기"
+  },
+  "search": {
+    "title": "찾다",
+    "placeholder": {
+      "thisProject": "이 프로젝트에서 검색...",
+      "allProjects": "모든 프로젝트에서 검색..."
+    },
+    "currentProjectOnly": "현재 프로젝트만 해당",
+    "allTypes": "모든 유형",
+    "entityTypes": {
+      "repositoryCase": "저장소 사례"
+    },
+    "results": {
+      "tryAdjusting": "검색어 또는 필터를 조정해 보세요.",
+      "searchingFor": "검색 중",
+      "within": "이내에",
+      "currentProject": "현재 프로젝트",
+      "page": "페이지"
+    },
+    "errors": {
+      "searchFailed": "검색에 실패했습니다. 다시 시도해 주세요.",
+      "tryAgain": "다시 시도해 보세요"
+    },
+    "startTyping": "검색하려면 입력을 시작하세요.",
+    "typesSelected": "{count, plural, one {# 유형} other {# 유형}}",
+    "customFieldFilters": "사용자 정의 필드 필터",
+    "customFiltersApplied": "사용자 지정 필터",
+    "customFields": "사용자 정의 필드",
+    "addFilter": "필터 추가",
+    "filter": "필터",
+    "noCustomFilters": "사용자 지정 필드 필터가 적용되지 않았습니다.",
+    "selectDate": "날짜를 선택하세요",
+    "selectOption": "옵션을 선택하세요",
+    "selectOptions": "옵션을 선택하세요",
+    "operators": {
+      "equals": "동등하다",
+      "not_equals": "같지 않음",
+      "contains": "포함됨",
+      "not_contains": "포함하지 않습니다",
+      "starts_with": "~로 시작합니다",
+      "ends_with": "끝맺음",
+      "gt": "보다 큰",
+      "lt": "미만",
+      "gte": "크거나 같음",
+      "lte": "이하",
+      "between": "사이",
+      "in": "~ 안에",
+      "not_in": "아닙니다",
+      "exists": "존재한다",
+      "not_exists": "존재하지 않습니다"
+    },
+    "help": {
+      "exactPhrases": "정확한 문구",
+      "exactPhrasesDesc": "정확한 구문을 맞추려면 용어를 따옴표로 묶으세요.",
+      "proximity": "근접 검색",
+      "proximityDesc": "서로 N 위치 이내에 있는 단어들",
+      "booleanOperators": "불리언 연산자",
+      "andDesc": "두 용어가 일치해야 합니다.",
+      "orDesc": "두 용어 모두 일치할 수 있습니다.",
+      "notDesc": "특정 용어가 포함된 결과를 제외합니다.",
+      "prefixDesc": "특정 조건을 요구하거나 배제합니다.",
+      "groupingDesc": "복잡한 쿼리를 위한 그룹 용어",
+      "wildcards": "와일드카드",
+      "wildcardMultiDesc": "모든 문자와 일치합니다",
+      "wildcardSingleDesc": "단일 문자와 일치합니다",
+      "fuzzyMatching": "퍼지 매칭",
+      "fuzzyDesc": "오타를 수정하는 데 도움이 되는 유사 용어를 찾아줍니다.",
+      "defaultBehavior": "여러 단어를 검색할 때 기본적으로 OR 연산자가 사용됩니다. 이름과 일치하는 결과가 가장 높은 순위에 표시됩니다.",
+      "fullSyntaxLink": "Lucene 쿼리 구문 전체 참조"
+    },
+    "filters": {
+      "title": "고급 필터",
+      "active": "필터 활성화됨",
+      "activeCount": "{count, plural, =0 {필터 없음} one {필터 개수} other {필터 개수}} 활성",
+      "apply": "필터 적용",
+      "common": "공통 필터",
+      "entitySpecific": "유형별 필터",
+      "searchPlaceholder": "검색 필터 옵션...",
+      "states": "워크플로 상태",
+      "createdAt": "생성일",
+      "updatedAt": "업데이트 날짜",
+      "completedAt": "완료일",
+      "from": "에서",
+      "to": "에게",
+      "testRunType": "테스트 실행 유형",
+      "regular": "정기적인",
+      "junit": "JUnit",
+      "automatedOnly": "자동화 전용",
+      "archivedOnly": "보관된 자료 전용",
+      "completedOnly": "완료됨만",
+      "manualOnly": "수동 전용",
+      "estimateRange": "예상 범위",
+      "elapsedRange": "경과 시간 범위",
+      "minValue": "민",
+      "maxValue": "맥스",
+      "hasExternalId": "외부 ID를 가지고 있습니다",
+      "dueDateRange": "마감일 범위",
+      "hasParent": "부모의 중요한 순간이 있습니다",
+      "milestoneType": "이정표 유형",
+      "minutes": "분",
+      "hours": "시간",
+      "days": "날",
+      "searchingIn": "검색 중",
+      "includeDeleted": "삭제된 항목을 포함하세요",
+      "filterActive": "필터 활성화됨:",
+      "applyFilter": "필터 적용",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "첫 번째 값은 두 번째 값보다 작아야 합니다.",
+        "firstDateMustBeBeforeSecond": "첫 번째 데이트는 두 번째 데이트보다 먼저 이루어져야 합니다."
+      },
+      "link": {
+        "domainHelp": "도메인만 입력하세요 (예: \"github.com\" 또는 \"example.org\")."
+      }
+    }
+  },
+  "email": {
+    "greeting": "안녕하세요,",
+    "greetingWithName": "안녕하세요 {name} 님,",
+    "notification": {
+      "intro": "새로운 알림이 있습니다:",
+      "viewDetails": "상세 정보 보기",
+      "viewAll": "모든 알림 보기"
+    },
+    "digest": {
+      "intro": "TestPlanIt에서 보내드린 일일 알림 요약입니다.",
+      "viewDetails": "상세 정보 보기",
+      "viewAll": "모든 알림 보기",
+      "noNotifications": "오늘은 새로운 알림이 없습니다.",
+      "footer": "일일 요약 알림을 활성화하셨기 때문에 이 이메일을 받으셨습니다. 알림 설정은 설정에서 변경할 수 있습니다.",
+      "profileSettings": "프로필 설정"
+    },
+    "footer": {
+      "sentBy": "이 이메일은 다음 사람이 보냈습니다.",
+      "unsubscribe": "구독 취소",
+      "managePreferences": "환경설정 관리",
+      "allRightsReserved": "모든 권리 보유."
+    },
+    "magicLink": {
+      "subject": "TestPlanIt에 로그인하세요",
+      "heading": "TestPlanIt에 로그인하세요",
+      "intro": "아래 버튼을 클릭하여 로그인하세요.",
+      "signInButton": "로그인",
+      "copyPasteIntro": "또는 이 링크를 복사하여 브라우저에 붙여넣으세요.",
+      "disclaimer": "이 이메일을 요청하지 않으셨다면 무시하셔도 됩니다.",
+      "textBody": "TestPlanIt에 로그인하세요\n\n아래 링크를 클릭하여 로그인하세요:\n{url}\n\n이 이메일을 요청하지 않으셨다면 무시하셔도 됩니다."
+    }
+  },
+  "comments": {
+    "title": "댓글",
+    "placeholder": "댓글을 남겨주세요... (댓글을 달려면 @를 사용하세요)",
+    "editPlaceholder": "댓글을 수정하세요...",
+    "postComment": "댓글을 남겨주세요",
+    "noComments": "아직 댓글이 없습니다. 첫 번째 댓글을 남겨주세요!",
+    "edited": "편집됨",
+    "confirmDelete": "이 댓글을 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "deleteDialog": {
+      "title": "댓글 삭제"
+    },
+    "errors": {
+      "createFailed": "댓글을 작성하는 데 실패했습니다. 다시 시도해 주세요.",
+      "updateFailed": "댓글 업데이트에 실패했습니다. 다시 시도해 주세요.",
+      "deleteFailed": "댓글 삭제에 실패했습니다. 다시 시도해 주세요.",
+      "loadFailed": "댓글을 불러오는 데 실패했습니다. 다시 시도해 주세요."
+    },
+    "mentions": {
+      "notAMember": "프로젝트 멤버가 아닙니다",
+      "noUsersFound": "사용자를 찾을 수 없습니다."
+    }
+  },
+  "Trial": {
+    "daysRemaining": "재판 종료까지 남은 시간: {count, plural, =1 {1일} other {#일}}",
+    "expiresT oday": "오늘부로 무료 체험 기간이 만료됩니다.",
+    "expired": "{count, plural, =1 {체험 기간이 1일 전에 만료되었습니다} other {체험 기간이 #일 전에 만료되었습니다}}",
+    "contactSales": "영업 담당자에게 문의하세요."
+  },
+  "feedback": {
+    "sheetTitle": "여러분의 의견을 공유해주세요",
+    "sheetDescription": "TestPlanIt 개선에 도움을 주시려면 여러분의 경험을 공유해 주세요.",
+    "bannerMessage": "재판은 어떻게 진행되고 있나요? 여러분의 생각을 듣고 싶습니다.",
+    "menuItem": "피드백을 공유해 주세요"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "AI 태그",
+      "tagAll": "모두 태그하기",
+      "aiAutoTag": "자동 태그",
+      "tagActions": "태그 액션",
+      "startTagging": "태그 시작",
+      "selectEntityType": "엔티티 유형을 선택하세요",
+      "selectProject": "프로젝트를 선택하세요",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {테스트 케이스} other {테스트 케이스}}",
+        "testRun": "{count, plural, one {테스트 실행} other {테스트 실행}}",
+        "session": "{count, plural, one {세션} other {세션들}}"
+      }
+    },
+    "review": {
+      "title": "리뷰 태그 제안",
+      "description": "태그를 클릭하여 수락 여부를 전환하세요. 태그 이름을 수정하려면 두 번 클릭하세요.",
+      "selectEntity": "태그 제안을 보려면 엔티티를 선택하세요.",
+      "noTagsSelected": "선택된 태그 없음",
+      "footerSummary": "{assignCount, plural, one {# 태그} other {# 태그}} 가 할당됩니다. {newCount, plural, one {# 새 태그} other {# 새 태그}} 가 생성됩니다.",
+      "footerAssignCount": "{assignCount, plural, one {# 태그} other {# 태그}} 가 할당됩니다.",
+      "footerNewCount": "{newCount, plural, one {# 새 태그} other {# 새 태그}} 가 생성됩니다",
+      "newTagsPopoverTitle": "새 태그를 생성하려면",
+      "applying": "지원 중...",
+      "applySuccess": "{tagCount, plural, one {# 태그} other {# 태그}} {entityCount, plural, one {~ 엔티티} other {# 엔티티}}에 적용됨",
+      "applySuccessNewTags": "{tagCount, plural, one {# 태그} other {# 태그}} {entityCount, plural, one {에 적용됨 # 엔티티} other {# 엔티티}}, {newCount, plural, one {# 새 태그} other {# 새 태그}} 생성됨",
+      "applyError": "태그를 적용하는 데 실패했습니다. 다시 시도해 주세요.",
+      "suggestedTags": "추천 태그",
+      "noSuggestions": "AI가 태그를 생성할 수 없었습니다.",
+      "alreadyApplied": "이미 지원했습니다",
+      "filterEntities": "엔티티 필터링...",
+      "noEntitiesMatch": "검색 조건과 일치하는 항목이 없습니다.",
+      "tagCount": "{count, plural, one {# 태그} other {# 태그}}",
+      "noTags": "없음",
+      "failed": "실패한",
+      "analysisFailed": "이 개체를 분석할 수 없습니다.",
+      "responseTruncated": "응답이 잘렸습니다. LLM 설정에서 최대 출력 토큰 수를 늘리세요.",
+      "tooltipExisting": "기존 태그",
+      "tooltipNew": "새 태그가 생성될 예정입니다.",
+      "tooltipAssign": "기존 태그 할당",
+      "toggleFailed": "실패한 엔티티를 표시/숨기기",
+      "showFailed": "표시 실패"
+    },
+    "progress": {
+      "starting": "분석 시작 중...",
+      "analyzed": "{analyzed}/{total} 엔티티를 분석했습니다.",
+      "sizing": "최적의 배치 크기를 찾는 중( {size} 엔티티를 시도해 보는 중)...",
+      "streaming": "AI 응답 수신 중 ({analyzed}/{total} 엔티티 완료)...",
+      "finalizing": "결과를 준비하는 중...",
+      "complete": "분석 완료",
+      "reviewSuggestions": "리뷰 제안",
+      "failed": "분석 실패"
+    },
+    "wizard": {
+      "description": "AI는 프로젝트 전체의 테스트 케이스, 테스트 실행 및 세션을 분석하여 콘텐츠에 기반한 관련 태그를 제안합니다.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "분석 시작",
+      "untaggedOnly": "기존 태그가 없는 레코드만 분석합니다.",
+      "allowNewTags": "새 태그 생성을 허용합니다",
+      "noLlmConfigured": "(LLM이 구성되지 않았습니다)",
+      "analyzingDescription": "AI가 엔티티를 분석하고 태그 제안을 생성하고 있습니다. 잠시 시간이 걸릴 수 있습니다."
+    },
+    "entityDetail": {
+      "customFields": "사용자 정의 필드",
+      "noDetails": "추가 정보는 없습니다.",
+      "openInNewTab": "새 탭에서 열기"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "매우 약함",
+    "weak": "약한",
+    "fair": "공정한",
+    "good": "좋은",
+    "strong": "강한",
+    "minLength": "최소 {count} 문자",
+    "uppercase": "적어도 하나의 대문자",
+    "lowercase": "적어도 하나의 소문자",
+    "numbers": "적어도 하나의 숫자",
+    "specialChars": "특수 문자: {chars}",
+    "history": "이 비밀번호는 최근 {depth} 번 비밀번호에 사용되었습니다."
+  },
+  "TrialExpired": {
+    "title": "체험 기간이 만료되었습니다.",
+    "description": "TestPlanIt을 이용해 주셔서 감사합니다! 평가 기간이 종료되어 더 이상 해당 인스턴스에 접속할 수 없습니다.",
+    "nextSteps": "TestPlanIt을 계속 사용하고 테스트 데이터에 액세스하려면 영업팀에 문의하십시오.",
+    "pricingPlans": "가격 플랜",
+    "dataRetention": "테스트 데이터는 안전하게 저장되며, 계정을 업그레이드하시면 이용하실 수 있습니다."
+  }
+}

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Naam",
+    "cancel": "Annuleren",
+    "dismiss": "Afwijzen",
+    "of": "van",
+    "on": "op",
+    "at": "bij",
+    "in": "in",
+    "add": "Toevoegen",
+    "never": "Nooit",
+    "select": "Selecteer...",
+    "file": "Bestand",
+    "selectMultiple": "Selecteer meerdere...",
+    "searchUsers": "Zoeken naar gebruikers...",
+    "searchCases": "{count, plural, =0 {Zoek gevallen} one {Zoek # geval} other {Zoek # gevallen}}",
+    "searchProjects": "{count, plural, =0 {Zoek projecten} one {Zoek # project} other {Zoek # projecten}}",
+    "searchTags": "Zoeken naar tags...",
+    "searchRuns": "{count, plural, =0 {Zoektestruns} one {Zoek # testrun} other {Zoek # testruns}}",
+    "searchSessions": "{count, plural, =0 {Zoeksessies} one {Zoek # sessie} other {Zoek # sessies}}",
+    "search": "Zoekopdracht...",
+    "defaultOption": "Standaardoptie",
+    "yes": "Ja",
+    "no": "Nee",
+    "updated": "Bijgewerkt",
+    "groupedBy": "gegroepeerd op",
+    "lastEditedBy": "Laatst bewerkt door",
+    "actions": {
+      "edit": "Bewerking",
+      "save": "Redden",
+      "delete": "Verwijderen",
+      "create": "Creëren",
+      "submit": "Indienen",
+      "close": "Dichtbij",
+      "done": "Klaar",
+      "verify": "Verifiëren",
+      "signIn": "Aanmelden",
+      "signOut": "Afmelden",
+      "signUp": "Aanmelden",
+      "resend": "Opnieuw verzenden",
+      "deleting": "Verwijderen...",
+      "next": "Volgende",
+      "previous": "Vorig",
+      "finish": "Finish",
+      "download": "Download",
+      "apply": "Toepassen",
+      "confirm": "Bevestigen",
+      "confirmDelete": "Bevestig Verwijderen",
+      "saveChanges": "Wijzigingen opslaan",
+      "saving": "Besparing...",
+      "submitting": "Verzenden...",
+      "start": "Begin",
+      "pause": "Pauze",
+      "reset": "Reset",
+      "copy": "Kopiëren",
+      "copyLink": "Link kopiëren",
+      "copied": "Gekopieerd!",
+      "complete": "Compleet",
+      "back": "Rug",
+      "clear": "Duidelijk",
+      "expand": "Uitbreiden",
+      "collapse": "Instorten",
+      "addResult": "Resultaat toevoegen",
+      "passAndNext": "Pass & Next",
+      "viewInRepository": "Bekijk in repository",
+      "resultAdded": "Testresultaat toegevoegd",
+      "resultAddedDescription": "Het testresultaat is succesvol toegevoegd.",
+      "resultUpdated": "Testresultaat bijgewerkt",
+      "resultDeleted": "Testresultaat verwijderd",
+      "deleteResult": "Testresultaat verwijderen",
+      "deleteResultConfirmation": "Weet u zeker dat u dit testresultaat wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+      "editResult": "Testresultaat bewerken",
+      "resultDetails": "Resultaatdetails",
+      "actionsLabel": "Acties",
+      "assign": "Toewijzen",
+      "assignSelected": "Wijs {count, plural, one {toe # geval} other {# gevallen}}",
+      "refresh": "Vernieuwen",
+      "addResultSelected": "Voeg het resultaat toe aan {count, plural, one {# geval} other {# gevallen}}",
+      "resultsAdded": "{count, plural, one {# Resultaat} other {# Resultaten}} Toegevoegd",
+      "resultsAddedDescription": "{count, plural, one {Resultaat is toegevoegd aan testcase} other {Resultaten zijn toegevoegd aan testcases}} succesvol",
+      "addingResultsToMultiple": "Resultaten toevoegen aan {count, plural, one {# testgeval} other {# testgevallen}}",
+      "addedToTestRun": "Toegevoegd aan testrun",
+      "addedToTestRunDescription": "De testcase is toegevoegd aan de Test Run.",
+      "noAvailableTestRuns": "Alle actieve testruns bevatten deze testcase al.",
+      "resultUpdateError": "Het is niet gelukt om het testresultaat bij te werken",
+      "resultDeleteError": "Het is niet gelukt om het testresultaat te verwijderen",
+      "selectStatus": "Selecteer status",
+      "addToTestRun": "Toevoegen aan testrun",
+      "status": "Status",
+      "resultDetailsPlaceholder": "Voer resultaatdetails in...",
+      "selectAll": "Selecteer alles",
+      "deselectAll": "Alles deselecteren",
+      "clearAll": "Alles wissen",
+      "selectFile": "Selecteer bestand",
+      "restore": "Herstellen",
+      "purge": "Zuiveren",
+      "previousCase": "Vorige zaak",
+      "nextCase": "Volgende zaak",
+      "startTesting": "Begin met testen",
+      "expandLeftPanel": "Linkerpaneel uitvouwen",
+      "collapseLeftPanel": "Linkerpaneel samenvouwen",
+      "expandRightPanel": "Rechterpaneel uitvouwen",
+      "collapseRightPanel": "Rechterpaneel samenvouwen",
+      "createTag": "Tag \"{name}\" maken",
+      "noTagsFound": "Geen tags gevonden",
+      "duplicate": "Duplicaat",
+      "exportPdf": "PDF exporteren",
+      "exportingPdf": "Exporteren...",
+      "change": "Wijziging",
+      "viewAll": "Bekijk alles",
+      "undo": "Ongedaan maken",
+      "undoDelete": "Verwijderen ongedaan maken",
+      "automated": {
+        "details": "Details van de geautomatiseerde test",
+        "message": "Bericht",
+        "line": "Lijn",
+        "testSuite": "Testsuite:"
+      },
+      "junit": {
+        "details": "Details van de geautomatiseerde testresultaten",
+        "import": {
+          "title": "Testresultaten importeren",
+          "description": "Upload testresultatenbestanden om te importeren in een nieuwe testrun. Ondersteunt JUnit, TestNG, xUnit, NUnit, MSTest, Mocha en Cucumber-formaten.",
+          "testRun": {
+            "label": "Testrun",
+            "placeholder": "Selecteer een testrun"
+          },
+          "file": {
+            "label": "Testresultatenbestanden"
+          },
+          "import": "Importeren",
+          "selectFolder": "Selecteer een map",
+          "createNewFolder": "Maak een nieuwe map aan",
+          "createNewFolderNamed": "Nieuwe map aanmaken: {name}",
+          "progress": {
+            "initializing": "Importeren initialiseren...",
+            "validating": "Validatie van invoergegevens...",
+            "creatingRun": "Testrun maken...",
+            "fetchingTemplate": "Sjabloongegevens ophalen...",
+            "countingTests": "Verwerken van {count} testcases uit {files} bestand(en)...",
+            "parsingFile": "Bestand {current} van {total}parseren ...",
+            "processingSuite": "Verwerkingssuite: {name}",
+            "processingCase": "Verwerking testcase {current} van {total}...",
+            "finalizing": "Importeren afronden...",
+            "completed": "Import succesvol voltooid!",
+            "errorParsing": "Fout bij het parseren van bestand {index}: {error}",
+            "skippingFile": "Ongeldig bestand overslaan {index}"
+          },
+          "error": {
+            "title": "Importfout",
+            "importFailed": "Het importeren van de testresultaten is mislukt. Probeer het opnieuw."
+          },
+          "success": {
+            "title": "Importeren succesvol",
+            "description": "De testresultaten zijn succesvol geïmporteerd."
+          },
+          "fileRequired": "Upload minimaal één testresultaatbestand."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Resultaatindeling",
+            "placeholder": "Selecteer formaat"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Herstel bevestigen",
+      "confirmPurgeTitle": "Bevestigen van zuivering",
+      "remove": "Verwijderen",
+      "reconfigure": "Herconfigureer en probeer het opnieuw."
+    },
+    "permissions": {
+      "addEdit": "Toevoegen/bewerken"
+    },
+    "auth": {
+      "internal": "E-mailadres/wachtwoord",
+      "sso": "Alleen SSO",
+      "both": "E-mail en SSO"
+    },
+    "status": {
+      "deleted": "Verwijderd",
+      "disabled": "Gehandicapt",
+      "noCustomFieldData": "Geen aanvullende details.",
+      "pending": "In behandeling",
+      "uploading": "Uploaden...",
+      "notApplicable": "N.v.t.",
+      "redirecting": "Omleiden...",
+      "pendingDelete": "Wordt verwijderd",
+      "pendingChanges": "Wijzigingen in behandeling",
+      "importing": "Importeren...",
+      "addingTestCases": "Testgevallen toevoegen..."
+    },
+    "priority": {
+      "low": "Laag",
+      "medium": "Medium",
+      "high": "Hoog"
+    },
+    "filters": {
+      "allStatuses": "Alle statussen",
+      "allPriorities": "Alle prioriteiten"
+    },
+    "fields": {
+      "groupName": "Groepsnaam",
+      "users": "Gebruikers",
+      "mixed": "Alle waarden",
+      "type": "Type",
+      "default": "Standaard",
+      "enabled": "Ingeschakeld",
+      "projects": "Projecten",
+      "iconColor": "Icoon/Kleur",
+      "selectWorkflow": "Workflow selecteren",
+      "icon": "Icon",
+      "systemName": "Systeemnaam",
+      "aliases": "Aliassen",
+      "scope": "Domein",
+      "success": "Succes",
+      "failure": "Mislukking",
+      "completed": "Voltooid",
+      "elapsed": "Verstreken tijd",
+      "totalElapsed": "Totale verstreken tijd",
+      "totalEstimate": "Geschatte resterende tijd",
+      "completionRate": "Voltooiingspercentage",
+      "attachments": "Bijlagen",
+      "documentation": "Documentatie",
+      "state": "Staat",
+      "configuration": "Configuratie",
+      "configurations": "Configuraties",
+      "milestone": "Mijlpaal",
+      "tags": "Labels",
+      "createdBy": "Gemaakt door",
+      "description": "Beschrijving",
+      "description_placeholder": "Voeg een beschrijving toe...",
+      "testCases": "Testgevallen",
+      "sessions": "Sessies",
+      "sharedSteps": "Gezamenlijke stappen",
+      "email": "E-mail",
+      "password": "Wachtwoord",
+      "confirmPassword": "Bevestig wachtwoord",
+      "token": "Token",
+      "access": "Toegang",
+      "avatar": "Avatar",
+      "steps": "Stappen",
+      "step": "Stap",
+      "expectedResult": "Verwacht resultaat",
+      "notes": "Notities",
+      "estimate": "Schatting",
+      "date": "Datum",
+      "size": "Maat",
+      "created": "Gemaakt",
+      "template": "Sjabloon",
+      "mission": "Missie",
+      "assignedTo": "Toegewezen aan",
+      "executedBy": "Uitgevoerd door",
+      "optional": "Optioneel",
+      "role": "Rol",
+      "defaultRole": "Standaardrol",
+      "systemAccess": "Systeemtoegang",
+      "authMethod": "Authenticatiemethode",
+      "dateCreated": "Datum aangemaakt",
+      "apiUser": "API-gebruiker",
+      "unverified": "Ongeverifieerd",
+      "selfRegistered": "Zelf geregistreerd",
+      "role_placeholder": "Selecteer een rol",
+      "usersCreated": "Gebruikers aangemaakt",
+      "groups": "Groepen",
+      "apiAccess": "API-toegang",
+      "requiredForAdmin": "Vereist voor beheerder",
+      "account": "Rekening",
+      "accountHistory": "Accountgeschiedenis",
+      "activity": "Activiteit",
+      "lastActive": "Laatst actief",
+      "theme": "Thema",
+      "locale": "Taal",
+      "timezone": "Tijdzone",
+      "itemsPerPage": "Items per pagina",
+      "notificationMode": "Meldingen",
+      "value": "Waarde",
+      "key": "Sleutel",
+      "configurationDetails": "Configuratiedetails",
+      "isActive": "Actief",
+      "members": "Leden",
+      "milestoneTypes": "Mijlpaaltypen",
+      "milestones": "Mijlpalen",
+      "createdAt": "Gemaakt op",
+      "completedOn": "Voltooid op",
+      "variants": "Varianten",
+      "emailVerified": "E-mail geverifieerd",
+      "issueTracker": "Probleemtracker",
+      "caseFields": "Casevelden",
+      "resultFields": "Resultaatvelden",
+      "displayName": "Weergavenaam",
+      "hint": "Tip",
+      "required": "Vereist",
+      "restricted": "Beperkt",
+      "fieldType": "Veldtype",
+      "templates": "Sjablonen",
+      "started": "Begonnen",
+      "startDate": "Startdatum",
+      "automated": "Geautomatiseerd",
+      "manual": "Handmatig",
+      "notAutomated": "Niet geautomatiseerd",
+      "testRuns": "Testruns",
+      "title": "Titel",
+      "project": "Project",
+      "priority": "Prioriteit",
+      "integration": "Integratie",
+      "lastSyncedAt": "Laatst gesynchroniseerd",
+      "externalKey": "Externe sleutel",
+      "initialHeight": "Initiële hoogte",
+      "minValue": "Minimale waarde",
+      "maxValue": "Maximale waarde",
+      "minIntegerValue": "Minimale gehele waarde",
+      "maxIntegerValue": "Maximale gehele waarde",
+      "defaultValue": "Standaardwaarde",
+      "checked": "Gecontroleerd",
+      "version": "Versie",
+      "issues": "Problemen",
+      "internalIssues": "Interne problemen",
+      "externalIssues": "{provider} Problemen",
+      "data": "Gegevens",
+      "note": "Opmerking",
+      "externalId": "Externe ID",
+      "forecast": "Voorspelling",
+      "forecastManual": "Weersverwachting Handleiding",
+      "forecastAutomated": "Geautomatiseerde voorspelling",
+      "executedAt": "Uitgevoerd op",
+      "className": "Klas",
+      "suiteName": "Suite",
+      "duration": "Duur",
+      "session": "Sessie",
+      "charter": "Charter",
+      "summary": "Samenvatting",
+      "progress": "Voortgang",
+      "assertions": "Beweringen",
+      "properties": "Eigenschappen",
+      "systemOutput": "Testcase-logboeken",
+      "systemError": "Systeemfout",
+      "resultStatus": "Resultaat",
+      "links": "Links",
+      "id": "ID",
+      "JUNIT": "JUnit-import",
+      "API": "API",
+      "folder": "Map",
+      "parentFolder": "Oudermap voor nieuwe gevallen",
+      "multipleValues": "Meerdere waarden",
+      "provider": "Aanbieder",
+      "updatedAt": "Bijgewerkt op",
+      "tools": "Hulpmiddelen",
+      "codeRepository": "Code Repo",
+      "aiModels": "Standaard LLM",
+      "configKeys": {
+        "edit_results_duration": "Bewerken Resultaten Duur",
+        "project_docs_default": "Projectdocumenten Standaard",
+        "notificationSettings": "Globale instellingen voor meldingen",
+        "elasticsearch_replicas": "Elasticsearch-replica's"
+      },
+      "options": {
+        "label": "Label",
+        "validation": {
+          "empty": "Optie kan niet leeg zijn",
+          "invalidChars": "De optie bevat een ongeldig teken: \"{char}\"",
+          "duplicate": "Optie moet uniek zijn",
+          "systemNameError": "Systeemnaam is ongeldig",
+          "initialHeightMax": "De beginhoogte mag niet groter zijn dan 600px.",
+          "displayNameRequiredResult": "Voer een weergavenaam in voor het Resultaatveld.",
+          "displayNameRequiredCase": "Voer een weergavenaam in voor het Case-veld.",
+          "minValueMaxValue": "De minimumwaarde moet kleiner zijn dan de maximumwaarde en beide moeten zijn ingesteld als er één is ingesteld.",
+          "minMaxValueInteger": "De minimale gehele waarde moet kleiner zijn dan de maximale gehele waarde. Als er één is ingesteld, moeten beide waarden zijn ingesteld.",
+          "systemNameRequired": "De systeemnaam mag niet leeg zijn.",
+          "systemNameRegex": "De systeemnaam moet met een letter beginnen en mag alleen letters, cijfers en underscores bevatten.",
+          "fieldTypeRequired": "Het veldtype is verplicht."
+        }
+      },
+      "placeholders": {
+        "key": "Enter-toets",
+        "value": "Voer waarde in",
+        "addVariant": "Variant toevoegen",
+        "addCategory": "Categorie toevoegen",
+        "displayName": "Voer de weergavenaam in",
+        "systemName": "Voer de systeemnaam in",
+        "hint": "Voer hint in"
+      },
+      "hints": {
+        "systemName": "De systeemnaam moet uniek zijn en alleen letters, cijfers en onderstrepingstekens bevatten",
+        "fieldType": "(Het veldtype kan niet meer worden gewijzigd nadat het is aangemaakt)"
+      },
+      "validation": {
+        "nameRequired": "Naam is vereist",
+        "stateRequired": "Staat is vereist",
+        "urlRequired": "URL is vereist",
+        "invalidUrl": "Ongeldige URL-indeling"
+      }
+    },
+    "filter": {
+      "placeholder": "Filter {item}..."
+    },
+    "access": {
+      "admin": "Beheerder",
+      "projectAdmin": "Projectbeheerder",
+      "user": "Gebruiker",
+      "none": "Geen"
+    },
+    "validation": {
+      "required": "Voer {field}in",
+      "invalidDuration": "Voer een geldige duur in",
+      "maxDuration": "De duur mag niet langer zijn dan {max} minuten",
+      "minLength": "{field} moet minimaal {min} tekens bevatten",
+      "emailFormat": "Ongeldig e-mailadres",
+      "passwordMatch": "Wachtwoorden moeten overeenkomen",
+      "unique": "{field} moet uniek zijn",
+      "roleRequired": "Rol is vereist",
+      "nameMinLength": "Naam moet minimaal 2 tekens lang zijn",
+      "invalidDurationFormat": "Ongeldige duurnotatie. Probeer iets als 30 minuten, 1 week of 1 uur en 25 minuten."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Bevestig {action}",
+        "message": "Weet u zeker dat u {action}wilt?"
+      },
+      "confirmDelete": {
+        "description": "Weet u zeker dat u dit item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "assign": {
+        "title": "Testcase toewijzen",
+        "description": "Wijs de testcase \"{testCase}\" toe aan een gebruiker",
+        "selectUser": "Selecteer een gebruiker"
+      },
+      "assignBulk": {
+        "title": "Bulktoewijzing van testcases",
+        "description": "Wijs {count, plural, one {# geselecteerde testcase} other {# geselecteerde testcases}} toe aan een gebruiker"
+      },
+      "complete": {
+        "title": "Volledige testrun",
+        "description": "Weet u zeker dat u deze testrun wilt voltooien?",
+        "warning": "Nadat de testrun is voltooid, kan deze niet meer worden gewijzigd.",
+        "apple": {
+          "title": "Apple Sign In configureren",
+          "description": "Stel uw Apple Sign In-gegevens in. U kunt deze verkrijgen via de Apple Developer Portal.",
+          "clientId": "Service-ID",
+          "clientIdPlaceholder": "com.voorbeeld.service",
+          "teamId": "Team-ID",
+          "teamIdPlaceholder": "Uw team-ID van 10 tekens",
+          "keyId": "Sleutel-ID",
+          "keyIdPlaceholder": "Uw 10-cijferige sleutel-ID",
+          "privateKey": "Privésleutel",
+          "privateKeyPlaceholder": "Plak hier de inhoud van uw .p8-privésleutel",
+          "instructions": {
+            "title": "Installatie-instructies:",
+            "step1": "Ga naar de Apple Developer Portal",
+            "step2": "Maak een Service ID aan en configureer Aanmelden met Apple",
+            "step3": "Maak een sleutel aan voor Aanmelden met Apple",
+            "step4": "Download het .p8-privésleutelbestand",
+            "step5": "Voeg de volgende omleidings-URL toe:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Alle velden zijn verplicht"
+          }
+        }
+      },
+      "delete": {
+        "title": "Verwijder {item}",
+        "description": "Weet u zeker dat u {name}wilt verwijderen?",
+        "warning": "Deze actie kan niet ongedaan worden gemaakt. De {item}wordt permanent verwijderd."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Item succesvol verwijderd",
+      "deleteError": "Er is een fout opgetreden bij het verwijderen van het item",
+      "moveSuccess": "Item succesvol verplaatst",
+      "moveError": "Er is een fout opgetreden bij het verplaatsen van het item",
+      "updateSuccess": "Item succesvol bijgewerkt",
+      "updateError": "Er is een fout opgetreden tijdens het bijwerken van het item",
+      "linkCopied": "Link gekopieerd naar klembord",
+      "copyFailed": "Het is niet gelukt om de link naar het klembord te kopiëren",
+      "created": "Testrun succesvol aangemaakt",
+      "createdDescription": "De testrun is gemaakt en is nu zichtbaar in de lijst Testruns.",
+      "createError": "Er is een onbekende fout opgetreden. Probeer het opnieuw.",
+      "emptyActive": "Geen actieve testruns",
+      "emptyCompleted": "Geen voltooide testruns",
+      "projectUpdated": "Project succesvol bijgewerkt",
+      "projectUpdateError": "Er is een fout opgetreden tijdens het bijwerken van het project",
+      "noProjects": "Geen projecten gevonden"
+    },
+    "placeholders": {
+      "email": "E-mailadres",
+      "name": "Voer naam in",
+      "mission": "Beschrijf je missie...",
+      "selectMilestone": "Selecteer Mijlpaal",
+      "selectStatus": "Selecteer een status",
+      "selectTemplate": "Selecteer sjabloon",
+      "duration": "bijv. 1u 30m of 90m",
+      "docs": "Documentatie toevoegen...",
+      "select": "Selecteer",
+      "selectState": "Selecteer staat",
+      "selectConfiguration": "Selecteer configuratie",
+      "selectConfigurations": "Selecteer configuraties",
+      "selectOption": "Selecteer een optie",
+      "date": "Selecteer een datum",
+      "selectEncoding": "Codering selecteren...",
+      "selectATemplate": "Selecteer een sjabloon...",
+      "selectVersion": "Selecteer versie",
+      "selectAModel": "Selecteer een model",
+      "selectWorkflowType": "Selecteer het workflowtype",
+      "addAnOption": "Een optie toevoegen",
+      "addADescription": "Voeg een beschrijving toe...",
+      "optionalDescription": "Optionele beschrijving...",
+      "projectNotes": "Projectnotities...",
+      "filterByName": "Filteren op naam...",
+      "filterByValue": "Filteren op waarde...",
+      "selectOperator": "Selecteer operator",
+      "searchIcons": "Zoekpictogrammen...",
+      "value": "Waarde",
+      "stepCount": "stappen",
+      "enterText": "Voer tekst in...",
+      "enterUrl": "Voer de URL in",
+      "issueIdExample": "NUMMER-123",
+      "selectPriorityValuesOrEmpty": "Selecteer prioriteitswaarden (of laat alles leeg)"
+    },
+    "errors": {
+      "error": "Fout",
+      "somethingWentWrong": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw.",
+      "emailRequired": "Voer uw e-mailadres in.",
+      "emailInvalid": "Dit is geen geldig e-mailadres.",
+      "passwordRequired": "Een wachtwoord is vereist.",
+      "confirmPasswordRequired": "Bevestig uw wachtwoord.",
+      "passwordDoesNotMeetPolicy": "Het wachtwoord voldoet niet aan de beveiligingsvereisten.",
+      "passwordsDoNotMatch": "De wachtwoorden komen niet overeen",
+      "nameRequired": "Vul uw volledige naam in",
+      "duplicate": "Kies een unieke naam.",
+      "userExists": "Gebruiker bestaat al.",
+      "unknown": "Er is een onbekende fout opgetreden.",
+      "invalidCredentials": "Ongeldige gebruikersnaam of wachtwoord",
+      "projectNotFound": "Project niet gevonden",
+      "projectNotFoundDescription": "Het project dat u zoekt, bestaat niet of u hebt er geen toegang toe.",
+      "tokenRequired": "Voer uw e-mailadres voor verificatie in of klik op de link in uw e-mail.",
+      "noSuccessStatus": "Geen successtatus geselecteerd",
+      "missingTestRunCase": "Testrun case-ID ontbreekt",
+      "fieldRequired": "Dit veld is verplicht",
+      "projectNameExists": "Er bestaat al een project met deze naam",
+      "defaultNotFound": "Standaardwaarde niet gevonden",
+      "emailExists": "Er bestaat al een gebruiker met dit e-mailadres",
+      "nameExists": "Er bestaat al een gebruiker met deze naam",
+      "duplicateValue": "Deze waarde is al in gebruik",
+      "unauthorized": "U bent niet bevoegd om deze actie uit te voeren.",
+      "accessDenied": "Toegang geweigerd",
+      "sessionNotFound": "Sessie niet gevonden of ongeldig.",
+      "issueTrackerNotConfigured": "Issue tracker is niet geconfigureerd voor dit project.",
+      "noUserSession": "Geen gebruikersessie gevonden",
+      "noProjectId": "Geen project-ID gevonden",
+      "unknownErrorWithMessage": "Er is een onbekende fout opgetreden. {message}",
+      "unauthenticated": "Gebruiker niet geauthenticeerd",
+      "fetchFailed": "Het ophalen van gegevens is mislukt. Probeer het later opnieuw.",
+      "unsupportedFieldType": "Niet-ondersteund veldtype",
+      "notAuthenticated": {
+        "title": "Niet geverifieerd",
+        "message": "U moet ingelogd zijn om deze actie uit te voeren."
+      },
+      "failedToFetchAssignments": {
+        "title": "Opdrachten ophalen mislukt",
+        "message": "Opdrachten ophalen mislukt. Probeer het later opnieuw."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Probleem succesvol gekoppeld",
+        "linkError": "Fout bij het koppelen",
+        "unlinkedSuccess": "Probleem succesvol losgekoppeld",
+        "unlinkError": "Fout bij het loskoppelen",
+        "noActiveIntegration": "Er is geen actieve integratie gevonden voor dit project"
+      },
+      "roleRequiredForSpecificRole": "Rol is vereist wanneer het toegangstype Specifieke rol is.",
+      "projectCreationFailed": "Het aanmaken van het project is mislukt, er is geen ID geretourneerd.",
+      "invalidRoleId": "Ongeldige rol-ID",
+      "workflowStateExists": "Workflowstatus bestaat al. Kies een nieuwe naam.",
+      "failedToLoadCaseData": "Het laden van de casusgegevens is mislukt. Kan niet worden opgeslagen.",
+      "atLeastOneTagRequired": "Er is minimaal één tag vereist",
+      "atLeastOneIssueRequired": "Er is minimaal één probleem vereist",
+      "atLeastOneOptionRequired": "Er moet minimaal één optie geselecteerd zijn",
+      "valueRequired": "Waarde is vereist",
+      "contentRequired": "Inhoud is vereist",
+      "invalidContentFormat": "Ongeldige inhoudsindeling",
+      "caseNameRequired": "Geef de testcase een naam.",
+      "caseStateRequired": "Selecteer een staat.",
+      "caseFolderRequired": "Selecteer een map",
+      "estimateTooLarge": "De schatting is te hoog.",
+      "estimateRequiredValid": "Een schatting is vereist en moet een geldige tijdsduur aangeven (bijv. 1 uur en 30 minuten).",
+      "invalidDurationOrExceedsMax": "Ongeldig tijdsduurformaat of overschrijdt de maximale limiet (bijv. 1 uur 30 minuten)",
+      "configurationNameExists": "De configuratienaam bestaat al. Kies een andere naam.",
+      "variantNameExists": "Deze variantnaam bestaat al. Kies een andere naam.",
+      "categoryNameExists": "De categorienaam bestaat al. Kies een andere naam.",
+      "workflowStateNameExists": "De naam van de workflowstatus bestaat al. Kies een andere naam.",
+      "folderNameRequired": "Geef de map een naam op.",
+      "folderNameRequiredEnter": "Geef de map een naam.",
+      "workflowStateNameRequired": "Voer een naam in voor de workflowstatus.",
+      "roleNameEmpty": "De rolnaam mag niet leeg zijn.",
+      "groupNameRequired": "Groepsnaam is verplicht",
+      "templateNameRequired": "Geef een naam op voor de sjabloon.",
+      "caseStateInvalid": "Selecteer een geldige staat.",
+      "caseTemplateRequired": "Selecteer een sjabloon.",
+      "invalidContent": "Ongeldige inhoud",
+      "milestoneNameRequired": "Geef een naam op voor de mijlpaal.",
+      "milestoneTypeRequired": "Selecteer een type mijlpaal.",
+      "testRunNameMinLength": "De naam moet minimaal 2 tekens lang zijn.",
+      "stateRequiredDot": "De staat moet vermeld worden.",
+      "milestoneTypeNameMinLength": "De naam van het mijlpaaltype moet minimaal 2 tekens lang zijn.",
+      "projectNameRequired": "Projectnaam is verplicht",
+      "workflowScopeRequired": "Kies een workflow voor de staat.",
+      "workflowTypeRequired": "Selecteer een workflowtype.",
+      "newTestCaseAdded": "Nieuwe testcase toegevoegd",
+      "repositoryDeleted": "Repository verwijderd",
+      "failedToDeleteRepository": "Het verwijderen van de repository is mislukt.",
+      "permissionDenied": "U hebt geen toestemming om deze pagina te bezoeken.",
+      "resultSubmitPermissionDenied": "Je kunt voor deze zaak geen resultaten indienen. Vraag een projectbeheerder om deze zaak aan je toe te wijzen.",
+      "noModelsFound": "Geen modellen gevonden",
+      "failedToFetchModels": "Het ophalen van modellen is mislukt",
+      "failedToCopyToClipboard": "Kopiëren naar klembord mislukt",
+      "failedToLoadJobResults": "Het laden van de taakresultaten is mislukt.",
+      "failedToUpdateRepositoryStatus": "Het bijwerken van de repositorystatus is mislukt."
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "Dashboard",
+      "twoFactorVerification": "Tweefactorauthenticatie",
+      "changePassword": "Wachtwoord wijzigen",
+      "twoFactorSetup": "Tweefactorauthenticatie-instelling",
+      "signUp": "Aanmelden",
+      "signIn": "Inloggen",
+      "verifyEmail": "E-mailadres verifiëren",
+      "trialExpired": "Proefperiode verlopen",
+      "linkSsoAccount": "Koppel SSO-account",
+      "userProfile": "Gebruikersprofiel",
+      "users": "Gebruikers",
+      "issues": "Problemen",
+      "tags": "Tags",
+      "tagDetails": "Labeldetails",
+      "aiModels": "AI-modellen",
+      "integrations": "Integraties",
+      "quickscript": "QuickScript",
+      "webhooks": "Webhooks",
+      "shares": "Aandelen",
+      "repository": "Opslagplaats",
+      "testCaseVersion": "Testcaseversie",
+      "duplicateTestCases": "Dubbele testgevallen",
+      "documentation": "Documentatie",
+      "sharedSteps": "Gezamenlijke stappen",
+      "stepDuplicates": "Stapduplicaten",
+      "sessions": "Sessies",
+      "sessionVersion": "Sessieversie",
+      "milestones": "Mijlpalen",
+      "testRuns": "Testruns",
+      "reports": "Rapporten",
+      "adminSamlConfig": "Beheerder - SAML-configuratie",
+      "apiDocumentation": "API-documentatie",
+      "sharedContent": "Gedeelde inhoud"
+    },
+    "aria": {
+      "userMenu": "Gebruikersmenu",
+      "search": "Zoekopdracht",
+      "helpMenu": "Helpmenu",
+      "help": "Hulp",
+      "grouped": "Gegroepeerd",
+      "group": "Groep",
+      "selectAll": "Alles selecteren",
+      "selectRow": "Selecteer rij",
+      "removeIssue": "Probleem verwijderen",
+      "selectDeselectAllAddEdit": "Alles selecteren/deselecteren Toevoegen/bewerken",
+      "selectDeselectAllDelete": "Alles selecteren/deselecteren Verwijderen",
+      "selectDeselectAllClose": "Alles selecteren/deselecteren Sluiten",
+      "clearFilter": "Filter wissen",
+      "olderVersion": "Oudere versie",
+      "newerVersion": "Nieuwere versie",
+      "deletedUser": "Verwijderde gebruiker",
+      "restrictedField": "Beperkt veld",
+      "backToTestCase": "Terug naar testcase"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Project} other {# Projecten}}",
+      "templates": "Sjablonen en velden",
+      "workflows": "Werkstromen",
+      "statuses": "Statussen",
+      "roles": "Rollen",
+      "unknownRole": "Onbekende rol",
+      "unknownGroup": "Onbekende groep",
+      "file": "bestand",
+      "files": "bestanden",
+      "existingAttachments": "Bestaande bijlagen",
+      "new": "Nieuw",
+      "noElapsedTime": "Geen tijd geregistreerd",
+      "untested": "Niet getest",
+      "noResults": "Geen resultaten",
+      "resultsWithNoElapsedTime": "Geen tijd geregistreerd voor resultaten",
+      "total": "Totaal",
+      "noCases": "Geen testgevallen",
+      "unknown": "Onbekend",
+      "selectedTestCases": "Geselecteerde testcases",
+      "editToModifyCasesTitle": "Deze lijst kan niet worden gewijzigd.",
+      "editToModifyCases": "Bewerk de testrun en klik op Geselecteerde testcases om de lijst te wijzigen.",
+      "noTestCasesSelected": "Geen testgevallen geselecteerd",
+      "editToSelectTestCases": "Bewerk de testrun om testcases te selecteren.",
+      "casesInRun": "{count, plural, =0 {Geen testgevallen in de testrun} =1 {1 testgeval in de testrun} other {# testgevallen in de testrun}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Uniek geval} other {# Unieke gevallen}} over {configCount, plural, =1 {1 Configuratie} other {# Configuraties}} ({totalCount} totaal aantal gevallen)",
+      "viewTestRunDetails": "Bekijk testrundetails",
+      "sortByStatus": "Groeperen op status",
+      "sortByDate": "Sorteren op datum",
+      "testRuns": "{count, plural, =0 {Geen testruns} =1 {1 testrun} other {# testruns}}",
+      "sessions": "{count, plural, =0 {Geen sessies} =1 {1 sessie} other {# sessies}}",
+      "noOptions": "Geen opties beschikbaar",
+      "multiConfiguration": "Onderdeel van een groep met meerdere configuraties",
+      "otherConfigurations": "Andere configuraties",
+      "selected": "Geselecteerd: {count}",
+      "defaultProjectAccess": "Standaard projecttoegang",
+      "defaultAccessType": "Standaard toegangstype",
+      "assignedUsersCount": "{count, plural, =0 {Geen gebruikers toegewezen} =1 {# Gebruiker toegewezen} other {# Gebruikers toegewezen}}",
+      "successRate": "Succespercentage",
+      "unassigned": "Niet toegewezen",
+      "testRunName": "Testrunnaam",
+      "estimatesEllipsis": "Schattingen...",
+      "access": {
+        "noAccess": "Geen toegang",
+        "globalRole": "Globale rol gebruiken",
+        "specificRole": "Specifieke rol",
+        "projectDefault": "Project Standaard",
+        "usersGlobalRole": "Globale rol van de gebruiker"
+      },
+      "unknownUser": "Onbekende gebruiker",
+      "unknownProject": "Onbekend project",
+      "unknownTag": "Onbekende tag",
+      "filesSelectedForUpload": "{count, plural, =1 {1 bestand geselecteerd voor upload} other {# bestanden geselecteerd voor upload}}"
+    },
+    "empty": {
+      "description": "Geen beschrijving",
+      "documentation": "Geen documentatie",
+      "childMilestones": "Geen kindermijlpalen",
+      "sessions": "Geen sessies",
+      "activeSessions": "Geen actieve sessies",
+      "completedSessions": "Geen voltooide sessies",
+      "testCase": "Geen testcase gevonden",
+      "noTestCasesOrSessions": "Geen testcases of sessies gevonden",
+      "noTestCasesSessionsOrRuns": "Geen testcases, sessies of runs gevonden"
+    },
+    "or": "of",
+    "for": "voor",
+    "and": "En",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt-logo",
+      "tagline": "Test alles wat er maar te testen valt."
+    },
+    "table": {
+      "columns": {
+        "columns": "Kolommen",
+        "required": "(vereist)"
+      },
+      "filter": "Filterlijst...",
+      "selectNone": "Selecteer niets",
+      "sort": "Kolom sorteren",
+      "sortAscending": "Oplopend gesorteerd",
+      "sortDescending": "Aflopend gesorteerd",
+      "sortNone": "Niet gesorteerd",
+      "resize": "Kolomgrootte wijzigen"
+    },
+    "pagination": {
+      "selectPage": "Selecteer pagina",
+      "morePages": "Meer pagina's",
+      "goToPrevious": "Ga naar de vorige pagina",
+      "goToNext": "Ga naar de volgende pagina",
+      "all": "Alle artikelen",
+      "entries": "{count, plural, =1 {# item} other {# items}}",
+      "pageSize": "Paginaformaat",
+      "showing": "Tonen",
+      "total": "totaal {count, plural, =1 {# items} other {# items}}",
+      "filtered": "gefilterd van",
+      "pageOfPages": "Pagina {current} van {total}"
+    },
+    "upload": {
+      "title": "Nieuwe profielfoto uploaden",
+      "description": "Versleep uw afbeelding of klik op de onderstaande knop om een bestand te selecteren.",
+      "attachments": {
+        "title": "Bijlagen uploaden",
+        "description": "Versleep uw bestanden of klik op de onderstaande knop om bestanden te selecteren.",
+        "selectFiles": "{count, plural, =0 {Selecteer bestanden} one {1 geselecteerd bestand} other {# geselecteerde bestanden}}",
+        "selectFile": "{count, plural, =0 {Bestand selecteren} other {1 Geselecteerd bestand}}",
+        "filesSelected": "{count, plural, one {1 bestand geselecteerd} other {# bestanden geselecteerd}}",
+        "addMoreFiles": "Voeg meer bestanden toe...",
+        "replaceFile": "Bestand vervangen...",
+        "invalidFileType": "Ongeldig bestandstype. Alleen {types} bestanden zijn toegestaan.",
+        "altText": {
+          "emoji": "emoji"
+        },
+        "count": "{count, plural, =1 {# bestand} other {# bestanden}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Sleep een CSV-bestand hierheen om testcases te importeren.",
+      "dropToImportTestResults": "Sleep het bestand hierheen om de testresultaten te importeren.",
+      "supportedCsvFormats": "Ondersteunde bestandsformaten: .csv",
+      "supportedResultFormats": "Ondersteunde bestandsformaten: .xml, .trx, .json",
+      "unsupportedFileType": "Niet-ondersteund bestandstype. Verwacht: {expected}",
+      "noFilesDetected": "Geen bestanden gevonden in de drop."
+    },
+    "editor": {
+      "setColor": "Kleur instellen",
+      "enterUrl": "Voer de URL in, inclusief https://",
+      "uploadFile": "Bestand uploaden",
+      "video": {
+        "controls": "Bedieningselementen voor de videospeler"
+      },
+      "image": {
+        "alignLeft": "Links uitlijnen",
+        "alignCenter": "Centreren",
+        "alignRight": "Rechts uitlijnen",
+        "sizeSmall": "Klein formaat",
+        "sizeMedium": "Middelgroot",
+        "sizeLarge": "Groot formaat",
+        "sizeFull": "Volledige breedte",
+        "resetSize": "Terugzetten naar originele grootte",
+        "rotate": "90° draaien",
+        "delete": "Afbeelding verwijderen"
+      },
+      "table": {
+        "insertTable": "Tabel invoegen",
+        "headerRow": "Kopregel",
+        "addColumnBefore": "Voeg een kolom toe vóór",
+        "addColumnAfter": "Voeg een kolom toe na",
+        "deleteColumn": "Kolom verwijderen",
+        "addRowBefore": "Voeg een rij toe vóór",
+        "addRowAfter": "Voeg een rij toe na",
+        "deleteRow": "Rij verwijderen",
+        "deleteTable": "Tabel verwijderen"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Voeg hieronder een alinea toe",
+        "clearFormatting": "Duidelijke opmaak",
+        "copyToClipboard": "Kopiëren naar het klembord"
+      },
+      "textMenu": {
+        "bold": "Vetgedrukt",
+        "italic": "Cursief",
+        "underline": "Onderstrepen",
+        "strikethrough": "Doorhalen",
+        "code": "Code",
+        "codeBlock": "Codeblok",
+        "highlightText": "Markeer tekst",
+        "textColor": "Tekstkleur",
+        "moreOptions": "Meer opties",
+        "subscript": "Subscript",
+        "superscript": "Superscript",
+        "alignLeft": "Links uitlijnen",
+        "alignCenter": "Centreren",
+        "alignRight": "Rechts uitlijnen",
+        "justify": "Verantwoorden",
+        "setLink": "Link instellen",
+        "editLink": "Link bewerken",
+        "removeLink": "Link verwijderen",
+        "resetColorToDefault": "Kleur terugzetten naar standaardinstelling"
+      }
+    },
+    "ai": {
+      "title": "AI-schrijfassistent",
+      "improveWriting": "Verbeter schrijven",
+      "makeShorter": "Korter maken",
+      "makeLonger": "Maak langer",
+      "fixGrammar": "Grammatica corrigeren",
+      "changeTone": "Toon veranderen",
+      "professional": "Professioneel",
+      "casual": "Casual",
+      "formal": "Formeel",
+      "translate": "Vertalen",
+      "english": "Engels",
+      "spanish": "Spaans",
+      "french": "Frans",
+      "summarize": "Samenvatten",
+      "addExamples": "Voorbeelden toevoegen",
+      "originalText": "Originele tekst",
+      "suggestion": "AI-suggestie",
+      "generating": "Suggestie genereren...",
+      "noSuggestion": "Er is nog geen suggestie gegenereerd.",
+      "acceptSuggestion": "Suggestie accepteren",
+      "errors": {
+        "contentBlocked": "De inhoud is geblokkeerd door veiligheidsfilters. Probeer uw verzoek anders te formuleren.",
+        "emptyContent": "De AI kon geen antwoord genereren. Probeer uw verzoek anders te formuleren of probeer het later opnieuw.",
+        "maxTokens": "Het AI-antwoord was te lang en werd afgekapt. Probeer een korter verzoek of vraag om een bondiger antwoord.",
+        "rateLimit": "De AI-service is tijdelijk niet beschikbaar vanwege snelheidsbeperkingen. Probeer het over een paar minuten opnieuw.",
+        "accessDenied": "U hebt geen toestemming om AI-functies voor dit project te gebruiken.",
+        "generic": "Er is een fout opgetreden bij het verwerken van uw verzoek."
+      }
+    },
+    "by": "door",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Inhoudsopgave",
+        "emptyMessage": "Begin met het toevoegen van koppen aan uw document …"
+      },
+      "carousel": {
+        "previousSlide": "Vorige dia",
+        "nextSlide": "Volgende dia"
+      },
+      "dialog": {
+        "toggleFullScreen": "Volledig scherm in-/uitschakelen"
+      },
+      "command": {
+        "title": "Opdrachtmenu",
+        "description": "Zoek en voer opdrachten uit"
+      },
+      "breadcrumb": {
+        "more": "Meer"
+      },
+      "clickToViewDetails": "Klik om details te bekijken",
+      "clickToExpand": "Klik om uit te breiden",
+      "clickToCollapse": "Klik om in te klappen",
+      "search": {
+        "filters": "Filters",
+        "noResultsFound": "Geen resultaten gevonden",
+        "loadingProjects": "Projecten laden...",
+        "noProjectsFound": "Geen projecten gevonden.",
+        "viewAllProjects": "Bekijk alle projecten",
+        "states": "Staten",
+        "automationStatus": "Automatiseringsstatus",
+        "parent": "Ouder"
+      },
+      "issues": {
+        "errorLoadingDetails": "Fout bij het laden van probleemdetails: ",
+        "updated": "Bijgewerkt: ",
+        "openInJira": "Openen in Jira",
+        "openInExternalSystem": "Openen in {provider}",
+        "assignee": "Cessionaris",
+        "status": "Status: ",
+        "clickToOpenInNewTab": "Klik om te openen in een nieuw tabblad",
+        "url": "URL: ",
+        "externalId": "Externe ID: ",
+        "viewIn": "Bekijk in",
+        "fieldType": "Veldtype: ",
+        "richTextContent": "Rich text-inhoud",
+        "invalidContent": "Ongeldige inhoud",
+        "fieldInformation": "Veldinformatie"
+      },
+      "onboarding": {
+        "skipTour": "Tour overslaan"
+      },
+      "charts": {
+        "resultsDistribution": "Resultatenverdeling",
+        "statusTimeline": "Statustijdlijn",
+        "testDurationHistogram": "Testduurhistogram",
+        "zoomDonutChart": "Zoom Donut-diagram",
+        "zoomStatusTimeline": "Zoom-statustijdlijn",
+        "zoomHistogramChart": "Zoom histogram grafiek",
+        "duration": "Duur: {seconds} seconden",
+        "durationLabel": "Duur"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Informatie over de issue tracker wordt geladen...",
+      "enterDocumentation": "Voer documentatie in...",
+      "noAutomatedTestResults": "Er zijn geen geautomatiseerde testresultaten gevonden voor deze run."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {minuut} other {minuten}}",
+      "seconds": "{count, plural, =1 {seconde} other {seconden}}"
+    },
+    "units": {
+      "time": "Tijd"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {geval} other {gevallen}}",
+      "result": "{count, plural, =1 {resultaat} other {resultaten}}",
+      "run": "{count, plural, =1 {loopt} other {loopt}}",
+      "comment": "{count, plural, =1 {{count} commentaar} other {{count} opmerkingen}}"
+    },
+    "success": {
+      "assigned": "Testgeval succesvol toegewezen",
+      "unassigned": "Testgeval succesvol ongedaan gemaakt",
+      "bulkAssigned": "{count, plural, one {# testgeval} other {# testgevallen}} succesvol toegewezen",
+      "bulkUnassigned": "{count, plural, one {# testgeval} other {# testgevallen}} succesvol ontkoppeld"
+    },
+    "tabs": {
+      "general": "Algemeen",
+      "settings": "Instellingen"
+    },
+    "selectFilter": "Selecteer een filterwaarde om testcases te bekijken.",
+    "invalidProject": "Ongeldige project-ID.",
+    "visualization": "Visualisatie",
+    "results": "Resultaten",
+    "loading": "Bezig met laden..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Een nieuw account aanmaken",
+      "sso": {
+        "title": "Aanmelden met SSO",
+        "googleOAuth": "Doorgaan met Google",
+        "apple": "Doorgaan met Apple",
+        "microsoft": "Ga verder met Microsoft",
+        "samlProvider": "Meld je aan met {name}",
+        "magicLink": "Aanmelden met Magic Link",
+        "emailLogin": "Doorgaan met e-mail"
+      },
+      "magicLink": {
+        "description": "Voer uw e-mailadres in en wij sturen u een beveiligde link om in te loggen. Geen wachtwoord vereist. U moet al een account hebben.",
+        "emailPlaceholder": "Voer uw e-mailadres in",
+        "sendLink": "Magische link verzenden",
+        "sending": "Verzenden...",
+        "checkEmail": "Controleer je e-mail.",
+        "success": "We hebben een magische link naar {email} gestuurd als je een account hebt. Klik op de link in de e-mail om in te loggen.",
+        "error": "Het verzenden van de magische link is mislukt. Probeer het opnieuw.",
+        "backToSignIn": "Terug naar inloggen"
+      },
+      "twoFactor": {
+        "title": "Tweefactorauthenticatie",
+        "description": "Voer de 6-cijferige code van uw authenticatie-app in of gebruik een reservecode."
+      },
+      "troubleSigningIn": "Problemen met inloggen?",
+      "contactAdmin": "Neem contact op met de systeembeheerder."
+    },
+    "errors": {
+      "accessDenied": "Toegang geweigerd. Uw account is mogelijk inactief of u hebt geen toestemming om u aan te melden.",
+      "configuration": "Er is een probleem met de serverconfiguratie.",
+      "verification": "Het verificatietoken is verlopen of al gebruikt.",
+      "invalid2FACode": "Ongeldige verificatiecode. Probeer het opnieuw.",
+      "twoFactorTokenRequired": "Token vereist",
+      "verificationCodeRequired": "Een verificatiecode is vereist."
+    },
+    "signup": {
+      "description": "Vul uw gegevens in om een nieuw account aan te maken.",
+      "signIn": "Meld u aan bij uw bestaande account.",
+      "registrationDisabled": "Neem contact op met een beheerder om een account aan te maken.",
+      "errors": {
+        "emailRequired": "E-mailadres is vereist",
+        "passwordRequired": "Het wachtwoord voldoet niet aan de beveiligingsvereisten.",
+        "confirmPasswordRequired": "Bevestiging van het wachtwoord is vereist.",
+        "passwordsDoNotMatch": "Wachtwoorden komen niet overeen",
+        "domainRestricted": "Registratie is alleen mogelijk voor goedgekeurde e-maildomeinen. Neem contact op met uw beheerder als u denkt dat dit een fout is."
+      }
+    },
+    "verifyEmail": {
+      "title": "E-mailadres verifiëren",
+      "loading": "E-mailadres verifiëren...",
+      "success": "E-mail succesvol geverifieerd",
+      "error": "E-mailadres kan niet worden geverifieerd",
+      "expired": "Verificatielink is verlopen",
+      "invalid": "Ongeldige verificatielink",
+      "alreadyVerified": "E-mail al geverifieerd",
+      "toast": {
+        "verifySuccess": {
+          "description": "U kunt nu inloggen op uw account."
+        },
+        "verifyError": {
+          "description": "Er is een fout opgetreden bij het verifiëren van het e-mailadres"
+        },
+        "resendSuccess": {
+          "title": "E-mailverificatielink verzonden",
+          "description": "Controleer uw e-mail voor de verificatielink."
+        },
+        "resendError": {
+          "title": "Het is niet gelukt om de e-mailverificatielink te verzenden",
+          "description": "Er is een fout opgetreden bij het versturen van de e-mailverificatielink."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Tweefactorauthenticatie instellen",
+      "description": "Uw organisatie vereist tweefactorauthenticatie. Stel dit in om verder te gaan.",
+      "backupDescription": "Sla je back-upcodes op voordat je verdergaat.",
+      "required": "Tweefactorauthenticatie is vereist volgens het beveiligingsbeleid van uw organisatie.",
+      "loading": "Voorbereiding van de installatie...",
+      "manualEntry": "Of voer deze code handmatig in:",
+      "verifyLabel": "Verificatiecode",
+      "verify": "Verifiëren en inschakelen",
+      "backupCodesInfo": "Bewaar deze codes op een veilige plek. Je kunt ze gebruiken om toegang tot je account te krijgen als je je authenticatieapparaat kwijtraakt.",
+      "copyCodes": "Kopieer alle codes",
+      "continue": "Doorgaan met inloggen"
+    },
+    "twoFactorVerify": {
+      "title": "Verifieer uw identiteit",
+      "description": "Voer de 6-cijferige code van uw authenticatie-app in om verder te gaan.",
+      "backupCodeLabel": "Back-upcode",
+      "backupCodeHint": "U kunt ook een back-upcode van 8 tekens invoeren.",
+      "useAuthenticator": "Gebruik in plaats daarvan de authenticatiecode.",
+      "useBackupCode": "Gebruik in plaats daarvan een back-upcode.",
+      "signOut": "Meld u af en gebruik een ander account."
+    },
+    "forceChangePassword": {
+      "title": "Wijzig je wachtwoord",
+      "adminDescription": "Je beheerder vraagt je om je wachtwoord te wijzigen.",
+      "expiredDescription": "Je wachtwoord is verlopen. Stel een nieuw wachtwoord in om verder te gaan.",
+      "newPasswordLabel": "Nieuw wachtwoord",
+      "confirmPasswordLabel": "Nieuw wachtwoord bevestigen",
+      "submitButton": "Wachtwoord wijzigen",
+      "signOut": "Meld je in plaats daarvan af.",
+      "passwordsMustMatch": "De wachtwoorden komen niet overeen.",
+      "passwordRequired": "Een wachtwoord is vereist.",
+      "genericError": "Er is een fout opgetreden. Probeer het opnieuw.",
+      "policyTitle": "Wachtwoordvereisten:",
+      "policyMinLength": "Ten minste {count} tekens",
+      "policyUppercase": "Ten minste één hoofdletter",
+      "policyLowercase": "Ten minste één kleine letter",
+      "policyNumbers": "Ten minste één getal",
+      "policySpecialChars": "Ten minste één speciaal teken ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "SSO-account koppelen",
+      "description": "Koppel uw account aan een Single Sign-On-provider",
+      "availableProviders": "Beschikbare SSO-providers",
+      "linkWithGoogle": "Link met Google",
+      "linkWithSaml": "Link met {name}",
+      "accountLinked": "Account succesvol gekoppeld",
+      "linkingFailed": "Account koppelen mislukt",
+      "noProvidersAvailable": "Er zijn momenteel geen SSO-providers beschikbaar voor koppeling",
+      "linkingInfo": "Door een SSO-provider te koppelen, kunt u inloggen met die provider in plaats van met uw wachtwoord. Uw bestaande accountgegevens blijven ongewijzigd.",
+      "signInWithGoogle": "Aanmelden met Google",
+      "enterpriseSamlSso": "Enterprise SAML SSO",
+      "linkProvider": "Linkprovider",
+      "linking": "Koppelen...",
+      "noProvidersContactAdmin": "Er zijn momenteel geen SSO-providers beschikbaar. Neem contact op met uw beheerder."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Dashboard",
+      "admin": "Administratie",
+      "profile": "Profiel"
+    },
+    "admin": {
+      "crossProjectReports": "Projectoverstijgende rapporten"
+    },
+    "projects": {
+      "sections": {
+        "management": "Beheer"
+      },
+      "menu": {
+        "repository": "Opslagplaats",
+        "runs": "Testruns en resultaten"
+      },
+      "dropdown": {
+        "selectProject": "Selecteer een project",
+        "selectProjectAriaLabel": "Selecteer project {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "Project-ID: {id}",
+      "active": "Project is actief",
+      "completed": "Project is voltooid"
+    },
+    "overview": {
+      "title": "Overzicht",
+      "currentMilestones": "Huidige mijlpalen",
+      "seeAllMilestones": "{count, plural, =1 {Zie # Mijlpaal} other {Zie alle # Mijlpalen}}",
+      "seeAllTestCases": "{count, plural, =1 {Zie # Test Case} other {Zie alle # Test Cases}}",
+      "latestTestCases": "Laatste testgevallen",
+      "createdOn": "Gemaakt op",
+      "seeAllTags": "Bekijk alle tags",
+      "seeAllActiveSessions": "{count, plural, =1 {Zie # Actieve sessie} other {Zie alle # Actieve sessies}}",
+      "latestSessions": "Laatste sessies",
+      "activeTestRuns": "Actieve testruns",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Zie # Actieve testrun} other {Zie alle # Actieve testruns}}",
+      "latestTestRuns": "Laatste testruns",
+      "testCaseBreakdown": "Testcase-analyse",
+      "noTestCases": "De projectrepository is leeg. Voeg testcases toe met behulp van de repository.",
+      "noTestCasesPrefix": "De projectrepository is leeg. Voeg testgevallen toe met behulp van de",
+      "noTestCasesLink": "Opslagplaats"
+    },
+    "icon": {
+      "upload": {
+        "title": "Projectpictogram uploaden",
+        "description": "Upload een vierkante afbeelding (beeldverhouding 1:1) tot 4 MB.",
+        "errors": {
+          "invalidFileType": "Alleen afbeeldingen zijn toegestaan.",
+          "fileTooLarge": "Het bestand is te groot. De maximale grootte is {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Beheer instellingen voor {projectName}",
+      "moreSettingsComingSoon": "Binnenkort meer instellingen",
+      "moreSettingsDescription": "In toekomstige updates zullen hier aanvullende projectconfiguratieopties beschikbaar zijn",
+      "integrations": {
+        "description": "Beheer integraties van problemen van derden voor dit project",
+        "availableIntegrations": "Beschikbare probleemintegraties",
+        "availableDescription": "Selecteer een probleemintegratie om verbinding te maken met dit project",
+        "configuredIntegration": "Geconfigureerde integratie",
+        "noIntegrationAssigned": "Geen probleemintegratie toegewezen",
+        "noIntegrationDescription": "Selecteer een probleemintegratie uit de beschikbare opties om aan de slag te gaan",
+        "selectIntegration": "Selecteer een probleemintegratie om te configureren",
+        "integration": {
+          "assignError": "Het is niet gelukt om de probleemintegratie toe te wijzen",
+          "updateSuccess": "Integratie-instellingen bijgewerkt",
+          "updateError": "Het is niet gelukt om de integratie-instellingen voor het probleem bij te werken",
+          "removeError": "Het is niet gelukt om de probleemintegratie te verwijderen",
+          "removeIntegration": "Integratie verwijderen",
+          "confirmRemove": "Bevestig verwijderen",
+          "authDescription": "U moet zich authenticeren met {provider} om deze probleemintegratie te gebruiken",
+          "authenticating": "Authenticatie...",
+          "authSuccess": "Authenticatie succesvol",
+          "selectProject": "Selecteer {provider} Project",
+          "selectProjectPlaceholder": "Kies een project om te linken",
+          "linkedProject": "Gekoppeld project",
+          "loadProjectsError": "Projecten konden niet worden geladen",
+          "settingsSaved": "Integratie-instellingen succesvol opgeslagen",
+          "saveSettingsError": "Het is niet gelukt om de integratie-instellingen voor het probleem op te slaan",
+          "authorizationRequired": "Autorisatie vereist",
+          "authenticationError": "Authenticatie mislukt. Probeer het opnieuw.",
+          "authorizationRequiredDescription": "U moet deze probleemintegratie autoriseren om toegang te krijgen tot externe projecten",
+          "authorizationMessage": "Geef toestemming voor de integratie van het probleem om door te gaan",
+          "authorizeIntegration": "Autoriseren {name}",
+          "integrationSettings": "{name} Instellingen",
+          "integrationSettingsDescription": "Configureer probleemintegratie-instellingen voor dit project",
+          "selectExternalProject": "Selecteer extern project",
+          "refreshProjects": "Projecten vernieuwen",
+          "defaultIssueType": "Standaard probleemtype",
+          "selectDefaultIssueType": "Selecteer standaardprobleemtype",
+          "defaultIssueTypeDescription": "Dit probleemtype wordt vooraf geselecteerd bij het maken van nieuwe problemen",
+          "issueTypePlaceholder": "bijv. Bug, Taak, Verhaal",
+          "defaultComponent": "Standaardcomponent",
+          "componentPlaceholder": "bijv. Frontend, Backend",
+          "automaticSync": "Automatische synchronisatie",
+          "automaticSyncDescription": "Synchroniseer automatisch problemen tussen TestPlanIt en het externe systeem",
+          "simpleUrlDescription": "Deze issue-integratie maakt gebruik van een eenvoudig URL-patroon om te linken naar externe issues. Issues worden geopend in een nieuw tabblad met behulp van het geconfigureerde URL-patroon.",
+          "externalProjectHelp": "Hiermee wordt het standaardproject ingesteld voor het maken van nieuwe issues vanuit TestPlanIt. U kunt nog steeds issues vanuit andere externe projecten koppelen en synchroniseren - elke issue volgt zijn eigen bronproject.",
+          "linkedProjects": "Gekoppelde externe projecten",
+          "linkedProjectsDescription": "Externe projecten die via deze integratie met elkaar verbonden zijn",
+          "noLinkedProjects": "Geen externe projecten gekoppeld",
+          "noLinkedProjectsDescription": "Voeg een extern project toe om het zoeken naar problemen en de synchronisatie ervan mogelijk te maken.",
+          "addProjects": "Projecten toevoegen",
+          "addSelected": "Geselecteerde toevoegen",
+          "setAsDefault": "Instellen als standaard",
+          "removeProject": "Project verwijderen",
+          "removeProjectConfirmation": "Als u dit project verwijdert, worden er geen problemen meer vanuit dit project gesynchroniseerd. Eerder gesynchroniseerde problemen worden niet verwijderd. Doorgaan?",
+          "removeProjectWebhookCascadeBullet": "De inkomende webhook voor dit project wordt ook verwijderd.",
+          "keepProject": "Project behouden",
+          "defaultIndicator": "Standaard",
+          "syncStatusSyncing": "Synchroniseren",
+          "syncStatusCompleted": "Gesynchroniseerd",
+          "syncStatusError": "Synchronisatiefout",
+          "fanOutPartialFailure": "Project(en) {count} konden niet worden bereikt. Resultaten van project(en) {successCount} worden weergegeven.",
+          "projectSelectorLabel": "Project",
+          "defaultIssueTypeHelp": "Bij het aanmaken van nieuwe issues vanuit TestPlanIt wordt dit issuetype automatisch geselecteerd. Dit bespaart tijd als u doorgaans hetzelfde type issues aanmaakt.",
+          "automaticSyncHelp": "Wanneer ingeschakeld, worden problemen automatisch gesynchroniseerd wanneer er wijzigingen in het externe systeem worden gedetecteerd (via webhooks). Handmatige synchronisatie is altijd beschikbaar.",
+          "removeWarningTitle": "Het verwijderen van deze probleemintegratie zal het volgende tot gevolg hebben:",
+          "removeWarning1": "Koppel alle gekoppelde problemen los van deze probleemintegratie (problemen blijven in de database)",
+          "removeWarning2": "Verwijder alle probleemintegratiespecifieke instellingen voor dit project",
+          "removeWarning3": "Herconfiguratie vereist als u deze probleemintegratie opnieuw wilt gebruiken",
+          "removeWarning4": "Verwijder de inkomende webhook die voor deze integratie is geconfigureerd.",
+          "switchIntegration": "Switch-integratie",
+          "switchWarningTitle": "Overstappen naar een ander AI-model zal:",
+          "switchWarning1": "Koppel alle problemen los die momenteel gekoppeld zijn aan de huidige probleemintegratie",
+          "switchWarning2": "Behoud de problemen in de database (ze worden losgekoppeld)",
+          "switchWarning3": "Vervang de huidige probleemintegratieconfiguratie door de nieuwe",
+          "switchWarning4": "Verwijder de inkomende webhook die is geconfigureerd voor de huidige integratie."
+        },
+        "integrationAssigned": "Integratie succesvol toegewezen",
+        "integrationAssignError": "Het is niet gelukt om de probleemintegratie aan het project toe te wijzen",
+        "integrationRemoved": "Integratie succesvol verwijderd",
+        "integrationRemoveError": "Het is niet gelukt om de probleemintegratie uit het project te verwijderen",
+        "add": {
+          "jira": {
+            "description": "Koppel uw Jira-account om problemen rechtstreeks vanuit TestPlanIt te beheren."
+          },
+          "simple_url": {
+            "description": "Maak verbinding met een extern systeem om problemen bij te houden."
+          },
+          "github": {
+            "description": "Maak verbinding met GitHub voor het bijhouden van problemen en het beheren van repositories."
+          },
+          "gitlab": {
+            "description": "Maak verbinding met GitLab om problemen en merge requests te volgen."
+          },
+          "gitea": {
+            "description": "Maak verbinding met een zelfgehoste Gitea-, Forgejo- of Gogs-instantie voor het bijhouden van problemen."
+          },
+          "azure_devops": {
+            "description": "Maak verbinding met Azure DevOps voor het bijhouden van werkitems."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Configureer inkomende webhooks om gekoppelde issues gesynchroniseerd te houden.",
+        "inboundDescription": "Configureer inkomende webhooks om gekoppelde issues gesynchroniseerd te houden.",
+        "outboundDescription": "Configureer uitgaande webhooks om TestPlanIt-gebeurtenissen naar Slack of een andere HMAC-ondertekende URL te verzenden.",
+        "directionInbound": "Inkomend",
+        "directionOutbound": "Uitgaande",
+        "inboundAddButtonAllConfigured": "De inkomende adapter is al geconfigureerd.",
+        "inboundAddButtonNoIntegration": "Wijs een Issue Integration toe aan dit project voordat u een inkomende webhook toevoegt.",
+        "inboundEmptyWithIntegration": "Er zijn geen inkomende webhooks geconfigureerd. <link>Voeg er één toe</link> om updates over issues te ontvangen van de aan u toegewezen Issue Integration.",
+        "inboundEmptyNoIntegration": "Een <link>Issue Integration</link> is vereist om inkomende issue-updates te ontvangen. Wijs er een toe aan uw project om te beginnen.",
+        "deliveriesEmptyNoConfigs": "Er zijn nog geen webhook-leveringen ontvangen. Maak een inkomende of uitgaande webhook aan op de andere tabbladen om ze te gaan ontvangen.",
+        "noConfig": "Geen webhook geconfigureerd",
+        "createButton": "Webhook aanmaken",
+        "url": "Webhook-URL",
+        "urlHelp": "Plak deze URL in de webhookconfiguratie van de issue tracker.",
+        "secret": "Webhook-geheim",
+        "secretHelp": "Plak dit geheim in de webhookconfiguratie van de issue tracker.",
+        "revealedShownOnceWarning": "Kopieer de URL en het geheim hieronder nu — ze worden slechts één keer weergegeven en kunnen later niet meer worden opgevraagd.",
+        "secretMasked": "Verborgen — draai om te bekijken",
+        "rotateSecret": "Geheim draaien",
+        "rotateConfirmTitle": "Webhook-geheim roteren?",
+        "rotateConfirm": "Door het geheime sleutelbestand te roteren, wordt de huidige configuratie aan de kant van de issue tracker ongeldig totdat u deze daar bijwerkt. Doorgaan?",
+        "isActive": "Ingeschakeld",
+        "deleteConfirmTitle": "Webhook-configuratie verwijderen?",
+        "deleteConfirm": "Als u deze webhookconfiguratie wilt verwijderen, worden inkomende leveringen geweigerd.",
+        "sendTest": "Testwebhook verzenden",
+        "testSuccess": "Testwebhook geaccepteerd (HTTP {statusCode}, resultaat: {outcome})",
+        "testFailure": "Test webhook mislukt (HTTP {statusCode}): {error}",
+        "saveError": "Het opslaan van de webhookconfiguratie is mislukt.",
+        "lastReceived": "Laatst ontvangen: {timestamp}",
+        "lastReceivedLabel": "Laatst ontvangen:",
+        "lastReceivedNever": "Nog geen leveringen",
+        "copyUrl": "Webhook-URL kopiëren",
+        "copySecret": "Webhook-geheim kopiëren",
+        "urlCopied": "Webhook-URL gekopieerd naar het klembord.",
+        "secretCopied": "Webhook-geheim naar klembord gekopieerd",
+        "nextSteps": "Plak deze gegevens vervolgens in de webhookconfiguratie van de issue tracker en klik op 'Testwebhook verzenden' hieronder om de pipeline te controleren. Klik op 'Klaar' zodra u het geheim hebt opgeslagen; het kan niet meer worden weergegeven.",
+        "revealDone": "Klaar",
+        "pageTitle": "Webhooks",
+        "inboundTab": "Inkomend",
+        "outboundTab": "Uitgaande",
+        "outboundEmpty": "Er zijn geen uitgaande webhooks geconfigureerd. Voeg er een toe om TestPlanIt-gebeurtenissen naar Slack of een andere HMAC-ondertekende URL te verzenden.",
+        "outboundAddButton": "Voeg een uitgaande webhook toe",
+        "outboundCreateTitle": "Nieuwe uitgaande webhook",
+        "outboundCreateName": "Naam",
+        "outboundCreateNameHelp": "Een label voor deze bestemming, bijvoorbeeld \"Engineering Slack\".",
+        "outboundCreateNamePlaceholder": "Technische speling",
+        "outboundCreateNameRequired": "Naam is verplicht.",
+        "outboundCreateUrlRequired": "Een URL is vereist.",
+        "outboundCreateUrlInvalid": "Voer een geldige URL in (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "De URL moet HTTPS gebruiken.",
+        "outboundNameLabel": "Naam",
+        "outboundUnnamedConfig": "(naamloze webhook)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "De bestemmings-URL. Slack-webhook-URL's voor inkomende berichten worden automatisch gedetecteerd.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Gedetecteerd: Slack",
+        "outboundDetectedHmac": "Gedetecteerd: Generieke HMAC",
+        "adapterLabelSlack": "Slack",
+        "adapterLabelGenericHmac": "Generieke HMAC-webhook",
+        "outboundCreateSubscriptionsTitle": "Abonnementen",
+        "outboundCreateSubscriptionsHelp": "Kies welke gebeurtenissen naar deze bestemming worden verzonden. Je kunt dit later wijzigen.",
+        "outboundSubsTestRunsAndSessions": "Testruns en -sessies",
+        "outboundSubsTestRuns": "Testruns",
+        "outboundSubsSessions": "Sessies",
+        "eventVerbs": {
+          "duplicated": "Gedupliceerd",
+          "stateChanged": "Staat gewijzigd",
+          "resultAdded": "Resultaat toegevoegd"
+        },
+        "events": {
+          "testRunCreated": "Testrun aangemaakt",
+          "testRunStateChanged": "Testuitvoeringsstatus gewijzigd",
+          "testRunCompleted": "Testrun voltooid",
+          "testRunDuplicated": "Testrun gedupliceerd",
+          "testRunResultAdded": "Testresultaat toegevoegd",
+          "sessionCreated": "Sessie aangemaakt",
+          "sessionStateChanged": "Sessiestatus gewijzigd",
+          "sessionCompleted": "Sessie voltooid",
+          "sessionDuplicated": "Sessie gedupliceerd",
+          "sessionResultAdded": "Sessieresultaat toegevoegd",
+          "issueCreated": "Probleem aangemaakt",
+          "issueUpdated": "Probleem bijgewerkt",
+          "issueDeleted": "Probleem verwijderd",
+          "caseCreated": "Zaak aangemaakt",
+          "caseUpdated": "Zaak bijgewerkt",
+          "caseDeleted": "Zaak verwijderd",
+          "jiraIssueCreated": "Jira-ticket aangemaakt",
+          "jiraIssueUpdated": "Jira-ticket bijgewerkt",
+          "jiraIssueDeleted": "Jira-ticket verwijderd",
+          "githubIssues": "GitHub issues-evenement",
+          "githubPullRequest": "GitHub pull request",
+          "githubPush": "GitHub push",
+          "githubIssueComment": "GitHub-probleemreactie",
+          "adoWorkitemCreated": "Azure DevOps-werkitem aangemaakt",
+          "adoWorkitemUpdated": "Azure DevOps-werkitem bijgewerkt",
+          "adoWorkitemDeleted": "Azure DevOps-werkitem verwijderd",
+          "webhookTest": "Testevenement"
+        },
+        "outboundSubsIssues": "Problemen",
+        "outboundSubsCases": "gevallen",
+        "outboundSubsSelectAll": "Selecteer alles in deze sectie",
+        "outboundCreateSubmit": "Webhook aanmaken",
+        "outboundCreateCancel": "Annuleren",
+        "outboundCreateSuccess": "Uitgaande webhook aangemaakt.",
+        "outboundCreateError": "Het aanmaken van een uitgaande webhook is mislukt.",
+        "outboundUrlLabel": "Bestemmings-URL",
+        "outboundActiveToggle": "Actief",
+        "outboundSlackHint": "Deze URL is gevoelig — iedereen die hem heeft, kan berichten op je kanaal plaatsen.",
+        "outboundHmacSecretsTitle": "Geheimhouding",
+        "outboundHmacActiveSecret": "Actief",
+        "outboundHmacInactiveSecret": "Inactief",
+        "outboundHmacRetiringSecret": "Met pensioen gaan",
+        "outboundHmacAutoRetireIn": "Gaat automatisch met pensioen over {days} dagen",
+        "outboundHmacRotateButton": "Geheim draaien",
+        "outboundHmacExtendButton": "Verleng met 7 dagen",
+        "outboundHmacRetireNowButton": "Ga nu met pensioen.",
+        "outboundRotateConfirmTitle": "Het ondertekeningsgeheim roteren?",
+        "outboundRotateConfirm": "Er wordt een nieuw actief geheim gegenereerd. Het vorige geheim blijft nog 7 dagen geldig terwijl gebruikers hun software bijwerken.",
+        "outboundRotateSuccess": "Geheim geroteerd. De nieuwe platte tekst wordt hieronder eenmaal weergegeven.",
+        "outboundRotateError": "Het roteren van het geheim is mislukt.",
+        "outboundRetireConfirmTitle": "Stop nu met je geheim te bewaren?",
+        "outboundRetireConfirm": "Het oude geheime wachtwoord wordt niet meer geaccepteerd. Consumenten die nog steeds gebruikmaken van het oude geheime wachtwoord zullen nieuwe datapakketten weigeren.",
+        "outboundRetireSuccess": "Geheim is met pensioen gegaan.",
+        "outboundRetireError": "Het is niet gelukt om het geheim met pensioen te sturen.",
+        "outboundExtendSuccess": "De automatische pensioenregeling is met 7 dagen verlengd.",
+        "outboundExtendError": "Het is niet gelukt om het geheim te verlengen.",
+        "outboundSendTestButton": "Testgebeurtenis verzenden",
+        "outboundSendTestQueued": "Testgebeurtenis in wachtrij geplaatst — controleer uw bestemming op het bericht.",
+        "outboundSendTestError": "Het lukte niet om het testevenement in de wachtrij te plaatsen.",
+        "outboundDeleteButton": "Webhook verwijderen",
+        "outboundDeleteConfirmTitle": "Uitgaande webhook verwijderen?",
+        "outboundDeleteConfirm": "Alle toekomstige evenementen naar deze bestemming worden onmiddellijk stopgezet.",
+        "outboundDeleteSuccess": "Webhook verwijderd.",
+        "outboundDeleteError": "Het verwijderen van de webhook is mislukt.",
+        "outboundSecretCopy": "Kopieer geheim",
+        "outboundSecretShownOnce": "Bewaar dit geheim nu goed, het mag niet meer worden onthuld.",
+        "outboundSecretDone": "Klaar",
+        "inboundAddButton": "Inkomende webhook toevoegen",
+        "inboundChooserTitle": "Kies adapter",
+        "inboundChooserDescription": "Kies de issue-tracker die webhooks naar TestPlanIt zal verzenden. Elk project kan één Jira-, één GitHub- en één Azure DevOps-webhook hebben.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Reeds geconfigureerd",
+        "inboundChooserSubmit": "Doorgaan",
+        "inboundChooserCancel": "Annuleren",
+        "inboundEmpty": "Er zijn geen inkomende webhooks geconfigureerd. Voeg er een toe om updates over issues te ontvangen van Jira, GitHub, GitLab, Gitea of Azure DevOps.",
+        "inboundJiraTitle": "Jira inkomende webhook",
+        "inboundGithubTitle": "GitHub inkomende webhook",
+        "inboundGithubScopeHint": "GitHub-issues <code></code> gebeurtenissen werken gekoppelde TestPlanIt-issues bij. Pull-request- en issue-commentaar-gebeurtenissen worden geaccepteerd, maar werken de issues nog niet bij.",
+        "inboundGitlabTitle": "GitLab inkomende webhook",
+        "inboundGitlabScopeHint": "GitLab <code>Issue Hook</code> gebeurtenissen werken gekoppelde TestPlanIt-issues bij. Andere gebeurtenistypen worden geaccepteerd, maar werken geen issues bij.",
+        "inboundGiteaTitle": "Gitea inkomende webhook",
+        "inboundGiteaScopeHint": "Gitea-problemen <code>en gebeurtenissen</code> werken gekoppelde TestPlanIt-problemen bij. Andere gebeurtenistypen worden geaccepteerd, maar werken geen problemen bij.",
+        "inboundAdoTitle": "Azure DevOps inkomende webhook",
+        "inboundAdoScopeHint": "Azure DevOps <code>workitem.updated</code> gebeurtenissen werken gekoppelde TestPlanIt-problemen bij. Andere gebeurtenissen worden geaccepteerd, maar werken de problemen niet bij.",
+        "inboundAdoUsername": "Gebruikersnaam",
+        "inboundAdoPassword": "Wachtwoord",
+        "inboundAdoUsernamePlaceholder": "serviceaccount",
+        "inboundAdoUsernameHelp": "Geconfigureerd aan de kant van de Azure DevOps Service Hook. TestPlanIt verifieert dit via HTTP Basic Auth.",
+        "inboundAdoPasswordHelp": "Wordt versleuteld opgeslagen. Sla deze waarde ook op aan de kant van de Azure DevOps Service Hook.",
+        "inboundAdoResourceDetailsHint": "Bij het configureren van de Azure DevOps Service Hook moet u 'Resource details to send' instellen op 'All', zodat System.State in de payload wordt opgenomen.",
+        "setupStepsTitle": "Installatiestappen",
+        "setupStepsJiraStep1": "Ga in Jira naar Instellingen → Systeem → WebHooks (of de configuratiepagina voor webhooks van je Jira-beheerder).",
+        "setupStepsJiraStep2": "Klik op \"Een webhook maken\". Plak de onderstaande URL in het URL-veld en het geheim in het geheim-veld.",
+        "setupStepsJiraStep3": "Schakel onder 'Probleemgerelateerde gebeurtenissen' het vakje 'bijgewerkt' in, zodat wijzigingen in de probleemstatus worden verzonden.",
+        "setupStepsJiraStep4": "Sla de webhook op. Gebruik \"Verzend testwebhook\" hieronder om de pipeline te controleren.",
+        "setupStepsGithubStep1": "Ga in je GitHub-repository naar Instellingen → Webhooks → Webhook toevoegen.",
+        "setupStepsGithubStep2": "Plak de onderstaande URL in het veld 'Payload URL'. Stel het inhoudstype in op application/json.",
+        "setupStepsGithubStep3": "Plak het onderstaande geheim in het veld 'Geheim'.",
+        "setupStepsGithubStep4": "Kies 'Laat me individuele gebeurtenissen selecteren' en vink 'Problemen' aan.",
+        "setupStepsGithubStep5": "Klik op \"Webhook toevoegen\". Gebruik \"Testwebhook verzenden\" hieronder om de pipeline te controleren.",
+        "setupStepsAdoStep1": "Ga in je Azure DevOps-project naar Projectinstellingen → Servicehooks → Abonnement maken.",
+        "setupStepsAdoStep2": "Kies 'Web Hooks' als service. Stel de trigger in op 'Werkitem bijgewerkt'.",
+        "setupStepsAdoStep3": "Stel de te verzenden resourcegegevens in op 'Alles', zodat System.State wordt meegenomen.",
+        "setupStepsAdoStep4": "Plak de onderstaande URL in het URL-veld. Stel de gebruikersnaam en het wachtwoord voor basisverificatie in op de waarden die u hierboven hebt ingevoerd.",
+        "setupStepsAdoStep5": "Sla het abonnement op. Gebruik 'Testwebhook verzenden' hieronder om de pipeline te controleren.",
+        "setupStepsGitlabStep1": "Ga in GitLab naar je project → Instellingen → Webhooks.",
+        "setupStepsGitlabStep2": "Plak de onderstaande URL in het URL-veld. Plak het onderstaande geheim in het veld 'Geheim token'.",
+        "setupStepsGitlabStep3": "Schakel onder Trigger het vakje 'Probleemgebeurtenissen' in.",
+        "setupStepsGitlabStep4": "Klik op \"Webhook toevoegen\". Gebruik \"Testwebhook verzenden\" hieronder om de pipeline te controleren.",
+        "setupStepsGiteaStep1": "Ga in Gitea naar je repository → Instellingen → Webhooks.",
+        "setupStepsGiteaStep2": "Klik op \"Webhook toevoegen\" en kies \"Gitea\".",
+        "setupStepsGiteaStep3": "Plak de onderstaande URL in het veld 'Doel-URL'. Plak het onderstaande geheim in het veld 'Geheim'.",
+        "setupStepsGiteaStep4": "Selecteer onder \"Activeren op\" de optie \"Problemen\".",
+        "setupStepsGiteaStep5": "Klik op \"Webhook toevoegen\". Gebruik \"Testwebhook verzenden\" hieronder om de pipeline te controleren.",
+        "deliveriesTab": "Leveringen",
+        "filterConfigPlaceholder": "Alle webhooks",
+        "filterStatusAll": "Alle",
+        "filterStatusFailed": "Mislukt",
+        "filterStatusSuccess": "Succes",
+        "filterSinceDefault": "Sinds…",
+        "filterUntilDefault": "Totdat…",
+        "filterReset": "Filters resetten",
+        "filterBulkReplayButton": "Massale herhaling {count} uitgaande fouten",
+        "filterBulkReplayHidden": "Alle zichtbare fouten zijn inkomend — activeer in plaats daarvan de upstream-gebeurtenis opnieuw.",
+        "deliveriesEmpty": "Geen leveringen voldoen aan deze filters.",
+        "deliveriesResetFilters": "Filters resetten",
+        "deliveriesLoadMore": "Meer laden",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Evenement",
+        "tableHeaderStatus": "Status",
+        "tableHeaderError": "Fout",
+        "tableHeaderReceivedAt": "Ontvangen",
+        "tableHeaderAttempt": "Poging",
+        "tableHeaderDirection": "Richting",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Bekijk details",
+        "drawerTitle": "Leveringsdetails",
+        "drawerLabelEvent": "Evenement",
+        "drawerLabelDirection": "Richting",
+        "drawerLabelStatusCode": "Statuscode",
+        "drawerLabelLatency": "Latentie",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Fout",
+        "drawerLabelPayloadDigest": "Payload samenvatting",
+        "drawerLabelEventId": "Gebeurtenis-ID",
+        "drawerLabelAttempt": "Poging",
+        "drawerLabelReceivedAt": "Ontvangen te",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Herhaling van {id}",
+        "drawerReplayButton": "Speel deze levering opnieuw af.",
+        "drawerInboundReplayNotSupported": "Inkomende leveringen kunnen niet opnieuw worden afgespeeld; activeer in plaats daarvan de upstream-gebeurtenis opnieuw.",
+        "replayConfirmTitle": "Deze levering opnieuw afspelen?",
+        "replayConfirm": "Dit zal een echt {direction} {adapterType} verzoek versturen.",
+        "replayAction": "Opnieuw afspelen",
+        "bulkReplayConfirmTitle": "Fouten bij het opnieuw afspelen van uitgaande verbindingen?",
+        "bulkReplayConfirm": "Herhaal de mislukte uitgaande verzoeken {count} naar {configName}? Dit zal {count} echte HTTP-verzoeken genereren.",
+        "bulkReplayCapExceeded": "Het afspelen van bulkverzoeken is beperkt tot 100 uitgaande verzoeken tegelijk. Verfijn het filter of voer de verzoeken sequentieel uit. Momenteel wordt {count} afgespeeld.",
+        "bulkReplayAction": "Opnieuw afspelen {count}",
+        "healthBadge": {
+          "HEALTHY": "Gezond",
+          "DEGRADED": "Gedegradeerd",
+          "DISABLED": "Gehandicapt"
+        },
+        "healthTooltipHealthy": "Laatste succes: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} opeenvolgende mislukkingen · laatste bij {lastFailureAt}",
+        "healthTooltipDisabled": "Uitgeschakeld na 10 opeenvolgende mislukkingen · {lastFailureAt}",
+        "activityLabel": "Leveringsactiviteit",
+        "activityLastDispatched": "Laatst verzonden",
+        "activityLastSuccess": "Laatste succes",
+        "activityLastFailure": "Laatste mislukking",
+        "activityNever": "Nooit",
+        "reEnable": "Opnieuw inschakelen",
+        "reEnableConfirmTitle": "Deze webhook opnieuw inschakelen?",
+        "reEnableConfirm": "Controleer of het probleem aan de bovenliggende server is opgelost voordat u de webhook opnieuw inschakelt. De webhook zal dan direct weer berichten verzenden.",
+        "toastReplaySuccess": "Afspelen in de wachtrij",
+        "toastReplayFailed": "Opnieuw afspelen mislukt: {error}",
+        "toastReplayInboundNotSupported": "Inkomende leveringen kunnen niet opnieuw worden afgespeeld.",
+        "toastBulkReplaySuccess": "Bulk replay gestart · batch {batchId}",
+        "toastBulkReplayFailed": "Bulk replay mislukt: {error}",
+        "toastReEnableSuccess": "Webhook opnieuw ingeschakeld",
+        "toastReEnableFailed": "Het opnieuw inschakelen is mislukt: {error}"
+      },
+      "aiModels": {
+        "description": "Configureer AI-modellen voor het genereren en analyseren van intelligente testcases",
+        "availableModels": "Projectstandaard",
+        "availableModelsDescription": "Kies voor dit project een standaard AI-model uit de modellen die door uw systeembeheerder zijn geconfigureerd.",
+        "currentModelSettings": "Huidige modelinstellingen",
+        "currentModelDescription": "Configuratiegegevens voor het momenteel actieve AI-model: {name}",
+        "noModelsAvailable": "Er zijn momenteel geen AI-modellen beschikbaar. Neem contact op met uw systeembeheerder om AI-modellen voor uw organisatie te configureren.",
+        "monthlyBudget": "Maandelijks budget",
+        "model": "Model",
+        "budget": "Begroting",
+        "streamingTooltip": "Realtime responsstreaming ingeschakeld",
+        "systemDefault": "Systeemstandaard",
+        "setAsDefault": "Instellen als standaard",
+        "clearDefault": "Standaardwaarde wissen",
+        "useForProject": "Gebruik voor project",
+        "removeModel": "Standaardwaarde wissen",
+        "removeWarningTitle": "Door het standaard AI-model te wissen, wordt het volgende bereikt:",
+        "removeWarning1": "Schakel AI-gestuurde functies uit, tenzij er per functie uitzonderingen zijn geconfigureerd.",
+        "removeWarning2": "Verwijder het fallback-model dat wordt gebruikt voor het genereren en analyseren van testgevallen.",
+        "switchModel": "Standaardwaarde wijzigen",
+        "switchWarningTitle": "Het wijzigen van het standaard AI-model zal het volgende teweegbrengen:",
+        "switchWarning1": "Wijzig hoe AI-functies zich in dit project gedragen",
+        "switchWarning2": "Kan de kwaliteit en stijl van gegenereerde content beïnvloeden",
+        "modelAssigned": "Standaard AI-modelset voor dit project",
+        "modelAssignError": "Het instellen van het standaard AI-model is mislukt.",
+        "modelRemoved": "Standaard AI-model gewist",
+        "modelRemoveError": "Het standaard AI-model kon niet worden gewist.",
+        "confirmRemove": "Weet je zeker dat je \"{name}\" als standaardwaarde voor dit project wilt wissen?",
+        "confirmSwitch": "Weet je zeker dat je de standaardwaarde wilt wijzigen van \"{from}\" naar \"{to}\"?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/maand"
+        },
+        "promptConfig": "Promptconfiguratie",
+        "promptConfigDescription": "Selecteer welke AI-promptconfiguratie u voor dit project wilt gebruiken.",
+        "useSystemDefault": "Gebruik de systeemstandaard",
+        "promptConfigChanged": "De promptconfiguratie is succesvol bijgewerkt.",
+        "featureOverrides": {
+          "title": "LLM-overrides per functie",
+          "description": "De standaard LLM-integratie overschrijven voor specifieke AI-functies. Overschrijvingen hebben de hoogste prioriteit in de afhandelingsketen.",
+          "feature": "Functie",
+          "override": "Overschrijven",
+          "effectiveLlm": "Effectief LLM-programma",
+          "source": "Bron",
+          "noOverride": "Geen overschrijving mogelijk",
+          "noLlm": "Geen LLM (uitgeschakeld)",
+          "disabledOverride": "Uitgeschakeld (Overschrijven)",
+          "projectOverride": "Projectoverride",
+          "promptConfig": "Promptconfiguratie",
+          "noLlmConfigured": "Geen LLM geconfigureerd",
+          "selectIntegration": "Selecteer integratie...",
+          "overrideSaved": "Functie-override opgeslagen",
+          "overrideCleared": "Functie-override gewist",
+          "overrideError": "Het opslaan van de functie-override is mislukt."
+        }
+      },
+      "shares": {
+        "title": "Aandelen beheren",
+        "description": "Bekijk en beheer alle deelbare links voor dit project."
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Schakel QuickScript in en verbind een codeopslagplaats voor het genereren van tests met behulp van AI.",
+        "enableLabel": "QuickScript inschakelen",
+        "enableDescription": " Geef teamleden in dit project de mogelijkheid om QuickScript te gebruiken om testcases om te zetten in automatiseringsscripts.",
+        "enabledToast": "QuickScript ingeschakeld",
+        "disabledToast": "QuickScript uitgeschakeld",
+        "noRepos": {
+          "title": "Er zijn geen code repositories geconfigureerd.",
+          "adminDescription": "Stel een repositoryverbinding in voordat u de codecontext voor dit project configureert.",
+          "adminLink": "Ga naar Code Repositories",
+          "userDescription": "Neem contact op met uw systeembeheerder om een verbinding met de codeopslagplaats in te stellen."
+        },
+        "repository": {
+          "title": "Codeopslagplaats",
+          "description": "Selecteer de codeopslagplaats die u wilt gebruiken voor de AI-context.",
+          "placeholder": "Selecteer een codeopslagplaats...",
+          "branchLabel": "Tak",
+          "branchPlaceholder": "Laat dit veld leeg om de standaardbranch van de repository te gebruiken."
+        },
+        "pathPatterns": {
+          "title": "Padpatronen",
+          "description": "Geef aan welke bestanden moeten worden opgenomen. Elke regel combineert een basispad met een glob-patroon. Voorbeelden: path=tests/e2e/pages + pattern=* bevat alle bestanden direct in die map; path=src + pattern=**/*.test.ts bevat alle testbestanden recursief.",
+          "pathLabel": "Pad",
+          "pathPlaceholder": "tests/e2e/pagina's",
+          "patternLabel": "Patroon",
+          "addPath": "Pad toevoegen",
+          "previewFiles": "Voorbeeldbestanden",
+          "scanningRepo": "Bestanden in de repository scannen… ({seconds}s)",
+          "files": "{count, plural, one {# bestand} other {# bestanden}}",
+          "truncatedBadge": "De resultaten kunnen onvolledig zijn (beperkingen van de aanbieder).",
+          "exceedsLimit": "De totale grootte overschrijdt de AI-contextlimiet met {overflow}. Tijdens het exporteren worden bestanden gerangschikt op relevantie voor de te exporteren testcase. De meest relevante bestanden worden als eerste opgenomen en minder relevante bestanden worden overgeslagen wanneer het budget is bereikt. Verfijn uw padpatronen als u meer controle wilt over welke bestanden worden opgenomen."
+        },
+        "preview": {
+          "resolvingBranch": "Oplossende tak…",
+          "scanningFiles": "Bestanden scannen in {scope}…",
+          "scanningFilesCount": "Bestanden scannen in {scope}… ({count} gevonden)",
+          "filtering": "Filters toepassen op {count} bestanden…"
+        },
+        "cache": {
+          "title": "Cache-instellingen",
+          "description": "Bestanden worden in Valkey in de cache opgeslagen voor snelle toegang tijdens het genereren van AI.",
+          "enableLabel": "Bestandscaching inschakelen",
+          "disabledWarning": "Bestandscaching is uitgeschakeld. Repositorybestanden worden direct bij uw provider opgehaald tijdens het exporteren en worden niet opgeslagen in TestPlanIt. AI-gestuurde QuickScript zal nog steeds codecontext bevatten, maar elke export zal een live verzoek naar uw repository sturen.",
+          "ttlLabel": "Cacheduur (dagen)",
+          "statusTitle": "Cachestatus",
+          "refreshButton": "Cache vernieuwen",
+          "listingFiles": "Lijst met bestanden…",
+          "cachingFiles": "{count} bestanden in de cache opslaan…",
+          "statusNeverFetched": "Nooit opgehaald",
+          "statusPending": "Verfrissend...",
+          "lastFetched": "Laatst opgehaald",
+          "filesCached": "Bestanden in cache opgeslagen",
+          "totalSize": "Totale grootte"
+        },
+        "save": "Configuratie opslaan",
+        "saved": "Codecontextconfiguratie opgeslagen",
+        "saveError": "Configuratie opslaan mislukt",
+        "listError": "Het is niet gelukt om de bestanden in de repository weer te geven.",
+        "contentsError": "Het is niet gelukt om de inhoud van het bestand in de cache op te slaan.",
+        "networkError": "Netwerkfout tijdens het vernieuwen van de cache.",
+        "refreshSuccess": "Cache vernieuwd: {fileCount} bestanden ({contentCached} inhoud in cache opgeslagen)",
+        "refreshRateLimited": "Cache vernieuwd: {fileCount} bestanden weergegeven, {contentCached}/{fileCount} inhoud in cache opgeslagen (snelheid beperkt — vernieuw opnieuw om te voltooien)",
+        "validation": {
+          "pathRequired": "Pad is vereist",
+          "patternRequired": "Een patroon is vereist.",
+          "repositoryRequired": "Een repository is vereist.",
+          "pathPatternRequired": "Er is ten minste één padpatroon vereist."
+        },
+        "exportTemplates": {
+          "title": "Export sjablonen",
+          "description": "Wijs exporttemplates toe aan dit project. Alleen toegewezen templates worden weergegeven in het exportdialoogvenster.",
+          "noTemplates": "Er zijn geen exporttemplates ingeschakeld. Neem contact op met uw systeembeheerder.",
+          "assignedLabel": "Toegewezen sjablonen",
+          "selectPlaceholder": "Selecteer sjablonen om toe te wijzen...",
+          "defaultLabel": "Standaardsjabloon",
+          "defaultPlaceholder": "Geen (gebruik de globale standaardinstelling)",
+          "assigned": "Toegewezen",
+          "save": "Sjabloonopdrachten opslaan",
+          "saved": "Sjabloonopdrachten opgeslagen",
+          "saveError": "Het opslaan van sjabloontoewijzingen is mislukt."
+        },
+        "disconnect": "Ontkoppel de opslagplaats",
+        "confirmDisconnect": "Weet je zeker dat je \"{name}\" van dit project wilt loskoppelen?",
+        "disconnectWarningTitle": "Als u de verbinding met deze repository verbreekt, zal het volgende gebeuren:",
+        "disconnectWarning1": "Verwijder alle in de cache opgeslagen repositorybestanden.",
+        "disconnectWarning2": "Verwijder padpatroon- en vertakkingsconfiguraties",
+        "disconnectWarning3": "Stop met het opnemen van codecontext in door AI gegenereerde exports.",
+        "disconnectSuccess": "Codeopslagplaats is losgekoppeld",
+        "disconnectError": "Het is niet gelukt om de verbinding met de codeopslagplaats te verbreken."
+      }
+    }
+  },
+  "milestones": {
+    "title": "Mijlpaaldetails",
+    "fields": {
+      "parent": "Ouderlijke mijlpaal",
+      "dueDate": "Deadline",
+      "automaticCompletion": "Automatisch aanvullen op de vervaldatum",
+      "notifyDaysBefore": "Breng het enkele dagen voor de vervaldatum in kennis.",
+      "notifyDaysBeforeValue": "Melden {count, plural, one {# dag} other {# dagen}} vóór de vervaldatum",
+      "dueDateNotifications": "Meldingen over de vervaldatum"
+    },
+    "labels": {
+      "childMilestones": "Mijlpalen voor kinderen"
+    },
+    "placeholders": {
+      "description": "Voer een beschrijving van de mijlpaal in...",
+      "documentation": "Voer mijlpaaldocumentatie in...",
+      "selectType": "Selecteer mijlpaaltype...",
+      "selectParent": "Selecteer bovenliggende mijlpaal..."
+    },
+    "empty": {
+      "active": "Geen actieve mijlpalen",
+      "completed": "Geen voltooide mijlpalen",
+      "description": "Geen beschrijving verstrekt",
+      "documentation": "Geen documentatie verstrekt",
+      "testRuns": "Geen testritten",
+      "forecasts": "Geen prognosegegevens beschikbaar"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Niet gestart",
+      "IN_PROGRESS": "In uitvoering",
+      "STOPPED": "Gestopt",
+      "BLOCKED": "Geblokkeerd",
+      "CANCELLED": "Geannuleerd",
+      "unscheduled": "Ongepland",
+      "upcoming": "Aankomende",
+      "delayed": "Vertraagd",
+      "pastDue": "Te laat",
+      "started": "Gestart",
+      "completed": "Voltooid"
+    },
+    "status": {
+      "stop": "Stop",
+      "reopen": "Heropenen"
+    },
+    "dates": {
+      "pickStartDate": "Kies startdatum",
+      "pickCompletionDate": "Kies voltooiingsdatum",
+      "selectDate": "Selecteer datum...",
+      "completionWarning": "Waarschuwing: Hiermee wordt de mijlpaal als voltooid gemarkeerd"
+    },
+    "toast": {
+      "deleted": "Mijlpaal {name} verwijderd",
+      "updated": "Mijlpaal bijgewerkt",
+      "updateFailed": "Mijlpaal kan niet worden bijgewerkt",
+      "completed": "Mijlpaal \"{name}\" voltooid.",
+      "completedWithDependencies": "De mijlpaal en bijbehorende afhankelijkheden zijn succesvol afgerond."
+    },
+    "errors": {
+      "nameExists": "Er bestaat al een mijlpaal met deze naam",
+      "nameRequired": "Mijlpaalnaam is vereist",
+      "notFound": "Mijlpaal niet gevonden"
+    },
+    "actions": {
+      "add": "Mijlpaal toevoegen"
+    },
+    "delete": {
+      "title": "Mijlpaal verwijderen",
+      "confirmMessage": "Weet u zeker dat u de mijlpaal {name}wilt verwijderen?",
+      "warning": "Deze mijlpaal wordt uit het project verwijderd. Historische gegevens voor deze mijlpaal blijven wel in het project aanwezig.",
+      "toast": {
+        "loading": "Mijlpaal verwijderen...",
+        "success": "Mijlpaal succesvol verwijderd",
+        "error": {
+          "title": "Mijlpaal verwijderen mislukt",
+          "description": "Er is een fout opgetreden bij het verwijderen van de mijlpaal"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Bevestig mijlpaalvoltooiing",
+      "confirmDescription": "Als u deze mijlpaal bereikt, worden ook de volgende gerelateerde items voltooid:",
+      "impactActiveTestRuns": "{count, plural, one {# actieve testrun} other {# actieve testruns}}",
+      "impactActiveSessions": "{count, plural, one {# actieve sessie} other {# actieve sessies}}",
+      "impactDescendantMilestones": "{count, plural, one {# afstammeling mijlpaal} other {# afstammeling mijlpalen}}",
+      "completeTestRunsLabel": "Voltooi de bijbehorende testruns ({count, plural, one {# actief} other {# actief}})",
+      "completeSessionsLabel": "Voltooi de bijbehorende sessies ({count, plural, one {# actief} other {# actief}})",
+      "testRunStateLabel": "Testuitvoering voltooid",
+      "sessionStateLabel": "Sessie voltooiingsstatus",
+      "itemsRemaining": "De volgende items blijven actief:",
+      "processing": "Verwerken...",
+      "confirmAndCompleteAll": "Bevestig en voltooi alles"
+    },
+    "notifications": {
+      "dueSoon": "Mijlpaal \"{name}\" moet op {dueDate} worden voltooid",
+      "overdue": "Mijlpaal \"{name}\" moest op {dueDate} plaatsvinden"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Sessie} other {Sessies}}",
+    "labels": {
+      "totalElapsed": "Bestede tijd",
+      "remaining": "Resterend: {time}",
+      "overtime": "Over de schatting met: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Er zijn geen voltooide sessies die aan uw filter voldoen."
+    },
+    "filter": {
+      "placeholder": "Sessies filteren..."
+    },
+    "actions": {
+      "add": "Sessie toevoegen",
+      "create": "Nieuwe sessie maken",
+      "edit": "Sessie bewerken",
+      "complete": "Volledige sessie",
+      "delete": "Sessie verwijderen",
+      "viewSessionDetails": "Sessie bekijken"
+    },
+    "noMilestone": "Geen mijlpaal",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Er zijn geen voltooiingsworkflows geconfigureerd voor dit project. Configureer workflows in de beheerdersinstellingen om sessievoltooiing in te schakelen."
+    },
+    "messages": {
+      "createSuccess": "Sessie succesvol aangemaakt",
+      "createSuccessMultiple": "{count} Sessies succesvol aangemaakt",
+      "duplicateSuccess": "Sessie succesvol gedupliceerd",
+      "duplicateSuccessMultiple": "{count} Sessies succesvol gedupliceerd"
+    },
+    "duplicateDialog": {
+      "title": "Dubbele sessie",
+      "description": "Maak een kopie van sessie <nameStyle>{name}</nameStyle> met alle metadata, maar zonder resultaten."
+    },
+    "errors": {
+      "failedToCreate": "Het is niet gelukt om een nieuwe sessie te maken",
+      "failedToCreateVersion": "Het is niet gelukt om een sessieversie te maken",
+      "nameAlreadyExists": "Sessienaam bestaat al. Kies een nieuwe naam.",
+      "createFailed": "Sessie aanmaken mislukt",
+      "duplicateFailed": "Het dupliceren van de sessie is mislukt."
+    },
+    "validation": {
+      "nameMinLength": "De naam moet minimaal 2 tekens bevatten.",
+      "templateRequired": "Selecteer een sjabloon",
+      "maxDuration": "De duur moet kleiner of gelijk zijn aan {max}."
+    },
+    "placeholders": {
+      "estimate": "Schatting (bijv. 1 uur en 30 minuten)",
+      "elapsed": "Verstreken (bijv. 2 dagen 4 uur)",
+      "selectUser": "Selecteer gebruiker",
+      "estimateHint": "bijv. 2u 30m",
+      "noEstimate": "Geen schatting ingesteld"
+    },
+    "delete": {
+      "confirmMessage": "Weet u zeker dat u sessie {name}wilt verwijderen?",
+      "warning": "Deze sessie wordt uit het project verwijderd. Historische gegevens voor deze sessie blijven in het project aanwezig.",
+      "toast": {
+        "loading": "Sessie verwijderen...",
+        "success": "Sessie succesvol verwijderd",
+        "error": {
+          "title": "Sessie kan niet worden verwijderd",
+          "description": "Er is een fout opgetreden bij het verwijderen van de sessie"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Weet u zeker dat u sessie {name}wilt voltooien?",
+      "warning": "Zodra de sessie is voltooid, wordt deze permanent gearchiveerd en kan deze niet meer worden bijgewerkt.",
+      "fields": {
+        "completionDate": "Voltooiingsdatum"
+      },
+      "placeholders": {
+        "pickDate": "Kies een datum"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Geschatte totale resterende tijd:",
+      "recentResultsTitle": "Samenvatting van recente resultaten",
+      "recentResultsDescription": "Samenvatting van de sessieresultaten.",
+      "noRecentResults": "Er zijn recentelijk geen sessieresultaten geregistreerd.",
+      "completionTrendTitle": "Voltooiingstrend",
+      "completionTrendDescription": "Voltooide sessies per maand.",
+      "noCompletedRuns": "Er zijn geen voltooide runs gevonden in de laatste 6 maanden.",
+      "completionTrendTitle6Mo": "Voltooiingstrend (laatste 6 maanden)",
+      "noCompletedSessions6Mo": "Er zijn geen sessies voltooid in de laatste 6 maanden."
+    },
+    "version": {
+      "title": "Sessiegeschiedenis weergeven",
+      "notFound": "Sessieversie niet gevonden.",
+      "selectVersion": "Selecteer versie",
+      "backToSession": "Terug naar sessie",
+      "backToLatest": "Terug naar de nieuwste versie",
+      "versionInfo": {
+        "created": "Versie {number} Gemaakt",
+        "latestUpdated": "Laatste versie {number} bijgewerkt"
+      },
+      "renderer": {
+        "noEstimate": "Geen schatting",
+        "noTimeLogged": "Geen tijd geregistreerd",
+        "noContent": "Geen inhoud",
+        "currentVersion": "Huidige versie",
+        "previousVersion": "Vorige versie"
+      },
+      "diff": {
+        "added": "Toegevoegd",
+        "removed": "VERWIJDERD",
+        "changed": "Gewijzigd"
+      }
+    },
+    "results": {
+      "section": "Sessielogboek",
+      "add": "Sessieresultaat toevoegen",
+      "edit": "Sessieresultaat bewerken",
+      "editDescription": "Breng wijzigingen aan in het sessieresultaat en klik op Opslaan als u klaar bent.",
+      "details": "Voer hier details over het resultaat in...",
+      "noResults": "Er zijn nog geen resultaten toegevoegd.",
+      "noNotes": "Er zijn geen notities toegevoegd voor dit resultaat.",
+      "deleteSuccess": "Sessieresultaat succesvol verwijderd",
+      "deleteError": "Sessieresultaat kan niet worden verwijderd",
+      "updateSuccess": "Sessieresultaat succesvol bijgewerkt",
+      "updateError": "Het is niet gelukt om het sessieresultaat bij te werken",
+      "linkCopied": "Sessieresultaatlink gekopieerd naar klembord",
+      "copyFailed": "Het kopiëren van de sessieresultaatlink is mislukt",
+      "confirmDelete": {
+        "title": "Sessieresultaat verwijderen",
+        "description": "Weet u zeker dat u dit sessieresultaat wilt verwijderen?"
+      }
+    },
+    "notFound": "Sessie niet gevonden"
+  },
+  "home": {
+    "dashboard": {
+      "title": "Uw dashboard",
+      "users": "Er zijn {count, plural, =1 {# Gebruiker} other {en # Gebruikers}}",
+      "yourProjects": "Uw projecten",
+      "projects": "Je hebt toegang tot {count, plural, =1 {# Project} other {# Projecten}}",
+      "loading": "Dashboard wordt geladen...",
+      "noItems": "Er is niets aan u toegewezen dat op dit moment uw aandacht vereist.",
+      "pendingRuns": "In afwachting van testruns",
+      "activeSessions": "Actieve sessies",
+      "yourActiveSessions": "{count, plural, =0 {Geen actieve sessies} =1 {# Actieve sessie} other {# Actieve sessies}}",
+      "yourPendingRuns": "{count, plural, =0 {Geen in behandeling zijnde testuitvoeringen} =1 {# Actieve testuitvoering} other {# Actieve testuitvoeringen}}",
+      "yourAssignments": "Jouw opdrachten",
+      "totalTime": "Geschatte totale tijd: ",
+      "totalWorkEffort": "Totale werkinspanning: ",
+      "scheduleSpan": "Schemaperiode: "
+    },
+    "initialPreferences": {
+      "title": "Stel uw voorkeuren in",
+      "description": "Kies de standaardinstellingen die het beste bij je passen. Je kunt deze op elk moment wijzigen via je profiel.",
+      "dateFormat": "Datumformaat",
+      "timeFormat": "Tijdformaat",
+      "timezonePlaceholder": "Zoek tijdzone...",
+      "skip": "Standaardinstellingen behouden",
+      "save": "Voorkeuren opslaan",
+      "success": "Voorkeuren bijgewerkt",
+      "error": "Er is iets misgegaan tijdens het opslaan van uw voorkeuren."
+    },
+    "noAccess": {
+      "title": "Geen projecttoegang",
+      "description": "U hebt geen toegang tot projecten in dit systeem.",
+      "contact": "Neem contact op met uw systeembeheerder om toegang tot projecten aan te vragen.",
+      "adminAddProject": "Voeg je eerste project toe om aan de slag te gaan!",
+      "footer": "Toegang is vereist om testplanningsactiviteiten te bekijken en eraan deel te nemen."
+    },
+    "noProjectAccess": {
+      "description": "U hebt geen toegang tot dit project.",
+      "contact": "Neem contact op met uw projectbeheerder om toegang aan te vragen."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Testgevallen} =1 {# Testgeval} other {# Testgevallen}}",
+      "activeMilestones": "{count, plural, =0 {# Actieve mijlpalen} =1 {# Actieve mijlpaal} other {# Actieve mijlpalen}}",
+      "activeRuns": "{count, plural, =0 {# Actieve uitvoeringen} =1 {# Actieve uitvoeringen} other {# Actieve uitvoeringen}}",
+      "activeSessions": "{count, plural, =0 {# Actieve sessies} =1 {# Actieve sessie} other {# Actieve sessies}}",
+      "issues": "{count, plural, =0 {# Problemen} =1 {# Problemen} other {# Problemen}}"
+    }
+  },
+  "users": {
+    "description": "Beheer gebruikersaccounts, stel toegangsniveaus tot het systeem in en wijs algemene rollen toe.",
+    "filter": "Gebruikers filteren...",
+    "profile": {
+      "title": "Gebruikersprofiel",
+      "edit": {
+        "title": "Profiel bewerken",
+        "timezonePlaceholder": "Selecteer of zoek tijdzone...",
+        "timezoneRequired": "Tijdzone is vereist.",
+        "avatarUpdated": "Avatar succesvol bijgewerkt.",
+        "avatarUpdateError": "Avatar kon niet worden bijgewerkt.",
+        "deleteAvatar": "Avatar verwijderen",
+        "deleteAvatarConfirm": "Weet u zeker dat u uw avatar wilt verwijderen?",
+        "emailDisabledForSso": "E-mailadres kan niet worden gewijzigd voor SSO-accounts. Werk het bij via uw identiteitsprovider.",
+        "emailEditableForBoth": "U kunt inloggen met zowel e-mailadres/wachtwoord als SSO. Wijzigingen in e-mailadressen hebben alleen invloed op wachtwoordverificatie.",
+        "linkSsoProvider": "SSO-provider koppelen"
+      },
+      "preferences": {
+        "title": "Voorkeuren"
+      },
+      "access": {
+        "title": "Toegang"
+      },
+      "notifications": {
+        "title": "Meldingsvoorkeuren",
+        "description": "Pas aan hoe u meldingen ontvangt",
+        "currentGlobal": "Huidige globale instelling: {mode}",
+        "mode": {
+          "label": "Meldingsmodus",
+          "useGlobal": "Gebruik algemene instellingen"
+        },
+        "options": {
+          "title": "Extra opties",
+          "email": {
+            "label": "E-mailmeldingen",
+            "description": "Ontvang meldingen via e-mail"
+          }
+        },
+        "success": {
+          "title": "Voorkeuren opgeslagen",
+          "description": "Uw meldingsvoorkeuren zijn bijgewerkt"
+        },
+        "error": {
+          "description": "Het is niet gelukt om de meldingsvoorkeuren op te slaan"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Wachtwoord wijzigen",
+        "setPasswordButtonText": "Stel een wachtwoord in",
+        "description": "Voer uw huidige wachtwoord en een nieuw wachtwoord in om uw accountwachtwoord te wijzigen. Hiermee wijzigt u alleen uw intern beheerde wachtwoord. Als u inlogt via SSO, verandert dat wachtwoord niet.",
+        "setPasswordDescription": "Je hebt je aangemeld via SSO en hebt nog geen lokaal wachtwoord ingesteld. Voer een nieuw wachtwoord in om aanmelden met e-mail en wachtwoord voor je account mogelijk te maken.",
+        "currentPasswordLabel": "Huidig wachtwoord",
+        "newPasswordLabel": "Nieuw wachtwoord",
+        "confirmPasswordLabel": "Bevestig nieuw wachtwoord",
+        "validation": {
+          "passwordsDoNotMatch": "Nieuwe wachtwoorden komen niet overeen.",
+          "newPasswordTooShort": "Het nieuwe wachtwoord voldoet niet aan de beveiligingsvereisten."
+        },
+        "success": {
+          "passwordChanged": "Wachtwoord succesvol gewijzigd."
+        }
+      },
+      "mentionedComments": {
+        "title": "Vermeld in de reacties",
+        "description": "Reacties waarin je genoemd wordt",
+        "noComments": "Je bent nog in geen enkele reactie genoemd.",
+        "comment": "Opmerking",
+        "showingResults": "Toont {start} - {end} van {total}"
+      },
+      "twoFactor": {
+        "enable": "Schakel 2FA in.",
+        "disable": "Uitzetten",
+        "disableNotAllowed": "Uw organisatie vereist tweefactorauthenticatie.",
+        "ssoBypassNotice": "SSO-aanmeldingen omzeilen deze 2FA-instelling. Neem contact op met uw beheerder om 2FA voor alle aanmeldingen af te dwingen.",
+        "regenerateCodes": "Nieuwe codes",
+        "setup": {
+          "description": "Scan de QR-code met je authenticatie-app (zoals Google Authenticator of Authy) en voer de verificatiecode in.",
+          "backupCodesTitle": "Bewaar uw back-upcodes",
+          "done": "Ik heb mijn codes opgeslagen."
+        },
+        "disableConfirm": {
+          "title": "Tweefactorauthenticatie uitschakelen?",
+          "description": "Dit maakt uw account minder veilig. Voer uw huidige 2FA-code of een reservecode in ter bevestiging.",
+          "placeholder": "Voer de code in"
+        },
+        "regenerate": {
+          "title": "Codes voor back-up opnieuw genereren",
+          "description": "Hierdoor worden uw bestaande back-upcodes ongeldig. Voer uw huidige 2FA-code in om verder te gaan.",
+          "confirm": "Codes opnieuw genereren",
+          "newCodesTitle": "Uw nieuwe back-upcodes",
+          "newCodesDescription": "Uw oude codes zijn ongeldig. Bewaar deze nieuwe codes op een veilige plek."
+        }
+      },
+      "apiTokens": {
+        "description": "API-tokens stellen externe applicaties en scripts in staat om namens u toegang te krijgen tot TestPlanIt. Tokens hebben dezelfde machtigingen als uw account.",
+        "create": "Token aanmaken",
+        "createTitle": "API-token genereren",
+        "createDescription": "Maak een nieuw API-token aan om externe tools en scripts te authenticeren.",
+        "nameLabel": "Tokennaam",
+        "namePlaceholder": "bijvoorbeeld CI/CD-pipeline, CLI-tool",
+        "noTokens": "Er zijn nog geen API-tokens aangemaakt.",
+        "expiryLabel": "Vervaldatum (optioneel)",
+        "expiryHint": "Laat het leeg voor onbeperkte houdbaarheid.",
+        "tokenCreated": "Token aangemaakt",
+        "tokenCreatedDescription": "Uw API-token is succesvol aangemaakt.",
+        "copyWarning": "Kopieer dit token nu. Je kunt het daarna niet meer terugzien!",
+        "yourToken": "Uw token",
+        "deleteTitle": "API-token verwijderen?",
+        "deleteDescription": "Deze actie kan niet ongedaan worden gemaakt. Applicaties die dit token gebruiken, kunnen zich niet langer authenticeren.",
+        "readOnlyLabel": "Alleen-lezen",
+        "readOnlyDescription": "Te gebruiken voor AI-agenten die alleen gegevens mogen opvragen en nooit wijzigen.",
+        "agentTokenLabel": "Markeer als agenttoken",
+        "agentTokenDescription": "Voorzie auditlogboekvermeldingen van tags met metadata.source: \"mcp\", zodat beheerders agentgestuurde wijzigingen kunnen toeschrijven.",
+        "readOnlyBadge": "Alleen-lezen",
+        "agentTokenBadge": "Agent-token",
+        "errors": {
+          "nameRequired": "Een tokennaam is vereist."
+        }
+      }
+    },
+    "access": {
+      "guest": "Gast"
+    },
+    "avatar": {
+      "update": "Avatar bijwerken",
+      "remove": "Avatar verwijderen",
+      "changeProfilePicture": "Profielfoto wijzigen",
+      "notAuthenticated": "Je moet ingelogd zijn om een avatar te uploaden."
+    },
+    "deletedUser": "Verwijderde gebruiker"
+  },
+  "userMenu": {
+    "viewProfile": "Bekijk profiel",
+    "locale": "Locatie",
+    "themes": {
+      "light": "Licht",
+      "dark": "Donker",
+      "system": "Systeem",
+      "green": "Groente",
+      "purple": "Paars",
+      "orange": "Oranje"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Testcaseversie niet gevonden.",
+      "detailsRegion": "Testcasedetails",
+      "metadataRegion": "Testcase-metagegevens",
+      "versionCreated": "Versie {version} Gemaakt",
+      "latestVersionUpdated": "Laatste versie {version} bijgewerkt",
+      "historyView": "Testcase geschiedenisweergave"
+    },
+    "fields": {
+      "optionNotFound": "Optie niet gevonden",
+      "hasValue": "Heeft waarde",
+      "noValue": "Geen waarde",
+      "hasDate": "Heeft datum",
+      "noDate": "Geen datum",
+      "hasText": "Bevat tekst",
+      "noText": "Geen tekst",
+      "hasLink": "Heeft link",
+      "noLink": "Geen link",
+      "hasSteps": "Heeft stappen",
+      "noSteps": "Geen trappen",
+      "unchecked": "Ongecontroleerd",
+      "linkedCases": "Gekoppelde gevallen",
+      "clickToViewFullContent": "Klik om de volledige inhoud te bekijken"
+    },
+    "steps": {
+      "add": "Stap toevoegen",
+      "addSharedSteps": "Gedeelde stappen toevoegen",
+      "delete": "Stap verwijderen",
+      "confirmDelete": "Verwijderen bevestigen Stap {number}?",
+      "createSharedSteps": "Gedeelde {number, plural, one {Stap} other {Stappen}}maken",
+      "sharedStepsName": "Naam gedeelde stappen",
+      "sharedStepsDescription": "Voer een naam in voor je nieuwe gedeelde {number, plural, one {stap} other {stappen}}. Dit omvat {number, plural, one {# geselecteerde stap} other {# geselecteerde stappen}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Selecteer stappen en voer een naam in om gedeelde stappen te maken.",
+        "failedToCreateSharedStepGroupError": "Het aanmaken van de gedeelde stappen is mislukt. Probeer het opnieuw.",
+        "sharedStepGroupCreatedSuccess": "Gedeelde stappen succesvol aangemaakt!",
+        "genericSharedStepCreationError": "Er is een onbekende fout opgetreden bij het aanmaken van de gedeelde stappen. Probeer het opnieuw.",
+        "errorCreatingSharedGroup": "Het aanmaken van gedeelde stappen is mislukt. Probeer het opnieuw.",
+        "sharedGroupCreatedSuccess": "Gedeelde stappengroep succesvol aangemaakt!"
+      },
+      "selectSharedStepsTitle": "Selecteer gedeelde stappen",
+      "selectSharedStepsDescription": "Kies gedeelde stappen die u aan uw testcase wilt toevoegen.",
+      "sharedStepsListPlaceholder": "Gedeelde stappen laden...",
+      "sharedStepsNamePlaceholder": "Voer een naam in om de gedeelde stappen te identificeren",
+      "noSharedStepsFound": "Er zijn geen gedeelde stappen gevonden voor dit project.",
+      "sharedStepGroupTitle": "Gedeelde stappen: {name}",
+      "confirmDeleteSharedStepBlock": "Weet u zeker dat u het gedeelde stappenblok \"{name}\" uit deze testcase wilt verwijderen? Hiermee wordt de gedeelde stappengroep zelf niet verwijderd.",
+      "removeBlockButton": "Blok verwijderen",
+      "loadingSharedStepsItems": "Stappen laden...",
+      "noStepsInSharedGroup": "Deze gedeelde stappengroep is leeg.",
+      "searchSharedStepsPlaceholder": "Selecteer gedeelde stappen...",
+      "stepsCountLabel": "{count, plural, =0 {# stappen} =1 {# stap} other {# stappen}}",
+      "reviewSelectedStepsTitle": "Bekijk geselecteerde stappen",
+      "noStepsInSelectedGroup": "De geselecteerde groep heeft geen stappen.",
+      "sharedGroupSuffix": "(Gedeelde stappen)",
+      "unnamedSharedGroup": "Naamloze gedeelde stappen"
+    },
+    "testCase": {
+      "toggleAutomated": "Schakel geautomatiseerd testen in",
+      "editAttachmentsIndividually": "Bewerk bijlagen afzonderlijk.",
+      "automatedStatus": "Geautomatiseerd testen is {status}"
+    },
+    "templateNotAssignedWarning": "Deze testcase gebruikt de sjabloon \"{templateName}\", die momenteel niet is toegewezen aan het project \"{projectName}\". Mogelijk moet u deze sjabloon aan het project toewijzen of de testcase aanpassen om een andere sjabloon te gebruiken.",
+    "orphanedStepsWarning": "Deze testcase heeft stappen, maar de huidige sjabloon \"{templateName}\" bevat geen veld voor stappen. De stappen kunnen pas worden bewerkt als de testcase een sjabloon met een veld voor stappen heeft.",
+    "orphanedFieldsWarning": "Deze testcase heeft {count, plural, =1 {# veldwaarde} other {# veldwaarden}} die {count, plural, =1 {is} other {zijn}} niet opgenomen in de huidige sjabloon \"{templateName}\". {count, plural, =1 {Dit veld is} other {Deze velden zijn}} hieronder weergegeven, maar kunnen mogelijk pas worden bewerkt nadat ze aan de sjabloon zijn toegevoegd.",
+    "title": "Test Case Repository",
+    "folders": "Mappen",
+    "showDescendants": "Toon alle afstammelingen",
+    "addFolder": "Map toevoegen",
+    "emptyFolders": "Klik hierboven op de knop Map toevoegen om de eerste map toe te voegen.",
+    "selectedAllCases": "{count, plural, =0 {Alle gevallen geselecteerd} one {Aantal gevallen geselecteerd op alle pagina's} other {Aantal gevallen geselecteerd op alle pagina's}}",
+    "deselectedAllCases": "Alle cases op alle pagina's zijn gedeselecteerd.",
+    "selectAllTooltip": "Selecteer/deselecteer alle cases op deze pagina",
+    "selectAllShiftTooltip": "{count, plural, =0 {Selecteer/deselecteer alle gevallen op alle pagina's} one {Selecteer/deselecteer # gevallen op alle pagina's} other {Selecteer/deselecteer # gevallen op alle pagina's}}",
+    "deselectAllShiftTooltip": "Alle gevallen op alle pagina's deselecteren/selecteren",
+    "shiftClickHint": "Houd Shift ingedrukt om alle pagina's te selecteren/deselecteren.",
+    "treeView": {
+      "expandAll": "Alles uitvouwen",
+      "collapseAll": "Alles samenvouwen",
+      "altKey": "Houd de Alt-toets ingedrukt om alle onderliggende items uit te vouwen/samen te vouwen"
+    },
+    "dragDrop": {
+      "move": "Beweging",
+      "copy": "Kopiëren",
+      "promptTitle": "Wat zou je graag willen doen?",
+      "copying": "… kopiëren",
+      "copyComplete": "{count, plural, =1 {1 case gekopieerd naar {folder}} other {# cases gekopieerd naar {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {1 case verplaatst naar {folder}} other {# cases verplaatst naar {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Het kopiëren van 1 case naar {folder}is mislukt.} other {Het kopiëren van # cases naar {folder}is mislukt.}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Het verplaatsen van 1 case naar {folder}is mislukt.} other {Het verplaatsen van # cases naar {folder}is mislukt.}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyAlreadyRunning": "Een andere kopie is al in bewerking. Wacht alstublieft tot deze klaar is.",
+      "currentSuffix": "(Huidig)",
+      "moveDisabledSameFolder": "De dossiers bevinden zich al in deze map.",
+      "dragPreviewCase": "Testgeval",
+      "dragPreviewCount": "{count, plural, =1 {# testgeval} other {# testgevallen}}",
+      "modifierHintMac": "Houd ⇧ ingedrukt om te verplaatsen of ⌥ om te kopiëren terwijl u sleept om dit menu over te slaan.",
+      "modifierHintWin": "Houd Shift ingedrukt om te verplaatsen of Ctrl om te kopiëren tijdens het slepen om dit menu over te slaan."
+    },
+    "folderActions": {
+      "edit": "Map bewerken",
+      "delete": "Map verwijderen",
+      "rename": "Map hernoemen"
+    },
+    "cases": {
+      "filter": "Filter gevallen...",
+      "selectFolder": "Selecteer een map om testcases aan toe te voegen of weer te geven.",
+      "selectCases": "Selecteer testgevallen",
+      "noTestCases": "Geen testgevallen om weer te geven.",
+      "addCase": "Case toevoegen",
+      "notFound": "Testcase niet gevonden.",
+      "selectFilter": "Filter selecteren",
+      "testResultHistory": "Testresultaatgeschiedenis",
+      "testResultHistoryDescription": "Bekijk de geschiedenis van de testresultaten voor deze testcase",
+      "noTestResults": "Er zijn geen testresultaten gevonden voor deze testcase",
+      "unknownRun": "Onbekende run",
+      "attempt": "Poging",
+      "invalidProject": "Ongeldig project",
+      "noSearchResults": "Er zijn geen cases gevonden die aan uw zoekcriteria voldoen.",
+      "bulkEdit": "Bulkbewerking",
+      "createTestRun": "Testrun maken",
+      "copyMoveToProject": "Kopiëren / Verplaatsen",
+      "export": "Exporteren",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Het is niet mogelijk om testgevallen over meerdere pagina's te herschikken. Om de volgorde te wijzigen, kunt u alle gevallen op één pagina weergeven door 'Alles' te selecteren in het menu voor paginagrootte, of gevallen op andere pagina's deselecteren. U kunt geselecteerde gevallen nog steeds naar mappen slepen.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Alles in beeld ({count})"
+        },
+        "textLongFormat": {
+          "label": "Rich Text-indeling"
+        },
+        "rowMode": {
+          "label": "Testcase-rijen",
+          "multi": "Enkele rij per stap"
+        }
+      },
+      "importWizard": {
+        "title": "Testcases importeren",
+        "fields": {
+          "workflowState": "Workflowstatus",
+          "column": "Kolom {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# testcase} other {# testcases}} succesvol geïmporteerd"
+        },
+        "errors": {
+          "templateRequired": "Sjabloonselectie is vereist",
+          "folderRequired": "Voor deze importlocatie is mapselectie vereist",
+          "fileRequired": "Een CSV- of Markdown-bestand is vereist.",
+          "markdownParseFailed": "Het parseren van het Markdown-bestand is mislukt.",
+          "markdownLlmFailed": "AI-parsing niet beschikbaar, standaardparser wordt gebruikt."
+        },
+        "page1": {
+          "fileType": {
+            "label": "Bestandstype",
+            "csv": "CSV",
+            "markdown": "Markdown"
+          },
+          "parsingMarkdown": "Markdown-bestand verwerken...",
+          "useAiParsing": "Gebruik AI ter ondersteuning van veldkartering.",
+          "importLocation": {
+            "label": "Importlocatie",
+            "singleFolder": "Voeg alle gevallen toe aan één map",
+            "rootFolder": "Voeg alle dossiers en mappen toe aan een hoofdmap (mapping vereist).",
+            "topLevel": "Voeg alle dossiers en mappen toe aan het hoogste niveau (mapping vereist)"
+          },
+          "selectFolder": "Selecteer map",
+          "selectFolderPlaceholder": "Selecteer een map...",
+          "delimiters": {
+            "tab": "Tab"
+          },
+          "hasHeaders": "De eerste rij bevat kolomnamen",
+          "template": "Repository Case-sjabloon",
+          "rowMode": {
+            "single": "Elke rij is een enkele testcase",
+            "multi": "Testcases kunnen meerdere rijen beslaan"
+          }
+        },
+        "page2": {
+          "title": "CSV-kolommen toewijzen aan velden",
+          "description": "U kunt elke CSV-kolom toewijzen aan een veld in de sjabloon, of ervoor kiezen deze te negeren.",
+          "ignoreColumn": "Kolom negeren",
+          "requiredFieldsWarning": "{count, plural, one {# verplicht veld is} other {# verplichte velden zijn}} niet toegewezen"
+        },
+        "page3": {
+          "title": "Samenvatting van veldtoewijzing",
+          "mappingSummary": "Kaartsamenvatting",
+          "folderSplitMode": {
+            "label": "Maphiërarchiemodus",
+            "plain": "Platte tekst (geen splitsing)",
+            "plainExample": "Voorbeeld: 'Deze/is.a>Map' → Eén map met de naam 'Deze/is.a>Map'",
+            "slash": "Gesplitst door slash (/)",
+            "slashExample": "Voorbeeld: 'Deze/is.a>Map' → 'Deze' > 'is.a>Map'",
+            "dot": "Gesplitst door punt (.)",
+            "dotExample": "Voorbeeld: 'Dit/is.een>Map' → 'Dit/is' > 'een>Map'",
+            "greaterThan": "Gesplitst door groter dan (>)",
+            "greaterThanExample": "Voorbeeld: 'Dit/is.een>Map' → 'Dit/is.een' > 'Map'"
+          }
+        },
+        "page4": {
+          "title": "Voorbeeld importeren",
+          "showing": "{start}-{end} van {total} gevallen weergeven",
+          "case": "Geval {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Testgeval toevoegen",
+      "name": "Testcasenaam",
+      "namePlaceholder": "Voer de naam van de testcase in",
+      "selectTemplate": "Selecteer een sjabloon",
+      "selectState": "Selecteer een staat",
+      "estimatePlaceholder": "Voer een schatting in",
+      "create": "Testcase maken",
+      "successMessage": "Nieuwe testcase toegevoegd",
+      "errorMessage": "Onbekende fout bij het toevoegen van een nieuwe testcase"
+    },
+    "columns": {
+      "selectCase": "Selecteer zaak",
+      "runOrder": "Volgorde van de uitvoering",
+      "lastTestResult": "Laatste resultaat",
+      "testedOn": "Laatst getest"
+    },
+    "actions": {
+      "archive": "Archief"
+    },
+    "parentFolder": "Bovenliggende map",
+    "rootFolder": "Hoofdmap",
+    "removeParentFolder": "Verwijder de bovenliggende map",
+    "createInSelectedFolder": "Terugkeren naar de bovenliggende map",
+    "deleteCase": {
+      "title": "Testgeval verwijderen",
+      "confirmMessageStart": "Weet u zeker dat u de testcase wilt verwijderen? ",
+      "confirmMessageEnd": "?",
+      "warning": "Deze testcase wordt uit het project verwijderd. Historische gegevens voor deze testcase blijven in het project aanwezig, inclusief de resultaten.",
+      "activeRunWarningMessage": "Deze testcase maakt deel uit van {count, plural, =1 {# actieve testrun} other {# actieve testruns}}. Als u de testcase verwijdert, wordt deze binnen die runs als verwijderd gemarkeerd."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Als u deze map verwijdert, worden ook alle submappen verwijderd. Weet u het zeker?} one {Als u deze map verwijdert, worden ook 1 testcase in deze map en alle submappen verwijderd. Weet u het zeker?} other {Als u deze map verwijdert, worden ook # testcases in deze map en alle submappen verwijderd. Weet u het zeker?}}",
+      "warning": "Deze map en alle bijbehorende testcases worden uit het project verwijderd. Historische gegevens voor deze testcases blijven wel in het project aanwezig, inclusief de resultaten.",
+      "confirm": "Bevestig het verwijderen van de map",
+      "success": "Map en alle submappen/zaken succesvol verwijderd."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "De mapnaam bestaat al. Kies een andere naam."
+      }
+    },
+    "views": {
+      "byAutomation": "Automatisering",
+      "allTemplates": "Alle sjablonen",
+      "allStates": "Alle staten",
+      "allCreators": "Alle makers",
+      "allCases": "Alle gevallen",
+      "allAssignees": "Alle toegewezen personen",
+      "anyTag": "Elke tag",
+      "noTags": "Geen tags",
+      "byTag": "Label",
+      "byIssue": "Probleem",
+      "anyIssue": "Elk probleem",
+      "noIssues": "Geen problemen"
+    },
+    "noFoldersTitle": "Nog geen mappen",
+    "noFoldersDescription": "Begin met het maken van uw eerste map om uw testcases te organiseren.",
+    "noFoldersOrCasesNoPermission": "Er zijn geen mappen of testcases om weer te geven.",
+    "createFirstFolder": "Maak uw eerste map aan",
+    "bulkEdit": {
+      "title": "Bulk bewerken {count, plural, one {# Geval} other {# Gevallen}}",
+      "description": "Bewerken {count, plural, one {# geselecteerde zaak} other {# geselecteerde zaken}}. Vink een veld aan om bewerken mogelijk te maken.",
+      "defineStepsTitle": "Stappen voor bulkupdate definiëren",
+      "saveNewSteps": "Nieuwe stappen opslaan",
+      "newStepsDefined": "Nieuwe stappen gedefinieerd ({count}) - Klik op de knop om te bewerken",
+      "clearExistingStepsWarning": "Bestaande stappen worden verwijderd",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Meerdere sjablonen geselecteerd",
+          "description": "Alleen standaardvelden kunnen worden bewerkt wanneer cases met verschillende sjablonen zijn geselecteerd. Dynamische velden kunnen worden bewerkt door cases te selecteren die dezelfde sjabloon gebruiken."
+        },
+        "junitLimitations": {
+          "title": "Beperkingen van geautomatiseerde testcasebewerking",
+          "description": "De velden 'Schatting' en 'Geautomatiseerd' kunnen niet worden gewijzigd voor testgevallen die zijn geïmporteerd uit geautomatiseerde testresultaten."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Fout bij het laden van gevallen",
+        "fetchErrorDescription": "Gegevens voor de geselecteerde cases konden niet worden geladen. Sluit het venster en probeer het opnieuw.",
+        "updateErrorTitle": "Update mislukt",
+        "updateFailed": "Er is een fout opgetreden bij het opslaan van de wijzigingen. Controleer de gegevens en probeer het opnieuw.",
+        "fetchError": "Fout bij het ophalen van de casusgegevens."
+      },
+      "success": {
+        "casesUpdated": "Cases succesvol bijgewerkt"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Validatiefout",
+      "stepsCannotBeBulkEdited": "Stappen kunnen niet in bulk worden bewerkt",
+      "stepsInfoTitle": "Stappen Info",
+      "stepsCannotBeBulkEditedInfo": "Stappen kunnen niet in bulk worden bewerkt. Bewerk stappen door de cases afzonderlijk te bewerken.",
+      "confirmDeleteCases": "Weet u zeker dat u {count, plural, one {# geselecteerde case} other {# geselecteerde cases}}wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+      "replaceAll": "Alles vervangen",
+      "searchReplace": "Zoeken en vervangen",
+      "searchFor": "Zoeken naar",
+      "replaceWith": "Vervangen door",
+      "searchText": "Voer tekst in om te zoeken",
+      "replacementText": "Voer vervangende tekst in",
+      "useRegex": "Gebruik reguliere expressie",
+      "caseSensitive": "Hoofdlettergevoelig",
+      "regexHint": "Gebruik .* voor alle tekens, \\d+ voor getallen, \\w+ voor woorden. Vang groepen: (patroon) en gebruik dan $1, $2, enz.",
+      "preview": "Voorvertoning",
+      "matches": "wedstrijden",
+      "noMatches": "Geen overeenkomsten gevonden",
+      "invalidRegexPattern": "Ongeldig regulier expressiepatroon",
+      "searchPatternRequired": "Zoekpatroon is vereist",
+      "stepsSearchReplaceInfo": "Zoeken en vervangen wordt toegepast op zowel stapbeschrijvingen als verwachte resultaten."
+    },
+    "exportModal": {
+      "title": "Testcases exporteren",
+      "description": "Kies hieronder uw exportopties.",
+      "scope": {
+        "selected": "Geselecteerd ({count})",
+        "allFiltered": "Alles (huidige weergave) ({count})",
+        "allProject": "Alles in project ({count})"
+      },
+      "format": {
+        "label": "Formaat",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Markdown"
+      },
+      "columns": {
+        "all": "Alle",
+        "visible": "Zichtbaar"
+      },
+      "delimiter": {
+        "label": "scheidingsteken",
+        "placeholder": "Selecteer scheidingsteken...",
+        "comma": "Komma (,)",
+        "semicolon": "Puntkomma (;)",
+        "colon": "Dubbele punt (:)",
+        "pipe": "Pijp (|)"
+      },
+      "textLongFormat": {
+        "label": "Tekst lang formaat"
+      },
+      "attachmentFormat": {
+        "label": "Bijlage-indeling",
+        "names": "Namen",
+        "json": "JSON",
+        "embedded": "Afbeeldingen insluiten"
+      },
+      "stepsFormat": {
+        "label": "Stappen Formaat",
+        "plainText": "Platte tekst"
+      },
+      "rowMode": {
+        "label": "Rijen per geval",
+        "single": "Eén rij per geval",
+        "multi": "Meerdere rijen per stap"
+      },
+      "comingSoon": "Binnenkort beschikbaar",
+      "exporting": "Exporteren...",
+      "exportError": "Exporteren is mislukt. Probeer het opnieuw."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Converteer geselecteerde testgevallen naar automatiseringsscripts met behulp van een sjabloon of AI.",
+      "templatePlaceholder": "Selecteer een sjabloon...",
+      "searchPlaceholder": "Zoeksjablonen...",
+      "noTemplatesFound": "Geen sjablonen gevonden.",
+      "outputModeLabel": "Uitvoermodus",
+      "outputModeSingle": "Enkel bestand ({count, plural, one {# geval} other {alle # gevallen}})",
+      "outputModeIndividual": "{count, plural, one {Individueel bestand (.zip)} other {Individuele bestanden (.zip)}}",
+      "casesToExport": "{count, plural, one {# geval} other {# gevallen}} om te exporteren",
+      "exportSuccess": "Export succesvol afgerond.",
+      "noAvailableTemplates": "Geen sjablonen beschikbaar. Neem contact op met uw beheerder."
+    },
+    "aiExport": {
+      "toggleLabel": "Genereer met AI",
+      "generating": "Genereren...",
+      "generatingProgress": "Genereren van geval {current} van {total}...",
+      "generatingBatch": "Genereren van {count, plural, one {# geval} other {# gevallen}} in één bestand...",
+      "previewTitle": "Exporteervoorbeeld",
+      "previewDescription": "{count, plural, one {# bestand} other {# bestanden}} gegenereerd",
+      "copySuccess": "Gekopieerd naar het klembord",
+      "fallbackBadge": "Gegenereerd met behulp van een sjabloon (AI niet beschikbaar)",
+      "retryButton": "AI-generatie opnieuw proberen",
+      "aiGenerated": "AI-gegenereerd",
+      "templateGenerated": "Sjabloon gegenereerd",
+      "truncatedWarning": "De uitvoer is afgekapt — het model heeft de tokenlimiet bereikt. Probeer de batchgrootte te verkleinen of het maximale aantal uitvoertokens in uw promptconfiguratie te verhogen.",
+      "contextFiles": "{count, plural, one {(# contextbestand)} other {(# contextbestanden)}}",
+      "noCodeContextHint": "Er is geen code-repository geconfigureerd. De AI zal gebruikmaken van standaard frameworkpatronen.",
+      "generatingParallelProgress": "Er zijn {done} van {total} bestanden gegenereerd...",
+      "cancelledGeneration": "Geannuleerd"
+    },
+    "duplicates": {
+      "findDuplicates": "Dubbele items zoeken",
+      "viewResults": "Weergave {count, plural, one {# Resultaat} other {# Resultaten}}",
+      "retryScan": "Scan opnieuw uitvoeren",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Resultaten verbeteren met AI...",
+      "scanComplete": "Analyse van duplicaten voltooid — {count, plural, =0 {geen duplicaten gevonden} one {# potentieel duplicaat gevonden} other {# potentieel duplicaten gevonden}}",
+      "scanFailed": "Dubbele analyse mislukt",
+      "scanFailedDescription": "Er is een onverwachte fout opgetreden.",
+      "pageTitle": "Dubbele kandidaten",
+      "pageDescription": "Controleer of er tijdens de laatste scan mogelijk dubbele testgevallen zijn gevonden.",
+      "rescan": "Opnieuw scannen",
+      "cancelScan": "Scan annuleren",
+      "loading": "Dubbele kandidaten worden geladen...",
+      "noDuplicatesFound": "Geen duplicaten gevonden",
+      "noDuplicatesDescription": "De laatste scan is voltooid en er zijn geen overeenkomende paren gevonden.",
+      "loadMore": "Meer laden",
+      "filterPlaceholder": "Dubbele resultaten filteren...",
+      "columnConfidence": "Vertrouwen",
+      "columnCaseA": "Geval A",
+      "columnCaseB": "Geval B",
+      "columnMatchedFields": "Overeenkomende velden",
+      "columnScore": "Score",
+      "compareButton": "Vergelijken",
+      "viewCaseDetails": "Bekijk de details van de zaak",
+      "selectAll": "Alles selecteren",
+      "selectRow": "Selecteer rij",
+      "selected": "{count, plural, one {# geselecteerd} other {# geselecteerd}}",
+      "bulkDismiss": "Geen duplicaten ({count})",
+      "bulkLink": "Link als gerelateerd ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# paar afgewezen} other {# paren afgewezen}}",
+      "bulkLinkSuccess": "{count, plural, one {# gekoppeld paar} other {# gekoppelde paren}}",
+      "bulkError": "Sommige bewerkingen zijn mislukt. Probeer het opnieuw.",
+      "tableHint": "Klik op een rij of op de knop 'Vergelijken' om een dubbel paar te bekijken en op te lossen.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "Vergelijk deze mogelijke duplicaten en kies hoe je ze wilt oplossen.",
+      "selectPrimary": "Klik op een zaak om deze als primaire zaak voor samenvoeging te selecteren.",
+      "selectedAsPrimary": "Geselecteerd als primaire",
+      "mergeButton": "Primaire behouden",
+      "linkButton": "Link als gerelateerd",
+      "dismissButton": "Geen duplicaat",
+      "merging": "Samenvoegen...",
+      "linking": "Koppelen...",
+      "dismissing": "Ontslag...",
+      "mergeSuccess": "Testgevallen succesvol samengevoegd. {runsTransferred, plural, =0 {Geen testruns overgedragen} one {# testrun overgedragen} other {# testruns overgedragen}}.",
+      "linkSuccess": "Gekoppelde gevallen als verwant.",
+      "dismissSuccess": "Het paar is afgewezen. Het zal niet meer in toekomstige scans verschijnen.",
+      "resolveError": "Het is niet gelukt om een dubbel paar te vinden. Probeer het opnieuw.",
+      "loadingDetails": "Details van de zaak worden geladen...",
+      "caseDetailsError": "Het laden van de casusdetails is mislukt.",
+      "sourceLabel": "Bron",
+      "fieldValuesLabel": "Veldwaarden",
+      "lastRunLabel": "Laatste run",
+      "noFieldValues": "Geen veldwaarden",
+      "noLastRun": "Ren nooit",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Geen map",
+      "duplicateWarning": "Mogelijke duplicaten gevonden",
+      "duplicateWarningDescription": "{count, plural, one {# bestaand geval} other {# bestaande gevallen}} kunnen vergelijkbare functionaliteit omvatten",
+      "duplicateWarningReview": "Beoordeling",
+      "importWarning": "Mogelijk een duplicaat",
+      "importWarningTooltip": "Deze casusnaam is vergelijkbaar met {count, plural, one {# bestaande casus} other {# bestaande casussen}}: {names}",
+      "importIntraWarning": "Duplicaat binnen import",
+      "importIntraWarningTooltip": "Rijen {rows} in deze import hebben dezelfde of een zeer vergelijkbare naam.",
+      "checkingDuplicates": "Controleren op duplicaten..."
+    },
+    "generateTestCases": {
+      "buttonText": "Testcases genereren",
+      "title": "Genereer testcases met AI",
+      "description": "Gebruik AI om automatisch uitgebreide testgevallen te genereren op basis van externe problemen of documenten.",
+      "loadingResults": "De gegenereerde testgevallen worden geladen...",
+      "generatingPreparing": "Verzoek voorbereiden...",
+      "generatingCallingAi": "Wachten tot de AI testgevallen genereert...",
+      "generatingStreaming": "AI genereert testcase {count}...",
+      "generatingStreamingPage": "AI genereert testcase {count} — pagina {current} van {total}: {page}",
+      "generatingProcessing": "Verwerking van gegenereerde testgevallen...",
+      "generatingHint": "Dit kan een minuut duren, afhankelijk van de complexiteit van uw bronmateriaal.",
+      "steps": {
+        "selectIssue": "Selecteer bron",
+        "selectTemplate": "Kies sjabloon",
+        "reviewGenerated": "Beoordelen en importeren"
+      },
+      "selectSource": {
+        "title": "Selecteer Vereistenbron",
+        "description": "Kies of u testcases wilt genereren op basis van een probleem of een vereistendocument.",
+        "folderContextTip": "Bestaande testgevallen uit \"{folderName}\" en de bijbehorende mappen worden als context gebruikt om duplicaten te voorkomen. Zorg ervoor dat u de juiste map hebt geselecteerd voordat u verdergaat.",
+        "currentFolder": "huidige map",
+        "fromIssue": "Van uitgave",
+        "fromDocument": "Van document",
+        "documentTitle": "Documenttitel",
+        "documentTitlePlaceholder": "Voer de titel van uw vereistendocument in",
+        "documentDescription": "Vereisten Document",
+        "documentDescriptionPlaceholder": "Plak hier de inhoud van uw vereistendocument...",
+        "documentPriority": "Prioriteit (optioneel)",
+        "selectPriority": "Selecteer prioriteit",
+        "saveDocument": "Vereisten voor het opslaan van documenten",
+        "fromUrl": "Van URL",
+        "recentGenerations": "Recente taken: Testcases genereren vanuit URL",
+        "recentJobInfo": "{pages, plural, one {# pagina} other {# pagina's}}{hasTestCases, select, true { · {testCases, plural, one {# testgeval} other {# testgevallen}}} other {}}",
+        "recentJobHasResults": "Klaar om te beoordelen",
+        "recentJobClickToGenerate": "Klik om testgevallen te genereren",
+        "recentJobCrawling": "Aan het kruipen... {pages, plural, one {# pagina} other {# pagina's}} tot nu toe",
+        "removeJobTitle": "Generatie verwijderen",
+        "confirmRemoveJob": "Hiermee worden de in de cache opgeslagen crawlgegevens en alle gegenereerde testcases verwijderd. Je kunt ze altijd opnieuw genereren via dezelfde URL.",
+        "loadingRecentJobs": "Recente vacatures worden geladen...",
+        "urlInput": "Pagina-URL",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "Wat bevat deze URL?",
+        "urlModeRequirements": "Vereisten",
+        "urlModeRequirementsHint": "De pagina beschrijft wat er gebouwd moet worden.",
+        "urlModeApplication": "Sollicitatie",
+        "urlModeApplicationHint": "Page is de app om te testen.",
+        "urlValidationError": "Voer een geldige URL in die begint met http:// of https://",
+        "followLinks": "Volg de links",
+        "followLinksHint": "Alleen pagina's op hetzelfde domein als de URL die u invoert, worden geïndexeerd.",
+        "maxDepth": "Maximale diepte",
+        "maxPages": "Max pagina's",
+        "crawlProgress": "{current, plural, one {Pagina # opgehaald tot nu toe...} other {Pagina # opgehaald tot nu toe...}}",
+        "generatingSinglePage": "Testgevallen genereren...",
+        "generatingSetup": "Voorbereidingen treffen om testgevallen te genereren...",
+        "robotsSkipped": "{count, plural, one {# pagina overgeslagen} other {# pagina's overgeslagen}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Selecteer extern probleem",
+        "description": "Selecteer een probleem uit uw externe systeem (zoals Jira) om testcases van te genereren.",
+        "searchButton": "Zoeken naar problemen"
+      },
+      "selectTemplate": {
+        "title": "Kies testcase-sjabloon",
+        "description": "Selecteer de sjabloon die gebruikt zal worden voor het genereren van testcases. De AI vult velden in volgens deze sjabloon.",
+        "placeholder": "Selecteer een sjabloon...",
+        "fieldsDescription": "Selecteer welke velden AI moet invullen. Verplichte velden zijn altijd inbegrepen.",
+        "requiredOnly": "Alleen vereist"
+      },
+      "addNotes": {
+        "title": "Notities en richtlijnen toevoegen",
+        "description": "Bied aanvullende context en begeleiding om de AI te helpen betere testcases te genereren.",
+        "quantity": "Aantal te genereren testcases",
+        "placeholder": "Voeg specifieke instructies toe voor het genereren van testcases...\n\nBijvoorbeeld:\n• Focus op beveiligingstesten\n• Neem edge cases en randvoorwaarden op\n• Test zowel happy path- als error-scenario's\n• Houd rekening met mobiele en desktop-scenario's\n• Focus op API-testen",
+        "suggestions": "Snelle suggesties:",
+        "quantityOptions": {
+          "justOne": "Slechts één",
+          "couple": "Een stel (2)",
+          "few": "Een paar (2-3)",
+          "several": "Meerdere (4-6)",
+          "many": "Veel (7-10)",
+          "maximum": "Maximaal"
+        },
+        "suggestionItems": {
+          "security": "Focus op beveiligingstesten",
+          "edgeCases": "Inclusief randgevallen",
+          "happyPath": "Test alleen het gelukkige pad",
+          "mobile": "Houd rekening met mobiele scenario's",
+          "api": "Focus op API-testen",
+          "accessibility": "Inclusief toegankelijkheidstests"
+        }
+      },
+      "review": {
+        "title": "Gegenereerde testcases beoordelen",
+        "description": "Bekijk de door de AI gegenereerde testcases, breng eventuele wijzigingen aan en selecteer welke u wilt importeren.",
+        "selected": "{count} van {total} geselecteerd",
+        "moreSteps": "... en {count, plural, one {# volgende stap} other {# volgende stappen}}",
+        "templateFields": "Sjabloonvelden:",
+        "moreFields": "... en {count, plural, one {# meer veld} other {# meer velden}}",
+        "crawledUrls": "{count, plural, one {# pagina's gecrawld} other {# pagina's gecrawld}}",
+        "spaWarning": "Deze pagina vereist mogelijk JavaScript voor weergave. De resultaten kunnen onvolledig zijn.",
+        "filterByPage": "Filteren op pagina",
+        "allPages": "Alle pagina's ({pages, plural, one {# pagina} other {# pagina's}}, {cases, plural, one {# geval} other {# gevallen}})"
+      },
+      "generatingLegacy": "Testgevallen genereren met AI...",
+      "expandProgress": "{done} van {total} gegenereerd",
+      "import": "{count, plural, =0 {Testcases importeren} =1 {1 testcase importeren} other {# Testcases importeren}}",
+      "importing": "{count, plural, =0 {Testgevallen importeren...} =1 {1 testgeval importeren...} other {# testgevallen importeren...}}",
+      "openInExternalSystem": "Openen in {provider}",
+      "externalSystem": "Extern systeem",
+      "autoGenerateTags": "Automatisch tags genereren voor testcases",
+      "success": {
+        "imported": "{count, plural, =1 {1 testcase succesvol geïmporteerd} other {# testcases succesvol geïmporteerd}}"
+      },
+      "importData": {
+        "issueDescription": "Externe kwestie gekoppeld aan het genereren van testgevallen",
+        "generatedFolderName": "gegenereerd"
+      },
+      "errors": {
+        "generateFailed": "Het genereren van testcases is mislukt. Probeer het opnieuw.",
+        "importFailed": "Het importeren van testcases is mislukt. Probeer het opnieuw.",
+        "noTestCasesGenerated": "Er zijn geen testcases gegenereerd. Probeer het opnieuw met andere invoer.",
+        "jobNoLongerAvailable": "Deze generatie is niet langer beschikbaar. Start een nieuwe generatie via de wizard 'Testgevallen genereren'.",
+        "noAiModel": "Er is geen AI-model geconfigureerd voor dit project. Configureer een AI-model in de projectinstellingen.",
+        "noIssueSelected": "Selecteer een probleem om testgevallen voor te genereren.",
+        "noDocumentProvided": "Gelieve de details van het vereistendocument te verstrekken.",
+        "noTemplateSelected": "Selecteer een sjabloon voor de testgevallen.",
+        "noFieldsSelected": "Selecteer ten minste één veld waarvoor u inhoud wilt genereren.",
+        "noTestCasesSelectedForImport": "Selecteer ten minste één testcase om te importeren.",
+        "templateRequired": "U moet een sjabloon selecteren. Ga terug en kies een sjabloon.",
+        "repositoryNotFound": "Projectrepository niet gevonden. Neem contact op met uw beheerder.",
+        "workflowNotConfigured": "Projectworkflow niet geconfigureerd. Controleer de projectinstellingen.",
+        "authenticationError": "Authenticatiefout. Vernieuw de pagina en probeer het opnieuw.",
+        "caseCreationFailed": "Het is niet gelukt om een testcase aan te maken: {name}",
+        "caseAlreadyExists": "Testgeval \"{name}\" bestaat al in deze map.",
+        "invalidTemplateConfig": "Ongeldige sjabloonconfiguratie voor testgeval \"{name}\".",
+        "nameTooLong": "De testcasenaam \"{name}\" is te lang. Gebruik een kortere naam.",
+        "caseCreationError": "Het is niet gelukt om \"{name}\" te maken: {error}",
+        "templateNotFound": "Het geselecteerde sjabloon kon niet worden gevonden. Vernieuw de pagina en probeer het opnieuw.",
+        "repositoryConfigError": "Fout in de configuratie van de projectrepository. Neem contact op met uw beheerder.",
+        "workflowConfigError": "Fout in de projectworkflowconfiguratie. Controleer de projectinstellingen.",
+        "permissionDenied": "Je hebt geen toestemming om testcases aan te maken in dit project.",
+        "validationFailed": "Gegevensvalidatie is mislukt. Controleer de inhoud van de testcase en probeer het opnieuw.",
+        "databaseError": "Fout bij de databaseverbinding. Probeer het over een moment opnieuw.",
+        "genericImportError": "Import mislukt: {error}",
+        "networkRoutingError": "Probleem met netwerkroutering of serverconfiguratie - HTML-foutpagina ontvangen in plaats van API-antwoord",
+        "invalidSourceConfig": "Ongeldige bronconfiguratie",
+        "failedToCreateCaseVersion": "Het is niet gelukt om een case-versie aan te maken.",
+        "noUrlProvided": "Voer een URL in om testcases te genereren.",
+        "urlFetchFailed": "Het ophalen van content van de opgegeven URL is mislukt. Controleer de URL en probeer het opnieuw.",
+        "llm": {
+          "genericTitle": "AI-generatiefout",
+          "genericMessage": "Er is een fout opgetreden bij het genereren van testcases met AI. Probeer het opnieuw of pas uw invoer aan.",
+          "overloaded": {
+            "title": "Service tijdelijk niet beschikbaar",
+            "message": "Er is momenteel veel vraag naar de AI-service. Probeer het over enkele ogenblikken opnieuw."
+          },
+          "quota": {
+            "title": "Gebruikslimiet bereikt",
+            "message": "U heeft uw AI-gebruikslimiet voor deze periode bereikt. Probeer het later opnieuw of neem contact op met uw beheerder."
+          },
+          "timeout": {
+            "title": "Verzoek verlopen",
+            "message": "De AI-aanvraag duurde te lang om te voltooien. Dit kan gebeuren bij complexe vereisten of een groot aantal testcases."
+          },
+          "network": {
+            "title": "Netwerkfout",
+            "message": "Er kan geen verbinding worden gemaakt met de AI-service. Controleer uw internetverbinding en probeer het opnieuw."
+          },
+          "unauthorized": {
+            "title": "Authenticatie voor AI-service mislukt",
+            "message": "De AI-service heeft onze inloggegevens afgewezen. Een beheerder moet de API-sleutel van de LLM-integratie controleren in de beheerdersinstellingen."
+          },
+          "forbidden": {
+            "title": "Toegang tot AI-service geweigerd",
+            "message": "De AI-service heeft dit verzoek geweigerd. Een beheerder moet de machtigingen en projecttoegang van de LLM-integratie verifiëren."
+          },
+          "projectNotFound": {
+            "title": "Project niet gevonden",
+            "message": "We konden dit project niet vinden, of je hebt geen toestemming om hier AI-generatie te gebruiken."
+          },
+          "noIntegration": {
+            "title": "Geen actieve LLM-integratie",
+            "message": "Er is geen actieve LLM-integratie geconfigureerd voor dit project. Een beheerder moet deze inschakelen in de beheerdersinstellingen."
+          },
+          "invalidRequest": {
+            "title": "Ongeldig verzoek",
+            "message": "Bij het genereren van de AI ontbraken essentiële gegevens. Vernieuw de pagina en probeer het opnieuw."
+          },
+          "retryButton": "Opnieuw proberen",
+          "dismissButton": "Afwijzen",
+          "suggestionsHeading": "Suggesties",
+          "suggestions": {
+            "retryLater": "Probeer het over een paar minuten nog eens.",
+            "contactAdmin": "Neem contact op met uw beheerder als het probleem aanhoudt.",
+            "checkStatus": "Controleer de status van de AI-service.",
+            "checkNetwork": "Controleer je internetverbinding."
+          },
+          "timestampLabel": "Er is een fout opgetreden bij",
+          "showDetails": "Details weergeven",
+          "hideDetails": "Details verbergen",
+          "copyDetails": "Kopieer details",
+          "detailsCopied": "Foutdetails gekopieerd naar klembord"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Niet-opgeslagen bewerkingen",
+        "description": "{count, plural, =1 {Je hebt 1 testgeval met niet-opgeslagen wijzigingen.} other {Je hebt # testgevallen met niet-opgeslagen wijzigingen.}}",
+        "warning": "Als u doorgaat zonder op te slaan, gaan uw wijzigingen verloren.",
+        "saveAllAndImport": "Alles opslaan en importeren",
+        "discardAndImport": "Bewerkingen verwijderen en importeren"
+      },
+      "linkedIssuesDroppedTitle": "Sommige gerelateerde onderwerpen zijn niet opgenomen.",
+      "linkedIssuesDropped": "{count, plural, =1 {# gekoppeld probleem is verwijderd} other {# gekoppelde problemen zijn verwijderd}} vanwege tokenbudget: {keys}.",
+      "linkedIssuesPreviewHeading": "Gerelateerde onderwerpen die zullen worden opgenomen"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Tag toevoegen",
+      "title": "Nieuwe tag toevoegen",
+      "fields": {
+        "name_error": "Tagnaam is vereist"
+      },
+      "errors": {
+        "nameExists": "Er bestaat al een tag met deze naam."
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Er bestaat al een tag met deze naam"
+      }
+    },
+    "filterPlaceholder": "Labels filteren...",
+    "defaultName": "Naamloze tag",
+    "noProject": "Geen project",
+    "description": "Beheer en organiseer uw testcases en sessies met tags",
+    "detail": {
+      "title": "Tagdetails",
+      "filterPlaceholder": "Items filteren...",
+      "noResults": "Geen items gevonden",
+      "noFilterResults": "Geen items voldoen aan de huidige filters.",
+      "filters": {
+        "hideCompletedSessions": "Verberg voltooide sessies",
+        "hideCompletedTestRuns": "Verberg voltooide testruns",
+        "caseTypeLabel": "Case type",
+        "allCases": "Alle"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Zoek tags...",
+      "searchOrAddPlaceholder": "Zoek of voeg tags toe...",
+      "noOptions": "Geen opties"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Bijlageviewer"
+    },
+    "delete": {
+      "confirmMessage": "Weet u zeker dat u deze bijlage wilt verwijderen?",
+      "deferredMessage": "Deze bijlage wordt verwijderd wanneer u opslaat."
+    }
+  },
+  "runs": {
+    "notFound": "Testrun niet gevonden.",
+    "add": {
+      "title": "Testrun toevoegen",
+      "description": "Voeg een nieuwe testrun toe aan het project",
+      "success": {
+        "title": "Testrun succesvol toegevoegd",
+        "description": "De testrun is toegevoegd aan het project",
+        "descriptionMultiple": "{count, plural, one {# testrun heeft} other {# testruns hebben}} zijn aangemaakt voor '{name}'"
+      },
+      "estimates": {
+        "manual": "Geschatte handmatige tijd",
+        "automated": "Geschatte geautomatiseerde tijd",
+        "mixed": "Geschatte handmatige/geautomatiseerde tijd"
+      },
+      "creatingProgress": "Testrun {current} van {total} aanmaken ..."
+    },
+    "magicSelect": {
+      "title": "Magische selectie",
+      "description": "AI-gestuurde selectie van testgevallen op basis van de context van uw testuitvoering.",
+      "counting": "Op zoek naar relevante testgevallen...",
+      "reasoning": "AI-redenering",
+      "reviewSelection": "Bekijk de voorgestelde testgevallen",
+      "viewSuggested": "Bekijk voorgestelde casussen",
+      "tokenUsage": "{total} tokens gebruikt",
+      "noLlmIntegration": "AI-functies vereisen een LLM-integratie. Configureer deze in de projectinstellingen.",
+      "configure": {
+        "title": "Testcasebereik",
+        "description": "Gevonden {count, plural, =1 {# testcase} other {# testcases}} in de repository",
+        "descriptionFiltered": "Gevonden {count, plural, =1 {# mogelijk relevante testcase} other {# mogelijk relevante testcases}} van {total, plural, =1 {# totaal} other {# totaal}} in de repository",
+        "noMatchesTitle": "Geen overeenkomende testgevallen gevonden",
+        "noMatchesDescription": "De naam en beschrijving van de testrun komen niet overeen met testgevallen. Ga terug naar de vorige stap en voeg specifiekere details toe, zoals functienamen, componentnamen of trefwoorden die in uw testgevallen voorkomen.",
+        "maxResultsTitle": "Maximaal aantal testgevallen komt overeen",
+        "maxResultsDescription": "De zoekcriteria kwamen overeen met een groot aantal testgevallen. Voor meer gerichte resultaten kunt u teruggaan naar de vorige stap en meer specifieke details aan de testuitvoering toevoegen.",
+        "batchSize": "Batchgrootte",
+        "batchSizeAll": "Alle gevallen (één aanvraag)",
+        "batchSizePercent": "{percent}% ({count} gevallen)",
+        "requestsNeeded": "{count, plural, =1 {# AI-verzoek wordt gedaan} other {# AI-verzoeken worden gedaan}}",
+        "batchNote": "De resultaten van alle batches worden gecombineerd."
+      },
+      "loading": {
+        "batch": "Batch {current} van {total} wordt verwerkt",
+        "analyzing": "Testgevallen analyseren...",
+        "progress": "Geanalyseerde {analyzed} van {total} testgevallen...",
+        "waitingForAi": "Wachten op AI-reactie (batch {batch} van {total})...",
+        "selectedSoFar": "{count, plural, =1 {# tot nu toe geselecteerde testgevallen} other {# tot nu toe geselecteerde testgevallen}}",
+        "resolving_integration": "Het oplossen van AI-integratieproblemen...",
+        "fetching_cases": "Testgevallen ophalen..."
+      },
+      "success": {
+        "title": "Voorgestelde testgevallen",
+        "description": "{count, plural, =1 {# testgeval geselecteerd} other {# testgevallen geselecteerd}} op basis van uw testuitvoeringscontext",
+        "linkedCasesAdded": "{count, plural, =1 {# gekoppelde gevallen automatisch opgenomen} other {# gekoppelde gevallen automatisch opgenomen}}",
+        "truncationWarningTitle": "Gedeeltelijke resultaten",
+        "truncationWarning": "{count, plural, =1 {# batch werd afgekapt} other {# batches werden afgekapt}} door het AI-model — sommige testgevallen zijn mogelijk niet geëvalueerd."
+      },
+      "noSuggestions": {
+        "title": "Geen overeenkomende testgevallen gevonden",
+        "description": "Er zijn geen testgevallen gevonden die aan de criteria voldoen. Probeer meer context of verduidelijking toe te voegen."
+      },
+      "clarification": {
+        "label": "Aanvullende context (optioneel)",
+        "placeholder": "Voeg extra context toe om relevante testgevallen te selecteren...",
+        "refine": "Selectie verfijnen"
+      },
+      "actions": {
+        "start": "Testgevallen analyseren",
+        "startBatched": "Testgevallen analyseren ({count, plural, one {# batch} other {# batches}})",
+        "accept": "Toevoegen aan selectie"
+      },
+      "errors": {
+        "title": "Selectie mislukt",
+        "generic": "Er is een fout opgetreden tijdens het selecteren van testgevallen. Probeer het opnieuw.",
+        "noTestRunName": "Voer een naam in voor de testrun voordat u Magic Select gebruikt."
+      }
+    },
+    "delete": {
+      "title": "Testrun verwijderen",
+      "description": "Weet u zeker dat u deze testrun wilt verwijderen? De resultaten worden bewaard voor historische analyse.",
+      "warning": "Deze actie kan niet ongedaan worden gemaakt.",
+      "toast": {
+        "loading": "Testrun verwijderen...",
+        "success": "Testrun succesvol verwijderd",
+        "error": {
+          "title": "Het is niet gelukt om de testrun te verwijderen",
+          "description": "Er is een fout opgetreden bij het verwijderen van de testrun"
+        }
+      }
+    },
+    "summary": {
+      "title": "Samenvatting van de testrun",
+      "description": "Bekijk de samenvatting van de testrun",
+      "activeRunsAndEstTime": "Actieve runs en geschatte tijd",
+      "activeRunsLabel": "loopt",
+      "totalEstTime": "Totale geschatte tijd",
+      "responsibleUsers": "Verantwoordelijke gebruikers",
+      "allActiveRuns": "Alle actieve runs",
+      "recentResultsTitle": "Recente handmatige resultaten",
+      "recentResultsDescription": "Bekijk de recente resultaten van de testrun",
+      "recentAutomatedResultsTitle": "Recente geautomatiseerde resultaten",
+      "noRecentAutomatedResults": "Geen recente geautomatiseerde resultaten gevonden.",
+      "recentResultsDateRange": "Datumbereik",
+      "recentResultsElapsed": "Verstreken",
+      "noRecentResults": "Er zijn geen recente resultaten gevonden.",
+      "completionTrendTitle": "Voltooiingstrend (vorige 6 maanden)",
+      "workDistributionTitle": "Werkverdeling",
+      "workDistributionDescription": "Geschatte werkverdeling per toegewezen persoon.",
+      "noWorkDistributionData": "Er zijn geen actieve sessies met toegewezen personen of schattingen om weer te geven."
+    },
+    "details": {
+      "title": "Testrundetails",
+      "description": "Bekijk de details van de testrun"
+    },
+    "duplicateDialog": {
+      "title": "Dubbele testrun",
+      "description": "Maak een kopie van testrun <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Testgevallen om te dupliceren",
+          "allCases": "Alle testgevallen",
+          "specificStatuses": "Testgevallen met specifieke statussen"
+        },
+        "statusesToInclude": {
+          "label": "Testgevallen om op te nemen",
+          "description": "Selecteer de statussen van testcases die u wilt opnemen in de gedupliceerde testrun.",
+          "noStatuses": "Er zijn geen specifieke statussen gevonden tijdens deze testrun of de resultaten worden nog geladen.",
+          "noStatusesRecorded": "Er zijn geen specifieke statussen geregistreerd in deze run. Dupliceren omvat alle testcases (meestal als 'Niet getest')."
+        },
+        "copyAssignments": {
+          "label": "Testcase-opdrachten",
+          "copy": "Bestaande testcasetoewijzingen kopiëren",
+          "assign": "Alle testcases in de gedupliceerde testrun behouden hun bestaande toewijzingen",
+          "unassign": "Alle testgevallen in de gedupliceerde testrun worden niet toegewezen"
+        }
+      },
+      "successMessage": "Testrun '{name}' is succesvol gedupliceerd.",
+      "errorMessage": "Het is niet gelukt om de testrun te dupliceren. Fout: {error}"
+    },
+    "filter": {
+      "placeholder": "Filtertest uitgevoerd..."
+    },
+    "typeFilter": {
+      "label": "Show",
+      "both": "Handmatig en geautomatiseerd"
+    },
+    "empty": {
+      "noMatchingCompleted": "Er zijn geen voltooide testruns die aan uw filter voldoen."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Voornaamst",
+      "projects": "Projecten",
+      "templatesAndFields": "Sjablonen en velden",
+      "fields": "Velden",
+      "workflows": "Werkstromen",
+      "statuses": "Statussen",
+      "milestoneTypes": "Soorten mijlpalen",
+      "configurations": "Configuraties",
+      "users": "Gebruikers",
+      "groups": "Groepen",
+      "roles": "Rollen",
+      "tags": "Tags",
+      "issues": "Problemen",
+      "appConfig": "Toepassingsconfiguratie",
+      "notifications": "Meldingen",
+      "imports": "Gegevensimport",
+      "integrations": "Probleemintegraties",
+      "webhooks": "Webhooks",
+      "llm": "AI-modellen",
+      "prompts": "Promptconfiguraties",
+      "exportTemplates": "Export sjablonen",
+      "codeRepositories": "Codeopslagplaatsen",
+      "quickScript": "QuickScript",
+      "sso": "Authenticatie",
+      "security": "Beveiliging",
+      "trash": "Afval",
+      "reports": "Rapporten",
+      "shares": "Aandelen beheren",
+      "elasticsearch": "Zoekmachine",
+      "queues": "Taakwachtrijen",
+      "auditLogs": "Auditlogboeken",
+      "apiTokens": "API-tokens",
+      "quickscriptTemplates": "QuickScript-sjablonen",
+      "testManagement": "Testmanagement",
+      "peopleAndAccess": "Mensen & Toegang",
+      "toolsAndIntegrations": "Tools en integraties",
+      "system": "Systeem"
+    },
+    "imports": {
+      "description": "Importeer gegevens van externe testmanagementtools in TestPlanIt.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Upload een Testmo JSON-export om de inhoud te analyseren en uw migratietoewijzing voor te bereiden.",
+        "wizard": {
+          "steps": {
+            "upload": "Uploaden exporteren",
+            "analysis": "Beoordelingsanalyse",
+            "mapping": "Toewijzing configureren",
+            "import": "Monitor import"
+          },
+          "stepIndicator": "Stap {step} van {total}"
+        },
+        "fileLabel": "Testmo JSON-bestand",
+        "fileHelp": "Selecteer de JSON-export die u van Testmo hebt gedownload.",
+        "analyze": "Export analyseren",
+        "analyzing": "Analyseren...",
+        "reset": "Duidelijke resultaten",
+        "job": {
+          "discoveringDatasets": "Datasets ontdekken...",
+          "scanningFile": "Testmo-exportbestand scannen...",
+          "datasetsProcessed": "{processed, number} dataset{processed, plural, one {} other {s}} verwerkt",
+          "datasetsProcessedWithTotal": "{processed, number} van {total, number} dataset{total, plural, one {} other {s}} verwerkt",
+          "rowsProcessed": "{value, number} rijen verwerkt",
+          "itemsProcessed": "{processed, number} van {total, number} items verwerkt",
+          "analysisInProgress": "Export analyseren…",
+          "cancel": "Import annuleren",
+          "cancelRequested": "Annuleren aangevraagd",
+          "processingRate": "Tarief:",
+          "estimatedTimeRemaining": "Geschatte resterende tijd:",
+          "datasetsLabel": "Gegevenssets:",
+          "rowsProcessedLabel": "Rijen:"
+        },
+        "summaryHeading": "Exportsamenvatting",
+        "summary": {
+          "datasets": "Gegevenssets",
+          "fileName": "Bestandsnaam",
+          "fileSize": "Bestandsgrootte",
+          "analysisTime": "Analysetijd"
+        },
+        "datasetTable": {
+          "name": "Gegevensset",
+          "rows": "Rijen",
+          "samples": "Gevangen monsters"
+        },
+        "status": {
+          "truncated": "Afgeknot"
+        },
+        "selectDataset": "Selecteer dataset",
+        "schema": "Schema",
+        "samples": "Voorbeeldrijen",
+        "noSamples": "Er zijn geen monsters verzameld voor deze dataset.",
+        "mappingHeading": "Toewijzingsconfiguratie",
+        "mappingRefresh": "Vernieuwingsanalyse",
+        "mappingDescription": "Bekijk de analysedetails en wijs Testmo-entiteiten toe aan bestaande TestPlanIt-records, of kies ervoor om nieuwe te maken.",
+        "mappingAnalysisError": "We konden geen kaartanalyse genereren. Probeer het opnieuw.",
+        "mappingLoading": "Analyse van gebouwkaarten…",
+        "mappingSummaryHeading": "Gedetecteerde entiteiten",
+        "mappingSummaryPending": "{count, plural, =1 {# in behandeling} other {# in behandeling}}",
+        "mappingOutstandingTitle": "Los openstaande toewijzingen op",
+        "mappingOutstandingDescription": "Voltooi de resterende toewijzingen voordat u met importeren begint.",
+        "mappingOutstandingItem": "{count, plural, =1 {# onopgelost item} other {# onopgeloste items}} in {label}",
+        "mappingSummaryTemplateFields": "Sjabloonvelden",
+        "mappingDatasetLabels": {
+          "field_values": "Veldwaarden",
+          "repository_case_values": "Repository case-waarden",
+          "configs": "Configuratie-instellingen",
+          "session_issues": "Sessieproblemen",
+          "session_tags": "Sessietags",
+          "states": "Werkstroomstaten",
+          "statuses": "Statussen",
+          "templates": "Sjablonen",
+          "template_fields": "Sjabloonvelden",
+          "milestone_types": "Mijlpaaltypen",
+          "roles": "Rollen",
+          "users": "Gebruikers",
+          "groups": "Groepen",
+          "user_groups": "Gebruikersgroepen",
+          "issue_targets": "Integraties van problemen",
+          "tags": "Tags",
+          "sessions": "Sessies",
+          "session_results": "Sessieresultaten",
+          "fields": "Velden",
+          "projects": "Projecten",
+          "repositories": "Repositories",
+          "repository_folders": "Repositorymappen",
+          "repository_cases": "Repository-cases",
+          "repository_case_steps": "Stappen in het repository-casescenario",
+          "repository_case_tags": "Repository case tags",
+          "milestones": "Mijlpalen",
+          "runs": "Testruns",
+          "run_tests": "Testuitvoeringsgevallen",
+          "run_results": "Testresultaten",
+          "run_result_steps": "Testresultaten van de uitvoeringsstap",
+          "run_links": "Testrun-links",
+          "run_tags": "Testrun-tags",
+          "issues": "Problemen",
+          "milestone_issues": "Mijlpaalproblemen",
+          "repository_case_issues": "Problemen met repository-cases",
+          "run_issues": "Testrunproblemen",
+          "run_result_issues": "Problemen met de testresultaten",
+          "session_result_issues": "problemen met sessieresultaten",
+          "automation_cases": "Automatiseringscases",
+          "automation_runs": "Automatiseringsruns",
+          "automation_run_tests": "Automatiseringstests uitvoeren",
+          "automation_run_test_fields": "Automatiseringstestvelden uitvoeren",
+          "automation_run_links": "Automatiseringslinks uitvoeren",
+          "automation_run_tags": "Automatiseringsuitvoeringslabels",
+          "session_values": "Sessiewaarden"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Controleer de werkstroomstatussen om TestPlanIt-werkstromen in kaart te brengen of te maken.",
+          "statuses": "Configureer hoe Testmo-statussen worden gekoppeld aan TestPlanIt-statussen.",
+          "templates": "Bekijk de sjabloondefinities die zijn geïmporteerd uit Testmo.",
+          "template_fields": "Inspecteer de sjabloonvelddefinities die in de export zijn opgenomen.",
+          "fields": "Controleer aangepaste veldrecords die zijn geëxporteerd vanuit Testmo.",
+          "field_values": "Controleer de veldwaardedefinities die in de export zijn vastgelegd.",
+          "milestone_types": "Inspecteer de mijlpaaltypedefinities die in de export zijn vastgelegd.",
+          "roles": "Bekijk de roldefinities om de Testmo-machtigingen te begrijpen.",
+          "users": "Bekijk de gebruikersaccounts die zijn gedetecteerd in de Testmo-export.",
+          "groups": "Bekijk de groepsopdrachten die u van Testmo hebt overgenomen.",
+          "configs": "Wijs configuratienamen toe aan TestPlanIt-categorieën en -varianten.",
+          "tags": "Controleer de tagwaarden die in de Testmo-gegevens voorkomen.",
+          "repository_case_values": "Multi-Select-waarden toegewezen aan testcases.",
+          "sessions": "Sessies worden altijd aangemaakt als nieuwe sessies.",
+          "session_results": "Sessieresultaten zijn gekoppeld aan sessies.",
+          "session_issues": "Sessieproblemen hebben te maken met sessies.",
+          "session_tags": "Sessietags zijn gekoppeld aan sessies.",
+          "issue_targets": "Koppel Testmo-probleemdoelen aan TestPlanIt-integraties (Jira, GitHub, enz.)."
+        },
+        "mappingDatasetDefaultDescription": "Beoordeling {dataset} gedetecteerd in de Testmo-export.",
+        "mappingDatasetCount": "{count, number} record{count, plural, one {} other {s}} gedetecteerd",
+        "mappingDatasetNoEntitiesTitle": "Niets om in kaart te brengen",
+        "mappingDatasetNoEntitiesDescription": "Deze dataset hoeft niet te worden toegewezen. Ga naar de volgende dataset wanneer u er klaar voor bent.",
+        "mappingDatasetUnsupportedTitle": "Geen mapping vereist",
+        "mappingDatasetUnsupportedDescription": "Deze records worden automatisch geïmporteerd en gekoppeld aan de bijbehorende records in TestPlanIt. Handmatige toewijzing is niet nodig.",
+        "mappingDatasetEmptyTitle": "Geen datasets bewaard",
+        "mappingDatasetEmptyDescription": "De analyse heeft geen datasets bewaard voor configuratie. Upload een andere export als u aanvullende gegevens verwacht.",
+        "importProgressTitle": "Importvoortgang",
+        "importProgressDescription": "{count, plural, =0 {Alle records geïmporteerd over de gevolgde entiteiten.} =1 {1 record resterend over de gevolgde entiteiten.} other {# records resterend over de gevolgde entiteiten.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Geen resterende records} =1 {1 record resterend} other {# records resterend}}",
+        "importProgressProcessed": "{processed, number}/{total, number} records geïmporteerd",
+        "importProgressAria": "{percent}% van import voltooid",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Totale tijd:",
+        "activityLogTitle": "Importactiviteit",
+        "activityLogDescription": "Gedetailleerd logboek van de stappen van achtergrondimport. Tijdstempels zijn gebaseerd op de tijdzone van de server.",
+        "activitySummaryProcessed": "{count, plural, =1 {# record verwerkt} other {# records verwerkt}}",
+        "activitySummaryCreated": "{count, plural, =1 {# aangemaakt} other {# aangemaakt}}",
+        "activitySummaryMapped": "{count, plural, =1 {# toegewezen} other {# toegewezen}}",
+        "activitySummaryUnknown": "Importstap",
+        "activityDefaultMessage": "Importupdate",
+        "previousImportsHeading": "Bekijk eerdere importen",
+        "previousImportsDescription": "Laad de resultaten van een voltooide import om configuratie- of activiteitenlogboeken te inspecteren.",
+        "previousImportsRefresh": "Lijst vernieuwen",
+        "previousImportsPlaceholder": "Selecteer een eerdere import",
+        "previousImportsEmpty": "Er zijn geen eerdere imports voor uw account gevonden.",
+        "previousImportsCreatedLabel": "Gemaakt: ",
+        "previousImportsFileLabel": "Bestand: ",
+        "previousImportsNoFilename": "Onbekend bestand",
+        "jobHistoryLoadFailed": "Eerder geïmporteerde taken konden niet worden geladen.",
+        "jobLoadFailed": "We konden die importtaak niet laden.",
+        "uploadProgressAnalyzing": "Uploaden voltooid. Bestand…analyseren",
+        "uploadProgressComplete": "Upload voltooid",
+        "etaLabel": "Verwachte aankomsttijd: {time}",
+        "startImportButton": "Importeren starten",
+        "workflowCreate": {
+          "nameLabel": "Workflownaam",
+          "namePlaceholder": "Voer een workflownaam in",
+          "scopePlaceholder": "Selecteer bereik",
+          "iconColorLabel": "Icoon & kleur",
+          "typeLabel": "Workflowtype"
+        },
+        "mappingDatasets": "Datasets die beoordeeld moeten worden",
+        "mappingImportConfiguration": "Configuratie importeren",
+        "mappingExportConfiguration": "Configuratie exporteren",
+        "mappingImportConfigurationFailed": "We konden dat configuratiebestand niet importeren. Controleer of het een geldige JSON is en probeer het opnieuw.",
+        "mappingInvalidConfiguration": "Configuratie moet geldige JSON zijn.",
+        "mappingSaveFailed": "De configuratie kon niet worden opgeslagen. Probeer het opnieuw.",
+        "mappingSaveConfiguration": "Configuratie opslaan",
+        "mappingSavingConfiguration": "Opslaan…",
+        "mappingStartImport": "Achtergrondimport starten",
+        "mappingStartingImport": "Import starten…",
+        "mappingImportFailed": "Het importeren op de achtergrond kon niet worden gestart. Probeer het opnieuw.",
+        "mappingImportDisabled": "Sla een configuratie op voordat u met de achtergrondimport begint.",
+        "mappingImportInProgress": "Achtergrondimport bezig",
+        "mappingImportInProgressDescription": "De importworker verwerkt de configuratie. U kunt de status hierboven bekijken.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# opnemen} other {# opnemen}} ",
+          "columnSource": "Testmo-entiteit",
+          "columnSourceDetails": "Details",
+          "columnSuggestedWorkflowType": "Voorgesteld type",
+          "columnTarget": "Doel",
+          "workflowTypeUnknown": "Niet gedetecteerd",
+          "actionMap": "Kaart naar bestaande",
+          "actionCreate": "Nieuw maken",
+          "workflowTypePlaceholder": "Selecteer type",
+          "noWorkflowsAvailable": "Geen workflows beschikbaar.",
+          "noStatusesAvailable": "Geen statussen beschikbaar.",
+          "noGroupsAvailable": "Geen groepen beschikbaar.",
+          "groupSelectPlaceholder": "Selecteer groep",
+          "groupNotePlaceholder": "Opmerkingen (optioneel)",
+          "groupNoteEmpty": "Er zijn geen aanvullende details verstrekt.",
+          "noUsersAvailable": "Geen gebruikers beschikbaar.",
+          "userNoExistingTargets": "Er zijn geen gebruikers beschikbaar om in kaart te brengen.",
+          "userNamePlaceholder": "Volledige naam",
+          "userAccessPlaceholder": "Selecteer toegangsniveau",
+          "userRoleUnavailable": "Er zijn geen rollen beschikbaar om toe te wijzen.",
+          "userPasswordPlaceholder": "Tijdelijk wachtwoord",
+          "userPasswordHint": "Geef een tijdelijk wachtwoord op. Gebruikers kunnen dit wijzigen nadat ze zijn ingelogd.",
+          "userActiveLabel": "Actief account",
+          "userDisplayFallback": "Gebruiker {id}",
+          "userMissingRequired": "Vereiste gegevens ontbreken",
+          "noConfigurationsAvailable": "Geen configuraties beschikbaar.",
+          "configurationNoTokens": "Er zijn geen varianten gedetecteerd in deze configuratie.",
+          "configurationNoExistingTargets": "Er zijn geen configuraties beschikbaar om in kaart te brengen.",
+          "configurationNamePlaceholder": "Voer een configuratienaam in",
+          "configurationVariantLabel": "Variant {index}",
+          "configurationVariantActionLabel": "Hoe moet met deze variant worden omgegaan?",
+          "configurationVariantActionPlaceholder": "Kies een optie",
+          "configurationVariantMapOption": "Toewijzen aan bestaande variant",
+          "configurationVariantExistingCategoryOption": "Variant aanmaken in bestaande categorie",
+          "configurationVariantNewCategoryOption": "Nieuwe categorie en variant aanmaken",
+          "configurationVariantSelectLabel": "Selecteer variant",
+          "configurationVariantNoVariants": "Er zijn geen varianten beschikbaar om in kaart te brengen.",
+          "configurationVariantCategoryLabel": "Categorie",
+          "configurationVariantNameLabel": "Variantnaam",
+          "configurationVariantNamePlaceholder": "Voer een variantnaam in",
+          "configurationVariantNoCategories": "Geen categorieën beschikbaar.",
+          "configurationVariantCategoryNameLabel": "Categorienaam",
+          "configurationVariantCategoryNamePlaceholder": "Voer een categorienaam in",
+          "noTemplateFieldsAvailable": "Er zijn geen sjabloonvelden beschikbaar.",
+          "templateFieldDisplayFallback": "Veld {id}",
+          "templateFieldUnknownTemplate": "Onbekende sjabloon",
+          "templateFieldTargetCase": "Caseveld",
+          "templateFieldTargetResult": "Resultaatveld",
+          "templateFieldSelectPlaceholder": "Selecteer veld",
+          "templateFieldNoExistingTargets": "Er zijn geen velden beschikbaar om in kaart te brengen.",
+          "templateFieldTypePlaceholder": "Selecteer veldtype",
+          "templateFieldRestrictedLabel": "Beperkt veld",
+          "templateFieldOptionsLabel": "Keuzemenu-opties",
+          "templateFieldOptionsPlaceholder": "Voer één optie per regel in",
+          "templateFieldOptionsHint": "Scheid elke optie met een nieuwe regel.",
+          "templateFieldOptionsListLabel": "Opties",
+          "templateFieldOptionsCheckedLabel": "Standaard aangevinkt",
+          "templateFieldOptionsMinValueLabel": "Minimale waarde",
+          "templateFieldOptionsMaxValueLabel": "Maximale waarde",
+          "templateFieldOptionsMinIntegerLabel": "Minimaal geheel getal",
+          "templateFieldOptionsMaxIntegerLabel": "Maximaal geheel getal",
+          "templateFieldNewFieldSummaryTitle": "Nieuwe velddetails",
+          "templateFieldNewFieldSummaryDescription": "Controleer de waarden die gebruikt zullen worden om dit TestPlanIt-veld te maken.",
+          "templateFieldConfigureFieldButton": "Details configureren",
+          "templateFieldEditFieldButton": "Gegevens bewerken",
+          "templateFieldSummaryMissingValue": "Niet ingesteld",
+          "templateFieldSummaryMissingDetailsHint": "Geef de nieuwe velddetails op voordat u verdergaat.",
+          "templateFieldModalSaveButton": "Gegevens opslaan",
+          "templateFieldTargetTypeLabel": "Doeltype",
+          "templateFieldTypeMismatchWarning": "Het geselecteerde veldtype {target} komt niet overeen met het Testmo-veldtype {source}.",
+          "templateFieldDuplicateTargetWarning": "Het geselecteerde doel is al toegewezen aan een ander Testmo-veld. Kies een ander doel.",
+          "templateFieldTargetAlreadyUsed": "Al in kaart gebracht",
+          "templateFieldMappedSummary": "Toegewezen aan {name} ({type})",
+          "templateFieldIssueMissingTarget": "Selecteer een doelveld.",
+          "templateFieldIssueMissingDetails": "Geef de weergavenaam, de systeemnaam en het veldtype op voordat u verdergaat.",
+          "noTemplatesAvailable": "Er zijn geen sjablonen beschikbaar.",
+          "templateColumnFields": "Velden",
+          "templateFieldStatusMapped": "In kaart gebracht",
+          "templateFieldStatusCreate": "Nieuw veld maken",
+          "templateFieldStatusMissing": "Niet in kaart gebracht",
+          "templateFieldStatusMismatch": "Doel mismatch",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# caseveld} other {# casevelden}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# resultaatveld} other {# resultaatvelden}}",
+          "templateMapLabel": "Toewijzen aan bestaande sjabloon",
+          "templateCreateLabel": "Nieuwe sjabloon maken",
+          "templateNoMatchingTargets": "Er zijn geen overeenkomende sjablonen beschikbaar.",
+          "templateNewNameLabel": "Sjabloonnaam",
+          "templateMapHintIncomplete": "Koppel alle Testmo-velden aan bestaande case- en resultaatvelden voordat u ze koppelt aan een bestaande sjabloon.",
+          "templateMapHintDuplicate": "Elk Testmo-veld moet worden toegewezen aan een uniek TestPlanIt-veld.",
+          "templateMapHintNoMatch": "Er bestaat geen enkele sjabloon die dezelfde set velden gebruikt.",
+          "templateMapHintAlreadyMapped": "Alle overeenkomende sjablonen zijn al toegewezen. Wis de andere toewijzing voordat u verdergaat.",
+          "templateIssueNoSelection": "Selecteer een bestaand sjabloon om in kaart te brengen.",
+          "templateIssueTargetConflict": "Er is al een andere sjabloon aan dit doel toegewezen.",
+          "templateIssueFieldErrors": "Los de gemarkeerde sjabloonvelden op.",
+          "templateTargetFieldsMismatch": "Velden komen niet overeen met deze sjabloon.",
+          "templateTargetNoLongerMatching": "Velden komen niet meer overeen met deze sjabloon.",
+          "noRolesAvailable": "Er zijn geen functies beschikbaar.",
+          "roleSelectPlaceholder": "Selecteer rol",
+          "roleNameLabel": "Rolnaam",
+          "roleNamePlaceholder": "Voer een rolnaam in",
+          "rolePermissionsEmpty": "Geen rechten toegewezen",
+          "rolePermissionAddEdit": "Toevoegen / Bewerken",
+          "noMilestoneTypesAvailable": "Er zijn geen mijlpaaltypen beschikbaar.",
+          "milestoneSelectPlaceholder": "Selecteer mijlpaaltype",
+          "milestoneNamePlaceholder": "Voer een naam in voor het mijlpaaltype",
+          "milestoneDefaultLabel": "Standaard mijlpaaltype",
+          "milestoneIconRequired": "Selecteer een pictogram",
+          "statusColorPlaceholder": "Kleur hex (optioneel)",
+          "issueTargetSelectPlaceholder": "Selecteer integratie...",
+          "noIssueTargetsAvailable": "Geen probleemintegraties beschikbaar",
+          "issueTargetNamePlaceholder": "Integratienaam...",
+          "templateFieldsHeading": "Sjabloonvelden",
+          "roleAreaColumn": "Gebied",
+          "workflowSelectPlaceholder": "Selecteer workflow",
+          "statusSelectPlaceholder": "Selecteer status",
+          "statusNamePlaceholder": "Voer een statusnaam in",
+          "statusSystemNamePlaceholder": "Voer een systeemnaam in",
+          "labelSystemName": "Systeemnaam",
+          "groupNamePlaceholder": "Voer een groepsnaam in",
+          "configurationNameLabel": "Configuratienaam",
+          "userSelectPlaceholder": "Gebruiker selecteren",
+          "userApiLabel": "API-gebruiker",
+          "templateCaseFieldsLabel": "Zaakvelden",
+          "templateResultFieldsLabel": "Resultaatvelden",
+          "templateNoFieldsPlaceholder": "Er zijn geen velden geconfigureerd voor deze sjabloon.",
+          "templateTargetAlreadyUsed": "Doel is al gekoppeld aan een andere sjabloon.",
+          "templateFieldRequiredLabel": "Verplicht veld",
+          "templateFieldOptionsDefaultValueLabel": "Standaardwaarde",
+          "templateFieldOptionsInitialHeightLabel": "Initiële hoogte",
+          "templateFieldTemplateLabelSingular": "sjabloon",
+          "templateFieldTemplateLabelPlural": "sjablonen",
+          "templateFieldTargetGroupCase": "Zaakvelden",
+          "templateFieldTargetGroupResult": "Resultaatvelden",
+          "columnAction": "Actie"
+        },
+        "nextSteps": "Nadat de achtergrondimport is voltooid, kunt u de gemigreerde gegevens uit de doelprojecten bekijken.",
+        "nextStepsDescription": "Achtergrondimporten worden asynchroon uitgevoerd. U kunt de status hierboven controleren of de pagina vernieuwen om updates te bekijken."
+      },
+      "comingSoon": {
+        "description": "Importeren voor TestRail, Zephyr en andere tools staat op de planning."
+      },
+      "errors": {
+        "fileRequired": "Selecteer een Testmo-export-JSON-bestand voordat u gaat analyseren.",
+        "uploadFailed": "We konden de export niet uploaden naar de opslag. Probeer het opnieuw.",
+        "analysisFailed": "We konden die export niet analyseren. Controleer het bestand en probeer het opnieuw."
+      }
+    },
+    "sso": {
+      "description": "Beheer authenticatie- en beveiligingsinstellingen",
+      "sections": {
+        "providers": {
+          "title": "Aanmeldingsaanbieders",
+          "description": "Configureer hoe gebruikers zich kunnen aanmelden bij uw applicatie."
+        },
+        "security": {
+          "title": "Beveiliging",
+          "description": "Configureer beveiligingsbeleid voor authenticatie."
+        }
+      },
+      "globalSettings": {
+        "title": "Globale SSO-instellingen",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Google OAuth-authenticatie in- of uitschakelen"
+        },
+        "samlProvider": {
+          "title": "SAML-provider",
+          "description": "SAML-authenticatie in- of uitschakelen"
+        },
+        "apple": {
+          "title": "Apple Aanmelden",
+          "description": "Apple Sign In-verificatie in- of uitschakelen"
+        },
+        "microsoft": {
+          "title": "Microsoft SSO",
+          "description": "Microsoft-authenticatie (Azure AD / Entra ID) in- of uitschakelen"
+        },
+        "magicLink": {
+          "title": "Magic Link-authenticatie",
+          "description": "E-mailgebaseerde authenticatie zonder wachtwoord inschakelen of uitschakelen"
+        },
+        "forceSso": {
+          "title": "Forceer SSO-aanmelding",
+          "description": "Schakel e-mailaanmelding uit en eis dat gebruikers SSO gebruiken"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Vereis tweefactorauthenticatie (2FA) voor wachtwoordaanmeldingen.",
+            "description": "Gebruikers die inloggen met e-mail/wachtwoord moeten tweefactorauthenticatie instellen en gebruiken."
+          },
+          "forceAllLogins": {
+            "title": "Vereis tweefactorauthenticatie voor alle aanmeldingen.",
+            "description": "Alle gebruikers moeten zich na het inloggen verifiëren met tweefactorauthenticatie (2FA), inclusief gebruikers met single sign-on (SSO)."
+          }
+        }
+      },
+      "providers": {
+        "configure": "SAML configureren",
+        "delete": "Provider verwijderen",
+        "entryPoint": "Ingangspunt: ",
+        "autoProvision": "Automatische voorziening: ",
+        "defaultAccess": "Standaardtoegang: ",
+        "configurationMessage": "SAML-configuratie niet ingesteld. Klik op de instellingenknop om te configureren."
+      },
+      "samlConfiguration": {
+        "title": "SAML-provider configureren",
+        "backButton": "Terug naar SSO-providers",
+        "description": "SAML-instellingen configureren voor {name}",
+        "samlSettings": {
+          "title": "SAML-instellingen",
+          "description": "Configureer uw SAML-identiteitsproviderinstellingen",
+          "ssoUrl": "SSO-URL (toegangspunt)",
+          "entityId": "Entiteits-ID (uitgever)",
+          "certificate": "X.509-certificaat",
+          "callbackUrl": "Terugbel-URL",
+          "logoutUrl": "Uitlog-URL (optioneel)"
+        },
+        "userProvisioning": {
+          "title": "Gebruikersinrichting",
+          "description": "Configureer hoe gebruikers worden aangemaakt en toegewezen",
+          "autoProvision": "Nieuwe gebruikers automatisch inrichten",
+          "defaultAccess": "Standaard systeemtoegang voor nieuwe gebruikers",
+          "accessDescription": "Nieuwe gebruikers krijgen de standaardrol uit de database en dit systeemtoegangsniveau toegewezen."
+        },
+        "attributeMapping": {
+          "title": "Attribuuttoewijzing",
+          "description": "SAML-kenmerken toewijzen aan gebruikersvelden",
+          "email": "E-mailadres kenmerk",
+          "displayName": "Weergavenaamkenmerk",
+          "userId": "Gebruikers-ID-kenmerk",
+          "firstName": "Voornaamkenmerk (optioneel)",
+          "lastName": "Achternaamkenmerk (optioneel)",
+          "groups": "Groepskenmerk (optioneel)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Google OAuth ingeschakeld",
+        "googleDisabled": "Google OAuth uitgeschakeld",
+        "googleCreated": "Google OAuth-provider aangemaakt",
+        "googleUpdateFailed": "Google OAuth kan niet worden bijgewerkt",
+        "samlCreated": "SAML-provider aangemaakt",
+        "createFailed": "Aanbieder aanmaken mislukt",
+        "deleted": "Provider verwijderd",
+        "deleteFailed": "Provider verwijderen mislukt",
+        "enabled": "Provider ingeschakeld",
+        "disabled": "Provider uitgeschakeld",
+        "updateFailed": "Het is niet gelukt om de provider bij te werken",
+        "forceSsoEnabled": "Force SSO wereldwijd ingeschakeld",
+        "forceSsoDisabled": "Forceer SSO wereldwijd uitgeschakeld",
+        "forceSsoUpdateFailed": "Het is niet gelukt om de force SSO-instelling bij te werken",
+        "force2FANonSSOEnabled": "Tweefactorauthenticatie is vereist voor wachtwoordaanmeldingen.",
+        "force2FANonSSODisabled": "Tweefactorauthenticatie is niet langer vereist voor wachtwoordaanmeldingen.",
+        "force2FAAllLoginsEnabled": "Tweefactorauthenticatie is vereist voor alle aanmeldingen.",
+        "force2FAAllLoginsDisabled": "Tweefactorauthenticatie is niet langer vereist voor alle aanmeldingen.",
+        "force2FAUpdateFailed": "Het bijwerken van de tweefactorauthenticatie-instellingen is mislukt.",
+        "configUpdated": "SAML-configuratie bijgewerkt",
+        "configCreated": "SAML-configuratie gemaakt",
+        "configSaveFailed": "Het is niet gelukt om de SAML-configuratie op te slaan",
+        "googleConfigSaved": "Google OAuth-configuratie succesvol opgeslagen",
+        "googleConfigFailed": "Configuratie kon niet worden opgeslagen",
+        "appleEnabled": "Apple Sign In ingeschakeld",
+        "appleDisabled": "Apple-aanmelding uitgeschakeld",
+        "appleCreated": "Apple Sign In-provider aangemaakt",
+        "appleConfigSaved": "Apple Sign In-configuratie succesvol opgeslagen",
+        "appleConfigFailed": "Het is niet gelukt om de Apple Sign In-configuratie op te slaan",
+        "appleUpdateFailed": "Het is niet gelukt om de Apple Sign In-provider bij te werken",
+        "microsoftEnabled": "Microsoft SSO ingeschakeld",
+        "microsoftDisabled": "Microsoft SSO uitgeschakeld",
+        "microsoftCreated": "Microsoft SSO-provider gemaakt",
+        "microsoftConfigSaved": "De Microsoft SSO-configuratie is succesvol opgeslagen.",
+        "microsoftConfigFailed": "Het opslaan van de Microsoft SSO-configuratie is mislukt.",
+        "microsoftUpdateFailed": "Het bijwerken van de Microsoft SSO-provider is mislukt.",
+        "magicLinkEnabled": "Magic Link-authenticatie ingeschakeld",
+        "magicLinkDisabled": "Magic Link-authenticatie uitgeschakeld",
+        "magicLinkCreated": "Magic Link-aanbieder gemaakt",
+        "magicLinkUpdateFailed": "Het bijwerken van de Magic Link-provider is mislukt.",
+        "samlConfigSaved": "SAML-configuratie succesvol opgeslagen",
+        "configureFirst": "Configureer de provider voordat u deze inschakelt",
+        "domainRestrictionEnabled": "E-maildomeinbeperking ingeschakeld",
+        "domainRestrictionDisabled": "E-maildomeinbeperking uitgeschakeld",
+        "domainRestrictionUpdateFailed": "Het is niet gelukt om de domeinbeperkingsinstelling bij te werken",
+        "domainRequired": "Voer een domein in",
+        "invalidDomain": "Voer een geldig domein in (bijv. example.com)",
+        "domainAdded": "Domein succesvol toegevoegd",
+        "domainExists": "Dit domein staat al in de toegestane lijst",
+        "domainAddFailed": "Het toevoegen van het domein is mislukt",
+        "domainEnabled": "Domein ingeschakeld",
+        "domainDisabled": "Domein uitgeschakeld",
+        "domainUpdateFailed": "Het is niet gelukt om het domein bij te werken",
+        "domainDeleted": "Domein succesvol verwijderd",
+        "domainDeleteFailed": "Het verwijderen van het domein is mislukt",
+        "defaultAccessUpdated": "Standaard toegangsniveau bijgewerkt",
+        "defaultAccessUpdateFailed": "Het bijwerken van het standaardtoegangsniveau is mislukt.",
+        "emailVerificationEnabled": "E-mailverificatie is nu vereist voor nieuwe gebruikers.",
+        "emailVerificationDisabled": "E-mailverificatie is niet langer vereist voor nieuwe gebruikers.",
+        "emailVerificationDisabledAndVerified": "E-mailverificatie uitgeschakeld en {count, plural, one {# gebruikersaccount} other {# gebruikersaccounts}} geverifieerd",
+        "emailVerificationUpdateFailed": "Het bijwerken van de e-mailverificatie-instellingen is mislukt.",
+        "emailServerNotConfigured": "E-mailverificatie kan niet worden ingeschakeld: de e-mailserver is niet geconfigureerd.",
+        "openRegistrationEnabled": "Zelfregistratie is nu mogelijk.",
+        "openRegistrationDisabled": "Zelfregistratie is nu uitgeschakeld.",
+        "openRegistrationUpdateFailed": "Het bijwerken van de zelfregistratie-instellingen is mislukt."
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Google OAuth configureren",
+          "description": "Stel uw Google OAuth-clientreferenties in. U kunt deze verkrijgen via de Google Cloud Console.",
+          "clientIdPlaceholder": "Uw Google OAuth-client-ID",
+          "clientSecretPlaceholder": "Uw Google OAuth-clientgeheim",
+          "instructions": {
+            "title": "Om deze inloggegevens te verkrijgen:",
+            "step1": "Ga naar de Google Cloud Console",
+            "step2": "Selecteer uw project of maak een nieuw project aan",
+            "step3": "Schakel de Google+ API in",
+            "step4": "Ga naar Referenties en maak een OAuth 2.0 Client ID aan",
+            "step5": "Stel de geautoriseerde omleidings-URI in op:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "Zowel de Client-ID als het Client-geheim zijn vereist"
+          }
+        },
+        "microsoft": {
+          "title": "Microsoft SSO configureren",
+          "description": "Stel uw Microsoft Entra ID (Azure AD) toepassingsreferenties in. U kunt deze verkrijgen via de Azure-portal.",
+          "clientIdPlaceholder": "Uw applicatie-ID (client-ID)",
+          "clientSecretPlaceholder": "De waarde van uw klantgeheim",
+          "tenantId": "Huurders-ID (optioneel)",
+          "tenantIdPlaceholder": "Uw directory-ID (tenant-ID)",
+          "tenantIdHint": "Laat dit veld leeg voor meerdere tenants (\"gemeenschappelijk\"). Stel uw specifieke tenant-ID in om de toegang te beperken tot uw organisatie.",
+          "instructions": {
+            "title": "Om deze inloggegevens te verkrijgen:",
+            "step1": "Ga naar de Azure-portal (portal.azure.com)",
+            "step2": "Ga naar Microsoft Entra ID > App-registraties",
+            "step3": "Registreer een nieuwe applicatie of selecteer een bestaande.",
+            "step4": "Maak onder Certificaten en geheimen een nieuw clientgeheim aan.",
+            "step5": "Voeg de volgende omleidings-URI toe onder Authenticatie:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "Zowel de client-ID als het clientgeheim zijn vereist."
+          }
+        },
+        "saml": {
+          "description": "Stel uw SAML Identity Provider-configuratie in. U kunt deze gegevens opvragen bij uw SAML IdP.",
+          "entryPoint": "SSO-invoerpunt-URL",
+          "issuer": "Uitgever (Entiteits-ID)",
+          "callbackUrl": "ACS (Callback) URL",
+          "logoutUrl": "SLO-uitlog-URL (optioneel)",
+          "entryPointPlaceholder": "https://uw-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:uw-idp:entiteits-id",
+          "certPlaceholder": "-----BEGIN CERTIFICAAT-----...",
+          "logoutUrlPlaceholder": "https://uw-idp.com/slo/saml",
+          "instructions": {
+            "title": "Om SAML te configureren:",
+            "step1": "Neem contact op met uw SAML Identity Provider-beheerder",
+            "step2": "Vraag de SSO Entry Point URL en Entity ID op",
+            "step3": "Download het X.509-certificaat",
+            "step4": "Configureer deze ACS-URL in uw IdP:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "Toegangspunt, uitgever, certificaat en callback-URL zijn vereist"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "E-mailverificatie uitschakelen?",
+          "description": "Hierdoor wordt e-mailverificatie voor nieuwe gebruikersregistraties uitgeschakeld en worden alle bestaande, niet-geverifieerde accounts geverifieerd.",
+          "warning": "⚠️ Beveiligingswaarschuwing",
+          "warningPoint1": "Alleen aanbevolen voor beveiligde installaties (privénetwerken, VPN's of vertrouwde omgevingen).",
+          "warningPoint2": "Alle bestaande, niet-geverifieerde accounts worden direct geverifieerd en krijgen toegang tot het systeem.",
+          "confirmation": "Weet je zeker dat je e-mailverificatie wilt uitschakelen en alle accounts wilt verifiëren?",
+          "confirm": "Alles uitschakelen en verifiëren",
+          "verifying": "Accounts verifiëren..."
+        }
+      },
+      "status": {
+        "configured": "Geconfigureerd",
+        "setup": "Instellen"
+      },
+      "registration": {
+        "title": "Registratie-instellingen",
+        "description": "Bepaal wie zich kan registreren voor nieuwe accounts",
+        "restrictDomains": {
+          "title": "E-maildomeinen beperken",
+          "description": "Alleen registratie toestaan vanaf specifieke e-maildomeinen"
+        },
+        "allowedDomains": {
+          "title": "Toegestane e-maildomeinen",
+          "placeholder": "voorbeeld.com",
+          "add": "Domein toevoegen",
+          "empty": "Geen toegestane domeinen geconfigureerd. Alle domeinen worden geblokkeerd wanneer de beperking is ingeschakeld."
+        },
+        "defaultAccess": {
+          "title": "Standaard toegangsniveau",
+          "description": "Het toegangsniveau tot het systeem dat aan nieuwe gebruikers wordt toegewezen bij hun registratie.",
+          "options": {
+            "NONE": "Geen toegang - Gebruikers hebben geen toegang tot het systeem totdat een beheerder toegang verleent.",
+            "USER": "Gebruiker - Standaard gebruikerstoegang tot toegewezen projecten",
+            "PROJECTADMIN": "Projectbeheerder - Kan de projecten beheren waaraan hij/zij is toegewezen.",
+            "ADMIN": "Admin - Volledige toegang tot systeembeheer"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "E-mailverificatie vereist",
+          "description": "Gebruikers moeten hun e-mailadres verifiëren voordat ze toegang krijgen tot het systeem.",
+          "noEmailServerWarning": "De e-mailserver is niet geconfigureerd. E-mailverificatie is automatisch uitgeschakeld totdat er een e-mailserver is ingesteld."
+        },
+        "allowOpenRegistration": {
+          "title": "Zelfregistratie toestaan",
+          "description": "Wanneer deze functie is uitgeschakeld, kunnen nieuwe gebruikers zich niet rechtstreeks registreren of een account aanmaken via SSO. Bestaande gebruikers kunnen zich nog steeds aanmelden."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Ongeldige provider of geen SAML-provider."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Projecten filteren..."
+      },
+      "complete": {
+        "title": "Volledig project",
+        "description": "Met deze actie wordt het project voltooid en kunnen er geen verdere testruns meer worden toegevoegd."
+      },
+      "add": {
+        "button": "Project toevoegen",
+        "title": "Nieuw project toevoegen",
+        "defaultFields": "Standaard sjabloon, standaard mijlpaaltype en alle workflows en statussen worden toegevoegd aan het project wanneer het wordt aangemaakt.",
+        "selectIssueTracker": "Selecteer Issue Tracker",
+        "issueTrackerRequired": "Issue Tracker is vereist"
+      },
+      "wizard": {
+        "title": "Nieuw project maken",
+        "description": "Een nieuw project opzetten met alle benodigde configuraties",
+        "steps": {
+          "details": "Projectdetails",
+          "workflows": "Workflows, statussen en mijlpaaltypen",
+          "integrations": "Integraties",
+          "permissions": "Gebruikers en machtigingen"
+        },
+        "labels": {
+          "selected": "Gekozen",
+          "statuses": "Teststatussen",
+          "issueTrackers": "Probleemtrackers"
+        },
+        "placeholders": {
+          "projectName": "Voer projectnaam in",
+          "selectDefaultAccess": "Selecteer standaardtoegangstype"
+        },
+        "descriptions": {
+          "templates": "Selecteer minimaal één sjabloon om de structuur van testcases in dit project te definiëren.",
+          "workflows": "Configureer workflows, statussen en mijlpaaltypen voor het beheren van projectactiviteiten.",
+          "integrations": "Optioneel: sluit externe issue trackers en AI-modellen aan voor verbeterde functionaliteit.",
+          "noIntegrations": "Er zijn momenteel geen integraties geconfigureerd. U kunt deze stap overslaan of later integraties configureren.",
+          "aiModels": "Schakel AI-modellen in voor het genereren van testcases en intelligente suggesties.",
+          "permissions": "Configureer gebruikers- en groepsmachtigingen voor dit project.",
+          "milestoneTypes": "Selecteer mijlpaaltypen om de voortgang en deadlines van het project bij te houden."
+        },
+        "actions": {
+          "selectDefault": "Standaard gebruiken",
+          "create": "Project maken",
+          "creating": "Project maken..."
+        },
+        "errors": {
+          "nameRequired": "Projectnaam is vereist",
+          "validationFailed": "Het valideren van de projectnaam is mislukt. Probeer het opnieuw.",
+          "templateRequired": "Er moet minimaal één sjabloon worden geselecteerd",
+          "workflowRequired": "Er moet minimaal één workflow worden geselecteerd",
+          "statusRequired": "Er moet minimaal één status geselecteerd zijn",
+          "roleRequired": "Selecteer een rol wanneer u het toegangstype 'Specifieke rol' gebruikt",
+          "creationFailed": "Het aanmaken van het project is mislukt. Probeer het opnieuw."
+        },
+        "success": {
+          "created": "Project succesvol aangemaakt"
+        }
+      },
+      "edit": {
+        "title": "Project bewerken",
+        "labels": {
+          "groupProjectAccess": "Toegang tot groepsprojecten",
+          "groupPermissions": "Groepsrechten",
+          "userPermissions": "Gebruikersrechten",
+          "noEffect": "Geen effect",
+          "access": {
+            "groupsGlobalRole": "De wereldwijde rol van de Groep",
+            "groupDefault": "Groepsstandaard",
+            "groupSpecificRole": "Groepsspecifieke rol",
+            "groupProjectDefault": "Groepsproject Standaard",
+            "groupProjectNoAccess": "Groepsproject Geen toegang",
+            "groupProjectSpecificRole": "Groepsprojectspecifieke rol",
+            "effectiveAccess": "Effectieve toegang"
+          },
+          "accessHints": {
+            "noAccess": "Gebruikers krijgen geen toegang tot dit project, tenzij dit expliciet is verleend via een directe toewijzing of lidmaatschap van een groep.",
+            "globalRole": "Alle gebruikers met toegang tot de site kunnen dit project bekijken. Hun rechten worden bepaald door hun globaal toegewezen rol.",
+            "specificRole": "Gebruikers krijgen niet automatisch toegang. Toegang moet worden verleend via directe toewijzing aan de gebruiker of via lidmaatschap van een groep. Gebruikers die via groepen zijn toegewezen, gebruiken deze rol, tenzij dit wordt overschreven door directe toewijzing."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Selecteer standaardtoegang",
+          "groupPermissionsUI": "Gebruikersinterface voor beheer van groepsmachtigingen komt hier...",
+          "userPermissionsUI": "De gebruikersinterface voor beheer van gebruikersrechten komt hier...",
+          "selectAccess": "Selecteer toegang...",
+          "selectRole": "Selecteer rol...",
+          "searchUsersToAdd": "Zoek gebruikers om toe te voegen..."
+        },
+        "tableHeaders": {
+          "globalRole": "Wereldwijde rol",
+          "projectAccess": "Projecttoegang"
+        },
+        "messages": {
+          "noUsersAssigned": "Er zijn geen gebruikers met specifieke rechten toegewezen.",
+          "noGroupsFound": "Geen groepen gevonden."
+        },
+        "actions": {
+          "removeUser": "Gebruiker verwijderen"
+        },
+        "loadingUserPermissions": "Gebruikersrechten laden..."
+      },
+      "delete": {
+        "title": "Project verwijderen",
+        "confirmMessage": "Weet u zeker dat u dit project wilt verwijderen?"
+      }
+    },
+    "templates": {
+      "description": "Testcasesjablonen en velden beheren",
+      "help": {
+        "caseFields": "Testcasevelden definiëren de eigenschappen en gegevens die voor elke testcase in de repository kunnen worden vastgelegd. Ze stellen u in staat om testcase-informatie aan te passen, naast de standaardvelden.",
+        "resultFields": "Resultaatvelden definiëren aanvullende gegevens die kunnen worden vastgelegd bij het registreren van testresultaten. Ze stellen u in staat om aangepaste informatie bij te houden die specifiek is voor de uitkomsten van de testuitvoering."
+      },
+      "confirmSetAsDefault": "Instellen als standaardsjabloon",
+      "confirmSetAsDefaultDescription": "Weet u zeker dat u deze sjabloon als standaard wilt instellen?",
+      "confirmSetAsDefaultProjects": "Deze sjabloon wordt aan alle projecten toegevoegd.",
+      "add": {
+        "button": "Sjabloon toevoegen",
+        "title": "Nieuwe sjabloon toevoegen",
+        "defaultTemplateHint": "Deze sjabloon wordt aan alle projecten toegewezen."
+      },
+      "edit": {
+        "title": "Sjabloon bewerken"
+      },
+      "delete": {
+        "title": "Sjabloon verwijderen",
+        "confirmMessage": "Weet je zeker dat je de sjabloon <strong>{name}</strong> wilt verwijderen?",
+        "warning": "Alle testgevallen en verkennende sessies die momenteel dit sjabloon gebruiken, worden automatisch opnieuw toegewezen aan het standaardsjabloon.",
+        "errors": {
+          "defaultTemplateNotFound": "Standaardsjabloon niet gevonden. Verwijderen is niet mogelijk.",
+          "unknown": "Er is een onbekende fout opgetreden bij het verwijderen van de sjabloon."
+        }
+      },
+      "caseFields": {
+        "description": "Beheer casevelden",
+        "add": {
+          "button": "Caseveld toevoegen",
+          "title": "Nieuw zaakveld toevoegen"
+        },
+        "edit": {
+          "title": "Caseveld bewerken"
+        },
+        "delete": {
+          "title": "Verwijder zaakveld",
+          "confirmMessage": "Weet u zeker dat u dit Caseveld wilt verwijderen?",
+          "warning": "Het veld 'Case' wordt uit alle sjablonen verwijderd. Deze actie kan niet ongedaan worden gemaakt."
+        }
+      },
+      "resultFields": {
+        "description": "Resultaatvelden beheren",
+        "add": {
+          "button": "Resultaatveld toevoegen",
+          "title": "Nieuw resultaatveld toevoegen"
+        },
+        "edit": {
+          "title": "Resultaatveld bewerken"
+        },
+        "delete": {
+          "title": "Resultaatveld verwijderen",
+          "confirmMessage": "Weet u zeker dat u <strong>{name}</strong>wilt verwijderen?",
+          "warning": "Het resultaatveld wordt uit alle sjablonen verwijderd. Deze actie kan niet ongedaan worden gemaakt."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Codeopslagplaatsen",
+      "description": "Beheer de verbindingen met de codeopslagplaats voor de QuickScript-context.",
+      "addRepository": "Repository toevoegen",
+      "noRepos": {
+        "title": "Er zijn geen code repositories geconfigureerd.",
+        "description": "Koppel een Git-repository om bestandscontext te bieden voor het genereren van testexports met behulp van AI."
+      },
+      "delete": {
+        "title": "Repository verwijderen",
+        "confirmMessage": "Weet je zeker dat je <strong>{name}</strong>wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+        "fallbackName": "deze repository"
+      },
+      "testConnection": "Testverbinding",
+      "connectionSuccess": "Verbinding succesvol",
+      "connectionFailed": "Verbinding mislukt",
+      "networkError": "Netwerkfout",
+      "editTitle": "Code repository bewerken",
+      "addTitle": "Code repository toevoegen",
+      "repositoryUpdated": "Repository bijgewerkt",
+      "repositoryCreated": "Repository aangemaakt",
+      "saveFailed": "Het opslaan van de repository is mislukt.",
+      "namePlaceholder": "Mijn repository",
+      "selectProvider": "Selecteer provider",
+      "httpWarning": "Deze URL gebruikt HTTP. Inloggegevens worden in platte tekst verzonden. Gebruik HTTPS voor beveiligde verbindingen."
+    },
+    "exportTemplates": {
+      "title": "QuickScript-sjablonen",
+      "description": "Beheer sjablonen die QuickScript gebruikt om testgevallen om te zetten in automatiseringsscripts.",
+      "confirmSetAsDefault": "Instellen als standaard exportsjabloon",
+      "confirmSetAsDefaultDescription": "Weet je zeker dat je deze sjabloon als standaard wilt instellen? Deze wordt automatisch geselecteerd wanneer gebruikers testcases exporteren.",
+      "fields": {
+        "category": "Categorie",
+        "framework": "Kader",
+        "fileExtension": "Bestandsextensie",
+        "headerBody": "Koptekstsjabloon",
+        "templateBody": "Sjablooninhoud",
+        "footerBody": "Voettekstsjabloon",
+        "validation": {
+          "categoryRequired": "Categorie is vereist.",
+          "frameworkRequired": "Een framework is vereist.",
+          "templateBodyRequired": "De templatebody is vereist.",
+          "fileExtensionRequired": "Een bestandsextensie is vereist.",
+          "languageRequired": "Taalvaardigheid is vereist."
+        },
+        "placeholders": {
+          "name": "bijv. Playwright (TypeScript)",
+          "description": "bijvoorbeeld genereert teststubs voor Playwright",
+          "category": "bijvoorbeeld Browser E2E",
+          "framework": "bijvoorbeeld toneelschrijver",
+          "fileExtension": "bijv. .spec.ts",
+          "language": "bijvoorbeeld TypeScript",
+          "headerBody": "Optioneel. Inhoud die eenmaal bovenaan wordt weergegeven (bijv. importinstructies).",
+          "templateBody": "Voer de Mustache-sjabloon in...\n\nBeschikbare variabelen:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nStappensectie:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nAangepaste velden:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Optioneel. Inhoud die eenmaal onderaan wordt weergegeven (bijv. afsluitende code)."
+        },
+        "combobox": {
+          "typeNew": "Typ om een nieuwe waarde in te voeren"
+        }
+      },
+      "add": {
+        "button": "Voeg een QuickScript-sjabloon toe",
+        "title": "Nieuwe QuickScript-sjabloon toevoegen"
+      },
+      "edit": {
+        "title": "QuickScript-sjabloon bewerken"
+      },
+      "delete": {
+        "title": "QuickScript-sjabloon verwijderen",
+        "confirmMessage": "Weet je zeker dat je de QuickScript-sjabloon <strong>{name}</strong> wilt verwijderen?"
+      },
+      "preview": {
+        "title": "Voorbeeldweergave (gesimuleerde gegevens)",
+        "empty": "Voer een sjabloontekst in om een voorbeeld te bekijken.",
+        "error": "Fout bij het weergeven van de sjabloon. Controleer je Mustache-syntaxis."
+      },
+      "filterPlaceholder": "Filtersjablonen...",
+      "noResults": "Er zijn geen sjablonen gevonden die overeenkomen met uw filter.",
+      "templateCount": "{count, plural, one {# sjabloon} other {# sjablonen}}",
+      "allFrameworks": "Alle frameworks",
+      "allFileExtensions": "Alle extensies",
+      "allLanguages": "Alle talen",
+      "showEnabled": "Alleen ingeschakeld",
+      "showAll": "Alle",
+      "variableInserter": {
+        "placeholder": "Variabele invoegen...",
+        "groups": {
+          "customFields": "Aangepaste velden"
+        },
+        "stepsBlock": "Stappenblokkering"
+      }
+    },
+    "users": {
+      "showInactive": "Inactief weergeven",
+      "add": {
+        "button": "Gebruiker toevoegen",
+        "title": "Nieuwe gebruiker toevoegen",
+        "fields": {
+          "email_invalid": "Ongeldig e-mailadres",
+          "password_error": "Wachtwoord is vereist",
+          "confirmPassword_error": "Bevestig wachtwoord is vereist",
+          "passwordOptionalHelp": "Laat dit veld leeg als de gebruiker zich moet aanmelden via een magic link of SSO."
+        }
+      },
+      "edit": {
+        "title": "Gebruiker bewerken"
+      },
+      "delete": {
+        "title": "Gebruiker verwijderen"
+      },
+      "restore": {
+        "title": "Verwijderde gebruiker herstellen",
+        "description": "Er is een verwijderde gebruiker gevonden met het e-mailadres {email} . Wilt u deze gebruiker herstellen?",
+        "confirm": "Gebruiker herstellen"
+      },
+      "forcePasswordChange": "Wachtwoordwijziging afdwingen",
+      "revokePassword": "Wachtwoord intrekken",
+      "forcePasswordChangeDialogTitle": "Wachtwoordwijziging afdwingen",
+      "forcePasswordChangeDialogDescription": "Dit vereist dat {name} hun wachtwoord bij de volgende aanmelding wijzigen.",
+      "revokePasswordDialogTitle": "Wachtwoord intrekken",
+      "revokePasswordDialogDescription": "Dit maakt het wachtwoord van {name}onmiddellijk ongeldig. Ze moeten een andere inlogmethode gebruiken.",
+      "confirmAction": "Bevestigen",
+      "forcePasswordChangeSuccess": "Wachtwoordwijziging vereist voor {name}",
+      "forcePasswordChangeFailed": "Wachtwoordwijziging is mislukt",
+      "revokePasswordSuccess": "Wachtwoord ingetrokken voor {name}",
+      "revokePasswordFailed": "Wachtwoord intrekken mislukt"
+    },
+    "security": {
+      "title": "Beveiliging",
+      "description": "Configureer het wachtwoordbeleid, de vergrendelingsinstellingen en de handhavingsacties.",
+      "passwordPolicyTitle": "Wachtwoordbeleid",
+      "passwordPolicyDescription": "Stel vereisten in voor gebruikerswachtwoorden.",
+      "lockoutPolicyTitle": "Uitsluitingsbeleid",
+      "lockoutPolicyDescription": "Configureer accountvergrendeling na mislukte inlogpogingen.",
+      "enforcementTitle": "Handhavingsmaatregelen",
+      "enforcementDescription": "Wachtwoordwijzigingen afdwingen voor gebruikers met inloggegevens",
+      "minPasswordLengthLabel": "Minimale wachtwoordlengte",
+      "minPasswordLengthDescription": "Wachtwoorden moeten minimaal dit aantal tekens bevatten (8-128).",
+      "requireUppercaseLabel": "Vereist hoofdletters",
+      "requireLowercaseLabel": "Vereist kleine letters",
+      "requireNumbersLabel": "Getallen vereisen",
+      "requiredSpecialCharsLabel": "Vereiste speciale tekens",
+      "requiredSpecialCharsDescription": "Laat dit veld leeg om uit te schakelen. Voer de tekens in die moeten verschijnen (bijv. !@#$)",
+      "passwordHistoryDepthLabel": "Wachtwoordgeschiedenis Diepte",
+      "passwordHistoryDepthDescription": "Voorkom hergebruik van de laatste N wachtwoorden (0 = uitgeschakeld)",
+      "passwordExpirationDaysLabel": "Vervaldatum wachtwoord (dagen)",
+      "passwordExpirationDaysDescription": "Wachtwoordwijziging afdwingen na N dagen (0 = uitgeschakeld)",
+      "lockoutThresholdLabel": "Vergrendelingsdrempel",
+      "lockoutThresholdDescription": "Aantal mislukte pogingen vóór accountblokkering (minimaal 1)",
+      "lockoutDurationMinutesLabel": "Vergrendelingsduur (minuten)",
+      "lockoutDurationMinutesDescription": "Hoe lang het account geblokkeerd blijft (minimaal 1)",
+      "saveChanges": "Wijzigingen opslaan",
+      "forceAllUsers": "Alle gebruikers dwingen hun wachtwoord te wijzigen",
+      "forceAllUsersDialogTitle": "Wachtwoordwijziging afdwingen voor alle gebruikers",
+      "forceAllUsersDialogDescription": "This will require {count} credential-based users to change their password on next login.",
+      "forceAllUsersDialogWarning": "Deze actie kan niet ongedaan gemaakt worden.",
+      "forceAllUsersDialogConfirm": "Krachtverandering",
+      "saved": "Beveiligingsinstellingen opgeslagen",
+      "saveFailed": "Beveiligingsinstellingen konden niet worden opgeslagen.",
+      "forceAllSuccess": "Wachtwoordwijziging vereist voor {count} gebruikers",
+      "forceAllFailed": "Wachtwoordwijziging is mislukt"
+    },
+    "apiTokens": {
+      "description": "API-tokens voor alle gebruikers bekijken en beheren. Tokens intrekken als er beveiligingsrisico's zijn.",
+      "filterPlaceholder": "Filteren op tokennaam of gebruiker...",
+      "showInactive": "Weergeven ingetrokken",
+      "noTokens": "Er zijn nog geen API-tokens aangemaakt.",
+      "columns": {
+        "lastUsed": "Laatst gebruikt",
+        "expires": "Verloopt"
+      },
+      "status": {
+        "revoked": "ingetrokken",
+        "expired": "Verlopen"
+      },
+      "noExpiry": "Geen vervaldatum",
+      "revokeToken": "Token intrekken",
+      "revokeConfirmTitle": "API-token intrekken",
+      "revokeConfirmMessage": "Weet u zeker dat u dit API-token wilt intrekken? Deze actie kan niet ongedaan worden gemaakt.",
+      "revokeConfirmDescription": "Het token \"{name}\" dat bij {user} hoort, wordt onmiddellijk ingetrokken en kan niet langer worden gebruikt voor API-toegang.",
+      "revokeSuccess": "API-token succesvol ingetrokken",
+      "revokeError": "Het intrekken van het API-token is mislukt.",
+      "revokeAllTokens": "Alle tokens intrekken",
+      "revokeAllTitle": "Alle API-tokens intrekken",
+      "revokeAllDescription": "Hierdoor worden ALLE actieve API-tokens van alle gebruikers onmiddellijk ingetrokken. Deze actie kan niet ongedaan worden gemaakt en kan geautomatiseerde workflows verstoren.",
+      "revokeAllConfirm": "Typ \"REVOKE ALL\" om te bevestigen.",
+      "revokeAllPlaceholder": "TREK ALLES IN",
+      "revokeAllSuccess": "Alle API-tokens zijn ingetrokken.",
+      "revokeAllError": "Het intrekken van alle tokens is mislukt."
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Er is een fout opgetreden bij het maken van de tag"
+        }
+      },
+      "delete": {
+        "title": "Tag verwijderen",
+        "confirmMessage": "Weet u zeker dat u deze tag wilt verwijderen?",
+        "warning": "Deze tag wordt uit alle testcases en sessies verwijderd.",
+        "errors": {
+          "unknown": "Er is een fout opgetreden bij het verwijderen van de tag"
+        }
+      },
+      "edit": {
+        "title": "Tag bewerken"
+      }
+    },
+    "workflows": {
+      "description": "Testcase-workflows beheren",
+      "add": {
+        "button": "Workflow toevoegen",
+        "title": "Nieuwe workflow toevoegen",
+        "defaultHelp": "Instellen als standaardworkflow voor nieuwe testcases",
+        "scopeLabel": "Werkstroombereik",
+        "errors": {
+          "nameExists": "Er bestaat al een workflow met deze naam"
+        }
+      },
+      "edit": {
+        "title": "Workflow bewerken",
+        "lastWorkflowTypeWarning": "Dit is het laatste workflowtype. Er moet minimaal één workflowtype ingeschakeld zijn.",
+        "errors": {
+          "nameRequired": "Workflownaam is vereist",
+          "unknownWorkflow": "Onbekende workflow"
+        }
+      },
+      "delete": {
+        "title": "Workflow verwijderen",
+        "confirmMessage": "Weet u zeker dat u deze workflow wilt verwijderen?"
+      },
+      "setDefault": {
+        "title": "Standaardworkflow instellen",
+        "confirmMessage": "Weet u zeker dat u deze workflow als standaard wilt instellen?",
+        "description": "Deze workflow wordt aan alle projecten toegevoegd."
+      }
+    },
+    "roles": {
+      "description": "Definieer welke acties gebruikers kunnen uitvoeren door de machtigingen voor elk toepassingsgebied in of uit te schakelen.",
+      "filterPlaceholder": "Rollen filteren...",
+      "add": {
+        "button": "Rol toevoegen",
+        "title": "Nieuwe rol toevoegen",
+        "fields": {
+          "name_error": "Rolnaam is vereist"
+        },
+        "errors": {
+          "nameExists": "Er bestaat al een rol met deze naam"
+        }
+      },
+      "edit": {
+        "title": "Rol bewerken",
+        "permissionsTitle": "Machtigingen",
+        "areaHeader": "Toepassingsgebied"
+      },
+      "delete": {
+        "title": "Rol verwijderen",
+        "confirmMessage": "Weet u zeker dat u deze rol wilt verwijderen?",
+        "warning": "Deze actie kan niet ongedaan worden gemaakt. Gebruikers met deze rol krijgen de standaardrol toegewezen.",
+        "errors": {
+          "defaultNotFound": "Kan standaardrol niet verwijderen"
+        }
+      }
+    },
+    "statuses": {
+      "description": "Teststatussen beheren",
+      "add": {
+        "button": "Status toevoegen",
+        "title": "Nieuwe status toevoegen",
+        "systemNameHelp": "De systeemnaam identificeert deze status. Kan na aanmaak niet meer worden gewijzigd.",
+        "aliasesHelp": "Door komma's gescheiden lijst met aliassen",
+        "errors": {
+          "nameExists": "Er bestaat al een status met deze naam",
+          "systemNameEmpty": "Systeemnaam is vereist",
+          "systemNameInvalid": "Systeemnaam moet alfanumeriek zijn",
+          "aliasesInvalid": "Aliassen moeten alfanumeriek zijn",
+          "missingColor": "Kleur niet gevonden. Selecteer een andere kleur."
+        }
+      },
+      "edit": {
+        "title": "Bewerkingsstatus",
+        "systemNameHelp": "De systeemnaam identificeert deze status voor geautomatiseerde processen. Kan na aanmaak niet meer worden gewijzigd.",
+        "unmodifiableHelp": "De status 'niet getest' is een systeemstatus en kan niet worden gewijzigd.",
+        "untestedHelp": "De naam 'niet getest' is gereserveerd voor een systeemstatus en kan niet worden gebruikt.",
+        "success": "Status succesvol bijgewerkt"
+      },
+      "delete": {
+        "title": "Status verwijderen",
+        "confirmMessage": "Weet u zeker dat u status <strong>{name}</strong>wilt verwijderen?",
+        "errors": {
+          "inUse": "Deze status is in gebruik en kan niet worden verwijderd",
+          "defaultNotFound": "Standaardstatus niet gevonden"
+        },
+        "success": "Status succesvol verwijderd"
+      },
+      "fields": {
+        "final": "Eindstand",
+        "system": "Systeemstatus",
+        "forTestCase": "Voor testcase",
+        "forTestRun": "Voor testrun",
+        "forSession": "Voor sessie",
+        "color": "Kleur"
+      }
+    },
+    "appConfig": {
+      "description": "Beheer globale applicatieconfiguraties",
+      "addConfig": "Toepassingsconfiguratie toevoegen",
+      "editConfig": "Applicatieconfiguratie bewerken",
+      "keyPlaceholder": "Voer configuratiesleutel in...",
+      "valuePlaceholder": "Voer JSON-waarde in...",
+      "currentTranslation": "Huidige vertaling",
+      "filterPlaceholder": "Filter op sleutel...",
+      "errors": {
+        "keyRequired": "Sleutel is vereist",
+        "invalidJson": "Ongeldige JSON-indeling"
+      },
+      "configKeys": {
+        "project_docs_default": "Projectdocumentatie Standaard"
+      }
+    },
+    "configurations": {
+      "description": "Configuraties zijn een combinatie van categorieën en varianten die worden gebruikt om een testomgeving te definiëren. Bijvoorbeeld: besturingssysteem/browser, testserver, taal, enz.",
+      "addConfiguration": "Configuratie toevoegen",
+      "editConfiguration": "Configuratie bewerken",
+      "filterPlaceholder": "Filterconfiguraties...",
+      "categories": {
+        "title": "Categorieën",
+        "description": "Globale categorieën beheren",
+        "editCategory": "Categorie bewerken",
+        "selectCategory": "Selecteer categorie",
+        "filterPlaceholder": "Categorieën filteren...",
+        "add": {
+          "title": "Nieuwe categorie toevoegen"
+        },
+        "delete": {
+          "confirmMessage": "Weet u zeker dat u deze categorie wilt verwijderen?",
+          "deleteCategory": "Categorie verwijderen",
+          "deleteCategoryConfirm": "Weet u zeker dat u categorie <strong>{name}</strong>wilt verwijderen?",
+          "deleteCategoryWarning": "Met deze actie worden de categorie en alle bijbehorende varianten verwijderd."
+        },
+        "disable": {
+          "confirmDisableTitle": "Variant uitschakelen",
+          "confirmDisableDescription": "Weet u zeker dat u deze variant wilt uitschakelen?"
+        }
+      },
+      "combinations": {
+        "title": "Combinaties",
+        "description": "Beheer globale combinaties",
+        "addCombination": "Combinatie toevoegen",
+        "editCombination": "Combinatie bewerken",
+        "selectCombination": "Selecteer combinatie",
+        "selectCombinationDescription": "Selecteer een combinatie van varianten die u aan de configuratie wilt toevoegen.",
+        "allExist": "Alle combinaties bestaan al.",
+        "selectAtLeast": "Selecteer minimaal één combinatie."
+      },
+      "delete": {
+        "title": "Configuratie verwijderen",
+        "message": "Weet u zeker dat u de configuratie <strong>{name}</strong>wilt verwijderen?",
+        "confirmMessage": "Weet u zeker dat u deze configuratie wilt verwijderen?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Variant bewerken"
+        },
+        "delete": {
+          "title": "Variant verwijderen",
+          "message": "Weet u zeker dat u de variant <strong>{name}</strong>wilt verwijderen?",
+          "confirmMessage": "Weet u zeker dat u deze variant wilt verwijderen?",
+          "suggestion": "Overweeg in plaats daarvan de variant uit te schakelen."
+        },
+        "selection": {
+          "title": "Varianten selecteren",
+          "description": "Selecteer de varianten die u aan de configuratie wilt toevoegen."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Organiseer gebruikers in groepen om projecttoegang en rollen批量 toe te wijzen."
+      },
+      "filterPlaceholder": "Groepen filteren...",
+      "add": {
+        "button": "Groep toevoegen",
+        "title": "Nieuwe groep toevoegen",
+        "errors": {
+          "nameExists": "Er bestaat al een groep met deze naam"
+        }
+      },
+      "edit": {
+        "title": "Groep bewerken"
+      },
+      "delete": {
+        "deleteGroup": "Groep verwijderen",
+        "deleteGroupDescription": "Met deze actie worden de groep en alle bijbehorende gebruikers verwijderd.",
+        "confirmMessage": "Weet u zeker dat u deze groep wilt verwijderen?"
+      },
+      "noUsersSelected": "Er zijn nog geen gebruikers geselecteerd.",
+      "noUsersAssigned": "Er zijn geen gebruikers aan deze groep toegewezen."
+    },
+    "milestones": {
+      "description": "Mijlpaaltypen beheren",
+      "filterPlaceholder": "Mijlpaaltypen filteren...",
+      "addMilestones": "Mijlpalen in bulk toevoegen",
+      "confirmDefault": "Bevestig standaard",
+      "confirmDefaultDescription": "Weet u zeker dat u dit mijlpaaltype als standaard wilt instellen?",
+      "warning": "Dit mijlpaaltype wordt aan alle projecten toegevoegd.",
+      "wizard": {
+        "selectProjects": "Selecteer projecten",
+        "projectsSelected": "{count, plural, =0 {Geen projecten geselecteerd} one {# project geselecteerd} other {# projecten geselecteerd}}",
+        "createMilestone": "Mijlpaal maken",
+        "noCommonTypesTitle": "Geen gemeenschappelijke mijlpaaltypen",
+        "noCommonTypesDescription": "De geselecteerde projecten hebben geen gemeenschappelijke mijlpaaltypen. Zorg ervoor dat alle geselecteerde projecten ten minste één gemeenschappelijk mijlpaaltype hebben, of selecteer verschillende projecten."
+      },
+      "add": {
+        "button": "Mijlpaaltype toevoegen",
+        "title": "Nieuw mijlpaaltype toevoegen",
+        "errors": {
+          "nameExists": "Er bestaat al een mijlpaaltype met deze naam"
+        }
+      },
+      "edit": {
+        "title": "Mijlpaaltype bewerken"
+      },
+      "delete": {
+        "title": "Mijlpaaltype verwijderen",
+        "confirmMessage": "Weet u zeker dat u dit mijlpaaltype wilt verwijderen?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Link Probleem Tracker",
+      "link_description": "Configureer de basis-URL voor handmatig gekoppelde issues. Wanneer u een issue koppelt met alleen een externe ID, wordt deze basis-URL voorafgegaan om de volledige link te creëren.",
+      "filter": {
+        "show_inactive": "Inactieve configuraties weergeven",
+        "search_placeholder": "Filteren op configuratienaam..."
+      },
+      "base_url": "Basis-URL",
+      "link_update_success": "Linkconfiguratie succesvol bijgewerkt",
+      "link_update_error": "Het is niet gelukt de linkconfiguratie bij te werken",
+      "description": "Configureer integraties met externe issue tracking-systemen.",
+      "delete": {
+        "title": "Probleemconfiguratie verwijderen",
+        "confirmMessage": "Weet u zeker dat u configuratie <bold>{name}</bold>wilt verwijderen?",
+        "warning": "Deze actie kan niet ongedaan worden gemaakt. Alle projecten die momenteel aan deze tracker zijn toegewezen, worden opnieuw toegewezen aan de standaardtracker. Overweeg in plaats daarvan de configuratie te deactiveren.",
+        "cannotDeleteDefault": "De standaard issue tracker kan niet worden verwijderd.",
+        "noDefaultFound": "Kan niet verwijderen: Er is geen standaard issue tracker gevonden waaraan projecten opnieuw kunnen worden toegewezen."
+      },
+      "add": {
+        "title": "Probleemtracker toevoegen",
+        "description": "Maak een nieuwe configuratie voor een probleemopsporingssysteem.",
+        "name": "Configuratienaam",
+        "name_placeholder": "bijv. Project Jira Links",
+        "system_type": "Systeemtype",
+        "select_system_type": "Selecteer systeemtype",
+        "base_url": "Basis-URL inclusief de probleemplaceholder",
+        "base_url_placeholder": "bijvoorbeeld https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Probleemconfiguratie succesvol aangemaakt",
+        "create_error": "Fout bij het maken van de probleemconfiguratie",
+        "setDefaultWarning": "Als u dit als standaard instelt, wordt de standaardstatus uit de huidige standaardconfiguratie verwijderd."
+      },
+      "edit": {
+        "title": "Bewerk probleemtracker",
+        "description": "Werk de details voor deze probleemconfiguratie bij.",
+        "name_placeholder": "Voer de configuratienaam in",
+        "select_project": "Selecteer projecten...",
+        "update_success": "Probleemconfiguratie succesvol bijgewerkt",
+        "update_error": "Het is niet gelukt om de probleemconfiguratie bij te werken",
+        "edit_not_supported": "Het bewerken van de configuratie voor dit systeemtype wordt momenteel niet ondersteund."
+      }
+    },
+    "issues": {
+      "description": "Problemen beheren voor deze probleemtracker",
+      "filterPlaceholder": "Problemen met filteren...",
+      "add": {
+        "button": "Probleem toevoegen",
+        "title": "Nieuw probleem toevoegen"
+      },
+      "edit": {
+        "title": "Probleem bewerken"
+      },
+      "delete": {
+        "title": "Probleem verwijderen",
+        "confirmMessage": "Weet u zeker dat u het probleem \"{name}\" wilt verwijderen?"
+      },
+      "syncIssue": "Synchronisatieprobleem van extern systeem",
+      "syncSuccess": "Probleem succesvol gesynchroniseerd",
+      "syncSuccessDescription": "Probleem \"{name}\" is bijgewerkt met de nieuwste informatie van het externe systeem.",
+      "syncError": "Probleem met synchronisatie mislukt",
+      "syncErrorDescription": "Synchronisatie mislukt. Probeer het later opnieuw."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Projectkoppelingen",
+        "milestoneLinks": "Mijlpaalkoppelingen",
+        "icons": "Pictogrammen",
+        "fieldOptions": "Veldopties",
+        "configCategories": "Configuratiecategorieën",
+        "configVariants": "Configuratievarianten",
+        "repositories": "Opslagplaatsen",
+        "repositoryFolders": "Repository-mappen",
+        "repositoryCaseLinks": "Repository Case Links",
+        "repositoryCaseVersions": "Repository Case-versies",
+        "testRunStepResults": "Resultaten van de testrunstap",
+        "issueConfigs": "Probleemconfiguraties",
+        "sharedStepGroups": "Gedeelde stappengroepen"
+      },
+      "table": {
+        "title": "Verwijderd {itemType}",
+        "loading": "Verwijderde {itemType}laden ...",
+        "error": "Fout bij het laden van verwijderde {itemType}: {message}",
+        "noItems": "Geen verwijderde {itemType} gevonden.",
+        "noResults": "Er zijn geen verwijderde {itemType} gevonden die overeenkomen met uw zoekopdracht naar \"{query}\".",
+        "restoreConfirmationMessage": "Weet u zeker dat u deze rij uit de tabel {itemType} wilt herstellen? Gekoppelde gegevens worden mogelijk ook hersteld.",
+        "purgeConfirmationMessage": "Weet u zeker dat u deze rij definitief uit de tabel {itemType} wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt en kan de bijbehorende gegevens verwijderen."
+      }
+    },
+    "notifications": {
+      "title": "Meldingsbeheer",
+      "description": "Stel de standaardvoorkeuren voor meldingen in (die gebruikers kunnen overschrijven) en verstuur systeemmeldingen.",
+      "defaultMode": {
+        "label": "Standaard meldingsmodus",
+        "inApp": "Alleen in-app",
+        "inAppEmailImmediate": "In-app + e-mail (direct)",
+        "inAppEmailDaily": "In-app + e-mail (dagelijks overzicht)"
+      },
+      "options": {
+        "title": "Beschikbare meldingsopties",
+        "inApp": {
+          "label": "In-app-meldingen",
+          "description": "Meldingen weergeven binnen de applicatie"
+        },
+        "emailImmediate": {
+          "label": "Onmiddellijke e-mail",
+          "description": "Stuur onmiddellijk e-mailmeldingen wanneer er gebeurtenissen plaatsvinden"
+        },
+        "emailDaily": {
+          "label": "Dagelijkse e-mailsamenvatting",
+          "description": "Stuur dagelijks een samenvatting van meldingen via e-mail"
+        }
+      },
+      "save": "Instellingen opslaan",
+      "success": {
+        "title": "Instellingen opgeslagen",
+        "description": "Meldingsinstellingen zijn succesvol bijgewerkt"
+      },
+      "error": {
+        "description": "Het is niet gelukt om de meldingsinstellingen op te slaan"
+      },
+      "systemNotification": {
+        "title": "Systeemmeldingen",
+        "description": "Stuur belangrijke aankondigingen naar alle gebruikers",
+        "titlePlaceholder": "Voer een titel voor de melding in...",
+        "messagePlaceholder": "Voer een meldingsbericht in...",
+        "send": "Melding verzenden",
+        "success": {
+          "title": "Melding verzonden",
+          "description": "Systeemmelding verzonden naar {count, plural, one {# gebruiker} other {# gebruikers}}"
+        },
+        "error": {
+          "description": "Het is niet gelukt om een systeemmelding te verzenden",
+          "emptyFields": "Geef zowel de titel als het bericht op"
+        },
+        "history": {
+          "title": "Meldingsgeschiedenis",
+          "sentBy": "Verzonden door",
+          "sentAt": "Verzonden op",
+          "empty": "Er zijn nog geen systeemmeldingen verzonden"
+        }
+      }
+    },
+    "integrations": {
+      "description": "Beheer integraties met externe partijen voor het bijhouden van problemen.",
+      "list": {
+        "title": "Geconfigureerde probleemintegraties",
+        "description": "Bekijk en beheer uw geconfigureerde probleemintegraties"
+      },
+      "empty": {
+        "message": "Er zijn nog geen probleemintegraties geconfigureerd"
+      },
+      "addIntegration": "Integratie van problemen toevoegen",
+      "allIntegrations": "Alle Issue Integrations",
+      "manageDescription": "Configureer en beheer uw externe serviceprobleemintegraties",
+      "status": {
+        "active": "Actief",
+        "inactive": "Inactief"
+      },
+      "connectedProjects": "Verbonden projecten",
+      "noIntegrations": "Geen probleemintegraties geconfigureerd",
+      "testConnection": "Testverbinding",
+      "testSuccess": "Verbinding succesvol",
+      "testSuccessDescription": "De probleemintegratie is correct geconfigureerd en aangesloten",
+      "testFailed": "Verbinding mislukt",
+      "testFailedDescription": "Kan geen verbinding maken met de externe service",
+      "testError": "Testfout",
+      "testErrorDescription": "Er is een fout opgetreden tijdens het testen van de verbinding",
+      "syncInProgress": "Synchronisatieproblemen...",
+      "syncIntegration": "Synchroniseer alle problemen vanuit de probleemintegratie.",
+      "syncSuccess": "Synchronisatie in de wachtrij",
+      "syncSuccessDescription": "Problemen met \"{name}\" worden op de achtergrond gesynchroniseerd. Dit kan even duren. De tabel wordt automatisch bijgewerkt zodra deze is voltooid.",
+      "syncError": "Synchronisatie mislukt",
+      "syncErrorDescription": "Het is niet gelukt om een synchronisatietaak voor deze integratie in de wachtrij te plaatsen. Probeer het later opnieuw.",
+      "delete": {
+        "confirmMessage": "Weet u zeker dat u de probleemintegratie \"{name}\" wilt verwijderen?",
+        "warning": "Hiermee wordt de probleemintegratie verwijderd en losgekoppeld van alle projecten. Deze actie kan niet ongedaan worden gemaakt.",
+        "warningTitle": "Deze actie zal:",
+        "warning1": "Verwijder permanent de configuratie en referenties van de probleemintegratie",
+        "warning2": "Koppel alle gebruikersauthenticatietokens los voor deze probleemintegratie",
+        "warning3": "Behoud alle gekoppelde problemen in de database (problemen worden ontkoppeld)",
+        "warning4": "Vereist dat eerst de probleemintegratie uit alle projecten wordt verwijderd"
+      },
+      "deleteSuccess": "Integratieprobleem verwijderd",
+      "deleteSuccessDescription": "De probleemintegratie is succesvol verwijderd",
+      "deleteError": "Verwijderfout",
+      "add": {
+        "description": "Een nieuwe probleemintegratie met een externe service configureren",
+        "selectType": "Selecteer het type probleemintegratie",
+        "typeDescription": "Kies het type service dat u wilt integreren",
+        "successMessage": "Integratie van het probleem is succesvol aangemaakt.",
+        "successDescription": "De issue-integratie is geconfigureerd en klaar voor gebruik",
+        "simple_url": {
+          "name": "Eenvoudige URL",
+          "description": "Basisprobleemopsporing met aangepaste URL-patronen"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Maak verbinding met Atlassian Jira voor probleemopsporing en projectbeheer"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Maak verbinding met GitHub voor het bijhouden van problemen"
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Maak verbinding met GitLab voor het volgen van problemen en samenvoegingsverzoeken."
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Maak verbinding met een zelfgehoste Gitea-, Forgejo- of Gogs-instantie voor het bijhouden van problemen."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Maak verbinding met Azure DevOps voor het bijhouden van werkitems"
+        }
+      },
+      "filterPlaceholder": "Integraties filteren...",
+      "table": {
+        "lastSync": "Laatste synchronisatie",
+        "empty": "Geen integraties gevonden die problemen veroorzaken",
+        "loading": "Integraties voor probleemoplossing worden geladen...",
+        "configure": "Configure"
+      },
+      "edit": {
+        "description": "Update de instellingen en configuratie voor probleemintegratie.",
+        "successMessage": "Integratie van het probleem succesvol bijgewerkt.",
+        "successDescription": "De instellingen voor probleemintegratie zijn opgeslagen."
+      },
+      "editIntegration": "Integratie van bewerkingsprobleem",
+      "saveIntegration": "Integratie van problemen opslaan",
+      "deleteIntegration": "Integratie van problemen verwijderen",
+      "config": {
+        "name": "Naam van de probleemintegratie",
+        "namePlaceholder": "Voer een naam in voor deze integratie van problemen.",
+        "nameHelp": "Een beschrijvende naam om deze integratieproblematiek te identificeren",
+        "authType": "Authenticatietype",
+        "authTypeHelp": "Kies hoe u wilt authenticeren met de externe service",
+        "emailPlaceholder": "uw-e-mailadres@voorbeeld.com",
+        "emailHelp": "Uw account-e-mailadres",
+        "apiToken": "API-token",
+        "apiTokenPlaceholder": "Voer uw API-token in",
+        "apiTokenHelp": "Genereer een API-token vanuit uw accountinstellingen",
+        "jiraUrl": "Jira-URL",
+        "jiraUrlPlaceholder": "https://uw-site.atlassian.net",
+        "jiraUrlHelp": "De URL van uw Jira-instantie",
+        "clientId": "Client-ID",
+        "clientIdPlaceholder": "Voer uw OAuth-client-ID in",
+        "clientIdHelp": "De client-ID van uw OAuth-applicatie",
+        "clientSecret": "Clientgeheim",
+        "clientSecretPlaceholder": "Voer uw OAuth-clientgeheim in",
+        "clientSecretHelp": "Het clientgeheim van uw OAuth-applicatie",
+        "cloudId": "Cloud-ID",
+        "cloudIdPlaceholder": "Voer uw Atlassian Cloud ID in",
+        "cloudIdHelp": "Uw Atlassian Cloud-instance-ID (te vinden in uw Jira-URL)",
+        "apiUrl": "API-URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "De basis-URL voor de service-API",
+        "personalAccessTokenPlaceholder": "Voer uw persoonlijke toegangstoken in",
+        "personalAccessTokenHelp": "Een persoonlijke toegangstoken met de juiste machtigingen",
+        "apiKeyPlaceholder": "Voer uw API-sleutel in",
+        "apiKeyHelp": "De API-sleutel voor authenticatie",
+        "baseUrl": "URL-patroon",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "URL-patroon voor problemen. Gebruik {issueId} als tijdelijke aanduiding.",
+        "organizationUrl": "Organisatie-URL",
+        "organizationUrlPlaceholder": "https://dev.azure.com/uw-org",
+        "organizationUrlHelp": "De URL van uw Azure DevOps-organisatie",
+        "projectPath": "Projectpad",
+        "projectPathPlaceholder": "groep/subgroep/project",
+        "projectPathHelp": "Het volledige pad van je GitLab-project (bijv. mygroup/myproject)",
+        "instanceUrl": "Instantie-URL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "URL van uw zelfgehoste instantie. Laat dit veld leeg om gitlab.com te gebruiken.",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Eigenaar",
+        "ownerPlaceholder": "gebruikersnaam of organisatie",
+        "ownerHelp": "De Gitea-gebruiker of -organisatie die eigenaar is van de repository.",
+        "repo": "Opslagplaats",
+        "repoPlaceholder": "repository-naam",
+        "repoHelp": "De naam van de Gitea-repository",
+        "encrypted": "Versleuteld",
+        "encryptedHelp": "Dit veld is gecodeerd en veilig opgeslagen",
+        "changeCredential": "Wijziging",
+        "apiKeyWarningTitle": "Kennisgeving API-sleutelauthenticatie",
+        "apiKeyWarningDescription": "Bij gebruik van API-sleutelauthenticatie worden probleemmelders automatisch bepaald:",
+        "apiKeyWarningPoint1": "Als uw TestPlanIt-e-mailadres overeenkomt met het e-mailadres van een Jira-gebruiker, wordt u ingesteld als de melder",
+        "apiKeyWarningPoint2": "Als er geen e-mailadres overeenkomt, wordt uw TestPlanIt-naam gekoppeld aan Jira-weergavenamen",
+        "apiKeyWarningPoint3": "Als er geen overeenkomst wordt gevonden, wordt de eigenaar van de API-sleutel ingesteld als reporter",
+        "forgeApiKeyLabel": "Forge API-sleutel",
+        "forgeApiKeyDescription": "Deze sleutel wordt door de Atlassian Forge-app gebruikt om verzoeken vanuit Jira-issuepanelen te authenticeren. Genereer hier een sleutel en plak deze in de instellingen van uw Forge-app.",
+        "forgeApiKeyPlaceholder": "Klik op Genereren om een API-sleutel aan te maken.",
+        "forgeApiKeyGenerate": "Genereren",
+        "forgeApiKeyCopy": "Kopiëren",
+        "forgeApiKeyCopied": "Gekopieerd",
+        "platform": "Platform",
+        "platformPlaceholder": "Selecteer platform...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "API-sleutel",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Persoonlijke toegangstoken"
+      },
+      "validation": {
+        "nameRequired": "De naam van de issue-integratie is vereist.",
+        "clientIdRequired": "Client-ID is vereist",
+        "clientSecretRequired": "Clientgeheim is vereist",
+        "cloudIdRequired": "Cloud-ID is vereist",
+        "apiUrlRequired": "API-URL is vereist",
+        "tokenRequired": "Persoonlijke toegangstoken is vereist",
+        "apiKeyRequired": "API-sleutel is vereist"
+      },
+      "errors": {
+        "updateFailed": "Het bijwerken van de probleemintegratie is mislukt.",
+        "testFailed": "Verbindingstest mislukt",
+        "nameExists": "Er bestaat al een integratieprobleem met deze naam.",
+        "createFailed": "Het is niet gelukt om een integratieprobleem aan te maken.",
+        "deleteFailed": "Het verwijderen van de integratie van het probleem is mislukt."
+      },
+      "confirmDelete": {
+        "message": "Weet je zeker dat je de issue-integratie \"{name} \" wilt verwijderen?",
+        "warning": "Hierdoor wordt de issue-integratie verwijderd en de verbinding met alle projecten verbroken. Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "form": {
+        "success": "Integratie van het probleem succesvol opgeslagen.",
+        "successDescription": "De integratie met de issue-functionaliteit is geconfigureerd en klaar voor gebruik.",
+        "testing": "Verbinding testen..."
+      },
+      "oauth": {
+        "connectAccount": "Account verbinden",
+        "connected": "Aangesloten",
+        "notConnected": "Niet verbonden",
+        "authDescription": "U moet zich authenticeren met {provider} om deze integratie te gebruiken",
+        "authError": "Authenticatie mislukt",
+        "authErrorDescription": "Kan niet authenticeren met de externe service"
+      }
+    },
+    "llm": {
+      "addIntegration": "AI-model toevoegen",
+      "filterPlaceholder": "Filter AI-modellen...",
+      "testAll": "Test alle verbindingen",
+      "connectionTestComplete": "Verbindingstest voltooid",
+      "allIntegrationsTested": "Alle AI-modelverbindingen zijn getest",
+      "failedToTestConnections": "Het testen van enkele verbindingen is mislukt",
+      "notConfigured": "Niet geconfigureerd",
+      "defaultModel": "Geselecteerd model",
+      "budgetUsage": "Gebruik (deze maand)",
+      "noBudget": "Geen budget vastgesteld",
+      "streaming": "Streamen",
+      "add": {
+        "title": "AI-modelintegratie toevoegen",
+        "description": "Configureer een nieuw AI-model voor uw organisatie",
+        "integrationNamePlaceholder": "Voer een naam in voor deze integratie...",
+        "selectProvider": "Selecteer een aanbieder",
+        "openai": "OpenAI",
+        "anthropic": "Antropisch",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "customLlm": "Aangepaste LLM",
+        "apiKeyPlaceholder": "Voer uw API-sleutel in...",
+        "apiKeyDescription": "Uw API-sleutel voor authenticatie bij de provider",
+        "endpoint": "Eindpunt-URL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Tip: Als je een proxy gebruikt (bijvoorbeeld LiteLLM), probeer dan /v1 aan het einde van je endpoint-URL toe te voegen.",
+        "deploymentName": "Implementatienaam",
+        "deploymentNamePlaceholder": "Voer een implementatienaam in...",
+        "deploymentNameDescription": "Naam van Azure OpenAI-implementatie",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, enz.",
+        "defaultModelDescription": "Het model dat standaard moet worden gebruikt",
+        "maxTokensPerRequest": "Maximaal aantal tokens per aanvraag",
+        "maxRequestsPerMinute": "Maximaal aantal verzoeken per minuut",
+        "costPerInputToken": "Kosten per 1 miljoen invoertokens ($)",
+        "costPerOutputToken": "Kosten per 1 miljoen outputtokens ($)",
+        "monthlyBudget": "Maandelijks budget ($)",
+        "monthlyBudgetPlaceholder": "100,00",
+        "monthlyBudgetDescription": "Optioneel bestedingsdoel voor meldingen (blokkeert het gebruik niet)",
+        "billingPeriodStartDay": "Begindatum van de factureringsperiode",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "De dag van de maand (1-31) waarop uw factureringsperiode begint. Bij waarden 29-31 wordt de laatste dag van kortere maanden gebruikt.",
+        "defaultTemperature": "Standaardtemperatuur",
+        "defaultMaxTokens": "Standaard Max Tokens",
+        "timeout": "Verzoektime-out (ms)",
+        "timeoutDescription": "Maximale wachttijd voor een reactie van het AI-model (5000-600000 ms). Niet van toepassing op streamingverzoeken.",
+        "streamingEnabled": "Streaming inschakelen",
+        "streamingEnabledDescription": "Realtime responsstreaming toestaan",
+        "setAsDefault": "Instellen als standaard",
+        "setAsDefaultDescription": "Gebruik dit als het standaard AI-model voor de organisatie",
+        "fetchingModels": "Modellen ophalen...",
+        "failedToFetchModels": "Het ophalen van beschikbare modellen is mislukt",
+        "selectModel": "Selecteer een model",
+        "connectionSuccessfulDescription": "De verbinding met het AI-model is geverifieerd en werkt correct",
+        "failedToConnect": "Verbinding met de AI-modelprovider is mislukt",
+        "integrationCreated": "AI-modelintegratie succesvol gerealiseerd",
+        "failedToCreate": "Het is niet gelukt om een AI-modelintegratie te maken",
+        "validation": {
+          "nameRequired": "Integratienaam is verplicht",
+          "nameUnique": "Er bestaat al een integratie met deze naam.",
+          "defaultModelRequired": "Standaardmodel vereist"
+        }
+      },
+      "edit": {
+        "title": "Bewerken AI-modelintegratie",
+        "description": "Werk de configuratie voor deze AI-modelintegratie bij",
+        "statusDescription": "Deze integratie in- of uitschakelen",
+        "apiKeyPlaceholder": "Voer een nieuwe API-sleutel in om te updaten...",
+        "update": "Update",
+        "integrationUpdated": "Integratie van AI-model succesvol bijgewerkt",
+        "failedToUpdate": "Het is niet gelukt om de integratie van het AI-model bij te werken",
+        "validation": {
+          "nameRequired": "Integratienaam is verplicht",
+          "nameUnique": "Er bestaat al een integratie met deze naam.",
+          "defaultModelRequired": "Standaardmodel vereist"
+        }
+      },
+      "sections": {
+        "provider": "Aanbieder",
+        "costAndBudget": "Kosten en budget",
+        "advanced": "Geavanceerd"
+      },
+      "delete": {
+        "title": "AI-modelintegratie verwijderen",
+        "description": "Weet u zeker dat u deze AI-modelintegratie wilt verwijderen? Hiermee wordt de integratie uit alle projecten verwijderd en dit kan niet ongedaan worden gemaakt.",
+        "integrationDeletedSuccess": "AI-modelintegratie succesvol verwijderd",
+        "failedToDeleteIntegration": "Het is niet gelukt om de AI-modelintegratie te verwijderen",
+        "cannotDeleteDefault": "Het standaard AI-model kan niet worden verwijderd. Stel eerst een ander model in als standaard."
+      },
+      "validation": {
+        "defaultModelRequired": "Standaardmodel is vereist"
+      },
+      "test": {
+        "title": "Test AI-modelintegratie",
+        "description": "Test de verbinding en functionaliteit van {name}",
+        "connectionStatus": "Verbindingsstatus",
+        "connectionStatusDescription": "Controleer of het AI-model toegankelijk is",
+        "retest": "Verbinding opnieuw testen",
+        "connectionSuccessfulDescription": "Het AI-model is toegankelijk en reageert correct",
+        "failedToConnect": "Verbinding met AI-model mislukt",
+        "errorTestingConnection": "Er is een fout opgetreden tijdens het testen van de verbinding",
+        "testMessage": "Testbericht",
+        "testMessagePlaceholder": "Voer een bericht in om naar het AI-model te sturen...",
+        "sendTestMessage": "Testbericht verzenden",
+        "response": "Antwoord",
+        "testSuccessful": "Test succesvol",
+        "responseReceived": "Antwoord succesvol ontvangen (Kosten: ${cost})",
+        "testFailed": "Test mislukt",
+        "failedToGetResponse": "Er kon geen reactie van het AI-model worden ontvangen",
+        "failedToSendMessage": "Het is niet gelukt om het testbericht te verzenden",
+        "defaultTestMessage": "Hallo! Graag ontvang ik een korte bevestiging dat alles goed werkt."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Het instellen van een maandelijks budget voorkomt niet dat het LLM-gebruik dit budget overschrijdt. Budgetlimieten dienen uitsluitend ter informatie voor administratieve besluitvorming.",
+        "budgetDisclaimerShort": "Budgetlimieten zijn uitsluitend ter informatie en blokkeren het gebruik niet.",
+        "spendLabel": "Uitgaven van deze maand",
+        "spendOfBudget": "{currentSpend} van {budgetLimit}",
+        "overBudget": "Budget overschreden",
+        "budgetPercentage": "{percentage}% van het budget gebruikt",
+        "spendReset": "De uitgaven van de huidige maand zijn gereset."
+      }
+    },
+    "prompts": {
+      "title": "Promptconfiguraties",
+      "description": "Beheer AI-prompt-sjablonen voor verschillende functies.",
+      "addPromptConfig": "Voeg promptconfiguratie toe",
+      "filterPlaceholder": "Filterpromptconfiguraties...",
+      "features": "Functies",
+      "featureCount": "{count, plural, one {# functie} other {# functies}}",
+      "llmIntegration": "LLM-integratie",
+      "modelOverride": "Modeloverride",
+      "llmIntegrationPlaceholder": "Projectstandaard",
+      "modelOverridePlaceholder": "Integratiestandaard",
+      "projectDefault": "Projectstandaard (wissen)",
+      "integrationDefault": "Integratie Standaard (wissen)",
+      "systemPrompt": "Systeemprompt",
+      "userPrompt": "Gebruikersprompt",
+      "temperature": "Temperatuur",
+      "maxOutputTokens": "Maximale uitvoer van tokens",
+      "variables": "Variabelen",
+      "insertVariable": "Variabele invoegen",
+      "noConfigs": "Er zijn geen promptconfiguraties gevonden. Voeg uw eerste configuratie toe om te beginnen.",
+      "add": {
+        "title": "Voeg promptconfiguratie toe",
+        "description": "Maak een nieuwe AI-promptconfiguratie met prompts voor elke functie. Standaardinstellingen zijn automatisch toegepast."
+      },
+      "edit": {
+        "title": "Configuratie van de prompt bewerken",
+        "description": "Werk deze AI-promptconfiguratie bij."
+      },
+      "delete": {
+        "title": "Configuratie van prompt verwijderen",
+        "confirmMessage": "Weet je zeker dat je <strong>{name}</strong>wilt verwijderen? Projecten die deze prompt gebruiken, vallen terug op de systeemstandaard.",
+        "warning": "Deze actie kan niet ongedaan worden gemaakt. Alle projecten die deze configuratie gebruiken, zullen terugkeren naar de standaard promptconfiguratie."
+      },
+      "llmColumn": "LLM",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "De standaard promptconfiguratie kan niet worden verwijderd. Stel eerst een andere prompt als standaard in.",
+      "defaultChanged": "De standaard promptconfiguratie is succesvol bijgewerkt.",
+      "featureLabels": {
+        "markdown_parsing": "Markdown-testcaseparsing",
+        "test_case_generation": "Testcasegeneratie",
+        "magic_select_cases": "Slimme testcaseselectie",
+        "editor_assistant": "Redacteur/Schrijfassistent",
+        "llm_test": "LLM-verbindingstest",
+        "export_code_generation": "Exportcodegeneratie",
+        "auto_tag": "AI-tagsuggesties",
+        "duplicate_detection": "Detectie van duplicaten",
+        "generate_from_url": "Testcases genereren vanuit URL (vereisten)",
+        "generate_from_url_app": "Testcases genereren vanuit URL (applicatietesten)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Elasticsearch-beheer",
+      "description": "Beheer zoekmachine-indexering en onderhoud",
+      "status": {
+        "title": "Elasticsearch-status",
+        "description": "Huidige verbinding en gezondheidsstatus van de zoekmachine",
+        "checking": "Status controleren...",
+        "disconnected": "Losgekoppeld",
+        "nodes": "Knooppunten",
+        "indices": "Indexen",
+        "documents": "documenten",
+        "error": {
+          "title": "Verbindingsfout",
+          "description": "Kan geen verbinding maken met de Elasticsearch-service"
+        }
+      },
+      "settings": {
+        "description": "Configureer Elasticsearch-instellingen voor uw implementatie",
+        "numberOfReplicas": "Aantal replica's",
+        "replicasHelp": "Instellen op 0 voor clusters met één knooppunt, 1+ voor clusters met meerdere knooppunten met redundantie",
+        "savedDescription": "Configuratie is opgeslagen in de database",
+        "updated": "Indexen bijgewerkt",
+        "updatedDescription": "Alle bestaande indices zijn bijgewerkt met de nieuwe replica-instellingen",
+        "error": "Fout bij het opslaan van instellingen",
+        "errorDescription": "Configuratie opslaan mislukt. Probeer het opnieuw.",
+        "note": {
+          "description": "Wijzigingen worden direct toegepast op nieuwe indices. Bestaande indices worden bijgewerkt wanneer u opslaat. Stel replica's in op 0 om de GELE status op clusters met één knooppunt om te zetten."
+        }
+      },
+      "reindex": {
+        "title": "Gegevens opnieuw indexeren",
+        "description": "Herbouw zoekindexen voor verbeterde zoekprestaties",
+        "entities": {
+          "all": "Alle entiteiten"
+        },
+        "button": {
+          "start": "Start herindexering",
+          "indexing": "Indexeren..."
+        },
+        "warning": {
+          "title": "Belangrijk",
+          "description": "Het opnieuw indexeren kan enkele minuten duren, afhankelijk van de hoeveelheid data. De zoekfunctionaliteit kan tijdens dit proces beperkt zijn."
+        },
+        "complete": {
+          "title": "Herindexering voltooid",
+          "description": "Alle geselecteerde entiteiten zijn succesvol opnieuw geïndexeerd"
+        },
+        "success": {
+          "title": "Herindexering succesvol",
+          "description": "{count, plural, one {# document} other {# documenten}} succesvol geïndexeerd"
+        },
+        "error": {
+          "title": "Herindexering mislukt",
+          "description": "Er is een fout opgetreden tijdens het herindexeren. Probeer het opnieuw."
+        }
+      }
+    },
+    "queues": {
+      "title": "Achtergrondtaakwachtrijen",
+      "description": "Achtergrondtaakverwerkingswachtrijen bewaken en beheren",
+      "queueNames": {
+        "forecast-updates": "Weersverwachtingen",
+        "emails": "E-mailwachtrij",
+        "issue-sync": "Probleem synchronisatie",
+        "testmo-imports": "Testmo Imports",
+        "elasticsearch-reindex": "Elasticsearch-herindexering",
+        "audit-logs": "Auditlogboeken",
+        "budget-alerts": "Budgetwaarschuwingen",
+        "auto-tag": "AI-automatische tagging",
+        "repo-cache": "Repositorycache",
+        "copy-move": "Kopiëren en verplaatsen",
+        "duplicate-scan": "Dubbele scan",
+        "magic-select": "Magische selectie",
+        "step-scan": "Stapsequentiescan"
+      },
+      "status": {
+        "paused": "Gepauzeerd",
+        "idle": "Inactief"
+      },
+      "table": {
+        "queue": "Wachtrij",
+        "concurrency": "Gelijktijdigheid",
+        "waiting": "Wachten",
+        "failed": "Mislukt"
+      },
+      "concurrency": {
+        "title": "Werknemersgelijktijdigheid",
+        "description": "Gelijktijdigheid bepaalt hoeveel taken elke werker tegelijkertijd verwerkt. Hogere waarden kunnen de doorvoer verbeteren, maar gebruiken meer systeembronnen (CPU en geheugen).",
+        "configureTitle": "Gelijktijdigheid configureren",
+        "configureDescription": "Om gelijktijdigheid aan te passen, stelt u omgevingsvariabelen in en start u workers opnieuw. Zie de documentatie voor details.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo-import (standaard: 1, geheugenintensief)",
+          "SYNC_CONCURRENCY": "Probleemsynchronisatie (standaard: 2, I/O-intensief)",
+          "EMAIL_CONCURRENCY": "E-mail verzenden (standaard: 3, I/O-intensief)",
+          "NOTIFICATION_CONCURRENCY": "Meldingen (standaard: 5, lichtgewicht)",
+          "FORECAST_CONCURRENCY": "Weersverwachtingupdates (standaard: 5, CPU-intensief)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Pauze wachtrij",
+          "confirmDescription": "Hiermee wordt voorkomen dat nieuwe taken worden verwerkt. Actieve taken worden wel doorgezet tot ze zijn voltooid."
+        },
+        "resume": {
+          "confirmTitle": "Hervat wachtrij",
+          "confirmDescription": "Hierdoor kan de wachtrij de taken die in behandeling zijn, verwerken."
+        },
+        "clean": {
+          "confirmTitle": "Schone wachtrij",
+          "confirmDescription": "Hiermee worden voltooide en mislukte taken uit de wachtrij verwijderd. Deze actie kan niet ongedaan worden gemaakt."
+        },
+        "drain": {
+          "confirmTitle": "Afvoer wachtrij",
+          "confirmDescription": "Hiermee worden alle taken in de wachtrij verwijderd. Actieve taken worden voortgezet tot ze voltooid zijn. Deze actie kan niet ongedaan worden gemaakt."
+        },
+        "obliterate": {
+          "confirmTitle": "Wachtrij wissen",
+          "confirmDescription": "Hiermee wordt de wachtrij volledig gewist en worden alle taken verwijderd, ongeacht hun status. Deze actie kan niet ongedaan worden gemaakt en mag alleen in noodsituaties worden gebruikt."
+        },
+        "warning": "Waarschuwing",
+        "irreversible": "Deze actie kan niet ongedaan worden gemaakt. Bevestig dat u wilt doorgaan."
+      },
+      "success": {
+        "actionCompleted": "Actie voltooid",
+        "queuePaused": "Wachtrij is gepauzeerd",
+        "queueResumed": "De wachtrij is hervat",
+        "queueCleaned": "Wachtrij is opgeschoond",
+        "queueDrained": "De wachtrij is leeggemaakt",
+        "queueObliterated": "De wachtrij is verwijderd"
+      },
+      "error": {
+        "loadFailed": "Het laden van wachtrijen is mislukt",
+        "actionFailed": "Actie mislukt"
+      },
+      "jobs": {
+        "title": "Wachtrijtaken",
+        "description": "Bekijk en beheer individuele taken in de wachtrij",
+        "noJobs": "Geen banen gevonden in deze wachtrij",
+        "table": {
+          "id": "Taak-ID",
+          "name": "Functienaam",
+          "attempts": "Pogingen"
+        },
+        "details": {
+          "title": "Taakdetails",
+          "failedReason": "Reden van mislukking",
+          "stacktrace": "Stapeltracering",
+          "data": "Taakgegevens",
+          "returnValue": "Retourwaarde",
+          "options": "Werkopties",
+          "processed": "Verwerkt",
+          "finished": "Afgerond"
+        },
+        "success": {
+          "actionCompleted": "Taakactie voltooid",
+          "jobRetried": "Taak is opnieuw geprobeerd",
+          "jobPromoted": "De baan is gepromoveerd",
+          "jobRemoved": "Taak is verwijderd"
+        },
+        "error": {
+          "loadFailed": "Het laden van taken is mislukt",
+          "actionFailed": "Taakactie mislukt"
+        },
+        "forceRemove": {
+          "title": "Taak geforceerd verwijderen",
+          "question": "Wilt u deze taak geforceerd verwijderen?",
+          "warning": "Hiermee wordt geprobeerd de taak meerdere keren te verwijderen, met vertraging. Let op: zelfs als de taak daadwerkelijk is vergrendeld door een actieve worker, kan deze nog steeds mislukken.",
+          "confirm": "Geforceerd verwijderen"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Bekijk het systeemwijde auditlogboek voor het bijhouden van beveiliging en naleving.",
+      "filterPlaceholder": "Zoeken op entiteit, gebruiker of actie...",
+      "filterAction": "Actie",
+      "filterEntityType": "Entiteitstype",
+      "allActions": "Alle acties",
+      "allEntityTypes": "Alle entiteitstypen",
+      "showing": "Toont {start} tot {end} van {total} items",
+      "viewDetails": "Bekijk details",
+      "detailTitle": "Auditlogboekdetails",
+      "userInfo": "Gebruikersinformatie",
+      "changes": "Wijzigingen",
+      "metadata": "Metadata",
+      "oldValue": "Oud",
+      "newValue": "Nieuw",
+      "columns": {
+        "timestamp": "Tijdstempel",
+        "entityId": "Entiteits-ID",
+        "entityName": "Entiteitsnaam",
+        "userId": "Gebruikers-ID",
+        "ipAddress": "IP-adres",
+        "userAgent": "Gebruikersagent"
+      },
+      "exportCsv": "Exporteer naar CSV",
+      "timeRange": "Tijdsbereik",
+      "timeRangeOptions": {
+        "last24h": "Afgelopen 24 uur",
+        "last7d": "Afgelopen 7 dagen",
+        "last30d": "Afgelopen 30 dagen",
+        "last90d": "Afgelopen 90 dagen",
+        "allTime": "Alle tijden"
+      },
+      "systemActor": "Systeem",
+      "systemActorTooltip": "Actie uitgevoerd door het systeem, niet door een ingelogde gebruiker."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Geen meldingen",
+      "aria": {
+        "notifications": "Meldingen ({count} ongelezen)"
+      },
+      "actions": {
+        "markRead": "Markeer als gelezen",
+        "markUnread": "Markeer als ongelezen",
+        "markAllRead": "Markeer alles als gelezen",
+        "deleteAll": "Verwijder alles"
+      },
+      "success": {
+        "deleted": "Melding verwijderd",
+        "markedAllRead": "Alle meldingen gemarkeerd als gelezen",
+        "deletedAll": "Alle meldingen verwijderd"
+      },
+      "error": {
+        "markRead": "Het is niet gelukt om het bericht als gelezen te markeren",
+        "markUnread": "Het is niet gelukt om het bericht als ongelezen te markeren",
+        "delete": "Het is niet gelukt om de melding te verwijderen",
+        "markAllRead": "Het is niet gelukt om alles als gelezen te markeren",
+        "deleteAll": "Het verwijderen van meldingen is mislukt."
+      },
+      "deleteAllDialog": {
+        "title": "Alle meldingen verwijderen?",
+        "description": "Hiermee worden al je meldingen permanent verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+        "confirm": "Verwijder alles"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Nieuwe testcasetoewijzing",
+        "multipleTestCaseAssignmentTitle": "Meerdere testgevallen toegewezen",
+        "sessionAssignmentTitle": "Nieuwe sessietoewijzing",
+        "commentMentionTitle": "Je werd genoemd in een reactie",
+        "systemAnnouncementTitle": "Systeemaankondiging",
+        "assignedTestCase": "heeft u toegewezen aan de testcase",
+        "assignedMultipleTestCases": "toegewezen aan jou {count, plural, one {# testgeval} other {# testgevallen}}",
+        "assignedSession": "je toegewezen aan sessie",
+        "mentionedYouInComment": "noemde je in een reactie op",
+        "inProject": "in project",
+        "testRun": "Testrun:",
+        "casesInProject": "{count, plural, =1 {# geval} other {# gevallen}} in",
+        "sentBy": "Verzonden door {name}",
+        "milestoneDueSoonTitle": "Mijlpaal binnenkort bereikt",
+        "milestoneOverdueTitle": "Mijlpaal te laat",
+        "milestoneDueSoon": "De mijlpaal \"{milestoneName}\" in project \"{projectName}\" moet op {dueDate} voltooid zijn.",
+        "milestoneOverdue": "De mijlpaal \"{milestoneName}\" in project \"{projectName}\" had op {dueDate} moeten worden voltooid en is nu te laat.",
+        "milestoneNotificationReason": "U ontvangt deze melding omdat u hebt deelgenomen aan werkzaamheden die verband houden met deze mijlpaal (testruns, sessies of als maker van de mijlpaal).",
+        "milestoneNotificationContinue": "Je blijft dagelijks herinneringen ontvangen totdat deze mijlpaal is voltooid.",
+        "shareLinkAccessedTitle": "Deellink geopend",
+        "shareLinkAccessedAnonymousViewer": "Iemand",
+        "shareLinkAccessedMessage": "{viewer} heeft uw gedeelde rapport bekeken: \"{shareTitle}\"",
+        "viewedYourSharedLink": "Ik heb je gedeelde link bekeken.",
+        "viewedAt": "Bekeken op",
+        "budgetDisclaimer": "Budgetlimieten zijn slechts informatief en belemmeren het gebruik niet.",
+        "llmBudgetExceededTitle": "Budget voor LLM overschreden",
+        "llmBudgetThresholdTitle": "LLM-budget {threshold}% gebruikt",
+        "llmBudgetExceededMessage": "{providerName} heeft zijn maandbudget overschreden: {spend} heeft uitgegeven van het budget van {budget}.",
+        "llmBudgetThresholdMessage": "{providerName} heeft {threshold}% van zijn maandbudget gebruikt: {spend} van {budget}.",
+        "userRegisteredTitle": "Nieuwe gebruikersregistratie",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) heeft zich geregistreerd via SSO",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) heeft zich geregistreerd via het registratieformulier",
+        "viewUserList": "Gebruikerslijst bekijken",
+        "reviewGeneratedCases": "Review gegenereerde testgevallen",
+        "generateFromUrlCompleteTitle": "Pagina's succesvol gecrawld",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# pagina} other {# pagina's}} gecrawld vanuit {url} in project \"{projectName}\". Klik om te bekijken en testgevallen te genereren.",
+        "generateFromUrlFailedTitle": "URL-crawl mislukt"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Problemen met zoeken of koppelen...",
+        "create_label": "Linkprobleem \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Voer een samenvatting van het probleem in"
+        },
+        "fields": {
+          "name": {
+            "label": "Samenvatting"
+          },
+          "description": {
+            "placeholder": "Beschrijf het probleem...",
+            "helper": "Geef gedetailleerde informatie over het probleem"
+          },
+          "project": {
+            "helper": "Selecteer het project in de externe issue tracker"
+          }
+        },
+        "loading_metadata": "Integratie-instellingen laden...",
+        "errors": {
+          "creation_failed": "Het probleem kon niet worden veroorzaakt. Probeer het opnieuw."
+        },
+        "success": {
+          "created": "Probleem succesvol aangemaakt",
+          "external_created": "Probleem gecreëerd en gekoppeld aan externe tracker"
+        },
+        "warnings": {
+          "external_failed": "Probleem lokaal gecreëerd, maar kon niet worden gesynchroniseerd met externe tracker"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "U moet uw account verbinden met {integrationName} om problemen te creëren."
+      },
+      "search_issues_dialog": {
+        "title": "Zoek- en koppelingsproblemen",
+        "placeholder": "Zoeken naar problemen...",
+        "searching": "Zoeken...",
+        "searchError": "Problemen met zoeken mislukt",
+        "linkButton": "Link",
+        "linkedCount": "{count, plural, one {# probleem} other {# problemen}} gekoppeld"
+      }
+    },
+    "copyMove": {
+      "title": "Kopiëren / Verplaatsen naar project",
+      "step1Desc": "Selecteer een doelproject en -map voor de testgevallen.",
+      "step2Desc": "Kies de bewerking en controleer de compatibiliteit.",
+      "step3Desc": "Volg de voortgang en evalueer de resultaten.",
+      "targetProject": "Doelproject",
+      "searchProjects": "Zoek projecten...",
+      "loadingProjects": "Projecten laden...",
+      "noProjectsFound": "Geen projecten gevonden.",
+      "completed": "(Compleet)",
+      "targetFolder": "Doelmap",
+      "newFolderPlaceholder": "Nieuwe mapnaam...",
+      "operation": "Operatie",
+      "operationCopy": "Kopiëren",
+      "operationCopyDesc": "Hiermee wordt een kopie gemaakt van de geselecteerde casus(sen) in het doelproject. De originelen blijven ongewijzigd.",
+      "operationMove": "Beweging",
+      "operationMoveDesc": "Verplaatst de geselecteerde case(s) naar het doelproject. De originelen worden verwijderd uit de bron.",
+      "checkingCompatibility": "Compatibiliteit controleren...",
+      "noTargetWriteAccess": "Je hebt geen schrijftoegang tot het betreffende project.",
+      "noSourceUpdateAccess": "Je hebt geen bewerkingsrechten voor het bronproject om cases te verplaatsen.",
+      "templateMismatch": "Sjabloon komt niet overeen",
+      "autoAssignTemplates": "Ontbrekende sjablonen automatisch toewijzen aan het doelproject",
+      "templatesMayNotDisplay": "Ontbrekende sjablonen zijn niet beschikbaar in het doelproject. Casussen worden wel gekopieerd, maar velden uit die sjablonen worden mogelijk niet correct weergegeven.",
+      "workflowFallback": "Sommige workflowstatussen zijn niet beschikbaar in het doelproject. In deze gevallen wordt de standaardstatus van het doelproject gebruikt.",
+      "default": "(standaard)",
+      "conflicts": "Van toepassing op alle conflicten:",
+      "conflictSkip": "Overslaan",
+      "conflictRename": "Naam wijzigen",
+      "sharedStepGroups": "Wanneer er in het doel al gedeelde stappengroepen bestaan:",
+      "sharedStepGroupReuse": "Hergebruik bestaande",
+      "sharedStepGroupReuseDesc": "De casussen zullen verwijzen naar de bestaande gedeelde stappengroep.",
+      "sharedStepGroupCreateNew": "Maak een nieuwe aan",
+      "sharedStepGroupCreateNewDesc": "Er wordt een nieuwe gezamenlijke stappengroep aangemaakt.",
+      "go": "Gaan",
+      "processing": "Bezig met verwerken...",
+      "progressText": "{processed} van {total} verwerkte gevallen",
+      "successCount": "{count} geval(len) {operation}succesvol",
+      "skipped": "Overgeslagen: {count}",
+      "droppedLinks": "Links tussen projecten verwijderd: {count}",
+      "errorCount": "{count} geval(len) mislukt",
+      "viewInTargetProject": "Bekijken in doelproject",
+      "failed": "Mislukt",
+      "folderMode": "Map \"{folderName}\" — {caseCount, plural, one {# geval} other {# gevallen}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Gekoppelde problemen",
+    "linkedIssuesDescription": "Problemen met dit item",
+    "refreshed": "Problemen vernieuwd",
+    "refreshedDescription": "De lijst met gekoppelde problemen is bijgewerkt",
+    "unlinked": "Probleem niet gekoppeld",
+    "unlinkedDescription": "Het probleem is uit dit item verwijderd",
+    "linked": "Probleem gekoppeld",
+    "linkedDescription": "Het probleem is gekoppeld aan dit item",
+    "searchAndLink": "Zoeken en koppelen",
+    "createAndLink": "Maken en koppelen",
+    "noLinkedIssues": "Geen gekoppelde problemen",
+    "viewExternal": "Bekijk in {provider}",
+    "unlink": "Ontkoppelen",
+    "linkError": "Probleem met koppelen mislukt",
+    "linkExternalIssue": "Link {provider} Probleem",
+    "linkIssue": "Linkprobleem",
+    "addIssue": "Voeg een probleem toe",
+    "unlinkError": "Probleem met het loskoppelen is mislukt",
+    "noIssuesFound": "Geen problemen gevonden",
+    "startTypingToSearch": "Begin met typen om naar problemen te zoeken",
+    "selectedCount": "{count} geselecteerd",
+    "confirmSelection": "Selectie bevestigen",
+    "alreadyLinked": "Al gekoppeld",
+    "authenticate": "Authenticeren",
+    "authenticationRequired": "Authenticatie vereist",
+    "authenticationDescription": "U moet zich verifiëren met {provider} om naar problemen te zoeken.",
+    "searchIn": "Zoeken in {provider}",
+    "searchPlaceholder": "Zoekproblemen...",
+    "searchIssues": "Zoekproblemen",
+    "searchIssuesDescription": "Zoek naar interne problemen om naar dit item te linken.",
+    "searchExternalDescription": "Zoek naar {provider} problemen om naar dit item te linken.",
+    "error": "Fout bij het laden van problemen",
+    "errorDescription": "Problemen met laden mislukt. Probeer het opnieuw.",
+    "selectIssues": "Selecteer problemen",
+    "authRequiredDescription": "Gelieve te authenticeren met {provider} om te zoeken naar problemen",
+    "integrationNotConfigured": "Integratie niet geconfigureerd",
+    "integrationNotConfiguredDescription": "Deze integratie is niet volledig geconfigureerd. Neem contact op met uw projectbeheerder om het externe project te configureren in de projectinstellingen.",
+    "createIssue": "Probleem maken",
+    "createNewIssue": "Nieuw probleem maken",
+    "createIssueDescription": "Een nieuw probleem maken",
+    "createIssueDescriptionWithIntegration": "Maak een nieuw probleem met {provider}",
+    "createIssueDescriptionSimpleUrl": "Een nieuw intern probleem aanmaken (eenvoudige URL-integratie)",
+    "creatingWith": "Probleem met {provider}creëren",
+    "authenticatedAndReady": "Geverifieerd en klaar om problemen te creëren",
+    "created": "Probleem gecreëerd",
+    "createdInExternal": "Probleem gecreëerd in {provider}",
+    "createdInternal": "Probleem lokaal gecreëerd",
+    "createdInternalSimpleUrl": "Probleem intern aangemaakt en kan via een eenvoudige URL worden gekoppeld",
+    "createError": "Het is niet gelukt om een probleem te creëren",
+    "useIntegration": "Gebruik {provider}",
+    "useIntegrationDescription": "Probleem creëren in extern systeem",
+    "externalProject": "Extern project",
+    "selectProject": "Selecteer project",
+    "issueType": "Probleemtype",
+    "selectIssueType": "Selecteer het type probleem",
+    "noIssueTypes": "Geen probleemtypen beschikbaar",
+    "priorityUrgent": "Dringend",
+    "additionalFields": "Extra velden",
+    "createIssueInJira": "Probleem aanmaken in Jira",
+    "createIssueInJiraDescription": "Gebruik de interface van Jira om een nieuw probleem te maken met alle beschikbare velden en opties",
+    "createIssueInJiraFallbackDescription": "Open Jira in een nieuw tabblad om een probleem te maken met vooraf ingevulde informatie",
+    "jiraIframeError": "Kan de Jira-interface niet laden. Probeer het in een nieuw tabblad te openen.",
+    "jiraIframeFallback": "Jira vereist om veiligheidsredenen een nieuw tabblad. Klik op de onderstaande knop om uw probleem aan te maken.",
+    "jiraFallbackNote": "Nadat u het probleem in Jira hebt aangemaakt, kunt u hier terugkeren om het probleem aan uw testcase te koppelen.",
+    "openInNewTab": "Openen in nieuw tabblad",
+    "jiraIframeNote": "Nadat u het probleem in Jira hebt aangemaakt, kunt u dit dialoogvenster sluiten en de probleemlijst vernieuwen.",
+    "fillInRequiredFields": "Vul de vereiste velden in om een nieuw probleem aan te maken",
+    "failedToFetchFields": "Het is niet gelukt om probleemvelden uit Jira op te halen",
+    "enterSummary": "Geef een korte samenvatting van het probleem",
+    "enterDescription": "Geef een gedetailleerde beschrijving van het probleem",
+    "failedToCreateIssue": "Het is niet gelukt om een probleem in Jira te creëren",
+    "issueCreatedDescription": "Probleem {key} is succesvol aangemaakt",
+    "addLabel": "Voeg een label toe en druk op Enter",
+    "labelHint": "Spaties worden vervangen door koppeltekens",
+    "labelFormatNote": "Labels mogen geen spaties bevatten. Spaties worden automatisch vervangen door koppeltekens.",
+    "enterIssueKey": "Voer de uitgiftesleutel in (bijv. PROJ-123)",
+    "issueLinkHelp": "Voer de sleutel van een bestaand probleem in om te koppelen",
+    "searchForIssue": "Zoek naar een probleem om te linken",
+    "searchUsers": "Zoeken naar gebruikers",
+    "noTeamsAvailable": "Geen teams beschikbaar",
+    "filterAll": "Alle",
+    "fanOutPartialFailure": "Project(en) {count} konden niet worden bereikt. Resultaten van project(en) {successCount} worden weergegeven.",
+    "projectSelectorLabel": "Project",
+    "searchFailedTitle": "Zoeken mislukt"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Bekijk en beheer alle problemen.",
+      "filterPlaceholder": "Filter problemen op naam..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Documentatie",
+      "Milestones": "Mijlpalen",
+      "TestCaseRepository": "Testcase-repository",
+      "TestCaseRestrictedFields": "Testcase beperkte velden",
+      "TestRuns": "Testruns",
+      "ClosedTestRuns": "Gesloten testruns",
+      "TestRunResults": "Testresultaten",
+      "TestRunResultRestrictedFields": "Beperkte velden voor testresultaten",
+      "Sessions": "Sessies",
+      "SessionsRestrictedFields": "Sessie beperkte velden",
+      "ClosedSessions": "Gesloten sessies",
+      "SessionResults": "Sessieresultaten",
+      "Tags": "Tags",
+      "SharedSteps": "Gedeelde stappen",
+      "Issues": "Problemen",
+      "IssueIntegration": "Probleemintegratie",
+      "Forecasting": "Voorspelling",
+      "Reporting": "Rapportage",
+      "Settings": "Instellingen"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Nog niet gestart",
+      "IN_PROGRESS": "In behandeling",
+      "DONE": "Klaar"
+    }
+  },
+  "charts": {
+    "average": "Gemiddeld",
+    "count": "Aantal: {count}",
+    "percent": "Percentage: {percent}%",
+    "completed": "Voltooid: {count}",
+    "durationRange": "Duur: {from}s - {to}s",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# testgeval} other {# testgevallen}}",
+    "estimate": "Est: {value}",
+    "partOf": "(Deel van {parent})",
+    "status": "Status: {status}"
+  },
+  "linkedCases": {
+    "title": "Gekoppelde testcases",
+    "addLink": "Link toevoegen",
+    "addLinkedTestCase": "Gekoppelde testcase toevoegen",
+    "testCase": "Testgeval",
+    "linkType": "Linktype",
+    "noLinkedCases": "Geen gekoppelde testcases.",
+    "linkedBy": "Gekoppeld door",
+    "on": "Gelinkt aan",
+    "alreadyLinked": "Deze zaak is al gelinkt.",
+    "cannotLinkSelf": "Kan een zaak niet aan zichzelf koppelen.",
+    "circularLink": "Er is een cirkelvormige verbinding gedetecteerd.",
+    "failedToCreate": "Het is niet gelukt om de link te maken.",
+    "confirmRemoveLink": "Weet u zeker dat u deze link wilt verwijderen?",
+    "DEPENDS_ON": "Afhankelijkheid",
+    "DUPLICATED_FROM": "Gedupliceerd van",
+    "SAME_TEST_DIFFERENT_SOURCE": "Zelfde test (andere bron)",
+    "status": "Laatste status",
+    "at": "Uitgevoerd"
+  },
+  "ganttTooltip": {
+    "task": "Taak",
+    "group": "Run/Sessie:",
+    "project": "Project:",
+    "starts": "Begint:",
+    "scheduledCompletion": "Geplande voltooiing:",
+    "estWorkEffort": "Geschatte werkinspanning:",
+    "noTasks": "Er zijn geen taken om weer te geven in het Gantt-diagram."
+  },
+  "help": {
+    "project": {
+      "name": "## Projectnaam\nDe unieke identificatie voor uw project.\n\n- Moet uniek zijn voor alle projecten.\n- Wordt gebruikt in navigatie en rapporten.\n- Moet duidelijk en beschrijvend zijn.\n- Helpt teamleden de projectomvang te identificeren.",
+      "description": "## Projectbeschrijving\nAanvullende details over het doel en de reikwijdte van het project.\n\n- Optioneel maar aanbevolen\n- Helpt teamleden de projectdoelen te begrijpen\n- Kan belangrijke doelstellingen of vereisten bevatten\n- Beperkt tot 256 tekens",
+      "icon": "## Projectpictogram\nEen visuele identificatie voor uw project.\n\n- Helpt het project snel te identificeren in lijsten en dashboards.\n- Kies uit een verscheidenheid aan vooraf gedefinieerde pictogrammen.\n- Kan op elk moment worden gewijzigd.\n- Verschijnt in projectnavigatie en rapporten.",
+      "completed": "## Projectstatus\nGeeft aan of het project actief of voltooid is.\n\n- Actieve projecten zijn beschikbaar voor testen en updates.\n- Voltooide projecten zijn alleen-lezen.\n- Beïnvloedt de zichtbaarheid van projecten in dashboards.\n- Kan indien nodig worden teruggedraaid.",
+      "completedAt": "## Voltooiingsdatum\nDe datum waarop het project als voltooid is gemarkeerd.\n\n- Automatisch ingesteld bij het markeren van een project als voltooid\n- Gebruikt voor rapportage en tracking\n- Helpt bij het bijhouden van de projectgeschiedenis\n- Kan indien nodig worden gewijzigd",
+      "defaultAccess": "## Standaard projecttoegang\nDefinieer de standaard toegangsrechten voor gebruikers en groepen in dit project. Deze kunnen per gebruiker of per groep worden overschreven.",
+      "issueTracker": "## Issue Tracker-configuratie\nSelecteer de issue tracker-configuratie die moet worden gebruikt voor het beheren van problemen met betrekking tot dit project."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Extern project\nSelecteer het project of de repository in het externe systeem om te koppelen aan dit TestPlanIt-project.\n\n- Problemen die vanuit TestPlanIt worden aangemaakt, worden in dit project aangemaakt.\n- Maakt integratie van probleemregistratie tussen systemen mogelijk.\n- Vereist de juiste machtigingen in het externe systeem.",
+          "defaultIssueTypeHelp": "## Standaardprobleemtype\nHet probleemtype dat vooraf wordt geselecteerd bij het maken van nieuwe problemen vanuit TestPlanIt.\n\n- Bespaart tijd door standaard uw meest voorkomende probleemtype te gebruiken\n- Kan worden overschreven bij het maken van individuele problemen\n- Moet een geldig probleemtype zijn voor het geselecteerde externe project\n- Werk dit bij als uw workflow verandert",
+          "automaticSyncHelp": "## Automatische synchronisatie\nMaakt automatische synchronisatie van de probleemstatus tussen TestPlanIt en het externe systeem mogelijk.\n\n- Problemen die aan testcases zijn gekoppeld, werken hun status automatisch bij.\n- Helpt de probleemtracking consistent te houden in alle systemen.\n- Kan het API-gebruik met de externe service verhogen.\n- Kan worden uitgeschakeld als handmatige controle de voorkeur heeft."
+        }
+      }
+    },
+    "user": {
+      "name": "## Gebruikersnaam\nDe volledige naam van de gebruiker.\n\n- Gebruikt voor identificatie in het hele systeem\n- Wordt weergegeven in opdrachten en rapporten\n- Moet uniek zijn voor elke gebruiker",
+      "email": "## E-mailadres\nHet e-mailadres van de gebruiker voor toegang tot het account.\n\n- Gebruikt voor systeemlogin\n- Moet uniek zijn voor elke gebruiker\n- Gebruikt voor systeemmeldingen",
+      "password": "## Wachtwoord\nHet accountwachtwoord van de gebruiker.\n\n- Optioneel wanneer een wachtwoordloze aanmeldmethode is geconfigureerd (Magic Link SSO-provider of e-mailserver) — laat leeg om aanmelden via Magic Link of SSO te vereisen.\n- Indien opgegeven, moet voldoen aan het wachtwoordbeleid dat is ingesteld in **Beheer → Beveiliging** (minimale lengte en tekenklassen).\n- Gebruikt voor beveiligde accounttoegang.\n- Moet vertrouwelijk worden behandeld.",
+      "token": "## Verificatietoken\nVoer het token in dat u per e-mail heeft ontvangen om uw account te verifiëren. Als u geen token heeft, kunt u een nieuwe aanvragen.",
+      "confirmPassword": "## Wachtwoord bevestigen\nVoer het wachtwoord opnieuw in om te controleren of het correct is ingevoerd.\n\n- Moet exact overeenkomen met het wachtwoord\n- Helpt typefouten te voorkomen\n- Alleen vereist wanneer een wachtwoord is ingevoerd — laat leeg als het wachtwoordveld leeg is.",
+      "access": "## Systeemtoegangsniveau\nBepaalt de systeembrede machtigingen van de gebruiker.\n\n- **Beheerder:** Volledige systeemtoegang en configuratie\n- **Projectbeheerder:** Kan toegewezen projecten beheren\n- **Gebruiker:** Standaardtoegang tot toegewezen projecten\n- **Geen:** Kan alleen hun dashboard bekijken",
+      "role": "## Systeemrol\nDeze rol bepaalt de standaard projectmachtigingen van de gebruiker.\n\n- Definieert standaardtoegangsniveaus voor projecten.\n- Kan worden aangepast in Rolbeheer.\n- Beïnvloedt beschikbare functies en mogelijkheden.",
+      "active": "## Actieve status\nBepaalt of een gebruiker toegang heeft tot het systeem.\n\n- Actieve gebruikers kunnen zich aanmelden en toegang krijgen tot hun toegewezen bronnen.\n- Inactieve gebruikers kunnen zich niet aanmelden, maar hun gegevens blijven behouden.\n  - Gebruik dit om de toegang tijdelijk uit te schakelen zonder het account te verwijderen.",
+      "api": "## API-toegang\nMaakt programmatische toegang tot het systeem mogelijk via API-eindpunten.\n\n- Maakt integratie met externe tools en automatisering mogelijk\n- Vereist API-sleutelauthenticatie\n- Onderworpen aan snelheidsbeperkingen en toegangscontroles",
+      "projects": "## Projecttoewijzing\nSelecteer tot welke projecten deze gebruiker toegang heeft.\n\n- Bepaalt welke projecten in het dashboard van de gebruiker verschijnen\n- Vereist voor projectdeelname\n- Kan later door beheerders worden gewijzigd\n- Gebruik \"Alles selecteren\" om snel alle beschikbare projecten toe te wijzen",
+      "groups": "## Groepstoewijzing\nSelecteer tot welke groepen deze gebruiker behoort.\n\n- Groepen helpen bij het organiseren van gebruikers en machtigingen\n- Gebruikers erven machtigingen van hun groepen\n- Vereenvoudigt toegangsbeheer\n- Kan later door beheerders worden gewijzigd",
+      "itemsPerPage": "## Items per pagina\nBepaalt het standaard aantal items dat in tabellen en lijsten wordt weergegeven.\n\n- Beïnvloedt alle paginaweergaven in de toepassing.\n- Kan op elk moment worden gewijzigd.\n- Helpt grote datasets efficiënt te beheren.\n- Beschikbare opties: 10, 25, 50 of 100 items.",
+      "dateFormat": "## Datumnotatie\nStelt uw voorkeursnotatie voor de datumweergave in.\n\n- Wordt consistent toegepast in de hele applicatie\n- Helpt de nauwkeurigheid van de datuminterpretatie te garanderen\n- Wijzigingen worden onmiddellijk van kracht\n- De voorbeelden in de vervolgkeuzelijst weerspiegelen de werkelijke notatie",
+      "timeFormat": "## Tijdnotatie\nStelt uw voorkeursnotatie voor tijdweergave in.\n\n- Kies tussen 12-uurs- en 24-uursnotaties\n- Wordt consistent toegepast in de hele applicatie\n- Wijzigingen treden onmiddellijk in werking\n- De voorbeelden in de vervolgkeuzelijst weerspiegelen de werkelijke notatie",
+      "timezone": "## Tijdzone\nStelt uw voorkeurstijdzone in voor de weergave van datum en tijd.\n\n- Wordt consistent toegepast in de hele applicatie",
+      "theme": "## Thema\nKies het visuele thema dat u wilt gebruiken voor de applicatie.\n\n- **Systeem:** Stemt automatisch af op het thema van uw besturingssysteem\n- **Licht:** Schone, heldere interface voor gebruik overdag\n- **Donker:** Oogvriendelijke donkere modus voor omgevingen met weinig licht\n- **Groen, oranje, paars:** Een leuk kleuraccent!",
+      "locale": "## Taal\nSelecteer uw voorkeurstaal voor de applicatie-interface.\n\n- Wijzigt alle tekst, labels en berichten naar de door u gekozen taal.\n- Datum- en tijdnotaties worden aangepast aan regionale conventies.\n- Wordt onmiddellijk van kracht zonder dat de pagina hoeft te worden vernieuwd.\n- Beschikbare talen zijn afhankelijk van de geïnstalleerde vertalingen.",
+      "notificationMode": "## Meldingsvoorkeuren\nBepaalt hoe u meldingen ontvangt voor werkopdrachten en updates.\n\n- **Gebruik algemene instellingen:** Volg de standaardinstellingen van het systeem die door beheerders zijn ingesteld\n- **Geen meldingen:** Schakel alle meldingen uit\n- **Alleen in-app:** Ontvang alleen meldingen binnen de applicatie\n- **In-app + e-mail (direct):** Ontvang zowel in-app-meldingen als directe e-mailwaarschuwingen\n- **In-app + e-mail (dagelijks overzicht):** Ontvang in-app-meldingen en een dagelijks e-mailoverzicht\n\nU kunt deze voorkeur op elk gewenst moment wijzigen om deze aan te passen aan uw workflow."
+    },
+    "milestone": {
+      "name": "## Mijlpaalnaam\nEen duidelijke, beschrijvende naam die deze mijlpaal in uw project identificeert.\n\n- Moet uniek en betekenisvol zijn.\n- Helpt teamleden om snel het doel van de mijlpaal te begrijpen.\n- Wordt gebruikt in rapporten en projecttracking.",
+      "type": "## Mijlpaaltype\nCategoriseert de mijlpaal en bepaalt het uiterlijk en gedrag ervan.\n\n- Verschillende typen kunnen verschillende workflows hebben\n- Helpt bij het organiseren en filteren van mijlpalen\n- Kan van invloed zijn op rapportage en tracking",
+      "started": "## Startstatus\nGeeft aan dat het werk aan deze mijlpaal is begonnen.\n\n- Markeert de mijlpaal als in uitvoering.\n- Werkt de werkelijke startdatum automatisch bij wanneer deze wordt ingeschakeld.\n- Beïnvloedt de projecttijdlijn en voortgangsregistratie.",
+      "completed": "## Voltooiingsstatus\nGeeft aan dat het werk aan deze mijlpaal is voltooid.\n\n- Markeert de mijlpaal als voltooid.\n- Werkt de werkelijke voltooiingsdatum automatisch bij.\n- Gebruikt voor het bijhouden van de voortgang en rapportage.\n- Beïnvloedt afhankelijke mijlpalen en projecttijdlijnen.",
+      "startDate": "## Geplande startdatum\nDe datum waarop het werk aan deze mijlpaal naar verwachting zal beginnen.\n\n- Helpt bij de projectplanning en -schema's\n- Gebruikt voor tijdlijnprojecties\n- Ondersteunt de planning van de toewijzing van middelen",
+      "dueDate": "## Vervaldatum\nDe streefdatum voor het voltooien van deze mijlpaal.\n\n- Stelt deadlineverwachtingen in.\n- Gebruikt voor planning van projecttijdlijnen.\n- Helpt de voortgang van mijlpalen te volgen ten opzichte van de planning.",
+      "parent": "## Bovenliggende mijlpaal\nKoppelt deze mijlpaal aan een bovenliggende mijlpaal, waardoor een hiërarchie ontstaat.\n\n- Organiseert mijlpalen in logische groepen.\n- Toont afhankelijkheden en relaties.\n- Helpt de voortgang van grotere initiatieven bij te houden.",
+      "description": "## Beschrijving\nGedetailleerde informatie over het doel, de vereisten en de reikwijdte van de mijlpaal.\n\n- Biedt context voor teamleden\n- Documenteert de belangrijkste vereisten en doelstellingen\n- Ondersteunt samenwerking en afstemming",
+      "documentation": "## Documentatie\nAanvullende details, referenties en ondersteunend materiaal.\n\n- Technische specificaties\n- Ontwerpdocumenten\n- Externe referenties\n- Vergadernotities en beslissingen",
+      "automaticCompletion": "## Automatisch voltooien op de vervaldatum\nMarkeer deze mijlpaal automatisch als voltooid wanneer de vervaldatum is bereikt.\n\n- De mijlpaal wordt voltooid op het geplande tijdstip op de vervaldatum.\n- Handig voor mijlpalen met een tijdslimiet die moeten worden afgesloten ongeacht de voltooiingsstatus.\n- Kan worden overschreven door de mijlpaal handmatig te voltooien vóór de vervaldatum.\n- Vereist dat een vervaldatum is ingesteld.",
+      "notifyDaysBefore": "## Meldingen versturen dagen voor de deadline\nStuur meldingen naar toegewezen teamleden wanneer de deadline van de mijlpaal nadert.\n\n- Schakel de schakelaar in om meldingen in te schakelen, uit om ze uit te schakelen.\n- Voer het aantal dagen voor de deadline in om herinneringen te verzenden.\n- Meldingen worden verzonden naar gebruikers die zijn toegewezen aan testruns en sessies binnen deze mijlpaal.\n- Mijlpalen die te laat zijn, blijven herinneringen verzenden totdat ze zijn voltooid."
+    },
+    "session": {
+      "name": "## Sessienaam\nEen duidelijke, beschrijvende naam die het doel van uw testsessie aangeeft.\n\n- Moet uniek en betekenisvol zijn.\n- Helpt teamleden te begrijpen wat er wordt getest.\n- Wordt gebruikt in rapporten en tracking.",
+      "template": "## Sjabloon\nSjablonen definiëren de structuur en inhoud van uw testsessie.\n\n- Biedt een consistente opmaak voor testdocumentatie\n- Bevat vooraf gedefinieerde secties en velden\n- Helpt testnormen in uw project te handhaven",
+      "configuration": "## Configuratie\nDe specifieke omgeving of opstelling die vereist is voor deze testsessie.\n\n- Testomgeving (bijv. staging, productie)\n- Speciale configuraties of instellingen\n- Vereiste testgegevens of -voorwaarden",
+      "milestone": "## Mijlpaal\nKoppelt deze sessie aan een projectmijlpaal.\n\n- Helpt de testvoortgang richting projectdoelen te volgen.\n- Groepeert gerelateerde testsessies.\n- Ondersteunt rapportage op basis van mijlpalen.",
+      "description": "## Beschrijving\nEen kort overzicht van wat deze testsessie omvat.\n\n- Belangrijkste gebieden of functies die worden getest\n- Belangrijke context of achtergrond\n- Speciale overwegingen of vereisten",
+      "mission": "## Missie\nDe missie definieert de specifieke doelstellingen en doelen voor deze testsessie.\n\n- Wat test u?\n- Wat zijn de belangrijkste aandachtsgebieden?\n- Wat zijn de verwachte resultaten?\n\nEen duidelijke missie helpt om testen gefocust en productief te houden.",
+      "estimate": "## Geschatte tijd\nGeschatte tijd om deze testsessie te voltooien.\n\nVoorbeelden:\n- \"30m\" gedurende 30 minuten\n- \"1u 30m\" gedurende 1 uur en 30 minuten\n- \"2 dagen\" gedurende 2 dagen\n- \"1 week\" gedurende 1 week",
+      "elapsed": "## Verstreken tijd\nDe werkelijke tijd die aan deze testsessie is besteed.\n\nVoorbeelden:\n- \"45m\" gedurende 45 minuten\n- \"2u 15m\" gedurende 2 uur en 15 minuten\n- \"3 days\" gedurende 3 dagen\n\nHoud de tijd nauwkeurig bij om toekomstige schattingen te verbeteren.",
+      "state": "## Workflowstatus\nDe huidige status van deze testsessie in uw workflow.\n\n- Helpt de sessievoortgang bij te houden\n- Ondersteunt workflowbeheer\n- Wordt gebruikt voor rapportage en tracking",
+      "assignedTo": "## Toegewezen aan\nHet teamlid dat verantwoordelijk is voor het uitvoeren van deze testsessie.\n\n- Identificeert wie de test uitvoert.\n- Helpt bij het beheer van resources.\n- Ondersteunt de verantwoording en het bijhouden van de voortgang.",
+      "tags": "## Tags\nTrefwoorden of labels die helpen bij het categoriseren en organiseren van testsessies.\n\n- Maakt sessies gemakkelijker te vinden.\n- Groepeert gerelateerde testactiviteiten.\n- Ondersteunt filteren en rapporteren.",
+      "attachments": "## Bijlagen\nBestanden, schermafbeeldingen of andere documenten met betrekking tot deze testsessie.\n\n- Testgegevensbestanden\n- Schermafbeeldingen of opnames\n- Ondersteunende documentatie\n- Referentiemateriaal",
+      "issues": "## Problemen\nKoppel relevante problemen aan deze sessie."
+    },
+    "testRun": {
+      "name": "## Naam testrun\nVoer een beschrijvende naam in voor deze testrun, zodat u deze later gemakkelijk kunt herkennen.",
+      "description": "## Beschrijving\nGeef een korte samenvatting of notities over deze testrun.",
+      "configuration": "## Configuraties\nSelecteer een of meer configuraties (bijv. omgeving, browser, apparaat) waaronder de testruns worden uitgevoerd. Het selecteren van meerdere configuraties maakt voor elke configuratie een aparte testrun aan.",
+      "milestone": "## Mijlpaal\nKoppel deze testrun aan een specifieke projectmijlpaal om de voortgang richting grotere doelen bij te houden.",
+      "docs": "## Documentatie\nVoeg alle relevante documentatie, links of gedetailleerde notities voor deze testrun toe.",
+      "state": "## Status\nGeeft de huidige status of uitkomst van deze testrun aan volgens de workflow van uw project.",
+      "tags": "## Tags\nPas relevante tags toe om deze testrun te categoriseren en te filteren.",
+      "issues": "## Problemen\nKoppel alle gerelateerde problemen (bugs, taken, enz.) aan deze testrun.",
+      "attachments": "## Bijlagen\nUpload ondersteunende bestanden, schermafbeeldingen of logboeken met betrekking tot deze testrun.",
+      "duplicate": {
+        "statusesToInclude": "## Statussen om op te nemen\nSelecteer de statussen van testcases die u wilt opnemen in de gedupliceerde testrun.",
+        "copyAssignments": "## Toewijzingen kopiëren\nAls deze optie is ingeschakeld, worden de toewijzingen van de testcases gekopieerd naar de gedupliceerde testrun."
+      }
+    },
+    "appConfig": {
+      "key": "## Sleutel\nDe unieke identificatie voor deze configuratie.",
+      "value": "## Waarde\nDe waarde van deze configuratie."
+    },
+    "milestoneType": {
+      "icon": "## Mijlpaaltypepictogram\nEen visuele identificatie voor dit mijlpaaltype.\n\n- Helpt het mijlpaaltype snel te identificeren in lijsten en dashboards.\n- Kies uit een verscheidenheid aan vooraf gedefinieerde pictogrammen.\n- Kan op elk moment worden gewijzigd.\n- Verschijnt in projectnavigatie en rapporten.",
+      "name": "## Naam van het mijlpaaltype\nEen duidelijke, beschrijvende naam die dit mijlpaaltype in uw project identificeert.\n\n- Helpt teamleden om snel het doel van het mijlpaaltype te begrijpen.\n- Wordt gebruikt in rapporten en projecttracking.",
+      "isDefault": "## Standaardmijlpaaltype\nGeeft aan of dit mijlpaaltype het standaard is voor uw project.\n\n- Standaardmijlpaaltype is vooraf geselecteerd voor nieuwe mijlpalen.\n- Kan op elk moment worden gewijzigd.",
+      "projects": "## Geassocieerde projecten\nSelecteer voor welke projecten dit mijlpaaltype beschikbaar zal zijn.\n\n- Als er geen projecten zijn geselecteerd, is het mijlpaaltype wereldwijd beschikbaar.\n- Door het toe te wijzen aan specifieke projecten wordt het gebruik ervan beperkt tot alleen die projecten."
+    },
+    "tag": {
+      "name": "## Tagnaam\nEen duidelijke, beknopte, beschrijvende naam of trefwoord(en) die in alle projecten wordt gebruikt.\n\n- Helpt teamleden snel gerelateerde testcases, testruns en sessies te vinden."
+    },
+    "role": {
+      "name": "## Rolnaam\nEen duidelijke, beknopte, beschrijvende naam of trefwoord(en) die in alle projecten wordt gebruikt.\n\n- Helpt teamleden snel gerelateerde testcases, testruns en sessies te vinden.",
+      "isDefault": "## Standaardrol\nGeeft aan of deze rol de standaard is voor uw project.\n\n- Standaardrol is vooraf geselecteerd voor nieuwe gebruikers.\n- Kan op elk moment worden gewijzigd.",
+      "permissions": {
+        "canAddEdit": "## Toevoegen/bewerken\nGeeft aan of deze rol het gerelateerde toepassingsgebied kan toevoegen en bewerken.",
+        "canDelete": "## Verwijderen\nGeeft aan of deze rol het gerelateerde toepassingsgebied kan verwijderen.",
+        "canClose": "## Close\nGeeft aan of deze rol het gerelateerde toepassingsgebied kan sluiten."
+      }
+    },
+    "group": {
+      "name": "## Groepsnaam\nEen duidelijke, beknopte, beschrijvende naam of trefwoord(en) die in alle projecten wordt gebruikt.\n\n- Helpt teamleden snel gerelateerde testcases, testruns en sessies te vinden.",
+      "users": "## Gebruikers\nGeeft de gebruikers aan die aan deze groep zijn toegewezen."
+    },
+    "template": {
+      "name": "## Sjabloonnaam\nEen unieke en beschrijvende naam voor deze sjabloon (bijv. 'Standaardtestgeval', 'API-testresultaten').",
+      "isEnabled": "## Ingeschakeld\nIndien aangevinkt, is deze sjabloon beschikbaar voor selectie bij het aanmaken van nieuwe testcases of het definiëren van testrunstructuren. Als een sjabloon is ingesteld als 'Standaard', moet deze ook 'Ingeschakeld' zijn.",
+      "isDefault": "## Standaard\nIndien aangevinkt, wordt deze sjabloon automatisch geselecteerd voor nieuwe projecten of als standaard voor alle projecten als er geen projectspecifieke standaard is ingesteld. Slechts één sjabloon kan de standaard zijn voor alle projecten. Als u deze optie inschakelt, worden alle andere sjablonen die momenteel als standaard zijn ingesteld, uitgeschakeld.",
+      "caseFields": "## Testcasevelden\nSelecteer en rangschik de aangepaste velden die beschikbaar zullen zijn bij het maken of bewerken van testcases met behulp van deze sjabloon.\n\n- Voeg velden toe vanuit de dropdown om ze in de sjabloon op te nemen\n- Versleep velden om de volgorde te wijzigen\n- De volgorde bepaalt hoe velden in formulieren worden weergegeven\n- Alleen ingeschakelde testcasevelden zijn beschikbaar voor selectie\n- Testcasevelden definiëren de structuur en de vastgelegde gegevens voor testcases",
+      "resultFields": "## Resultaatvelden\nSelecteer en rangschik de aangepaste velden die beschikbaar zullen zijn bij het toevoegen van testresultaten met behulp van deze sjabloon.\n\n- Voeg velden toe vanuit de dropdown om ze in de sjabloon op te nemen\n- Versleep de velden om de volgorde te wijzigen\n- De volgorde bepaalt hoe de velden worden weergegeven bij het invoeren van testresultaten\n- Alleen ingeschakelde resultaatvelden zijn beschikbaar voor selectie\n- Resultaatvelden leggen aanvullende gegevens vast die specifiek zijn voor de uitkomsten van de testuitvoering",
+      "projects": "## Gekoppelde projecten\nSelecteer voor welke projecten deze sjabloon beschikbaar zal zijn. Als er geen projecten zijn geselecteerd, is de sjabloon wereldwijd beschikbaar. Door een sjabloon aan specifieke projecten toe te wijzen, wordt het gebruik ervan beperkt tot alleen die projecten."
+    },
+    "llm": {
+      "name": "## Integratienaam\nEen beschrijvend label voor deze LLM-integratie.\n\n- Wordt gebruikt om deze te identificeren in lijsten en instellingen.\n- Voorbeeld: \"OpenAI GPT-4o\" of \"Interne Ollama\"",
+      "provider": "## Provider\nDe LLM-service die deze integratie mogelijk maakt.\n\n- Bepaalt het API-protocol en de beschikbare modellen.\n- Kan na aanmaak niet meer worden gewijzigd.",
+      "apiKey": "## API-sleutel\nUw authenticatiesleutel voor de API van de LLM-provider.\n\n- Deze kunt u verkrijgen via de ontwikkelaarsconsole van uw provider.\n- Deze wordt versleuteld bewaard en na opslag nooit weergegeven.\n- Niet vereist voor Ollama (lokale implementatie).",
+      "endpoint": "## API-eindpunt\nDe basis-URL voor de API van de LLM-provider.\n\n- Laat leeg voor OpenAI, Anthropic en Gemini — officiële URL's worden automatisch gebruikt\n- Vereist voor Ollama (bijv. `http://localhost:11434`), Azure OpenAI en Custom LLM\n- Optioneel voor elke provider — verwijs naar een OpenAI-compatibele proxy (bijv. LiteLLM) door de URL in te voeren\n- **Privé-/interne adressen** (localhost, 127.0.0.1, privé-IP's, cloudmetadata) worden geblokkeerd, tenzij expliciet toegestaan via de omgevingsvariabele `ALLOWED_PRIVATE_HOSTS`",
+      "deploymentName": "## Azure-implementatienaam\nDe naam van uw Azure OpenAI-modelimplementatie.\n\n- Te vinden in Azure OpenAI Studio onder Implementaties\n- Verschilt van de modelnaam — bijvoorbeeld `my-gpt4-deploy` komt overeen met `gpt-4`\n- Alleen vereist voor Azure OpenAI",
+      "defaultModel": "## Standaardmodel\nHet model dat wordt gebruikt voor AI-verzoeken met deze integratie.\n\n- Voor OpenAI, Anthropic en Gemini worden beschikbare modellen automatisch opgehaald van uw API-sleutel.\n- Zorg ervoor dat het model is ingeschakeld in uw provideraccount.\n- Voorbeeld: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Maximaal aantal tokens per verzoek\nDe **harde limiet** voor het aantal uitvoertokens per verzoek.\n\n- Verzoeken die dit overschrijden, worden **met een foutmelding afgewezen** voordat ze de LLM bereiken.\n- Stel dit in op de werkelijke maximale capaciteit van uw model voor uitvoertokens.\n- Voorbeeld: `16384` voor GPT-4o, `8192` voor Claude 3.5 Sonnet.\n- Als dit te laag wordt ingesteld, zullen AI-functies falen of afgekorte uitvoer produceren.",
+      "defaultMaxTokens": "## Standaard maximum tokens\nDe **terugval**-limiet voor uitvoertokens die wordt gebruikt wanneer een verzoek geen eigen limiet specificeert.\n\n- Elke AI-functie (testgeneratie, code-export, enz.) stelt zijn eigen limiet in in **Beheer → Promptconfiguratie**\n- Deze waarde wordt alleen gebruikt als terugvaloptie voor functies waarvoor geen specifieke limiet is geconfigureerd\n- Moet ≤ Max Tokens Per Verzoek zijn",
+      "maxRequestsPerMinute": "## Maximaal aantal verzoeken per minuut\nBeperkt het aantal API-aanroepen dat per minuut naar deze provider kan worden gedaan.\n\n- Stel dit in op de limiet van uw providerabonnement.\n- Overtollige verzoeken worden in de wachtrij geplaatst, niet geweigerd.\n- Raadpleeg de documentatie van uw provider voor de limiet van uw abonnement.",
+      "costPerInputToken": "## Kosten per invoertoken (USD)\nDe kosten in USD voor elk invoertoken (prompt) dat naar het model wordt verzonden.\n\n- Gebruikt voor kostenbewaking en budgetwaarschuwingen\n- Vind dit op de prijslijst van uw provider\n- Voorbeeld: `0,000005` = $5 per miljoen invoertokens",
+      "costPerOutputToken": "## Kosten per outputtoken (USD)\nDe kosten in USD voor elk outputtoken (voltooiingstoken) dat door het model wordt gegenereerd.\n\n- Meestal hoger dan de kosten van de inputtokens\n- Gebruikt voor kostenbewaking en budgetwaarschuwingen\n- Voorbeeld: `0,000015` = $15 per miljoen outputtokens",
+      "monthlyBudget": "## Maandelijks budget (USD)\nEen optioneel bestedingsdoel voor deze integratie.\n\n- Stel in op `0` om budgetbewaking uit te schakelen\n- Het budget is **alleen ter informatie** — het blokkeert het gebruik van LLM niet\n- U ontvangt meldingen bij 80%, 90% en 100% van het budget\n- De kosten worden berekend met behulp van de bovenstaande tarieven per token",
+      "billingPeriodStartDay": "## Startdatum factureringsperiode\nDe dag van de maand (1-31) waarop uw factureringsperiode begint.\n\n- Standaardwaarde `1` komt overeen met de kalendermaand.\n- Stel in op `15` voor een cyclus van 15 tot 15 (bijv. om overeen te komen met de factuurdatum van uw leverancier).\n- Waarden `29-31` worden automatisch aangepast aan de laatste dag van kortere maanden (februari in niet-schrikjaren, enz.).\n- Beïnvloedt het uitgavenvenster **Maandelijks budget** en de actie **Uitgaven resetten**.",
+      "defaultTemperature": "## Standaardtemperatuur\nRegelt de willekeurigheid van modelreacties (0–2).\n\n- **0:** Deterministisch — identieke uitvoer voor dezelfde invoer\n- **0,3:** Gericht — aanbevolen voor het genereren van tests en code-uitvoer\n- **1+:** Creatief — meer gevarieerde reacties\n- Individuele functies kunnen dit overschrijven in de promptconfiguratie",
+      "timeout": "## Time-out voor verzoek (ms)\nHoe lang er gewacht moet worden op een reactie voordat het verzoek wordt geannuleerd.\n\n- De waarde is in milliseconden (bijv. `30000` = 30 seconden)\n- Streamingverzoeken (bijv. code-exportvoorbeeld) negeren deze time-out\n- Verhoog deze waarde voor trage of grote modellen\n- Bereik: 5.000 – 600.000 ms",
+      "streamingEnabled": "## Streaming inschakelen\nStreamt het antwoord token voor token in plaats van te wachten op de volledige uitvoer.\n\n- Vereist voor realtime codevoorbeeld in het exportvenster\n- Vermindert de waargenomen latentie bij lange antwoorden\n- Aanbevolen voor alle ondersteunde providers",
+      "isDefault": "## Instellen als standaardintegratie\nHiermee wordt deze integratie standaard gebruikt voor alle AI-functies.\n\n- Er kan slechts één integratie tegelijk als standaard worden ingesteld.\n- Functies waarvoor geen specifieke provider is geconfigureerd, gebruiken de standaardintegratie.\n- Kan op elk moment worden gewijzigd."
+    },
+    "integration": {
+      "name": "## Integratienaam\nEen beschrijvende naam om deze integratie in het systeem te identificeren.\n\n- Moet uniek zijn om te onderscheiden van andere integraties.\n- Wordt gebruikt in projectinstellingen en configuratie.\n- Moet duidelijk de service en het doel aangeven.",
+      "authType": "## Authenticatietype\nKies hoe u wilt authenticeren met de externe service.\n\n- **API-sleutel:** Eenvoudige authenticatie met behulp van e-mail en API-token\n- **OAuth 2.0:** Veilige authenticatie met behulp van de OAuth-stroom\n- **Persoonlijke toegangstoken:** Directe op tokens gebaseerde authenticatie",
+      "email": "## E-mailadres\nUw e-mailadres voor de externe service.\n\n- Gebruikt voor API-sleutelauthenticatie\n- Moet overeenkomen met het account dat het API-token heeft gegenereerd\n- Vereist voor Jira en soortgelijke services",
+      "apiToken": "## API-token\nGenereer een API-token vanuit uw accountinstellingen in de externe service.\n\n- Meestal te vinden in Accountinstellingen → Beveiliging → API-tokens\n- Biedt veilige toegang zonder uw wachtwoord bloot te stellen\n- Kan indien nodig worden ingetrokken en opnieuw worden gegenereerd",
+      "jiraUrl": "## Jira URL\nDe basis-URL van uw Jira-instantie.\n\n- Formaat: https://your-site.atlassian.net\n- Voeg geen /browse of andere paden toe\n- Moet toegankelijk zijn vanaf deze server",
+      "clientId": "## OAuth Client ID\nDe client-ID van uw OAuth-toepassingsconfiguratie.\n\n- Gemaakt in de ontwikkelaarsconsole van de externe service\n- Gebruikt om uw toepassing te identificeren tijdens de OAuth-stroom\n- Veilig om te delen in configuratiebestanden",
+      "clientSecret": "## OAuth Client Secret\nHet clientgeheim uit uw OAuth-toepassingsconfiguratie.\n\n- Gemaakt samen met de client-ID\n- Moet vertrouwelijk en veilig worden bewaard\n- Wordt gebruikt om uw toepassing te verifiëren",
+      "personalAccessToken": "## Persoonlijke toegangstoken\nEen persoonlijke toegangstoken met de juiste machtigingen voor de externe service.\n\n- Gemaakt in uw accountinstellingen\n- Moet machtigingen hebben voor lees- en schrijfproblemen\n- Veiliger dan wachtwoordauthenticatie",
+      "baseUrl": "## URL-patroon\nURL-patroon voor het linken naar externe problemen.\n\n- Gebruik '{issueId}' als tijdelijke aanduiding voor de probleem-ID\n- Voorbeeld: https://example.com/issues/'{issueId}'\n- Gebruikt voor eenvoudige URL-gebaseerde integraties",
+      "organizationUrl": "## Organisatie-URL\nUw Azure DevOps-organisatie-URL.\n\n- Formaat: https://dev.azure.com/uw-org\n- Moet toegankelijk zijn vanaf deze server\n- Wordt gebruikt voor toegang tot Azure DevOps API's",
+      "apiKey": "## API-sleutel\nDe API-sleutel voor authenticatie met de externe service.\n\n- Wordt gegenereerd in de API-instellingen van de service.\n- Biedt programmatische toegang tot de service.\n- Beveiligd en regelmatig roterend.",
+      "forgeApiKey": "## Forge API-sleutel\nWordt gebruikt om de Atlassian Forge-app te authenticeren wanneer deze testgegevens ophaalt uit uw Jira-issues.\n\n- Klik op Genereren om een nieuwe sleutel te maken.\n- Kopieer de sleutel en plak deze in de Forge-app-instellingen in Jira (Apps beheren → TestPlanIt-instellingen).\n- Het opnieuw genereren maakt de vorige sleutel ongeldig.",
+      "owner": "## Eigenaar / Naamruimte\nDe gebruiker of organisatie die eigenaar is van de repository.\n\n- Voor GitHub/GitLab: de gebruikersnaam of organisatienaam\n- Voor Gitea/Forgejo/Gogs: de gebruikers- of groepsnaam\n- Voorbeeld: mijn-org of mijn-gebruikersnaam",
+      "repo": "## Naam van de repository\nDe naam van de repository waaraan issues gekoppeld moeten worden.\n\n- Exacte naam van de repository (niet de volledige URL)\n- Voorbeeld: my-project\n- Moet toegankelijk zijn met de opgegeven inloggegevens",
+      "instanceUrl": "## Instantie-URL\nDe basis-URL van uw zelfgehoste instantie.\n\n- Formaat: https://git.example.com\n- Geen afsluitende schuine strepen of paden\n- Moet toegankelijk zijn vanaf deze server",
+      "projectPath": "## Projectpad\nHet volledige pad naar je GitLab-project.\n\n- Formaat: namespace/project of groep/subgroep/project\n- Voorbeeld: my-org/my-project\n- Te vinden in de project-URL: gitlab.com/namespace/project",
+      "platform": "## Platform\nHet zelfgehoste Git-platform waarmee u verbinding maakt.\n\n- **Gitea**: instanties gebaseerd op gitea.io\n- **Forgejo**: instanties gebaseerd op forgejo.org (fork van Gitea)\n- **Gogs**: instanties gebaseerd op gogs.io\n\nDit bepaalt welk pictogram wordt weergegeven en kan de API-compatibiliteit beïnvloeden."
+    },
+    "config": {
+      "name": "## Configuratie Naam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt bij het beschrijven van de variantencombinaties waaruit de configuratie bestaat (bijv. \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", enz.)."
+    },
+    "configCategory": {
+      "name": "## Categorienaam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt bij het organiseren van varianten (bijv. Chrome, Firefox, Safari, Edge, enz.) in categorieën (bijv. browsers)."
+    },
+    "configVariant": {
+      "name": "## Variantnaam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt de variant te beschrijven die deel uitmaakt van een testomgeving (bijv. Chrome, Safari, Windows 10, Windows 11, macOS 15.5, enz.)."
+    },
+    "issueConfig": {
+      "name": "## Probleemconfiguratienaam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt de probleemconfiguratie te beschrijven (bijv. Jira, GitHub, enz.).",
+      "baseUrl": "## Basis-URL\nDe basis-URL voor de probleemconfiguratie inclusief de probleemplaceholder (bijv. https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Systeemtype\nHet type probleemvolgsysteem (bijv. LINK Jira, enz.).",
+      "isActive": "## Actief\nGeeft aan of deze probleemconfiguratie actief is.",
+      "isDefault": "## Standaard\nGeeft aan of deze probleemconfiguratie de standaard is voor uw project.\n\n- Standaardprobleemconfiguratie is vooraf geselecteerd voor nieuwe problemen.\n- Kan op elk moment worden gewijzigd.",
+      "projects": "## Projecten\nGeeft de projecten aan die aan deze probleemconfiguratie zijn toegewezen."
+    },
+    "issue": {
+      "name": "## Probleemnaam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt het probleem te beschrijven (bijv. \"Probleem 123\", \"Bug 456\", enz.).",
+      "title": "## Probleemtitel\nEen voor mensen leesbare titel die het probleem beschrijft.\n\n- Biedt context over waar het probleem over gaat\n- Wordt weergegeven in lijsten en probleemweergaven\n- Moet duidelijk en beschrijvend zijn",
+      "externalKey": "## Externe sleutel\nDe unieke sleutel of identificatie van het externe probleemvolgsysteem.\n\n- Voor JIRA: Probleemsleutel zoals \"PROJ-123\"\n- Voor GitHub: Probleemnummer zoals \"456\"\n- Voor Azure DevOps: Werkitem-ID\n- Genereert automatisch de externe URL bij het opslaan",
+      "externalId": "## Externe ID\nDe unieke identificatie voor dit probleem in het probleemvolgsysteem (bijv. \"Issue-123\", \"Bug456\", enz.).\n\n- Deze wordt gebruikt als probleemplaatsaanduiding in de basis-URL.",
+      "description": "## Beschrijving\nEen kort overzicht van wat dit probleem omvat.\n\n- Belangrijke gebieden of functies die worden getest\n- Belangrijke context of achtergrond\n- Speciale overwegingen of vereisten",
+      "project": "## Project\nHet project waaraan dit probleem is gekoppeld.\n\n- Problemen kunnen worden gekoppeld aan testcases in meerdere projecten.\n- Het instellen van een primair project helpt bij het organiseren van problemen.\n- Kan leeg worden gelaten voor problemen die zich over meerdere projecten uitstrekken.",
+      "state": "## Status\nGeef de huidige status of uitkomst van dit probleem aan volgens de workflow van uw project.",
+      "tags": "## Tags\nPas relevante tags toe om dit probleem te categoriseren en te filteren.",
+      "issues": "## Problemen\nKoppel alle gerelateerde problemen (bugs, taken, enz.) aan dit probleem."
+    },
+    "status": {
+      "name": "## Statusnaam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt de status van de testresultaten te beschrijven (bijv. Geslaagd, Mislukt, Geblokkeerd, enz.).",
+      "color": "## Kleur\nDe kleur van deze status.",
+      "systemName": "## Systeemnaam\nDe naam van de status die door het back-endsysteem wordt gebruikt (bijv. databasequery's, rapporten, enz.).",
+      "aliases": "## Aliassen\nExtra namen of synoniemen voor deze status die kunnen worden gebruikt om externe systeemstatussen aan deze status te koppelen.",
+      "enabled": "## Ingeschakeld\nGeeft aan of deze status is ingeschakeld.",
+      "isEnabled": "## Ingeschakeld\nGeeft aan of deze status is ingeschakeld en beschikbaar is voor gebruik.\n\n- Wanneer ingeschakeld, kan deze status worden geselecteerd bij het vastleggen van testresultaten.\n- Uitgeschakelde statussen zijn niet selecteerbaar, maar blijven behouden in bestaande resultaten.",
+      "success": "## Succes\nGeeft aan of deze status een successtatus is.",
+      "isSuccess": "## Successtatus\nGeeft aan of deze status een succesvolle testuitslag vertegenwoordigt.\n\n- Successtatussen dragen bij aan de statistiek van het slagingspercentage.\n- Wordt gebruikt in rapportages en analyses om de effectiviteit van tests te volgen.",
+      "completed": "## Voltooid\nGeeft aan of deze status een voltooide status is.",
+      "isCompleted": "## Voltooide status\nGeeft aan of deze status een voltooide testuitvoering vertegenwoordigt.\n\n- Voltooide statussen geven aan dat de test klaar is met draaien.\n- Wordt gebruikt om voltooiingspercentages en voortgangsregistratie te berekenen.",
+      "failure": "## Mislukking\nGeeft aan of deze status een mislukkingsstatus is.",
+      "isFailure": "## Foutstatus\nGeeft aan of deze status een mislukte testuitslag vertegenwoordigt.\n\n- Foutstatussen dragen bij aan de statistieken over het foutpercentage.\n- Worden gebruikt in rapportages en analyses om problemen te identificeren.",
+      "scope": "## Scope\nGeeft de scope van deze status aan (Test Run, Sessie, Automatisering).",
+      "projects": "## Projecten\nGeeft de projecten aan die deze status kunnen gebruiken."
+    },
+    "workflow": {
+      "scope": "## Scope\nGeeft de scope van deze workflow aan (Test Run, Sessie, Automatisering).\n\n- Kan niet worden gewijzigd nadat de workflow is gemaakt.",
+      "iconColor": "## Icoon/Kleur\nHet icoon en de kleur voor deze workflow.",
+      "name": "## Naam\nEen duidelijke, beschrijvende naam die in alle projecten wordt gebruikt.\n\n- Helpt de workflow te beschrijven (bijv. \"Concept\", \"Wordt beoordeeld\", \"Actief\", enz.).",
+      "workflowType": "## Type\nHet type workflow (Niet gestart, In uitvoering, Voltooid).",
+      "type": "## Werkstroomtype\nDe categorie van de werkstroomstatus (Niet gestart, In uitvoering, Voltooid).\n\n- Bepaalt hoe deze status de voortgangsregistratie beïnvloedt\n- De status 'Niet gestart' geeft aan dat er nog niet aan het werk is begonnen\n- De status 'In uitvoering' geeft aan dat er actief aan het werk is\n- De status 'Voltooid' geeft aan dat het werk is afgerond",
+      "isDefault": "## Standaard\nGeeft aan of deze workflow de standaard is voor uw project.\n\n- De standaardworkflow is vooraf geselecteerd voor nieuwe testruns, sessies en automatisering.",
+      "isEnabled": "## Ingeschakeld\nGeeft aan of deze workflow is ingeschakeld.",
+      "isActive": "## Actief\nGeeft aan of deze workflowstatus actief en beschikbaar is voor gebruik.\n\n- Actieve workflows kunnen worden geselecteerd bij het bijwerken van testruns, sessies of automatisering.\n- Inactieve workflows zijn niet selecteerbaar, maar blijven behouden in bestaande items.",
+      "projects": "## Projecten\nGeeft de projecten aan die deze workflow kunnen gebruiken."
+    },
+    "testResult": {
+      "status": "## Status\nSelecteer de algemene status van de testuitvoering. De status die u kiest, kan van invloed zijn op projectstatistieken en -rapporten.",
+      "elapsedTime": "## Verstreken tijd\nVoer de totale tijd in die nodig is om deze testcase uit te voeren. U kunt eenheden gebruiken zoals **s** voor seconden, **m** voor minuten en **h** voor uren (bijv. 30s, 5m, 1u20m).",
+      "resultData": "## Resultaatdetails\nGeef gedetailleerde aantekeningen, observaties of andere relevante gegevens over de algehele uitvoering van de test. Dit kan details over de configuratie, de gevolgde stappen bij afwijking van het plan of algemene opmerkingen omvatten.",
+      "evidence": "## Bewijs/Bijlagen\nUpload alle bestanden (bijv. screenshots, logs, databestanden) die als bewijs voor dit testresultaat dienen. Deze bijlagen worden aan dit specifieke resultaat gekoppeld.",
+      "issues": "## Gekoppelde problemen\nKoppel alle problemen uit uw geïntegreerde probleemtracker die gerelateerd zijn aan dit testresultaat. Dit helpt bij het volgen van defecten of taken die verband houden met de uitkomst van deze test.",
+      "stepStatus": "## Stapstatus\nSelecteer de status voor deze specifieke teststap. Dit maakt gedetailleerde tracking van de voortgang binnen één testcase mogelijk.",
+      "stepElapsedTime": "## Stap Verstreken Tijd\nVoer de tijd in die nodig is om deze specifieke stap uit te voeren. Gebruik eenheden zoals **s**, **m**, **h** (bijv. 10s, 2m). Dit is optioneel.",
+      "stepNotes": "## Stapnotities\nVoeg eventuele notities, observaties of gegevens toe die specifiek zijn voor de uitvoering van deze teststap.",
+      "stepIssues": "## Stap gekoppelde problemen\nKoppel problemen uit uw probleemtracker die specifiek gerelateerd zijn aan de uitkomst of observaties van deze teststap."
+    },
+    "case": {
+      "name": "## Testcasenaam\nEen duidelijke, beschrijvende naam voor de testcase.",
+      "state": "## Status\nGeeft de huidige workflowstatus van deze case aan.",
+      "template": "## Sjabloon\nSelecteer de sjabloon die deze case zal gebruiken voor de casevelden en resultaatvelden.",
+      "estimate": "## Schatting\nDe handmatig ingevoerde geschatte tijd om deze testcase te voltooien.",
+      "automated": "## Geautomatiseerd\nGeeft aan of deze testcase geautomatiseerd is of niet.",
+      "tags": "## Tags\nPas relevante tags toe om deze zaak te categoriseren en te filteren.",
+      "issues": "## Problemen\nKoppel alle gerelateerde problemen (bugs, taken, enz.) aan deze case."
+    },
+    "folder": {
+      "name": "## Mapnaam\nEen duidelijke, beschrijvende naam voor de map.",
+      "documentation": "## Documentatie\nAanvullende details, referenties en ondersteunend materiaal."
+    },
+    "bulkEdit": {
+      "name": "## Naam\nEen duidelijke, beschrijvende naam voor de testcases.",
+      "state": "## Status\nGeeft de huidige workflowstatus van deze testcases aan.",
+      "estimate": "## Schatting\nDe handmatig ingevoerde geschatte tijd om elk van deze testcases te voltooien.",
+      "automated": "## Geautomatiseerd\nGeeft aan of deze testcases geautomatiseerd zijn of niet.",
+      "tags": "## Tags\nPas relevante tags toe om deze testcases te categoriseren en te filteren.",
+      "issues": "## Problemen\nKoppel alle gerelateerde problemen (bugs, taken, enz.) aan deze testcases."
+    },
+    "caseField": {
+      "displayName": "## Weergavenaam\nDit is de voor mensen leesbare naam voor het veld dat aan gebruikers wordt getoond in formulieren en weergaven. Zorg dat deze duidelijk en beschrijvend is.",
+      "systemName": "## Systeemnaam\nEen unieke identificatie voor dit veld die intern door het systeem wordt gebruikt (bijvoorbeeld in API-aanroepen en databasequery's). Deze wordt automatisch gegenereerd op basis van de weergavenaam, maar kan worden aangepast. Moet beginnen met een letter. Mag alleen letters, cijfers en onderstrepingstekens bevatten (geen spaties of speciale tekens).",
+      "hint": "## Hinttekst (optioneel)\nGeef een korte instructie of voorbeeld dat onder het veld verschijnt om gebruikers te begeleiden. Dit kan de verwachte invoer of opmaak verduidelijken.",
+      "enabled": "## Ingeschakeld\nBepaalt of dit veld actief is en beschikbaar is voor gebruik in sjablonen en testcases. Uitgeschakelde velden zijn verborgen en hun gegevens worden bewaard, maar niet gebruikt.",
+      "required": "## Vereist\nAls dit is aangevinkt, moeten gebruikers een waarde voor dit veld opgeven bij het maken of bewerken van een testcase met behulp van een sjabloon die dit veld bevat.",
+      "restricted": "## Beperkt\nIndien aangevinkt, kunnen alleen gebruikers met speciale rechten (bijvoorbeeld superadmins of gebruikers met de machtiging 'Case Restricted Fields') de waarde van dit veld bewerken nadat een case is aangemaakt. Andere gebruikers zien het als alleen-lezen. Dit is handig voor velden zoals 'Beoordeeld door' of 'Goedkeuringsdatum' die na een bepaalde fase niet meer door algemene gebruikers mogen worden gewijzigd.",
+      "fieldType": "## Veldtype\nBepaalt het soort gegevens dat in dit veld wordt opgeslagen en hoe het wordt weergegeven (bijv. Tekst, Getal, Datum, Dropdown). Het veldtype kan na aanmaak niet meer worden gewijzigd.",
+      "defaultValue": "## Standaardwaarde (optioneel)\nStel een vooraf ingevulde waarde in voor dit veld. Gebruik voor het type 'Selectievakje' 'true' of 'false'. Voor 'Dropdown' of 'Multi-Select' verwijst dit meestal naar de ID('s) van de standaardoptie(s). Voor andere typen is dit de letterlijke standaardtekst/-getal. Dit kan worden overschreven wanneer het veld aan een sjabloon wordt toegevoegd.",
+      "isChecked": "## Standaardstatus (voor selectievakje)\nBepaalt of het selectievakje standaard moet worden aangevinkt wanneer een nieuw item (bijv. testcase) wordt gemaakt.",
+      "minValue": "## Minimumwaarde (voor getal/geheel getal)\nStelt de laagste toegestane numerieke waarde voor dit veld in. Zowel de minimum- als de maximumwaarde moeten worden ingesteld als er een wordt gebruikt.",
+      "maxValue": "## Maximumwaarde (voor getal/geheel getal)\nStelt de hoogste toegestane numerieke waarde voor dit veld in. Zowel de minimum- als maximumwaarde moeten worden ingesteld als er een wordt gebruikt.",
+      "initialHeight": "## Beginhoogte (voor lange tekst)\nSpecificeer de beginhoogte (in pixels) voor velden in de RTF-editor. Dit helpt bij het bepalen van de formulierindeling voor langere tekstinvoer.",
+      "dropdownOptions": "## Opties (voor dropdown/meervoudige selectie)\nDefinieer de lijst met beschikbare opties. U kunt de volgorde van opties wijzigen, een standaardwaarde instellen en individuele opties in- of uitschakelen."
+    },
+    "resultField": {
+      "displayName": "## Weergavenaam\nDit is de voor mensen leesbare naam voor het veld dat aan gebruikers wordt getoond bij het invoeren van testresultaten. Zorg ervoor dat deze duidelijk en beschrijvend is.",
+      "systemName": "## Systeemnaam\nEen unieke identificatie voor dit veld die intern door het systeem wordt gebruikt (bijvoorbeeld in API-aanroepen en databasequery's). Deze wordt automatisch gegenereerd op basis van de weergavenaam, maar kan worden aangepast.\n- Moet beginnen met een letter.\n- Mag alleen letters, cijfers en onderstrepingstekens bevatten (geen spaties of speciale tekens).",
+      "hint": "## Hinttekst (optioneel)\nGeef een korte instructie of voorbeeld dat onder het veld verschijnt om gebruikers te begeleiden. Dit kan de verwachte invoer of opmaak verduidelijken bij het invoeren van resultaatgegevens.",
+      "enabled": "## Ingeschakeld\nBepaalt of dit veld actief is en beschikbaar is voor gebruik in sjablonen bij het invoeren van testresultaten. Uitgeschakelde velden zijn verborgen en hun gegevens worden bewaard, maar niet gebruikt.",
+      "required": "## Vereist\nAls dit is aangevinkt, moeten gebruikers een waarde voor dit veld opgeven bij het toevoegen van een testresultaat met behulp van een sjabloon die dit veld bevat.",
+      "restricted": "## Beperkt\nIndien aangevinkt, kunnen alleen gebruikers met speciale machtigingen (bijvoorbeeld superadmins of gebruikers met de machtiging 'Test Run Result Restricted Fields') de waarde van dit veld bewerken nadat een resultaat is verzonden. Andere gebruikers zien het als alleen-lezen.",
+      "fieldType": "## Veldtype\nBepaalt het soort gegevens dat in dit veld wordt opgeslagen en hoe het wordt weergegeven voor testresultaten (bijv. Tekst, Getal, Datum, Dropdown). Het veldtype kan na aanmaak niet meer worden gewijzigd.",
+      "defaultValue": "## Standaardwaarde (optioneel)\nStel een vooraf ingevulde waarde in voor dit veld bij het toevoegen van een nieuw testresultaat. Gebruik voor het type 'Selectievakje' 'true' of 'false'. Voor 'Dropdown' of 'Multi-Select' verwijst dit meestal naar de ID('s) van de standaardoptie(s). Voor andere typen is dit de letterlijke standaardtekst/-getal.",
+      "isChecked": "## Standaardstatus (voor selectievakje)\nBepaalt of het selectievakje standaard moet worden aangevinkt wanneer een nieuw testresultaat wordt toegevoegd.",
+      "minValue": "## Minimumwaarde (voor getal/geheel getal)\nStelt de laagste toegestane numerieke waarde voor dit veld in bij het invoeren van resultaatgegevens. Zowel de minimum- als de maximumwaarde moeten worden ingesteld als er een wordt gebruikt.",
+      "maxValue": "## Maximumwaarde (voor getal/geheel getal)\nStelt de hoogste toegestane numerieke waarde voor dit veld in bij het invoeren van resultaatgegevens. Zowel de minimum- als maximumwaarde moeten worden ingesteld als er een wordt gebruikt.",
+      "initialHeight": "## Beginhoogte (voor lange tekst)\nSpecificeer de beginhoogte (in pixels) voor velden in de RTF-editor die in resultaten worden gebruikt. Dit helpt bij het bepalen van de formulierindeling voor langere tekstinvoer.",
+      "dropdownOptions": "## Opties (voor dropdown/meervoudige selectie)\nDefinieer de lijst met beschikbare opties voor selectie bij het invoeren van resultaatgegevens. U kunt de volgorde van opties wijzigen, een standaardwaarde instellen en individuele opties in- of uitschakelen."
+    },
+    "exportModal": {
+      "scope": "## Export Scope\nBepaalt welke testcases worden opgenomen in de export:\n- **Geselecteerd:** Exporteert alleen de testcases die u expliciet in de tabel hebt geselecteerd.\n- **Alle gefilterde:** Exporteert alle testcases die voldoen aan de huidige filtercriteria in de tabel, zelfs als niet alle testcases op dit moment zichtbaar zijn op de pagina.\n- **Alle projecten:** Exporteert elke testcase in het huidige project, waarbij selecties of filters worden genegeerd.",
+      "format": "## Exportformaat\nKies het bestandsformaat voor uw export.\n- **CSV (Comma Separated Values):** Een platte tekstbestand dat geschikt is voor spreadsheets (Excel, Google Sheets) en data-analysetools. PDF-export is gepland voor een toekomstige release.",
+      "columns": "## Te exporteren kolommen (alleen CSV)\nBepaalt welke gegevenskolommen voor elke testcase worden opgenomen:\n- **Alle kolommen:** Exporteert alle beschikbare gegevensvelden voor de testcases, inclusief aangepaste velden uit hun sjablonen.\n- **Zichtbare kolommen:** Exporteert alleen de kolommen die momenteel zichtbaar zijn in de testcasetabel.",
+      "delimiter": "## CSV-scheidingsteken (alleen CSV)\nKies het teken dat wordt gebruikt om waarden in het CSV-bestand te scheiden. Het meest gebruikte teken is een komma. Gebruik een ander scheidingsteken als uw gegevens komma's in tekstvelden bevatten (bijvoorbeeld een puntkomma).",
+      "textLongFormat": "## Opmaak van lange tekstvelden (alleen CSV)\nBepaalt hoe rich text-velden (zoals 'Beschrijving' of aangepaste velden voor 'Lange tekst') worden geëxporteerd:\n- **JSON:** Exporteert de inhoud als een JSON-string, waarbij alle opmaak (vet, lijsten, enz.) behouden blijft. Dit is het meest geschikt voor herimport of programmatische verwerking.\n- **Platte tekst:** Exporteert de inhoud als platte tekst, waarbij de opmaak wordt verwijderd. Dit is beter leesbaar in eenvoudige tekstviewers.",
+      "stepsFormat": "## Stappenindeling (alleen CSV)\nBepaalt hoe teststappen (inclusief verwachte resultaten) worden geëxporteerd:\n- **JSON:** Exporteert stappen als een JSON-array met objecten, waarbij de structuur en RTF-tekst behouden blijven. Geschikt voor herimport of gedetailleerde analyse.\n- **Platte tekst:** Exporteert stappen in een vereenvoudigde, leesbare platte tekstindeling, waarbij elke stap en het verwachte resultaat op een nieuwe regel staan.",
+      "rowMode": "## Rijmodus (alleen CSV)\nBepaalt hoe velden met meerdere waarden (zoals tags of aangepaste velden met meerdere selecties) en stappen worden weergegeven:\n- **Eén rij per case:** Elke testcase is één rij. Velden met meerdere waarden en stappen worden gecondenseerd tot de bijbehorende cellen (vaak als JSON of gecombineerde tekst).\n- **Meerdere rijen per case:** Een testcase kan meerdere rijen beslaan als deze meerdere tags, waarden met meerdere selecties of stappen bevat. Elke unieke waarde/stap voor dergelijke velden creëert een nieuwe rij, waarbij de gegevens van andere cases worden herhaald. Dit is handig voor gedetailleerde analyses of pivoting.",
+      "attachmentFormat": "## Bijlage-info-indeling (alleen CSV)\nBepaalt hoe informatie over bijlagen wordt geëxporteerd:\n- **JSON:** Exporteert bijlagegegevens (zoals bestandsnaam, URL, grootte) als een JSON-array. Dit is uitgebreid, maar minder leesbaar voor mensen direct in een CSV.\n- **Alleen namen:** Exporteert een door komma's gescheiden lijst met bestandsnamen van bijlagen. Eenvoudiger voor snelle referentie."
+    },
+    "reportMetrics": {
+      "count": "## Testresultaten Aantal\nAantal testresultaten in deze groep.",
+      "passRate": "## Slagingspercentage\nFractie van de resultaten in deze groep met een geslaagde status.",
+      "avgElapsed": "## Gemiddelde verstreken tijd\nGemiddelde verstreken tijd voor resultaten in deze groep.",
+      "sumElapsed": "## Totale verstreken tijd\nSom van de verstreken tijd voor de resultaten in deze groep.",
+      "executionCount": "## Testuitvoeringen\nTotaal aantal uitgevoerde testuitvoeringen.",
+      "testCaseCount": "## Test Cases Count\nTotaal aantal testcases in deze groep.",
+      "testRunCount": "## Test Runs Count\nTotaal aantal testruns in deze groep.",
+      "automationRate": "## Automatiseringspercentage\nPercentage testcases dat geautomatiseerd is.",
+      "averageSteps": "## Gemiddeld aantal stappen per testgeval\nGemiddeld aantal stappen per testgeval.",
+      "automatedCount": "## Geautomatiseerde gevallen\nAantal geautomatiseerde testgevallen.",
+      "manualCount": "## Handmatige gevallen\nAantal handmatige testgevallen.",
+      "totalSteps": "## Totaal aantal stappen\nTotaal aantal teststappen in alle gevallen.",
+      "createdCaseCount": "## Gemaakte testcases\nAantal testcases dat in deze periode is gemaakt.",
+      "sessionResultCount": "## Sessieresultaten\nAantal sessietestresultaten.",
+      "sessionCount": "## Sessieaantal\nTotaal aantal testsessies.",
+      "activeSessions": "## Actieve sessies\nAantal sessies dat momenteel actief is (isActive = true).",
+      "milestoneCompletion": "## Voltooiing van mijlpalen\nPercentage van voltooide testgevallen in mijlpalen. Berekend als (voltooide testresultaten / totaal aantal testgevallen in testruns) × 100.",
+      "averageTimeSpent": "## Gemiddelde tijd besteed\nGemiddelde tijd besteed aan activiteiten.",
+      "sessionParticipation": "## Sessiedeelname\nNiveau van deelname aan testsessies.",
+      "lastActiveDate": "## Laatste actieve datum\nMeest recente datum van activiteit.",
+      "averageAge": "## Gemiddelde leeftijd\nGemiddelde leeftijd van items in dagen.",
+      "issueCount": "## Aantal problemen\nTotaal aantal gevolgde problemen.",
+      "milestoneCount": "## Mijlpaalaantal\nTotaal aantal mijlpalen.",
+      "milestoneCompletionRate": "## Mijlpaalvoltooiingspercentage\nPercentage voltooide mijlpalen.",
+      "averageMilestoneDuration": "## Gemiddelde mijlpaalduur\nGemiddelde duur van mijlpalen in dagen."
+    },
+    "reportDimensions": {
+      "user": "## Gebruikersdimensie\nGroepeert resultaten op basis van de gebruiker die de tests heeft uitgevoerd of aan de items is toegewezen.",
+      "status": "## Statusdimensie\nGroepeert resultaten op basis van de uitvoeringsstatus van de test (bijv. Geslaagd, Mislukt, Geblokkeerd).",
+      "project": "## Projectdimensie\nGroepeert resultaten per project voor analyse tussen projecten.",
+      "testRun": "## Test Run Dimension\nGroepeert resultaten op de testrun die de uitgevoerde testcases bevat.",
+      "testCase": "## Test Case Dimension\nGroepeert resultaten per individuele testcase voor gedetailleerde analyse.",
+      "milestone": "## Mijlpaaldimensie\nGroepeert resultaten op projectmijlpalen om de voortgang richting doelen bij te houden.",
+      "configuration": "## Configuratiedimensie\nGroepeert resultaten op basis van de configuratie van de testomgeving (bijv. browser, besturingssysteem).",
+      "template": "## Template Dimension\nGroepeert resultaten op basis van de sjabloon die is gebruikt voor de testcasestructuur.",
+      "creator": "## Creator Dimension\nGroepeert resultaten op basis van de gebruiker die de testcases of testruns heeft gemaakt.",
+      "state": "## Statusdimensie\nGroepeert resultaten op workflowstatus (bijv. Concept, Actief, Voltooid).",
+      "role": "## Roldimensie\nGroepeert resultaten op gebruikersrollen voor toegangs- en verantwoordelijkheidsanalyse.",
+      "group": "## Groepsdimensie\nGroepeert resultaten per gebruikersgroep. Gebruikers kunnen tot meerdere groepen behoren, dus activiteiten worden geteld voor elke groep waartoe de gebruiker behoort.",
+      "folder": "## Mapdimensie\nGroepeert resultaten op basis van de mapstructuur van de opslagplaats voor organisatorische analyse.",
+      "session": "## Sessiedimensie\nGroepeert resultaten op testsessies voor sessiegebaseerde analyse.",
+      "assignedTo": "## Toegewezen aan dimensie\nGroepeert resultaten op basis van de gebruiker die is toegewezen om de items uit te voeren of te beheren.",
+      "issueType": "## Dimensie Probleemtype\nGroepeert resultaten op basis van het type problemen dat wordt bijgehouden (bijv. Bug, Taak, Story, Verbetering).",
+      "issueTracker": "## Dimensie Issue Tracker\nGroepeert resultaten op basis van de gebruikte issue-trackingintegratie (bijv. Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Dimensie Probleemstatus\nGroepeert resultaten op basis van de huidige status van problemen (bijv. Open, In behandeling, Opgelost, Gesloten).",
+      "priority": "## Prioriteitsdimensie\nGroepeert resultaten op prioriteitsniveau van het probleem (bijv. Hoog, Gemiddeld, Laag).",
+      "source": "## Brondimensie\nGroepeert resultaten op basis van de bron van de testuitvoering (bijv. Handmatig, JUnit, API).",
+      "date": "## Datumdimensie\nGroepeert resultaten op datum voor tijdgebaseerde analyses en trends."
+    },
+    "reportBuilder": {
+      "dimensions": "## Dimensies\nSelecteer de dimensies die u in uw rapport wilt analyseren. Dimensies zijn kenmerken die uw gegevens categoriseren, zoals Datum, Gebruiker, Status, enz. U kunt ze slepen om de volgorde te wijzigen.",
+      "metrics": "## Metrics\nSelecteer de metrics die u in uw rapport wilt meten. Metrics zijn kwantitatieve metingen die zijn afgeleid van uw gegevens, zoals het aantal testresultaten, het slagingspercentage, de gemiddelde verstreken tijd, enz. U kunt ze slepen om de volgorde te wijzigen.",
+      "dateRange": "## Datumbereik\nFilter uw rapportgegevens op een specifieke periode. U kunt kiezen uit vooraf gedefinieerde bereiken zoals 'Afgelopen 7 dagen' of 'Vorige maand', of een aangepast datumbereik definiëren. Dit filter is van toepassing op het relevante datumveld voor elk rapporttype (bijv. uitvoeringsdatum voor testresultaten, aanmaakdatum voor testcases)."
+    },
+    "codeRepository": {
+      "name": "## Naam van de repository\nEen gebruiksvriendelijke weergavenaam voor deze repositoryverbinding.\n\n- Wordt gebruikt om deze te identificeren in de contextinstellingen van de projectcode.\n- Hoef niet overeen te komen met de repositorynaam op de provider.",
+      "provider": "## Git-provider\nHet platform waarop deze repository wordt gehost.\n\n- **GitHub** — github.com (cloud of Enterprise)\n- **GitLab** — gitlab.com of zelf gehost\n- **Bitbucket Cloud** — bitbucket.org (alleen cloud)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — zelf gehoste Git-servers met compatibele API's",
+      "githubToken": "## Persoonlijk toegangstoken\nEen GitHub-token met **Inhoud: Lezen**-toegangsrechten.\n\nGenereer er een via: GitHub → Profielinstellingen → Ontwikkelaarsinstellingen → Persoonlijke toegangstokens → Gedetailleerde tokens.",
+      "owner": "## Eigenaar\nDe GitHub-organisatie of het gebruikersaccount dat eigenaar is van de repository.\n\n- Voorbeeld: `myorg` of `myusername`\n- Dit is het eerste padsegment in de URL van je repository op github.com",
+      "repo": "## Repository\nDe naam van de repository, zonder het eigenaarsvoorvoegsel.\n\n- Voorbeeld: `my-repo` (niet `myorg/my-repo`)\n- Dit is het tweede padsegment in de URL van je repository op github.com",
+      "gitlabToken": "## Persoonlijk toegangstoken\nEen GitLab-token met de scopes **read_api** en **read_repository**.\n\nGenereer er een via: GitLab → Gebruikersinstellingen → Toegangstokens.",
+      "projectPath": "## Project-ID of pad\nDe numerieke project-ID of het volledige naamruimtepad.\n\n- Voorbeeldpad: `myorg/my-project`\n- Voorbeeld-ID: `12345678`\n- Te vinden in GitLab onder Instellingen → Algemeen.",
+      "baseUrl": "## GitLab-URL\nLaat leeg voor gitlab.com. Voor zelfgehoste instanties voert u uw GitLab-URL in.\n\n- Voorbeeld: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian-account e-mailadres\nHet e-mailadres dat is gekoppeld aan uw Atlassian-account.\n\n- Dit is het e-mailadres dat u gebruikt om in te loggen bij Bitbucket Cloud.",
+      "bitbucketApiToken": "## API-token\nEen Bitbucket API-token met **Repositories: Lezen**-scope.\n\nMaak er een aan via: Bitbucket → Persoonlijke instellingen → API-tokens.\n\n> App-wachtwoorden zijn door Atlassian afgeschaft ten gunste van API-tokens.",
+      "workspace": "## Werkruimte\nDe slug van de werkruimte uit je Bitbucket-URL.\n\n- Voorbeeld: `myworkspace` van `bitbucket.org/myworkspace`",
+      "repoSlug": "## Repository Slug\nDe repository-identificatiecode uit de URL.\n\n- Voorbeeld: `my-repo` van `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Persoonlijk toegangstoken\nEen Azure DevOps PAT met **Code (Lezen)** machtiging.\n\nMaak er een aan via: Azure DevOps → Gebruikersinstellingen → Persoonlijke toegangstokens.",
+      "organizationUrl": "## Organisatie-URL\nDe URL van uw Azure DevOps-organisatie.\n\n- Voorbeeld: `https://dev.azure.com/myorg`",
+      "project": "## Projectnaam\nDe naam van het Azure DevOps-project dat de repository bevat.\n\n- Te vinden als het derde padsegment in uw Azure DevOps-URL na de organisatienaam",
+      "azureRepoId": "## Naam of ID van de repository\nDe naam of GUID van de repository binnen het Azure DevOps-project.\n\n- Voorbeeld: `my-repo`",
+      "giteaToken": "## Persoonlijk toegangstoken\nEen token met leesrechten voor de repository.\n\nGenereer er een via: Sitebeheer → Toepassingen of Gebruikersinstellingen → Toepassingen.\n\n- Werkt met Gitea, Forgejo, Gogs en elke server die een compatibele API beschikbaar stelt.",
+      "giteaBaseUrl": "## Server-URL\nDe basis-URL van uw zelfgehoste Git-server.\n\n- Voorbeeld: `https://gitea.example.com`\n- Moet het protocol bevatten (https:// aanbevolen)\n- Werkt met Gitea, Forgejo, Gogs en andere servers met een Gitea-compatibele `/api/v1/` REST API",
+      "giteaOwner": "## Eigenaar\nDe organisatie of het gebruikersaccount dat eigenaar is van de repository.\n\n- Voorbeeld: `myorg` of `myusername`\n- Dit is het eerste padsegment in de URL van uw repository.",
+      "giteaRepo": "## Repository\nDe naam van de repository, zonder het eigenaarsvoorvoegsel.\n\n- Voorbeeld: `my-repo` (niet `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Configuratienaam\nEen unieke, beschrijvende naam voor deze promptconfiguratie.\n\n- Wordt gebruikt om de configuratie te identificeren bij het toewijzen aan een project (bijv. \"GPT-40 Prompts\", \"Conservatieve Prompts\").",
+      "description": "## Beschrijving\nEen optionele samenvatting van wat deze configuratie uniek maakt.\n\n- Helpt beheerders in één oogopslag het doel te begrijpen (bijv. \"Lagere temperatuurprompts voor deterministische uitvoer\").",
+      "isActive": "## Actief\nWanneer deze configuratie is ingeschakeld, kan deze door projecten worden gebruikt.\n\n- Inactieve configuraties worden verborgen in de dropdownmenu's voor projecttoewijzing.\n- De standaardconfiguratie kan niet worden gedeactiveerd.",
+      "isDefault": "## Standaardconfiguratie\nWanneer deze is ingeschakeld, wordt deze configuratie gebruikt door elk project waaraan geen specifieke configuratie is toegewezen.\n\n- Er kan slechts één configuratie tegelijk de standaard zijn.\n- Het instellen van een nieuwe standaardconfiguratie maakt de vorige automatisch ongedaan.",
+      "systemPrompt": "## Systeemprompt\nInstructies die naar het AI-model worden gestuurd vóórdat er gebruikersinvoer plaatsvindt. Definieert de rol van het model, het uitvoerformaat en de beperkingen.\n\n- Ondersteunt placeholders met dubbele accolades (bijv. FRAMEWORK, LANGUAGE, CASE_NAME) die tijdens de uitvoering worden vervangen.\n- Wijzigingen hier zijn van invloed op elk project dat deze configuratie gebruikt.",
+      "userPrompt": "## Gebruikersprompt\nHet bericht dat namens de gebruiker naar de AI wordt verzonden. Laat dit veld leeg als de functie het gebruikersbericht volledig in code construeert.\n\n- Ondersteunt placeholders met dubbele accolades (bijv. ISSUE_TITLE, CASE_NAME, CODE_CONTEXT) die tijdens de uitvoering worden vervangen.\n- De beschikbare placeholders voor elke functie staan vermeld in het gedeelte Variabelen hieronder.",
+      "temperature": "## Temperatuur\nRegelt de willekeurigheid van de AI-uitvoer. Bereik: 0–2.\n\n- **0,0–0,3** — Zeer deterministisch, het beste voor gestructureerde uitvoer (JSON, code).\n- **0,4–0,7** — Evenwichtig, goed voor het genereren van testgevallen.\n- **0,8–2,0** — Creatiever en gevarieerder, geschikt voor open tekst.",
+      "maxOutputTokens": "## Maximaal aantal uitvoertokens\nHet maximale aantal tokens dat het model in één reactie genereert.\n\n- Hogere waarden maken langere reacties mogelijk, maar verhogen de kosten en latentie.\n- Typische bereiken: 2048 voor korte tekst, 4096 voor codegeneratie, 6000+ voor uitvoer met meerdere hoofd- en kleine letters."
+    },
+    "menu": {
+      "startTour": "Rondleiding Welkom",
+      "startProjectTour": "Projecttour",
+      "startAdminTour": "Beheerdersrondleiding",
+      "startDemoProjectTour": "Demo Projectrondleiding"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Welkom bij TestPlanIt!",
+          "content": "Laten we eens kort de belangrijkste functies van TestPlanIt doornemen, zodat u aan de slag kunt met uw testworkflow."
+        },
+        "projects": {
+          "content": "Krijg hier toegang tot al uw testprojecten. Elk project bevat testcases, runs en functies voor teamsamenwerking."
+        },
+        "project": {
+          "title": "Projectkaart",
+          "content": "Klik op een projectkaart om de details te bekijken. Kies 'Project Tour' in het helpmenu voor een rondleiding langs de projectfuncties."
+        },
+        "globalFeatures": {
+          "title": "Globale functies",
+          "content": "Beheer tags voor categorisatie, volg problemen in projecten en beheer gebruikers met op rollen gebaseerde toegangscontrole."
+        },
+        "search": {
+          "content": "Contextuele zoekopdracht op basis van uw huidige pagina. Vind snel testcases, runs, problemen of andere content. Gebruik Cmd+K (of Ctrl+K) voor directe toegang."
+        },
+        "help": {
+          "title": "Hulp en ondersteuning",
+          "content": "U kunt op elk gewenst moment deze rondleiding volgen of onze uitgebreide documentatie raadplegen voor gedetailleerde hulp."
+        },
+        "notifications": {
+          "content": "Blijf op de hoogte van voltooide testruns, probleemupdates en teamactiviteiten. Configureer voorkeuren in uw accountinstellingen."
+        },
+        "account": {
+          "title": "Accountmenu",
+          "content": "Pas je profiel, meldingsvoorkeuren en accountinstellingen aan. Schakel tussen lichte en donkere thema's."
+        },
+        "assignments": {
+          "content": "Bekijk de testcases en runs die aan u zijn toegewezen voor alle projecten. Dit is uw persoonlijke dashboard om uw testwerk te volgen."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Projectselector",
+          "content": "Schakel snel tussen projecten met deze dropdown. Bekijk projectdetails en krijg toegang tot projectbrede instellingen."
+        },
+        "projectSections": {
+          "title": "Projectsecties",
+          "content": "Navigeer door Overzicht voor het projectdashboard, Documentatie voor projectgidsen en Mijlpalen om de voortgang te volgen."
+        },
+        "repository": {
+          "content": "Beheer uw testcases, organiseer ze in mappen en maak nieuwe testscenario's voor een grondige testdekking."
+        },
+        "repositoryPanels": {
+          "title": "Linkerpaneel van de repository",
+          "content": "Het linkerpaneel toont uw mappenstructuur en testcaseboom. Gebruik de weergaveselector om te schakelen tussen verschillende organisatieweergaven."
+        },
+        "repositoryRightPanel": {
+          "title": "Rechterpaneel van de repository",
+          "content": "In het rechterpaneel worden testcasedetails en uitvoeringsresultaten weergegeven. Ook vindt u hier acties om nieuwe testcases te maken of bestaande testcases te importeren."
+        },
+        "sharedSteps": {
+          "title": "Gezamenlijke stappen",
+          "content": "Definieer herbruikbare stappengroepen waarnaar vanuit meerdere testgevallen kan worden verwezen. Houd uw teststappen DRY (Don't Repeat Yourself) en consistent."
+        },
+        "testRuns": {
+          "content": "Voer geplande tests uit, volg de voortgang en beheer testopdrachten binnen uw team. Bekijk gedetailleerde uitvoeringsresultaten."
+        },
+        "testRunsPage": {
+          "title": "Testruns Dashboard",
+          "content": "Dit is de pagina Testruns waar u nieuwe testruns kunt aanmaken, de voortgang van de uitvoering kunt volgen, resultaten kunt bekijken en testopdrachten kunt beheren. Volg de testactiviteiten van uw team vanaf één centrale locatie."
+        },
+        "sessions": {
+          "title": "Verkennende sessies",
+          "content": "Documenteer verkennende testsessies, leg bevindingen vast en houd bij hoeveel tijd u besteedt aan ad-hoc testactiviteiten."
+        },
+        "sessionsPage": {
+          "title": "Dashboard voor verkennende sessies",
+          "content": "Op de pagina 'Sessies' kunt u verkennende testsessies aanmaken en beheren. Documenteer bevindingen, houd de bestede tijd bij en houd een overzicht bij van alle ad-hoc testactiviteiten voor een betere testdekking."
+        },
+        "tags": {
+          "title": "Tagsbeheer",
+          "content": "Organiseer en categoriseer uw testcases met behulp van tags. Maak aangepaste tags om de organisatie en filtering van testcases te verbeteren."
+        },
+        "issues": {
+          "title": "Probleemopsporing",
+          "content": "Volg en beheer problemen die tijdens het testen zijn ontdekt. Koppel problemen aan testcases en integreer ze met externe bugtrackingsystemen."
+        },
+        "reports": {
+          "title": "Rapporten en analyses",
+          "content": "Genereer uitgebreide rapporten en analyses voor uw project. Bekijk testdekking, uitvoeringstrends, teamprestatiegegevens en maak aangepaste rapporten voor stakeholders."
+        },
+        "settings": {
+          "title": "Projectinstellingen",
+          "content": "Beheer hier projectintegraties, AI-modelconfiguraties en gedeelde links."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Welkom bij Admin Controls",
+          "content": "Volg een rondleiding door de beheerfuncties van TestPlanIt. Beheer projecten, gebruikers, configuraties en systeeminstellingen vanuit dit centrale beheerpaneel."
+        },
+        "projects": {
+          "title": "Projectbeheer",
+          "content": "Beheer alle projecten in uw organisatie. Maak, configureer en archiveer projecten. Stel projectbrede machtigingen en toegangscontroles in."
+        },
+        "templatesAndFields": {
+          "content": "Maak en beheer testcasesjablonen en aangepaste velden. Definieer veldtypen, validatieregels en organiseer sjablonen voor een consistente testcasestructuur in alle projecten."
+        },
+        "workflows": {
+          "title": "Workflowbeheer",
+          "content": "Definieer testcaseworkflows en statusovergangen. Configureer hoe testcases door verschillende statussen heen gaan, zoals Concept, Review en Goedgekeurd."
+        },
+        "statuses": {
+          "title": "Testresultaatstatussen",
+          "content": "Configureer beschikbare testresultaatstatussen zoals Geslaagd, Gezakt, Geblokkeerd en Overgeslagen. Stel aangepaste statussen in en definieer hun gedrag en weergave."
+        },
+        "milestones": {
+          "content": "Definieer mijlpaaltypen voor projecttracking. Configureer releasetypen, sprintcategorieën en andere projectmijlpaalclassificaties."
+        },
+        "configurations": {
+          "title": "Testconfiguraties",
+          "content": "Beheer testconfiguraties en -omgevingen. Stel browsercombinaties, apparaattypen, besturingssystemen en andere testuitvoeringscontexten in."
+        },
+        "users": {
+          "title": "Gebruikersbeheer",
+          "content": "Beheer gebruikersaccounts, machtigingen en toegangsniveaus. Maak nieuwe gebruikers aan, wijs rollen toe en configureer authenticatie-instellingen."
+        },
+        "groups": {
+          "title": "Groepsmanagement",
+          "content": "Organiseer gebruikers in groepen voor eenvoudiger rechtenbeheer. Creëer afdelingsgroepen, projectteams en rolgebaseerde toegangsgroepen."
+        },
+        "roles": {
+          "title": "Rollenbeheer",
+          "content": "Definieer gebruikersrollen en -rechten. Configureer welke acties verschillende rollen kunnen uitvoeren binnen projecten en systeembeheer."
+        },
+        "tags": {
+          "title": "Globale tags",
+          "content": "Beheer organisatiebrede tags voor het categoriseren van testcases, projecten en andere entiteiten. Creëer taghiërarchieën en standaardiseer tagging binnen projecten."
+        },
+        "reports": {
+          "content": "Genereer rapporten die meerdere projecten bestrijken. Analyseer trends, prestatiegegevens en de effectiviteit van organisatorische tests in uw gehele werkruimte."
+        },
+        "notifications": {
+          "title": "Meldingsinstellingen",
+          "content": "Configureer systeembrede meldingsvoorkeuren. Stel e-mailsjablonen, meldingsregels en standaardinstellingen voor gebruikersmeldingen in."
+        },
+        "integrations": {
+          "title": "Systeemintegraties",
+          "content": "Beheer integraties van derden en API-verbindingen. Configureer Jira, GitHub en andere externe toolintegraties voor uw organisatie."
+        },
+        "llm": {
+          "title": "AI-configuratie",
+          "content": "Configureer AI-modellen en -instellingen voor geautomatiseerde generatie van testcases en intelligente functies. Beheer API-sleutels en modelvoorkeuren."
+        },
+        "sso": {
+          "title": "Eenmalige aanmelding",
+          "content": "Configureer SSO-providers en authenticatiemethoden. Stel SAML, OAuth en andere identiteitsproviderintegraties in voor naadloze gebruikerstoegang."
+        },
+        "appConfig": {
+          "content": "Beheer globale applicatie-instellingen en systeemvoorkeuren. Configureer standaardwaarden, functie-instellingen en systeembreed gedrag."
+        },
+        "trash": {
+          "title": "Systeemprullenbak",
+          "content": "Bekijk en beheer verwijderde items in alle projecten. Herstel per ongeluk verwijderde content of verwijder items permanent uit het systeem."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Welkom bij het demoproject.",
+          "content": "Dit project is vooraf geladen met voorbeeldgegevens. Laten we samen de belangrijkste functies doornemen. Gebruik dit keuzemenu om tussen projecten te schakelen."
+        },
+        "overview": {
+          "title": "Projectoverzicht",
+          "content": "Het overzicht is je projectdashboard. Het toont de voortgang van mijlpalen en samenvattingen van testgevallen, actieve uitvoeringen, sessies en tags."
+        },
+        "documentation": {
+          "title": "Documentatie",
+          "content": "Elk project heeft een documentatiepagina. Gebruik deze voor testplannen, projectnotities of links naar externe bronnen."
+        },
+        "documentationContent": {
+          "title": "Rich Text Editor",
+          "content": "De documentatie ondersteunt opmaak met koppen, lijsten, links en afbeeldingen. Probeer deze pagina te bewerken om te zien hoe het werkt."
+        },
+        "milestones": {
+          "title": "Mijlpalen",
+          "content": "Houd je testactiviteiten bij ten opzichte van sprints, releases en andere doelen. Koppel testruns en -sessies aan mijlpalen voor het bijhouden van de voortgang."
+        },
+        "milestonesPage": {
+          "title": "Mijlpaaltijdlijn",
+          "content": "Bekijk alle mijlpalen voor dit project. Elke mijlpaal toont de status en de voortgang richting voltooiing."
+        },
+        "repository": {
+          "title": "Testcase-repository",
+          "content": "Organiseer testgevallen in mappen met aangepaste velden, stappen en prioriteiten. Bekijk de voorbeeldmappen om te zien hoe testgevallen zijn gestructureerd."
+        },
+        "repositoryPanels": {
+          "title": "Mappen en etuis",
+          "content": "In het linkerpaneel ziet u mappen. Klik op een map om de bijbehorende testgevallen te bekijken. Elk testgeval bevat stappen, beschrijvingen en gedeelde stapverwijzingen."
+        },
+        "repositoryCases": {
+          "title": "Testgevallen",
+          "content": "Hier ziet u de testgevallen voor de geselecteerde map. Elke rij toont de naam van het testgeval, de prioriteit en de aangepaste velden. Klik op een testgeval om de volledige details en stappen ervan te bekijken."
+        },
+        "sharedSteps": {
+          "title": "Gezamenlijke stappen",
+          "content": "Definieer herbruikbare stappengroepen waarnaar vanuit meerdere testgevallen kan worden verwezen. Dit zorgt ervoor dat veelgebruikte stappen consistent blijven en gemakkelijk te onderhouden zijn."
+        },
+        "sharedStepsPage": {
+          "title": "Gedeelde stappengroepen",
+          "content": "Elke groep bevat een reeks geordende stappen. Verwijs ernaar vanuit elk testgeval om uw stappen DRY (Don't Repeat Yourself) en consistent te houden."
+        },
+        "testRuns": {
+          "title": "Testruns",
+          "content": "Maak testruns aan om testgevallen uit te voeren en de resultaten vast te leggen. Wijs runs toe aan mijlpalen en volg de voortgang (geslaagd/mislukt)."
+        },
+        "testRunsPage": {
+          "title": "Testresultaten",
+          "content": "Bekijk de testresultaten en de voortgang. Elke testrun toont de status, de toegewezen mijlpaal en een overzicht van geslaagde/mislukte resultaten."
+        },
+        "sessions": {
+          "title": "Verkenningssessies",
+          "content": "Leg ad-hoc testen vast met sessiegebaseerde testen. Registreer bevindingen, ken statussen toe en houd de bestede tijd bij."
+        },
+        "sessionsPage": {
+          "title": "Sessieresultaten",
+          "content": "Elke sessie bevat gedetailleerde bevindingen met statusinformatie en notities. Klik op een sessie om de resultaten te bekijken."
+        },
+        "tags": {
+          "title": "Tags",
+          "content": "Tags helpen bij het organiseren en filteren van testgevallen, testruns en testsessies. Bekijk de voorbeeldtags om te zien hoe ze content categoriseren."
+        },
+        "tagsPage": {
+          "title": "Tagbeheer",
+          "content": "Hier kunt u tags aanmaken, bewerken en toewijzen. Gebruik tags om content in uw project te groeperen en te filteren."
+        },
+        "issues": {
+          "title": "Problemen",
+          "content": "Registreer bugs en defecten die tijdens het testen worden gevonden. Problemen kunnen worden gekoppeld aan mislukte testresultaten en sessiebevindingen voor volledige traceerbaarheid."
+        },
+        "issuesPage": {
+          "title": "Probleemtracker",
+          "content": "Bekijk voorbeelden van problemen die verband houden met mislukte resultaten. Problemen kunnen worden herleid tot de testuitvoering of sessie die ze aan het licht bracht."
+        },
+        "reports": {
+          "title": "Rapporten en analyses",
+          "content": "Genereer rapporten over testdekking, uitvoeringstrends en teamprestaties. Gebruik vooraf gedefinieerde rapporten of maak aangepaste rapporten voor belanghebbenden."
+        },
+        "settings": {
+          "title": "Projectinstellingen",
+          "content": "Beheer hier projectintegraties, AI-modelconfiguraties en gedeelde links."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Projectoverstijgende rapporten maken en beheren"
+      },
+      "reportsTabDescription": "Bekijk en analyseer vooraf samengestelde rapporten voor uw project.",
+      "reportType": "Rapporttype",
+      "selectReportType": "Selecteer rapporttype",
+      "selectReport": "Rapport selecteren",
+      "dimensions": "Afmetingen",
+      "dimensionsSubtitle": "Afmetingen (slepen om opnieuw te ordenen, hieronder toevoegen)",
+      "metrics": "Metrieken",
+      "addDimension": "Voeg dimensie toe...",
+      "addMetric": "Metrisch toevoegen...",
+      "runReport": "Rapport uitvoeren",
+      "noResultsFound": "Geen resultaten gevonden.",
+      "selectAtLeastOneDimensionAndMetric": "Selecteer minimaal één dimensie en één metriek.",
+      "noDataMatchingCriteria": "Er zijn geen gegevens gevonden die overeenkomen met de geselecteerde dimensies en statistieken.",
+      "noDataMatchingCriteriaWithDateFilter": "Er zijn geen gegevens gevonden die overeenkomen met de geselecteerde dimensies en statistieken. Probeer uw filter voor het datumbereik aan te passen.",
+      "noDataAvailable": "Er zijn geen gegevens beschikbaar voor dit rapport.",
+      "generatedAt": "Rapport gegenereerd op",
+      "crossProjectAnalytics": "Projectoverschrijdende analyse en rapportage",
+      "unauthorizedAdmin": "Niet geautoriseerd: beheerdersrechten vereist.",
+      "title": "Rapportbouwer",
+      "description": "Maak aangepaste rapporten om uw projectgegevens te analyseren",
+      "crossProjectDescription": "Analyseer gegevens in alle projecten in uw werkruimte",
+      "selectDimensions": "Selecteer afmetingen...",
+      "selectMetrics": "Selecteer statistieken...",
+      "dimensionOrder": "Dimensievolgorde",
+      "metricOrder": "Metrische volgorde",
+      "filtersDescription": "Filter de rapportgegevens op basis van specifieke criteria.",
+      "activeFilters": "Actieve filters:",
+      "priorityFilterPlaceholder": "Selecteer prioriteitswaarden (of laat alles leeg)",
+      "dateRange": {
+        "selectDateRange": "Selecteer datumbereik",
+        "chooseStartDate": "Kies een startdatum",
+        "chooseEndDate": "Kies een einddatum",
+        "categories": {
+          "day": "Dag",
+          "week": "Week",
+          "month": "Maand",
+          "quarter": "Kwartaal",
+          "year": "Jaar"
+        },
+        "today": "Vandaag",
+        "yesterday": "Gisteren",
+        "last7Days": "Laatste 7 dagen",
+        "last30Days": "Laatste 30 dagen",
+        "thisWeek": "Deze week",
+        "lastWeek": "Vorige week",
+        "last2Weeks": "Afgelopen 2 weken",
+        "thisMonth": "Deze maand",
+        "lastMonth": "Vorige maand",
+        "last3Months": "Afgelopen 3 maanden",
+        "thisQuarter": "Dit kwartaal",
+        "lastQuarter": "Laatste kwartaal",
+        "thisYear": "Dit jaar",
+        "lastYear": "Vorig jaar",
+        "last12Months": "Afgelopen 12 maanden",
+        "allTime": "Alle tijden",
+        "custom": "Aangepast datumbereik"
+      },
+      "dateGrouping": {
+        "label": "Groeperen op",
+        "daily": "Dagelijks",
+        "weekly": "Wekelijks",
+        "monthly": "Maandelijks",
+        "quarterly": "Driemaandelijks",
+        "annually": "Jaarlijks"
+      },
+      "filters": {
+        "selectFilter": "Selecteer een filtertype",
+        "allProjects": "Alle projecten"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Het is niet gelukt om de rapportmetagegevens te laden",
+        "failedToRunReport": "Rapport uitvoeren mislukt",
+        "atLeastOneDimensionRequired": "Er is minimaal één dimensie vereist.",
+        "atLeastOneMetricRequired": "Er moet minimaal één metriek worden opgegeven.",
+        "invalidCombinationDateLastActive": "De metriek 'Laatste actieve datum' kan niet worden gecombineerd met de dimensie 'Activiteitsdatum'.",
+        "lastActiveDateOnlyWithUser": "De metriek 'Laatst actieve datum' kan alleen worden gebruikt met de dimensie 'Gebruiker'.",
+        "invalidDimensionCombination": "De dimensies '{dim1}' en '{dim2}' kunnen niet samen worden gebruikt in testuitvoeringsrapporten.",
+        "startDateRequiredWithEndDate": "Wanneer u een einddatum opgeeft, is de startdatum vereist.",
+        "endDateMustBeAfterStartDate": "De einddatum moet gelijk zijn aan of later zijn dan de startdatum."
+      },
+      "chartDataTruncated": {
+        "title": "Grafiekgegevens afgekapt",
+        "message": "Voor de leesbaarheid worden {shown} van {total} gegevenspunten weergegeven. Gebruik filters of datumbereiken om uw resultaten te verfijnen, of bekijk de volledige gegevens in de onderstaande resultatentabel."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Testuitvoeringsrapporten",
+          "description": "Analyseer testresultaten, slagingspercentages en uitvoeringsstatistieken"
+        },
+        "repositoryStats": {
+          "label": "Statistieken van de repository",
+          "description": "Testcasestatistieken, dekking en repositorystatus"
+        },
+        "userEngagement": {
+          "label": "Gebruikersbetrokkenheid",
+          "description": "Analyse van gebruikersactiviteit, productiviteit en werklast"
+        },
+        "projectHealth": {
+          "label": "Project Gezondheid",
+          "description": "Projectvoortgang, mijlpalen en voltooiingsstatus"
+        },
+        "sessionAnalysis": {
+          "label": "Sessieanalyse",
+          "description": "Sessievoltooiing, duur en toewijzingsstatistieken"
+        },
+        "issueTracking": {
+          "label": "Probleemregistratie",
+          "description": "Probleemcreatie, oplossing en impactanalyse"
+        },
+        "automationTrends": {
+          "label": "Automatiseringstrends",
+          "description": "Volg de voortgang van de automatisering week na week op basis van prioriteit."
+        },
+        "flakyTests": {
+          "label": "Onbetrouwbare tests",
+          "description": "Identificeer tests met inconsistente slaag-/faalresultaten."
+        },
+        "testCaseHealth": {
+          "label": "Testgeval Gezondheid",
+          "description": "Identificeer verouderde, defecte of verdachte testgevallen op basis van uitvoeringspatronen."
+        },
+        "issueTestCoverage": {
+          "label": "Testdekking van het probleem",
+          "description": "Bekijk problemen met de bijbehorende testgevallen en de meest recente uitvoeringsstatus."
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Laatste opeenvolgende runs",
+        "consecutiveRunsHelp": "Aantal recente testuitvoeringen om te analyseren (5-30). Resultaten met de status 'niet getest' worden uitgesloten.",
+        "flipThreshold": "Minimum Flips",
+        "flipThresholdHelp": "Het minimale aantal geslaagde/mislukte overgangen is vereist om als onbetrouwbaar te worden beschouwd.",
+        "flips": "Flips",
+        "lastNResults": "Laatste {count, plural, one {# Resultaat} other {# Resultaten}}",
+        "newest": "Nieuw",
+        "oldest": "Oud",
+        "noFlakyTests": "Er zijn geen onbetrouwbare tests gevonden die aan de criteria voldoen.",
+        "includeFilter": "Erbij betrekken",
+        "testRunDeleted": "De testrun is verwijderd.",
+        "chart": {
+          "highPriority": "Vereist aandacht",
+          "lowPriority": "Lagere prioriteit",
+          "recencyAxis": "Mislukking Recentheid",
+          "flipsAxis": "Aantal omdraaien",
+          "oldFailures": "Ouder",
+          "recentFailures": "Recent",
+          "failureRate": "Faalpercentage",
+          "recency": "Recentheidsscore",
+          "backlogTitle": "Tests met lagere prioriteit",
+          "backlogDescription": "{count, plural, one {# extra onbetrouwbare test} other {# extra onbetrouwbare tests}} niet weergegeven"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Oud na (dagen)",
+        "staleDaysThresholdHelp": "Aantal dagen zonder uitvoering voordat een test als verouderd wordt beschouwd (7-90).",
+        "minExecutions": "Minimaal aantal uitvoeringen voor tarief",
+        "minExecutionsHelp": "Minimum aantal uitvoeringen vereist om zinvolle statistieken over het slagingspercentage te berekenen (3-20).",
+        "lookbackDays": "Terugkijkperiode",
+        "lookbackDaysHelp": "Aantal dagen om de uitvoeringsgeschiedenis te analyseren (30-365).",
+        "includeFilter": "Erbij betrekken",
+        "staleFilter": "Veroudering",
+        "stale": "Muf",
+        "notStale": "Niet oud",
+        "status": "Gezondheidsstatus",
+        "healthScore": "Score",
+        "lastExecuted": "Laatst uitgevoerd",
+        "executions": "Executies",
+        "passRate": "Slagingspercentage",
+        "passCount": "Passen",
+        "failCount": "Mislukkingen",
+        "never": "Nooit",
+        "daysSince": "Aantal dagen sinds de executie",
+        "count": "Graaf",
+        "totalTests": "testgevallen",
+        "noData": "Geen testgevallen gevonden",
+        "noExecutedTests": "Geen uitgevoerde tests om weer te geven",
+        "healthStatus": {
+          "healthy": "Gezond",
+          "stale": "Muf",
+          "neverExecuted": "Nooit geëxecuteerd",
+          "alwaysPassing": "Altijd voorbijgaand",
+          "alwaysFailing": "Altijd falen"
+        },
+        "chart": {
+          "distribution": "Statusverdeling",
+          "healthyRecent": "Gezond en recent",
+          "unhealthyStale": "Vereist aandacht",
+          "daysAxis": "Aantal dagen sinds laatste executie",
+          "healthScoreAxis": "Gezondheidsscore"
+        },
+        "stats": {
+          "totalTests": "Totaal aantal tests",
+          "needsAttention": "Vereist aandacht",
+          "needsAttentionTooltip": "Altijd mislukt + Nooit uitgevoerd + Verouderde tests",
+          "healthy": "Gezond",
+          "healthyTooltip": "Gezond + altijd slagen voor de tests",
+          "avgScore": "Gemiddelde gezondheidsscore"
+        },
+        "healthScoreTooltip": {
+          "title": "De score begint bij 100, aftrekpunten:",
+          "neverExecuted": "Nooit uitgevoerd: -50",
+          "stale90": "Niet uitgevoerd in de afgelopen 90+ dagen: -40",
+          "stale60": "Niet uitgevoerd in de afgelopen 60 dagen of langer: -25",
+          "stale30": "Niet uitgevoerd in de afgelopen 30 dagen of langer: -10",
+          "alwaysPassing": "Altijd geslaagd (100%): -5",
+          "alwaysFailing": "Altijd mislukken (0%): -30",
+          "lowPassRate": "Laag slagingspercentage (<50%): -20",
+          "lowExecutions": "Weinig executies (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Weergavemodus",
+        "summaryView": "Samenvatting (per nummer)",
+        "detailView": "Details (per testgeval)",
+        "issue": "Probleem",
+        "testCase": "Testgeval",
+        "testCases": "{count, plural, =1 {Testgeval} other {Testgevallen}}",
+        "issueStatus": "Status",
+        "priority": "Prioriteit",
+        "linkedTests": "Gekoppelde tests",
+        "testResults": "Resultaten (P/F/U)",
+        "passRate": "Slagingspercentage",
+        "passed": "Geslaagd",
+        "failed": "Mislukt",
+        "lastStatus": "Laatste status",
+        "lastExecuted": "Laatst uitgevoerd",
+        "notTested": "Niet getest",
+        "noData": "Er zijn geen problemen gevonden met gekoppelde testgevallen.",
+        "noIssuesNeedingAttention": "Alle onderwerpen zijn geslaagd voor de tests - geweldig werk!",
+        "stats": {
+          "totalIssues": "Totaal aantal nummers",
+          "issuesWithFailures": "Met mislukkingen",
+          "issuesWithFailuresTooltip": "Problemen met ten minste één mislukte testcase.",
+          "issuesWithUntested": "Met ongetest",
+          "issuesWithUntestedTooltip": "Problemen met ten minste één testgeval dat nog niet is uitgevoerd.",
+          "issuesAllPassing": "Alle passerende",
+          "overallPassRate": "Slagingspercentage",
+          "numberOfIssues": "Aantal problemen"
+        },
+        "charts": {
+          "passRateDistribution": "Verdeling van het slagingspercentage van de test",
+          "linkedTestCases": "Aantal gekoppelde testgevallen",
+          "untestedTestCases": "Aantal niet-geteste testgevallen",
+          "testCoverageVsExecution": "Testdekking versus uitvoeringsstatus"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Cross-project testuitvoering",
+          "description": "Analyseer testresultaten, slagingspercentages en uitvoeringsstatistieken voor alle projecten"
+        },
+        "repositoryStats": {
+          "label": "Statistieken over meerdere projecten in de repository",
+          "description": "Testcasestatistieken, dekking en repositorystatus voor projecten"
+        },
+        "userEngagement": {
+          "label": "Gebruikersbetrokkenheid tussen projecten",
+          "description": "Analyse van gebruikersactiviteit, productiviteit en werklast in projecten"
+        },
+        "issueTracking": {
+          "label": "Cross-project probleemopsporing",
+          "description": "Het creëren, oplossen en analyseren van de impact van problemen in projecten"
+        },
+        "automationTrends": {
+          "label": "Trends in projectoverstijgende automatisering",
+          "description": "Volg de voortgang van de automatisering wekelijks per prioriteit binnen de verschillende projecten."
+        },
+        "flakyTests": {
+          "label": "Tests voor onbetrouwbare resultaten tussen projecten",
+          "description": "Identificeer tests met inconsistente slaag-/faalresultaten in verschillende projecten."
+        },
+        "testCaseHealth": {
+          "label": "Gezondheid van testgevallen die meerdere projecten omvatten",
+          "description": "Identificeer verouderde, defecte of verdachte testgevallen in verschillende projecten."
+        },
+        "issueTestCoverage": {
+          "label": "Testdekking voor problemen die meerdere projecten omvatten",
+          "description": "Bekijk problemen met de bijbehorende testcases en de meest recente uitvoeringsstatus in alle projecten."
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Alleen projectbeheerders en beheerders hebben toegang tot projectrapporten.",
+      "projectIdRequired": "Project-ID is vereist",
+      "missingRequiredFields": "Ontbrekende verplichte velden",
+      "unsupportedDimension": "Niet-ondersteunde dimensie: {dimension}",
+      "unsupportedMetric": "Niet-ondersteunde metriek: {metric}",
+      "atLeastOneDimensionMetricRequired": "Er is minimaal één dimensie en één metriek vereist",
+      "atLeastOneMetricRequired": "Er moet minimaal één metriek worden opgegeven",
+      "projectDimensionsMetricsRequired": "Project-ID, dimensies en statistieken zijn vereist",
+      "unsupportedDimensions": "Niet-ondersteunde dimensie(s): {dimensions}",
+      "unsupportedMetrics": "Niet-ondersteunde metriek(en): {metrics}",
+      "unexpectedError": "Er is een onverwachte fout opgetreden."
+    },
+    "dimensions": {
+      "project": "Project",
+      "status": "Status",
+      "user": "Gebruiker",
+      "executor": "Uitvoerder",
+      "assignedTo": "Toegewezen aan",
+      "configuration": "Configuratie",
+      "date": "Datum",
+      "executionDate": "Uitvoeringsdatum",
+      "creationDate": "Aanmaakdatum",
+      "activityDate": "Activiteitsdatum",
+      "testRun": "Testrun",
+      "testCase": "Testgeval",
+      "milestone": "Mijlpaal",
+      "template": "Sjabloon",
+      "creator": "Schepper",
+      "state": "Staat",
+      "source": "Bron",
+      "folder": "Map",
+      "group": "Groep",
+      "role": "Rol",
+      "session": "Sessie",
+      "weekEnding": "Week eindigend",
+      "period": "Periode",
+      "priority": "Prioriteit",
+      "automationStatus": "Automatiseringsstatus",
+      "issueType": "Probleemtype",
+      "issueTracker": "Probleemtracker",
+      "issueStatus": "Probleemstatus"
+    },
+    "metrics": {
+      "testResults": "Testresultaten",
+      "testResultCount": "Testresultaten tellen",
+      "passRate": "Slagingspercentage (%)",
+      "avgElapsed": "Gemiddelde verstreken tijd",
+      "avgElapsedTime": "Gemiddelde verstreken tijd",
+      "totalElapsedTime": "Totale verstreken tijd",
+      "testRunCount": "Aantal testruns",
+      "testCaseCount": "Aantal testgevallen",
+      "automationRate": "Automatiseringspercentage (%)",
+      "avgStepsPerCase": "Gemiddeld aantal stappen per geval",
+      "averageSteps": "Gemiddeld aantal stappen per geval",
+      "automatedCount": "Geautomatiseerde gevallen",
+      "manualCount": "Handmatige gevallen",
+      "totalCount": "Totaal aantal gevallen",
+      "totalSteps": "Totaal aantal stappen",
+      "executionCount": "Testuitvoeringen",
+      "createdCaseCount": "Aantal gemaakte testcases",
+      "sessionResultCount": "Sessieresultaat aantal",
+      "caseCreations": "Aangemaakte gevallen",
+      "sessionParticipation": "Deelname aan de sessie",
+      "averageElapsed": "Gemiddelde tijd per uitvoering",
+      "lastActiveDate": "Laatste actieve datum",
+      "issueCount": "Aantal problemen",
+      "averageAge": "Gemiddelde leeftijd (dagen)",
+      "sessionCount": "Sessie aantal",
+      "activeSessions": "Actieve sessies",
+      "averageTimeSpent": "Gemiddelde bestede tijd (minuten)",
+      "milestoneCount": "Mijlpaaltelling",
+      "milestoneCompletionRate": "Mijlpaalvoltooiingspercentage (%)",
+      "averageMilestoneDuration": "Gemiddelde mijlpaalduur (dagen)",
+      "totalMilestones": "Totale mijlpalen",
+      "activeMilestones": "Actieve mijlpalen",
+      "milestoneCompletion": "Voltooiing van de mijlpaal (%)",
+      "averageDuration": "Gemiddelde duur",
+      "totalDuration": "Totale duur"
+    },
+    "drillDown": {
+      "title": "Gedetailleerde gegevens",
+      "loading": "Gegevens laden...",
+      "loadingMore": "Meer laden...",
+      "noRecords": "Geen gegevens gevonden",
+      "error": "Het laden van records is mislukt.",
+      "recordCount": "{count} {count, plural, =1 {record} other {records}}",
+      "allRecords": "Alle records",
+      "allLoaded": "Alle records geladen"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Deel",
+      "dialogTitle": "Rapport delen",
+      "dialogDescription": "Maak een deelbare link aan of beheer bestaande gedeelde rapportlinks.",
+      "tabs": {
+        "create": "Aanmaken Delen",
+        "list": "Mijn aandelen"
+      },
+      "shareMode": {
+        "label": "Deelmodus",
+        "authenticated": {
+          "title": "Geauthenticeerd (aanmelden vereist)",
+          "description": "Alleen ingelogde gebruikers met toegang tot dit project kunnen dit bekijken.",
+          "descriptionCrossProject": "Alleen ingelogde gebruikers met beheerdersrechten kunnen dit bekijken."
+        },
+        "passwordProtected": {
+          "title": "Wachtwoordbeveiligd",
+          "description": "Iedereen met de link en het wachtwoord kan de pagina bekijken. Ingelogde gebruikers met projecttoegang hoeven geen wachtwoord in te voeren.",
+          "descriptionCrossProject": "Iedereen met de link en het wachtwoord kan de gegevens bekijken. Gebruikers met beheerdersrechten hoeven geen wachtwoord in te voeren."
+        },
+        "public": {
+          "title": "Openbaar (iedereen met een link)",
+          "description": "Iedereen die de link heeft, kan dit rapport bekijken zonder in te loggen."
+        }
+      },
+      "expiration": {
+        "label": "Vervaldatum",
+        "noExpiration": "Geen vervaldatum",
+        "expiresAtMidnight": "De link verloopt aan het einde van de geselecteerde dag (uw lokale tijd)."
+      },
+      "notifyOnView": {
+        "label": "Laat het me weten als iemand deze link bekijkt",
+        "description": "Je ontvangt een melding wanneer de deelbare link wordt geopend, conform je meldingsvoorkeuren."
+      },
+      "title": {
+        "placeholder": "bijvoorbeeld een testuitvoeringsrapport",
+        "leaveEmptyToUse": "Laat dit veld leeg voor gebruik:"
+      },
+      "description": {
+        "placeholder": "Voeg een beschrijving toe voor dit gedeelde rapport..."
+      },
+      "actions": {
+        "createShareLink": "Deellink aanmaken",
+        "creating": "Aan het creëren..."
+      },
+      "errors": {
+        "loginRequired": "Je moet ingelogd zijn om een deelbare link te kunnen maken.",
+        "createFailed": "Het is niet gelukt om een deelbare link aan te maken.",
+        "genericError": "Er is een onbekende fout opgetreden."
+      },
+      "status": {
+        "revoked": {
+          "title": "Deellink ingetrokken",
+          "description": "Deze deelbare link is ingetrokken en niet langer toegankelijk."
+        },
+        "expired": {
+          "title": "Deellink verlopen",
+          "description": "Deze deelbare link is verlopen en niet langer toegankelijk."
+        }
+      },
+      "footer": {
+        "poweredBy": "Mogelijk gemaakt door"
+      },
+      "manageShares": {
+        "title": "Aandelen beheren",
+        "description": "Bekijk en beheer alle deelbare links voor dit project.",
+        "adminTitle": "Beheer alle aandelen",
+        "adminDescription": "Deelkoppelingen voor al uw projecten bekijken en beheren."
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Modus",
+          "views": "Uitzichten",
+          "expires": "Verloopt"
+        },
+        "status": {
+          "revoked": "ingetrokken",
+          "expired": "Verlopen"
+        },
+        "notifications": {
+          "enabled": "Op",
+          "disabled": "Uit"
+        },
+        "empty": {
+          "title": "Er zijn nog geen deelbare links aangemaakt.",
+          "description": "Maak je eerste deelbare link aan om te beginnen."
+        },
+        "defaultTitle": "{entityType} delen",
+        "noProject": "Projectoverstijgend",
+        "actions": {
+          "copyLink": "Link kopiëren",
+          "revoke": "Herroepen"
+        },
+        "revokeDialog": {
+          "title": "Deellink intrekken?",
+          "description": "Hierdoor wordt de deelbare link onmiddellijk ingetrokken. Iedereen die probeert de link te openen, krijgt een foutmelding te zien. Deze actie kan niet ongedaan worden gemaakt.",
+          "confirm": "Link intrekken",
+          "revoking": "Intrekking..."
+        },
+        "deleteDialog": {
+          "title": "Deellink verwijderen?",
+          "description": "Hiermee wordt de deelbare link permanent verwijderd. Als de link momenteel actief is, verloopt deze onmiddellijk en is deze niet langer toegankelijk. Deze actie kan niet ongedaan worden gemaakt.",
+          "confirm": "Link verwijderen"
+        },
+        "toast": {
+          "linkCopied": "Link gekopieerd!",
+          "linkCopiedDescription": "De deelbare link is naar uw klembord gekopieerd.",
+          "copyFailed": "Kopiëren mislukt",
+          "copyFailedDescription": "Kopieer de link handmatig.",
+          "linkRevoked": "Deellink ingetrokken",
+          "linkRevokedDescription": "De deelbare link is ingetrokken en niet langer toegankelijk.",
+          "revokeFailed": "Intrekking mislukt",
+          "revokeFailedDescription": "Er is een fout opgetreden tijdens het intrekken van de deelbare link.",
+          "notificationsEnabled": "Meldingen ingeschakeld",
+          "notificationsEnabledDescription": "Je ontvangt een melding wanneer iemand deze deelbare link bekijkt.",
+          "notificationsDisabled": "Meldingen uitgeschakeld",
+          "notificationsDisabledDescription": "Je ontvangt geen meldingen wanneer iemand deze deelbare link bekijkt.",
+          "notificationUpdateFailed": "Het bijwerken van meldingen is mislukt.",
+          "notificationUpdateFailedDescription": "Er is een fout opgetreden tijdens het bijwerken van de meldingsinstellingen.",
+          "linkDeleted": "Deellink verwijderd",
+          "linkDeletedDescription": "De deelbare link is verwijderd en verschijnt niet meer in je lijst.",
+          "deleteFailed": "Verwijderen mislukt",
+          "deleteFailedDescription": "Er is een fout opgetreden tijdens het verwijderen van de deelbare link."
+        }
+      },
+      "created": {
+        "title": "Deelbare link aangemaakt!",
+        "description": "Je deelbare link is klaar voor gebruik. Kopieer hem en deel hem met anderen.",
+        "shareLink": "Deellink",
+        "copy": "Kopiëren",
+        "openInNewTab": "Openen in een nieuw tabblad",
+        "metadata": {
+          "mode": "Modus",
+          "expires": "Verloopt",
+          "views": "Uitzichten"
+        },
+        "warnings": {
+          "publicLink": "Openbare link:",
+          "publicLinkDescription": "Iedereen met deze link heeft zonder authenticatie toegang tot het rapport.",
+          "expiresSoon": "Deze link verloopt aan het einde van"
+        },
+        "actions": {
+          "createAnother": "Maak nog een"
+        }
+      },
+      "editDialog": {
+        "title": "Deellink bewerken",
+        "description": "Werk de instellingen voor deze deelbare link bij.",
+        "passwordExists": "Deze deelbare link is al beveiligd met een wachtwoord. Laat het wachtwoordveld leeg om het bestaande wachtwoord te behouden.",
+        "passwordPlaceholder": "Laat dit veld leeg om het bestaande wachtwoord te behouden."
+      }
+    },
+    "passwordDialog": {
+      "title": "Wachtwoord vereist",
+      "description": "Deze gedeelde inhoud van <strong>{projectName}</strong> is met een wachtwoord beveiligd. Voer het wachtwoord in om verder te gaan.",
+      "passwordPlaceholder": "Voer wachtwoord in",
+      "showPassword": "Wachtwoord weergeven",
+      "hidePassword": "Wachtwoord verbergen",
+      "verifying": "Bezig met controleren...",
+      "errors": {
+        "emptyPassword": "Voer een wachtwoord in",
+        "tooManyAttempts": "Te veel mislukte pogingen. Probeer het later opnieuw{resetAt, select, null {} other { op {resetAt}}}.",
+        "genericError": "Er is een fout opgetreden. Probeer het opnieuw."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Geen pogingen meer over. Probeer het later opnieuw.",
+        "attemptsRemaining": "{count, plural, =1 {1 poging} other {# pogingen}} resterend."
+      }
+    },
+    "sharedReport": {
+      "loading": "Rapport laden...",
+      "errors": {
+        "onlyReportSharing": "Momenteel is alleen het delen van rapporten mogelijk.",
+        "failedToLoad": "Het laden van rapportgegevens is mislukt."
+      },
+      "defaultTitle": "Gedeeld rapport",
+      "fromProject": "Vanuit het project:",
+      "dateRange": "Datumbereik:",
+      "readOnlyNotice": "Dit is een gedeelde weergave die alleen-lezen is.",
+      "viewCount": "{count, plural, =1 {1 weergave} other {# weergaven}}",
+      "viewInFullApp": "Bekijk in de volledige app",
+      "pagination": {
+        "showing": "Weergeven",
+        "of": "van",
+        "results": "resultaten"
+      }
+    },
+    "authBypass": {
+      "title": "Je hebt toegang tot dit project.",
+      "description": "Weergave als {userName} met toegang tot {projectName}.",
+      "viewInApp": "Bekijk in de volledige app"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Gedeelde stappen filteren...",
+    "noGroups": "Geen gedeelde stappen gevonden.",
+    "noTestCases": "Er zijn geen testcases die deze gedeelde stapgroep gebruiken.",
+    "selectGroupPrompt": "Selecteer een gedeelde stapgroep om de stappen ervan te bekijken.",
+    "deleteTitle": "Gedeelde stappengroep verwijderen?",
+    "deleteDescription": "Weet u zeker dat u deze gedeelde stapgroep wilt verwijderen? De stappen worden verwijderd uit alle testcases die ze gebruiken.",
+    "saveSuccess": "Gedeelde stappen succesvol bijgewerkt.",
+    "saveError": "Er is een fout opgetreden bij het opslaan van gedeelde stappen.",
+    "stepsCount": "{count, plural, one {# stap} other {# stappen}}",
+    "testCasesUsing": "{count, plural, one {# testgeval} other {# testgevallen}}",
+    "importWizard": {
+      "title": "Gedeelde stappen importeren",
+      "fields": {
+        "order": "Volgorde",
+        "stepNumber": "Stap #",
+        "stepContent": "Stap Inhoud",
+        "expectedResultContent": "Verwachte resultaatinhoud",
+        "combinedStepData": "Gecombineerde stapgegevens",
+        "stepsData": "Stappen Gegevens"
+      },
+      "success": {
+        "description": "{count, plural, one {# gedeelde stap} other {# gedeelde stappen}} succesvol geïmporteerd"
+      },
+      "errors": {
+        "parseFailed": "Het is niet gelukt om het CSV-bestand te parseren",
+        "validationFailed": "Validatie mislukt",
+        "validationDescription": "{count, plural, one {# validatiefout} other {# validatiefouten}} gevonden",
+        "importFailed": "Importeren mislukt",
+        "fileRequired": "Een CSV-bestand is vereist."
+      },
+      "page1": {
+        "title": "Bestand en configuratie uploaden",
+        "selectedFile": "Geselecteerd bestand",
+        "delimiter": "Veldscheidingsteken",
+        "delimiters": {
+          "tab": "Tabblad (\\t)"
+        },
+        "hasHeaders": "Eerste rij bevat kolomkoppen",
+        "encoding": "Bestandscodering",
+        "rowMode": {
+          "label": "Rijmodus",
+          "single": "Eén rij per gedeelde stap",
+          "multi": "Meerdere rijen voor complexe gedeelde stappen"
+        }
+      },
+      "page2": {
+        "title": "CSV-kolommen toewijzen aan gedeelde stapvelden",
+        "description": "Koppel uw CSV-kolommen aan gedeelde stapvelden. Verplichte velden moeten worden gekoppeld.",
+        "ignoreColumn": "Negeer deze kolom",
+        "requiredFieldsWarning": "{count, plural, one {# Vereist veld is} other {# Vereist veld is}} niet toegewezen. Wijs alle vereiste velden toe om verder te gaan."
+      },
+      "page3": {
+        "title": "Voorbeeld importeren van gegevens",
+        "showing": "Weergave van {start} tot {end} van {total} gedeelde stappen",
+        "step": "Gedeelde stap {number}",
+        "noValue": "(leeg)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Handmatig toevoegen",
+      "description": "Een nieuwe gedeelde stapgroep maken met handmatige invoer",
+      "groupNamePlaceholder": "Voer een naam in voor deze gedeelde stapgroep",
+      "success": "Gedeelde stappen succesvol aangemaakt",
+      "errors": {
+        "groupNameRequired": "Groepsnaam is vereist",
+        "stepsRequired": "Er is minimaal één stap vereist",
+        "saveFailed": "Het opslaan van gedeelde stappen is mislukt"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Stapvolgorde duplicaten",
+      "pageDescription": "Bekijk overeenkomende stappenreeksen in alle testgevallen. Converteer overeenkomsten naar gedeelde stappengroepen of verwijder valse positieven.",
+      "noResultsFound": "Geen dubbele stappen gevonden",
+      "noResultsDescription": "Voer een scan uit om herhaalde stappenreeksen in uw testgevallen te detecteren.",
+      "filterPlaceholder": "Filteren op zaaknaam...",
+      "selected": "{count, plural, one {# geselecteerd} other {# geselecteerd}}",
+      "bulkDismiss": "Afwijzen ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# wedstrijd beëindigd} other {# wedstrijden beëindigd}}",
+      "bulkError": "Sommige bewerkingen zijn mislukt. Probeer het opnieuw.",
+      "tableHint": "Klik op een rij om een voorbeeld van de overeenkomende stappen te bekijken. Selecteer rijen met selectievakjes voor bulkacties.",
+      "columns": {
+        "matchedSteps": "Overeenkomende stappen",
+        "casesCount": "gevallen",
+        "review": "Beoordeling"
+      },
+      "scanning": "Bezig met scannen...",
+      "scanComplete": "{count, plural, one {# overeenkomst gevonden} other {# overeenkomsten gevonden}}",
+      "scanFailed": "Scan mislukt",
+      "scanFailedDescription": "Er is een fout opgetreden tijdens het scannen. Probeer het opnieuw.",
+      "cancelScan": "Scan annuleren",
+      "findStepDuplicates": "Zoek naar dubbele stappen",
+      "rescan": "Scannen",
+      "viewResults": "Resultaten bekijken ({count})",
+      "retryScan": "Scan opnieuw uitvoeren",
+      "dialog": {
+        "title": "Omzetten naar gedeelde stappen",
+        "previewTitle": "Overeenkomende stappenvolgorde",
+        "casesTitle": "Betrokken testgevallen",
+        "casesDescription": "Schakel de gevallen uit die u wilt uitsluiten van de conversie.",
+        "nameLabel": "Naam van de gedeelde stapgroep",
+        "namePlaceholder": "Geef een naam op voor de gedeelde stappengroep...",
+        "converting": "Bezig met converteren...",
+        "dismissMatch": "Wedstrijd sluiten",
+        "dismissing": "Ontslag...",
+        "convertSuccess": "De gedeelde stappengroep is succesvol aangemaakt!",
+        "convertError": "Conversie mislukt. Probeer het opnieuw.",
+        "dismissSuccess": "Wedstrijd afgelopen.",
+        "dismissError": "Het sluiten is mislukt. Probeer het opnieuw.",
+        "viewSharedStep": "Bekijk de gedeelde stappengroep",
+        "skippedWarning": "{count, plural, one {# geval overgeslagen} other {# gevallen overgeslagen}} (verouderd of reeds geconverteerd).",
+        "noCasesSelected": "Selecteer ten minste één geval om te converteren.",
+        "selectAll": "Alles selecteren"
+      }
+    },
+    "findStepDuplicates": "Dubbele items zoeken"
+  },
+  "search": {
+    "title": "Zoekopdracht",
+    "placeholder": {
+      "thisProject": "Zoeken in dit project...",
+      "allProjects": "Zoeken in alle projecten..."
+    },
+    "currentProjectOnly": "Alleen huidig project",
+    "allTypes": "Alle soorten",
+    "entityTypes": {
+      "repositoryCase": "Repository-gevallen"
+    },
+    "results": {
+      "tryAdjusting": "Probeer uw zoektermen of filters aan te passen",
+      "searchingFor": "Op zoek naar",
+      "within": "binnenin",
+      "currentProject": "huidig project",
+      "page": "Pagina"
+    },
+    "errors": {
+      "searchFailed": "Zoeken mislukt. Probeer het opnieuw.",
+      "tryAgain": "Probeer het opnieuw"
+    },
+    "startTyping": "Begin met typen om te zoeken",
+    "typesSelected": "{count, plural, one {# type} other {# types}}",
+    "customFieldFilters": "Aangepaste veldfilters",
+    "customFiltersApplied": "aangepaste filters",
+    "customFields": "Aangepaste velden",
+    "addFilter": "Filter toevoegen",
+    "filter": "Filter",
+    "noCustomFilters": "Er zijn geen aangepaste veldfilters toegepast",
+    "selectDate": "Selecteer datum",
+    "selectOption": "Selecteer optie",
+    "selectOptions": "Selecteer opties",
+    "operators": {
+      "equals": "is gelijk aan",
+      "not_equals": "Niet gelijk",
+      "contains": "Bevat",
+      "not_contains": "Bevat niet",
+      "starts_with": "Begint met",
+      "ends_with": "Eindigt met",
+      "gt": "Groter dan",
+      "lt": "Minder dan",
+      "gte": "Groter dan of gelijk aan",
+      "lte": "Minder dan of gelijk aan",
+      "between": "Tussen",
+      "in": "In",
+      "not_in": "Niet in",
+      "exists": "Bestaat",
+      "not_exists": "Bestaat niet"
+    },
+    "help": {
+      "exactPhrases": "Exacte formuleringen",
+      "exactPhrasesDesc": "Plaats termen tussen aanhalingstekens zodat ze exact overeenkomen met de formulering:",
+      "proximity": "Nabijheidszoekfunctie",
+      "proximityDesc": "woorden binnen N posities van elkaar",
+      "booleanOperators": "Booleaanse operatoren",
+      "andDesc": "beide termen moeten overeenkomen.",
+      "orDesc": "beide termen kunnen overeenkomen",
+      "notDesc": "resultaten met term uitsluiten",
+      "prefixDesc": "een term vereisen of uitsluiten",
+      "groupingDesc": "groepeer termen voor complexe zoekopdrachten",
+      "wildcards": "Jokers",
+      "wildcardMultiDesc": "komt overeen met alle tekens",
+      "wildcardSingleDesc": "komt overeen met één enkel teken",
+      "fuzzyMatching": "Vage overeenkomst",
+      "fuzzyDesc": "zoekt naar vergelijkbare termen om typefouten te voorkomen.",
+      "defaultBehavior": "Bij meerdere woorden wordt standaard 'OF' gebruikt. Resultaten die overeenkomen met de naam krijgen de hoogste ranking.",
+      "fullSyntaxLink": "Volledige referentie voor de Lucene-querysyntaxis"
+    },
+    "filters": {
+      "title": "Geavanceerde filters",
+      "active": "filters actief",
+      "activeCount": "{count, plural, =0 {Geen filters} one {# filter} other {# filters}} actief",
+      "apply": "Filters toepassen",
+      "common": "Algemene filters",
+      "entitySpecific": "Typespecifieke filters",
+      "searchPlaceholder": "Zoekfilteropties...",
+      "states": "Workflowstatussen",
+      "createdAt": "Aanmaakdatum",
+      "updatedAt": "Bijgewerkte datum",
+      "completedAt": "Voltooiingsdatum",
+      "from": "Van",
+      "to": "Naar",
+      "testRunType": "Testruntype",
+      "regular": "Normaal",
+      "junit": "JUnit",
+      "automatedOnly": "Alleen geautomatiseerd",
+      "archivedOnly": "Alleen gearchiveerd",
+      "completedOnly": "Alleen voltooid",
+      "manualOnly": "Alleen handmatig",
+      "estimateRange": "Schattingsbereik",
+      "elapsedRange": "Verstreken tijdsbereik",
+      "minValue": "Min",
+      "maxValue": "Maximaal",
+      "hasExternalId": "Heeft externe ID",
+      "dueDateRange": "Vervaldatumbereik",
+      "hasParent": "Heeft oudermijlpaal",
+      "milestoneType": "Mijlpaaltype",
+      "minutes": "notulen",
+      "hours": "uren",
+      "days": "dagen",
+      "searchingIn": "Zoeken in",
+      "includeDeleted": "Verwijderde items opnemen",
+      "filterActive": "Actief filter:",
+      "applyFilter": "Filter toepassen",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "De eerste waarde moet kleiner zijn dan de tweede waarde.",
+        "firstDateMustBeBeforeSecond": "De eerste date moet vóór de tweede date plaatsvinden."
+      },
+      "link": {
+        "domainHelp": "Voer alleen het domein in (bijv. \"github.com\" of \"example.org\")."
+      }
+    }
+  },
+  "email": {
+    "greeting": "Hallo,",
+    "greetingWithName": "Hallo {name},",
+    "notification": {
+      "intro": "U heeft een nieuwe melding:",
+      "viewDetails": "Bekijk details",
+      "viewAll": "Alle meldingen bekijken"
+    },
+    "digest": {
+      "intro": "Hier is uw dagelijkse overzicht van meldingen van TestPlanIt:",
+      "viewDetails": "Bekijk details",
+      "viewAll": "Bekijk alle meldingen",
+      "noNotifications": "Je hebt vandaag geen nieuwe meldingen.",
+      "footer": "U ontvangt deze e-mail omdat u dagelijkse samenvattingsmeldingen hebt ingeschakeld. U kunt uw meldingsvoorkeuren wijzigen in uw",
+      "profileSettings": "profielinstellingen"
+    },
+    "footer": {
+      "sentBy": "Deze e-mail is verzonden door",
+      "unsubscribe": "Uitschrijven",
+      "managePreferences": "Voorkeuren beheren",
+      "allRightsReserved": "Alle rechten voorbehouden."
+    },
+    "magicLink": {
+      "subject": "Meld je aan bij TestPlanIt",
+      "heading": "Meld je aan bij TestPlanIt",
+      "intro": "Klik op de onderstaande knop om in te loggen:",
+      "signInButton": "Inloggen",
+      "copyPasteIntro": "Of kopieer en plak deze link in uw browser:",
+      "disclaimer": "Als u deze e-mail niet hebt aangevraagd, kunt u deze gerust negeren.",
+      "textBody": "Meld u aan bij TestPlanIt\n\nKlik op de onderstaande link om u aan te melden:\n{url}\n\nAls u deze e-mail niet hebt aangevraagd, kunt u deze gerust negeren."
+    }
+  },
+  "comments": {
+    "title": "Reacties",
+    "placeholder": "Schrijf een reactie... (gebruik @ om gebruikers te vermelden)",
+    "editPlaceholder": "Bewerk uw opmerking...",
+    "postComment": "Plaats een reactie",
+    "noComments": "Nog geen reacties. Wees de eerste om te reageren!",
+    "edited": "bewerkt",
+    "confirmDelete": "Weet u zeker dat u deze opmerking wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+    "deleteDialog": {
+      "title": "Reactie verwijderen"
+    },
+    "errors": {
+      "createFailed": "Reactie plaatsen is mislukt. Probeer het opnieuw.",
+      "updateFailed": "Reactie bijwerken is mislukt. Probeer het opnieuw.",
+      "deleteFailed": "Reactie verwijderen mislukt. Probeer het opnieuw.",
+      "loadFailed": "Reacties laden mislukt. Probeer het opnieuw."
+    },
+    "mentions": {
+      "notAMember": "Geen projectlid",
+      "noUsersFound": "Geen gebruikers gevonden"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "Proeftijd eindigt over {count, plural, =1 {1 dag} other {# dagen}}",
+    "expiresT oday": "De proefperiode verloopt vandaag.",
+    "expired": "{count, plural, =1 {Proefperiode 1 dag geleden verlopen} other {Proefperiode # dagen geleden verlopen}}",
+    "contactSales": "Neem contact op met de verkoopafdeling."
+  },
+  "feedback": {
+    "sheetTitle": "Deel uw feedback",
+    "sheetDescription": "Help ons TestPlanIt te verbeteren door uw ervaringen te delen.",
+    "bannerMessage": "Hoe verloopt je proefperiode? We horen graag je mening.",
+    "menuItem": "Deel feedback"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "AI-tag",
+      "tagAll": "Alles taggen",
+      "aiAutoTag": "Auto-Tag",
+      "tagActions": "Tagacties",
+      "startTagging": "Beginnen met taggen",
+      "selectEntityType": "Selecteer entiteitstype",
+      "selectProject": "Selecteer een project",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Testgeval} other {Testgevallen}}",
+        "testRun": "{count, plural, one {Testrun} other {Testruns}}",
+        "session": "{count, plural, one {Sessie} other {Sessies}}"
+      }
+    },
+    "review": {
+      "title": "Suggesties voor reviewtags",
+      "description": "Klik op tags om de acceptatie ervan in of uit te schakelen. Dubbelklik om een tagnaam te bewerken.",
+      "selectEntity": "Selecteer een entiteit om suggesties voor tags te bekijken.",
+      "noTagsSelected": "Geen tags geselecteerd",
+      "footerSummary": "{assignCount, plural, one {# tag} other {# tags}} worden toegewezen, {newCount, plural, one {# nieuwe tag} other {# nieuwe tags}} worden aangemaakt",
+      "footerAssignCount": "{assignCount, plural, one {# tag} other {# tags}} zullen worden toegewezen",
+      "footerNewCount": "{newCount, plural, one {# nieuwe tag} other {# nieuwe tags}} worden aangemaakt",
+      "newTagsPopoverTitle": "Nieuwe tags om te maken",
+      "applying": "Aanvragen...",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tags}} toegepast op {entityCount, plural, one {# entiteit} other {# entiteiten}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} toegepast op {entityCount, plural, one {# entiteit} other {# entiteiten}}, {newCount, plural, one {# nieuwe tag} other {# nieuwe tags}} aangemaakt",
+      "applyError": "Het toepassen van tags is mislukt. Probeer het opnieuw.",
+      "suggestedTags": "Voorgestelde tags",
+      "noSuggestions": "De AI kon geen tags genereren.",
+      "alreadyApplied": "Reeds aangevraagd",
+      "filterEntities": "Entiteiten filteren...",
+      "noEntitiesMatch": "Er zijn geen resultaten gevonden die overeenkomen met uw zoekopdracht.",
+      "tagCount": "{count, plural, one {# tag} other {# tags}}",
+      "noTags": "geen",
+      "failed": "Mislukt",
+      "analysisFailed": "Deze entiteit kon niet worden geanalyseerd.",
+      "responseTruncated": "Reactie afgekapt — verhoog het maximale aantal uitvoertokens in de LLM-instellingen.",
+      "tooltipExisting": "Bestaande tag",
+      "tooltipNew": "Nieuwe tag — wordt aangemaakt",
+      "tooltipAssign": "Wijs een bestaande tag toe",
+      "toggleFailed": "Mislukte entiteiten weergeven/verbergen",
+      "showFailed": "Weergave mislukt"
+    },
+    "progress": {
+      "starting": "Analyse starten...",
+      "analyzed": "Geanalyseerde {analyzed}/{total} entiteiten",
+      "sizing": "Het vinden van de optimale batchgrootte (proberen {size} entiteiten)...",
+      "streaming": "AI-reactie ontvangen ({analyzed}/{total} entiteiten voltooid)...",
+      "finalizing": "Resultaten voorbereiden...",
+      "complete": "Analyse voltooid",
+      "reviewSuggestions": "Suggesties voor beoordelingen",
+      "failed": "Analyse mislukt"
+    },
+    "wizard": {
+      "description": "AI analyseert alle testgevallen, testruns en sessies van je project om relevante tags voor te stellen op basis van hun inhoud.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Start analyse",
+      "untaggedOnly": "Analyseer alleen records zonder bestaande tags.",
+      "allowNewTags": "Sta het aanmaken van nieuwe tags toe.",
+      "noLlmConfigured": "(Geen LLM geconfigureerd)",
+      "analyzingDescription": "De AI analyseert uw entiteiten en genereert suggesties voor tags. Dit kan even duren."
+    },
+    "entityDetail": {
+      "customFields": "Aangepaste velden",
+      "noDetails": "Geen verdere details beschikbaar.",
+      "openInNewTab": "Openen in een nieuw tabblad"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Zeer zwak",
+    "weak": "Zwak",
+    "fair": "Eerlijk",
+    "good": "Goed",
+    "strong": "Sterk",
+    "minLength": "Ten minste {count} tekens",
+    "uppercase": "Ten minste één hoofdletter",
+    "lowercase": "Ten minste één kleine letter",
+    "numbers": "Ten minste één getal",
+    "specialChars": "Speciaal teken van: {chars}",
+    "history": "Wachtwoord werd gebruikt in uw laatste {depth} wachtwoorden"
+  },
+  "TrialExpired": {
+    "title": "Je proefperiode is verlopen.",
+    "description": "Bedankt voor het uitproberen van TestPlanIt! Uw proefperiode is afgelopen en deze instantie is niet langer toegankelijk.",
+    "nextSteps": "Om TestPlanIt te blijven gebruiken en toegang te krijgen tot uw testgegevens, kunt u contact opnemen met ons verkoopteam.",
+    "pricingPlans": "Prijsplannen",
+    "dataRetention": "Je testgegevens worden veilig opgeslagen en zijn beschikbaar wanneer je je account upgradet."
+  }
+}

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Nazwa",
+    "cancel": "Anulować",
+    "dismiss": "Odrzucać",
+    "of": "z",
+    "on": "NA",
+    "at": "Na",
+    "in": "W",
+    "add": "Dodać",
+    "never": "Nigdy",
+    "select": "Wybierać...",
+    "file": "Plik",
+    "selectMultiple": "Wybierz wiele...",
+    "searchUsers": "Wyszukaj użytkowników...",
+    "searchCases": "{count, plural, =0 {Wyszukaj przypadki} one {Wyszukaj # przypadków} other {Wyszukaj # przypadków}}",
+    "searchProjects": "{count, plural, =0 {Wyszukaj projekty} one {Wyszukaj # projekt} other {Wyszukaj # projekty}}",
+    "searchTags": "Wyszukaj tagi...",
+    "searchRuns": "{count, plural, =0 {Wyszukaj przebiegi testowe} one {Wyszukaj # przebiegi testowe} other {Wyszukaj # przebiegi testowe}}",
+    "searchSessions": "{count, plural, =0 {Wyszukaj sesje} one {Wyszukaj # sesję} other {Wyszukaj # sesje}}",
+    "search": "Szukaj...",
+    "defaultOption": "Opcja domyślna",
+    "yes": "Tak",
+    "no": "NIE",
+    "updated": "Zaktualizowano",
+    "groupedBy": "pogrupowane według",
+    "lastEditedBy": "Ostatnio edytowane przez",
+    "actions": {
+      "edit": "Redagować",
+      "save": "Ratować",
+      "delete": "Usuwać",
+      "create": "Tworzyć",
+      "submit": "Składać",
+      "close": "Zamknąć",
+      "done": "Zrobione",
+      "verify": "Zweryfikować",
+      "signIn": "Zalogować się",
+      "signOut": "Wyloguj się",
+      "signUp": "Zapisać się",
+      "resend": "Wyślij ponownie",
+      "deleting": "Usuwanie...",
+      "next": "Następny",
+      "previous": "Poprzedni",
+      "finish": "Skończyć",
+      "download": "Pobierać",
+      "apply": "Stosować",
+      "confirm": "Potwierdzać",
+      "confirmDelete": "Potwierdź usunięcie",
+      "saveChanges": "Zapisz zmiany",
+      "saving": "Oszczędność...",
+      "submitting": "Przedkładający...",
+      "start": "Start",
+      "pause": "Pauza",
+      "reset": "Nastawić",
+      "copy": "Kopia",
+      "copyLink": "Kopiuj link",
+      "copied": "Skopiowano!",
+      "complete": "Kompletny",
+      "back": "Z powrotem",
+      "clear": "Jasne",
+      "expand": "Zwiększać",
+      "collapse": "Zawalić się",
+      "addResult": "Dodaj wynik",
+      "passAndNext": "Pass & Next",
+      "viewInRepository": "Wyświetl w repozytorium",
+      "resultAdded": "Dodano wynik testu",
+      "resultAddedDescription": "Wynik testu został pomyślnie dodany.",
+      "resultUpdated": "Zaktualizowano wynik testu",
+      "resultDeleted": "Wynik testu został usunięty",
+      "deleteResult": "Usuń wynik testu",
+      "deleteResultConfirmation": "Czy na pewno chcesz usunąć ten wynik testu? Tej czynności nie można cofnąć.",
+      "editResult": "Edytuj wynik testu",
+      "resultDetails": "Szczegóły wyników",
+      "actionsLabel": "Akcje",
+      "assign": "Przydzielać",
+      "assignSelected": "Przypisz {count, plural, one {# przypadek} other {# przypadki}}",
+      "refresh": "Odświeżać",
+      "addResultSelected": "Dodaj wynik do {count, plural, one {# przypadek} other {# przypadki}}",
+      "resultsAdded": "{count, plural, one {# Wynik} other {# Wyniki}} Dodano",
+      "resultsAddedDescription": "{count, plural, one {Wynik został dodany do # przypadku testowego} other {Wyniki zostały dodane do # przypadków testowych}} pomyślnie",
+      "addingResultsToMultiple": "Dodawanie wyników do {count, plural, one {# przypadek testowy} other {# przypadki testowe}}",
+      "addedToTestRun": "Dodano do testu",
+      "addedToTestRunDescription": "Przypadek testowy został dodany do przebiegu testu.",
+      "noAvailableTestRuns": "Wszystkie aktywne przebiegi testów zawierają już ten przypadek testowy.",
+      "resultUpdateError": "Nie udało się zaktualizować wyniku testu",
+      "resultDeleteError": "Nie udało się usunąć wyniku testu",
+      "selectStatus": "Wybierz status",
+      "addToTestRun": "Dodaj do uruchomienia testowego",
+      "status": "Status",
+      "resultDetailsPlaceholder": "Wprowadź szczegóły wyników...",
+      "selectAll": "Zaznacz wszystko",
+      "deselectAll": "Odznacz wszystko",
+      "clearAll": "Wyczyść wszystko",
+      "selectFile": "Wybierz plik",
+      "restore": "Przywrócić",
+      "purge": "Oczyszczać",
+      "previousCase": "Poprzednia sprawa",
+      "nextCase": "Następny przypadek",
+      "startTesting": "Rozpocznij testowanie",
+      "expandLeftPanel": "Rozszerz lewy panel",
+      "collapseLeftPanel": "Zwiń lewy panel",
+      "expandRightPanel": "Rozszerz prawy panel",
+      "collapseRightPanel": "Zwiń prawy panel",
+      "createTag": "Utwórz tag „{name}”",
+      "noTagsFound": "Nie znaleziono tagów",
+      "duplicate": "Duplikat",
+      "exportPdf": "Eksportuj PDF",
+      "exportingPdf": "Eksportowanie...",
+      "change": "Zmiana",
+      "viewAll": "Zobacz wszystko",
+      "undo": "Anulować",
+      "undoDelete": "Cofnij usunięcie",
+      "automated": {
+        "details": "Szczegóły testu automatycznego",
+        "message": "Wiadomość",
+        "line": "Linia",
+        "testSuite": "Zestaw testowy:"
+      },
+      "junit": {
+        "details": "Szczegóły wyników testów automatycznych",
+        "import": {
+          "title": "Importuj wyniki testów",
+          "description": "Prześlij pliki z wynikami testów, aby zaimportować je do nowego przebiegu testu. Obsługuje formaty JUnit, TestNG, xUnit, NUnit, MSTest, Mocha i Cucumber.",
+          "testRun": {
+            "label": "Test jazdy",
+            "placeholder": "Wybierz przebieg testowy"
+          },
+          "file": {
+            "label": "Pliki wyników testów"
+          },
+          "import": "Import",
+          "selectFolder": "Wybierz folder",
+          "createNewFolder": "Utwórz nowy folder",
+          "createNewFolderNamed": "Utwórz nowy folder: {name}",
+          "progress": {
+            "initializing": "Inicjalizacja importu...",
+            "validating": "Sprawdzanie poprawności danych wejściowych...",
+            "creatingRun": "Tworzenie przebiegu testowego...",
+            "fetchingTemplate": "Pobieranie danych szablonu...",
+            "countingTests": "Przetwarzanie {count} przypadków testowych z {files} plików...",
+            "parsingFile": "Analizowanie pliku {current} z {total}...",
+            "processingSuite": "Zestaw przetwarzania: {name}",
+            "processingCase": "Przetwarzanie przypadku testowego {current} z {total}...",
+            "finalizing": "Finalizowanie importu...",
+            "completed": "Import zakończony pomyślnie!",
+            "errorParsing": "Błąd podczas parsowania pliku {index}: {error}",
+            "skippingFile": "Pomijanie nieprawidłowego pliku {index}"
+          },
+          "error": {
+            "title": "Błąd importu",
+            "importFailed": "Nie udało się zaimportować wyników testu. Spróbuj ponownie."
+          },
+          "success": {
+            "title": "Import pomyślny",
+            "description": "Wyniki testów zostały pomyślnie zaimportowane."
+          },
+          "fileRequired": "Proszę przesłać co najmniej jeden plik z wynikami testu."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Format wyników",
+            "placeholder": "Wybierz format"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Potwierdź przywrócenie",
+      "confirmPurgeTitle": "Potwierdź czyszczenie",
+      "remove": "Usunąć",
+      "reconfigure": "Skonfiguruj ponownie i spróbuj ponownie"
+    },
+    "permissions": {
+      "addEdit": "Dodaj/Edytuj"
+    },
+    "auth": {
+      "internal": "E-mail/Hasło",
+      "sso": "Tylko SSO",
+      "both": "E-mail i logowanie jednokrotne"
+    },
+    "status": {
+      "deleted": "Usunięto",
+      "disabled": "Wyłączony",
+      "noCustomFieldData": "Brak dodatkowych szczegółów.",
+      "pending": "Aż do",
+      "uploading": "Przesyłanie...",
+      "notApplicable": "Nie dotyczy",
+      "redirecting": "Przekierowywanie...",
+      "pendingDelete": "Zostanie usunięte",
+      "pendingChanges": "Oczekujące zmiany",
+      "importing": "Importowanie...",
+      "addingTestCases": "Dodawanie przypadków testowych..."
+    },
+    "priority": {
+      "low": "Niski",
+      "medium": "Średni",
+      "high": "Wysoki"
+    },
+    "filters": {
+      "allStatuses": "Wszystkie statusy",
+      "allPriorities": "Wszystkie priorytety"
+    },
+    "fields": {
+      "groupName": "Nazwa grupy",
+      "users": "Użytkownicy",
+      "mixed": "Wszystkie wartości",
+      "type": "Typ",
+      "default": "Domyślny",
+      "enabled": "Włączony",
+      "projects": "Projektowanie",
+      "iconColor": "Ikona/Kolor",
+      "selectWorkflow": "Wybierz przepływ pracy",
+      "icon": "Ikona",
+      "systemName": "Nazwa systemu",
+      "aliases": "Pseudonimy",
+      "scope": "Zakres",
+      "success": "Sukces",
+      "failure": "Awaria",
+      "completed": "Zakończony",
+      "elapsed": "Upływający czas",
+      "totalElapsed": "Całkowity czas upłynięty",
+      "totalEstimate": "Szacowany pozostały czas",
+      "completionRate": "Wskaźnik ukończenia",
+      "attachments": "Załączniki",
+      "documentation": "Dokumentacja",
+      "state": "Państwo",
+      "configuration": "Konfiguracja",
+      "configurations": "Konfiguracje",
+      "milestone": "Kamień milowy",
+      "tags": "Tagi",
+      "createdBy": "Stworzone przez",
+      "description": "Opis",
+      "description_placeholder": "Dodaj opis...",
+      "testCases": "Przypadki testowe",
+      "sessions": "Sesje",
+      "sharedSteps": "Wspólne kroki",
+      "email": "E-mail",
+      "password": "Hasło",
+      "confirmPassword": "Potwierdź hasło",
+      "token": "Znak",
+      "access": "Dostęp",
+      "avatar": "Awatara",
+      "steps": "Kroki",
+      "step": "Krok",
+      "expectedResult": "Oczekiwany wynik",
+      "notes": "Notatki",
+      "estimate": "Oszacować",
+      "date": "Data",
+      "size": "Rozmiar",
+      "created": "Stworzony",
+      "template": "Szablon",
+      "mission": "Misja",
+      "assignedTo": "Przypisany do",
+      "executedBy": "Wykonany przez",
+      "optional": "Fakultatywny",
+      "role": "Rola",
+      "defaultRole": "Domyślna rola",
+      "systemAccess": "Dostęp do systemu",
+      "authMethod": "Metoda uwierzytelniania",
+      "dateCreated": "Data utworzenia",
+      "apiUser": "Użytkownik API",
+      "unverified": "Niesprawdzony",
+      "selfRegistered": "Zarejestrowany samodzielnie",
+      "role_placeholder": "Wybierz rolę",
+      "usersCreated": "Utworzono użytkowników",
+      "groups": "Grupy",
+      "apiAccess": "Dostęp do API",
+      "requiredForAdmin": "wymagane dla administratora",
+      "account": "Konto",
+      "accountHistory": "Historia konta",
+      "activity": "Działalność",
+      "lastActive": "Ostatnio aktywny",
+      "theme": "Temat",
+      "locale": "Język",
+      "timezone": "Strefa czasowa",
+      "itemsPerPage": "Liczba elementów na stronę",
+      "notificationMode": "Powiadomienia",
+      "value": "Wartość",
+      "key": "Klawisz",
+      "configurationDetails": "Szczegóły konfiguracji",
+      "isActive": "Aktywny",
+      "members": "Członkowie",
+      "milestoneTypes": "Typy kamieni milowych",
+      "milestones": "Kamienie milowe",
+      "createdAt": "Utworzono w",
+      "completedOn": "Zakończono dnia",
+      "variants": "Warianty",
+      "emailVerified": "E-mail zweryfikowany",
+      "issueTracker": "Śledzenie problemów",
+      "caseFields": "Pola przypadku",
+      "resultFields": "Pola wyników",
+      "displayName": "Nazwa wyświetlana",
+      "hint": "Wskazówka",
+      "required": "Wymagany",
+      "restricted": "Ograniczony",
+      "fieldType": "Typ pola",
+      "templates": "Szablony",
+      "started": "Rozpoczęto",
+      "startDate": "Data rozpoczęcia",
+      "automated": "Zautomatyzowany",
+      "manual": "Podręcznik",
+      "notAutomated": "Niezautomatyzowane",
+      "testRuns": "Testy biegowe",
+      "title": "Tytuł",
+      "project": "Projekt",
+      "priority": "Priorytet",
+      "integration": "Integracja",
+      "lastSyncedAt": "Ostatnia synchronizacja",
+      "externalKey": "Klucz zewnętrzny",
+      "initialHeight": "Wysokość początkowa",
+      "minValue": "Wartość minimalna",
+      "maxValue": "Maksymalna wartość",
+      "minIntegerValue": "Minimalna wartość całkowita",
+      "maxIntegerValue": "Maksymalna wartość całkowita",
+      "defaultValue": "Wartość domyślna",
+      "checked": "Sprawdzony",
+      "version": "Wersja",
+      "issues": "Kwestie",
+      "internalIssues": "Problemy wewnętrzne",
+      "externalIssues": "{provider} Problemy",
+      "data": "Dane",
+      "note": "Notatka",
+      "externalId": "Identyfikator zewnętrzny",
+      "forecast": "Prognoza",
+      "forecastManual": "Podręcznik prognozy",
+      "forecastAutomated": "Prognoza automatyczna",
+      "executedAt": "Wykonano w",
+      "className": "Klasa",
+      "suiteName": "Apartament",
+      "duration": "Czas trwania",
+      "session": "Sesja",
+      "charter": "Czarter",
+      "summary": "Streszczenie",
+      "progress": "Postęp",
+      "assertions": "Twierdzenia",
+      "properties": "Właściwości",
+      "systemOutput": "Dzienniki przypadków testowych",
+      "systemError": "Błąd systemu",
+      "resultStatus": "Wynik",
+      "links": "Spinki do mankietów",
+      "id": "ID",
+      "JUNIT": "Importowanie JUnit",
+      "API": "API",
+      "folder": "Falcówka",
+      "parentFolder": "Folder nadrzędny dla nowych spraw",
+      "multipleValues": "Wiele wartości",
+      "provider": "Dostawca",
+      "updatedAt": "Zaktualizowano w",
+      "tools": "Narzędzia",
+      "codeRepository": "Repozytorium kodu",
+      "aiModels": "Domyślny LLM",
+      "configKeys": {
+        "edit_results_duration": "Edytuj czas trwania wyników",
+        "project_docs_default": "Domyślne dokumenty projektu",
+        "notificationSettings": "Globalne ustawienie powiadomień",
+        "elasticsearch_replicas": "Repliki Elasticsearch"
+      },
+      "options": {
+        "label": "Etykieta",
+        "validation": {
+          "empty": "Opcja nie może być pusta",
+          "invalidChars": "Opcja zawiera nieprawidłowy znak: „{char}”",
+          "duplicate": "Opcja musi być unikalna",
+          "systemNameError": "Nazwa systemu jest nieprawidłowa",
+          "initialHeightMax": "Wysokość początkowa nie może być większa niż 600px.",
+          "displayNameRequiredResult": "Wprowadź nazwę wyświetlaną dla Pola Wyniku.",
+          "displayNameRequiredCase": "Wprowadź nazwę wyświetlaną dla pola sprawy.",
+          "minValueMaxValue": "Wartość minimalna musi być mniejsza od wartości maksymalnej, a jeśli ustawiono jedną, obie muszą zostać ustawione.",
+          "minMaxValueInteger": "Minimalna wartość całkowita musi być mniejsza niż maksymalna wartość całkowita, a jeśli ustawiono jedną, obie muszą zostać ustawione.",
+          "systemNameRequired": "Nazwa systemu nie może być pusta.",
+          "systemNameRegex": "Nazwa systemu musi zaczynać się od litery i może zawierać wyłącznie litery, cyfry i znaki podkreślenia.",
+          "fieldTypeRequired": "Typ pola jest wymagany."
+        }
+      },
+      "placeholders": {
+        "key": "Klawisz Enter",
+        "value": "Wprowadź wartość",
+        "addVariant": "Dodaj wariant",
+        "addCategory": "Dodaj kategorię",
+        "displayName": "Wprowadź nazwę wyświetlaną",
+        "systemName": "Wprowadź nazwę systemu",
+        "hint": "Wprowadź wskazówkę"
+      },
+      "hints": {
+        "systemName": "Nazwa systemu musi być unikatowa i zawierać wyłącznie litery, cyfry i znaki podkreślenia",
+        "fieldType": "(Typu pola nie można zmienić po jego utworzeniu)"
+      },
+      "validation": {
+        "nameRequired": "Imię jest wymagane",
+        "stateRequired": "Stan jest wymagany",
+        "urlRequired": "Adres URL jest wymagany",
+        "invalidUrl": "Nieprawidłowy format adresu URL"
+      }
+    },
+    "filter": {
+      "placeholder": "Filtr {item}..."
+    },
+    "access": {
+      "admin": "Administrator",
+      "projectAdmin": "Administrator projektu",
+      "user": "Użytkownik",
+      "none": "Nic"
+    },
+    "validation": {
+      "required": "Proszę wpisać {field}",
+      "invalidDuration": "Proszę wprowadzić prawidłowy czas trwania",
+      "maxDuration": "Czas trwania nie może przekroczyć {max} minut",
+      "minLength": "{field} musi mieć co najmniej {min} znaków",
+      "emailFormat": "Nieprawidłowy format adresu e-mail",
+      "passwordMatch": "Hasła muszą być zgodne",
+      "unique": "{field} musi być unikalny",
+      "roleRequired": "Rola jest wymagana",
+      "nameMinLength": "Nazwa musi mieć co najmniej 2 znaki",
+      "invalidDurationFormat": "Nieprawidłowy format czasu trwania. Spróbuj czegoś takiego jak 30 min, 1 tydzień lub 1 godz. 25 min."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Potwierdź {action}",
+        "message": "Czy na pewno chcesz {action}?"
+      },
+      "confirmDelete": {
+        "description": "Czy na pewno chcesz usunąć ten element? Tej czynności nie można cofnąć."
+      },
+      "assign": {
+        "title": "Przypisz przypadek testowy",
+        "description": "Przypisz użytkownikowi przypadek testowy „{testCase}”",
+        "selectUser": "Wybierz użytkownika"
+      },
+      "assignBulk": {
+        "title": "Masowe przypisywanie przypadków testowych",
+        "description": "Przypisz {count, plural, one {# wybrany przypadek testowy} other {# wybrane przypadki testowe}} użytkownikowi"
+      },
+      "complete": {
+        "title": "Pełny przebieg testu",
+        "description": "Czy na pewno chcesz ukończyć ten test?",
+        "warning": "Po zakończeniu testu nie będzie można go modyfikować.",
+        "apple": {
+          "title": "Skonfiguruj logowanie Apple",
+          "description": "Skonfiguruj swoje dane logowania Apple. Możesz je uzyskać w Portalu dla programistów Apple.",
+          "clientId": "Identyfikator usługi",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "Identyfikator zespołu",
+          "teamIdPlaceholder": "Twój 10-znakowy identyfikator zespołu",
+          "keyId": "Identyfikator klucza",
+          "keyIdPlaceholder": "Twój 10-znakowy identyfikator klucza",
+          "privateKey": "Klucz prywatny",
+          "privateKeyPlaceholder": "Wklej tutaj zawartość swojego klucza prywatnego .p8",
+          "instructions": {
+            "title": "Instrukcje konfiguracji:",
+            "step1": "Przejdź do portalu dla programistów Apple",
+            "step2": "Utwórz identyfikator usługi i skonfiguruj logowanie za pomocą Apple",
+            "step3": "Utwórz klucz do logowania za pomocą Apple",
+            "step4": "Pobierz plik klucza prywatnego .p8",
+            "step5": "Dodaj następujący adres URL przekierowania:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Wszystkie pola są wymagane"
+          }
+        }
+      },
+      "delete": {
+        "title": "Usuń {item}",
+        "description": "Czy na pewno chcesz usunąć {name}?",
+        "warning": "Tej czynności nie można cofnąć. Spowoduje to trwałe usunięcie elementu {item}."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Element został pomyślnie usunięty",
+      "deleteError": "Wystąpił błąd podczas usuwania elementu",
+      "moveSuccess": "Przedmiot został pomyślnie przeniesiony",
+      "moveError": "Wystąpił błąd podczas przenoszenia elementu",
+      "updateSuccess": "Element zaktualizowany pomyślnie",
+      "updateError": "Wystąpił błąd podczas aktualizacji elementu",
+      "linkCopied": "Link skopiowany do schowka",
+      "copyFailed": "Nie udało się skopiować linku do schowka",
+      "created": "Test został pomyślnie utworzony",
+      "createdDescription": "Test został utworzony i jest teraz widoczny na liście testów.",
+      "createError": "Wystąpił nieznany błąd. Spróbuj ponownie.",
+      "emptyActive": "Brak aktywnych przebiegów testowych",
+      "emptyCompleted": "Brak ukończonych przebiegów testowych",
+      "projectUpdated": "Projekt pomyślnie zaktualizowany",
+      "projectUpdateError": "Wystąpił błąd podczas aktualizacji projektu",
+      "noProjects": "Nie znaleziono projektów"
+    },
+    "placeholders": {
+      "email": "Adres e-mail",
+      "name": "Wprowadź nazwę",
+      "mission": "Opisz swoją misję...",
+      "selectMilestone": "Wybierz kamień milowy",
+      "selectStatus": "Wybierz status",
+      "selectTemplate": "Wybierz szablon",
+      "duration": "np. 1 godz. 30 min lub 90 min",
+      "docs": "Dodaj dokumentację...",
+      "select": "Wybierać",
+      "selectState": "Wybierz stan",
+      "selectConfiguration": "Wybierz konfigurację",
+      "selectConfigurations": "Wybierz konfiguracje",
+      "selectOption": "Wybierz opcję",
+      "date": "Wybierz datę",
+      "selectEncoding": "Wybierz kodowanie...",
+      "selectATemplate": "Wybierz szablon...",
+      "selectVersion": "Wybierz wersję",
+      "selectAModel": "Wybierz model",
+      "selectWorkflowType": "Wybierz typ przepływu pracy",
+      "addAnOption": "Dodaj opcję",
+      "addADescription": "Dodaj opis...",
+      "optionalDescription": "Opis opcjonalny...",
+      "projectNotes": "Notatki dotyczące projektu...",
+      "filterByName": "Filtruj według nazwy...",
+      "filterByValue": "Filtruj według wartości...",
+      "selectOperator": "Wybierz operatora",
+      "searchIcons": "Szukaj ikon...",
+      "value": "Wartość",
+      "stepCount": "Liczba kroków",
+      "enterText": "Wprowadź tekst...",
+      "enterUrl": "Wprowadź adres URL",
+      "issueIdExample": "WYDANIE-123",
+      "selectPriorityValuesOrEmpty": "Wybierz wartości priorytetowe (lub pozostaw puste dla wszystkich)"
+    },
+    "errors": {
+      "error": "Błąd",
+      "somethingWentWrong": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.",
+      "emailRequired": "Podaj swój adres e-mail.",
+      "emailInvalid": "To nie jest prawidłowy adres e-mail.",
+      "passwordRequired": "Hasło jest wymagane.",
+      "confirmPasswordRequired": "Potwierdź swoje hasło.",
+      "passwordDoesNotMeetPolicy": "Hasło nie spełnia wymogów bezpieczeństwa.",
+      "passwordsDoNotMatch": "Hasła nie pasują",
+      "nameRequired": "Proszę podać swoje pełne imię i nazwisko",
+      "duplicate": "Proszę wybrać unikalną nazwę.",
+      "userExists": "Użytkownik już istnieje.",
+      "unknown": "Wystąpił nieznany błąd.",
+      "invalidCredentials": "Nieprawidłowa nazwa użytkownika lub hasło",
+      "projectNotFound": "Projekt nie znaleziony",
+      "projectNotFoundDescription": "Projekt, którego szukasz nie istnieje lub nie masz do niego dostępu.",
+      "tokenRequired": "Wprowadź swój token weryfikacyjny e-mail lub kliknij link w wiadomości e-mail.",
+      "noSuccessStatus": "Nie wybrano statusu powodzenia",
+      "missingTestRunCase": "Brak identyfikatora przypadku testu",
+      "fieldRequired": "To pole jest wymagane",
+      "projectNameExists": "Projekt o tej nazwie już istnieje",
+      "defaultNotFound": "Nie znaleziono wartości domyślnej",
+      "emailExists": "Użytkownik o tym adresie e-mail już istnieje",
+      "nameExists": "Użytkownik o tej nazwie już istnieje",
+      "duplicateValue": "Ta wartość jest już używana",
+      "unauthorized": "Nie masz uprawnień do wykonania tej czynności.",
+      "accessDenied": "Odmowa dostępu",
+      "sessionNotFound": "Sesja nie została znaleziona lub jest nieprawidłowa.",
+      "issueTrackerNotConfigured": "W tym projekcie nie skonfigurowano modułu śledzenia problemów.",
+      "noUserSession": "Nie znaleziono sesji użytkownika",
+      "noProjectId": "Nie znaleziono identyfikatora projektu",
+      "unknownErrorWithMessage": "Wystąpił nieznany błąd. {message}",
+      "unauthenticated": "Użytkownik nie został uwierzytelniony",
+      "fetchFailed": "Nie udało się pobrać danych. Spróbuj ponownie później.",
+      "unsupportedFieldType": "Nieobsługiwany typ pola",
+      "notAuthenticated": {
+        "title": "Nie uwierzytelniono",
+        "message": "Aby wykonać tę czynność, musisz być zalogowany."
+      },
+      "failedToFetchAssignments": {
+        "title": "Nie udało się pobrać zadań",
+        "message": "Nie udało się pobrać zadań. Spróbuj ponownie później."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Problem został pomyślnie połączony",
+        "linkError": "Błąd podczas łączenia",
+        "unlinkedSuccess": "Problem został pomyślnie odłączony",
+        "unlinkError": "Błąd podczas rozłączania",
+        "noActiveIntegration": "Nie znaleziono aktywnej integracji dla tego projektu"
+      },
+      "roleRequiredForSpecificRole": "Rola jest wymagana, gdy typem dostępu jest Rola konkretna.",
+      "projectCreationFailed": "Utworzenie projektu nie powiodło się, nie zwrócono identyfikatora.",
+      "invalidRoleId": "Nieprawidłowy identyfikator roli",
+      "workflowStateExists": "Stan przepływu pracy już istnieje. Wybierz nową nazwę.",
+      "failedToLoadCaseData": "Nie udało się załadować danych sprawy. Nie można zapisać.",
+      "atLeastOneTagRequired": "Wymagany jest co najmniej jeden tag",
+      "atLeastOneIssueRequired": "Wymagany jest co najmniej jeden problem",
+      "atLeastOneOptionRequired": "Należy wybrać co najmniej jedną opcję",
+      "valueRequired": "Wartość jest wymagana",
+      "contentRequired": "Treść jest wymagana",
+      "invalidContentFormat": "Nieprawidłowy format zawartości",
+      "caseNameRequired": "Proszę podać nazwę przypadku testowego",
+      "caseStateRequired": "Proszę wybrać stan",
+      "caseFolderRequired": "Proszę wybrać folder",
+      "estimateTooLarge": "Oszacowanie jest zbyt duże",
+      "estimateRequiredValid": "Wymagane jest podanie szacunkowego czasu trwania (np. 1 godz. 30 min).",
+      "invalidDurationOrExceedsMax": "Nieprawidłowy format czasu trwania lub przekroczenie maksymalnego limitu (np. 1 godz. 30 min)",
+      "configurationNameExists": "Nazwa konfiguracji już istnieje. Wybierz inną nazwę.",
+      "variantNameExists": "Nazwa wariantu już istnieje. Wybierz inną nazwę.",
+      "categoryNameExists": "Nazwa kategorii już istnieje. Wybierz inną nazwę.",
+      "workflowStateNameExists": "Nazwa stanu przepływu pracy już istnieje. Wybierz inną nazwę.",
+      "folderNameRequired": "Proszę podać nazwę folderu",
+      "folderNameRequiredEnter": "Wprowadź nazwę folderu.",
+      "workflowStateNameRequired": "Proszę wprowadzić nazwę stanu przepływu pracy",
+      "roleNameEmpty": "Nazwa roli nie może być pusta",
+      "groupNameRequired": "Nazwa grupy jest wymagana",
+      "templateNameRequired": "Proszę podać nazwę szablonu",
+      "caseStateInvalid": "Proszę wybrać prawidłowy stan",
+      "caseTemplateRequired": "Proszę wybrać szablon",
+      "invalidContent": "Nieprawidłowa treść",
+      "milestoneNameRequired": "Proszę podać nazwę kamienia milowego",
+      "milestoneTypeRequired": "Proszę wybrać typ kamienia milowego",
+      "testRunNameMinLength": "Nazwa musi mieć co najmniej 2 znaki.",
+      "stateRequiredDot": "Podanie stanu jest wymagane.",
+      "milestoneTypeNameMinLength": "Nazwa typu kamienia milowego musi składać się co najmniej z 2 znaków.",
+      "projectNameRequired": "Nazwa projektu jest wymagana",
+      "workflowScopeRequired": "Proszę wybrać przepływ pracy dla stanu",
+      "workflowTypeRequired": "Proszę wybrać typ przepływu pracy",
+      "newTestCaseAdded": "Dodano nowy przypadek testowy",
+      "repositoryDeleted": "Repozytorium zostało usunięte",
+      "failedToDeleteRepository": "Nie udało się usunąć repozytorium",
+      "permissionDenied": "Nie masz uprawnień dostępu do tej strony.",
+      "resultSubmitPermissionDenied": "Nie możesz przesłać wyników dla tej sprawy. Poproś administratora projektu o jej przypisanie.",
+      "noModelsFound": "Nie znaleziono modeli",
+      "failedToFetchModels": "Nie udało się pobrać modeli",
+      "failedToCopyToClipboard": "Nie udało się skopiować do schowka",
+      "failedToLoadJobResults": "Nie udało się załadować wyników zadania",
+      "failedToUpdateRepositoryStatus": "Nie udało się zaktualizować statusu repozytorium"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "Panel",
+      "twoFactorVerification": "Weryfikacja dwuskładnikowa",
+      "changePassword": "Zmień hasło",
+      "twoFactorSetup": "Konfiguracja dwuskładnikowa",
+      "signUp": "Zapisać się",
+      "signIn": "Zalogować się",
+      "verifyEmail": "Zweryfikuj adres e-mail",
+      "trialExpired": "Okres próbny wygasł",
+      "linkSsoAccount": "Połącz konto SSO",
+      "userProfile": "Profil użytkownika",
+      "users": "Użytkownicy",
+      "issues": "Kwestie",
+      "tags": "Tagi",
+      "tagDetails": "Szczegóły tagu",
+      "aiModels": "Modele AI",
+      "integrations": "Integracje",
+      "quickscript": "QuickScript",
+      "webhooks": "Webhooki",
+      "shares": "Akcje",
+      "repository": "Magazyn",
+      "testCaseVersion": "Wersja przypadku testowego",
+      "duplicateTestCases": "Duplikaty przypadków testowych",
+      "documentation": "Dokumentacja",
+      "sharedSteps": "Wspólne kroki",
+      "stepDuplicates": "Duplikaty kroków",
+      "sessions": "Sesje",
+      "sessionVersion": "Wersja sesji",
+      "milestones": "Kamienie milowe",
+      "testRuns": "Testy biegowe",
+      "reports": "Raporty",
+      "adminSamlConfig": "Administrator – Konfiguracja SAML",
+      "apiDocumentation": "Dokumentacja API",
+      "sharedContent": "Udostępniana treść"
+    },
+    "aria": {
+      "userMenu": "Menu użytkownika",
+      "search": "Szukaj",
+      "helpMenu": "Menu pomocy",
+      "help": "Pomoc",
+      "grouped": "Zgrupowane",
+      "group": "Grupa",
+      "selectAll": "Zaznacz wszystko",
+      "selectRow": "Wybierz wiersz",
+      "removeIssue": "Usuń problem",
+      "selectDeselectAllAddEdit": "Zaznacz/Odznacz wszystko Dodaj/Edytuj",
+      "selectDeselectAllDelete": "Zaznacz/Odznacz wszystko Usuń",
+      "selectDeselectAllClose": "Zaznacz/Odznacz wszystko Zamknij",
+      "clearFilter": "Wyczyść filtr",
+      "olderVersion": "Starsza wersja",
+      "newerVersion": "Nowsza wersja",
+      "deletedUser": "Usunięty użytkownik",
+      "restrictedField": "Pole ograniczone",
+      "backToTestCase": "Powrót do przypadku testowego"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Projekt} other {# Projekty}}",
+      "templates": "Szablony i pola",
+      "workflows": "Przepływy pracy",
+      "statuses": "Statusy",
+      "roles": "Role",
+      "unknownRole": "Nieznana rola",
+      "unknownGroup": "Nieznana grupa",
+      "file": "plik",
+      "files": "akta",
+      "existingAttachments": "Istniejące załączniki",
+      "new": "Nowy",
+      "noElapsedTime": "Brak zarejestrowanego czasu",
+      "untested": "Nieprzetestowane",
+      "noResults": "Brak wyników",
+      "resultsWithNoElapsedTime": "Brak zarejestrowanego czasu dla wyników",
+      "total": "Całkowity",
+      "noCases": "Brak przypadków testowych",
+      "unknown": "Nieznany",
+      "selectedTestCases": "Wybrane przypadki testowe",
+      "editToModifyCasesTitle": "Tej listy nie można modyfikować.",
+      "editToModifyCases": "Edytuj przebieg testu i kliknij Wybrane przypadki testowe, aby zmodyfikować listę.",
+      "noTestCasesSelected": "Nie wybrano przypadków testowych",
+      "editToSelectTestCases": "Edytuj przebieg testu, aby wybrać przypadki testowe.",
+      "casesInRun": "{count, plural, =0 {Brak przypadków testowych w przebiegu testu} =1 {1 przypadek testowy w przebiegu testu} other {# przypadków testowych w przebiegu testu}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Unikalny przypadek} other {# Unikalne przypadki}} w poprzek {configCount, plural, =1 {1 Konfiguracja} other {# Konfiguracje}} ({totalCount} całkowita liczba przypadków)",
+      "viewTestRunDetails": "Wyświetl szczegóły testu",
+      "sortByStatus": "Grupuj według statusu",
+      "sortByDate": "Sortuj według daty",
+      "testRuns": "{count, plural, =0 {Brak przebiegów testowych} =1 {1 przebieg testowy} other {# przebiegów testowych}}",
+      "sessions": "{count, plural, =0 {Brak sesji} =1 {1 sesja} other {# sesji}}",
+      "noOptions": "Brak dostępnych opcji",
+      "multiConfiguration": "Część grupy wielokonfiguracyjnej",
+      "otherConfigurations": "Inne konfiguracje",
+      "selected": "Wybrano: {count}",
+      "defaultProjectAccess": "Domyślny dostęp do projektu",
+      "defaultAccessType": "Domyślny typ dostępu",
+      "assignedUsersCount": "{count, plural, =0 {Nie przypisano żadnych użytkowników} =1 {# Przypisano użytkowników} other {# Przypisano użytkowników}}",
+      "successRate": "Wskaźnik sukcesu",
+      "unassigned": "Nieprzypisane",
+      "testRunName": "Nazwa przebiegu testu",
+      "estimatesEllipsis": "Szacunki...",
+      "access": {
+        "noAccess": "Dostęp wzbroniony",
+        "globalRole": "Użyj roli globalnej",
+        "specificRole": "Konkretna rola",
+        "projectDefault": "Projekt domyślny",
+        "usersGlobalRole": "Globalna rola użytkownika"
+      },
+      "unknownUser": "Nieznany użytkownik",
+      "unknownProject": "Nieznany projekt",
+      "unknownTag": "Nieznany tag",
+      "filesSelectedForUpload": "{count, plural, =1 {Wybrano 1 plik do przesłania} other {Wybrano # plików do przesłania}}"
+    },
+    "empty": {
+      "description": "Brak opisu",
+      "documentation": "Brak dokumentacji",
+      "childMilestones": "Brak kamieni milowych dla dzieci",
+      "sessions": "Brak sesji",
+      "activeSessions": "Brak aktywnych sesji",
+      "completedSessions": "Brak ukończonych sesji",
+      "testCase": "Nie znaleziono przypadku testowego",
+      "noTestCasesOrSessions": "Nie znaleziono przypadków testowych ani sesji",
+      "noTestCasesSessionsOrRuns": "Nie znaleziono przypadków testowych, sesji ani przebiegów"
+    },
+    "or": "Lub",
+    "for": "Do",
+    "and": "I",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "Logo TestPlanIt",
+      "tagline": "Testuj wszystko pod słońcem"
+    },
+    "table": {
+      "columns": {
+        "columns": "Kolumny",
+        "required": "(wymagany)"
+      },
+      "filter": "Lista filtrów...",
+      "selectNone": "Wybierz Brak",
+      "sort": "Sortuj kolumnę",
+      "sortAscending": "Posortowane rosnąco",
+      "sortDescending": "Posortowane malejąco",
+      "sortNone": "Nie posortowano",
+      "resize": "Zmień rozmiar kolumny"
+    },
+    "pagination": {
+      "selectPage": "Wybierz stronę",
+      "morePages": "Więcej stron",
+      "goToPrevious": "Przejdź do poprzedniej strony",
+      "goToNext": "Przejdź do następnej strony",
+      "all": "Wszystkie przedmioty",
+      "entries": "{count, plural, =1 {# element} other {# elementy}}",
+      "pageSize": "Rozmiar strony",
+      "showing": "Seans",
+      "total": "suma {count, plural, =1 {# element} other {# elementy}}",
+      "filtered": "odfiltrowane z",
+      "pageOfPages": "Strona {current} z {total}"
+    },
+    "upload": {
+      "title": "Prześlij nowe zdjęcie profilowe",
+      "description": "Przeciągnij i upuść obraz lub kliknij przycisk poniżej, aby wybrać plik.",
+      "attachments": {
+        "title": "Prześlij załączniki",
+        "description": "Przeciągnij i upuść pliki lub kliknij przycisk poniżej, aby wybrać pliki.",
+        "selectFiles": "{count, plural, =0 {Wybierz pliki} one {1 Wybrany plik} other {# Wybrane pliki}}",
+        "selectFile": "{count, plural, =0 {Wybierz plik} other {1 Wybrany plik}}",
+        "filesSelected": "{count, plural, one {Wybrano 1 plik} other {Wybrano # plików}}",
+        "addMoreFiles": "Dodaj więcej plików...",
+        "replaceFile": "Zastąp plik...",
+        "invalidFileType": "Nieprawidłowy typ pliku. Dozwolone są tylko pliki {types} .",
+        "altText": {
+          "emoji": "emotikon"
+        },
+        "count": "{count, plural, =1 {# plik} other {# pliki}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Upuść plik CSV, aby zaimportować przypadki testowe",
+      "dropToImportTestResults": "Upuść plik, aby zaimportować wyniki testów",
+      "supportedCsvFormats": "Obsługiwane: .csv",
+      "supportedResultFormats": "Obsługiwane: .xml, .trx, .json",
+      "unsupportedFileType": "Nieobsługiwany typ pliku. Oczekiwano: {expected}",
+      "noFilesDetected": "Nie wykryto plików podczas upuszczania"
+    },
+    "editor": {
+      "setColor": "Ustaw kolor",
+      "enterUrl": "Wprowadź adres URL zawierający https://",
+      "uploadFile": "Prześlij plik",
+      "video": {
+        "controls": "Sterowanie odtwarzaczem wideo"
+      },
+      "image": {
+        "alignLeft": "Wyrównaj do lewej",
+        "alignCenter": "Wyrównaj do środka",
+        "alignRight": "Wyrównaj do prawej",
+        "sizeSmall": "Mały rozmiar",
+        "sizeMedium": "Średniej wielkości",
+        "sizeLarge": "Duży rozmiar",
+        "sizeFull": "Pełna szerokość",
+        "resetSize": "Przywróć oryginalny rozmiar",
+        "rotate": "Obróć o 90°",
+        "delete": "Usuń obraz"
+      },
+      "table": {
+        "insertTable": "Wstaw tabelę",
+        "headerRow": "Wiersz nagłówka",
+        "addColumnBefore": "Dodaj kolumnę przed",
+        "addColumnAfter": "Dodaj kolumnę po",
+        "deleteColumn": "Usuń kolumnę",
+        "addRowBefore": "Dodaj wiersz przed",
+        "addRowAfter": "Dodaj wiersz po",
+        "deleteRow": "Usuń wiersz",
+        "deleteTable": "Usuń tabelę"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Dodaj akapit poniżej",
+        "clearFormatting": "Wyczyść formatowanie",
+        "copyToClipboard": "Kopiuj do schowka"
+      },
+      "textMenu": {
+        "bold": "Pogrubiony",
+        "italic": "italski",
+        "underline": "Podkreślać",
+        "strikethrough": "Przekreślenie",
+        "code": "Kod",
+        "codeBlock": "Blok kodu",
+        "highlightText": "Podświetl tekst",
+        "textColor": "Kolor tekstu",
+        "moreOptions": "Więcej opcji",
+        "subscript": "Indeks dolny",
+        "superscript": "Napisany u góry",
+        "alignLeft": "Wyrównaj do lewej",
+        "alignCenter": "Wyrównaj do środka",
+        "alignRight": "Wyrównaj do prawej",
+        "justify": "Uzasadniać",
+        "setLink": "Ustaw łącze",
+        "editLink": "Edytuj link",
+        "removeLink": "Usuń link",
+        "resetColorToDefault": "Przywróć kolor do domyślnego"
+      }
+    },
+    "ai": {
+      "title": "Asystent pisania AI",
+      "improveWriting": "Popraw pisanie",
+      "makeShorter": "Uczyń krótszym",
+      "makeLonger": "Zrób dłuższe",
+      "fixGrammar": "Napraw gramatykę",
+      "changeTone": "Zmień ton",
+      "professional": "Profesjonalny",
+      "casual": "Zwykły",
+      "formal": "Formalny",
+      "translate": "Tłumaczyć",
+      "english": "angielski",
+      "spanish": "hiszpański",
+      "french": "francuski",
+      "summarize": "Streszczać",
+      "addExamples": "Dodaj przykłady",
+      "originalText": "Oryginalny tekst",
+      "suggestion": "Sugestia AI",
+      "generating": "Generowanie sugestii...",
+      "noSuggestion": "Nie wygenerowano jeszcze żadnej sugestii.",
+      "acceptSuggestion": "Zaakceptuj sugestię",
+      "errors": {
+        "contentBlocked": "Treść została zablokowana przez filtry bezpieczeństwa. Spróbuj sformułować prośbę inaczej.",
+        "emptyContent": "Sztuczna inteligencja nie mogła wygenerować odpowiedzi. Spróbuj inaczej sformułować żądanie lub spróbuj ponownie później.",
+        "maxTokens": "Odpowiedź AI była za długa i została skrócona. Spróbuj wysłać krótsze zapytanie lub poproś o bardziej zwięzłą odpowiedź.",
+        "rateLimit": "Usługa AI jest tymczasowo niedostępna z powodu ograniczeń przepustowości. Spróbuj ponownie za kilka minut.",
+        "accessDenied": "Nie masz uprawnień do korzystania z funkcji sztucznej inteligencji w tym projekcie.",
+        "generic": "Przepraszamy, wystąpił błąd podczas przetwarzania Twojego żądania."
+      }
+    },
+    "by": "przez",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Spis treści",
+        "emptyMessage": "Zacznij dodawać nagłówki do swojego dokumentu …"
+      },
+      "carousel": {
+        "previousSlide": "Poprzedni slajd",
+        "nextSlide": "Następny slajd"
+      },
+      "dialog": {
+        "toggleFullScreen": "Przełącz pełny ekran"
+      },
+      "command": {
+        "title": "Menu poleceń",
+        "description": "Wyszukaj i wykonaj polecenia"
+      },
+      "breadcrumb": {
+        "more": "Więcej"
+      },
+      "clickToViewDetails": "Kliknij, aby zobaczyć szczegóły",
+      "clickToExpand": "Kliknij, aby rozwinąć",
+      "clickToCollapse": "Kliknij, aby zwinąć",
+      "search": {
+        "filters": "Filtry",
+        "noResultsFound": "Nie znaleziono wyników",
+        "loadingProjects": "Ładowanie projektów...",
+        "noProjectsFound": "Nie znaleziono projektów.",
+        "viewAllProjects": "Zobacz wszystkie projekty",
+        "states": "Stany",
+        "automationStatus": "Status automatyzacji",
+        "parent": "Roślina mateczna"
+      },
+      "issues": {
+        "errorLoadingDetails": "Błąd podczas ładowania szczegółów problemu: ",
+        "updated": "Zaktualizowano: ",
+        "openInJira": "Otwórz w Jira",
+        "openInExternalSystem": "Otwórz za {provider}",
+        "assignee": "Mandatariusz",
+        "status": "Status: ",
+        "clickToOpenInNewTab": "Kliknij, aby otworzyć w nowej karcie",
+        "url": "Adres URL: ",
+        "externalId": "Identyfikator zewnętrzny: ",
+        "viewIn": "Widok w",
+        "fieldType": "Typ pola: ",
+        "richTextContent": "Bogata treść tekstowa",
+        "invalidContent": "Nieprawidłowa treść",
+        "fieldInformation": "Informacje terenowe"
+      },
+      "onboarding": {
+        "skipTour": "Pomiń wycieczkę"
+      },
+      "charts": {
+        "resultsDistribution": "Dystrybucja wyników",
+        "statusTimeline": "Oś czasu statusu",
+        "testDurationHistogram": "Histogram czasu trwania testu",
+        "zoomDonutChart": "Wykres pierścieniowy Zoom",
+        "zoomStatusTimeline": "Oś czasu statusu powiększenia",
+        "zoomHistogramChart": "Wykres histogramu powiększenia",
+        "duration": "Czas trwania: {seconds} sekund",
+        "durationLabel": "Czas trwania"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Ładowanie informacji o śledzeniu problemów...",
+      "enterDocumentation": "Wprowadź dokumentację...",
+      "noAutomatedTestResults": "Nie znaleziono wyników automatycznego testu dla tego przebiegu."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {minuta} other {minuta}}",
+      "seconds": "{count, plural, =1 {sekunda} other {sekund}}"
+    },
+    "units": {
+      "time": "Czas"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {przypadek} other {przypadki}}",
+      "result": "{count, plural, =1 {wynik} other {wyniki}}",
+      "run": "{count, plural, =1 {biegnij} other {biegnij}}",
+      "comment": "{count, plural, =1 {{count} komentarz} other {{count} komentarze}}"
+    },
+    "success": {
+      "assigned": "Przypadek testowy przypisany pomyślnie",
+      "unassigned": "Przypadek testowy został pomyślnie anulowany",
+      "bulkAssigned": "{count, plural, one {# przypadek testowy} other {# przypadki testowe}} przypisano pomyślnie",
+      "bulkUnassigned": "{count, plural, one {# przypadek testowy} other {# przypadki testowe}} pomyślnie nieprzypisane"
+    },
+    "tabs": {
+      "general": "Ogólny",
+      "settings": "Ustawienia"
+    },
+    "selectFilter": "Aby wyświetlić przypadki testowe, wybierz wartość filtru.",
+    "invalidProject": "Nieprawidłowy identyfikator projektu.",
+    "visualization": "Wyobrażanie sobie",
+    "results": "Wyniki",
+    "loading": "Załadunek..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Utwórz nowe konto",
+      "sso": {
+        "title": "Zaloguj się za pomocą SSO",
+        "googleOAuth": "Kontynuuj z Google",
+        "apple": "Kontynuuj z Apple",
+        "microsoft": "Kontynuuj z Microsoft",
+        "samlProvider": "Zaloguj się za pomocą {name}",
+        "magicLink": "Zaloguj się za pomocą Magic Link",
+        "emailLogin": "Kontynuuj z e-mailem"
+      },
+      "magicLink": {
+        "description": "Podaj swój adres e-mail, a wyślemy Ci bezpieczny link do logowania. Hasło nie jest wymagane. Musisz już posiadać konto.",
+        "emailPlaceholder": "Podaj swój adres e-mail",
+        "sendLink": "Wyślij magiczny link",
+        "sending": "Przesyłka...",
+        "checkEmail": "Sprawdź swoją pocztę e-mail",
+        "success": "Jeśli masz konto, wysłaliśmy magiczny link na adres {email} . Kliknij link w wiadomości e-mail, aby się zalogować.",
+        "error": "Nie udało się wysłać magicznego linku. Spróbuj ponownie.",
+        "backToSignIn": "Powrót do logowania"
+      },
+      "twoFactor": {
+        "title": "Uwierzytelnianie dwuskładnikowe",
+        "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej lub użyj kodu zapasowego."
+      },
+      "troubleSigningIn": "Masz problemy z zalogowaniem?",
+      "contactAdmin": "Skontaktuj się z administratorem systemu"
+    },
+    "errors": {
+      "accessDenied": "Dostęp zabroniony. Twoje konto może być nieaktywne lub nie masz uprawnień do logowania.",
+      "configuration": "Wystąpił problem z konfiguracją serwera.",
+      "verification": "Token weryfikacyjny wygasł lub został już użyty.",
+      "invalid2FACode": "Nieprawidłowy kod weryfikacyjny. Spróbuj ponownie.",
+      "twoFactorTokenRequired": "Token jest wymagany",
+      "verificationCodeRequired": "Wymagany jest kod weryfikacyjny"
+    },
+    "signup": {
+      "description": "Wprowadź swoje dane, aby utworzyć nowe konto.",
+      "signIn": "Zaloguj się na swoje istniejące konto.",
+      "registrationDisabled": "Aby utworzyć konto, skontaktuj się z administratorem.",
+      "errors": {
+        "emailRequired": "Adres e-mail jest wymagany",
+        "passwordRequired": "Hasło nie spełnia wymagań bezpieczeństwa",
+        "confirmPasswordRequired": "Potwierdź, że hasło jest wymagane",
+        "passwordsDoNotMatch": "Hasła nie pasują",
+        "domainRestricted": "Rejestracja jest ograniczona do zatwierdzonych domen e-mail. Jeśli uważasz, że to błąd, skontaktuj się z administratorem."
+      }
+    },
+    "verifyEmail": {
+      "title": "Zweryfikuj adres e-mail",
+      "loading": "Weryfikowanie adresu e-mail...",
+      "success": "Adres e-mail zweryfikowany pomyślnie",
+      "error": "Nie udało się zweryfikować adresu e-mail",
+      "expired": "Link weryfikacyjny wygasł",
+      "invalid": "Nieprawidłowy link weryfikacyjny",
+      "alreadyVerified": "Adres e-mail został już zweryfikowany",
+      "toast": {
+        "verifySuccess": {
+          "description": "Możesz teraz zalogować się na swoje konto."
+        },
+        "verifyError": {
+          "description": "Wystąpił błąd podczas weryfikacji adresu e-mail"
+        },
+        "resendSuccess": {
+          "title": "Wysłano link weryfikacyjny e-mail",
+          "description": "Sprawdź swoją skrzynkę e-mail, aby znaleźć link weryfikacyjny."
+        },
+        "resendError": {
+          "title": "Nie udało się wysłać linku weryfikacyjnego e-mail",
+          "description": "Wystąpił błąd podczas wysyłania linku weryfikacyjnego e-mail."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Skonfiguruj uwierzytelnianie dwuskładnikowe",
+      "description": "Twoja organizacja wymaga uwierzytelniania dwuskładnikowego. Skonfiguruj je, aby kontynuować.",
+      "backupDescription": "Przed kontynuowaniem zapisz kody zapasowe",
+      "required": "Polityka bezpieczeństwa Twojej organizacji wymaga uwierzytelniania dwuskładnikowego.",
+      "loading": "Przygotowywanie konfiguracji...",
+      "manualEntry": "Lub wprowadź ten kod ręcznie:",
+      "verifyLabel": "Kod weryfikacyjny",
+      "verify": "Zweryfikuj i włącz",
+      "backupCodesInfo": "Zapisz te kody w bezpiecznym miejscu. Będziesz mógł ich użyć do uzyskania dostępu do swojego konta, jeśli zgubisz urządzenie uwierzytelniające.",
+      "copyCodes": "Skopiuj wszystkie kody",
+      "continue": "Kontynuuj logowanie"
+    },
+    "twoFactorVerify": {
+      "title": "Zweryfikuj swoją tożsamość",
+      "description": "Aby kontynuować, wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+      "backupCodeLabel": "Kod zapasowy",
+      "backupCodeHint": "Możesz również wprowadzić 8-znakowy kod zapasowy",
+      "useAuthenticator": "Zamiast tego użyj kodu uwierzytelniającego",
+      "useBackupCode": "Zamiast tego użyj kodu zapasowego",
+      "signOut": "Wyloguj się i użyj innego konta"
+    },
+    "forceChangePassword": {
+      "title": "Zmień swoje hasło",
+      "adminDescription": "Administrator wymaga zmiany hasła.",
+      "expiredDescription": "Twoje hasło wygasło. Ustaw nowe hasło, aby kontynuować.",
+      "newPasswordLabel": "Nowe hasło",
+      "confirmPasswordLabel": "Potwierdź nowe hasło",
+      "submitButton": "Zmień hasło",
+      "signOut": "Zamiast tego wyloguj się",
+      "passwordsMustMatch": "Hasła nie są takie same.",
+      "passwordRequired": "Hasło jest wymagane.",
+      "genericError": "Wystąpił błąd. Spróbuj ponownie.",
+      "policyTitle": "Wymagania dotyczące hasła:",
+      "policyMinLength": "Co najmniej {count} znaków",
+      "policyUppercase": "Co najmniej jedna wielka litera",
+      "policyLowercase": "Co najmniej jedna mała litera",
+      "policyNumbers": "Co najmniej jedna liczba",
+      "policySpecialChars": "Co najmniej jeden znak specjalny ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "Połącz konto SSO",
+      "description": "Połącz swoje konto z dostawcą usługi Single Sign-On",
+      "availableProviders": "Dostępni dostawcy SSO",
+      "linkWithGoogle": "Połącz z Google",
+      "linkWithSaml": "Połącz z {name}",
+      "accountLinked": "Konto zostało pomyślnie połączone",
+      "linkingFailed": "Nie udało się połączyć konta",
+      "noProvidersAvailable": "Obecnie nie ma dostępnych dostawców SSO umożliwiających łączenie",
+      "linkingInfo": "Powiązanie dostawcy usługi SSO umożliwia logowanie się za pomocą tego dostawcy zamiast hasła. Dane Twojego konta pozostaną niezmienione.",
+      "signInWithGoogle": "Zaloguj się za pomocą Google",
+      "enterpriseSamlSso": "Enterprise SAML SSO",
+      "linkProvider": "Dostawca łącza",
+      "linking": "Łączenie...",
+      "noProvidersContactAdmin": "Obecnie nie ma dostępnych dostawców SSO. Skontaktuj się z administratorem."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Panel",
+      "admin": "Administracja",
+      "profile": "Profil"
+    },
+    "admin": {
+      "crossProjectReports": "Raporty międzyprojektowe"
+    },
+    "projects": {
+      "sections": {
+        "management": "Kierownictwo"
+      },
+      "menu": {
+        "repository": "Magazyn",
+        "runs": "Testy i wyniki"
+      },
+      "dropdown": {
+        "selectProject": "Wybierz projekt",
+        "selectProjectAriaLabel": "Wybierz projekt {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "Identyfikator projektu: {id}",
+      "active": "Projekt jest aktywny",
+      "completed": "Projekt zakończony"
+    },
+    "overview": {
+      "title": "Przegląd",
+      "currentMilestones": "Aktualne kamienie milowe",
+      "seeAllMilestones": "{count, plural, =1 {Zobacz # Kamień milowy} other {Zobacz wszystkie # Kamienie milowe}}",
+      "seeAllTestCases": "{count, plural, =1 {Zobacz # Przypadek testowy} other {Zobacz wszystkie # Przypadki testowe}}",
+      "latestTestCases": "Najnowsze przypadki testowe",
+      "createdOn": "Utworzono dnia",
+      "seeAllTags": "Zobacz wszystkie tagi",
+      "seeAllActiveSessions": "{count, plural, =1 {Zobacz # Aktywna sesja} other {Zobacz wszystkie # Aktywne sesje}}",
+      "latestSessions": "Najnowsze sesje",
+      "activeTestRuns": "Aktywne przebiegi testowe",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Zobacz # Aktywny przebieg testu} other {Zobacz wszystkie # Aktywne przebiegi testu}}",
+      "latestTestRuns": "Najnowsze testy",
+      "testCaseBreakdown": "Podział przypadków testowych",
+      "noTestCases": "Repozytorium projektu jest puste. Dodaj przypadki testowe za pomocą repozytorium.",
+      "noTestCasesPrefix": "Repozytorium projektu jest puste. Dodaj przypadki testowe za pomocą",
+      "noTestCasesLink": "Magazyn"
+    },
+    "icon": {
+      "upload": {
+        "title": "Prześlij ikonę projektu",
+        "description": "Prześlij obraz kwadratowy (proporcje obrazu 1:1) o rozmiarze do 4 MB.",
+        "errors": {
+          "invalidFileType": "Dozwolone są wyłącznie pliki graficzne.",
+          "fileTooLarge": "Plik jest za duży. Maksymalny rozmiar to {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Zarządzaj ustawieniami dla {projectName}",
+      "moreSettingsComingSoon": "Więcej ustawień wkrótce",
+      "moreSettingsDescription": "Dodatkowe opcje konfiguracji projektu będą dostępne w przyszłych aktualizacjach",
+      "integrations": {
+        "description": "Zarządzaj integracją problemów stron trzecich dla tego projektu",
+        "availableIntegrations": "Dostępne integracje problemów",
+        "availableDescription": "Wybierz integrację problemu, aby połączyć ją z tym projektem",
+        "configuredIntegration": "Skonfigurowana integracja",
+        "noIntegrationAssigned": "Brak przypisanej integracji problemów",
+        "noIntegrationDescription": "Aby rozpocząć, wybierz integrację problemu z dostępnych opcji",
+        "selectIntegration": "Wybierz integrację problemu do skonfigurowania",
+        "integration": {
+          "assignError": "Nie udało się przypisać integracji problemu",
+          "updateSuccess": "Zaktualizowano ustawienia integracji",
+          "updateError": "Nie udało się zaktualizować ustawień integracji problemu",
+          "removeError": "Nie udało się usunąć integracji problemu",
+          "removeIntegration": "Usuń integrację",
+          "confirmRemove": "Potwierdź Usuń",
+          "authDescription": "Aby skorzystać z integracji tego problemu, należy uwierzytelnić się za pomocą {provider}",
+          "authenticating": "Uwierzytelnianie...",
+          "authSuccess": "Uwierzytelnianie pomyślne",
+          "selectProject": "Wybierz projekt {provider}",
+          "selectProjectPlaceholder": "Wybierz projekt do połączenia",
+          "linkedProject": "Powiązany projekt",
+          "loadProjectsError": "Nie udało się załadować projektów",
+          "settingsSaved": "Ustawienia integracji zostały pomyślnie zapisane",
+          "saveSettingsError": "Nie udało się zapisać ustawień integracji problemu",
+          "authorizationRequired": "Wymagana autoryzacja",
+          "authenticationError": "Uwierzytelnianie nie powiodło się. Spróbuj ponownie.",
+          "authorizationRequiredDescription": "Aby uzyskać dostęp do projektów zewnętrznych, musisz autoryzować integrację tego problemu",
+          "authorizationMessage": "Proszę o autoryzację integracji problemu, aby kontynuować",
+          "authorizeIntegration": "Autoryzuj {name}",
+          "integrationSettings": "Ustawienia {name}",
+          "integrationSettingsDescription": "Skonfiguruj ustawienia integracji problemów dla tego projektu",
+          "selectExternalProject": "Wybierz projekt zewnętrzny",
+          "refreshProjects": "Odśwież projekty",
+          "defaultIssueType": "Domyślny typ problemu",
+          "selectDefaultIssueType": "Wybierz domyślny typ problemu",
+          "defaultIssueTypeDescription": "Ten typ problemu będzie wstępnie wybierany podczas tworzenia nowych problemów",
+          "issueTypePlaceholder": "np. Błąd, Zadanie, Historia",
+          "defaultComponent": "Domyślny komponent",
+          "componentPlaceholder": "np. Frontend, Backend",
+          "automaticSync": "Automatyczna synchronizacja",
+          "automaticSyncDescription": "Automatyczna synchronizacja problemów między TestPlanIt a systemem zewnętrznym",
+          "simpleUrlDescription": "Ta integracja zgłoszeń wykorzystuje prosty wzorzec adresu URL do linkowania do zgłoszeń zewnętrznych. Zgłoszenia będą otwierane w nowej karcie z użyciem skonfigurowanego wzorca adresu URL.",
+          "externalProjectHelp": "Ustawia domyślny projekt do tworzenia nowych zgłoszeń z TestPlanIt. Nadal możesz łączyć i synchronizować zgłoszenia z innych projektów zewnętrznych – każde zgłoszenie śledzi swój własny projekt źródłowy.",
+          "linkedProjects": "Powiązane projekty zewnętrzne",
+          "linkedProjectsDescription": "Projekty zewnętrzne połączone poprzez tę integrację",
+          "noLinkedProjects": "Brak powiązanych projektów zewnętrznych",
+          "noLinkedProjectsDescription": "Dodaj projekt zewnętrzny, aby umożliwić wyszukiwanie problemów i synchronizację.",
+          "addProjects": "Dodaj projekty",
+          "addSelected": "Dodaj wybrane",
+          "setAsDefault": "Ustaw jako domyślne",
+          "removeProject": "Usuń projekt",
+          "removeProjectConfirmation": "Usunięcie tego projektu spowoduje zatrzymanie synchronizowania z nim problemów. Wcześniej zsynchronizowane problemy nie zostaną usunięte. Kontynuować?",
+          "removeProjectWebhookCascadeBullet": "Przychodzący webhook dla tego projektu również zostanie usunięty.",
+          "keepProject": "Zachowaj projekt",
+          "defaultIndicator": "Domyślny",
+          "syncStatusSyncing": "Synchronizacja",
+          "syncStatusCompleted": "Zsynchronizowane",
+          "syncStatusError": "Błąd synchronizacji",
+          "fanOutPartialFailure": "Nie udało się nawiązać połączenia z {count} projektami. Wyświetlane są wyniki z {successCount} projektów.",
+          "projectSelectorLabel": "Projekt",
+          "defaultIssueTypeHelp": "Podczas tworzenia nowych zgłoszeń w TestPlanIt, ten typ zgłoszenia zostanie automatycznie wybrany. Oszczędza to czas, jeśli zazwyczaj tworzysz zgłoszenia tego samego typu.",
+          "automaticSyncHelp": "Po włączeniu problemy będą automatycznie synchronizowane po wykryciu zmian w systemie zewnętrznym (za pośrednictwem webhooków). Synchronizacja ręczna jest zawsze dostępna.",
+          "removeWarningTitle": "Usunięcie tej integracji problemów spowoduje:",
+          "removeWarning1": "Odłącz wszystkie powiązane problemy od tej integracji problemów (problemy pozostają w bazie danych)",
+          "removeWarning2": "Usuń wszystkie ustawienia specyficzne dla integracji problemów dla tego projektu",
+          "removeWarning3": "Wymagana jest ponowna konfiguracja, jeśli chcesz ponownie skorzystać z integracji tego problemu",
+          "removeWarning4": "Usuń przychodzący webhook skonfigurowany dla tej integracji",
+          "switchIntegration": "Integracja przełączników",
+          "switchWarningTitle": "Przejście na inny model sztucznej inteligencji spowoduje:",
+          "switchWarning1": "Odłącz wszystkie problemy aktualnie powiązane z integracją bieżącego problemu",
+          "switchWarning2": "Zachowaj problemy w bazie danych (staną się niepowiązane)",
+          "switchWarning3": "Zastąp obecną konfigurację integracji problemów nową",
+          "switchWarning4": "Usuń przychodzący webhook skonfigurowany dla bieżącej integracji"
+        },
+        "integrationAssigned": "Integracja przypisana pomyślnie",
+        "integrationAssignError": "Nie udało się przypisać integracji problemu do projektu",
+        "integrationRemoved": "Integracja została pomyślnie usunięta",
+        "integrationRemoveError": "Nie udało się usunąć integracji problemu z projektu",
+        "add": {
+          "jira": {
+            "description": "Połącz swoje konto Jira, aby zarządzać zgłoszeniami bezpośrednio z TestPlanIt."
+          },
+          "simple_url": {
+            "description": "Połącz się z systemem zewnętrznym w celu śledzenia problemów."
+          },
+          "github": {
+            "description": "Połącz się z GitHubem, aby śledzić problemy i zarządzać repozytorium."
+          },
+          "gitlab": {
+            "description": "Połącz się z GitLab, aby śledzić zgłoszenia i prośby o scalenie."
+          },
+          "gitea": {
+            "description": "Połącz się z samodzielnie hostowaną instancją Gitea, Forgejo lub Gogs w celu śledzenia problemów."
+          },
+          "azure_devops": {
+            "description": "Połącz się z usługą Azure DevOps, aby śledzić elementy pracy."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Skonfiguruj przychodzące webhooki, aby zachować synchronizację powiązanych problemów.",
+        "inboundDescription": "Skonfiguruj przychodzące webhooki, aby zachować synchronizację powiązanych problemów.",
+        "outboundDescription": "Skonfiguruj webhooki wychodzące, aby wysyłać zdarzenia TestPlanIt do Slacka lub dowolnego adresu URL podpisanego HMAC.",
+        "directionInbound": "Przychodzące",
+        "directionOutbound": "Wychodzące",
+        "inboundAddButtonAllConfigured": "Karta przychodząca jest już skonfigurowana.",
+        "inboundAddButtonNoIntegration": "Przed dodaniem przychodzącego webhooka przypisz integrację problemu do tego projektu.",
+        "inboundEmptyWithIntegration": "Nie skonfigurowano żadnych przychodzących webhooków. <link>Dodaj jeden</link> , aby otrzymywać aktualizacje problemów z przypisanej integracji problemów.",
+        "inboundEmptyNoIntegration": "Do odbierania przychodzących aktualizacji zgłoszeń wymagana jest integracja <link>zgłoszeń</link> . Przypisz ją do swojego projektu, aby rozpocząć.",
+        "deliveriesEmptyNoConfigs": "Nie ma jeszcze żadnych dostaw webhooków — utwórz webhook przychodzący lub wychodzący na innych kartach, aby zacząć je odbierać.",
+        "noConfig": "Nie skonfigurowano żadnego webhooka",
+        "createButton": "Utwórz webhook",
+        "url": "Adres URL webhooka",
+        "urlHelp": "Wklej ten adres URL do konfiguracji webhooka narzędzia do śledzenia problemów.",
+        "secret": "Sekret webhooka",
+        "secretHelp": "Wklej ten sekret do konfiguracji webhooka narzędzia do śledzenia problemów.",
+        "revealedShownOnceWarning": "Skopiuj poniższy adres URL i klucz tajny — zostaną one wyświetlone tylko raz i nie będzie można ich później odzyskać.",
+        "secretMasked": "Ukryte — obróć, aby zobaczyć",
+        "rotateSecret": "Obróć sekret",
+        "rotateConfirmTitle": "Obrócić tajny webhook?",
+        "rotateConfirm": "Zmiana klucza tajnego spowoduje unieważnienie bieżącej konfiguracji w systemie śledzenia problemów do czasu jej aktualizacji. Kontynuować?",
+        "isActive": "Włączony",
+        "deleteConfirmTitle": "Usunąć konfigurację webhooka?",
+        "deleteConfirm": "Usunąć tę konfigurację webhooka? Dostawy przychodzące zostaną odrzucone.",
+        "sendTest": "Wyślij testowy webhook",
+        "testSuccess": "Zaakceptowano webhook testowy (HTTP {statusCode}, wynik: {outcome})",
+        "testFailure": "Nieudany test webhooka (HTTP {statusCode}): {error}",
+        "saveError": "Nie udało się zapisać konfiguracji webhooka",
+        "lastReceived": "Ostatnio odebrano: {timestamp}",
+        "lastReceivedLabel": "Ostatnio otrzymano:",
+        "lastReceivedNever": "Dostawy jeszcze nie zrealizowane",
+        "copyUrl": "Kopiuj adres URL webhooka",
+        "copySecret": "Kopiuj sekret webhooka",
+        "urlCopied": "Adres URL webhooka skopiowany do schowka",
+        "secretCopied": "Tajny kod webhooka skopiowany do schowka",
+        "nextSteps": "Następnie: wklej je do konfiguracji webhooka w systemie śledzenia zgłoszeń, a następnie kliknij „Wyślij testowy webhook” poniżej, aby zweryfikować potok. Kliknij „Gotowe” po zapisaniu tajnego hasła — nie będzie można go ponownie wyświetlić.",
+        "revealDone": "Zrobione",
+        "pageTitle": "Webhooki",
+        "inboundTab": "Przychodzące",
+        "outboundTab": "Wychodzące",
+        "outboundEmpty": "Brak skonfigurowanych webhooków wychodzących. Dodaj jeden, aby wysyłać zdarzenia TestPlanIt do Slacka lub dowolnego adresu URL podpisanego HMAC.",
+        "outboundAddButton": "Dodaj wychodzący webhook",
+        "outboundCreateTitle": "Nowy webhook wychodzący",
+        "outboundCreateName": "Nazwa",
+        "outboundCreateNameHelp": "Etykieta tego miejsca docelowego, np. „Slack inżynieryjny”.",
+        "outboundCreateNamePlaceholder": "Inżynieria Slack",
+        "outboundCreateNameRequired": "Imię jest wymagane.",
+        "outboundCreateUrlRequired": "Adres URL jest wymagany.",
+        "outboundCreateUrlInvalid": "Wprowadź prawidłowy adres URL (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "Adres URL musi używać protokołu HTTPS",
+        "outboundNameLabel": "Nazwa",
+        "outboundUnnamedConfig": "(nienazwany webhook)",
+        "outboundCreateUrl": "Adres URL",
+        "outboundCreateUrlHelp": "Adres URL docelowy. Adresy URL przychodzących webhooków Slack są wykrywane automatycznie.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Wykryto: Slack",
+        "outboundDetectedHmac": "Wykryto: Ogólny HMAC",
+        "adapterLabelSlack": "Luźny",
+        "adapterLabelGenericHmac": "Ogólny webhook HMAC",
+        "outboundCreateSubscriptionsTitle": "Subskrypcje",
+        "outboundCreateSubscriptionsHelp": "Wybierz zdarzenia, które mają być uruchamiane w tym miejscu docelowym. Możesz je później zmienić.",
+        "outboundSubsTestRunsAndSessions": "Testy i sesje",
+        "outboundSubsTestRuns": "Testy biegowe",
+        "outboundSubsSessions": "Sesje",
+        "eventVerbs": {
+          "duplicated": "Duplikat",
+          "stateChanged": "Stan zmieniony",
+          "resultAdded": "Wynik dodany"
+        },
+        "events": {
+          "testRunCreated": "Utworzono przebieg testowy",
+          "testRunStateChanged": "Zmieniono stan testu",
+          "testRunCompleted": "Zakończono jazdę próbną",
+          "testRunDuplicated": "Powtórzono przebieg testu",
+          "testRunResultAdded": "Dodano wynik testu",
+          "sessionCreated": "Sesja utworzona",
+          "sessionStateChanged": "Zmieniono stan sesji",
+          "sessionCompleted": "Sesja zakończona",
+          "sessionDuplicated": "Sesja zduplikowana",
+          "sessionResultAdded": "Dodano wynik sesji",
+          "issueCreated": "Utworzono problem",
+          "issueUpdated": "Zaktualizowano wydanie",
+          "issueDeleted": "Problem usunięty",
+          "caseCreated": "Utworzono sprawę",
+          "caseUpdated": "Sprawa zaktualizowana",
+          "caseDeleted": "Sprawa usunięta",
+          "jiraIssueCreated": "Utworzono problem w Jira",
+          "jiraIssueUpdated": "Zaktualizowano problem w Jira",
+          "jiraIssueDeleted": "Usunięto problem w Jira",
+          "githubIssues": "Wydarzenie związane z problemami GitHub",
+          "githubPullRequest": "Żądanie ściągnięcia GitHub",
+          "githubPush": "GitHub push",
+          "githubIssueComment": "Komentarz do problemu GitHub",
+          "adoWorkitemCreated": "Utworzono element roboczy usługi Azure DevOps",
+          "adoWorkitemUpdated": "Zaktualizowano element roboczy usługi Azure DevOps",
+          "adoWorkitemDeleted": "Usunięto element roboczy usługi Azure DevOps",
+          "webhookTest": "Wydarzenie testowe"
+        },
+        "outboundSubsIssues": "Kwestie",
+        "outboundSubsCases": "Sprawy",
+        "outboundSubsSelectAll": "Zaznacz wszystko w tej sekcji",
+        "outboundCreateSubmit": "Utwórz webhook",
+        "outboundCreateCancel": "Anulować",
+        "outboundCreateSuccess": "Utworzono webhook wychodzący.",
+        "outboundCreateError": "Nie udało się utworzyć webhooka wychodzącego.",
+        "outboundUrlLabel": "Adres URL docelowy",
+        "outboundActiveToggle": "Aktywny",
+        "outboundSlackHint": "Ten adres URL jest poufny — każdy, kto go zna, może publikować na Twoim kanale.",
+        "outboundHmacSecretsTitle": "Podpisywanie sekretów",
+        "outboundHmacActiveSecret": "Aktywny",
+        "outboundHmacInactiveSecret": "Nieaktywny",
+        "outboundHmacRetiringSecret": "Ustępujący",
+        "outboundHmacAutoRetireIn": "Automatyczne wycofanie za {days} dni",
+        "outboundHmacRotateButton": "Obróć sekret",
+        "outboundHmacExtendButton": "Przedłuż o 7 dni",
+        "outboundHmacRetireNowButton": "Przejdź na emeryturę teraz",
+        "outboundRotateConfirmTitle": "Obrócić tajny podpis?",
+        "outboundRotateConfirm": "Generowany jest nowy aktywny klucz tajny. Poprzedni klucz tajny jest podpisany przez 7 dni, podczas gdy użytkownicy aktualizują dane.",
+        "outboundRotateSuccess": "Sekret obrócony. Nowy tekst jawny jest wyświetlany poniżej.",
+        "outboundRotateError": "Nie udało się obrócić klucza tajnego.",
+        "outboundRetireConfirmTitle": "Wycofać się z tajemnicy już teraz?",
+        "outboundRetireConfirm": "Wycofywany sekret natychmiast przestaje podpisywać. Konsumenci, którzy nadal korzystają ze starego sekretu, odrzucą nowe ładunki.",
+        "outboundRetireSuccess": "Tajemnica wycofana.",
+        "outboundRetireError": "Nie udało się wycofać tajnego żądania.",
+        "outboundExtendSuccess": "Automatyczne przejście na emeryturę przedłużone o 7 dni.",
+        "outboundExtendError": "Nie udało się rozszerzyć tajnego klucza.",
+        "outboundSendTestButton": "Wyślij zdarzenie testowe",
+        "outboundSendTestQueued": "Zdarzenie testowe w kolejce — sprawdź, do kogo jest kierowana wiadomość.",
+        "outboundSendTestError": "Nie udało się dodać zdarzenia testowego do kolejki.",
+        "outboundDeleteButton": "Usuń webhook",
+        "outboundDeleteConfirmTitle": "Usunąć wychodzący webhook?",
+        "outboundDeleteConfirm": "Wszystkie przyszłe zdarzenia dla tego miejsca docelowego zostaną natychmiast zatrzymane.",
+        "outboundDeleteSuccess": "Webhook został usunięty.",
+        "outboundDeleteError": "Nie udało się usunąć webhooka.",
+        "outboundSecretCopy": "Kopiuj sekret",
+        "outboundSecretShownOnce": "Zapisz ten sekret już teraz — nie będzie można go już pokazać.",
+        "outboundSecretDone": "Zrobione",
+        "inboundAddButton": "Dodaj przychodzący webhook",
+        "inboundChooserTitle": "Wybierz adapter",
+        "inboundChooserDescription": "Wybierz system śledzenia zgłoszeń, który będzie wysyłał webhooki do TestPlanIt. Każdy projekt może mieć jeden przychodzący webhook w Jira, jeden w GitHub i jeden w Azure DevOps.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Już skonfigurowano",
+        "inboundChooserSubmit": "Kontynuować",
+        "inboundChooserCancel": "Anulować",
+        "inboundEmpty": "Brak skonfigurowanych webhooków przychodzących. Dodaj jeden, aby otrzymywać aktualizacje zgłoszeń z Jira, GitHub, GitLab, Gitea lub Azure DevOps.",
+        "inboundJiraTitle": "Jira inbound webhook",
+        "inboundGithubTitle": "GitHub przychodzący webhook",
+        "inboundGithubScopeHint": "Zdarzenia GitHub <code>dotyczące problemów</code> aktualizują powiązane problemy TestPlanIt. Zdarzenia pull request i komentarzy do problemów są akceptowane, ale nie aktualizują jeszcze problemów.",
+        "inboundGitlabTitle": "GitLab przychodzący webhook",
+        "inboundGitlabScopeHint": "Zdarzenia GitLab <code>Issue Hook</code> aktualizują powiązane zgłoszenia TestPlanIt. Akceptowane są inne typy zdarzeń, ale nie aktualizują zgłoszeń.",
+        "inboundGiteaTitle": "Gitea przychodzący webhook",
+        "inboundGiteaScopeHint": "Zdarzenia Gitea <code>zgłaszają problemy</code> i aktualizują powiązane problemy TestPlanIt. Inne typy zdarzeń są akceptowane, ale nie aktualizują problemów.",
+        "inboundAdoTitle": "Przychodzący webhook Azure DevOps",
+        "inboundAdoScopeHint": "Zdarzenia Azure DevOps <code>workitem.updated</code> aktualizują powiązane problemy TestPlanIt. Pozostałe zdarzenia są akceptowane, ale nie aktualizują problemów.",
+        "inboundAdoUsername": "Nazwa użytkownika",
+        "inboundAdoPassword": "Hasło",
+        "inboundAdoUsernamePlaceholder": "konto usługowe",
+        "inboundAdoUsernameHelp": "Skonfigurowano po stronie haka usługi Azure DevOps. TestPlanIt weryfikuje go za pomocą uwierzytelniania podstawowego HTTP.",
+        "inboundAdoPasswordHelp": "Przechowywane w postaci zaszyfrowanej w stanie spoczynku. Zapisz tę wartość również po stronie haka usługi Azure DevOps.",
+        "inboundAdoResourceDetailsHint": "Podczas konfigurowania haka usługi Azure DevOps ustaw opcję „Szczegóły zasobu do wysłania” = „Wszystkie”, aby zmienna System.State została uwzględniona w ładunku.",
+        "setupStepsTitle": "Kroki konfiguracji",
+        "setupStepsJiraStep1": "W Jira przejdź do Ustawienia → System → Webhooki (lub na stronę konfiguracji webhooków administratora Jira).",
+        "setupStepsJiraStep2": "Kliknij „Utwórz webhook”. Wklej poniższy adres URL w polu „Adres URL”, a klucz tajny w polu „Sekret”.",
+        "setupStepsJiraStep3": "W sekcji „Zdarzenia związane z problemem” zaznacz opcję „zaktualizowano”, aby wysyłać zmiany statusu problemu.",
+        "setupStepsJiraStep4": "Zapisz webhook. Użyj poniższej opcji „Wyślij testowy webhook”, aby zweryfikować potok.",
+        "setupStepsGithubStep1": "W repozytorium GitHub przejdź do Ustawienia → Webhooki → Dodaj webhook.",
+        "setupStepsGithubStep2": "Wklej poniższy adres URL w polu „Adres URL treści”. Ustaw typ zawartości na application/json.",
+        "setupStepsGithubStep3": "Wklej poniższy sekret w polu Sekret.",
+        "setupStepsGithubStep4": "Wybierz opcję „Pozwól mi wybrać pojedyncze zdarzenia” i zaznacz „Problemy”.",
+        "setupStepsGithubStep5": "Kliknij „Dodaj webhook”. Użyj poniższej opcji „Wyślij testowy webhook”, aby zweryfikować potok.",
+        "setupStepsAdoStep1": "W projekcie Azure DevOps przejdź do Ustawień projektu → Haki usługi → Utwórz subskrypcję.",
+        "setupStepsAdoStep2": "Wybierz usługę „Web Hooks”. Ustaw wyzwalacz na „Zaktualizowano element roboczy”.",
+        "setupStepsAdoStep3": "Ustaw Szczegóły zasobu na send = All, aby uwzględnić System.State.",
+        "setupStepsAdoStep4": "Wklej poniższy adres URL w polu adresu URL. Ustaw nazwę użytkownika i hasło uwierzytelniania podstawowego na wartości wprowadzone powyżej.",
+        "setupStepsAdoStep5": "Zapisz subskrypcję. Użyj poniższej opcji „Wyślij testowy webhook”, aby zweryfikować potok.",
+        "setupStepsGitlabStep1": "W GitLabie przejdź do swojego projektu → Ustawienia → Webhooki.",
+        "setupStepsGitlabStep2": "Wklej poniższy adres URL w polu „Adres URL”. Wklej poniższy klucz tajny w polu „Token tajny”.",
+        "setupStepsGitlabStep3": "W sekcji Wyzwalacz zaznacz opcję „Występuje problem ze zdarzeniami”.",
+        "setupStepsGitlabStep4": "Kliknij „Dodaj webhook”. Użyj poniższej opcji „Wyślij testowy webhook”, aby zweryfikować potok.",
+        "setupStepsGiteaStep1": "W Gitea przejdź do swojego repozytorium → Ustawienia → Webhooki.",
+        "setupStepsGiteaStep2": "Kliknij „Dodaj webhook” i wybierz „Gitea”.",
+        "setupStepsGiteaStep3": "Wklej poniższy adres URL w polu „Adres docelowy”. Wklej poniższy klucz tajny w polu „Sekret”.",
+        "setupStepsGiteaStep4": "W sekcji „Włącz” wybierz „Problemy”.",
+        "setupStepsGiteaStep5": "Kliknij „Dodaj webhook”. Użyj poniższej opcji „Wyślij testowy webhook”, aby zweryfikować potok.",
+        "deliveriesTab": "Dostawy",
+        "filterConfigPlaceholder": "Wszystkie webhooki",
+        "filterStatusAll": "Wszystko",
+        "filterStatusFailed": "Przegrany",
+        "filterStatusSuccess": "Sukces",
+        "filterSinceDefault": "Ponieważ…",
+        "filterUntilDefault": "Do…",
+        "filterReset": "Zresetuj filtry",
+        "filterBulkReplayButton": "Odtwarzanie zbiorcze {count} błędów wychodzących",
+        "filterBulkReplayHidden": "Wszystkie widoczne awarie są przychodzące — zamiast tego należy ponownie wywołać zdarzenie nadrzędne.",
+        "deliveriesEmpty": "Żadna dostawa nie spełnia tych kryteriów.",
+        "deliveriesResetFilters": "Zresetuj filtry",
+        "deliveriesLoadMore": "Załaduj więcej",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Wydarzenie",
+        "tableHeaderStatus": "Status",
+        "tableHeaderError": "Błąd",
+        "tableHeaderReceivedAt": "Otrzymane",
+        "tableHeaderAttempt": "Próba",
+        "tableHeaderDirection": "Kierunek",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Zobacz szczegóły",
+        "drawerTitle": "Szczegóły dostawy",
+        "drawerLabelEvent": "Wydarzenie",
+        "drawerLabelDirection": "Kierunek",
+        "drawerLabelStatusCode": "Kod statusu",
+        "drawerLabelLatency": "Utajenie",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Błąd",
+        "drawerLabelPayloadDigest": "Podsumowanie ładunku",
+        "drawerLabelEventId": "Identyfikator zdarzenia",
+        "drawerLabelAttempt": "Próba",
+        "drawerLabelReceivedAt": "Otrzymano w",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Powtórka {id}",
+        "drawerReplayButton": "Odtwórz tę dostawę",
+        "drawerInboundReplayNotSupported": "Nie można odtworzyć przesyłek przychodzących — zamiast tego należy ponownie wywołać zdarzenie nadrzędne.",
+        "replayConfirmTitle": "Czy chcesz odtworzyć tę dostawę?",
+        "replayConfirm": "Spowoduje to wygenerowanie rzeczywistego żądania {direction} {adapterType}.",
+        "replayAction": "Powtórna rozgrywka",
+        "bulkReplayConfirmTitle": "Odtworzyć błędy wychodzące?",
+        "bulkReplayConfirm": "Odtwórz {count} błędów wychodzących do {configName}? Spowoduje to wygenerowanie {count} rzeczywistych żądań HTTP.",
+        "bulkReplayCapExceeded": "Odtwarzanie zbiorcze ograniczone do 100 połączeń wychodzących na raz. Zawęź filtr lub odtwarzaj sekwencyjnie. Obecnie odtwarzane będzie {count}.",
+        "bulkReplayAction": "Powtórka {count}",
+        "healthBadge": {
+          "HEALTHY": "Zdrowy",
+          "DEGRADED": "Zdegradowany",
+          "DISABLED": "Wyłączony"
+        },
+        "healthTooltipHealthy": "Ostatni sukces: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} kolejnych niepowodzeń · ostatnia o {lastFailureAt}",
+        "healthTooltipDisabled": "Wyłączone po 10 kolejnych awariach · {lastFailureAt}",
+        "activityLabel": "Aktywność dostawcza",
+        "activityLastDispatched": "Ostatnia wysyłka",
+        "activityLastSuccess": "Ostatni sukces",
+        "activityLastFailure": "Ostatnia awaria",
+        "activityNever": "Nigdy",
+        "reEnable": "Włącz ponownie",
+        "reEnableConfirmTitle": "Czy ponownie włączyć ten webhook?",
+        "reEnableConfirm": "Przed ponownym włączeniem sprawdź, czy problem z upstream został rozwiązany. Wysyłanie webhooka zostanie natychmiast wznowione.",
+        "toastReplaySuccess": "Powtórka w kolejce",
+        "toastReplayFailed": "Nie udało się odtworzyć: {error}",
+        "toastReplayInboundNotSupported": "Dostaw przychodzących nie można odtworzyć.",
+        "toastBulkReplaySuccess": "Rozpoczęto odtwarzanie zbiorcze · partia {batchId}",
+        "toastBulkReplayFailed": "Nie udało się odtworzyć zbiorczo: {error}",
+        "toastReEnableSuccess": "Ponownie włączono webhook",
+        "toastReEnableFailed": "Nie udało się ponownie włączyć: {error}"
+      },
+      "aiModels": {
+        "description": "Konfiguruj modele AI do inteligentnego generowania i analizy przypadków testowych",
+        "availableModels": "Projekt domyślny",
+        "availableModelsDescription": "Wybierz domyślny model AI dla tego projektu spośród modeli skonfigurowanych przez administratora systemu.",
+        "currentModelSettings": "Bieżące ustawienia modelu",
+        "currentModelDescription": "Szczegóły konfiguracji dla aktualnie aktywnego modelu AI: {name}",
+        "noModelsAvailable": "Obecnie nie ma dostępnych modeli AI. Skontaktuj się z administratorem systemu, aby skonfigurować modele AI dla swojej organizacji.",
+        "monthlyBudget": "Miesięczny budżet",
+        "model": "Model",
+        "budget": "Budżet",
+        "streamingTooltip": "Włączono strumieniowanie odpowiedzi w czasie rzeczywistym",
+        "systemDefault": "Domyślne ustawienia systemu",
+        "setAsDefault": "Ustaw jako domyślne",
+        "clearDefault": "Wyczyść domyślne",
+        "useForProject": "Użyj do projektu",
+        "removeModel": "Wyczyść domyślne",
+        "removeWarningTitle": "Wyczyszczenie domyślnego modelu AI spowoduje:",
+        "removeWarning1": "Wyłącz funkcje oparte na sztucznej inteligencji, chyba że skonfigurowano nadpisywanie poszczególnych funkcji",
+        "removeWarning2": "Usuń model zapasowy używany do generowania i analizy przypadków testowych",
+        "switchModel": "Zmień domyślne",
+        "switchWarningTitle": "Zmiana domyślnego modelu sztucznej inteligencji spowoduje:",
+        "switchWarning1": "Zmień sposób działania funkcji sztucznej inteligencji w tym projekcie",
+        "switchWarning2": "Może mieć wpływ na jakość i styl generowanych treści",
+        "modelAssigned": "Domyślny model AI ustawiony dla tego projektu",
+        "modelAssignError": "Nie udało się ustawić domyślnego modelu AI",
+        "modelRemoved": "Domyślny model AI został wyczyszczony",
+        "modelRemoveError": "Nie udało się wyczyścić domyślnego modelu AI",
+        "confirmRemove": "Czy na pewno chcesz wyczyścić „{name}” jako domyślną wartość dla tego projektu?",
+        "confirmSwitch": "Czy na pewno chcesz zmienić wartość domyślną z „{from}” na „{to}”?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/miesiąc"
+        },
+        "promptConfig": "Szybka konfiguracja",
+        "promptConfigDescription": "Wybierz konfigurację monitu AI, której chcesz użyć w tym projekcie",
+        "useSystemDefault": "Użyj domyślnych ustawień systemowych",
+        "promptConfigChanged": "Konfiguracja komunikatu została pomyślnie zaktualizowana.",
+        "featureOverrides": {
+          "title": "Nadpisania LLM dla poszczególnych funkcji",
+          "description": "Zastąp domyślną integrację LLM dla określonych funkcji AI. Zastąpienia mają najwyższy priorytet w łańcuchu rozwiązań.",
+          "feature": "Funkcja",
+          "override": "Prześcigać",
+          "effectiveLlm": "Skuteczny LLM",
+          "source": "Źródło",
+          "noOverride": "Brak nadpisania",
+          "noLlm": "Brak LLM (niepełnosprawny)",
+          "disabledOverride": "Wyłączone (nadpisanie)",
+          "projectOverride": "Nadpisanie projektu",
+          "promptConfig": "Szybka konfiguracja",
+          "noLlmConfigured": "Brak skonfigurowanego LLM",
+          "selectIntegration": "Wybierz integrację...",
+          "overrideSaved": "Zapisano nadpisanie funkcji",
+          "overrideCleared": "Nadpisanie funkcji zostało usunięte",
+          "overrideError": "Nie udało się zapisać nadpisania funkcji"
+        }
+      },
+      "shares": {
+        "title": "Zarządzaj udziałami",
+        "description": "Wyświetl i zarządzaj wszystkimi linkami udostępniania dla tego projektu"
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Włącz QuickScript i podłącz repozytorium kodu, aby generować testy wspomagane przez sztuczną inteligencję.",
+        "enableLabel": "Włącz QuickScript",
+        "enableDescription": " Zezwól członkom zespołu na używanie QuickScript do konwersji przypadków testowych na skrypty automatyzacji w tym projekcie.",
+        "enabledToast": "Włączony QuickScript",
+        "disabledToast": "QuickScript wyłączony",
+        "noRepos": {
+          "title": "Brak skonfigurowanych repozytoriów kodu",
+          "adminDescription": "Przed skonfigurowaniem kontekstu kodu dla tego projektu skonfiguruj połączenie z repozytorium.",
+          "adminLink": "Przejdź do repozytoriów kodu",
+          "userDescription": "Skontaktuj się z administratorem systemu, aby skonfigurować połączenie z repozytorium kodu."
+        },
+        "repository": {
+          "title": "Repozytorium kodu",
+          "description": "Wybierz repozytorium kodu, którego chcesz użyć w kontekście sztucznej inteligencji",
+          "placeholder": "Wybierz repozytorium kodu...",
+          "branchLabel": "Oddział",
+          "branchPlaceholder": "Pozostaw puste, aby użyć domyślnej gałęzi repozytorium"
+        },
+        "pathPatterns": {
+          "title": "Wzory ścieżek",
+          "description": "Określ, które pliki mają zostać uwzględnione. Każdy wiersz łączy ścieżkę bazową i wzorzec globu. Przykłady: ścieżka=tests/e2e/pages + wzór=* uwzględnia wszystkie pliki bezpośrednio w tym folderze; ścieżka=src + wzór=**/*.test.ts uwzględnia rekurencyjnie wszystkie pliki testowe.",
+          "pathLabel": "Ścieżka",
+          "pathPlaceholder": "testy/e2e/strony",
+          "patternLabel": "Wzór",
+          "addPath": "Dodaj ścieżkę",
+          "previewFiles": "Podgląd plików",
+          "scanningRepo": "Skanowanie plików repozytorium… ({seconds}s)",
+          "files": "{count, plural, one {# plik} other {# pliki}}",
+          "truncatedBadge": "Wyniki mogą być niekompletne (limit dostawcy)",
+          "exceedsLimit": "Całkowity rozmiar przekracza limit kontekstu AI o {overflow}. Podczas eksportu pliki są klasyfikowane według istotności dla eksportowanego przypadku testowego — pliki najbardziej istotne są uwzględniane jako pierwsze, a pliki o niższej randze są pomijane po osiągnięciu budżetu. Zawęź wzorce ścieżek, jeśli chcesz mieć większą kontrolę nad tym, które pliki są uwzględniane."
+        },
+        "preview": {
+          "resolvingBranch": "Rozwiązywanie gałęzi…",
+          "scanningFiles": "Skanowanie plików w {scope}…",
+          "scanningFilesCount": "Skanowanie plików w {scope}… (znaleziono{count})",
+          "filtering": "Stosowanie filtrów do plików {count}…"
+        },
+        "cache": {
+          "title": "Ustawienia pamięci podręcznej",
+          "description": "Pliki są buforowane w Valkey, co umożliwia szybki dostęp do nich podczas generowania sztucznej inteligencji.",
+          "enableLabel": "Włącz buforowanie plików",
+          "disabledWarning": "Buforowanie plików jest wyłączone. Pliki repozytorium zostaną pobrane bezpośrednio od dostawcy w momencie eksportu i nie będą przechowywane w TestPlanIt. Oparty na sztucznej inteligencji skrypt QuickScript nadal będzie zawierał kontekst kodu, ale każdy eksport będzie wysyłał żądanie do repozytorium na żywo.",
+          "ttlLabel": "Czas trwania pamięci podręcznej (dni)",
+          "statusTitle": "Status pamięci podręcznej",
+          "refreshButton": "Odśwież pamięć podręczną",
+          "listingFiles": "Wyświetlanie plików…",
+          "cachingFiles": "Buforowanie {count} plików…",
+          "statusNeverFetched": "Nigdy nie pobrano",
+          "statusPending": "Orzeźwiający...",
+          "lastFetched": "Ostatnio pobrano",
+          "filesCached": "Pliki w pamięci podręcznej",
+          "totalSize": "Całkowity rozmiar"
+        },
+        "save": "Zapisz konfigurację",
+        "saved": "Zapisano konfigurację kontekstu kodu",
+        "saveError": "Nie udało się zapisać konfiguracji",
+        "listError": "Nie udało się wyświetlić listy plików repozytorium",
+        "contentsError": "Nie udało się zapisać zawartości pliku w pamięci podręcznej",
+        "networkError": "Błąd sieciowy podczas odświeżania pamięci podręcznej",
+        "refreshSuccess": "Odświeżono pamięć podręczną: {fileCount} plików (zawartość w pamięci podręcznej:{contentCached})",
+        "refreshRateLimited": "Odświeżono pamięć podręczną: {fileCount} plików na liście, {contentCached}/{fileCount} zawartości w pamięci podręcznej (ograniczona szybkość — w celu dokończenia należy odświeżyć ponownie)",
+        "validation": {
+          "pathRequired": "Ścieżka jest wymagana",
+          "patternRequired": "Wzór jest wymagany",
+          "repositoryRequired": "Repozytorium jest wymagane",
+          "pathPatternRequired": "Wymagany jest co najmniej jeden wzorzec ścieżki"
+        },
+        "exportTemplates": {
+          "title": "Eksportuj szablony",
+          "description": "Przypisz szablony eksportu do tego projektu. W oknie dialogowym eksportu pojawią się tylko przypisane szablony.",
+          "noTemplates": "Brak włączonych szablonów eksportu. Skontaktuj się z administratorem systemu.",
+          "assignedLabel": "Przypisane szablony",
+          "selectPlaceholder": "Wybierz szablony, które chcesz przypisać...",
+          "defaultLabel": "Szablon domyślny",
+          "defaultPlaceholder": "Brak (użyj domyślnego ustawienia globalnego)",
+          "assigned": "Przydzielony",
+          "save": "Zapisz zadania szablonów",
+          "saved": "Zapisano zadania szablonów",
+          "saveError": "Nie udało się zapisać przypisań szablonów"
+        },
+        "disconnect": "Odłącz repozytorium",
+        "confirmDisconnect": "Czy na pewno chcesz odłączyć „{name}” od tego projektu?",
+        "disconnectWarningTitle": "Odłączenie tego repozytorium spowoduje:",
+        "disconnectWarning1": "Usuń wszystkie pliki z pamięci podręcznej repozytorium",
+        "disconnectWarning2": "Usuń wzorzec ścieżki i konfiguracje gałęzi",
+        "disconnectWarning3": "Przestań uwzględniać kontekst kodu w eksportach generowanych przez sztuczną inteligencję",
+        "disconnectSuccess": "Repozytorium kodu odłączone",
+        "disconnectError": "Nie udało się odłączyć repozytorium kodu"
+      }
+    }
+  },
+  "milestones": {
+    "title": "Szczegóły kamienia milowego",
+    "fields": {
+      "parent": "Kamień milowy dla rodziców",
+      "dueDate": "Termin wykonania",
+      "automaticCompletion": "Automatyczne uzupełnianie w terminie",
+      "notifyDaysBefore": "Powiadom na kilka dni przed terminem płatności",
+      "notifyDaysBeforeValue": "Powiadom {count, plural, one {# dzień} other {# dni}} przed terminem",
+      "dueDateNotifications": "Powiadomienia o terminach"
+    },
+    "labels": {
+      "childMilestones": "Kamienie milowe dziecka"
+    },
+    "placeholders": {
+      "description": "Wprowadź opis kamienia milowego...",
+      "documentation": "Wprowadź dokumentację dotyczącą kamienia milowego...",
+      "selectType": "Wybierz typ kamienia milowego...",
+      "selectParent": "Wybierz nadrzędny kamień milowy..."
+    },
+    "empty": {
+      "active": "Brak aktywnych kamieni milowych",
+      "completed": "Brak ukończonych kamieni milowych",
+      "description": "Brak opisu",
+      "documentation": "Brak dokumentacji",
+      "testRuns": "Brak przebiegów testowych",
+      "forecasts": "Brak dostępnych danych prognostycznych"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Nie rozpoczęto",
+      "IN_PROGRESS": "W toku",
+      "STOPPED": "Zatrzymany",
+      "BLOCKED": "Zablokowany",
+      "CANCELLED": "Odwołany",
+      "unscheduled": "Nieplanowane",
+      "upcoming": "Nadchodzące",
+      "delayed": "Opóźniony",
+      "pastDue": "Zaległość",
+      "started": "Rozpoczęto",
+      "completed": "Zakończony"
+    },
+    "status": {
+      "stop": "Zatrzymywać się",
+      "reopen": "Otworzyć na nowo"
+    },
+    "dates": {
+      "pickStartDate": "Wybierz datę rozpoczęcia",
+      "pickCompletionDate": "Wybierz datę zakończenia",
+      "selectDate": "Wybierz datę...",
+      "completionWarning": "Ostrzeżenie: spowoduje to oznaczenie kamienia milowego jako ukończonego"
+    },
+    "toast": {
+      "deleted": "Kamień milowy {name} usunięty",
+      "updated": "Zaktualizowano kamień milowy",
+      "updateFailed": "Nie udało się zaktualizować kamienia milowego",
+      "completed": "Kamień milowy „{name}” ukończony.",
+      "completedWithDependencies": "Kamienie milowe i zależności zostały pomyślnie ukończone."
+    },
+    "errors": {
+      "nameExists": "Kamień milowy o tej nazwie już istnieje",
+      "nameRequired": "Nazwa kamienia milowego jest wymagana",
+      "notFound": "Nie znaleziono kamienia milowego"
+    },
+    "actions": {
+      "add": "Dodaj kamień milowy"
+    },
+    "delete": {
+      "title": "Usuń kamień milowy",
+      "confirmMessage": "Czy na pewno chcesz usunąć kamień milowy {name}?",
+      "warning": "Ten kamień milowy zostanie usunięty z projektu. Dane historyczne dla tego kamienia milowego nadal będą dostępne w projekcie.",
+      "toast": {
+        "loading": "Usuwanie kamienia milowego...",
+        "success": "Kamień milowy został pomyślnie usunięty",
+        "error": {
+          "title": "Nie udało się usunąć kamienia milowego",
+          "description": "Wystąpił błąd podczas usuwania kamienia milowego"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Potwierdź ukończenie kamienia milowego",
+      "confirmDescription": "Ukończenie tego kamienia milowego spowoduje również ukończenie następujących powiązanych elementów:",
+      "impactActiveTestRuns": "{count, plural, one {# aktywny przebieg testu} other {# aktywne przebiegi testu}}",
+      "impactActiveSessions": "{count, plural, one {# aktywna sesja} other {# aktywne sesje}}",
+      "impactDescendantMilestones": "{count, plural, one {# kamień milowy potomka} other {# kamienie milowe potomków}}",
+      "completeTestRunsLabel": "Ukończ powiązane przebiegi testowe ({count, plural, one {# aktywne} other {# aktywne}})",
+      "completeSessionsLabel": "Ukończ powiązane sesje ({count, plural, one {# aktywne} other {# aktywne}})",
+      "testRunStateLabel": "Stan ukończenia testu",
+      "sessionStateLabel": "Stan ukończenia sesji",
+      "itemsRemaining": "Następujące elementy pozostaną aktywne:",
+      "processing": "Przetwarzanie...",
+      "confirmAndCompleteAll": "Potwierdź i zakończ wszystko"
+    },
+    "notifications": {
+      "dueSoon": "Kamień milowy „{name}” ma zostać osiągnięty {dueDate}",
+      "overdue": "Kamień milowy „{name}” miał zostać osiągnięty {dueDate}"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Sesja} other {Sesje}}",
+    "labels": {
+      "totalElapsed": "Czas spędzony",
+      "remaining": "Pozostało: {time}",
+      "overtime": "Powyżej szacunku o: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Żadna z zakończonych sesji nie spełnia kryteriów filtra."
+    },
+    "filter": {
+      "placeholder": "Filtruj sesje..."
+    },
+    "actions": {
+      "add": "Dodaj sesję",
+      "create": "Utwórz nową sesję",
+      "edit": "Edytuj sesję",
+      "complete": "Pełna sesja",
+      "delete": "Usuń sesję",
+      "viewSessionDetails": "Wyświetl sesję"
+    },
+    "noMilestone": "Brak kamienia milowego",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Dla tego projektu nie skonfigurowano żadnych przepływów pracy związanych z ukończeniem. Skonfiguruj przepływy pracy w ustawieniach administratora, aby umożliwić ukończenie sesji."
+    },
+    "messages": {
+      "createSuccess": "Sesja utworzona pomyślnie",
+      "createSuccessMultiple": "{count} Sesje utworzone pomyślnie",
+      "duplicateSuccess": "Sesja została pomyślnie zduplikowana",
+      "duplicateSuccessMultiple": "{count} Sesje zostały pomyślnie zduplikowane"
+    },
+    "duplicateDialog": {
+      "title": "Duplikat sesji",
+      "description": "Utwórz kopię sesji <nameStyle>{name}</nameStyle> ze wszystkimi metadanymi, ale bez wyników."
+    },
+    "errors": {
+      "failedToCreate": "Nie udało się utworzyć nowej sesji",
+      "failedToCreateVersion": "Nie udało się utworzyć wersji sesji",
+      "nameAlreadyExists": "Nazwa sesji już istnieje. Wybierz nową nazwę.",
+      "createFailed": "Nie udało się utworzyć sesji",
+      "duplicateFailed": "Nie udało się zduplikować sesji"
+    },
+    "validation": {
+      "nameMinLength": "Nazwa musi mieć co najmniej 2 znaki.",
+      "templateRequired": "Proszę wybrać szablon",
+      "maxDuration": "Czas trwania musi być mniejszy lub równy {max}."
+    },
+    "placeholders": {
+      "estimate": "Oszacowanie (np. 1 godz. 30 min)",
+      "elapsed": "Upłynęło (np. 2 dni i 4 godz.)",
+      "selectUser": "Wybierz użytkownika",
+      "estimateHint": "np. 2 godz. 30 min",
+      "noEstimate": "Brak ustalonego szacunku"
+    },
+    "delete": {
+      "confirmMessage": "Czy na pewno chcesz usunąć sesję {name}?",
+      "warning": "Ta sesja zostanie usunięta z projektu. Dane historyczne dotyczące tej sesji nadal będą dostępne w projekcie.",
+      "toast": {
+        "loading": "Usuwanie sesji...",
+        "success": "Sesja została pomyślnie usunięta",
+        "error": {
+          "title": "Nie udało się usunąć sesji",
+          "description": "Wystąpił błąd podczas usuwania sesji"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Czy na pewno chcesz zakończyć sesję {name}?",
+      "warning": "Po zakończeniu sesja zostanie trwale zarchiwizowana i nie będzie można jej już aktualizować.",
+      "fields": {
+        "completionDate": "Data zakończenia"
+      },
+      "placeholders": {
+        "pickDate": "Wybierz datę"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Całkowity szacowany pozostały czas:",
+      "recentResultsTitle": "Podsumowanie ostatnich wyników",
+      "recentResultsDescription": "Podsumowanie wyników sesji.",
+      "noRecentResults": "Brak wyników sesji zarejestrowanych ostatnio.",
+      "completionTrendTitle": "Trend ukończenia",
+      "completionTrendDescription": "Liczba sesji ukończonych w danym miesiącu.",
+      "noCompletedRuns": "Nie znaleziono ukończonych przebiegów w ciągu ostatnich 6 miesięcy.",
+      "completionTrendTitle6Mo": "Trend ukończenia (ostatnie 6 miesięcy)",
+      "noCompletedSessions6Mo": "Brak ukończonych sesji w ciągu ostatnich 6 miesięcy."
+    },
+    "version": {
+      "title": "Widok historii sesji",
+      "notFound": "Nie znaleziono wersji sesji.",
+      "selectVersion": "Wybierz wersję",
+      "backToSession": "Powrót do sesji",
+      "backToLatest": "Powrót do najnowszej wersji",
+      "versionInfo": {
+        "created": "Wersja {number} Utworzono",
+        "latestUpdated": "Najnowsza wersja {number} Zaktualizowana"
+      },
+      "renderer": {
+        "noEstimate": "Brak szacunków",
+        "noTimeLogged": "Brak zarejestrowanego czasu",
+        "noContent": "Brak treści",
+        "currentVersion": "Aktualna wersja",
+        "previousVersion": "Poprzednia wersja"
+      },
+      "diff": {
+        "added": "W dodatku",
+        "removed": "REMOVED",
+        "changed": "Zmieniono"
+      }
+    },
+    "results": {
+      "section": "Dziennik sesji",
+      "add": "Dodaj wynik sesji",
+      "edit": "Edytuj wynik sesji",
+      "editDescription": "Wprowadź zmiany w wynikach sesji i po zakończeniu kliknij przycisk Zapisz.",
+      "details": "Wprowadź tutaj szczegóły wyniku...",
+      "noResults": "Nie dodano jeszcze żadnych wyników.",
+      "noNotes": "Do tego wyniku nie dodano żadnych notatek.",
+      "deleteSuccess": "Wynik sesji został pomyślnie usunięty",
+      "deleteError": "Nie udało się usunąć wyniku sesji",
+      "updateSuccess": "Wynik sesji został pomyślnie zaktualizowany",
+      "updateError": "Nie udało się zaktualizować wyniku sesji",
+      "linkCopied": "Link do wyniku sesji skopiowany do schowka",
+      "copyFailed": "Nie udało się skopiować linku do wyniku sesji",
+      "confirmDelete": {
+        "title": "Usuń wynik sesji",
+        "description": "Czy na pewno chcesz usunąć ten wynik sesji?"
+      }
+    },
+    "notFound": "Sesja nie znaleziona"
+  },
+  "home": {
+    "dashboard": {
+      "title": "Twój panel",
+      "users": "Jest {count, plural, =1 {# Użytkownik} other {jest # Użytkowników}}",
+      "yourProjects": "Twoje projekty",
+      "projects": "Masz dostęp do {count, plural, =1 {# Projekt} other {# Projekty}}",
+      "loading": "Ładowanie pulpitu nawigacyjnego...",
+      "noItems": "Nic, co zostało Ci przydzielone, nie wymaga teraz Twojej uwagi.",
+      "pendingRuns": "Oczekujące przebiegi testów",
+      "activeSessions": "Aktywne sesje",
+      "yourActiveSessions": "{count, plural, =0 {Brak aktywnych sesji} =1 {# Aktywna sesja} other {# Aktywne sesje}}",
+      "yourPendingRuns": "{count, plural, =0 {Brak oczekujących przebiegów testów} =1 {# Aktywny przebieg testu} other {# Aktywne przebiegi testów}}",
+      "yourAssignments": "Twoje zadania",
+      "totalTime": "Całkowity szacowany czas: ",
+      "totalWorkEffort": "Całkowity nakład pracy: ",
+      "scheduleSpan": "Zakres harmonogramu: "
+    },
+    "initialPreferences": {
+      "title": "Ustaw swoje preferencje",
+      "description": "Wybierz ustawienia domyślne, które najbardziej Ci odpowiadają. Możesz je w każdej chwili zmienić w swoim profilu.",
+      "dateFormat": "Format daty",
+      "timeFormat": "Format czasu",
+      "timezonePlaceholder": "Wyszukaj strefę czasową...",
+      "skip": "Zachowaj ustawienia domyślne",
+      "save": "Zapisz preferencje",
+      "success": "Preferencje zaktualizowane",
+      "error": "Wystąpił błąd podczas zapisywania preferencji"
+    },
+    "noAccess": {
+      "title": "Brak dostępu do projektu",
+      "description": "Nie masz dostępu do żadnych projektów w tym systemie.",
+      "contact": "Aby uzyskać dostęp do projektów, skontaktuj się z administratorem systemu.",
+      "adminAddProject": "Dodaj swój pierwszy projekt, aby rozpocząć!",
+      "footer": "Aby móc przeglądać i uczestniczyć w działaniach związanych z planowaniem testów, wymagany jest dostęp."
+    },
+    "noProjectAccess": {
+      "description": "Nie masz dostępu do tego projektu.",
+      "contact": "Aby uzyskać dostęp, skontaktuj się z administratorem projektu."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Przypadki testowe} =1 {# Przypadek testowy} other {# Przypadki testowe}}",
+      "activeMilestones": "{count, plural, =0 {# Aktywne kamienie milowe} =1 {# Aktywny kamień milowy} other {# Aktywne kamienie milowe}}",
+      "activeRuns": "{count, plural, =0 {# Aktywne przebiegi} =1 {# Aktywne przebiegi} other {# Aktywne przebiegi}}",
+      "activeSessions": "{count, plural, =0 {# Aktywne sesje} =1 {# Aktywna sesja} other {# Aktywne sesje}}",
+      "issues": "{count, plural, =0 {# Problemy} =1 {# Problemy} other {# Problemy}}"
+    }
+  },
+  "users": {
+    "description": "Zarządzaj kontami użytkowników, ustawiaj poziomy dostępu do systemu i przypisuj role globalne.",
+    "filter": "Filtruj użytkowników...",
+    "profile": {
+      "title": "Profil użytkownika",
+      "edit": {
+        "title": "Edytuj profil",
+        "timezonePlaceholder": "Wybierz lub wyszukaj strefę czasową...",
+        "timezoneRequired": "Podanie strefy czasowej jest wymagane.",
+        "avatarUpdated": "Awatar został pomyślnie zaktualizowany.",
+        "avatarUpdateError": "Nie udało się zaktualizować awatara.",
+        "deleteAvatar": "Usuń awatar",
+        "deleteAvatarConfirm": "Czy na pewno chcesz usunąć swój awatar?",
+        "emailDisabledForSso": "Adresu e-mail nie można zmienić dla kont SSO. Zaktualizuj go za pośrednictwem swojego dostawcy tożsamości.",
+        "emailEditableForBoth": "Możesz zalogować się zarówno za pomocą adresu e-mail i hasła, jak i za pomocą logowania jednokrotnego (SSO). Zmiany adresu e-mail wpłyną tylko na uwierzytelnianie hasłem.",
+        "linkSsoProvider": "Dostawca SSO Link"
+      },
+      "preferences": {
+        "title": "Preferencje"
+      },
+      "access": {
+        "title": "Dostęp"
+      },
+      "notifications": {
+        "title": "Preferencje powiadomień",
+        "description": "Dostosuj sposób otrzymywania powiadomień",
+        "currentGlobal": "Aktualne ustawienie globalne: {mode}",
+        "mode": {
+          "label": "Tryb powiadomień",
+          "useGlobal": "Użyj ustawień globalnych"
+        },
+        "options": {
+          "title": "Opcje dodatkowe",
+          "email": {
+            "label": "Powiadomienia e-mail",
+            "description": "Otrzymuj powiadomienia e-mailem"
+          }
+        },
+        "success": {
+          "title": "Preferencje zapisane",
+          "description": "Twoje preferencje dotyczące powiadomień zostały zaktualizowane"
+        },
+        "error": {
+          "description": "Nie udało się zapisać preferencji powiadomień"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Zmień hasło",
+        "setPasswordButtonText": "Ustaw hasło",
+        "description": "Wprowadź swoje obecne hasło i nowe hasło, aby zmienić hasło do konta. Zmiana ta spowoduje jedynie zmianę hasła zarządzanego wewnętrznie. Jeśli zalogujesz się przez SSO, hasło to nie ulegnie zmianie.",
+        "setPasswordDescription": "Zalogowałeś się za pomocą logowania jednokrotnego (SSO) i nie ustawiłeś jeszcze hasła lokalnego. Wprowadź nowe hasło, aby umożliwić logowanie za pomocą adresu e-mail i hasła do swojego konta.",
+        "currentPasswordLabel": "Aktualne hasło",
+        "newPasswordLabel": "Nowe hasło",
+        "confirmPasswordLabel": "Potwierdź nowe hasło",
+        "validation": {
+          "passwordsDoNotMatch": "Nowe hasła nie są takie same.",
+          "newPasswordTooShort": "Nowe hasło nie spełnia wymagań bezpieczeństwa."
+        },
+        "success": {
+          "passwordChanged": "Hasło zostało pomyślnie zmienione."
+        }
+      },
+      "mentionedComments": {
+        "title": "Wspomniano w komentarzach",
+        "description": "Komentarze, w których wspomniano o Tobie",
+        "noComments": "Nie wspomniano o Tobie jeszcze w żadnych komentarzach.",
+        "comment": "Komentarz",
+        "showingResults": "Wyświetlanie {start} - {end} z {total}"
+      },
+      "twoFactor": {
+        "enable": "Włącz 2FA",
+        "disable": "Wyłączyć",
+        "disableNotAllowed": "Twoja organizacja wymaga uwierzytelniania dwuskładnikowego",
+        "ssoBypassNotice": "Logowania jednokrotne (SSO) ominą to ustawienie 2FA. Skontaktuj się z administratorem, aby wymusić 2FA dla wszystkich logowań.",
+        "regenerateCodes": "Nowe kody",
+        "setup": {
+          "description": "Zeskanuj kod QR za pomocą aplikacji uwierzytelniającej (np. Google Authenticator lub Authy) i wprowadź kod weryfikacyjny.",
+          "backupCodesTitle": "Zapisz swoje kody zapasowe",
+          "done": "Zapisałem moje kody"
+        },
+        "disableConfirm": {
+          "title": "Wyłączyć uwierzytelnianie dwuskładnikowe?",
+          "description": "To obniży bezpieczeństwo Twojego konta. Wprowadź swój aktualny kod 2FA lub kod zapasowy, aby potwierdzić.",
+          "placeholder": "Wprowadź kod"
+        },
+        "regenerate": {
+          "title": "Regeneruj kody zapasowe",
+          "description": "Spowoduje to unieważnienie istniejących kodów zapasowych. Wprowadź aktualny kod 2FA, aby kontynuować.",
+          "confirm": "Regeneruj kody",
+          "newCodesTitle": "Twoje nowe kody zapasowe",
+          "newCodesDescription": "Twoje stare kody zostały unieważnione. Zachowaj nowe kody w bezpiecznym miejscu."
+        }
+      },
+      "apiTokens": {
+        "description": "Tokeny API umożliwiają zewnętrznym aplikacjom i skryptom dostęp do TestPlanIt w Twoim imieniu. Tokeny mają takie same uprawnienia jak Twoje konto.",
+        "create": "Utwórz token",
+        "createTitle": "Utwórz token API",
+        "createDescription": "Utwórz nowy token API w celu uwierzytelniania zewnętrznych narzędzi i skryptów.",
+        "nameLabel": "Nazwa tokena",
+        "namePlaceholder": "np. potok CI/CD, narzędzie CLI",
+        "noTokens": "Nie utworzono jeszcze żadnych tokenów API.",
+        "expiryLabel": "Data ważności (opcjonalnie)",
+        "expiryHint": "Pozostaw puste, aby nie utracić ważności.",
+        "tokenCreated": "Token utworzony",
+        "tokenCreatedDescription": "Twój token API został pomyślnie utworzony.",
+        "copyWarning": "Skopiuj ten token teraz. Nie będziesz go już mógł zobaczyć!",
+        "yourToken": "Twój token",
+        "deleteTitle": "Usunąć token API?",
+        "deleteDescription": "Tej czynności nie można cofnąć. Aplikacje korzystające z tego tokena nie będą już mogły się uwierzytelniać.",
+        "readOnlyLabel": "Tylko do odczytu",
+        "readOnlyDescription": "Stosuj w przypadku agentów AI, którzy powinni jedynie wykonywać zapytania o dane, a nie je modyfikować.",
+        "agentTokenLabel": "Oznacz jako token agenta",
+        "agentTokenDescription": "Oznacza wpisy dziennika audytu metadanymi.Źródło: „mcp”, dzięki czemu administratorzy mogą przypisywać zmiany wprowadzone przez agenta.",
+        "readOnlyBadge": "Tylko do odczytu",
+        "agentTokenBadge": "Token agenta",
+        "errors": {
+          "nameRequired": "Nazwa tokena jest wymagana."
+        }
+      }
+    },
+    "access": {
+      "guest": "Gość"
+    },
+    "avatar": {
+      "update": "Zaktualizuj awatar",
+      "remove": "Usuń awatar",
+      "changeProfilePicture": "Zmień zdjęcie profilowe",
+      "notAuthenticated": "Aby przesłać awatar, musisz się zalogować."
+    },
+    "deletedUser": "Usunięty użytkownik"
+  },
+  "userMenu": {
+    "viewProfile": "Wyświetl profil",
+    "locale": "Widownia",
+    "themes": {
+      "light": "Światło",
+      "dark": "Ciemny",
+      "system": "System",
+      "green": "Zielony",
+      "purple": "Fioletowy",
+      "orange": "Pomarańczowy"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Nie znaleziono wersji przypadku testowego.",
+      "detailsRegion": "Szczegóły przypadku testowego",
+      "metadataRegion": "Metadane przypadku testowego",
+      "versionCreated": "Wersja {version} Utworzono",
+      "latestVersionUpdated": "Najnowsza wersja {version} Zaktualizowana",
+      "historyView": "Widok historii przypadków testowych"
+    },
+    "fields": {
+      "optionNotFound": "Opcja nie znaleziona",
+      "hasValue": "Ma wartość",
+      "noValue": "Brak wartości",
+      "hasDate": "Ma datę",
+      "noDate": "Brak daty",
+      "hasText": "Ma tekst",
+      "noText": "Brak tekstu",
+      "hasLink": "Ma link",
+      "noLink": "Brak łącza",
+      "hasSteps": "Ma kroki",
+      "noSteps": "Brak kroków",
+      "unchecked": "Niepowstrzymany",
+      "linkedCases": "Powiązane przypadki",
+      "clickToViewFullContent": "Kliknij, aby zobaczyć pełną treść"
+    },
+    "steps": {
+      "add": "Dodaj krok",
+      "addSharedSteps": "Dodaj współdzielone kroki",
+      "delete": "Usuń krok",
+      "confirmDelete": "Potwierdź usunięcie Krok {number}?",
+      "createSharedSteps": "Utwórz współdzielone {number, plural, one {Krok} other {Kroki}}",
+      "sharedStepsName": "Nazwa wspólnych kroków",
+      "sharedStepsDescription": "Wprowadź nazwę nowego współdzielonego kroku {number, plural, one {} other {}}. Będzie ona obejmować {number, plural, one {# wybrany krok} other {# wybrane kroki}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Wybierz kroki i wpisz nazwę, aby utworzyć współdzielone kroki.",
+        "failedToCreateSharedStepGroupError": "Nie udało się utworzyć udostępnionych kroków. Spróbuj ponownie.",
+        "sharedStepGroupCreatedSuccess": "Udostępnione kroki zostały utworzone pomyślnie!",
+        "genericSharedStepCreationError": "Wystąpił nieznany błąd podczas tworzenia udostępnionych kroków. Spróbuj ponownie.",
+        "errorCreatingSharedGroup": "Nie udało się utworzyć współdzielonych kroków. Spróbuj ponownie.",
+        "sharedGroupCreatedSuccess": "Wspólna grupa kroków została utworzona pomyślnie!"
+      },
+      "selectSharedStepsTitle": "Wybierz współdzielone kroki",
+      "selectSharedStepsDescription": "Wybierz współdzielone kroki, które chcesz dodać do swojego przypadku testowego.",
+      "sharedStepsListPlaceholder": "Ładowanie współdzielonych kroków...",
+      "sharedStepsNamePlaceholder": "Wprowadź nazwę, aby zidentyfikować udostępnione kroki",
+      "noSharedStepsFound": "Nie znaleziono żadnych wspólnych kroków dla tego projektu.",
+      "sharedStepGroupTitle": "Wspólne kroki: {name}",
+      "confirmDeleteSharedStepBlock": "Czy na pewno chcesz usunąć blok kroków współdzielonych „{name}” z tego przypadku testowego? Nie spowoduje to usunięcia samej grupy kroków współdzielonych.",
+      "removeBlockButton": "Usuń blok",
+      "loadingSharedStepsItems": "Ładowanie kroków...",
+      "noStepsInSharedGroup": "Ta współdzielona grupa kroków jest pusta.",
+      "searchSharedStepsPlaceholder": "Wybierz udostępnione kroki...",
+      "stepsCountLabel": "{count, plural, =0 {# kroków} =1 {# kroku} other {# kroków}}",
+      "reviewSelectedStepsTitle": "Przejrzyj wybrane kroki",
+      "noStepsInSelectedGroup": "Wybrana grupa nie ma żadnych kroków.",
+      "sharedGroupSuffix": "(Wspólne kroki)",
+      "unnamedSharedGroup": "Nienazwane współdzielone kroki"
+    },
+    "testCase": {
+      "toggleAutomated": "Przełącz automatyczne testowanie",
+      "editAttachmentsIndividually": "Edytuj załączniki indywidualnie.",
+      "automatedStatus": "Testowanie automatyczne to {status}"
+    },
+    "templateNotAssignedWarning": "Ten przypadek testowy używa szablonu „{templateName}”, który nie jest obecnie przypisany do projektu „{projectName}”. Może być konieczne przypisanie tego szablonu do projektu lub zmiana przypadku testowego na inny.",
+    "orphanedStepsWarning": "Ten przypadek testowy zawiera kroki, ale obecny szablon „{templateName}” nie zawiera pola „Kroki”. Kroków nie można edytować, dopóki przypadek testowy nie będzie miał szablonu z polem „Kroki”.",
+    "orphanedFieldsWarning": "Ten przypadek testowy ma {count, plural, =1 {# wartość pola} other {# wartości pola}} które {count, plural, =1 {są} other {i}} nie są uwzględnione w bieżącym szablonie \"{templateName}\". {count, plural, =1 {To pole jest} other {Te pola są}} pokazane poniżej, ale mogą nie być edytowalne, dopóki nie zostaną dodane do szablonu.",
+    "title": "Repozytorium przypadków testowych",
+    "folders": "Lornetka składana",
+    "showDescendants": "Pokaż wszystkich potomków",
+    "addFolder": "Dodaj folder",
+    "emptyFolders": "Kliknij przycisk Dodaj folder powyżej, aby dodać pierwszy folder.",
+    "selectedAllCases": "{count, plural, =0 {Wybrano wszystkie przypadki} one {Wybrano # przypadków na wszystkich stronach} other {Wybrano # przypadków na wszystkich stronach}}",
+    "deselectedAllCases": "Odznaczono wszystkie przypadki na wszystkich stronach",
+    "selectAllTooltip": "Zaznacz/Odznacz wszystkie przypadki na tej stronie",
+    "selectAllShiftTooltip": "{count, plural, =0 {Zaznacz/Odznacz wszystkie przypadki na wszystkich stronach} one {Zaznacz/Odznacz # przypadek na wszystkich stronach} other {Zaznacz/Odznacz # przypadków na wszystkich stronach}}",
+    "deselectAllShiftTooltip": "Odznacz/Zaznacz wszystkie przypadki na wszystkich stronach",
+    "shiftClickHint": "Przytrzymaj klawisz Shift, aby zaznaczyć/odznaczyć wszystkie strony",
+    "treeView": {
+      "expandAll": "Rozwiń wszystko",
+      "collapseAll": "Zwiń wszystko",
+      "altKey": "Przytrzymaj klawisz Alt, aby rozwinąć/zwinąć wszystkie elementy podrzędne"
+    },
+    "dragDrop": {
+      "move": "Przenosić",
+      "copy": "Kopia",
+      "promptTitle": "Co chciałbyś zrobić?",
+      "copying": "Kopiowanie…",
+      "copyComplete": "{count, plural, =1 {Skopiowano 1 przypadek do {folder}} other {Skopiowano # przypadków do {folder}}}{dest, select, samename {} crossProject { w {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {Przeniesiono 1 sprawę do {folder}} other {Przeniesiono # spraw do {folder}}}{dest, select, samename {} crossProject { w {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Nie udało się skopiować 1 przypadku do {folder}} other {Nie udało się skopiować # przypadków do {folder}}}{dest, select, samename {} crossProject { w {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Nie udało się przenieść 1 sprawy do {folder}} other {Nie udało się przenieść # spraw do {folder}}}{dest, select, samename {} crossProject { w {projectName}} other {}}",
+      "copyAlreadyRunning": "Kolejna kopia jest już w trakcie tworzenia. Proszę poczekać na jej zakończenie.",
+      "currentSuffix": "(Aktualny)",
+      "moveDisabledSameFolder": "Sprawy już znajdują się w tym folderze",
+      "dragPreviewCase": "Przypadek testowy",
+      "dragPreviewCount": "{count, plural, =1 {# przypadek testowy} other {# przypadki testowe}}",
+      "modifierHintMac": "Przytrzymaj ⇧, aby przesunąć lub ⌥, aby skopiować, a przeciągając, aby pominąć to menu.",
+      "modifierHintWin": "Aby pominąć to menu, przytrzymaj klawisz Shift, aby przesunąć, lub klawisz Ctrl, aby skopiować, podczas przeciągania."
+    },
+    "folderActions": {
+      "edit": "Edytuj folder",
+      "delete": "Usuń folder",
+      "rename": "Zmień nazwę folderu"
+    },
+    "cases": {
+      "filter": "Przypadki filtrów...",
+      "selectFolder": "Wybierz folder, aby dodać lub wyświetlić przypadki testowe.",
+      "selectCases": "Wybierz przypadki testowe",
+      "noTestCases": "Brak przypadków testowych do wyświetlenia.",
+      "addCase": "Dodaj sprawę",
+      "notFound": "Nie znaleziono przypadku testowego.",
+      "selectFilter": "Wybierz filtr",
+      "testResultHistory": "Historia wyników testów",
+      "testResultHistoryDescription": "Wyświetl historię wyników testów dla tego przypadku testowego",
+      "noTestResults": "Nie znaleziono wyników testów dla tego przypadku testowego",
+      "unknownRun": "Nieznany bieg",
+      "attempt": "Próba",
+      "invalidProject": "Nieprawidłowy projekt",
+      "noSearchResults": "Brak przypadków odpowiadających kryteriom wyszukiwania.",
+      "bulkEdit": "Edycja zbiorcza",
+      "createTestRun": "Utwórz przebieg testowy",
+      "copyMoveToProject": "Kopiuj / Przenieś",
+      "export": "Eksport",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Nie można zmienić kolejności przypadków testowych na wielu stronach. Aby zmienić kolejność, wyświetl wszystkie przypadki na jednej stronie, wybierając opcję „Wszystkie” z menu rozmiaru strony, lub odznacz przypadki na innych stronach. Nadal możesz przeciągać wybrane przypadki do folderów.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Wszystko w widoku ({count})"
+        },
+        "textLongFormat": {
+          "label": "Format RTF"
+        },
+        "rowMode": {
+          "label": "Wiersze przypadków testowych",
+          "multi": "Pojedynczy rząd na krok"
+        }
+      },
+      "importWizard": {
+        "title": "Importuj przypadki testowe",
+        "fields": {
+          "workflowState": "Stan przepływu pracy",
+          "column": "Kolumna {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# przypadek testowy} other {# przypadki testowe}} zaimportowano pomyślnie"
+        },
+        "errors": {
+          "templateRequired": "Wymagany jest wybór szablonu",
+          "folderRequired": "W przypadku tej lokalizacji importu wymagany jest wybór folderu",
+          "fileRequired": "Wymagany jest plik CSV lub Markdown",
+          "markdownParseFailed": "Nie udało się przeanalizować pliku Markdown",
+          "markdownLlmFailed": "Analiza AI niedostępna, używany jest standardowy parser"
+        },
+        "page1": {
+          "fileType": {
+            "label": "Typ pliku",
+            "csv": "CSV",
+            "markdown": "Obniżka cen"
+          },
+          "parsingMarkdown": "Analizowanie pliku markdown...",
+          "useAiParsing": "Wykorzystaj sztuczną inteligencję do pomocy w mapowaniu terenu",
+          "importLocation": {
+            "label": "Lokalizacja importu",
+            "singleFolder": "Dodaj wszystkie sprawy do jednego folderu",
+            "rootFolder": "Dodaj wszystkie sprawy i foldery do folderu głównego (wymagane mapowanie)",
+            "topLevel": "Dodaj wszystkie sprawy i foldery do najwyższego poziomu (wymagane mapowanie)"
+          },
+          "selectFolder": "Wybierz folder",
+          "selectFolderPlaceholder": "Wybierz folder...",
+          "delimiters": {
+            "tab": "Patka"
+          },
+          "hasHeaders": "Pierwszy wiersz zawiera nazwy kolumn",
+          "template": "Szablon sprawy repozytorium",
+          "rowMode": {
+            "single": "Każdy wiersz to pojedynczy przypadek testowy",
+            "multi": "Przypadki testowe mogą obejmować wiele wierszy"
+          }
+        },
+        "page2": {
+          "title": "Mapowanie kolumn CSV na pola",
+          "description": "Przypisz każdą kolumnę CSV do pola w szablonie lub zignoruj ją.",
+          "ignoreColumn": "Ignoruj kolumnę",
+          "requiredFieldsWarning": "{count, plural, one {# wymagane pole to} other {# wymagane pola to}} nie są mapowane"
+        },
+        "page3": {
+          "title": "Podsumowanie mapowania terenu",
+          "mappingSummary": "Podsumowanie mapowania",
+          "folderSplitMode": {
+            "label": "Tryb hierarchii folderów",
+            "plain": "Zwykły tekst (bez podziału)",
+            "plainExample": "Przykład: „This/is.a>Folder” → Pojedynczy folder o nazwie „This/is.a>Folder”",
+            "slash": "Podziel ukośnikiem (/)",
+            "slashExample": "Przykład: „This/is.a>Folder” → „This” > „is.a>Folder”",
+            "dot": "Podziel kropką (.)",
+            "dotExample": "Przykład: „This/is.a>Folder” → „This/is” > „a>Folder”",
+            "greaterThan": "Podziel przez większe niż (>)",
+            "greaterThanExample": "Przykład: „This/is.a>Folder” → „This/is.a” > „Folder”"
+          }
+        },
+        "page4": {
+          "title": "Podgląd importu",
+          "showing": "Wyświetlanie {start}-{end} z {total} przypadków",
+          "case": "Przypadek {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Dodaj przypadek testowy",
+      "name": "Nazwa przypadku testowego",
+      "namePlaceholder": "Wprowadź nazwę przypadku testowego",
+      "selectTemplate": "Wybierz szablon",
+      "selectState": "Wybierz stan",
+      "estimatePlaceholder": "Wprowadź szacunkową kwotę",
+      "create": "Utwórz przypadek testowy",
+      "successMessage": "Dodano nowy przypadek testowy",
+      "errorMessage": "Nieznany błąd podczas dodawania nowego przypadku testowego"
+    },
+    "columns": {
+      "selectCase": "Wybierz sprawę",
+      "runOrder": "Kolejność wykonania",
+      "lastTestResult": "Ostatni wynik",
+      "testedOn": "Ostatnio testowane"
+    },
+    "actions": {
+      "archive": "Archiwum"
+    },
+    "parentFolder": "Folder nadrzędny",
+    "rootFolder": "Folder główny",
+    "removeParentFolder": "Usuń folder nadrzędny",
+    "createInSelectedFolder": "Wróć do folderu nadrzędnego",
+    "deleteCase": {
+      "title": "Usuń przypadek testowy",
+      "confirmMessageStart": "Czy na pewno chcesz usunąć przypadek testowy? ",
+      "confirmMessageEnd": "?",
+      "warning": "Ten przypadek testowy zostanie usunięty z projektu. Dane historyczne dla tego przypadku testowego, w tym wyniki, pozostaną w projekcie.",
+      "activeRunWarningMessage": "Ten przypadek testowy jest częścią {count, plural, =1 {# aktywny przebieg testu} other {# aktywne przebiegi testu}}. Usunięcie go spowoduje oznaczenie go jako usuniętego w tych przebiegach."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Usunięcie tego folderu spowoduje również usunięcie wszystkich podfolderów. Czy jesteś pewien?} one {Usunięcie tego folderu spowoduje również usunięcie 1 przypadku testowego w tym folderze i wszystkich podfolderach. Czy jesteś pewien?} other {Usunięcie tego folderu spowoduje również usunięcie # przypadków testowych w tym folderze i wszystkich podfolderach. Czy jesteś pewien?}}",
+      "warning": "Ten folder i wszystkie jego przypadki testowe zostaną usunięte z projektu. Dane historyczne tych przypadków testowych, w tym wyniki, pozostaną w projekcie.",
+      "confirm": "Potwierdź usunięcie folderu",
+      "success": "Folder i wszystkie podfoldery/sprawy zostały pomyślnie usunięte."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "Nazwa folderu już istnieje. Wybierz inną nazwę."
+      }
+    },
+    "views": {
+      "byAutomation": "Automatyzacja",
+      "allTemplates": "Wszystkie szablony",
+      "allStates": "Wszystkie stany",
+      "allCreators": "Wszyscy twórcy",
+      "allCases": "Wszystkie przypadki",
+      "allAssignees": "Wszyscy cesjonariusze",
+      "anyTag": "Dowolny tag",
+      "noTags": "Brak tagów",
+      "byTag": "Etykietka",
+      "byIssue": "Wydanie",
+      "anyIssue": "Jakikolwiek problem",
+      "noIssues": "Brak problemów"
+    },
+    "noFoldersTitle": "Brak folderów",
+    "noFoldersDescription": "Zacznij od utworzenia pierwszego folderu, w którym uporządkujesz przypadki testowe.",
+    "noFoldersOrCasesNoPermission": "Brak folderów lub przypadków testowych do wyświetlenia.",
+    "createFirstFolder": "Utwórz swój pierwszy folder",
+    "bulkEdit": {
+      "title": "Edycja zbiorcza {count, plural, one {# Przypadek} other {# Przypadki}}",
+      "description": "Edycja {count, plural, one {# wybrany przypadek} other {# wybrane przypadki}}. Zaznacz pole, aby włączyć edycję.",
+      "defineStepsTitle": "Zdefiniuj kroki aktualizacji zbiorczej",
+      "saveNewSteps": "Zapisz nowe kroki",
+      "newStepsDefined": "Zdefiniowano nowe kroki ({count}) - Kliknij przycisk, aby edytować",
+      "clearExistingStepsWarning": "Istniejące kroki zostaną usunięte",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Wybrano wiele szablonów",
+          "description": "Po wybraniu spraw z różnymi szablonami można edytować tylko pola standardowe. Pola dynamiczne można edytować, wybierając sprawy korzystające z tego samego szablonu."
+        },
+        "junitLimitations": {
+          "title": "Ograniczenia edycji automatycznych przypadków testowych",
+          "description": "Pola Szacunek i Zautomatyzowane nie mogą być modyfikowane w przypadku przypadków testowych importowanych z wyników testów automatycznych."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Błąd ładowania przypadków",
+        "fetchErrorDescription": "Nie udało się załadować danych dla wybranych przypadków. Zamknij okno modalne i spróbuj ponownie.",
+        "updateErrorTitle": "Aktualizacja nie powiodła się",
+        "updateFailed": "Wystąpił błąd podczas zapisywania zmian. Sprawdź dane i spróbuj ponownie.",
+        "fetchError": "Błąd podczas pobierania danych o sprawie."
+      },
+      "success": {
+        "casesUpdated": "Sprawy zostały pomyślnie zaktualizowane"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Błąd walidacji",
+      "stepsCannotBeBulkEdited": "Kroków nie można edytować zbiorczo",
+      "stepsInfoTitle": "Informacje o krokach",
+      "stepsCannotBeBulkEditedInfo": "Kroków nie można edytować zbiorczo. Edytuj kroki, edytując przypadki pojedynczo.",
+      "confirmDeleteCases": "Czy na pewno chcesz usunąć {count, plural, one {# wybrany przypadek} other {# wybrane przypadki}}? Tej czynności nie można cofnąć.",
+      "replaceAll": "Zamień wszystko",
+      "searchReplace": "Wyszukaj i zamień",
+      "searchFor": "Szukaj",
+      "replaceWith": "Zastąp przez",
+      "searchText": "Wprowadź tekst, aby wyszukać",
+      "replacementText": "Wprowadź tekst zastępczy",
+      "useRegex": "Użyj wyrażenia regularnego",
+      "caseSensitive": "Rozróżniana wielkość liter",
+      "regexHint": "Użyj .* dla dowolnych znaków, \\d+ dla cyfr, \\w+ dla słów. Grupy przechwytujące: (wzorzec), a następnie użyj $1, $2 itd.",
+      "preview": "Zapowiedź",
+      "matches": "zapałki",
+      "noMatches": "Nie znaleziono wyników",
+      "invalidRegexPattern": "Nieprawidłowy wzorzec wyrażenia regularnego",
+      "searchPatternRequired": "Wymagany jest wzór wyszukiwania",
+      "stepsSearchReplaceInfo": "Funkcja wyszukiwania i zamiany zostanie zastosowana zarówno do opisów kroków, jak i oczekiwanych wyników."
+    },
+    "exportModal": {
+      "title": "Eksportuj przypadki testowe",
+      "description": "Wybierz poniżej opcje eksportu.",
+      "scope": {
+        "selected": "Wybrano ({count})",
+        "allFiltered": "Wszystko (Widok bieżący) ({count})",
+        "allProject": "Wszystko w projekcie ({count})"
+      },
+      "format": {
+        "label": "Format",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Obniżka cen"
+      },
+      "columns": {
+        "all": "Wszystko",
+        "visible": "Widoczny"
+      },
+      "delimiter": {
+        "label": "Rozgranicznik",
+        "placeholder": "Wybierz separator...",
+        "comma": "Przecinek (,)",
+        "semicolon": "Średnik (;)",
+        "colon": "Okrężnica (:)",
+        "pipe": "Rura (|)"
+      },
+      "textLongFormat": {
+        "label": "Tekst w długim formacie"
+      },
+      "attachmentFormat": {
+        "label": "Format załącznika",
+        "names": "Nazwy",
+        "json": "JSON",
+        "embedded": "Osadź obrazy"
+      },
+      "stepsFormat": {
+        "label": "Format kroków",
+        "plainText": "Zwykły tekst"
+      },
+      "rowMode": {
+        "label": "Wierszy na przypadek",
+        "single": "Pojedynczy rząd na skrzynkę",
+        "multi": "Wiele rzędów na krok"
+      },
+      "comingSoon": "Już wkrótce",
+      "exporting": "Eksportowanie...",
+      "exportError": "Eksport nie powiódł się. Spróbuj ponownie."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Konwertuj wybrane przypadki testowe na skrypty automatyzacji, korzystając z szablonu lub sztucznej inteligencji.",
+      "templatePlaceholder": "Wybierz szablon...",
+      "searchPlaceholder": "Wyszukaj szablony...",
+      "noTemplatesFound": "Nie znaleziono szablonów.",
+      "outputModeLabel": "Tryb wyjściowy",
+      "outputModeSingle": "Pojedynczy plik ({count, plural, one {# przypadek} other {wszystkie # przypadki}})",
+      "outputModeIndividual": "{count, plural, one {Pojedynczy plik (.zip)} other {Pojedyncze pliki (.zip)}}",
+      "casesToExport": "{count, plural, one {# przypadek} other {# przypadki}} do eksportu",
+      "exportSuccess": "Eksport zakończony pomyślnie.",
+      "noAvailableTemplates": "Brak dostępnych szablonów. Skontaktuj się z administratorem."
+    },
+    "aiExport": {
+      "toggleLabel": "Generuj za pomocą AI",
+      "generating": "Generowanie...",
+      "generatingProgress": "Generowanie przypadku {current} z {total}...",
+      "generatingBatch": "Generowanie {count, plural, one {# przypadków} other {# przypadków}} w jednym pliku...",
+      "previewTitle": "Podgląd eksportu",
+      "previewDescription": "{count, plural, one {# plik} other {# pliki}} wygenerowano",
+      "copySuccess": "Skopiowano do schowka",
+      "fallbackBadge": "Wygenerowano przy użyciu szablonu (AI niedostępne)",
+      "retryButton": "Ponów generowanie sztucznej inteligencji",
+      "aiGenerated": "Wygenerowane przez sztuczną inteligencję",
+      "templateGenerated": "Szablon wygenerowany",
+      "truncatedWarning": "Dane wyjściowe zostały obcięte — model osiągnął limit tokenów. Spróbuj zmniejszyć rozmiar partii lub zwiększyć maksymalną liczbę tokenów wyjściowych w konfiguracji monitu.",
+      "contextFiles": "{count, plural, one {(# plik kontekstowy)} other {(# pliki kontekstowe)}}",
+      "noCodeContextHint": "Brak skonfigurowanego repozytorium kodu. Sztuczna inteligencja będzie korzystać ze standardowych wzorców frameworków.",
+      "generatingParallelProgress": "Wygenerowano {done} z {total} plików...",
+      "cancelledGeneration": "Odwołany"
+    },
+    "duplicates": {
+      "findDuplicates": "Znajdź duplikaty",
+      "viewResults": "Widok {count, plural, one {# Wynik} other {# Wyniki}}",
+      "retryScan": "Ponów skanowanie",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Poprawa wyników dzięki sztucznej inteligencji...",
+      "scanComplete": "Zakończono analizę duplikatów — {count, plural, =0 {nie znaleziono duplikatów} one {# znaleziono potencjalny duplikat} other {# znaleziono potencjalne duplikaty}}",
+      "scanFailed": "Duplikacja analizy nie powiodła się",
+      "scanFailedDescription": "Wystąpił nieoczekiwany błąd",
+      "pageTitle": "Duplikaty kandydatów",
+      "pageDescription": "Przejrzyj potencjalnie zduplikowane przypadki testowe znalezione podczas ostatniego skanowania.",
+      "rescan": "Ponowne skanowanie",
+      "cancelScan": "Anuluj skanowanie",
+      "loading": "Ładowanie zduplikowanych kandydatów...",
+      "noDuplicatesFound": "Nie znaleziono duplikatów",
+      "noDuplicatesDescription": "Ostatnie skanowanie nie wykazało żadnych pasujących par.",
+      "loadMore": "Załaduj więcej",
+      "filterPlaceholder": "Filtruj duplikaty...",
+      "columnConfidence": "Zaufanie",
+      "columnCaseA": "Przypadek A",
+      "columnCaseB": "Przypadek B",
+      "columnMatchedFields": "Dopasowane pola",
+      "columnScore": "Wynik",
+      "compareButton": "Porównywać",
+      "viewCaseDetails": "Zobacz szczegóły sprawy",
+      "selectAll": "Zaznacz wszystko",
+      "selectRow": "Wybierz wiersz",
+      "selected": "{count, plural, one {# wybrano} other {# wybrano}}",
+      "bulkDismiss": "Nie duplikaty ({count})",
+      "bulkLink": "Link jako powiązany ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# para odrzucona} other {# pary odrzucone}}",
+      "bulkLinkSuccess": "{count, plural, one {# para połączona} other {# pary połączone}}",
+      "bulkError": "Niektóre operacje nie powiodły się. Spróbuj ponownie.",
+      "tableHint": "Kliknij wiersz lub przycisk Porównaj, aby przejrzeć i rozwiązać duplikat pary.",
+      "comparisonTitle": "{caseA} kontra {caseB}",
+      "comparisonDescription": "Porównaj te potencjalne duplikaty i zdecyduj, jak je rozwiązać.",
+      "selectPrimary": "Kliknij sprawę, aby wybrać ją jako sprawę podstawową do scalenia",
+      "selectedAsPrimary": "Wybrany jako podstawowy",
+      "mergeButton": "Zachowaj podstawowe",
+      "linkButton": "Link jako powiązany",
+      "dismissButton": "Nie jest duplikatem",
+      "merging": "Łączenie...",
+      "linking": "Łączenie...",
+      "dismissing": "Odrzucenie...",
+      "mergeSuccess": "Sprawy zostały pomyślnie połączone. {runsTransferred, plural, =0 {Nie przeniesiono żadnych przebiegów testów} one {# przeniesiono przebiegi testów} other {# przeniesiono przebiegi testów}}.",
+      "linkSuccess": "Sprawy powiązano jako powiązane.",
+      "dismissSuccess": "Para odrzucona. Nie pojawi się w przyszłych skanach.",
+      "resolveError": "Nie udało się rozwiązać zduplikowanej pary. Spróbuj ponownie.",
+      "loadingDetails": "Ładowanie szczegółów sprawy...",
+      "caseDetailsError": "Nie udało się załadować szczegółów sprawy.",
+      "sourceLabel": "Źródło",
+      "fieldValuesLabel": "Wartości pól",
+      "lastRunLabel": "Ostatni bieg",
+      "noFieldValues": "Brak wartości pól",
+      "noLastRun": "Nigdy nie biegaj",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Brak folderu",
+      "duplicateWarning": "Znaleziono możliwe duplikaty",
+      "duplicateWarningDescription": "{count, plural, one {# istniejący przypadek} other {# istniejące przypadki}} mogą obejmować podobną funkcjonalność",
+      "duplicateWarningReview": "Recenzja",
+      "importWarning": "Możliwy duplikat",
+      "importWarningTooltip": "Nazwa tego przypadku jest podobna do {count, plural, one {# istniejący przypadek} other {# istniejące przypadki}}: {names}",
+      "importIntraWarning": "Duplikat w imporcie",
+      "importIntraWarningTooltip": "Wiersze {rows} w tym imporcie mają taką samą lub bardzo podobną nazwę",
+      "checkingDuplicates": "Sprawdzanie duplikatów..."
+    },
+    "generateTestCases": {
+      "buttonText": "Generuj przypadki testowe",
+      "title": "Generuj przypadki testowe za pomocą sztucznej inteligencji",
+      "description": "Użyj sztucznej inteligencji do automatycznego generowania kompleksowych przypadków testowych na podstawie zewnętrznych problemów lub dokumentów.",
+      "loadingResults": "Ładowanie wygenerowanych przypadków testowych...",
+      "generatingPreparing": "Przygotowywanie żądania...",
+      "generatingCallingAi": "Czekamy, aż sztuczna inteligencja wygeneruje przypadki testowe...",
+      "generatingStreaming": "Sztuczna inteligencja generuje przypadek testowy {count}...",
+      "generatingStreamingPage": "Sztuczna inteligencja generuje przypadek testowy {count} — strona {current} z {total}: {page}",
+      "generatingProcessing": "Przetwarzanie wygenerowanych przypadków testowych...",
+      "generatingHint": "Może to potrwać chwilę, w zależności od stopnia złożoności materiału źródłowego.",
+      "steps": {
+        "selectIssue": "Wybierz źródło",
+        "selectTemplate": "Wybierz szablon",
+        "reviewGenerated": "Przegląd i import"
+      },
+      "selectSource": {
+        "title": "Wybierz źródło wymagań",
+        "description": "Wybierz, czy chcesz generować przypadki testowe na podstawie zgłoszenia czy dokumentu wymagań.",
+        "folderContextTip": "Istniejące przypadki testowe z folderu „{folderName}” i jego folderów nadrzędnych/podrzędnych zostaną użyte jako kontekst, aby uniknąć duplikatów. Przed kontynuowaniem upewnij się, że wybrałeś właściwy folder.",
+        "currentFolder": "bieżący folder",
+        "fromIssue": "Z wydania",
+        "fromDocument": "Z dokumentu",
+        "documentTitle": "Tytuł dokumentu",
+        "documentTitlePlaceholder": "Wprowadź tytuł dokumentu wymagań",
+        "documentDescription": "Dokument wymagań",
+        "documentDescriptionPlaceholder": "Wklej tutaj treść dokumentu wymagań...",
+        "documentPriority": "Priorytet (opcjonalnie)",
+        "selectPriority": "Wybierz priorytet",
+        "saveDocument": "Zapisz wymagania dotyczące dokumentu",
+        "fromUrl": "Z adresu URL",
+        "recentGenerations": "Ostatnie generowanie przypadków testowych z zadań URL",
+        "recentJobInfo": "{pages, plural, one {# strona} other {# strony}}{hasTestCases, select, true { · {testCases, plural, one {# przypadek testowy} other {# przypadki testowe}}} other {}}",
+        "recentJobHasResults": "Gotowy do recenzji",
+        "recentJobClickToGenerate": "Kliknij, aby wygenerować przypadki testowe",
+        "recentJobCrawling": "Pełzanie... {pages, plural, one {# strona} other {# stron}} do tej pory",
+        "removeJobTitle": "Usuń generację",
+        "confirmRemoveJob": "Spowoduje to usunięcie buforowanego indeksowania i wszystkich wygenerowanych przypadków testowych. Zawsze możesz wygenerować ponownie z tego samego adresu URL.",
+        "loadingRecentJobs": "Ładowanie ostatnich ofert pracy...",
+        "urlInput": "Adres URL strony",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "Co zawiera ten adres URL?",
+        "urlModeRequirements": "Wymagania",
+        "urlModeRequirementsHint": "Strona opisuje, co zbudować",
+        "urlModeApplication": "Aplikacja",
+        "urlModeApplicationHint": "Strona jest aplikacją do testowania",
+        "urlValidationError": "Proszę wpisać prawidłowy adres URL zaczynający się od http:// lub https://",
+        "followLinks": "Podążaj za linkami",
+        "followLinksHint": "Zostaną przeszukane tylko strony znajdujące się w tej samej domenie, co podany adres URL.",
+        "maxDepth": "Maksymalna głębokość",
+        "maxPages": "Maksymalna liczba stron",
+        "crawlProgress": "{current, plural, one {Pobrano dotychczas # stron...} other {Pobrano dotychczas # stron...}}",
+        "generatingSinglePage": "Generowanie przypadków testowych...",
+        "generatingSetup": "Przygotowywanie się do generowania przypadków testowych...",
+        "robotsSkipped": "{count, plural, one {# pominięta strona} other {# pominięte strony}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Wybierz problem zewnętrzny",
+        "description": "Wybierz problem z zewnętrznego systemu (np. Jira), na podstawie którego wygenerujesz przypadki testowe.",
+        "searchButton": "Wyszukaj problemy"
+      },
+      "selectTemplate": {
+        "title": "Wybierz szablon przypadku testowego",
+        "description": "Wybierz szablon, który będzie używany do generowania przypadków testowych. Sztuczna inteligencja wypełni pola zgodnie z tym szablonem.",
+        "placeholder": "Wybierz szablon...",
+        "fieldsDescription": "Wybierz pola, które AI ma wypełnić. Pola wymagane są zawsze uwzględniane.",
+        "requiredOnly": "Tylko wymagane"
+      },
+      "addNotes": {
+        "title": "Dodaj notatki i wskazówki",
+        "description": "Zapewnij dodatkowy kontekst i wskazówki, które pomogą sztucznej inteligencji generować lepsze przypadki testowe.",
+        "quantity": "Liczba przypadków testowych do wygenerowania",
+        "placeholder": "Dodaj szczegółowe instrukcje dotyczące generowania przypadków testowych...\n\nNa przykład:\n• Skup się na testowaniu bezpieczeństwa\n• Uwzględnij przypadki brzegowe i warunki brzegowe\n• Przetestuj scenariusze zarówno prawidłowej ścieżki, jak i błędu\n• Weź pod uwagę scenariusze mobilne i stacjonarne\n• Skup się na testowaniu interfejsu API",
+        "suggestions": "Szybkie sugestie:",
+        "quantityOptions": {
+          "justOne": "Tylko jeden",
+          "couple": "Para (2)",
+          "few": "Kilka (2-3)",
+          "several": "Kilka (4-6)",
+          "many": "Wiele (7-10)",
+          "maximum": "Maksymalny"
+        },
+        "suggestionItems": {
+          "security": "Skup się na testach bezpieczeństwa",
+          "edgeCases": "Uwzględnij przypadki brzegowe",
+          "happyPath": "Testuj tylko szczęśliwą ścieżkę",
+          "mobile": "Weź pod uwagę scenariusze mobilne",
+          "api": "Skupienie się na testowaniu API",
+          "accessibility": "Uwzględnij testy dostępności"
+        }
+      },
+      "review": {
+        "title": "Przejrzyj wygenerowane przypadki testowe",
+        "description": "Przejrzyj wygenerowane przez sztuczną inteligencję przypadki testowe, wprowadź niezbędne zmiany i wybierz te, które chcesz zaimportować.",
+        "selected": "{count} z {total} zaznaczono",
+        "moreSteps": "... i {count, plural, one {# więcej kroków} other {# więcej kroków}}",
+        "templateFields": "Pola szablonu:",
+        "moreFields": "... i {count, plural, one {# więcej pól} other {# więcej pól}}",
+        "crawledUrls": "{count, plural, one {Liczba przeszukanych stron} other {Liczba przeszukanych stron}}",
+        "spaWarning": "Ta strona może wymagać renderowania JavaScript. Wyniki mogą być niekompletne.",
+        "filterByPage": "Filtruj według strony",
+        "allPages": "Wszystkie strony ({pages, plural, one {# strona} other {# strony}}, {cases, plural, one {# przypadek} other {# przypadki}})"
+      },
+      "generatingLegacy": "Generowanie przypadków testowych za pomocą sztucznej inteligencji...",
+      "expandProgress": "Wygenerowano {done} z {total}",
+      "import": "{count, plural, =0 {Importuj przypadki testowe} =1 {Importuj 1 przypadek testowy} other {Importuj # przypadków testowych}}",
+      "importing": "{count, plural, =0 {Importowanie przypadków testowych...} =1 {Importowanie 1 przypadku testowego...} other {Importowanie # przypadków testowych...}}",
+      "openInExternalSystem": "Otwórz za {provider}",
+      "externalSystem": "System zewnętrzny",
+      "autoGenerateTags": "Automatyczne generowanie tagów dla przypadków testowych",
+      "success": {
+        "imported": "{count, plural, =1 {Pomyślnie zaimportowano 1 przypadek testowy} other {Pomyślnie zaimportowano # przypadków testowych}}"
+      },
+      "importData": {
+        "issueDescription": "Problem zewnętrzny powiązany z generowaniem przypadków testowych",
+        "generatedFolderName": "Wygenerowano"
+      },
+      "errors": {
+        "generateFailed": "Nie udało się wygenerować przypadków testowych. Spróbuj ponownie.",
+        "importFailed": "Nie udało się zaimportować przypadków testowych. Spróbuj ponownie.",
+        "noTestCasesGenerated": "Nie wygenerowano żadnych przypadków testowych. Spróbuj ponownie, podając inne dane wejściowe.",
+        "jobNoLongerAvailable": "Ta generacja nie jest już dostępna. Uruchom nową w kreatorze generowania przypadków testowych.",
+        "noAiModel": "W tym projekcie nie skonfigurowano żadnego modelu AI. Skonfiguruj model AI w ustawieniach projektu.",
+        "noIssueSelected": "Wybierz problem, na podstawie którego chcesz wygenerować przypadki testowe.",
+        "noDocumentProvided": "Proszę podać szczegóły dokumentu wymagań.",
+        "noTemplateSelected": "Proszę wybrać szablon dla przypadków testowych.",
+        "noFieldsSelected": "Proszę wybrać co najmniej jedno pole, dla którego ma zostać wygenerowana treść.",
+        "noTestCasesSelectedForImport": "Proszę wybrać co najmniej jeden przypadek testowy do zaimportowania.",
+        "templateRequired": "Wymagany jest wybór szablonu. Wróć i wybierz szablon.",
+        "repositoryNotFound": "Nie znaleziono repozytorium projektu. Skontaktuj się z administratorem.",
+        "workflowNotConfigured": "Przepływ pracy projektu nie został skonfigurowany. Sprawdź ustawienia projektu.",
+        "authenticationError": "Błąd uwierzytelniania. Odśwież stronę i spróbuj ponownie.",
+        "caseCreationFailed": "Nie udało się utworzyć przypadku testowego: {name}",
+        "caseAlreadyExists": "Przypadek testowy „{name}” już istnieje w tym folderze.",
+        "invalidTemplateConfig": "Nieprawidłowa konfiguracja szablonu dla przypadku testowego „{name}”.",
+        "nameTooLong": "Nazwa przypadku testowego „{name}” jest za długa. Użyj krótszej nazwy.",
+        "caseCreationError": "Nie udało się utworzyć „{name}”: {error}",
+        "templateNotFound": "Nie znaleziono wybranego szablonu. Odśwież stronę i spróbuj ponownie.",
+        "repositoryConfigError": "Błąd konfiguracji repozytorium projektu. Skontaktuj się z administratorem.",
+        "workflowConfigError": "Błąd konfiguracji przepływu pracy projektu. Sprawdź ustawienia projektu.",
+        "permissionDenied": "Nie masz uprawnień do tworzenia przypadków testowych w tym projekcie.",
+        "validationFailed": "Walidacja danych nie powiodła się. Sprawdź zawartość przypadku testowego i spróbuj ponownie.",
+        "databaseError": "Błąd połączenia z bazą danych. Spróbuj ponownie za chwilę.",
+        "genericImportError": "Nieudany import: {error}",
+        "networkRoutingError": "Problem z trasowaniem sieci lub konfiguracją serwera — zamiast odpowiedzi API otrzymano stronę błędu HTML",
+        "invalidSourceConfig": "Nieprawidłowa konfiguracja źródła",
+        "failedToCreateCaseVersion": "Nie udało się utworzyć wersji sprawy",
+        "noUrlProvided": "Proszę podać adres URL, z którego będą generowane przypadki testowe",
+        "urlFetchFailed": "Nie udało się pobrać treści z podanego adresu URL. Sprawdź adres URL i spróbuj ponownie.",
+        "llm": {
+          "genericTitle": "Błąd generacji AI",
+          "genericMessage": "Wystąpił błąd podczas generowania przypadków testowych z użyciem sztucznej inteligencji. Spróbuj ponownie lub zmień dane wejściowe.",
+          "overloaded": {
+            "title": "Usługa tymczasowo niedostępna",
+            "message": "Usługa AI cieszy się obecnie dużym zainteresowaniem. Spróbuj ponownie za chwilę."
+          },
+          "quota": {
+            "title": "Osiągnięto limit wykorzystania",
+            "message": "Osiągnąłeś limit wykorzystania sztucznej inteligencji na ten okres. Spróbuj ponownie później lub skontaktuj się z administratorem."
+          },
+          "timeout": {
+            "title": "Żądanie przekroczyło limit czasu",
+            "message": "Realizacja żądania AI trwała zbyt długo. Może się to zdarzyć w przypadku złożonych wymagań lub dużej liczby przypadków testowych."
+          },
+          "network": {
+            "title": "Błąd sieciowy",
+            "message": "Nie można połączyć się z usługą AI. Sprawdź połączenie internetowe i spróbuj ponownie."
+          },
+          "unauthorized": {
+            "title": "Uwierzytelnianie usługi AI nie powiodło się",
+            "message": "Usługa AI odrzuciła nasze dane uwierzytelniające. Administrator musi sprawdzić klucz API integracji LLM w ustawieniach administratora."
+          },
+          "forbidden": {
+            "title": "Dostęp do usługi AI zabroniony",
+            "message": "Usługa AI odrzuciła to żądanie. Administrator musi zweryfikować uprawnienia integracji LLM i dostęp do projektu."
+          },
+          "projectNotFound": {
+            "title": "Projekt nie znaleziony",
+            "message": "Nie znaleźliśmy tego projektu albo nie masz uprawnień do korzystania z generowania sztucznej inteligencji."
+          },
+          "noIntegration": {
+            "title": "Brak aktywnej integracji LLM",
+            "message": "W tym projekcie nie skonfigurowano żadnej aktywnej integracji LLM. Administrator musi ją włączyć w ustawieniach administratora."
+          },
+          "invalidRequest": {
+            "title": "Nieprawidłowe żądanie",
+            "message": "Żądanie generowania sztucznej inteligencji nie zawierało wymaganych informacji. Odśwież stronę i spróbuj ponownie."
+          },
+          "retryButton": "Spróbować ponownie",
+          "dismissButton": "Odrzucać",
+          "suggestionsHeading": "Sugestie",
+          "suggestions": {
+            "retryLater": "Spróbuj ponownie za kilka minut",
+            "contactAdmin": "Jeśli problem będzie się powtarzał, skontaktuj się z administratorem",
+            "checkStatus": "Sprawdź status usługi AI",
+            "checkNetwork": "Sprawdź swoje połączenie internetowe"
+          },
+          "timestampLabel": "Wystąpił błąd w",
+          "showDetails": "Pokaż szczegóły",
+          "hideDetails": "Ukryj szczegóły",
+          "copyDetails": "Kopiuj szczegóły",
+          "detailsCopied": "Szczegóły błędu skopiowano do schowka"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Niezapisane edycje",
+        "description": "{count, plural, =1 {Masz 1 przypadek testowy z niezapisanymi edycjami.} other {Masz # przypadków testowych z niezapisanymi edycjami.}}",
+        "warning": "Jeśli kontynuujesz bez zapisania, zmiany zostaną utracone.",
+        "saveAllAndImport": "Zapisz wszystko i importuj",
+        "discardAndImport": "Odrzuć edycje i importuj"
+      },
+      "linkedIssuesDroppedTitle": "Niektóre powiązane problemy nie zostały uwzględnione",
+      "linkedIssuesDropped": "{count, plural, =1 {# powiązane problemy zostały usunięte} other {# powiązane problemy zostały usunięte}} z powodu budżetu tokenów: {keys}.",
+      "linkedIssuesPreviewHeading": "Powiązane problemy, które zostaną uwzględnione"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Dodaj tag",
+      "title": "Dodaj nowy tag",
+      "fields": {
+        "name_error": "Nazwa tagu jest wymagana"
+      },
+      "errors": {
+        "nameExists": "Tag o tej nazwie już istnieje"
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Tag o tej nazwie już istnieje"
+      }
+    },
+    "filterPlaceholder": "Filtruj tagi...",
+    "defaultName": "Nienazwany tag",
+    "noProject": "Brak projektu",
+    "description": "Zarządzaj i organizuj przypadki testowe i sesje za pomocą tagów",
+    "detail": {
+      "title": "Szczegóły tagu",
+      "filterPlaceholder": "Filtruj elementy...",
+      "noResults": "Nie znaleziono żadnych pozycji",
+      "noFilterResults": "Brak elementów pasujących do obecnych filtrów",
+      "filters": {
+        "hideCompletedSessions": "Ukryj zakończone sesje",
+        "hideCompletedTestRuns": "Ukryj ukończone przebiegi testowe",
+        "caseTypeLabel": "Typ sprawy",
+        "allCases": "Wszystko"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Szukaj tagów...",
+      "searchOrAddPlaceholder": "Wyszukaj lub dodaj tagi...",
+      "noOptions": "Brak opcji"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Przeglądarka załączników"
+    },
+    "delete": {
+      "confirmMessage": "Czy na pewno chcesz usunąć ten załącznik?",
+      "deferredMessage": "Ten załącznik zostanie usunięty po zapisaniu."
+    }
+  },
+  "runs": {
+    "notFound": "Nie znaleziono przebiegu testowego.",
+    "add": {
+      "title": "Dodaj uruchomienie testowe",
+      "description": "Dodaj nowy przebieg testu do projektu",
+      "success": {
+        "title": "Test dodany pomyślnie",
+        "description": "Dodano przebieg testowy do projektu",
+        "descriptionMultiple": "{count, plural, one {# wykonano} other {# wykonano}} testów dla '{name}'"
+      },
+      "estimates": {
+        "manual": "Szacowany czas ręczny",
+        "automated": "Szacowany czas automatyczny",
+        "mixed": "Szacowany czas ręczny/automatyczny"
+      },
+      "creatingProgress": "Tworzenie testu {current} z {total}..."
+    },
+    "magicSelect": {
+      "title": "Magiczny wybór",
+      "description": "Wybór przypadków testowych oparty na sztucznej inteligencji na podstawie kontekstu przebiegu testu",
+      "counting": "Szukam odpowiednich przypadków testowych...",
+      "reasoning": "Rozumowanie AI",
+      "reviewSelection": "Przejrzyj sugerowane przypadki testowe",
+      "viewSuggested": "Wyświetl sugerowane przypadki",
+      "tokenUsage": "{total} użytych tokenów",
+      "noLlmIntegration": "Funkcje AI wymagają integracji LLM. Skonfiguruj ją w ustawieniach projektu.",
+      "configure": {
+        "title": "Zakres przypadku testowego",
+        "description": "Znaleziono {count, plural, =1 {# przypadek testowy} other {# przypadki testowe}} w repozytorium",
+        "descriptionFiltered": "Znaleziono {count, plural, =1 {# potencjalnie istotnych przypadków testowych} other {# potencjalnie istotnych przypadków testowych}} z {total, plural, =1 {# łącznie} other {# łącznie}} w repozytorium",
+        "noMatchesTitle": "Nie znaleziono pasujących przypadków testowych",
+        "noMatchesDescription": "Nazwa i opis przebiegu testu nie pasują do żadnego przypadku testowego. Wróć do poprzedniego kroku i dodaj bardziej szczegółowe informacje, takie jak nazwy funkcji, nazwy komponentów lub słowa kluczowe, które pojawiają się w przypadkach testowych.",
+        "maxResultsTitle": "Maksymalna liczba pasujących przypadków testowych",
+        "maxResultsDescription": "Kryteria wyszukiwania pasowały do dużej liczby przypadków testowych. Aby uzyskać bardziej precyzyjne wyniki, wróć do poprzedniego kroku i dodaj bardziej szczegółowe informacje do przebiegu testu.",
+        "batchSize": "Wielkość partii",
+        "batchSizeAll": "Wszystkie przypadki (pojedyncze żądanie)",
+        "batchSizePercent": "{percent}% ({count} przypadków)",
+        "requestsNeeded": "{count, plural, =1 {# Żądanie AI zostanie wysłane} other {# Żądanie AI zostanie wysłane}}",
+        "batchNote": "Wyniki ze wszystkich partii zostaną połączone"
+      },
+      "loading": {
+        "batch": "Przetwarzanie partii {current} z {total}",
+        "analyzing": "Analizowanie przypadków testowych...",
+        "progress": "Przeanalizowano {analyzed} z {total} przypadków testowych...",
+        "waitingForAi": "Oczekiwanie na odpowiedź AI (partia {batch} z {total})...",
+        "selectedSoFar": "{count, plural, =1 {# dotychczas wybrany przypadek testowy} other {# dotychczas wybrany przypadek testowy}}",
+        "resolving_integration": "Rozwiązywanie problemu integracji AI...",
+        "fetching_cases": "Pobieranie przypadków testowych..."
+      },
+      "success": {
+        "title": "Sugerowane przypadki testowe",
+        "description": "{count, plural, =1 {# wybrany przypadek testowy} other {# wybrany przypadek testowy}} na podstawie kontekstu uruchomienia testu",
+        "linkedCasesAdded": "{count, plural, =1 {# automatycznie uwzględniono powiązany przypadek} other {# automatycznie uwzględniono powiązane przypadki}}",
+        "truncationWarningTitle": "Częściowe wyniki",
+        "truncationWarning": "{count, plural, =1 {# partia została obcięta} other {# partie zostały obcięte}} przez model sztucznej inteligencji — niektóre przypadki testowe mogły nie zostać ocenione."
+      },
+      "noSuggestions": {
+        "title": "Brak pasujących przypadków testowych",
+        "description": "Żaden przypadek testowy nie spełnił kryteriów. Spróbuj dodać więcej kontekstu lub wyjaśnień."
+      },
+      "clarification": {
+        "label": "Dodatkowy kontekst (opcjonalny)",
+        "placeholder": "Dodaj dodatkowy kontekst, aby ułatwić wybór odpowiednich przypadków testowych...",
+        "refine": "Doprecyzuj wybór"
+      },
+      "actions": {
+        "start": "Analizuj przypadki testowe",
+        "startBatched": "Przeanalizuj przypadki testowe ({count, plural, one {# partia} other {# partie}})",
+        "accept": "Dodaj do wyboru"
+      },
+      "errors": {
+        "title": "Wybór nieudany",
+        "generic": "Wystąpił błąd podczas wybierania przypadków testowych. Spróbuj ponownie.",
+        "noTestRunName": "Przed użyciem Magic Select wprowadź nazwę testu."
+      }
+    },
+    "delete": {
+      "title": "Usuń przebieg testowy",
+      "description": "Czy na pewno chcesz usunąć ten test? Wyniki zostaną zachowane do analizy historycznej.",
+      "warning": "Tej czynności nie można cofnąć.",
+      "toast": {
+        "loading": "Usuwanie przebiegu testu...",
+        "success": "Test został pomyślnie usunięty",
+        "error": {
+          "title": "Nie udało się usunąć przebiegu testowego",
+          "description": "Wystąpił błąd podczas usuwania przebiegu testu"
+        }
+      }
+    },
+    "summary": {
+      "title": "Podsumowanie testu",
+      "description": "Wyświetl podsumowanie przebiegu testu",
+      "activeRunsAndEstTime": "Aktywne przebiegi i szacowany czas",
+      "activeRunsLabel": "Biegi",
+      "totalEstTime": "Całkowity szacowany czas",
+      "responsibleUsers": "Odpowiedzialni użytkownicy",
+      "allActiveRuns": "Wszystkie aktywne przebiegi",
+      "recentResultsTitle": "Ostatnie wyniki ręczne",
+      "recentResultsDescription": "Zobacz najnowsze wyniki testu",
+      "recentAutomatedResultsTitle": "Ostatnie zautomatyzowane wyniki",
+      "noRecentAutomatedResults": "Nie znaleziono ostatnio wyników automatycznych.",
+      "recentResultsDateRange": "Zakres dat",
+      "recentResultsElapsed": "Upłynął",
+      "noRecentResults": "Nie znaleziono ostatnich wyników.",
+      "completionTrendTitle": "Trend ukończenia (poprzednie 6 miesięcy)",
+      "workDistributionTitle": "Dystrybucja pracy",
+      "workDistributionDescription": "Szacowany podział pracy według osoby odpowiedzialnej.",
+      "noWorkDistributionData": "Brak aktywnych sesji z osobami przypisanymi lub szacunkami do wyświetlenia."
+    },
+    "details": {
+      "title": "Szczegóły przebiegu testu",
+      "description": "Wyświetl szczegóły przebiegu testu"
+    },
+    "duplicateDialog": {
+      "title": "Duplikat testu",
+      "description": "Utwórz kopię przebiegu testowego <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Przypadki testowe do duplikacji",
+          "allCases": "Wszystkie przypadki testowe",
+          "specificStatuses": "Przypadki testowe ze specyficznymi statusami"
+        },
+        "statusesToInclude": {
+          "label": "Przypadki testowe do uwzględnienia",
+          "description": "Wybierz statusy przypadków testowych, które chcesz uwzględnić w zduplikowanym przebiegu testu.",
+          "noStatuses": "Nie znaleziono żadnych konkretnych statusów w tym przebiegu testu lub wyniki są nadal ładowane.",
+          "noStatusesRecorded": "W tym przebiegu nie zarejestrowano żadnych konkretnych statusów. Duplikacja obejmie wszystkie przypadki testowe (zazwyczaj oznaczone jako „Nieprzetestowane”)."
+        },
+        "copyAssignments": {
+          "label": "Zadania przypadków testowych",
+          "copy": "Skopiuj istniejące przypisania przypadków testowych",
+          "assign": "Wszystkie przypadki testowe w zduplikowanym przebiegu testu zachowają swoje istniejące przypisania",
+          "unassign": "Wszystkie przypadki testowe w zduplikowanym przebiegu testu zostaną nieprzypisane"
+        }
+      },
+      "successMessage": "Pomyślnie zduplikowano przebieg testu '{name}'.",
+      "errorMessage": "Nie udało się zduplikować przebiegu testu. Błąd: {error}"
+    },
+    "filter": {
+      "placeholder": "Przeprowadź testy filtrów..."
+    },
+    "typeFilter": {
+      "label": "Pokazywać",
+      "both": "Manualne i automatyczne"
+    },
+    "empty": {
+      "noMatchingCompleted": "Nie znaleziono żadnych zakończonych przebiegów testowych odpowiadających wybranemu filtrowi."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Główny",
+      "projects": "Projektowanie",
+      "templatesAndFields": "Szablony i pola",
+      "fields": "Pola",
+      "workflows": "Przepływy pracy",
+      "statuses": "Statusy",
+      "milestoneTypes": "Typy kamieni milowych",
+      "configurations": "Konfiguracje",
+      "users": "Użytkownicy",
+      "groups": "Grupy",
+      "roles": "Role",
+      "tags": "Tagi",
+      "issues": "Kwestie",
+      "appConfig": "Konfiguracja aplikacji",
+      "notifications": "Powiadomienia",
+      "imports": "Import danych",
+      "integrations": "Integracje problemów",
+      "webhooks": "Webhooki",
+      "llm": "Modele AI",
+      "prompts": "Konfiguracje monitów",
+      "exportTemplates": "Eksportuj szablony",
+      "codeRepositories": "Repozytoria kodu",
+      "quickScript": "QuickScript",
+      "sso": "Uwierzytelnianie",
+      "security": "Bezpieczeństwo",
+      "trash": "Śmieci",
+      "reports": "Raporty",
+      "shares": "Zarządzaj udziałami",
+      "elasticsearch": "Wyszukiwarka",
+      "queues": "Kolejki zadań",
+      "auditLogs": "Dzienniki audytu",
+      "apiTokens": "Tokeny API",
+      "quickscriptTemplates": "Szablony QuickScript",
+      "testManagement": "Zarządzanie testami",
+      "peopleAndAccess": "Ludzie i dostęp",
+      "toolsAndIntegrations": "Narzędzia i integracje",
+      "system": "System"
+    },
+    "imports": {
+      "description": "Przenieś dane z zewnętrznych narzędzi do zarządzania testami do TestPlanIt.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Prześlij eksport pliku JSON Testmo, aby przeanalizować jego zawartość i przygotować mapowanie migracji.",
+        "wizard": {
+          "steps": {
+            "upload": "Prześlij eksport",
+            "analysis": "Analiza przeglądu",
+            "mapping": "Konfiguruj mapowanie",
+            "import": "Monitoruj import"
+          },
+          "stepIndicator": "Krok {step} z {total}"
+        },
+        "fileLabel": "Plik JSON Testmo",
+        "fileHelp": "Wybierz eksport JSON pobrany z Testmo.",
+        "analyze": "Analizuj eksport",
+        "analyzing": "Analizowanie...",
+        "reset": "Wyraźne wyniki",
+        "job": {
+          "discoveringDatasets": "Odkrywanie zbiorów danych...",
+          "scanningFile": "Skanowanie pliku eksportowego testmo...",
+          "datasetsProcessed": "{processed, number} zbiór danych{processed, plural, one {} other {s}} przetworzony",
+          "datasetsProcessedWithTotal": "{processed, number} z {total, number} zestawu danych{total, plural, one {} other {s}} przetworzono",
+          "rowsProcessed": "{value, number} przetworzonych wierszy",
+          "itemsProcessed": "Przetworzono {processed, number} z {total, number} elementów",
+          "analysisInProgress": "Analiza eksportu…",
+          "cancel": "Anuluj import",
+          "cancelRequested": "Anuluj żądanie",
+          "processingRate": "Wskaźnik:",
+          "estimatedTimeRemaining": "Szacowany pozostały czas:",
+          "datasetsLabel": "Zestawy danych:",
+          "rowsProcessedLabel": "Wydziwianie:"
+        },
+        "summaryHeading": "Podsumowanie eksportu",
+        "summary": {
+          "datasets": "Zestawy danych",
+          "fileName": "Nazwa pliku",
+          "fileSize": "Rozmiar pliku",
+          "analysisTime": "Czas analizy"
+        },
+        "datasetTable": {
+          "name": "Zestaw danych",
+          "rows": "Wydziwianie",
+          "samples": "Pobrane próbki"
+        },
+        "status": {
+          "truncated": "Kadłubowy"
+        },
+        "selectDataset": "Wybierz zestaw danych",
+        "schema": "Schemat",
+        "samples": "Przykładowe wiersze",
+        "noSamples": "Nie pobrano żadnych próbek dla tego zestawu danych.",
+        "mappingHeading": "Konfiguracja mapowania",
+        "mappingRefresh": "Odśwież analizę",
+        "mappingDescription": "Przejrzyj szczegóły analizy i przypisz encje Testmo do istniejących rekordów TestPlanIt lub utwórz nowe.",
+        "mappingAnalysisError": "Nie udało się wygenerować analizy mapowania. Spróbuj ponownie.",
+        "mappingLoading": "Analiza mapowania budynków…",
+        "mappingSummaryHeading": "Wykryte podmioty",
+        "mappingSummaryPending": "{count, plural, =1 {# oczekujące} other {# oczekujące}}",
+        "mappingOutstandingTitle": "Rozwiąż nierozwiązane mapowania",
+        "mappingOutstandingDescription": "Przed rozpoczęciem importu należy wykonać pozostałe mapowania.",
+        "mappingOutstandingItem": "{count, plural, =1 {# nierozwiązany element} other {# nierozwiązane elementy}} w {label}",
+        "mappingSummaryTemplateFields": "Pola szablonu",
+        "mappingDatasetLabels": {
+          "field_values": "Wartości pól",
+          "repository_case_values": "Wartości przypadków repozytorium",
+          "configs": "Ustawienia konfiguracji",
+          "session_issues": "Problemy sesyjne",
+          "session_tags": "Tagi sesji",
+          "states": "Stany przepływu pracy",
+          "statuses": "Statusy",
+          "templates": "Szablony",
+          "template_fields": "Pola szablonu",
+          "milestone_types": "Typy kamieni milowych",
+          "roles": "Role",
+          "users": "Użytkownicy",
+          "groups": "Grupy",
+          "user_groups": "Grupy użytkowników",
+          "issue_targets": "Integracje problemów",
+          "tags": "Tagi",
+          "sessions": "Sesje",
+          "session_results": "Wyniki sesji",
+          "fields": "Pola",
+          "projects": "Projektowanie",
+          "repositories": "Repozytoria",
+          "repository_folders": "Foldery repozytorium",
+          "repository_cases": "Sprawy repozytorium",
+          "repository_case_steps": "Kroki postępowania w przypadku repozytorium",
+          "repository_case_tags": "Tagi przypadków repozytorium",
+          "milestones": "Kamienie milowe",
+          "runs": "Przebiegi testowe",
+          "run_tests": "Przypadki testowe",
+          "run_results": "Wyniki testów",
+          "run_result_steps": "Wyniki testu krok po kroku",
+          "run_links": "Linki do testów",
+          "run_tags": "Tagi testów",
+          "issues": "Kwestie",
+          "milestone_issues": "Kluczowe kwestie",
+          "repository_case_issues": "Problemy ze sprawami repozytorium",
+          "run_issues": "Problemy z uruchomieniem testu",
+          "run_result_issues": "Problemy z wynikami testów",
+          "session_result_issues": "Problemy z wynikami sesji",
+          "automation_cases": "Przypadki automatyzacji",
+          "automation_runs": "Automatyzacja działa",
+          "automation_run_tests": "Testy automatyczne",
+          "automation_run_test_fields": "Pola testów automatycznych",
+          "automation_run_links": "Linki do uruchamiania automatyzacji",
+          "automation_run_tags": "Tagi uruchamiania automatyzacji",
+          "session_values": "Wartości sesji"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Przeglądaj stany przepływu pracy, aby mapować lub tworzyć przepływy pracy TestPlanIt.",
+          "statuses": "Skonfiguruj sposób mapowania statusów Testmo na statusy TestPlanIt.",
+          "templates": "Przeglądaj definicje szablonów zaimportowane z Testmo.",
+          "template_fields": "Sprawdź definicje pól szablonu uwzględnione w eksporcie.",
+          "fields": "Przejrzyj niestandardowe rekordy pól wyeksportowane z Testmo.",
+          "field_values": "Sprawdź definicje wartości pól przechwycone podczas eksportu.",
+          "milestone_types": "Sprawdź definicje typów kamieni milowych przechwycone podczas eksportu.",
+          "roles": "Przejrzyj definicje ról, aby zrozumieć uprawnienia Testmo.",
+          "users": "Zobacz konta użytkowników wykryte w eksporcie Testmo.",
+          "groups": "Przejrzyj zadania grupowe przeniesione z Testmo.",
+          "configs": "Przypisz nazwy konfiguracji do kategorii i wariantów TestPlanIt.",
+          "tags": "Sprawdź wartości tagów, które pojawiają się w danych Testmo.",
+          "repository_case_values": "Wartości wielokrotnego wyboru przypisane przypadkom testowym.",
+          "sessions": "Sesje są zawsze tworzone jako nowe sesje.",
+          "session_results": "Wyniki sesji są powiązane z sesjami.",
+          "session_issues": "Problemy z sesjami są powiązane z sesjami.",
+          "session_tags": "Tagi sesji są powiązane z sesjami.",
+          "issue_targets": "Przypisz cele problemów Testmo do integracji TestPlanIt (Jira, GitHub itp.)."
+        },
+        "mappingDatasetDefaultDescription": "Wykryto {dataset} w eksporcie Testmo.",
+        "mappingDatasetCount": "{count, number} rekord{count, plural, one {} other {s}} wykryto",
+        "mappingDatasetNoEntitiesTitle": "Nic do mapowania",
+        "mappingDatasetNoEntitiesDescription": "Ten zestaw danych nie wymaga mapowania. Przejdź do następnego zestawu danych, gdy będziesz gotowy.",
+        "mappingDatasetUnsupportedTitle": "Nie jest wymagane mapowanie",
+        "mappingDatasetUnsupportedDescription": "Te rekordy zostaną automatycznie zaimportowane i połączone z powiązanymi rekordami w TestPlanIt. Ręczne mapowanie nie jest wymagane.",
+        "mappingDatasetEmptyTitle": "Nie zachowano żadnych zestawów danych",
+        "mappingDatasetEmptyDescription": "Analiza nie zachowała żadnych zestawów danych do konfiguracji. Prześlij inny eksport, jeśli oczekujesz dodatkowych danych.",
+        "importProgressTitle": "Postęp importu",
+        "importProgressDescription": "{count, plural, =0 {Wszystkie rekordy zaimportowane między śledzonymi jednostkami.} =1 {Pozostało 1 rekord między śledzonymi jednostkami.} other {Pozostało # rekordów między śledzonymi jednostkami.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Brak pozostałych rekordów} =1 {Pozostał 1 rekord} other {Pozostała liczba rekordów}}",
+        "importProgressProcessed": "{processed, number}/{total, number} zaimportowano rekordy",
+        "importProgressAria": "{percent}% ukończenia importu",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Całkowity czas:",
+        "activityLogTitle": "Aktywność importowa",
+        "activityLogDescription": "Szczegółowy dziennik kroków importu w tle. Znaczniki czasu są oparte na strefie czasowej serwera.",
+        "activitySummaryProcessed": "{count, plural, =1 {# przetworzonych rekordów} other {# przetworzonych rekordów}}",
+        "activitySummaryCreated": "{count, plural, =1 {# utworzono} other {# utworzono}}",
+        "activitySummaryMapped": "{count, plural, =1 {# mapowane} other {# mapowane}}",
+        "activitySummaryUnknown": "Krok importu",
+        "activityDefaultMessage": "Importuj aktualizację",
+        "previousImportsHeading": "Przejrzyj poprzednie importy",
+        "previousImportsDescription": "Obciąż wyniki analizy po zakończeniu importu, umożliwiające sprawdzenie konfiguracji lub dzienników aktywności.",
+        "previousImportsRefresh": "Odśwież listę",
+        "previousImportsPlaceholder": "Wybierz poprzedni import",
+        "previousImportsEmpty": "Nie znaleziono wcześniejszych importów dla Twojego konta.",
+        "previousImportsCreatedLabel": "Stworzony: ",
+        "previousImportsFileLabel": "Plik: ",
+        "previousImportsNoFilename": "Nieznany plik",
+        "jobHistoryLoadFailed": "Nie udało się załadować wcześniej zaimportowanych zadań.",
+        "jobLoadFailed": "Nie udało się załadować tego zadania importu.",
+        "uploadProgressAnalyzing": "Przesyłanie zakończone. Analizowanie pliku…",
+        "uploadProgressComplete": "Przesyłanie zakończone",
+        "etaLabel": "ETA: {time}",
+        "startImportButton": "Rozpocznij import",
+        "workflowCreate": {
+          "nameLabel": "Nazwa przepływu pracy",
+          "namePlaceholder": "Wprowadź nazwę przepływu pracy",
+          "scopePlaceholder": "Wybierz zakres",
+          "iconColorLabel": "Ikona i kolor",
+          "typeLabel": "Typ przepływu pracy"
+        },
+        "mappingDatasets": "Zestawy danych wymagające przeglądu",
+        "mappingImportConfiguration": "Importuj konfigurację",
+        "mappingExportConfiguration": "Eksportuj konfigurację",
+        "mappingImportConfigurationFailed": "Nie udało się zaimportować tego pliku konfiguracyjnego. Sprawdź, czy jest to poprawny plik JSON i spróbuj ponownie.",
+        "mappingInvalidConfiguration": "Konfiguracja musi być poprawnym formatem JSON.",
+        "mappingSaveFailed": "Nie udało się zapisać konfiguracji. Spróbuj ponownie.",
+        "mappingSaveConfiguration": "Zapisz konfigurację",
+        "mappingSavingConfiguration": "Zapisywanie…",
+        "mappingStartImport": "Rozpocznij importowanie w tle",
+        "mappingStartingImport": "Rozpoczęcie importu…",
+        "mappingImportFailed": "Nie udało się rozpocząć importowania w tle. Spróbuj ponownie.",
+        "mappingImportDisabled": "Zapisz konfigurację przed rozpoczęciem importowania w tle.",
+        "mappingImportInProgress": "Trwa importowanie w tle",
+        "mappingImportInProgressDescription": "Pracownik importu przetwarza konfigurację. Możesz monitorować status powyżej.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# rekord} other {# rekordy}} ",
+          "columnSource": "Jednostka Testmo",
+          "columnSourceDetails": "Bliższe dane",
+          "columnSuggestedWorkflowType": "Sugerowany typ",
+          "columnTarget": "Cel",
+          "workflowTypeUnknown": "Nie wykryto",
+          "actionMap": "Mapa do istniejącego",
+          "actionCreate": "Utwórz nowy",
+          "workflowTypePlaceholder": "Wybierz typ",
+          "noWorkflowsAvailable": "Brak dostępnych przepływów pracy.",
+          "noStatusesAvailable": "Brak dostępnych statusów.",
+          "noGroupsAvailable": "Brak dostępnych grup.",
+          "groupSelectPlaceholder": "Wybierz grupę",
+          "groupNotePlaceholder": "Notatki (opcjonalnie)",
+          "groupNoteEmpty": "Nie podano dodatkowych szczegółów.",
+          "noUsersAvailable": "Brak dostępnych użytkowników.",
+          "userNoExistingTargets": "Brak użytkowników dostępnych do mapowania.",
+          "userNamePlaceholder": "Pełne imię i nazwisko",
+          "userAccessPlaceholder": "Wybierz poziom dostępu",
+          "userRoleUnavailable": "Brak dostępnych ról do przypisania.",
+          "userPasswordPlaceholder": "Hasło tymczasowe",
+          "userPasswordHint": "Podaj hasło tymczasowe. Użytkownicy mogą je zmienić po zalogowaniu.",
+          "userActiveLabel": "Aktywne konto",
+          "userDisplayFallback": "Użytkownik {id}",
+          "userMissingRequired": "Brak wymaganych szczegółów",
+          "noConfigurationsAvailable": "Brak dostępnych konfiguracji.",
+          "configurationNoTokens": "Nie wykryto żadnych wariantów w tej konfiguracji.",
+          "configurationNoExistingTargets": "Brak dostępnych konfiguracji do mapowania.",
+          "configurationNamePlaceholder": "Wprowadź nazwę konfiguracji",
+          "configurationVariantLabel": "Wariant {index}",
+          "configurationVariantActionLabel": "Jak należy postępować w przypadku tego wariantu?",
+          "configurationVariantActionPlaceholder": "Wybierz opcję",
+          "configurationVariantMapOption": "Mapa do istniejącego wariantu",
+          "configurationVariantExistingCategoryOption": "Utwórz wariant w istniejącej kategorii",
+          "configurationVariantNewCategoryOption": "Utwórz nową kategorię i wariant",
+          "configurationVariantSelectLabel": "Wybierz wariant",
+          "configurationVariantNoVariants": "Brak wariantów dostępnych do zmapowania.",
+          "configurationVariantCategoryLabel": "Kategoria",
+          "configurationVariantNameLabel": "Nazwa wariantu",
+          "configurationVariantNamePlaceholder": "Wprowadź nazwę wariantu",
+          "configurationVariantNoCategories": "Brak dostępnych kategorii.",
+          "configurationVariantCategoryNameLabel": "Nazwa kategorii",
+          "configurationVariantCategoryNamePlaceholder": "Wprowadź nazwę kategorii",
+          "noTemplateFieldsAvailable": "Brak dostępnych pól szablonu.",
+          "templateFieldDisplayFallback": "Pole {id}",
+          "templateFieldUnknownTemplate": "Nieznany szablon",
+          "templateFieldTargetCase": "Pole przypadku",
+          "templateFieldTargetResult": "Pole wyniku",
+          "templateFieldSelectPlaceholder": "Wybierz pole",
+          "templateFieldNoExistingTargets": "Brak dostępnych pól do mapowania.",
+          "templateFieldTypePlaceholder": "Wybierz typ pola",
+          "templateFieldRestrictedLabel": "Pole ograniczone",
+          "templateFieldOptionsLabel": "Opcje rozwijane",
+          "templateFieldOptionsPlaceholder": "Wprowadź jedną opcję w każdym wierszu",
+          "templateFieldOptionsHint": "Każdą opcję należy oddzielić nowym wierszem.",
+          "templateFieldOptionsListLabel": "Opcje",
+          "templateFieldOptionsCheckedLabel": "Zaznaczone domyślnie",
+          "templateFieldOptionsMinValueLabel": "Wartość minimalna",
+          "templateFieldOptionsMaxValueLabel": "Maksymalna wartość",
+          "templateFieldOptionsMinIntegerLabel": "Minimalna liczba całkowita",
+          "templateFieldOptionsMaxIntegerLabel": "Maksymalna liczba całkowita",
+          "templateFieldNewFieldSummaryTitle": "Szczegóły nowego pola",
+          "templateFieldNewFieldSummaryDescription": "Przejrzyj wartości, które zostaną użyte do utworzenia pola TestPlanIt.",
+          "templateFieldConfigureFieldButton": "Konfiguruj szczegóły",
+          "templateFieldEditFieldButton": "Edytuj szczegóły",
+          "templateFieldSummaryMissingValue": "Nie ustawiono",
+          "templateFieldSummaryMissingDetailsHint": "Aby kontynuować, wprowadź szczegóły nowego pola.",
+          "templateFieldModalSaveButton": "Zapisz szczegóły",
+          "templateFieldTargetTypeLabel": "Typ docelowy",
+          "templateFieldTypeMismatchWarning": "Wybrany typ pola {target} nie pasuje do typu pola Testmo {source}.",
+          "templateFieldDuplicateTargetWarning": "Wybrany cel jest już zmapowany na inne pole Testmo. Wybierz inny cel.",
+          "templateFieldTargetAlreadyUsed": "Już zmapowane",
+          "templateFieldMappedSummary": "Przypisano do {name} ({type})",
+          "templateFieldIssueMissingTarget": "Wybierz pole docelowe.",
+          "templateFieldIssueMissingDetails": "Przed kontynuowaniem podaj nazwę wyświetlaną, nazwę systemu i typ pola.",
+          "noTemplatesAvailable": "Brak dostępnych szablonów.",
+          "templateColumnFields": "Pola",
+          "templateFieldStatusMapped": "Zmapowano",
+          "templateFieldStatusCreate": "Utwórz nowe pole",
+          "templateFieldStatusMissing": "Nie zmapowano",
+          "templateFieldStatusMismatch": "Niedopasowanie celu",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# pole przypadku} other {# pola przypadku}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# pole wyniku} other {# pola wyników}}",
+          "templateMapLabel": "Mapa do istniejącego szablonu",
+          "templateCreateLabel": "Utwórz nowy szablon",
+          "templateNoMatchingTargets": "Brak pasujących szablonów.",
+          "templateNewNameLabel": "Nazwa szablonu",
+          "templateMapHintIncomplete": "Zmapuj wszystkie pola Testmo do istniejących pól sprawy i wyników przed zmapowaniem do istniejącego szablonu.",
+          "templateMapHintDuplicate": "Każde pole Testmo musi być mapowane na unikalne pole TestPlanIt.",
+          "templateMapHintNoMatch": "Żaden z istniejących szablonów nie używa tego samego zestawu pól.",
+          "templateMapHintAlreadyMapped": "Wszystkie pasujące szablony są już zmapowane. Wyczyść pozostałe mapowanie przed kontynuowaniem.",
+          "templateIssueNoSelection": "Wybierz istniejący szablon do mapowania.",
+          "templateIssueTargetConflict": "Inny szablon jest już zamapowany na ten cel.",
+          "templateIssueFieldErrors": "Rozwiąż podświetlone pola szablonu.",
+          "templateTargetFieldsMismatch": "Pola nie pasują do tego szablonu.",
+          "templateTargetNoLongerMatching": "Pola nie pasują już do tego szablonu.",
+          "noRolesAvailable": "Brak dostępnych ról.",
+          "roleSelectPlaceholder": "Wybierz rolę",
+          "roleNameLabel": "Nazwa roli",
+          "roleNamePlaceholder": "Wprowadź nazwę roli",
+          "rolePermissionsEmpty": "Brak przypisanych uprawnień",
+          "rolePermissionAddEdit": "Dodaj/Edytuj",
+          "noMilestoneTypesAvailable": "Brak dostępnych typów kamieni milowych.",
+          "milestoneSelectPlaceholder": "Wybierz typ kamienia milowego",
+          "milestoneNamePlaceholder": "Wprowadź nazwę typu kamienia milowego",
+          "milestoneDefaultLabel": "Domyślny typ kamienia milowego",
+          "milestoneIconRequired": "Wybierz ikonę",
+          "statusColorPlaceholder": "Kolor hex (opcjonalnie)",
+          "issueTargetSelectPlaceholder": "Wybierz integrację...",
+          "noIssueTargetsAvailable": "Brak dostępnych integracji problemów",
+          "issueTargetNamePlaceholder": "Nazwa integracji...",
+          "templateFieldsHeading": "Pola szablonu",
+          "roleAreaColumn": "Obszar",
+          "workflowSelectPlaceholder": "Wybierz przepływ pracy",
+          "statusSelectPlaceholder": "Wybierz status",
+          "statusNamePlaceholder": "Wprowadź nazwę statusu",
+          "statusSystemNamePlaceholder": "Wprowadź nazwę systemu",
+          "labelSystemName": "Nazwa systemu",
+          "groupNamePlaceholder": "Wprowadź nazwę grupy",
+          "configurationNameLabel": "Nazwa konfiguracji",
+          "userSelectPlaceholder": "Wybierz użytkownika",
+          "userApiLabel": "Użytkownik API",
+          "templateCaseFieldsLabel": "Pola przypadku",
+          "templateResultFieldsLabel": "Pola wyników",
+          "templateNoFieldsPlaceholder": "Brak skonfigurowanych pól dla tego szablonu.",
+          "templateTargetAlreadyUsed": "Cel jest już zamapowany na inny szablon.",
+          "templateFieldRequiredLabel": "Pole wymagane",
+          "templateFieldOptionsDefaultValueLabel": "Wartość domyślna",
+          "templateFieldOptionsInitialHeightLabel": "Wysokość początkowa",
+          "templateFieldTemplateLabelSingular": "szablon",
+          "templateFieldTemplateLabelPlural": "szablony",
+          "templateFieldTargetGroupCase": "Pola przypadku",
+          "templateFieldTargetGroupResult": "Pola wyników",
+          "columnAction": "Działanie"
+        },
+        "nextSteps": "Po zakończeniu importu w tle można przejrzeć zmigrowane dane z projektów docelowych.",
+        "nextStepsDescription": "Importy w tle działają asynchronicznie. Możesz monitorować status powyżej lub odświeżyć stronę, aby zobaczyć aktualizacje."
+      },
+      "comingSoon": {
+        "description": "Importowanie narzędzi TestRail, Zephyr i innych jest w planach."
+      },
+      "errors": {
+        "fileRequired": "Przed analizą wybierz plik JSON eksportu Testmo.",
+        "uploadFailed": "Nie udało się przesłać eksportu do magazynu. Spróbuj ponownie.",
+        "analysisFailed": "Nie mogliśmy przeanalizować tego eksportu. Sprawdź plik i spróbuj ponownie."
+      }
+    },
+    "sso": {
+      "description": "Zarządzaj ustawieniami uwierzytelniania i zabezpieczeń",
+      "sections": {
+        "providers": {
+          "title": "Dostawcy logowania",
+          "description": "Skonfiguruj sposób, w jaki użytkownicy mogą logować się do Twojej aplikacji"
+        },
+        "security": {
+          "title": "Bezpieczeństwo",
+          "description": "Konfigurowanie zasad bezpieczeństwa dla uwierzytelniania"
+        }
+      },
+      "globalSettings": {
+        "title": "Globalne ustawienia logowania jednokrotnego",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Włączanie lub wyłączanie uwierzytelniania Google OAuth"
+        },
+        "samlProvider": {
+          "title": "Dostawca SAML",
+          "description": "Włączanie lub wyłączanie uwierzytelniania SAML"
+        },
+        "apple": {
+          "title": "Zaloguj się do Apple",
+          "description": "Włączanie lub wyłączanie uwierzytelniania Apple Sign In"
+        },
+        "microsoft": {
+          "title": "Logowanie jednokrotne firmy Microsoft",
+          "description": "Włączanie lub wyłączanie uwierzytelniania Microsoft (Azure AD/Entra ID)"
+        },
+        "magicLink": {
+          "title": "Uwierzytelnianie Magic Link",
+          "description": "Włączanie lub wyłączanie uwierzytelniania bez hasła na podstawie wiadomości e-mail"
+        },
+        "forceSso": {
+          "title": "Wymuś logowanie jednokrotne",
+          "description": "Wyłącz logowanie za pomocą poczty e-mail i wymagaj od użytkowników korzystania z logowania jednokrotnego (SSO)"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Wymagaj uwierzytelniania dwuskładnikowego (2FA) do logowania za pomocą hasła",
+            "description": "Użytkownicy logujący się za pomocą adresu e-mail i hasła muszą skonfigurować i używać uwierzytelniania dwuskładnikowego"
+          },
+          "forceAllLogins": {
+            "title": "Wymagaj uwierzytelniania dwuskładnikowego (2FA) dla wszystkich logowań",
+            "description": "Wszyscy użytkownicy muszą dokonać weryfikacji za pomocą uwierzytelniania dwuskładnikowego po zalogowaniu, w tym użytkownicy korzystający z logowania jednokrotnego"
+          }
+        }
+      },
+      "providers": {
+        "configure": "Konfigurowanie SAML",
+        "delete": "Usuń dostawcę",
+        "entryPoint": "Punkt wejścia: ",
+        "autoProvision": "Automatyczne udostępnianie: ",
+        "defaultAccess": "Dostęp domyślny: ",
+        "configurationMessage": "Konfiguracja SAML nie została skonfigurowana. Kliknij przycisk ustawień, aby ją skonfigurować."
+      },
+      "samlConfiguration": {
+        "title": "Skonfiguruj dostawcę SAML",
+        "backButton": "Powrót do dostawców SSO",
+        "description": "Skonfiguruj ustawienia SAML dla {name}",
+        "samlSettings": {
+          "title": "Ustawienia SAML",
+          "description": "Skonfiguruj ustawienia dostawcy tożsamości SAML",
+          "ssoUrl": "Adres URL logowania jednokrotnego (punkt wejścia)",
+          "entityId": "Identyfikator podmiotu (wydawca)",
+          "certificate": "Certyfikat X.509",
+          "callbackUrl": "Adres URL wywołania zwrotnego",
+          "logoutUrl": "Adres URL wylogowania (opcjonalnie)"
+        },
+        "userProvisioning": {
+          "title": "Zaopatrzenie użytkowników",
+          "description": "Skonfiguruj sposób tworzenia i mapowania użytkowników",
+          "autoProvision": "Automatyczne dodawanie nowych użytkowników",
+          "defaultAccess": "Domyślny dostęp do systemu dla nowych użytkowników",
+          "accessDescription": "Nowym użytkownikom zostanie przypisana domyślna rola z bazy danych i ten poziom dostępu do systemu."
+        },
+        "attributeMapping": {
+          "title": "Mapowanie atrybutów",
+          "description": "Mapowanie atrybutów SAML na pola użytkownika",
+          "email": "Atrybut e-maila",
+          "displayName": "Atrybut nazwy wyświetlanej",
+          "userId": "Atrybut identyfikatora użytkownika",
+          "firstName": "Atrybut imienia (opcjonalnie)",
+          "lastName": "Atrybut nazwiska (opcjonalnie)",
+          "groups": "Atrybut grup (opcjonalny)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Włączono Google OAuth",
+        "googleDisabled": "Wyłączono Google OAuth",
+        "googleCreated": "Utworzono dostawcę Google OAuth",
+        "googleUpdateFailed": "Nie udało się zaktualizować Google OAuth",
+        "samlCreated": "Utworzono dostawcę SAML",
+        "createFailed": "Nie udało się utworzyć dostawcy",
+        "deleted": "Dostawca usunięty",
+        "deleteFailed": "Nie udało się usunąć dostawcy",
+        "enabled": "Dostawca włączony",
+        "disabled": "Dostawca wyłączony",
+        "updateFailed": "Nie udało się zaktualizować dostawcy",
+        "forceSsoEnabled": "Wymuś logowanie jednokrotne włączone globalnie",
+        "forceSsoDisabled": "Wymuś wyłączenie logowania jednokrotnego globalnie",
+        "forceSsoUpdateFailed": "Nie udało się zaktualizować ustawienia wymuszonego logowania jednokrotnego",
+        "force2FANonSSOEnabled": "Do logowania za pomocą hasła wymagane jest uwierzytelnianie dwuskładnikowe",
+        "force2FANonSSODisabled": "Dwuskładnikowe uwierzytelnianie nie jest już wymagane do logowania się za pomocą hasła",
+        "force2FAAllLoginsEnabled": "Wymagane jest uwierzytelnianie dwuskładnikowe dla wszystkich logowań",
+        "force2FAAllLoginsDisabled": "Dwuskładnikowe uwierzytelnianie nie jest już wymagane przy wszystkich logowaniach",
+        "force2FAUpdateFailed": "Nie udało się zaktualizować ustawień uwierzytelniania dwuskładnikowego",
+        "configUpdated": "Zaktualizowano konfigurację SAML",
+        "configCreated": "Utworzono konfigurację SAML",
+        "configSaveFailed": "Nie udało się zapisać konfiguracji SAML",
+        "googleConfigSaved": "Konfiguracja Google OAuth została pomyślnie zapisana",
+        "googleConfigFailed": "Nie udało się zapisać konfiguracji",
+        "appleEnabled": "Włączono logowanie Apple",
+        "appleDisabled": "Logowanie Apple wyłączone",
+        "appleCreated": "Utworzono dostawcę logowania Apple",
+        "appleConfigSaved": "Konfiguracja logowania Apple została pomyślnie zapisana",
+        "appleConfigFailed": "Nie udało się zapisać konfiguracji logowania Apple",
+        "appleUpdateFailed": "Nie udało się zaktualizować dostawcy usługi Apple Sign In",
+        "microsoftEnabled": "Włączone logowanie jednokrotne firmy Microsoft",
+        "microsoftDisabled": "Wyłączone logowanie jednokrotne firmy Microsoft",
+        "microsoftCreated": "Utworzono dostawcę Microsoft SSO",
+        "microsoftConfigSaved": "Konfiguracja logowania jednokrotnego firmy Microsoft została pomyślnie zapisana",
+        "microsoftConfigFailed": "Nie udało się zapisać konfiguracji logowania jednokrotnego firmy Microsoft",
+        "microsoftUpdateFailed": "Nie udało się zaktualizować dostawcy usługi Microsoft SSO",
+        "magicLinkEnabled": "Włączono uwierzytelnianie Magic Link",
+        "magicLinkDisabled": "Uwierzytelnianie Magic Link wyłączone",
+        "magicLinkCreated": "Utworzono dostawcę Magic Link",
+        "magicLinkUpdateFailed": "Nie udało się zaktualizować dostawcy Magic Link",
+        "samlConfigSaved": "Konfiguracja SAML została pomyślnie zapisana",
+        "configureFirst": "Przed włączeniem dostawcy należy go skonfigurować",
+        "domainRestrictionEnabled": "Włączono ograniczenie domeny e-mail",
+        "domainRestrictionDisabled": "Ograniczenie domeny e-mail wyłączone",
+        "domainRestrictionUpdateFailed": "Nie udało się zaktualizować ustawień ograniczeń domeny",
+        "domainRequired": "Proszę wpisać domenę",
+        "invalidDomain": "Proszę wprowadzić prawidłową domenę (np. example.com)",
+        "domainAdded": "Domena dodana pomyślnie",
+        "domainExists": "Ta domena znajduje się już na liście dozwolonych",
+        "domainAddFailed": "Nie udało się dodać domeny",
+        "domainEnabled": "Domena włączona",
+        "domainDisabled": "Domena wyłączona",
+        "domainUpdateFailed": "Nie udało się zaktualizować domeny",
+        "domainDeleted": "Domena została pomyślnie usunięta",
+        "domainDeleteFailed": "Nie udało się usunąć domeny",
+        "defaultAccessUpdated": "Zaktualizowano domyślny poziom dostępu",
+        "defaultAccessUpdateFailed": "Nie udało się zaktualizować domyślnego poziomu dostępu",
+        "emailVerificationEnabled": "Nowi użytkownicy muszą teraz zweryfikować adres e-mail",
+        "emailVerificationDisabled": "Weryfikacja adresu e-mail nie jest już wymagana dla nowych użytkowników",
+        "emailVerificationDisabledAndVerified": "Weryfikacja adresu e-mail wyłączona i {count, plural, one {# konto użytkownika} other {# konta użytkowników}} zweryfikowane",
+        "emailVerificationUpdateFailed": "Nie udało się zaktualizować ustawień weryfikacji adresu e-mail",
+        "emailServerNotConfigured": "Nie można włączyć weryfikacji poczty e-mail: serwer poczty e-mail nie jest skonfigurowany",
+        "openRegistrationEnabled": "Samodzielna rejestracja jest teraz włączona",
+        "openRegistrationDisabled": "Samodzielna rejestracja jest teraz wyłączona",
+        "openRegistrationUpdateFailed": "Nie udało się zaktualizować ustawień samodzielnej rejestracji"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Skonfiguruj Google OAuth",
+          "description": "Skonfiguruj dane uwierzytelniające klienta Google OAuth. Możesz je uzyskać w Konsoli Google Cloud.",
+          "clientIdPlaceholder": "Twój identyfikator klienta Google OAuth",
+          "clientSecretPlaceholder": "Twój tajny klucz klienta Google OAuth",
+          "instructions": {
+            "title": "Aby uzyskać te dane uwierzytelniające:",
+            "step1": "Przejdź do konsoli Google Cloud",
+            "step2": "Wybierz swój projekt lub utwórz nowy",
+            "step3": "Włącz API Google+",
+            "step4": "Przejdź do sekcji Poświadczenia i utwórz identyfikator klienta OAuth 2.0",
+            "step5": "Ustaw autoryzowany adres URI przekierowania na:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "Wymagane są zarówno ID klienta, jak i tajny klucz klienta"
+          }
+        },
+        "microsoft": {
+          "title": "Konfigurowanie logowania jednokrotnego firmy Microsoft",
+          "description": "Skonfiguruj poświadczenia aplikacji Microsoft Entra ID (Azure AD). Możesz je uzyskać w portalu Azure.",
+          "clientIdPlaceholder": "Twój identyfikator aplikacji (klienta)",
+          "clientSecretPlaceholder": "Wartość Twojego sekretu klienta",
+          "tenantId": "ID najemcy (opcjonalnie)",
+          "tenantIdPlaceholder": "Twój identyfikator katalogu (najemcy)",
+          "tenantIdHint": "Pozostaw puste dla wielu najemców („wspólnych”). Ustaw na konkretny identyfikator najemcy, aby ograniczyć go tylko do swojej organizacji.",
+          "instructions": {
+            "title": "Aby uzyskać te dane uwierzytelniające:",
+            "step1": "Przejdź do portalu Azure (portal.azure.com)",
+            "step2": "Przejdź do Microsoft Entra ID > Rejestracje aplikacji",
+            "step3": "Zarejestruj nową aplikację lub wybierz istniejącą",
+            "step4": "W obszarze Certyfikaty i sekrety utwórz nowy sekret klienta",
+            "step5": "Dodaj następujący adres URI przekierowania w obszarze Uwierzytelnianie:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "Wymagane są zarówno ID klienta, jak i tajny klucz klienta"
+          }
+        },
+        "saml": {
+          "description": "Skonfiguruj swojego dostawcę tożsamości SAML. Szczegóły te możesz uzyskać od swojego dostawcy tożsamości SAML.",
+          "entryPoint": "Adres URL punktu wejścia SSO",
+          "issuer": "Wydawca (ID podmiotu)",
+          "callbackUrl": "Adres URL ACS (wywołanie zwrotne)",
+          "logoutUrl": "Adres URL wylogowania SLO (opcjonalnie)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:twoje-idp:identyfikator-jednostki",
+          "certPlaceholder": "-----ROZPOCZĄTEK CERTYFIKATU-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "Aby skonfigurować SAML:",
+            "step1": "Skontaktuj się z administratorem swojego dostawcy tożsamości SAML",
+            "step2": "Poproś o adres URL punktu wejścia SSO i identyfikator jednostki",
+            "step3": "Pobierz certyfikat X.509",
+            "step4": "Skonfiguruj ten adres URL ACS w swoim dostawcy tożsamości:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "Wymagane są punkt wejścia, wystawca, certyfikat i adres URL wywołania zwrotnego"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "Wyłączyć weryfikację adresu e-mail?",
+          "description": "Spowoduje to wyłączenie weryfikacji adresu e-mail przy rejestracji nowych użytkowników i weryfikację wszystkich istniejących niezweryfikowanych kont.",
+          "warning": "⚠️ Ostrzeżenie bezpieczeństwa",
+          "warningPoint1": "Zalecane wyłącznie w przypadku instalacji zabezpieczonych (sieci prywatne, sieci VPN lub zaufane środowiska)",
+          "warningPoint2": "Wszystkie istniejące niezweryfikowane konta zostaną natychmiast zweryfikowane i otrzymają dostęp do systemu",
+          "confirmation": "Czy na pewno chcesz wyłączyć weryfikację adresu e-mail i zweryfikować wszystkie konta?",
+          "confirm": "Wyłącz i zweryfikuj wszystko",
+          "verifying": "Weryfikowanie kont..."
+        }
+      },
+      "status": {
+        "configured": "Skonfigurowano",
+        "setup": "Organizować coś"
+      },
+      "registration": {
+        "title": "Ustawienia rejestracji",
+        "description": "Kontroluj, kto może rejestrować nowe konta",
+        "restrictDomains": {
+          "title": "Ogranicz domeny e-mail",
+          "description": "Zezwalaj na rejestrację tylko z określonych domen e-mail"
+        },
+        "allowedDomains": {
+          "title": "Dozwolone domeny e-mail",
+          "placeholder": "example.com",
+          "add": "Dodaj domenę",
+          "empty": "Nie skonfigurowano żadnych dozwolonych domen. Po włączeniu ograniczeń wszystkie domeny zostaną zablokowane."
+        },
+        "defaultAccess": {
+          "title": "Domyślny poziom dostępu",
+          "description": "Poziom dostępu do systemu przypisywany nowym użytkownikom podczas rejestracji",
+          "options": {
+            "NONE": "Brak dostępu – Użytkownicy nie mogą uzyskać dostępu do systemu, dopóki administrator nie przyzna im dostępu.",
+            "USER": "Użytkownik – standardowy dostęp użytkownika do przypisanych projektów",
+            "PROJECTADMIN": "Administrator projektu – może zarządzać projektami, do których jest przypisany",
+            "ADMIN": "Administrator – pełny dostęp administracyjny systemu"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "Wymagaj weryfikacji adresu e-mail",
+          "description": "Użytkownicy muszą zweryfikować swój adres e-mail przed uzyskaniem dostępu do systemu",
+          "noEmailServerWarning": "Serwer e-mail nie jest skonfigurowany. Weryfikacja adresu e-mail jest automatycznie wyłączona do czasu skonfigurowania serwera e-mail."
+        },
+        "allowOpenRegistration": {
+          "title": "Zezwól na samodzielną rejestrację",
+          "description": "Po wyłączeniu tej opcji nowi użytkownicy nie mogą rejestrować się bezpośrednio ani tworzyć kont za pomocą logowania jednokrotnego (SSO). Istniejący użytkownicy nadal mogą się logować."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Nieprawidłowy dostawca lub dostawca nie jest dostawcą SAML."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Filtruj projekty..."
+      },
+      "complete": {
+        "title": "Ukończ projekt",
+        "description": "Ta czynność zakończy projekt i uniemożliwi dodanie dalszych przebiegów testów."
+      },
+      "add": {
+        "button": "Dodaj projekt",
+        "title": "Dodaj nowy projekt",
+        "defaultFields": "Domyślny szablon, domyślny typ kamienia milowego oraz wszystkie przepływy pracy i statusy zostaną dodane do projektu po jego utworzeniu.",
+        "selectIssueTracker": "Wybierz narzędzie do śledzenia problemów",
+        "issueTrackerRequired": "Wymagany jest moduł śledzenia problemów"
+      },
+      "wizard": {
+        "title": "Utwórz nowy projekt",
+        "description": "Skonfiguruj nowy projekt ze wszystkimi niezbędnymi konfiguracjami",
+        "steps": {
+          "details": "Szczegóły projektu",
+          "workflows": "Przepływy pracy, statusy i typy kamieni milowych",
+          "integrations": "Integracje",
+          "permissions": "Użytkownicy i uprawnienia"
+        },
+        "labels": {
+          "selected": "Wybrany",
+          "statuses": "Statusy testów",
+          "issueTrackers": "Śledzenie problemów"
+        },
+        "placeholders": {
+          "projectName": "Wprowadź nazwę projektu",
+          "selectDefaultAccess": "Wybierz domyślny typ dostępu"
+        },
+        "descriptions": {
+          "templates": "Wybierz co najmniej jeden szablon, aby zdefiniować strukturę przypadków testowych w tym projekcie.",
+          "workflows": "Konfiguruj przepływy pracy, statusy i typy kamieni milowych w celu zarządzania działaniami projektu.",
+          "integrations": "Opcjonalnie: Podłącz zewnętrzne systemy śledzenia problemów i modele sztucznej inteligencji, aby zwiększyć funkcjonalność.",
+          "noIntegrations": "Obecnie nie skonfigurowano żadnych integracji. Możesz pominąć ten krok lub skonfigurować integracje później.",
+          "aiModels": "Włącz modele AI do generowania przypadków testowych i inteligentnych sugestii.",
+          "permissions": "Skonfiguruj dostęp użytkowników i uprawnienia grupy dla tego projektu.",
+          "milestoneTypes": "Wybierz typy kamieni milowych, aby śledzić postęp projektu i terminy."
+        },
+        "actions": {
+          "selectDefault": "Użyj domyślnego",
+          "create": "Utwórz projekt",
+          "creating": "Tworzenie projektu..."
+        },
+        "errors": {
+          "nameRequired": "Nazwa projektu jest wymagana",
+          "validationFailed": "Nie udało się zweryfikować nazwy projektu. Spróbuj ponownie.",
+          "templateRequired": "Należy wybrać co najmniej jeden szablon",
+          "workflowRequired": "Należy wybrać co najmniej jeden przepływ pracy",
+          "statusRequired": "Należy wybrać co najmniej jeden status",
+          "roleRequired": "Wybierz rolę, jeśli używasz typu dostępu „Konkretna rola”",
+          "creationFailed": "Nie udało się utworzyć projektu. Spróbuj ponownie."
+        },
+        "success": {
+          "created": "Projekt został pomyślnie utworzony"
+        }
+      },
+      "edit": {
+        "title": "Edytuj projekt",
+        "labels": {
+          "groupProjectAccess": "Dostęp do projektu grupowego",
+          "groupPermissions": "Uprawnienia grupy",
+          "userPermissions": "Uprawnienia użytkownika",
+          "noEffect": "Brak efektu",
+          "access": {
+            "groupsGlobalRole": "Globalna rola Grupy",
+            "groupDefault": "Grupa domyślna",
+            "groupSpecificRole": "Rola specyficzna dla grupy",
+            "groupProjectDefault": "Projekt grupowy domyślny",
+            "groupProjectNoAccess": "Projekt grupowy Brak dostępu",
+            "groupProjectSpecificRole": "Rola specyficzna dla projektu grupowego",
+            "effectiveAccess": "Skuteczny dostęp"
+          },
+          "accessHints": {
+            "noAccess": "Użytkownicy nie będą mieli dostępu do tego projektu, dopóki nie otrzymają na to wyraźnej zgody poprzez bezpośrednie przypisanie lub członkostwo w grupie.",
+            "globalRole": "Wszyscy użytkownicy z dostępem do witryny mogą przeglądać ten projekt. Ich uprawnienia są określone przez globalnie przypisaną rolę.",
+            "specificRole": "Użytkownicy nie otrzymują dostępu automatycznie. Dostęp musi zostać przyznany poprzez bezpośrednie przypisanie użytkownika lub członkostwo w grupie. Użytkownicy przypisani za pośrednictwem grup będą korzystać z tej roli, chyba że zostanie ona zastąpiona przez bezpośrednie przypisanie."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Wybierz domyślny dostęp",
+          "groupPermissionsUI": "Tutaj znajduje się interfejs użytkownika zarządzania uprawnieniami grupy...",
+          "userPermissionsUI": "Tutaj znajduje się interfejs użytkownika do zarządzania uprawnieniami użytkownika...",
+          "selectAccess": "Wybierz dostęp...",
+          "selectRole": "Wybierz rolę...",
+          "searchUsersToAdd": "Wyszukaj użytkowników, aby dodać..."
+        },
+        "tableHeaders": {
+          "globalRole": "Globalna rola",
+          "projectAccess": "Dostęp do projektu"
+        },
+        "messages": {
+          "noUsersAssigned": "Brak użytkowników posiadających określone uprawnienia.",
+          "noGroupsFound": "Nie znaleziono grup."
+        },
+        "actions": {
+          "removeUser": "Usuń użytkownika"
+        },
+        "loadingUserPermissions": "Ładowanie uprawnień użytkownika..."
+      },
+      "delete": {
+        "title": "Usuń projekt",
+        "confirmMessage": "Czy na pewno chcesz usunąć ten projekt?"
+      }
+    },
+    "templates": {
+      "description": "Zarządzaj szablonami i polami przypadków testowych",
+      "help": {
+        "caseFields": "Pola przypadków definiują właściwości i dane, które można przechwycić dla każdego przypadku testowego w repozytorium. Pozwalają one dostosować informacje o przypadku testowym poza polami standardowymi.",
+        "resultFields": "Pola wyników definiują dodatkowe dane, które można rejestrować podczas rejestrowania wyników testów. Umożliwiają one śledzenie niestandardowych informacji dotyczących wyników wykonania testów."
+      },
+      "confirmSetAsDefault": "Ustaw jako domyślny szablon",
+      "confirmSetAsDefaultDescription": "Czy na pewno chcesz ustawić ten szablon jako domyślny?",
+      "confirmSetAsDefaultProjects": "Ten szablon zostanie dodany do wszystkich projektów.",
+      "add": {
+        "button": "Dodaj szablon",
+        "title": "Dodaj nowy szablon",
+        "defaultTemplateHint": "Ten szablon będzie przypisany do wszystkich projektów."
+      },
+      "edit": {
+        "title": "Edytuj szablon"
+      },
+      "delete": {
+        "title": "Usuń szablon",
+        "confirmMessage": "Czy na pewno chcesz usunąć szablon <strong>{name}</strong>?",
+        "warning": "Wszystkie przypadki testowe i sesje eksploracyjne aktualnie wykorzystujące ten szablon zostaną automatycznie przypisane do szablonu domyślnego.",
+        "errors": {
+          "defaultTemplateNotFound": "Nie znaleziono szablonu domyślnego. Nie można kontynuować usuwania.",
+          "unknown": "Podczas usuwania szablonu wystąpił nieznany błąd."
+        }
+      },
+      "caseFields": {
+        "description": "Zarządzaj polami sprawy",
+        "add": {
+          "button": "Dodaj pole sprawy",
+          "title": "Dodaj nowe pole sprawy"
+        },
+        "edit": {
+          "title": "Edytuj pole sprawy"
+        },
+        "delete": {
+          "title": "Usuń pole sprawy",
+          "confirmMessage": "Czy na pewno chcesz usunąć to pole sprawy?",
+          "warning": "Pole „Sprawa” zostanie usunięte ze wszystkich szablonów. Tej czynności nie można cofnąć."
+        }
+      },
+      "resultFields": {
+        "description": "Zarządzaj polami wyników",
+        "add": {
+          "button": "Dodaj pole wyniku",
+          "title": "Dodaj nowe pole wyniku"
+        },
+        "edit": {
+          "title": "Edytuj pole wyniku"
+        },
+        "delete": {
+          "title": "Usuń pole wyniku",
+          "confirmMessage": "Czy na pewno chcesz usunąć <strong>{name}</strong>?",
+          "warning": "Pole wyniku zostanie usunięte ze wszystkich szablonów. Tej czynności nie można cofnąć."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Repozytoria kodu",
+      "description": "Zarządzaj połączeniami z repozytorium kodu dla kontekstu QuickScript.",
+      "addRepository": "Dodaj repozytorium",
+      "noRepos": {
+        "title": "Brak skonfigurowanych repozytoriów kodu",
+        "description": "Połącz repozytorium Git, aby zapewnić kontekst pliku na potrzeby generowania testów eksportowych obsługiwanych przez sztuczną inteligencję."
+      },
+      "delete": {
+        "title": "Usuń repozytorium",
+        "confirmMessage": "Czy na pewno chcesz usunąć <strong>{name}</strong>? Tej czynności nie można cofnąć.",
+        "fallbackName": "to repozytorium"
+      },
+      "testConnection": "Połączenie testowe",
+      "connectionSuccess": "Połączenie pomyślne",
+      "connectionFailed": "Połączenie nieudane",
+      "networkError": "Błąd sieciowy",
+      "editTitle": "Edytuj repozytorium kodu",
+      "addTitle": "Dodaj repozytorium kodu",
+      "repositoryUpdated": "Zaktualizowano repozytorium",
+      "repositoryCreated": "Utworzono repozytorium",
+      "saveFailed": "Nie udało się zapisać repozytorium",
+      "namePlaceholder": "Moje repozytorium",
+      "selectProvider": "Wybierz dostawcę",
+      "httpWarning": "Ten adres URL używa protokołu HTTP. Dane uwierzytelniające zostaną wysłane w postaci zwykłego tekstu. Użyj protokołu HTTPS do bezpiecznych połączeń."
+    },
+    "exportTemplates": {
+      "title": "Szablony QuickScript",
+      "description": "Zarządzaj szablonami używanymi przez QuickScript do konwersji przypadków testowych na skrypty automatyzacji.",
+      "confirmSetAsDefault": "Ustaw jako domyślny szablon eksportu",
+      "confirmSetAsDefaultDescription": "Czy na pewno chcesz ustawić ten szablon jako domyślny? Będzie on domyślnie wybierany, gdy użytkownicy będą eksportować przypadki testowe.",
+      "fields": {
+        "category": "Kategoria",
+        "framework": "Struktura",
+        "fileExtension": "Rozszerzenie pliku",
+        "headerBody": "Szablon nagłówka",
+        "templateBody": "Szablon treści",
+        "footerBody": "Szablon stopki",
+        "validation": {
+          "categoryRequired": "Kategoria jest wymagana.",
+          "frameworkRequired": "Wymagany jest framework.",
+          "templateBodyRequired": "Treść szablonu jest wymagana.",
+          "fileExtensionRequired": "Rozszerzenie pliku jest wymagane.",
+          "languageRequired": "Język jest wymagany."
+        },
+        "placeholders": {
+          "name": "np. Playwright (TypeScript)",
+          "description": "np. generuje fragmenty testów Playwrighta",
+          "category": "np. Przeglądarka E2E",
+          "framework": "np. dramatopisarz",
+          "fileExtension": "np. .spec.ts",
+          "language": "np. maszynopis",
+          "headerBody": "Opcjonalnie. Treść renderowana raz na górze (np. polecenia importu).",
+          "templateBody": "Wprowadź szablon Mustache...\n\nDostępne zmienne:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSekcja kroków:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nPola niestandardowe:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Opcjonalnie. Treść renderowana raz na dole (np. zamykanie kodu)."
+        },
+        "combobox": {
+          "typeNew": "Wpisz, aby wprowadzić nową wartość"
+        }
+      },
+      "add": {
+        "button": "Dodaj szablon QuickScript",
+        "title": "Dodaj nowy szablon QuickScript"
+      },
+      "edit": {
+        "title": "Edytuj szablon QuickScript"
+      },
+      "delete": {
+        "title": "Usuń szablon QuickScript",
+        "confirmMessage": "Czy na pewno chcesz usunąć szablon QuickScript <strong>{name}</strong>?"
+      },
+      "preview": {
+        "title": "Podgląd (dane pozorowane)",
+        "empty": "Wprowadź treść szablonu, aby zobaczyć podgląd.",
+        "error": "Błąd renderowania szablonu. Sprawdź składnię Mustache."
+      },
+      "filterPlaceholder": "Szablony filtrów...",
+      "noResults": "Brak szablonów spełniających kryteria filtra.",
+      "templateCount": "{count, plural, one {# szablon} other {# szablony}}",
+      "allFrameworks": "Wszystkie frameworki",
+      "allFileExtensions": "Wszystkie rozszerzenia",
+      "allLanguages": "Wszystkie języki",
+      "showEnabled": "Tylko włączone",
+      "showAll": "Wszystko",
+      "variableInserter": {
+        "placeholder": "Wstaw zmienną...",
+        "groups": {
+          "customFields": "Pola niestandardowe"
+        },
+        "stepsBlock": "Blok schodów"
+      }
+    },
+    "users": {
+      "showInactive": "Pokaż nieaktywne",
+      "add": {
+        "button": "Dodaj użytkownika",
+        "title": "Dodaj nowego użytkownika",
+        "fields": {
+          "email_invalid": "Nieprawidłowy adres e-mail",
+          "password_error": "Wymagane jest hasło",
+          "confirmPassword_error": "Potwierdź hasło jest wymagane",
+          "passwordOptionalHelp": "Pozostaw puste pole, jeśli chcesz, aby użytkownik zalogował się za pomocą łącza Magic Link lub SSO."
+        }
+      },
+      "edit": {
+        "title": "Edytuj użytkownika"
+      },
+      "delete": {
+        "title": "Usuń użytkownika"
+      },
+      "restore": {
+        "title": "Przywróć usuniętego użytkownika",
+        "description": "Znaleziono usuniętego użytkownika o adresie e-mail {email} . Czy chcesz przywrócić tego użytkownika?",
+        "confirm": "Przywróć użytkownika"
+      },
+      "forcePasswordChange": "Wymuś zmianę hasła",
+      "revokePassword": "Odwołaj hasło",
+      "forcePasswordChangeDialogTitle": "Wymuś zmianę hasła",
+      "forcePasswordChangeDialogDescription": "Będzie to wymagało od {name} zmiany hasła przy następnym logowaniu.",
+      "revokePasswordDialogTitle": "Odwołaj hasło",
+      "revokePasswordDialogDescription": "Spowoduje to natychmiastowe unieważnienie hasła użytkownika {name}. Będzie on musiał użyć innej metody logowania.",
+      "confirmAction": "Potwierdzać",
+      "forcePasswordChangeSuccess": "Wymagana zmiana hasła dla {name}",
+      "forcePasswordChangeFailed": "Nie udało się wymusić zmiany hasła",
+      "revokePasswordSuccess": "Hasło dla {name} zostało unieważnione",
+      "revokePasswordFailed": "Nie udało się cofnąć hasła"
+    },
+    "security": {
+      "title": "Bezpieczeństwo",
+      "description": "Konfiguruj zasady dotyczące haseł, ustawienia blokady i działania egzekucyjne",
+      "passwordPolicyTitle": "Polityka haseł",
+      "passwordPolicyDescription": "Ustaw wymagania dotyczące haseł użytkowników",
+      "lockoutPolicyTitle": "Polityka blokady",
+      "lockoutPolicyDescription": "Skonfiguruj blokadę konta po nieudanych próbach logowania",
+      "enforcementTitle": "Działania egzekucyjne",
+      "enforcementDescription": "Wymuś zmianę hasła dla użytkowników opartych na poświadczeniach",
+      "minPasswordLengthLabel": "Minimalna długość hasła",
+      "minPasswordLengthDescription": "Hasła muszą mieć co najmniej taką liczbę znaków (8–128)",
+      "requireUppercaseLabel": "Wymagaj wielkich liter",
+      "requireLowercaseLabel": "Wymagaj małych liter",
+      "requireNumbersLabel": "Wymagaj liczb",
+      "requiredSpecialCharsLabel": "Wymagane znaki specjalne",
+      "requiredSpecialCharsDescription": "Pozostaw puste, aby wyłączyć. Wprowadź znaki, które muszą się pojawić (np. !@#$)",
+      "passwordHistoryDepthLabel": "Głębokość historii haseł",
+      "passwordHistoryDepthDescription": "Zapobiegaj ponownemu użyciu ostatnich N haseł (0 = wyłączone)",
+      "passwordExpirationDaysLabel": "Wygaśnięcie hasła (dni)",
+      "passwordExpirationDaysDescription": "Wymuś zmianę hasła po N dniach (0 = wyłączone)",
+      "lockoutThresholdLabel": "Próg blokady",
+      "lockoutThresholdDescription": "Liczba nieudanych prób przed zablokowaniem konta (minimum 1)",
+      "lockoutDurationMinutesLabel": "Czas trwania blokady (minuty)",
+      "lockoutDurationMinutesDescription": "Jak długo konto pozostaje zablokowane (minimum 1)",
+      "saveChanges": "Zapisz zmiany",
+      "forceAllUsers": "Wymuś zmianę hasła przez wszystkich użytkowników",
+      "forceAllUsersDialogTitle": "Wymuś zmianę hasła dla wszystkich użytkowników",
+      "forceAllUsersDialogDescription": "Wymagać to będzie od {count} użytkowników posiadających dane uwierzytelniające zmiany hasła przy następnym logowaniu.",
+      "forceAllUsersDialogWarning": "Tej czynności nie można cofnąć.",
+      "forceAllUsersDialogConfirm": "Wymuś zmianę",
+      "saved": "Ustawienia zabezpieczeń zostały zapisane",
+      "saveFailed": "Nie udało się zapisać ustawień zabezpieczeń",
+      "forceAllSuccess": "Wymagana zmiana hasła dla użytkowników {count}",
+      "forceAllFailed": "Nie udało się wymusić zmiany hasła"
+    },
+    "apiTokens": {
+      "description": "Przeglądaj i zarządzaj tokenami API dla wszystkich użytkowników. Unieważniaj tokeny w przypadku problemów z bezpieczeństwem.",
+      "filterPlaceholder": "Filtruj według nazwy tokena lub użytkownika...",
+      "showInactive": "Pokaż odwołane",
+      "noTokens": "Nie utworzono jeszcze żadnych tokenów API.",
+      "columns": {
+        "lastUsed": "Ostatnio używany",
+        "expires": "Wygasa"
+      },
+      "status": {
+        "revoked": "Odwołany",
+        "expired": "Wygasły"
+      },
+      "noExpiry": "Brak wygaśnięcia",
+      "revokeToken": "Odwołaj token",
+      "revokeConfirmTitle": "Odwołaj token API",
+      "revokeConfirmMessage": "Czy na pewno chcesz unieważnić ten token API? Tej czynności nie można cofnąć.",
+      "revokeConfirmDescription": "Token „{name}” należący do {user} zostanie natychmiast unieważniony i nie będzie mógł być już używany w celu uzyskania dostępu do API.",
+      "revokeSuccess": "Token API został pomyślnie cofnięty",
+      "revokeError": "Nie udało się odwołać tokenu API",
+      "revokeAllTokens": "Odwołaj wszystkie tokeny",
+      "revokeAllTitle": "Cofnij wszystkie tokeny API",
+      "revokeAllDescription": "Spowoduje to natychmiastowe unieważnienie WSZYSTKICH aktywnych tokenów API dla wszystkich użytkowników. Tej czynności nie można cofnąć i może ona zakłócić automatyczne przepływy pracy.",
+      "revokeAllConfirm": "Wpisz „COFNIJ WSZYSTKO”, aby potwierdzić",
+      "revokeAllPlaceholder": "COFNIJ WSZYSTKIE",
+      "revokeAllSuccess": "Wszystkie tokeny API zostały unieważnione",
+      "revokeAllError": "Nie udało się unieważnić wszystkich tokenów"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Wystąpił błąd podczas tworzenia tagu"
+        }
+      },
+      "delete": {
+        "title": "Usuń tag",
+        "confirmMessage": "Czy na pewno chcesz usunąć ten tag?",
+        "warning": "Ten tag zostanie usunięty ze wszystkich przypadków testowych i sesji.",
+        "errors": {
+          "unknown": "Wystąpił błąd podczas usuwania tagu"
+        }
+      },
+      "edit": {
+        "title": "Edytuj tag"
+      }
+    },
+    "workflows": {
+      "description": "Zarządzaj przepływami pracy przypadków testowych",
+      "add": {
+        "button": "Dodaj przepływ pracy",
+        "title": "Dodaj nowy przepływ pracy",
+        "defaultHelp": "Ustaw jako domyślny przepływ pracy dla nowych przypadków testowych",
+        "scopeLabel": "Zakres przepływu pracy",
+        "errors": {
+          "nameExists": "Przepływ pracy o tej nazwie już istnieje"
+        }
+      },
+      "edit": {
+        "title": "Edytuj przepływ pracy",
+        "lastWorkflowTypeWarning": "To ostatni typ przepływu pracy. Musi być włączony co najmniej jeden typ przepływu pracy.",
+        "errors": {
+          "nameRequired": "Nazwa przepływu pracy jest wymagana",
+          "unknownWorkflow": "Nieznany przepływ pracy"
+        }
+      },
+      "delete": {
+        "title": "Usuń przepływ pracy",
+        "confirmMessage": "Czy na pewno chcesz usunąć ten przepływ pracy?"
+      },
+      "setDefault": {
+        "title": "Ustaw domyślny przepływ pracy",
+        "confirmMessage": "Czy na pewno chcesz ustawić ten przepływ pracy jako domyślny?",
+        "description": "Ten przepływ pracy zostanie dodany do wszystkich projektów."
+      }
+    },
+    "roles": {
+      "description": "Zdefiniuj, jakie działania mogą wykonywać użytkownicy, przełączając uprawnienia dla każdego obszaru aplikacji.",
+      "filterPlaceholder": "Filtruj role...",
+      "add": {
+        "button": "Dodaj rolę",
+        "title": "Dodaj nową rolę",
+        "fields": {
+          "name_error": "Nazwa roli jest wymagana"
+        },
+        "errors": {
+          "nameExists": "Rola o tej nazwie już istnieje"
+        }
+      },
+      "edit": {
+        "title": "Edytuj rolę",
+        "permissionsTitle": "Uprawnienia",
+        "areaHeader": "Obszar zastosowania"
+      },
+      "delete": {
+        "title": "Usuń rolę",
+        "confirmMessage": "Czy na pewno chcesz usunąć tę rolę?",
+        "warning": "Tej czynności nie można cofnąć. Użytkownicy z tą rolą zostaną przypisani do roli domyślnej.",
+        "errors": {
+          "defaultNotFound": "Nie można usunąć roli domyślnej"
+        }
+      }
+    },
+    "statuses": {
+      "description": "Zarządzaj statusami testów",
+      "add": {
+        "button": "Dodaj status",
+        "title": "Dodaj nowy status",
+        "systemNameHelp": "Nazwa systemu identyfikuje ten status. Nie można go zmienić po utworzeniu.",
+        "aliasesHelp": "Lista aliasów rozdzielona przecinkami",
+        "errors": {
+          "nameExists": "Status o tej nazwie już istnieje",
+          "systemNameEmpty": "Nazwa systemu jest wymagana",
+          "systemNameInvalid": "Nazwa systemu musi być alfanumeryczna",
+          "aliasesInvalid": "Aliasy muszą być alfanumeryczne",
+          "missingColor": "Nie znaleziono koloru. Wybierz inny kolor."
+        }
+      },
+      "edit": {
+        "title": "Edytuj status",
+        "systemNameHelp": "Nazwa systemu identyfikuje ten status dla procesów zautomatyzowanych. Nie można go zmienić po utworzeniu.",
+        "unmodifiableHelp": "Status „nieprzetestowany” jest statusem systemowym i nie można go zmienić.",
+        "untestedHelp": "Nazwa „nieprzetestowany” jest zarezerwowana dla statusu systemu i nie może być używana.",
+        "success": "Status zaktualizowano pomyślnie"
+      },
+      "delete": {
+        "title": "Usuń status",
+        "confirmMessage": "Czy na pewno chcesz usunąć status <strong>{name}</strong>?",
+        "errors": {
+          "inUse": "Ten status jest używany i nie można go usunąć",
+          "defaultNotFound": "Nie znaleziono domyślnego statusu"
+        },
+        "success": "Status pomyślnie usunięty"
+      },
+      "fields": {
+        "final": "Finał",
+        "system": "Stan systemu",
+        "forTestCase": "Do przypadku testowego",
+        "forTestRun": "Do testu",
+        "forSession": "Na sesję",
+        "color": "Kolor"
+      }
+    },
+    "appConfig": {
+      "description": "Zarządzaj globalnymi konfiguracjami aplikacji",
+      "addConfig": "Dodaj konfigurację aplikacji",
+      "editConfig": "Edytuj konfigurację aplikacji",
+      "keyPlaceholder": "Wprowadź klucz konfiguracyjny...",
+      "valuePlaceholder": "Wprowadź wartość JSON...",
+      "currentTranslation": "Aktualne tłumaczenie",
+      "filterPlaceholder": "Filtruj według klucza...",
+      "errors": {
+        "keyRequired": "Klucz jest wymagany",
+        "invalidJson": "Nieprawidłowy format JSON"
+      },
+      "configKeys": {
+        "project_docs_default": "Domyślna dokumentacja projektu"
+      }
+    },
+    "configurations": {
+      "description": "Konfiguracje to kombinacja kategorii i wariantów używanych do definiowania środowiska testowego. Na przykład system operacyjny/przeglądarka, serwer testowy, język itp.",
+      "addConfiguration": "Dodaj konfigurację",
+      "editConfiguration": "Edytuj konfigurację",
+      "filterPlaceholder": "Konfiguracje filtrów...",
+      "categories": {
+        "title": "Kategorie",
+        "description": "Zarządzaj kategoriami globalnymi",
+        "editCategory": "Edytuj kategorię",
+        "selectCategory": "Wybierz kategorię",
+        "filterPlaceholder": "Kategorie filtrów...",
+        "add": {
+          "title": "Dodaj nową kategorię"
+        },
+        "delete": {
+          "confirmMessage": "Czy na pewno chcesz usunąć tę kategorię?",
+          "deleteCategory": "Usuń kategorię",
+          "deleteCategoryConfirm": "Czy na pewno chcesz usunąć kategorię <strong>{name}</strong>?",
+          "deleteCategoryWarning": "Ta czynność spowoduje usunięcie kategorii i wszystkich powiązanych wariantów."
+        },
+        "disable": {
+          "confirmDisableTitle": "Wyłącz wariant",
+          "confirmDisableDescription": "Czy na pewno chcesz wyłączyć tę wersję?"
+        }
+      },
+      "combinations": {
+        "title": "Kombinacje",
+        "description": "Zarządzaj kombinacjami globalnymi",
+        "addCombination": "Dodaj kombinację",
+        "editCombination": "Edytuj kombinację",
+        "selectCombination": "Wybierz kombinację",
+        "selectCombinationDescription": "Wybierz kombinację wariantów, aby dodać ją do konfiguracji.",
+        "allExist": "Wszystkie kombinacje już istnieją.",
+        "selectAtLeast": "Proszę wybrać co najmniej jedną kombinację."
+      },
+      "delete": {
+        "title": "Usuń konfigurację",
+        "message": "Czy na pewno chcesz usunąć konfigurację <strong>{name}</strong>?",
+        "confirmMessage": "Czy na pewno chcesz usunąć tę konfigurację?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Edytuj wariant"
+        },
+        "delete": {
+          "title": "Usuń wariant",
+          "message": "Czy na pewno chcesz usunąć wariant <strong>{name}</strong>?",
+          "confirmMessage": "Czy na pewno chcesz usunąć ten wariant?",
+          "suggestion": "Zamiast tego należy rozważyć wyłączenie tej opcji."
+        },
+        "selection": {
+          "title": "Wybierz warianty",
+          "description": "Wybierz warianty, które chcesz dodać do konfiguracji."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Organizuj użytkowników w grupy, aby zbiorczo przypisywać dostęp do projektu i role."
+      },
+      "filterPlaceholder": "Grupy filtrów...",
+      "add": {
+        "button": "Dodaj grupę",
+        "title": "Dodaj nową grupę",
+        "errors": {
+          "nameExists": "Grupa o tej nazwie już istnieje"
+        }
+      },
+      "edit": {
+        "title": "Edytuj grupę"
+      },
+      "delete": {
+        "deleteGroup": "Usuń grupę",
+        "deleteGroupDescription": "Ta czynność spowoduje usunięcie grupy i wszystkich powiązanych z nią użytkowników.",
+        "confirmMessage": "Czy na pewno chcesz usunąć tę grupę?"
+      },
+      "noUsersSelected": "Nie wybrano jeszcze żadnego użytkownika.",
+      "noUsersAssigned": "Do tej grupy nie przypisano żadnego użytkownika."
+    },
+    "milestones": {
+      "description": "Zarządzaj typami kamieni milowych",
+      "filterPlaceholder": "Filtruj typy kamieni milowych...",
+      "addMilestones": "Masowe dodawanie kamieni milowych",
+      "confirmDefault": "Potwierdź domyślne",
+      "confirmDefaultDescription": "Czy na pewno chcesz ustawić ten typ kamienia milowego jako domyślny?",
+      "warning": "Ten typ kamienia milowego zostanie dodany do wszystkich projektów.",
+      "wizard": {
+        "selectProjects": "Wybierz projekty",
+        "projectsSelected": "{count, plural, =0 {Nie wybrano żadnych projektów} one {# wybrano projekt} other {# wybrano projekty}}",
+        "createMilestone": "Utwórz kamień milowy",
+        "noCommonTypesTitle": "Brak wspólnych typów kamieni milowych",
+        "noCommonTypesDescription": "Wybrane projekty nie mają wspólnych typów kamieni milowych. Upewnij się, że wszystkie wybrane projekty mają co najmniej jeden wspólny typ kamienia milowego lub wybierz różne projekty."
+      },
+      "add": {
+        "button": "Dodaj typ kamienia milowego",
+        "title": "Dodaj nowy typ kamienia milowego",
+        "errors": {
+          "nameExists": "Typ kamienia milowego o tej nazwie już istnieje"
+        }
+      },
+      "edit": {
+        "title": "Edytuj typ kamienia milowego"
+      },
+      "delete": {
+        "title": "Usuń typ kamienia milowego",
+        "confirmMessage": "Czy na pewno chcesz usunąć ten typ kamienia milowego?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Śledzenie problemów z linkami",
+      "link_description": "Skonfiguruj adres URL bazowy dla ręcznie połączonych zgłoszeń. Podczas łączenia zgłoszenia przy użyciu tylko identyfikatora zewnętrznego, ten adres URL bazowy zostanie dodany na początku, aby utworzyć pełny link.",
+      "filter": {
+        "show_inactive": "Pokaż nieaktywne konfiguracje",
+        "search_placeholder": "Filtruj według nazwy konfiguracji..."
+      },
+      "base_url": "Podstawowy adres URL",
+      "link_update_success": "Konfiguracja łącza została pomyślnie zaktualizowana",
+      "link_update_error": "Nie udało się zaktualizować konfiguracji łącza",
+      "description": "Konfiguruj integracje z zewnętrznymi systemami śledzenia problemów.",
+      "delete": {
+        "title": "Usuń konfigurację problemu",
+        "confirmMessage": "Czy na pewno chcesz usunąć konfigurację <bold>{name}</bold>?",
+        "warning": "Tej czynności nie można cofnąć. Wszystkie projekty aktualnie przypisane do tego trackera zostaną przypisane do trackera domyślnego. Zamiast tego rozważ dezaktywację konfiguracji.",
+        "cannotDeleteDefault": "Domyślnego modułu śledzenia problemów nie można usunąć.",
+        "noDefaultFound": "Nie można usunąć: Nie znaleziono domyślnego systemu śledzenia problemów, do którego można by ponownie przypisać projekty."
+      },
+      "add": {
+        "title": "Dodaj moduł śledzenia problemów",
+        "description": "Utwórz nową konfigurację systemu śledzenia problemów.",
+        "name": "Nazwa konfiguracji",
+        "name_placeholder": "np. Linki do projektu Jira",
+        "system_type": "Typ systemu",
+        "select_system_type": "Wybierz typ systemu",
+        "base_url": "Podstawowy adres URL zawierający symbol zastępczy problemu",
+        "base_url_placeholder": "np. https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Konfiguracja problemu została pomyślnie utworzona",
+        "create_error": "Błąd podczas tworzenia konfiguracji problemu",
+        "setDefaultWarning": "Ustawienie tej opcji jako domyślnej spowoduje usunięcie domyślnego statusu z bieżącej domyślnej konfiguracji."
+      },
+      "edit": {
+        "title": "Edytuj śledzenie problemów",
+        "description": "Zaktualizuj szczegóły dotyczące konfiguracji tego problemu.",
+        "name_placeholder": "Wprowadź nazwę konfiguracji",
+        "select_project": "Wybierz projekty...",
+        "update_success": "Konfiguracja problemu została pomyślnie zaktualizowana",
+        "update_error": "Nie udało się zaktualizować konfiguracji problemu",
+        "edit_not_supported": "Edycja konfiguracji dla tego typu systemu nie jest obecnie obsługiwana."
+      }
+    },
+    "issues": {
+      "description": "Zarządzaj problemami w tym systemie śledzenia problemów",
+      "filterPlaceholder": "Problemy z filtrem...",
+      "add": {
+        "button": "Dodaj problem",
+        "title": "Dodaj nowy problem"
+      },
+      "edit": {
+        "title": "Edytuj problem"
+      },
+      "delete": {
+        "title": "Usuń problem",
+        "confirmMessage": "Czy na pewno chcesz usunąć zgłoszenie „{name}”?"
+      },
+      "syncIssue": "Problem z synchronizacją z systemem zewnętrznym",
+      "syncSuccess": "Problem został pomyślnie zsynchronizowany",
+      "syncSuccessDescription": "Problem „{name}” został zaktualizowany o najnowsze informacje z systemu zewnętrznego.",
+      "syncError": "Nie udało się zsynchronizować problemu",
+      "syncErrorDescription": "Nie udało się zsynchronizować problemu. Spróbuj ponownie później."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Linki do projektu",
+        "milestoneLinks": "Linki do kamieni milowych",
+        "icons": "Ikony",
+        "fieldOptions": "Opcje pola",
+        "configCategories": "Kategorie konfiguracji",
+        "configVariants": "Warianty konfiguracji",
+        "repositories": "Repozytoria",
+        "repositoryFolders": "Foldery repozytorium",
+        "repositoryCaseLinks": "Linki do spraw repozytorium",
+        "repositoryCaseVersions": "Wersje przypadków repozytorium",
+        "testRunStepResults": "Wyniki testu krok po kroku",
+        "issueConfigs": "Konfiguracje problemów",
+        "sharedStepGroups": "Wspólne grupy kroków"
+      },
+      "table": {
+        "title": "Usunięto {itemType}",
+        "loading": "Ładowanie usuniętego {itemType}...",
+        "error": "Błąd ładowania usuniętego {itemType}: {message}",
+        "noItems": "Nie znaleziono usuniętych {itemType} .",
+        "noResults": "Nie znaleziono usuniętych {itemType} odpowiadających wyszukiwaniu „{query}”.",
+        "restoreConfirmationMessage": "Czy na pewno chcesz przywrócić ten wiersz z tabeli {itemType} ? Powiązane dane również mogą zostać przywrócone.",
+        "purgeConfirmationMessage": "Czy na pewno chcesz trwale usunąć ten wiersz z tabeli {itemType} ? Tej czynności nie można cofnąć i może ona spowodować usunięcie powiązanych danych."
+      }
+    },
+    "notifications": {
+      "title": "Administracja powiadomień",
+      "description": "Ustaw domyślne preferencje powiadomień (użytkownicy mogą je zmienić) i wysyłaj powiadomienia systemowe.",
+      "defaultMode": {
+        "label": "Domyślny tryb powiadomień",
+        "inApp": "Tylko w aplikacji",
+        "inAppEmailImmediate": "W aplikacji + e-mail (natychmiast)",
+        "inAppEmailDaily": "W aplikacji + e-mail (podsumowanie dnia)"
+      },
+      "options": {
+        "title": "Dostępne opcje powiadomień",
+        "inApp": {
+          "label": "Powiadomienia w aplikacji",
+          "description": "Pokaż powiadomienia w aplikacji"
+        },
+        "emailImmediate": {
+          "label": "Natychmiastowy e-mail",
+          "description": "Wysyłaj natychmiastowe powiadomienia e-mail w przypadku wystąpienia zdarzeń"
+        },
+        "emailDaily": {
+          "label": "Codzienny przegląd wiadomości e-mail",
+          "description": "Wyślij codzienne podsumowanie powiadomień e-mailem"
+        }
+      },
+      "save": "Zapisz ustawienia",
+      "success": {
+        "title": "Ustawienia zapisane",
+        "description": "Ustawienia powiadomień zostały pomyślnie zaktualizowane"
+      },
+      "error": {
+        "description": "Nie udało się zapisać ustawień powiadomień"
+      },
+      "systemNotification": {
+        "title": "Powiadomienia systemowe",
+        "description": "Wysyłaj ważne ogłoszenia do wszystkich użytkowników",
+        "titlePlaceholder": "Wprowadź tytuł powiadomienia...",
+        "messagePlaceholder": "Wprowadź treść powiadomienia...",
+        "send": "Wyślij powiadomienie",
+        "success": {
+          "title": "Powiadomienie wysłane",
+          "description": "Powiadomienie systemowe wysłane do {count, plural, one {# użytkownik} other {# użytkownicy}}"
+        },
+        "error": {
+          "description": "Nie udało się wysłać powiadomienia systemowego",
+          "emptyFields": "Proszę podać tytuł i wiadomość"
+        },
+        "history": {
+          "title": "Historia powiadomień",
+          "sentBy": "Wysłane przez",
+          "sentAt": "Wysłano w",
+          "empty": "Nie wysłano jeszcze żadnych powiadomień systemowych"
+        }
+      }
+    },
+    "integrations": {
+      "description": "Zarządzaj integracjami stron trzecich w celu śledzenia problemów",
+      "list": {
+        "title": "Skonfigurowane integracje problemów",
+        "description": "Przeglądaj i zarządzaj skonfigurowanymi integracjami problemów"
+      },
+      "empty": {
+        "message": "Nie skonfigurowano jeszcze żadnych integracji problemów"
+      },
+      "addIntegration": "Dodaj integrację problemu",
+      "allIntegrations": "Wszystkie integracje problemów",
+      "manageDescription": "Konfiguruj i zarządzaj integracją problemów z usługami zewnętrznymi",
+      "status": {
+        "active": "Aktywny",
+        "inactive": "Nieaktywny"
+      },
+      "connectedProjects": "Połączone projekty",
+      "noIntegrations": "Brak skonfigurowanych integracji problemów",
+      "testConnection": "Połączenie testowe",
+      "testSuccess": "Połączenie pomyślne",
+      "testSuccessDescription": "Integracja problemu jest poprawnie skonfigurowana i połączona",
+      "testFailed": "Połączenie nieudane",
+      "testFailedDescription": "Nie można połączyć się z usługą zewnętrzną",
+      "testError": "Błąd testu",
+      "testErrorDescription": "Wystąpił błąd podczas testowania połączenia",
+      "syncInProgress": "Problemy z synchronizacją...",
+      "syncIntegration": "Synchronizuj wszystkie problemy z integracji problemów",
+      "syncSuccess": "Synchronizacja w kolejce",
+      "syncSuccessDescription": "Problemy z „{name}” są synchronizowane w tle. Może to potrwać chwilę. Tabela zostanie zaktualizowana automatycznie po zakończeniu.",
+      "syncError": "Synchronizacja nie powiodła się",
+      "syncErrorDescription": "Nie udało się dodać zadania synchronizacji do kolejki dla tej integracji problemu. Spróbuj ponownie później.",
+      "delete": {
+        "confirmMessage": "Czy na pewno chcesz usunąć integrację problemu „{name}”?",
+        "warning": "Spowoduje to usunięcie integracji problemu i odłączenie go od wszystkich projektów. Tej czynności nie można cofnąć.",
+        "warningTitle": "Ta akcja spowoduje:",
+        "warning1": "Trwale usuń konfigurację integracji problemu i poświadczenia",
+        "warning2": "Odłącz wszystkie tokeny uwierzytelniania użytkownika na potrzeby tej integracji problemu",
+        "warning3": "Zachowaj wszystkie powiązane problemy w bazie danych (problemy staną się niepowiązane)",
+        "warning4": "Wymagaj najpierw usunięcia integracji problemu ze wszystkich projektów"
+      },
+      "deleteSuccess": "Usunięto integrację problemu",
+      "deleteSuccessDescription": "Integracja problemu została pomyślnie usunięta",
+      "deleteError": "Usuń błąd",
+      "add": {
+        "description": "Konfigurowanie integracji nowego problemu z usługą zewnętrzną",
+        "selectType": "Wybierz typ integracji problemu",
+        "typeDescription": "Wybierz rodzaj usługi, którą chcesz zintegrować",
+        "successMessage": "Integracja problemu została pomyślnie utworzona",
+        "successDescription": "Integracja problemu została skonfigurowana i jest gotowa do użycia",
+        "simple_url": {
+          "name": "Prosty adres URL",
+          "description": "Podstawowe śledzenie problemów z niestandardowymi wzorcami adresów URL"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Połącz się z Atlassian Jira, aby śledzić problemy i zarządzać projektami"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Połącz się z GitHubem, aby śledzić problemy"
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Połącz się z GitLab, aby śledzić zgłoszenia i żądania scalenia"
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Połącz się z samodzielnie hostowaną instancją Gitea, Forgejo lub Gogs w celu śledzenia problemów"
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Połącz się z usługą Azure DevOps, aby śledzić elementy pracy"
+        }
+      },
+      "filterPlaceholder": "Integracje filtrów...",
+      "table": {
+        "lastSync": "Ostatnia synchronizacja",
+        "empty": "Nie znaleziono integracji problemów",
+        "loading": "Ładowanie integracji problemów...",
+        "configure": "Konfiguruj"
+      },
+      "edit": {
+        "description": "Zaktualizuj ustawienia integracji problemów i konfigurację",
+        "successMessage": "Integracja problemu została pomyślnie zaktualizowana",
+        "successDescription": "Ustawienia integracji problemu zostały zapisane"
+      },
+      "editIntegration": "Edytuj integrację problemu",
+      "saveIntegration": "Zapisz integrację problemu",
+      "deleteIntegration": "Usuń integrację problemu",
+      "config": {
+        "name": "Nazwa integracji problemu",
+        "namePlaceholder": "Wprowadź nazwę integracji tego problemu",
+        "nameHelp": "Opisowa nazwa identyfikująca ten problem integracji",
+        "authType": "Typ uwierzytelniania",
+        "authTypeHelp": "Wybierz sposób uwierzytelniania za pomocą usługi zewnętrznej",
+        "emailPlaceholder": "twój-email@example.com",
+        "emailHelp": "Adres e-mail Twojego konta",
+        "apiToken": "Token API",
+        "apiTokenPlaceholder": "Wprowadź swój token API",
+        "apiTokenHelp": "Wygeneruj token API z ustawień swojego konta",
+        "jiraUrl": "Adres URL Jira",
+        "jiraUrlPlaceholder": "https://twoja-strona.atlassian.net",
+        "jiraUrlHelp": "Adres URL Twojej instancji Jira",
+        "clientId": "Identyfikator klienta",
+        "clientIdPlaceholder": "Wprowadź swój identyfikator klienta OAuth",
+        "clientIdHelp": "Identyfikator klienta z Twojej aplikacji OAuth",
+        "clientSecret": "Tajemnica klienta",
+        "clientSecretPlaceholder": "Wprowadź swój tajny klucz klienta OAuth",
+        "clientSecretHelp": "Tajemnica klienta z Twojej aplikacji OAuth",
+        "cloudId": "Identyfikator chmury",
+        "cloudIdPlaceholder": "Wprowadź swój identyfikator Atlassian Cloud",
+        "cloudIdHelp": "Identyfikator Twojej instancji Atlassian Cloud (znajdujący się w adresie URL Jira)",
+        "apiUrl": "Adres URL API",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "Podstawowy adres URL interfejsu API usługi",
+        "personalAccessTokenPlaceholder": "Wprowadź swój osobisty token dostępu",
+        "personalAccessTokenHelp": "Osobisty token dostępu z odpowiednimi uprawnieniami",
+        "apiKeyPlaceholder": "Wprowadź swój klucz API",
+        "apiKeyHelp": "Klucz API do uwierzytelniania",
+        "baseUrl": "Wzorzec adresu URL",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "Wzorzec adresu URL dla problemów. Użyj {issueId} jako symbolu zastępczego.",
+        "organizationUrl": "Adres URL organizacji",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "Twój adres URL organizacji Azure DevOps",
+        "projectPath": "Ścieżka projektu",
+        "projectPathPlaceholder": "grupa/podgrupa/projekt",
+        "projectPathHelp": "Pełna ścieżka Twojego projektu GitLab (np. mygroup/myproject)",
+        "instanceUrl": "Adres URL instancji",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "Adres URL Twojej samodzielnie hostowanej instancji. Pozostaw puste, aby użyć gitlab.com",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Właściciel",
+        "ownerPlaceholder": "nazwa użytkownika lub organizacja",
+        "ownerHelp": "Użytkownik lub organizacja Gitea będąca właścicielem repozytorium",
+        "repo": "Magazyn",
+        "repoPlaceholder": "nazwa-repozytorium",
+        "repoHelp": "Nazwa repozytorium Gitea",
+        "encrypted": "Zaszyfrowane",
+        "encryptedHelp": "To pole jest szyfrowane i przechowywane bezpiecznie",
+        "changeCredential": "Zmiana",
+        "apiKeyWarningTitle": "Powiadomienie o uwierzytelnianiu klucza API",
+        "apiKeyWarningDescription": "W przypadku korzystania z uwierzytelniania za pomocą klucza API osoby zgłaszające problemy są automatycznie identyfikowane:",
+        "apiKeyWarningPoint1": "Jeśli Twój adres e-mail w usłudze TestPlanIt jest zgodny z adresem e-mail użytkownika usługi Jira, zostaniesz ustawiony jako osoba raportująca",
+        "apiKeyWarningPoint2": "Jeśli nie ma pasującego adresu e-mail, nazwa TestPlanIt zostanie dopasowana do nazw wyświetlanych w Jira",
+        "apiKeyWarningPoint3": "Jeśli nie zostanie znalezione żadne dopasowanie, właściciel klucza API zostanie ustawiony jako osoba zgłaszająca",
+        "forgeApiKeyLabel": "Klucz API Forge",
+        "forgeApiKeyDescription": "Używany przez aplikację Atlassian Forge do uwierzytelniania żądań z paneli zgłoszeń Jira. Wygeneruj klucz tutaj i wklej go w ustawieniach aplikacji Forge.",
+        "forgeApiKeyPlaceholder": "Kliknij „Generuj”, aby utworzyć klucz API",
+        "forgeApiKeyGenerate": "Spowodować",
+        "forgeApiKeyCopy": "Kopia",
+        "forgeApiKeyCopied": "Skopiowano",
+        "platform": "Platforma",
+        "platformPlaceholder": "Wybierz platformę...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "Klucz API",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Token dostępu osobistego"
+      },
+      "validation": {
+        "nameRequired": "Nazwa integracji problemu jest wymagana",
+        "clientIdRequired": "Wymagane jest podanie identyfikatora klienta",
+        "clientSecretRequired": "Wymagany jest tajny kod klienta",
+        "cloudIdRequired": "Wymagane jest ID chmury",
+        "apiUrlRequired": "Wymagany jest adres URL API",
+        "tokenRequired": "Wymagany jest osobisty token dostępu",
+        "apiKeyRequired": "Klucz API jest wymagany"
+      },
+      "errors": {
+        "updateFailed": "Nie udało się zaktualizować integracji problemu",
+        "testFailed": "Test połączenia nie powiódł się",
+        "nameExists": "Problem integracji o tej nazwie już istnieje",
+        "createFailed": "Nie udało się utworzyć integracji problemu",
+        "deleteFailed": "Nie udało się usunąć integracji problemu"
+      },
+      "confirmDelete": {
+        "message": "Czy na pewno chcesz usunąć integrację problemu „{name}”?",
+        "warning": "Spowoduje to usunięcie integracji problemu i odłączenie go od wszystkich projektów. Tej czynności nie można cofnąć."
+      },
+      "form": {
+        "success": "Integracja problemu została pomyślnie zapisana",
+        "successDescription": "Integracja problemu została skonfigurowana i jest gotowa do użycia",
+        "testing": "Testowanie połączenia..."
+      },
+      "oauth": {
+        "connectAccount": "Połącz konto",
+        "connected": "Połączony",
+        "notConnected": "Nie połączony",
+        "authDescription": "Aby skorzystać z tej integracji, należy uwierzytelnić się za pomocą {provider}",
+        "authError": "Uwierzytelnianie nie powiodło się",
+        "authErrorDescription": "Nie można uwierzytelnić się za pomocą usługi zewnętrznej"
+      }
+    },
+    "llm": {
+      "addIntegration": "Dodaj model AI",
+      "filterPlaceholder": "Filtruj modele AI...",
+      "testAll": "Przetestuj wszystkie połączenia",
+      "connectionTestComplete": "Test połączenia zakończony",
+      "allIntegrationsTested": "Przetestowano wszystkie połączenia modelu AI",
+      "failedToTestConnections": "Nie udało się przetestować niektórych połączeń",
+      "notConfigured": "Nie skonfigurowano",
+      "defaultModel": "Wybrany model",
+      "budgetUsage": "Wykorzystanie (w tym miesiącu)",
+      "noBudget": "Brak ustalonego budżetu",
+      "streaming": "Transmisja strumieniowa",
+      "add": {
+        "title": "Dodaj integrację modelu AI",
+        "description": "Skonfiguruj nowy model AI dla swojej organizacji",
+        "integrationNamePlaceholder": "Wprowadź nazwę tej integracji...",
+        "selectProvider": "Wybierz dostawcę",
+        "openai": "OpenAI",
+        "anthropic": "Antropiczny",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "customLlm": "Niestandardowy LLM",
+        "apiKeyPlaceholder": "Wprowadź swój klucz API...",
+        "apiKeyDescription": "Twój klucz API do uwierzytelniania u dostawcy",
+        "endpoint": "Adres URL punktu końcowego",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Wskazówka: Jeśli używasz serwera proxy (np. LiteLLM), spróbuj dodać /v1 na końcu adresu URL punktu końcowego.",
+        "deploymentName": "Nazwa wdrożenia",
+        "deploymentNamePlaceholder": "Wprowadź nazwę wdrożenia...",
+        "deploymentNameDescription": "Nazwa wdrożenia Azure OpenAI",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, itd.",
+        "defaultModelDescription": "Model do użycia domyślnie",
+        "maxTokensPerRequest": "Maksymalna liczba tokenów na żądanie",
+        "maxRequestsPerMinute": "Maksymalna liczba żądań na minutę",
+        "costPerInputToken": "Koszt za 1 mln tokenów wejściowych ($)",
+        "costPerOutputToken": "Koszt za 1 mln tokenów wyjściowych ($)",
+        "monthlyBudget": "Miesięczny budżet ($)",
+        "monthlyBudgetPlaceholder": "100,00",
+        "monthlyBudgetDescription": "Opcjonalny cel wydatków na powiadomienia (nie blokuje wykorzystania)",
+        "billingPeriodStartDay": "Dzień rozpoczęcia okresu rozliczeniowego",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "Dzień miesiąca (1–31), w którym rozpoczyna się okres rozliczeniowy. Wartości 29–31 oznaczają ostatni dzień krótszych miesięcy.",
+        "defaultTemperature": "Domyślna temperatura",
+        "defaultMaxTokens": "Domyślna maksymalna liczba tokenów",
+        "timeout": "Limit czasu żądania (ms)",
+        "timeoutDescription": "Maksymalny czas oczekiwania na odpowiedź modelu AI (5000–600000 ms). Nie dotyczy żądań strumieniowych.",
+        "streamingEnabled": "Włącz strumieniowanie",
+        "streamingEnabledDescription": "Zezwól na strumieniowe przesyłanie odpowiedzi w czasie rzeczywistym",
+        "setAsDefault": "Ustaw jako domyślne",
+        "setAsDefaultDescription": "Użyj tego jako domyślnego modelu sztucznej inteligencji dla organizacji",
+        "fetchingModels": "Pobieranie modeli...",
+        "failedToFetchModels": "Nie udało się pobrać dostępnych modeli",
+        "selectModel": "Wybierz model",
+        "connectionSuccessfulDescription": "Połączenie z modelem AI zostało zweryfikowane i działa poprawnie",
+        "failedToConnect": "Nie udało się połączyć z dostawcą modelu AI",
+        "integrationCreated": "Pomyślnie ukończono integrację modelu AI",
+        "failedToCreate": "Nie udało się utworzyć integracji modelu AI",
+        "validation": {
+          "nameRequired": "Nazwa integracji jest wymagana",
+          "nameUnique": "Integracja o tej nazwie już istnieje",
+          "defaultModelRequired": "Wymagany jest model domyślny"
+        }
+      },
+      "edit": {
+        "title": "Edytuj integrację modelu AI",
+        "description": "Zaktualizuj konfigurację integracji tego modelu AI",
+        "statusDescription": "Włącz lub wyłącz tę integrację",
+        "apiKeyPlaceholder": "Wprowadź nowy klucz API, aby zaktualizować...",
+        "update": "Aktualizacja",
+        "integrationUpdated": "Pomyślnie zaktualizowano integrację modelu AI",
+        "failedToUpdate": "Nie udało się zaktualizować integracji modelu AI",
+        "validation": {
+          "nameRequired": "Nazwa integracji jest wymagana",
+          "nameUnique": "Integracja o tej nazwie już istnieje",
+          "defaultModelRequired": "Wymagany jest model domyślny"
+        }
+      },
+      "sections": {
+        "provider": "Dostawca",
+        "costAndBudget": "Koszt i budżet",
+        "advanced": "Zaawansowany"
+      },
+      "delete": {
+        "title": "Usuń integrację modelu AI",
+        "description": "Czy na pewno chcesz usunąć tę integrację modelu AI? Spowoduje to usunięcie jej ze wszystkich projektów i nie będzie można tego cofnąć.",
+        "integrationDeletedSuccess": "Pomyślnie usunięto integrację modelu AI",
+        "failedToDeleteIntegration": "Nie udało się usunąć integracji modelu AI",
+        "cannotDeleteDefault": "Nie można usunąć domyślnego modelu AI. Najpierw ustaw inny jako domyślny."
+      },
+      "validation": {
+        "defaultModelRequired": "Wymagany jest model domyślny"
+      },
+      "test": {
+        "title": "Testuj integrację modelu AI",
+        "description": "Przetestuj połączenie i funkcjonalność {name}",
+        "connectionStatus": "Status połączenia",
+        "connectionStatusDescription": "Sprawdź, czy model AI jest dostępny",
+        "retest": "Ponowne testowanie połączenia",
+        "connectionSuccessfulDescription": "Model sztucznej inteligencji jest dostępny i reaguje prawidłowo",
+        "failedToConnect": "Nie udało się połączyć z modelem AI",
+        "errorTestingConnection": "Wystąpił błąd podczas testowania połączenia",
+        "testMessage": "Wiadomość testowa",
+        "testMessagePlaceholder": "Wprowadź wiadomość, którą chcesz wysłać do modelu AI...",
+        "sendTestMessage": "Wyślij wiadomość testową",
+        "response": "Odpowiedź",
+        "testSuccessful": "Test pomyślny",
+        "responseReceived": "Odpowiedź otrzymana pomyślnie (Koszt: ${cost})",
+        "testFailed": "Test nieudany",
+        "failedToGetResponse": "Nie udało się uzyskać odpowiedzi od modelu AI",
+        "failedToSendMessage": "Nie udało się wysłać wiadomości testowej",
+        "defaultTestMessage": "Witaj! Proszę o krótką odpowiedź z potwierdzeniem, że wszystko działa poprawnie."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Ustalenie miesięcznego budżetu nie zapobiega jego przekroczeniu w ramach LLM. Limity budżetowe mają charakter wyłącznie informacyjny i służą do podejmowania decyzji administracyjnych.",
+        "budgetDisclaimerShort": "Limity budżetowe mają charakter wyłącznie informacyjny i nie blokują użytkowania.",
+        "spendLabel": "Wydatki w bieżącym miesiącu",
+        "spendOfBudget": "{currentSpend} z {budgetLimit}",
+        "overBudget": "Przekroczenie budżetu",
+        "budgetPercentage": "{percentage}% wykorzystanego budżetu",
+        "spendReset": "Wydatki z bieżącego miesiąca zostały zresetowane"
+      }
+    },
+    "prompts": {
+      "title": "Konfiguracje monitowe",
+      "description": "Zarządzaj szablonami monitów AI dla różnych funkcji",
+      "addPromptConfig": "Dodaj konfigurację monitu",
+      "filterPlaceholder": "Konfiguracje monitów filtru...",
+      "features": "Cechy",
+      "featureCount": "{count, plural, one {# funkcja} other {# funkcje}}",
+      "llmIntegration": "Integracja LLM",
+      "modelOverride": "Nadpisanie modelu",
+      "llmIntegrationPlaceholder": "Projekt domyślny",
+      "modelOverridePlaceholder": "Domyślna integracja",
+      "projectDefault": "Projekt domyślny (wyczyść)",
+      "integrationDefault": "Domyślna integracja (wyczyść)",
+      "systemPrompt": "Monit systemowy",
+      "userPrompt": "Monit użytkownika",
+      "temperature": "Temperatura",
+      "maxOutputTokens": "Maksymalna liczba tokenów wyjściowych",
+      "variables": "Zmienne",
+      "insertVariable": "Wstaw zmienną",
+      "noConfigs": "Nie znaleziono żadnych konfiguracji. Dodaj pierwszą konfigurację, aby rozpocząć.",
+      "add": {
+        "title": "Dodaj konfigurację monitu",
+        "description": "Utwórz nową konfigurację podpowiedzi AI z podpowiedziami dla każdej funkcji. Ustawienia domyślne zostały zastosowane automatycznie."
+      },
+      "edit": {
+        "title": "Edytuj konfigurację monitu",
+        "description": "Zaktualizuj tę konfigurację monitu AI"
+      },
+      "delete": {
+        "title": "Usuń konfigurację monitu",
+        "confirmMessage": "Czy na pewno chcesz usunąć <strong>{name}</strong>? Projekty korzystające z tego monitu powrócą do ustawień domyślnych systemu.",
+        "warning": "Tej czynności nie można cofnąć. Wszystkie projekty korzystające z tej konfiguracji powrócą do domyślnej konfiguracji monitu."
+      },
+      "llmColumn": "Magister prawa",
+      "mixedLlms": "{count} LLM-y",
+      "cannotDeleteDefault": "Nie można usunąć domyślnej konfiguracji monitu. Najpierw ustaw inną jako domyślną.",
+      "defaultChanged": "Domyślna konfiguracja monitu została pomyślnie zaktualizowana.",
+      "featureLabels": {
+        "markdown_parsing": "Analiza przypadków testowych Markdown",
+        "test_case_generation": "Generowanie przypadków testowych",
+        "magic_select_cases": "Inteligentny wybór przypadków testowych",
+        "editor_assistant": "Asystent redaktora ds. pisania",
+        "llm_test": "Test połączenia LLM",
+        "export_code_generation": "Generowanie kodu eksportowego",
+        "auto_tag": "Sugestie tagów AI",
+        "duplicate_detection": "Wykrywanie duplikatów",
+        "generate_from_url": "Generuj przypadki testowe z adresu URL (wymagania)",
+        "generate_from_url_app": "Generuj przypadki testowe z adresu URL (testowanie aplikacji)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Zarządzanie Elasticsearch",
+      "description": "Zarządzanie indeksowaniem i konserwacją wyszukiwarek",
+      "status": {
+        "title": "Status Elasticsearch",
+        "description": "Aktualne połączenie i stan zdrowia wyszukiwarki",
+        "checking": "Sprawdzanie statusu...",
+        "disconnected": "Bezładny",
+        "nodes": "Węzły",
+        "indices": "Indeksy",
+        "documents": "dokumenty",
+        "error": {
+          "title": "Błąd połączenia",
+          "description": "Nie można połączyć się z usługą Elasticsearch"
+        }
+      },
+      "settings": {
+        "description": "Skonfiguruj ustawienia Elasticsearch dla swojego wdrożenia",
+        "numberOfReplicas": "Liczba replik",
+        "replicasHelp": "Ustaw na 0 dla klastrów jednowęzłowych, 1+ dla klastrów wielowęzłowych z redundancją",
+        "savedDescription": "Konfiguracja została zapisana w bazie danych",
+        "updated": "Zaktualizowane indeksy",
+        "updatedDescription": "Wszystkie istniejące indeksy zostały zaktualizowane o nowe ustawienia repliki",
+        "error": "Błąd zapisywania ustawień",
+        "errorDescription": "Nie udało się zapisać konfiguracji. Spróbuj ponownie.",
+        "note": {
+          "description": "Zmiany zostaną zastosowane do nowych indeksów natychmiast. Istniejące indeksy zostaną zaktualizowane po zapisaniu. Ustaw repliki na 0, aby rozwiązać problem ze statusem ŻÓŁTYM w klastrach jednowęzłowych."
+        }
+      },
+      "reindex": {
+        "title": "Ponowne indeksowanie danych",
+        "description": "Przebudowa indeksów wyszukiwania w celu poprawy wydajności wyszukiwania",
+        "entities": {
+          "all": "Wszystkie podmioty"
+        },
+        "button": {
+          "start": "Rozpocznij ponowne indeksowanie",
+          "indexing": "Indeksowanie..."
+        },
+        "warning": {
+          "title": "Ważny",
+          "description": "Ponowne indeksowanie może potrwać kilka minut, w zależności od ilości danych. Podczas tego procesu funkcjonalność wyszukiwania może być ograniczona."
+        },
+        "complete": {
+          "title": "Ponowne indeksowanie zakończone",
+          "description": "Wszystkie wybrane jednostki zostały pomyślnie ponownie zaindeksowane"
+        },
+        "success": {
+          "title": "Ponowne indeksowanie zakończone sukcesem",
+          "description": "{count, plural, one {# dokument} other {# dokumenty}} pomyślnie zindeksowano"
+        },
+        "error": {
+          "title": "Ponowne indeksowanie nie powiodło się",
+          "description": "Wystąpił błąd podczas ponownego indeksowania. Spróbuj ponownie."
+        }
+      }
+    },
+    "queues": {
+      "title": "Kolejki zadań w tle",
+      "description": "Monitoruj i zarządzaj kolejkami przetwarzania zadań w tle",
+      "queueNames": {
+        "forecast-updates": "Aktualizacje prognoz",
+        "emails": "Kolejka e-maili",
+        "issue-sync": "Synchronizacja problemów",
+        "testmo-imports": "Importy Testmo",
+        "elasticsearch-reindex": "Ponowna indeksacja Elasticsearch",
+        "audit-logs": "Dzienniki audytu",
+        "budget-alerts": "Alerty budżetowe",
+        "auto-tag": "Automatyczne tagowanie AI",
+        "repo-cache": "Pamięć podręczna repozytorium",
+        "copy-move": "Kopiuj i przenieś",
+        "duplicate-scan": "Duplikat skanowania",
+        "magic-select": "Magiczny wybór",
+        "step-scan": "Skanowanie sekwencji kroków"
+      },
+      "status": {
+        "paused": "Wstrzymano",
+        "idle": "Bezczynny"
+      },
+      "table": {
+        "queue": "Kolejka",
+        "concurrency": "Współbieżność",
+        "waiting": "Czekanie",
+        "failed": "Przegrany"
+      },
+      "concurrency": {
+        "title": "Współbieżność pracowników",
+        "description": "Współbieżność kontroluje liczbę zadań przetwarzanych jednocześnie przez każdy proces roboczy. Wyższe wartości mogą poprawić przepustowość, ale zużywają więcej zasobów systemowych (procesora i pamięci).",
+        "configureTitle": "Konfigurowanie współbieżności",
+        "configureDescription": "Aby dostosować współbieżność, ustaw zmienne środowiskowe i uruchom ponownie procesy robocze. Szczegóły znajdziesz w dokumentacji.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Importy Testmo (domyślnie: 1, wymagające dużej ilości pamięci)",
+          "SYNC_CONCURRENCY": "Wydanie synchronizacji (domyślnie: 2, intensywne operacje wejścia/wyjścia)",
+          "EMAIL_CONCURRENCY": "Wysyłanie wiadomości e-mail (domyślnie: 3, intensywne przetwarzanie danych)",
+          "NOTIFICATION_CONCURRENCY": "Powiadomienia (domyślne: 5, lekkie)",
+          "FORECAST_CONCURRENCY": "Aktualizacje prognoz (domyślnie: 5, wymagające dużej mocy obliczeniowej procesora)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Wstrzymaj kolejkę",
+          "confirmDescription": "Zapobiegnie to przetwarzaniu nowych zadań. Aktywne zadania będą kontynuowane do momentu ich ukończenia."
+        },
+        "resume": {
+          "confirmTitle": "Wznów kolejkę",
+          "confirmDescription": "Umożliwi to kolejce przetwarzanie oczekujących zadań."
+        },
+        "clean": {
+          "confirmTitle": "Czysta kolejka",
+          "confirmDescription": "Spowoduje to usunięcie z kolejki zadań zakończonych i nieudanych. Tej czynności nie można cofnąć."
+        },
+        "drain": {
+          "confirmTitle": "Kolejka spustowa",
+          "confirmDescription": "Spowoduje to usunięcie wszystkich oczekujących zadań z kolejki. Aktywne zadania będą kontynuowane do końca. Tej czynności nie można cofnąć."
+        },
+        "obliterate": {
+          "confirmTitle": "Zniszcz kolejkę",
+          "confirmDescription": "Spowoduje to całkowite wyczyszczenie kolejki, usuwając wszystkie zadania, niezależnie od ich stanu. Tej czynności nie można cofnąć i należy jej używać wyłącznie w sytuacjach awaryjnych."
+        },
+        "warning": "Ostrzeżenie",
+        "irreversible": "Tej czynności nie można cofnąć. Potwierdź, że chcesz kontynuować."
+      },
+      "success": {
+        "actionCompleted": "Akcja zakończona",
+        "queuePaused": "Kolejka została wstrzymana",
+        "queueResumed": "Kolejka została wznowiona",
+        "queueCleaned": "Kolejka została oczyszczona",
+        "queueDrained": "Kolejka została opróżniona",
+        "queueObliterated": "Kolejka została zlikwidowana"
+      },
+      "error": {
+        "loadFailed": "Nie udało się załadować kolejek",
+        "actionFailed": "Akcja nie powiodła się"
+      },
+      "jobs": {
+        "title": "Zadania w kolejce",
+        "description": "Przeglądaj i zarządzaj poszczególnymi zadaniami w kolejce",
+        "noJobs": "Nie znaleziono żadnych zadań w tej kolejce",
+        "table": {
+          "id": "Identyfikator zadania",
+          "name": "Nazwa stanowiska",
+          "attempts": "Próbowanie"
+        },
+        "details": {
+          "title": "Szczegóły pracy",
+          "failedReason": "Powód awarii",
+          "stacktrace": "Ślad stosu",
+          "data": "Dane dotyczące pracy",
+          "returnValue": "Wartość zwracana",
+          "options": "Opcje pracy",
+          "processed": "Obrobiony",
+          "finished": "Gotowy"
+        },
+        "success": {
+          "actionCompleted": "Akcja robocza zakończona",
+          "jobRetried": "Zadanie zostało powtórzone",
+          "jobPromoted": "Praca została awansowana",
+          "jobRemoved": "Praca została usunięta"
+        },
+        "error": {
+          "loadFailed": "Nie udało się załadować zadań",
+          "actionFailed": "Akcja robocza nie powiodła się"
+        },
+        "forceRemove": {
+          "title": "Wymuś usunięcie zadania",
+          "question": "Czy chcesz wymusić usunięcie tego zadania?",
+          "warning": "Spowoduje to wielokrotną próbę usunięcia go z opóźnieniem. Uwaga: nawet jeśli zadanie jest rzeczywiście zablokowane przez działający proces roboczy, może się nie powieść.",
+          "confirm": "Wymuś usunięcie"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Przeglądaj ścieżkę audytu w całym systemie, aby śledzić bezpieczeństwo i zgodność",
+      "filterPlaceholder": "Wyszukaj według jednostki, użytkownika lub akcji...",
+      "filterAction": "Działanie",
+      "filterEntityType": "Typ jednostki",
+      "allActions": "Wszystkie akcje",
+      "allEntityTypes": "Wszystkie typy jednostek",
+      "showing": "Wyświetlanie od {start} do {end} z {total} wpisów",
+      "viewDetails": "Zobacz szczegóły",
+      "detailTitle": "Szczegóły dziennika audytu",
+      "userInfo": "Informacje o użytkowniku",
+      "changes": "Zmiany",
+      "metadata": "Metadane",
+      "oldValue": "Stary",
+      "newValue": "Nowy",
+      "columns": {
+        "timestamp": "Znak czasu",
+        "entityId": "Identyfikator jednostki",
+        "entityName": "Nazwa jednostki",
+        "userId": "Identyfikator użytkownika",
+        "ipAddress": "Adres IP",
+        "userAgent": "Agent użytkownika"
+      },
+      "exportCsv": "Eksportuj CSV",
+      "timeRange": "Zakres czasu",
+      "timeRangeOptions": {
+        "last24h": "Ostatnie 24 godziny",
+        "last7d": "Ostatnie 7 dni",
+        "last30d": "Ostatnie 30 dni",
+        "last90d": "Ostatnie 90 dni",
+        "allTime": "Cały czas"
+      },
+      "systemActor": "System",
+      "systemActorTooltip": "Akcja wykonywana przez system, a nie przez zalogowanego użytkownika"
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Brak powiadomień",
+      "aria": {
+        "notifications": "Powiadomienia ({count} nieprzeczytane)"
+      },
+      "actions": {
+        "markRead": "Oznacz jako przeczytane",
+        "markUnread": "Oznacz jako nieprzeczytane",
+        "markAllRead": "Oznacz wszystkie jako przeczytane",
+        "deleteAll": "Usuń wszystko"
+      },
+      "success": {
+        "deleted": "Powiadomienie zostało usunięte",
+        "markedAllRead": "Wszystkie powiadomienia oznaczone jako przeczytane",
+        "deletedAll": "Wszystkie powiadomienia zostały usunięte"
+      },
+      "error": {
+        "markRead": "Nie udało się oznaczyć jako przeczytane",
+        "markUnread": "Nie udało się oznaczyć jako nieprzeczytane",
+        "delete": "Nie udało się usunąć powiadomienia",
+        "markAllRead": "Nie udało się oznaczyć wszystkich jako przeczytanych",
+        "deleteAll": "Nie udało się usunąć powiadomień"
+      },
+      "deleteAllDialog": {
+        "title": "Usunąć wszystkie powiadomienia?",
+        "description": "Spowoduje to trwałe usunięcie wszystkich powiadomień. Tej czynności nie można cofnąć.",
+        "confirm": "Usuń wszystko"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Nowe przypisanie przypadku testowego",
+        "multipleTestCaseAssignmentTitle": "Przypisano wiele przypadków testowych",
+        "sessionAssignmentTitle": "Nowe przypisanie sesji",
+        "commentMentionTitle": "Zostałeś wspomniany w komentarzu",
+        "systemAnnouncementTitle": "Ogłoszenie systemowe",
+        "assignedTestCase": "przydzielono ci przypadek testowy",
+        "assignedMultipleTestCases": "przypisano Ci {count, plural, one {# przypadek testowy} other {# przypadki testowe}}",
+        "assignedSession": "przypisano cię do sesji",
+        "mentionedYouInComment": "wspomniałem o tobie w komentarzu",
+        "inProject": "w projekcie",
+        "testRun": "Test biegowy:",
+        "casesInProject": "{count, plural, =1 {# przypadek} other {# przypadki}} w",
+        "sentBy": "Wysłane przez {name}",
+        "milestoneDueSoonTitle": "Kamień milowy wkrótce",
+        "milestoneOverdueTitle": "Przekroczony kamień milowy",
+        "milestoneDueSoon": "Kamień milowy „{milestoneName}” w projekcie „{projectName}” przypada na {dueDate}.",
+        "milestoneOverdue": "Kamień milowy „{milestoneName}” w projekcie „{projectName}” miał zostać zrealizowany w dniu {dueDate} , ale jest już przeterminowany.",
+        "milestoneNotificationReason": "Otrzymujesz to powiadomienie, ponieważ brałeś udział w pracach związanych z tym kamieniem milowym (przebiegi testowe, sesje lub jako twórca kamienia milowego).",
+        "milestoneNotificationContinue": "Będziesz otrzymywać codzienne przypomnienia, aż do momentu, gdy ten kamień milowy zostanie oznaczony jako ukończony.",
+        "shareLinkAccessedTitle": "Dostęp do łącza udostępniania",
+        "shareLinkAccessedAnonymousViewer": "Ktoś",
+        "shareLinkAccessedMessage": "{viewer} wyświetlił(a) Twój udostępniony raport: „{shareTitle}”",
+        "viewedYourSharedLink": "wyświetlił udostępniony przez Ciebie link",
+        "viewedAt": "Oglądane w",
+        "budgetDisclaimer": "Limity budżetowe mają charakter wyłącznie informacyjny i nie uniemożliwiają korzystania z usługi.",
+        "llmBudgetExceededTitle": "Budżet LLM przekroczony",
+        "llmBudgetThresholdTitle": "Budżet LLM {threshold}% wykorzystania",
+        "llmBudgetExceededMessage": "{providerName} przekroczyło swój miesięczny budżet: {spend} wydało z {budget} budżetu.",
+        "llmBudgetThresholdMessage": "{providerName} wykorzystał {threshold}% swojego miesięcznego budżetu: {spend} z {budget}.",
+        "userRegisteredTitle": "Rejestracja nowego użytkownika",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) zarejestrował się za pomocą SSO",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) zarejestrował się poprzez formularz rejestracyjny",
+        "viewUserList": "Wyświetl listę użytkowników",
+        "reviewGeneratedCases": "Przejrzyj wygenerowane przypadki testowe",
+        "generateFromUrlCompleteTitle": "Strony przeszukane pomyślnie",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# strona} other {# strony}} pobrane z {url} w projekcie „{projectName}”. Kliknij, aby przejrzeć i wygenerować przypadki testowe.",
+        "generateFromUrlFailedTitle": "Nie udało się przeszukać adresu URL"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Problemy z wyszukiwaniem lub linkami...",
+        "create_label": "Problem z linkiem „{name}”"
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Wprowadź podsumowanie problemu"
+        },
+        "fields": {
+          "name": {
+            "label": "Streszczenie"
+          },
+          "description": {
+            "placeholder": "Opisz problem...",
+            "helper": "Podaj szczegółowe informacje na temat problemu"
+          },
+          "project": {
+            "helper": "Wybierz projekt w zewnętrznym systemie śledzenia problemów"
+          }
+        },
+        "loading_metadata": "Ładowanie ustawień integracji...",
+        "errors": {
+          "creation_failed": "Nie udało się utworzyć zgłoszenia. Spróbuj ponownie."
+        },
+        "success": {
+          "created": "Problem został pomyślnie utworzony",
+          "external_created": "Problem został utworzony i powiązany z zewnętrznym trackerem"
+        },
+        "warnings": {
+          "external_failed": "Problem został utworzony lokalnie, ale nie można go było zsynchronizować z zewnętrznym modułem śledzącym"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "Aby tworzyć zgłoszenia, musisz połączyć swoje konto z {integrationName} ."
+      },
+      "search_issues_dialog": {
+        "title": "Problemy z wyszukiwaniem i linkami",
+        "placeholder": "Wyszukaj problemy...",
+        "searching": "Badawczy...",
+        "searchError": "Nie udało się wyszukać problemów",
+        "linkButton": "Połączyć",
+        "linkedCount": "{count, plural, one {# problem} other {# problemy}} połączone"
+      }
+    },
+    "copyMove": {
+      "title": "Kopiuj / Przenieś do projektu",
+      "step1Desc": "Wybierz projekt docelowy i folder dla przypadków testowych.",
+      "step2Desc": "Wybierz operację i sprawdź zgodność.",
+      "step3Desc": "Śledź postępy i przeglądaj wyniki.",
+      "targetProject": "Projekt docelowy",
+      "searchProjects": "Wyszukaj projekty...",
+      "loadingProjects": "Ładowanie projektów...",
+      "noProjectsFound": "Nie znaleziono projektów.",
+      "completed": "(Kompletny)",
+      "targetFolder": "Folder docelowy",
+      "newFolderPlaceholder": "Nowa nazwa folderu...",
+      "operation": "Działanie",
+      "operationCopy": "Kopia",
+      "operationCopyDesc": "Tworzy kopię wybranych spraw w projekcie docelowym. Oryginały pozostają niezmienione.",
+      "operationMove": "Przenosić",
+      "operationMoveDesc": "Przenosi wybrane sprawy do projektu docelowego. Oryginały zostaną usunięte ze źródła.",
+      "checkingCompatibility": "Sprawdzanie zgodności...",
+      "noTargetWriteAccess": "Nie masz uprawnień do zapisu w projekcie docelowym.",
+      "noSourceUpdateAccess": "Nie masz uprawnień do edycji projektu źródłowego, aby móc przenosić sprawy.",
+      "templateMismatch": "Niedopasowanie szablonu",
+      "autoAssignTemplates": "Automatyczne przypisywanie brakujących szablonów do projektu docelowego",
+      "templatesMayNotDisplay": "Brakujące szablony nie będą dostępne w projekcie docelowym. Sprawy zostaną skopiowane, ale pola z tych szablonów mogą nie wyświetlać się poprawnie.",
+      "workflowFallback": "Niektóre stany przepływu pracy nie są dostępne w projekcie docelowym. W takich przypadkach zostanie użyty domyślny stan projektu docelowego.",
+      "default": "(domyślny)",
+      "conflicts": "Zastosuj do wszystkich konfliktów:",
+      "conflictSkip": "Pominąć",
+      "conflictRename": "Przemianować",
+      "sharedStepGroups": "Jeśli w miejscu docelowym istnieją już współdzielone grupy kroków:",
+      "sharedStepGroupReuse": "Ponowne wykorzystanie istniejących",
+      "sharedStepGroupReuseDesc": "Przypadki będą odwoływać się do istniejącej współdzielonej grupy kroków.",
+      "sharedStepGroupCreateNew": "Utwórz nowy",
+      "sharedStepGroupCreateNewDesc": "Zostanie utworzona nowa współdzielona grupa kroków.",
+      "go": "Iść",
+      "processing": "Przetwarzanie...",
+      "progressText": "Przetworzono {processed} z {total} przypadków",
+      "successCount": "{count} przypadków {operation}pomyślnie",
+      "skipped": "Pominięto: {count}",
+      "droppedLinks": "Usunięto linki międzyprojektowe: {count}",
+      "errorCount": "{count} przypadków zakończyło się niepowodzeniem",
+      "viewInTargetProject": "Widok w projekcie docelowym",
+      "failed": "Przegrany",
+      "folderMode": "Folder \"{folderName}\" — {caseCount, plural, one {# przypadek} other {# przypadki}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Powiązane problemy",
+    "linkedIssuesDescription": "Problemy związane z tym elementem",
+    "refreshed": "Odświeżone wydania",
+    "refreshedDescription": "Zaktualizowano listę powiązanych problemów",
+    "unlinked": "Problem niepowiązany",
+    "unlinkedDescription": "Problem został usunięty z tego elementu",
+    "linked": "Problem powiązany",
+    "linkedDescription": "Problem został powiązany z tym elementem",
+    "searchAndLink": "Szukaj i linkuj",
+    "createAndLink": "Utwórz i połącz",
+    "noLinkedIssues": "Brak powiązanych problemów",
+    "viewExternal": "Wyświetl w {provider}",
+    "unlink": "Odczepić",
+    "linkError": "Nie udało się połączyć problemu",
+    "linkExternalIssue": "Problem z linkiem {provider}",
+    "linkIssue": "Problem z linkiem",
+    "addIssue": "Dodaj problem",
+    "unlinkError": "Nie udało się odłączyć problemu",
+    "noIssuesFound": "Nie znaleziono problemów",
+    "startTypingToSearch": "Zacznij pisać, aby wyszukać problemy",
+    "selectedCount": "{count} wybrano",
+    "confirmSelection": "Potwierdź wybór",
+    "alreadyLinked": "Już połączone",
+    "authenticate": "Uwierzytelniać",
+    "authenticationRequired": "Wymagane uwierzytelnienie",
+    "authenticationDescription": "Aby wyszukać problemy, należy uwierzytelnić się za pomocą {provider} .",
+    "searchIn": "Szukaj w {provider}",
+    "searchPlaceholder": "Problemy z wyszukiwaniem...",
+    "searchIssues": "Problemy z wyszukiwaniem",
+    "searchIssuesDescription": "Wyszukaj problemy wewnętrzne, aby utworzyć link do tego elementu.",
+    "searchExternalDescription": "Wyszukaj {provider} numerów, aby utworzyć link do tego elementu.",
+    "error": "Wystąpił błąd podczas ładowania",
+    "errorDescription": "Nie udało się załadować problemów. Spróbuj ponownie.",
+    "selectIssues": "Wybierz problemy",
+    "authRequiredDescription": "Aby wyszukać problemy, należy uwierzytelnić się za pomocą {provider}",
+    "integrationNotConfigured": "Integracja nie jest skonfigurowana",
+    "integrationNotConfiguredDescription": "Ta integracja nie została w pełni skonfigurowana. Skontaktuj się z administratorem projektu, aby skonfigurować projekt zewnętrzny w ustawieniach projektu.",
+    "createIssue": "Utwórz problem",
+    "createNewIssue": "Utwórz nowy problem",
+    "createIssueDescription": "Utwórz nowy problem",
+    "createIssueDescriptionWithIntegration": "Utwórz nowy problem używając {provider}",
+    "createIssueDescriptionSimpleUrl": "Utwórz nowy problem wewnętrzny (prosta integracja adresu URL)",
+    "creatingWith": "Tworzenie problemu z {provider}",
+    "authenticatedAndReady": "Zweryfikowano i gotowe do tworzenia zgłoszeń",
+    "created": "Utworzono problem",
+    "createdInExternal": "Problem utworzony w {provider}",
+    "createdInternal": "Problem utworzony lokalnie",
+    "createdInternalSimpleUrl": "Problem został utworzony wewnętrznie i można go połączyć za pomocą prostego adresu URL",
+    "createError": "Nie udało się utworzyć problemu",
+    "useIntegration": "Użyj {provider}",
+    "useIntegrationDescription": "Utwórz problem w systemie zewnętrznym",
+    "externalProject": "Projekt zewnętrzny",
+    "selectProject": "Wybierz projekt",
+    "issueType": "Typ problemu",
+    "selectIssueType": "Wybierz typ problemu",
+    "noIssueTypes": "Brak dostępnych typów problemów",
+    "priorityUrgent": "Pilny",
+    "additionalFields": "Pola dodatkowe",
+    "createIssueInJira": "Utwórz problem w Jira",
+    "createIssueInJiraDescription": "Użyj interfejsu Jira, aby utworzyć nowe zgłoszenie ze wszystkimi dostępnymi polami i opcjami",
+    "createIssueInJiraFallbackDescription": "Otwórz Jirę w nowej karcie, aby utworzyć zgłoszenie z wstępnie wypełnionymi informacjami",
+    "jiraIframeError": "Nie można załadować interfejsu Jira. Spróbuj otworzyć w nowej karcie.",
+    "jiraIframeFallback": "Ze względów bezpieczeństwa Jira wymaga otwarcia w nowej karcie. Kliknij poniższy przycisk, aby utworzyć zgłoszenie.",
+    "jiraFallbackNote": "Po utworzeniu zgłoszenia w Jira wróć tutaj, aby kontynuować łączenie go z przypadkiem testowym.",
+    "openInNewTab": "Otwórz w nowej karcie",
+    "jiraIframeNote": "Po utworzeniu zgłoszenia w Jira możesz zamknąć to okno dialogowe i odświeżyć listę zgłoszeń.",
+    "fillInRequiredFields": "Wypełnij wymagane pola, aby utworzyć nowe zgłoszenie",
+    "failedToFetchFields": "Nie udało się pobrać pól problemu z Jira",
+    "enterSummary": "Wprowadź krótkie podsumowanie problemu",
+    "enterDescription": "Wprowadź szczegółowy opis problemu",
+    "failedToCreateIssue": "Nie udało się utworzyć problemu w Jira",
+    "issueCreatedDescription": "Problem {key} został pomyślnie utworzony",
+    "addLabel": "Dodaj etykietę i naciśnij Enter",
+    "labelHint": "Spacje zostaną zastąpione myślnikami",
+    "labelFormatNote": "Etykiety nie mogą zawierać spacji. Spacje zostaną automatycznie zastąpione myślnikami.",
+    "enterIssueKey": "Wprowadź klucz problemu (np. PROJ-123)",
+    "issueLinkHelp": "Wprowadź klucz istniejącego problemu, aby go połączyć",
+    "searchForIssue": "Wyszukaj problem, który chcesz połączyć",
+    "searchUsers": "Wyszukaj użytkowników",
+    "noTeamsAvailable": "Brak dostępnych zespołów",
+    "filterAll": "Wszystko",
+    "fanOutPartialFailure": "Nie udało się nawiązać połączenia z {count} projektami. Wyświetlane są wyniki z {successCount} projektów.",
+    "projectSelectorLabel": "Projekt",
+    "searchFailedTitle": "Wyszukiwanie nie powiodło się"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Przeglądaj i zarządzaj wszystkimi problemami.",
+      "filterPlaceholder": "Filtruj problemy według nazwy..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Dokumentacja",
+      "Milestones": "Kamienie milowe",
+      "TestCaseRepository": "Repozytorium przypadków testowych",
+      "TestCaseRestrictedFields": "Pola ograniczone przypadku testowego",
+      "TestRuns": "Testy biegowe",
+      "ClosedTestRuns": "Zamknięte testy",
+      "TestRunResults": "Wyniki testu",
+      "TestRunResultRestrictedFields": "Pola ograniczone wyniku testu",
+      "Sessions": "Sesje",
+      "SessionsRestrictedFields": "Pola ograniczone dla sesji",
+      "ClosedSessions": "Sesje zamknięte",
+      "SessionResults": "Wyniki sesji",
+      "Tags": "Tagi",
+      "SharedSteps": "Wspólne kroki",
+      "Issues": "Kwestie",
+      "IssueIntegration": "Integracja problemów",
+      "Forecasting": "Prognozowanie",
+      "Reporting": "Raportowanie",
+      "Settings": "Ustawienia"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Nie rozpoczęto",
+      "IN_PROGRESS": "W toku",
+      "DONE": "Zrobione"
+    }
+  },
+  "charts": {
+    "average": "Przeciętny",
+    "count": "Liczba: {count}",
+    "percent": "Procent: {percent}%",
+    "completed": "Zakończono: {count}",
+    "durationRange": "Czas trwania: {from}s - {to}s",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# przypadek testowy} other {# przypadki testowe}}",
+    "estimate": "Szacunkowo: {value}",
+    "partOf": "(Część {parent})",
+    "status": "Stan: {status}"
+  },
+  "linkedCases": {
+    "title": "Powiązane przypadki testowe",
+    "addLink": "Dodaj link",
+    "addLinkedTestCase": "Dodaj powiązany przypadek testowy",
+    "testCase": "Przypadek testowy",
+    "linkType": "Typ łącza",
+    "noLinkedCases": "Brak powiązanych przypadków testowych.",
+    "linkedBy": "Połączone przez",
+    "on": "Połączone na",
+    "alreadyLinked": "Ta sprawa jest już powiązana.",
+    "cannotLinkSelf": "Nie można połączyć sprawy z samą sobą.",
+    "circularLink": "Wykryto połączenie cykliczne.",
+    "failedToCreate": "Nie udało się utworzyć linku.",
+    "confirmRemoveLink": "Czy na pewno chcesz usunąć ten link?",
+    "DEPENDS_ON": "Zależność",
+    "DUPLICATED_FROM": "Duplikat z",
+    "SAME_TEST_DIFFERENT_SOURCE": "Ten sam test (inne źródło)",
+    "status": "Najnowszy status",
+    "at": "Wykonany"
+  },
+  "ganttTooltip": {
+    "task": "Zadanie",
+    "group": "Uruchom/Sesja:",
+    "project": "Projekt:",
+    "starts": "Początek:",
+    "scheduledCompletion": "Planowane zakończenie:",
+    "estWorkEffort": "Szacowany nakład pracy:",
+    "noTasks": "Brak zadań do wyświetlenia na wykresie Gantta."
+  },
+  "help": {
+    "project": {
+      "name": "## Nazwa projektu\nUnikalny identyfikator Twojego projektu.\n\n– Musi być unikatowy we wszystkich projektach\n– Używany w nawigacji i raportach\n– Powinien być jasny i opisowy\n– Pomaga członkom zespołu określić zakres projektu",
+      "description": "## Opis projektu\nDodatkowe szczegóły dotyczące celu i zakresu projektu.\n\n– Opcjonalne, ale zalecane\n– Pomaga członkom zespołu zrozumieć cele projektu\n– Może zawierać kluczowe cele lub wymagania\n– Ograniczone do 256 znaków",
+      "icon": "## Ikona projektu\nWizualny identyfikator Twojego projektu.\n\n- Pomaga szybko zidentyfikować projekt na listach i pulpitach nawigacyjnych\n- Wybierz jedną z wielu predefiniowanych ikon\n- Można ją zmienić w dowolnym momencie\n- Pojawia się w nawigacji projektu i raportach",
+      "completed": "## Status projektu\nWskazuje, czy projekt jest aktywny czy ukończony.\n\n— Aktywne projekty są dostępne do testowania i aktualizacji\n— Ukończone projekty są dostępne tylko do odczytu\n— Ma wpływ na widoczność projektu na pulpitach nawigacyjnych\n— Można to cofnąć, jeśli to konieczne",
+      "completedAt": "## Data ukończenia\nData, kiedy projekt został oznaczony jako ukończony.\n\n- Ustawiane automatycznie podczas oznaczania projektu jako ukończonego\n- Służy do raportowania i śledzenia\n- Pomaga w prowadzeniu historii projektu\n- Można modyfikować w razie potrzeby",
+      "defaultAccess": "## Domyślny dostęp do projektu\nZdefiniuj domyślne uprawnienia dostępu dla użytkowników i grup w tym projekcie. Można je zmienić dla każdego użytkownika lub grupy.",
+      "issueTracker": "## Konfiguracja modułu śledzenia problemów\nWybierz konfigurację modułu śledzenia problemów, która będzie używana do zarządzania problemami związanymi z tym projektem."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Projekt zewnętrzny\nWybierz projekt lub repozytorium w systemie zewnętrznym, które ma zostać połączone z tym projektem TestPlanIt.\n\n— Zgłoszenia utworzone z TestPlanIt zostaną utworzone w tym projekcie\n— Włącza integrację śledzenia zgłoszeń między systemami\n— Wymagane są odpowiednie uprawnienia w systemie zewnętrznym",
+          "defaultIssueTypeHelp": "## Domyślny typ zgłoszenia\nTyp zgłoszenia, który będzie wstępnie wybierany podczas tworzenia nowych zgłoszeń z TestPlanIt.\n\n— Oszczędza czas dzięki domyślnemu użyciu najczęściej używanego typu zgłoszenia\n— Można zastąpić podczas tworzenia pojedynczych zgłoszeń\n— Musi to być prawidłowy typ zgłoszenia dla wybranego projektu zewnętrznego\n— Zaktualizuj to, jeśli zmieni się Twój przepływ pracy",
+          "automaticSyncHelp": "## Automatyczna synchronizacja\nWłącza automatyczną synchronizację statusu problemu między TestPlanIt a systemem zewnętrznym.\n\n— Problemy powiązane z przypadkami testowymi będą automatycznie aktualizować swój status.\n— Pomaga zachować spójność śledzenia problemów w różnych systemach.\n— Może zwiększyć wykorzystanie interfejsu API z usługą zewnętrzną.\n— Można wyłączyć, jeśli preferowana jest kontrola ręczna."
+        }
+      }
+    },
+    "user": {
+      "name": "## Nazwa użytkownika\nPełna nazwa użytkownika.\n\n- Służy do identyfikacji w systemie\n- Wyświetlana w zadaniach i raportach\n- Musi być unikatowa dla każdego użytkownika",
+      "email": "## Adres e-mail\nAdres e-mail użytkownika umożliwiający dostęp do konta.\n\n— używany do logowania do systemu\n— musi być unikatowy dla każdego użytkownika\n— używany do powiadomień systemowych",
+      "password": "## Hasło\nHasło konta użytkownika.\n\n- Opcjonalne, gdy skonfigurowano metodę logowania bez hasła (dostawca Magic Link SSO lub serwer e-mail) — pozostaw puste, aby wymagać logowania za pomocą Magic Link lub SSO\n- Jeśli podano, musi spełniać zasady dotyczące haseł ustawione w **Administrator → Bezpieczeństwo** (minimalna długość i klasy znaków)\n- Używane do bezpiecznego dostępu do konta\n- Powinno pozostać poufne",
+      "token": "## Token weryfikacyjny\nWprowadź token otrzymany w wiadomości e-mail, aby zweryfikować swoje konto. Jeśli nie masz tokena, możesz poprosić o nowy.",
+      "confirmPassword": "## Potwierdź hasło\nWprowadź ponownie hasło, aby upewnić się, że zostało wpisane poprawnie.\n\n— Musi dokładnie odpowiadać hasłu.\n— Pomaga uniknąć błędów w pisowni.\n— Wymagane tylko wtedy, gdy wpisane jest hasło — pozostaw puste, jeśli pole hasła jest puste.",
+      "access": "## Poziom dostępu do systemu\nOkreśla uprawnienia użytkownika w całym systemie.\n\n- **Administrator:** Pełny dostęp do systemu i konfiguracja\n- **Administrator projektu:** Może zarządzać przypisanymi projektami\n- **Użytkownik:** Standardowy dostęp do przypisanych projektów\n- **Brak:** Może tylko przeglądać swój pulpit nawigacyjny",
+      "role": "## Rola systemowa\nTa rola określa domyślne uprawnienia użytkownika do projektu.\n\n— Definiuje domyślne poziomy dostępu do projektów.\n— Można dostosować w Administracji rolami.\n— Ma wpływ na dostępne funkcje i możliwości.",
+      "active": "## Status aktywny\nKontroluje, czy użytkownik może uzyskać dostęp do systemu.\n\n— Aktywni użytkownicy mogą się logować i uzyskiwać dostęp do przypisanych im zasobów.\n— Nieaktywni użytkownicy nie mogą się logować, ale ich dane są zachowywane.\n  — Użyj tej opcji, aby tymczasowo wyłączyć dostęp bez usuwania konta.",
+      "api": "## Dostęp do API\nUmożliwia programowy dostęp do systemu za pomocą punktów końcowych API.\n\n— Umożliwia integrację z narzędziami zewnętrznymi i automatyzacją\n— Wymaga uwierzytelnienia kluczem API\n— Podlega ograniczeniom przepustowości i kontroli dostępu",
+      "projects": "## Przypisanie projektu\nWybierz projekty, do których dany użytkownik ma dostęp.\n\n— Kontroluje, które projekty pojawiają się na pulpicie użytkownika.\n— Wymagane do uczestnictwa w projekcie.\n— Może zostać później zmodyfikowane przez administratorów.\n— Użyj opcji „Zaznacz wszystko”, aby szybko przypisać wszystkie dostępne projekty.",
+      "groups": "## Przypisanie grupy\nWybierz grupy, do których należy ten użytkownik.\n\n- Grupy pomagają organizować użytkowników i uprawnienia\n- Użytkownicy dziedziczą uprawnienia ze swoich grup\n- Ułatwia zarządzanie dostępem\n- Administratorzy mogą później modyfikować",
+      "itemsPerPage": "## Elementów na stronę\nSteruje domyślną liczbą elementów wyświetlanych w tabelach i listach.\n\n— Dotyczy wszystkich widoków stronicowanych w aplikacji\n— Można zmienić w dowolnym momencie\n— Pomaga efektywnie zarządzać dużymi zestawami danych\n— Dostępne opcje: 10, 25, 50 lub 100 elementów",
+      "dateFormat": "## Format daty\nUstawia preferowany format wyświetlania daty.\n\n— Stosowany spójnie w całej aplikacji\n— Pomaga zapewnić dokładność interpretacji daty\n— Zmiany wchodzą w życie natychmiast\n— Przykłady pokazane na liście rozwijanej odzwierciedlają rzeczywisty format",
+      "timeFormat": "## Format czasu\nUstawia preferowany format wyświetlania czasu.\n\n- Wybierz pomiędzy formatem 12-godzinnym i 24-godzinnym\n- Stosowany spójnie w całej aplikacji\n- Zmiany wchodzą w życie natychmiast\n- Przykłady pokazane na liście rozwijanej odzwierciedlają rzeczywisty format",
+      "timezone": "## Strefa czasowa\nUstawia preferowaną strefę czasową do wyświetlania daty i godziny.\n\n- Stosowana spójnie w całej aplikacji",
+      "theme": "## Motyw\nWybierz preferowany motyw wizualny aplikacji.\n\n- **System:** Automatycznie dopasowuje się do motywu systemu operacyjnego\n- **Jasny:** Przejrzysty, jasny interfejs do użytku dziennego\n- **Ciemny:** Przyjazny dla oczu tryb ciemny do pomieszczeń o słabym oświetleniu\n- **Zielony, pomarańczowy, fioletowy:** Zabawny, wyrazisty kolor!",
+      "locale": "## Język\nWybierz preferowany język interfejsu aplikacji.\n\n— Zmienia cały tekst, etykiety i komunikaty na wybrany język.\n— Formaty daty i godziny są dostosowywane do konwencji regionalnych.\n— Działa natychmiast, bez konieczności odświeżania strony.\n— Dostępne języki zależą od zainstalowanych tłumaczeń.",
+      "notificationMode": "## Preferencje dotyczące powiadomień\nSteruje sposobem otrzymywania powiadomień o zadaniach służbowych i aktualizacjach.\n\n- **Użyj ustawień globalnych:** Postępuj zgodnie z domyślnymi ustawieniami systemu ustawionymi przez administratorów\n- **Brak powiadomień:** Wyłącz wszystkie powiadomienia\n- **Tylko w aplikacji:** Otrzymuj powiadomienia tylko w aplikacji\n- **W aplikacji + e-mail (natychmiastowe):** Otrzymuj powiadomienia w aplikacji i natychmiastowe alerty e-mail\n- **W aplikacji + e-mail (dzienne podsumowanie):** Otrzymuj powiadomienia w aplikacji i codzienne podsumowanie e-mail\n\nMożesz w dowolnym momencie zmienić te preferencje, aby dopasować je do swojego przepływu pracy."
+    },
+    "milestone": {
+      "name": "## Nazwa kamienia milowego\nJasna, opisowa nazwa identyfikująca ten kamień milowy w projekcie.\n\n– Powinna być unikatowa i znacząca\n– Pomaga członkom zespołu szybko zrozumieć cel kamienia milowego\n– Używana w raportach i śledzeniu projektu",
+      "type": "## Typ kamienia milowego\nKategoryzuje kamień milowy i określa jego wygląd i zachowanie.\n\n— Różne typy mogą mieć różne przepływy pracy\n— Pomaga organizować i filtrować kamienie milowe\n— Może mieć wpływ na raportowanie i śledzenie",
+      "started": "## Status rozpoczęcia\nOznacza, że praca nad tym kamieniem milowym została rozpoczęta.\n\n- Oznacza kamień milowy jako w toku\n- Automatycznie aktualizuje rzeczywistą datę rozpoczęcia po przełączeniu\n- Ma wpływ na harmonogram projektu i śledzenie postępów",
+      "completed": "## Status ukończenia\nOznacza, że praca nad tym kamieniem milowym została zakończona.\n\n- Oznacza kamień milowy jako ukończony\n- Automatycznie aktualizuje faktyczną datę ukończenia\n- Służy do śledzenia postępów i raportowania\n- Ma wpływ na zależne kamienie milowe i harmonogramy projektu",
+      "startDate": "## Planowana data rozpoczęcia\nData, od której spodziewane jest rozpoczęcie prac nad tym kamieniem milowym.\n\n- Pomaga w planowaniu i ustalaniu harmonogramu projektu\n- Służy do prognozowania harmonogramu\n- Wspiera planowanie alokacji zasobów",
+      "dueDate": "## Termin\nDocelowa data ukończenia tego kamienia milowego.\n\n- Ustawia oczekiwania dotyczące terminu\n- Służy do planowania harmonogramu projektu\n- Pomaga śledzić postęp realizacji kamienia milowego w stosunku do harmonogramu",
+      "parent": "## Kamień milowy nadrzędny\nŁączy ten kamień milowy z kamieniem milowym nadrzędnym, tworząc hierarchię.\n\n— Organizuje kamienie milowe w logiczne grupy\n— Pokazuje zależności i relacje\n— Pomaga śledzić postęp większych inicjatyw",
+      "description": "## Opis\nSzczegółowe informacje o celu, wymaganiach i zakresie kamienia milowego.\n\n— Zapewnia kontekst dla członków zespołu\n— Dokumentuje kluczowe wymagania i cele\n— Wspiera współpracę i spójność",
+      "documentation": "## Dokumentacja\nDodatkowe szczegóły, odniesienia i materiały pomocnicze.\n\n- Specyfikacje techniczne\n- Dokumentacja projektowa\n- Odniesienia zewnętrzne\n- Notatki ze spotkań i decyzje",
+      "automaticCompletion": "## Automatyczne uzupełnianie w terminie\nAutomatycznie oznacza ten kamień milowy jako ukończony po osiągnięciu jego terminu.\n\n- Kamień milowy zostanie ukończony w zaplanowanym czasie w terminie\n- Przydatne w przypadku kamieni milowych ograniczonych czasowo, które powinny zostać zamknięte niezależnie od statusu ukończenia\n- Można pominąć, ręcznie uzupełniając kamień milowy przed terminem\n- Wymaga ustawienia terminu",
+      "notifyDaysBefore": "## Powiadom na dni przed terminem\nWysyłaj powiadomienia do przypisanych członków zespołu, gdy zbliża się termin osiągnięcia kamienia milowego.\n\n— Włącz, aby włączyć powiadomienia, wyłącz, aby je wyłączyć\n— Wprowadź liczbę dni przed terminem, aby rozpocząć wysyłanie przypomnień\n— Powiadomienia są wysyłane do użytkowników przypisanych do przebiegów testowych i sesji w ramach tego kamienia milowego\n— Przekroczone kamienie milowe będą nadal wysyłać przypomnienia do momentu ich ukończenia"
+    },
+    "session": {
+      "name": "## Nazwa sesji\nJasna, opisowa nazwa identyfikująca cel sesji testowej.\n\n– Powinna być unikatowa i znacząca\n– Pomaga członkom zespołu zrozumieć, co jest testowane\n– Używana w raportach i śledzeniu",
+      "template": "## Szablon\nSzablony definiują strukturę i zawartość sesji testowej.\n\n— Zapewnia spójny format dokumentacji testowej\n— Zawiera predefiniowane sekcje i pola\n— Pomaga zachować standardy testowania w całym projekcie",
+      "configuration": "## Konfiguracja\nOkreślone środowisko lub konfiguracja wymagana dla tej sesji testowej.\n\n— Środowisko testowe (np. środowisko przygotowawcze, produkcyjne)\n— Specjalne konfiguracje lub ustawienia\n— Wymagane dane lub warunki testowe",
+      "milestone": "## Kamień milowy\nKojarzy tę sesję z kamieniem milowym projektu.\n\n— Pomaga śledzić postęp testowania w kierunku celów projektu.\n— Grupuje powiązane sesje testowe.\n— Obsługuje raportowanie oparte na kamieniach milowych.",
+      "description": "## Opis\nKrótki przegląd tego, co obejmuje ta sesja testowa.\n\n- Kluczowe obszary lub funkcje podlegające testowaniu\n- Ważny kontekst lub tło\n- Specjalne względy lub wymagania",
+      "mission": "## Misja\nMisja definiuje szczegółowe cele i zadania dla tej sesji testowej.\n\n- Co testujesz?\n- Jakie są główne obszary zainteresowania?\n- Jakie są oczekiwane rezultaty?\n\nJasna misja pomaga zachować koncentrację i produktywność podczas testowania.",
+      "estimate": "## Szacowany czas\nSzacowany czas ukończenia tej sesji testowej.\n\nPrzykłady:\n- „30 min” dla 30 minut\n- „1 godz. 30 min” dla 1 godziny i 30 minut\n- „2 dni” dla 2 dni\n- „1 tydzień” dla 1 tygodnia",
+      "elapsed": "## Czas upłynięty\nRzeczywisty czas spędzony na tej sesji testowej.\n\nPrzykłady:\n- „45m” dla 45 minut\n- „2h 15m” dla 2 godzin i 15 minut\n- „3 days” dla 3 dni\n\nDokładnie śledź czas, aby udoskonalić przyszłe szacunki.",
+      "state": "## Stan przepływu pracy\nAktualny stan tej sesji testowej w Twoim przepływie pracy.\n\n- Pomaga śledzić postęp sesji\n- Obsługuje zarządzanie przepływem pracy\n- Służy do raportowania i śledzenia",
+      "assignedTo": "## Przypisano do\nCzłonek zespołu odpowiedzialny za przeprowadzenie tej sesji testowej.\n\n- Identyfikuje osobę przeprowadzającą testowanie\n- Pomaga w zarządzaniu zasobami\n- Wspiera rozliczalność i śledzenie",
+      "tags": "## Tagi\nSłowa kluczowe lub etykiety ułatwiające kategoryzację i organizację sesji testowych.\n\n- Ułatwia znajdowanie sesji\n- Grupuje powiązane działania testowe\n- Obsługuje filtrowanie i raportowanie",
+      "attachments": "## Załączniki\nPliki, zrzuty ekranu lub inne dokumenty powiązane z tą sesją testową.\n\n- Pliki danych testowych\n- Zrzuty ekranu lub nagrania\n- Dokumentacja pomocnicza\n- Materiały referencyjne",
+      "issues": "## Problemy\nPołącz istotne problemy z tą sesją."
+    },
+    "testRun": {
+      "name": "## Nazwa przebiegu testu\nWprowadź opisową nazwę tego przebiegu testu, aby później łatwo go zidentyfikować.",
+      "description": "## Opis\nPodaj krótkie podsumowanie lub notatki dotyczące tego przebiegu testu.",
+      "configuration": "## Konfiguracje\nWybierz jedną lub więcej konfiguracji (np. środowisko, przeglądarkę, urządzenie), w których będą wykonywane testy. Wybranie wielu konfiguracji spowoduje utworzenie osobnych testów dla każdej z nich.",
+      "milestone": "## Kamień milowy\nPowiąż ten przebieg testowy z konkretnym kamieniem milowym projektu, aby śledzić postęp w kierunku większych celów.",
+      "docs": "## Dokumentacja\nDołącz wszelką istotną dokumentację, linki lub szczegółowe notatki dotyczące tego przebiegu testu.",
+      "state": "## Stan\nWskaż bieżący status lub wynik tego przebiegu testu zgodnie z przepływem pracy Twojego projektu.",
+      "tags": "## Tagi\nZastosuj odpowiednie tagi, aby skategoryzować i filtrować ten przebieg testu.",
+      "issues": "## Problemy\nPowiąż wszelkie powiązane problemy (błędy, zadania itp.) z tym przebiegiem testu.",
+      "attachments": "## Załączniki\nPrześlij wszelkie pliki pomocnicze, zrzuty ekranu lub dzienniki związane z tym przebiegiem testu.",
+      "duplicate": {
+        "statusesToInclude": "## Statusy do uwzględnienia\nWybierz statusy przypadków testowych, które chcesz uwzględnić w zduplikowanym przebiegu testu.",
+        "copyAssignments": "## Kopiuj przypisania\nJeśli opcja jest włączona, przypisania przypadków testowych zostaną skopiowane do zduplikowanego przebiegu testu."
+      }
+    },
+    "appConfig": {
+      "key": "## Klawisz\nUnikalny identyfikator tej konfiguracji.",
+      "value": "## Wartość\nWartość tej konfiguracji."
+    },
+    "milestoneType": {
+      "icon": "## Ikona typu kamienia milowego\nWizualny identyfikator tego typu kamienia milowego.\n\n— Pomaga szybko zidentyfikować typ kamienia milowego na listach i pulpitach nawigacyjnych\n— Wybierz jedną z wielu predefiniowanych ikon\n— Można ją zmienić w dowolnym momencie\n— Pojawia się w nawigacji projektu i raportach",
+      "name": "## Nazwa typu kamienia milowego\nJasna, opisowa nazwa identyfikująca ten typ kamienia milowego w projekcie.\n\n— Pomaga członkom zespołu szybko zrozumieć cel danego typu kamienia milowego\n— Używana w raportach i śledzeniu projektu",
+      "isDefault": "## Domyślny typ kamienia milowego\nWskazuje, czy ten typ kamienia milowego jest domyślny dla Twojego projektu.\n\n- Domyślny typ kamienia milowego jest wstępnie wybrany dla nowych kamieni milowych\n- Można go zmienić w dowolnym momencie",
+      "projects": "## Powiązane projekty\nWybierz, dla których projektów będzie dostępny ten typ kamienia milowego.\n\n— Jeśli nie wybrano żadnych projektów, typ kamienia milowego będzie dostępny globalnie.\n— Przypisanie do określonych projektów ogranicza jego użycie tylko do tych projektów."
+    },
+    "tag": {
+      "name": "## Nazwa tagu\nJasna, zwięzła, opisowa nazwa lub słowo(a) kluczowe używane we wszystkich projektach.\n\n— Pomaga członkom zespołu szybko znaleźć powiązane przypadki testowe, przebiegi testów i sesje."
+    },
+    "role": {
+      "name": "## Nazwa roli\nJasna, zwięzła, opisowa nazwa lub słowo(a) kluczowe używane we wszystkich projektach.\n\n— Pomaga członkom zespołu szybko znaleźć powiązane przypadki testowe, przebiegi testów i sesje.",
+      "isDefault": "## Rola domyślna\nWskazuje, czy ta rola jest domyślna dla Twojego projektu.\n\n— Rola domyślna jest wstępnie wybrana dla nowych użytkowników.\n— Można ją zmienić w dowolnym momencie.",
+      "permissions": {
+        "canAddEdit": "## Dodaj/Edytuj\nWskazuje, czy ta rola może dodawać i edytować powiązany obszar aplikacji.",
+        "canDelete": "## Usuń\nWskazuje, czy ta rola może usunąć powiązany obszar aplikacji.",
+        "canClose": "## Zamknij\nWskazuje, czy ta rola może zamknąć powiązany obszar aplikacji."
+      }
+    },
+    "group": {
+      "name": "## Nazwa grupy\nJasna, zwięzła, opisowa nazwa lub słowo(a) kluczowe używane we wszystkich projektach.\n\n— Pomaga członkom zespołu szybko znaleźć powiązane przypadki testowe, przebiegi testów i sesje.",
+      "users": "## Użytkownicy\nWskazuje użytkowników przypisanych do tej grupy."
+    },
+    "template": {
+      "name": "## Nazwa szablonu\nUnikalna i opisowa nazwa tego szablonu (np. „Standardowy przypadek testowy”, „Wyniki testów API”).",
+      "isEnabled": "## Włączone\nJeśli zaznaczone, ten szablon będzie dostępny do wyboru podczas tworzenia nowych przypadków testowych lub definiowania struktur przebiegów testów. Jeśli szablon jest ustawiony jako „Domyślny”, musi być również „Włączony”.",
+      "isDefault": "## Domyślny\nJeśli zaznaczysz tę opcję, ten szablon będzie automatycznie wybierany dla nowych projektów lub jako domyślny dla wszystkich projektów, jeśli nie zostanie ustawiony żaden szablon domyślny dla danego projektu. Tylko jeden szablon może być domyślny we wszystkich projektach. Włączenie tej opcji wyłączy wszystkie inne szablony ustawione jako domyślne.",
+      "caseFields": "## Pola przypadków\nWybierz i uporządkuj pola niestandardowe, które będą dostępne podczas tworzenia lub edytowania przypadków testowych przy użyciu tego szablonu.\n\n— Dodaj pola z listy rozwijanej, aby uwzględnić je w szablonie\n— Przeciągnij i upuść, aby zmienić kolejność pól\n— Kolejność określa sposób wyświetlania pól w formularzach\n— Dostępne są do wyboru tylko włączone pola przypadków\n— Pola przypadków definiują strukturę i dane przechwytywane dla przypadków testowych",
+      "resultFields": "## Pola wyników\nWybierz i uporządkuj pola niestandardowe, które będą dostępne podczas dodawania wyników testów za pomocą tego szablonu.\n\n— Dodaj pola z listy rozwijanej, aby uwzględnić je w szablonie\n— Przeciągnij i upuść, aby zmienić kolejność pól\n— Kolejność określa sposób wyświetlania pól podczas wprowadzania wyników testów\n— Dostępne do wyboru są tylko włączone pola wyników\n— Pola wyników przechwytują dodatkowe dane specyficzne dla wyników wykonania testu",
+      "projects": "## Powiązane projekty\nWybierz projekty, dla których ten szablon będzie dostępny. Jeśli nie wybrano żadnych projektów, szablon będzie dostępny globalnie. Przypisanie szablonu do konkretnych projektów ogranicza jego użycie tylko do tych projektów."
+    },
+    "llm": {
+      "name": "## Nazwa integracji\nOpisowa etykieta tej integracji LLM.\n\n— używana do identyfikacji na listach i w ustawieniach\n— przykład: „OpenAI GPT-4o” lub „Internal Ollama”",
+      "provider": "## Dostawca\nUsługa LLM, która obsługuje tę integrację.\n\n— Określa protokół API i dostępne modele\n— Nie można zmienić po utworzeniu",
+      "apiKey": "## Klucz API\nTwój klucz uwierzytelniający dla API dostawcy LLM.\n\n— Uzyskaj go z konsoli programistycznej swojego dostawcy.\n— Przechowywany w postaci zaszyfrowanej i nigdy nie wyświetlany po zapisaniu.\n— Nie jest wymagany w przypadku Ollama (wdrożenie lokalne).",
+      "endpoint": "## Punkt końcowy interfejsu API\nPodstawowy adres URL interfejsu API dostawcy LLM.\n\n— Pozostaw puste dla OpenAI, Anthropic i Gemini — oficjalne adresy URL są używane automatycznie\n— Wymagane dla Ollama (np. `http://localhost:11434`), Azure OpenAI i Custom LLM\n— Opcjonalne dla dowolnego dostawcy — wskaż serwer proxy zgodny z OpenAI (np. LiteLLM), wprowadzając jego adres URL\n— **Prywatne/wewnętrzne adresy** (localhost, 127.0.0.1, prywatne adresy IP, metadane w chmurze) są blokowane, chyba że wyraźnie zezwolą na to za pomocą zmiennej środowiskowej `ALLOWED_PRIVATE_HOSTS`",
+      "deploymentName": "## Nazwa wdrożenia platformy Azure\nNazwa wdrożenia modelu Azure OpenAI.\n\n— znajduje się w obszarze Wdrożenia w usłudze Azure OpenAI Studio\n— różni się od nazwy modelu — np. „my-gpt4-deploy” jest mapowane na „gpt-4”\n— wymagane tylko w przypadku usługi Azure OpenAI",
+      "defaultModel": "## Model domyślny\nModel używany do żądań AI z tą integracją.\n\n— W przypadku OpenAI, Anthropic i Gemini — dostępne modele są pobierane automatycznie z klucza API\n— Upewnij się, że model jest włączony na koncie dostawcy\n— Przykład: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Maksymalna liczba tokenów na żądanie\n**Sztywny pułap** tokenów wyjściowych dla pojedynczego żądania.\n\n— Żądania przekraczające tę wartość są **odrzucane z błędem** przed osiągnięciem LLM\n— Ustaw tę wartość na rzeczywistą maksymalną pojemność tokenów wyjściowych modelu\n— Przykład: `16384` dla GPT-4o, `8192` dla sonetu Claude 3.5\n— Ustawienie zbyt niskiej wartości powoduje awarię funkcji AI lub generowanie obciętych danych wyjściowych",
+      "defaultMaxTokens": "## Domyślna maksymalna liczba tokenów\n**Rezerwowy** limit tokenów wyjściowych używany, gdy żądanie nie określa własnego.\n\n— Każda funkcja AI (generowanie testów, eksport kodu itp.) ustawia własny limit w **Administrator → Konfiguracja monitu**\n— Ta wartość jest używana wyłącznie jako zapasowa dla funkcji bez skonfigurowanego konkretnego limitu\n— Powinna być ≤ Maksymalna liczba tokenów na żądanie",
+      "maxRequestsPerMinute": "## Maksymalna liczba żądań na minutę\nOgranicza liczbę wywołań API, jakie można wykonać do tego dostawcy na minutę.\n\n— Ustaw zgodnie z limitem szybkości planu swojego dostawcy.\n— Nadmiarowe żądania są kolejkowane, a nie odrzucane.\n— Sprawdź dokumentację swojego dostawcy, aby poznać limit swojego planu.",
+      "costPerInputToken": "## Koszt za token wejściowy (USD)\nKoszt w USD za każdy token wejściowy (monit) wysłany do modelu.\n\n— Służy do śledzenia kosztów i alertów budżetowych\n— Znajdziesz to na stronie cennika swojego dostawcy\n— Przykład: `0,000005` = 5 USD za milion tokenów wejściowych",
+      "costPerOutputToken": "## Koszt za token wyjściowy (USD)\nKoszt w USD za każdy token wyjściowy (ukończony) wygenerowany przez model.\n\n- Zwykle wyższy niż koszt tokena wejściowego\n- Służy do śledzenia kosztów i alertów budżetowych\n- Przykład: `0,000015` = 15 USD za milion tokenów wyjściowych",
+      "monthlyBudget": "## Miesięczny budżet (USD)\nOpcjonalny cel wydatków dla tej integracji.\n\n- Ustaw na `0`, aby wyłączyć śledzenie budżetu\n- Budżet ma charakter **wyłącznie informacyjny** — nie blokuje korzystania z LLM\n- Otrzymasz powiadomienia przy osiągnięciu 80%, 90% i 100% budżetu\n- Koszty są obliczane przy użyciu powyższych stawek za token",
+      "billingPeriodStartDay": "## Dzień rozpoczęcia okresu rozliczeniowego\nDzień miesiąca (1–31), w którym rozpoczyna się okres rozliczeniowy.\n\n— Domyślna wartość `1` odpowiada miesiącowi kalendarzowemu.\n— Ustaw na `15`, aby uzyskać cykl od 15. do 15. (np. aby dopasować datę faktury dostawcy).\n— Wartości `29–31` są automatycznie ograniczane do ostatniego dnia krótszych miesięcy (lutego w latach nieprzestępnych itd.).\n— Ma wpływ na okno wydatków **Miesięcznego budżetu** i akcję **Resetuj wydatki**.",
+      "defaultTemperature": "## Temperatura domyślna\nSteruje losowością odpowiedzi modelu (0–2).\n\n- **0:** Deterministyczna — identyczne wyjście dla tego samego wejścia\n- **0,3:** Skupiona — zalecana do generowania testów i wyjścia kodu\n- **1+:** Kreatywna — bardziej zróżnicowane odpowiedzi\n- Poszczególne funkcje mogą to zastąpić w konfiguracji monitu",
+      "timeout": "## Limit czasu żądania (ms)\nJak długo czekać na odpowiedź, zanim żądanie zostanie anulowane.\n\n- Wartość jest w milisekundach (np. `30000` = 30 sekund)\n- Żądania strumieniowe (np. podgląd eksportu kodu) ignorują ten limit czasu\n- Zwiększ w przypadku wolnych lub dużych modeli\n- Zakres: 5000 – 600 000 ms",
+      "streamingEnabled": "## Włącz strumieniowanie\nPrzesyła strumieniowo odpowiedź token po tokenie zamiast czekać na pełne dane wyjściowe.\n\n— wymagane do podglądu kodu w czasie rzeczywistym w oknie dialogowym eksportu\n— zmniejsza odczuwalne opóźnienie w przypadku długich odpowiedzi\n— zalecane dla wszystkich obsługiwanych dostawców",
+      "isDefault": "## Ustaw jako domyślną integrację\nSprawia, że ta integracja będzie domyślnie używana dla wszystkich funkcji AI.\n\n— Tylko jedna integracja może być domyślna w danym momencie\n— Funkcje bez skonfigurowanego konkretnego dostawcy będą używać domyślnej\n— Można ją zmienić w dowolnym momencie"
+    },
+    "integration": {
+      "name": "## Nazwa integracji\nOpisowa nazwa identyfikująca tę integrację w systemie.\n\n— musi być unikatowa, aby odróżnić ją od innych integracji\n— używana w ustawieniach projektu i konfiguracji\n— powinna wyraźnie wskazywać usługę i cel",
+      "authType": "## Typ uwierzytelniania\nWybierz sposób uwierzytelniania za pomocą usługi zewnętrznej.\n\n- **Klucz API:** Proste uwierzytelnianie przy użyciu adresu e-mail i tokenu API\n- **OAuth 2.0:** Bezpieczne uwierzytelnianie przy użyciu przepływu OAuth\n- **Token dostępu osobistego:** Bezpośrednie uwierzytelnianie na podstawie tokenu",
+      "email": "## Adres e-mail\nTwój adres e-mail konta dla usługi zewnętrznej.\n\n— używany do uwierzytelniania kluczem API\n— musi być zgodny z kontem, które wygenerowało token API\n— wymagany dla Jira i podobnych usług",
+      "apiToken": "## Token API\nWygeneruj token API z ustawień konta w usłudze zewnętrznej.\n\n— Zwykle znajduje się w Ustawieniach konta → Bezpieczeństwo → Tokeny API\n— Zapewnia bezpieczny dostęp bez ujawniania hasła\n— Można go cofnąć i wygenerować ponownie w razie potrzeby",
+      "jiraUrl": "## Adres URL Jira\nPodstawowy adres URL Twojej instancji Jira.\n\n— Format: https://twoja-strona.atlassian.net\n— Nie uwzględniaj ścieżki /browse ani innych ścieżek\n— Musi być dostępny z tego serwera",
+      "clientId": "## Identyfikator klienta OAuth\nIdentyfikator klienta z konfiguracji aplikacji OAuth.\n\n— Utworzono w konsoli programisty usługi zewnętrznej\n— Służy do identyfikacji aplikacji podczas przepływu OAuth\n— Można go bezpiecznie udostępniać w plikach konfiguracyjnych",
+      "clientSecret": "## Tajny klucz klienta OAuth\nTajny klucz klienta z konfiguracji aplikacji OAuth.\n\n— Tworzony wraz z identyfikatorem klienta\n— Musi być zachowany w tajemnicy i bezpieczny\n— Służy do uwierzytelniania aplikacji",
+      "personalAccessToken": "## Osobisty token dostępu\nOsobisty token dostępu z odpowiednimi uprawnieniami do usługi zewnętrznej.\n\n— Generowany w ustawieniach konta\n— Powinien zawierać uprawnienia do odczytu i zapisu\n— Bezpieczniejszy niż uwierzytelnianie hasłem",
+      "baseUrl": "## Wzorzec adresu URL\nWzorzec adresu URL do linkowania do problemów zewnętrznych.\n\n- Użyj „{issueId}” jako symbolu zastępczego dla identyfikatora problemu\n- Przykład: https://example.com/issues/'{issueId}'\n- Używany w przypadku prostych integracji opartych na adresie URL",
+      "organizationUrl": "## Adres URL organizacji\nAdres URL organizacji Azure DevOps.\n\n— Format: https://dev.azure.com/your-org\n— Musi być dostępny z tego serwera\n— Służy do uzyskiwania dostępu do interfejsów API Azure DevOps",
+      "apiKey": "## Klucz API\nKlucz API do uwierzytelniania w usłudze zewnętrznej.\n\n— Generowany w ustawieniach API usługi\n— Zapewnia programowy dostęp do usługi\n— Przechowuj w bezpiecznym miejscu i regularnie zmieniaj klucz API",
+      "forgeApiKey": "## Klucz API Forge\nSłuży do uwierzytelniania aplikacji Atlassian Forge podczas pobierania danych testowych z Twoich zgłoszeń Jira.\n\n— Kliknij Wygeneruj, aby utworzyć nowy klucz\n— Skopiuj klucz i wklej go w ustawieniach aplikacji Forge w Jira (Zarządzaj aplikacjami → Ustawienia TestPlanIt)\n— Ponowne wygenerowanie unieważni poprzedni klucz",
+      "owner": "## Właściciel / Przestrzeń nazw\nUżytkownik lub organizacja będąca właścicielem repozytorium.\n\n- W przypadku GitHub/GitLab: nazwa użytkownika lub nazwa organizacji\n- W przypadku Gitea/Forgejo/Gogs: nazwa użytkownika lub grupy\n- Przykład: my-org lub my-username",
+      "repo": "## Nazwa repozytorium\nNazwa repozytorium, z którego mają być łączone problemy.\n\n- Dokładna nazwa repozytorium (nie pełny adres URL)\n- Przykład: my-project\n- Musi być dostępne przy użyciu podanych poświadczeń",
+      "instanceUrl": "## Adres URL instancji\nPodstawowy adres URL samodzielnie hostowanej instancji.\n\n— Format: https://git.example.com\n— Nie należy uwzględniać końcowych ukośników ani ścieżek\n— Musi być dostępny z tego serwera",
+      "projectPath": "## Ścieżka projektu\nPełna ścieżka do Twojego projektu GitLab.\n\n- Format: przestrzeń nazw/projekt lub grupa/podgrupa/projekt\n- Przykład: my-org/my-project\n- Znajduje się w adresie URL projektu: gitlab.com/namespace/project",
+      "platform": "## Platforma\nSamodzielnie hostowana platforma Git, z którą się łączysz.\n\n- **Gitea**: instancje oparte na gitea.io\n- **Forgejo**: instancje oparte na forgejo.org (fork Gitea)\n- **Gogs**: instancje oparte na gogs.io\n\nKontroluje, która ikona jest wyświetlana, i może mieć wpływ na zgodność z API."
+    },
+    "config": {
+      "name": "## Nazwa konfiguracji\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n— pomaga opisać warianty konfiguracji (np. „Chrome, Windows 10”, „Safari/macOS 15.5”, „Edge/Windows 11” itd.)."
+    },
+    "configCategory": {
+      "name": "## Nazwa kategorii\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n— pomaga organizować warianty (np. Chrome, Firefox, Safari, Edge itd.) w kategorie (np. przeglądarki)."
+    },
+    "configVariant": {
+      "name": "## Nazwa wariantu\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n— pomaga opisać wariant będący częścią środowiska testowego (np. Chrome, Safari, Windows 10, Windows 11, macOS 15.5 itd.)."
+    },
+    "issueConfig": {
+      "name": "## Nazwa konfiguracji problemu\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n— pomaga opisać konfigurację problemu (np. Jira, GitHub itp.).",
+      "baseUrl": "## Adres URL bazowy\nAdres URL bazowy konfiguracji zgłoszenia, obejmujący symbol zastępczy zgłoszenia (np. https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Typ systemu\nTyp systemu śledzenia problemów (np. LINK Jira itp.).",
+      "isActive": "## Aktywny\nWskazuje, czy ta konfiguracja problemu jest aktywna.",
+      "isDefault": "## Domyślna\nWskazuje, czy ta konfiguracja problemu jest domyślną konfiguracją dla Twojego projektu.\n\n— Domyślna konfiguracja problemu jest wstępnie wybierana dla nowych problemów.\n— Można ją zmienić w dowolnym momencie.",
+      "projects": "## Projekty\nWskazuje projekty przypisane do tej konfiguracji problemu."
+    },
+    "issue": {
+      "name": "## Nazwa problemu\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n– pomaga opisać problem (np. „Problem 123”, „Błąd 456” itd.).",
+      "title": "## Tytuł problemu\nCzytelny dla człowieka tytuł opisujący problem.\n\n— Zawiera kontekst dotyczący przedmiotu problemu\n— Wyświetlany na listach i w wyświetlaczach problemów\n— Powinien być jasny i opisowy",
+      "externalKey": "## Klucz zewnętrzny\nUnikalny klucz lub identyfikator z zewnętrznego systemu śledzenia problemów.\n\n– W przypadku JIRA: Klucz problemu, np. „PROJ-123”\n– W przypadku GitHub: Numer problemu, np. „456”\n– W przypadku Azure DevOps: Identyfikator elementu roboczego\n– Automatycznie generuje zewnętrzny adres URL podczas zapisywania",
+      "externalId": "## Identyfikator zewnętrzny\nUnikalny identyfikator tego problemu w systemie śledzenia problemów (np. „Problem-123”, „Błąd 456” itd.).\n\n— jest używany jako symbol zastępczy problemu w podstawowym adresie URL.",
+      "description": "## Opis\nKrótki przegląd zagadnień objętych tym problemem.\n\n- Kluczowe obszary lub funkcje będące przedmiotem testów\n- Ważny kontekst lub tło\n- Szczególne względy lub wymagania",
+      "project": "## Projekt\nProjekt, z którym powiązane jest to zgłoszenie.\n\n— Zgłoszenia można łączyć z przypadkami testowymi w wielu projektach\n— Ustawienie projektu głównego ułatwia organizację zgłoszeń\n— Można pozostawić puste w przypadku zgłoszeń międzyprojektowych",
+      "state": "## Stan\nWskaż aktualny status lub wynik tego problemu zgodnie z przepływem pracy Twojego projektu.",
+      "tags": "## Tagi\nZastosuj odpowiednie tagi, aby skategoryzować i filtrować ten problem.",
+      "issues": "## Problemy\nPowiąż wszelkie powiązane problemy (błędy, zadania itp.) z tym problemem."
+    },
+    "status": {
+      "name": "## Nazwa statusu\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n– Pomaga opisać status wyniku testu (np. Zaliczony, Niezaliczony, Zablokowany itd.).",
+      "color": "## Kolor\nKolor tego statusu.",
+      "systemName": "## Nazwa systemu\nNazwa statusu używana przez system zaplecza (np. zapytania do bazy danych, raporty itp.).",
+      "aliases": "## Aliasy\nDodatkowe nazwy lub synonimy tego statusu, których można używać do łączenia zewnętrznych statusów systemowych z tym statusem.",
+      "enabled": "## Włączone\nWskazuje, czy ten status jest włączony.",
+      "isEnabled": "## Włączone\nWskazuje, czy ten status jest włączony i dostępny do użycia.\n\n— Po włączeniu można wybrać ten status podczas rejestrowania wyników testu.\n— Wyłączone statusy są ukryte przed wyborem, ale zachowane w istniejących wynikach.",
+      "success": "## Sukces\nWskazuje, czy ten status jest statusem sukcesu.",
+      "isSuccess": "## Status sukcesu\nWskazuje, czy ten status oznacza pomyślny wynik testu.\n\n— Statusy sukcesu wpływają na wskaźniki wskaźnika zdawalności\n— Używane w raportowaniu i analityce w celu śledzenia skuteczności testu",
+      "completed": "## Zakończono\nWskazuje, czy ten status jest statusem ukończonym.",
+      "isCompleted": "## Status ukończenia\nWskazuje, czy ten status oznacza ukończenie wykonywania testu.\n\n— Statusy ukończenia oznaczają, że test został ukończony.\n— Służy do obliczania wskaźników ukończenia i śledzenia postępu.",
+      "failure": "## Awaria\nWskazuje, czy ten status jest statusem awarii.",
+      "isFailure": "## Status awarii\nWskazuje, czy ten status oznacza niepowodzenie testu.\n\n— Statusy awarii wpływają na metryki wskaźnika awarii\n— Używane w raportowaniu i analityce w celu identyfikacji problemów",
+      "scope": "## Zakres\nWskazuje zakres tego statusu (Uruchomienie testu, Sesja, Automatyzacja).",
+      "projects": "## Projekty\nWskazuje projekty, które mogą korzystać z tego statusu."
+    },
+    "workflow": {
+      "scope": "## Zakres\nWskazuje zakres tego przepływu pracy (uruchomienie testu, sesja, automatyzacja).\n\n— Nie można go zmienić po utworzeniu przepływu pracy.",
+      "iconColor": "## Ikona/Kolor\nIkona i kolor dla tego przepływu pracy.",
+      "name": "## Nazwa\nJasna, opisowa nazwa używana we wszystkich projektach.\n\n– pomaga opisać przepływ pracy (np. „Wersja robocza”, „W trakcie przeglądu”, „Aktywny” itd.).",
+      "workflowType": "## Typ\nTyp przepływu pracy (Nierozpoczęty, W trakcie, Zakończony).",
+      "type": "## Typ przepływu pracy\nKategoria stanu przepływu pracy (Nierozpoczęty, W toku, Zakończony).\n\n— Określa, jak ten stan wpływa na śledzenie postępu\n— Stany Nierozpoczęty oznaczają, że praca się nie rozpoczęła\n— Stany W toku oznaczają aktywną pracę\n— Stany Zakończone oznaczają, że praca została zakończona",
+      "isDefault": "## Domyślny\nWskazuje, czy ten przepływ pracy jest domyślny dla Twojego projektu.\n\n— Domyślny przepływ pracy jest wstępnie wybierany dla nowych przebiegów testów, sesji i automatyzacji.",
+      "isEnabled": "## Włączone\nWskazuje, czy ten przepływ pracy jest włączony.",
+      "isActive": "## Aktywny\nWskazuje, czy ten stan przepływu pracy jest aktywny i dostępny do użycia.\n\n— Aktywne przepływy pracy można wybierać podczas aktualizowania przebiegów testów, sesji lub automatyzacji.\n— Nieaktywne przepływy pracy są ukryte przed wyborem, ale zachowywane w istniejących elementach.",
+      "projects": "## Projekty\nWskazuje projekty, które mogą korzystać z tego przepływu pracy."
+    },
+    "testResult": {
+      "status": "## Status\nWybierz ogólny status wykonania testu. Wybrany status może mieć wpływ na metryki i raporty projektu.",
+      "elapsedTime": "## Czas upłynięty\nWprowadź całkowity czas potrzebny na wykonanie tego przypadku testowego. Możesz użyć jednostek takich jak **s** dla sekund, **m** dla minut, **h** dla godzin (np. 30 s, 5 min, 1 godz. 20 min).",
+      "resultData": "## Szczegóły wyników\nPodaj szczegółowe notatki, obserwacje lub inne istotne dane dotyczące ogólnego wykonania testu. Mogą to być szczegóły konfiguracji, kroki podjęte w przypadku odchyleń od planu lub ogólne komentarze.",
+      "evidence": "## Dowody/załączniki\nPrześlij wszystkie pliki (np. zrzuty ekranu, logi, pliki danych), które stanowią dowód na ten wynik testu. Załączniki te będą powiązane z tym konkretnym wynikiem.",
+      "issues": "## Powiązane problemy\nPowiąż wszystkie problemy ze zintegrowanego systemu śledzenia problemów, które są powiązane z tym wynikiem testu. Ułatwia to śledzenie defektów lub zadań powiązanych z wynikiem tego testu.",
+      "stepStatus": "## Status kroku\nWybierz status dla tego konkretnego kroku testu. Umożliwia to szczegółowe śledzenie postępu w ramach jednego przypadku testowego.",
+      "stepElapsedTime": "## Czas trwania kroku\nWprowadź czas potrzebny na wykonanie tego konkretnego kroku. Użyj jednostek takich jak **s**, **m**, **h** (np. 10 s, 2 min). To jest opcjonalne.",
+      "stepNotes": "## Notatki dotyczące kroku\nDodaj wszelkie notatki, obserwacje lub dane specyficzne dla wykonania tego kroku testu.",
+      "stepIssues": "## Powiązane problemy\nPołącz problemy z systemu śledzenia problemów, które są bezpośrednio związane z wynikami lub obserwacjami tego kroku testu."
+    },
+    "case": {
+      "name": "## Nazwa przypadku testowego\nJasna, opisowa nazwa przypadku testowego.",
+      "state": "## Stan\nWskaż aktualny stan przepływu pracy dla tej sprawy.",
+      "template": "## Szablon\nWybierz szablon, którego ta sprawa będzie używać dla pól sprawy i pól wyników.",
+      "estimate": "## Oszacowanie\nWprowadzony ręcznie szacowany czas potrzebny na ukończenie tego przypadku testowego.",
+      "automated": "## Zautomatyzowany\nWskazuje, czy ten przypadek testowy jest zautomatyzowany, czy nie.",
+      "tags": "## Tagi\nZastosuj odpowiednie tagi, aby skategoryzować i filtrować ten przypadek.",
+      "issues": "## Problemy\nPowiąż wszelkie powiązane problemy (błędy, zadania itp.) z tą sprawą."
+    },
+    "folder": {
+      "name": "## Nazwa folderu\nJasna, opisowa nazwa folderu.",
+      "documentation": "## Dokumentacja\nDodatkowe szczegóły, odniesienia i materiały pomocnicze."
+    },
+    "bulkEdit": {
+      "name": "## Nazwa\nJasna, opisowa nazwa przypadków testowych.",
+      "state": "## Stan\nWskazuje aktualny stan przepływu pracy tych przypadków testowych.",
+      "estimate": "## Oszacowanie\nSzacowany, ręcznie wprowadzony czas potrzebny na ukończenie każdego z tych przypadków testowych.",
+      "automated": "## Zautomatyzowany\nWskazuje, czy te przypadki testowe są zautomatyzowane, czy nie.",
+      "tags": "## Tagi\nZastosuj odpowiednie tagi, aby kategoryzować i filtrować te przypadki testowe.",
+      "issues": "## Problemy\nPowiąż wszelkie powiązane problemy (błędy, zadania itp.) z tymi przypadkami testowymi."
+    },
+    "caseField": {
+      "displayName": "## Nazwa wyświetlana\nTo czytelna dla człowieka nazwa pola, która będzie wyświetlana użytkownikom w formularzach i widokach. Niech będzie jasna i opisowa.",
+      "systemName": "## Nazwa systemu\nUnikalny identyfikator tego pola używany wewnętrznie przez system (np. w wywołaniach API, zapytaniach do bazy danych). Będzie generowany automatycznie z nazwy wyświetlanej, ale można go dostosować. Musi zaczynać się od litery. Może zawierać tylko litery, cyfry i podkreślenia (bez spacji i znaków specjalnych).",
+      "hint": "## Tekst podpowiedzi (opcjonalnie)\nPodaj krótką instrukcję lub przykład, który pojawi się pod polem, aby pomóc użytkownikom. Może to wyjaśnić oczekiwane dane wejściowe lub formatowanie.",
+      "enabled": "## Włączone\nOkreśla, czy to pole jest aktywne i dostępne do użycia w szablonach i przypadkach testowych. Wyłączone pola są ukryte, a ich dane są zachowywane, ale nieużywane.",
+      "required": "## Wymagane\nJeśli zaznaczone, użytkownicy muszą podać wartość tego pola podczas tworzenia lub edytowania przypadku testowego przy użyciu szablonu zawierającego to pole.",
+      "restricted": "## Ograniczone\nJeśli zaznaczone, tylko użytkownicy ze specjalnymi uprawnieniami (np. superadministratorzy lub osoby z uprawnieniem „Pola ograniczone w sprawie”) mogą edytować wartość tego pola po utworzeniu sprawy. Inni użytkownicy zobaczą ją jako tylko do odczytu. Jest to przydatne w przypadku pól takich jak „Sprawdzone przez” lub „Data zatwierdzenia”, których zwykli użytkownicy nie powinni zmieniać po pewnym etapie.",
+      "fieldType": "## Typ pola\nOkreśla rodzaj danych, które to pole będzie przechowywać i sposób ich wyświetlania (np. tekst, liczba, data, lista rozwijana). Typu pola nie można zmienić po utworzeniu.",
+      "defaultValue": "## Wartość domyślna (opcjonalnie)\nUstaw wstępnie wypełnioną wartość dla tego pola. W przypadku typu „Pole wyboru” użyj „prawda” lub „fałsz”. W przypadku typu „Lista rozwijana” lub „Wybór wielokrotny” zazwyczaj odnosi się to do identyfikatorów domyślnych opcji. W przypadku innych typów jest to dosłowny domyślny tekst/liczba. Można to zmienić podczas dodawania pola do szablonu.",
+      "isChecked": "## Stan domyślny (dla pola wyboru)\nOkreśla, czy pole wyboru powinno być domyślnie zaznaczone, gdy tworzony jest nowy element (np. przypadek testowy).",
+      "minValue": "## Wartość minimalna (dla liczby/liczby całkowitej)\nUstawia najmniejszą dozwoloną wartość liczbową dla tego pola. Należy ustawić zarówno wartość minimalną, jak i maksymalną, jeśli użyto jednej z nich.",
+      "maxValue": "## Wartość maksymalna (dla liczby/liczby całkowitej)\nUstawia największą dozwoloną wartość liczbową dla tego pola. Należy ustawić zarówno wartość minimalną, jak i maksymalną, jeśli użyto jednej z nich.",
+      "initialHeight": "## Wysokość początkowa (dla długiego tekstu)\nOkreśl początkową wysokość wyświetlania (w pikselach) dla pól edytora tekstu sformatowanego. Ułatwia to kontrolę układu formularza w przypadku dłuższych danych tekstowych.",
+      "dropdownOptions": "## Opcje (dla listy rozwijanej/wyboru wielokrotnego)\nZdefiniuj listę dostępnych opcji do wyboru. Możesz zmienić kolejność opcji, ustawić wartość domyślną oraz włączać/wyłączać poszczególne opcje."
+    },
+    "resultField": {
+      "displayName": "## Nazwa wyświetlana\nTo czytelna dla człowieka nazwa pola, która będzie wyświetlana użytkownikom podczas wprowadzania wyników testu. Niech będzie jasna i opisowa.",
+      "systemName": "## Nazwa systemu\nUnikalny identyfikator tego pola używany wewnętrznie przez system (np. w wywołaniach API, zapytaniach do bazy danych). Będzie generowany automatycznie z nazwy wyświetlanej, ale można go dostosować.\n– musi zaczynać się od litery.\n– może zawierać tylko litery, cyfry i znaki podkreślenia (bez spacji i znaków specjalnych).",
+      "hint": "## Tekst podpowiedzi (opcjonalnie)\nPodaj krótką instrukcję lub przykład, który pojawi się pod polem, aby pomóc użytkownikom. Może to wyjaśnić oczekiwane dane wejściowe lub formatowanie podczas wprowadzania danych wynikowych.",
+      "enabled": "## Włączone\nOkreśla, czy to pole jest aktywne i dostępne do użycia w szablonach podczas wprowadzania wyników testów. Wyłączone pola są ukryte, a ich dane są zachowywane, ale nieużywane.",
+      "required": "## Wymagane\nJeśli zaznaczone, użytkownicy muszą podać wartość tego pola podczas dodawania wyniku testu przy użyciu szablonu zawierającego to pole.",
+      "restricted": "## Ograniczone\nJeśli zaznaczone, tylko użytkownicy ze specjalnymi uprawnieniami (np. superadministratorzy lub osoby z uprawnieniem „Pola ograniczone w wynikach testów”) mogą edytować wartość tego pola po przesłaniu wyniku. Pozostali użytkownicy zobaczą je jako tylko do odczytu.",
+      "fieldType": "## Typ pola\nOkreśla rodzaj danych, które będzie przechowywane w tym polu i sposób ich wyświetlania w wynikach testu (np. tekst, liczba, data, lista rozwijana). Typu pola nie można zmienić po utworzeniu.",
+      "defaultValue": "## Wartość domyślna (opcjonalnie)\nUstaw wstępnie wypełnioną wartość dla tego pola podczas dodawania nowego wyniku testu. W przypadku typu „Pole wyboru” użyj „prawda” lub „fałsz”. W przypadku typu „Lista rozwijana” lub „Wybór wielokrotny” zazwyczaj odnosi się to do identyfikatorów domyślnych opcji. W przypadku innych typów jest to dosłowny domyślny tekst/liczba.",
+      "isChecked": "## Stan domyślny (dla pola wyboru)\nOkreśla, czy pole wyboru powinno być domyślnie zaznaczone podczas dodawania nowego wyniku testu.",
+      "minValue": "## Wartość minimalna (dla liczby/liczby całkowitej)\nUstawia najmniejszą dozwoloną wartość liczbową dla tego pola podczas wprowadzania danych wynikowych. Należy ustawić zarówno wartość minimalną, jak i maksymalną, jeśli używana jest jedna z nich.",
+      "maxValue": "## Wartość maksymalna (dla liczby/liczby całkowitej)\nUstawia największą dozwoloną wartość liczbową dla tego pola podczas wprowadzania danych wynikowych. Należy ustawić zarówno wartość minimalną, jak i maksymalną, jeśli używana jest jedna z nich.",
+      "initialHeight": "## Wysokość początkowa (dla długiego tekstu)\nOkreśl początkową wysokość wyświetlania (w pikselach) dla pól edytora tekstu sformatowanego używanych w wynikach. Pomaga to kontrolować układ formularza w przypadku dłuższych danych tekstowych.",
+      "dropdownOptions": "## Opcje (dla listy rozwijanej/wyboru wielokrotnego)\nZdefiniuj listę opcji dostępnych do wyboru podczas wprowadzania danych wynikowych. Możesz zmienić kolejność opcji, ustawić wartość domyślną oraz włączać/wyłączać poszczególne opcje."
+    },
+    "exportModal": {
+      "scope": "## Zakres eksportu\nOkreśla, które przypadki testowe zostaną uwzględnione w eksporcie:\n- **Wybrane:** Eksportuje tylko przypadki testowe, które zostały wyraźnie wybrane w tabeli.\n- **Wszystkie przefiltrowane:** Eksportuje wszystkie przypadki testowe, które odpowiadają bieżącym kryteriom filtrowania w tabeli, nawet jeśli nie wszystkie są obecnie widoczne na stronie.\n- **Cały projekt:** Eksportuje wszystkie przypadki testowe w bieżącym projekcie, ignorując wszelkie wybory lub filtry.",
+      "format": "## Format eksportu\nWybierz format pliku do eksportu.\n- **CSV (wartości rozdzielone przecinkami):** Zwykły plik tekstowy odpowiedni dla arkuszy kalkulacyjnych (Excel, Arkusze Google) i narzędzi do analizy danych. Eksport do formatu PDF jest planowany w przyszłej wersji.",
+      "columns": "## Kolumny do eksportu (tylko CSV)\nOkreśla, które kolumny danych zostaną uwzględnione dla każdego przypadku testowego:\n- **Wszystkie kolumny:** Eksportuje wszystkie dostępne pola danych dla przypadków testowych, w tym pola niestandardowe z ich szablonów.\n- **Widoczne kolumny:** Eksportuje tylko kolumny, które są obecnie widoczne w tabeli przypadku testowego.",
+      "delimiter": "## Separator CSV (tylko CSV)\nWybierz znak używany do oddzielania wartości w pliku CSV. Najczęściej używanym znakiem jest przecinek. Użyj innego separatora, jeśli dane zawierają przecinki w polach tekstowych (np. średnik).",
+      "textLongFormat": "## Format pola długiego tekstu (tylko CSV)\nOkreśla sposób eksportowania pól z sformatowanym tekstem (takich jak „Opis” lub niestandardowe pola „Długi tekst”):\n- **JSON:** Eksportuje zawartość jako ciąg JSON, zachowując całe formatowanie (pogrubienie, listy itp.). Najlepiej sprawdza się to przy ponownym importowaniu lub przetwarzaniu programowym.\n- **Zwykły tekst:** Eksportuje zawartość jako zwykły tekst, usuwając formatowanie. Jest to bardziej czytelne w prostych przeglądarkach tekstu.",
+      "stepsFormat": "## Format kroków (tylko CSV)\nOkreśla sposób eksportowania kroków testu (w tym oczekiwanych wyników):\n- **JSON:** Eksportuje kroki jako tablicę obiektów JSON, zachowując strukturę i sformatowany tekst. Nadaje się do ponownego importu lub szczegółowej analizy.\n- **Zwykły tekst:** Eksportuje kroki w uproszczonym, czytelnym formacie zwykłego tekstu, gdzie każdy krok i oczekiwany wynik znajdują się w nowym wierszu.",
+      "rowMode": "## Tryb wiersza (tylko CSV)\nOkreśla sposób reprezentacji pól wielowartościowych (takich jak Tagi lub pola wielokrotnego wyboru) i kroków:\n- **Pojedynczy wiersz na przypadek:** Każdy przypadek testowy to pojedynczy wiersz. Pola wielowartościowe i kroki zostaną skondensowane w odpowiednich komórkach (często jako JSON lub tekst łączony).\n- **Wiele wierszy na przypadek:** Przypadek testowy może obejmować wiele wierszy, jeśli zawiera wiele tagów, wartości wielokrotnego wyboru lub kroków. Każda unikalna wartość/krok dla takich pól utworzy nowy wiersz, a dane z innych przypadków zostaną powtórzone. Jest to przydatne do szczegółowej analizy lub przestawiania.",
+      "attachmentFormat": "## Format informacji o załączniku (tylko CSV)\nOkreśla sposób eksportowania informacji o załącznikach:\n- **JSON:** Eksportuje szczegóły załącznika (takie jak nazwa pliku, adres URL, rozmiar) jako tablicę JSON. Jest to kompleksowe, ale mniej czytelne dla człowieka rozwiązanie bezpośrednio w pliku CSV.\n- **Tylko nazwy:** Eksportuje listę nazw plików załączników rozdzielonych przecinkami. Prostsze rozwiązanie do szybkiego wyszukiwania."
+    },
+    "reportMetrics": {
+      "count": "## Liczba wyników testów\nLiczba wyników testów w tej grupie.",
+      "passRate": "## Wskaźnik zdawalności\nUłamek wyników w tej grupie ze statusem zdawalności.",
+      "avgElapsed": "## Średni czas upłynięcia\nŚredni czas upłynięcia wyników w tej grupie.",
+      "sumElapsed": "## Całkowity czas upłynięty\nSuma czasu upłyniętego dla wyników w tej grupie.",
+      "executionCount": "## Wykonania testów\nCałkowita liczba wykonanych wykonań testów.",
+      "testCaseCount": "## Liczba przypadków testowych\nCałkowita liczba przypadków testowych w tej grupie.",
+      "testRunCount": "## Liczba przebiegów testowych\nŁączna liczba przebiegów testowych w tej grupie.",
+      "automationRate": "## Współczynnik automatyzacji\nProcent przypadków testowych, które są zautomatyzowane.",
+      "averageSteps": "## Średnia liczba kroków na przypadek testowy\nŚrednia liczba kroków na przypadek testowy.",
+      "automatedCount": "## Zautomatyzowane przypadki\nLiczba zautomatyzowanych przypadków testowych.",
+      "manualCount": "## Przypadki ręczne\nLiczba przypadków testowych ręcznych.",
+      "totalSteps": "## Łączna liczba kroków\nŁączna liczba kroków testowych we wszystkich przypadkach.",
+      "createdCaseCount": "## Utworzone przypadki testowe\nLiczba przypadków testowych utworzonych w tym okresie.",
+      "sessionResultCount": "## Wyniki sesji\nLiczba wyników testów sesji.",
+      "sessionCount": "## Liczba sesji\nCałkowita liczba sesji testowych.",
+      "activeSessions": "## Aktywne sesje\nLiczba aktualnie aktywnych sesji (isActive = true).",
+      "milestoneCompletion": "## Ukończenie kamienia milowego\nProcent przypadków testowych ukończonych w kamieniach milowych. Obliczany jako (ukończone wyniki testów / łączna liczba przypadków testowych w uruchomieniach testowych) × 100.",
+      "averageTimeSpent": "## Średni czas spędzony\nŚredni czas spędzony na wykonywanych czynnościach.",
+      "sessionParticipation": "## Udział w sesjach\nPoziom uczestnictwa w sesjach testowych.",
+      "lastActiveDate": "## Data ostatniej aktywności\nNajnowsza data aktywności.",
+      "averageAge": "## Średni wiek\nŚredni wiek przedmiotów w dniach.",
+      "issueCount": "## Liczba problemów\nCałkowita liczba śledzonych problemów.",
+      "milestoneCount": "## Liczba kamieni milowych\nŁączna liczba kamieni milowych.",
+      "milestoneCompletionRate": "## Współczynnik ukończenia kamieni milowych\nProcent ukończonych kamieni milowych.",
+      "averageMilestoneDuration": "## Średni czas trwania kamieni milowych\nŚredni czas trwania kamieni milowych w dniach."
+    },
+    "reportDimensions": {
+      "user": "## Wymiar użytkownika\nGrupuje wyniki według użytkownika, który wykonał testy lub jest przypisany do elementów.",
+      "status": "## Wymiar statusu\nGrupuje wyniki według statusu wykonania testu (np. Zaliczony, Niezaliczony, Zablokowany).",
+      "project": "## Wymiar projektu\nGrupuje wyniki według projektu w celu przeprowadzenia analizy międzyprojektowej.",
+      "testRun": "## Wymiar przebiegu testu\nGrupuje wyniki według przebiegu testu zawierającego wykonane przypadki testowe.",
+      "testCase": "## Wymiar przypadku testowego\nGrupuje wyniki według poszczególnych przypadków testowych w celu przeprowadzenia szczegółowej analizy.",
+      "milestone": "## Wymiar kamieni milowych\nGrupuje wyniki według kamieni milowych projektu, aby śledzić postęp w realizacji celów.",
+      "configuration": "## Wymiar konfiguracji\nGrupuje wyniki według konfiguracji środowiska testowego (np. przeglądarka, system operacyjny).",
+      "template": "## Wymiar szablonu\nGrupuje wyniki według szablonu użytego do struktury przypadku testowego.",
+      "creator": "## Wymiar twórcy\nGrupuje wyniki według użytkownika, który utworzył przypadki testowe lub przebiegi testów.",
+      "state": "## Wymiar stanu\nGrupuje wyniki według stanu przepływu pracy (np. Wersja robocza, Aktywny, Zakończony).",
+      "role": "## Wymiar roli\nGrupuje wyniki według ról użytkownika na potrzeby analizy dostępu i odpowiedzialności.",
+      "group": "## Wymiar grupy\nGrupuje wyniki według grup użytkowników. Użytkownicy mogą należeć do wielu grup, więc aktywności będą zliczane dla każdej grupy, do której należy użytkownik.",
+      "folder": "## Wymiar folderu\nGrupuje wyniki według struktury folderów repozytorium na potrzeby analizy organizacyjnej.",
+      "session": "## Wymiar sesji\nGrupuje wyniki według sesji testowych w celu przeprowadzenia analizy opartej na sesjach.",
+      "assignedTo": "## Przypisano do wymiaru\nGrupuje wyniki według użytkownika przypisanego do wykonywania lub zarządzania elementami.",
+      "issueType": "## Wymiar typu problemu\nGrupuje wyniki według typu śledzonych problemów (np. Błąd, Zadanie, Historia, Ulepszenie).",
+      "issueTracker": "## Wymiar śledzenia problemów\nGrupuje wyniki według użytej integracji śledzenia problemów (np. Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Wymiar statusu problemu\nGrupuje wyniki według bieżącego statusu problemów (np. Otwarte, W toku, Rozwiązane, Zamknięte).",
+      "priority": "## Wymiar priorytetu\nGrupuje wyniki według poziomu priorytetu problemu (np. Wysoki, Średni, Niski).",
+      "source": "## Wymiar źródłowy\nGrupuje wyniki według źródła wykonania testu (np. Manual, JUnit, API).",
+      "date": "## Wymiar daty\nGrupuje wyniki według daty w celu przeprowadzenia analizy opartej na czasie i określenia trendów."
+    },
+    "reportBuilder": {
+      "dimensions": "## Wymiary\nWybierz wymiary, które chcesz analizować w raporcie. Wymiary to atrybuty, które kategoryzują dane, takie jak Data, Użytkownik, Status itp. Możesz je przeciągać, aby zmienić ich kolejność.",
+      "metrics": "## Metryki\nWybierz metryki, które chcesz mierzyć w raporcie. Metryki to ilościowe pomiary pochodzące z danych, takie jak liczba wyników testów, wskaźnik zdawalności, średni czas trwania testu itp. Możesz je przeciągać, aby zmienić ich kolejność.",
+      "dateRange": "## Zakres dat\nFiltruj dane raportu według określonego okresu. Możesz wybrać spośród predefiniowanych zakresów, takich jak „Ostatnie 7 dni” lub „Poprzedni miesiąc”, lub zdefiniować własny zakres dat. Ten filtr ma zastosowanie do odpowiedniego pola daty dla każdego typu raportu (np. daty wykonania dla wyników testów, daty utworzenia dla przypadków testowych)."
+    },
+    "codeRepository": {
+      "name": "## Nazwa repozytorium\nPrzyjazna nazwa wyświetlana dla tego połączenia z repozytorium.\n\n— używana do identyfikacji w ustawieniach kontekstu kodu projektu.\n— nie musi być zgodna z nazwą repozytorium u dostawcy.",
+      "provider": "## Dostawca Git\nPlatforma hostująca to repozytorium.\n\n- **GitHub** — github.com (chmura lub Enterprise)\n- **GitLab** — gitlab.com lub hostowane samodzielnie\n- **Bitbucket Cloud** — bitbucket.org (tylko chmura)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — hostowane samodzielnie serwery Git ze zgodnymi interfejsami API",
+      "githubToken": "## Osobisty token dostępu\nToken GitHub z uprawnieniem **Zawartość: Odczyt**.\n\nWygeneruj go w: GitHub → Ustawienia profilu → Ustawienia programisty → Osobiste tokeny dostępu → Tokeny szczegółowe.",
+      "owner": "## Właściciel\nOrganizacja GitHub lub konto użytkownika, które jest właścicielem repozytorium.\n\n— Przykład: `myorg` lub `myusername`\n— Jest to pierwszy segment ścieżki w adresie URL repozytorium w witrynie github.com",
+      "repo": "## Repozytorium\nNazwa repozytorium bez prefiksu właściciela.\n\n- Przykład: `my-repo` (nie `myorg/my-repo`)\n- Jest to drugi segment ścieżki w adresie URL repozytorium na github.com",
+      "gitlabToken": "## Osobisty token dostępu\nToken GitLab z zakresami **read_api** i **read_repository**.\n\nWygeneruj go w: GitLab → Ustawienia użytkownika → Tokeny dostępu.",
+      "projectPath": "## Identyfikator lub ścieżka projektu\nNumeryczny identyfikator projektu lub pełna ścieżka przestrzeni nazw.\n\n- Przykładowa ścieżka: `myorg/my-project`\n- Przykładowy identyfikator: `12345678`\n- Znaleziono w GitLab w Ustawienia → Ogólne.",
+      "baseUrl": "## Adres URL GitLab\nPozostaw puste dla gitlab.com. W przypadku instancji hostowanych samodzielnie wprowadź swój adres URL GitLab.\n\n- Przykład: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Adres e-mail konta Atlassian\nAdres e-mail powiązany z Twoim kontem Atlassian.\n\n— Jest to adres e-mail, którego używasz do logowania się do usługi Bitbucket Cloud.",
+      "bitbucketApiToken": "## Token API\nToken API Bitbucket z zakresem **Repozytoria: Odczyt**.\n\nUtwórz go w: Bitbucket → Ustawienia osobiste → Tokeny API.\n\n> Hasła aplikacji zostały wycofane przez firmę Atlassian na rzecz tokenów API.",
+      "workspace": "## Obszar roboczy\nŚlimak obszaru roboczego z adresu URL Bitbucket.\n\n— Przykład: `myworkspace` z `bitbucket.org/myworkspace`",
+      "repoSlug": "## Ślimak repozytorium\nIdentyfikator repozytorium z jego adresu URL.\n\n— Przykład: `my-repo` z `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Osobisty token dostępu\nToken dostępu PAT usługi Azure DevOps z uprawnieniem **Kod (odczyt)**.\n\nUtwórz go w: Azure DevOps → Ustawienia użytkownika → Osobiste tokeny dostępu.",
+      "organizationUrl": "## Adres URL organizacji\nAdres URL organizacji Azure DevOps.\n\n— Przykład: `https://dev.azure.com/myorg`",
+      "project": "## Nazwa projektu\nNazwa projektu Azure DevOps zawierającego repozytorium.\n\n— znajduje się jako trzeci segment ścieżki w adresie URL Azure DevOps po nazwie organizacji",
+      "azureRepoId": "## Nazwa lub identyfikator repozytorium\nNazwa repozytorium lub identyfikator GUID w projekcie Azure DevOps.\n\n— Przykład: `my-repo`",
+      "giteaToken": "## Personal Access Token\nToken z uprawnieniami do odczytu repozytorium.\n\nWygeneruj go w: Administracja witryną → Aplikacje lub Ustawienia użytkownika → Aplikacje.\n\n— Działa z Gitea, Forgejo, Gogs i dowolnym serwerem udostępniającym zgodny interfejs API.",
+      "giteaBaseUrl": "## Adres URL serwera\nPodstawowy adres URL Twojego samodzielnie hostowanego serwera Git.\n\n- Przykład: `https://gitea.example.com`\n- Musi zawierać protokół (zalecany https://)\n- Działa z serwerami Gitea, Forgejo, Gogs i innymi serwerami z interfejsem REST API `/api/v1/` zgodnym z Gitea",
+      "giteaOwner": "## Właściciel\nOrganizacja lub konto użytkownika, które jest właścicielem repozytorium.\n\n- Przykład: `myorg` lub `myusername`\n- Jest to pierwszy segment ścieżki w adresie URL repozytorium",
+      "giteaRepo": "## Repozytorium\nNazwa repozytorium bez prefiksu właściciela.\n\n- Przykład: `my-repo` (nie `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Nazwa konfiguracji\nUnikalna, opisowa nazwa tej konfiguracji monitu.\n\n— używana do identyfikacji konfiguracji podczas przypisywania jej do projektu (np. „Monity GPT-4o”, „Monity konserwatywne”).",
+      "description": "## Opis\nOpcjonalne podsumowanie cech wyróżniających tę konfigurację.\n\n— Pomaga administratorom na pierwszy rzut oka zrozumieć cel (np. „Niższa temperatura powoduje deterministyczne wyjście”).",
+      "isActive": "## Aktywny\nPo włączeniu ta konfiguracja jest dostępna do użytku przez projekty.\n\n— Nieaktywne konfiguracje są ukrywane na rozwijanych listach zadań projektów.\n— Domyślnej konfiguracji nie można dezaktywować.",
+      "isDefault": "## Konfiguracja domyślna\nPo włączeniu ta konfiguracja będzie używana przez każdy projekt, któremu nie przypisano konkretnej konfiguracji.\n\n— W danym momencie tylko jedna konfiguracja może być domyślna.\n— Ustawienie nowej konfiguracji domyślnej automatycznie anuluje poprzednią.",
+      "systemPrompt": "## Monit systemowy\nInstrukcje wysyłane do modelu AI przed wprowadzeniem jakichkolwiek danych przez użytkownika. Definiuje rolę modelu, format wyjściowy i ograniczenia.\n\n– Obsługuje symbole zastępcze w postaci podwójnych nawiasów klamrowych (np. FRAMEWORK, LANGUAGE, CASE_NAME), które są podstawiane w czasie wykonywania.\n– Zmiany wprowadzone w tym miejscu mają wpływ na każdy projekt korzystający z tej konfiguracji.",
+      "userPrompt": "## Monit użytkownika\nWiadomość wysyłana do sztucznej inteligencji (AI) w imieniu użytkownika. Pozostaw puste, jeśli funkcja konstruuje wiadomość użytkownika w całości w kodzie.\n\n– Obsługuje symbole zastępcze w postaci podwójnych nawiasów klamrowych (np. ISSUE_TITLE, CASE_NAME, CODE_CONTEXT), które są podstawiane w czasie wykonywania.\n– Dostępne symbole zastępcze dla każdej funkcji są wymienione w sekcji Zmienne poniżej.",
+      "temperature": "## Temperatura\nSteruje losowością wyjścia AI. Zakres: 0–2.\n\n- **0,0–0,3** — Wysoce deterministyczna, najlepsza do ustrukturyzowanego wyjścia (JSON, kod).\n- **0,4–0,7** — Zrównoważona, dobra do generowania przypadków testowych.\n- **0,8–2,0** — Bardziej kreatywna i zróżnicowana, odpowiednia do tekstów otwartych.",
+      "maxOutputTokens": "## Maksymalna liczba tokenów wyjściowych\nMaksymalna liczba tokenów, które model wygeneruje w pojedynczej odpowiedzi.\n\n— Wyższe wartości pozwalają na dłuższe odpowiedzi, ale zwiększają koszt i opóźnienie.\n— Typowe zakresy: 2048 dla krótkiego tekstu, 4096 dla generowania kodu, 6000+ dla wyników obejmujących wiele przypadków."
+    },
+    "menu": {
+      "startTour": "Wycieczka powitalna z przewodnikiem",
+      "startProjectTour": "Wycieczka po projekcie",
+      "startAdminTour": "Wycieczka administracyjna",
+      "startDemoProjectTour": "Wycieczka po projekcie demonstracyjnym"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Witamy w TestPlanIt!",
+          "content": "Przyjrzyjmy się pokrótce najważniejszym funkcjom TestPlanIt, które pomogą Ci rozpocząć pracę nad przepływem prac testowych."
+        },
+        "projects": {
+          "content": "Uzyskaj dostęp do wszystkich swoich projektów testowych. Każdy projekt zawiera przypadki testowe, przebiegi i funkcje współpracy zespołowej."
+        },
+        "project": {
+          "title": "Karta projektu",
+          "content": "Kliknij kartę projektu, aby wyświetlić jej szczegóły. Wybierz „Przewodnik po projekcie” z menu pomocy, aby zapoznać się z funkcjami projektu."
+        },
+        "globalFeatures": {
+          "title": "Funkcje globalne",
+          "content": "Zarządzaj tagami w celu kategoryzacji, śledź problemy w różnych projektach i zarządzaj użytkownikami dzięki kontroli dostępu opartej na rolach."
+        },
+        "search": {
+          "content": "Wyszukiwanie kontekstowe oparte na bieżącej stronie. Szybko znajdź przypadki testowe, uruchomienia, problemy i dowolne treści. Użyj Cmd+K (lub Ctrl+K), aby uzyskać natychmiastowy dostęp."
+        },
+        "help": {
+          "title": "Pomoc i wsparcie",
+          "content": "Możesz w dowolnej chwili uzyskać dostęp do tego przewodnika lub zapoznać się z naszą obszerną dokumentacją, aby uzyskać szczegółową pomoc."
+        },
+        "notifications": {
+          "content": "Bądź na bieżąco z ukończonymi testami, aktualizacjami zgłoszeń i działaniami zespołu. Skonfiguruj preferencje w ustawieniach konta."
+        },
+        "account": {
+          "title": "Menu konta",
+          "content": "Dostosuj swój profil, preferencje dotyczące powiadomień i ustawienia konta. Przełączaj się między jasnym i ciemnym motywem."
+        },
+        "assignments": {
+          "content": "Przeglądaj przypadki testowe i przebiegi przypisane do Ciebie we wszystkich projektach. To Twój osobisty panel do śledzenia Twojej pracy testowej."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Selektor projektów",
+          "content": "Szybko przełączaj się między projektami za pomocą tego menu rozwijanego. Przeglądaj szczegóły projektu i uzyskaj dostęp do ustawień całego projektu."
+        },
+        "projectSections": {
+          "title": "Sekcje projektu",
+          "content": "Przejdź do sekcji Przegląd, aby uzyskać dostęp do pulpitu nawigacyjnego projektu, do Dokumentacji, aby uzyskać dostęp do przewodników po projekcie, oraz do Kamienie milowe, aby śledzić postępy."
+        },
+        "repository": {
+          "content": "Zarządzaj przypadkami testowymi, organizuj je w folderach i twórz nowe scenariusze testowe, aby zapewnić dokładne pokrycie testami."
+        },
+        "repositoryPanels": {
+          "title": "Lewy panel repozytorium",
+          "content": "Lewy panel pokazuje strukturę folderów i drzewo przypadków testowych. Użyj selektora widoków, aby przełączać się między różnymi widokami organizacyjnymi."
+        },
+        "repositoryRightPanel": {
+          "title": "Prawy panel repozytorium",
+          "content": "Prawy panel wyświetla szczegóły przypadków testowych, wyniki wykonania oraz udostępnia działania umożliwiające tworzenie nowych przypadków testowych lub importowanie istniejących."
+        },
+        "sharedSteps": {
+          "title": "Wspólne kroki",
+          "content": "Zdefiniuj wielokrotnego użytku grupy kroków, do których można odwoływać się z wielu przypadków testowych. Zadbaj o to, aby kroki testowe były suche i spójne."
+        },
+        "testRuns": {
+          "content": "Wykonuj zaplanowane testy, śledź postępy i zarządzaj zadaniami testowymi w swoim zespole. Przeglądaj szczegółowe wyniki wykonania."
+        },
+        "testRunsPage": {
+          "title": "Panel przebiegów testowych",
+          "content": "To strona „Przebiegi testów”, na której możesz tworzyć nowe przebiegi testów, monitorować postępy w ich wykonywaniu, przeglądać wyniki i zarządzać zadaniami testowymi. Śledź działania testowe swojego zespołu z jednego centralnego miejsca."
+        },
+        "sessions": {
+          "title": "Sesje eksploracyjne",
+          "content": "Dokumentuj sesje testów eksploracyjnych, zapisuj ustalenia i śledź czas poświęcony na doraźne działania testowe."
+        },
+        "sessionsPage": {
+          "title": "Panel sesji eksploracyjnych",
+          "content": "Na tej stronie „Sesje” możesz tworzyć i zarządzać sesjami testów eksploracyjnych. Dokumentuj wyniki, śledź czas i rejestruj wszystkie doraźne działania testowe, aby zapewnić lepsze pokrycie testami."
+        },
+        "tags": {
+          "title": "Zarządzanie tagami",
+          "content": "Organizuj i kategoryzuj swoje przypadki testowe za pomocą tagów. Twórz własne tagi, aby usprawnić organizację i filtrowanie przypadków testowych."
+        },
+        "issues": {
+          "title": "Śledzenie problemów",
+          "content": "Śledź i zarządzaj problemami wykrytymi podczas testów. Powiąż problemy z przypadkami testowymi i zintegruj je z zewnętrznymi systemami śledzenia błędów."
+        },
+        "reports": {
+          "title": "Raporty i analizy",
+          "content": "Generuj kompleksowe raporty i analizy dla swojego projektu. Przeglądaj pokrycie testami, trendy wykonania, wskaźniki wydajności zespołu i twórz niestandardowe raporty dla interesariuszy."
+        },
+        "settings": {
+          "title": "Ustawienia projektu",
+          "content": "Stąd możesz zarządzać integracjami na poziomie projektu, konfiguracjami modeli AI i udostępnianymi linkami."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Witamy w Kontroli administracyjnej",
+          "content": "Zapoznaj się z funkcjami administracyjnymi TestPlanIt. Zarządzaj projektami, użytkownikami, konfiguracjami i ustawieniami systemu z tego centralnego panelu administracyjnego."
+        },
+        "projects": {
+          "title": "Administracja projektu",
+          "content": "Zarządzaj wszystkimi projektami w swojej organizacji. Twórz, konfiguruj i archiwizuj projekty. Ustawiaj uprawnienia i kontrolę dostępu w całym projekcie."
+        },
+        "templatesAndFields": {
+          "content": "Twórz i zarządzaj szablonami przypadków testowych oraz polami niestandardowymi. Definiuj typy pól, reguły walidacji i organizuj szablony, aby zapewnić spójną strukturę przypadków testowych w różnych projektach."
+        },
+        "workflows": {
+          "title": "Zarządzanie przepływem pracy",
+          "content": "Zdefiniuj przepływy pracy przypadków testowych i przejścia między stanami. Skonfiguruj, jak przypadki testowe przechodzą przez różne stany, takie jak Wersja robocza, Przegląd i Zatwierdzenie."
+        },
+        "statuses": {
+          "title": "Statusy wyników testów",
+          "content": "Skonfiguruj dostępne statusy wyników testów, takie jak „Zaliczony”, „Niezaliczony”, „Zablokowany” i „Pominięty”. Skonfiguruj niestandardowe statusy i zdefiniuj ich zachowanie oraz wygląd."
+        },
+        "milestones": {
+          "content": "Zdefiniuj typy kamieni milowych do śledzenia projektu. Skonfiguruj typy wydań, kategorie sprintów i inne klasyfikacje kamieni milowych projektu."
+        },
+        "configurations": {
+          "title": "Konfiguracje testowe",
+          "content": "Zarządzaj konfiguracjami i środowiskami testów. Konfiguruj kombinacje przeglądarek, typy urządzeń, systemy operacyjne i inne konteksty wykonywania testów."
+        },
+        "users": {
+          "title": "Zarządzanie użytkownikami",
+          "content": "Zarządzaj kontami użytkowników, uprawnieniami i poziomami dostępu. Twórz nowych użytkowników, przypisuj role i konfiguruj ustawienia uwierzytelniania."
+        },
+        "groups": {
+          "title": "Zarządzanie Grupą",
+          "content": "Organizuj użytkowników w grupy, aby ułatwić zarządzanie uprawnieniami. Twórz grupy działowe, zespoły projektowe i grupy dostępu oparte na rolach."
+        },
+        "roles": {
+          "title": "Zarządzanie rolami",
+          "content": "Zdefiniuj role i uprawnienia użytkowników. Skonfiguruj działania, jakie mogą wykonywać poszczególne role w projektach i administracji systemem."
+        },
+        "tags": {
+          "title": "Tagi globalne",
+          "content": "Zarządzaj tagami w całej organizacji, aby kategoryzować przypadki testowe, projekty i inne jednostki. Twórz hierarchie tagów i standaryzuj tagowanie w projektach."
+        },
+        "reports": {
+          "content": "Generuj raporty obejmujące wiele projektów. Analizuj trendy, wskaźniki wydajności i skuteczność testów organizacyjnych w całym obszarze roboczym."
+        },
+        "notifications": {
+          "title": "Ustawienia powiadomień",
+          "content": "Skonfiguruj preferencje powiadomień w całym systemie. Skonfiguruj szablony wiadomości e-mail, reguły powiadomień i ustawienia domyślne powiadomień użytkowników."
+        },
+        "integrations": {
+          "title": "Integracje systemowe",
+          "content": "Zarządzaj integracjami z aplikacjami innych firm i połączeniami API. Skonfiguruj integracje z Jira, GitHub i innymi narzędziami zewnętrznymi dla swojej organizacji."
+        },
+        "llm": {
+          "title": "Konfiguracja AI",
+          "content": "Konfiguruj modele i ustawienia AI do automatycznego generowania przypadków testowych i inteligentnych funkcji. Zarządzaj kluczami API i preferencjami modeli."
+        },
+        "sso": {
+          "title": "Jednokrotne logowanie",
+          "content": "Skonfiguruj dostawców SSO i metody uwierzytelniania. Skonfiguruj integracje SAML, OAuth i innych dostawców tożsamości, aby zapewnić użytkownikom bezproblemowy dostęp."
+        },
+        "appConfig": {
+          "content": "Zarządzaj globalnymi ustawieniami aplikacji i preferencjami systemowymi. Konfiguruj wartości domyślne, przełączniki funkcji i zachowania w całym systemie."
+        },
+        "trash": {
+          "title": "Kosz systemowy",
+          "content": "Przeglądaj i zarządzaj usuniętymi elementami we wszystkich projektach. Przywracaj przypadkowo usunięte treści lub trwale usuwaj elementy z systemu."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Witamy w projekcie demonstracyjnym",
+          "content": "Ten projekt ma wstępnie załadowane przykładowe dane. Przeanalizujmy wspólnie jego kluczowe funkcje. Użyj tej listy rozwijanej, aby przełączać się między projektami."
+        },
+        "overview": {
+          "title": "Przegląd projektu",
+          "content": "Podsumowanie to pulpit nawigacyjny Twojego projektu. Pokazuje postępy w realizacji kamieni milowych oraz podsumowania przypadków testowych, aktywnych uruchomień, sesji i tagów."
+        },
+        "documentation": {
+          "title": "Dokumentacja",
+          "content": "Każdy projekt ma stronę z dokumentacją. Użyj jej do przechowywania planów testów, notatek projektowych lub linków do zasobów zewnętrznych."
+        },
+        "documentationContent": {
+          "title": "Edytor tekstu sformatowanego",
+          "content": "Dokumentacja obsługuje tekst sformatowany z nagłówkami, listami, linkami i obrazami. Spróbuj edytować tę stronę, aby zobaczyć, jak to działa."
+        },
+        "milestones": {
+          "title": "Kamienie milowe",
+          "content": "Monitoruj swoje testy w kontekście sprintów, wydań i innych celów. Powiąż przebiegi i sesje testowe z kamieniami milowymi, aby śledzić postępy."
+        },
+        "milestonesPage": {
+          "title": "Oś czasu kamienia milowego",
+          "content": "Zobacz wszystkie kamienie milowe tego projektu. Każdy kamień milowy pokazuje jego status i postęp w realizacji."
+        },
+        "repository": {
+          "title": "Repozytorium przypadków testowych",
+          "content": "Organizuj przypadki testowe w folderach z niestandardowymi polami, krokami i priorytetami. Przejrzyj przykładowe foldery, aby zobaczyć, jak zorganizowane są przypadki."
+        },
+        "repositoryPanels": {
+          "title": "Teczki i etui",
+          "content": "Lewy panel pokazuje foldery. Kliknij folder, aby zobaczyć jego przypadki testowe. Każdy przypadek zawiera kroki, opisy i wspólne odniesienia do kroków."
+        },
+        "repositoryCases": {
+          "title": "Przypadki testowe",
+          "content": "Tutaj możesz zobaczyć przypadki testowe dla wybranego folderu. Każdy wiersz zawiera nazwę przypadku, priorytet i pola niestandardowe. Kliknij przypadek, aby wyświetlić jego pełne szczegóły i kroki."
+        },
+        "sharedSteps": {
+          "title": "Wspólne kroki",
+          "content": "Zdefiniuj wielokrotnego użytku grupy kroków, do których można odwoływać się z wielu przypadków testowych. Dzięki temu wspólne kroki będą spójne i łatwe w utrzymaniu."
+        },
+        "sharedStepsPage": {
+          "title": "Wspólne grupy kroków",
+          "content": "Każda grupa zawiera zestaw uporządkowanych kroków. Odwołuj się do nich w dowolnym przypadku testowym, aby zachować spójność i spójność kroków."
+        },
+        "testRuns": {
+          "title": "Testy biegowe",
+          "content": "Twórz przebiegi testowe, aby wykonywać przypadki i rejestrować wyniki. Przypisuj przebiegi do kamieni milowych i śledź postępy w zakresie zaliczeń/niezaliczeń."
+        },
+        "testRunsPage": {
+          "title": "Wyniki testu",
+          "content": "Przeglądaj wyniki i postępy testów. Każdy test pokazuje swój status, przypisany kamień milowy oraz podział na zaliczone/niezaliczone testy."
+        },
+        "sessions": {
+          "title": "Sesje eksploracyjne",
+          "content": "Rejestruj testy ad-hoc dzięki testom sesyjnym. Rejestruj wyniki, przypisuj statusy i śledź czas poświęcony na testy."
+        },
+        "sessionsPage": {
+          "title": "Wyniki sesji",
+          "content": "Każda sesja zawiera szczegółowe ustalenia wraz ze statusem i notatkami. Kliknij sesję, aby zobaczyć jej wyniki."
+        },
+        "tags": {
+          "title": "Tagi",
+          "content": "Tagi pomagają organizować i filtrować przypadki testowe, przebiegi i sesje. Przejrzyj przykładowe tagi, aby zobaczyć, jak kategoryzują one treści."
+        },
+        "tagsPage": {
+          "title": "Zarządzanie tagami",
+          "content": "Twórz, edytuj i przypisuj tagi. Używaj tagów do grupowania i filtrowania treści w całym projekcie."
+        },
+        "issues": {
+          "title": "Kwestie",
+          "content": "Śledź błędy i defekty wykryte podczas testowania. Problemy można powiązać z wynikami nieudanych testów i ustaleniami sesji, aby zapewnić pełne śledzenie."
+        },
+        "issuesPage": {
+          "title": "Śledzenie problemów",
+          "content": "Zobacz przykładowe problemy powiązane z nieudanymi wynikami. Problemy można prześledzić do wyników testów lub sesji, które je wykryły."
+        },
+        "reports": {
+          "title": "Raporty i analizy",
+          "content": "Generuj raporty dotyczące pokrycia testami, trendów wykonania i wydajności zespołu. Korzystaj z gotowych raportów lub twórz własne raporty dla interesariuszy."
+        },
+        "settings": {
+          "title": "Ustawienia projektu",
+          "content": "Stąd możesz zarządzać integracjami na poziomie projektu, konfiguracjami modeli AI i udostępnianymi linkami."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Tworzenie i zarządzanie raportami międzyprojektowymi"
+      },
+      "reportsTabDescription": "Przeglądaj i analizuj gotowe raporty dla swojego projektu",
+      "reportType": "Typ raportu",
+      "selectReportType": "Wybierz typ raportu",
+      "selectReport": "Wybierz raport",
+      "dimensions": "Wymiary",
+      "dimensionsSubtitle": "Wymiary (przeciągnij, aby zmienić kolejność, dodaj poniżej)",
+      "metrics": "Metryka",
+      "addDimension": "Dodaj wymiar...",
+      "addMetric": "Dodaj metrykę...",
+      "runReport": "Uruchom raport",
+      "noResultsFound": "Nie znaleziono wyników.",
+      "selectAtLeastOneDimensionAndMetric": "Wybierz co najmniej jeden wymiar i jedną metrykę.",
+      "noDataMatchingCriteria": "Nie znaleziono danych odpowiadających wybranym wymiarom i metrykom.",
+      "noDataMatchingCriteriaWithDateFilter": "Nie znaleziono danych pasujących do wybranych wymiarów i metryk. Spróbuj dostosować filtr zakresu dat.",
+      "noDataAvailable": "Brak danych dostępnych dla tego raportu.",
+      "generatedAt": "Raport wygenerowany w",
+      "crossProjectAnalytics": "Analityka i raportowanie międzyprojektowe",
+      "unauthorizedAdmin": "Nieautoryzowane: Wymagany dostęp administratora.",
+      "title": "Kreator raportów",
+      "description": "Twórz niestandardowe raporty, aby analizować dane swojego projektu",
+      "crossProjectDescription": "Analizuj dane we wszystkich projektach w swojej przestrzeni roboczej",
+      "selectDimensions": "Wybierz wymiary...",
+      "selectMetrics": "Wybierz metryki...",
+      "dimensionOrder": "Kolejność wymiarów",
+      "metricOrder": "Zamówienie metryczne",
+      "filtersDescription": "Filtruj dane raportu według określonych kryteriów",
+      "activeFilters": "Aktywne filtry:",
+      "priorityFilterPlaceholder": "Wybierz wartości priorytetowe (lub pozostaw puste dla wszystkich)",
+      "dateRange": {
+        "selectDateRange": "Wybierz zakres dat",
+        "chooseStartDate": "Wybierz datę rozpoczęcia",
+        "chooseEndDate": "Wybierz datę zakończenia",
+        "categories": {
+          "day": "Dzień",
+          "week": "Tydzień",
+          "month": "Miesiąc",
+          "quarter": "Kwartał",
+          "year": "Rok"
+        },
+        "today": "Dzisiaj",
+        "yesterday": "Wczoraj",
+        "last7Days": "Ostatnie 7 dni",
+        "last30Days": "Ostatnie 30 dni",
+        "thisWeek": "W tym tygodniu",
+        "lastWeek": "W zeszłym tygodniu",
+        "last2Weeks": "Ostatnie 2 tygodnie",
+        "thisMonth": "W tym miesiącu",
+        "lastMonth": "W zeszłym miesiącu",
+        "last3Months": "Ostatnie 3 miesiące",
+        "thisQuarter": "W tym kwartale",
+        "lastQuarter": "Ostatni kwartał",
+        "thisYear": "W tym roku",
+        "lastYear": "W ubiegłym roku",
+        "last12Months": "Ostatnie 12 miesięcy",
+        "allTime": "Cały czas",
+        "custom": "Niestandardowy zakres dat"
+      },
+      "dateGrouping": {
+        "label": "Grupuj według",
+        "daily": "Codziennie",
+        "weekly": "Tygodnik",
+        "monthly": "Miesięczny",
+        "quarterly": "Kwartalny",
+        "annually": "Rocznie"
+      },
+      "filters": {
+        "selectFilter": "Wybierz typ filtra",
+        "allProjects": "Wszystkie projekty"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Nie udało się załadować metadanych raportu",
+        "failedToRunReport": "Nie udało się uruchomić raportu",
+        "atLeastOneDimensionRequired": "Wymagany jest co najmniej jeden wymiar.",
+        "atLeastOneMetricRequired": "Należy określić co najmniej jedną metrykę.",
+        "invalidCombinationDateLastActive": "Metryki „Data ostatniej aktywności” nie można łączyć z wymiarem „Data aktywności”.",
+        "lastActiveDateOnlyWithUser": "Metrykę „Data ostatniej aktywności” można stosować wyłącznie w połączeniu z wymiarem „Użytkownik”.",
+        "invalidDimensionCombination": "Wymiarów „{dim1}” i „{dim2}” nie można używać razem w raportach wykonania testów.",
+        "startDateRequiredWithEndDate": "Data rozpoczęcia jest wymagana, jeśli określono datę zakończenia.",
+        "endDateMustBeAfterStartDate": "Data zakończenia musi być późniejsza lub równa dacie rozpoczęcia."
+      },
+      "chartDataTruncated": {
+        "title": "Dane wykresu zostały obcięte",
+        "message": "Wyświetlanie {shown} z {total} punktów danych dla lepszej czytelności. Użyj filtrów lub zakresów dat, aby zawęzić wyniki, albo wyświetl pełne dane w poniższej tabeli wyników."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Raporty z wykonania testów",
+          "description": "Analizuj wyniki testów, wskaźniki zdawalności i wskaźniki wykonania"
+        },
+        "repositoryStats": {
+          "label": "Statystyki repozytorium",
+          "description": "Statystyki przypadków testowych, zasięg i stan repozytorium"
+        },
+        "userEngagement": {
+          "label": "Zaangażowanie użytkowników",
+          "description": "Analiza aktywności, produktywności i obciążenia użytkownika"
+        },
+        "projectHealth": {
+          "label": "Projekt Zdrowie",
+          "description": "Postęp projektu, kamienie milowe i status ukończenia"
+        },
+        "sessionAnalysis": {
+          "label": "Analiza sesji",
+          "description": "Metryki ukończenia sesji, czasu trwania i zadań"
+        },
+        "issueTracking": {
+          "label": "Śledzenie problemów",
+          "description": "Tworzenie problemów, rozwiązywanie ich i analiza wpływu"
+        },
+        "automationTrends": {
+          "label": "Trendy automatyzacji",
+          "description": "Śledź postęp automatyzacji tydzień po tygodniu według priorytetu"
+        },
+        "flakyTests": {
+          "label": "Niestabilne testy",
+          "description": "Identyfikuj testy z niespójnymi wynikami zaliczenia/niezaliczenia"
+        },
+        "testCaseHealth": {
+          "label": "Przypadek testowy Stan zdrowia",
+          "description": "Identyfikuj nieaktualne, uszkodzone lub podejrzane przypadki testowe na podstawie wzorców wykonywania"
+        },
+        "issueTestCoverage": {
+          "label": "Zakres testów problemu",
+          "description": "Wyświetlanie problemów z powiązanymi przypadkami testowymi i najnowszym stanem wykonania"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Ostatnie kolejne biegi",
+        "consecutiveRunsHelp": "Liczba ostatnio wykonanych testów do analizy (5–30). Wyniki ze statusem „nieprzetestowane” są pomijane.",
+        "flipThreshold": "Minimalna liczba flipów",
+        "flipThresholdHelp": "Minimalna liczba przejść zaliczonych/niezaliczonych, aby uznać test za niepewny.",
+        "flips": "Flipy",
+        "lastNResults": "Ostatni {count, plural, one {# Wynik} other {# Wyniki}}",
+        "newest": "Nowy",
+        "oldest": "Stary",
+        "noFlakyTests": "Nie znaleziono żadnych niestabilnych testów spełniających kryteria",
+        "includeFilter": "Włączać",
+        "testRunDeleted": "Test został usunięty",
+        "chart": {
+          "highPriority": "Wymaga uwagi",
+          "lowPriority": "Niższy priorytet",
+          "recencyAxis": "Aktualność awarii",
+          "flipsAxis": "Liczba flipów",
+          "oldFailures": "Starszy",
+          "recentFailures": "Ostatni",
+          "failureRate": "Współczynnik awaryjności",
+          "recency": "Wynik aktualności",
+          "backlogTitle": "Testy o niższym priorytecie",
+          "backlogDescription": "{count, plural, one {# dodatkowy niestabilny test} other {# dodatkowe niestabilne testy}} nie pokazano"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Stale After (dni)",
+        "staleDaysThresholdHelp": "Liczba dni bez wykonania testu, po których test zostaje uznany za nieaktualny (7–90).",
+        "minExecutions": "Minimalna liczba realizacji dla stawki",
+        "minExecutionsHelp": "Minimalna liczba wykonań wymagana do obliczenia wiarygodnych statystyk wskaźnika zdawalności (3–20).",
+        "lookbackDays": "Okres retrospektywny",
+        "lookbackDaysHelp": "Liczba dni potrzebnych do analizy historii wykonania (30–365).",
+        "includeFilter": "Włączać",
+        "staleFilter": "Stęchliznę",
+        "stale": "Nieświeży",
+        "notStale": "Nie czerstwy",
+        "status": "Stan zdrowia",
+        "healthScore": "Wynik",
+        "lastExecuted": "Ostatnio wykonane",
+        "executions": "Egzekucje",
+        "passRate": "Wskaźnik zdawalności",
+        "passCount": "Przepustki",
+        "failCount": "Awarie",
+        "never": "Nigdy",
+        "daysSince": "Dni od egzekucji",
+        "count": "Liczyć",
+        "totalTests": "przypadki testowe",
+        "noData": "Nie znaleziono przypadków testowych",
+        "noExecutedTests": "Brak wykonanych testów do wyświetlenia",
+        "healthStatus": {
+          "healthy": "Zdrowy",
+          "stale": "Nieświeży",
+          "neverExecuted": "Nigdy nie wykonano",
+          "alwaysPassing": "Zawsze przechodząc",
+          "alwaysFailing": "Zawsze zawodzi"
+        },
+        "chart": {
+          "distribution": "Dystrybucja statusu",
+          "healthyRecent": "Zdrowe i niedawne",
+          "unhealthyStale": "Wymaga uwagi",
+          "daysAxis": "Dni od ostatniej egzekucji",
+          "healthScoreAxis": "Wynik Zdrowia"
+        },
+        "stats": {
+          "totalTests": "Całkowita liczba testów",
+          "needsAttention": "Wymaga uwagi",
+          "needsAttentionTooltip": "Zawsze zawodzące + Nigdy nie wykonywane + Nieaktualne testy",
+          "healthy": "Zdrowy",
+          "healthyTooltip": "Zdrowy + Zawsze przechodzący testy",
+          "avgScore": "Średni wynik zdrowia"
+        },
+        "healthScoreTooltip": {
+          "title": "Wynik zaczyna się od 100, potrącenia:",
+          "neverExecuted": "Nigdy nie wykonano: -50",
+          "stale90": "Nieuruchomione w ciągu 90+ dni: -40",
+          "stale60": "Nieuruchomione w ciągu 60+ dni: -25",
+          "stale30": "Nieuruchomione w ciągu 30+ dni: -10",
+          "alwaysPassing": "Zawsze przechodzi (100%): -5",
+          "alwaysFailing": "Zawsze niepowodzenie (0%): -30",
+          "lowPassRate": "Niski wskaźnik zdawalności (<50%): -20",
+          "lowExecutions": "Mało egzekucji (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Tryb widoku",
+        "summaryView": "Podsumowanie (według wydania)",
+        "detailView": "Szczegóły (według przypadku testowego)",
+        "issue": "Wydanie",
+        "testCase": "Przypadek testowy",
+        "testCases": "{count, plural, =1 {Przypadek testowy} other {Przypadki testowe}}",
+        "issueStatus": "Status",
+        "priority": "Priorytet",
+        "linkedTests": "Powiązane testy",
+        "testResults": "Wyniki (P/F/U)",
+        "passRate": "Wskaźnik zdawalności",
+        "passed": "Przeszedł",
+        "failed": "Przegrany",
+        "lastStatus": "Ostatni status",
+        "lastExecuted": "Ostatnio wykonane",
+        "notTested": "Nie testowano",
+        "noData": "Nie znaleziono problemów z powiązanymi przypadkami testowymi",
+        "noIssuesNeedingAttention": "Wszystkie wydania przeszły testy pozytywne - świetna robota!",
+        "stats": {
+          "totalIssues": "Łączna liczba wydań",
+          "issuesWithFailures": "Z porażkami",
+          "issuesWithFailuresTooltip": "Problemy z co najmniej jednym nieudanym przypadkiem testowym",
+          "issuesWithUntested": "Z nieprzetestowanym",
+          "issuesWithUntestedTooltip": "Problemy z co najmniej jednym przypadkiem testowym, który nie został wykonany",
+          "issuesAllPassing": "Wszystkie podania",
+          "overallPassRate": "Wskaźnik zdawalności",
+          "numberOfIssues": "Liczba wydań"
+        },
+        "charts": {
+          "passRateDistribution": "Dystrybucja wskaźnika zdawalności testu",
+          "linkedTestCases": "Liczba powiązanych przypadków testowych",
+          "untestedTestCases": "Liczba nieprzetestowanych przypadków testowych",
+          "testCoverageVsExecution": "Pokrycie testów a status wykonania"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Wykonywanie testów międzyprojektowych",
+          "description": "Analizuj wyniki testów, wskaźniki zdawalności i wskaźniki wykonania we wszystkich projektach"
+        },
+        "repositoryStats": {
+          "label": "Statystyki repozytorium międzyprojektowego",
+          "description": "Statystyki przypadków testowych, zasięg i stan repozytorium w różnych projektach"
+        },
+        "userEngagement": {
+          "label": "Zaangażowanie użytkowników w ramach wielu projektów",
+          "description": "Analiza aktywności użytkowników, produktywności i obciążenia pracą w różnych projektach"
+        },
+        "issueTracking": {
+          "label": "Śledzenie problemów międzyprojektowych",
+          "description": "Tworzenie i rozwiązywanie problemów oraz analiza wpływu na różne projekty"
+        },
+        "automationTrends": {
+          "label": "Trendy automatyzacji międzyprojektowej",
+          "description": "Śledź postęp automatyzacji tydzień po tygodniu według priorytetów w różnych projektach"
+        },
+        "flakyTests": {
+          "label": "Niestabilne testy międzyprojektowe",
+          "description": "Identyfikuj testy z niespójnymi wynikami zaliczenia/niezaliczenia w różnych projektach"
+        },
+        "testCaseHealth": {
+          "label": "Międzyprojektowy przypadek testowy – stan zdrowia",
+          "description": "Identyfikuj nieaktualne, uszkodzone lub podejrzane przypadki testowe w różnych projektach"
+        },
+        "issueTestCoverage": {
+          "label": "Pokrycie testowe problemów w ramach wielu projektów",
+          "description": "Przeglądaj problemy z powiązanymi przypadkami testowymi i najnowszym statusem wykonania w różnych projektach"
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Tylko administratorzy projektu i administratorzy mają dostęp do raportów projektu.",
+      "projectIdRequired": "Wymagane jest podanie identyfikatora projektu",
+      "missingRequiredFields": "Brak wymaganych pól",
+      "unsupportedDimension": "Nieobsługiwany wymiar: {dimension}",
+      "unsupportedMetric": "Nieobsługiwana metryka: {metric}",
+      "atLeastOneDimensionMetricRequired": "Wymagany jest co najmniej jeden wymiar i jedna metryka",
+      "atLeastOneMetricRequired": "Należy określić co najmniej jedną metrykę",
+      "projectDimensionsMetricsRequired": "Wymagane jest podanie identyfikatora projektu, wymiarów i metryk",
+      "unsupportedDimensions": "Nieobsługiwane wymiary: {dimensions}",
+      "unsupportedMetrics": "Nieobsługiwane metryki: {metrics}",
+      "unexpectedError": "Wystąpił nieoczekiwany błąd."
+    },
+    "dimensions": {
+      "project": "Projekt",
+      "status": "Status",
+      "user": "Użytkownik",
+      "executor": "Wykonawca",
+      "assignedTo": "Przypisany do",
+      "configuration": "Konfiguracja",
+      "date": "Data",
+      "executionDate": "Data wykonania",
+      "creationDate": "Data utworzenia",
+      "activityDate": "Data aktywności",
+      "testRun": "Test jazdy",
+      "testCase": "Przypadek testowy",
+      "milestone": "Kamień milowy",
+      "template": "Szablon",
+      "creator": "Twórca",
+      "state": "Państwo",
+      "source": "Źródło",
+      "folder": "Falcówka",
+      "group": "Grupa",
+      "role": "Rola",
+      "session": "Sesja",
+      "weekEnding": "Tydzień kończący się",
+      "period": "Okres",
+      "priority": "Priorytet",
+      "automationStatus": "Status automatyzacji",
+      "issueType": "Typ problemu",
+      "issueTracker": "Śledzenie problemów",
+      "issueStatus": "Status wydania"
+    },
+    "metrics": {
+      "testResults": "Wyniki testów",
+      "testResultCount": "Liczba wyników testów",
+      "passRate": "Wskaźnik zdawalności (%)",
+      "avgElapsed": "Średni czas upłynięty",
+      "avgElapsedTime": "Średni czas upłynięty",
+      "totalElapsedTime": "Całkowity czas upłynięty",
+      "testRunCount": "Liczba przebiegów testowych",
+      "testCaseCount": "Liczba przypadków testowych",
+      "automationRate": "Współczynnik automatyzacji (%)",
+      "avgStepsPerCase": "Średnia liczba kroków na sprawę",
+      "averageSteps": "Średnia liczba kroków na przypadek",
+      "automatedCount": "Zautomatyzowane przypadki",
+      "manualCount": "Przypadki ręczne",
+      "totalCount": "Łączna liczba przypadków",
+      "totalSteps": "Całkowita liczba kroków",
+      "executionCount": "Wykonania testów",
+      "createdCaseCount": "Liczba utworzonych przypadków testowych",
+      "sessionResultCount": "Liczba wyników sesji",
+      "caseCreations": "Utworzone przypadki",
+      "sessionParticipation": "Udział w sesji",
+      "averageElapsed": "Średni czas wykonania",
+      "lastActiveDate": "Data ostatniej aktywności",
+      "issueCount": "Liczba wydań",
+      "averageAge": "Średni wiek (dni)",
+      "sessionCount": "Liczba sesji",
+      "activeSessions": "Aktywne sesje",
+      "averageTimeSpent": "Średni czas spędzony (minuty)",
+      "milestoneCount": "Liczba kamieni milowych",
+      "milestoneCompletionRate": "Wskaźnik ukończenia kamieni milowych (%)",
+      "averageMilestoneDuration": "Średni czas trwania kamienia milowego (dni)",
+      "totalMilestones": "Łączna liczba kamieni milowych",
+      "activeMilestones": "Aktywne kamienie milowe",
+      "milestoneCompletion": "Ukończenie kamienia milowego (%)",
+      "averageDuration": "Średni czas trwania",
+      "totalDuration": "Całkowity czas trwania"
+    },
+    "drillDown": {
+      "title": "Szczegółowe zapisy",
+      "loading": "Ładowanie rekordów...",
+      "loadingMore": "Ładowanie kolejnych...",
+      "noRecords": "Nie znaleziono żadnych rekordów",
+      "error": "Nie udało się załadować rekordów",
+      "recordCount": "{count} {count, plural, =1 {rekord} other {rekordy}}",
+      "allRecords": "Wszystkie rekordy",
+      "allLoaded": "Wszystkie rekordy załadowane"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Udział",
+      "dialogTitle": "Udostępnij raport",
+      "dialogDescription": "Utwórz link do udostępniania lub zarządzaj istniejącymi linkami do udostępnianych raportów.",
+      "tabs": {
+        "create": "Utwórz Udostępnij",
+        "list": "Moje udziały"
+      },
+      "shareMode": {
+        "label": "Tryb udostępniania",
+        "authenticated": {
+          "title": "Zweryfikowano (wymaga logowania)",
+          "description": "Tylko zalogowani użytkownicy z dostępem do tego projektu mogą go przeglądać.",
+          "descriptionCrossProject": "Tylko zalogowani użytkownicy z dostępem administratora mogą przeglądać."
+        },
+        "passwordProtected": {
+          "title": "Zabezpieczone hasłem",
+          "description": "Każdy, kto ma link i hasło, może przeglądać. Zalogowani użytkownicy z dostępem do projektu pomijają hasło.",
+          "descriptionCrossProject": "Każdy, kto ma link i hasło, może obejrzeć. Zalogowani użytkownicy z dostępem administratora pomijają hasło."
+        },
+        "public": {
+          "title": "Publiczny (każdy, kto ma link)",
+          "description": "Każda osoba mająca link może wyświetlić ten raport bez konieczności logowania się."
+        }
+      },
+      "expiration": {
+        "label": "Wygaśnięcie",
+        "noExpiration": "Brak daty ważności",
+        "expiresAtMidnight": "Link wygaśnie z końcem wybranego dnia (Twojego czasu lokalnego)"
+      },
+      "notifyOnView": {
+        "label": "Powiadom mnie, gdy ktoś wyświetli ten link",
+        "description": "Otrzymasz powiadomienie, gdy ktoś uzyska dostęp do linku do udostępniania, zgodnie z Twoimi preferencjami dotyczącymi powiadomień."
+      },
+      "title": {
+        "placeholder": "np. Raport wykonania testu",
+        "leaveEmptyToUse": "Pozostaw puste, aby użyć:"
+      },
+      "description": {
+        "placeholder": "Dodaj opis tego udostępnionego raportu..."
+      },
+      "actions": {
+        "createShareLink": "Utwórz link do udostępniania",
+        "creating": "Tworzenie..."
+      },
+      "errors": {
+        "loginRequired": "Aby utworzyć link do udostępniania, musisz się zalogować",
+        "createFailed": "Nie udało się utworzyć łącza udostępniania",
+        "genericError": "Wystąpił nieznany błąd"
+      },
+      "status": {
+        "revoked": {
+          "title": "Udostępnij link odwołany",
+          "description": "Ten link do udostępniania został anulowany i nie jest już dostępny."
+        },
+        "expired": {
+          "title": "Link do udostępniania wygasł",
+          "description": "Ten link do udostępniania wygasł i nie jest już dostępny."
+        }
+      },
+      "footer": {
+        "poweredBy": "Zasilane przez"
+      },
+      "manageShares": {
+        "title": "Zarządzaj udziałami",
+        "description": "Wyświetl i zarządzaj wszystkimi linkami udostępniania dla tego projektu",
+        "adminTitle": "Zarządzaj wszystkimi udziałami",
+        "adminDescription": "Przeglądaj i zarządzaj linkami udostępniania we wszystkich projektach"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Tryb",
+          "views": "Widoki",
+          "expires": "Wygasa"
+        },
+        "status": {
+          "revoked": "Odwołany",
+          "expired": "Wygasły"
+        },
+        "notifications": {
+          "enabled": "NA",
+          "disabled": "Wyłączony"
+        },
+        "empty": {
+          "title": "Nie utworzono jeszcze żadnych linków do udostępniania.",
+          "description": "Aby rozpocząć, utwórz swój pierwszy link do udostępniania."
+        },
+        "defaultTitle": "{entityType} udostępnij",
+        "noProject": "Międzyprojektowy",
+        "actions": {
+          "copyLink": "Kopiuj link",
+          "revoke": "Unieważnić"
+        },
+        "revokeDialog": {
+          "title": "Cofnąć link udostępniania?",
+          "description": "Spowoduje to natychmiastowe anulowanie linku do udostępniania. Każda próba uzyskania do niego dostępu spowoduje wyświetlenie komunikatu o błędzie. Tej czynności nie można cofnąć.",
+          "confirm": "Odwołaj link",
+          "revoking": "Odwoływanie..."
+        },
+        "deleteDialog": {
+          "title": "Usunąć link udostępniania?",
+          "description": "Spowoduje to trwałe usunięcie linku do udostępniania. Jeśli link jest obecnie aktywny, natychmiast wygaśnie i nie będzie już dostępny. Tej czynności nie można cofnąć.",
+          "confirm": "Usuń link"
+        },
+        "toast": {
+          "linkCopied": "Link skopiowany!",
+          "linkCopiedDescription": "Link do udostępniania został skopiowany do schowka.",
+          "copyFailed": "Nie udało się skopiować",
+          "copyFailedDescription": "Proszę skopiować link ręcznie.",
+          "linkRevoked": "Link do udostępniania został odwołany",
+          "linkRevokedDescription": "Link do udostępniania został anulowany i nie jest już dostępny.",
+          "revokeFailed": "Nie udało się odwołać",
+          "revokeFailedDescription": "Wystąpił błąd podczas cofania linku udostępniania.",
+          "notificationsEnabled": "Powiadomienia włączone",
+          "notificationsEnabledDescription": "Otrzymasz powiadomienie, gdy ktoś wyświetli ten link do udostępnienia.",
+          "notificationsDisabled": "Powiadomienia wyłączone",
+          "notificationsDisabledDescription": "Nie otrzymasz powiadomień, gdy ktoś wyświetli ten link do udostępnienia.",
+          "notificationUpdateFailed": "Nie udało się zaktualizować powiadomień",
+          "notificationUpdateFailedDescription": "Wystąpił błąd podczas aktualizacji ustawień powiadomień.",
+          "linkDeleted": "Udostępnij link usunięty",
+          "linkDeletedDescription": "Link do udostępniania został usunięty i nie będzie już wyświetlany na Twojej liście.",
+          "deleteFailed": "Nie udało się usunąć",
+          "deleteFailedDescription": "Wystąpił błąd podczas usuwania linku do udostępniania."
+        }
+      },
+      "created": {
+        "title": "Udostępnij link utworzony!",
+        "description": "Twój link do udostępniania jest gotowy do użycia. Skopiuj go i udostępnij innym.",
+        "shareLink": "Udostępnij link",
+        "copy": "Kopia",
+        "openInNewTab": "Otwórz w nowej karcie",
+        "metadata": {
+          "mode": "Tryb",
+          "expires": "Wygasa",
+          "views": "Widoki"
+        },
+        "warnings": {
+          "publicLink": "Link publiczny:",
+          "publicLinkDescription": "Każda osoba mająca ten link może uzyskać dostęp do raportu bez uwierzytelniania.",
+          "expiresSoon": "Ten link wygaśnie po zakończeniu"
+        },
+        "actions": {
+          "createAnother": "Utwórz inny"
+        }
+      },
+      "editDialog": {
+        "title": "Edytuj link do udostępniania",
+        "description": "Zaktualizuj ustawienia tego łącza udostępniania.",
+        "passwordExists": "Ten link do udostępniania ma już hasło. Pozostaw pole hasła puste, aby zachować istniejące hasło.",
+        "passwordPlaceholder": "Pozostaw puste, aby zachować istniejące hasło"
+      }
+    },
+    "passwordDialog": {
+      "title": "Wymagane hasło",
+      "description": "Ta udostępniona treść od <strong>{projectName}</strong> jest chroniona hasłem. Wprowadź hasło, aby kontynuować.",
+      "passwordPlaceholder": "Wprowadź hasło",
+      "showPassword": "Pokaż hasło",
+      "hidePassword": "Ukryj hasło",
+      "verifying": "Weryfikowanie...",
+      "errors": {
+        "emptyPassword": "Proszę podać hasło",
+        "tooManyAttempts": "Zbyt wiele nieudanych prób. Spróbuj ponownie później{resetAt, select, null {} other { o {resetAt}}}.",
+        "genericError": "Wystąpił błąd. Spróbuj ponownie."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Brak prób. Spróbuj ponownie później.",
+        "attemptsRemaining": "{count, plural, =1 {1 próba} other {# prób pozostało}}."
+      }
+    },
+    "sharedReport": {
+      "loading": "Ładowanie raportu...",
+      "errors": {
+        "onlyReportSharing": "Obecnie wdrożono wyłącznie funkcję udostępniania raportów",
+        "failedToLoad": "Nie udało się załadować danych raportu"
+      },
+      "defaultTitle": "Wspólny raport",
+      "fromProject": "Z projektu:",
+      "dateRange": "Zakres dat:",
+      "readOnlyNotice": "To jest widok współdzielony, tylko do odczytu",
+      "viewCount": "{count, plural, =1 {1 widok} other {# widoków}}",
+      "viewInFullApp": "Zobacz w pełnej aplikacji",
+      "pagination": {
+        "showing": "Seans",
+        "of": "z",
+        "results": "wyniki"
+      }
+    },
+    "authBypass": {
+      "title": "Masz dostęp do tego projektu",
+      "description": "Wyświetlanie jako {userName} z dostępem do {projectName}.",
+      "viewInApp": "Zobacz w pełnej aplikacji"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Filtruj udostępnione kroki...",
+    "noGroups": "Nie znaleziono żadnych wspólnych kroków.",
+    "noTestCases": "Żaden przypadek testowy nie wykorzystuje tej współdzielonej grupy kroków.",
+    "selectGroupPrompt": "Wybierz udostępnioną grupę kroków, aby wyświetlić jej kroki.",
+    "deleteTitle": "Usunąć współdzieloną grupę kroków?",
+    "deleteDescription": "Czy na pewno chcesz usunąć tę współdzieloną grupę kroków? Kroki zostaną usunięte ze wszystkich przypadków testowych, które z nich korzystają.",
+    "saveSuccess": "Wspólne kroki zostały pomyślnie zaktualizowane.",
+    "saveError": "Wystąpił błąd podczas zapisywania udostępnionych kroków.",
+    "stepsCount": "{count, plural, one {# krok} other {# kroki}}",
+    "testCasesUsing": "{count, plural, one {# przypadek testowy} other {# przypadki testowe}}",
+    "importWizard": {
+      "title": "Importuj współdzielone kroki",
+      "fields": {
+        "order": "Zamówienie",
+        "stepNumber": "Krok nr",
+        "stepContent": "Zawartość kroku",
+        "expectedResultContent": "Oczekiwana treść wyniku",
+        "combinedStepData": "Połączone dane kroków",
+        "stepsData": "Dane kroków"
+      },
+      "success": {
+        "description": "{count, plural, one {# współdzielony krok} other {# współdzielone kroki}} zaimportowano pomyślnie"
+      },
+      "errors": {
+        "parseFailed": "Nie udało się przeanalizować pliku CSV",
+        "validationFailed": "Walidacja nie powiodła się",
+        "validationDescription": "{count, plural, one {# błąd walidacji} other {# błędy walidacji}} znaleziono",
+        "importFailed": "Import nie powiódł się",
+        "fileRequired": "Wymagany jest plik CSV"
+      },
+      "page1": {
+        "title": "Prześlij plik i konfigurację",
+        "selectedFile": "Wybrany plik",
+        "delimiter": "Ogranicznik pola",
+        "delimiters": {
+          "tab": "Karta (\\t)"
+        },
+        "hasHeaders": "Pierwszy wiersz zawiera nagłówki kolumn",
+        "encoding": "Kodowanie plików",
+        "rowMode": {
+          "label": "Tryb wiersza",
+          "single": "Pojedynczy wiersz na wspólny krok",
+          "multi": "Wiele wierszy dla złożonych współdzielonych kroków"
+        }
+      },
+      "page2": {
+        "title": "Mapowanie kolumn CSV na pola kroków współdzielonych",
+        "description": "Zmapuj kolumny CSV na pola kroków współdzielonych. Wymagane pola muszą być zmapowane.",
+        "ignoreColumn": "Zignoruj tę kolumnę",
+        "requiredFieldsWarning": "{count, plural, one {# pole wymagane to} other {# pola wymagane to}} niezmapowane. Aby kontynuować, zmapuj wszystkie wymagane pola."
+      },
+      "page3": {
+        "title": "Podgląd importowanych danych",
+        "showing": "Wyświetlanie od {start} do {end} z {total} udostępnionych kroków",
+        "step": "Wspólny krok {number}",
+        "noValue": "(pusty)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Dodaj ręcznie",
+      "description": "Utwórz nową współdzieloną grupę kroków z ręcznym wprowadzaniem",
+      "groupNamePlaceholder": "Wprowadź nazwę tej współdzielonej grupy kroków",
+      "success": "Wspólne kroki zostały pomyślnie utworzone",
+      "errors": {
+        "groupNameRequired": "Nazwa grupy jest wymagana",
+        "stepsRequired": "Wymagany jest co najmniej jeden krok",
+        "saveFailed": "Nie udało się zapisać udostępnionych kroków"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Duplikaty sekwencji kroków",
+      "pageDescription": "Przejrzyj dopasowane sekwencje kroków w różnych przypadkach testowych. Przekształć dopasowania w grupy kroków współdzielonych lub odrzuć fałszywe alarmy.",
+      "noResultsFound": "Nie znaleziono duplikatów sekwencji kroków",
+      "noResultsDescription": "Uruchom skanowanie w celu wykrycia powtarzających się sekwencji kroków w przypadkach testowych.",
+      "filterPlaceholder": "Filtruj według nazwy sprawy...",
+      "selected": "{count, plural, one {# wybrano} other {# wybrano}}",
+      "bulkDismiss": "Odrzuć ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# dopasowanie odrzucone} other {# dopasowania odrzucone}}",
+      "bulkError": "Niektóre operacje nie powiodły się. Spróbuj ponownie.",
+      "tableHint": "Kliknij wiersz, aby wyświetlić podgląd dopasowanych kroków. Zaznacz wiersze z polami wyboru, aby wykonać działania zbiorcze.",
+      "columns": {
+        "matchedSteps": "Dopasowane kroki",
+        "casesCount": "Sprawy",
+        "review": "Recenzja"
+      },
+      "scanning": "Łów...",
+      "scanComplete": "{count, plural, one {# znaleziono dopasowanie} other {# znaleziono dopasowania}}",
+      "scanFailed": "Skanowanie nie powiodło się",
+      "scanFailedDescription": "Wystąpił błąd podczas skanowania. Spróbuj ponownie.",
+      "cancelScan": "Anuluj skanowanie",
+      "findStepDuplicates": "Znajdź duplikaty kroków",
+      "rescan": "Skandować",
+      "viewResults": "Wyświetl wyniki ({count})",
+      "retryScan": "Ponów skanowanie",
+      "dialog": {
+        "title": "Konwertuj na kroki współdzielone",
+        "previewTitle": "Dopasowana sekwencja kroków",
+        "casesTitle": "Dotknięte przypadki testowe",
+        "casesDescription": "Odznacz przypadki, które chcesz wykluczyć z konwersji.",
+        "nameLabel": "Nazwa grupy wspólnych kroków",
+        "namePlaceholder": "Wprowadź nazwę współdzielonej grupy kroków...",
+        "converting": "Konwersja...",
+        "dismissMatch": "Odrzuć mecz",
+        "dismissing": "Odrzucenie...",
+        "convertSuccess": "Wspólna grupa kroków została utworzona pomyślnie!",
+        "convertError": "Nie udało się przekonwertować. Spróbuj ponownie.",
+        "dismissSuccess": "Mecz odwołany.",
+        "dismissError": "Nie udało się zamknąć. Spróbuj ponownie.",
+        "viewSharedStep": "Wyświetl wspólną grupę kroków",
+        "skippedWarning": "{count, plural, one {# przypadek został pominięty} other {# przypadek został pominięty}} (nieaktualne lub już przekonwertowane).",
+        "noCasesSelected": "Wybierz co najmniej jeden przypadek do przekonwertowania.",
+        "selectAll": "Zaznacz wszystko"
+      }
+    },
+    "findStepDuplicates": "Znajdź duplikaty"
+  },
+  "search": {
+    "title": "Szukaj",
+    "placeholder": {
+      "thisProject": "Wyszukaj w tym projekcie...",
+      "allProjects": "Wyszukaj we wszystkich projektach..."
+    },
+    "currentProjectOnly": "Tylko bieżący projekt",
+    "allTypes": "Wszystkie typy",
+    "entityTypes": {
+      "repositoryCase": "Sprawy repozytorium"
+    },
+    "results": {
+      "tryAdjusting": "Spróbuj dostosować warunki wyszukiwania lub filtry",
+      "searchingFor": "Szukam",
+      "within": "w",
+      "currentProject": "bieżący projekt",
+      "page": "Strona"
+    },
+    "errors": {
+      "searchFailed": "Wyszukiwanie nie powiodło się. Spróbuj ponownie.",
+      "tryAgain": "Spróbuj ponownie"
+    },
+    "startTyping": "Zacznij pisać, aby wyszukać",
+    "typesSelected": "{count, plural, one {# typ} other {# typy}}",
+    "customFieldFilters": "Niestandardowe filtry pól",
+    "customFiltersApplied": "niestandardowe filtry",
+    "customFields": "Pola niestandardowe",
+    "addFilter": "Dodaj filtr",
+    "filter": "Filtr",
+    "noCustomFilters": "Nie zastosowano żadnych niestandardowych filtrów pól",
+    "selectDate": "Wybierz datę",
+    "selectOption": "Wybierz opcję",
+    "selectOptions": "Wybierz opcje",
+    "operators": {
+      "equals": "Równa się",
+      "not_equals": "Nie równy",
+      "contains": "Zawiera",
+      "not_contains": "Nie zawiera",
+      "starts_with": "Zaczyna się od",
+      "ends_with": "Kończy się na",
+      "gt": "Większy niż",
+      "lt": "Mniej niż",
+      "gte": "Większy lub równy",
+      "lte": "Mniejsze lub równe",
+      "between": "Między",
+      "in": "W",
+      "not_in": "Nie w",
+      "exists": "Istnieje",
+      "not_exists": "Nie istnieje"
+    },
+    "help": {
+      "exactPhrases": "Dokładne frazy",
+      "exactPhrasesDesc": "Umieść terminy w cudzysłowie, aby dopasować je do dokładnych fraz:",
+      "proximity": "Wyszukiwanie w pobliżu",
+      "proximityDesc": "słowa w N pozycjach od siebie",
+      "booleanOperators": "Operatorzy Boole'a",
+      "andDesc": "oba terminy muszą być zgodne",
+      "orDesc": "oba terminy mogą pasować",
+      "notDesc": "wyklucz wyniki z terminem",
+      "prefixDesc": "wymagać lub wykluczać termin",
+      "groupingDesc": "terminy grupowe dla złożonych zapytań",
+      "wildcards": "Dzikie karty",
+      "wildcardMultiDesc": "pasuje do dowolnych znaków",
+      "wildcardSingleDesc": "dopasowuje pojedynczy znak",
+      "fuzzyMatching": "Dopasowanie rozmyte",
+      "fuzzyDesc": "znajduje podobne terminy, aby pomóc w przypadku literówek",
+      "defaultBehavior": "W przypadku wielu słów domyślnie stosuje się operator OR. Wyniki pasujące do nazwy są najwyżej oceniane.",
+      "fullSyntaxLink": "Pełna referencja dotycząca składni zapytań Lucene"
+    },
+    "filters": {
+      "title": "Zaawansowane filtry",
+      "active": "filtry aktywne",
+      "activeCount": "{count, plural, =0 {Brak filtrów} one {# filtr} other {# filtry}} aktywne",
+      "apply": "Zastosuj filtry",
+      "common": "Typowe filtry",
+      "entitySpecific": "Filtry specyficzne dla typu",
+      "searchPlaceholder": "Opcje filtrów wyszukiwania...",
+      "states": "Stany przepływu pracy",
+      "createdAt": "Data utworzenia",
+      "updatedAt": "Data aktualizacji",
+      "completedAt": "Data ukończenia",
+      "from": "Z",
+      "to": "Do",
+      "testRunType": "Typ testu",
+      "regular": "Regularny",
+      "junit": "JUnit",
+      "automatedOnly": "Tylko automatyczne",
+      "archivedOnly": "Tylko zarchiwizowane",
+      "completedOnly": "Tylko ukończone",
+      "manualOnly": "Tylko ręcznie",
+      "estimateRange": "Zakres szacowania",
+      "elapsedRange": "Zakres czasu upłyniętego",
+      "minValue": "Min",
+      "maxValue": "Maksym",
+      "hasExternalId": "Posiada zewnętrzne ID",
+      "dueDateRange": "Zakres dat wymagalności",
+      "hasParent": "Ma kamień milowy dla rodziców",
+      "milestoneType": "Typ kamienia milowego",
+      "minutes": "protokół",
+      "hours": "godziny",
+      "days": "dni",
+      "searchingIn": "Wyszukiwanie w",
+      "includeDeleted": "Uwzględnij usunięte elementy",
+      "filterActive": "Filtr aktywny:",
+      "applyFilter": "Zastosuj filtr",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "Pierwsza wartość musi być mniejsza od drugiej wartości",
+        "firstDateMustBeBeforeSecond": "Pierwsza randka musi odbyć się przed drugą."
+      },
+      "link": {
+        "domainHelp": "Wprowadź tylko domenę (np. „github.com” lub „example.org”)"
+      }
+    }
+  },
+  "email": {
+    "greeting": "Cześć,",
+    "greetingWithName": "Cześć {name},",
+    "notification": {
+      "intro": "Masz nowe powiadomienie:",
+      "viewDetails": "Zobacz szczegóły",
+      "viewAll": "Wyświetl wszystkie powiadomienia"
+    },
+    "digest": {
+      "intro": "Oto codzienny przegląd powiadomień z TestPlanIt:",
+      "viewDetails": "Zobacz szczegóły",
+      "viewAll": "Wyświetl wszystkie powiadomienia",
+      "noNotifications": "Nie masz dziś żadnych nowych powiadomień.",
+      "footer": "Otrzymujesz tę wiadomość e-mail, ponieważ masz włączone powiadomienia o podsumowaniu dziennym. Możesz zmienić swoje preferencje dotyczące powiadomień w ustawieniach.",
+      "profileSettings": "ustawienia profilu"
+    },
+    "footer": {
+      "sentBy": "Ten e-mail został wysłany przez",
+      "unsubscribe": "Anuluj subskrypcję",
+      "managePreferences": "Zarządzaj preferencjami",
+      "allRightsReserved": "Wszelkie prawa zastrzeżone."
+    },
+    "magicLink": {
+      "subject": "Zaloguj się do TestPlanIt",
+      "heading": "Zaloguj się do TestPlanIt",
+      "intro": "Kliknij poniższy przycisk, aby się zalogować:",
+      "signInButton": "Zalogować się",
+      "copyPasteIntro": "Lub skopiuj i wklej ten link do przeglądarki:",
+      "disclaimer": "Jeśli nie prosiłeś o wysłanie tego e-maila, możesz go bezpiecznie zignorować.",
+      "textBody": "Zaloguj się do TestPlanIt\n\nKliknij poniższy link, aby się zalogować:\n{url}\n\nJeśli nie prosiłeś o otrzymanie tego e-maila, możesz go bezpiecznie zignorować."
+    }
+  },
+  "comments": {
+    "title": "Uwagi",
+    "placeholder": "Napisz komentarz... (użyj @, aby wspomnieć o użytkownikach)",
+    "editPlaceholder": "Edytuj swój komentarz...",
+    "postComment": "Dodaj komentarz",
+    "noComments": "Brak komentarzy. Bądź pierwszy, który skomentuje!",
+    "edited": "edytowany",
+    "confirmDelete": "Czy na pewno chcesz usunąć ten komentarz? Tej czynności nie można cofnąć.",
+    "deleteDialog": {
+      "title": "Usuń komentarz"
+    },
+    "errors": {
+      "createFailed": "Nie udało się utworzyć komentarza. Spróbuj ponownie.",
+      "updateFailed": "Nie udało się zaktualizować komentarza. Spróbuj ponownie.",
+      "deleteFailed": "Nie udało się usunąć komentarza. Spróbuj ponownie.",
+      "loadFailed": "Nie udało się załadować komentarzy. Spróbuj ponownie."
+    },
+    "mentions": {
+      "notAMember": "Nie jestem członkiem projektu",
+      "noUsersFound": "Nie znaleziono użytkowników"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "Okres próbny kończy się za {count, plural, =1 {1 dzień} other {# dni}}",
+    "expiresT oday": "Okres próbny kończy się dzisiaj",
+    "expired": "{count, plural, =1 {Okres próbny wygasł 1 dzień temu} other {Okres próbny wygasł # dni temu}}",
+    "contactSales": "Skontaktuj się ze sprzedażą"
+  },
+  "feedback": {
+    "sheetTitle": "Podziel się swoją opinią",
+    "sheetDescription": "Pomóż nam ulepszyć TestPlanIt, dzieląc się swoimi doświadczeniami.",
+    "bannerMessage": "Jak przebiega Twój proces? Chętnie poznamy Twoją opinię.",
+    "menuItem": "Udostępnij opinię"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "Tag AI",
+      "tagAll": "Oznacz wszystko",
+      "aiAutoTag": "Automatyczne tagowanie",
+      "tagActions": "Akcje tagów",
+      "startTagging": "Rozpocznij tagowanie",
+      "selectEntityType": "Wybierz typ jednostki",
+      "selectProject": "Wybierz projekt",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Przypadek testowy} other {Przypadki testowe}}",
+        "testRun": "{count, plural, one {Test rozruchowy} other {Testy rozruchowe}}",
+        "session": "{count, plural, one {Sesja} other {Sesje}}"
+      }
+    },
+    "review": {
+      "title": "Przejrzyj sugestie tagów",
+      "description": "Kliknij tagi, aby przełączyć akceptację. Kliknij dwukrotnie, aby edytować nazwę tagu.",
+      "selectEntity": "Wybierz jednostkę, aby wyświetlić sugestie tagów.",
+      "noTagsSelected": "Nie wybrano tagów",
+      "footerSummary": "{assignCount, plural, one {# tag} other {# tagi}} zostaną przypisane, {newCount, plural, one {# nowy tag} other {# nowe tagi}} zostaną utworzone",
+      "footerAssignCount": "{assignCount, plural, one {# tag} other {# tagi}} zostaną przypisane",
+      "footerNewCount": "{newCount, plural, one {# nowy tag} other {# nowe tagi}} zostaną utworzone",
+      "newTagsPopoverTitle": "Nowe tagi do utworzenia",
+      "applying": "Aplikowanie...",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tagi}} zastosowano do {entityCount, plural, one {# encja} other {# encje}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tagi}} zastosowano do {entityCount, plural, one {# encja} other {# encje}}, {newCount, plural, one {# nowy tag} other {# nowe tagi}} utworzono",
+      "applyError": "Nie udało się zastosować tagów. Spróbuj ponownie.",
+      "suggestedTags": "Sugerowane tagi",
+      "noSuggestions": "Sztuczna inteligencja nie mogła wygenerować żadnych tagów.",
+      "alreadyApplied": "Już zastosowane",
+      "filterEntities": "Filtruj jednostki...",
+      "noEntitiesMatch": "Brak podmiotów odpowiadających wyszukiwaniu.",
+      "tagCount": "{count, plural, one {# tag} other {# tagi}}",
+      "noTags": "nic",
+      "failed": "Przegrany",
+      "analysisFailed": "Nie można przeanalizować tego bytu",
+      "responseTruncated": "Odpowiedź została skrócona — zwiększ maksymalną liczbę tokenów wyjściowych w ustawieniach LLM",
+      "tooltipExisting": "Istniejący tag",
+      "tooltipNew": "Nowy tag — zostanie utworzony",
+      "tooltipAssign": "Przypisz istniejący tag",
+      "toggleFailed": "Pokaż/ukryj nieudane jednostki",
+      "showFailed": "Pokaz nieudany"
+    },
+    "progress": {
+      "starting": "Rozpoczęcie analizy...",
+      "analyzed": "Przeanalizowano {analyzed}/{total} jednostek",
+      "sizing": "Znalezienie optymalnego rozmiaru partii (próbowanie {size} jednostek)...",
+      "streaming": "Otrzymywanie odpowiedzi AI ({analyzed}/{total} jednostek gotowych)...",
+      "finalizing": "Przygotowywanie wyników...",
+      "complete": "Analiza ukończona",
+      "reviewSuggestions": "Sugestie dotyczące recenzji",
+      "failed": "Analiza nie powiodła się"
+    },
+    "wizard": {
+      "description": "Sztuczna inteligencja przeanalizuje wszystkie przypadki testowe, przebiegi testów i sesje Twojego projektu, aby na podstawie ich zawartości zasugerować odpowiednie tagi.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Rozpocznij analizę",
+      "untaggedOnly": "Analizuj tylko rekordy bez istniejących tagów",
+      "allowNewTags": "Zezwól na tworzenie nowych tagów",
+      "noLlmConfigured": "(LLM nie został skonfigurowany)",
+      "analyzingDescription": "Sztuczna inteligencja analizuje Twoje jednostki i generuje sugestie tagów. Może to chwilę potrwać."
+    },
+    "entityDetail": {
+      "customFields": "Pola niestandardowe",
+      "noDetails": "Brak dodatkowych szczegółów.",
+      "openInNewTab": "Otwórz w nowej karcie"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Bardzo słaby",
+    "weak": "Słaby",
+    "fair": "Sprawiedliwy",
+    "good": "Dobry",
+    "strong": "Mocny",
+    "minLength": "Co najmniej {count} znaków",
+    "uppercase": "Co najmniej jedna wielka litera",
+    "lowercase": "Co najmniej jedna mała litera",
+    "numbers": "Co najmniej jedna liczba",
+    "specialChars": "Znak specjalny z: {chars}",
+    "history": "Hasło zostało użyte w Twoich ostatnich {depth} hasłach"
+  },
+  "TrialExpired": {
+    "title": "Twój okres próbny wygasł",
+    "description": "Dziękujemy za wypróbowanie TestPlanIt! Twój okres próbny dobiegł końca i ta instancja nie jest już dostępna.",
+    "nextSteps": "Aby nadal używać TestPlanIt i uzyskać dostęp do danych testowych, skontaktuj się z naszym zespołem sprzedaży.",
+    "pricingPlans": "Plany cenowe",
+    "dataRetention": "Twoje dane testowe są bezpiecznie przechowywane i będą dostępne po uaktualnieniu konta."
+  }
+}

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Nome",
+    "cancel": "Cancelar",
+    "dismiss": "Liberar",
+    "of": "de",
+    "on": "sobre",
+    "at": "no",
+    "in": "em",
+    "add": "Adicionar",
+    "never": "Nunca",
+    "select": "Selecione...",
+    "file": "Arquivo",
+    "selectMultiple": "Selecione várias opções...",
+    "searchUsers": "Pesquisar usuários...",
+    "searchCases": "{count, plural, =0 {Pesquisar casos} one {Pesquisar # caso} other {Pesquisar # casos}}",
+    "searchProjects": "{count, plural, =0 {Pesquisar projetos} one {Pesquisar # projeto} other {Pesquisar # projetos}}",
+    "searchTags": "Pesquisar por etiquetas...",
+    "searchRuns": "{count, plural, =0 {Pesquisar execuções de teste} one {Pesquisar # execuções de teste} other {Pesquisar # execuções de teste}}",
+    "searchSessions": "{count, plural, =0 {Pesquisar sessões} one {Pesquisar # sessão} other {Pesquisar # sessões}}",
+    "search": "Procurar...",
+    "defaultOption": "Opção padrão",
+    "yes": "Sim",
+    "no": "Não",
+    "updated": "Atualizado",
+    "groupedBy": "agrupados por",
+    "lastEditedBy": "Última edição por",
+    "actions": {
+      "edit": "Editar",
+      "save": "Salvar",
+      "delete": "Excluir",
+      "create": "Criar",
+      "submit": "Enviar",
+      "close": "Fechar",
+      "done": "Feito",
+      "verify": "Verificar",
+      "signIn": "Entrar",
+      "signOut": "Sair",
+      "signUp": "Inscrever-se",
+      "resend": "Reenviar",
+      "deleting": "Excluindo...",
+      "next": "Próximo",
+      "previous": "Anterior",
+      "finish": "Terminar",
+      "download": "Download",
+      "apply": "Aplicar",
+      "confirm": "Confirmar",
+      "confirmDelete": "Confirmar exclusão",
+      "saveChanges": "Salvar alterações",
+      "saving": "Salvando...",
+      "submitting": "Enviando...",
+      "start": "Começar",
+      "pause": "Pausa",
+      "reset": "Reiniciar",
+      "copy": "Cópia",
+      "copyLink": "Copiar link",
+      "copied": "Copiado!",
+      "complete": "Completo",
+      "back": "Voltar",
+      "clear": "Claro",
+      "expand": "Expandir",
+      "collapse": "Colapso",
+      "addResult": "Adicionar resultado",
+      "passAndNext": "Passe e Próximo",
+      "viewInRepository": "Ver no repositório",
+      "resultAdded": "Resultado do teste adicionado",
+      "resultAddedDescription": "O resultado do teste foi adicionado com sucesso.",
+      "resultUpdated": "Resultado do teste atualizado",
+      "resultDeleted": "Resultado do teste excluído",
+      "deleteResult": "Excluir resultado do teste",
+      "deleteResultConfirmation": "Tem certeza de que deseja excluir este resultado de teste? Esta ação não pode ser desfeita.",
+      "editResult": "Editar resultado do teste",
+      "resultDetails": "Detalhes do resultado",
+      "actionsLabel": "Ações",
+      "assign": "Atribuir",
+      "assignSelected": "Atribuir {count, plural, one {# caso} other {# casos}}",
+      "refresh": "Atualizar",
+      "addResultSelected": "Adicionar resultado a {count, plural, one {# caso} other {# casos}}",
+      "resultsAdded": "{count, plural, one {# Resultado} other {# Resultados}} Adicionado",
+      "resultsAddedDescription": "{count, plural, one {Resultado adicionado ao caso de teste nº} other {Resultados adicionados aos casos de teste nº}} com sucesso",
+      "addingResultsToMultiple": "Adicionando resultados a {count, plural, one {# caso de teste} other {# casos de teste}}",
+      "addedToTestRun": "Adicionado ao Teste de Rotina",
+      "addedToTestRunDescription": "O caso de teste foi adicionado à Execução de Teste.",
+      "noAvailableTestRuns": "Todos os testes ativos já incluem este caso de teste.",
+      "resultUpdateError": "Falha ao atualizar o resultado do teste",
+      "resultDeleteError": "Falha ao excluir o resultado do teste",
+      "selectStatus": "Selecionar Status",
+      "addToTestRun": "Adicionar à Execução de Teste",
+      "status": "Status",
+      "resultDetailsPlaceholder": "Insira os detalhes do resultado...",
+      "selectAll": "Selecionar tudo",
+      "deselectAll": "Desmarcar tudo",
+      "clearAll": "Limpar tudo",
+      "selectFile": "Selecionar arquivo",
+      "restore": "Restaurar",
+      "purge": "Purga",
+      "previousCase": "Caso anterior",
+      "nextCase": "Próximo caso",
+      "startTesting": "Iniciar Testes",
+      "expandLeftPanel": "Expandir painel esquerdo",
+      "collapseLeftPanel": "Recolher painel esquerdo",
+      "expandRightPanel": "Expandir painel direito",
+      "collapseRightPanel": "Recolher painel direito",
+      "createTag": "Criar etiqueta \"{name}\"",
+      "noTagsFound": "Nenhuma etiqueta encontrada",
+      "duplicate": "Duplicado",
+      "exportPdf": "Exportar PDF",
+      "exportingPdf": "Exportador...",
+      "change": "Mudar",
+      "viewAll": "Ver tudo",
+      "undo": "Desfazer",
+      "undoDelete": "Desfazer exclusão",
+      "automated": {
+        "details": "Detalhes do teste automatizado",
+        "message": "Mensagem",
+        "line": "Linha",
+        "testSuite": "Conjunto de testes:"
+      },
+      "junit": {
+        "details": "Detalhes dos resultados do teste automatizado",
+        "import": {
+          "title": "Resultados do teste de importação",
+          "description": "Faça o upload de arquivos de resultados de testes para importá-los em uma nova execução de testes. Compatível com os formatos JUnit, TestNG, xUnit, NUnit, MSTest, Mocha e Cucumber.",
+          "testRun": {
+            "label": "Teste de execução",
+            "placeholder": "Selecione uma execução de teste."
+          },
+          "file": {
+            "label": "Arquivos de resultados de testes"
+          },
+          "import": "Importar",
+          "selectFolder": "Selecione uma pasta",
+          "createNewFolder": "Criar nova pasta",
+          "createNewFolderNamed": "Criar nova pasta: {name}",
+          "progress": {
+            "initializing": "Inicializando a importação...",
+            "validating": "Validação dos dados de entrada...",
+            "creatingRun": "Criando um teste de execução...",
+            "fetchingTemplate": "Obtendo dados do modelo...",
+            "countingTests": "Processando {count} casos de teste de {files} arquivo(s)...",
+            "parsingFile": "Analisando o arquivo {current} de {total}...",
+            "processingSuite": "Conjunto de processamento: {name}",
+            "processingCase": "Processando caso de teste {current} de {total}...",
+            "finalizing": "Finalizando a importação...",
+            "completed": "Importação concluída com sucesso!",
+            "errorParsing": "Erro ao analisar o arquivo {index}: {error}",
+            "skippingFile": "Ignorando arquivo inválido {index}"
+          },
+          "error": {
+            "title": "Erro de importação",
+            "importFailed": "Falha ao importar os resultados dos testes. Tente novamente."
+          },
+          "success": {
+            "title": "Importação concluída com sucesso",
+            "description": "Os resultados dos testes foram importados com sucesso."
+          },
+          "fileRequired": "Por favor, envie pelo menos um arquivo com os resultados dos testes."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Formato do resultado",
+            "placeholder": "Selecione o formato"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Confirmar restauração",
+      "confirmPurgeTitle": "Confirmar limpeza",
+      "remove": "Remover",
+      "reconfigure": "Reconfigure e tente novamente."
+    },
+    "permissions": {
+      "addEdit": "Adicionar/Editar"
+    },
+    "auth": {
+      "internal": "E-mail/Senha",
+      "sso": "Somente SSO",
+      "both": "E-mail e SSO"
+    },
+    "status": {
+      "deleted": "Excluído",
+      "disabled": "Desabilitado",
+      "noCustomFieldData": "Sem detalhes adicionais.",
+      "pending": "Pendente",
+      "uploading": "Carregando...",
+      "notApplicable": "N / D",
+      "redirecting": "Redirecionando...",
+      "pendingDelete": "Será excluído",
+      "pendingChanges": "Alterações pendentes",
+      "importing": "Importando...",
+      "addingTestCases": "Adicionando casos de teste..."
+    },
+    "priority": {
+      "low": "Baixo",
+      "medium": "Médio",
+      "high": "Alto"
+    },
+    "filters": {
+      "allStatuses": "Todos os status",
+      "allPriorities": "Todas as prioridades"
+    },
+    "fields": {
+      "groupName": "Nome do grupo",
+      "users": "Usuários",
+      "mixed": "Todos os valores",
+      "type": "Tipo",
+      "default": "Padrão",
+      "enabled": "Habilitado",
+      "projects": "Projetos",
+      "iconColor": "Ícone/Cor",
+      "selectWorkflow": "Selecione o fluxo de trabalho",
+      "icon": "Ícone",
+      "systemName": "Nome do sistema",
+      "aliases": "Aliases",
+      "scope": "Escopo",
+      "success": "Sucesso",
+      "failure": "Falha",
+      "completed": "Concluído",
+      "elapsed": "Tempo decorrido",
+      "totalElapsed": "Tempo total decorrido",
+      "totalEstimate": "Tempo estimado restante",
+      "completionRate": "Taxa de conclusão",
+      "attachments": "Anexos",
+      "documentation": "Documentação",
+      "state": "Estado",
+      "configuration": "Configuração",
+      "configurations": "Configurações",
+      "milestone": "Marco",
+      "tags": "Etiquetas",
+      "createdBy": "Criado por",
+      "description": "Descrição",
+      "description_placeholder": "Adicione uma descrição...",
+      "testCases": "Casos de teste",
+      "sessions": "Sessões",
+      "sharedSteps": "Passos Compartilhados",
+      "email": "E-mail",
+      "password": "Senha",
+      "confirmPassword": "Confirme sua senha",
+      "token": "Token",
+      "access": "Acesso",
+      "avatar": "Avatar",
+      "steps": "Passos",
+      "step": "Etapa",
+      "expectedResult": "Resultado esperado",
+      "notes": "Notas",
+      "estimate": "Estimativa",
+      "date": "Data",
+      "size": "Tamanho",
+      "created": "Criado",
+      "template": "Modelo",
+      "mission": "Missão",
+      "assignedTo": "Designado para",
+      "executedBy": "Executado por",
+      "optional": "Opcional",
+      "role": "Papel",
+      "defaultRole": "Função padrão",
+      "systemAccess": "Acesso ao sistema",
+      "authMethod": "Método de autenticação",
+      "dateCreated": "Data de criação",
+      "apiUser": "Usuário da API",
+      "unverified": "Não verificado",
+      "selfRegistered": "Auto-registrado",
+      "role_placeholder": "Selecione uma função",
+      "usersCreated": "Criado pelos usuários",
+      "groups": "Grupos",
+      "apiAccess": "Acesso à API",
+      "requiredForAdmin": "Necessário para Administrador",
+      "account": "Conta",
+      "accountHistory": "Histórico da conta",
+      "activity": "Atividade",
+      "lastActive": "Última atividade",
+      "theme": "Tema",
+      "locale": "Linguagem",
+      "timezone": "Fuso horário",
+      "itemsPerPage": "Itens por página",
+      "notificationMode": "Notificações",
+      "value": "Valor",
+      "key": "Chave",
+      "configurationDetails": "Detalhes da configuração",
+      "isActive": "Ativo",
+      "members": "Membros",
+      "milestoneTypes": "Tipos de marcos",
+      "milestones": "Conquistas",
+      "createdAt": "Criado em",
+      "completedOn": "Concluído em",
+      "variants": "Variantes",
+      "emailVerified": "E-mail verificado",
+      "issueTracker": "Rastreador de Problemas",
+      "caseFields": "Campos de caso",
+      "resultFields": "Campos de resultado",
+      "displayName": "Nome de exibição",
+      "hint": "Dica",
+      "required": "Obrigatório",
+      "restricted": "Restrito",
+      "fieldType": "Tipo de campo",
+      "templates": "Modelos",
+      "started": "Iniciado",
+      "startDate": "Data de início",
+      "automated": "Automatizado",
+      "manual": "Manual",
+      "notAutomated": "Não automatizado",
+      "testRuns": "Testes de execução",
+      "title": "Título",
+      "project": "Projeto",
+      "priority": "Prioridade",
+      "integration": "Integração",
+      "lastSyncedAt": "Última sincronização",
+      "externalKey": "Chave externa",
+      "initialHeight": "Altura inicial",
+      "minValue": "Valor mínimo",
+      "maxValue": "Valor máximo",
+      "minIntegerValue": "Valor inteiro mínimo",
+      "maxIntegerValue": "Valor inteiro máximo",
+      "defaultValue": "Valor padrão",
+      "checked": "Verificado",
+      "version": "Versão",
+      "issues": "Problemas",
+      "internalIssues": "Questões internas",
+      "externalIssues": "{provider} Problemas",
+      "data": "Dados",
+      "note": "Observação",
+      "externalId": "ID externo",
+      "forecast": "Previsão",
+      "forecastManual": "Manual de Previsão",
+      "forecastAutomated": "Previsão automatizada",
+      "executedAt": "Executado em",
+      "className": "Aula",
+      "suiteName": "Suíte",
+      "duration": "Duração",
+      "session": "Sessão",
+      "charter": "Carta",
+      "summary": "Resumo",
+      "progress": "Progresso",
+      "assertions": "Afirmações",
+      "properties": "Propriedades",
+      "systemOutput": "Registros de casos de teste",
+      "systemError": "Erro do sistema",
+      "resultStatus": "Resultado",
+      "links": "Links",
+      "id": "EU IA",
+      "JUNIT": "Importação JUnit",
+      "API": "API",
+      "folder": "Pasta",
+      "parentFolder": "Pasta principal para novos casos",
+      "multipleValues": "Valores múltiplos",
+      "provider": "Fornecedor",
+      "updatedAt": "Atualizado em",
+      "tools": "Ferramentas",
+      "codeRepository": "Repositório de código",
+      "aiModels": "LLM padrão",
+      "configKeys": {
+        "edit_results_duration": "Editar Duração dos Resultados",
+        "project_docs_default": "Documentação do projeto padrão",
+        "notificationSettings": "Configuração global de notificações",
+        "elasticsearch_replicas": "Réplicas do Elasticsearch"
+      },
+      "options": {
+        "label": "Rótulo",
+        "validation": {
+          "empty": "A opção não pode estar vazia.",
+          "invalidChars": "A opção contém um caractere inválido: \"{char}\"",
+          "duplicate": "A opção deve ser única.",
+          "systemNameError": "O nome do sistema é inválido.",
+          "initialHeightMax": "A altura inicial não pode ser superior a 600px.",
+          "displayNameRequiredResult": "Insira um nome de exibição para o campo de resultado.",
+          "displayNameRequiredCase": "Insira um nome de exibição para o campo Caso.",
+          "minValueMaxValue": "O valor mínimo deve ser menor que o valor máximo, e ambos devem ser definidos se apenas um deles estiver definido.",
+          "minMaxValueInteger": "O valor inteiro mínimo deve ser menor que o valor inteiro máximo, e ambos devem ser definidos se apenas um deles estiver definido.",
+          "systemNameRequired": "O nome do sistema não pode estar vazio.",
+          "systemNameRegex": "O nome do sistema deve começar com uma letra e só pode conter letras, números e sublinhados.",
+          "fieldTypeRequired": "O campo Tipo de Campo é obrigatório."
+        }
+      },
+      "placeholders": {
+        "key": "Tecla Enter",
+        "value": "Insira o valor",
+        "addVariant": "Adicionar variante",
+        "addCategory": "Adicionar categoria",
+        "displayName": "Digite o nome de exibição",
+        "systemName": "Digite o nome do sistema",
+        "hint": "Digite a dica"
+      },
+      "hints": {
+        "systemName": "O nome do sistema deve ser único e conter apenas letras, números e sublinhados.",
+        "fieldType": "(O tipo de campo não pode ser alterado após a criação)"
+      },
+      "validation": {
+        "nameRequired": "O nome é obrigatório.",
+        "stateRequired": "O Estado é obrigatório.",
+        "urlRequired": "É necessário um URL.",
+        "invalidUrl": "Formato de URL inválido"
+      }
+    },
+    "filter": {
+      "placeholder": "Filtrar {item}..."
+    },
+    "access": {
+      "admin": "Administrador",
+      "projectAdmin": "Administrador do Projeto",
+      "user": "Usuário",
+      "none": "Nenhum"
+    },
+    "validation": {
+      "required": "Por favor, digite {field}",
+      "invalidDuration": "Por favor, insira uma duração válida.",
+      "maxDuration": "A duração não pode exceder {max} minutos",
+      "minLength": "{field} deve ter pelo menos {min} caracteres",
+      "emailFormat": "Formato de e-mail inválido",
+      "passwordMatch": "As senhas devem corresponder",
+      "unique": "{field} deve ser único",
+      "roleRequired": "É necessário ter experiência na área.",
+      "nameMinLength": "O nome deve ter pelo menos 2 caracteres.",
+      "invalidDurationFormat": "Formato de duração inválido. Tente algo como 30m, 1 semana ou 1h 25m."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Confirmar {action}",
+        "message": "Tem certeza de que deseja {action}?"
+      },
+      "confirmDelete": {
+        "description": "Tem certeza de que deseja excluir este item? Esta ação não pode ser desfeita."
+      },
+      "assign": {
+        "title": "Atribuir caso de teste",
+        "description": "Atribua o caso de teste \"{testCase}\" a um usuário",
+        "selectUser": "Selecione um usuário"
+      },
+      "assignBulk": {
+        "title": "Atribuição em massa de casos de teste",
+        "description": "Atribua {count, plural, one {# caso de teste selecionado} other {# casos de teste selecionados}} a um usuário"
+      },
+      "complete": {
+        "title": "Teste completo",
+        "description": "Tem certeza de que deseja concluir este teste?",
+        "warning": "Uma vez concluído, o teste não poderá ser modificado.",
+        "apple": {
+          "title": "Configurar o início de sessão da Apple",
+          "description": "Configure suas credenciais de início de sessão da Apple. Você pode obtê-las no Portal do Desenvolvedor da Apple.",
+          "clientId": "ID do serviço",
+          "clientIdPlaceholder": "com.exemplo.serviço",
+          "teamId": "ID da equipe",
+          "teamIdPlaceholder": "Seu ID de equipe de 10 caracteres",
+          "keyId": "ID da chave",
+          "keyIdPlaceholder": "Seu código de identificação de 10 caracteres",
+          "privateKey": "Chave privada",
+          "privateKeyPlaceholder": "Cole aqui o conteúdo da sua chave privada .p8",
+          "instructions": {
+            "title": "Instruções de instalação:",
+            "step1": "Acesse o Portal do Desenvolvedor da Apple.",
+            "step2": "Crie um ID de serviço e configure o Iniciar sessão com a Apple.",
+            "step3": "Criar uma chave para iniciar sessão com a Apple",
+            "step4": "Baixe o arquivo de chave privada .p8",
+            "step5": "Adicione o seguinte URL de redirecionamento:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Todos os campos são obrigatórios."
+          }
+        }
+      },
+      "delete": {
+        "title": "Apagar {item}",
+        "description": "Tem certeza de que deseja excluir {name}?",
+        "warning": "Esta ação não pode ser desfeita. Ela excluirá permanentemente o {item}."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Item excluído com sucesso",
+      "deleteError": "Ocorreu um erro ao excluir o item.",
+      "moveSuccess": "O item foi movido com sucesso.",
+      "moveError": "Ocorreu um erro ao mover o item.",
+      "updateSuccess": "Item atualizado com sucesso",
+      "updateError": "Ocorreu um erro ao atualizar o item.",
+      "linkCopied": "Link copiado para a área de transferência",
+      "copyFailed": "Falha ao copiar o link para a área de transferência",
+      "created": "Execução de teste criada com sucesso",
+      "createdDescription": "O teste foi criado e agora está visível na lista de Testes.",
+      "createError": "Ocorreu um erro desconhecido. Por favor, tente novamente.",
+      "emptyActive": "Nenhum teste em andamento",
+      "emptyCompleted": "Nenhum teste concluído",
+      "projectUpdated": "Projeto atualizado com sucesso",
+      "projectUpdateError": "Ocorreu um erro ao atualizar o projeto.",
+      "noProjects": "Nenhum projeto encontrado"
+    },
+    "placeholders": {
+      "email": "Endereço de email",
+      "name": "Digite o nome",
+      "mission": "Descreva sua missão...",
+      "selectMilestone": "Selecione o marco",
+      "selectStatus": "Selecione um status",
+      "selectTemplate": "Selecione o modelo",
+      "duration": "Exemplo: 1h 30m ou 90m",
+      "docs": "Adicionar documentação...",
+      "select": "Selecione",
+      "selectState": "Selecione o estado",
+      "selectConfiguration": "Selecione a configuração",
+      "selectConfigurations": "Selecione as configurações",
+      "selectOption": "Selecione uma opção",
+      "date": "Selecione uma data",
+      "selectEncoding": "Selecione a codificação...",
+      "selectATemplate": "Selecione um modelo...",
+      "selectVersion": "Selecione a versão",
+      "selectAModel": "Selecione um modelo",
+      "selectWorkflowType": "Selecione o tipo de fluxo de trabalho",
+      "addAnOption": "Adicionar uma opção",
+      "addADescription": "Adicione uma descrição...",
+      "optionalDescription": "Descrição opcional...",
+      "projectNotes": "Anotações do projeto...",
+      "filterByName": "Filtrar por nome...",
+      "filterByValue": "Filtrar por valor...",
+      "selectOperator": "Selecione o operador",
+      "searchIcons": "Ícones de pesquisa...",
+      "value": "Valor",
+      "stepCount": "Contagem de passos",
+      "enterText": "Digite o texto...",
+      "enterUrl": "Insira o URL",
+      "issueIdExample": "EDIÇÃO-123",
+      "selectPriorityValuesOrEmpty": "Selecione os valores de prioridade (ou deixe em branco para todos)."
+    },
+    "errors": {
+      "error": "Erro",
+      "somethingWentWrong": "Ocorreu um erro inesperado. Tente novamente mais tarde.",
+      "emailRequired": "Insira seu endereço de e-mail.",
+      "emailInvalid": "Este endereço de e-mail não é válido.",
+      "passwordRequired": "É necessário usar uma senha.",
+      "confirmPasswordRequired": "Confirme sua senha.",
+      "passwordDoesNotMeetPolicy": "A senha não atende aos requisitos de segurança.",
+      "passwordsDoNotMatch": "As senhas não coincidem.",
+      "nameRequired": "Por favor, digite seu nome completo.",
+      "duplicate": "Por favor, escolha um nome único.",
+      "userExists": "O usuário já existe.",
+      "unknown": "Ocorreu um erro desconhecido.",
+      "invalidCredentials": "Nome de usuário ou senha inválidos",
+      "projectNotFound": "Projeto não encontrado",
+      "projectNotFoundDescription": "O projeto que você procura não existe ou você não tem acesso a ele.",
+      "tokenRequired": "Insira seu código de verificação de e-mail ou clique no link presente no seu e-mail.",
+      "noSuccessStatus": "Nenhum status de sucesso selecionado",
+      "missingTestRunCase": "O ID do caso de execução do teste está faltando.",
+      "fieldRequired": "Este campo é obrigatório",
+      "projectNameExists": "Já existe um projeto com esse nome.",
+      "defaultNotFound": "Valor padrão não encontrado",
+      "emailExists": "Já existe um usuário com este endereço de e-mail.",
+      "nameExists": "Já existe um usuário com esse nome.",
+      "duplicateValue": "Este valor já está em uso.",
+      "unauthorized": "Você não está autorizado a realizar esta ação.",
+      "accessDenied": "Acesso negado",
+      "sessionNotFound": "Sessão não encontrada ou inválida.",
+      "issueTrackerNotConfigured": "O sistema de rastreamento de problemas não está configurado para este projeto.",
+      "noUserSession": "Nenhuma sessão de usuário encontrada",
+      "noProjectId": "Nenhum ID de projeto encontrado",
+      "unknownErrorWithMessage": "Ocorreu um erro desconhecido. {message}",
+      "unauthenticated": "Usuário não autenticado",
+      "fetchFailed": "Não foi possível obter os dados. Tente novamente mais tarde.",
+      "unsupportedFieldType": "Tipo de campo não suportado",
+      "notAuthenticated": {
+        "title": "Não autenticado",
+        "message": "Você precisa estar conectado para realizar esta ação."
+      },
+      "failedToFetchAssignments": {
+        "title": "Falha ao buscar atribuições",
+        "message": "Não foi possível obter as tarefas. Tente novamente mais tarde."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Problema resolvido com sucesso",
+        "linkError": "Problema de vinculação",
+        "unlinkedSuccess": "Problema desvinculado com sucesso",
+        "unlinkError": "Problema ao desvincular",
+        "noActiveIntegration": "Nenhuma integração ativa encontrada para este projeto."
+      },
+      "roleRequiredForSpecificRole": "É necessário ter uma função específica quando o tipo de acesso for \"Função Específica\".",
+      "projectCreationFailed": "A criação do projeto falhou; nenhum ID foi retornado.",
+      "invalidRoleId": "ID de função inválido",
+      "workflowStateExists": "O estado do fluxo de trabalho já existe. Por favor, escolha um novo nome.",
+      "failedToLoadCaseData": "Falha ao carregar os dados do caso. Não foi possível salvar.",
+      "atLeastOneTagRequired": "É necessário pelo menos uma etiqueta.",
+      "atLeastOneIssueRequired": "É necessário pelo menos um problema.",
+      "atLeastOneOptionRequired": "Pelo menos uma opção deve ser selecionada.",
+      "valueRequired": "É necessário um valor.",
+      "contentRequired": "O conteúdo é obrigatório.",
+      "invalidContentFormat": "Formato de conteúdo inválido",
+      "caseNameRequired": "Por favor, insira um nome para o Caso de Teste.",
+      "caseStateRequired": "Por favor, selecione um estado.",
+      "caseFolderRequired": "Por favor, selecione uma pasta.",
+      "estimateTooLarge": "A estimativa é muito alta.",
+      "estimateRequiredValid": "É necessário fornecer uma estimativa, que deve ter uma duração válida (ex.: 1h 30m).",
+      "invalidDurationOrExceedsMax": "Formato de duração inválido ou excede o limite máximo (ex.: 1h 30m)",
+      "configurationNameExists": "O nome da configuração já existe. Por favor, escolha um nome diferente.",
+      "variantNameExists": "Já existe uma variante desse nome. Por favor, escolha um nome diferente.",
+      "categoryNameExists": "O nome da categoria já existe. Por favor, escolha um nome diferente.",
+      "workflowStateNameExists": "O nome do estado do fluxo de trabalho já existe. Por favor, escolha um nome diferente.",
+      "folderNameRequired": "Por favor, insira um nome para a pasta.",
+      "folderNameRequiredEnter": "Digite um nome para a pasta.",
+      "workflowStateNameRequired": "Por favor, insira um nome para o Estado do Fluxo de Trabalho.",
+      "roleNameEmpty": "O nome da função não pode estar vazio.",
+      "groupNameRequired": "O nome do grupo é obrigatório.",
+      "templateNameRequired": "Por favor, insira um nome para o modelo.",
+      "caseStateInvalid": "Por favor, selecione um estado válido.",
+      "caseTemplateRequired": "Por favor, selecione um modelo.",
+      "invalidContent": "Conteúdo inválido",
+      "milestoneNameRequired": "Por favor, insira um nome para o Marco.",
+      "milestoneTypeRequired": "Por favor, selecione um tipo de marco.",
+      "testRunNameMinLength": "O nome deve ter pelo menos 2 caracteres.",
+      "stateRequiredDot": "É necessário declarar.",
+      "milestoneTypeNameMinLength": "O nome do tipo de marco deve ter pelo menos 2 caracteres.",
+      "projectNameRequired": "O nome do projeto é obrigatório.",
+      "workflowScopeRequired": "Por favor, selecione um fluxo de trabalho para o estado.",
+      "workflowTypeRequired": "Por favor, selecione um tipo de fluxo de trabalho.",
+      "newTestCaseAdded": "Novo caso de teste adicionado",
+      "repositoryDeleted": "Repositório excluído",
+      "failedToDeleteRepository": "Falha ao excluir o repositório",
+      "permissionDenied": "Você não tem permissão para acessar esta página.",
+      "resultSubmitPermissionDenied": "Você não pode enviar resultados para este caso. Peça a um administrador do projeto para atribuí-lo a você.",
+      "noModelsFound": "Nenhum modelo encontrado",
+      "failedToFetchModels": "Falha ao buscar modelos",
+      "failedToCopyToClipboard": "Falha ao copiar para a área de transferência",
+      "failedToLoadJobResults": "Falha ao carregar os resultados da tarefa",
+      "failedToUpdateRepositoryStatus": "Falha ao atualizar o status do repositório"
+    },
+    "pageTitles": {
+      "appName": "Plano de Teste",
+      "dashboard": "Painel",
+      "twoFactorVerification": "Verificação de dois fatores",
+      "changePassword": "Alterar a senha",
+      "twoFactorSetup": "Configuração de dois fatores",
+      "signUp": "Inscrever-se",
+      "signIn": "Entrar",
+      "verifyEmail": "Verificar e-mail",
+      "trialExpired": "Período de teste expirado",
+      "linkSsoAccount": "Vincular conta SSO",
+      "userProfile": "Perfil do usuário",
+      "users": "Usuários",
+      "issues": "Problemas",
+      "tags": "Etiquetas",
+      "tagDetails": "Detalhes da etiqueta",
+      "aiModels": "Modelos de IA",
+      "integrations": "Integrações",
+      "quickscript": "QuickScript",
+      "webhooks": "Webhooks",
+      "shares": "Ações",
+      "repository": "Repositório",
+      "testCaseVersion": "Versão de caso de teste",
+      "duplicateTestCases": "Casos de teste duplicados",
+      "documentation": "Documentação",
+      "sharedSteps": "Passos Compartilhados",
+      "stepDuplicates": "Etapas duplicadas",
+      "sessions": "Sessões",
+      "sessionVersion": "Versão da sessão",
+      "milestones": "Conquistas",
+      "testRuns": "Testes de execução",
+      "reports": "Relatórios",
+      "adminSamlConfig": "Admin - Configuração SAML",
+      "apiDocumentation": "Documentação da API",
+      "sharedContent": "Conteúdo compartilhado"
+    },
+    "aria": {
+      "userMenu": "Menu do usuário",
+      "search": "Procurar",
+      "helpMenu": "Menu de ajuda",
+      "help": "Ajuda",
+      "grouped": "Agrupados",
+      "group": "Grupo",
+      "selectAll": "Selecionar tudo",
+      "selectRow": "Selecione a linha",
+      "removeIssue": "Remover problema",
+      "selectDeselectAllAddEdit": "Selecionar/Desmarcar Tudo Adicionar/Editar",
+      "selectDeselectAllDelete": "Selecionar/Desmarcar Tudo Excluir",
+      "selectDeselectAllClose": "Selecionar/Desmarcar Tudo Fechar",
+      "clearFilter": "Limpar filtro",
+      "olderVersion": "Versão antiga",
+      "newerVersion": "Nova versão",
+      "deletedUser": "Usuário excluído",
+      "restrictedField": "Campo restrito",
+      "backToTestCase": "Voltar ao caso de teste"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Projeto} other {# Projetos}}",
+      "templates": "Modelos e Campos",
+      "workflows": "Fluxos de trabalho",
+      "statuses": "Status",
+      "roles": "Funções",
+      "unknownRole": "Função desconhecida",
+      "unknownGroup": "Grupo desconhecido",
+      "file": "arquivo",
+      "files": "arquivos",
+      "existingAttachments": "Anexos existentes",
+      "new": "Novo",
+      "noElapsedTime": "Nenhum horário registrado",
+      "untested": "Não testado",
+      "noResults": "Nenhum resultado",
+      "resultsWithNoElapsedTime": "Nenhum horário registrado para os resultados.",
+      "total": "Total",
+      "noCases": "Nenhum caso de teste",
+      "unknown": "Desconhecido",
+      "selectedTestCases": "Casos de teste selecionados",
+      "editToModifyCasesTitle": "Esta lista não pode ser modificada.",
+      "editToModifyCases": "Edite a Execução de Teste e clique em Casos de Teste Selecionados para modificar a lista.",
+      "noTestCasesSelected": "Nenhum caso de teste selecionado",
+      "editToSelectTestCases": "Edite a Execução de Teste para selecionar os casos de teste.",
+      "casesInRun": "{count, plural, =0 {Nenhum caso de teste na execução do teste} =1 {1 caso de teste na execução do teste} other {Número total de casos de teste na execução do teste}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Caso Único} other {Nº de Casos Únicos}} em {configCount, plural, =1 {1 Configuração} other {Nº de Configurações}} ({totalCount} casos totais)",
+      "viewTestRunDetails": "Veja os detalhes da execução do teste.",
+      "sortByStatus": "Agrupar por status",
+      "sortByDate": "Ordenar por data",
+      "testRuns": "{count, plural, =0 {Nenhum teste realizado} =1 {1 teste realizado} other {Número total de testes realizados}}",
+      "sessions": "{count, plural, =0 {Sem sessões} =1 {1 sessão} other {Número de sessões}}",
+      "noOptions": "Nenhuma opção disponível",
+      "multiConfiguration": "Parte de um grupo de múltiplas configurações",
+      "otherConfigurations": "Outras configurações",
+      "selected": "Selecionado: {count}",
+      "defaultProjectAccess": "Acesso ao projeto padrão",
+      "defaultAccessType": "Tipo de acesso padrão",
+      "assignedUsersCount": "{count, plural, =0 {Nenhum usuário atribuído} =1 {# Usuário atribuído} other {# Usuários atribuídos}}",
+      "successRate": "Taxa de sucesso",
+      "unassigned": "Não atribuído",
+      "testRunName": "Nome da Execução de Teste",
+      "estimatesEllipsis": "Estimativas...",
+      "access": {
+        "noAccess": "Sem acesso",
+        "globalRole": "Usar função global",
+        "specificRole": "Função específica",
+        "projectDefault": "Projeto Padrão",
+        "usersGlobalRole": "Função global do usuário"
+      },
+      "unknownUser": "Usuário desconhecido",
+      "unknownProject": "Projeto desconhecido",
+      "unknownTag": "Etiqueta desconhecida",
+      "filesSelectedForUpload": "{count, plural, =1 {1 arquivo selecionado para upload} other {# arquivos selecionados para upload}}"
+    },
+    "empty": {
+      "description": "Sem descrição",
+      "documentation": "Sem documentação",
+      "childMilestones": "Sem marcos do desenvolvimento infantil",
+      "sessions": "Sem sessões",
+      "activeSessions": "Nenhuma sessão ativa",
+      "completedSessions": "Nenhuma sessão concluída",
+      "testCase": "Nenhum caso de teste encontrado",
+      "noTestCasesOrSessions": "Nenhum caso de teste ou sessão encontrada",
+      "noTestCasesSessionsOrRuns": "Não foram encontrados casos de teste, sessões ou execuções."
+    },
+    "or": "ou",
+    "for": "para",
+    "and": "e",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "Logotipo do TestPlanIt",
+      "tagline": "Teste tudo o que existe sob o sol."
+    },
+    "table": {
+      "columns": {
+        "columns": "Colunas",
+        "required": "(obrigatório)"
+      },
+      "filter": "Lista de filtros...",
+      "selectNone": "Não selecionar nenhuma opção.",
+      "sort": "Coluna de classificação",
+      "sortAscending": "Em ordem crescente",
+      "sortDescending": "Em ordem decrescente",
+      "sortNone": "Não resolvido",
+      "resize": "Redimensionar coluna"
+    },
+    "pagination": {
+      "selectPage": "Selecione a página",
+      "morePages": "Mais páginas",
+      "goToPrevious": "Ir para a página anterior",
+      "goToNext": "Acesse a próxima página.",
+      "all": "Todos os itens",
+      "entries": "{count, plural, =1 {# item} other {# itens}}",
+      "pageSize": "Tamanho da página",
+      "showing": "Exibindo",
+      "total": "total {count, plural, =1 {# item} other {# itens}}",
+      "filtered": "filtrado de",
+      "pageOfPages": "Página {current} de {total}"
+    },
+    "upload": {
+      "title": "Carregar nova foto de perfil",
+      "description": "Arraste e solte a sua imagem ou clique no botão abaixo para selecionar um arquivo.",
+      "attachments": {
+        "title": "Carregar anexos",
+        "description": "Arraste e solte seus arquivos ou clique no botão abaixo para selecionar os arquivos.",
+        "selectFiles": "{count, plural, =0 {Selecionar Arquivos} one {1 Arquivo Selecionado} other {Nº de Arquivos Selecionados}}",
+        "selectFile": "{count, plural, =0 {Selecionar Arquivo} other {1 Arquivo Selecionado}}",
+        "filesSelected": "{count, plural, one {1 arquivo selecionado} other {# arquivos selecionados}}",
+        "addMoreFiles": "Adicionar mais arquivos...",
+        "replaceFile": "Substituir arquivo...",
+        "invalidFileType": "Tipo de arquivo inválido. Somente arquivos {types} são permitidos.",
+        "altText": {
+          "emoji": "emoji"
+        },
+        "count": "{count, plural, =1 {# arquivo} other {# arquivos}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Arraste e solte o arquivo CSV para importar os casos de teste.",
+      "dropToImportTestResults": "Arraste e solte o arquivo para importar os resultados do teste.",
+      "supportedCsvFormats": "Formatos suportados: .csv",
+      "supportedResultFormats": "Formatos suportados: .xml, .trx, .json",
+      "unsupportedFileType": "Tipo de arquivo não suportado. Esperado: {expected}",
+      "noFilesDetected": "Nenhum arquivo detectado na pasta drop"
+    },
+    "editor": {
+      "setColor": "Definir cor",
+      "enterUrl": "Insira o URL incluindo https://",
+      "uploadFile": "Carregar arquivo",
+      "video": {
+        "controls": "controles do reprodutor de vídeo"
+      },
+      "image": {
+        "alignLeft": "Alinhar à esquerda",
+        "alignCenter": "Alinhar ao centro",
+        "alignRight": "Alinhar à direita",
+        "sizeSmall": "Tamanho pequeno",
+        "sizeMedium": "Tamanho médio",
+        "sizeLarge": "Tamanho grande",
+        "sizeFull": "Largura total",
+        "resetSize": "Redefinir para o tamanho original",
+        "rotate": "Girar 90°",
+        "delete": "Excluir imagem"
+      },
+      "table": {
+        "insertTable": "Inserir tabela",
+        "headerRow": "Linha de cabeçalho",
+        "addColumnBefore": "Adicionar coluna antes",
+        "addColumnAfter": "Adicionar coluna após",
+        "deleteColumn": "Excluir coluna",
+        "addRowBefore": "Adicionar linha antes",
+        "addRowAfter": "Adicionar linha após",
+        "deleteRow": "Excluir linha",
+        "deleteTable": "Excluir tabela"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Adicione o parágrafo abaixo.",
+        "clearFormatting": "Formatação clara",
+        "copyToClipboard": "Copiar para a área de transferência"
+      },
+      "textMenu": {
+        "bold": "Audacioso",
+        "italic": "itálico",
+        "underline": "Sublinhado",
+        "strikethrough": "Riscado",
+        "code": "Código",
+        "codeBlock": "Bloco de código",
+        "highlightText": "Texto destacado",
+        "textColor": "Cor do texto",
+        "moreOptions": "Mais opções",
+        "subscript": "Subscrito",
+        "superscript": "Sobrescrito",
+        "alignLeft": "Alinhar à esquerda",
+        "alignCenter": "Alinhar ao centro",
+        "alignRight": "Alinhar à direita",
+        "justify": "Justificar",
+        "setLink": "Definir link",
+        "editLink": "Editar link",
+        "removeLink": "Remover link",
+        "resetColorToDefault": "Redefinir cor para o padrão"
+      }
+    },
+    "ai": {
+      "title": "Assistente de escrita com IA",
+      "improveWriting": "Aprimore sua escrita",
+      "makeShorter": "Resumir",
+      "makeLonger": "Aumentar",
+      "fixGrammar": "Corrigir gramática",
+      "changeTone": "Alterar tom",
+      "professional": "Profissional",
+      "casual": "Casual",
+      "formal": "Formal",
+      "translate": "Traduzir",
+      "english": "Inglês",
+      "spanish": "Espanhol",
+      "french": "Francês",
+      "summarize": "Resumir",
+      "addExamples": "Adicionar exemplos",
+      "originalText": "Texto original",
+      "suggestion": "Sugestão de IA",
+      "generating": "Gerando sugestões...",
+      "noSuggestion": "Nenhuma sugestão foi gerada ainda.",
+      "acceptSuggestion": "Aceitar sugestão",
+      "errors": {
+        "contentBlocked": "O conteúdo foi bloqueado pelos filtros de segurança. Por favor, tente reformular sua solicitação com outras palavras.",
+        "emptyContent": "A IA não conseguiu gerar uma resposta. Por favor, tente reformular sua solicitação ou tente novamente mais tarde.",
+        "maxTokens": "A resposta da IA foi muito longa e foi truncada. Por favor, tente fazer uma solicitação mais curta ou peça uma resposta mais concisa.",
+        "rateLimit": "O serviço de IA está temporariamente indisponível devido a limites de taxa. Tente novamente em alguns minutos.",
+        "accessDenied": "Você não tem permissão para usar recursos de IA neste projeto.",
+        "generic": "Desculpe, ocorreu um erro ao processar sua solicitação."
+      }
+    },
+    "by": "por",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Índice",
+        "emptyMessage": "Comece a adicionar títulos ao seu documento …"
+      },
+      "carousel": {
+        "previousSlide": "Slide anterior",
+        "nextSlide": "Próximo slide"
+      },
+      "dialog": {
+        "toggleFullScreen": "Alternar tela cheia"
+      },
+      "command": {
+        "title": "Menu de comandos",
+        "description": "Comandos de busca e execução"
+      },
+      "breadcrumb": {
+        "more": "Mais"
+      },
+      "clickToViewDetails": "Clique para ver os detalhes",
+      "clickToExpand": "Clique para expandir",
+      "clickToCollapse": "Clique para recolher",
+      "search": {
+        "filters": "Filtros",
+        "noResultsFound": "Nenhum resultado encontrado",
+        "loadingProjects": "Carregando projetos...",
+        "noProjectsFound": "Nenhum projeto encontrado.",
+        "viewAllProjects": "Ver todos os projetos",
+        "states": "Estados",
+        "automationStatus": "Status da automação",
+        "parent": "Pais"
+      },
+      "issues": {
+        "errorLoadingDetails": "Detalhes do problema de carregamento: ",
+        "updated": "Atualizado: ",
+        "openInJira": "Abrir no Jira",
+        "openInExternalSystem": "Abrir em {provider}",
+        "assignee": "Cedente",
+        "status": "Status: ",
+        "clickToOpenInNewTab": "Clique para abrir em uma nova aba.",
+        "url": "URL: ",
+        "externalId": "ID externo: ",
+        "viewIn": "Ver em",
+        "fieldType": "Tipo de campo: ",
+        "richTextContent": "Conteúdo de texto rico",
+        "invalidContent": "Conteúdo inválido",
+        "fieldInformation": "Informações de campo"
+      },
+      "onboarding": {
+        "skipTour": "Pular tour"
+      },
+      "charts": {
+        "resultsDistribution": "Distribuição dos resultados",
+        "statusTimeline": "Linha do tempo do status",
+        "testDurationHistogram": "Histograma da duração do teste",
+        "zoomDonutChart": "Gráfico de Rosquinhas com Zoom",
+        "zoomStatusTimeline": "Linha do tempo do status do Zoom",
+        "zoomHistogramChart": "Gráfico de histograma com zoom",
+        "duration": "Duração: {seconds} segundos",
+        "durationLabel": "Duração"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Carregando informações do rastreador de problemas...",
+      "enterDocumentation": "Insira a documentação...",
+      "noAutomatedTestResults": "Nenhum resultado de teste automatizado foi encontrado para esta execução."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {minuto} other {minutos}}",
+      "seconds": "{count, plural, =1 {segundo} other {segundos}}"
+    },
+    "units": {
+      "time": "Tempo"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {caso} other {casos}}",
+      "result": "{count, plural, =1 {resultado} other {resultados}}",
+      "run": "{count, plural, =1 {executar} other {executa}}",
+      "comment": "{count, plural, =1 {{count} comentário} other {{count} comentários}}"
+    },
+    "success": {
+      "assigned": "Caso de teste atribuído com sucesso",
+      "unassigned": "Caso de teste não atribuído com sucesso",
+      "bulkAssigned": "{count, plural, one {# caso de teste} other {# casos de teste}} atribuídos com sucesso",
+      "bulkUnassigned": "{count, plural, one {# caso de teste} other {# casos de teste}} não atribuídos com sucesso"
+    },
+    "tabs": {
+      "general": "Em geral",
+      "settings": "Configurações"
+    },
+    "selectFilter": "Selecione um valor de filtro para visualizar os casos de teste.",
+    "invalidProject": "ID do projeto inválido.",
+    "visualization": "Visualização",
+    "results": "Resultados",
+    "loading": "Carregando..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Criar uma nova conta",
+      "sso": {
+        "title": "Entrar com SSO",
+        "googleOAuth": "Continuar com o Google",
+        "apple": "Continue com a Apple",
+        "microsoft": "Continue com a Microsoft",
+        "samlProvider": "Faça login com {name}",
+        "magicLink": "Faça login com o Magic Link",
+        "emailLogin": "Continuar com o e-mail"
+      },
+      "magicLink": {
+        "description": "Insira seu endereço de e-mail e enviaremos um link seguro para você acessar. Não é necessário senha. Você precisa já ter uma conta.",
+        "emailPlaceholder": "Insira seu e-mail",
+        "sendLink": "Enviar link mágico",
+        "sending": "Enviando...",
+        "checkEmail": "Verifique seu e-mail",
+        "success": "Enviamos um link mágico para {email} caso você tenha uma conta. Clique no link no e-mail para fazer login.",
+        "error": "Não foi possível enviar o link mágico. Tente novamente.",
+        "backToSignIn": "Voltar para a página de login"
+      },
+      "twoFactor": {
+        "title": "Autenticação de dois fatores",
+        "description": "Insira o código de 6 dígitos do seu aplicativo autenticador ou use um código de backup."
+      },
+      "troubleSigningIn": "Problemas com o login?",
+      "contactAdmin": "Contate o administrador do sistema."
+    },
+    "errors": {
+      "accessDenied": "Acesso negado. Sua conta pode estar inativa ou você não tem permissão para fazer login.",
+      "configuration": "Existe um problema com a configuração do servidor.",
+      "verification": "O token de verificação expirou ou já foi utilizado.",
+      "invalid2FACode": "Código de verificação inválido. Tente novamente.",
+      "twoFactorTokenRequired": "É necessário um token.",
+      "verificationCodeRequired": "É necessário um código de verificação."
+    },
+    "signup": {
+      "description": "Insira suas informações para criar uma nova conta.",
+      "signIn": "Faça login na sua conta existente.",
+      "registrationDisabled": "Contate um administrador para criar uma conta.",
+      "errors": {
+        "emailRequired": "É necessário enviar um e-mail.",
+        "passwordRequired": "A senha não atende aos requisitos de segurança.",
+        "confirmPasswordRequired": "É necessário confirmar a senha.",
+        "passwordsDoNotMatch": "As senhas não coincidem.",
+        "domainRestricted": "O cadastro está restrito a domínios de e-mail aprovados. Entre em contato com seu administrador se acreditar que isso é um erro."
+      }
+    },
+    "verifyEmail": {
+      "title": "Verificar e-mail",
+      "loading": "Verificando e-mail...",
+      "success": "E-mail verificado com sucesso",
+      "error": "Falha na verificação do e-mail",
+      "expired": "O link de verificação expirou.",
+      "invalid": "Link de verificação inválido",
+      "alreadyVerified": "E-mail já verificado",
+      "toast": {
+        "verifySuccess": {
+          "description": "Agora você pode acessar sua conta."
+        },
+        "verifyError": {
+          "description": "Ocorreu um erro ao verificar o e-mail."
+        },
+        "resendSuccess": {
+          "title": "Link de verificação por e-mail enviado",
+          "description": "Por favor, verifique seu e-mail para obter o link de verificação."
+        },
+        "resendError": {
+          "title": "Falha ao enviar o link de verificação por e-mail",
+          "description": "Ocorreu um erro ao enviar o link de verificação por e-mail."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Configurar autenticação de dois fatores",
+      "description": "Sua organização exige autenticação de dois fatores. Configure-a para continuar.",
+      "backupDescription": "Salve seus códigos de backup antes de continuar.",
+      "required": "A autenticação de dois fatores é exigida pela política de segurança da sua organização.",
+      "loading": "Preparando a configuração...",
+      "manualEntry": "Ou insira este código manualmente:",
+      "verifyLabel": "Código de verificação",
+      "verify": "Verificar e ativar",
+      "backupCodesInfo": "Guarde esses códigos em um local seguro. Você poderá usá-los para acessar sua conta caso perca seu dispositivo autenticador.",
+      "copyCodes": "Copiar todos os códigos",
+      "continue": "Continuar para iniciar sessão"
+    },
+    "twoFactorVerify": {
+      "title": "Verifique sua identidade",
+      "description": "Digite o código de 6 dígitos do seu aplicativo autenticador para continuar.",
+      "backupCodeLabel": "Código de backup",
+      "backupCodeHint": "Você também pode inserir um código de backup de 8 caracteres.",
+      "useAuthenticator": "Use o código de autenticação em vez disso.",
+      "useBackupCode": "Use um código de backup em vez disso.",
+      "signOut": "Saia da sua conta e use uma conta diferente."
+    },
+    "forceChangePassword": {
+      "title": "Alterar sua senha",
+      "adminDescription": "Seu administrador exige que você altere sua senha.",
+      "expiredDescription": "Sua senha expirou. Por favor, defina uma nova senha para continuar.",
+      "newPasswordLabel": "Nova Senha",
+      "confirmPasswordLabel": "Confirmar nova senha",
+      "submitButton": "Alterar a senha",
+      "signOut": "Em vez disso, faça logout.",
+      "passwordsMustMatch": "As senhas não coincidem.",
+      "passwordRequired": "É necessário usar uma senha.",
+      "genericError": "Ocorreu um erro. Tente novamente.",
+      "policyTitle": "Requisitos de senha:",
+      "policyMinLength": "Pelo menos {count} caracteres",
+      "policyUppercase": "Pelo menos uma letra maiúscula",
+      "policyLowercase": "Pelo menos uma letra minúscula",
+      "policyNumbers": "Pelo menos um número",
+      "policySpecialChars": "Pelo menos um caractere especial ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "Vincular conta SSO",
+      "description": "Vincule sua conta a um provedor de Single Sign-On.",
+      "availableProviders": "Provedores de SSO disponíveis",
+      "linkWithGoogle": "Conectar com o Google",
+      "linkWithSaml": "Link com {name}",
+      "accountLinked": "Conta vinculada com sucesso",
+      "linkingFailed": "Falha ao vincular a conta",
+      "noProvidersAvailable": "Atualmente, não há provedores de SSO disponíveis para vinculação.",
+      "linkingInfo": "Ao vincular um provedor de SSO, você poderá fazer login usando esse provedor em vez da sua senha. Os dados da sua conta atual permanecerão inalterados.",
+      "signInWithGoogle": "Iniciar sessão com o Google",
+      "enterpriseSamlSso": "SSO SAML empresarial",
+      "linkProvider": "Fornecedor de links",
+      "linking": "Conectando...",
+      "noProvidersContactAdmin": "Não há provedores de SSO disponíveis no momento. Entre em contato com o administrador."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Painel",
+      "admin": "Administração",
+      "profile": "Perfil"
+    },
+    "admin": {
+      "crossProjectReports": "Relatórios entre projetos"
+    },
+    "projects": {
+      "sections": {
+        "management": "Gerenciamento"
+      },
+      "menu": {
+        "repository": "Repositório",
+        "runs": "Testes e Resultados"
+      },
+      "dropdown": {
+        "selectProject": "Selecione um projeto",
+        "selectProjectAriaLabel": "Selecione o projeto {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "ID do projeto: {id}",
+      "active": "O projeto está ativo.",
+      "completed": "Projeto concluído"
+    },
+    "overview": {
+      "title": "Visão geral",
+      "currentMilestones": "Marcos atuais",
+      "seeAllMilestones": "{count, plural, =1 {Ver # Marco} other {Ver todos os # Marcos}}",
+      "seeAllTestCases": "{count, plural, =1 {Ver # Caso de Teste} other {Ver todos os # Casos de Teste}}",
+      "latestTestCases": "Casos de teste mais recentes",
+      "createdOn": "Criado em",
+      "seeAllTags": "Ver todas as etiquetas",
+      "seeAllActiveSessions": "{count, plural, =1 {Ver # Sessões Ativas} other {Ver todas as # Sessões Ativas}}",
+      "latestSessions": "Últimas Sessões",
+      "activeTestRuns": "Execuções de teste ativas",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Ver # Execuções de Teste Ativas} other {Ver todas as # Execuções de Teste Ativas}}",
+      "latestTestRuns": "Últimos testes de execução",
+      "testCaseBreakdown": "Análise do caso de teste",
+      "noTestCases": "O repositório do projeto está vazio. Adicione casos de teste usando o repositório.",
+      "noTestCasesPrefix": "O repositório do projeto está vazio. Adicione casos de teste usando o",
+      "noTestCasesLink": "Repositório"
+    },
+    "icon": {
+      "upload": {
+        "title": "Ícone de upload do projeto",
+        "description": "Faça o upload de uma imagem quadrada (proporção 1:1) de até 4 MB.",
+        "errors": {
+          "invalidFileType": "Somente arquivos de imagem são permitidos.",
+          "fileTooLarge": "O arquivo é muito grande. O tamanho máximo é {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Gerenciar configurações para {projectName}",
+      "moreSettingsComingSoon": "Mais configurações em breve",
+      "moreSettingsDescription": "Opções adicionais de configuração do projeto estarão disponíveis aqui em atualizações futuras.",
+      "integrations": {
+        "description": "Gerenciar integrações de problemas de terceiros para este projeto.",
+        "availableIntegrations": "Integrações de problemas disponíveis",
+        "availableDescription": "Selecione uma integração de problema para conectar a este projeto.",
+        "configuredIntegration": "Integração configurada",
+        "noIntegrationAssigned": "Nenhuma integração de problemas atribuída",
+        "noIntegrationDescription": "Selecione uma integração de problema dentre as opções disponíveis para começar.",
+        "selectIntegration": "Selecione uma integração de problema para configurar.",
+        "integration": {
+          "assignError": "Falha ao atribuir a integração de problemas",
+          "updateSuccess": "Configurações de integração atualizadas",
+          "updateError": "Falha ao atualizar as configurações de integração de problemas",
+          "removeError": "Falha ao remover a integração do problema",
+          "removeIntegration": "Remover integração",
+          "confirmRemove": "Confirmar remoção",
+          "authDescription": "Você precisa se autenticar com {provider} para usar esta integração de problemas.",
+          "authenticating": "Autenticando...",
+          "authSuccess": "Autenticação realizada com sucesso.",
+          "selectProject": "Selecione {provider} Projeto",
+          "selectProjectPlaceholder": "Escolha um projeto para vincular.",
+          "linkedProject": "Projeto Vinculado",
+          "loadProjectsError": "Falha ao carregar os projetos",
+          "settingsSaved": "Configurações de integração salvas com sucesso",
+          "saveSettingsError": "Falha ao salvar as configurações de integração do problema",
+          "authorizationRequired": "É necessária autorização.",
+          "authenticationError": "A autenticação falhou. Tente novamente.",
+          "authorizationRequiredDescription": "Você precisa autorizar esta integração de problemas para acessar projetos externos.",
+          "authorizationMessage": "Por favor, autorize a continuidade da integração do problema.",
+          "authorizeIntegration": "Autorizar {name}",
+          "integrationSettings": "{name} Configurações",
+          "integrationSettingsDescription": "Configure as definições de integração de problemas para este projeto.",
+          "selectExternalProject": "Selecione um projeto externo",
+          "refreshProjects": "Atualizar projetos",
+          "defaultIssueType": "Tipo de problema padrão",
+          "selectDefaultIssueType": "Selecione o tipo de problema padrão",
+          "defaultIssueTypeDescription": "Este tipo de problema será pré-selecionado ao criar novos problemas.",
+          "issueTypePlaceholder": "Exemplo: Bug, Tarefa, História",
+          "defaultComponent": "Componente padrão",
+          "componentPlaceholder": "Por exemplo, Frontend, Backend",
+          "automaticSync": "Sincronização automática",
+          "automaticSyncDescription": "Sincronizar automaticamente os problemas entre o TestPlanIt e o sistema externo.",
+          "simpleUrlDescription": "Esta integração de problemas utiliza um padrão de URL simples para criar links para problemas externos. Os problemas serão abertos em uma nova aba usando o padrão de URL configurado.",
+          "externalProjectHelp": "Isso define o projeto padrão para a criação de novas tarefas no TestPlanIt. Você ainda pode vincular e sincronizar tarefas de outros projetos externos — cada tarefa rastreia seu próprio projeto de origem.",
+          "linkedProjects": "Projetos externos vinculados",
+          "linkedProjectsDescription": "Projetos externos conectados por meio dessa integração",
+          "noLinkedProjects": "Nenhum projeto externo vinculado",
+          "noLinkedProjectsDescription": "Adicione um projeto externo para habilitar a busca e sincronização de problemas.",
+          "addProjects": "Adicionar projetos",
+          "addSelected": "Adicionar Selecionado",
+          "setAsDefault": "Definir como padrão",
+          "removeProject": "Remover projeto",
+          "removeProjectConfirmation": "Remover este projeto interromperá a sincronização de tarefas relacionadas a ele. As tarefas sincronizadas anteriormente não serão excluídas. Continuar?",
+          "removeProjectWebhookCascadeBullet": "O webhook de entrada para este projeto também será removido.",
+          "keepProject": "Continue o projeto",
+          "defaultIndicator": "Padrão",
+          "syncStatusSyncing": "Sincronizando",
+          "syncStatusCompleted": "Sincronizado",
+          "syncStatusError": "Erro de sincronização",
+          "fanOutPartialFailure": "Não foi possível acessar {count} projetos. Exibindo resultados de {successCount} projetos.",
+          "projectSelectorLabel": "Projeto",
+          "defaultIssueTypeHelp": "Ao criar novas tarefas no TestPlanIt, esse tipo de tarefa será selecionado automaticamente. Isso economiza tempo se você costuma criar sempre o mesmo tipo de tarefa.",
+          "automaticSyncHelp": "Quando ativada, a sincronização automática de problemas ocorrerá quando forem detectadas alterações no sistema externo (via webhooks). A sincronização manual estará sempre disponível.",
+          "removeWarningTitle": "A remoção dessa integração problemática irá:",
+          "removeWarning1": "Desconecte todos os problemas vinculados a esta integração de problemas (os problemas permanecem no banco de dados).",
+          "removeWarning2": "Remova todas as configurações específicas de integração de problemas para este projeto.",
+          "removeWarning3": "Será necessário reconfigurar se desejar usar novamente esta integração de problemas.",
+          "removeWarning4": "Remova o webhook de entrada configurado para esta integração.",
+          "switchIntegration": "Integração de interruptores",
+          "switchWarningTitle": "A mudança para um modelo de IA diferente irá:",
+          "switchWarning1": "Desconecte todos os problemas atualmente vinculados à integração do problema atual.",
+          "switchWarning2": "Preserve os problemas no banco de dados (eles serão desvinculados).",
+          "switchWarning3": "Substitua a configuração de integração de problemas atual pela nova.",
+          "switchWarning4": "Remova o webhook de entrada configurado para a integração atual."
+        },
+        "integrationAssigned": "Integração atribuída com sucesso",
+        "integrationAssignError": "Falha ao atribuir a integração de problemas ao projeto",
+        "integrationRemoved": "Integração removida com sucesso",
+        "integrationRemoveError": "Falha ao remover a integração de problemas do projeto",
+        "add": {
+          "jira": {
+            "description": "Conecte sua conta Jira para gerenciar problemas diretamente do TestPlanIt."
+          },
+          "simple_url": {
+            "description": "Conecte-se a um sistema de terceiros para rastreamento de problemas."
+          },
+          "github": {
+            "description": "Conecte-se ao GitHub para rastreamento de problemas e gerenciamento de repositórios."
+          },
+          "gitlab": {
+            "description": "Conecte-se ao GitLab para rastrear problemas e solicitações de mesclagem."
+          },
+          "gitea": {
+            "description": "Conecte-se a uma instância auto-hospedada do Gitea, Forgejo ou Gogs para rastreamento de problemas."
+          },
+          "azure_devops": {
+            "description": "Conecte-se ao Azure DevOps para rastrear itens de trabalho."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Configure webhooks de entrada para manter as tarefas vinculadas sincronizadas.",
+        "inboundDescription": "Configure webhooks de entrada para manter as tarefas vinculadas sincronizadas.",
+        "outboundDescription": "Configure webhooks de saída para enviar eventos do TestPlanIt para o Slack ou qualquer URL assinada com HMAC.",
+        "directionInbound": "Entrada",
+        "directionOutbound": "Saída",
+        "inboundAddButtonAllConfigured": "O adaptador de entrada já está configurado.",
+        "inboundAddButtonNoIntegration": "Atribua uma integração de problemas a este projeto antes de adicionar um webhook de entrada.",
+        "inboundEmptyWithIntegration": "Nenhum webhook de entrada configurado. <link>Adicione um</link> para receber atualizações de problemas da sua integração de problemas atribuída.",
+        "inboundEmptyNoIntegration": "É necessário um <link>Issue Integration</link> para receber atualizações de problemas. Atribua um ao seu projeto para começar.",
+        "deliveriesEmptyNoConfigs": "Ainda não há entregas de webhook — crie um webhook de entrada ou de saída nas outras abas para começar a recebê-las.",
+        "noConfig": "Nenhum webhook configurado",
+        "createButton": "Criar webhook",
+        "url": "URL do Webhook",
+        "urlHelp": "Cole este URL na configuração do webhook do sistema de rastreamento de problemas.",
+        "secret": "Segredo do webhook",
+        "secretHelp": "Cole este segredo na configuração do webhook do rastreador de problemas.",
+        "revealedShownOnceWarning": "Copie agora mesmo o URL e a chave secreta abaixo — eles serão exibidos apenas uma vez e não poderão ser recuperados posteriormente.",
+        "secretMasked": "Oculto — gire para visualizar",
+        "rotateSecret": "Segredo de rotação",
+        "rotateConfirmTitle": "Rotacionar o webhook secreto?",
+        "rotateConfirm": "A rotação da chave secreta invalidará a configuração atual no sistema de rastreamento de problemas até que você a atualize lá. Deseja continuar?",
+        "isActive": "Habilitado",
+        "deleteConfirmTitle": "Excluir configuração de webhook?",
+        "deleteConfirm": "Excluir esta configuração de webhook? As entregas de entrada serão rejeitadas.",
+        "sendTest": "Enviar webhook de teste",
+        "testSuccess": "Webhook de teste aceito (HTTP {statusCode}, resultado: {outcome})",
+        "testFailure": "Teste de webhook falhou (HTTP {statusCode}): {error}",
+        "saveError": "Falha ao salvar a configuração do webhook",
+        "lastReceived": "Última recepção: {timestamp}",
+        "lastReceivedLabel": "Última vez recebida:",
+        "lastReceivedNever": "Ainda não há entregas.",
+        "copyUrl": "Copiar URL do webhook",
+        "copySecret": "Copiar segredo do webhook",
+        "urlCopied": "URL do webhook copiada para a área de transferência",
+        "secretCopied": "Senha do webhook copiada para a área de transferência",
+        "nextSteps": "Em seguida: cole essas informações na configuração do webhook do rastreador de problemas e clique em \"Enviar webhook de teste\" abaixo para verificar o pipeline. Clique em \"Concluído\" depois de salvar o segredo — ele não poderá ser exibido novamente.",
+        "revealDone": "Feito",
+        "pageTitle": "Webhooks",
+        "inboundTab": "Entrada",
+        "outboundTab": "Saída",
+        "outboundEmpty": "Nenhum webhook de saída configurado. Adicione um para enviar eventos do TestPlanIt para o Slack ou qualquer URL assinada com HMAC.",
+        "outboundAddButton": "Adicionar webhook de saída",
+        "outboundCreateTitle": "Novo webhook de saída",
+        "outboundCreateName": "Nome",
+        "outboundCreateNameHelp": "Uma etiqueta para este destino, por exemplo, \"Slack de Engenharia\".",
+        "outboundCreateNamePlaceholder": "Slack de Engenharia",
+        "outboundCreateNameRequired": "O nome é obrigatório.",
+        "outboundCreateUrlRequired": "É necessário um URL.",
+        "outboundCreateUrlInvalid": "Insira um URL válido (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "O URL deve usar HTTPS.",
+        "outboundNameLabel": "Nome",
+        "outboundUnnamedConfig": "(webhook sem nome)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "O URL de destino. Os URLs de webhook de entrada do Slack são detectados automaticamente.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Detectado: Slack",
+        "outboundDetectedHmac": "Detectado: HMAC genérico",
+        "adapterLabelSlack": "Slack",
+        "adapterLabelGenericHmac": "Webhook HMAC genérico",
+        "outboundCreateSubscriptionsTitle": "Assinaturas",
+        "outboundCreateSubscriptionsHelp": "Escolha quais eventos serão disparados para este destino. Você poderá alterar isso posteriormente.",
+        "outboundSubsTestRunsAndSessions": "Testes e sessões de avaliação",
+        "outboundSubsTestRuns": "Testes de execução",
+        "outboundSubsSessions": "Sessões",
+        "eventVerbs": {
+          "duplicated": "Duplicado",
+          "stateChanged": "Estado alterado",
+          "resultAdded": "Resultado adicionado"
+        },
+        "events": {
+          "testRunCreated": "Execução de teste criada",
+          "testRunStateChanged": "O estado da execução do teste foi alterado.",
+          "testRunCompleted": "Teste concluído",
+          "testRunDuplicated": "Execução de teste duplicada",
+          "testRunResultAdded": "Resultado do teste adicionado",
+          "sessionCreated": "Sessão criada",
+          "sessionStateChanged": "Estado da sessão alterado",
+          "sessionCompleted": "Sessão concluída",
+          "sessionDuplicated": "Sessão duplicada",
+          "sessionResultAdded": "Resultado da sessão adicionado",
+          "issueCreated": "Problema criado",
+          "issueUpdated": "Problema atualizado",
+          "issueDeleted": "Problema resolvido",
+          "caseCreated": "Caso criado",
+          "caseUpdated": "Caso atualizado",
+          "caseDeleted": "Caso excluído",
+          "jiraIssueCreated": "Problema criado no Jira",
+          "jiraIssueUpdated": "Problema no Jira atualizado",
+          "jiraIssueDeleted": "Problema no Jira excluído",
+          "githubIssues": "Evento de problemas do GitHub",
+          "githubPullRequest": "Solicitação de pull request do GitHub",
+          "githubPush": "Envio do GitHub",
+          "githubIssueComment": "Comentário sobre o problema no GitHub",
+          "adoWorkitemCreated": "Item de trabalho do Azure DevOps criado",
+          "adoWorkitemUpdated": "Item de trabalho do Azure DevOps atualizado",
+          "adoWorkitemDeleted": "Item de trabalho do Azure DevOps excluído",
+          "webhookTest": "Evento de teste"
+        },
+        "outboundSubsIssues": "Problemas",
+        "outboundSubsCases": "Casos",
+        "outboundSubsSelectAll": "Selecione tudo nesta seção",
+        "outboundCreateSubmit": "Criar webhook",
+        "outboundCreateCancel": "Cancelar",
+        "outboundCreateSuccess": "Webhook de saída criado.",
+        "outboundCreateError": "Falha ao criar o webhook de saída.",
+        "outboundUrlLabel": "URL de destino",
+        "outboundActiveToggle": "Ativo",
+        "outboundSlackHint": "Este URL é confidencial — qualquer pessoa que o possua pode publicar no seu canal.",
+        "outboundHmacSecretsTitle": "Assinar segredos",
+        "outboundHmacActiveSecret": "Ativo",
+        "outboundHmacInactiveSecret": "Inativo",
+        "outboundHmacRetiringSecret": "Aposentadoria",
+        "outboundHmacAutoRetireIn": "Aposentadoria automática em {days} dias",
+        "outboundHmacRotateButton": "Segredo de rotação",
+        "outboundHmacExtendButton": "Prorrogar por 7 dias",
+        "outboundHmacRetireNowButton": "Aposente-se agora",
+        "outboundRotateConfirmTitle": "Segredo de assinatura rotativa?",
+        "outboundRotateConfirm": "Uma nova chave secreta ativa é gerada. A chave secreta anterior continua sendo usada para assinaturas por 7 dias enquanto os consumidores atualizam.",
+        "outboundRotateSuccess": "O segredo foi rotacionado. O novo texto simples é mostrado abaixo.",
+        "outboundRotateError": "Falha ao rotacionar o segredo.",
+        "outboundRetireConfirmTitle": "Retirar o segredo agora?",
+        "outboundRetireConfirm": "O segredo desativado para de assinar imediatamente. Os usuários que ainda utilizam o segredo antigo rejeitarão novas cargas úteis.",
+        "outboundRetireSuccess": "Segredo aposentado.",
+        "outboundRetireError": "Não conseguiu aposentar o segredo.",
+        "outboundExtendSuccess": "A aposentadoria automática foi prorrogada por 7 dias.",
+        "outboundExtendError": "Falha ao estender o segredo.",
+        "outboundSendTestButton": "Enviar evento de teste",
+        "outboundSendTestQueued": "Evento de teste enfileirado — verifique o destino da mensagem.",
+        "outboundSendTestError": "Falha ao enfileirar o evento de teste.",
+        "outboundDeleteButton": "Excluir webhook",
+        "outboundDeleteConfirmTitle": "Excluir webhook de saída?",
+        "outboundDeleteConfirm": "Todos os eventos futuros com destino a este local devem cessar imediatamente.",
+        "outboundDeleteSuccess": "Webhook excluído.",
+        "outboundDeleteError": "Falha ao excluir o webhook.",
+        "outboundSecretCopy": "Copiar segredo",
+        "outboundSecretShownOnce": "Guarde este segredo agora — ele não poderá ser mostrado novamente.",
+        "outboundSecretDone": "Feito",
+        "inboundAddButton": "Adicionar webhook de entrada",
+        "inboundChooserTitle": "Escolha o adaptador",
+        "inboundChooserDescription": "Selecione o sistema de rastreamento de problemas que enviará webhooks para o TestPlanIt. Cada projeto pode ter um webhook de entrada do Jira, um do GitHub e um do Azure DevOps.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Já configurado",
+        "inboundChooserSubmit": "Continuar",
+        "inboundChooserCancel": "Cancelar",
+        "inboundEmpty": "Nenhum webhook de entrada configurado. Adicione um para receber atualizações de problemas do Jira, GitHub, GitLab, Gitea ou Azure DevOps.",
+        "inboundJiraTitle": "Webhook de entrada do Jira",
+        "inboundGithubTitle": "Webhook de entrada do GitHub",
+        "inboundGithubScopeHint": "GitHub <code>issues</code> eventos atualizam as issues vinculadas do TestPlanIt. Eventos de pull request e comentários em issues são aceitos, mas ainda não atualizam as issues.",
+        "inboundGitlabTitle": "Webhook de entrada do GitLab",
+        "inboundGitlabScopeHint": "Os eventos do GitLab <code>Issue Hook</code> atualizam as issues vinculadas do TestPlanIt. Outros tipos de eventos são aceitos, mas não atualizam as issues.",
+        "inboundGiteaTitle": "Webhook de entrada Gitea",
+        "inboundGiteaScopeHint": "Gitea <code>issues</code> events atualizam as issues vinculadas do TestPlanIt. Outros tipos de eventos são aceitos, mas não atualizam as issues.",
+        "inboundAdoTitle": "Webhook de entrada do Azure DevOps",
+        "inboundAdoScopeHint": "Os eventos do Azure DevOps <code>workitem.updated</code> atualizam as tarefas vinculadas do TestPlanIt. Outros eventos são aceitos, mas não atualizam as tarefas.",
+        "inboundAdoUsername": "Nome de usuário",
+        "inboundAdoPassword": "Senha",
+        "inboundAdoUsernamePlaceholder": "conta de serviço",
+        "inboundAdoUsernameHelp": "Configurado no lado do Azure DevOps Service Hook. O TestPlanIt verifica isso por meio de autenticação básica HTTP.",
+        "inboundAdoPasswordHelp": "Armazenado criptografado em repouso. Salve também esse valor no lado do gancho de serviço do Azure DevOps.",
+        "inboundAdoResourceDetailsHint": "Ao configurar o gancho de serviço do Azure DevOps, defina 'Detalhes do recurso a serem enviados' = 'Todos' para que System.State seja incluído na carga útil.",
+        "setupStepsTitle": "Etapas de configuração",
+        "setupStepsJiraStep1": "No Jira, acesse Configurações → Sistema → Webhooks (ou a página de configuração de webhooks do seu administrador do Jira).",
+        "setupStepsJiraStep2": "Clique em \"Criar um WebHook\". Cole o URL abaixo no campo URL e o segredo no campo Segredo.",
+        "setupStepsJiraStep3": "Em \"Eventos relacionados ao problema\", marque \"atualizado\" para que as alterações no status do problema sejam enviadas.",
+        "setupStepsJiraStep4": "Salve o webhook. Use \"Enviar webhook de teste\" abaixo para verificar o pipeline.",
+        "setupStepsGithubStep1": "No seu repositório do GitHub, acesse Configurações → Webhooks → Adicionar webhook.",
+        "setupStepsGithubStep2": "Cole o URL abaixo no campo URL do Payload. Defina o tipo de conteúdo como application/json.",
+        "setupStepsGithubStep3": "Cole o segredo abaixo no campo \"Segredo\".",
+        "setupStepsGithubStep4": "Selecione \"Permitir que eu selecione eventos individuais\" e marque \"Problemas\".",
+        "setupStepsGithubStep5": "Clique em \"Adicionar webhook\". Use \"Enviar webhook de teste\" abaixo para verificar o pipeline.",
+        "setupStepsAdoStep1": "No seu projeto do Azure DevOps, acesse Configurações do projeto → Ganchos de serviço → Criar assinatura.",
+        "setupStepsAdoStep2": "Selecione \"Web Hooks\" como serviço. Defina o gatilho como \"Item de trabalho atualizado\".",
+        "setupStepsAdoStep3": "Defina os detalhes do recurso para envio como \"Todos\" para que System.State seja incluído.",
+        "setupStepsAdoStep4": "Cole o URL abaixo no campo de URL. Defina o nome de usuário e a senha da autenticação básica com os valores que você inseriu acima.",
+        "setupStepsAdoStep5": "Salve a assinatura. Use \"Enviar webhook de teste\" abaixo para verificar o pipeline.",
+        "setupStepsGitlabStep1": "No GitLab, acesse seu projeto → Configurações → Webhooks.",
+        "setupStepsGitlabStep2": "Cole o URL abaixo no campo URL. Cole o segredo abaixo no campo Token secreto.",
+        "setupStepsGitlabStep3": "Em \"Gatilho\", marque \"Eventos de problemas\".",
+        "setupStepsGitlabStep4": "Clique em \"Adicionar webhook\". Use \"Enviar webhook de teste\" abaixo para verificar o pipeline.",
+        "setupStepsGiteaStep1": "No Gitea, acesse seu repositório → Configurações → Webhooks.",
+        "setupStepsGiteaStep2": "Clique em \"Adicionar Webhook\" e escolha \"Gitea\".",
+        "setupStepsGiteaStep3": "Cole o URL abaixo no campo \"URL de destino\". Cole o segredo abaixo no campo \"Segredo\".",
+        "setupStepsGiteaStep4": "Em \"Acionar\", selecione \"Problemas\".",
+        "setupStepsGiteaStep5": "Clique em \"Adicionar Webhook\". Use \"Enviar webhook de teste\" abaixo para verificar o pipeline.",
+        "deliveriesTab": "Entregas",
+        "filterConfigPlaceholder": "Todos os webhooks",
+        "filterStatusAll": "Todos",
+        "filterStatusFailed": "Fracassado",
+        "filterStatusSuccess": "Sucesso",
+        "filterSinceDefault": "Desde…",
+        "filterUntilDefault": "Até…",
+        "filterReset": "Redefinir filtros",
+        "filterBulkReplayButton": "Reprodução em massa {count} falhas de saída",
+        "filterBulkReplayHidden": "Todas as falhas visíveis são de entrada — em vez disso, acione novamente o evento upstream.",
+        "deliveriesEmpty": "Nenhuma entrega corresponde a esses filtros.",
+        "deliveriesResetFilters": "Redefinir filtros",
+        "deliveriesLoadMore": "Carregar mais",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Evento",
+        "tableHeaderStatus": "Status",
+        "tableHeaderError": "Erro",
+        "tableHeaderReceivedAt": "Recebido",
+        "tableHeaderAttempt": "Tentar",
+        "tableHeaderDirection": "Direção",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Ver detalhes",
+        "drawerTitle": "Detalhes da entrega",
+        "drawerLabelEvent": "Evento",
+        "drawerLabelDirection": "Direção",
+        "drawerLabelStatusCode": "Código de status",
+        "drawerLabelLatency": "Latência",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Erro",
+        "drawerLabelPayloadDigest": "resumo da carga útil",
+        "drawerLabelEventId": "ID do evento",
+        "drawerLabelAttempt": "Tentar",
+        "drawerLabelReceivedAt": "Recebido em",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Repetição de {id}",
+        "drawerReplayButton": "Reproduza esta entrega",
+        "drawerInboundReplayNotSupported": "As entregas de entrada não podem ser reproduzidas — em vez disso, acione novamente o evento anterior.",
+        "replayConfirmTitle": "Repetir esta entrega?",
+        "replayConfirm": "Isso irá disparar uma solicitação real {direction} {adapterType}.",
+        "replayAction": "Repetição",
+        "bulkReplayConfirmTitle": "Repetir falhas de saída?",
+        "bulkReplayConfirm": "Reproduzir {count} falhas de saída para {configName}? Isso disparará {count} solicitações HTTP reais.",
+        "bulkReplayCapExceeded": "A reprodução em lote é limitada a 100 envios por vez. Refine o filtro ou execute sequencialmente. Atualmente, {count} seria reproduzido.",
+        "bulkReplayAction": "Repetir {count}",
+        "healthBadge": {
+          "HEALTHY": "Saudável",
+          "DEGRADED": "Degradado",
+          "DISABLED": "Desabilitado"
+        },
+        "healthTooltipHealthy": "Último sucesso: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} falhas consecutivas · última em {lastFailureAt}",
+        "healthTooltipDisabled": "Desativado após 10 falhas consecutivas · {lastFailureAt}",
+        "activityLabel": "Atividade de entrega",
+        "activityLastDispatched": "Último envio",
+        "activityLastSuccess": "Último sucesso",
+        "activityLastFailure": "Último fracasso",
+        "activityNever": "Nunca",
+        "reEnable": "Reativar",
+        "reEnableConfirmTitle": "Reativar este webhook?",
+        "reEnableConfirm": "Confirme se o problema no servidor upstream foi resolvido antes de reativar o webhook. O envio de dados será retomado imediatamente.",
+        "toastReplaySuccess": "Repetição enfileirada",
+        "toastReplayFailed": "Falha na reprodução: {error}",
+        "toastReplayInboundNotSupported": "As entregas recebidas não podem ser reproduzidas.",
+        "toastBulkReplaySuccess": "Repetição em massa iniciada · lote {batchId}",
+        "toastBulkReplayFailed": "Falha na reprodução em massa: {error}",
+        "toastReEnableSuccess": "Webhook reativado",
+        "toastReEnableFailed": "Falha ao reativar: {error}"
+      },
+      "aiModels": {
+        "description": "Configure modelos de IA para geração e análise inteligentes de casos de teste.",
+        "availableModels": "Projeto Padrão",
+        "availableModelsDescription": "Escolha um modelo de IA padrão para este projeto dentre os configurados pelo administrador do sistema.",
+        "currentModelSettings": "Configurações atuais do modelo",
+        "currentModelDescription": "Detalhes de configuração do modelo de IA atualmente ativo: {name}",
+        "noModelsAvailable": "Nenhum modelo de IA está disponível no momento. Entre em contato com o administrador do sistema para configurar modelos de IA para sua organização.",
+        "monthlyBudget": "Orçamento mensal",
+        "model": "Modelo",
+        "budget": "Orçamento",
+        "streamingTooltip": "Transmissão de resposta em tempo real ativada",
+        "systemDefault": "Padrão do sistema",
+        "setAsDefault": "Definir como padrão",
+        "clearDefault": "Limpar padrão",
+        "useForProject": "Utilizar para projeto",
+        "removeModel": "Limpar padrão",
+        "removeWarningTitle": "Limpar o modelo de IA padrão irá:",
+        "removeWarning1": "Desative os recursos com inteligência artificial, a menos que as configurações de sobreposição para cada recurso sejam definidas.",
+        "removeWarning2": "Remova o modelo de fallback usado para geração e análise de casos de teste.",
+        "switchModel": "Alterar padrão",
+        "switchWarningTitle": "Alterar o modelo de IA padrão irá:",
+        "switchWarning1": "Alterar o comportamento das funcionalidades de IA neste projeto",
+        "switchWarning2": "Pode afetar a qualidade e o estilo do conteúdo gerado.",
+        "modelAssigned": "Modelo de IA padrão definido para este projeto",
+        "modelAssignError": "Falha ao definir o modelo de IA padrão",
+        "modelRemoved": "Modelo de IA padrão limpo",
+        "modelRemoveError": "Falha ao limpar o modelo de IA padrão",
+        "confirmRemove": "Tem certeza de que deseja limpar \"{name}\" como padrão para este projeto?",
+        "confirmSwitch": "Tem certeza de que deseja alterar o padrão de \"{from}\" para \"{to}\"?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/mo"
+        },
+        "promptConfig": "Configuração de prompts",
+        "promptConfigDescription": "Selecione qual configuração de prompt de IA usar para este projeto.",
+        "useSystemDefault": "Usar as configurações padrão do sistema",
+        "promptConfigChanged": "Configuração do prompt atualizada com sucesso.",
+        "featureOverrides": {
+          "title": "Substituições LLM por recurso",
+          "description": "Substitua a integração padrão do LLM para recursos específicos de IA. As substituições têm a prioridade mais alta na cadeia de resolução.",
+          "feature": "Recurso",
+          "override": "Substituir",
+          "effectiveLlm": "LLM eficaz",
+          "source": "Fonte",
+          "noOverride": "Sem sobreposição",
+          "noLlm": "Sem mestrado em Direito (com deficiência)",
+          "disabledOverride": "Desativado (Substituir)",
+          "projectOverride": "Substituição de projeto",
+          "promptConfig": "Configuração de prompt",
+          "noLlmConfigured": "Nenhum LLM configurado",
+          "selectIntegration": "Selecione a integração...",
+          "overrideSaved": "Substituição de recurso salva",
+          "overrideCleared": "Substituição de recurso desativada",
+          "overrideError": "Falha ao salvar a alteração de recurso."
+        }
+      },
+      "shares": {
+        "title": "Gerenciar ações",
+        "description": "Veja e gerencie todos os links de compartilhamento deste projeto."
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Habilite o QuickScript e conecte um repositório de código para geração de testes assistida por IA.",
+        "enableLabel": "Ativar QuickScript",
+        "enableDescription": " Permitir que os membros da equipe usem o QuickScript para converter casos de teste em scripts de automação neste projeto.",
+        "enabledToast": "QuickScript ativado",
+        "disabledToast": "QuickScript desativado",
+        "noRepos": {
+          "title": "Nenhum repositório de código configurado",
+          "adminDescription": "Configure uma conexão com o repositório antes de configurar o contexto de código para este projeto.",
+          "adminLink": "Acesse os repositórios de código.",
+          "userDescription": "Contate o administrador do sistema para configurar uma conexão com o repositório de código."
+        },
+        "repository": {
+          "title": "Repositório de código",
+          "description": "Selecione o repositório de código a ser usado para o contexto de IA.",
+          "placeholder": "Selecione um repositório de código...",
+          "branchLabel": "Filial",
+          "branchPlaceholder": "Deixe em branco para usar a ramificação padrão do repositório."
+        },
+        "pathPatterns": {
+          "title": "Padrões de Caminho",
+          "description": "Especifique quais arquivos incluir. Cada linha combina um caminho base e um padrão glob. Exemplos: `path=tests/e2e/pages + pattern=*` inclui todos os arquivos diretamente nessa pasta; `path=src + pattern=**/*.test.ts` inclui todos os arquivos de teste recursivamente.",
+          "pathLabel": "Caminho",
+          "pathPlaceholder": "testes/e2e/páginas",
+          "patternLabel": "Padrão",
+          "addPath": "Adicionar caminho",
+          "previewFiles": "Pré-visualização de arquivos",
+          "scanningRepo": "Analisando arquivos do repositório… ({seconds}s)",
+          "files": "{count, plural, one {# arquivo} other {# arquivos}}",
+          "truncatedBadge": "Os resultados podem estar incompletos (limitação do provedor).",
+          "exceedsLimit": "O tamanho total excede o limite do contexto de IA em {overflow}. Durante a exportação, os arquivos são classificados por relevância para o caso de teste que está sendo exportado — os arquivos mais relevantes são incluídos primeiro e os arquivos com classificação inferior são ignorados quando o limite é atingido. Refine seus padrões de caminho se desejar mais controle sobre quais arquivos serão incluídos."
+        },
+        "preview": {
+          "resolvingBranch": "Resolvendo ramificação…",
+          "scanningFiles": "Analisando arquivos em {scope}…",
+          "scanningFilesCount": "Analisando arquivos em {scope}… ({count} encontrado)",
+          "filtering": "Aplicando filtros a {count} arquivos…"
+        },
+        "cache": {
+          "title": "Configurações de cache",
+          "description": "Os arquivos são armazenados em cache no Valkey para acesso rápido durante a geração de IA.",
+          "enableLabel": "Ativar o cache de arquivos",
+          "disabledWarning": "O cache de arquivos está desativado. Os arquivos do repositório serão obtidos diretamente do seu provedor no momento da exportação e não serão armazenados no TestPlanIt. O QuickScript com inteligência artificial ainda incluirá o contexto do código, mas cada exportação fará uma solicitação em tempo real ao seu repositório.",
+          "ttlLabel": "Duração do cache (dias)",
+          "statusTitle": "Estado do cache",
+          "refreshButton": "Atualizar cache",
+          "listingFiles": "Listando arquivos…",
+          "cachingFiles": "Armazenando em cache {count} arquivos…",
+          "statusNeverFetched": "Nunca foi buscado",
+          "statusPending": "Refrescante...",
+          "lastFetched": "Última busca",
+          "filesCached": "Arquivos em cache",
+          "totalSize": "Tamanho total"
+        },
+        "save": "Salvar configuração",
+        "saved": "Configuração do contexto de código salva",
+        "saveError": "Falha ao salvar a configuração",
+        "listError": "Falha ao listar os arquivos do repositório",
+        "contentsError": "Falha ao armazenar em cache o conteúdo do arquivo",
+        "networkError": "Erro de rede durante a atualização do cache",
+        "refreshSuccess": "Cache atualizado: {fileCount} arquivos ({contentCached} conteúdo em cache)",
+        "refreshRateLimited": "Cache atualizado: {fileCount} arquivos listados, {contentCached}/{fileCount} conteúdo em cache (taxa limitada — atualize novamente para concluir)",
+        "validation": {
+          "pathRequired": "O caminho é obrigatório",
+          "patternRequired": "É necessário um padrão.",
+          "repositoryRequired": "É necessário um repositório.",
+          "pathPatternRequired": "É necessário pelo menos um padrão de caminho."
+        },
+        "exportTemplates": {
+          "title": "Exportar modelos",
+          "description": "Atribua modelos de exportação a este projeto. Somente os modelos atribuídos aparecerão na caixa de diálogo de exportação.",
+          "noTemplates": "Nenhum modelo de exportação está habilitado. Contate o administrador do sistema.",
+          "assignedLabel": "Modelos atribuídos",
+          "selectPlaceholder": "Selecione os modelos a serem atribuídos...",
+          "defaultLabel": "Modelo padrão",
+          "defaultPlaceholder": "Nenhum (usar padrão global)",
+          "assigned": "Atribuído",
+          "save": "Salvar atribuições de modelo",
+          "saved": "Atribuições de modelo salvas",
+          "saveError": "Falha ao salvar as atribuições do modelo."
+        },
+        "disconnect": "Desconectar Repositório",
+        "confirmDisconnect": "Tem certeza de que deseja desconectar \"{name}\" deste projeto?",
+        "disconnectWarningTitle": "Desconectar este repositório irá:",
+        "disconnectWarning1": "Remova todos os arquivos de repositório em cache.",
+        "disconnectWarning2": "Remover padrões de caminho e configurações de ramificação",
+        "disconnectWarning3": "Pare de incluir o contexto do código nas exportações geradas por IA.",
+        "disconnectSuccess": "Repositório de código desconectado",
+        "disconnectError": "Falha ao desconectar o repositório de código"
+      }
+    }
+  },
+  "milestones": {
+    "title": "Detalhes do Marco",
+    "fields": {
+      "parent": "Marco dos Pais",
+      "dueDate": "Data de vencimento",
+      "automaticCompletion": "Preenchimento automático na data de vencimento",
+      "notifyDaysBefore": "Avise com alguns dias de antecedência da data prevista para o vencimento.",
+      "notifyDaysBeforeValue": "Notificar {count, plural, one {# dias} other {# dias}} antes da data de vencimento",
+      "dueDateNotifications": "notificações de data de vencimento"
+    },
+    "labels": {
+      "childMilestones": "Marcos do desenvolvimento infantil"
+    },
+    "placeholders": {
+      "description": "Insira a descrição do marco...",
+      "documentation": "Inserir documentação de marcos...",
+      "selectType": "Selecione o tipo de marco...",
+      "selectParent": "Selecione o marco parental..."
+    },
+    "empty": {
+      "active": "Nenhum marco ativo",
+      "completed": "Nenhuma etapa concluída",
+      "description": "Nenhuma descrição fornecida",
+      "documentation": "Nenhuma documentação foi fornecida.",
+      "testRuns": "Sem testes corridos",
+      "forecasts": "Não há dados de previsão disponíveis."
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Não iniciado",
+      "IN_PROGRESS": "Em andamento",
+      "STOPPED": "Parou",
+      "BLOCKED": "Bloqueado",
+      "CANCELLED": "Cancelado",
+      "unscheduled": "Sem horário definido",
+      "upcoming": "Por vir",
+      "delayed": "Atrasado",
+      "pastDue": "Vencido",
+      "started": "Iniciado",
+      "completed": "Concluído"
+    },
+    "status": {
+      "stop": "Parar",
+      "reopen": "Reabrir"
+    },
+    "dates": {
+      "pickStartDate": "Selecione a data de início",
+      "pickCompletionDate": "Selecione a data de conclusão",
+      "selectDate": "Selecione a data...",
+      "completionWarning": "Aviso: Isso marcará a etapa como concluída."
+    },
+    "toast": {
+      "deleted": "Marco {name} excluído",
+      "updated": "Atualização do marco",
+      "updateFailed": "Falha na atualização do marco",
+      "completed": "Marco \"{name}\" concluído.",
+      "completedWithDependencies": "Etapa e dependências concluídas com sucesso."
+    },
+    "errors": {
+      "nameExists": "Já existe um marco com esse nome.",
+      "nameRequired": "O nome do marco é obrigatório.",
+      "notFound": "Marco não encontrado"
+    },
+    "actions": {
+      "add": "Adicionar marco"
+    },
+    "delete": {
+      "title": "Excluir marco",
+      "confirmMessage": "Tem certeza de que deseja excluir o marco {name}?",
+      "warning": "Este marco será removido do projeto. Os dados históricos referentes a este marco permanecerão no projeto.",
+      "toast": {
+        "loading": "Excluindo marco...",
+        "success": "Marco excluído com sucesso",
+        "error": {
+          "title": "Falha ao excluir o marco",
+          "description": "Ocorreu um erro ao excluir o marco."
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Confirmação da conclusão da etapa",
+      "confirmDescription": "A conclusão desta etapa também concluirá os seguintes itens relacionados:",
+      "impactActiveTestRuns": "{count, plural, one {# execução de teste ativa} other {# execuções de teste ativas}}",
+      "impactActiveSessions": "{count, plural, one {# sessão ativa} other {# sessões ativas}}",
+      "impactDescendantMilestones": "{count, plural, one {# marco descendente} other {# marcos descendentes}}",
+      "completeTestRunsLabel": "Concluir execuções de teste associadas ({count, plural, one {# ativo} other {# ativo}})",
+      "completeSessionsLabel": "Sessões Associadas Completas ({count, plural, one {# ativas} other {# ativas}})",
+      "testRunStateLabel": "Estado de conclusão da execução do teste",
+      "sessionStateLabel": "Estado de conclusão da sessão",
+      "itemsRemaining": "Os seguintes itens permanecerão ativos:",
+      "processing": "Processamento...",
+      "confirmAndCompleteAll": "Confirme e conclua tudo."
+    },
+    "notifications": {
+      "dueSoon": "O marco \"{name}\" vence em {dueDate}",
+      "overdue": "O marco \"{name}\" deveria ter sido entregue em {dueDate}"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Sessão} other {Sessões}}",
+    "labels": {
+      "totalElapsed": "Tempo gasto",
+      "remaining": "Restante: {time}",
+      "overtime": "Estimativa acima de: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Nenhuma sessão concluída corresponde ao seu filtro."
+    },
+    "filter": {
+      "placeholder": "Filtrar sessões..."
+    },
+    "actions": {
+      "add": "Adicionar sessão",
+      "create": "Criar nova sessão",
+      "edit": "Sessão de edição",
+      "complete": "Sessão completa",
+      "delete": "Excluir sessão",
+      "viewSessionDetails": "Visualizar sessão"
+    },
+    "noMilestone": "Sem marco",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Nenhum fluxo de trabalho de conclusão está configurado para este projeto. Configure os fluxos de trabalho nas configurações de administração para habilitar a conclusão da sessão."
+    },
+    "messages": {
+      "createSuccess": "Sessão criada com sucesso",
+      "createSuccessMultiple": "{count} Sessões criadas com sucesso",
+      "duplicateSuccess": "Sessão duplicada com sucesso.",
+      "duplicateSuccessMultiple": "{count} Sessões duplicadas com sucesso"
+    },
+    "duplicateDialog": {
+      "title": "Sessão duplicada",
+      "description": "Crie uma cópia da sessão <nameStyle>{name}</nameStyle> com todos os metadados, mas sem resultados."
+    },
+    "errors": {
+      "failedToCreate": "Falha ao criar nova sessão",
+      "failedToCreateVersion": "Falha ao criar a versão da sessão",
+      "nameAlreadyExists": "O nome da sessão já existe. Por favor, escolha um novo nome.",
+      "createFailed": "Falha ao criar sessão",
+      "duplicateFailed": "Falha ao duplicar a sessão"
+    },
+    "validation": {
+      "nameMinLength": "O nome deve ter pelo menos 2 caracteres.",
+      "templateRequired": "Por favor, selecione um modelo.",
+      "maxDuration": "A duração deve ser menor ou igual a {max}."
+    },
+    "placeholders": {
+      "estimate": "Estimativa (ex: 1h 30m)",
+      "elapsed": "Tempo decorrido (ex.: 2 dias e 4 horas)",
+      "selectUser": "Selecionar usuário",
+      "estimateHint": "Exemplo: 2h 30m",
+      "noEstimate": "Nenhuma estimativa definida"
+    },
+    "delete": {
+      "confirmMessage": "Tem certeza de que deseja excluir a sessão {name}?",
+      "warning": "Esta sessão será removida do projeto. Os dados históricos desta sessão permanecerão no projeto.",
+      "toast": {
+        "loading": "Excluindo sessão...",
+        "success": "Sessão encerrada com sucesso",
+        "error": {
+          "title": "Falha ao excluir a sessão",
+          "description": "Ocorreu um erro ao excluir a sessão."
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Tem certeza de que deseja concluir a sessão {name}?",
+      "warning": "Após a conclusão, a sessão será arquivada permanentemente e não poderá mais ser atualizada.",
+      "fields": {
+        "completionDate": "Data de conclusão"
+      },
+      "placeholders": {
+        "pickDate": "Escolha uma data"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Tempo total estimado restante:",
+      "recentResultsTitle": "Resumo dos Resultados Recentes",
+      "recentResultsDescription": "Resumo dos resultados da sessão.",
+      "noRecentResults": "Nenhum resultado de sessão foi registrado recentemente.",
+      "completionTrendTitle": "Tendência de conclusão",
+      "completionTrendDescription": "Sessões concluídas por mês.",
+      "noCompletedRuns": "Nenhuma execução concluída nos últimos 6 meses.",
+      "completionTrendTitle6Mo": "Tendência de conclusão (últimos 6 meses)",
+      "noCompletedSessions6Mo": "Nenhuma sessão concluída nos últimos 6 meses."
+    },
+    "version": {
+      "title": "Visualizar histórico da sessão",
+      "notFound": "Versão da sessão não encontrada.",
+      "selectVersion": "Selecione a versão",
+      "backToSession": "Voltar à sessão",
+      "backToLatest": "Voltar à versão mais recente",
+      "versionInfo": {
+        "created": "Versão {number} Criada",
+        "latestUpdated": "Última versão {number} Atualizada"
+      },
+      "renderer": {
+        "noEstimate": "Sem estimativa",
+        "noTimeLogged": "Nenhum tempo registrado",
+        "noContent": "Sem conteúdo",
+        "currentVersion": "Versão atual",
+        "previousVersion": "Versão anterior"
+      },
+      "diff": {
+        "added": "Adicionado",
+        "removed": "Removido",
+        "changed": "Mudado"
+      }
+    },
+    "results": {
+      "section": "Registro da sessão",
+      "add": "Adicionar resultado da sessão",
+      "edit": "Editar resultado da sessão",
+      "editDescription": "Faça as alterações desejadas no resultado da sessão e clique em Salvar quando terminar.",
+      "details": "Insira aqui os detalhes sobre o resultado...",
+      "noResults": "Nenhum resultado foi adicionado ainda.",
+      "noNotes": "Nenhuma observação adicional para este resultado.",
+      "deleteSuccess": "Resultado da sessão excluído com sucesso",
+      "deleteError": "Falha ao excluir o resultado da sessão",
+      "updateSuccess": "Resultado da sessão atualizado com sucesso",
+      "updateError": "Falha ao atualizar o resultado da sessão",
+      "linkCopied": "Link para o resultado da sessão copiado para a área de transferência",
+      "copyFailed": "Falha ao copiar o link do resultado da sessão",
+      "confirmDelete": {
+        "title": "Excluir resultado da sessão",
+        "description": "Tem certeza de que deseja excluir este resultado da sessão?"
+      }
+    },
+    "notFound": "Sessão não encontrada"
+  },
+  "home": {
+    "dashboard": {
+      "title": "Seu painel de controle",
+      "users": "Há {count, plural, =1 {usuários} other {usuários}}",
+      "yourProjects": "Seus projetos",
+      "projects": "Você tem acesso a {count, plural, =1 {# Projeto} other {# Projetos}}",
+      "loading": "Carregando painel...",
+      "noItems": "Nada que lhe tenha sido atribuído requer atenção neste momento.",
+      "pendingRuns": "Testes pendentes",
+      "activeSessions": "Sessões ativas",
+      "yourActiveSessions": "{count, plural, =0 {Sem sessões ativas} =1 {# Sessões ativas} other {# Sessões ativas}}",
+      "yourPendingRuns": "{count, plural, =0 {Sem execuções de teste pendentes} =1 {# Execuções de teste ativas} other {# Execuções de teste ativas}}",
+      "yourAssignments": "Suas tarefas",
+      "totalTime": "Tempo total estimado: ",
+      "totalWorkEffort": "Esforço total de trabalho: ",
+      "scheduleSpan": "Período de duração do cronograma: "
+    },
+    "initialPreferences": {
+      "title": "Defina suas preferências",
+      "description": "Escolha as configurações padrão que melhor se adaptam a você. Você pode alterá-las a qualquer momento no seu perfil.",
+      "dateFormat": "Formato de data",
+      "timeFormat": "Formato de tempo",
+      "timezonePlaceholder": "Pesquisar fuso horário...",
+      "skip": "Manter padrões",
+      "save": "Salvar preferências",
+      "success": "Preferências atualizadas",
+      "error": "Ocorreu um erro ao salvar suas preferências."
+    },
+    "noAccess": {
+      "title": "Sem acesso ao projeto",
+      "description": "Você não tem acesso a nenhum projeto neste sistema.",
+      "contact": "Contate o administrador do sistema para solicitar acesso aos projetos.",
+      "adminAddProject": "Adicione seu primeiro projeto para começar!",
+      "footer": "É necessário acesso para visualizar e participar das atividades de planejamento de testes."
+    },
+    "noProjectAccess": {
+      "description": "Você não tem acesso a este projeto.",
+      "contact": "Entre em contato com o administrador do seu projeto para solicitar acesso."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Casos de teste} =1 {# Caso de teste} other {# Casos de teste}}",
+      "activeMilestones": "{count, plural, =0 {# Marcos Ativos} =1 {# Marco Ativo} other {# Marcos Ativos}}",
+      "activeRuns": "{count, plural, =0 {# Execuções Ativas} =1 {# Execução Ativa} other {# Execuções Ativas}}",
+      "activeSessions": "{count, plural, =0 {# Sessões Ativas} =1 {# Sessão Ativa} other {# Sessões Ativas}}",
+      "issues": "{count, plural, =0 {# Problemas} =1 {# Problema} other {# Problemas}}"
+    }
+  },
+  "users": {
+    "description": "Gerencie contas de usuário, defina níveis de acesso ao sistema e atribua funções globais.",
+    "filter": "Filtrar usuários...",
+    "profile": {
+      "title": "Perfil do usuário",
+      "edit": {
+        "title": "Editar perfil",
+        "timezonePlaceholder": "Selecione ou pesquise o fuso horário...",
+        "timezoneRequired": "É necessário informar o fuso horário.",
+        "avatarUpdated": "Avatar atualizado com sucesso.",
+        "avatarUpdateError": "Falha ao atualizar o avatar.",
+        "deleteAvatar": "Excluir avatar",
+        "deleteAvatarConfirm": "Tem certeza de que deseja excluir seu avatar?",
+        "emailDisabledForSso": "O endereço de e-mail não pode ser alterado para contas SSO. Atualize-o através do seu provedor de identidade.",
+        "emailEditableForBoth": "Você pode fazer login com e-mail/senha e também com SSO. Alterações no e-mail afetarão apenas a autenticação por senha.",
+        "linkSsoProvider": "Provedor de SSO vinculado"
+      },
+      "preferences": {
+        "title": "Preferências"
+      },
+      "access": {
+        "title": "Acesso"
+      },
+      "notifications": {
+        "title": "Preferências de notificação",
+        "description": "Personalize a forma como você recebe notificações.",
+        "currentGlobal": "Configuração global atual: {mode}",
+        "mode": {
+          "label": "Modo de notificação",
+          "useGlobal": "Usar configurações globais"
+        },
+        "options": {
+          "title": "Opções adicionais",
+          "email": {
+            "label": "Notificações por e-mail",
+            "description": "Receba notificações por e-mail"
+          }
+        },
+        "success": {
+          "title": "Preferências salvas",
+          "description": "Suas preferências de notificação foram atualizadas."
+        },
+        "error": {
+          "description": "Não foi possível salvar as preferências de notificação."
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Alterar a senha",
+        "setPasswordButtonText": "Definir senha",
+        "description": "Digite sua senha atual e uma nova senha para alterar a senha da sua conta. Isso alterará apenas a senha gerenciada internamente. Se você fizer login por meio de SSO (Single Sign-On), essa senha não será alterada.",
+        "setPasswordDescription": "Você fez login via SSO e ainda não definiu uma senha local. Digite uma nova senha para habilitar o login por e-mail/senha para sua conta.",
+        "currentPasswordLabel": "Senha atual",
+        "newPasswordLabel": "Nova Senha",
+        "confirmPasswordLabel": "Confirmar nova senha",
+        "validation": {
+          "passwordsDoNotMatch": "As novas senhas não correspondem.",
+          "newPasswordTooShort": "A nova senha não atende aos requisitos de segurança."
+        },
+        "success": {
+          "passwordChanged": "Senha alterada com sucesso."
+        }
+      },
+      "mentionedComments": {
+        "title": "Mencionado nos comentários",
+        "description": "Comentários onde você é mencionado(a)",
+        "noComments": "Você ainda não foi mencionado(a) em nenhum comentário.",
+        "comment": "Comentário",
+        "showingResults": "Exibindo {start} - {end} de {total}"
+      },
+      "twoFactor": {
+        "enable": "Ative a autenticação de dois fatores (2FA).",
+        "disable": "Desativar",
+        "disableNotAllowed": "A autenticação de dois fatores é exigida pela sua organização.",
+        "ssoBypassNotice": "Os logins SSO ignorarão essa configuração de autenticação de dois fatores (2FA). Entre em contato com o administrador para exigir a 2FA em todos os logins.",
+        "regenerateCodes": "Novos Códigos",
+        "setup": {
+          "description": "Escaneie o código QR com seu aplicativo autenticador (como o Google Authenticator ou o Authy) e insira o código de verificação.",
+          "backupCodesTitle": "Salve seus códigos de backup",
+          "done": "Salvei meus códigos"
+        },
+        "disableConfirm": {
+          "title": "Desativar a autenticação de dois fatores?",
+          "description": "Isso tornará sua conta menos segura. Digite seu código 2FA atual ou um código de backup para confirmar.",
+          "placeholder": "Digite o código"
+        },
+        "regenerate": {
+          "title": "Regenerar códigos de backup",
+          "description": "Isso invalidará seus códigos de backup existentes. Digite seu código 2FA atual para continuar.",
+          "confirm": "Regenerar códigos",
+          "newCodesTitle": "Seus novos códigos de backup",
+          "newCodesDescription": "Seus códigos antigos foram invalidados. Guarde estes novos códigos em um local seguro."
+        }
+      },
+      "apiTokens": {
+        "description": "Os tokens de API permitem que aplicativos e scripts externos acessem o TestPlanIt em seu nome. Os tokens têm as mesmas permissões que sua conta.",
+        "create": "Criar token",
+        "createTitle": "Criar token de API",
+        "createDescription": "Crie um novo token de API para autenticar ferramentas e scripts externos.",
+        "nameLabel": "Nome do token",
+        "namePlaceholder": "Por exemplo, pipeline CI/CD, ferramenta de linha de comando",
+        "noTokens": "Nenhum token de API foi criado ainda.",
+        "expiryLabel": "Data de validade (opcional)",
+        "expiryHint": "Deixe em branco para que não expire.",
+        "tokenCreated": "Token criado",
+        "tokenCreatedDescription": "Seu token de API foi criado com sucesso.",
+        "copyWarning": "Copie este token agora. Você não poderá vê-lo novamente!",
+        "yourToken": "Seu token",
+        "deleteTitle": "Excluir token da API?",
+        "deleteDescription": "Esta ação é irreversível. Quaisquer aplicativos que utilizem este token não poderão mais se autenticar.",
+        "readOnlyLabel": "Somente leitura",
+        "readOnlyDescription": "Utilize para agentes de IA que devem apenas consultar dados, nunca modificá-los.",
+        "agentTokenLabel": "Marcar como token de agente",
+        "agentTokenDescription": "Adicione tags às entradas do log de auditoria com metadata.source: \"mcp\" para que os administradores possam atribuir alterações realizadas por agentes.",
+        "readOnlyBadge": "Somente leitura",
+        "agentTokenBadge": "Token do agente",
+        "errors": {
+          "nameRequired": "O nome do token é obrigatório."
+        }
+      }
+    },
+    "access": {
+      "guest": "Convidado"
+    },
+    "avatar": {
+      "update": "Atualizar avatar",
+      "remove": "Remover avatar",
+      "changeProfilePicture": "Alterar foto de perfil",
+      "notAuthenticated": "Você precisa estar conectado para enviar um avatar."
+    },
+    "deletedUser": "Usuário excluído"
+  },
+  "userMenu": {
+    "viewProfile": "Ver perfil",
+    "locale": "Localidade",
+    "themes": {
+      "light": "Luz",
+      "dark": "Escuro",
+      "system": "Sistema",
+      "green": "Verde",
+      "purple": "Roxo",
+      "orange": "Laranja"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Versão do caso de teste não encontrada.",
+      "detailsRegion": "Detalhes do caso de teste",
+      "metadataRegion": "Metadados do caso de teste",
+      "versionCreated": "Versão {version} Criada",
+      "latestVersionUpdated": "Última versão {version} Atualizada",
+      "historyView": "Visualização do histórico de casos de teste"
+    },
+    "fields": {
+      "optionNotFound": "Opção não encontrada",
+      "hasValue": "Tem valor",
+      "noValue": "Sem valor",
+      "hasDate": "Tem data",
+      "noDate": "Sem data",
+      "hasText": "Contém texto",
+      "noText": "Sem texto",
+      "hasLink": "Possui link",
+      "noLink": "Sem link",
+      "hasSteps": "Possui degraus",
+      "noSteps": "Sem degraus",
+      "unchecked": "Não verificado",
+      "linkedCases": "Casos relacionados",
+      "clickToViewFullContent": "Clique para ver o conteúdo completo."
+    },
+    "steps": {
+      "add": "Adicionar etapa",
+      "addSharedSteps": "Adicionar etapas compartilhadas",
+      "delete": "Excluir etapa",
+      "confirmDelete": "Confirmar exclusão Etapa {number}?",
+      "createSharedSteps": "Criar Compartilhado {number, plural, one {Etapa} other {Etapas}}",
+      "sharedStepsName": "Nome das etapas compartilhadas",
+      "sharedStepsDescription": "Insira um nome para seu novo {number, plural, one {passo} other {passos}}compartilhado. Isso incluirá {number, plural, one {# passo selecionado} other {# passos selecionados}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Selecione as etapas e insira um nome para criar etapas compartilhadas.",
+        "failedToCreateSharedStepGroupError": "Não foi possível criar as etapas compartilhadas. Tente novamente.",
+        "sharedStepGroupCreatedSuccess": "Etapas compartilhadas criadas com sucesso!",
+        "genericSharedStepCreationError": "Ocorreu um erro desconhecido ao criar as etapas compartilhadas. Tente novamente.",
+        "errorCreatingSharedGroup": "Não foi possível criar as etapas compartilhadas. Tente novamente.",
+        "sharedGroupCreatedSuccess": "Grupo de passos compartilhado criado com sucesso!"
+      },
+      "selectSharedStepsTitle": "Selecione Etapas Compartilhadas",
+      "selectSharedStepsDescription": "Selecione etapas compartilhadas para adicionar ao seu caso de teste.",
+      "sharedStepsListPlaceholder": "Carregando etapas compartilhadas...",
+      "sharedStepsNamePlaceholder": "Insira um nome para identificar as etapas compartilhadas.",
+      "noSharedStepsFound": "Não foram encontradas etapas compartilhadas para este projeto.",
+      "sharedStepGroupTitle": "Etapas compartilhadas: {name}",
+      "confirmDeleteSharedStepBlock": "Tem certeza de que deseja remover o bloco de etapas compartilhadas \"{name}\" deste caso de teste? Isso não excluirá o próprio grupo de etapas compartilhadas.",
+      "removeBlockButton": "Remover bloco",
+      "loadingSharedStepsItems": "Etapas de carregamento...",
+      "noStepsInSharedGroup": "Este grupo de etapas compartilhadas está vazio.",
+      "searchSharedStepsPlaceholder": "Selecione etapas compartilhadas...",
+      "stepsCountLabel": "{count, plural, =0 {# etapas} =1 {# etapa} other {# etapas}}",
+      "reviewSelectedStepsTitle": "Revisar etapas selecionadas",
+      "noStepsInSelectedGroup": "O grupo selecionado não possui degraus.",
+      "sharedGroupSuffix": "(Etapas Compartilhadas)",
+      "unnamedSharedGroup": "Degraus compartilhados sem nome"
+    },
+    "testCase": {
+      "toggleAutomated": "Ativar/desativar testes automatizados",
+      "editAttachmentsIndividually": "Edite os anexos individualmente.",
+      "automatedStatus": "Testes automatizados são {status}"
+    },
+    "templateNotAssignedWarning": "Este caso de teste usa o modelo \"{templateName}\" que atualmente não está atribuído ao projeto \"{projectName}\". Pode ser necessário atribuir este modelo ao projeto ou alterar o caso de teste para usar um modelo diferente.",
+    "orphanedStepsWarning": "Este caso de teste possui etapas, mas o modelo atual \"{templateName}\" não inclui o campo Etapas. As etapas não podem ser editadas até que o caso de teste tenha um modelo com um campo Etapas.",
+    "orphanedFieldsWarning": "Este caso de teste tem {count, plural, =1 {# valor de campo} other {# valores de campo}} que {count, plural, =1 {é} other {são}} não incluídos no modelo atual \"{templateName}\". {count, plural, =1 {Este campo é} other {Estes campos são}} mostrados abaixo, mas podem não ser editáveis até serem adicionados ao modelo.",
+    "title": "Repositório de casos de teste",
+    "folders": "Pastas",
+    "showDescendants": "Mostrar todos os descendentes",
+    "addFolder": "Adicionar pasta",
+    "emptyFolders": "Clique no botão Adicionar Pasta acima para adicionar a primeira pasta.",
+    "selectedAllCases": "{count, plural, =0 {Todos os casos selecionados} one {Número de casos selecionados em todas as páginas} other {Número de casos selecionados em todas as páginas}}",
+    "deselectedAllCases": "Desmarquei todos os casos em todas as páginas.",
+    "selectAllTooltip": "Selecione/Desmarque todos os casos nesta página",
+    "selectAllShiftTooltip": "{count, plural, =0 {Selecionar/Desmarcar todos os casos em todas as páginas} one {Selecionar/Desmarcar # casos em todas as páginas} other {Selecionar/Desmarcar # casos em todas as páginas}}",
+    "deselectAllShiftTooltip": "Desmarcar/Selecionar todos os casos em todas as páginas",
+    "shiftClickHint": "Mantenha a tecla Shift pressionada para selecionar/desmarcar todas as páginas.",
+    "treeView": {
+      "expandAll": "Expandir tudo",
+      "collapseAll": "Recolher tudo",
+      "altKey": "Mantenha pressionada a tecla Alt para expandir/recolher todos os filhos."
+    },
+    "dragDrop": {
+      "move": "Mover",
+      "copy": "Cópia",
+      "promptTitle": "O que você gostaria de fazer?",
+      "copying": "Copiando…",
+      "copyComplete": "{count, plural, =1 {Copiou 1 caso para {folder}} other {Copiou # casos para {folder}}}{dest, select, samename {} crossProject { em {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {Movido 1 caso para {folder}} other {Movido # casos para {folder}}}{dest, select, samename {} crossProject { em {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Falha ao copiar 1 caso para {folder}} other {Falha ao copiar # casos para {folder}}}{dest, select, samename {} crossProject { em {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Falha ao mover 1 caso para {folder}} other {Falha ao mover # casos para {folder}}}{dest, select, samename {} crossProject { em {projectName}} other {}}",
+      "copyAlreadyRunning": "Outra cópia já está em andamento. Aguarde até que seja concluída.",
+      "currentSuffix": "(Atual)",
+      "moveDisabledSameFolder": "Os casos já estão nesta pasta.",
+      "dragPreviewCase": "Caso de teste",
+      "dragPreviewCount": "{count, plural, =1 {# caso de teste} other {# casos de teste}}",
+      "modifierHintMac": "Mantenha pressionada a tecla ⇧ para mover ou ⌥ para copiar enquanto arrasta para ignorar este menu.",
+      "modifierHintWin": "Mantenha pressionada a tecla Shift para mover ou Ctrl para copiar enquanto arrasta para ignorar este menu."
+    },
+    "folderActions": {
+      "edit": "Pasta de edição",
+      "delete": "Excluir pasta",
+      "rename": "Renomear pasta"
+    },
+    "cases": {
+      "filter": "Caixas de filtro...",
+      "selectFolder": "Selecione uma pasta para adicionar ou exibir casos de teste.",
+      "selectCases": "Selecionar casos de teste",
+      "noTestCases": "Não há casos de teste para exibir.",
+      "addCase": "Adicionar caso",
+      "notFound": "Caso de teste não encontrado.",
+      "selectFilter": "Selecione o filtro",
+      "testResultHistory": "Histórico de resultados de testes",
+      "testResultHistoryDescription": "Veja o histórico dos resultados dos testes para este caso de teste.",
+      "noTestResults": "Nenhum resultado de teste encontrado para este caso de teste.",
+      "unknownRun": "Execução desconhecida",
+      "attempt": "Tentar",
+      "invalidProject": "Projeto inválido",
+      "noSearchResults": "Nenhum caso corresponde aos seus critérios de pesquisa.",
+      "bulkEdit": "Edição em massa",
+      "createTestRun": "Criar execução de teste",
+      "copyMoveToProject": "Copiar/Mover",
+      "export": "Exportar",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Não é possível reordenar os casos de teste em várias páginas. Para reordená-los, visualize todos os casos em uma única página selecionando \"Todos\" no menu de tamanho da página ou desmarque os casos em outras páginas. Você ainda pode arrastar os casos selecionados para pastas.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Tudo à vista ({count})"
+        },
+        "textLongFormat": {
+          "label": "Formato de texto rico"
+        },
+        "rowMode": {
+          "label": "Linhas de casos de teste",
+          "multi": "Uma única linha por degrau"
+        }
+      },
+      "importWizard": {
+        "title": "Importar casos de teste",
+        "fields": {
+          "workflowState": "Estado do fluxo de trabalho",
+          "column": "Coluna {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# caso de teste} other {# casos de teste}} importados com sucesso"
+        },
+        "errors": {
+          "templateRequired": "É necessário selecionar um modelo.",
+          "folderRequired": "É necessário selecionar uma pasta para este local de importação.",
+          "fileRequired": "É necessário um arquivo CSV ou Markdown.",
+          "markdownParseFailed": "Falha ao analisar o arquivo Markdown",
+          "markdownLlmFailed": "Análise por IA indisponível, usando o analisador padrão."
+        },
+        "page1": {
+          "fileType": {
+            "label": "Tipo de arquivo",
+            "csv": "CSV",
+            "markdown": "Markdown"
+          },
+          "parsingMarkdown": "Analisando arquivo Markdown...",
+          "useAiParsing": "Utilize IA para auxiliar no mapeamento de campo.",
+          "importLocation": {
+            "label": "Local de importação",
+            "singleFolder": "Adicione todos os casos a uma única pasta.",
+            "rootFolder": "Adicione todos os casos e pastas a uma pasta raiz (mapeamento necessário).",
+            "topLevel": "Adicione todos os casos e pastas ao nível superior (mapeamento necessário)."
+          },
+          "selectFolder": "Selecionar pasta",
+          "selectFolderPlaceholder": "Selecione uma pasta...",
+          "delimiters": {
+            "tab": "Aba"
+          },
+          "hasHeaders": "A primeira linha contém os nomes das colunas.",
+          "template": "Modelo de Caso de Repositório",
+          "rowMode": {
+            "single": "Cada linha representa um único caso de teste.",
+            "multi": "Os casos de teste podem abranger várias linhas."
+          }
+        },
+        "page2": {
+          "title": "Mapear colunas CSV para campos",
+          "description": "Mapeie cada coluna do arquivo CSV para um campo no modelo ou opte por ignorá-la.",
+          "ignoreColumn": "Ignorar coluna",
+          "requiredFieldsWarning": "{count, plural, one {# campo obrigatório é} other {# campos obrigatórios são}} não mapeados"
+        },
+        "page3": {
+          "title": "Resumo do Mapeamento de Campo",
+          "mappingSummary": "Resumo do mapeamento",
+          "folderSplitMode": {
+            "label": "Modo de hierarquia de pastas",
+            "plain": "Texto simples (sem divisão)",
+            "plainExample": "Exemplo: 'This/is.a>Folder' → Pasta única chamada 'This/is.a>Folder'",
+            "slash": "Dividido por barra (/)",
+            "slashExample": "Exemplo: 'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "Dividido por ponto (.)",
+            "dotExample": "Exemplo: 'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "Dividir por maior que (>)",
+            "greaterThanExample": "Exemplo: 'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "Pré-visualização Importação",
+          "showing": "Exibindo {start}-{end} de {total} casos",
+          "case": "Caso {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Adicionar caso de teste",
+      "name": "Nome do caso de teste",
+      "namePlaceholder": "Insira o nome do caso de teste",
+      "selectTemplate": "Selecione um modelo",
+      "selectState": "Selecione um estado",
+      "estimatePlaceholder": "Insira o orçamento",
+      "create": "Criar caso de teste",
+      "successMessage": "Novo caso de teste adicionado",
+      "errorMessage": "Erro desconhecido ao adicionar novo caso de teste"
+    },
+    "columns": {
+      "selectCase": "Selecione o caso",
+      "runOrder": "Ordem de execução",
+      "lastTestResult": "Último resultado",
+      "testedOn": "Último teste realizado"
+    },
+    "actions": {
+      "archive": "Arquivo"
+    },
+    "parentFolder": "Pasta principal",
+    "rootFolder": "Pasta raiz",
+    "removeParentFolder": "Remover pasta pai",
+    "createInSelectedFolder": "Reverter para a pasta pai",
+    "deleteCase": {
+      "title": "Excluir caso de teste",
+      "confirmMessageStart": "Tem certeza de que deseja excluir o caso de teste? ",
+      "confirmMessageEnd": "?",
+      "warning": "Este caso de teste será removido do projeto. Os dados históricos referentes a este caso de teste, incluindo os resultados, permanecerão no projeto.",
+      "activeRunWarningMessage": "Este caso de teste faz parte de {count, plural, =1 {# execuções de teste ativas} other {# execuções de teste ativas}}. Excluí-lo o marcará como excluído nessas execuções."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Excluir esta pasta também excluirá todas as subpastas. Tem certeza?} one {Excluir esta pasta também excluirá 1 caso de teste nesta pasta e em todas as subpastas. Tem certeza?} other {Excluir esta pasta também excluirá # casos de teste nesta pasta e em todas as subpastas. Tem certeza?}}",
+      "warning": "Esta pasta e todos os seus casos de teste serão removidos do projeto. Os dados históricos desses casos de teste, incluindo os resultados, permanecerão no projeto.",
+      "confirm": "Confirme a exclusão da pasta",
+      "success": "Pasta e todas as subpastas/caixas foram excluídas com sucesso."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "O nome da pasta já existe. Por favor, escolha um nome diferente."
+      }
+    },
+    "views": {
+      "byAutomation": "Automação",
+      "allTemplates": "Todos os modelos",
+      "allStates": "Todos os estados",
+      "allCreators": "Todos os Criadores",
+      "allCases": "Todos os casos",
+      "allAssignees": "Todos os cessionários",
+      "anyTag": "Qualquer etiqueta",
+      "noTags": "Sem etiquetas",
+      "byTag": "Marcação",
+      "byIssue": "Emitir",
+      "anyIssue": "Algum problema?",
+      "noIssues": "Sem problemas"
+    },
+    "noFoldersTitle": "Ainda não há pastas.",
+    "noFoldersDescription": "Comece criando sua primeira pasta para organizar seus casos de teste.",
+    "noFoldersOrCasesNoPermission": "Não há pastas ou casos de teste para exibir.",
+    "createFirstFolder": "Crie sua primeira pasta",
+    "bulkEdit": {
+      "title": "Edição em massa {count, plural, one {# Caso} other {# Casos}}",
+      "description": "Editando {count, plural, one {# caso selecionado} other {# casos selecionados}}. Marque um campo para habilitar a edição.",
+      "defineStepsTitle": "Defina as etapas para a atualização em massa.",
+      "saveNewSteps": "Salvar novas etapas",
+      "newStepsDefined": "Novas etapas definidas ({count}) - Clique no botão para editar",
+      "clearExistingStepsWarning": "As etapas existentes serão removidas.",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Vários modelos selecionados",
+          "description": "Somente os campos padrão podem ser editados quando casos com modelos diferentes são selecionados. Os campos dinâmicos podem ser editados selecionando casos que utilizam o mesmo modelo."
+        },
+        "junitLimitations": {
+          "title": "Limitações da edição automatizada de casos de teste",
+          "description": "Os campos Estimativa e Automatizado não podem ser modificados para casos de teste importados de resultados de testes automatizados."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Erro ao carregar casos",
+        "fetchErrorDescription": "Não foi possível carregar os dados para os casos selecionados. Feche a janela e tente novamente.",
+        "updateErrorTitle": "Atualização falhou",
+        "updateFailed": "Ocorreu um erro ao salvar as alterações. Verifique os dados e tente novamente.",
+        "fetchError": "Erro ao obter os dados do caso."
+      },
+      "success": {
+        "casesUpdated": "Casos atualizados com sucesso"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Erro de validação",
+      "stepsCannotBeBulkEdited": "Não é possível editar etapas em massa.",
+      "stepsInfoTitle": "Informações sobre os passos",
+      "stepsCannotBeBulkEditedInfo": "Não é possível editar etapas em massa. Edite as etapas editando os casos individualmente.",
+      "confirmDeleteCases": "Tem certeza de que deseja excluir {count, plural, one {# caso selecionado} other {# casos selecionados}}? Esta ação não pode ser desfeita.",
+      "replaceAll": "Substituir tudo",
+      "searchReplace": "Localizar e substituir",
+      "searchFor": "Procurar",
+      "replaceWith": "Substitua por",
+      "searchText": "Digite o texto para pesquisar",
+      "replacementText": "Insira o texto de substituição",
+      "useRegex": "Use expressões regulares",
+      "caseSensitive": "Maiúsculas e minúsculas",
+      "regexHint": "Use .* para quaisquer caracteres, \\d+ para números, \\w+ para palavras. Grupos de captura: (padrão) então use $1, $2, etc.",
+      "preview": "Pré-visualização",
+      "matches": "partidas",
+      "noMatches": "Nenhuma correspondência encontrada",
+      "invalidRegexPattern": "Padrão de expressão regular inválido",
+      "searchPatternRequired": "É necessário um padrão de pesquisa.",
+      "stepsSearchReplaceInfo": "A função de localizar e substituir será aplicada tanto às descrições das etapas quanto aos resultados esperados."
+    },
+    "exportModal": {
+      "title": "Exportar casos de teste",
+      "description": "Selecione suas opções de exportação abaixo.",
+      "scope": {
+        "selected": "Selecionado ({count})",
+        "allFiltered": "Todos (Visualização atual) ({count})",
+        "allProject": "Tudo no Projeto ({count})"
+      },
+      "format": {
+        "label": "Formatar",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Markdown"
+      },
+      "columns": {
+        "all": "Todos",
+        "visible": "Visível"
+      },
+      "delimiter": {
+        "label": "Delimitador",
+        "placeholder": "Selecione o delimitador...",
+        "comma": "Vírgula (,)",
+        "semicolon": "Ponto e vírgula (;)",
+        "colon": "Dois pontos (:)",
+        "pipe": "Tubo (|)"
+      },
+      "textLongFormat": {
+        "label": "Formato de texto longo"
+      },
+      "attachmentFormat": {
+        "label": "Formato do anexo",
+        "names": "Nomes",
+        "json": "JSON",
+        "embedded": "Incorporar imagens"
+      },
+      "stepsFormat": {
+        "label": "Formato de etapas",
+        "plainText": "Texto simples"
+      },
+      "rowMode": {
+        "label": "Linhas por caixa",
+        "single": "Uma única fileira por caixa",
+        "multi": "Várias linhas por etapa"
+      },
+      "comingSoon": "Em breve",
+      "exporting": "Exportador...",
+      "exportError": "A exportação falhou. Tente novamente."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Converta casos de teste selecionados em scripts de automação usando um modelo ou IA.",
+      "templatePlaceholder": "Selecione um modelo...",
+      "searchPlaceholder": "Pesquisar modelos...",
+      "noTemplatesFound": "Nenhum modelo encontrado.",
+      "outputModeLabel": "Modo de saída",
+      "outputModeSingle": "Arquivo único ({count, plural, one {# caso} other {todos os # casos}})",
+      "outputModeIndividual": "{count, plural, one {Arquivo individual (.zip)} other {Arquivos individuais (.zip)}}",
+      "casesToExport": "{count, plural, one {# caso} other {# casos}} para exportar",
+      "exportSuccess": "Exportação concluída com sucesso.",
+      "noAvailableTemplates": "Não há modelos disponíveis. Contate o administrador."
+    },
+    "aiExport": {
+      "toggleLabel": "Gere com IA",
+      "generating": "Gerando...",
+      "generatingProgress": "Gerando caso {current} de {total}...",
+      "generatingBatch": "Gerando {count, plural, one {# caso} other {# casos}} em um arquivo...",
+      "previewTitle": "Pré-visualização da exportação",
+      "previewDescription": "{count, plural, one {# arquivo} other {# arquivos}} gerados",
+      "copySuccess": "Copiado para a área de transferência",
+      "fallbackBadge": "Gerado usando modelo (IA indisponível)",
+      "retryButton": "Tentativa de repetição da geração de IA",
+      "aiGenerated": "Gerado por IA",
+      "templateGenerated": "Modelo gerado",
+      "truncatedWarning": "A saída foi truncada — o modelo atingiu o limite de tokens. Tente reduzir o tamanho do lote ou aumentar o número máximo de tokens de saída na sua configuração de prompts.",
+      "contextFiles": "{count, plural, one {(# arquivo de contexto)} other {(# arquivos de contexto)}}",
+      "noCodeContextHint": "Nenhum repositório de código configurado. A IA usará padrões de framework padrão.",
+      "generatingParallelProgress": "Gerados {done} de {total} arquivos...",
+      "cancelledGeneration": "Cancelado"
+    },
+    "duplicates": {
+      "findDuplicates": "Encontrar duplicados",
+      "viewResults": "Visualizar {count, plural, one {# Resultado} other {# Resultados}}",
+      "retryScan": "Repetir verificação",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Aprimorando resultados com IA...",
+      "scanComplete": "Análise de duplicados concluída — {count, plural, =0 {nenhum duplicado encontrado} one {# possível duplicado encontrado} other {# possível duplicado encontrado}}",
+      "scanFailed": "A análise de duplicados falhou.",
+      "scanFailedDescription": "Ocorreu um erro inesperado.",
+      "pageTitle": "Candidatos duplicados",
+      "pageDescription": "Analise os possíveis casos de teste duplicados encontrados durante a última verificação.",
+      "rescan": "Nova verificação",
+      "cancelScan": "Cancelar digitalização",
+      "loading": "Carregando candidatos duplicados...",
+      "noDuplicatesFound": "Nenhum duplicado encontrado",
+      "noDuplicatesDescription": "Última verificação concluída sem pares correspondentes.",
+      "loadMore": "Carregar mais",
+      "filterPlaceholder": "Filtrar duplicados...",
+      "columnConfidence": "Confiança",
+      "columnCaseA": "Caso A",
+      "columnCaseB": "Caso B",
+      "columnMatchedFields": "Campos correspondentes",
+      "columnScore": "Pontuação",
+      "compareButton": "Comparar",
+      "viewCaseDetails": "Ver detalhes do caso",
+      "selectAll": "Selecionar tudo",
+      "selectRow": "Selecione a linha",
+      "selected": "{count, plural, one {# selecionado} other {# selecionado}}",
+      "bulkDismiss": "Não duplicados ({count})",
+      "bulkLink": "Link como relacionado ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# par dispensado} other {# pares dispensados}}",
+      "bulkLinkSuccess": "{count, plural, one {# par vinculado} other {# pares vinculados}}",
+      "bulkError": "Algumas operações falharam. Por favor, tente novamente.",
+      "tableHint": "Clique em uma linha ou no botão Comparar para revisar e resolver pares duplicados.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "Compare esses possíveis duplicados e escolha como resolvê-los.",
+      "selectPrimary": "Clique em um caso para selecioná-lo como o principal para mesclagem.",
+      "selectedAsPrimary": "Selecionado como Principal",
+      "mergeButton": "Manter Primário",
+      "linkButton": "Link como relacionado",
+      "dismissButton": "Não é uma duplicata",
+      "merging": "Fusão...",
+      "linking": "Conectando...",
+      "dismissing": "Dispensando...",
+      "mergeSuccess": "Casos mesclados com sucesso. {runsTransferred, plural, =0 {Nenhuma execução de teste transferida} one {# execução de teste transferida} other {# execuções de teste transferidas}}.",
+      "linkSuccess": "Casos relacionados.",
+      "dismissSuccess": "Par dispensado. Não aparecerá em futuras digitalizações.",
+      "resolveError": "Não foi possível resolver o problema do par duplicado. Tente novamente.",
+      "loadingDetails": "Carregando detalhes do caso...",
+      "caseDetailsError": "Não foi possível carregar os detalhes do caso.",
+      "sourceLabel": "Fonte",
+      "fieldValuesLabel": "Valores de campo",
+      "lastRunLabel": "Última corrida",
+      "noFieldValues": "Nenhum valor de campo",
+      "noLastRun": "Nunca corra",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Sem pasta",
+      "duplicateWarning": "Possíveis duplicados encontrados",
+      "duplicateWarningDescription": "{count, plural, one {# caso existente} other {# casos existentes}} podem abranger funcionalidades semelhantes",
+      "duplicateWarningReview": "Análise",
+      "importWarning": "Possível duplicado",
+      "importWarningTooltip": "Este nome de caso é semelhante a {count, plural, one {# caso existente} other {# casos existentes}}: {names}",
+      "importIntraWarning": "Duplicado na importação",
+      "importIntraWarningTooltip": "As linhas {rows} nesta importação têm o mesmo nome ou nomes muito semelhantes.",
+      "checkingDuplicates": "Verificando duplicados..."
+    },
+    "generateTestCases": {
+      "buttonText": "Gerar casos de teste",
+      "title": "Gere casos de teste com IA.",
+      "description": "Utilize IA para gerar automaticamente casos de teste abrangentes a partir de problemas ou documentos externos.",
+      "loadingResults": "Carregando casos de teste gerados...",
+      "generatingPreparing": "Preparando solicitação...",
+      "generatingCallingAi": "Aguardando a IA gerar casos de teste...",
+      "generatingStreaming": "A IA está gerando casos de teste {count}...",
+      "generatingStreamingPage": "A IA está gerando o caso de teste {count} — página {current} de {total}: {page}",
+      "generatingProcessing": "Processando casos de teste gerados...",
+      "generatingHint": "Isso pode levar um minuto, dependendo da complexidade do seu material de origem.",
+      "steps": {
+        "selectIssue": "Selecionar fonte",
+        "selectTemplate": "Escolha um modelo",
+        "reviewGenerated": "Análise e Importação"
+      },
+      "selectSource": {
+        "title": "Selecione a fonte de requisitos",
+        "description": "Escolha se deseja gerar casos de teste a partir de um problema ou de um documento de requisitos.",
+        "folderContextTip": "Os casos de teste existentes de \"{folderName}\" e suas pastas pai/filho serão usados como contexto para evitar duplicatas. Certifique-se de ter selecionado a pasta correta antes de prosseguir.",
+        "currentFolder": "pasta atual",
+        "fromIssue": "Da edição",
+        "fromDocument": "Do documento",
+        "documentTitle": "Título do documento",
+        "documentTitlePlaceholder": "Insira o título do seu documento de requisitos.",
+        "documentDescription": "Documento de Requisitos",
+        "documentDescriptionPlaceholder": "Cole aqui o conteúdo do seu documento de requisitos...",
+        "documentPriority": "Prioridade (Opcional)",
+        "selectPriority": "Selecione a prioridade",
+        "saveDocument": "Requisitos para salvar o documento",
+        "fromUrl": "A partir do URL",
+        "recentGenerations": "Tarefas recentes de geração de casos de teste a partir de URLs",
+        "recentJobInfo": "{pages, plural, one {# página} other {# páginas}}{hasTestCases, select, true { · {testCases, plural, one {# caso de teste} other {# casos de teste}}} other {}}",
+        "recentJobHasResults": "Pronto para revisar",
+        "recentJobClickToGenerate": "Clique para gerar casos de teste",
+        "recentJobCrawling": "Rastejando... {pages, plural, one {# página} other {# páginas}} até agora",
+        "removeJobTitle": "Remover geração",
+        "confirmRemoveJob": "Isso removerá o rastreamento em cache e quaisquer casos de teste gerados. Você sempre poderá gerar novamente a partir da mesma URL.",
+        "loadingRecentJobs": "Carregando trabalhos recentes...",
+        "urlInput": "URL da página",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "O que contém este URL?",
+        "urlModeRequirements": "Requisitos",
+        "urlModeRequirementsHint": "A página descreve o que construir.",
+        "urlModeApplication": "Aplicativo",
+        "urlModeApplicationHint": "Page é o aplicativo para testar",
+        "urlValidationError": "Por favor, insira um URL válido que comece com http:// ou https://",
+        "followLinks": "Siga os links",
+        "followLinksHint": "Somente as páginas do mesmo domínio que o URL inserido serão rastreadas.",
+        "maxDepth": "Profundidade máxima",
+        "maxPages": "Número máximo de páginas",
+        "crawlProgress": "{current, plural, one {Páginas buscadas até o momento...} other {Páginas buscadas até o momento...}}",
+        "generatingSinglePage": "Gerando casos de teste...",
+        "generatingSetup": "Preparando para gerar casos de teste...",
+        "robotsSkipped": "{count, plural, one {# página pulada} other {# páginas puladas}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Selecione Problema Externo",
+        "description": "Escolha um problema do seu sistema externo (como o Jira) para gerar casos de teste.",
+        "searchButton": "Pesquisar problemas"
+      },
+      "selectTemplate": {
+        "title": "Escolha um modelo de caso de teste.",
+        "description": "Selecione o modelo que será usado para gerar os casos de teste. A IA preencherá os campos de acordo com esse modelo.",
+        "placeholder": "Selecione um modelo...",
+        "fieldsDescription": "Selecione quais campos a IA deve preencher. Os campos obrigatórios são sempre incluídos.",
+        "requiredOnly": "Somente necessário"
+      },
+      "addNotes": {
+        "title": "Adicionar notas e orientações",
+        "description": "Forneça contexto e orientação adicionais para ajudar a IA a gerar melhores casos de teste.",
+        "quantity": "Número de casos de teste a serem gerados",
+        "placeholder": "Adicione instruções específicas para a geração de casos de teste...\n\nPor exemplo:\n• Concentre-se em testes de segurança\n• Inclua casos extremos e condições de contorno\n• Teste cenários de sucesso e de erro\n• Considere cenários para dispositivos móveis e desktops\n• Concentre-se em testes de API",
+        "suggestions": "Sugestões rápidas:",
+        "quantityOptions": {
+          "justOne": "Apenas um",
+          "couple": "Um casal (2)",
+          "few": "Alguns (2-3)",
+          "several": "Vários (4-6)",
+          "many": "Muitos (7-10)",
+          "maximum": "Máximo"
+        },
+        "suggestionItems": {
+          "security": "Foque em testes de segurança",
+          "edgeCases": "Incluir casos extremos",
+          "happyPath": "Teste apenas o caminho feliz",
+          "mobile": "Considere cenários móveis",
+          "api": "Foque nos testes de API",
+          "accessibility": "Incluir testes de acessibilidade"
+        }
+      },
+      "review": {
+        "title": "Revisão dos casos de teste gerados",
+        "description": "Analise os casos de teste gerados por IA, faça as edições necessárias e selecione quais importar.",
+        "selected": "{count} de {total} selecionados",
+        "moreSteps": "... e {count, plural, one {# mais etapas} other {# mais etapas}}",
+        "templateFields": "Campos do modelo:",
+        "moreFields": "... e {count, plural, one {# mais campos} other {# mais campos}}",
+        "crawledUrls": "{count, plural, one {# páginas rastreadas} other {# páginas rastreadas}}",
+        "spaWarning": "Esta página pode exigir o uso de JavaScript. Os resultados podem estar incompletos.",
+        "filterByPage": "Filtrar por página",
+        "allPages": "Todas as páginas ({pages, plural, one {# página} other {# páginas}}, {cases, plural, one {# caso} other {# casos}})"
+      },
+      "generatingLegacy": "Geração de casos de teste com IA...",
+      "expandProgress": "{done} de {total} gerado",
+      "import": "{count, plural, =0 {Importar casos de teste} =1 {Importar 1 caso de teste} other {Importar # casos de teste}}",
+      "importing": "{count, plural, =0 {Importando casos de teste...} =1 {Importando 1 caso de teste...} other {Importando # casos de teste...}}",
+      "openInExternalSystem": "Abrir em {provider}",
+      "externalSystem": "Sistema externo",
+      "autoGenerateTags": "Gere automaticamente etiquetas para casos de teste.",
+      "success": {
+        "imported": "{count, plural, =1 {Importado com sucesso 1 caso de teste} other {Importados com sucesso # casos de teste}}"
+      },
+      "importData": {
+        "issueDescription": "Problema externo vinculado à geração de casos de teste",
+        "generatedFolderName": "Gerado"
+      },
+      "errors": {
+        "generateFailed": "Falha ao gerar os casos de teste. Tente novamente.",
+        "importFailed": "Falha ao importar os casos de teste. Tente novamente.",
+        "noTestCasesGenerated": "Nenhum caso de teste foi gerado. Tente novamente com entradas diferentes.",
+        "jobNoLongerAvailable": "Esta geração não está mais disponível. Inicie uma nova a partir do assistente Gerar Casos de Teste.",
+        "noAiModel": "Nenhum modelo de IA está configurado para este projeto. Por favor, configure um modelo de IA nas configurações do projeto.",
+        "noIssueSelected": "Selecione um problema para gerar casos de teste.",
+        "noDocumentProvided": "Por favor, forneça os detalhes do documento com os requisitos.",
+        "noTemplateSelected": "Por favor, selecione um modelo para os casos de teste.",
+        "noFieldsSelected": "Selecione pelo menos um campo para o qual deseja gerar conteúdo.",
+        "noTestCasesSelectedForImport": "Selecione pelo menos um caso de teste para importar.",
+        "templateRequired": "É necessário selecionar um modelo. Por favor, volte e selecione um modelo.",
+        "repositoryNotFound": "Repositório do projeto não encontrado. Por favor, entre em contato com o administrador.",
+        "workflowNotConfigured": "Fluxo de trabalho do projeto não configurado. Verifique as configurações do projeto.",
+        "authenticationError": "Erro de autenticação. Atualize a página e tente novamente.",
+        "caseCreationFailed": "Falha ao criar o caso de teste: {name}",
+        "caseAlreadyExists": "O caso de teste \"{name}\" já existe nesta pasta.",
+        "invalidTemplateConfig": "Configuração de modelo inválida para o caso de teste \"{name}\".",
+        "nameTooLong": "O nome do caso de teste \"{name}\" é muito longo. Por favor, use um nome mais curto.",
+        "caseCreationError": "Falha ao criar \"{name}\": {error}",
+        "templateNotFound": "O modelo selecionado não foi encontrado. Atualize a página e tente novamente.",
+        "repositoryConfigError": "Erro na configuração do repositório do projeto. Entre em contato com o administrador.",
+        "workflowConfigError": "Erro na configuração do fluxo de trabalho do projeto. Verifique as configurações do projeto.",
+        "permissionDenied": "Você não tem permissão para criar casos de teste neste projeto.",
+        "validationFailed": "A validação de dados falhou. Verifique o conteúdo do caso de teste e tente novamente.",
+        "databaseError": "Erro de conexão com o banco de dados. Tente novamente em instantes.",
+        "genericImportError": "A importação falhou: {error}",
+        "networkRoutingError": "Problema de roteamento de rede ou configuração do servidor - recebi uma página de erro HTML em vez da resposta da API.",
+        "invalidSourceConfig": "Configuração de origem inválida",
+        "failedToCreateCaseVersion": "Falha ao criar a versão do caso",
+        "noUrlProvided": "Por favor, insira um URL para gerar casos de teste.",
+        "urlFetchFailed": "Não foi possível obter o conteúdo do URL fornecido. Verifique o URL e tente novamente.",
+        "llm": {
+          "genericTitle": "Erro de geração de IA",
+          "genericMessage": "Ocorreu um erro ao gerar os casos de teste com IA. Tente novamente ou ajuste sua entrada.",
+          "overloaded": {
+            "title": "Serviço temporariamente indisponível",
+            "message": "O serviço de IA está com alta demanda no momento. Por favor, tente novamente em alguns instantes."
+          },
+          "quota": {
+            "title": "Limite de uso atingido",
+            "message": "Você atingiu seu limite de uso de IA para este período. Tente novamente mais tarde ou entre em contato com o administrador."
+          },
+          "timeout": {
+            "title": "Tempo limite da solicitação excedido",
+            "message": "A solicitação de IA demorou muito para ser concluída. Isso pode ocorrer com requisitos complexos ou um grande número de casos de teste."
+          },
+          "network": {
+            "title": "Erro de rede",
+            "message": "Não foi possível conectar-se ao serviço de IA. Verifique sua conexão com a internet e tente novamente."
+          },
+          "unauthorized": {
+            "title": "A autenticação do serviço de IA falhou.",
+            "message": "O serviço de IA rejeitou nossas credenciais. Um administrador precisa revisar a chave da API da integração do LLM nas configurações administrativas."
+          },
+          "forbidden": {
+            "title": "Acesso ao serviço de IA negado",
+            "message": "O serviço de IA recusou esta solicitação. Um administrador precisa verificar as permissões de integração do LLM e o acesso ao projeto."
+          },
+          "projectNotFound": {
+            "title": "Projeto não encontrado",
+            "message": "Não foi possível encontrar este projeto, ou você não tem permissão para usar a geração de IA aqui."
+          },
+          "noIntegration": {
+            "title": "Sem integração ativa de LLM",
+            "message": "Nenhuma integração ativa do LLM está configurada para este projeto. Um administrador precisa habilitá-la nas configurações administrativas."
+          },
+          "invalidRequest": {
+            "title": "Solicitação inválida",
+            "message": "A solicitação de geração de IA não continha as informações necessárias. Atualize a página e tente novamente."
+          },
+          "retryButton": "Tentar novamente",
+          "dismissButton": "Liberar",
+          "suggestionsHeading": "Sugestões",
+          "suggestions": {
+            "retryLater": "Tente novamente em alguns minutos.",
+            "contactAdmin": "Se o problema persistir, entre em contato com o administrador.",
+            "checkStatus": "Verifique o status do serviço de IA",
+            "checkNetwork": "Verifique sua conexão com a internet."
+          },
+          "timestampLabel": "Ocorreu um erro em",
+          "showDetails": "Mostrar detalhes",
+          "hideDetails": "Ocultar detalhes",
+          "copyDetails": "Copiar detalhes",
+          "detailsCopied": "Detalhes do erro copiados para a área de transferência"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Edições não salvas",
+        "description": "{count, plural, =1 {Você tem 1 caso de teste com edições não salvas.} other {Você tem # casos de teste com edições não salvas.}}",
+        "warning": "Se você prosseguir sem salvar, suas alterações serão perdidas.",
+        "saveAllAndImport": "Salvar tudo e importar",
+        "discardAndImport": "Descartar edições e importar"
+      },
+      "linkedIssuesDroppedTitle": "Algumas questões relacionadas não foram incluídas.",
+      "linkedIssuesDropped": "{count, plural, =1 {# problema vinculado foi descartado} other {# problemas vinculados foram descartados}} devido ao orçamento de tokens: {keys}.",
+      "linkedIssuesPreviewHeading": "Questões relacionadas que serão incluídas"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Adicionar etiqueta",
+      "title": "Adicionar nova etiqueta",
+      "fields": {
+        "name_error": "O nome da tag é obrigatório."
+      },
+      "errors": {
+        "nameExists": "Já existe uma etiqueta com este nome."
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Já existe uma etiqueta com este nome."
+      }
+    },
+    "filterPlaceholder": "Etiquetas de filtro...",
+    "defaultName": "Etiqueta sem nome",
+    "noProject": "Nenhum projeto",
+    "description": "Gerencie e organize seus casos de teste e sessões com tags.",
+    "detail": {
+      "title": "Detalhes da etiqueta",
+      "filterPlaceholder": "Filtrar itens...",
+      "noResults": "Nenhum item encontrado",
+      "noFilterResults": "Nenhum item corresponde aos filtros atuais.",
+      "filters": {
+        "hideCompletedSessions": "Ocultar sessões concluídas",
+        "hideCompletedTestRuns": "Ocultar execuções de teste concluídas",
+        "caseTypeLabel": "Tipo de caso",
+        "allCases": "Todos"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Etiquetas de pesquisa...",
+      "searchOrAddPlaceholder": "Pesquise ou adicione etiquetas...",
+      "noOptions": "Sem opções"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Visualizador de anexos"
+    },
+    "delete": {
+      "confirmMessage": "Tem certeza de que deseja excluir este anexo?",
+      "deferredMessage": "Este anexo será apagado ao salvar."
+    }
+  },
+  "runs": {
+    "notFound": "Teste de execução não encontrado.",
+    "add": {
+      "title": "Adicionar Execução de Teste",
+      "description": "Adicione uma nova execução de teste ao projeto.",
+      "success": {
+        "title": "Execução de teste adicionada com sucesso",
+        "description": "O teste foi adicionado ao projeto.",
+        "descriptionMultiple": "{count, plural, one {# execução de teste foi} other {# execuções de teste foram}} criadas para '{name}'"
+      },
+      "estimates": {
+        "manual": "Tempo estimado de trabalho manual",
+        "automated": "Tempo estimado de automação",
+        "mixed": "Tempo estimado para processamento manual/automatizado"
+      },
+      "creatingProgress": "Criando execução de teste {current} de {total}..."
+    },
+    "magicSelect": {
+      "title": "Seleção Mágica",
+      "description": "Seleção de casos de teste com inteligência artificial baseada no contexto da sua execução de testes.",
+      "counting": "Procurando por casos de teste relevantes...",
+      "reasoning": "Raciocínio de IA",
+      "reviewSelection": "Analise os casos de teste sugeridos.",
+      "viewSuggested": "Veja os casos sugeridos",
+      "tokenUsage": "{total} tokens usados",
+      "noLlmIntegration": "Os recursos de IA exigem integração com o LLM. Configure uma nas configurações do projeto.",
+      "configure": {
+        "title": "Escopo do Caso de Teste",
+        "description": "Encontrados {count, plural, =1 {# caso de teste} other {# casos de teste}} no repositório",
+        "descriptionFiltered": "Encontrados {count, plural, =1 {# casos de teste possivelmente relevantes} other {# casos de teste possivelmente relevantes}} de {total, plural, =1 {# total} other {# total}} no repositório",
+        "noMatchesTitle": "Nenhum caso de teste correspondente encontrado.",
+        "noMatchesDescription": "O nome e a descrição da execução do teste não correspondem a nenhum caso de teste. Volte à etapa anterior e adicione detalhes mais específicos, como nomes de recursos, nomes de componentes ou palavras-chave que aparecem em seus casos de teste.",
+        "maxResultsTitle": "Número máximo de casos de teste correspondentes",
+        "maxResultsDescription": "Os critérios de pesquisa corresponderam a um grande número de casos de teste. Para resultados mais específicos, volte à etapa anterior e adicione detalhes mais precisos à execução do teste.",
+        "batchSize": "Tamanho do lote",
+        "batchSizeAll": "Todos os casos (pedido único)",
+        "batchSizePercent": "{percent}% ({count} casos)",
+        "requestsNeeded": "{count, plural, =1 {# Solicitação de IA será feita} other {# Solicitações de IA serão feitas}}",
+        "batchNote": "Os resultados de todos os lotes serão combinados."
+      },
+      "loading": {
+        "batch": "Processando lote {current} de {total}",
+        "analyzing": "Analisando casos de teste...",
+        "progress": "Analisados {analyzed} de {total} casos de teste...",
+        "waitingForAi": "Aguardando resposta da IA (lote {batch} de {total})...",
+        "selectedSoFar": "{count, plural, =1 {# casos de teste selecionados até o momento} other {# casos de teste selecionados até o momento}}",
+        "resolving_integration": "Resolvendo a integração da IA...",
+        "fetching_cases": "Buscando casos de teste..."
+      },
+      "success": {
+        "title": "Casos de teste sugeridos",
+        "description": "{count, plural, =1 {# caso de teste selecionado} other {# casos de teste selecionados}} com base no contexto de execução do teste",
+        "linkedCasesAdded": "{count, plural, =1 {# casos vinculados incluídos automaticamente} other {# casos vinculados incluídos automaticamente}}",
+        "truncationWarningTitle": "Resultados parciais",
+        "truncationWarning": "{count, plural, =1 {# lote foi truncado} other {# lotes foram truncados}} pelo modelo de IA — alguns casos de teste podem não ter sido avaliados."
+      },
+      "noSuggestions": {
+        "title": "Nenhum caso de teste correspondente",
+        "description": "Nenhum caso de teste correspondeu aos critérios. Tente adicionar mais contexto ou esclarecimentos."
+      },
+      "clarification": {
+        "label": "Contexto adicional (opcional)",
+        "placeholder": "Adicione contexto adicional para ajudar na seleção de casos de teste relevantes...",
+        "refine": "Refinar seleção"
+      },
+      "actions": {
+        "start": "Analisar casos de teste",
+        "startBatched": "Analisar casos de teste ({count, plural, one {# lote} other {# lotes}})",
+        "accept": "Adicionar à seleção"
+      },
+      "errors": {
+        "title": "Seleção falhou",
+        "generic": "Ocorreu um erro ao selecionar os casos de teste. Tente novamente.",
+        "noTestRunName": "Por favor, insira um nome para a execução do teste antes de usar o Magic Select."
+      }
+    },
+    "delete": {
+      "title": "Excluir Execução de Teste",
+      "description": "Tem certeza de que deseja excluir este teste? Os resultados serão mantidos para análises históricas.",
+      "warning": "Esta ação não pode ser desfeita.",
+      "toast": {
+        "loading": "Excluindo execução de teste...",
+        "success": "Execução de teste excluída com sucesso",
+        "error": {
+          "title": "Falha ao excluir a execução de teste.",
+          "description": "Ocorreu um erro ao excluir a execução de teste."
+        }
+      }
+    },
+    "summary": {
+      "title": "Resumo da Execução do Teste",
+      "description": "Veja o resumo da execução do teste.",
+      "activeRunsAndEstTime": "Corridas ativas e tempo estimado",
+      "activeRunsLabel": "Corridas",
+      "totalEstTime": "Tempo total estimado",
+      "responsibleUsers": "Usuários responsáveis",
+      "allActiveRuns": "Todas as corridas ativas",
+      "recentResultsTitle": "Resultados Manuais Recentes",
+      "recentResultsDescription": "Veja os resultados recentes do teste.",
+      "recentAutomatedResultsTitle": "Resultados automatizados recentes",
+      "noRecentAutomatedResults": "Nenhum resultado automatizado recente encontrado.",
+      "recentResultsDateRange": "Intervalo de datas",
+      "recentResultsElapsed": "Decorrido",
+      "noRecentResults": "Nenhum resultado recente encontrado.",
+      "completionTrendTitle": "Tendência de conclusão (últimos 6 meses)",
+      "workDistributionTitle": "Distribuição do trabalho",
+      "workDistributionDescription": "Distribuição estimada do trabalho por responsável.",
+      "noWorkDistributionData": "Não há sessões ativas com responsáveis ou estimativas para exibir."
+    },
+    "details": {
+      "title": "Detalhes do teste de execução",
+      "description": "Veja os detalhes da execução do teste."
+    },
+    "duplicateDialog": {
+      "title": "Execução de teste duplicada",
+      "description": "Crie uma cópia da execução de teste <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Casos de teste a duplicar",
+          "allCases": "Todos os casos de teste",
+          "specificStatuses": "Casos de teste com status específicos"
+        },
+        "statusesToInclude": {
+          "label": "Casos de teste a incluir",
+          "description": "Selecione os status dos casos de teste que você deseja incluir na execução de teste duplicada.",
+          "noStatuses": "Nenhum status específico foi encontrado nesta execução de teste, ou os resultados ainda estão sendo carregados.",
+          "noStatusesRecorded": "Nenhum status específico foi registrado nesta execução. A duplicação incluirá todos os casos de teste (normalmente como 'Não testado')."
+        },
+        "copyAssignments": {
+          "label": "Atribuições de casos de teste",
+          "copy": "Copiar atribuições de casos de teste existentes",
+          "assign": "Todos os casos de teste na execução de teste duplicada manterão suas atribuições existentes.",
+          "unassign": "Todos os casos de teste na execução de teste duplicada serão desatribuídos."
+        }
+      },
+      "successMessage": "Execução de teste duplicada com sucesso '{name}'.",
+      "errorMessage": "Falha ao duplicar a execução do teste. Erro: {error}"
+    },
+    "filter": {
+      "placeholder": "Execução de testes de filtro..."
+    },
+    "typeFilter": {
+      "label": "Mostrar",
+      "both": "Manual e automatizado"
+    },
+    "empty": {
+      "noMatchingCompleted": "Nenhum teste concluído corresponde ao seu filtro."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Principal",
+      "projects": "Projetos",
+      "templatesAndFields": "Modelos e Campos",
+      "fields": "Campos",
+      "workflows": "Fluxos de trabalho",
+      "statuses": "Status",
+      "milestoneTypes": "Tipos de marcos",
+      "configurations": "Configurações",
+      "users": "Usuários",
+      "groups": "Grupos",
+      "roles": "Funções",
+      "tags": "Etiquetas",
+      "issues": "Problemas",
+      "appConfig": "Configuração do aplicativo",
+      "notifications": "Notificações",
+      "imports": "Importação de dados",
+      "integrations": "Integrações de problemas",
+      "webhooks": "Webhooks",
+      "llm": "Modelos de IA",
+      "prompts": "Configurações de prompt",
+      "exportTemplates": "Exportar modelos",
+      "codeRepositories": "Repositórios de código",
+      "quickScript": "QuickScript",
+      "sso": "Autenticação",
+      "security": "Segurança",
+      "trash": "Lixo",
+      "reports": "Relatórios",
+      "shares": "Gerenciar ações",
+      "elasticsearch": "Mecanismo de busca",
+      "queues": "Filas de Tarefas",
+      "auditLogs": "Registros de auditoria",
+      "apiTokens": "Tokens de API",
+      "quickscriptTemplates": "Modelos QuickScript",
+      "testManagement": "Gestão de Testes",
+      "peopleAndAccess": "Pessoas e Acesso",
+      "toolsAndIntegrations": "Ferramentas e integrações",
+      "system": "Sistema"
+    },
+    "imports": {
+      "description": "Importe dados de ferramentas externas de gerenciamento de testes para o TestPlanIt.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Faça o upload de um arquivo JSON exportado pelo Testmo para analisar seu conteúdo e preparar seu mapeamento de migração.",
+        "wizard": {
+          "steps": {
+            "upload": "Carregar exportação",
+            "analysis": "Análise da revisão",
+            "mapping": "Configurar mapeamento",
+            "import": "Importação de monitoramento"
+          },
+          "stepIndicator": "Etapa {step} de {total}"
+        },
+        "fileLabel": "Arquivo JSON Testmo",
+        "fileHelp": "Selecione o arquivo JSON exportado que você baixou do Testmo.",
+        "analyze": "Analisar exportação",
+        "analyzing": "Analisando...",
+        "reset": "Resultados claros",
+        "job": {
+          "discoveringDatasets": "Descobrindo conjuntos de dados...",
+          "scanningFile": "Analisando o arquivo de exportação do testmo...",
+          "datasetsProcessed": "{processed, number} conjunto de dados{processed, plural, one {} other {s}} processados",
+          "datasetsProcessedWithTotal": "{processed, number} de {total, number} conjunto de dados{total, plural, one {} other {s}} processados",
+          "rowsProcessed": "{value, number} linhas processadas",
+          "itemsProcessed": "{processed, number} de {total, number} itens processados",
+          "analysisInProgress": "Analisando exportação…",
+          "cancel": "Cancelar importação",
+          "cancelRequested": "Cancelar solicitação",
+          "processingRate": "Avaliar:",
+          "estimatedTimeRemaining": "Tempo estimado restante:",
+          "datasetsLabel": "Conjuntos de dados:",
+          "rowsProcessedLabel": "Linhas:"
+        },
+        "summaryHeading": "Resumo da exportação",
+        "summary": {
+          "datasets": "Conjuntos de dados",
+          "fileName": "Nome do arquivo",
+          "fileSize": "Tamanho do arquivo",
+          "analysisTime": "Tempo de análise"
+        },
+        "datasetTable": {
+          "name": "Conjunto de dados",
+          "rows": "Linhas",
+          "samples": "Amostras coletadas"
+        },
+        "status": {
+          "truncated": "Truncado"
+        },
+        "selectDataset": "Selecione o conjunto de dados",
+        "schema": "Esquema",
+        "samples": "Linhas de exemplo",
+        "noSamples": "Nenhuma amostra foi coletada para este conjunto de dados.",
+        "mappingHeading": "Configuração de mapeamento",
+        "mappingRefresh": "Análise de atualização",
+        "mappingDescription": "Analise os detalhes da análise e mapeie as entidades do Testmo para os registros existentes do TestPlanIt ou opte por criar novos.",
+        "mappingAnalysisError": "Não foi possível gerar a análise de mapeamento. Tente novamente.",
+        "mappingLoading": "Análise de mapeamento de edifícios…",
+        "mappingSummaryHeading": "Entidades detectadas",
+        "mappingSummaryPending": "{count, plural, =1 {# pendente} other {# pendente}}",
+        "mappingOutstandingTitle": "Resolver mapeamentos pendentes",
+        "mappingOutstandingDescription": "Conclua os mapeamentos restantes antes de iniciar a importação.",
+        "mappingOutstandingItem": "{count, plural, =1 {# item não resolvido} other {# itens não resolvidos}} em {label}",
+        "mappingSummaryTemplateFields": "Campos do modelo",
+        "mappingDatasetLabels": {
+          "field_values": "Valores de campo",
+          "repository_case_values": "Valores de caso do repositório",
+          "configs": "Configurações",
+          "session_issues": "Problemas de sessão",
+          "session_tags": "Etiquetas de sessão",
+          "states": "Estados do fluxo de trabalho",
+          "statuses": "Status",
+          "templates": "Modelos",
+          "template_fields": "Campos do modelo",
+          "milestone_types": "Tipos de marcos",
+          "roles": "Funções",
+          "users": "Usuários",
+          "groups": "Grupos",
+          "user_groups": "Grupos de usuários",
+          "issue_targets": "Integrações de problemas",
+          "tags": "Etiquetas",
+          "sessions": "Sessões",
+          "session_results": "Resultados da sessão",
+          "fields": "Campos",
+          "projects": "Projetos",
+          "repositories": "Repositórios",
+          "repository_folders": "Pastas do repositório",
+          "repository_cases": "Casos de repositório",
+          "repository_case_steps": "Etapas do caso do repositório",
+          "repository_case_tags": "Etiquetas de caso do repositório",
+          "milestones": "Conquistas",
+          "runs": "Testes de execução",
+          "run_tests": "Casos de teste",
+          "run_results": "Resultados do teste",
+          "run_result_steps": "Resultados da etapa de execução do teste",
+          "run_links": "Links de teste",
+          "run_tags": "Tags de execução de teste",
+          "issues": "Problemas",
+          "milestone_issues": "Questões importantes",
+          "repository_case_issues": "Problemas com casos de repositório",
+          "run_issues": "Problemas na execução do teste",
+          "run_result_issues": "Problemas com os resultados da execução do teste",
+          "session_result_issues": "Problemas com os resultados da sessão",
+          "automation_cases": "Casos de automação",
+          "automation_runs": "Execução de automação",
+          "automation_run_tests": "Testes de execução automatizada",
+          "automation_run_test_fields": "Campos de teste de execução automatizada",
+          "automation_run_links": "Links de execução de automação",
+          "automation_run_tags": "Etiquetas de execução de automação",
+          "session_values": "Valores da sessão"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Analise os estados do fluxo de trabalho para mapear ou criar fluxos de trabalho do TestPlanIt.",
+          "statuses": "Configure como os status do Testmo são mapeados para os status do TestPlanIt.",
+          "templates": "Revisar definições de modelos importadas do Testmo.",
+          "template_fields": "Inspecione as definições dos campos do modelo incluídos na exportação.",
+          "fields": "Analise os registros de campos personalizados que foram exportados do Testmo.",
+          "field_values": "Inspecione as definições de valores de campo capturadas na exportação.",
+          "milestone_types": "Inspecione as definições dos tipos de marcos capturadas na exportação.",
+          "roles": "Analise as definições de funções para compreender as permissões do Testmo.",
+          "users": "Veja as contas de usuário detectadas na exportação do Testmo.",
+          "groups": "Revisar tarefas de grupo transferidas do Testmo.",
+          "configs": "Mapear nomes de configuração para categorias e variantes do TestPlanIt.",
+          "tags": "Inspecione os valores das tags que aparecem nos dados do Testmo.",
+          "repository_case_values": "Valores de seleção múltipla atribuídos aos casos de teste.",
+          "sessions": "As sessões são sempre criadas como novas sessões.",
+          "session_results": "Os resultados das sessões estão relacionados às sessões.",
+          "session_issues": "Problemas de sessão estão relacionados às sessões.",
+          "session_tags": "As tags de sessão estão associadas às sessões.",
+          "issue_targets": "Mapeie os destinos de problemas do Testmo para as integrações do TestPlanIt (Jira, GitHub, etc.)."
+        },
+        "mappingDatasetDefaultDescription": "Revisão {dataset} detectada na exportação do Testmo.",
+        "mappingDatasetCount": "{count, number} registro{count, plural, one {} other {s}} detectado",
+        "mappingDatasetNoEntitiesTitle": "Nada para mapear",
+        "mappingDatasetNoEntitiesDescription": "Este conjunto de dados não requer mapeamento. Passe para o próximo conjunto de dados quando estiver pronto.",
+        "mappingDatasetUnsupportedTitle": "Não é necessário mapeamento.",
+        "mappingDatasetUnsupportedDescription": "Esses registros serão importados automaticamente e conectados aos seus respectivos registros no TestPlanIt. Não é necessário mapeamento manual.",
+        "mappingDatasetEmptyTitle": "Nenhum conjunto de dados foi preservado.",
+        "mappingDatasetEmptyDescription": "A análise não preservou nenhum conjunto de dados para configuração. Envie uma exportação diferente se precisar de dados adicionais.",
+        "importProgressTitle": "Progresso da importação",
+        "importProgressDescription": "{count, plural, =0 {Todos os registros importados entre as entidades rastreadas.} =1 {1 registro restante entre as entidades rastreadas.} other {Número de registros restantes entre as entidades rastreadas.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Nenhum registro restante} =1 {1 registro restante} other {Número de registros restantes}}",
+        "importProgressProcessed": "{processed, number}/{total, number} registros importados",
+        "importProgressAria": "{percent}% de importação concluída",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Tempo total:",
+        "activityLogTitle": "Atividade de importação",
+        "activityLogDescription": "Registro detalhado das etapas de importação em segundo plano. Os registros de data e hora são baseados no fuso horário do servidor.",
+        "activitySummaryProcessed": "{count, plural, =1 {# registros processados} other {# registros processados}}",
+        "activitySummaryCreated": "{count, plural, =1 {# criado} other {# criado}}",
+        "activitySummaryMapped": "{count, plural, =1 {# mapeado} other {# mapeado}}",
+        "activitySummaryUnknown": "Etapa de importação",
+        "activityDefaultMessage": "Atualização de importação",
+        "previousImportsHeading": "Analisar importações anteriores",
+        "previousImportsDescription": "A análise de carga resulta de uma importação concluída para inspecionar os registros de configuração ou de atividade.",
+        "previousImportsRefresh": "Atualizar lista",
+        "previousImportsPlaceholder": "Selecione uma importação anterior",
+        "previousImportsEmpty": "Nenhuma importação anterior foi encontrada para sua conta.",
+        "previousImportsCreatedLabel": "Criado: ",
+        "previousImportsFileLabel": "Arquivo: ",
+        "previousImportsNoFilename": "Arquivo desconhecido",
+        "jobHistoryLoadFailed": "Não foi possível carregar os trabalhos importados anteriormente.",
+        "jobLoadFailed": "Não foi possível carregar essa tarefa de importação.",
+        "uploadProgressAnalyzing": "Upload concluído. Analisando arquivo…",
+        "uploadProgressComplete": "Upload concluído",
+        "etaLabel": "ETA: {time}",
+        "startImportButton": "Iniciar importação",
+        "workflowCreate": {
+          "nameLabel": "Nome do fluxo de trabalho",
+          "namePlaceholder": "Insira o nome do fluxo de trabalho.",
+          "scopePlaceholder": "Selecione o escopo",
+          "iconColorLabel": "Ícone e cor",
+          "typeLabel": "Tipo de fluxo de trabalho"
+        },
+        "mappingDatasets": "Conjuntos de dados que requerem revisão",
+        "mappingImportConfiguration": "Importar configuração",
+        "mappingExportConfiguration": "Exportar configuração",
+        "mappingImportConfigurationFailed": "Não foi possível importar esse arquivo de configuração. Verifique se ele é um JSON válido e tente novamente.",
+        "mappingInvalidConfiguration": "A configuração deve ser um JSON válido.",
+        "mappingSaveFailed": "Não foi possível salvar a configuração. Tente novamente.",
+        "mappingSaveConfiguration": "Salvar configuração",
+        "mappingSavingConfiguration": "Salvando…",
+        "mappingStartImport": "Iniciar importação em segundo plano",
+        "mappingStartingImport": "Iniciando a importação…",
+        "mappingImportFailed": "Não foi possível iniciar a importação em segundo plano. Tente novamente.",
+        "mappingImportDisabled": "Salve a configuração antes de iniciar a importação em segundo plano.",
+        "mappingImportInProgress": "Importação em segundo plano em andamento",
+        "mappingImportInProgressDescription": "O processo de importação está processando a configuração. Você pode acompanhar o status acima.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# registro} other {# registros}} ",
+          "columnSource": "Entidade Testmo",
+          "columnSourceDetails": "Detalhes",
+          "columnSuggestedWorkflowType": "Tipo sugerido",
+          "columnTarget": "Alvo",
+          "workflowTypeUnknown": "Não detectado",
+          "actionMap": "Mapa para o existente",
+          "actionCreate": "Criar novo",
+          "workflowTypePlaceholder": "Selecione o tipo",
+          "noWorkflowsAvailable": "Nenhum fluxo de trabalho disponível.",
+          "noStatusesAvailable": "Nenhum status disponível.",
+          "noGroupsAvailable": "Não há grupos disponíveis.",
+          "groupSelectPlaceholder": "Selecionar grupo",
+          "groupNotePlaceholder": "Notas (opcional)",
+          "groupNoteEmpty": "Nenhuma informação adicional foi fornecida.",
+          "noUsersAvailable": "Nenhum usuário disponível.",
+          "userNoExistingTargets": "Nenhum usuário disponível para mapear.",
+          "userNamePlaceholder": "Nome completo",
+          "userAccessPlaceholder": "Selecione o nível de acesso",
+          "userRoleUnavailable": "Não há funções disponíveis para atribuir.",
+          "userPasswordPlaceholder": "Senha temporária",
+          "userPasswordHint": "Forneça uma senha temporária. Os usuários poderão alterá-la após fazerem login.",
+          "userActiveLabel": "Conta ativa",
+          "userDisplayFallback": "Usuário {id}",
+          "userMissingRequired": "Detalhes obrigatórios ausentes",
+          "noConfigurationsAvailable": "Nenhuma configuração disponível.",
+          "configurationNoTokens": "Nenhuma variante detectada nesta configuração.",
+          "configurationNoExistingTargets": "Nenhuma configuração disponível para mapear.",
+          "configurationNamePlaceholder": "Insira um nome de configuração",
+          "configurationVariantLabel": "Variante {index}",
+          "configurationVariantActionLabel": "Como essa variante deve ser tratada?",
+          "configurationVariantActionPlaceholder": "Escolha uma opção",
+          "configurationVariantMapOption": "Mapear para variante existente",
+          "configurationVariantExistingCategoryOption": "Criar variante em categoria existente",
+          "configurationVariantNewCategoryOption": "Criar nova categoria e variante",
+          "configurationVariantSelectLabel": "Selecione a variante",
+          "configurationVariantNoVariants": "Nenhuma variante disponível para mapear.",
+          "configurationVariantCategoryLabel": "Categoria",
+          "configurationVariantNameLabel": "Nome da variante",
+          "configurationVariantNamePlaceholder": "Insira um nome de variante",
+          "configurationVariantNoCategories": "Nenhuma categoria disponível.",
+          "configurationVariantCategoryNameLabel": "Nome da categoria",
+          "configurationVariantCategoryNamePlaceholder": "Digite o nome de uma categoria",
+          "noTemplateFieldsAvailable": "Nenhum campo de modelo disponível.",
+          "templateFieldDisplayFallback": "Campo {id}",
+          "templateFieldUnknownTemplate": "Modelo desconhecido",
+          "templateFieldTargetCase": "Campo de caso",
+          "templateFieldTargetResult": "Campo de resultado",
+          "templateFieldSelectPlaceholder": "Selecione o campo",
+          "templateFieldNoExistingTargets": "Não há campos disponíveis para mapear.",
+          "templateFieldTypePlaceholder": "Selecione o tipo de campo",
+          "templateFieldRestrictedLabel": "Campo restrito",
+          "templateFieldOptionsLabel": "Opções suspensas",
+          "templateFieldOptionsPlaceholder": "Insira uma opção por linha",
+          "templateFieldOptionsHint": "Separe cada opção com uma nova linha.",
+          "templateFieldOptionsListLabel": "Opções",
+          "templateFieldOptionsCheckedLabel": "Marcado por padrão",
+          "templateFieldOptionsMinValueLabel": "Valor mínimo",
+          "templateFieldOptionsMaxValueLabel": "Valor máximo",
+          "templateFieldOptionsMinIntegerLabel": "Número inteiro mínimo",
+          "templateFieldOptionsMaxIntegerLabel": "Número inteiro máximo",
+          "templateFieldNewFieldSummaryTitle": "Novos detalhes do campo",
+          "templateFieldNewFieldSummaryDescription": "Analise os valores que serão usados para criar este campo do TestPlanIt.",
+          "templateFieldConfigureFieldButton": "Detalhes da configuração",
+          "templateFieldEditFieldButton": "Editar detalhes",
+          "templateFieldSummaryMissingValue": "Não definido",
+          "templateFieldSummaryMissingDetailsHint": "Forneça os detalhes do novo campo antes de prosseguir.",
+          "templateFieldModalSaveButton": "Salvar detalhes",
+          "templateFieldTargetTypeLabel": "Tipo de alvo",
+          "templateFieldTypeMismatchWarning": "O tipo de campo selecionado {target} não corresponde ao tipo de campo Testmo {source}.",
+          "templateFieldDuplicateTargetWarning": "O alvo selecionado já está mapeado para outro campo do Testmo. Escolha um alvo diferente.",
+          "templateFieldTargetAlreadyUsed": "Já mapeado",
+          "templateFieldMappedSummary": "Mapeado para {name} ({type})",
+          "templateFieldIssueMissingTarget": "Selecione um campo de destino.",
+          "templateFieldIssueMissingDetails": "Antes de prosseguir, forneça o nome de exibição, o nome do sistema e o tipo de campo.",
+          "noTemplatesAvailable": "Nenhum modelo disponível.",
+          "templateColumnFields": "Campos",
+          "templateFieldStatusMapped": "Mapeado",
+          "templateFieldStatusCreate": "Criar novo campo",
+          "templateFieldStatusMissing": "Não mapeado",
+          "templateFieldStatusMismatch": "Incompatibilidade de alvo",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# campo case} other {# campos case}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# campo de resultado} other {# campos de resultado}}",
+          "templateMapLabel": "Mapear para modelo existente",
+          "templateCreateLabel": "Criar novo modelo",
+          "templateNoMatchingTargets": "Não existem modelos correspondentes.",
+          "templateNewNameLabel": "Nome do modelo",
+          "templateMapHintIncomplete": "Mapeie todos os campos do Testmo para os campos de caso e resultado existentes antes de mapeá-los para um modelo existente.",
+          "templateMapHintDuplicate": "Cada campo do Testmo deve corresponder a um campo único do TestPlanIt.",
+          "templateMapHintNoMatch": "Nenhum modelo existente utiliza o mesmo conjunto de campos.",
+          "templateMapHintAlreadyMapped": "Todos os modelos correspondentes já estão mapeados. Limpe os outros mapeamentos antes de continuar.",
+          "templateIssueNoSelection": "Selecione um modelo existente para mapear.",
+          "templateIssueTargetConflict": "Outro modelo já está mapeado para este destino.",
+          "templateIssueFieldErrors": "Resolva os campos do modelo destacados.",
+          "templateTargetFieldsMismatch": "Os campos não correspondem a este modelo.",
+          "templateTargetNoLongerMatching": "Os campos não correspondem mais a este modelo.",
+          "noRolesAvailable": "Não há vagas disponíveis.",
+          "roleSelectPlaceholder": "Selecione a função",
+          "roleNameLabel": "Nome do cargo",
+          "roleNamePlaceholder": "Insira o nome da função",
+          "rolePermissionsEmpty": "Nenhuma permissão atribuída",
+          "rolePermissionAddEdit": "Adicionar/Editar",
+          "noMilestoneTypesAvailable": "Não há tipos de marcos disponíveis.",
+          "milestoneSelectPlaceholder": "Selecione o tipo de marco",
+          "milestoneNamePlaceholder": "Insira um nome para o tipo de marco.",
+          "milestoneDefaultLabel": "Tipo de marco padrão",
+          "milestoneIconRequired": "Selecione um ícone",
+          "statusColorPlaceholder": "Código hexadecimal da cor (opcional)",
+          "issueTargetSelectPlaceholder": "Selecione a integração...",
+          "noIssueTargetsAvailable": "Não há integrações disponíveis.",
+          "issueTargetNamePlaceholder": "Nome da integração...",
+          "templateFieldsHeading": "Campos de modelo",
+          "roleAreaColumn": "Área",
+          "workflowSelectPlaceholder": "Selecione o fluxo de trabalho",
+          "statusSelectPlaceholder": "Selecione o status",
+          "statusNamePlaceholder": "Insira um nome de status",
+          "statusSystemNamePlaceholder": "Digite o nome do sistema",
+          "labelSystemName": "Nome do sistema",
+          "groupNamePlaceholder": "Digite o nome do grupo",
+          "configurationNameLabel": "Nome da configuração",
+          "userSelectPlaceholder": "Selecionar usuário",
+          "userApiLabel": "Usuário da API",
+          "templateCaseFieldsLabel": "Campos do caso",
+          "templateResultFieldsLabel": "Campos de resultado",
+          "templateNoFieldsPlaceholder": "Nenhum campo configurado para este modelo.",
+          "templateTargetAlreadyUsed": "O destino já está mapeado para outro modelo.",
+          "templateFieldRequiredLabel": "Campo obrigatório",
+          "templateFieldOptionsDefaultValueLabel": "Valor padrão",
+          "templateFieldOptionsInitialHeightLabel": "Altura inicial",
+          "templateFieldTemplateLabelSingular": "modelo",
+          "templateFieldTemplateLabelPlural": "modelos",
+          "templateFieldTargetGroupCase": "Campos do caso",
+          "templateFieldTargetGroupResult": "Campos de resultado",
+          "columnAction": "Ação"
+        },
+        "nextSteps": "Após a conclusão da importação em segundo plano, você poderá revisar os dados migrados dos projetos de destino.",
+        "nextStepsDescription": "As importações em segundo plano são executadas de forma assíncrona. Você pode monitorar o status acima ou atualizar a página para visualizar as atualizações."
+      },
+      "comingSoon": {
+        "description": "A importação de ferramentas como TestRail, Zephyr e outras está nos planos futuros."
+      },
+      "errors": {
+        "fileRequired": "Por favor, selecione um arquivo JSON de exportação do Testmo antes de analisar.",
+        "uploadFailed": "Não foi possível enviar o arquivo de exportação para o armazenamento. Tente novamente.",
+        "analysisFailed": "Não foi possível analisar essa exportação. Verifique o arquivo e tente novamente."
+      }
+    },
+    "sso": {
+      "description": "Gerenciar configurações de autenticação e segurança",
+      "sections": {
+        "providers": {
+          "title": "Fornecedores de login",
+          "description": "Configure como os usuários podem fazer login no seu aplicativo."
+        },
+        "security": {
+          "title": "Segurança",
+          "description": "Configure as políticas de segurança para autenticação."
+        }
+      },
+      "globalSettings": {
+        "title": "Configurações globais de SSO",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Ativar ou desativar a autenticação OAuth do Google"
+        },
+        "samlProvider": {
+          "title": "Provedor SAML",
+          "description": "Ativar ou desativar a autenticação SAML"
+        },
+        "apple": {
+          "title": "Iniciar sessão com a Apple",
+          "description": "Ativar ou desativar a autenticação de início de sessão da Apple."
+        },
+        "microsoft": {
+          "title": "SSO da Microsoft",
+          "description": "Ativar ou desativar a autenticação da Microsoft (Azure AD / Entra ID)."
+        },
+        "magicLink": {
+          "title": "Autenticação Magic Link",
+          "description": "Ativar ou desativar a autenticação sem senha baseada em e-mail."
+        },
+        "forceSso": {
+          "title": "Forçar login SSO",
+          "description": "Desative o login por e-mail e exija que os usuários usem o SSO (Single Sign-On)."
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Exigir autenticação de dois fatores (2FA) para logins com senha.",
+            "description": "Usuários que acessarem o sistema com e-mail/senha deverão configurar e utilizar a autenticação de dois fatores."
+          },
+          "forceAllLogins": {
+            "title": "Exigir autenticação de dois fatores para todos os logins.",
+            "description": "Todos os usuários devem realizar a autenticação de dois fatores (2FA) após o login, incluindo usuários com SSO (Single Sign-On)."
+          }
+        }
+      },
+      "providers": {
+        "configure": "Configurar SAML",
+        "delete": "Excluir provedor",
+        "entryPoint": "Ponto de entrada: ",
+        "autoProvision": "Provisionamento automático: ",
+        "defaultAccess": "Acesso padrão: ",
+        "configurationMessage": "A configuração SAML não está definida. Clique no botão de configurações para configurar."
+      },
+      "samlConfiguration": {
+        "title": "Configurar o provedor SAML",
+        "backButton": "Voltar para Provedores de SSO",
+        "description": "Configure as definições SAML para {name}",
+        "samlSettings": {
+          "title": "Configurações SAML",
+          "description": "Configure as definições do seu provedor de identidade SAML.",
+          "ssoUrl": "URL de SSO (Ponto de Entrada)",
+          "entityId": "ID da entidade (emissor)",
+          "certificate": "Certificado X.509",
+          "callbackUrl": "URL de retorno de chamada",
+          "logoutUrl": "URL de logout (opcional)"
+        },
+        "userProvisioning": {
+          "title": "Provisionamento de usuários",
+          "description": "Configure como os usuários são criados e mapeados.",
+          "autoProvision": "Provisionar novos usuários automaticamente",
+          "defaultAccess": "Acesso padrão do sistema para novos usuários",
+          "accessDescription": "Os novos usuários receberão a função padrão do banco de dados e este nível de acesso ao sistema."
+        },
+        "attributeMapping": {
+          "title": "Mapeamento de Atributos",
+          "description": "Mapear atributos SAML para campos de usuário",
+          "email": "Atributo de e-mail",
+          "displayName": "Atributo de nome de exibição",
+          "userId": "Atributo de ID do usuário",
+          "firstName": "Atributo de nome (opcional)",
+          "lastName": "Atributo Sobrenome (Opcional)",
+          "groups": "Atributo de grupos (opcional)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "OAuth do Google ativado",
+        "googleDisabled": "OAuth do Google desativado",
+        "googleCreated": "Provedor OAuth do Google criado",
+        "googleUpdateFailed": "Falha ao atualizar o OAuth do Google",
+        "samlCreated": "provedor SAML criado",
+        "createFailed": "Falha ao criar o provedor",
+        "deleted": "Fornecedor excluído",
+        "deleteFailed": "Falha ao excluir o provedor",
+        "enabled": "Provedor habilitado",
+        "disabled": "Provedor desativado",
+        "updateFailed": "Falha ao atualizar o provedor",
+        "forceSsoEnabled": "Forçar SSO ativado globalmente",
+        "forceSsoDisabled": "Forçar SSO desativado globalmente",
+        "forceSsoUpdateFailed": "Falha ao atualizar a configuração de SSO forçado.",
+        "force2FANonSSOEnabled": "Autenticação de dois fatores obrigatória para logins com senha.",
+        "force2FANonSSODisabled": "A autenticação de dois fatores não é mais necessária para logins com senha.",
+        "force2FAAllLoginsEnabled": "Autenticação de dois fatores obrigatória para todos os logins.",
+        "force2FAAllLoginsDisabled": "A autenticação de dois fatores não é mais obrigatória para todos os logins.",
+        "force2FAUpdateFailed": "Falha ao atualizar a configuração de autenticação de dois fatores",
+        "configUpdated": "Configuração SAML atualizada",
+        "configCreated": "Configuração SAML criada",
+        "configSaveFailed": "Falha ao salvar a configuração SAML",
+        "googleConfigSaved": "Configuração do Google OAuth salva com sucesso.",
+        "googleConfigFailed": "Falha ao salvar a configuração",
+        "appleEnabled": "Iniciar sessão com a Apple ativado",
+        "appleDisabled": "Iniciar sessão com a Apple desativado",
+        "appleCreated": "Provedor de login da Apple criado",
+        "appleConfigSaved": "Configuração de início de sessão da Apple salva com sucesso.",
+        "appleConfigFailed": "Falha ao salvar a configuração de início de sessão da Apple.",
+        "appleUpdateFailed": "Falha ao atualizar o provedor de início de sessão da Apple",
+        "microsoftEnabled": "SSO da Microsoft ativado",
+        "microsoftDisabled": "SSO da Microsoft desativado",
+        "microsoftCreated": "Provedor de SSO da Microsoft criado",
+        "microsoftConfigSaved": "Configuração do SSO da Microsoft salva com sucesso",
+        "microsoftConfigFailed": "Falha ao salvar a configuração do SSO da Microsoft",
+        "microsoftUpdateFailed": "Falha ao atualizar o provedor de SSO da Microsoft",
+        "magicLinkEnabled": "Autenticação Magic Link ativada",
+        "magicLinkDisabled": "Autenticação do Magic Link desativada",
+        "magicLinkCreated": "Provedor Magic Link criado",
+        "magicLinkUpdateFailed": "Falha ao atualizar o provedor Magic Link",
+        "samlConfigSaved": "Configuração SAML salva com sucesso.",
+        "configureFirst": "Configure o provedor antes de ativá-lo.",
+        "domainRestrictionEnabled": "Restrição de domínio de e-mail ativada",
+        "domainRestrictionDisabled": "Restrição de domínio de e-mail desativada",
+        "domainRestrictionUpdateFailed": "Falha ao atualizar a configuração de restrição de domínio",
+        "domainRequired": "Por favor, insira um domínio.",
+        "invalidDomain": "Por favor, insira um domínio válido (ex.: exemplo.com)",
+        "domainAdded": "Domínio adicionado com sucesso",
+        "domainExists": "Este domínio já está na lista de permitidos.",
+        "domainAddFailed": "Falha ao adicionar o domínio",
+        "domainEnabled": "Domínio ativado",
+        "domainDisabled": "Domínio desativado",
+        "domainUpdateFailed": "Falha ao atualizar o domínio",
+        "domainDeleted": "Domínio removido com sucesso",
+        "domainDeleteFailed": "Falha ao remover o domínio",
+        "defaultAccessUpdated": "Nível de acesso padrão atualizado",
+        "defaultAccessUpdateFailed": "Falha ao atualizar o nível de acesso padrão",
+        "emailVerificationEnabled": "A verificação por e-mail agora é obrigatória para novos usuários.",
+        "emailVerificationDisabled": "A verificação por e-mail não é mais obrigatória para novos usuários.",
+        "emailVerificationDisabledAndVerified": "Verificação de e-mail desativada e {count, plural, one {# contas de usuário} other {# contas de usuário}} verificadas",
+        "emailVerificationUpdateFailed": "Falha ao atualizar as configurações de verificação de e-mail",
+        "emailServerNotConfigured": "Não foi possível ativar a verificação de e-mail: o servidor de e-mail não está configurado.",
+        "openRegistrationEnabled": "O auto-registro já está ativado.",
+        "openRegistrationDisabled": "O auto-registro agora está desativado.",
+        "openRegistrationUpdateFailed": "Falha ao atualizar as configurações de auto-registro"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Configure o Google OAuth",
+          "description": "Configure suas credenciais de cliente OAuth do Google. Você pode obtê-las no Console do Google Cloud.",
+          "clientIdPlaceholder": "Seu ID de cliente OAuth do Google",
+          "clientSecretPlaceholder": "Sua chave secreta do cliente OAuth do Google",
+          "instructions": {
+            "title": "Para obter essas credenciais:",
+            "step1": "Acesse o Console do Google Cloud",
+            "step2": "Selecione seu projeto ou crie um novo.",
+            "step3": "Ative a API do Google+",
+            "step4": "Acesse Credenciais e crie um ID de cliente OAuth 2.0.",
+            "step5": "Defina o URI de redirecionamento autorizado para:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "São necessários tanto o ID do Cliente quanto o Segredo do Cliente."
+          }
+        },
+        "microsoft": {
+          "title": "Configure o SSO da Microsoft",
+          "description": "Configure suas credenciais de aplicativo do Microsoft Entra ID (Azure AD). Você pode obtê-las no Portal do Azure.",
+          "clientIdPlaceholder": "ID do seu aplicativo (cliente)",
+          "clientSecretPlaceholder": "O valor secreto do seu cliente",
+          "tenantId": "ID do inquilino (opcional)",
+          "tenantIdPlaceholder": "Seu ID de diretório (locatário)",
+          "tenantIdHint": "Deixe em branco para multi-inquilino (\"comum\"). Defina com o seu ID de inquilino específico para restringir apenas à sua organização.",
+          "instructions": {
+            "title": "Para obter essas credenciais:",
+            "step1": "Acesse o Portal do Azure (portal.azure.com)",
+            "step2": "Acesse Microsoft Entra ID > Registros de aplicativos",
+            "step3": "Registre um novo aplicativo ou selecione um existente.",
+            "step4": "Em Certificados e segredos, crie um novo segredo do cliente.",
+            "step5": "Adicione o seguinte URI de redirecionamento em Autenticação:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "São necessários tanto o ID do Cliente quanto o Segredo do Cliente."
+          }
+        },
+        "saml": {
+          "description": "Configure seu provedor de identidade SAML. Você pode obter esses detalhes com seu provedor de identidade SAML.",
+          "entryPoint": "URL do ponto de entrada SSO",
+          "issuer": "Emissor (ID da Entidade)",
+          "callbackUrl": "URL de retorno de chamada ACS",
+          "logoutUrl": "URL de logout do SLO (opcional)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:seu-idp:id-da-entidade",
+          "certPlaceholder": "-----INÍCIO DO CERTIFICADO-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "Para configurar o SAML:",
+            "step1": "Contate o administrador do seu provedor de identidade SAML.",
+            "step2": "Solicite o URL do ponto de entrada SSO e o ID da entidade.",
+            "step3": "Baixe o certificado X.509",
+            "step4": "Configure este URL do ACS no seu IdP:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "O ponto de entrada, o emissor, o certificado e o URL de retorno de chamada são obrigatórios."
+          }
+        },
+        "disableEmailVerification": {
+          "title": "Desativar a verificação de e-mail?",
+          "description": "Isso desativará a verificação de e-mail para novos cadastros de usuários e verificará todas as contas existentes que ainda não foram verificadas.",
+          "warning": "⚠️ Aviso de segurança",
+          "warningPoint1": "Recomendado apenas para instalações seguras (redes privadas, VPNs ou ambientes confiáveis).",
+          "warningPoint2": "Todas as contas não verificadas existentes serão verificadas instantaneamente e receberão acesso ao sistema.",
+          "confirmation": "Tem certeza de que deseja desativar a verificação de e-mail e verificar todas as contas?",
+          "confirm": "Desativar e verificar tudo",
+          "verifying": "Verificando contas..."
+        }
+      },
+      "status": {
+        "configured": "Configurado",
+        "setup": "Configurar"
+      },
+      "registration": {
+        "title": "Configurações de registro",
+        "description": "Controle quem pode se cadastrar para novas contas.",
+        "restrictDomains": {
+          "title": "Restringir domínios de e-mail",
+          "description": "Permitir o cadastro somente a partir de domínios de e-mail específicos"
+        },
+        "allowedDomains": {
+          "title": "Domínios de e-mail permitidos",
+          "placeholder": "exemplo.com",
+          "add": "Adicionar domínio",
+          "empty": "Nenhum domínio permitido configurado. Todos os domínios serão bloqueados quando a restrição estiver ativada."
+        },
+        "defaultAccess": {
+          "title": "Nível de acesso padrão",
+          "description": "O nível de acesso ao sistema atribuído a novos usuários no momento do cadastro.",
+          "options": {
+            "NONE": "Sem acesso - Os usuários não podem acessar o sistema até que um administrador conceda acesso.",
+            "USER": "Usuário - Acesso padrão de usuário aos projetos atribuídos",
+            "PROJECTADMIN": "Administrador de Projetos - Capaz de gerenciar os projetos que lhe forem atribuídos.",
+            "ADMIN": "Administrador - Acesso total à administração do sistema."
+          }
+        },
+        "requireEmailVerification": {
+          "title": "Exigir verificação por e-mail",
+          "description": "Os usuários devem verificar seu endereço de e-mail antes de acessar o sistema.",
+          "noEmailServerWarning": "O servidor de e-mail não está configurado. A verificação de e-mail é desativada automaticamente até que um servidor de e-mail seja configurado."
+        },
+        "allowOpenRegistration": {
+          "title": "Permitir o auto-registro",
+          "description": "Quando desativado, o recurso impede que novos usuários se cadastrem diretamente ou criem uma conta via SSO. Usuários já cadastrados ainda poderão acessar suas contas."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Provedor inválido ou não é um provedor SAML."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Filtrar projetos..."
+      },
+      "complete": {
+        "title": "Projeto completo",
+        "description": "Esta ação concluirá o projeto e impedirá a adição de novas execuções de teste."
+      },
+      "add": {
+        "button": "Adicionar projeto",
+        "title": "Adicionar novo projeto",
+        "defaultFields": "O modelo padrão, o tipo de marco padrão e todos os fluxos de trabalho e status serão adicionados ao projeto quando ele for criado.",
+        "selectIssueTracker": "Selecionar rastreador de problemas",
+        "issueTrackerRequired": "É necessário um sistema de rastreamento de problemas."
+      },
+      "wizard": {
+        "title": "Criar novo projeto",
+        "description": "Configure um novo projeto com todas as configurações necessárias.",
+        "steps": {
+          "details": "Detalhes do projeto",
+          "workflows": "Fluxos de trabalho, status e tipos de marcos",
+          "integrations": "Integrações",
+          "permissions": "Usuários e permissões"
+        },
+        "labels": {
+          "selected": "Selecionado",
+          "statuses": "Status dos testes",
+          "issueTrackers": "Rastreadores de problemas"
+        },
+        "placeholders": {
+          "projectName": "Insira o nome do projeto",
+          "selectDefaultAccess": "Selecione o tipo de acesso padrão"
+        },
+        "descriptions": {
+          "templates": "Selecione pelo menos um modelo para definir a estrutura dos casos de teste neste projeto.",
+          "workflows": "Configure fluxos de trabalho, status e tipos de marcos para gerenciar as atividades do projeto.",
+          "integrations": "Opcional: Conecte sistemas externos de rastreamento de problemas e modelos de IA para funcionalidades aprimoradas.",
+          "noIntegrations": "Nenhuma integração está configurada no momento. Você pode pular esta etapa ou configurar as integrações posteriormente.",
+          "aiModels": "Habilite modelos de IA para geração de casos de teste e sugestões inteligentes.",
+          "permissions": "Configure o acesso de usuários e as permissões de grupo para este projeto.",
+          "milestoneTypes": "Selecione tipos de marcos para acompanhar o progresso e os prazos do projeto."
+        },
+        "actions": {
+          "selectDefault": "Usar padrão",
+          "create": "Criar projeto",
+          "creating": "Criando o projeto..."
+        },
+        "errors": {
+          "nameRequired": "É necessário dar um nome ao projeto.",
+          "validationFailed": "Não foi possível validar o nome do projeto. Tente novamente.",
+          "templateRequired": "Pelo menos um modelo deve ser selecionado.",
+          "workflowRequired": "Pelo menos um fluxo de trabalho deve ser selecionado.",
+          "statusRequired": "Pelo menos um status deve ser selecionado.",
+          "roleRequired": "Por favor, selecione uma função ao usar o tipo de acesso 'Função Específica'.",
+          "creationFailed": "Falha ao criar o projeto. Tente novamente."
+        },
+        "success": {
+          "created": "Projeto criado com sucesso"
+        }
+      },
+      "edit": {
+        "title": "Editar projeto",
+        "labels": {
+          "groupProjectAccess": "Acesso ao projeto em grupo",
+          "groupPermissions": "Permissões de grupo",
+          "userPermissions": "Permissões do usuário",
+          "noEffect": "Sem efeito",
+          "access": {
+            "groupsGlobalRole": "Papel global do grupo",
+            "groupDefault": "Grupo Padrão",
+            "groupSpecificRole": "Função específica do grupo",
+            "groupProjectDefault": "Projeto de Grupo Padrão",
+            "groupProjectNoAccess": "Projeto em grupo sem acesso",
+            "groupProjectSpecificRole": "Papel específico no projeto em grupo",
+            "effectiveAccess": "Acesso Efetivo"
+          },
+          "accessHints": {
+            "noAccess": "Os usuários não terão acesso a este projeto a menos que seja explicitamente concedido por meio de atribuição direta ou participação em grupo.",
+            "globalRole": "Todos os usuários com acesso ao site podem visualizar este projeto. Suas permissões são determinadas pela função que lhes foi atribuída globalmente.",
+            "specificRole": "O acesso não é concedido automaticamente aos usuários. O acesso deve ser concedido por meio de atribuição direta ao usuário ou por associação a um grupo. Os usuários atribuídos por meio de grupos usarão essa função, a menos que seja substituída por uma atribuição direta."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Selecione Acesso Padrão",
+          "groupPermissionsUI": "Interface de gerenciamento de permissões de grupo aqui...",
+          "userPermissionsUI": "Interface de gerenciamento de permissões de usuário aqui...",
+          "selectAccess": "Selecione o acesso...",
+          "selectRole": "Selecione a função...",
+          "searchUsersToAdd": "Pesquisar usuários para adicionar..."
+        },
+        "tableHeaders": {
+          "globalRole": "Papel global",
+          "projectAccess": "Acesso ao Projeto"
+        },
+        "messages": {
+          "noUsersAssigned": "Nenhum usuário recebeu permissões específicas.",
+          "noGroupsFound": "Nenhum grupo encontrado."
+        },
+        "actions": {
+          "removeUser": "Remover usuário"
+        },
+        "loadingUserPermissions": "Carregando permissões de usuário..."
+      },
+      "delete": {
+        "title": "Excluir projeto",
+        "confirmMessage": "Tem certeza de que deseja excluir este projeto?"
+      }
+    },
+    "templates": {
+      "description": "Gerenciar modelos e campos de casos de teste",
+      "help": {
+        "caseFields": "Os campos de caso definem as propriedades e os dados que podem ser capturados para cada caso de teste no repositório. Eles permitem personalizar as informações do caso de teste além dos campos padrão.",
+        "resultFields": "Os campos de resultado definem dados adicionais que podem ser capturados ao registrar os resultados dos testes. Eles permitem rastrear informações personalizadas específicas para os resultados da execução dos testes."
+      },
+      "confirmSetAsDefault": "Definir como modelo padrão",
+      "confirmSetAsDefaultDescription": "Tem certeza de que deseja definir este modelo como padrão?",
+      "confirmSetAsDefaultProjects": "Este modelo será adicionado a todos os projetos.",
+      "add": {
+        "button": "Adicionar modelo",
+        "title": "Adicionar novo modelo",
+        "defaultTemplateHint": "Este modelo será atribuído a todos os projetos."
+      },
+      "edit": {
+        "title": "Editar modelo"
+      },
+      "delete": {
+        "title": "Excluir modelo",
+        "confirmMessage": "Tem certeza de que deseja excluir o modelo <strong>{name}</strong>?",
+        "warning": "Todos os casos de teste e sessões exploratórias que atualmente utilizam este modelo serão automaticamente reatribuídos ao modelo padrão.",
+        "errors": {
+          "defaultTemplateNotFound": "Modelo padrão não encontrado. A exclusão não pode prosseguir.",
+          "unknown": "Ocorreu um erro desconhecido ao excluir o modelo."
+        }
+      },
+      "caseFields": {
+        "description": "Gerenciar campos de caso",
+        "add": {
+          "button": "Adicionar campo de caso",
+          "title": "Adicionar novo campo de caso"
+        },
+        "edit": {
+          "title": "Campo Editar Maiúsculas/Minúsculas"
+        },
+        "delete": {
+          "title": "Excluir campo Maiúsculas/Minúsculas",
+          "confirmMessage": "Tem certeza de que deseja excluir este campo de caso?",
+          "warning": "O campo \"Case\" será removido de todos os modelos. Esta ação é irreversível."
+        }
+      },
+      "resultFields": {
+        "description": "Gerenciar campos de resultado",
+        "add": {
+          "button": "Adicionar campo de resultado",
+          "title": "Adicionar novo campo de resultado"
+        },
+        "edit": {
+          "title": "Campo de edição de resultados"
+        },
+        "delete": {
+          "title": "Excluir campo de resultado",
+          "confirmMessage": "Tem certeza de que deseja excluir <strong>{name}</strong>?",
+          "warning": "O campo de resultado será removido de todos os modelos. Esta ação é irreversível."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Repositórios de código",
+      "description": "Gerencie as conexões do repositório de código para o contexto do QuickScript.",
+      "addRepository": "Adicionar repositório",
+      "noRepos": {
+        "title": "Nenhum repositório de código configurado",
+        "description": "Conecte um repositório Git para fornecer contexto de arquivo para a geração de exportações de teste com tecnologia de IA."
+      },
+      "delete": {
+        "title": "Excluir repositório",
+        "confirmMessage": "Tem certeza de que deseja excluir <strong>{name}</strong>? Esta ação não pode ser desfeita.",
+        "fallbackName": "este repositório"
+      },
+      "testConnection": "Conexão de teste",
+      "connectionSuccess": "Conexão bem-sucedida",
+      "connectionFailed": "Falha na conexão",
+      "networkError": "Erro de rede",
+      "editTitle": "Editar Repositório de Código",
+      "addTitle": "Adicionar repositório de código",
+      "repositoryUpdated": "Repositório atualizado",
+      "repositoryCreated": "Repositório criado",
+      "saveFailed": "Falha ao salvar o repositório",
+      "namePlaceholder": "Meu Repositório",
+      "selectProvider": "Selecione o fornecedor",
+      "httpWarning": "Este URL utiliza HTTP. As credenciais serão enviadas em texto simples. Utilize HTTPS para conexões seguras."
+    },
+    "exportTemplates": {
+      "title": "Modelos QuickScript",
+      "description": "Gerencie os modelos usados pelo QuickScript para converter casos de teste em scripts de automação.",
+      "confirmSetAsDefault": "Definir como modelo de exportação padrão",
+      "confirmSetAsDefaultDescription": "Tem certeza de que deseja definir este modelo como padrão? Ele será pré-selecionado quando os usuários exportarem casos de teste.",
+      "fields": {
+        "category": "Categoria",
+        "framework": "Estrutura",
+        "fileExtension": "Extensão de arquivo",
+        "headerBody": "Modelo de cabeçalho",
+        "templateBody": "Corpo do modelo",
+        "footerBody": "Modelo de rodapé",
+        "validation": {
+          "categoryRequired": "É necessário categorizar.",
+          "frameworkRequired": "É necessário um framework.",
+          "templateBodyRequired": "O corpo do modelo é obrigatório.",
+          "fileExtensionRequired": "É necessário ter a extensão do arquivo.",
+          "languageRequired": "É necessário conhecimento da língua."
+        },
+        "placeholders": {
+          "name": "Exemplo: Dramaturgo (TypeScript)",
+          "description": "Exemplo: Gera esboços de teste do Playwright",
+          "category": "Por exemplo, navegador E2E",
+          "framework": "Por exemplo, dramaturgo",
+          "fileExtension": "Exemplo: .spec.ts",
+          "language": "Por exemplo, TypeScript",
+          "headerBody": "Opcional. Conteúdo renderizado uma única vez no topo (ex.: instruções de importação).",
+          "templateBody": "Inserir modelo Mustache...\n\nVariáveis disponíveis:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSeção de etapas:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nCampos personalizados:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Opcional. Conteúdo exibido uma única vez na parte inferior (ex.: código de fechamento)."
+        },
+        "combobox": {
+          "typeNew": "Digite para inserir um novo valor."
+        }
+      },
+      "add": {
+        "button": "Adicionar modelo QuickScript",
+        "title": "Adicionar novo modelo QuickScript"
+      },
+      "edit": {
+        "title": "Editar modelo QuickScript"
+      },
+      "delete": {
+        "title": "Excluir modelo QuickScript",
+        "confirmMessage": "Tem certeza de que deseja excluir o modelo QuickScript <strong>{name}</strong>?"
+      },
+      "preview": {
+        "title": "Pré-visualização (dados simulados)",
+        "empty": "Insira um corpo de modelo para ver uma pré-visualização.",
+        "error": "Erro ao renderizar o modelo. Verifique a sintaxe do Mustache."
+      },
+      "filterPlaceholder": "Filtrar modelos...",
+      "noResults": "Nenhum modelo corresponde ao seu filtro.",
+      "templateCount": "{count, plural, one {# modelo} other {# modelos}}",
+      "allFrameworks": "Todas as estruturas",
+      "allFileExtensions": "Todas as extensões",
+      "allLanguages": "Todos os idiomas",
+      "showEnabled": "Somente habilitado",
+      "showAll": "Todos",
+      "variableInserter": {
+        "placeholder": "Inserir variável...",
+        "groups": {
+          "customFields": "Campos personalizados"
+        },
+        "stepsBlock": "Bloco de degraus"
+      }
+    },
+    "users": {
+      "showInactive": "Mostrar inativos",
+      "add": {
+        "button": "Adicionar usuário",
+        "title": "Adicionar novo usuário",
+        "fields": {
+          "email_invalid": "Endereço de e-mail inválido",
+          "password_error": "É necessário usar uma senha.",
+          "confirmPassword_error": "É necessário confirmar a senha.",
+          "passwordOptionalHelp": "Deixe em branco para exigir que o usuário faça login por meio de um link mágico ou SSO."
+        }
+      },
+      "edit": {
+        "title": "Editar usuário"
+      },
+      "delete": {
+        "title": "Excluir usuário"
+      },
+      "restore": {
+        "title": "Restaurar usuário excluído",
+        "description": "Foi encontrado um usuário excluído com o endereço de e-mail {email} . Deseja restaurar este usuário?",
+        "confirm": "Restaurar usuário"
+      },
+      "forcePasswordChange": "Forçar alteração de senha",
+      "revokePassword": "Revogar Senha",
+      "forcePasswordChangeDialogTitle": "Forçar alteração de senha",
+      "forcePasswordChangeDialogDescription": "Isso exigirá que {name} altere sua senha no próximo login.",
+      "revokePasswordDialogTitle": "Revogar Senha",
+      "revokePasswordDialogDescription": "Isso invalidará imediatamente a senha de {name}. Eles precisarão usar outro método de login.",
+      "confirmAction": "Confirmar",
+      "forcePasswordChangeSuccess": "É necessário alterar a senha para {name}",
+      "forcePasswordChangeFailed": "Falha ao forçar a alteração de senha",
+      "revokePasswordSuccess": "Senha revogada para {name}",
+      "revokePasswordFailed": "Falha ao revogar a senha"
+    },
+    "security": {
+      "title": "Segurança",
+      "description": "Configure a política de senhas, as configurações de bloqueio e as ações de aplicação.",
+      "passwordPolicyTitle": "Política de senhas",
+      "passwordPolicyDescription": "Defina requisitos para senhas de usuário.",
+      "lockoutPolicyTitle": "Política de bloqueio",
+      "lockoutPolicyDescription": "Configure o bloqueio de conta após tentativas de login falhas.",
+      "enforcementTitle": "Ações de fiscalização",
+      "enforcementDescription": "Forçar a alteração de senha para usuários com credenciais.",
+      "minPasswordLengthLabel": "Comprimento mínimo da senha",
+      "minPasswordLengthDescription": "As senhas devem ter pelo menos este número de caracteres (8-128).",
+      "requireUppercaseLabel": "Exigir letras maiúsculas",
+      "requireLowercaseLabel": "Exigir letras minúsculas",
+      "requireNumbersLabel": "Números necessários",
+      "requiredSpecialCharsLabel": "Caracteres especiais obrigatórios",
+      "requiredSpecialCharsDescription": "Deixe em branco para desativar. Digite os caracteres que devem aparecer (ex: !@#$)",
+      "passwordHistoryDepthLabel": "Profundidade do histórico de senhas",
+      "passwordHistoryDepthDescription": "Impedir a reutilização das últimas N senhas (0 = desativado)",
+      "passwordExpirationDaysLabel": "Validade da senha (em dias)",
+      "passwordExpirationDaysDescription": "Forçar alteração de senha após N dias (0 = desativado)",
+      "lockoutThresholdLabel": "Limiar de bloqueio",
+      "lockoutThresholdDescription": "Número de tentativas falhas antes do bloqueio da conta (mínimo 1)",
+      "lockoutDurationMinutesLabel": "Duração do bloqueio (minutos)",
+      "lockoutDurationMinutesDescription": "Por quanto tempo a conta permanece bloqueada (mínimo 1 dia)?",
+      "saveChanges": "Salvar alterações",
+      "forceAllUsers": "Obrigar todos os usuários a alterar a senha",
+      "forceAllUsersDialogTitle": "Forçar alteração de senha para todos os usuários",
+      "forceAllUsersDialogDescription": "Isto exigirá que os usuários com base em {count} modifiquem sua senha no próximo login.",
+      "forceAllUsersDialogWarning": "Esta ação não pode ser desfeita.",
+      "forceAllUsersDialogConfirm": "Mudança de Força",
+      "saved": "Configurações de segurança salvas",
+      "saveFailed": "Falha ao salvar as configurações de segurança",
+      "forceAllSuccess": "É necessário alterar a senha para {count} usuários",
+      "forceAllFailed": "Falha ao forçar a alteração de senha"
+    },
+    "apiTokens": {
+      "description": "Visualize e gerencie tokens de API de todos os usuários. Revogue tokens caso haja preocupações com a segurança.",
+      "filterPlaceholder": "Filtrar por nome do token ou usuário...",
+      "showInactive": "Mostrar revogado",
+      "noTokens": "Nenhum token de API foi criado ainda.",
+      "columns": {
+        "lastUsed": "Último uso",
+        "expires": "Expira"
+      },
+      "status": {
+        "revoked": "Revogado",
+        "expired": "Expirado"
+      },
+      "noExpiry": "Sem prazo de validade",
+      "revokeToken": "Revogar Token",
+      "revokeConfirmTitle": "Revogar token da API",
+      "revokeConfirmMessage": "Tem certeza de que deseja revogar este token de API? Esta ação não pode ser desfeita.",
+      "revokeConfirmDescription": "O token \"{name}\" pertencente a {user} será imediatamente revogado e não poderá mais ser usado para acesso à API.",
+      "revokeSuccess": "Token da API revogado com sucesso",
+      "revokeError": "Falha ao revogar o token da API",
+      "revokeAllTokens": "Revogar todos os tokens",
+      "revokeAllTitle": "Revogar todos os tokens de API",
+      "revokeAllDescription": "Isso revogará imediatamente TODOS os tokens de API ativos para todos os usuários. Essa ação é irreversível e pode interromper fluxos de trabalho automatizados.",
+      "revokeAllConfirm": "Digite \"REVOGAR TUDO\" para confirmar.",
+      "revokeAllPlaceholder": "REVOGAR TUDO",
+      "revokeAllSuccess": "Todos os tokens da API foram revogados.",
+      "revokeAllError": "Falha ao revogar todos os tokens."
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Ocorreu um erro ao criar a tag."
+        }
+      },
+      "delete": {
+        "title": "Excluir etiqueta",
+        "confirmMessage": "Tem certeza de que deseja excluir esta etiqueta?",
+        "warning": "Esta etiqueta será removida de todos os casos de teste e sessões.",
+        "errors": {
+          "unknown": "Ocorreu um erro ao excluir a tag."
+        }
+      },
+      "edit": {
+        "title": "Editar etiqueta"
+      }
+    },
+    "workflows": {
+      "description": "Gerenciar fluxos de trabalho de casos de teste",
+      "add": {
+        "button": "Adicionar fluxo de trabalho",
+        "title": "Adicionar novo fluxo de trabalho",
+        "defaultHelp": "Definir como fluxo de trabalho padrão para novos casos de teste",
+        "scopeLabel": "Escopo do fluxo de trabalho",
+        "errors": {
+          "nameExists": "Já existe um fluxo de trabalho com esse nome."
+        }
+      },
+      "edit": {
+        "title": "Editar fluxo de trabalho",
+        "lastWorkflowTypeWarning": "Este é o último tipo de fluxo de trabalho. Pelo menos um tipo de fluxo de trabalho deve estar ativado.",
+        "errors": {
+          "nameRequired": "O nome do fluxo de trabalho é obrigatório.",
+          "unknownWorkflow": "Fluxo de trabalho desconhecido"
+        }
+      },
+      "delete": {
+        "title": "Excluir fluxo de trabalho",
+        "confirmMessage": "Tem certeza de que deseja excluir este fluxo de trabalho?"
+      },
+      "setDefault": {
+        "title": "Definir fluxo de trabalho padrão",
+        "confirmMessage": "Tem certeza de que deseja definir este fluxo de trabalho como padrão?",
+        "description": "Este fluxo de trabalho será adicionado a todos os projetos."
+      }
+    },
+    "roles": {
+      "description": "Defina quais ações os usuários podem executar, ativando ou desativando as permissões para cada área do aplicativo.",
+      "filterPlaceholder": "Funções de filtro...",
+      "add": {
+        "button": "Adicionar função",
+        "title": "Adicionar nova função",
+        "fields": {
+          "name_error": "O nome do cargo é obrigatório."
+        },
+        "errors": {
+          "nameExists": "Já existe uma vaga com esse nome."
+        }
+      },
+      "edit": {
+        "title": "Editar função",
+        "permissionsTitle": "Permissões",
+        "areaHeader": "Área de aplicação"
+      },
+      "delete": {
+        "title": "Excluir função",
+        "confirmMessage": "Tem certeza de que deseja excluir esta função?",
+        "warning": "Esta ação não pode ser desfeita. Os usuários com esta função serão atribuídos à função padrão.",
+        "errors": {
+          "defaultNotFound": "Não é possível excluir a função padrão."
+        }
+      }
+    },
+    "statuses": {
+      "description": "Gerenciar status de testes",
+      "add": {
+        "button": "Adicionar status",
+        "title": "Adicionar novo status",
+        "systemNameHelp": "O nome do sistema identifica este estado. Não pode ser alterado após a criação.",
+        "aliasesHelp": "Lista de nomes alternativos separados por vírgulas",
+        "errors": {
+          "nameExists": "Já existe um status com esse nome.",
+          "systemNameEmpty": "O nome do sistema é obrigatório.",
+          "systemNameInvalid": "O nome do sistema deve ser alfanumérico.",
+          "aliasesInvalid": "Os aliases devem ser alfanuméricos.",
+          "missingColor": "A cor não foi encontrada. Selecione outra cor."
+        }
+      },
+      "edit": {
+        "title": "Editar status",
+        "systemNameHelp": "O nome do sistema identifica esse status para processos automatizados. Não pode ser alterado após a criação.",
+        "unmodifiableHelp": "O status \"não testado\" é um status do sistema e não pode ser modificado.",
+        "untestedHelp": "O nome 'não testado' é reservado para um estado do sistema e não pode ser usado.",
+        "success": "Status atualizado com sucesso"
+      },
+      "delete": {
+        "title": "Excluir status",
+        "confirmMessage": "Tem certeza de que deseja excluir o status <strong>{name}</strong>?",
+        "errors": {
+          "inUse": "Este status está em uso e não pode ser excluído.",
+          "defaultNotFound": "Status padrão não encontrado"
+        },
+        "success": "Status excluído com sucesso"
+      },
+      "fields": {
+        "final": "Final",
+        "system": "Status do sistema",
+        "forTestCase": "Para o caso de teste",
+        "forTestRun": "Para teste de funcionamento",
+        "forSession": "Para Sessão",
+        "color": "Cor"
+      }
+    },
+    "appConfig": {
+      "description": "Gerenciar configurações globais de aplicativos",
+      "addConfig": "Adicionar configuração do aplicativo",
+      "editConfig": "Editar configuração do aplicativo",
+      "keyPlaceholder": "Insira a chave de configuração...",
+      "valuePlaceholder": "Insira o valor JSON...",
+      "currentTranslation": "Tradução atual",
+      "filterPlaceholder": "Filtrar por palavra-chave...",
+      "errors": {
+        "keyRequired": "É necessária uma chave.",
+        "invalidJson": "Formato JSON inválido"
+      },
+      "configKeys": {
+        "project_docs_default": "Documentação do projeto padrão"
+      }
+    },
+    "configurations": {
+      "description": "As configurações são uma combinação de categorias e variantes usadas para definir um ambiente de teste. Por exemplo, SO/Navegador, Servidor de Teste, Idioma, etc.",
+      "addConfiguration": "Adicionar configuração",
+      "editConfiguration": "Editar configuração",
+      "filterPlaceholder": "Configurações de filtro...",
+      "categories": {
+        "title": "Categorias",
+        "description": "Gerenciar categorias globais",
+        "editCategory": "Editar categoria",
+        "selectCategory": "Selecione a categoria",
+        "filterPlaceholder": "Filtrar categorias...",
+        "add": {
+          "title": "Adicionar nova categoria"
+        },
+        "delete": {
+          "confirmMessage": "Tem certeza de que deseja excluir esta categoria?",
+          "deleteCategory": "Excluir categoria",
+          "deleteCategoryConfirm": "Tem certeza de que deseja excluir a categoria <strong>{name}</strong>?",
+          "deleteCategoryWarning": "Esta ação excluirá a categoria e todas as variantes associadas."
+        },
+        "disable": {
+          "confirmDisableTitle": "Desativar variante",
+          "confirmDisableDescription": "Tem certeza de que deseja desativar esta variante?"
+        }
+      },
+      "combinations": {
+        "title": "Combinações",
+        "description": "Gerenciar combinações globais",
+        "addCombination": "Adicionar combinação",
+        "editCombination": "Combinação de edição",
+        "selectCombination": "Selecione a combinação",
+        "selectCombinationDescription": "Selecione uma combinação de variantes para adicionar à configuração.",
+        "allExist": "Todas as combinações já existem.",
+        "selectAtLeast": "Por favor, selecione pelo menos uma combinação."
+      },
+      "delete": {
+        "title": "Excluir configuração",
+        "message": "Tem certeza de que deseja excluir a configuração <strong>{name}</strong>?",
+        "confirmMessage": "Tem certeza de que deseja excluir esta configuração?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Editar variante"
+        },
+        "delete": {
+          "title": "Excluir variante",
+          "message": "Tem certeza de que deseja excluir a variante <strong>{name}</strong>?",
+          "confirmMessage": "Tem certeza de que deseja excluir esta variante?",
+          "suggestion": "Considere desativar a variante."
+        },
+        "selection": {
+          "title": "Selecione as variantes",
+          "description": "Selecione as variantes que deseja adicionar à configuração."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Organize os usuários em grupos para atribuir acesso a projetos e funções em massa."
+      },
+      "filterPlaceholder": "Grupos de filtros...",
+      "add": {
+        "button": "Adicionar grupo",
+        "title": "Adicionar novo grupo",
+        "errors": {
+          "nameExists": "Já existe um grupo com esse nome."
+        }
+      },
+      "edit": {
+        "title": "Editar grupo"
+      },
+      "delete": {
+        "deleteGroup": "Excluir grupo",
+        "deleteGroupDescription": "Esta ação excluirá o grupo e todos os usuários associados.",
+        "confirmMessage": "Tem certeza de que deseja excluir este grupo?"
+      },
+      "noUsersSelected": "Nenhum usuário selecionado ainda.",
+      "noUsersAssigned": "Nenhum usuário foi atribuído a este grupo."
+    },
+    "milestones": {
+      "description": "Gerenciar tipos de marcos",
+      "filterPlaceholder": "Filtrar tipos de marcos...",
+      "addMilestones": "Adicionar marcos em massa",
+      "confirmDefault": "Confirmar padrão",
+      "confirmDefaultDescription": "Tem certeza de que deseja definir este tipo de marco como padrão?",
+      "warning": "Este tipo de marco será adicionado a todos os projetos.",
+      "wizard": {
+        "selectProjects": "Selecionar projetos",
+        "projectsSelected": "{count, plural, =0 {Nenhum projeto selecionado} one {# projeto selecionado} other {# projetos selecionados}}",
+        "createMilestone": "Criar marco",
+        "noCommonTypesTitle": "Não existem tipos comuns de marcos.",
+        "noCommonTypesDescription": "Os projetos selecionados não têm nenhum tipo de marco em comum. Certifique-se de que todos os projetos selecionados tenham pelo menos um tipo de marco em comum ou selecione projetos diferentes."
+      },
+      "add": {
+        "button": "Adicionar tipo de marco",
+        "title": "Adicionar novo tipo de marco",
+        "errors": {
+          "nameExists": "Já existe um tipo de marco com esse nome."
+        }
+      },
+      "edit": {
+        "title": "Editar tipo de marco"
+      },
+      "delete": {
+        "title": "Excluir tipo de marco",
+        "confirmMessage": "Tem certeza de que deseja excluir este tipo de marco?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Rastreador de Problemas de Links",
+      "link_description": "Configure o URL base para problemas vinculados manualmente. Ao vincular um problema usando apenas um ID externo, este URL base será adicionado para criar o link completo.",
+      "filter": {
+        "show_inactive": "Mostrar configurações inativas",
+        "search_placeholder": "Filtrar por nome de configuração..."
+      },
+      "base_url": "URL base",
+      "link_update_success": "Configuração de link atualizada com sucesso",
+      "link_update_error": "Falha ao atualizar a configuração do link",
+      "description": "Configure integrações com sistemas externos de rastreamento de problemas.",
+      "delete": {
+        "title": "Excluir configuração de problema",
+        "confirmMessage": "Tem certeza de que deseja excluir a configuração <bold>{name}</bold>?",
+        "warning": "Esta ação não pode ser desfeita. Quaisquer projetos atualmente atribuídos a este rastreador serão reatribuídos ao rastreador padrão. Considere desativar a configuração.",
+        "cannotDeleteDefault": "O sistema de rastreamento de problemas padrão não pode ser excluído.",
+        "noDefaultFound": "Não é possível excluir: Nenhum rastreador de problemas padrão foi encontrado para reatribuir os projetos."
+      },
+      "add": {
+        "title": "Adicionar rastreador de problemas",
+        "description": "Crie uma nova configuração para um sistema de rastreamento de problemas.",
+        "name": "Nome da configuração",
+        "name_placeholder": "Por exemplo, Links do Projeto Jira",
+        "system_type": "Tipo de sistema",
+        "select_system_type": "Selecione o tipo de sistema",
+        "base_url": "URL base incluindo o marcador de problema",
+        "base_url_placeholder": "Exemplo: https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Configuração do problema criada com sucesso",
+        "create_error": "Erro ao criar a configuração do problema",
+        "setDefaultWarning": "Definir esta opção como padrão removerá o status padrão da configuração padrão atual."
+      },
+      "edit": {
+        "title": "Editar rastreador de problemas",
+        "description": "Atualize os detalhes da configuração deste problema.",
+        "name_placeholder": "Insira o nome da configuração",
+        "select_project": "Selecione os projetos...",
+        "update_success": "Configuração do problema atualizada com sucesso",
+        "update_error": "Falha ao atualizar a configuração do problema",
+        "edit_not_supported": "Atualmente, não há suporte para edição de configurações deste tipo de sistema."
+      }
+    },
+    "issues": {
+      "description": "Gerencie os problemas deste rastreador de problemas.",
+      "filterPlaceholder": "Problemas com o filtro...",
+      "add": {
+        "button": "Adicionar problema",
+        "title": "Adicionar novo problema"
+      },
+      "edit": {
+        "title": "Editar problema"
+      },
+      "delete": {
+        "title": "Excluir problema",
+        "confirmMessage": "Tem certeza de que deseja excluir o problema \"{name}\"?"
+      },
+      "syncIssue": "Problema de sincronização com sistema externo",
+      "syncSuccess": "Problema sincronizado com sucesso",
+      "syncSuccessDescription": "A questão \"{name}\" foi atualizada com as informações mais recentes do sistema externo.",
+      "syncError": "Problema de sincronização",
+      "syncErrorDescription": "Não foi possível sincronizar o problema. Tente novamente mais tarde."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Links do projeto",
+        "milestoneLinks": "Links importantes",
+        "icons": "Ícones",
+        "fieldOptions": "Opções de campo",
+        "configCategories": "Categorias de configuração",
+        "configVariants": "Variantes de configuração",
+        "repositories": "Repositórios",
+        "repositoryFolders": "Pastas do repositório",
+        "repositoryCaseLinks": "Links para casos no repositório",
+        "repositoryCaseVersions": "Versões de casos do repositório",
+        "testRunStepResults": "Resultados da etapa de execução do teste",
+        "issueConfigs": "Configurações de problemas",
+        "sharedStepGroups": "Grupos de passos compartilhados"
+      },
+      "table": {
+        "title": "Excluído {itemType}",
+        "loading": "Carregando conteúdo excluído {itemType}...",
+        "error": "Erro ao carregar o arquivo excluído {itemType}: {message}",
+        "noItems": "Nenhum {itemType} excluído encontrado.",
+        "noResults": "Nenhum {itemType} excluído encontrado que corresponda à sua pesquisa por \"{query}\".",
+        "restoreConfirmationMessage": "Tem certeza de que deseja restaurar esta linha da tabela {itemType} ? Os dados associados também podem ser restaurados.",
+        "purgeConfirmationMessage": "Tem certeza de que deseja excluir permanentemente esta linha da tabela {itemType} ? Esta ação não pode ser desfeita e pode remover dados associados."
+      }
+    },
+    "notifications": {
+      "title": "Administração de notificações",
+      "description": "Defina as preferências de notificação padrão (os usuários podem alterá-las) e envie notificações do sistema.",
+      "defaultMode": {
+        "label": "Modo de notificação padrão",
+        "inApp": "Somente no aplicativo",
+        "inAppEmailImmediate": "No aplicativo + E-mail (Imediato)",
+        "inAppEmailDaily": "No aplicativo + E-mail (Resumo Diário)"
+      },
+      "options": {
+        "title": "Opções de notificação disponíveis",
+        "inApp": {
+          "label": "Notificações no aplicativo",
+          "description": "Exibir notificações dentro do aplicativo"
+        },
+        "emailImmediate": {
+          "label": "E-mail imediato",
+          "description": "Enviar notificações por e-mail imediatamente quando os eventos ocorrerem."
+        },
+        "emailDaily": {
+          "label": "Resumo diário por e-mail",
+          "description": "Enviar um resumo diário de notificações por e-mail."
+        }
+      },
+      "save": "Salvar configurações",
+      "success": {
+        "title": "Configurações salvas",
+        "description": "As configurações de notificação foram atualizadas com sucesso."
+      },
+      "error": {
+        "description": "Falha ao salvar as configurações de notificação"
+      },
+      "systemNotification": {
+        "title": "Notificações do sistema",
+        "description": "Enviar comunicados importantes para todos os usuários",
+        "titlePlaceholder": "Insira o título da notificação...",
+        "messagePlaceholder": "Digite a mensagem de notificação...",
+        "send": "Enviar notificação",
+        "success": {
+          "title": "Notificação enviada",
+          "description": "Notificação do sistema enviada para {count, plural, one {# usuário} other {# usuários}}"
+        },
+        "error": {
+          "description": "Falha ao enviar notificação do sistema",
+          "emptyFields": "Por favor, forneça o título e a mensagem."
+        },
+        "history": {
+          "title": "Histórico de notificações",
+          "sentBy": "Enviado por",
+          "sentAt": "Enviado em",
+          "empty": "Nenhuma notificação do sistema foi enviada ainda."
+        }
+      }
+    },
+    "integrations": {
+      "description": "Gerencie integrações de terceiros para rastreamento de problemas.",
+      "list": {
+        "title": "Integrações de problemas configuradas",
+        "description": "Visualize e gerencie suas integrações de problemas configuradas."
+      },
+      "empty": {
+        "message": "Nenhuma integração de problemas configurada ainda"
+      },
+      "addIntegration": "Adicionar integração de problemas",
+      "allIntegrations": "Todas as integrações de problemas",
+      "manageDescription": "Configure e gerencie suas integrações de problemas de serviço externo.",
+      "status": {
+        "active": "Ativo",
+        "inactive": "Inativo"
+      },
+      "connectedProjects": "Projetos Conectados",
+      "noIntegrations": "Nenhuma integração configurada",
+      "testConnection": "Conexão de teste",
+      "testSuccess": "Conexão bem-sucedida",
+      "testSuccessDescription": "A integração do problema está configurada e conectada corretamente.",
+      "testFailed": "Conexão falhou",
+      "testFailedDescription": "Não foi possível conectar-se ao serviço externo.",
+      "testError": "Erro de teste",
+      "testErrorDescription": "Ocorreu um erro ao testar a conexão.",
+      "syncInProgress": "Problemas de sincronização...",
+      "syncIntegration": "Sincronizar todos os problemas da integração de problemas",
+      "syncSuccess": "Sincronização em fila",
+      "syncSuccessDescription": "Os problemas de \"{name}\" estão sendo sincronizados em segundo plano. Isso pode levar alguns instantes. A tabela será atualizada automaticamente quando o processo for concluído.",
+      "syncError": "Falha na sincronização",
+      "syncErrorDescription": "Não foi possível enfileirar a tarefa de sincronização para esta integração. Tente novamente mais tarde.",
+      "delete": {
+        "confirmMessage": "Tem certeza de que deseja excluir a integração de problemas \"{name}\"?",
+        "warning": "Isso removerá a integração do problema e o desconectará de todos os projetos. Essa ação não pode ser desfeita.",
+        "warningTitle": "Esta ação irá:",
+        "warning1": "Remover permanentemente a configuração e as credenciais de integração do problema.",
+        "warning2": "Desconecte todos os tokens de autenticação do usuário para esta integração de problema.",
+        "warning3": "Preservar todos os problemas vinculados no banco de dados (os problemas serão desvinculados).",
+        "warning4": "Primeiro, é necessário remover a integração do problema de todos os projetos."
+      },
+      "deleteSuccess": "Integração de problemas excluída",
+      "deleteSuccessDescription": "A integração do problema foi removida com sucesso.",
+      "deleteError": "Erro ao excluir",
+      "add": {
+        "description": "Configure uma nova integração de problema com um serviço externo.",
+        "selectType": "Selecione o tipo de integração do problema",
+        "typeDescription": "Escolha o tipo de serviço que deseja integrar.",
+        "successMessage": "Integração de problemas criada com sucesso",
+        "successDescription": "A integração de problemas foi configurada e está pronta para uso.",
+        "simple_url": {
+          "name": "URL simples",
+          "description": "Rastreamento básico de problemas com padrões de URL personalizados"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Conecte-se ao Atlassian Jira para rastreamento de problemas e gerenciamento de projetos."
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Conecte-se ao GitHub para rastrear problemas."
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Conecte-se ao GitLab para rastrear problemas e solicitações de merge."
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Conecte-se a uma instância auto-hospedada do Gitea, Forgejo ou Gogs para rastreamento de problemas."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Conecte-se ao Azure DevOps para rastreamento de itens de trabalho."
+        }
+      },
+      "filterPlaceholder": "Integrações de filtros...",
+      "table": {
+        "lastSync": "Última sincronização",
+        "empty": "Nenhuma integração problemática encontrada",
+        "loading": "Carregando integrações de problemas...",
+        "configure": "Configurar"
+      },
+      "edit": {
+        "description": "Atualizar configurações e definições de integração de problemas",
+        "successMessage": "Integração de problemas atualizada com sucesso",
+        "successDescription": "As configurações de integração do problema foram salvas."
+      },
+      "editIntegration": "Editar integração de problemas",
+      "saveIntegration": "Salvar integração de problemas",
+      "deleteIntegration": "Excluir integração de problemas",
+      "config": {
+        "name": "Nome da integração do problema",
+        "namePlaceholder": "Insira um nome para esta integração de problemas.",
+        "nameHelp": "Um nome descritivo para identificar este problema de integração.",
+        "authType": "Tipo de autenticação",
+        "authTypeHelp": "Escolha como autenticar com o serviço externo.",
+        "emailPlaceholder": "seu-email@exemplo.com",
+        "emailHelp": "O endereço de e-mail da sua conta",
+        "apiToken": "Token da API",
+        "apiTokenPlaceholder": "Insira seu token de API",
+        "apiTokenHelp": "Gere um token de API nas configurações da sua conta.",
+        "jiraUrl": "URL do Jira",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "A URL da sua instância do Jira.",
+        "clientId": "ID do cliente",
+        "clientIdPlaceholder": "Insira seu ID de cliente OAuth",
+        "clientIdHelp": "O ID do cliente do seu aplicativo OAuth",
+        "clientSecret": "Segredo do cliente",
+        "clientSecretPlaceholder": "Insira sua chave secreta do cliente OAuth",
+        "clientSecretHelp": "O segredo do cliente do seu aplicativo OAuth",
+        "cloudId": "ID da nuvem",
+        "cloudIdPlaceholder": "Insira seu ID do Atlassian Cloud",
+        "cloudIdHelp": "Seu ID de instância do Atlassian Cloud (encontrado no seu URL do Jira)",
+        "apiUrl": "URL da API",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "A URL base para a API do serviço.",
+        "personalAccessTokenPlaceholder": "Insira seu token de acesso pessoal.",
+        "personalAccessTokenHelp": "Um token de acesso pessoal com as permissões apropriadas.",
+        "apiKeyPlaceholder": "Insira sua chave de API",
+        "apiKeyHelp": "A chave da API para autenticação",
+        "baseUrl": "Padrão de URL",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "Padrão de URL para problemas. Use {issueId} como marcador.",
+        "organizationUrl": "URL da organização",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "URL da sua organização do Azure DevOps",
+        "projectPath": "Caminho do Projeto",
+        "projectPathPlaceholder": "grupo/subgrupo/projeto",
+        "projectPathHelp": "O caminho completo do seu projeto GitLab (ex: mygroup/myproject)",
+        "instanceUrl": "URL da instância",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "URL da sua instância auto-hospedada. Deixe em branco para usar gitlab.com.",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Proprietário",
+        "ownerPlaceholder": "nome de usuário ou organização",
+        "ownerHelp": "O usuário ou organização do Gitea que possui o repositório.",
+        "repo": "Repositório",
+        "repoPlaceholder": "nome-do-repositório",
+        "repoHelp": "O nome do repositório Gitea",
+        "encrypted": "Criptografado",
+        "encryptedHelp": "Este campo está criptografado e armazenado com segurança.",
+        "changeCredential": "Mudar",
+        "apiKeyWarningTitle": "Aviso de autenticação por chave de API",
+        "apiKeyWarningDescription": "Ao usar a autenticação por chave de API, os responsáveis pela notificação de problemas são determinados automaticamente:",
+        "apiKeyWarningPoint1": "Se o seu e-mail do TestPlanIt corresponder ao e-mail de um usuário do Jira, você será definido como o responsável pela notificação.",
+        "apiKeyWarningPoint2": "Se não houver correspondência de e-mail, seu nome no TestPlanIt será associado aos nomes de exibição do Jira.",
+        "apiKeyWarningPoint3": "Caso nenhuma correspondência seja encontrada, o proprietário da chave da API será definido como o solicitante.",
+        "forgeApiKeyLabel": "Chave da API do Forge",
+        "forgeApiKeyDescription": "Utilizada pelo aplicativo Atlassian Forge para autenticar solicitações dos painéis de problemas do Jira. Gere uma chave aqui e cole-a nas configurações do seu aplicativo Forge.",
+        "forgeApiKeyPlaceholder": "Clique em Gerar para criar uma chave de API.",
+        "forgeApiKeyGenerate": "Gerar",
+        "forgeApiKeyCopy": "Cópia",
+        "forgeApiKeyCopied": "Copiado",
+        "platform": "Plataforma",
+        "platformPlaceholder": "Selecione a plataforma...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "Chave de API",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Token de Acesso Pessoal"
+      },
+      "validation": {
+        "nameRequired": "É obrigatório o nome da integração do problema.",
+        "clientIdRequired": "É necessário o ID do cliente.",
+        "clientSecretRequired": "É necessário o Segredo do Cliente.",
+        "cloudIdRequired": "É necessário um ID da nuvem.",
+        "apiUrlRequired": "É necessário o URL da API.",
+        "tokenRequired": "É necessário um Token de Acesso Pessoal.",
+        "apiKeyRequired": "É necessário ter uma chave de API."
+      },
+      "errors": {
+        "updateFailed": "Falha ao atualizar a integração de problemas",
+        "testFailed": "Teste de conexão falhou",
+        "nameExists": "Já existe uma integração de problema com este nome.",
+        "createFailed": "Falha ao criar a integração de problemas",
+        "deleteFailed": "Falha ao excluir a integração do problema"
+      },
+      "confirmDelete": {
+        "message": "Tem certeza de que deseja excluir a integração de problemas \"{name}\"?",
+        "warning": "Isso removerá a integração do problema e o desconectará de todos os projetos. Essa ação não pode ser desfeita."
+      },
+      "form": {
+        "success": "Integração de problemas salva com sucesso",
+        "successDescription": "A integração de problemas foi configurada e está pronta para uso.",
+        "testing": "Testando a conexão..."
+      },
+      "oauth": {
+        "connectAccount": "Conta de Conexão",
+        "connected": "Conectado",
+        "notConnected": "Não conectado",
+        "authDescription": "Você precisa se autenticar com {provider} para usar esta integração.",
+        "authError": "A autenticação falhou.",
+        "authErrorDescription": "Não foi possível autenticar com o serviço externo."
+      }
+    },
+    "llm": {
+      "addIntegration": "Adicionar modelo de IA",
+      "filterPlaceholder": "Filtrar modelos de IA...",
+      "testAll": "Testar todas as conexões",
+      "connectionTestComplete": "Teste de conexão concluído",
+      "allIntegrationsTested": "Todas as conexões do modelo de IA foram testadas.",
+      "failedToTestConnections": "Falha ao testar algumas conexões",
+      "notConfigured": "Não configurado",
+      "defaultModel": "Modelo selecionado",
+      "budgetUsage": "Uso (este mês)",
+      "noBudget": "Sem orçamento definido",
+      "streaming": "Transmissão",
+      "add": {
+        "title": "Adicionar integração de modelo de IA",
+        "description": "Configure um novo modelo de IA para sua organização.",
+        "integrationNamePlaceholder": "Insira um nome para esta integração...",
+        "selectProvider": "Selecione um fornecedor",
+        "openai": "OpenAI",
+        "anthropic": "Antrópico",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "customLlm": "LLM personalizado",
+        "apiKeyPlaceholder": "Insira sua chave de API...",
+        "apiKeyDescription": "Sua chave de API para autenticação com o provedor.",
+        "endpoint": "URL do ponto de extremidade",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Dica: Se estiver usando um proxy (por exemplo, LiteLLM), tente adicionar /v1 ao final da URL do seu endpoint.",
+        "deploymentName": "Nome da implantação",
+        "deploymentNamePlaceholder": "Insira o nome da implantação...",
+        "deploymentNameDescription": "nome da implantação do Azure OpenAI",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, etc.",
+        "defaultModelDescription": "O modelo a ser usado por padrão",
+        "maxTokensPerRequest": "Número máximo de tokens por solicitação",
+        "maxRequestsPerMinute": "Número máximo de solicitações por minuto",
+        "costPerInputToken": "Custo por 1 milhão de tokens de entrada ($)",
+        "costPerOutputToken": "Custo por 1 milhão de tokens de saída ($)",
+        "monthlyBudget": "Orçamento mensal ($)",
+        "monthlyBudgetPlaceholder": "100,00",
+        "monthlyBudgetDescription": "Meta de gastos opcional para notificações (não bloqueia o uso)",
+        "billingPeriodStartDay": "Dia de início do período de faturamento",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "Dia do mês (1-31) em que seu período de faturamento começa. Os valores de 29 a 31 consideram o último dia dos meses mais curtos.",
+        "defaultTemperature": "Temperatura padrão",
+        "defaultMaxTokens": "Número máximo padrão de tokens",
+        "timeout": "Tempo limite da solicitação (ms)",
+        "timeoutDescription": "Tempo máximo de espera para resposta do modelo de IA (5000-600000 ms). Não se aplica a solicitações de streaming.",
+        "streamingEnabled": "Ativar streaming",
+        "streamingEnabledDescription": "Permitir streaming de resposta em tempo real",
+        "setAsDefault": "Definir como padrão",
+        "setAsDefaultDescription": "Use isso como o modelo de IA padrão para a organização.",
+        "fetchingModels": "Buscando modelos...",
+        "failedToFetchModels": "Não foi possível obter os modelos disponíveis.",
+        "selectModel": "Selecione um modelo",
+        "connectionSuccessfulDescription": "A conexão do modelo de IA foi verificada e está funcionando corretamente.",
+        "failedToConnect": "Falha ao conectar-se ao provedor do modelo de IA",
+        "integrationCreated": "Integração de modelo de IA criada com sucesso",
+        "failedToCreate": "Falha na criação da integração do modelo de IA",
+        "validation": {
+          "nameRequired": "O nome da integração é obrigatório.",
+          "nameUnique": "Já existe uma integração com esse nome.",
+          "defaultModelRequired": "O modelo padrão é obrigatório."
+        }
+      },
+      "edit": {
+        "title": "Editar integração de modelo de IA",
+        "description": "Atualize a configuração para esta integração de modelo de IA.",
+        "statusDescription": "Ative ou desative esta integração.",
+        "apiKeyPlaceholder": "Insira a nova chave de API para atualizar...",
+        "update": "Atualizar",
+        "integrationUpdated": "Integração do modelo de IA atualizada com sucesso",
+        "failedToUpdate": "Falha ao atualizar a integração do modelo de IA",
+        "validation": {
+          "nameRequired": "O nome da integração é obrigatório.",
+          "nameUnique": "Já existe uma integração com esse nome.",
+          "defaultModelRequired": "O modelo padrão é obrigatório."
+        }
+      },
+      "sections": {
+        "provider": "Fornecedor",
+        "costAndBudget": "Custo e orçamento",
+        "advanced": "Avançado"
+      },
+      "delete": {
+        "title": "Excluir integração de modelo de IA",
+        "description": "Tem certeza de que deseja excluir essa integração de modelo de IA? Isso a removerá de todos os projetos e não poderá ser desfeito.",
+        "integrationDeletedSuccess": "A integração do modelo de IA foi excluída com sucesso.",
+        "failedToDeleteIntegration": "Falha ao excluir a integração do modelo de IA",
+        "cannotDeleteDefault": "Não é possível excluir o modelo de IA padrão. Defina outro como padrão primeiro."
+      },
+      "validation": {
+        "defaultModelRequired": "O modelo padrão é obrigatório."
+      },
+      "test": {
+        "title": "Testar a integração do modelo de IA",
+        "description": "Teste a conexão e a funcionalidade de {name}",
+        "connectionStatus": "Status da conexão",
+        "connectionStatusDescription": "Verifique se o modelo de IA é acessível.",
+        "retest": "Testar novamente a conexão",
+        "connectionSuccessfulDescription": "O modelo de IA está acessível e respondendo corretamente.",
+        "failedToConnect": "Falha ao conectar-se ao modelo de IA",
+        "errorTestingConnection": "Ocorreu um erro ao testar a conexão.",
+        "testMessage": "Mensagem de teste",
+        "testMessagePlaceholder": "Digite uma mensagem para enviar ao modelo de IA...",
+        "sendTestMessage": "Enviar mensagem de teste",
+        "response": "Resposta",
+        "testSuccessful": "Teste bem-sucedido",
+        "responseReceived": "Resposta recebida com sucesso (Custo: ${cost})",
+        "testFailed": "Teste falhou",
+        "failedToGetResponse": "Não foi possível obter resposta do modelo de IA.",
+        "failedToSendMessage": "Falha ao enviar mensagem de teste",
+        "defaultTestMessage": "Olá! Por favor, responda com uma breve confirmação de que está tudo funcionando corretamente."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Definir um orçamento mensal não impede que o uso do LLM o exceda. Os limites orçamentários são apenas informativos para auxiliar na tomada de decisões administrativas.",
+        "budgetDisclaimerShort": "Os limites orçamentários são apenas informativos e não impedem o uso.",
+        "spendLabel": "Gastos do mês atual",
+        "spendOfBudget": "{currentSpend} de {budgetLimit}",
+        "overBudget": "Acima do orçamento",
+        "budgetPercentage": "{percentage}% do orçamento utilizado",
+        "spendReset": "Os gastos do mês atual foram zerados."
+      }
+    },
+    "prompts": {
+      "title": "Configurações de prompt",
+      "description": "Gerencie modelos de prompts de IA para diferentes funcionalidades.",
+      "addPromptConfig": "Adicionar configuração de prompt",
+      "filterPlaceholder": "Configurações de prompts de filtro...",
+      "features": "Características",
+      "featureCount": "{count, plural, one {# recurso} other {# recursos}}",
+      "llmIntegration": "Integração do LLM",
+      "modelOverride": "Substituição do modelo",
+      "llmIntegrationPlaceholder": "Projeto Padrão",
+      "modelOverridePlaceholder": "Integração padrão",
+      "projectDefault": "Projeto Padrão (limpar)",
+      "integrationDefault": "Integração padrão (limpar)",
+      "systemPrompt": "Mensagem do sistema",
+      "userPrompt": "Instruções para o usuário",
+      "temperature": "Temperatura",
+      "maxOutputTokens": "Tokens de saída máxima",
+      "variables": "Variáveis",
+      "insertVariable": "Inserir variável",
+      "noConfigs": "Nenhuma configuração de prompt encontrada. Adicione sua primeira configuração para começar.",
+      "add": {
+        "title": "Adicionar configuração de prompt",
+        "description": "Crie uma nova configuração de prompts de IA com prompts para cada recurso. Os valores padrão foram aplicados automaticamente."
+      },
+      "edit": {
+        "title": "Editar configuração de prompt",
+        "description": "Atualize esta configuração de prompt de IA"
+      },
+      "delete": {
+        "title": "Excluir configuração de prompt",
+        "confirmMessage": "Tem certeza de que deseja excluir <strong>{name}</strong>? Os projetos que usam este prompt voltarão ao padrão do sistema.",
+        "warning": "Esta ação não pode ser desfeita. Todos os projetos que utilizam esta configuração retornarão à configuração de prompt padrão."
+      },
+      "llmColumn": "Mestrado em Direito",
+      "mixedLlms": "{count} Mestrados em Direito",
+      "cannotDeleteDefault": "Não é possível excluir a configuração de prompt padrão. Defina outra como padrão primeiro.",
+      "defaultChanged": "A configuração padrão do prompt foi atualizada com sucesso.",
+      "featureLabels": {
+        "markdown_parsing": "Análise de casos de teste em Markdown",
+        "test_case_generation": "Geração de casos de teste",
+        "magic_select_cases": "Seleção inteligente de casos de teste",
+        "editor_assistant": "Assistente de Redação Editorial",
+        "llm_test": "Teste de Conexão LLM",
+        "export_code_generation": "Geração de código de exportação",
+        "auto_tag": "Sugestões de tags por IA",
+        "duplicate_detection": "Detecção de duplicados",
+        "generate_from_url": "Gerar casos de teste a partir de URL (Requisitos)",
+        "generate_from_url_app": "Gerar casos de teste a partir de URL (Teste de Aplicativos)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Gerenciamento do Elasticsearch",
+      "description": "Gerenciar a indexação e a manutenção dos mecanismos de busca.",
+      "status": {
+        "title": "Status do Elasticsearch",
+        "description": "Estado atual da conexão e da saúde do mecanismo de busca",
+        "checking": "Verificando o status...",
+        "disconnected": "Desconectado",
+        "nodes": "Nós",
+        "indices": "Índices",
+        "documents": "documentos",
+        "error": {
+          "title": "Erro de conexão",
+          "description": "Não foi possível conectar ao serviço Elasticsearch."
+        }
+      },
+      "settings": {
+        "description": "Configure as definições do Elasticsearch para a sua implementação.",
+        "numberOfReplicas": "Número de réplicas",
+        "replicasHelp": "Defina como 0 para clusters de nó único e como 1 ou mais para clusters de vários nós com redundância.",
+        "savedDescription": "A configuração foi salva no banco de dados.",
+        "updated": "Índices atualizados",
+        "updatedDescription": "Todos os índices existentes foram atualizados com as novas configurações de réplica.",
+        "error": "Erro ao salvar as configurações",
+        "errorDescription": "Falha ao salvar a configuração. Tente novamente.",
+        "note": {
+          "description": "As alterações se aplicam imediatamente aos novos índices. Os índices existentes são atualizados ao salvar. Defina as réplicas como 0 para resolver o status AMARELO em clusters de nó único."
+        }
+      },
+      "reindex": {
+        "title": "Dados de Reindexação",
+        "description": "Reconstrua os índices de pesquisa para melhorar o desempenho da pesquisa.",
+        "entities": {
+          "all": "Todas as entidades"
+        },
+        "button": {
+          "start": "Iniciar Reindexação",
+          "indexing": "Indexação..."
+        },
+        "warning": {
+          "title": "Importante",
+          "description": "A reindexação pode demorar vários minutos, dependendo do volume de dados. A funcionalidade de pesquisa pode ficar limitada durante esse processo."
+        },
+        "complete": {
+          "title": "Reindexação concluída",
+          "description": "Todas as entidades selecionadas foram reindexadas com sucesso."
+        },
+        "success": {
+          "title": "Reindexação bem-sucedida",
+          "description": "{count, plural, one {# documento} other {# documentos}} indexados com sucesso"
+        },
+        "error": {
+          "title": "Reindexação falhou",
+          "description": "Ocorreu um erro durante a reindexação. Tente novamente."
+        }
+      }
+    },
+    "queues": {
+      "title": "Filas de tarefas em segundo plano",
+      "description": "Monitorar e gerenciar filas de processamento de tarefas em segundo plano.",
+      "queueNames": {
+        "forecast-updates": "Atualizações da previsão",
+        "emails": "Fila de e-mails",
+        "issue-sync": "Sincronização de Problemas",
+        "testmo-imports": "Testmo Imports",
+        "elasticsearch-reindex": "Reindexação do Elasticsearch",
+        "audit-logs": "Registros de auditoria",
+        "budget-alerts": "Alertas orçamentários",
+        "auto-tag": "Etiquetagem automática por IA",
+        "repo-cache": "Cache do repositório",
+        "copy-move": "Copiar e mover",
+        "duplicate-scan": "Leitura duplicada",
+        "magic-select": "Seleção Mágica",
+        "step-scan": "Varredura de sequência passo a passo"
+      },
+      "status": {
+        "paused": "Em pausa",
+        "idle": "Parado"
+      },
+      "table": {
+        "queue": "Fila",
+        "concurrency": "Concorrência",
+        "waiting": "Esperando",
+        "failed": "Fracassado"
+      },
+      "concurrency": {
+        "title": "Concorrência de trabalhadores",
+        "description": "A concorrência controla quantas tarefas cada trabalhador processa simultaneamente. Valores mais altos podem melhorar o desempenho, mas consomem mais recursos do sistema (CPU e memória).",
+        "configureTitle": "Configurando a Concorrência",
+        "configureDescription": "Para ajustar a concorrência, defina as variáveis de ambiente e reinicie os processos. Consulte a documentação para obter mais detalhes.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Importações do Testmo (padrão: 1, uso intensivo de memória)",
+          "SYNC_CONCURRENCY": "Sincronização de tarefas (padrão: 2, uso intensivo de E/S)",
+          "EMAIL_CONCURRENCY": "Envio de e-mail (padrão: 3, uso intensivo de E/S)",
+          "NOTIFICATION_CONCURRENCY": "Notificações (padrão: 5, nível leve)",
+          "FORECAST_CONCURRENCY": "Atualizações de previsão (padrão: 5, uso intensivo de CPU)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Fila de pausa",
+          "confirmDescription": "Isso impedirá o processamento de novas tarefas. As tarefas em andamento continuarão até a sua conclusão."
+        },
+        "resume": {
+          "confirmTitle": "Fila de retomada",
+          "confirmDescription": "Isso permitirá que a fila processe as tarefas em espera."
+        },
+        "clean": {
+          "confirmTitle": "Limpar fila",
+          "confirmDescription": "Isso removerá da fila os trabalhos concluídos e os que falharam. Essa ação não pode ser desfeita."
+        },
+        "drain": {
+          "confirmTitle": "Fila de drenagem",
+          "confirmDescription": "Isso removerá todos os trabalhos em espera da fila. Os trabalhos ativos continuarão até a conclusão. Esta ação não pode ser desfeita."
+        },
+        "obliterate": {
+          "confirmTitle": "Apagar fila",
+          "confirmDescription": "Isso limpará completamente a fila, removendo todos os trabalhos, independentemente do estado. Essa ação é irreversível e só deve ser usada em situações de emergência."
+        },
+        "warning": "Aviso",
+        "irreversible": "Esta ação não pode ser desfeita. Por favor, confirme que deseja prosseguir."
+      },
+      "success": {
+        "actionCompleted": "Ação concluída",
+        "queuePaused": "A fila foi pausada.",
+        "queueResumed": "A fila foi retomada.",
+        "queueCleaned": "A fila foi limpa.",
+        "queueDrained": "A fila foi esvaziada.",
+        "queueObliterated": "A fila foi destruída."
+      },
+      "error": {
+        "loadFailed": "Falha ao carregar as filas",
+        "actionFailed": "A ação falhou"
+      },
+      "jobs": {
+        "title": "Tarefas em fila",
+        "description": "Visualize e gerencie tarefas individuais na fila.",
+        "noJobs": "Nenhuma tarefa encontrada nesta fila.",
+        "table": {
+          "id": "ID da vaga",
+          "name": "Nome do cargo",
+          "attempts": "Tentativas"
+        },
+        "details": {
+          "title": "Detalhes da vaga",
+          "failedReason": "Motivo da falha",
+          "stacktrace": "Rastreamento de pilha",
+          "data": "Dados do trabalho",
+          "returnValue": "Valor de retorno",
+          "options": "Opções de emprego",
+          "processed": "Processado",
+          "finished": "Finalizado"
+        },
+        "success": {
+          "actionCompleted": "Ação de trabalho concluída",
+          "jobRetried": "O trabalho foi refeito",
+          "jobPromoted": "O cargo foi promovido.",
+          "jobRemoved": "A vaga foi removida."
+        },
+        "error": {
+          "loadFailed": "Falha ao carregar os trabalhos",
+          "actionFailed": "A ação trabalhista fracassou"
+        },
+        "forceRemove": {
+          "title": "Forçar a remoção do trabalho",
+          "question": "Deseja remover esta vaga à força?",
+          "warning": "Isso tentará removê-lo várias vezes com atrasos. Observação: se a tarefa estiver realmente bloqueada por um processo em execução, ela ainda poderá falhar.",
+          "confirm": "Forçar remoção"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Visualize o histórico de auditoria de todo o sistema para fins de segurança e conformidade.",
+      "filterPlaceholder": "Pesquisar por entidade, usuário ou ação...",
+      "filterAction": "Ação",
+      "filterEntityType": "Tipo de entidade",
+      "allActions": "Todas as ações",
+      "allEntityTypes": "Todos os tipos de entidade",
+      "showing": "Exibindo {start} a {end} de {total} entradas",
+      "viewDetails": "Ver detalhes",
+      "detailTitle": "Detalhes do registro de auditoria",
+      "userInfo": "Informações do usuário",
+      "changes": "Mudanças",
+      "metadata": "Metadados",
+      "oldValue": "Velho",
+      "newValue": "Novo",
+      "columns": {
+        "timestamp": "Carimbo de data/hora",
+        "entityId": "ID da entidade",
+        "entityName": "Nome da entidade",
+        "userId": "ID do usuário",
+        "ipAddress": "Endereço IP",
+        "userAgent": "Agente do usuário"
+      },
+      "exportCsv": "Exportar CSV",
+      "timeRange": "Intervalo de tempo",
+      "timeRangeOptions": {
+        "last24h": "Últimas 24 horas",
+        "last7d": "Últimos 7 dias",
+        "last30d": "Últimos 30 dias",
+        "last90d": "Últimos 90 dias",
+        "allTime": "O tempo todo"
+      },
+      "systemActor": "Sistema",
+      "systemActorTooltip": "Ação realizada pelo sistema, não por um usuário conectado."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Nenhuma notificação",
+      "aria": {
+        "notifications": "Notificações ({count} não lidas)"
+      },
+      "actions": {
+        "markRead": "Marcar como lido",
+        "markUnread": "Marcar como não lida",
+        "markAllRead": "Marcar tudo como lido",
+        "deleteAll": "Apagar tudo"
+      },
+      "success": {
+        "deleted": "Notificação excluída",
+        "markedAllRead": "Todas as notificações marcadas como lidas",
+        "deletedAll": "Todas as notificações foram excluídas."
+      },
+      "error": {
+        "markRead": "Não foi possível marcar como lida.",
+        "markUnread": "Não foi possível marcar como não lida.",
+        "delete": "Falha ao excluir a notificação",
+        "markAllRead": "Não foi possível marcar tudo como lido.",
+        "deleteAll": "Falha ao excluir notificações"
+      },
+      "deleteAllDialog": {
+        "title": "Apagar todas as notificações?",
+        "description": "Isso removerá permanentemente todas as suas notificações. Esta ação não pode ser desfeita.",
+        "confirm": "Apagar tudo"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Nova atribuição de caso de teste",
+        "multipleTestCaseAssignmentTitle": "Vários casos de teste atribuídos",
+        "sessionAssignmentTitle": "Nova atribuição de sessão",
+        "commentMentionTitle": "Você foi mencionado(a) em um comentário.",
+        "systemAnnouncementTitle": "Anúncio do sistema",
+        "assignedTestCase": "Você foi designado para testar o caso.",
+        "assignedMultipleTestCases": "atribuído a você {count, plural, one {# caso de teste} other {# casos de teste}}",
+        "assignedSession": "Você foi designado para a sessão",
+        "mentionedYouInComment": "te mencionei em um comentário sobre",
+        "inProject": "no projeto",
+        "testRun": "Teste de execução:",
+        "casesInProject": "{count, plural, =1 {# caso} other {# casos}} em",
+        "sentBy": "Enviado por {name}",
+        "milestoneDueSoonTitle": "Marco a ser atingido em breve",
+        "milestoneOverdueTitle": "Marco atrasado",
+        "milestoneDueSoon": "O marco \"{milestoneName}\" no projeto \"{projectName}\" vence em {dueDate}.",
+        "milestoneOverdue": "O marco \"{milestoneName}\" no projeto \"{projectName}\" tinha vencimento em {dueDate} e agora está atrasado.",
+        "milestoneNotificationReason": "Você está recebendo esta notificação porque participou de atividades relacionadas a este marco (testes, sessões ou como criador do marco).",
+        "milestoneNotificationContinue": "Você continuará recebendo lembretes diários até que esta etapa seja marcada como concluída.",
+        "shareLinkAccessedTitle": "Link de compartilhamento acessado",
+        "shareLinkAccessedAnonymousViewer": "Alguém",
+        "shareLinkAccessedMessage": "{viewer} visualizou seu relatório compartilhado: \"{shareTitle}\"",
+        "viewedYourSharedLink": "Visualizei o link que você compartilhou.",
+        "viewedAt": "Visto em",
+        "budgetDisclaimer": "Os limites orçamentários são apenas informativos e não impedem o uso.",
+        "llmBudgetExceededTitle": "Orçamento do LLM excedido",
+        "llmBudgetThresholdTitle": "Orçamento do LLM {threshold}% Utilizado",
+        "llmBudgetExceededMessage": "{providerName} excedeu seu orçamento mensal: {spend} gastou de {budget} orçamento.",
+        "llmBudgetThresholdMessage": "{providerName} utilizou {threshold}% do seu orçamento mensal: {spend} de {budget}.",
+        "userRegisteredTitle": "Cadastro de novo usuário",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) registrou-se via SSO",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) se registrou através do formulário de inscrição",
+        "viewUserList": "Ver lista de usuários",
+        "reviewGeneratedCases": "Análise dos casos de teste gerados",
+        "generateFromUrlCompleteTitle": "As páginas foram rastreadas com sucesso.",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# página} other {# páginas}} rastreadas de {url} no projeto \"{projectName}\". Clique para revisar e gerar casos de teste.",
+        "generateFromUrlFailedTitle": "falha na indexação da URL"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Problemas de pesquisa ou links...",
+        "create_label": "Problema de link \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Insira o resumo do problema"
+        },
+        "fields": {
+          "name": {
+            "label": "Resumo"
+          },
+          "description": {
+            "placeholder": "Descreva o problema...",
+            "helper": "Forneça informações detalhadas sobre o problema."
+          },
+          "project": {
+            "helper": "Selecione o projeto no rastreador de problemas externo."
+          }
+        },
+        "loading_metadata": "Carregando configurações de integração...",
+        "errors": {
+          "creation_failed": "Não foi possível criar a solicitação. Tente novamente."
+        },
+        "success": {
+          "created": "Problema criado com sucesso",
+          "external_created": "Problema criado e vinculado ao rastreador externo."
+        },
+        "warnings": {
+          "external_failed": "Problema criado localmente, mas não foi possível sincronizar com o rastreador externo."
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "Você precisa conectar sua conta a {integrationName} para criar problemas."
+      },
+      "search_issues_dialog": {
+        "title": "Problemas de pesquisa e links",
+        "placeholder": "Pesquisar problemas...",
+        "searching": "Procurando...",
+        "searchError": "Falha ao pesquisar problemas",
+        "linkButton": "Link",
+        "linkedCount": "{count, plural, one {# problema} other {# problemas}} vinculados"
+      }
+    },
+    "copyMove": {
+      "title": "Copiar/Mover para o Projeto",
+      "step1Desc": "Selecione um projeto e uma pasta de destino para os casos de teste.",
+      "step2Desc": "Selecione a operação e verifique a compatibilidade.",
+      "step3Desc": "Acompanhe o progresso e analise os resultados.",
+      "targetProject": "Projeto Alvo",
+      "searchProjects": "Pesquisar projetos...",
+      "loadingProjects": "Carregando projetos...",
+      "noProjectsFound": "Nenhum projeto encontrado.",
+      "completed": "(Completo)",
+      "targetFolder": "Pasta de destino",
+      "newFolderPlaceholder": "Novo nome de pasta...",
+      "operation": "Operação",
+      "operationCopy": "Cópia",
+      "operationCopyDesc": "Cria uma cópia dos casos selecionados no projeto de destino. Os originais permanecem inalterados.",
+      "operationMove": "Mover",
+      "operationMoveDesc": "Move os casos selecionados para o projeto de destino. Os originais serão removidos da origem.",
+      "checkingCompatibility": "Verificando compatibilidade...",
+      "noTargetWriteAccess": "Você não tem permissão de escrita para o projeto de destino.",
+      "noSourceUpdateAccess": "Você não tem permissão de edição no projeto de origem para mover casos.",
+      "templateMismatch": "Modelo incompatível",
+      "autoAssignTemplates": "Atribua automaticamente modelos ausentes ao projeto de destino.",
+      "templatesMayNotDisplay": "Os modelos ausentes não estarão disponíveis no projeto de destino. Os casos serão copiados, mas os campos desses modelos podem não ser exibidos corretamente.",
+      "workflowFallback": "Alguns estados de fluxo de trabalho não estão disponíveis no projeto de destino. Nesses casos, será utilizado o estado padrão do projeto de destino.",
+      "default": "(padrão)",
+      "conflicts": "Aplica-se a todos os conflitos:",
+      "conflictSkip": "Pular",
+      "conflictRename": "Renomear",
+      "sharedStepGroups": "Quando já existirem grupos de etapas compartilhadas no destino:",
+      "sharedStepGroupReuse": "Reutilize o que já existe.",
+      "sharedStepGroupReuseDesc": "Os casos farão referência ao grupo de etapas compartilhadas existente.",
+      "sharedStepGroupCreateNew": "Criar novo",
+      "sharedStepGroupCreateNewDesc": "Um novo grupo de passos compartilhados será criado.",
+      "go": "Ir",
+      "processing": "Processamento...",
+      "progressText": "{processed} de {total} casos processados",
+      "successCount": "{count} caso(s) {operation}d com sucesso",
+      "skipped": "Ignorado: {count}",
+      "droppedLinks": "Links entre projetos foram removidos: {count}",
+      "errorCount": "{count} caso(s) falhou(ram)",
+      "viewInTargetProject": "Visualizar no projeto alvo",
+      "failed": "Fracassado",
+      "folderMode": "Pasta \"{folderName}\" — {caseCount, plural, one {# caso} other {# casos}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Questões relacionadas",
+    "linkedIssuesDescription": "Problemas associados a este item",
+    "refreshed": "Edições atualizadas",
+    "refreshedDescription": "A lista de problemas relacionados foi atualizada.",
+    "unlinked": "Problema não relacionado",
+    "unlinkedDescription": "O problema foi resolvido neste item.",
+    "linked": "Problema relacionado",
+    "linkedDescription": "O problema foi relacionado a este item.",
+    "searchAndLink": "Pesquisar e criar links",
+    "createAndLink": "Criar e vincular",
+    "noLinkedIssues": "Nenhum problema relacionado",
+    "viewExternal": "Ver em {provider}",
+    "unlink": "Desvincular",
+    "linkError": "Falha ao vincular o problema",
+    "linkExternalIssue": "Link {provider} Problema",
+    "linkIssue": "Problema com o link",
+    "addIssue": "Adicionar problema",
+    "unlinkError": "Falha ao desvincular o problema",
+    "noIssuesFound": "Nenhum problema encontrado",
+    "startTypingToSearch": "Comece a digitar para pesquisar problemas",
+    "selectedCount": "{count} selecionado",
+    "confirmSelection": "Confirmar seleção",
+    "alreadyLinked": "Já está vinculado",
+    "authenticate": "Autenticar",
+    "authenticationRequired": "Autenticação necessária",
+    "authenticationDescription": "Você precisa se autenticar com {provider} para pesquisar problemas.",
+    "searchIn": "Pesquisar em {provider}",
+    "searchPlaceholder": "Problemas de pesquisa...",
+    "searchIssues": "Problemas de pesquisa",
+    "searchIssuesDescription": "Procure por edições internas para criar um link para este item.",
+    "searchExternalDescription": "Pesquise por {provider} problemas para criar um link para este item.",
+    "error": "Problemas de carregamento",
+    "errorDescription": "Falha ao carregar os problemas. Tente novamente.",
+    "selectIssues": "Selecione os problemas",
+    "authRequiredDescription": "Por favor, autentique-se com {provider} para pesquisar problemas.",
+    "integrationNotConfigured": "Integração não configurada",
+    "integrationNotConfiguredDescription": "Esta integração ainda não foi totalmente configurada. Entre em contato com o administrador do projeto para configurar o projeto externo nas configurações do projeto.",
+    "createIssue": "Criar problema",
+    "createNewIssue": "Criar novo problema",
+    "createIssueDescription": "Criar uma nova solicitação",
+    "createIssueDescriptionWithIntegration": "Crie um novo problema usando {provider}",
+    "createIssueDescriptionSimpleUrl": "Criar uma nova solicitação interna (Integração simples de URL)",
+    "creatingWith": "Criando problema com {provider}",
+    "authenticatedAndReady": "Autenticado e pronto para criar problemas",
+    "created": "Problema criado",
+    "createdInExternal": "Problema criado em {provider}",
+    "createdInternal": "Problema criado localmente",
+    "createdInternalSimpleUrl": "Problema criado internamente e pode ser vinculado por meio de URL simples.",
+    "createError": "Falha ao criar o problema",
+    "useIntegration": "Use {provider}",
+    "useIntegrationDescription": "Criar problema em sistema externo",
+    "externalProject": "Projeto externo",
+    "selectProject": "Selecione o projeto",
+    "issueType": "Tipo de problema",
+    "selectIssueType": "Selecione o tipo de problema",
+    "noIssueTypes": "Não há tipos de problema disponíveis",
+    "priorityUrgent": "Urgente",
+    "additionalFields": "Campos adicionais",
+    "createIssueInJira": "Criar solicitação no Jira",
+    "createIssueInJiraDescription": "Utilize a interface do Jira para criar uma nova solicitação com todos os campos e opções disponíveis.",
+    "createIssueInJiraFallbackDescription": "Abra o Jira em uma nova aba para criar uma solicitação com informações pré-preenchidas.",
+    "jiraIframeError": "Não foi possível carregar a interface do Jira. Tente abrir em uma nova aba.",
+    "jiraIframeFallback": "Por motivos de segurança, o Jira exige que seja aberto em uma nova aba. Clique no botão abaixo para criar sua solicitação.",
+    "jiraFallbackNote": "Após criar a solicitação no Jira, retorne aqui para continuar vinculando-a ao seu caso de teste.",
+    "openInNewTab": "Abrir em nova aba",
+    "jiraIframeNote": "Após criar a solicitação no Jira, você pode fechar esta caixa de diálogo e atualizar a lista de solicitações.",
+    "fillInRequiredFields": "Preencha os campos obrigatórios para criar uma nova ocorrência.",
+    "failedToFetchFields": "Falha ao buscar os campos da issue no Jira.",
+    "enterSummary": "Insira um breve resumo do problema.",
+    "enterDescription": "Insira uma descrição detalhada do problema.",
+    "failedToCreateIssue": "Falha ao criar a solicitação no Jira",
+    "issueCreatedDescription": "A solicitação {key} foi criada com sucesso.",
+    "addLabel": "Adicione uma etiqueta e pressione Enter.",
+    "labelHint": "Os espaços serão substituídos por hífenes.",
+    "labelFormatNote": "Os rótulos não podem conter espaços. Os espaços serão automaticamente substituídos por hífenes.",
+    "enterIssueKey": "Insira a chave da edição (ex.: PROJ-123)",
+    "issueLinkHelp": "Insira a chave de um problema existente para criar um link.",
+    "searchForIssue": "Procure um problema para vincular.",
+    "searchUsers": "Pesquisar usuários",
+    "noTeamsAvailable": "Nenhuma equipe disponível",
+    "filterAll": "Todos",
+    "fanOutPartialFailure": "Não foi possível acessar {count} projetos. Exibindo resultados de {successCount} projetos.",
+    "projectSelectorLabel": "Projeto",
+    "searchFailedTitle": "A busca falhou"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Navegue e gerencie todos os problemas.",
+      "filterPlaceholder": "Filtrar problemas por nome..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Documentação",
+      "Milestones": "Conquistas",
+      "TestCaseRepository": "Repositório de casos de teste",
+      "TestCaseRestrictedFields": "Campos restritos do caso de teste",
+      "TestRuns": "Testes de execução",
+      "ClosedTestRuns": "Testes fechados",
+      "TestRunResults": "Resultados do teste",
+      "TestRunResultRestrictedFields": "Campos restritos do resultado da execução do teste",
+      "Sessions": "Sessões",
+      "SessionsRestrictedFields": "Campos restritos de sessão",
+      "ClosedSessions": "Sessões fechadas",
+      "SessionResults": "Resultados da sessão",
+      "Tags": "Etiquetas",
+      "SharedSteps": "Passos Compartilhados",
+      "Issues": "Problemas",
+      "IssueIntegration": "Integração de Problemas",
+      "Forecasting": "Previsão",
+      "Reporting": "Relatórios",
+      "Settings": "Configurações"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Não iniciado",
+      "IN_PROGRESS": "Em andamento",
+      "DONE": "Feito"
+    }
+  },
+  "charts": {
+    "average": "Média",
+    "count": "Contagem: {count}",
+    "percent": "Percentagem: {percent}%",
+    "completed": "Concluído: {count}",
+    "durationRange": "Duração: {from}s - {to}s",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# caso de teste} other {# casos de teste}}",
+    "estimate": "Est: {value}",
+    "partOf": "(Parte de {parent})",
+    "status": "Status: {status}"
+  },
+  "linkedCases": {
+    "title": "Casos de teste vinculados",
+    "addLink": "Adicionar link",
+    "addLinkedTestCase": "Adicionar caso de teste vinculado",
+    "testCase": "Caso de teste",
+    "linkType": "Tipo de link",
+    "noLinkedCases": "Não há casos de teste relacionados.",
+    "linkedBy": "Ligado por",
+    "on": "Ligado em",
+    "alreadyLinked": "Este caso já está vinculado.",
+    "cannotLinkSelf": "Não é possível vincular um caso a si mesmo.",
+    "circularLink": "Ligação circular detectada.",
+    "failedToCreate": "Não foi possível criar o link.",
+    "confirmRemoveLink": "Tem certeza de que deseja remover este link?",
+    "DEPENDS_ON": "Dependência",
+    "DUPLICATED_FROM": "Duplicado de",
+    "SAME_TEST_DIFFERENT_SOURCE": "Mesmo teste (fonte diferente)",
+    "status": "Status mais recente",
+    "at": "Executado"
+  },
+  "ganttTooltip": {
+    "task": "Tarefa",
+    "group": "Execução/Sessão:",
+    "project": "Projeto:",
+    "starts": "Inícios:",
+    "scheduledCompletion": "Conclusão prevista:",
+    "estWorkEffort": "Esforço de trabalho estimado:",
+    "noTasks": "Não há tarefas para exibir no gráfico de Gantt."
+  },
+  "help": {
+    "project": {
+      "name": "## Nome do Projeto\nO identificador único do seu projeto.\n\n- Deve ser único em todos os projetos\n- Usado na navegação e em relatórios\n- Deve ser claro e descritivo\n- Ajuda os membros da equipe a identificar o escopo do projeto",
+      "description": "## Descrição do Projeto\nDetalhes adicionais sobre o propósito e o escopo do projeto.\n\n- Opcional, mas recomendado\n- Ajuda os membros da equipe a entenderem os objetivos do projeto\n- Pode incluir objetivos ou requisitos principais\n- Limitado a 256 caracteres",
+      "icon": "## Ícone do Projeto\nUm identificador visual para o seu projeto.\n\n- Ajuda a identificar rapidamente o projeto em listas e painéis\n- Escolha entre uma variedade de ícones predefinidos\n- Pode ser alterado a qualquer momento\n- Aparece na navegação e nos relatórios do projeto",
+      "completed": "## Status do Projeto\nIndica se o projeto está ativo ou concluído.\n\n- Projetos ativos estão disponíveis para testes e atualizações\n- Projetos concluídos são somente leitura\n- Afeta a visibilidade do projeto nos painéis\n- Pode ser revertido, se necessário",
+      "completedAt": "## Data de Conclusão\nA data em que o projeto foi marcado como concluído.\n\n- Definida automaticamente ao marcar um projeto como concluído\n- Usada para relatórios e acompanhamento\n- Ajuda a manter o histórico do projeto\n- Pode ser modificada, se necessário",
+      "defaultAccess": "## Acesso padrão do projeto\nDefina as permissões de acesso padrão para usuários e grupos neste projeto. Isso pode ser alterado para usuários ou grupos individualmente.",
+      "issueTracker": "## Configuração do rastreador de problemas\nSelecione a configuração do rastreador de problemas a ser usada para gerenciar problemas relacionados a este projeto."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Projeto Externo\nSelecione o projeto ou repositório no sistema externo para vincular a este projeto do TestPlanIt.\n\n- Os problemas criados no TestPlanIt serão criados neste projeto\n- Permite a integração do rastreamento de problemas entre sistemas\n- É necessário ter as permissões apropriadas no sistema externo",
+          "defaultIssueTypeHelp": "## Tipo de Incidente Padrão\nO tipo de incidente que será pré-selecionado ao criar novos incidentes no TestPlanIt.\n\n- Economiza tempo ao usar como padrão o tipo de incidente mais comum\n- Pode ser alterado ao criar incidentes individuais\n- Deve ser um tipo de incidente válido para o projeto externo selecionado\n- Atualize este valor se o seu fluxo de trabalho mudar",
+          "automaticSyncHelp": "## Sincronização Automática\nAtiva a sincronização automática do status das tarefas entre o TestPlanIt e o sistema externo.\n\n- As tarefas vinculadas a casos de teste terão seu status atualizado automaticamente.\n- Ajuda a manter o rastreamento de tarefas consistente entre os sistemas.\n- Pode aumentar o uso da API com o serviço externo.\n- Pode ser desativada se o controle manual for preferido."
+        }
+      }
+    },
+    "user": {
+      "name": "## Nome de Usuário\nO nome completo do usuário.\n\n- Usado para identificação em todo o sistema\n- Exibido em tarefas e relatórios\n- Deve ser único para cada usuário",
+      "email": "## Endereço de e-mail\nO endereço de e-mail do usuário para acesso à conta.\n\n- Usado para login no sistema\n- Deve ser único para cada usuário\n- Usado para notificações do sistema",
+      "password": "## Senha\nA senha da conta do usuário.\n\n- Opcional quando um método de login sem senha estiver configurado (provedor SSO Magic Link ou servidor de e-mail) — deixe em branco para exigir login via link mágico ou SSO\n- Quando fornecida, deve atender à política de senhas definida em **Administração → Segurança** (comprimento mínimo e classes de caracteres)\n- Usada para acesso seguro à conta\n- Deve ser mantida em sigilo",
+      "token": "## Token de verificação\nInsira o token que você recebeu por e-mail para verificar sua conta. Se você não tiver um token, poderá solicitar um novo.",
+      "confirmPassword": "## Confirmar Senha\nDigite a senha novamente para garantir que foi digitada corretamente.\n\n- Deve ser exatamente igual à senha\n- Ajuda a evitar erros de digitação\n- Obrigatório apenas quando uma senha é inserida — deixe em branco se o campo de senha estiver vazio",
+      "access": "## Nível de Acesso ao Sistema\nDetermina as permissões do usuário em todo o sistema.\n\n- **Administrador:** Acesso total ao sistema e configuração\n- **Administrador de Projetos:** Pode gerenciar projetos atribuídos\n- **Usuário:** Acesso padrão aos projetos atribuídos\n- **Nenhum:** Pode apenas visualizar seu painel de controle",
+      "role": "## Função do Sistema\nEsta função determina as permissões padrão do usuário para projetos.\n\n- Define os níveis de acesso padrão para projetos\n- Pode ser personalizada na Administração de Funções\n- Afeta os recursos e funcionalidades disponíveis",
+      "active": "## Status Ativo\nControla se um usuário pode acessar o sistema.\n\n- Usuários ativos podem fazer login e acessar os recursos atribuídos a eles.\n- Usuários inativos não podem fazer login, mas seus dados são preservados.\n  - Use esta opção para desativar temporariamente o acesso sem excluir a conta.",
+      "api": "## Acesso à API\nPermite o acesso programático ao sistema por meio de endpoints da API.\n\n- Permite a integração com ferramentas externas e automação\n- Requer autenticação por chave de API\n- Sujeito a limitação de taxa e controles de acesso",
+      "projects": "## Atribuição de Projetos\nSelecione a quais projetos este usuário pode acessar.\n\n- Controla quais projetos aparecem no painel do usuário\n- Obrigatório para participação no projeto\n- Pode ser modificado posteriormente pelos administradores\n- Use \"Selecionar tudo\" para atribuir rapidamente todos os projetos disponíveis",
+      "groups": "## Atribuição de Grupos\nSelecione a quais grupos este usuário pertence.\n\n- Os grupos ajudam a organizar usuários e permissões\n- Os usuários herdam as permissões de seus grupos\n- Simplifica o gerenciamento de acesso\n- Pode ser modificado posteriormente pelos administradores",
+      "itemsPerPage": "## Itens por Página\nControla o número padrão de itens exibidos em tabelas e listas.\n\n- Afeta todas as visualizações paginadas do aplicativo\n- Pode ser alterado a qualquer momento\n- Ajuda a gerenciar grandes conjuntos de dados com eficiência\n- Opções disponíveis: 10, 25, 50 ou 100 itens",
+      "dateFormat": "## Formato de Data\nDefine o formato de exibição de data preferido.\n\n- Aplicado de forma consistente em todo o aplicativo\n- Ajuda a garantir a precisão na interpretação da data\n- As alterações entram em vigor imediatamente\n- Os exemplos mostrados no menu suspenso refletem o formato real",
+      "timeFormat": "## Formato de Hora\nDefine o formato de exibição de hora preferido.\n\n- Escolha entre os formatos de 12 e 24 horas\n- Aplicado de forma consistente em todo o aplicativo\n- As alterações entram em vigor imediatamente\n- Os exemplos mostrados no menu suspenso refletem o formato real",
+      "timezone": "## Fuso horário\nDefine o fuso horário de sua preferência para exibição de data e hora.\n\n- Aplicado de forma consistente em todo o aplicativo",
+      "theme": "## Tema\nEscolha seu tema visual preferido para o aplicativo.\n\n- **Sistema:** Combina automaticamente com o tema do seu sistema operacional\n- **Claro:** Interface limpa e brilhante para uso diurno\n- **Escuro:** Modo escuro que não agride os olhos em ambientes com pouca luz\n- **Verde, Laranja, Roxo:** Um toque divertido de cor!",
+      "locale": "## Idioma\nSelecione o idioma de sua preferência para a interface do aplicativo.\n\n- Altera todo o texto, rótulos e mensagens para o idioma escolhido.\n- Os formatos de data e hora se ajustam às convenções regionais.\n- A alteração entra em vigor imediatamente, sem a necessidade de atualizar a página.\n- Os idiomas disponíveis dependem das traduções instaladas.",
+      "notificationMode": "## Preferências de Notificação\nControla como você recebe notificações de tarefas e atualizações.\n\n- **Usar Configurações Globais:** Seguir as configurações padrão do sistema definidas pelos administradores\n- **Sem Notificações:** Desativar todas as notificações\n- **Somente no Aplicativo:** Receber notificações apenas dentro do aplicativo\n- **No Aplicativo + E-mail (Imediato):** Receber notificações no aplicativo e alertas imediatos por e-mail\n- **No Aplicativo + E-mail (Resumo Diário):** Receber notificações no aplicativo e um resumo diário por e-mail\n\nVocê pode alterar essa preferência a qualquer momento para adequá-la ao seu fluxo de trabalho."
+    },
+    "milestone": {
+      "name": "## Nome do Marco\nUm nome claro e descritivo que identifique este marco em seu projeto.\n\n- Deve ser único e significativo\n- Ajuda os membros da equipe a entenderem rapidamente o propósito do marco\n- Usado em relatórios e acompanhamento do projeto",
+      "type": "## Tipo de Marco\nCategoriza o marco e determina sua aparência e comportamento.\n\n- Diferentes tipos podem ter fluxos de trabalho diferentes\n- Ajuda a organizar e filtrar marcos\n- Pode afetar a geração de relatórios e o acompanhamento",
+      "started": "## Status de Início\nIndica que o trabalho nesta etapa foi iniciado.\n\n- Marca a etapa como em andamento\n- Atualiza a data de início real automaticamente quando ativada\n- Afeta o cronograma do projeto e o acompanhamento do progresso",
+      "completed": "## Status Concluído\nIndica que o trabalho nesta etapa foi finalizado.\n\n- Marca a etapa como concluída\n- Atualiza automaticamente a data de conclusão real\n- Usado para acompanhamento e relatório de progresso\n- Afeta etapas dependentes e cronogramas do projeto",
+      "startDate": "## Data de Início Planejada\nA data prevista para o início do trabalho nesta etapa.\n\n- Auxilia no planejamento e cronograma do projeto\n- Utilizada para projeções de cronograma\n- Auxilia no planejamento de alocação de recursos",
+      "dueDate": "## Data de Vencimento\nA data prevista para a conclusão desta etapa.\n\n- Define as expectativas de prazo\n- Usada para o planejamento do cronograma do projeto\n- Ajuda a acompanhar o progresso da etapa em relação ao cronograma",
+      "parent": "## Marco Principal\nVincula este marco a um marco principal, criando uma hierarquia.\n\n- Organiza os marcos em grupos lógicos\n- Mostra dependências e relacionamentos\n- Ajuda a acompanhar o progresso de iniciativas maiores",
+      "description": "## Descrição\nInformações detalhadas sobre o propósito, os requisitos e o escopo do marco.\n\n- Fornece contexto para os membros da equipe\n- Documenta os principais requisitos e objetivos\n- Apoia a colaboração e o alinhamento",
+      "documentation": "## Documentação\nDetalhes adicionais, referências e materiais de apoio.\n\n- Especificações técnicas\n- Documentos de projeto\n- Referências externas\n- Atas e decisões de reuniões",
+      "automaticCompletion": "## Preenchimento automático na data de vencimento\nMarca automaticamente este marco como concluído quando a data de vencimento for atingida.\n\n- O marco será concluído no horário agendado na data de vencimento.\n- Útil para marcos com tempo definido que devem ser fechados independentemente do status de conclusão.\n- Pode ser substituído pela conclusão manual do marco antes da data de vencimento.\n- Requer que uma data de vencimento seja definida.",
+      "notifyDaysBefore": "## Notificar dias antes do prazo\nEnviar notificações aos membros da equipe atribuídos quando a data de vencimento do marco estiver se aproximando.\n\n- Ative para habilitar as notificações, desative para desabilitar\n- Insira o número de dias antes do prazo para começar a enviar lembretes\n- As notificações são enviadas aos usuários atribuídos às execuções e sessões de teste dentro deste marco\n- Marcos atrasados continuarão enviando lembretes até serem concluídos"
+    },
+    "session": {
+      "name": "## Nome da Sessão\nUm nome claro e descritivo que identifique o propósito da sua sessão de testes.\n\n- Deve ser único e significativo\n- Ajuda os membros da equipe a entenderem o que está sendo testado\n- Usado em relatórios e rastreamento",
+      "template": "## Modelo\nOs modelos definem a estrutura e o conteúdo da sua sessão de testes.\n\n- Fornece um formato consistente para a documentação de testes\n- Inclui seções e campos predefinidos\n- Ajuda a manter os padrões de teste em todo o seu projeto",
+      "configuration": "## Configuração\nO ambiente ou configuração específica necessária para esta sessão de teste.\n\n- Ambiente de teste (ex.: Staging, Produção)\n- Configurações ou definições especiais\n- Dados ou condições de teste necessários",
+      "milestone": "## Marco\nAssocia esta sessão a um marco do projeto.\n\n- Ajuda a acompanhar o progresso dos testes em relação às metas do projeto\n- Agrupa sessões de teste relacionadas\n- Suporta relatórios baseados em marcos",
+      "description": "## Descrição\nUma breve visão geral do que esta sessão de testes abrange.\n\n- Principais áreas ou funcionalidades que estão sendo testadas\n- Contexto ou histórico importante\n- Considerações ou requisitos especiais",
+      "mission": "## Missão\nA missão define os objetivos e metas específicos para esta sessão de testes.\n\n- O que você está testando?\n- Quais são as principais áreas de foco?\n- Quais são os resultados esperados?\n\nUma missão clara ajuda a manter os testes focados e produtivos.",
+      "estimate": "## Estimativa de Tempo\nTempo estimado para concluir esta sessão de teste.\n\nExemplos:\n- \"30m\" para 30 minutos\n- \"1h 30m\" para 1 hora e 30 minutos\n- \"2 dias\" para 2 dias\n- \"1 semana\" para 1 semana",
+      "elapsed": "## Tempo Decorrido\nO tempo real gasto nesta sessão de teste.\n\nExemplos:\n- \"45m\" para 45 minutos\n- \"2h 15m\" para 2 horas e 15 minutos\n- \"3 dias\" para 3 dias\n\nRegistre o tempo com precisão para melhorar as estimativas futuras.",
+      "state": "## Estado do Fluxo de Trabalho\nO status atual desta sessão de teste no seu fluxo de trabalho.\n\n- Ajuda a acompanhar o progresso da sessão\n- Suporta o gerenciamento do fluxo de trabalho\n- Usado para geração de relatórios e acompanhamento",
+      "assignedTo": "## Atribuído a\nO membro da equipe responsável por conduzir esta sessão de testes.\n\n- Identifica quem está realizando o teste\n- Auxilia no gerenciamento de recursos\n- Apoia a responsabilização e o acompanhamento",
+      "tags": "## Etiquetas\nPalavras-chave ou rótulos que ajudam a categorizar e organizar as sessões de teste.\n\n- Facilita a localização das sessões\n- Agrupa atividades de teste relacionadas\n- Auxilia na filtragem e geração de relatórios",
+      "attachments": "## Anexos\nArquivos, capturas de tela ou outros documentos relacionados a esta sessão de teste.\n\n- Arquivos de dados de teste\n- Capturas de tela ou gravações\n- Documentação complementar\n- Materiais de referência",
+      "issues": "## Problemas\nVincule problemas relevantes a esta sessão."
+    },
+    "testRun": {
+      "name": "## Nome da Execução de Teste\nInsira um nome descritivo para esta execução de teste para identificá-la facilmente mais tarde.",
+      "description": "## Descrição\nForneça um breve resumo ou anotações sobre esta execução de teste.",
+      "configuration": "## Configurações\nSelecione uma ou mais configurações (por exemplo, ambiente, navegador, dispositivo) sob as quais os testes serão executados. Selecionar várias configurações criará testes separados para cada uma.",
+      "milestone": "## Marco\nAssocie esta execução de teste a um marco específico do projeto para acompanhar o progresso em direção a objetivos maiores.",
+      "docs": "## Documentação\nInclua qualquer documentação, links ou notas detalhadas relevantes para esta execução de teste.",
+      "state": "## Estado\nIndique o estado atual ou o resultado desta execução de teste de acordo com o fluxo de trabalho do seu projeto.",
+      "tags": "## Etiquetas\nAplique etiquetas relevantes para categorizar e filtrar esta execução de teste.",
+      "issues": "## Problemas\nVincule quaisquer problemas relacionados (bugs, tarefas, etc.) a esta execução de teste.",
+      "attachments": "## Anexos\nEnvie quaisquer arquivos, capturas de tela ou registros relacionados a esta execução de teste.",
+      "duplicate": {
+        "statusesToInclude": "## Status a incluir\nSelecione os status dos casos de teste que você deseja incluir na execução de teste duplicada.",
+        "copyAssignments": "## Copiar atribuições\nSe ativado, as atribuições dos casos de teste serão copiadas para a execução de teste duplicada."
+      }
+    },
+    "appConfig": {
+      "key": "## Chave\nO identificador único para esta configuração.",
+      "value": "## Valor\nO valor desta configuração."
+    },
+    "milestoneType": {
+      "icon": "## Ícone do Tipo de Marco\nUm identificador visual para este tipo de marco.\n\n- Ajuda a identificar rapidamente o tipo de marco em listas e painéis\n- Escolha entre uma variedade de ícones predefinidos\n- Pode ser alterado a qualquer momento\n- Aparece na navegação do projeto e em relatórios",
+      "name": "## Nome do Tipo de Marco\nUm nome claro e descritivo que identifica este tipo de marco em seu projeto.\n\n- Ajuda os membros da equipe a entenderem rapidamente a finalidade do tipo de marco.\n- Usado em relatórios e acompanhamento do projeto.",
+      "isDefault": "## Tipo de Marco Padrão\nIndica se este tipo de marco é o padrão para o seu projeto.\n\n- O tipo de marco padrão já está pré-selecionado para novos marcos.\n- Pode ser alterado a qualquer momento.",
+      "projects": "## Projetos Associados\nSelecione para quais projetos este tipo de marco estará disponível.\n\n- Se nenhum projeto for selecionado, o tipo de marco estará disponível globalmente.\n- Atribuir a projetos específicos restringe seu uso apenas a esses projetos."
+    },
+    "tag": {
+      "name": "## Nome da Tag\nUm nome ou palavra(s)-chave clara(s), concisa(s) e descritiva(s) que é(são) usada(s) em todos os projetos.\n\n- Ajuda os membros da equipe a encontrar rapidamente casos de teste, execuções de teste e sessões relacionadas."
+    },
+    "role": {
+      "name": "## Nome da função\nUm nome ou palavra(s)-chave clara(s), concisa(s) e descritiva(s) que seja(m) usada(s) em todos os projetos.\n\n- Ajuda os membros da equipe a encontrar rapidamente casos de teste, execuções de teste e sessões relacionadas.",
+      "isDefault": "## Função Padrão\nIndica se esta função é a padrão para o seu projeto.\n\n- A função padrão é pré-selecionada para novos usuários.\n- Pode ser alterada a qualquer momento.",
+      "permissions": {
+        "canAddEdit": "## Adicionar/Editar\nIndica se esta função pode adicionar e editar a área de aplicação relacionada.",
+        "canDelete": "## Excluir\nIndica se esta função pode excluir a área de aplicação relacionada.",
+        "canClose": "## Fechar\nIndica se esta função pode fechar a área de aplicação relacionada."
+      }
+    },
+    "group": {
+      "name": "## Nome do Grupo\nUm nome ou palavra(s)-chave clara(s), concisa(s) e descritiva(s) que seja(m) usada(s) em todos os projetos.\n\n- Ajuda os membros da equipe a encontrar rapidamente casos de teste, execuções de teste e sessões relacionadas.",
+      "users": "## Usuários\nIndica os usuários que estão atribuídos a este grupo."
+    },
+    "template": {
+      "name": "## Nome do modelo\nUm nome único e descritivo para este modelo (por exemplo, 'Caso de teste padrão', 'Resultados do teste de API').",
+      "isEnabled": "## Ativado\nSe marcado, este modelo estará disponível para seleção ao criar novos casos de teste ou definir estruturas de execução de testes. Se um modelo estiver definido como 'Padrão', ele também deverá estar 'Ativado'.",
+      "isDefault": "## Padrão\nSe marcado, este modelo será selecionado automaticamente para novos projetos ou como padrão para todos os projetos, caso nenhum padrão específico do projeto esteja definido. Apenas um modelo pode ser o padrão para todos os projetos. Habilitar esta opção desabilitará qualquer outro modelo atualmente definido como padrão.",
+      "caseFields": "## Campos de Caso\nSelecione e ordene os campos personalizados que estarão disponíveis ao criar ou editar casos de teste usando este modelo.\n\n- Adicione campos da lista suspensa para incluí-los no modelo\n- Arraste e solte para reordenar os campos\n- A ordem determina como os campos aparecem nos formulários\n- Somente os campos de caso habilitados estão disponíveis para seleção\n- Os campos de caso definem a estrutura e os dados capturados para os casos de teste",
+      "resultFields": "## Campos de Resultado\nSelecione e ordene os campos personalizados que estarão disponíveis ao adicionar resultados de teste usando este modelo.\n\n- Adicione campos da lista suspensa para incluí-los no modelo\n- Arraste e solte para reordenar os campos\n- A ordem determina como os campos aparecem ao inserir resultados de teste\n- Somente os campos de resultado habilitados estão disponíveis para seleção\n- Os campos de resultado capturam dados adicionais específicos dos resultados da execução do teste",
+      "projects": "## Projetos Associados\nSelecione para quais projetos este modelo estará disponível. Se nenhum projeto for selecionado, o modelo estará disponível globalmente. Atribuir um modelo a projetos específicos restringe seu uso apenas a esses projetos."
+    },
+    "llm": {
+      "name": "## Nome da integração\nUm rótulo descritivo para esta integração do LLM.\n\n- Usado para identificá-la em listas e configurações\n- Exemplo: \"OpenAI GPT-4o\" ou \"Internal Ollama\"",
+      "provider": "## Provedor\nO serviço LLM que viabiliza esta integração.\n\n- Determina o protocolo da API e os modelos disponíveis\n- Não pode ser alterado após a criação",
+      "apiKey": "## Chave da API\nSua chave de autenticação para a API do provedor LLM.\n\n- Obtenha-a no console do desenvolvedor do seu provedor.\n- Mantida criptografada e nunca exibida após o salvamento.\n- Não é necessária para o Ollama (implantação local).",
+      "endpoint": "## Endpoint da API\nA URL base para a API do provedor LLM.\n\n- Deixe em branco para OpenAI, Anthropic e Gemini — as URLs oficiais são usadas automaticamente\n- Obrigatório para Ollama (ex.: `http://localhost:11434`), Azure OpenAI e LLM personalizado\n- Opcional para qualquer provedor — aponte para um proxy compatível com OpenAI (ex.: LiteLLM) inserindo sua URL\n- **Endereços privados/internos** (localhost, 127.0.0.1, IPs privados, metadados da nuvem) são bloqueados, a menos que sejam explicitamente permitidos por meio da variável de ambiente `ALLOWED_PRIVATE_HOSTS`",
+      "deploymentName": "## Nome da Implantação do Azure\nO nome da sua implantação do modelo do Azure OpenAI.\n\n- Encontrado no Azure OpenAI Studio em Implantações\n- Diferente do nome do modelo — por exemplo, `my-gpt4-deploy` corresponde a `gpt-4`\n- Necessário apenas para o Azure OpenAI",
+      "defaultModel": "## Modelo Padrão\nO modelo usado para solicitações de IA com esta integração.\n\n- Para OpenAI, Anthropic e Gemini — os modelos disponíveis são obtidos automaticamente da sua chave de API\n- Certifique-se de que o modelo esteja habilitado na sua conta de provedor\n- Exemplo: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Tokens Máximos por Requisição\nO **limite máximo** de tokens de saída para qualquer requisição individual.\n\n- Requisições que excedam este limite são **rejeitadas com um erro** antes de atingirem o LLM.\n- Defina este valor para a capacidade máxima real de tokens de saída do seu modelo.\n- Exemplo: `16384` para GPT-4o, `8192` para Claude 3.5 Sonnet.\n- Definir este valor muito baixo faz com que os recursos de IA falhem ou produzam resultados truncados.",
+      "defaultMaxTokens": "## Tokens Máximos Padrão\nO limite de tokens de saída **de fallback** usado quando uma solicitação não especifica o seu próprio.\n\n- Cada recurso de IA (geração de testes, exportação de código, etc.) define seu próprio limite em **Administração → Configuração de Solicitações**\n- Este valor é usado apenas como fallback para recursos sem um limite específico configurado\n- Deve ser ≤ Tokens Máximos por Solicitação",
+      "maxRequestsPerMinute": "## Número máximo de solicitações por minuto\nLimita quantas chamadas de API podem ser feitas para este provedor por minuto.\n\n- Defina para corresponder ao limite de taxa do seu plano de provedor.\n- Solicitações excedentes são enfileiradas, não rejeitadas.\n- Consulte a documentação do seu provedor para verificar o limite do seu plano.",
+      "costPerInputToken": "## Custo por Token de Entrada (USD)\nO custo em USD para cada token de entrada (prompt) enviado ao modelo.\n\n- Usado para rastreamento de custos e alertas de orçamento\n- Encontre isso na página de preços do seu provedor\n- Exemplo: `0,000005` = US$ 5 por milhão de tokens de entrada",
+      "costPerOutputToken": "## Custo por Token de Saída (USD)\nO custo em USD para cada token de saída (conclusão) gerado pelo modelo.\n\n- Geralmente maior que o custo do token de entrada\n- Usado para controle de custos e alertas de orçamento\n- Exemplo: `0,000015` = US$ 15 por milhão de tokens de saída",
+      "monthlyBudget": "## Orçamento Mensal (USD)\nUma meta de gastos opcional para esta integração.\n\n- Defina como `0` para desativar o rastreamento do orçamento\n- O orçamento é **apenas informativo** — ele não bloqueia o uso do LLM\n- Você receberá notificações quando o orçamento atingir 80%, 90% e 100%\n- Os custos são calculados usando as taxas por token acima",
+      "billingPeriodStartDay": "## Dia de Início do Período de Faturamento\nO dia do mês (1 a 31) em que seu período de faturamento começa.\n\n- O valor padrão `1` alinha-se com o mês do calendário.\n- Defina como `15` para um ciclo de 15 a 15 (por exemplo, para corresponder à data da fatura do seu fornecedor).\n- Os valores `29 a 31` são automaticamente ajustados ao último dia dos meses mais curtos (fevereiro em anos não bissextos, etc.).\n- Afeta o período de gastos do **Orçamento Mensal** e a ação **Redefinir Gastos**.",
+      "defaultTemperature": "## Temperatura Padrão\nControla a aleatoriedade das respostas do modelo (0–2).\n\n- **0:** Determinístico — saída idêntica para a mesma entrada\n- **0,3:** Focado — recomendado para geração de testes e saída de código\n- **1+:** Criativo — respostas mais variadas\n- Recursos individuais podem substituir isso na Configuração de Prompt",
+      "timeout": "## Tempo limite da solicitação (ms)\nTempo de espera por uma resposta antes que a solicitação seja cancelada.\n\n- O valor está em milissegundos (ex.: `30000` = 30 segundos)\n- Solicitações de streaming (ex.: pré-visualização de exportação de código) ignoram este tempo limite\n- Aumente para modelos lentos ou grandes\n- Intervalo: 5.000 – 600.000 ms",
+      "streamingEnabled": "## Habilitar Streaming\nTransmite a resposta token por token em vez de esperar pela saída completa.\n\n- Necessário para a pré-visualização do código em tempo real no modal de Exportação\n- Reduz a latência percebida para respostas longas\n- Recomendado para todos os provedores compatíveis",
+      "isDefault": "## Definir como integração padrão\nDefine esta integração como padrão para todos os recursos de IA.\n\n- Apenas uma integração pode ser definida como padrão por vez.\n- Recursos sem um provedor específico configurado usarão a integração padrão.\n- Pode ser alterada a qualquer momento."
+    },
+    "integration": {
+      "name": "## Nome da Integração\nUm nome descritivo para identificar esta integração em todo o sistema.\n\n- Deve ser único para diferenciá-lo de outras integrações\n- Usado nas configurações e definições do projeto\n- Deve indicar claramente o serviço e a finalidade",
+      "authType": "## Tipo de Autenticação\nEscolha como autenticar com o serviço externo.\n\n- **Chave de API:** Autenticação simples usando e-mail e token de API\n- **OAuth 2.0:** Autenticação segura usando o fluxo OAuth\n- **Token de Acesso Pessoal:** Autenticação direta baseada em token",
+      "email": "## Endereço de e-mail\nSeu endereço de e-mail para o serviço externo.\n\n- Usado para autenticação da chave da API\n- Deve corresponder à conta que gerou o token da API\n- Obrigatório para o Jira e serviços similares",
+      "apiToken": "## Token de API\nGere um token de API nas configurações da sua conta no serviço externo.\n\n- Geralmente encontrado em Configurações da conta → Segurança → Tokens de API\n- Fornece acesso seguro sem expor sua senha\n- Pode ser revogado e regenerado conforme necessário",
+      "jiraUrl": "## URL do Jira\nA URL base da sua instância do Jira.\n\n- Formato: https://seu-site.atlassian.net\n- Não inclua /browse ou outros caminhos\n- Deve ser acessível a partir deste servidor",
+      "clientId": "## ID do Cliente OAuth\nO ID do cliente da configuração do seu aplicativo OAuth.\n\n- Criado no console do desenvolvedor do serviço externo\n- Usado para identificar seu aplicativo durante o fluxo OAuth\n- Pode ser compartilhado com segurança em arquivos de configuração",
+      "clientSecret": "## Segredo do Cliente OAuth\nO Segredo do Cliente da configuração do seu aplicativo OAuth.\n\n- Criado junto com o ID do Cliente\n- Deve ser mantido em sigilo e segurança\n- Usado para autenticar seu aplicativo",
+      "personalAccessToken": "## Token de Acesso Pessoal\nUm token de acesso pessoal com as permissões apropriadas para o serviço externo.\n\n- Gerado nas configurações da sua conta\n- Deve ter permissões de leitura e gravação\n- Mais seguro do que a autenticação por senha",
+      "baseUrl": "## Padrão de URL\nPadrão de URL para criar links para problemas externos.\n\n- Use '{issueId}' como um marcador para o identificador do problema\n- Exemplo: https://example.com/issues/'{issueId}'\n- Usado para integrações simples baseadas em URL",
+      "organizationUrl": "## URL da organização\nURL da sua organização do Azure DevOps.\n\n- Formato: https://dev.azure.com/sua-organização\n- Deve ser acessível a partir deste servidor\n- Usada para acessar as APIs do Azure DevOps",
+      "apiKey": "## Chave da API\nA chave da API para autenticação com o serviço externo.\n\n- Gerada nas configurações da API do serviço\n- Fornece acesso programático ao serviço\n- Mantenha em segurança e alterne regularmente",
+      "forgeApiKey": "## Chave da API do Forge\nUsada para autenticar o aplicativo Atlassian Forge quando ele busca dados de teste de suas tarefas do Jira.\n\n- Clique em Gerar para criar uma nova chave\n- Copie a chave e cole-a nas configurações do aplicativo Forge no Jira (Gerenciar Aplicativos → Configurações do TestPlanIt)\n- Gerar novamente invalidará a chave anterior",
+      "owner": "## Proprietário / Namespace\nO usuário ou organização que possui o repositório.\n\n- Para GitHub/GitLab: o nome de usuário ou nome da organização\n- Para Gitea/Forgejo/Gogs: o nome do usuário ou grupo\n- Exemplo: my-org ou my-username",
+      "repo": "## Nome do Repositório\nO nome do repositório do qual os problemas serão vinculados.\n\n- Nome exato do repositório (não a URL completa)\n- Exemplo: meu-projeto\n- Deve ser acessível com as credenciais fornecidas",
+      "instanceUrl": "## URL da instância\nA URL base da sua instância auto-hospedada.\n\n- Formato: https://git.example.com\n- Não inclua barras ou caminhos no final\n- Deve ser acessível a partir deste servidor",
+      "projectPath": "## Caminho do Projeto\nO caminho completo para o seu projeto GitLab.\n\n- Formato: namespace/projeto ou grupo/subgrupo/projeto\n- Exemplo: my-org/my-project\n- Encontrado na URL do projeto: gitlab.com/namespace/project",
+      "platform": "## Plataforma\nA plataforma Git auto-hospedada à qual você está se conectando.\n\n- **Gitea**: instâncias baseadas em gitea.io\n- **Forgejo**: instâncias baseadas em forgejo.org (fork do Gitea)\n- **Gogs**: instâncias baseadas em gogs.io\n\nIsso controla qual ícone é exibido e pode afetar a compatibilidade da API."
+    },
+    "config": {
+      "name": "## Nome da Configuração\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever as combinações de variantes que compõem a Configuração (por exemplo, \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", etc.)."
+    },
+    "configCategory": {
+      "name": "## Nome da Categoria\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a organizar variantes (por exemplo, Chrome, Firefox, Safari, Edge, etc.) em categorias (por exemplo, Navegadores)."
+    },
+    "configVariant": {
+      "name": "## Nome da variante\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever a variante que faz parte de um ambiente de teste (por exemplo, Chrome, Safari, Windows 10, Windows 11, macOS 15.5, etc.)."
+    },
+    "issueConfig": {
+      "name": "## Nome da Configuração da Incidência\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever a configuração da incidência (ex: Jira, GitHub, etc.).",
+      "baseUrl": "## URL base\nA URL base para a configuração da tarefa, incluindo o espaço reservado para a tarefa (ex: https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Tipo de sistema\nO tipo de sistema de rastreamento de problemas (ex: LINK Jira, etc.).",
+      "isActive": "## Ativo\nIndica se esta configuração de problema está ativa.",
+      "isDefault": "## Padrão\nIndica se esta configuração de problema é a padrão para o seu projeto.\n\n- A configuração de problema padrão é pré-selecionada para novos problemas.\n- Pode ser alterada a qualquer momento.",
+      "projects": "## Projetos\nIndica os projetos que estão atribuídos a esta configuração de problema."
+    },
+    "issue": {
+      "name": "## Nome do Problema\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever o problema (ex: \"Problema 123\", \"Bug 456\", etc.).",
+      "title": "## Título da Edição\nUm título legível que descreve a edição.\n\n- Fornece contexto sobre o assunto da edição\n- Exibido em listas e visualizações de edições\n- Deve ser claro e descritivo",
+      "externalKey": "## Chave Externa\nA chave ou identificador exclusivo do sistema externo de rastreamento de problemas.\n\n- Para JIRA: Chave do problema, como \"PROJ-123\"\n- Para GitHub: Número do problema, como \"456\"\n- Para Azure DevOps: ID do item de trabalho\n- Gera automaticamente a URL externa ao salvar",
+      "externalId": "## ID externo\nO identificador único para este problema no sistema de rastreamento de problemas (por exemplo, \"Problema-123\", \"Bug456\", etc.).\n\n- Este é usado como marcador de posição do problema no URL base.",
+      "description": "## Descrição\nUma breve visão geral do que esta questão abrange.\n\n- Principais áreas ou funcionalidades que estão sendo testadas\n- Contexto ou histórico importante\n- Considerações ou requisitos especiais",
+      "project": "## Projeto\nO projeto ao qual este problema está associado.\n\n- Problemas podem ser vinculados a casos de teste em vários projetos\n- Definir um projeto principal ajuda a organizar os problemas\n- Pode ser deixado em branco para problemas que abrangem vários projetos",
+      "state": "## Estado\nIndique o estado atual ou o resultado deste problema de acordo com o fluxo de trabalho do seu projeto.",
+      "tags": "## Etiquetas\nAplique etiquetas relevantes para categorizar e filtrar este problema.",
+      "issues": "## Problemas\nVincule quaisquer problemas relacionados (bugs, tarefas, etc.) a este problema."
+    },
+    "status": {
+      "name": "## Nome do Status\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever o status do resultado do teste (ex: Aprovado, Reprovado, Bloqueado, etc.).",
+      "color": "## Cor\nA cor deste status.",
+      "systemName": "## Nome do Sistema\nO nome do status usado pelo sistema de backend (por exemplo, consultas de banco de dados, relatórios, etc.).",
+      "aliases": "## Aliases\nNomes adicionais ou sinônimos para este status que podem ser usados para vincular status de sistemas externos a este status.",
+      "enabled": "## Ativado\nIndica se este status está ativado.",
+      "isEnabled": "## Ativado\nIndica se este status está ativado e disponível para uso.\n\n- Quando ativado, este status pode ser selecionado ao registrar os resultados dos testes.\n- Os status desativados ficam ocultos para seleção, mas são preservados nos resultados existentes.",
+      "success": "## Sucesso\nIndica se este status é um status de sucesso.",
+      "isSuccess": "## Status de Sucesso\nIndica se este status representa um resultado de teste bem-sucedido.\n\n- Os status de sucesso contribuem para as métricas de taxa de aprovação.\n- Usado em relatórios e análises para acompanhar a eficácia do teste.",
+      "completed": "## Concluído\nIndica se este status foi concluído.",
+      "isCompleted": "## Status de Conclusão\nIndica se este status representa uma execução de teste concluída.\n\n- Status de conclusão indicam que o teste terminou de ser executado.\n- Usado para calcular taxas de conclusão e acompanhamento do progresso.",
+      "failure": "## Falha\nIndica se este status é um status de falha.",
+      "isFailure": "## Status de Falha\nIndica se este status representa um resultado de teste falho.\n\n- Os status de falha contribuem para as métricas de taxa de falha.\n- Usado em relatórios e análises para identificar problemas.",
+      "scope": "## Escopo\nIndica o escopo deste status (Execução de Teste, Sessão, Automação).",
+      "projects": "## Projetos\nIndica os projetos que podem usar este status."
+    },
+    "workflow": {
+      "scope": "## Escopo\nIndica o escopo deste fluxo de trabalho (Execução de Teste, Sessão, Automação).\n\n- Não pode ser alterado depois que o fluxo de trabalho for criado.",
+      "iconColor": "## Ícone/Cor\nO ícone e a cor para este fluxo de trabalho.",
+      "name": "## Nome\nUm nome claro e descritivo que é usado em todos os projetos.\n\n- Ajuda a descrever o fluxo de trabalho (ex.: \"Rascunho\", \"Em revisão\", \"Ativo\", etc.).",
+      "workflowType": "## Digite\no tipo de fluxo de trabalho (Não iniciado, Em andamento, Concluído).",
+      "type": "## Tipo de Fluxo de Trabalho\nA categoria do estado do fluxo de trabalho (Não Iniciado, Em Andamento, Concluído).\n\n- Determina como esse estado afeta o acompanhamento do progresso\n- Os estados \"Não Iniciado\" indicam que o trabalho não começou\n- Os estados \"Em Andamento\" mostram o trabalho ativo\n- Os estados \"Concluído\" marcam o trabalho finalizado",
+      "isDefault": "## Padrão\nIndica se este fluxo de trabalho é o padrão para o seu projeto.\n\n- O fluxo de trabalho padrão é pré-selecionado para novas execuções de teste, sessões e automação.",
+      "isEnabled": "## Ativado\nIndica se este fluxo de trabalho está ativado.",
+      "isActive": "## Ativo\nIndica se este estado de fluxo de trabalho está ativo e disponível para uso.\n\n- Fluxos de trabalho ativos podem ser selecionados ao atualizar execuções de teste, sessões ou automação.\n- Fluxos de trabalho inativos ficam ocultos para seleção, mas são preservados nos itens existentes.",
+      "projects": "## Projetos\nIndica os projetos que podem usar este fluxo de trabalho."
+    },
+    "testResult": {
+      "status": "## Status\nSelecione o status geral da execução do teste. O status escolhido pode afetar as métricas e os relatórios do projeto.",
+      "elapsedTime": "## Tempo Decorrido\nInsira o tempo total gasto para executar este caso de teste. Você pode usar unidades como **s** para segundos, **m** para minutos, **h** para horas (por exemplo, 30s, 5m, 1h 20m).",
+      "resultData": "## Detalhes do Resultado\nForneça notas detalhadas, observações ou quaisquer outros dados relevantes sobre a execução geral do teste. Isso pode incluir detalhes de configuração, etapas seguidas caso tenha havido desvio do plano ou comentários gerais.",
+      "evidence": "## Evidências/Anexos\nEnvie quaisquer arquivos (por exemplo, capturas de tela, registros, arquivos de dados) que sirvam como evidência para este resultado de teste. Esses anexos serão vinculados a este resultado específico.",
+      "issues": "## Problemas Vinculados\nVincule quaisquer problemas do seu sistema de rastreamento de problemas integrado que estejam relacionados a este resultado de teste. Isso ajuda no rastreamento de defeitos ou tarefas associadas ao resultado deste teste.",
+      "stepStatus": "## Status da Etapa\nSelecione o status para esta etapa de teste específica. Isso permite o acompanhamento detalhado do progresso dentro de um único caso de teste.",
+      "stepElapsedTime": "## Tempo Decorrido da Etapa\nInsira o tempo gasto para executar esta etapa específica. Use unidades como **s**, **m**, **h** (ex.: 10s, 2m). Este campo é opcional.",
+      "stepNotes": "## Notas da Etapa\nAdicione quaisquer notas, observações ou dados específicos para a execução desta etapa de teste.",
+      "stepIssues": "## Problemas relacionados à etapa\nVincule problemas do seu rastreador de problemas que estejam especificamente relacionados ao resultado ou às observações desta etapa de teste."
+    },
+    "case": {
+      "name": "## Nome do caso de teste\nUm nome claro e descritivo para o caso de teste.",
+      "state": "## Estado\nIndica o estado atual do fluxo de trabalho deste caso.",
+      "template": "## Modelo\nSelecione o modelo que este caso usará para seus campos de caso e campos de resultado.",
+      "estimate": "## Estimativa\nO tempo estimado inserido manualmente para concluir este caso de teste.",
+      "automated": "## Automatizado\nIndica se este caso de teste é automatizado ou não.",
+      "tags": "## Etiquetas\nAplique etiquetas relevantes para categorizar e filtrar este caso.",
+      "issues": "## Problemas\nVincule quaisquer problemas relacionados (bugs, tarefas, etc.) a este caso."
+    },
+    "folder": {
+      "name": "## Nome da pasta\nUm nome claro e descritivo para a pasta.",
+      "documentation": "## Documentação\nDetalhes adicionais, referências e materiais de apoio."
+    },
+    "bulkEdit": {
+      "name": "## Nome\nUm nome claro e descritivo para os casos de teste.",
+      "state": "## Estado\nIndica o estado atual do fluxo de trabalho destes casos de teste.",
+      "estimate": "## Estimativa\nO tempo estimado inserido manualmente para concluir cada um desses casos de teste.",
+      "automated": "## Automatizado\nIndica se esses casos de teste são automatizados ou não.",
+      "tags": "## Etiquetas\nAplique etiquetas relevantes para categorizar e filtrar esses casos de teste.",
+      "issues": "## Problemas\nVincule quaisquer problemas relacionados (bugs, tarefas, etc.) a estes casos de teste."
+    },
+    "caseField": {
+      "displayName": "## Nome de Exibição\nEste é o nome legível para humanos do campo que será mostrado aos usuários em formulários e visualizações. Seja claro e descritivo.",
+      "systemName": "## Nome do Sistema\nUm identificador único para este campo, usado internamente pelo sistema (por exemplo, em chamadas de API, consultas de banco de dados). Ele será gerado automaticamente a partir do Nome de Exibição, mas pode ser personalizado. Deve começar com uma letra. Pode conter apenas letras, números e sublinhados (sem espaços ou caracteres especiais).",
+      "hint": "## Texto de dica (opcional)\nForneça uma breve instrução ou exemplo que aparecerá abaixo do campo para orientar os usuários. Isso pode esclarecer a entrada ou formatação esperada.",
+      "enabled": "## Ativado\nDetermina se este campo está ativo e disponível para uso em modelos e casos de teste. Campos desativados são ocultos e seus dados são preservados, mas não utilizados.",
+      "required": "## Obrigatório\nSe marcado, os usuários devem fornecer um valor para este campo ao criar ou editar um caso de teste usando um modelo que inclua este campo.",
+      "restricted": "## Restrito\nSe marcado, somente usuários com permissões especiais (por exemplo, Super Administradores ou aqueles com a permissão 'Campos Restritos do Caso') poderão editar o valor deste campo após a criação de um caso. Outros usuários o verão como somente leitura. Isso é útil para campos como 'Revisado por' ou 'Data de Aprovação', que não devem ser alterados por usuários comuns após uma determinada etapa.",
+      "fieldType": "## Tipo de campo\nDetermina o tipo de dados que este campo armazenará e como eles serão exibidos (por exemplo, Texto, Número, Data, Lista suspensa). O tipo de campo não pode ser alterado após a criação.",
+      "defaultValue": "## Valor Padrão (Opcional)\nDefina um valor predefinido para este campo. Para o tipo 'Caixa de seleção', use 'true' ou 'false'. Para 'Lista suspensa' ou 'Seleção múltipla', geralmente se refere ao(s) ID(s) da(s) opção(ões) padrão. Para outros tipos, é o texto/número padrão literal. Este valor pode ser alterado quando o campo for adicionado a um modelo.",
+      "isChecked": "## Estado padrão (para caixa de seleção)\nDetermina se a caixa de seleção deve ser marcada por padrão quando um novo item (por exemplo, caso de teste) está sendo criado.",
+      "minValue": "## Valor mínimo (para número/inteiro)\nDefine o menor valor numérico permitido para este campo. Os valores mínimo e máximo devem ser definidos se um deles for usado.",
+      "maxValue": "## Valor Máximo (para Número/Inteiro)\nDefine o maior valor numérico permitido para este campo. Os valores Mínimo e Máximo devem ser definidos se apenas um for utilizado.",
+      "initialHeight": "## Altura inicial (para texto longo)\nEspecifique a altura de exibição inicial (em pixels) para campos do editor de texto rico. Isso ajuda a controlar o layout do formulário para entradas de texto mais longas.",
+      "dropdownOptions": "## Opções (para lista suspensa/seleção múltipla)\nDefina a lista de opções disponíveis para seleção. Você pode reordenar as opções, definir um valor padrão e ativar/desativar opções individuais."
+    },
+    "resultField": {
+      "displayName": "## Nome de Exibição\nEste é o nome legível para humanos do campo que será mostrado aos usuários ao inserir resultados de testes. Seja claro e descritivo.",
+      "systemName": "## Nome do Sistema\nUm identificador único para este campo, usado internamente pelo sistema (por exemplo, em chamadas de API, consultas de banco de dados). Ele será gerado automaticamente a partir do Nome de Exibição, mas pode ser personalizado.\n- Deve começar com uma letra.\n- Pode conter apenas letras, números e sublinhados (sem espaços ou caracteres especiais).",
+      "hint": "## Texto de dica (opcional)\nForneça uma breve instrução ou exemplo que aparecerá abaixo do campo para orientar os usuários. Isso pode esclarecer a entrada ou formatação esperada ao inserir dados de resultados.",
+      "enabled": "## Ativado\nDetermina se este campo está ativo e disponível para uso em modelos ao inserir resultados de testes. Campos desativados são ocultos e seus dados são preservados, mas não utilizados.",
+      "required": "## Obrigatório\nSe marcado, os usuários devem fornecer um valor para este campo ao adicionar um resultado de teste usando um modelo que inclua este campo.",
+      "restricted": "## Restrito\nSe marcado, somente usuários com permissões especiais (por exemplo, Super Administradores ou aqueles com a permissão 'Campos Restritos de Resultados de Teste') poderão editar o valor deste campo após o envio de um resultado. Outros usuários o verão como somente leitura.",
+      "fieldType": "## Tipo de campo\nDetermina o tipo de dados que este campo armazenará e como eles serão exibidos nos resultados dos testes (por exemplo, Texto, Número, Data, Lista suspensa). O tipo de campo não pode ser alterado após a criação.",
+      "defaultValue": "## Valor Padrão (Opcional)\nDefina um valor predefinido para este campo ao adicionar um novo resultado de teste. Para o tipo 'Caixa de seleção', use 'true' ou 'false'. Para 'Lista suspensa' ou 'Seleção múltipla', geralmente se refere ao(s) ID(s) da(s) opção(ões) padrão. Para outros tipos, é o texto/número padrão literal.",
+      "isChecked": "## Estado padrão (para caixa de seleção)\nDetermina se a caixa de seleção deve ser marcada por padrão quando um novo resultado de teste é adicionado.",
+      "minValue": "## Valor Mínimo (para Número/Inteiro)\nDefine o menor valor numérico permitido para este campo ao inserir dados de resultado. Os valores Mínimo e Máximo devem ser definidos se apenas um for utilizado.",
+      "maxValue": "## Valor Máximo (para Número/Inteiro)\nDefine o maior valor numérico permitido para este campo ao inserir dados de resultado. Os valores Mínimo e Máximo devem ser definidos se apenas um for utilizado.",
+      "initialHeight": "## Altura inicial (para texto longo)\nEspecifique a altura de exibição inicial (em pixels) para campos do editor de texto rico usados nos resultados. Isso ajuda a controlar o layout do formulário para entradas de texto mais longas.",
+      "dropdownOptions": "## Opções (para lista suspensa/seleção múltipla)\nDefina a lista de opções disponíveis para seleção ao inserir dados de resultado. Você pode reordenar as opções, definir um valor padrão e ativar/desativar opções individuais."
+    },
+    "exportModal": {
+      "scope": "## Escopo da Exportação\nDetermina quais casos de teste serão incluídos na exportação:\n- **Selecionados:** Exporta apenas os casos de teste que você selecionou explicitamente na tabela.\n- **Todos Filtrados:** Exporta todos os casos de teste que correspondem aos critérios de filtro atuais na tabela, mesmo que nem todos estejam visíveis na página.\n- **Todo o Projeto:** Exporta todos os casos de teste do projeto atual, ignorando quaisquer seleções ou filtros.",
+      "format": "## Formato de Exportação\nEscolha o formato de arquivo para sua exportação.\n- **CSV (Valores Separados por Vírgula):** Um arquivo de texto simples adequado para planilhas (Excel, Planilhas Google) e ferramentas de análise de dados. A exportação para PDF está planejada para uma versão futura.",
+      "columns": "## Colunas para Exportar (Somente CSV)\nDetermina quais colunas de dados serão incluídas para cada caso de teste:\n- **Todas as Colunas:** Exporta todos os campos de dados disponíveis para os casos de teste, incluindo campos personalizados de seus modelos.\n- **Colunas Visíveis:** Exporta apenas as colunas atualmente visíveis na tabela de casos de teste.",
+      "delimiter": "## Delimitador CSV (somente CSV)\nEscolha o caractere usado para separar os valores no arquivo CSV. O mais comum é a vírgula. Use um delimitador diferente se seus dados contiverem vírgulas dentro dos campos de texto (por exemplo, ponto e vírgula).",
+      "textLongFormat": "## Formato de Campo de Texto Longo (Somente CSV)\nDetermina como os campos de texto formatado (como 'Descrição' ou campos personalizados 'Texto Longo') são exportados:\n- **JSON:** Exporta o conteúdo como uma string JSON, preservando toda a formatação (negrito, listas, etc.). Esta opção é ideal para reimportação ou processamento programático.\n- **Texto Simples:** Exporta o conteúdo como texto simples, removendo a formatação. Isso facilita a leitura em visualizadores de texto simples.",
+      "stepsFormat": "## Formato das Etapas (Somente CSV)\nDetermina como as etapas do teste (incluindo os resultados esperados) são exportadas:\n- **JSON:** Exporta as etapas como uma matriz JSON de objetos, preservando a estrutura e o texto formatado. Adequado para reimportação ou análise detalhada.\n- **Texto Simples:** Exporta as etapas em um formato de texto simples e legível, com cada etapa e resultado esperado em uma nova linha.",
+      "rowMode": "## Modo de Linha (Somente CSV)\nDetermina como os campos com múltiplos valores (como Tags ou campos personalizados de seleção múltipla) e as Etapas são representados:\n- **Uma Linha por Caso:** Cada caso de teste corresponde a uma única linha. Os campos com múltiplos valores e as etapas serão condensados em suas respectivas células (geralmente como JSON ou texto concatenado).\n- **Várias Linhas por Caso:** Um caso de teste pode abranger várias linhas se possuir várias tags, valores de seleção múltipla ou etapas. Cada valor/etapa exclusivo para esses campos criará uma nova linha, com os demais dados do caso repetidos. Isso é útil para análises detalhadas ou para a criação de tabelas dinâmicas.",
+      "attachmentFormat": "## Formato das Informações do Anexo (Somente CSV)\nDetermina como as informações sobre os anexos são exportadas:\n- **JSON:** Exporta os detalhes do anexo (como nome do arquivo, URL, tamanho) como uma matriz JSON. Isso é abrangente, mas menos legível para humanos diretamente em um CSV.\n- **Somente Nomes:** Exporta uma lista de nomes de arquivos de anexos separados por vírgulas. Mais simples para referência rápida."
+    },
+    "reportMetrics": {
+      "count": "## Contagem de resultados de testes\nNúmero de resultados de execução de testes neste grupo.",
+      "passRate": "## Taxa de aprovação\nFração de resultados neste grupo com status de aprovação.",
+      "avgElapsed": "## Tempo médio decorrido\nTempo médio decorrido para os resultados neste grupo.",
+      "sumElapsed": "## Tempo Total Decorrido\nSoma do tempo decorrido para os resultados neste grupo.",
+      "executionCount": "## Execuções de teste\nNúmero total de execuções de teste realizadas.",
+      "testCaseCount": "## Contagem de casos de teste\nNúmero total de casos de teste neste grupo.",
+      "testRunCount": "## Contagem de execuções de teste\nNúmero total de execuções de teste neste grupo.",
+      "automationRate": "## Taxa de Automação\nPercentagem de casos de teste que foram automatizados.",
+      "averageSteps": "## Média de passos por caso\nNúmero médio de passos por caso de teste.",
+      "automatedCount": "## Casos automatizados\nNúmero de casos de teste automatizados.",
+      "manualCount": "## Casos Manuais\nNúmero de casos de teste manuais.",
+      "totalSteps": "## Total de etapas\nNúmero total de etapas de teste em todos os casos.",
+      "createdCaseCount": "## Casos de teste criados\nNúmero de casos de teste criados neste período.",
+      "sessionResultCount": "## Resultados da Sessão\nNúmero de resultados dos testes da sessão.",
+      "sessionCount": "## Contagem de Sessões\nNúmero total de sessões de teste.",
+      "activeSessions": "## Sessões Ativas\nNúmero de sessões que estão atualmente ativas (isActive = true).",
+      "milestoneCompletion": "## Conclusão de Marcos\nPercentual de casos de teste concluídos nos marcos. Calculado como (resultados de testes concluídos / total de casos de teste nas execuções de teste) × 100.",
+      "averageTimeSpent": "## Tempo médio gasto\nTempo médio gasto em atividades.",
+      "sessionParticipation": "## Participação na sessão\nNível de participação nas sessões de teste.",
+      "lastActiveDate": "## Data da última atividade\nData da atividade mais recente.",
+      "averageAge": "## Idade média\nIdade média dos itens em dias.",
+      "issueCount": "## Contagem de problemas\nNúmero total de problemas rastreados.",
+      "milestoneCount": "## Contagem de marcos\nNúmero total de marcos.",
+      "milestoneCompletionRate": "## Taxa de Conclusão de Marcos\nPercentagem de marcos concluídos.",
+      "averageMilestoneDuration": "## Duração média dos marcos\nDuração média dos marcos em dias."
+    },
+    "reportDimensions": {
+      "user": "## Dimensão do usuário\nAgrupa os resultados pelo usuário que executou os testes ou que está atribuído aos itens.",
+      "status": "## Dimensão de Status\nAgrupa os resultados pelo status de execução do teste (por exemplo, Aprovado, Reprovado, Bloqueado).",
+      "project": "## Dimensão do Projeto\nAgrupa os resultados por projeto para análise entre projetos.",
+      "testRun": "## Dimensão de Execução de Teste\nAgrupa os resultados pela execução de teste que contém os casos de teste executados.",
+      "testCase": "## Dimensão do Caso de Teste\nAgrupa os resultados por casos de teste individuais para análise detalhada.",
+      "milestone": "## Dimensão de Marcos\nAgrupa os resultados por marcos do projeto para acompanhar o progresso em direção às metas.",
+      "configuration": "## Dimensão de Configuração\nAgrupa os resultados por configuração do ambiente de teste (por exemplo, navegador, SO).",
+      "template": "## Dimensão do modelo\nAgrupa os resultados pelo modelo usado para a estrutura do caso de teste.",
+      "creator": "## Dimensão do Criador\nAgrupa os resultados pelo usuário que criou os casos de teste ou as execuções de teste.",
+      "state": "## Dimensão de estado\nAgrupa os resultados por estado do fluxo de trabalho (por exemplo, Rascunho, Ativo, Concluído).",
+      "role": "## Dimensão de função\nAgrupa os resultados por funções de usuário para análise de acesso e responsabilidade.",
+      "group": "## Dimensão de Grupo\nAgrupa os resultados por grupos de usuários. Os usuários podem pertencer a vários grupos, portanto, as atividades serão contabilizadas para cada grupo ao qual o usuário pertence.",
+      "folder": "## Dimensão de pastas\nAgrupa os resultados por estrutura de pastas do repositório para análise organizacional.",
+      "session": "## Dimensão de Sessão\nAgrupa os resultados por sessões de teste para análise baseada em sessão.",
+      "assignedTo": "## Atribuído à dimensão\nAgrupa os resultados pelo usuário atribuído para executar ou gerenciar os itens.",
+      "issueType": "## Dimensão Tipo de Problema\nAgrupa os resultados pelo tipo de problema rastreado (por exemplo, Bug, Tarefa, História, Melhoria).",
+      "issueTracker": "## Dimensão do rastreador de problemas\nAgrupa os resultados pela integração de rastreamento de problemas utilizada (por exemplo, Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Dimensão de Status da Incidência\nAgrupa os resultados pelo status atual das incidências (por exemplo, Aberta, Em Andamento, Resolvida, Fechada).",
+      "priority": "## Dimensão de Prioridade\nAgrupa os resultados por nível de prioridade do problema (por exemplo, Alto, Médio, Baixo).",
+      "source": "## Dimensão de origem\nAgrupa os resultados pela origem da execução do teste (por exemplo, Manual, JUnit, API).",
+      "date": "## Dimensão de data\nAgrupa os resultados por data para análise e tendências baseadas no tempo."
+    },
+    "reportBuilder": {
+      "dimensions": "## Dimensões\nSelecione as dimensões que deseja analisar no seu relatório. As dimensões são atributos que categorizam seus dados, como Data, Usuário, Status, etc. Você pode arrastar para reordená-las.",
+      "metrics": "## Métricas\nSelecione as métricas que deseja medir em seu relatório. As métricas são medidas quantitativas derivadas de seus dados, como Contagem de Resultados de Testes, Taxa de Aprovação, Tempo Médio Decorrido, etc. Você pode arrastar para reordená-las.",
+      "dateRange": "## Intervalo de Datas\nFiltre os dados do seu relatório por um período específico. Você pode selecionar intervalos predefinidos, como \"Últimos 7 dias\" ou \"Mês anterior\", ou definir um intervalo de datas personalizado. Este filtro se aplica ao campo de data relevante para cada tipo de relatório (por exemplo, data de execução para resultados de testes, data de criação para casos de teste)."
+    },
+    "codeRepository": {
+      "name": "## Nome do Repositório\nUm nome amigável para exibir esta conexão de repositório.\n\n- Usado para identificá-lo nas configurações de contexto do código do projeto.\n- Não precisa corresponder ao nome do repositório no provedor.",
+      "provider": "## Provedor Git\nA plataforma que hospeda este repositório.\n\n- **GitHub** — github.com (nuvem ou Enterprise)\n- **GitLab** — gitlab.com ou auto-hospedado\n- **Bitbucket Cloud** — bitbucket.org (somente nuvem)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — servidores Git auto-hospedados com APIs compatíveis",
+      "githubToken": "## Token de Acesso Pessoal\nUm token do GitHub com permissão de **Conteúdo: Leitura**.\n\nGere um em: GitHub → Configurações do perfil → Configurações do desenvolvedor → Tokens de acesso pessoal → Tokens de granularidade fina.",
+      "owner": "## Proprietário\nA organização ou conta de usuário do GitHub que possui o repositório.\n\n- Exemplo: `myorg` ou `myusername`\n- Este é o primeiro segmento do caminho no URL do seu repositório no github.com",
+      "repo": "## Repositório\nO nome do repositório, sem o prefixo do proprietário.\n\n- Exemplo: `my-repo` (e não `myorg/my-repo`)\n- Este é o segundo segmento do caminho no URL do seu repositório no github.com",
+      "gitlabToken": "## Token de Acesso Pessoal\nUm token do GitLab com escopos **read_api** e **read_repository**.\n\nGere um em: GitLab → Configurações do Usuário → Tokens de Acesso.",
+      "projectPath": "## ID ou Caminho do Projeto\nO ID numérico do projeto ou o caminho completo do namespace.\n\n- Exemplo de caminho: `myorg/my-project`\n- Exemplo de ID: `12345678`\n- Encontrado no GitLab em Configurações → Geral.",
+      "baseUrl": "## URL do GitLab\nDeixe em branco para gitlab.com. Para instâncias auto-hospedadas, insira sua URL do GitLab.\n\n- Exemplo: `https://gitlab.example.com`",
+      "bitbucketEmail": "## E-mail da conta Atlassian\nO endereço de e-mail associado à sua conta Atlassian.\n\n- Este é o e-mail que você usa para fazer login no Bitbucket Cloud.",
+      "bitbucketApiToken": "## Token da API\nUm token da API do Bitbucket com escopo **Repositórios: Leitura**.\n\nCrie um em: Bitbucket → Configurações pessoais → Tokens da API.\n\n> As senhas de aplicativos foram descontinuadas pela Atlassian em favor dos tokens da API.",
+      "workspace": "## Espaço de trabalho\nO slug do espaço de trabalho da sua URL do Bitbucket.\n\n- Exemplo: `myworkspace` de `bitbucket.org/myworkspace`",
+      "repoSlug": "## Slug do Repositório\nO identificador do repositório a partir de sua URL.\n\n- Exemplo: `my-repo` de `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Token de Acesso Pessoal\nUm PAT do Azure DevOps com permissão de **Código (Leitura)**.\n\nCrie um em: Azure DevOps → Configurações do usuário → Tokens de acesso pessoal.",
+      "organizationUrl": "## URL da organização\nURL da sua organização do Azure DevOps.\n\n- Exemplo: `https://dev.azure.com/myorg`",
+      "project": "## Nome do Projeto\nO nome do projeto do Azure DevOps que contém o repositório.\n\n- Encontrado como o terceiro segmento do caminho no seu URL do Azure DevOps, após o nome da organização.",
+      "azureRepoId": "## Nome ou ID do repositório\nO nome ou GUID do repositório dentro do projeto do Azure DevOps.\n\n- Exemplo: `meu-repositório`",
+      "giteaToken": "## Token de Acesso Pessoal\nUm token com permissões de leitura do repositório.\n\nGere um em: Administração do Site → Aplicativos ou Configurações do Usuário → Aplicativos.\n\n- Funciona com Gitea, Forgejo, Gogs e qualquer servidor que exponha uma API compatível.",
+      "giteaBaseUrl": "## URL do Servidor\nA URL base do seu servidor Git auto-hospedado.\n\n- Exemplo: `https://gitea.example.com`\n- Deve incluir o protocolo (https:// recomendado)\n- Funciona com Gitea, Forgejo, Gogs e outros servidores com uma API REST `/api/v1/` compatível com Gitea",
+      "giteaOwner": "## Proprietário\nA organização ou conta de usuário proprietária do repositório.\n\n- Exemplo: `myorg` ou `myusername`\n- Este é o primeiro segmento do caminho no URL do seu repositório",
+      "giteaRepo": "## Repositório\nO nome do repositório, sem o prefixo do proprietário.\n\n- Exemplo: `my-repo` (e não `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Nome da Configuração\nUm nome único e descritivo para esta configuração de prompts.\n\n- Usado para identificar a configuração ao atribuí-la a um projeto (ex.: \"Prompts GPT-4o\", \"Prompts Conservadores\").",
+      "description": "## Descrição\nUm resumo opcional do que torna esta configuração distinta.\n\n- Ajuda os administradores a entenderem o propósito rapidamente (ex.: \"Temperatura mais baixa solicita saída determinística\").",
+      "isActive": "## Ativo\nQuando ativado, esta configuração fica disponível para uso pelos projetos.\n\n- As configurações inativas ficam ocultas nas listas suspensas de atribuição de projetos.\n- A configuração padrão não pode ser desativada.",
+      "isDefault": "## Configuração Padrão\nQuando ativada, esta configuração é usada por qualquer projeto que não tenha uma configuração específica atribuída.\n\n- Apenas uma configuração pode ser a padrão por vez.\n- Definir uma nova configuração padrão remove automaticamente a anterior.",
+      "systemPrompt": "## Prompt do Sistema\nInstruções enviadas ao modelo de IA antes de qualquer entrada do usuário. Define a função, o formato de saída e as restrições do modelo.\n\n- Suporta marcadores de posição entre chaves duplas (por exemplo, FRAMEWORK, LANGUAGE, CASE_NAME) que são substituídos em tempo de execução.\n- As alterações aqui afetam todos os projetos que usam esta configuração.",
+      "userPrompt": "## Mensagem do Usuário\nA mensagem enviada à IA em nome do usuário. Deixe em branco se o recurso construir a mensagem do usuário inteiramente em código.\n\n- Suporta marcadores de posição entre chaves duplas (por exemplo, ISSUE_TITLE, CASE_NAME, CODE_CONTEXT) que são substituídos em tempo de execução.\n- Os marcadores de posição disponíveis para cada recurso estão listados na seção Variáveis abaixo.",
+      "temperature": "## Temperatura\nControla a aleatoriedade da saída da IA. Intervalo: 0–2.\n\n- **0,0–0,3** — Altamente determinístico, ideal para saídas estruturadas (JSON, código).\n- **0,4–0,7** — Equilibrado, bom para geração de casos de teste.\n- **0,8–2,0** — Mais criativo e variado, adequado para textos abertos.",
+      "maxOutputTokens": "## Tokens de Saída Máxima\nO número máximo de tokens que o modelo irá gerar em uma única resposta.\n\n- Valores mais altos permitem respostas mais longas, mas aumentam o custo e a latência.\n- Valores típicos: 2048 para texto curto, 4096 para geração de código, 6000+ para saída com múltiplas maiúsculas e minúsculas."
+    },
+    "menu": {
+      "startTour": "Visita guiada de boas-vindas",
+      "startProjectTour": "Tour do Projeto",
+      "startAdminTour": "Tour Administrativo",
+      "startDemoProjectTour": "Tour do Projeto de Demonstração"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Bem-vindo ao TestPlanIt!",
+          "content": "Vamos dar uma olhada rápida nos principais recursos do TestPlanIt para ajudar você a começar seu fluxo de trabalho de testes."
+        },
+        "projects": {
+          "content": "Acesse todos os seus projetos de teste aqui. Cada projeto contém casos de teste, execuções e recursos de colaboração em equipe."
+        },
+        "project": {
+          "title": "Cartão do Projeto",
+          "content": "Clique no cartão de um projeto para ver os detalhes. Selecione \"Tour do Projeto\" no menu de ajuda para um tour guiado pelas funcionalidades do projeto."
+        },
+        "globalFeatures": {
+          "title": "Recursos globais",
+          "content": "Gerencie tags para categorização, acompanhe problemas em vários projetos e gerencie usuários com controle de acesso baseado em funções."
+        },
+        "search": {
+          "content": "Busca contextual baseada na sua página atual. Encontre casos de teste, execuções, problemas ou qualquer conteúdo rapidamente. Use Cmd+K (ou Ctrl+K) para acesso instantâneo."
+        },
+        "help": {
+          "title": "Ajuda e suporte",
+          "content": "Acesse este tour guiado a qualquer momento ou consulte nossa documentação completa para obter ajuda detalhada."
+        },
+        "notifications": {
+          "content": "Mantenha-se informado sobre a conclusão dos testes, atualizações de problemas e atividades da equipe. Configure suas preferências nas configurações da sua conta."
+        },
+        "account": {
+          "title": "Menu da conta",
+          "content": "Personalize seu perfil, preferências de notificação e configurações da conta. Alterne entre os temas claro e escuro."
+        },
+        "assignments": {
+          "content": "Visualize os casos de teste e as execuções atribuídas a você em todos os projetos. Este é o seu painel pessoal para acompanhar seu trabalho de teste."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Seletor de Projetos",
+          "content": "Alterne rapidamente entre projetos usando este menu suspenso. Veja os detalhes do projeto e acesse as configurações gerais do projeto."
+        },
+        "projectSections": {
+          "title": "Seções do projeto",
+          "content": "Navegue pela Visão Geral para acessar o painel do projeto, pela Documentação para consultar os guias do projeto e pelos Marcos para acompanhar o progresso."
+        },
+        "repository": {
+          "content": "Gerencie seus casos de teste, organize-os em pastas e crie novos cenários de teste para uma cobertura completa."
+        },
+        "repositoryPanels": {
+          "title": "Painel esquerdo do repositório",
+          "content": "O painel esquerdo exibe a estrutura de pastas e a árvore de casos de teste. Use o seletor de visualização para alternar entre diferentes visualizações organizacionais."
+        },
+        "repositoryRightPanel": {
+          "title": "Painel direito do repositório",
+          "content": "O painel direito exibe detalhes do caso de teste, resultados da execução e fornece ações para criar novos casos de teste ou importar os existentes."
+        },
+        "sharedSteps": {
+          "title": "Passos Compartilhados",
+          "content": "Defina grupos de etapas reutilizáveis que possam ser referenciados em vários casos de teste. Mantenha suas etapas de teste DRY (Don't Repeat Yourself - Não se Repita) e consistentes."
+        },
+        "testRuns": {
+          "content": "Execute os testes planejados, acompanhe o progresso e gerencie as atribuições de teste em sua equipe. Visualize os resultados detalhados da execução."
+        },
+        "testRunsPage": {
+          "title": "Painel de Testes",
+          "content": "Esta é a página de Execuções de Teste, onde você pode criar novas execuções de teste, monitorar o progresso da execução, visualizar resultados e gerenciar atribuições de teste. Acompanhe as atividades de teste da sua equipe em um local centralizado."
+        },
+        "sessions": {
+          "title": "Sessões Exploratórias",
+          "content": "Documentar as sessões de testes exploratórios, registrar as descobertas e acompanhar o tempo gasto em atividades de teste ad hoc."
+        },
+        "sessionsPage": {
+          "title": "Painel de Sessões Exploratórias",
+          "content": "Esta é a página de Sessões, onde você pode criar e gerenciar sessões de testes exploratórios. Documente as descobertas, acompanhe o tempo gasto e mantenha um registro de todas as atividades de teste ad hoc para uma melhor cobertura de testes."
+        },
+        "tags": {
+          "title": "Gerenciamento de tags",
+          "content": "Organize e categorize seus casos de teste usando tags. Crie tags personalizadas para melhorar a organização e a filtragem dos casos de teste."
+        },
+        "issues": {
+          "title": "Rastreamento de Problemas",
+          "content": "Acompanhe e gerencie os problemas descobertos durante os testes. Vincule os problemas aos casos de teste e integre-os a sistemas externos de rastreamento de bugs."
+        },
+        "reports": {
+          "title": "Relatórios e análises",
+          "content": "Gere relatórios e análises abrangentes para o seu projeto. Visualize a cobertura de testes, tendências de execução, métricas de desempenho da equipe e crie relatórios personalizados para as partes interessadas."
+        },
+        "settings": {
+          "title": "Configurações do projeto",
+          "content": "Gerencie integrações em nível de projeto, configurações de modelos de IA e links compartilhados a partir daqui."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Bem-vindo aos Controles Administrativos",
+          "content": "Faça um tour guiado pelos recursos administrativos do TestPlanIt. Gerencie projetos, usuários, configurações e definições do sistema a partir deste painel de administração central."
+        },
+        "projects": {
+          "title": "Administração de Projetos",
+          "content": "Gerencie todos os projetos da sua organização. Crie, configure e arquive projetos. Defina permissões e controles de acesso para todos os projetos."
+        },
+        "templatesAndFields": {
+          "content": "Crie e gerencie modelos de casos de teste e campos personalizados. Defina tipos de campo, regras de validação e organize modelos para garantir uma estrutura consistente de casos de teste em todos os projetos."
+        },
+        "workflows": {
+          "title": "Gestão de fluxo de trabalho",
+          "content": "Defina os fluxos de trabalho dos casos de teste e as transições de estado. Configure como os casos de teste progridem por diferentes estados, como Rascunho, Revisão e Aprovado."
+        },
+        "statuses": {
+          "title": "Status dos resultados dos testes",
+          "content": "Configure os status de resultado de teste disponíveis, como Aprovado, Reprovado, Bloqueado e Ignorado. Defina status personalizados e configure seu comportamento e aparência."
+        },
+        "milestones": {
+          "content": "Defina os tipos de marcos para o acompanhamento do projeto. Configure os tipos de lançamento, as categorias de sprint e outras classificações de marcos do projeto."
+        },
+        "configurations": {
+          "title": "Configurações de teste",
+          "content": "Gerencie configurações e ambientes de teste. Configure combinações de navegadores, tipos de dispositivos, sistemas operacionais e outros contextos de execução de testes."
+        },
+        "users": {
+          "title": "Gerenciamento de usuários",
+          "content": "Gerencie contas de usuário, permissões e níveis de acesso. Crie novos usuários, atribua funções e configure as definições de autenticação."
+        },
+        "groups": {
+          "title": "Gestão de Grupo",
+          "content": "Organize os usuários em grupos para facilitar o gerenciamento de permissões. Crie grupos de departamento, equipes de projeto e grupos de acesso baseado em funções."
+        },
+        "roles": {
+          "title": "Gestão de funções",
+          "content": "Defina funções e permissões de usuário. Configure quais ações diferentes funções podem executar em projetos e na administração do sistema."
+        },
+        "tags": {
+          "title": "Etiquetas globais",
+          "content": "Gerencie tags em toda a organização para categorizar casos de teste, projetos e outras entidades. Crie hierarquias de tags e padronize a marcação em todos os projetos."
+        },
+        "reports": {
+          "content": "Gere relatórios que abrangem vários projetos. Analise tendências, métricas de desempenho e a eficácia dos testes organizacionais em todo o seu ambiente de trabalho."
+        },
+        "notifications": {
+          "title": "Configurações de notificação",
+          "content": "Configure as preferências de notificação de todo o sistema. Defina modelos de e-mail, regras de notificação e configurações padrão para notificações de usuário."
+        },
+        "integrations": {
+          "title": "Integrações de sistemas",
+          "content": "Gerencie integrações de terceiros e conexões de API. Configure integrações com Jira, GitHub e outras ferramentas externas para sua organização."
+        },
+        "llm": {
+          "title": "Configuração de IA",
+          "content": "Configure modelos e definições de IA para geração automatizada de casos de teste e funcionalidades inteligentes. Gerencie chaves de API e preferências de modelo."
+        },
+        "sso": {
+          "title": "Autenticação única",
+          "content": "Configure provedores de SSO e métodos de autenticação. Configure integrações com SAML, OAuth e outros provedores de identidade para acesso contínuo do usuário."
+        },
+        "appConfig": {
+          "content": "Gerencie as configurações globais do aplicativo e as preferências do sistema. Configure valores padrão, alternância de recursos e comportamentos de todo o sistema."
+        },
+        "trash": {
+          "title": "Lixo do sistema",
+          "content": "Visualize e gerencie itens excluídos em todos os projetos. Restaure conteúdo excluído acidentalmente ou remova itens permanentemente do sistema."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Bem-vindo ao Projeto de Demonstração",
+          "content": "Este projeto já vem com dados de exemplo. Vamos explorar juntos as principais funcionalidades. Use este menu suspenso para alternar entre os projetos."
+        },
+        "overview": {
+          "title": "Visão geral do projeto",
+          "content": "A visão geral é o painel de controle do seu projeto. Ela mostra o progresso das etapas e resumos de casos de teste, execuções ativas, sessões e tags."
+        },
+        "documentation": {
+          "title": "Documentação",
+          "content": "Cada projeto possui uma página de documentação. Utilize-a para planos de teste, anotações do projeto ou links para recursos externos."
+        },
+        "documentationContent": {
+          "title": "Editor de texto rico",
+          "content": "A documentação suporta texto formatado com títulos, listas, links e imagens. Experimente editar esta página para ver como funciona."
+        },
+        "milestones": {
+          "title": "Conquistas",
+          "content": "Acompanhe seus testes em relação a sprints, lançamentos e outras metas. Vincule execuções e sessões de teste a marcos para monitorar o progresso."
+        },
+        "milestonesPage": {
+          "title": "Cronograma de marcos",
+          "content": "Veja todos os marcos deste projeto. Cada marco mostra seu status e progresso em direção à conclusão."
+        },
+        "repository": {
+          "title": "Repositório de casos de teste",
+          "content": "Organize os casos de teste em pastas com campos, etapas e prioridades personalizados. Navegue pelas pastas de exemplo para ver como os casos são estruturados."
+        },
+        "repositoryPanels": {
+          "title": "Pastas e Estojos",
+          "content": "O painel esquerdo exibe as pastas. Clique em uma pasta para ver seus casos de teste. Cada caso possui etapas, descrições e referências de etapas compartilhadas."
+        },
+        "repositoryCases": {
+          "title": "Casos de teste",
+          "content": "Aqui você pode ver os casos de teste para a pasta selecionada. Cada linha mostra o nome do caso, a prioridade e os campos personalizados. Clique em um caso para visualizar todos os detalhes e etapas."
+        },
+        "sharedSteps": {
+          "title": "Passos Compartilhados",
+          "content": "Defina grupos de etapas reutilizáveis que possam ser referenciados em vários casos de teste. Isso mantém as etapas comuns consistentes e fáceis de manter."
+        },
+        "sharedStepsPage": {
+          "title": "Grupos de passos compartilhados",
+          "content": "Cada grupo contém um conjunto de etapas ordenadas. Consulte-as em qualquer caso de teste para manter suas etapas DRY (Don't Repeat Yourself - Não Repita, Não Se Instrua) e consistentes."
+        },
+        "testRuns": {
+          "title": "Testes de execução",
+          "content": "Crie execuções de teste para executar casos e registrar os resultados. Atribua as execuções a marcos e acompanhe o progresso de aprovação/reprovação."
+        },
+        "testRunsPage": {
+          "title": "Resultados do teste",
+          "content": "Visualize os resultados e o progresso dos testes. Cada execução mostra seu status, o marco atribuído e a classificação de aprovação/reprovação."
+        },
+        "sessions": {
+          "title": "Sessões Exploratórias",
+          "content": "Capture testes ad-hoc com testes baseados em sessão. Registre as descobertas, atribua status e acompanhe o tempo gasto."
+        },
+        "sessionsPage": {
+          "title": "Resultados da sessão",
+          "content": "Cada sessão inclui resultados detalhados com informações sobre o status e anotações. Clique em uma sessão para ver os resultados."
+        },
+        "tags": {
+          "title": "Etiquetas",
+          "content": "As tags ajudam a organizar e filtrar casos de teste, execuções e sessões. Navegue pelos exemplos de tags para ver como elas categorizam o conteúdo."
+        },
+        "tagsPage": {
+          "title": "Gerenciamento de tags",
+          "content": "Crie, edite e atribua etiquetas aqui. Use etiquetas para agrupar e filtrar conteúdo em todo o seu projeto."
+        },
+        "issues": {
+          "title": "Problemas",
+          "content": "Monitore os erros e defeitos encontrados durante os testes. Os problemas podem ser vinculados aos resultados de testes com falha e às conclusões das sessões para uma rastreabilidade completa."
+        },
+        "issuesPage": {
+          "title": "Rastreador de Problemas",
+          "content": "Veja exemplos de problemas relacionados a resultados com falha. Os problemas podem ser rastreados até a execução do teste ou a descoberta da sessão que os revelou."
+        },
+        "reports": {
+          "title": "Relatórios e análises",
+          "content": "Gere relatórios sobre cobertura de testes, tendências de execução e desempenho da equipe. Use relatórios predefinidos ou crie relatórios personalizados para as partes interessadas."
+        },
+        "settings": {
+          "title": "Configurações do projeto",
+          "content": "Gerencie integrações em nível de projeto, configurações de modelos de IA e links compartilhados a partir daqui."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Criar e gerenciar relatórios entre projetos"
+      },
+      "reportsTabDescription": "Visualize e analise relatórios predefinidos para o seu projeto.",
+      "reportType": "Tipo de relatório",
+      "selectReportType": "Selecione o tipo de relatório",
+      "selectReport": "Selecionar relatório",
+      "dimensions": "Dimensões",
+      "dimensionsSubtitle": "Dimensões (arraste para reordenar, adicione abaixo)",
+      "metrics": "Métricas",
+      "addDimension": "Adicionar dimensão...",
+      "addMetric": "Adicionar métrica...",
+      "runReport": "Executar relatório",
+      "noResultsFound": "Nenhum resultado encontrado.",
+      "selectAtLeastOneDimensionAndMetric": "Selecione pelo menos uma dimensão e uma métrica.",
+      "noDataMatchingCriteria": "Não foram encontrados dados que correspondam às dimensões e métricas selecionadas.",
+      "noDataMatchingCriteriaWithDateFilter": "Não foram encontrados dados que correspondam às dimensões e métricas selecionadas. Tente ajustar o filtro de intervalo de datas.",
+      "noDataAvailable": "Não há dados disponíveis para este relatório.",
+      "generatedAt": "Relatório gerado em",
+      "crossProjectAnalytics": "Análises e relatórios entre projetos",
+      "unauthorizedAdmin": "Não autorizado: É necessário acesso de administrador.",
+      "title": "Construtor de Relatórios",
+      "description": "Crie relatórios personalizados para analisar os dados do seu projeto.",
+      "crossProjectDescription": "Analise os dados de todos os projetos em seu espaço de trabalho.",
+      "selectDimensions": "Selecione as dimensões...",
+      "selectMetrics": "Selecione as métricas...",
+      "dimensionOrder": "Ordem Dimensional",
+      "metricOrder": "Ordem métrica",
+      "filtersDescription": "Filtre os dados do relatório por critérios específicos.",
+      "activeFilters": "Filtros ativos:",
+      "priorityFilterPlaceholder": "Selecione os valores de prioridade (ou deixe em branco para todos).",
+      "dateRange": {
+        "selectDateRange": "Selecione o intervalo de datas",
+        "chooseStartDate": "Escolha a data de início",
+        "chooseEndDate": "Selecione a data de término",
+        "categories": {
+          "day": "Dia",
+          "week": "Semana",
+          "month": "Mês",
+          "quarter": "Trimestre",
+          "year": "Ano"
+        },
+        "today": "Hoje",
+        "yesterday": "Ontem",
+        "last7Days": "Últimos 7 dias",
+        "last30Days": "Últimos 30 dias",
+        "thisWeek": "Essa semana",
+        "lastWeek": "Semana passada",
+        "last2Weeks": "Últimas 2 semanas",
+        "thisMonth": "Este mês",
+        "lastMonth": "Mês passado",
+        "last3Months": "Últimos 3 meses",
+        "thisQuarter": "Este trimestre",
+        "lastQuarter": "Último trimestre",
+        "thisYear": "Este ano",
+        "lastYear": "Ano passado",
+        "last12Months": "Últimos 12 meses",
+        "allTime": "Todos os tempos",
+        "custom": "Intervalo de datas personalizado"
+      },
+      "dateGrouping": {
+        "label": "Agrupar por",
+        "daily": "Diário",
+        "weekly": "Semanalmente",
+        "monthly": "Mensal",
+        "quarterly": "Trimestral",
+        "annually": "Anualmente"
+      },
+      "filters": {
+        "selectFilter": "Selecione um tipo de filtro",
+        "allProjects": "Todos os projetos"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Falha ao carregar os metadados do relatório",
+        "failedToRunReport": "Falha ao executar o relatório",
+        "atLeastOneDimensionRequired": "É necessária pelo menos uma dimensão.",
+        "atLeastOneMetricRequired": "Pelo menos uma métrica deve ser especificada.",
+        "invalidCombinationDateLastActive": "A métrica 'Data da Última Atividade' não pode ser combinada com a dimensão 'Data da Atividade'.",
+        "lastActiveDateOnlyWithUser": "A métrica 'Data da Última Atividade' só pode ser usada com a dimensão 'Usuário'.",
+        "invalidDimensionCombination": "As dimensões '{dim1}' e '{dim2}' não podem ser usadas juntas em relatórios de Execução de Teste.",
+        "startDateRequiredWithEndDate": "A data de início é obrigatória quando a data de término é especificada.",
+        "endDateMustBeAfterStartDate": "A data de término deve ser posterior ou igual à data de início."
+      },
+      "chartDataTruncated": {
+        "title": "Dados do gráfico truncados",
+        "message": "Exibindo {shown} de {total} pontos de dados para facilitar a leitura. Use filtros ou intervalos de datas para refinar seus resultados ou visualize os dados completos na tabela de Resultados abaixo."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Relatórios de Execução de Testes",
+          "description": "Analise os resultados dos testes, as taxas de aprovação e as métricas de execução."
+        },
+        "repositoryStats": {
+          "label": "Estatísticas do repositório",
+          "description": "Estatísticas de casos de teste, cobertura e integridade do repositório"
+        },
+        "userEngagement": {
+          "label": "Engajamento do usuário",
+          "description": "Análise da atividade, produtividade e carga de trabalho do usuário"
+        },
+        "projectHealth": {
+          "label": "Projeto Saúde",
+          "description": "Progresso do projeto, marcos e status de conclusão"
+        },
+        "sessionAnalysis": {
+          "label": "Análise da sessão",
+          "description": "Métricas de conclusão, duração e atribuição de sessões"
+        },
+        "issueTracking": {
+          "label": "Rastreamento de Problemas",
+          "description": "Criação, resolução e análise de impacto de problemas"
+        },
+        "automationTrends": {
+          "label": "Tendências de Automação",
+          "description": "Acompanhe o progresso da automação semana a semana por prioridade."
+        },
+        "flakyTests": {
+          "label": "Testes inconsistentes",
+          "description": "Identificar testes com resultados inconsistentes de aprovação/reprovação"
+        },
+        "testCaseHealth": {
+          "label": "Saúde do caso de teste",
+          "description": "Identifique casos de teste obsoletos, corrompidos ou suspeitos com base em padrões de execução."
+        },
+        "issueTestCoverage": {
+          "label": "Cobertura de Testes de Problemas",
+          "description": "Visualize os problemas com seus respectivos casos de teste e o status de execução mais recente."
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Últimas corridas consecutivas",
+        "consecutiveRunsHelp": "Número de execuções de teste recentes a serem analisadas (5-30). Resultados com status 'não testado' são excluídos.",
+        "flipThreshold": "Viradas mínimas",
+        "flipThresholdHelp": "Número mínimo de transições de aprovação/reprovação necessárias para que um resultado seja considerado instável.",
+        "flips": "Cambalhotas",
+        "lastNResults": "Último {count, plural, one {# Resultado} other {# Resultados}}",
+        "newest": "Novo",
+        "oldest": "Velho",
+        "noFlakyTests": "Não foram encontrados testes inconsistentes que atendessem aos critérios.",
+        "includeFilter": "Incluir",
+        "testRunDeleted": "O teste foi excluído.",
+        "chart": {
+          "highPriority": "Precisa de atenção",
+          "lowPriority": "Prioridade inferior",
+          "recencyAxis": "Recência da falha",
+          "flipsAxis": "Contagem de viradas",
+          "oldFailures": "Mais velho",
+          "recentFailures": "Recente",
+          "failureRate": "Taxa de falha",
+          "recency": "Pontuação de Recência",
+          "backlogTitle": "Testes de baixa prioridade",
+          "backlogDescription": "{count, plural, one {# teste instável adicional} other {# testes instáveis adicionais}} não exibido"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Desgastado após (dias)",
+        "staleDaysThresholdHelp": "Número de dias sem execução antes que um teste seja considerado obsoleto (7-90).",
+        "minExecutions": "Número mínimo de execuções por taxa",
+        "minExecutionsHelp": "Número mínimo de execuções necessárias para calcular estatísticas significativas de taxa de aprovação (3-20).",
+        "lookbackDays": "Período de retrospectiva",
+        "lookbackDaysHelp": "Número de dias para analisar o histórico de execução (30-365).",
+        "includeFilter": "Incluir",
+        "staleFilter": "Estagnação",
+        "stale": "velho",
+        "notStale": "Não está velho",
+        "status": "Estado de saúde",
+        "healthScore": "Pontuação",
+        "lastExecuted": "Última execução",
+        "executions": "Execuções",
+        "passRate": "Taxa de aprovação",
+        "passCount": "Passes",
+        "failCount": "Fracassos",
+        "never": "Nunca",
+        "daysSince": "Dias desde a execução",
+        "count": "Contar",
+        "totalTests": "casos de teste",
+        "noData": "Nenhum caso de teste encontrado",
+        "noExecutedTests": "Nenhum teste executado para exibir.",
+        "healthStatus": {
+          "healthy": "Saudável",
+          "stale": "velho",
+          "neverExecuted": "Nunca executado",
+          "alwaysPassing": "Sempre passando",
+          "alwaysFailing": "Sempre falhando"
+        },
+        "chart": {
+          "distribution": "Distribuição de status",
+          "healthyRecent": "Saudável e recente",
+          "unhealthyStale": "Precisa de atenção",
+          "daysAxis": "Dias desde a última execução",
+          "healthScoreAxis": "Pontuação de saúde"
+        },
+        "stats": {
+          "totalTests": "Total de testes",
+          "needsAttention": "Precisa de atenção",
+          "needsAttentionTooltip": "Sempre falhando + Nunca executados + Testes obsoletos",
+          "healthy": "Saudável",
+          "healthyTooltip": "Saudável + Sempre passando nos testes",
+          "avgScore": "Pontuação média de saúde"
+        },
+        "healthScoreTooltip": {
+          "title": "A pontuação inicial é 100, com deduções a seguir:",
+          "neverExecuted": "Nunca executado: -50",
+          "stale90": "Não executado nos últimos 90 dias: -40",
+          "stale60": "Não executado há mais de 60 dias: -25",
+          "stale30": "Não executado nos últimos 30 dias: -10",
+          "alwaysPassing": "Aprovado sempre (100%): -5",
+          "alwaysFailing": "Sempre falhando (0%): -30",
+          "lowPassRate": "Baixa taxa de aprovação (<50%): -20",
+          "lowExecutions": "Poucas execuções (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Modo de visualização",
+        "summaryView": "Resumo (por edição)",
+        "detailView": "Detalhes (por caso de teste)",
+        "issue": "Emitir",
+        "testCase": "Caso de teste",
+        "testCases": "{count, plural, =1 {Caso de teste} other {Casos de teste}}",
+        "issueStatus": "Status",
+        "priority": "Prioridade",
+        "linkedTests": "Testes Vinculados",
+        "testResults": "Resultados (P/F/U)",
+        "passRate": "Taxa de aprovação",
+        "passed": "Aprovado",
+        "failed": "Fracassado",
+        "lastStatus": "Último status",
+        "lastExecuted": "Última execução",
+        "notTested": "Não testado",
+        "noData": "Não foram encontrados problemas com os casos de teste vinculados.",
+        "noIssuesNeedingAttention": "Todos os testes foram aprovados - ótimo trabalho!",
+        "stats": {
+          "totalIssues": "Total de problemas",
+          "issuesWithFailures": "Com fracassos",
+          "issuesWithFailuresTooltip": "Problemas com pelo menos um caso de teste com falha",
+          "issuesWithUntested": "Com não testado",
+          "issuesWithUntestedTooltip": "Problemas com pelo menos um caso de teste que não foi executado.",
+          "issuesAllPassing": "Todos Passando",
+          "overallPassRate": "Taxa de aprovação",
+          "numberOfIssues": "Número de problemas"
+        },
+        "charts": {
+          "passRateDistribution": "Distribuição da taxa de aprovação nos testes",
+          "linkedTestCases": "Número de casos de teste vinculados",
+          "untestedTestCases": "Número de casos de teste não testados",
+          "testCoverageVsExecution": "Cobertura de testes versus status de execução"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Execução de testes entre projetos",
+          "description": "Analise os resultados dos testes, as taxas de aprovação e as métricas de execução em todos os projetos."
+        },
+        "repositoryStats": {
+          "label": "Estatísticas do Repositório Interprojetos",
+          "description": "Estatísticas de casos de teste, cobertura e integridade do repositório em todos os projetos"
+        },
+        "userEngagement": {
+          "label": "Envolvimento do usuário entre projetos",
+          "description": "Análise da atividade do usuário, produtividade e carga de trabalho em todos os projetos"
+        },
+        "issueTracking": {
+          "label": "Rastreamento de problemas entre projetos",
+          "description": "Criação, resolução e análise de impacto de problemas em diversos projetos."
+        },
+        "automationTrends": {
+          "label": "Tendências de automação entre projetos",
+          "description": "Acompanhe o progresso da automação semana a semana, priorizando os projetos."
+        },
+        "flakyTests": {
+          "label": "Testes inconsistentes entre projetos",
+          "description": "Identificar testes com resultados inconsistentes de aprovação/reprovação em diferentes projetos."
+        },
+        "testCaseHealth": {
+          "label": "Saúde dos casos de teste entre projetos",
+          "description": "Identificar casos de teste obsoletos, corrompidos ou suspeitos em todos os projetos."
+        },
+        "issueTestCoverage": {
+          "label": "Cobertura de testes de problemas entre projetos",
+          "description": "Visualize os problemas com seus respectivos casos de teste e o status de execução mais recente em todos os projetos."
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Somente os Administradores de Projeto e os Administradores podem acessar os relatórios do projeto.",
+      "projectIdRequired": "É necessário o ID do projeto.",
+      "missingRequiredFields": "Campos obrigatórios ausentes",
+      "unsupportedDimension": "Dimensão não suportada: {dimension}",
+      "unsupportedMetric": "Métrica não suportada: {metric}",
+      "atLeastOneDimensionMetricRequired": "É necessário pelo menos uma dimensão e uma métrica.",
+      "atLeastOneMetricRequired": "Pelo menos uma métrica deve ser especificada.",
+      "projectDimensionsMetricsRequired": "É necessário informar o ID do projeto, as dimensões e as métricas.",
+      "unsupportedDimensions": "Dimensão(ões) não suportada(s): {dimensions}",
+      "unsupportedMetrics": "Métrica(s) não suportada(s): {metrics}",
+      "unexpectedError": "Ocorreu um erro inesperado."
+    },
+    "dimensions": {
+      "project": "Projeto",
+      "status": "Status",
+      "user": "Usuário",
+      "executor": "Executor",
+      "assignedTo": "Designado para",
+      "configuration": "Configuração",
+      "date": "Data",
+      "executionDate": "Data de Execução",
+      "creationDate": "Data de criação",
+      "activityDate": "Data da atividade",
+      "testRun": "Teste de execução",
+      "testCase": "Caso de teste",
+      "milestone": "Marco",
+      "template": "Modelo",
+      "creator": "Criador",
+      "state": "Estado",
+      "source": "Fonte",
+      "folder": "Pasta",
+      "group": "Grupo",
+      "role": "Papel",
+      "session": "Sessão",
+      "weekEnding": "Semana que termina",
+      "period": "Período",
+      "priority": "Prioridade",
+      "automationStatus": "Status da automação",
+      "issueType": "Tipo de problema",
+      "issueTracker": "Rastreador de Problemas",
+      "issueStatus": "Status do problema"
+    },
+    "metrics": {
+      "testResults": "Resultados dos testes",
+      "testResultCount": "Contagem de resultados de testes",
+      "passRate": "Taxa de aprovação (%)",
+      "avgElapsed": "Tempo médio decorrido",
+      "avgElapsedTime": "Tempo médio decorrido",
+      "totalElapsedTime": "Tempo total decorrido",
+      "testRunCount": "Contagem de execuções de teste",
+      "testCaseCount": "Contagem de casos de teste",
+      "automationRate": "Taxa de automação (%)",
+      "avgStepsPerCase": "Média de passos por caso",
+      "averageSteps": "Média de passos por caso",
+      "automatedCount": "Casos automatizados",
+      "manualCount": "Casos manuais",
+      "totalCount": "Total de casos",
+      "totalSteps": "Total de passos",
+      "executionCount": "Execuções de teste",
+      "createdCaseCount": "Contagem de casos de teste criados",
+      "sessionResultCount": "Contagem de resultados da sessão",
+      "caseCreations": "Casos criados",
+      "sessionParticipation": "Participação na sessão",
+      "averageElapsed": "Tempo médio por execução",
+      "lastActiveDate": "Data da última atividade",
+      "issueCount": "Contagem de problemas",
+      "averageAge": "Idade média (dias)",
+      "sessionCount": "Contagem de sessões",
+      "activeSessions": "Sessões ativas",
+      "averageTimeSpent": "Tempo médio gasto (minutos)",
+      "milestoneCount": "Contagem de marcos",
+      "milestoneCompletionRate": "Taxa de conclusão de marcos (%)",
+      "averageMilestoneDuration": "Duração média do marco (dias)",
+      "totalMilestones": "Total de marcos",
+      "activeMilestones": "Marcos ativos",
+      "milestoneCompletion": "Conclusão de marcos (%)",
+      "averageDuration": "Duração média",
+      "totalDuration": "Duração total"
+    },
+    "drillDown": {
+      "title": "Registros detalhados",
+      "loading": "Carregando registros...",
+      "loadingMore": "Carregando mais...",
+      "noRecords": "Nenhum registro encontrado",
+      "error": "Falha ao carregar os registros",
+      "recordCount": "{count} {count, plural, =1 {registro} other {registros}}",
+      "allRecords": "Todos os registros",
+      "allLoaded": "Todos os registros foram carregados"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Compartilhar",
+      "dialogTitle": "Compartilhar relatório",
+      "dialogDescription": "Crie um link compartilhável ou gerencie links de relatórios compartilhados existentes.",
+      "tabs": {
+        "create": "Criar Compartilhar",
+        "list": "Minhas ações"
+      },
+      "shareMode": {
+        "label": "Modo de compartilhamento",
+        "authenticated": {
+          "title": "Autenticado (requer login)",
+          "description": "Somente usuários autenticados com acesso a este projeto podem visualizar.",
+          "descriptionCrossProject": "Somente usuários conectados com acesso de administrador podem visualizar."
+        },
+        "passwordProtected": {
+          "title": "Protegido por senha",
+          "description": "Qualquer pessoa com o link e a senha pode visualizar. Usuários logados com acesso ao projeto não precisam passar a senha.",
+          "descriptionCrossProject": "Qualquer pessoa com o link e a senha pode visualizar. Usuários logados com acesso de administrador não precisam passar a senha."
+        },
+        "public": {
+          "title": "Público (qualquer pessoa com link)",
+          "description": "Qualquer pessoa com o link pode visualizar este relatório sem precisar fazer login."
+        }
+      },
+      "expiration": {
+        "label": "Validade",
+        "noExpiration": "Sem prazo de validade",
+        "expiresAtMidnight": "O link expirará no final do dia selecionado (seu horário local)."
+      },
+      "notifyOnView": {
+        "label": "Avise-me quando alguém visualizar este link.",
+        "description": "Você receberá uma notificação quando o link de compartilhamento for acessado, de acordo com suas preferências de notificação."
+      },
+      "title": {
+        "placeholder": "Exemplo: Relatório de Execução de Testes",
+        "leaveEmptyToUse": "Deixe em branco para usar:"
+      },
+      "description": {
+        "placeholder": "Adicione uma descrição para este relatório compartilhado..."
+      },
+      "actions": {
+        "createShareLink": "Criar link de compartilhamento",
+        "creating": "Criando..."
+      },
+      "errors": {
+        "loginRequired": "Você precisa estar conectado para criar um link de compartilhamento.",
+        "createFailed": "Não foi possível criar o link de compartilhamento.",
+        "genericError": "Ocorreu um erro desconhecido."
+      },
+      "status": {
+        "revoked": {
+          "title": "Link de compartilhamento revogado",
+          "description": "Este link de compartilhamento foi revogado e não está mais acessível."
+        },
+        "expired": {
+          "title": "Link de compartilhamento expirado",
+          "description": "Este link de compartilhamento expirou e não está mais acessível."
+        }
+      },
+      "footer": {
+        "poweredBy": "Distribuído por"
+      },
+      "manageShares": {
+        "title": "Gerenciar ações",
+        "description": "Veja e gerencie todos os links de compartilhamento deste projeto.",
+        "adminTitle": "Gerenciar todas as ações",
+        "adminDescription": "Visualize e gerencie links de compartilhamento em todos os projetos."
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Modo",
+          "views": "Vistas",
+          "expires": "Expira"
+        },
+        "status": {
+          "revoked": "Revogado",
+          "expired": "Expirado"
+        },
+        "notifications": {
+          "enabled": "Sobre",
+          "disabled": "Desligado"
+        },
+        "empty": {
+          "title": "Nenhum link de compartilhamento foi criado ainda.",
+          "description": "Crie seu primeiro link de compartilhamento para começar."
+        },
+        "defaultTitle": "{entityType} compartilhar",
+        "noProject": "projeto transversal",
+        "actions": {
+          "copyLink": "Copiar link",
+          "revoke": "Revogar"
+        },
+        "revokeDialog": {
+          "title": "Revogar link de compartilhamento?",
+          "description": "Isso revogará imediatamente o link de compartilhamento. Qualquer pessoa que tentar acessá-lo verá uma mensagem de erro. Esta ação não pode ser desfeita.",
+          "confirm": "Revogar link",
+          "revoking": "Revogando..."
+        },
+        "deleteDialog": {
+          "title": "Excluir link de compartilhamento?",
+          "description": "Isso excluirá permanentemente o link de compartilhamento. Se o link estiver ativo, ele expirará imediatamente e não poderá mais ser acessado. Esta ação não pode ser desfeita.",
+          "confirm": "Excluir link"
+        },
+        "toast": {
+          "linkCopied": "Link copiado!",
+          "linkCopiedDescription": "O link de compartilhamento foi copiado para a sua área de transferência.",
+          "copyFailed": "Falha ao copiar",
+          "copyFailedDescription": "Por favor, copie o link manualmente.",
+          "linkRevoked": "Link de compartilhamento revogado",
+          "linkRevokedDescription": "O link de compartilhamento foi revogado e não está mais acessível.",
+          "revokeFailed": "Não conseguiu revogar",
+          "revokeFailedDescription": "Ocorreu um erro ao revogar o link de compartilhamento.",
+          "notificationsEnabled": "Notificações ativadas",
+          "notificationsEnabledDescription": "Você receberá notificações quando alguém visualizar este link de compartilhamento.",
+          "notificationsDisabled": "Notificações desativadas",
+          "notificationsDisabledDescription": "Você não receberá notificações quando alguém visualizar este link de compartilhamento.",
+          "notificationUpdateFailed": "Falha ao atualizar as notificações",
+          "notificationUpdateFailedDescription": "Ocorreu um erro ao atualizar as configurações de notificação.",
+          "linkDeleted": "Link de compartilhamento excluído",
+          "linkDeletedDescription": "O link de compartilhamento foi excluído e não aparecerá mais na sua lista.",
+          "deleteFailed": "Falha ao excluir",
+          "deleteFailedDescription": "Ocorreu um erro ao excluir o link de compartilhamento."
+        }
+      },
+      "created": {
+        "title": "Link de compartilhamento criado!",
+        "description": "Seu link de compartilhamento está pronto para uso. Copie e compartilhe com outras pessoas.",
+        "shareLink": "Compartilhar link",
+        "copy": "Cópia",
+        "openInNewTab": "Abrir em nova aba",
+        "metadata": {
+          "mode": "Modo",
+          "expires": "Expira",
+          "views": "Vistas"
+        },
+        "warnings": {
+          "publicLink": "Link público:",
+          "publicLinkDescription": "Qualquer pessoa com este link pode acessar o relatório sem autenticação.",
+          "expiresSoon": "Este link expirará no final de"
+        },
+        "actions": {
+          "createAnother": "Criar outro"
+        }
+      },
+      "editDialog": {
+        "title": "Editar link de compartilhamento",
+        "description": "Atualize as configurações deste link de compartilhamento.",
+        "passwordExists": "Este link de compartilhamento já possui uma senha. Deixe o campo de senha em branco para manter a senha atual.",
+        "passwordPlaceholder": "Deixe em branco para manter a senha atual."
+      }
+    },
+    "passwordDialog": {
+      "title": "Senha necessária",
+      "description": "Este conteúdo compartilhado de <strong>{projectName}</strong> está protegido por senha. Digite a senha para continuar.",
+      "passwordPlaceholder": "Digite a senha",
+      "showPassword": "Mostrar senha",
+      "hidePassword": "Ocultar senha",
+      "verifying": "Verificando...",
+      "errors": {
+        "emptyPassword": "Por favor, insira uma senha.",
+        "tooManyAttempts": "Muitas tentativas falharam. Por favor, tente novamente mais tarde{resetAt, select, null {} other { em {resetAt}}}.",
+        "genericError": "Ocorreu um erro. Tente novamente."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Não há mais tentativas disponíveis. Tente novamente mais tarde.",
+        "attemptsRemaining": "{count, plural, =1 {1 tentativa} other {# tentativas}} restantes."
+      }
+    },
+    "sharedReport": {
+      "loading": "Carregando relatório...",
+      "errors": {
+        "onlyReportSharing": "Atualmente, apenas o compartilhamento de relatórios está implementado.",
+        "failedToLoad": "Falha ao carregar os dados do relatório"
+      },
+      "defaultTitle": "Relatório Compartilhado",
+      "fromProject": "Do projeto:",
+      "dateRange": "Período:",
+      "readOnlyNotice": "Esta é uma visualização compartilhada somente leitura.",
+      "viewCount": "{count, plural, =1 {1 visualização} other {# visualizações}}",
+      "viewInFullApp": "Ver no aplicativo completo",
+      "pagination": {
+        "showing": "Exibindo",
+        "of": "de",
+        "results": "resultados"
+      }
+    },
+    "authBypass": {
+      "title": "Você tem acesso a este projeto.",
+      "description": "Visualizando como {userName} com acesso a {projectName}.",
+      "viewInApp": "Ver no aplicativo completo"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Filtrar etapas compartilhadas...",
+    "noGroups": "Nenhuma etapa compartilhada encontrada.",
+    "noTestCases": "Nenhum caso de teste utiliza este grupo de etapas compartilhado.",
+    "selectGroupPrompt": "Selecione um grupo de etapas compartilhadas para visualizar suas etapas.",
+    "deleteTitle": "Excluir grupo de etapas compartilhadas?",
+    "deleteDescription": "Tem certeza de que deseja excluir este grupo de etapas compartilhadas? As etapas serão removidas de todos os casos de teste que as utilizam.",
+    "saveSuccess": "Etapas compartilhadas atualizadas com sucesso.",
+    "saveError": "Ocorreu um erro ao salvar as etapas compartilhadas.",
+    "stepsCount": "{count, plural, one {# passo} other {# passos}}",
+    "testCasesUsing": "{count, plural, one {# caso de teste} other {# casos de teste}}",
+    "importWizard": {
+      "title": "Importar etapas compartilhadas",
+      "fields": {
+        "order": "Ordem",
+        "stepNumber": "Etapa #",
+        "stepContent": "Conteúdo da etapa",
+        "expectedResultContent": "Conteúdo do resultado esperado",
+        "combinedStepData": "Dados de etapas combinadas",
+        "stepsData": "Dados de etapas"
+      },
+      "success": {
+        "description": "{count, plural, one {# etapa compartilhada} other {# etapas compartilhadas}} importadas com sucesso"
+      },
+      "errors": {
+        "parseFailed": "Falha ao analisar o arquivo CSV",
+        "validationFailed": "Validação falhou",
+        "validationDescription": "{count, plural, one {# erro de validação} other {# erros de validação}} encontrados",
+        "importFailed": "A importação falhou",
+        "fileRequired": "É necessário um arquivo CSV."
+      },
+      "page1": {
+        "title": "Carregar arquivo e configuração",
+        "selectedFile": "Arquivo selecionado",
+        "delimiter": "Delimitador de campo",
+        "delimiters": {
+          "tab": "Tab (\\t)"
+        },
+        "hasHeaders": "A primeira linha contém os cabeçalhos das colunas.",
+        "encoding": "Codificação de arquivo",
+        "rowMode": {
+          "label": "Modo de linha",
+          "single": "Uma única linha por degrau compartilhado",
+          "multi": "Várias linhas para etapas compartilhadas complexas"
+        }
+      },
+      "page2": {
+        "title": "Mapear colunas CSV para campos de etapa compartilhados",
+        "description": "Mapeie as colunas do seu arquivo CSV para os campos de etapa compartilhados. Os campos obrigatórios devem ser mapeados.",
+        "ignoreColumn": "Ignore esta coluna",
+        "requiredFieldsWarning": "{count, plural, one {# campo obrigatório é} other {# campos obrigatórios são}} não mapeados. Por favor, mapeie todos os campos obrigatórios para continuar."
+      },
+      "page3": {
+        "title": "Visualizar dados de importação",
+        "showing": "Exibindo {start} a {end} de {total} etapas compartilhadas",
+        "step": "Etapa compartilhada {number}",
+        "noValue": "(vazio)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Adicionar manualmente",
+      "description": "Criar um novo grupo de etapas compartilhado com entrada manual",
+      "groupNamePlaceholder": "Insira um nome para este grupo de passos compartilhados.",
+      "success": "Etapas compartilhadas criadas com sucesso",
+      "errors": {
+        "groupNameRequired": "O nome do grupo é obrigatório.",
+        "stepsRequired": "É necessário pelo menos um passo.",
+        "saveFailed": "Falha ao salvar os passos compartilhados"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Duplicatas da sequência de etapas",
+      "pageDescription": "Analise as sequências de etapas correspondentes em todos os casos de teste. Converta as correspondências em grupos de etapas compartilhadas ou descarte os falsos positivos.",
+      "noResultsFound": "Nenhuma sequência de etapas duplicada foi encontrada.",
+      "noResultsDescription": "Execute uma varredura para detectar sequências de etapas repetidas em seus casos de teste.",
+      "filterPlaceholder": "Filtrar por nome do caso...",
+      "selected": "{count, plural, one {# selecionado} other {# selecionado}}",
+      "bulkDismiss": "Dispensar ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# partida encerrada} other {# partidas encerradas}}",
+      "bulkError": "Algumas operações falharam. Por favor, tente novamente.",
+      "tableHint": "Clique em uma linha para visualizar as etapas correspondentes. Selecione as linhas com caixas de seleção para realizar ações em massa.",
+      "columns": {
+        "matchedSteps": "Passos correspondentes",
+        "casesCount": "Casos",
+        "review": "Análise"
+      },
+      "scanning": "Analisando...",
+      "scanComplete": "{count, plural, one {# correspondências encontradas} other {# correspondências encontradas}}",
+      "scanFailed": "A digitalização falhou",
+      "scanFailedDescription": "Ocorreu um erro durante a verificação. Tente novamente.",
+      "cancelScan": "Cancelar digitalização",
+      "findStepDuplicates": "Encontrar etapas duplicadas",
+      "rescan": "Digitalizar",
+      "viewResults": "Ver resultados ({count})",
+      "retryScan": "Repetir verificação",
+      "dialog": {
+        "title": "Converter em etapas compartilhadas",
+        "previewTitle": "Sequência de passos correspondentes",
+        "casesTitle": "Casos de teste afetados",
+        "casesDescription": "Desmarque os casos que deseja excluir da conversão.",
+        "nameLabel": "Nome do Grupo de Etapas Compartilhadas",
+        "namePlaceholder": "Insira um nome para o grupo de passos compartilhados...",
+        "converting": "Convertendo...",
+        "dismissMatch": "Dispensar partida",
+        "dismissing": "Dispensando...",
+        "convertSuccess": "Grupo de passos compartilhado criado com sucesso!",
+        "convertError": "A conversão falhou. Tente novamente.",
+        "dismissSuccess": "Partida encerrada.",
+        "dismissError": "Falha ao fechar. Tente novamente.",
+        "viewSharedStep": "Ver Grupo de Etapas Compartilhadas",
+        "skippedWarning": "{count, plural, one {# caso foi ignorado} other {# casos foram ignorados}} (obsoleto ou já convertido).",
+        "noCasesSelected": "Selecione pelo menos um caso para converter.",
+        "selectAll": "Selecionar tudo"
+      }
+    },
+    "findStepDuplicates": "Encontrar duplicados"
+  },
+  "search": {
+    "title": "Procurar",
+    "placeholder": {
+      "thisProject": "Pesquisar neste projeto...",
+      "allProjects": "Pesquisar em todos os projetos..."
+    },
+    "currentProjectOnly": "Projeto atual apenas",
+    "allTypes": "Todos os tipos",
+    "entityTypes": {
+      "repositoryCase": "Casos de repositório"
+    },
+    "results": {
+      "tryAdjusting": "Tente ajustar seus termos de pesquisa ou filtros.",
+      "searchingFor": "Procurando por",
+      "within": "dentro de",
+      "currentProject": "projeto atual",
+      "page": "Página"
+    },
+    "errors": {
+      "searchFailed": "A busca falhou. Por favor, tente novamente.",
+      "tryAgain": "Tente novamente"
+    },
+    "startTyping": "Comece a digitar para pesquisar",
+    "typesSelected": "{count, plural, one {# tipo} other {# tipos}}",
+    "customFieldFilters": "Filtros de campo personalizados",
+    "customFiltersApplied": "filtros personalizados",
+    "customFields": "Campos personalizados",
+    "addFilter": "Adicionar filtro",
+    "filter": "Filtro",
+    "noCustomFilters": "Nenhum filtro de campo personalizado foi aplicado.",
+    "selectDate": "Selecione a data",
+    "selectOption": "Selecione a opção",
+    "selectOptions": "Selecione as opções",
+    "operators": {
+      "equals": "Igual a",
+      "not_equals": "Não é igual a",
+      "contains": "Contém",
+      "not_contains": "Não contém",
+      "starts_with": "Começa com",
+      "ends_with": "Termina com",
+      "gt": "Maior que",
+      "lt": "Menor que",
+      "gte": "Maior ou igual a",
+      "lte": "Menor ou igual a",
+      "between": "Entre",
+      "in": "Em",
+      "not_in": "Não em",
+      "exists": "Existe",
+      "not_exists": "Não existe"
+    },
+    "help": {
+      "exactPhrases": "Frases exatas",
+      "exactPhrasesDesc": "Coloque os termos entre aspas para corresponder às frases exatas:",
+      "proximity": "Busca por proximidade",
+      "proximityDesc": "palavras dentro de N posições umas das outras",
+      "booleanOperators": "Operadores booleanos",
+      "andDesc": "ambos os termos devem coincidir",
+      "orDesc": "Qualquer um dos termos pode coincidir.",
+      "notDesc": "excluir resultados com termo",
+      "prefixDesc": "exigir ou excluir um termo",
+      "groupingDesc": "Agrupar termos para consultas complexas",
+      "wildcards": "Coringas",
+      "wildcardMultiDesc": "corresponde a quaisquer caracteres",
+      "wildcardSingleDesc": "corresponde a um único caractere",
+      "fuzzyMatching": "Correspondência aproximada",
+      "fuzzyDesc": "Encontra termos semelhantes para ajudar com erros de digitação.",
+      "defaultBehavior": "Por padrão, o operador OR é usado para múltiplas palavras. Os resultados que correspondem ao nome são classificados em primeiro lugar.",
+      "fullSyntaxLink": "Referência completa da sintaxe de consulta do Lucene"
+    },
+    "filters": {
+      "title": "Filtros avançados",
+      "active": "filtros ativos",
+      "activeCount": "{count, plural, =0 {Sem filtros} one {# filtro} other {# filtros}} ativos",
+      "apply": "Aplicar filtros",
+      "common": "Filtros comuns",
+      "entitySpecific": "Filtros específicos por tipo",
+      "searchPlaceholder": "Opções de filtro de pesquisa...",
+      "states": "Estados do fluxo de trabalho",
+      "createdAt": "Data de criação",
+      "updatedAt": "Data de atualização",
+      "completedAt": "Data de conclusão",
+      "from": "De",
+      "to": "Para",
+      "testRunType": "Tipo de execução de teste",
+      "regular": "Regular",
+      "junit": "JUnit",
+      "automatedOnly": "Somente automatizado",
+      "archivedOnly": "Somente arquivado",
+      "completedOnly": "Somente concluído",
+      "manualOnly": "Somente manual",
+      "estimateRange": "Intervalo estimado",
+      "elapsedRange": "Intervalo de tempo decorrido",
+      "minValue": "Min",
+      "maxValue": "Máximo",
+      "hasExternalId": "Possui ID externo",
+      "dueDateRange": "Intervalo de datas de vencimento",
+      "hasParent": "Possui marco parental",
+      "milestoneType": "Tipo de marco",
+      "minutes": "minutos",
+      "hours": "horas",
+      "days": "dias",
+      "searchingIn": "Pesquisando em",
+      "includeDeleted": "Incluir itens excluídos",
+      "filterActive": "Filtro ativo:",
+      "applyFilter": "Aplicar filtro",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "O primeiro valor deve ser menor que o segundo valor.",
+        "firstDateMustBeBeforeSecond": "O primeiro encontro deve ser antes do segundo encontro."
+      },
+      "link": {
+        "domainHelp": "Insira apenas o domínio (por exemplo, \"github.com\" ou \"example.org\")"
+      }
+    }
+  },
+  "email": {
+    "greeting": "Olá,",
+    "greetingWithName": "Olá {name},",
+    "notification": {
+      "intro": "Você tem uma nova notificação:",
+      "viewDetails": "Ver detalhes",
+      "viewAll": "Ver todas as notificações"
+    },
+    "digest": {
+      "intro": "Aqui está seu resumo diário de notificações do TestPlanIt:",
+      "viewDetails": "Ver detalhes",
+      "viewAll": "Ver todas as notificações",
+      "noNotifications": "Você não tem nenhuma notificação nova hoje.",
+      "footer": "Você está recebendo este e-mail porque ativou as notificações diárias de resumo. Você pode alterar suas preferências de notificação em suas configurações.",
+      "profileSettings": "configurações de perfil"
+    },
+    "footer": {
+      "sentBy": "Este e-mail foi enviado por",
+      "unsubscribe": "Cancelar inscrição",
+      "managePreferences": "Gerenciar preferências",
+      "allRightsReserved": "Todos os direitos reservados."
+    },
+    "magicLink": {
+      "subject": "Faça login no TestPlanIt",
+      "heading": "Faça login no TestPlanIt",
+      "intro": "Clique no botão abaixo para iniciar sessão:",
+      "signInButton": "Entrar",
+      "copyPasteIntro": "Ou copie e cole este link no seu navegador:",
+      "disclaimer": "Se você não solicitou este e-mail, pode ignorá-lo sem problemas.",
+      "textBody": "Faça login no TestPlanIt\n\nClique no link abaixo para fazer login:\n{url}\n\nSe você não solicitou este e-mail, pode ignorá-lo com segurança."
+    }
+  },
+  "comments": {
+    "title": "Comentários",
+    "placeholder": "Escreva um comentário... (use @ para mencionar usuários)",
+    "editPlaceholder": "Edite seu comentário...",
+    "postComment": "Postar comentário",
+    "noComments": "Ainda não há comentários. Seja o primeiro a comentar!",
+    "edited": "editado",
+    "confirmDelete": "Tem certeza de que deseja excluir este comentário? Esta ação não pode ser desfeita.",
+    "deleteDialog": {
+      "title": "Excluir comentário"
+    },
+    "errors": {
+      "createFailed": "Não foi possível criar o comentário. Tente novamente.",
+      "updateFailed": "Não foi possível atualizar o comentário. Tente novamente.",
+      "deleteFailed": "Não foi possível excluir o comentário. Tente novamente.",
+      "loadFailed": "Não foi possível carregar os comentários. Tente novamente."
+    },
+    "mentions": {
+      "notAMember": "Não sou membro do projeto",
+      "noUsersFound": "Nenhum usuário encontrado"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "O teste termina em {count, plural, =1 {1 dia} other {# dias}}",
+    "expiresT oday": "O período de teste termina hoje.",
+    "expired": "{count, plural, =1 {Período de teste expirou há 1 dia} other {Período de teste expirou há # dias}}",
+    "contactSales": "Contate o departamento de vendas."
+  },
+  "feedback": {
+    "sheetTitle": "Compartilhe sua opinião",
+    "sheetDescription": "Ajude-nos a melhorar o TestPlanIt compartilhando sua experiência.",
+    "bannerMessage": "Como está indo o seu teste? Gostaríamos muito de saber sua opinião.",
+    "menuItem": "Compartilhe sua opinião"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "Etiqueta de IA",
+      "tagAll": "Etiquetar tudo",
+      "aiAutoTag": "Etiquetagem automática",
+      "tagActions": "Ações de tag",
+      "startTagging": "Comece a etiquetar",
+      "selectEntityType": "Selecione o tipo de entidade",
+      "selectProject": "Selecione um projeto",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Caso de teste} other {Casos de teste}}",
+        "testRun": "{count, plural, one {Execução de teste} other {Execuções de teste}}",
+        "session": "{count, plural, one {Sessão} other {Sessões}}"
+      }
+    },
+    "review": {
+      "title": "Sugestões de tags para avaliação",
+      "description": "Clique nas etiquetas para ativar/desativar a aceitação. Clique duas vezes para editar o nome da etiqueta.",
+      "selectEntity": "Selecione uma entidade para visualizar sugestões de tags.",
+      "noTagsSelected": "Nenhuma etiqueta selecionada",
+      "footerSummary": "{assignCount, plural, one {# tag} other {# tags}} serão atribuídas, {newCount, plural, one {# nova tag} other {# novas tags}} serão criadas",
+      "footerAssignCount": "{assignCount, plural, one {# tag} other {# tags}} serão atribuídas",
+      "footerNewCount": "{newCount, plural, one {# nova tag} other {# novas tags}} serão criadas",
+      "newTagsPopoverTitle": "Criar novas etiquetas",
+      "applying": "Candidatando-se...",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tags}} aplicadas a {entityCount, plural, one {# entidade} other {# entidades}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} aplicadas a {entityCount, plural, one {# entidade} other {# entidades}}, {newCount, plural, one {# nova tag} other {# novas tags}} criadas",
+      "applyError": "Não foi possível aplicar as tags. Tente novamente.",
+      "suggestedTags": "Etiquetas sugeridas",
+      "noSuggestions": "A IA não conseguiu gerar nenhuma etiqueta.",
+      "alreadyApplied": "Já se candidatou",
+      "filterEntities": "Filtrar entidades...",
+      "noEntitiesMatch": "Nenhuma entidade corresponde à sua pesquisa.",
+      "tagCount": "{count, plural, one {# etiqueta} other {# etiquetas}}",
+      "noTags": "nenhum",
+      "failed": "Fracassado",
+      "analysisFailed": "Não foi possível analisar esta entidade.",
+      "responseTruncated": "Resposta truncada — aumente o número máximo de tokens de saída nas configurações do LLM.",
+      "tooltipExisting": "Etiqueta existente",
+      "tooltipNew": "Nova etiqueta — será criada",
+      "tooltipAssign": "Atribuir etiqueta existente",
+      "toggleFailed": "Mostrar/ocultar entidades com falha",
+      "showFailed": "O show falhou"
+    },
+    "progress": {
+      "starting": "Iniciando a análise...",
+      "analyzed": "Entidades analisadas {analyzed}/{total}",
+      "sizing": "Encontrando o tamanho de lote ideal (tentando {size} entidades)...",
+      "streaming": "Recebendo resposta de IA ({analyzed}/{total} entidades concluídas)...",
+      "finalizing": "Preparando resultados...",
+      "complete": "Análise concluída",
+      "reviewSuggestions": "Sugestões de revisão",
+      "failed": "A análise falhou"
+    },
+    "wizard": {
+      "description": "A IA analisará todos os casos de teste, execuções de teste e sessões do seu projeto para sugerir tags relevantes com base no conteúdo.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Iniciar análise",
+      "untaggedOnly": "Analisar apenas registros sem tags existentes.",
+      "allowNewTags": "Permitir a criação de novas tags",
+      "noLlmConfigured": "(Nenhum LLM configurado)",
+      "analyzingDescription": "A IA está analisando suas entidades e gerando sugestões de tags. Isso pode levar alguns instantes."
+    },
+    "entityDetail": {
+      "customFields": "Campos personalizados",
+      "noDetails": "Nenhuma informação adicional disponível.",
+      "openInNewTab": "Abrir em nova aba"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Muito fraco",
+    "weak": "Fraco",
+    "fair": "Justo",
+    "good": "Bom",
+    "strong": "Forte",
+    "minLength": "Pelo menos {count} caracteres",
+    "uppercase": "Pelo menos uma letra maiúscula",
+    "lowercase": "Pelo menos uma letra minúscula",
+    "numbers": "Pelo menos um número",
+    "specialChars": "Caractere especial de: {chars}",
+    "history": "A senha foi usada em suas últimas {depth} senhas"
+  },
+  "TrialExpired": {
+    "title": "Seu período de teste expirou.",
+    "description": "Obrigado por experimentar o TestPlanIt! Seu período de avaliação terminou e esta instância não está mais acessível.",
+    "nextSteps": "Para continuar usando o TestPlanIt e acessar seus dados de teste, entre em contato com nossa equipe de vendas.",
+    "pricingPlans": "Planos de preços",
+    "dataRetention": "Seus dados de teste estão armazenados com segurança e estarão disponíveis quando você atualizar sua conta."
+  }
+}

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "Tên",
+    "cancel": "Hủy bỏ",
+    "dismiss": "Miễn nhiệm",
+    "of": "của",
+    "on": "TRÊN",
+    "at": "Tại",
+    "in": "TRONG",
+    "add": "Thêm vào",
+    "never": "Không bao giờ",
+    "select": "Lựa chọn...",
+    "file": "Tài liệu",
+    "selectMultiple": "Chọn nhiều mục...",
+    "searchUsers": "Tìm kiếm người dùng...",
+    "searchCases": "{count, plural, =0 {Tìm kiếm trường hợp} one {Tìm kiếm trường hợp số} other {Tìm kiếm trường hợp số}}",
+    "searchProjects": "{count, plural, =0 {Tìm kiếm dự án} one {Tìm kiếm # dự án} other {Tìm kiếm # dự án}}",
+    "searchTags": "Tìm kiếm thẻ...",
+    "searchRuns": "{count, plural, =0 {Chạy thử tìm kiếm} one {Chạy thử tìm kiếm #} other {Chạy thử tìm kiếm #}}",
+    "searchSessions": "{count, plural, =0 {Phiên tìm kiếm} one {Số phiên tìm kiếm} other {Số phiên tìm kiếm}}",
+    "search": "Tìm kiếm...",
+    "defaultOption": "Tùy chọn mặc định",
+    "yes": "Đúng",
+    "no": "KHÔNG",
+    "updated": "Đã cập nhật",
+    "groupedBy": "được nhóm theo",
+    "lastEditedBy": "Lần chỉnh sửa cuối cùng bởi",
+    "actions": {
+      "edit": "Biên tập",
+      "save": "Cứu",
+      "delete": "Xóa bỏ",
+      "create": "Tạo nên",
+      "submit": "Nộp",
+      "close": "Đóng",
+      "done": "Xong",
+      "verify": "Xác minh",
+      "signIn": "Đăng nhập",
+      "signOut": "Đăng xuất",
+      "signUp": "Đăng ký",
+      "resend": "Gửi lại",
+      "deleting": "Đang xóa...",
+      "next": "Kế tiếp",
+      "previous": "Trước",
+      "finish": "Hoàn thành",
+      "download": "Tải xuống",
+      "apply": "Áp dụng",
+      "confirm": "Xác nhận",
+      "confirmDelete": "Xác nhận xóa",
+      "saveChanges": "Lưu thay đổi",
+      "saving": "Đang lưu...",
+      "submitting": "Đang gửi...",
+      "start": "Bắt đầu",
+      "pause": "Tạm dừng",
+      "reset": "Cài lại",
+      "copy": "Sao chép",
+      "copyLink": "Sao chép liên kết",
+      "copied": "Đã sao chép!",
+      "complete": "Hoàn thành",
+      "back": "Mặt sau",
+      "clear": "Thông thoáng",
+      "expand": "Mở rộng",
+      "collapse": "Sụp đổ",
+      "addResult": "Thêm kết quả",
+      "passAndNext": "Pass & Next",
+      "viewInRepository": "Xem trong kho lưu trữ",
+      "resultAdded": "Đã thêm kết quả kiểm tra",
+      "resultAddedDescription": "Kết quả kiểm tra đã được thêm thành công.",
+      "resultUpdated": "Kết quả kiểm tra đã được cập nhật.",
+      "resultDeleted": "Kết quả kiểm tra đã bị xóa",
+      "deleteResult": "Xóa kết quả kiểm tra",
+      "deleteResultConfirmation": "Bạn có chắc chắn muốn xóa kết quả kiểm tra này không? Thao tác này không thể hoàn tác.",
+      "editResult": "Chỉnh sửa kết quả kiểm tra",
+      "resultDetails": "Chi tiết kết quả",
+      "actionsLabel": "Hành động",
+      "assign": "Giao phó",
+      "assignSelected": "Gán {count, plural, one {# trường hợp} other {# trường hợp}}",
+      "refresh": "Làm cho khỏe lại",
+      "addResultSelected": "Thêm kết quả vào {count, plural, one {# trường hợp} other {# trường hợp}}",
+      "resultsAdded": "{count, plural, one {# Kết quả} other {# Kết quả}} Đã thêm",
+      "resultsAddedDescription": "{count, plural, one {Kết quả đã được thêm vào trường hợp kiểm thử #} other {Kết quả đã được thêm vào trường hợp kiểm thử #}} thành công",
+      "addingResultsToMultiple": "Thêm kết quả vào {count, plural, one {# trường hợp kiểm thử} other {# trường hợp kiểm thử}}",
+      "addedToTestRun": "Đã thêm vào quá trình chạy thử nghiệm",
+      "addedToTestRunDescription": "Trường hợp thử nghiệm đã được thêm vào Chu trình chạy thử nghiệm.",
+      "noAvailableTestRuns": "Tất cả các lần chạy thử nghiệm hiện tại đều đã bao gồm trường hợp thử nghiệm này.",
+      "resultUpdateError": "Không thể cập nhật kết quả kiểm tra.",
+      "resultDeleteError": "Không thể xóa kết quả kiểm tra.",
+      "selectStatus": "Chọn trạng thái",
+      "addToTestRun": "Thêm vào Chạy thử",
+      "status": "Trạng thái",
+      "resultDetailsPlaceholder": "Nhập chi tiết kết quả...",
+      "selectAll": "Chọn tất cả",
+      "deselectAll": "Bỏ chọn tất cả",
+      "clearAll": "Xóa tất cả",
+      "selectFile": "Chọn tệp",
+      "restore": "Khôi phục",
+      "purge": "Xóa bỏ",
+      "previousCase": "Trường hợp trước đó",
+      "nextCase": "Vụ án tiếp theo",
+      "startTesting": "Bắt đầu thử nghiệm",
+      "expandLeftPanel": "Mở rộng bảng điều khiển bên trái",
+      "collapseLeftPanel": "Thu gọn bảng điều khiển bên trái",
+      "expandRightPanel": "Mở rộng bảng điều khiển bên phải",
+      "collapseRightPanel": "Thu gọn bảng điều khiển bên phải",
+      "createTag": "Tạo thẻ \"{name}\"",
+      "noTagsFound": "Không tìm thấy thẻ nào",
+      "duplicate": "Nhân bản",
+      "exportPdf": "Xuất PDF",
+      "exportingPdf": "Đang xuất khẩu...",
+      "change": "Thay đổi",
+      "viewAll": "Xem tất cả",
+      "undo": "Hoàn tác",
+      "undoDelete": "Hoàn tác xóa",
+      "automated": {
+        "details": "Chi tiết kiểm thử tự động",
+        "message": "Tin nhắn",
+        "line": "Đường kẻ",
+        "testSuite": "Bộ kiểm thử:"
+      },
+      "junit": {
+        "details": "Chi tiết kết quả kiểm tra tự động",
+        "import": {
+          "title": "Kết quả kiểm tra nhập khẩu",
+          "description": "Tải lên các tệp kết quả kiểm thử để nhập vào một lần chạy kiểm thử mới. Hỗ trợ các định dạng JUnit, TestNG, xUnit, NUnit, MSTest, Mocha và Cucumber.",
+          "testRun": {
+            "label": "Chạy thử nghiệm",
+            "placeholder": "Chọn một lần chạy thử nghiệm"
+          },
+          "file": {
+            "label": "Tệp kết quả kiểm tra"
+          },
+          "import": "Nhập khẩu",
+          "selectFolder": "Chọn một thư mục",
+          "createNewFolder": "Tạo thư mục mới",
+          "createNewFolderNamed": "Tạo thư mục mới: {name}",
+          "progress": {
+            "initializing": "Đang khởi tạo quá trình nhập khẩu...",
+            "validating": "Đang xác thực dữ liệu đầu vào...",
+            "creatingRun": "Đang tạo bản chạy thử nghiệm...",
+            "fetchingTemplate": "Đang tải dữ liệu mẫu...",
+            "countingTests": "Đang xử lý {count} trường hợp kiểm thử từ {files} tập tin...",
+            "parsingFile": "Đang phân tích tệp {current} của {total}...",
+            "processingSuite": "Bộ xử lý: {name}",
+            "processingCase": "Đang xử lý trường hợp kiểm thử {current} của {total}...",
+            "finalizing": "Đang hoàn tất quá trình nhập khẩu...",
+            "completed": "Quá trình nhập khẩu đã hoàn tất thành công!",
+            "errorParsing": "Lỗi khi phân tích tệp {index}: {error}",
+            "skippingFile": "Bỏ qua tệp không hợp lệ {index}"
+          },
+          "error": {
+            "title": "Lỗi nhập khẩu",
+            "importFailed": "Không thể nhập kết quả kiểm tra. Vui lòng thử lại."
+          },
+          "success": {
+            "title": "Nhập khẩu thành công",
+            "description": "Kết quả kiểm tra đã được nhập thành công."
+          },
+          "fileRequired": "Vui lòng tải lên ít nhất một tập tin kết quả kiểm tra."
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "Định dạng kết quả",
+            "placeholder": "Chọn định dạng"
+          }
+        }
+      },
+      "confirmRestoreTitle": "Xác nhận Khôi phục",
+      "confirmPurgeTitle": "Xác nhận xóa",
+      "remove": "Di dời",
+      "reconfigure": "Cấu hình lại và thử lại"
+    },
+    "permissions": {
+      "addEdit": "Thêm/Chỉnh sửa"
+    },
+    "auth": {
+      "internal": "Email/Mật khẩu",
+      "sso": "Chỉ SSO",
+      "both": "Email & SSO"
+    },
+    "status": {
+      "deleted": "Đã xóa",
+      "disabled": "Tàn tật",
+      "noCustomFieldData": "Không có thông tin chi tiết bổ sung.",
+      "pending": "Chưa giải quyết",
+      "uploading": "Đang tải lên...",
+      "notApplicable": "Không áp dụng",
+      "redirecting": "Đang chuyển hướng...",
+      "pendingDelete": "Sẽ bị xóa",
+      "pendingChanges": "Những thay đổi đang chờ xử lý",
+      "importing": "Đang nhập khẩu...",
+      "addingTestCases": "Đang thêm các trường hợp kiểm thử..."
+    },
+    "priority": {
+      "low": "Thấp",
+      "medium": "Trung bình",
+      "high": "Cao"
+    },
+    "filters": {
+      "allStatuses": "Tất cả trạng thái",
+      "allPriorities": "Tất cả các ưu tiên"
+    },
+    "fields": {
+      "groupName": "Tên nhóm",
+      "users": "Người dùng",
+      "mixed": "Tất cả các giá trị",
+      "type": "Kiểu",
+      "default": "Mặc định",
+      "enabled": "Đã bật",
+      "projects": "Dự án",
+      "iconColor": "Biểu tượng/Màu sắc",
+      "selectWorkflow": "Chọn quy trình làm việc",
+      "icon": "Biểu tượng",
+      "systemName": "Tên hệ thống",
+      "aliases": "Bí danh",
+      "scope": "Phạm vi",
+      "success": "Thành công",
+      "failure": "Sự thất bại",
+      "completed": "Hoàn thành",
+      "elapsed": "Thời gian trôi qua",
+      "totalElapsed": "Tổng thời gian đã trôi qua",
+      "totalEstimate": "Thời gian ước tính còn lại",
+      "completionRate": "Tỷ lệ hoàn thành",
+      "attachments": "Tệp đính kèm",
+      "documentation": "Tài liệu",
+      "state": "Tình trạng",
+      "configuration": "Cấu hình",
+      "configurations": "Cấu hình",
+      "milestone": "Cột mốc",
+      "tags": "Thẻ",
+      "createdBy": "Được tạo bởi",
+      "description": "Sự miêu tả",
+      "description_placeholder": "Thêm mô tả...",
+      "testCases": "Các trường hợp thử nghiệm",
+      "sessions": "Phiên họp",
+      "sharedSteps": "Các bước chung",
+      "email": "E-mail",
+      "password": "Mật khẩu",
+      "confirmPassword": "Xác nhận mật khẩu",
+      "token": "Mã thông báo",
+      "access": "Truy cập",
+      "avatar": "Avatar",
+      "steps": "Các bước",
+      "step": "Bước chân",
+      "expectedResult": "Kết quả dự kiến",
+      "notes": "Ghi chú",
+      "estimate": "Ước lượng",
+      "date": "Ngày",
+      "size": "Kích cỡ",
+      "created": "Tạo",
+      "template": "Bản mẫu",
+      "mission": "Nhiệm vụ",
+      "assignedTo": "Được giao cho",
+      "executedBy": "Được thực thi bởi",
+      "optional": "Không bắt buộc",
+      "role": "Vai trò",
+      "defaultRole": "Vai trò mặc định",
+      "systemAccess": "Truy cập hệ thống",
+      "authMethod": "Phương thức xác thực",
+      "dateCreated": "Ngày tạo",
+      "apiUser": "Người dùng API",
+      "unverified": "Chưa được xác minh",
+      "selfRegistered": "Tự đăng ký",
+      "role_placeholder": "Chọn một vai trò",
+      "usersCreated": "Người dùng đã tạo",
+      "groups": "Nhóm",
+      "apiAccess": "Truy cập API",
+      "requiredForAdmin": "Cần thiết cho Quản trị viên",
+      "account": "Tài khoản",
+      "accountHistory": "Lịch sử tài khoản",
+      "activity": "Hoạt động",
+      "lastActive": "Lần hoạt động cuối cùng",
+      "theme": "Chủ đề",
+      "locale": "Ngôn ngữ",
+      "timezone": "Múi giờ",
+      "itemsPerPage": "Số mục trên mỗi trang",
+      "notificationMode": "Thông báo",
+      "value": "Giá trị",
+      "key": "Chìa khóa",
+      "configurationDetails": "Chi tiết cấu hình",
+      "isActive": "Tích cực",
+      "members": "Thành viên",
+      "milestoneTypes": "Các loại cột mốc",
+      "milestones": "Các cột mốc",
+      "createdAt": "Được tạo vào lúc",
+      "completedOn": "Hoàn thành vào ngày",
+      "variants": "Các biến thể",
+      "emailVerified": "Email đã được xác minh",
+      "issueTracker": "Trình theo dõi sự cố",
+      "caseFields": "Trường hợp",
+      "resultFields": "Các trường kết quả",
+      "displayName": "Tên hiển thị",
+      "hint": "Gợi ý",
+      "required": "Yêu cầu",
+      "restricted": "Hạn chế",
+      "fieldType": "Loại trường",
+      "templates": "Mẫu",
+      "started": "Bắt đầu",
+      "startDate": "Ngày bắt đầu",
+      "automated": "Tự động",
+      "manual": "Thủ công",
+      "notAutomated": "Không tự động",
+      "testRuns": "Chạy thử nghiệm",
+      "title": "Tiêu đề",
+      "project": "Dự án",
+      "priority": "Sự ưu tiên",
+      "integration": "Tích hợp",
+      "lastSyncedAt": "Lần đồng bộ cuối cùng",
+      "externalKey": "Khóa ngoài",
+      "initialHeight": "Chiều cao ban đầu",
+      "minValue": "Giá trị tối thiểu",
+      "maxValue": "Giá trị tối đa",
+      "minIntegerValue": "Giá trị số nguyên tối thiểu",
+      "maxIntegerValue": "Giá trị số nguyên tối đa",
+      "defaultValue": "Giá trị mặc định",
+      "checked": "Đã kiểm tra",
+      "version": "Phiên bản",
+      "issues": "Vấn đề",
+      "internalIssues": "Các vấn đề nội bộ",
+      "externalIssues": "{provider} Vấn đề",
+      "data": "Dữ liệu",
+      "note": "Ghi chú",
+      "externalId": "ID bên ngoài",
+      "forecast": "Dự báo",
+      "forecastManual": "Sổ tay dự báo",
+      "forecastAutomated": "Dự báo tự động",
+      "executedAt": "Được thi hành tại",
+      "className": "Lớp học",
+      "suiteName": "Phòng suite",
+      "duration": "Khoảng thời gian",
+      "session": "Phiên họp",
+      "charter": "Hiến chương",
+      "summary": "Bản tóm tắt",
+      "progress": "Tiến triển",
+      "assertions": "Khẳng định",
+      "properties": "Của cải",
+      "systemOutput": "Nhật ký trường hợp kiểm thử",
+      "systemError": "Lỗi hệ thống",
+      "resultStatus": "Kết quả",
+      "links": "Liên kết",
+      "id": "NHẬN DẠNG",
+      "JUNIT": "Nhập khẩu JUnit",
+      "API": "API",
+      "folder": "Thư mục",
+      "parentFolder": "Thư mục cha dành cho các vụ án mới",
+      "multipleValues": "Nhiều giá trị",
+      "provider": "Nhà cung cấp",
+      "updatedAt": "Đã cập nhật lúc",
+      "tools": "Công cụ",
+      "codeRepository": "Kho mã nguồn",
+      "aiModels": "LLM mặc định",
+      "configKeys": {
+        "edit_results_duration": "Chỉnh sửa kết quả Thời lượng",
+        "project_docs_default": "Tài liệu dự án mặc định",
+        "notificationSettings": "Thông báo Cài đặt toàn cầu",
+        "elasticsearch_replicas": "Bản sao Elasticsearch"
+      },
+      "options": {
+        "label": "Nhãn",
+        "validation": {
+          "empty": "Tùy chọn không được để trống.",
+          "invalidChars": "Tùy chọn chứa ký tự không hợp lệ: \"{char}\"",
+          "duplicate": "Lựa chọn phải là duy nhất",
+          "systemNameError": "Tên hệ thống không hợp lệ",
+          "initialHeightMax": "Chiều cao ban đầu không được vượt quá 600px.",
+          "displayNameRequiredResult": "Nhập tên hiển thị cho trường Kết quả.",
+          "displayNameRequiredCase": "Nhập tên hiển thị cho trường Thông tin vụ việc.",
+          "minValueMaxValue": "Giá trị tối thiểu phải nhỏ hơn giá trị tối đa, và cả hai giá trị phải được thiết lập nếu một trong hai đã được thiết lập.",
+          "minMaxValueInteger": "Giá trị số nguyên tối thiểu phải nhỏ hơn giá trị số nguyên tối đa, và cả hai giá trị phải được thiết lập nếu một trong hai đã được thiết lập.",
+          "systemNameRequired": "Tên hệ thống không được để trống.",
+          "systemNameRegex": "Tên hệ thống phải bắt đầu bằng một chữ cái và chỉ được chứa chữ cái, số và dấu gạch dưới.",
+          "fieldTypeRequired": "Loại trường là bắt buộc."
+        }
+      },
+      "placeholders": {
+        "key": "Phím Enter",
+        "value": "Nhập giá trị",
+        "addVariant": "Thêm biến thể",
+        "addCategory": "Thêm danh mục",
+        "displayName": "Nhập tên hiển thị",
+        "systemName": "Nhập tên hệ thống",
+        "hint": "Nhập gợi ý"
+      },
+      "hints": {
+        "systemName": "Tên hệ thống phải là duy nhất và chỉ chứa chữ cái, số và dấu gạch dưới.",
+        "fieldType": "(Loại trường không thể thay đổi sau khi đã tạo)"
+      },
+      "validation": {
+        "nameRequired": "Tên là bắt buộc",
+        "stateRequired": "Tiểu bang yêu cầu",
+        "urlRequired": "URL là bắt buộc",
+        "invalidUrl": "Định dạng URL không hợp lệ"
+      }
+    },
+    "filter": {
+      "placeholder": "Bộ lọc {item}..."
+    },
+    "access": {
+      "admin": "Quản trị viên",
+      "projectAdmin": "Quản trị viên dự án",
+      "user": "Người dùng",
+      "none": "Không có"
+    },
+    "validation": {
+      "required": "Vui lòng nhập {field}",
+      "invalidDuration": "Vui lòng nhập thời lượng hợp lệ.",
+      "maxDuration": "Thời lượng không được vượt quá {max} phút",
+      "minLength": "{field} phải có ít nhất {min} ký tự",
+      "emailFormat": "Định dạng email không hợp lệ",
+      "passwordMatch": "Mật khẩu phải khớp",
+      "unique": "{field} phải là duy nhất",
+      "roleRequired": "Vị trí này là bắt buộc",
+      "nameMinLength": "Tên phải có ít nhất 2 ký tự.",
+      "invalidDurationFormat": "Định dạng thời lượng không hợp lệ. Hãy thử các định dạng khác như 30 phút, 1 tuần hoặc 1 giờ 25 phút."
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "Xác nhận {action}",
+        "message": "Bạn có chắc chắn muốn {action} không?"
+      },
+      "confirmDelete": {
+        "description": "Bạn có chắc chắn muốn xóa mục này không? Thao tác này không thể hoàn tác."
+      },
+      "assign": {
+        "title": "Phân công trường hợp kiểm thử",
+        "description": "Gán trường hợp kiểm thử \"{testCase}\" cho người dùng",
+        "selectUser": "Chọn người dùng"
+      },
+      "assignBulk": {
+        "title": "Gán hàng loạt trường hợp kiểm thử",
+        "description": "Gán {count, plural, one {# trường hợp kiểm thử đã chọn} other {# trường hợp kiểm thử đã chọn}} cho người dùng"
+      },
+      "complete": {
+        "title": "Chạy thử nghiệm hoàn tất",
+        "description": "Bạn có chắc chắn muốn hoàn thành lần chạy thử này không?",
+        "warning": "Sau khi hoàn tất, kết quả chạy thử nghiệm sẽ không thể chỉnh sửa được nữa.",
+        "apple": {
+          "title": "Cấu hình đăng nhập Apple",
+          "description": "Thiết lập thông tin đăng nhập Apple của bạn. Bạn có thể lấy thông tin này từ Cổng thông tin dành cho nhà phát triển của Apple.",
+          "clientId": "Mã dịch vụ",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "Mã số đội",
+          "teamIdPlaceholder": "Mã định danh nhóm gồm 10 ký tự của bạn",
+          "keyId": "Mã định danh chính",
+          "keyIdPlaceholder": "Mã định danh khóa 10 ký tự của bạn",
+          "privateKey": "Khóa riêng tư",
+          "privateKeyPlaceholder": "Dán nội dung khóa riêng .p8 của bạn vào đây",
+          "instructions": {
+            "title": "Hướng dẫn cài đặt:",
+            "step1": "Truy cập Cổng thông tin dành cho nhà phát triển của Apple.",
+            "step2": "Tạo ID dịch vụ và cấu hình Đăng nhập bằng Apple.",
+            "step3": "Tạo mã khóa để đăng nhập bằng Apple",
+            "step4": "Tải xuống tệp khóa riêng tư .p8",
+            "step5": "Thêm URL chuyển hướng sau:"
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "Tất cả các trường đều bắt buộc"
+          }
+        }
+      },
+      "delete": {
+        "title": "Xóa {item}",
+        "description": "Bạn có chắc chắn muốn xóa {name} không?",
+        "warning": "Thao tác này không thể hoàn tác. Nó sẽ xóa vĩnh viễn {item}."
+      }
+    },
+    "messages": {
+      "deleteSuccess": "Mục đã được xóa thành công",
+      "deleteError": "Đã xảy ra lỗi khi xóa mục",
+      "moveSuccess": "Vật phẩm đã được di chuyển thành công.",
+      "moveError": "Đã xảy ra lỗi trong quá trình di chuyển mục",
+      "updateSuccess": "Mục đã được cập nhật thành công.",
+      "updateError": "Đã xảy ra lỗi trong quá trình cập nhật mục",
+      "linkCopied": "Liên kết đã được sao chép vào clipboard",
+      "copyFailed": "Không thể sao chép liên kết vào clipboard",
+      "created": "Quá trình chạy thử nghiệm đã được tạo thành công.",
+      "createdDescription": "Quá trình chạy thử nghiệm đã được tạo và hiện đang hiển thị trong danh sách Các lần chạy thử nghiệm.",
+      "createError": "Đã xảy ra lỗi không xác định. Vui lòng thử lại.",
+      "emptyActive": "Hiện không có đợt chạy thử nghiệm nào đang hoạt động.",
+      "emptyCompleted": "Không có lần chạy thử nghiệm nào hoàn tất.",
+      "projectUpdated": "Dự án đã được cập nhật thành công.",
+      "projectUpdateError": "Đã xảy ra lỗi trong quá trình cập nhật dự án.",
+      "noProjects": "Không tìm thấy dự án nào."
+    },
+    "placeholders": {
+      "email": "Địa chỉ email",
+      "name": "Nhập tên",
+      "mission": "Hãy mô tả sứ mệnh của bạn...",
+      "selectMilestone": "Chọn cột mốc",
+      "selectStatus": "Chọn trạng thái",
+      "selectTemplate": "Chọn mẫu",
+      "duration": "ví dụ: 1 giờ 30 phút hoặc 90 phút",
+      "docs": "Thêm tài liệu...",
+      "select": "Lựa chọn",
+      "selectState": "Chọn tiểu bang",
+      "selectConfiguration": "Chọn cấu hình",
+      "selectConfigurations": "Chọn cấu hình",
+      "selectOption": "Chọn một tùy chọn",
+      "date": "Chọn ngày",
+      "selectEncoding": "Chọn mã hóa...",
+      "selectATemplate": "Chọn một mẫu...",
+      "selectVersion": "Chọn phiên bản",
+      "selectAModel": "Chọn một mẫu",
+      "selectWorkflowType": "Chọn loại quy trình làm việc",
+      "addAnOption": "Thêm một tùy chọn",
+      "addADescription": "Thêm mô tả...",
+      "optionalDescription": "Mô tả tùy chọn...",
+      "projectNotes": "Ghi chú dự án...",
+      "filterByName": "Lọc theo tên...",
+      "filterByValue": "Lọc theo giá trị...",
+      "selectOperator": "Chọn toán tử",
+      "searchIcons": "Biểu tượng tìm kiếm...",
+      "value": "Giá trị",
+      "stepCount": "Số bước",
+      "enterText": "Nhập văn bản...",
+      "enterUrl": "Nhập URL",
+      "issueIdExample": "SỐ 123",
+      "selectPriorityValuesOrEmpty": "Chọn các giá trị ưu tiên (hoặc để trống nếu muốn chọn tất cả)"
+    },
+    "errors": {
+      "error": "Lỗi",
+      "somethingWentWrong": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại sau.",
+      "emailRequired": "Nhập địa chỉ email của bạn.",
+      "emailInvalid": "Đây không phải là địa chỉ email hợp lệ.",
+      "passwordRequired": "Cần nhập mật khẩu.",
+      "confirmPasswordRequired": "Xác nhận mật khẩu của bạn.",
+      "passwordDoesNotMeetPolicy": "Mật khẩu không đáp ứng các yêu cầu bảo mật.",
+      "passwordsDoNotMatch": "Mật khẩu không khớp",
+      "nameRequired": "Vui lòng nhập đầy đủ họ tên của bạn",
+      "duplicate": "Hãy chọn một tên duy nhất.",
+      "userExists": "Người dùng đã tồn tại.",
+      "unknown": "Đã xảy ra lỗi không xác định.",
+      "invalidCredentials": "Tên người dùng hoặc mật khẩu không hợp lệ",
+      "projectNotFound": "Không tìm thấy dự án",
+      "projectNotFoundDescription": "Dự án bạn đang tìm kiếm không tồn tại hoặc bạn không có quyền truy cập vào nó.",
+      "tokenRequired": "Nhập mã xác nhận email của bạn hoặc nhấp vào liên kết trong email của bạn.",
+      "noSuccessStatus": "Chưa chọn trạng thái thành công nào.",
+      "missingTestRunCase": "Mã định danh trường hợp chạy thử nghiệm bị thiếu.",
+      "fieldRequired": "Trường này là bắt buộc",
+      "projectNameExists": "Đã có một dự án với tên gọi này tồn tại.",
+      "defaultNotFound": "Không tìm thấy giá trị mặc định",
+      "emailExists": "Đã có người dùng có địa chỉ email này.",
+      "nameExists": "Đã có người dùng có tên này.",
+      "duplicateValue": "Giá trị này hiện đang được sử dụng.",
+      "unauthorized": "Bạn không được phép thực hiện hành động này.",
+      "accessDenied": "Quyền truy cập bị từ chối",
+      "sessionNotFound": "Không tìm thấy phiên hoặc phiên không hợp lệ.",
+      "issueTrackerNotConfigured": "Hệ thống theo dõi lỗi chưa được cấu hình cho dự án này.",
+      "noUserSession": "Không tìm thấy phiên người dùng nào.",
+      "noProjectId": "Không tìm thấy ID dự án.",
+      "unknownErrorWithMessage": "Đã xảy ra lỗi không xác định. {message}",
+      "unauthenticated": "Người dùng chưa được xác thực",
+      "fetchFailed": "Không thể tải dữ liệu. Vui lòng thử lại sau.",
+      "unsupportedFieldType": "Loại trường không được hỗ trợ",
+      "notAuthenticated": {
+        "title": "Chưa được xác thực",
+        "message": "Bạn phải đăng nhập để thực hiện thao tác này."
+      },
+      "failedToFetchAssignments": {
+        "title": "Không thể tải bài tập",
+        "message": "Không thể tải bài tập. Vui lòng thử lại sau."
+      },
+      "issueManagement": {
+        "linkedSuccess": "Vấn đề đã được liên kết thành công",
+        "linkError": "Lỗi liên kết",
+        "unlinkedSuccess": "Sự cố đã được gỡ bỏ thành công.",
+        "unlinkError": "Lỗi khi hủy liên kết",
+        "noActiveIntegration": "Không tìm thấy tích hợp nào đang hoạt động cho dự án này."
+      },
+      "roleRequiredForSpecificRole": "Vai trò là bắt buộc khi loại truy cập là Vai trò cụ thể.",
+      "projectCreationFailed": "Quá trình tạo dự án thất bại, không trả về ID.",
+      "invalidRoleId": "ID vai trò không hợp lệ",
+      "workflowStateExists": "Trạng thái quy trình công việc đã tồn tại. Vui lòng chọn một tên mới.",
+      "failedToLoadCaseData": "Không thể tải dữ liệu vụ việc. Không thể lưu.",
+      "atLeastOneTagRequired": "Cần ít nhất một thẻ.",
+      "atLeastOneIssueRequired": "Ít nhất một vấn đề là cần thiết.",
+      "atLeastOneOptionRequired": "Ít nhất một lựa chọn phải được chọn",
+      "valueRequired": "Giá trị là cần thiết",
+      "contentRequired": "Nội dung là bắt buộc",
+      "invalidContentFormat": "Định dạng nội dung không hợp lệ",
+      "caseNameRequired": "Vui lòng nhập tên cho trường hợp kiểm thử.",
+      "caseStateRequired": "Vui lòng chọn một tiểu bang",
+      "caseFolderRequired": "Vui lòng chọn một thư mục",
+      "estimateTooLarge": "Ước tính quá lớn",
+      "estimateRequiredValid": "Cần phải cung cấp ước tính và thời lượng phải hợp lệ (ví dụ: 1 giờ 30 phút).",
+      "invalidDurationOrExceedsMax": "Định dạng thời lượng không hợp lệ hoặc vượt quá giới hạn tối đa (ví dụ: 1 giờ 30 phút)",
+      "configurationNameExists": "Tên cấu hình đã tồn tại. Vui lòng chọn một tên khác.",
+      "variantNameExists": "Tên biến thể này đã tồn tại. Vui lòng chọn một tên khác.",
+      "categoryNameExists": "Tên danh mục đã tồn tại. Vui lòng chọn một tên khác.",
+      "workflowStateNameExists": "Tên trạng thái quy trình công việc đã tồn tại. Vui lòng chọn một tên khác.",
+      "folderNameRequired": "Vui lòng nhập tên cho thư mục.",
+      "folderNameRequiredEnter": "Nhập tên cho thư mục.",
+      "workflowStateNameRequired": "Vui lòng nhập tên cho Trạng thái quy trình làm việc",
+      "roleNameEmpty": "Tên vai trò không được để trống.",
+      "groupNameRequired": "Tên nhóm là bắt buộc",
+      "templateNameRequired": "Vui lòng nhập tên cho mẫu.",
+      "caseStateInvalid": "Vui lòng chọn một tiểu bang hợp lệ.",
+      "caseTemplateRequired": "Vui lòng chọn một mẫu",
+      "invalidContent": "Nội dung không hợp lệ",
+      "milestoneNameRequired": "Vui lòng nhập tên cho Cột mốc",
+      "milestoneTypeRequired": "Vui lòng chọn Loại mốc quan trọng",
+      "testRunNameMinLength": "Tên phải có ít nhất 2 ký tự.",
+      "stateRequiredDot": "Thông tin tiểu bang là bắt buộc.",
+      "milestoneTypeNameMinLength": "Tên loại mốc thời gian phải có ít nhất 2 ký tự.",
+      "projectNameRequired": "Tên dự án là bắt buộc",
+      "workflowScopeRequired": "Vui lòng chọn một Quy trình làm việc cho Tiểu bang.",
+      "workflowTypeRequired": "Vui lòng chọn loại quy trình làm việc",
+      "newTestCaseAdded": "Đã thêm trường hợp kiểm thử mới.",
+      "repositoryDeleted": "Kho lưu trữ đã bị xóa",
+      "failedToDeleteRepository": "Không thể xóa kho lưu trữ",
+      "permissionDenied": "Bạn không có quyền truy cập vào trang này.",
+      "resultSubmitPermissionDenied": "Bạn không thể gửi kết quả cho trường hợp này. Hãy yêu cầu quản trị viên dự án chỉ định cho bạn.",
+      "noModelsFound": "Không tìm thấy mô hình nào.",
+      "failedToFetchModels": "Không thể tải mô hình",
+      "failedToCopyToClipboard": "Không thể sao chép vào clipboard",
+      "failedToLoadJobResults": "Không thể tải kết quả công việc",
+      "failedToUpdateRepositoryStatus": "Không thể cập nhật trạng thái kho lưu trữ."
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "Bảng điều khiển",
+      "twoFactorVerification": "Xác thực hai yếu tố",
+      "changePassword": "Thay đổi mật khẩu",
+      "twoFactorSetup": "Thiết lập xác thực hai yếu tố",
+      "signUp": "Đăng ký",
+      "signIn": "Đăng nhập",
+      "verifyEmail": "Xác minh email",
+      "trialExpired": "Thời gian dùng thử đã hết hạn",
+      "linkSsoAccount": "Liên kết tài khoản SSO",
+      "userProfile": "Hồ sơ người dùng",
+      "users": "Người dùng",
+      "issues": "Vấn đề",
+      "tags": "Thẻ",
+      "tagDetails": "Chi tiết thẻ",
+      "aiModels": "Mô hình AI",
+      "integrations": "Tích hợp",
+      "quickscript": "QuickScript",
+      "webhooks": "Webhooks",
+      "shares": "Cổ phiếu",
+      "repository": "Kho lưu trữ",
+      "testCaseVersion": "Phiên bản trường hợp thử nghiệm",
+      "duplicateTestCases": "Các trường hợp kiểm thử trùng lặp",
+      "documentation": "Tài liệu",
+      "sharedSteps": "Các bước chung",
+      "stepDuplicates": "Các bước trùng lặp",
+      "sessions": "Phiên họp",
+      "sessionVersion": "Phiên bản phiên",
+      "milestones": "Các cột mốc",
+      "testRuns": "Chạy thử nghiệm",
+      "reports": "Báo cáo",
+      "adminSamlConfig": "Quản trị viên - Cấu hình SAML",
+      "apiDocumentation": "Tài liệu API",
+      "sharedContent": "Nội dung được chia sẻ"
+    },
+    "aria": {
+      "userMenu": "Menu người dùng",
+      "search": "Tìm kiếm",
+      "helpMenu": "Menu trợ giúp",
+      "help": "Giúp đỡ",
+      "grouped": "Được nhóm lại",
+      "group": "Nhóm",
+      "selectAll": "Chọn tất cả",
+      "selectRow": "Chọn hàng",
+      "removeIssue": "Xóa vấn đề",
+      "selectDeselectAllAddEdit": "Chọn/Bỏ chọn tất cả Thêm/Chỉnh sửa",
+      "selectDeselectAllDelete": "Chọn/Bỏ chọn tất cả Xóa",
+      "selectDeselectAllClose": "Chọn/Bỏ chọn tất cả Đóng",
+      "clearFilter": "Xóa bộ lọc",
+      "olderVersion": "Phiên bản cũ hơn",
+      "newerVersion": "Phiên bản mới hơn",
+      "deletedUser": "Người dùng đã bị xóa",
+      "restrictedField": "Trường hạn chế",
+      "backToTestCase": "Quay lại trường hợp kiểm thử"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# Dự án} other {# Dự án}}",
+      "templates": "Mẫu & Trường",
+      "workflows": "Quy trình làm việc",
+      "statuses": "Trạng thái",
+      "roles": "Vai trò",
+      "unknownRole": "Vai trò không xác định",
+      "unknownGroup": "Nhóm không xác định",
+      "file": "tài liệu",
+      "files": "tệp",
+      "existingAttachments": "Các tệp đính kèm hiện có",
+      "new": "Mới",
+      "noElapsedTime": "Không có thời gian nào được ghi lại.",
+      "untested": "Chưa được kiểm thử",
+      "noResults": "Không có kết quả",
+      "resultsWithNoElapsedTime": "Không có thời gian nào được ghi lại cho kết quả.",
+      "total": "Tổng cộng",
+      "noCases": "Không có trường hợp thử nghiệm nào",
+      "unknown": "Không rõ",
+      "selectedTestCases": "Các trường hợp thử nghiệm được chọn",
+      "editToModifyCasesTitle": "Danh sách này không thể chỉnh sửa.",
+      "editToModifyCases": "Chỉnh sửa Lần chạy thử nghiệm và nhấp vào Các trường hợp thử nghiệm đã chọn để sửa đổi danh sách.",
+      "noTestCasesSelected": "Không có trường hợp thử nghiệm nào được chọn.",
+      "editToSelectTestCases": "Chỉnh sửa Lần chạy thử nghiệm để chọn các trường hợp thử nghiệm.",
+      "casesInRun": "{count, plural, =0 {Không có trường hợp kiểm thử nào trong lần chạy thử nghiệm} =1 {1 trường hợp kiểm thử trong lần chạy thử nghiệm} other {# trường hợp kiểm thử trong lần chạy thử nghiệm}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Trường hợp duy nhất} other {Số trường hợp duy nhất}} trên {configCount, plural, =1 {1 Cấu hình} other {Số cấu hình}} ({totalCount} tổng số trường hợp)",
+      "viewTestRunDetails": "Xem chi tiết kết quả chạy thử nghiệm",
+      "sortByStatus": "Phân nhóm theo trạng thái",
+      "sortByDate": "Sắp xếp theo ngày",
+      "testRuns": "{count, plural, =0 {Không có lần chạy thử} =1 {1 lần chạy thử} other {# lần chạy thử}}",
+      "sessions": "{count, plural, =0 {Không có buổi nào} =1 {1 buổi} other {# Buổi}}",
+      "noOptions": "Không có tùy chọn nào.",
+      "multiConfiguration": "Một phần của nhóm cấu hình đa dạng",
+      "otherConfigurations": "Các cấu hình khác",
+      "selected": "Đã chọn: {count}",
+      "defaultProjectAccess": "Quyền truy cập dự án mặc định",
+      "defaultAccessType": "Loại truy cập mặc định",
+      "assignedUsersCount": "{count, plural, =0 {Chưa có người dùng nào được chỉ định} =1 {Đã chỉ định người dùng} other {Đã chỉ định người dùng}}",
+      "successRate": "Tỷ lệ thành công",
+      "unassigned": "Chưa được chỉ định",
+      "testRunName": "Tên lần chạy thử nghiệm",
+      "estimatesEllipsis": "Ước tính...",
+      "access": {
+        "noAccess": "Không có quyền truy cập",
+        "globalRole": "Sử dụng vai trò toàn cầu",
+        "specificRole": "Vai trò cụ thể",
+        "projectDefault": "Dự án mặc định",
+        "usersGlobalRole": "Vai trò toàn cầu của người dùng"
+      },
+      "unknownUser": "Người dùng không xác định",
+      "unknownProject": "Dự án không xác định",
+      "unknownTag": "Thẻ không xác định",
+      "filesSelectedForUpload": "{count, plural, =1 {1 tập tin được chọn để tải lên} other {# tập tin được chọn để tải lên}}"
+    },
+    "empty": {
+      "description": "Không có mô tả",
+      "documentation": "Không có tài liệu nào",
+      "childMilestones": "Không có cột mốc phát triển nào của trẻ em.",
+      "sessions": "Không có buổi nào",
+      "activeSessions": "Không có phiên hoạt động nào.",
+      "completedSessions": "Chưa có phiên nào hoàn thành",
+      "testCase": "Không tìm thấy trường hợp thử nghiệm nào.",
+      "noTestCasesOrSessions": "Không tìm thấy trường hợp thử nghiệm hoặc phiên nào.",
+      "noTestCasesSessionsOrRuns": "Không tìm thấy trường hợp kiểm thử, phiên hoặc lần chạy nào."
+    },
+    "or": "hoặc",
+    "for": "vì",
+    "and": "Và",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "Logo TestPlanIt",
+      "tagline": "Hãy thử mọi thứ có thể."
+    },
+    "table": {
+      "columns": {
+        "columns": "Cột",
+        "required": "(yêu cầu)"
+      },
+      "filter": "Danh sách lọc...",
+      "selectNone": "Không chọn",
+      "sort": "Cột sắp xếp",
+      "sortAscending": "Sắp xếp tăng dần",
+      "sortDescending": "Sắp xếp theo thứ tự giảm dần",
+      "sortNone": "Chưa được sắp xếp",
+      "resize": "Thay đổi kích thước cột"
+    },
+    "pagination": {
+      "selectPage": "Chọn trang",
+      "morePages": "Thêm trang",
+      "goToPrevious": "Quay lại trang trước",
+      "goToNext": "Chuyển sang trang tiếp theo",
+      "all": "Tất cả các mặt hàng",
+      "entries": "{count, plural, =1 {# mục} other {# mục}}",
+      "pageSize": "Kích thước trang",
+      "showing": "Đang hiển thị",
+      "total": "Tổng số {count, plural, =1 {# mặt hàng} other {# mặt hàng}}",
+      "filtered": "được lọc từ",
+      "pageOfPages": "Trang {current} trên {total}"
+    },
+    "upload": {
+      "title": "Tải ảnh đại diện mới lên",
+      "description": "Kéo và thả hình ảnh của bạn hoặc nhấp vào nút bên dưới để chọn tệp.",
+      "attachments": {
+        "title": "Tải lên tệp đính kèm",
+        "description": "Kéo và thả tệp tin của bạn hoặc nhấp vào nút bên dưới để chọn tệp tin.",
+        "selectFiles": "{count, plural, =0 {Chọn tập tin} one {1 Tập tin đã chọn} other {# Tập tin đã chọn}}",
+        "selectFile": "{count, plural, =0 {Chọn tập tin} other {1 Tập tin đã chọn}}",
+        "filesSelected": "{count, plural, one {1 tập tin đã được chọn} other {# tập tin đã được chọn}}",
+        "addMoreFiles": "Thêm nhiều tập tin hơn...",
+        "replaceFile": "Thay thế tập tin...",
+        "invalidFileType": "Loại tệp không hợp lệ. Chỉ cho phép các tệp {types}.",
+        "altText": {
+          "emoji": "biểu tượng cảm xúc"
+        },
+        "count": "{count, plural, =1 {# tập tin} other {# tập tin}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "Kéo thả tệp CSV để nhập các trường hợp kiểm thử",
+      "dropToImportTestResults": "Kéo thả tệp để nhập kết quả kiểm tra",
+      "supportedCsvFormats": "Định dạng được hỗ trợ: .csv",
+      "supportedResultFormats": "Hỗ trợ các định dạng: .xml, .trx, .json",
+      "unsupportedFileType": "Loại tệp không được hỗ trợ. Dự kiến: {expected}",
+      "noFilesDetected": "Không tìm thấy tệp nào trong thư mục drop"
+    },
+    "editor": {
+      "setColor": "Đặt màu",
+      "enterUrl": "Nhập URL bao gồm https://",
+      "uploadFile": "Tải lên tệp",
+      "video": {
+        "controls": "Điều khiển trình phát video"
+      },
+      "image": {
+        "alignLeft": "Căn trái",
+        "alignCenter": "Căn giữa",
+        "alignRight": "Căn chỉnh sang phải",
+        "sizeSmall": "Kích thước nhỏ",
+        "sizeMedium": "Kích thước trung bình",
+        "sizeLarge": "Kích thước lớn",
+        "sizeFull": "Chiều rộng đầy đủ",
+        "resetSize": "Khôi phục về kích thước ban đầu",
+        "rotate": "Xoay 90°",
+        "delete": "Xóa ảnh"
+      },
+      "table": {
+        "insertTable": "Chèn bảng",
+        "headerRow": "Hàng tiêu đề",
+        "addColumnBefore": "Thêm cột trước",
+        "addColumnAfter": "Thêm cột sau",
+        "deleteColumn": "Xóa cột",
+        "addRowBefore": "Thêm hàng trước",
+        "addRowAfter": "Thêm hàng sau",
+        "deleteRow": "Xóa hàng",
+        "deleteTable": "Xóa bảng"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "Thêm đoạn văn bên dưới",
+        "clearFormatting": "Định dạng rõ ràng",
+        "copyToClipboard": "Sao chép vào clipboard"
+      },
+      "textMenu": {
+        "bold": "In đậm",
+        "italic": "Chữ nghiêng",
+        "underline": "Gạch chân",
+        "strikethrough": "Gạch ngang",
+        "code": "Mã số",
+        "codeBlock": "Khối mã",
+        "highlightText": "Văn bản được tô sáng",
+        "textColor": "Màu chữ",
+        "moreOptions": "Nhiều tùy chọn hơn",
+        "subscript": "Chỉ số dưới",
+        "superscript": "chỉ số trên",
+        "alignLeft": "Căn trái",
+        "alignCenter": "Căn giữa",
+        "alignRight": "Căn chỉnh sang phải",
+        "justify": "Giải thích",
+        "setLink": "Đặt liên kết",
+        "editLink": "Chỉnh sửa liên kết",
+        "removeLink": "Xóa liên kết",
+        "resetColorToDefault": "Đặt lại màu về mặc định"
+      }
+    },
+    "ai": {
+      "title": "Trợ lý viết AI",
+      "improveWriting": "Cải thiện kỹ năng viết",
+      "makeShorter": "Làm cho ngắn hơn",
+      "makeLonger": "Làm cho dài hơn",
+      "fixGrammar": "Sửa lỗi ngữ pháp",
+      "changeTone": "Thay đổi âm điệu",
+      "professional": "Chuyên nghiệp",
+      "casual": "Bình thường",
+      "formal": "Chính thức",
+      "translate": "Dịch",
+      "english": "Tiếng Anh",
+      "spanish": "tiếng Tây Ban Nha",
+      "french": "tiếng Pháp",
+      "summarize": "Tóm tắt",
+      "addExamples": "Thêm ví dụ",
+      "originalText": "Văn bản gốc",
+      "suggestion": "Gợi ý của AI",
+      "generating": "Đang tạo đề xuất...",
+      "noSuggestion": "Chưa có đề xuất nào được tạo ra.",
+      "acceptSuggestion": "Chấp nhận đề xuất",
+      "errors": {
+        "contentBlocked": "Nội dung đã bị chặn bởi bộ lọc an toàn. Vui lòng thử diễn đạt lại yêu cầu của bạn bằng từ ngữ khác.",
+        "emptyContent": "Trí tuệ nhân tạo không thể đưa ra phản hồi. Vui lòng thử diễn đạt lại yêu cầu của bạn hoặc thử lại sau.",
+        "maxTokens": "Câu trả lời của AI quá dài và bị cắt ngắn. Vui lòng thử gửi yêu cầu ngắn gọn hơn hoặc yêu cầu câu trả lời súc tích hơn.",
+        "rateLimit": "Dịch vụ AI hiện tạm thời không khả dụng do giới hạn số lượng yêu cầu. Vui lòng thử lại sau vài phút.",
+        "accessDenied": "Bạn không được phép sử dụng các tính năng trí tuệ nhân tạo cho dự án này.",
+        "generic": "Rất tiếc, đã xảy ra lỗi trong quá trình xử lý yêu cầu của bạn."
+      }
+    },
+    "by": "qua",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "Mục lục",
+        "emptyMessage": "Bắt đầu thêm tiêu đề vào tài liệu của bạn …"
+      },
+      "carousel": {
+        "previousSlide": "Trang trước",
+        "nextSlide": "Trang chiếu tiếp theo"
+      },
+      "dialog": {
+        "toggleFullScreen": "Bật/tắt chế độ toàn màn hình"
+      },
+      "command": {
+        "title": "Menu lệnh",
+        "description": "Tìm kiếm và thực thi lệnh"
+      },
+      "breadcrumb": {
+        "more": "Hơn"
+      },
+      "clickToViewDetails": "Nhấp chuột để xem chi tiết",
+      "clickToExpand": "Nhấp để mở rộng",
+      "clickToCollapse": "Nhấp chuột để thu gọn",
+      "search": {
+        "filters": "Bộ lọc",
+        "noResultsFound": "Không tìm thấy kết quả nào.",
+        "loadingProjects": "Đang tải dự án...",
+        "noProjectsFound": "Không tìm thấy dự án nào.",
+        "viewAllProjects": "Xem tất cả dự án",
+        "states": "Các tiểu bang",
+        "automationStatus": "Trạng thái tự động hóa",
+        "parent": "Phụ huynh"
+      },
+      "issues": {
+        "errorLoadingDetails": "Chi tiết lỗi khi tải: ",
+        "updated": "Đã cập nhật: ",
+        "openInJira": "Mở trong Jira",
+        "openInExternalSystem": "Mở trong {provider}",
+        "assignee": "Người được chỉ định",
+        "status": "Trạng thái: ",
+        "clickToOpenInNewTab": "Nhấp chuột để mở trong tab mới",
+        "url": "URL: ",
+        "externalId": "Mã định danh bên ngoài: ",
+        "viewIn": "Xem trong",
+        "fieldType": "Loại trường: ",
+        "richTextContent": "Nội dung văn bản phong phú",
+        "invalidContent": "Nội dung không hợp lệ",
+        "fieldInformation": "Thông tin thực địa"
+      },
+      "onboarding": {
+        "skipTour": "Bỏ qua chuyến tham quan"
+      },
+      "charts": {
+        "resultsDistribution": "Phân phối kết quả",
+        "statusTimeline": "Dòng thời gian trạng thái",
+        "testDurationHistogram": "Biểu đồ phân bố thời gian thử nghiệm",
+        "zoomDonutChart": "Biểu đồ hình bánh donut phóng to",
+        "zoomStatusTimeline": "Dòng thời gian trạng thái Zoom",
+        "zoomHistogramChart": "Biểu đồ tần số phóng to",
+        "duration": "Thời lượng: {seconds} giây",
+        "durationLabel": "Khoảng thời gian"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "Đang tải thông tin trình theo dõi sự cố...",
+      "enterDocumentation": "Nhập tài liệu...",
+      "noAutomatedTestResults": "Không tìm thấy kết quả kiểm tra tự động nào cho lần chạy này."
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {phút} other {phút}}",
+      "seconds": "{count, plural, =1 {giây} other {giây}}"
+    },
+    "units": {
+      "time": "Thời gian"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {trường hợp} other {các trường hợp}}",
+      "result": "{count, plural, =1 {kết quả} other {kết quả}}",
+      "run": "{count, plural, =1 {chạy} other {chạy}}",
+      "comment": "{count, plural, =1 {{count} bình luận} other {{count} bình luận}}"
+    },
+    "success": {
+      "assigned": "Trường hợp kiểm thử được gán thành công",
+      "unassigned": "Trường hợp kiểm thử đã được gỡ bỏ thành công.",
+      "bulkAssigned": "{count, plural, one {# trường hợp kiểm thử} other {# các trường hợp kiểm thử}} được gán thành công",
+      "bulkUnassigned": "{count, plural, one {# trường hợp kiểm thử} other {# các trường hợp kiểm thử}} đã được hủy gán thành công"
+    },
+    "tabs": {
+      "general": "Tổng quan",
+      "settings": "Cài đặt"
+    },
+    "selectFilter": "Vui lòng chọn một giá trị bộ lọc để xem các trường hợp thử nghiệm.",
+    "invalidProject": "Mã định danh dự án không hợp lệ.",
+    "visualization": "Trực quan hóa",
+    "results": "Kết quả",
+    "loading": "Đang tải..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "Tạo tài khoản mới",
+      "sso": {
+        "title": "Đăng nhập bằng SSO",
+        "googleOAuth": "Tiếp tục với Google",
+        "apple": "Tiếp tục với Apple",
+        "microsoft": "Tiếp tục với Microsoft",
+        "samlProvider": "Đăng nhập bằng {name}",
+        "magicLink": "Đăng nhập bằng Magic Link",
+        "emailLogin": "Tiếp tục với email"
+      },
+      "magicLink": {
+        "description": "Nhập địa chỉ email của bạn và chúng tôi sẽ gửi cho bạn một liên kết an toàn để đăng nhập. Không cần mật khẩu. Bạn phải đã có tài khoản.",
+        "emailPlaceholder": "Nhập email của bạn",
+        "sendLink": "Gửi liên kết ma thuật",
+        "sending": "Đang gửi...",
+        "checkEmail": "Kiểm tra email của bạn",
+        "success": "Chúng tôi đã gửi một liên kết thần kỳ đến {email} nếu bạn có tài khoản. Hãy nhấp vào liên kết trong email để đăng nhập.",
+        "error": "Không thể gửi liên kết ma thuật. Vui lòng thử lại.",
+        "backToSignIn": "Quay lại trang đăng nhập"
+      },
+      "twoFactor": {
+        "title": "Xác thực hai yếu tố",
+        "description": "Nhập mã 6 chữ số từ ứng dụng xác thực của bạn hoặc sử dụng mã dự phòng."
+      },
+      "troubleSigningIn": "Gặp sự cố khi đăng nhập?",
+      "contactAdmin": "Liên hệ với Quản trị viên hệ thống"
+    },
+    "errors": {
+      "accessDenied": "Truy cập bị từ chối. Tài khoản của bạn có thể không hoạt động hoặc bạn không có quyền đăng nhập.",
+      "configuration": "Có vấn đề với cấu hình máy chủ.",
+      "verification": "Mã xác thực đã hết hạn hoặc đã được sử dụng.",
+      "invalid2FACode": "Mã xác minh không hợp lệ. Vui lòng thử lại.",
+      "twoFactorTokenRequired": "Cần có mã thông báo.",
+      "verificationCodeRequired": "Cần có mã xác minh."
+    },
+    "signup": {
+      "description": "Nhập thông tin của bạn để đăng ký tài khoản mới.",
+      "signIn": "Đăng nhập vào tài khoản hiện có của bạn.",
+      "registrationDisabled": "Hãy liên hệ với quản trị viên để tạo tài khoản.",
+      "errors": {
+        "emailRequired": "Cần có email.",
+        "passwordRequired": "Mật khẩu không đáp ứng các yêu cầu bảo mật.",
+        "confirmPasswordRequired": "Cần xác nhận mật khẩu.",
+        "passwordsDoNotMatch": "Mật khẩu không khớp",
+        "domainRestricted": "Việc đăng ký chỉ dành cho các tên miền email đã được phê duyệt. Vui lòng liên hệ với quản trị viên của bạn nếu bạn cho rằng đây là lỗi."
+      }
+    },
+    "verifyEmail": {
+      "title": "Xác minh email",
+      "loading": "Đang xác minh email...",
+      "success": "Email đã được xác minh thành công.",
+      "error": "Xác minh email không thành công",
+      "expired": "Liên kết xác minh đã hết hạn",
+      "invalid": "Liên kết xác minh không hợp lệ",
+      "alreadyVerified": "Email đã được xác minh",
+      "toast": {
+        "verifySuccess": {
+          "description": "Bạn có thể đăng nhập vào tài khoản của mình ngay bây giờ."
+        },
+        "verifyError": {
+          "description": "Đã xảy ra lỗi trong quá trình xác minh email."
+        },
+        "resendSuccess": {
+          "title": "Đã gửi liên kết xác minh qua email.",
+          "description": "Vui lòng kiểm tra email của bạn để tìm liên kết xác nhận."
+        },
+        "resendError": {
+          "title": "Không thể gửi liên kết xác minh email.",
+          "description": "Đã xảy ra lỗi khi gửi liên kết xác minh email."
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "Thiết lập xác thực hai yếu tố",
+      "description": "Tổ chức của bạn yêu cầu xác thực hai yếu tố. Hãy thiết lập để tiếp tục.",
+      "backupDescription": "Hãy lưu lại mã dự phòng của bạn trước khi tiếp tục.",
+      "required": "Chính sách bảo mật của tổ chức bạn yêu cầu xác thực hai yếu tố.",
+      "loading": "Đang chuẩn bị thiết lập...",
+      "manualEntry": "Hoặc nhập mã này theo cách thủ công:",
+      "verifyLabel": "Mã xác minh",
+      "verify": "Xác minh & Kích hoạt",
+      "backupCodesInfo": "Hãy lưu giữ những mã này ở một nơi an toàn. Bạn có thể sử dụng chúng để truy cập tài khoản nếu bị mất thiết bị xác thực.",
+      "copyCodes": "Sao chép tất cả mã",
+      "continue": "Tiếp tục đăng nhập"
+    },
+    "twoFactorVerify": {
+      "title": "Xác minh danh tính của bạn",
+      "description": "Nhập mã 6 chữ số từ ứng dụng xác thực của bạn để tiếp tục.",
+      "backupCodeLabel": "Mã sao lưu",
+      "backupCodeHint": "Bạn cũng có thể nhập mã dự phòng gồm 8 ký tự.",
+      "useAuthenticator": "Hãy sử dụng mã xác thực thay thế.",
+      "useBackupCode": "Thay vào đó, hãy sử dụng mã dự phòng.",
+      "signOut": "Đăng xuất và sử dụng tài khoản khác."
+    },
+    "forceChangePassword": {
+      "title": "Thay đổi mật khẩu của bạn",
+      "adminDescription": "Quản trị viên yêu cầu bạn thay đổi mật khẩu.",
+      "expiredDescription": "Mật khẩu của bạn đã hết hạn. Vui lòng đặt mật khẩu mới để tiếp tục.",
+      "newPasswordLabel": "Mật khẩu mới",
+      "confirmPasswordLabel": "Xác nhận mật khẩu mới",
+      "submitButton": "Thay đổi mật khẩu",
+      "signOut": "Thay vào đó, hãy đăng xuất.",
+      "passwordsMustMatch": "Mật khẩu không khớp.",
+      "passwordRequired": "Cần nhập mật khẩu.",
+      "genericError": "Đã xảy ra lỗi. Vui lòng thử lại.",
+      "policyTitle": "Yêu cầu về mật khẩu:",
+      "policyMinLength": "Ít nhất {count} ký tự",
+      "policyUppercase": "Ít nhất một chữ cái viết hoa",
+      "policyLowercase": "Ít nhất một chữ cái viết thường",
+      "policyNumbers": "Ít nhất một số",
+      "policySpecialChars": "Ít nhất một ký tự đặc biệt ({chars})"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "Liên kết tài khoản SSO",
+      "description": "Liên kết tài khoản của bạn với nhà cung cấp Đăng nhập một lần (Single Sign-On).",
+      "availableProviders": "Các nhà cung cấp SSO hiện có",
+      "linkWithGoogle": "Liên kết với Google",
+      "linkWithSaml": "Liên kết với {name}",
+      "accountLinked": "Tài khoản đã được liên kết thành công.",
+      "linkingFailed": "Không thể liên kết tài khoản",
+      "noProvidersAvailable": "Hiện tại không có nhà cung cấp SSO nào khả dụng để liên kết.",
+      "linkingInfo": "Việc liên kết với nhà cung cấp SSO cho phép bạn đăng nhập bằng nhà cung cấp đó thay vì mật khẩu của mình. Dữ liệu tài khoản hiện có của bạn sẽ không bị thay đổi.",
+      "signInWithGoogle": "Đăng nhập bằng Google",
+      "enterpriseSamlSso": "Đăng nhập SAML doanh nghiệp",
+      "linkProvider": "Nhà cung cấp liên kết",
+      "linking": "Đang liên kết...",
+      "noProvidersContactAdmin": "Hiện tại chưa có nhà cung cấp SSO nào khả dụng. Vui lòng liên hệ với quản trị viên của bạn."
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "Bảng điều khiển",
+      "admin": "Sự quản lý",
+      "profile": "Hồ sơ"
+    },
+    "admin": {
+      "crossProjectReports": "Báo cáo liên dự án"
+    },
+    "projects": {
+      "sections": {
+        "management": "Sự quản lý"
+      },
+      "menu": {
+        "repository": "Kho lưu trữ",
+        "runs": "Các lần chạy thử nghiệm và kết quả"
+      },
+      "dropdown": {
+        "selectProject": "Chọn một dự án",
+        "selectProjectAriaLabel": "Chọn dự án {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "Mã dự án: {id}",
+      "active": "Dự án đang hoạt động",
+      "completed": "Dự án đã hoàn thành."
+    },
+    "overview": {
+      "title": "Tổng quan",
+      "currentMilestones": "Các cột mốc hiện tại",
+      "seeAllMilestones": "{count, plural, =1 {Xem # Cột mốc} other {Xem tất cả # Cột mốc}}",
+      "seeAllTestCases": "{count, plural, =1 {Xem trường hợp thử nghiệm #} other {Xem tất cả các trường hợp thử nghiệm #}}",
+      "latestTestCases": "Các trường hợp thử nghiệm mới nhất",
+      "createdOn": "Được tạo vào ngày",
+      "seeAllTags": "Xem tất cả thẻ",
+      "seeAllActiveSessions": "{count, plural, =1 {Xem # Phiên đang hoạt động} other {Xem tất cả # Phiên đang hoạt động}}",
+      "latestSessions": "Các phiên gần đây nhất",
+      "activeTestRuns": "Các đợt chạy thử nghiệm đang hoạt động",
+      "seeAllActiveTestRuns": "{count, plural, =1 {Xem # Lần chạy thử nghiệm đang hoạt động} other {Xem tất cả # Lần chạy thử nghiệm đang hoạt động}}",
+      "latestTestRuns": "Các lần chạy thử nghiệm mới nhất",
+      "testCaseBreakdown": "Phân tích trường hợp kiểm thử",
+      "noTestCases": "Kho lưu trữ dự án hiện trống. Hãy thêm các trường hợp kiểm thử bằng cách sử dụng Kho lưu trữ.",
+      "noTestCasesPrefix": "Kho lưu trữ dự án trống. Thêm các trường hợp kiểm thử bằng cách sử dụng...",
+      "noTestCasesLink": "Kho lưu trữ"
+    },
+    "icon": {
+      "upload": {
+        "title": "Biểu tượng Tải lên Dự án",
+        "description": "Tải lên ảnh vuông (tỷ lệ khung hình 1:1) có dung lượng tối đa 4MB.",
+        "errors": {
+          "invalidFileType": "Chỉ cho phép tải các tệp hình ảnh.",
+          "fileTooLarge": "Tệp quá lớn. Kích thước tối đa là {size}."
+        }
+      }
+    },
+    "settings": {
+      "description": "Quản lý cài đặt cho {projectName}",
+      "moreSettingsComingSoon": "Sẽ có thêm nhiều tùy chọn cài đặt trong thời gian tới.",
+      "moreSettingsDescription": "Các tùy chọn cấu hình dự án bổ sung sẽ có sẵn trong các bản cập nhật sau này.",
+      "integrations": {
+        "description": "Quản lý việc tích hợp các vấn đề của bên thứ ba cho dự án này.",
+        "availableIntegrations": "Các tích hợp vấn đề hiện có",
+        "availableDescription": "Chọn một phương thức tích hợp sự cố để kết nối với dự án này.",
+        "configuredIntegration": "Tích hợp cấu hình",
+        "noIntegrationAssigned": "Không có vấn đề tích hợp nào được chỉ định.",
+        "noIntegrationDescription": "Chọn phương pháp tích hợp vấn đề từ các tùy chọn có sẵn để bắt đầu.",
+        "selectIntegration": "Chọn một tích hợp sự cố để cấu hình",
+        "integration": {
+          "assignError": "Không thể gán tích hợp vấn đề",
+          "updateSuccess": "Cài đặt tích hợp đã được cập nhật",
+          "updateError": "Không thể cập nhật cài đặt tích hợp sự cố.",
+          "removeError": "Không thể gỡ bỏ sự cố tích hợp",
+          "removeIntegration": "Loại bỏ tích hợp",
+          "confirmRemove": "Xác nhận xóa",
+          "authDescription": "Bạn cần xác thực với {provider} để sử dụng tính năng tích hợp sự cố này.",
+          "authenticating": "Đang xác thực...",
+          "authSuccess": "Xác thực thành công",
+          "selectProject": "Chọn dự án {provider}",
+          "selectProjectPlaceholder": "Chọn một dự án để liên kết",
+          "linkedProject": "Dự án liên kết",
+          "loadProjectsError": "Không thể tải dự án",
+          "settingsSaved": "Cài đặt tích hợp đã được lưu thành công",
+          "saveSettingsError": "Không thể lưu cài đặt tích hợp sự cố.",
+          "authorizationRequired": "Cần có sự cho phép",
+          "authenticationError": "Xác thực không thành công. Vui lòng thử lại.",
+          "authorizationRequiredDescription": "Bạn cần cấp quyền cho việc tích hợp vấn đề này để truy cập các dự án bên ngoài.",
+          "authorizationMessage": "Vui lòng cho phép quá trình tích hợp vấn đề tiếp tục.",
+          "authorizeIntegration": "Ủy quyền {name}",
+          "integrationSettings": "{name} Cài đặt",
+          "integrationSettingsDescription": "Cấu hình cài đặt tích hợp sự cố cho dự án này",
+          "selectExternalProject": "Chọn dự án bên ngoài",
+          "refreshProjects": "Dự án làm mới",
+          "defaultIssueType": "Loại sự cố mặc định",
+          "selectDefaultIssueType": "Chọn loại sự cố mặc định",
+          "defaultIssueTypeDescription": "Loại sự cố này sẽ được chọn sẵn khi tạo sự cố mới.",
+          "issueTypePlaceholder": "Ví dụ: Lỗi, Nhiệm vụ, Câu chuyện",
+          "defaultComponent": "Thành phần mặc định",
+          "componentPlaceholder": "Ví dụ: Giao diện người dùng (Frontend), Phần xử lý phía máy chủ (Backend).",
+          "automaticSync": "Đồng bộ tự động",
+          "automaticSyncDescription": "Tự động đồng bộ các vấn đề giữa TestPlanIt và hệ thống bên ngoài.",
+          "simpleUrlDescription": "Tính năng tích hợp vấn đề này sử dụng một mẫu URL đơn giản để liên kết đến các vấn đề bên ngoài. Các vấn đề sẽ được mở trong một tab mới bằng cách sử dụng mẫu URL đã được cấu hình.",
+          "externalProjectHelp": "Thao tác này thiết lập dự án mặc định để tạo sự cố mới từ TestPlanIt. Bạn vẫn có thể liên kết và đồng bộ hóa các sự cố từ các dự án bên ngoài khác - mỗi sự cố theo dõi dự án nguồn riêng của nó.",
+          "linkedProjects": "Các dự án bên ngoài được liên kết",
+          "linkedProjectsDescription": "Các dự án bên ngoài được kết nối thông qua sự tích hợp này.",
+          "noLinkedProjects": "Không có dự án bên ngoài nào được liên kết",
+          "noLinkedProjectsDescription": "Thêm dự án bên ngoài để cho phép tìm kiếm và đồng bộ hóa sự cố.",
+          "addProjects": "Thêm dự án",
+          "addSelected": "Thêm mục đã chọn",
+          "setAsDefault": "Đặt làm mặc định",
+          "removeProject": "Xóa dự án",
+          "removeProjectConfirmation": "Việc xóa dự án này sẽ ngừng đồng bộ hóa các vấn đề từ dự án này. Các vấn đề đã được đồng bộ trước đó sẽ không bị xóa. Bạn có muốn tiếp tục không?",
+          "removeProjectWebhookCascadeBullet": "Webhook đến cho dự án này cũng sẽ bị xóa.",
+          "keepProject": "Dự án Keep",
+          "defaultIndicator": "Mặc định",
+          "syncStatusSyncing": "Đồng bộ hóa",
+          "syncStatusCompleted": "Đã đồng bộ",
+          "syncStatusError": "Lỗi đồng bộ",
+          "fanOutPartialFailure": "Không thể truy cập {count} dự án. Hiển thị kết quả từ {successCount} dự án.",
+          "projectSelectorLabel": "Dự án",
+          "defaultIssueTypeHelp": "Khi tạo sự cố mới từ TestPlanIt, loại sự cố này sẽ được tự động chọn. Điều này giúp tiết kiệm thời gian nếu bạn thường xuyên tạo cùng một loại sự cố.",
+          "automaticSyncHelp": "Khi được kích hoạt, các vấn đề sẽ tự động đồng bộ hóa khi phát hiện thay đổi trong hệ thống bên ngoài (thông qua webhook). Chức năng đồng bộ hóa thủ công luôn khả dụng.",
+          "removeWarningTitle": "Việc loại bỏ tính năng tích hợp này sẽ:",
+          "removeWarning1": "Ngắt kết nối tất cả các vấn đề được liên kết khỏi quá trình tích hợp vấn đề này (các vấn đề vẫn còn trong cơ sở dữ liệu).",
+          "removeWarning2": "Xóa tất cả các thiết lập liên quan đến việc tích hợp sự cố cho dự án này.",
+          "removeWarning3": "Cần cấu hình lại nếu bạn muốn sử dụng lại tính năng tích hợp sự cố này.",
+          "removeWarning4": "Xóa webhook đến được cấu hình cho tích hợp này.",
+          "switchIntegration": "Tích hợp chuyển mạch",
+          "switchWarningTitle": "Việc chuyển sang mô hình AI khác sẽ:",
+          "switchWarning1": "Ngắt kết nối tất cả các vấn đề hiện đang liên kết với quá trình tích hợp vấn đề hiện tại.",
+          "switchWarning2": "Lưu giữ các vấn đề trong cơ sở dữ liệu (chúng sẽ trở nên không liên kết với nhau)",
+          "switchWarning3": "Thay thế cấu hình tích hợp sự cố hiện tại bằng cấu hình mới.",
+          "switchWarning4": "Xóa webhook đến được cấu hình cho tích hợp hiện tại."
+        },
+        "integrationAssigned": "Quá trình tích hợp được thực hiện thành công.",
+        "integrationAssignError": "Không thể gán việc tích hợp vấn đề cho dự án.",
+        "integrationRemoved": "Quá trình tích hợp đã được gỡ bỏ thành công.",
+        "integrationRemoveError": "Không thể xóa sự cố tích hợp khỏi dự án.",
+        "add": {
+          "jira": {
+            "description": "Kết nối tài khoản Jira của bạn để quản lý sự cố trực tiếp từ TestPlanIt."
+          },
+          "simple_url": {
+            "description": "Kết nối với hệ thống bên thứ ba để theo dõi sự cố."
+          },
+          "github": {
+            "description": "Kết nối với GitHub để theo dõi lỗi và quản lý kho lưu trữ."
+          },
+          "gitlab": {
+            "description": "Kết nối với GitLab để theo dõi lỗi và yêu cầu hợp nhất."
+          },
+          "gitea": {
+            "description": "Kết nối với máy chủ ảo Gitea, Forgejo hoặc Gogs để theo dõi sự cố."
+          },
+          "azure_devops": {
+            "description": "Kết nối với Azure DevOps để theo dõi các hạng mục công việc."
+          }
+        }
+      },
+      "webhooks": {
+        "description": "Cấu hình webhook đến để giữ cho các vấn đề được liên kết luôn đồng bộ.",
+        "inboundDescription": "Cấu hình webhook đến để giữ cho các vấn đề được liên kết luôn đồng bộ.",
+        "outboundDescription": "Cấu hình webhook gửi đi để chuyển các sự kiện TestPlanIt đến Slack hoặc bất kỳ URL nào được ký bằng HMAC.",
+        "directionInbound": "Đầu vào",
+        "directionOutbound": "Đầu ra",
+        "inboundAddButtonAllConfigured": "Bộ chuyển đổi đầu vào đã được cấu hình.",
+        "inboundAddButtonNoIntegration": "Hãy gán một tích hợp sự cố cho dự án này trước khi thêm webhook đến.",
+        "inboundEmptyWithIntegration": "Chưa cấu hình webhook đến. <link>Thêm một</link> để nhận cập nhật sự cố từ Tích hợp Sự cố được chỉ định của bạn.",
+        "inboundEmptyNoIntegration": "Cần có một <link>Tích hợp sự cố</link> để nhận các bản cập nhật sự cố đến. Hãy chỉ định một tích hợp cho dự án của bạn để bắt đầu.",
+        "deliveriesEmptyNoConfigs": "Hiện chưa có webhook nào được gửi đến — hãy tạo webhook đến hoặc đi trên các tab khác để bắt đầu nhận chúng.",
+        "noConfig": "Chưa cấu hình webhook.",
+        "createButton": "Tạo webhook",
+        "url": "URL Webhook",
+        "urlHelp": "Hãy dán URL này vào phần cấu hình webhook của trình theo dõi sự cố.",
+        "secret": "Bí mật Webhook",
+        "secretHelp": "Hãy dán mã bí mật này vào phần cấu hình webhook của trình theo dõi sự cố.",
+        "revealedShownOnceWarning": "Hãy sao chép URL và mã bí mật bên dưới ngay bây giờ — chúng chỉ hiển thị một lần và không thể khôi phục lại sau này.",
+        "secretMasked": "Ẩn — xoay để xem",
+        "rotateSecret": "Xoay bí mật",
+        "rotateConfirmTitle": "Xoay vòng mã bí mật webhook?",
+        "rotateConfirm": "Việc xoay vòng khóa bí mật sẽ làm vô hiệu hóa cấu hình hiện tại trên hệ thống theo dõi sự cố cho đến khi bạn cập nhật nó ở đó. Tiếp tục chứ?",
+        "isActive": "Đã bật",
+        "deleteConfirmTitle": "Xóa cấu hình webhook?",
+        "deleteConfirm": "Xóa cấu hình webhook này? Các đơn hàng đến sẽ bị từ chối.",
+        "sendTest": "Gửi webhook thử nghiệm",
+        "testSuccess": "Webhook thử nghiệm đã được chấp nhận (HTTP {statusCode}, kết quả: {outcome})",
+        "testFailure": "Kiểm tra webhook thất bại (HTTP {statusCode}): {error}",
+        "saveError": "Không thể lưu cấu hình webhook.",
+        "lastReceived": "Lần nhận cuối cùng: {timestamp}",
+        "lastReceivedLabel": "Lần nhận cuối cùng:",
+        "lastReceivedNever": "Chưa có đơn hàng nào được giao.",
+        "copyUrl": "Sao chép URL webhook",
+        "copySecret": "Sao chép mã bí mật webhook",
+        "urlCopied": "URL Webhook đã được sao chép vào clipboard",
+        "secretCopied": "Mã bí mật Webhook đã được sao chép vào clipboard",
+        "nextSteps": "Tiếp theo: dán các thông tin này vào cấu hình webhook của trình theo dõi sự cố, sau đó nhấp vào \"Gửi webhook thử nghiệm\" bên dưới để xác minh quy trình. Nhấp vào \"Xong\" sau khi bạn đã lưu mã bí mật — mã này sẽ không hiển thị lại nữa.",
+        "revealDone": "Xong",
+        "pageTitle": "Webhooks",
+        "inboundTab": "Đầu vào",
+        "outboundTab": "Đầu ra",
+        "outboundEmpty": "Chưa cấu hình webhook gửi đi nào. Hãy thêm một webhook để gửi các sự kiện TestPlanIt đến Slack hoặc bất kỳ URL nào được ký bằng HMAC.",
+        "outboundAddButton": "Thêm webhook gửi đi",
+        "outboundCreateTitle": "Webhook gửi đi mới",
+        "outboundCreateName": "Tên",
+        "outboundCreateNameHelp": "Một nhãn cho điểm đến này, ví dụ: \"Engineering Slack\".",
+        "outboundCreateNamePlaceholder": "Kỹ thuật Slack",
+        "outboundCreateNameRequired": "Tên là bắt buộc.",
+        "outboundCreateUrlRequired": "URL là bắt buộc.",
+        "outboundCreateUrlInvalid": "Nhập URL hợp lệ (https://example.com/...).",
+        "outboundCreateUrlMustUseHttps": "URL phải sử dụng HTTPS",
+        "outboundNameLabel": "Tên",
+        "outboundUnnamedConfig": "(webhook không tên)",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "URL đích. URL webhook đến của Slack được tự động phát hiện.",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "Đã phát hiện: Slack",
+        "outboundDetectedHmac": "Đã phát hiện: HMAC chung",
+        "adapterLabelSlack": "Slack",
+        "adapterLabelGenericHmac": "Webhook HMAC chung",
+        "outboundCreateSubscriptionsTitle": "Đăng ký",
+        "outboundCreateSubscriptionsHelp": "Hãy chọn những sự kiện nào sẽ được gửi đến đích này. Bạn có thể thay đổi chúng sau này.",
+        "outboundSubsTestRunsAndSessions": "Chạy thử & Phiên thử nghiệm",
+        "outboundSubsTestRuns": "Chạy thử nghiệm",
+        "outboundSubsSessions": "Phiên họp",
+        "eventVerbs": {
+          "duplicated": "Đã sao chép",
+          "stateChanged": "Trạng thái đã thay đổi",
+          "resultAdded": "Kết quả đã được thêm"
+        },
+        "events": {
+          "testRunCreated": "Đã tạo bản chạy thử nghiệm",
+          "testRunStateChanged": "Trạng thái chạy thử nghiệm đã thay đổi",
+          "testRunCompleted": "Quá trình chạy thử nghiệm đã hoàn tất.",
+          "testRunDuplicated": "Chạy thử nghiệm trùng lặp",
+          "testRunResultAdded": "Đã thêm kết quả chạy thử nghiệm.",
+          "sessionCreated": "Phiên đã được tạo",
+          "sessionStateChanged": "Trạng thái phiên đã thay đổi",
+          "sessionCompleted": "Phiên họp đã hoàn thành",
+          "sessionDuplicated": "Phiên được sao chép",
+          "sessionResultAdded": "Kết quả phiên đã được thêm",
+          "issueCreated": "Sự cố đã được tạo",
+          "issueUpdated": "Vấn đề đã được cập nhật",
+          "issueDeleted": "Vấn đề đã được xóa",
+          "caseCreated": "Vụ việc đã được tạo",
+          "caseUpdated": "Hồ sơ đã được cập nhật.",
+          "caseDeleted": "Vụ việc đã bị xóa",
+          "jiraIssueCreated": "Sự cố Jira đã được tạo.",
+          "jiraIssueUpdated": "Sự cố Jira đã được cập nhật.",
+          "jiraIssueDeleted": "Sự cố Jira đã bị xóa",
+          "githubIssues": "Sự kiện vấn đề GitHub",
+          "githubPullRequest": "Yêu cầu kéo trên GitHub",
+          "githubPush": "Đẩy lên GitHub",
+          "githubIssueComment": "Bình luận về vấn đề trên GitHub",
+          "adoWorkitemCreated": "Đã tạo mục công việc Azure DevOps",
+          "adoWorkitemUpdated": "Mục công việc Azure DevOps đã được cập nhật",
+          "adoWorkitemDeleted": "Mục công việc Azure DevOps đã bị xóa",
+          "webhookTest": "Sự kiện thử nghiệm"
+        },
+        "outboundSubsIssues": "Vấn đề",
+        "outboundSubsCases": "Các trường hợp",
+        "outboundSubsSelectAll": "Chọn tất cả trong phần này",
+        "outboundCreateSubmit": "Tạo webhook",
+        "outboundCreateCancel": "Hủy bỏ",
+        "outboundCreateSuccess": "Webhook gửi đi đã được tạo.",
+        "outboundCreateError": "Không thể tạo webhook gửi đi.",
+        "outboundUrlLabel": "URL đích",
+        "outboundActiveToggle": "Tích cực",
+        "outboundSlackHint": "URL này rất nhạy cảm — bất kỳ ai có nó đều có thể đăng bài lên kênh của bạn.",
+        "outboundHmacSecretsTitle": "Bí mật ký kết",
+        "outboundHmacActiveSecret": "Tích cực",
+        "outboundHmacInactiveSecret": "Không hoạt động",
+        "outboundHmacRetiringSecret": "Nghỉ hưu",
+        "outboundHmacAutoRetireIn": "Tự động nghỉ hưu sau {days} ngày",
+        "outboundHmacRotateButton": "Xoay bí mật",
+        "outboundHmacExtendButton": "Gia hạn thêm 7 ngày",
+        "outboundHmacRetireNowButton": "Hãy nghỉ hưu ngay bây giờ",
+        "outboundRotateConfirmTitle": "Xoay vòng bí mật ký kết?",
+        "outboundRotateConfirm": "Một mã bí mật hoạt động mới được tạo ra. Mã bí mật cũ tiếp tục được sử dụng để ký trong 7 ngày trong khi người dùng cập nhật.",
+        "outboundRotateSuccess": "Mã bí mật đã được xoay. Văn bản gốc mới được hiển thị một lần bên dưới.",
+        "outboundRotateError": "Không thể xoay vòng mã bí mật.",
+        "outboundRetireConfirmTitle": "Bây giờ có nên tiết lộ bí mật không?",
+        "outboundRetireConfirm": "Việc ngừng sử dụng khóa bí mật sẽ chấm dứt việc ký xác thực ngay lập tức. Người dùng vẫn đang sử dụng khóa bí mật cũ sẽ từ chối các gói dữ liệu mới.",
+        "outboundRetireSuccess": "Bí mật đã được gỡ bỏ.",
+        "outboundRetireError": "Không thể loại bỏ bí mật.",
+        "outboundExtendSuccess": "Gia hạn thời gian nghỉ hưu tự động thêm 7 ngày.",
+        "outboundExtendError": "Không thể gia hạn mã bí mật.",
+        "outboundSendTestButton": "Gửi sự kiện kiểm thử",
+        "outboundSendTestQueued": "Sự kiện kiểm thử đã được xếp vào hàng đợi — hãy kiểm tra hộp thư đến của bạn để xem tin nhắn.",
+        "outboundSendTestError": "Không thể xếp sự kiện kiểm thử vào hàng đợi.",
+        "outboundDeleteButton": "Xóa webhook",
+        "outboundDeleteConfirmTitle": "Xóa webhook gửi đi?",
+        "outboundDeleteConfirm": "Tất cả các sự kiện trong tương lai tới địa điểm này sẽ ngừng hoạt động ngay lập tức.",
+        "outboundDeleteSuccess": "Webhook đã bị xóa.",
+        "outboundDeleteError": "Không thể xóa webhook.",
+        "outboundSecretCopy": "Sao chép bí mật",
+        "outboundSecretShownOnce": "Hãy giữ bí mật này ngay bây giờ — nó sẽ không bao giờ được tiết lộ nữa.",
+        "outboundSecretDone": "Xong",
+        "inboundAddButton": "Thêm webhook đến",
+        "inboundChooserTitle": "Chọn bộ chuyển đổi",
+        "inboundChooserDescription": "Hãy chọn hệ thống theo dõi sự cố sẽ gửi webhook đến TestPlanIt. Mỗi dự án có thể có một webhook đến từ Jira, một từ GitHub và một từ Azure DevOps.",
+        "inboundChooserJira": "Jira",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "Gitea",
+        "inboundChooserAlreadyConfigured": "Đã được cấu hình",
+        "inboundChooserSubmit": "Tiếp tục",
+        "inboundChooserCancel": "Hủy bỏ",
+        "inboundEmpty": "Hiện chưa có webhook đến nào được cấu hình. Hãy thêm một webhook để nhận thông báo cập nhật sự cố từ Jira, GitHub, GitLab, Gitea hoặc Azure DevOps.",
+        "inboundJiraTitle": "Webhook đến của Jira",
+        "inboundGithubTitle": "Webhook đến từ GitHub",
+        "inboundGithubScopeHint": "Sự kiện <code>trên GitHub cập nhật các sự kiện</code> trên TestPlanIt. Yêu cầu kéo (pull request) và sự kiện bình luận sự kiện được chấp nhận nhưng chưa cập nhật các sự kiện.",
+        "inboundGitlabTitle": "Webhook đến từ GitLab",
+        "inboundGitlabScopeHint": "Sự kiện GitLab <code>Issue Hook</code> cập nhật các vấn đề TestPlanIt được liên kết. Các loại sự kiện khác được chấp nhận nhưng không cập nhật vấn đề.",
+        "inboundGiteaTitle": "Webhook đến của Gitea",
+        "inboundGiteaScopeHint": "Gitea <code>issues</code> events cập nhật các vấn đề TestPlanIt được liên kết. Các loại sự kiện khác được chấp nhận nhưng không cập nhật vấn đề.",
+        "inboundAdoTitle": "Webhook đến từ Azure DevOps",
+        "inboundAdoScopeHint": "Sự kiện Azure DevOps <code>workitem.updated</code> cập nhật các vấn đề TestPlanIt được liên kết. Các sự kiện khác được chấp nhận nhưng không cập nhật vấn đề.",
+        "inboundAdoUsername": "Tên người dùng",
+        "inboundAdoPassword": "Mật khẩu",
+        "inboundAdoUsernamePlaceholder": "tài khoản dịch vụ",
+        "inboundAdoUsernameHelp": "Được cấu hình ở phía Hook của Azure DevOps Service. TestPlanIt xác minh điều này thông qua xác thực HTTP Basic Auth.",
+        "inboundAdoPasswordHelp": "Giá trị này được lưu trữ dưới dạng mã hóa khi ở trạng thái nghỉ. Hãy lưu giá trị này ở phía Hook của Azure DevOps Service nữa.",
+        "inboundAdoResourceDetailsHint": "Khi cấu hình Azure DevOps Service Hook, hãy đặt 'Chi tiết tài nguyên cần gửi' = 'Tất cả' để System.State được bao gồm trong tải trọng.",
+        "setupStepsTitle": "Các bước thiết lập",
+        "setupStepsJiraStep1": "Trong Jira, hãy vào Cài đặt → Hệ thống → WebHooks (hoặc trang cấu hình webhook của quản trị viên Jira).",
+        "setupStepsJiraStep2": "Nhấp vào \"Tạo WebHook\". Dán URL bên dưới vào trường URL và mã bí mật vào trường Mã bí mật.",
+        "setupStepsJiraStep3": "Trong mục \"Các sự kiện liên quan đến vấn đề\", hãy chọn \"đã cập nhật\" để thông báo về các thay đổi trạng thái của vấn đề.",
+        "setupStepsJiraStep4": "Lưu webhook. Sử dụng chức năng \"Gửi webhook thử nghiệm\" bên dưới để xác minh pipeline.",
+        "setupStepsGithubStep1": "Trong kho lưu trữ GitHub của bạn, hãy vào Cài đặt → Webhooks → Thêm webhook.",
+        "setupStepsGithubStep2": "Dán URL bên dưới vào trường URL Payload. Đặt loại nội dung là application/json.",
+        "setupStepsGithubStep3": "Dán mã bí mật bên dưới vào ô \"Mã bí mật\".",
+        "setupStepsGithubStep4": "Chọn \"Cho phép tôi chọn từng sự kiện riêng lẻ\" và đánh dấu vào ô \"Sự cố\".",
+        "setupStepsGithubStep5": "Nhấp vào \"Thêm webhook\". Sử dụng \"Gửi webhook thử nghiệm\" bên dưới để xác minh pipeline.",
+        "setupStepsAdoStep1": "Trong dự án Azure DevOps của bạn, hãy vào Cài đặt dự án → Kết nối dịch vụ → Tạo đăng ký.",
+        "setupStepsAdoStep2": "Chọn \"Web Hooks\" làm dịch vụ. Đặt Trigger là \"Work item updated\".",
+        "setupStepsAdoStep3": "Đặt chi tiết tài nguyên cần gửi = Tất cả để bao gồm cả System.State.",
+        "setupStepsAdoStep4": "Dán URL bên dưới vào ô URL. Đặt tên người dùng và mật khẩu xác thực cơ bản thành các giá trị bạn đã nhập ở trên.",
+        "setupStepsAdoStep5": "Lưu lại đăng ký. Sử dụng chức năng \"Gửi webhook thử nghiệm\" bên dưới để xác minh quy trình.",
+        "setupStepsGitlabStep1": "Trong GitLab, hãy vào dự án của bạn → Cài đặt → Webhooks.",
+        "setupStepsGitlabStep2": "Dán URL bên dưới vào ô URL. Dán mã bí mật bên dưới vào ô Mã bí mật.",
+        "setupStepsGitlabStep3": "Trong mục Trigger, chọn \"Issues events\".",
+        "setupStepsGitlabStep4": "Nhấp vào \"Thêm webhook\". Sử dụng \"Gửi webhook thử nghiệm\" bên dưới để xác minh pipeline.",
+        "setupStepsGiteaStep1": "Trong Gitea, hãy vào kho lưu trữ của bạn → Cài đặt → Webhooks.",
+        "setupStepsGiteaStep2": "Nhấp vào \"Thêm Webhook\" và chọn \"Gitea\".",
+        "setupStepsGiteaStep3": "Dán URL bên dưới vào trường URL đích. Dán mã bí mật bên dưới vào trường Mã bí mật.",
+        "setupStepsGiteaStep4": "Trong mục \"Kích hoạt khi\", chọn \"Sự cố\".",
+        "setupStepsGiteaStep5": "Nhấp vào \"Thêm Webhook\". Sử dụng chức năng \"Gửi webhook thử nghiệm\" bên dưới để xác minh pipeline.",
+        "deliveriesTab": "Giao hàng",
+        "filterConfigPlaceholder": "Tất cả webhook",
+        "filterStatusAll": "Tất cả",
+        "filterStatusFailed": "Thất bại",
+        "filterStatusSuccess": "Thành công",
+        "filterSinceDefault": "Kể từ…",
+        "filterUntilDefault": "Cho đến khi…",
+        "filterReset": "Đặt lại bộ lọc",
+        "filterBulkReplayButton": "Phát lại hàng loạt {count} lỗi gửi đi",
+        "filterBulkReplayHidden": "Tất cả các lỗi hiển thị đều là lỗi từ phía máy khách — hãy kích hoạt lại sự kiện ở phía máy chủ.",
+        "deliveriesEmpty": "Không có đơn hàng nào phù hợp với các bộ lọc này.",
+        "deliveriesResetFilters": "Đặt lại bộ lọc",
+        "deliveriesLoadMore": "Tải thêm",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "Sự kiện",
+        "tableHeaderStatus": "Trạng thái",
+        "tableHeaderError": "Lỗi",
+        "tableHeaderReceivedAt": "Đã nhận",
+        "tableHeaderAttempt": "Nỗ lực",
+        "tableHeaderDirection": "Phương hướng",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "Xem chi tiết",
+        "drawerTitle": "Chi tiết giao hàng",
+        "drawerLabelEvent": "Sự kiện",
+        "drawerLabelDirection": "Phương hướng",
+        "drawerLabelStatusCode": "Mã trạng thái",
+        "drawerLabelLatency": "Độ trễ",
+        "drawerLatencyValue": "{ms} ms",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "Lỗi",
+        "drawerLabelPayloadDigest": "Tóm tắt tải trọng",
+        "drawerLabelEventId": "Mã sự kiện",
+        "drawerLabelAttempt": "Nỗ lực",
+        "drawerLabelReceivedAt": "Đã nhận được tại",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "Phát lại {id}",
+        "drawerReplayButton": "Phát lại bản giao hàng này",
+        "drawerInboundReplayNotSupported": "Các lô hàng đến không thể được phát lại — thay vào đó hãy kích hoạt lại sự kiện ở phía trước.",
+        "replayConfirmTitle": "Bạn có muốn nghe lại đoạn giao hàng này không?",
+        "replayConfirm": "Điều này sẽ kích hoạt yêu cầu {direction} {adapterType} thực sự.",
+        "replayAction": "Phát lại",
+        "bulkReplayConfirmTitle": "Phát lại các lỗi gửi đi?",
+        "bulkReplayConfirm": "Phát lại các lỗi gửi đi {count} thành {configName}? Điều này sẽ kích hoạt {count} các yêu cầu HTTP thực sự.",
+        "bulkReplayCapExceeded": "Việc phát lại hàng loạt giới hạn ở 100 lần gửi đi cùng một lúc. Thu hẹp bộ lọc hoặc chạy tuần tự. Hiện tại {count} sẽ được phát lại.",
+        "bulkReplayAction": "Phát lại {count}",
+        "healthBadge": {
+          "HEALTHY": "Khỏe mạnh",
+          "DEGRADED": "bị xuống cấp",
+          "DISABLED": "Tàn tật"
+        },
+        "healthTooltipHealthy": "Thành công gần nhất: {lastSuccessAt}",
+        "healthTooltipDegraded": "{count} lần thất bại liên tiếp · lần cuối tại {lastFailureAt}",
+        "healthTooltipDisabled": "Bị vô hiệu hóa sau 10 lần thất bại liên tiếp · {lastFailureAt}",
+        "activityLabel": "Hoạt động giao hàng",
+        "activityLastDispatched": "Lần gửi cuối cùng",
+        "activityLastSuccess": "Thành công cuối cùng",
+        "activityLastFailure": "Thất bại cuối cùng",
+        "activityNever": "Không bao giờ",
+        "reEnable": "Kích hoạt lại",
+        "reEnableConfirmTitle": "Kích hoạt lại webhook này?",
+        "reEnableConfirm": "Hãy xác nhận sự cố ở phía máy chủ đã được khắc phục trước khi kích hoạt lại. Webhook sẽ tiếp tục gửi dữ liệu ngay lập tức.",
+        "toastReplaySuccess": "Đang chờ phát lại",
+        "toastReplayFailed": "Phát lại thất bại: {error}",
+        "toastReplayInboundNotSupported": "Các đơn hàng đến không thể được phát lại.",
+        "toastBulkReplaySuccess": "Phát lại hàng loạt đã bắt đầu · hàng loạt {batchId}",
+        "toastBulkReplayFailed": "Phát lại hàng loạt thất bại: {error}",
+        "toastReEnableSuccess": "Webhook đã được kích hoạt lại.",
+        "toastReEnableFailed": "Không thể kích hoạt lại: {error}"
+      },
+      "aiModels": {
+        "description": "Cấu hình các mô hình AI để tạo và phân tích trường hợp kiểm thử thông minh.",
+        "availableModels": "Dự án mặc định",
+        "availableModelsDescription": "Hãy chọn một mô hình AI mặc định cho dự án này từ những mô hình đã được quản trị viên hệ thống cấu hình.",
+        "currentModelSettings": "Cài đặt mô hình hiện tại",
+        "currentModelDescription": "Chi tiết cấu hình cho mô hình AI hiện đang hoạt động: {name}",
+        "noModelsAvailable": "Hiện tại chưa có mô hình AI nào khả dụng. Vui lòng liên hệ với quản trị viên hệ thống của bạn để cấu hình các mô hình AI cho tổ chức của bạn.",
+        "monthlyBudget": "Ngân sách hàng tháng",
+        "model": "Người mẫu",
+        "budget": "Ngân sách",
+        "streamingTooltip": "Đã kích hoạt tính năng truyền phát phản hồi thời gian thực.",
+        "systemDefault": "Mặc định hệ thống",
+        "setAsDefault": "Đặt làm mặc định",
+        "clearDefault": "Xóa cài đặt mặc định",
+        "useForProject": "Sử dụng cho dự án",
+        "removeModel": "Xóa cài đặt mặc định",
+        "removeWarningTitle": "Việc xóa mô hình AI mặc định sẽ:",
+        "removeWarning1": "Vô hiệu hóa các tính năng được hỗ trợ bởi AI trừ khi có thiết lập ghi đè riêng cho từng tính năng.",
+        "removeWarning2": "Loại bỏ mô hình dự phòng được sử dụng để tạo và phân tích trường hợp thử nghiệm.",
+        "switchModel": "Thay đổi mặc định",
+        "switchWarningTitle": "Việc thay đổi mô hình AI mặc định sẽ:",
+        "switchWarning1": "Thay đổi cách các tính năng AI hoạt động trong dự án này",
+        "switchWarning2": "Có thể ảnh hưởng đến chất lượng và phong cách của nội dung được tạo ra.",
+        "modelAssigned": "Bộ mô hình AI mặc định cho dự án này",
+        "modelAssignError": "Không thể thiết lập mô hình AI mặc định",
+        "modelRemoved": "Mô hình AI mặc định đã được xóa",
+        "modelRemoveError": "Không thể xóa mô hình AI mặc định",
+        "confirmRemove": "Bạn có chắc chắn muốn xóa \"{name}\" làm mặc định cho dự án này không?",
+        "confirmSwitch": "Bạn có chắc chắn muốn thay đổi giá trị mặc định từ \"{from}\" thành \"{to} \" không?",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/tháng"
+        },
+        "promptConfig": "Cấu hình nhắc nhở",
+        "promptConfigDescription": "Chọn cấu hình nhắc nhở AI mà bạn muốn sử dụng cho dự án này.",
+        "useSystemDefault": "Sử dụng cài đặt mặc định của hệ thống",
+        "promptConfigChanged": "Cấu hình nhắc nhở đã được cập nhật thành công.",
+        "featureOverrides": {
+          "title": "Ghi đè LLM theo từng tính năng",
+          "description": "Ghi đè tích hợp LLM mặc định cho các tính năng AI cụ thể. Các thiết lập ghi đè sẽ có ưu tiên cao nhất trong chuỗi xử lý.",
+          "feature": "Tính năng",
+          "override": "Ghi đè",
+          "effectiveLlm": "LLM hiệu quả",
+          "source": "Nguồn",
+          "noOverride": "Không có quyền ghi đè",
+          "noLlm": "Không có bằng Thạc sĩ Luật (người khuyết tật)",
+          "disabledOverride": "Đã vô hiệu hóa (Ghi đè)",
+          "projectOverride": "Ghi đè dự án",
+          "promptConfig": "Cấu hình nhắc nhở",
+          "noLlmConfigured": "Không có LLM nào được cấu hình",
+          "selectIntegration": "Chọn tích hợp...",
+          "overrideSaved": "Tính năng ghi đè đã được lưu",
+          "overrideCleared": "Tính năng ghi đè đã được xóa",
+          "overrideError": "Không thể lưu cài đặt ghi đè tính năng."
+        }
+      },
+      "shares": {
+        "title": "Quản lý cổ phần",
+        "description": "Xem và quản lý tất cả các liên kết chia sẻ cho dự án này."
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "Kích hoạt QuickScript và kết nối kho mã nguồn để tạo kiểm thử hỗ trợ bởi trí tuệ nhân tạo.",
+        "enableLabel": "Kích hoạt QuickScript",
+        "enableDescription": " Cho phép các thành viên nhóm sử dụng QuickScript để chuyển đổi các trường hợp kiểm thử thành các kịch bản tự động hóa trong dự án này.",
+        "enabledToast": "Đã bật QuickScript",
+        "disabledToast": "QuickScript đã bị vô hiệu hóa",
+        "noRepos": {
+          "title": "Chưa có kho lưu trữ mã nào được cấu hình.",
+          "adminDescription": "Hãy thiết lập kết nối kho lưu trữ trước khi cấu hình ngữ cảnh mã cho dự án này.",
+          "adminLink": "Truy cập Kho lưu trữ mã nguồn",
+          "userDescription": "Hãy liên hệ với quản trị viên hệ thống của bạn để thiết lập kết nối kho lưu trữ mã nguồn."
+        },
+        "repository": {
+          "title": "Kho lưu trữ mã nguồn",
+          "description": "Chọn kho mã nguồn để sử dụng cho ngữ cảnh AI.",
+          "placeholder": "Chọn một kho lưu trữ mã nguồn...",
+          "branchLabel": "Chi nhánh",
+          "branchPlaceholder": "Để trống nếu muốn sử dụng nhánh mặc định của kho lưu trữ."
+        },
+        "pathPatterns": {
+          "title": "Các kiểu đường đi",
+          "description": "Hãy chỉ định các tệp cần bao gồm. Mỗi hàng kết hợp đường dẫn cơ sở và mẫu glob. Ví dụ: path=tests/e2e/pages + pattern=* bao gồm tất cả các tệp trực tiếp trong thư mục đó; path=src + pattern=**/*.test.ts bao gồm tất cả các tệp kiểm thử một cách đệ quy.",
+          "pathLabel": "Con đường",
+          "pathPlaceholder": "bài kiểm tra/e2e/trang",
+          "patternLabel": "Mẫu",
+          "addPath": "Thêm đường dẫn",
+          "previewFiles": "Xem trước tệp",
+          "scanningRepo": "Đang quét các tệp kho lưu trữ… ({seconds}s)",
+          "files": "{count, plural, one {# tập tin} other {# tập tin}}",
+          "truncatedBadge": "Kết quả có thể không đầy đủ (giới hạn của nhà cung cấp)",
+          "exceedsLimit": "Tổng kích thước vượt quá giới hạn ngữ cảnh AI là {overflow}. Trong quá trình xuất, các tệp được xếp hạng theo mức độ liên quan đến trường hợp thử nghiệm đang được xuất — các tệp liên quan nhất được đưa vào trước và các tệp được xếp hạng thấp hơn sẽ bị bỏ qua khi đạt đến giới hạn ngân sách. Thu hẹp các mẫu đường dẫn của bạn nếu bạn muốn kiểm soát nhiều hơn các tệp được bao gồm."
+        },
+        "preview": {
+          "resolvingBranch": "Đang giải quyết nhánh…",
+          "scanningFiles": "Đang quét các tập tin trong {scope}…",
+          "scanningFilesCount": "Đang quét các tập tin trong {scope}… ({count} đã được tìm thấy)",
+          "filtering": "Áp dụng bộ lọc cho {count} tập tin…"
+        },
+        "cache": {
+          "title": "Cài đặt bộ nhớ đệm",
+          "description": "Các tệp được lưu vào bộ nhớ đệm trong Valkey để truy cập nhanh trong quá trình tạo AI.",
+          "enableLabel": "Bật tính năng lưu trữ tệp tạm thời",
+          "disabledWarning": "Tính năng lưu trữ tập tin tạm thời đã bị vô hiệu hóa. Các tập tin trong kho lưu trữ sẽ được tải trực tiếp từ nhà cung cấp của bạn tại thời điểm xuất và sẽ không được lưu trữ trong TestPlanIt. QuickScript được hỗ trợ bởi AI vẫn sẽ bao gồm ngữ cảnh mã, nhưng mỗi lần xuất sẽ thực hiện yêu cầu trực tiếp đến kho lưu trữ của bạn.",
+          "ttlLabel": "Thời gian lưu trữ (ngày)",
+          "statusTitle": "Trạng thái bộ nhớ đệm",
+          "refreshButton": "Làm mới bộ nhớ cache",
+          "listingFiles": "Liệt kê các tập tin…",
+          "cachingFiles": "Đang lưu trữ {count} tập tin…",
+          "statusNeverFetched": "Chưa bao giờ lấy được",
+          "statusPending": "Thật sảng khoái...",
+          "lastFetched": "Lần tải cuối cùng",
+          "filesCached": "Tệp tin được lưu vào bộ nhớ cache",
+          "totalSize": "Tổng kích thước"
+        },
+        "save": "Lưu cấu hình",
+        "saved": "Cấu hình ngữ cảnh mã đã được lưu",
+        "saveError": "Không thể lưu cấu hình",
+        "listError": "Không thể liệt kê các tệp trong kho lưu trữ.",
+        "contentsError": "Không thể lưu nội dung tệp vào bộ nhớ cache.",
+        "networkError": "Lỗi mạng trong quá trình làm mới bộ nhớ cache",
+        "refreshSuccess": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin ({contentCached} nội dung đã được lưu vào bộ nhớ cache)",
+        "refreshRateLimited": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin đã được liệt kê, {contentCached}/{fileCount} nội dung đã được lưu vào bộ nhớ cache (tốc độ truy cập bị giới hạn — hãy làm mới lại để hoàn tất)",
+        "validation": {
+          "pathRequired": "Cần có đường dẫn.",
+          "patternRequired": "Cần có mẫu.",
+          "repositoryRequired": "Cần có kho lưu trữ.",
+          "pathPatternRequired": "Cần ít nhất một kiểu đường đi."
+        },
+        "exportTemplates": {
+          "title": "Mẫu xuất khẩu",
+          "description": "Chỉ định mẫu xuất cho dự án này. Chỉ những mẫu đã được chỉ định mới xuất hiện trong hộp thoại xuất.",
+          "noTemplates": "Hiện chưa có mẫu xuất nào được kích hoạt. Vui lòng liên hệ với quản trị viên hệ thống của bạn.",
+          "assignedLabel": "Mẫu được chỉ định",
+          "selectPlaceholder": "Chọn các mẫu để gán...",
+          "defaultLabel": "Mẫu mặc định",
+          "defaultPlaceholder": "Không có (sử dụng giá trị mặc định toàn cục)",
+          "assigned": "Được chỉ định",
+          "save": "Lưu bài tập mẫu",
+          "saved": "Bài tập mẫu đã được lưu",
+          "saveError": "Không thể lưu các bài tập mẫu"
+        },
+        "disconnect": "Ngắt kết nối kho lưu trữ",
+        "confirmDisconnect": "Bạn có chắc chắn muốn ngắt kết nối \"{name}\" khỏi dự án này không?",
+        "disconnectWarningTitle": "Việc ngắt kết nối kho lưu trữ này sẽ:",
+        "disconnectWarning1": "Xóa tất cả các tệp kho lưu trữ đã được lưu vào bộ nhớ cache.",
+        "disconnectWarning2": "Xóa cấu hình đường dẫn và nhánh.",
+        "disconnectWarning3": "Ngừng việc đưa ngữ cảnh mã vào các bản xuất do AI tạo ra.",
+        "disconnectSuccess": "Kho lưu trữ mã nguồn đã bị ngắt kết nối",
+        "disconnectError": "Không thể ngắt kết nối kho lưu trữ mã."
+      }
+    }
+  },
+  "milestones": {
+    "title": "Chi tiết cột mốc",
+    "fields": {
+      "parent": "Cột mốc của cha mẹ",
+      "dueDate": "Ngày đến hạn",
+      "automaticCompletion": "Tự động hoàn thành vào ngày đến hạn",
+      "notifyDaysBefore": "Thông báo trước ngày đến hạn vài ngày.",
+      "notifyDaysBeforeValue": "Thông báo {count, plural, one {# ngày} other {# ngày}} trước ngày đến hạn",
+      "dueDateNotifications": "Thông báo ngày đến hạn"
+    },
+    "labels": {
+      "childMilestones": "Các cột mốc phát triển của trẻ"
+    },
+    "placeholders": {
+      "description": "Nhập mô tả mốc quan trọng...",
+      "documentation": "Nhập tài liệu về các mốc quan trọng...",
+      "selectType": "Chọn loại mốc thời gian...",
+      "selectParent": "Chọn mốc phát triển của cha mẹ..."
+    },
+    "empty": {
+      "active": "Không có mốc tiến độ nào đang hoạt động.",
+      "completed": "Chưa có mốc tiến độ nào được hoàn thành.",
+      "description": "Không có mô tả nào được cung cấp.",
+      "documentation": "Không có tài liệu nào được cung cấp.",
+      "testRuns": "Không có thử nghiệm nào được thực hiện",
+      "forecasts": "Không có dữ liệu dự báo nào."
+    },
+    "statusLabels": {
+      "NOT_STARTED": "Chưa bắt đầu",
+      "IN_PROGRESS": "Đang tiến hành",
+      "STOPPED": "Đã dừng lại",
+      "BLOCKED": "Bị chặn",
+      "CANCELLED": "Đã hủy",
+      "unscheduled": "Không theo lịch trình",
+      "upcoming": "Sắp tới",
+      "delayed": "Bị trì hoãn",
+      "pastDue": "Quá hạn",
+      "started": "Bắt đầu",
+      "completed": "Hoàn thành"
+    },
+    "status": {
+      "stop": "Dừng lại",
+      "reopen": "Mở cửa trở lại"
+    },
+    "dates": {
+      "pickStartDate": "Chọn ngày bắt đầu",
+      "pickCompletionDate": "Ngày hoàn thành chọn",
+      "selectDate": "Chọn ngày...",
+      "completionWarning": "Cảnh báo: Thao tác này sẽ đánh dấu mốc quan trọng đã hoàn thành."
+    },
+    "toast": {
+      "deleted": "Cột mốc {name} đã bị xóa",
+      "updated": "Đã cập nhật cột mốc quan trọng",
+      "updateFailed": "Không thể cập nhật mốc thời gian",
+      "completed": "Cột mốc \"{name}\" đã hoàn thành.",
+      "completedWithDependencies": "Các mốc quan trọng và các điều kiện phụ thuộc đã được hoàn thành thành công."
+    },
+    "errors": {
+      "nameExists": "Đã có một cột mốc mang tên này.",
+      "nameRequired": "Tên mốc quan trọng là bắt buộc",
+      "notFound": "Không tìm thấy cột mốc."
+    },
+    "actions": {
+      "add": "Thêm mốc quan trọng"
+    },
+    "delete": {
+      "title": "Xóa mốc thời gian",
+      "confirmMessage": "Bạn có chắc chắn muốn xóa mốc {name} không?",
+      "warning": "Mốc thời gian này sẽ bị xóa khỏi dự án. Dữ liệu lịch sử liên quan đến mốc thời gian này vẫn sẽ được lưu giữ trong dự án.",
+      "toast": {
+        "loading": "Đang xóa mốc thời gian...",
+        "success": "Cột mốc đã được xóa thành công",
+        "error": {
+          "title": "Không thể xóa mốc thời gian",
+          "description": "Đã xảy ra lỗi trong quá trình xóa mốc thời gian"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "Xác nhận hoàn thành cột mốc",
+      "confirmDescription": "Hoàn thành cột mốc này cũng sẽ hoàn thành các mục liên quan sau:",
+      "impactActiveTestRuns": "{count, plural, one {# Chạy thử nghiệm đang hoạt động} other {# Các lần chạy thử nghiệm đang hoạt động}}",
+      "impactActiveSessions": "{count, plural, one {# phiên hoạt động} other {# phiên hoạt động}}",
+      "impactDescendantMilestones": "{count, plural, one {# cột mốc hậu duệ} other {# cột mốc hậu duệ}}",
+      "completeTestRunsLabel": "Hoàn thành các lần chạy thử nghiệm liên quan ({count, plural, one {# đang hoạt động} other {# đang hoạt động}})",
+      "completeSessionsLabel": "Các phiên liên kết hoàn chỉnh ({count, plural, one {# đang hoạt động} other {# đang hoạt động}})",
+      "testRunStateLabel": "Trạng thái hoàn thành chạy thử nghiệm",
+      "sessionStateLabel": "Trạng thái hoàn thành phiên",
+      "itemsRemaining": "Các mục sau đây sẽ vẫn hoạt động:",
+      "processing": "Xử lý...",
+      "confirmAndCompleteAll": "Xác nhận và hoàn tất tất cả"
+    },
+    "notifications": {
+      "dueSoon": "Mốc thời gian \"{name}\" sẽ đến hạn vào ngày {dueDate}",
+      "overdue": "Cột mốc \"{name}\" dự kiến hoàn thành vào ngày {dueDate}"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {Phiên} other {Các phiên}}",
+    "labels": {
+      "totalElapsed": "Thời gian đã dành",
+      "remaining": "Còn lại: {time}",
+      "overtime": "Ước tính vượt quá bởi: {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "Không có phiên nào đã hoàn thành phù hợp với bộ lọc của bạn."
+    },
+    "filter": {
+      "placeholder": "Lọc các phiên..."
+    },
+    "actions": {
+      "add": "Thêm phiên",
+      "create": "Tạo phiên mới",
+      "edit": "Chỉnh sửa phiên",
+      "complete": "Phiên hoàn chỉnh",
+      "delete": "Xóa phiên",
+      "viewSessionDetails": "Xem phiên"
+    },
+    "noMilestone": "Không có cột mốc nào",
+    "completeDialog": {
+      "noWorkflowsConfigured": "Hiện chưa có quy trình hoàn thành nào được cấu hình cho dự án này. Vui lòng cấu hình quy trình trong cài đặt quản trị để kích hoạt tính năng hoàn thành phiên."
+    },
+    "messages": {
+      "createSuccess": "Phiên được tạo thành công",
+      "createSuccessMultiple": "{count} Phiên được tạo thành công",
+      "duplicateSuccess": "Phiên làm việc đã được sao chép thành công",
+      "duplicateSuccessMultiple": "{count} Phiên đã được sao chép thành công"
+    },
+    "duplicateDialog": {
+      "title": "Phiên trùng lặp",
+      "description": "Tạo bản sao của phiên <nameStyle>{name}</nameStyle> với tất cả siêu dữ liệu nhưng không có kết quả."
+    },
+    "errors": {
+      "failedToCreate": "Không thể tạo phiên mới",
+      "failedToCreateVersion": "Không thể tạo phiên bản phiên",
+      "nameAlreadyExists": "Tên phiên đã tồn tại. Vui lòng chọn tên mới.",
+      "createFailed": "Không thể tạo phiên",
+      "duplicateFailed": "Không thể sao chép phiên"
+    },
+    "validation": {
+      "nameMinLength": "Tên phải có ít nhất 2 ký tự.",
+      "templateRequired": "Vui lòng chọn một mẫu",
+      "maxDuration": "Thời lượng phải nhỏ hơn hoặc bằng {max}."
+    },
+    "placeholders": {
+      "estimate": "Ước tính (ví dụ: 1 giờ 30 phút)",
+      "elapsed": "Đã trôi qua (ví dụ: 2 ngày 4 giờ)",
+      "selectUser": "Chọn người dùng",
+      "estimateHint": "ví dụ: 2 giờ 30 phút",
+      "noEstimate": "Không có ước tính nào được thiết lập."
+    },
+    "delete": {
+      "confirmMessage": "Bạn có chắc chắn muốn xóa Phiên {name} không?",
+      "warning": "Phiên này sẽ bị xóa khỏi dự án. Dữ liệu lịch sử của phiên này vẫn sẽ được lưu giữ trong dự án.",
+      "toast": {
+        "loading": "Đang xóa phiên...",
+        "success": "Phiên đã được xóa thành công",
+        "error": {
+          "title": "Không thể xóa phiên",
+          "description": "Đã xảy ra lỗi trong quá trình xóa phiên."
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "Bạn có chắc chắn muốn hoàn thành Phiên {name} không?",
+      "warning": "Sau khi hoàn tất, phiên làm việc sẽ được lưu trữ vĩnh viễn và không thể cập nhật thêm.",
+      "fields": {
+        "completionDate": "Ngày hoàn thành"
+      },
+      "placeholders": {
+        "pickDate": "Chọn một ngày"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "Tổng thời gian ước tính còn lại:",
+      "recentResultsTitle": "Tóm tắt kết quả gần đây",
+      "recentResultsDescription": "Tóm tắt kết quả phiên họp.",
+      "noRecentResults": "Không có kết quả phiên nào được ghi nhận gần đây.",
+      "completionTrendTitle": "Xu hướng hoàn thành",
+      "completionTrendDescription": "Số buổi học hoàn thành mỗi tháng.",
+      "noCompletedRuns": "Không tìm thấy lần chạy nào hoàn tất trong 6 tháng qua.",
+      "completionTrendTitle6Mo": "Xu hướng hoàn thành (6 tháng gần đây)",
+      "noCompletedSessions6Mo": "Không có buổi trị liệu nào được hoàn thành trong 6 tháng qua."
+    },
+    "version": {
+      "title": "Xem lịch sử phiên",
+      "notFound": "Không tìm thấy phiên bản phiên.",
+      "selectVersion": "Chọn phiên bản",
+      "backToSession": "Trở lại phiên",
+      "backToLatest": "Trở lại phiên bản mới nhất",
+      "versionInfo": {
+        "created": "Phiên bản {number} Đã tạo",
+        "latestUpdated": "Phiên bản mới nhất {number} Đã cập nhật"
+      },
+      "renderer": {
+        "noEstimate": "Không có ước tính",
+        "noTimeLogged": "Không có thời gian nào được ghi lại.",
+        "noContent": "Không có nội dung",
+        "currentVersion": "Phiên bản hiện tại",
+        "previousVersion": "Phiên bản trước"
+      },
+      "diff": {
+        "added": "Đã thêm",
+        "removed": "LOẠI BỎ",
+        "changed": "Đã thay đổi"
+      }
+    },
+    "results": {
+      "section": "Nhật ký phiên",
+      "add": "Thêm kết quả phiên",
+      "edit": "Chỉnh sửa kết quả phiên",
+      "editDescription": "Hãy chỉnh sửa kết quả phiên và nhấn lưu khi hoàn tất.",
+      "details": "Vui lòng nhập thông tin chi tiết về kết quả tại đây...",
+      "noResults": "Chưa có kết quả nào được thêm vào.",
+      "noNotes": "Không có ghi chú nào được thêm cho kết quả này.",
+      "deleteSuccess": "Kết quả phiên đã được xóa thành công",
+      "deleteError": "Không thể xóa kết quả phiên.",
+      "updateSuccess": "Kết quả phiên được cập nhật thành công",
+      "updateError": "Không thể cập nhật kết quả phiên.",
+      "linkCopied": "Liên kết kết quả phiên đã được sao chép vào clipboard",
+      "copyFailed": "Không thể sao chép liên kết kết quả phiên.",
+      "confirmDelete": {
+        "title": "Xóa kết quả phiên",
+        "description": "Bạn có chắc chắn muốn xóa kết quả phiên này không?"
+      }
+    },
+    "notFound": "Không tìm thấy phiên"
+  },
+  "home": {
+    "dashboard": {
+      "title": "Bảng điều khiển của bạn",
+      "users": "Có {count, plural, =1 {# Người dùng} other {# Người dùng}}",
+      "yourProjects": "Dự án của bạn",
+      "projects": "Bạn có quyền truy cập vào {count, plural, =1 {# Dự án} other {# Dự án}}",
+      "loading": "Đang tải bảng điều khiển...",
+      "noItems": "Không có việc gì được giao cho bạn cần phải giải quyết ngay bây giờ.",
+      "pendingRuns": "Đang chờ chạy thử nghiệm",
+      "activeSessions": "Phiên hoạt động",
+      "yourActiveSessions": "{count, plural, =0 {Không có phiên hoạt động} =1 {# Phiên hoạt động} other {# Phiên hoạt động}}",
+      "yourPendingRuns": "{count, plural, =0 {Không có lượt chạy thử nghiệm nào đang chờ xử lý} =1 {# Lượt chạy thử nghiệm đang hoạt động} other {# Lượt chạy thử nghiệm đang hoạt động}}",
+      "yourAssignments": "Bài tập của bạn",
+      "totalTime": "Tổng thời gian ước tính: ",
+      "totalWorkEffort": "Tổng nỗ lực làm việc: ",
+      "scheduleSpan": "Khoảng thời gian dự kiến: "
+    },
+    "initialPreferences": {
+      "title": "Thiết lập tùy chọn của bạn",
+      "description": "Hãy chọn các cài đặt mặc định phù hợp nhất với bạn. Bạn có thể thay đổi chúng bất cứ lúc nào từ hồ sơ của mình.",
+      "dateFormat": "Định dạng ngày tháng",
+      "timeFormat": "Định dạng thời gian",
+      "timezonePlaceholder": "Tìm kiếm múi giờ...",
+      "skip": "Giữ nguyên cài đặt mặc định",
+      "save": "Lưu tùy chọn",
+      "success": "Tùy chọn đã được cập nhật",
+      "error": "Đã xảy ra lỗi khi lưu tùy chọn của bạn"
+    },
+    "noAccess": {
+      "title": "Không có quyền truy cập dự án",
+      "description": "Bạn không có quyền truy cập vào bất kỳ dự án nào trong hệ thống này.",
+      "contact": "Hãy liên hệ với quản trị viên hệ thống của bạn để yêu cầu quyền truy cập vào các dự án.",
+      "adminAddProject": "Thêm dự án đầu tiên của bạn để bắt đầu!",
+      "footer": "Cần có quyền truy cập để xem và tham gia vào các hoạt động lập kế hoạch thử nghiệm."
+    },
+    "noProjectAccess": {
+      "description": "Bạn không có quyền truy cập vào dự án này.",
+      "contact": "Hãy liên hệ với người quản lý dự án của bạn để yêu cầu quyền truy cập."
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Trường hợp kiểm thử} =1 {# Trường hợp kiểm thử} other {# Trường hợp kiểm thử}}",
+      "activeMilestones": "{count, plural, =0 {# Các mốc quan trọng đang hoạt động} =1 {# Mốc quan trọng đang hoạt động} other {# Các mốc quan trọng đang hoạt động}}",
+      "activeRuns": "{count, plural, =0 {# Các lượt chạy đang hoạt động} =1 {# Lượt chạy đang hoạt động} other {# Các lượt chạy đang hoạt động}}",
+      "activeSessions": "{count, plural, =0 {# Phiên đang hoạt động} =1 {# Phiên đang hoạt động} other {# Phiên đang hoạt động}}",
+      "issues": "{count, plural, =0 {# Vấn đề} =1 {# Vấn đề} other {# Vấn đề}}"
+    }
+  },
+  "users": {
+    "description": "Quản lý tài khoản người dùng, thiết lập cấp độ truy cập hệ thống và phân công vai trò toàn cầu.",
+    "filter": "Lọc người dùng...",
+    "profile": {
+      "title": "Hồ sơ người dùng",
+      "edit": {
+        "title": "Chỉnh sửa hồ sơ",
+        "timezonePlaceholder": "Chọn hoặc tìm kiếm múi giờ...",
+        "timezoneRequired": "Cần phải nhập múi giờ.",
+        "avatarUpdated": "Ảnh đại diện đã được cập nhật thành công.",
+        "avatarUpdateError": "Không thể cập nhật ảnh đại diện.",
+        "deleteAvatar": "Xóa ảnh đại diện",
+        "deleteAvatarConfirm": "Bạn có chắc chắn muốn xóa ảnh đại diện của mình không?",
+        "emailDisabledForSso": "Bạn không thể thay đổi email cho các tài khoản SSO. Vui lòng cập nhật email thông qua nhà cung cấp dịch vụ xác thực của bạn.",
+        "emailEditableForBoth": "Bạn có thể đăng nhập bằng cả email/mật khẩu và SSO. Việc thay đổi email chỉ ảnh hưởng đến xác thực bằng mật khẩu.",
+        "linkSsoProvider": "Nhà cung cấp SSO liên kết"
+      },
+      "preferences": {
+        "title": "Tùy chọn"
+      },
+      "access": {
+        "title": "Truy cập"
+      },
+      "notifications": {
+        "title": "Tùy chọn thông báo",
+        "description": "Tùy chỉnh cách bạn nhận thông báo",
+        "currentGlobal": "Cài đặt toàn cầu hiện tại: {mode}",
+        "mode": {
+          "label": "Chế độ thông báo",
+          "useGlobal": "Sử dụng cài đặt toàn cầu"
+        },
+        "options": {
+          "title": "Các tùy chọn bổ sung",
+          "email": {
+            "label": "Thông báo qua email",
+            "description": "Nhận thông báo qua email"
+          }
+        },
+        "success": {
+          "title": "Tùy chọn đã được lưu",
+          "description": "Tùy chọn thông báo của bạn đã được cập nhật."
+        },
+        "error": {
+          "description": "Không thể lưu tùy chọn thông báo."
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "Thay đổi mật khẩu",
+        "setPasswordButtonText": "Đặt mật khẩu",
+        "description": "Nhập mật khẩu hiện tại và mật khẩu mới để thay đổi mật khẩu tài khoản của bạn. Thao tác này chỉ thay đổi mật khẩu do hệ thống quản lý nội bộ của bạn. Nếu bạn đăng nhập thông qua SSO, mật khẩu đó sẽ không thay đổi.",
+        "setPasswordDescription": "Bạn đã đăng nhập bằng SSO và chưa thiết lập mật khẩu cục bộ. Vui lòng nhập mật khẩu mới để kích hoạt tính năng đăng nhập bằng email/mật khẩu cho tài khoản của bạn.",
+        "currentPasswordLabel": "Mật khẩu hiện tại",
+        "newPasswordLabel": "Mật khẩu mới",
+        "confirmPasswordLabel": "Xác nhận mật khẩu mới",
+        "validation": {
+          "passwordsDoNotMatch": "Mật khẩu mới không khớp.",
+          "newPasswordTooShort": "Mật khẩu mới không đáp ứng các yêu cầu bảo mật."
+        },
+        "success": {
+          "passwordChanged": "Mật khẩu đã được thay đổi thành công."
+        }
+      },
+      "mentionedComments": {
+        "title": "Được đề cập trong phần bình luận",
+        "description": "Những bình luận có nhắc đến bạn",
+        "noComments": "Bạn chưa được nhắc đến trong bất kỳ bình luận nào.",
+        "comment": "Bình luận",
+        "showingResults": "Hiển thị {start} - {end} trong số {total}"
+      },
+      "twoFactor": {
+        "enable": "Kích hoạt xác thực hai yếu tố (2FA).",
+        "disable": "Vô hiệu hóa",
+        "disableNotAllowed": "Tổ chức của bạn yêu cầu xác thực hai yếu tố.",
+        "ssoBypassNotice": "Đăng nhập bằng SSO sẽ bỏ qua thiết lập xác thực hai yếu tố này. Vui lòng liên hệ với quản trị viên của bạn để bắt buộc xác thực hai yếu tố cho tất cả các lần đăng nhập.",
+        "regenerateCodes": "Mã mới",
+        "setup": {
+          "description": "Quét mã QR bằng ứng dụng xác thực của bạn (như Google Authenticator hoặc Authy) và nhập mã xác minh.",
+          "backupCodesTitle": "Lưu trữ mã dự phòng của bạn",
+          "done": "Tôi đã lưu lại các mã của mình"
+        },
+        "disableConfirm": {
+          "title": "Vô hiệu hóa xác thực hai yếu tố?",
+          "description": "Việc này sẽ làm giảm tính bảo mật của tài khoản của bạn. Vui lòng nhập mã xác thực hai yếu tố (2FA) hiện tại hoặc mã dự phòng để xác nhận.",
+          "placeholder": "Nhập mã"
+        },
+        "regenerate": {
+          "title": "Tạo lại mã sao lưu",
+          "description": "Thao tác này sẽ vô hiệu hóa các mã dự phòng hiện có của bạn. Vui lòng nhập mã xác thực hai yếu tố (2FA) hiện tại của bạn để tiếp tục.",
+          "confirm": "Tạo lại mã",
+          "newCodesTitle": "Mã sao lưu mới của bạn",
+          "newCodesDescription": "Mã cũ của bạn đã bị vô hiệu hóa. Hãy lưu giữ mã mới này ở nơi an toàn."
+        }
+      },
+      "apiTokens": {
+        "description": "Mã thông báo API cho phép các ứng dụng và tập lệnh bên ngoài truy cập TestPlanIt thay mặt bạn. Mã thông báo có cùng quyền hạn với tài khoản của bạn.",
+        "create": "Tạo mã thông báo",
+        "createTitle": "Tạo mã thông báo API",
+        "createDescription": "Tạo mã thông báo API mới để xác thực các công cụ và tập lệnh bên ngoài.",
+        "nameLabel": "Tên mã thông báo",
+        "namePlaceholder": "Ví dụ: Quy trình CI/CD, Công cụ CLI",
+        "noTokens": "Chưa có mã thông báo API nào được tạo.",
+        "expiryLabel": "Ngày hết hạn (Tùy chọn)",
+        "expiryHint": "Để trống nếu không hết hạn sử dụng.",
+        "tokenCreated": "Mã thông báo đã được tạo",
+        "tokenCreatedDescription": "Mã API của bạn đã được tạo thành công.",
+        "copyWarning": "Hãy sao chép mã này ngay bây giờ. Bạn sẽ không thể nhìn thấy nó lần nữa!",
+        "yourToken": "Mã thông báo của bạn",
+        "deleteTitle": "Xóa mã thông báo API?",
+        "deleteDescription": "Thao tác này không thể hoàn tác. Bất kỳ ứng dụng nào sử dụng mã thông báo này sẽ không thể xác thực được nữa.",
+        "readOnlyLabel": "Chỉ đọc",
+        "readOnlyDescription": "Sử dụng cho các tác nhân AI chỉ nên truy vấn dữ liệu, không bao giờ được chỉnh sửa dữ liệu.",
+        "agentTokenLabel": "Đánh dấu là mã thông báo đại lý",
+        "agentTokenDescription": "Gắn thẻ các mục nhật ký kiểm toán với metadata.source: \"mcp\" để quản trị viên có thể xác định nguồn gốc các thay đổi do tác nhân thực hiện.",
+        "readOnlyBadge": "Chỉ đọc",
+        "agentTokenBadge": "Mã thông báo đại lý",
+        "errors": {
+          "nameRequired": "Tên mã thông báo là bắt buộc."
+        }
+      }
+    },
+    "access": {
+      "guest": "Khách mời"
+    },
+    "avatar": {
+      "update": "Cập nhật ảnh đại diện",
+      "remove": "Xóa ảnh đại diện",
+      "changeProfilePicture": "Thay đổi ảnh đại diện",
+      "notAuthenticated": "Bạn phải đăng nhập để tải ảnh đại diện lên."
+    },
+    "deletedUser": "Người dùng đã bị xóa"
+  },
+  "userMenu": {
+    "viewProfile": "Xem hồ sơ",
+    "locale": "Địa phương",
+    "themes": {
+      "light": "Ánh sáng",
+      "dark": "Tối tăm",
+      "system": "Hệ thống",
+      "green": "Màu xanh lá",
+      "purple": "Màu tím",
+      "orange": "Quả cam"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "Không tìm thấy phiên bản trường hợp kiểm thử.",
+      "detailsRegion": "Chi tiết trường hợp thử nghiệm",
+      "metadataRegion": "Siêu dữ liệu trường hợp thử nghiệm",
+      "versionCreated": "Phiên bản {version} Đã tạo",
+      "latestVersionUpdated": "Phiên bản mới nhất {version} Đã cập nhật",
+      "historyView": "Chế độ xem lịch sử trường hợp kiểm thử"
+    },
+    "fields": {
+      "optionNotFound": "Không tìm thấy tùy chọn",
+      "hasValue": "Có giá trị",
+      "noValue": "Không có giá trị",
+      "hasDate": "Có ngày tháng",
+      "noDate": "Không có ngày tháng",
+      "hasText": "Có văn bản",
+      "noText": "Không có văn bản",
+      "hasLink": "Có liên kết",
+      "noLink": "Không có liên kết",
+      "hasSteps": "Có các bước",
+      "noSteps": "Không có bậc thang",
+      "unchecked": "Chưa được kiểm tra",
+      "linkedCases": "Các vụ án liên quan",
+      "clickToViewFullContent": "Nhấp chuột để xem toàn bộ nội dung"
+    },
+    "steps": {
+      "add": "Thêm bước",
+      "addSharedSteps": "Thêm các bước được chia sẻ",
+      "delete": "Xóa bước",
+      "confirmDelete": "Xác nhận xóa Bước {number}?",
+      "createSharedSteps": "Tạo các bước chia sẻ {number, plural, one {Bước} other {Các bước}}",
+      "sharedStepsName": "Tên các bước được chia sẻ",
+      "sharedStepsDescription": "Nhập tên cho các bước {number, plural, one {được chia sẻ mới của bạn} other {các bước}}. Điều này sẽ bao gồm {number, plural, one {# bước đã chọn} other {# các bước đã chọn}}.",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "Vui lòng chọn các bước và nhập tên để tạo các bước được chia sẻ.",
+        "failedToCreateSharedStepGroupError": "Không thể tạo các bước chia sẻ. Vui lòng thử lại.",
+        "sharedStepGroupCreatedSuccess": "Các bước chia sẻ đã được tạo thành công!",
+        "genericSharedStepCreationError": "Đã xảy ra lỗi không xác định trong quá trình tạo các bước chia sẻ. Vui lòng thử lại.",
+        "errorCreatingSharedGroup": "Không thể tạo các bước chung. Vui lòng thử lại.",
+        "sharedGroupCreatedSuccess": "Nhóm bước chung đã được tạo thành công!"
+      },
+      "selectSharedStepsTitle": "Chọn các bước được chia sẻ",
+      "selectSharedStepsDescription": "Chọn các bước chung để thêm vào trường hợp kiểm thử của bạn.",
+      "sharedStepsListPlaceholder": "Đang tải các bước chia sẻ...",
+      "sharedStepsNamePlaceholder": "Nhập tên để xác định các bước được chia sẻ.",
+      "noSharedStepsFound": "Không tìm thấy các bước chung nào cho dự án này.",
+      "sharedStepGroupTitle": "Các bước được chia sẻ: {name}",
+      "confirmDeleteSharedStepBlock": "Bạn có chắc chắn muốn xóa khối bước dùng chung \"{name}\" khỏi trường hợp kiểm thử này không? Thao tác này sẽ không xóa nhóm bước dùng chung đó.",
+      "removeBlockButton": "Xóa khối",
+      "loadingSharedStepsItems": "Đang tải các bước...",
+      "noStepsInSharedGroup": "Nhóm bước chung này hiện đang trống.",
+      "searchSharedStepsPlaceholder": "Chọn các bước được chia sẻ...",
+      "stepsCountLabel": "{count, plural, =0 {# bước} =1 {# bước} other {# bước}}",
+      "reviewSelectedStepsTitle": "Xem lại các bước đã chọn",
+      "noStepsInSelectedGroup": "Nhóm được chọn không có bước nào.",
+      "sharedGroupSuffix": "(Các bước chung)",
+      "unnamedSharedGroup": "Các bước chung không tên"
+    },
+    "testCase": {
+      "toggleAutomated": "Bật/tắt kiểm thử tự động",
+      "editAttachmentsIndividually": "Chỉnh sửa từng tệp đính kèm riêng lẻ.",
+      "automatedStatus": "Kiểm thử tự động là {status}"
+    },
+    "templateNotAssignedWarning": "Trường hợp kiểm thử này sử dụng mẫu \"{templateName}\" hiện chưa được gán cho dự án \"{projectName}\". Bạn có thể cần gán mẫu này cho dự án hoặc thay đổi trường hợp kiểm thử để sử dụng một mẫu khác.",
+    "orphanedStepsWarning": "Trường hợp kiểm thử này có các Bước, nhưng mẫu hiện tại \"{templateName}\" không bao gồm trường Bước. Không thể chỉnh sửa các bước cho đến khi Trường hợp kiểm thử có mẫu với trường Bước.",
+    "orphanedFieldsWarning": "Trường hợp kiểm thử này có {count, plural, =1 {# giá trị trường} other {# giá trị trường}} mà {count, plural, =1 {là} other {là}} không được bao gồm trong mẫu hiện tại \"{templateName}\". {count, plural, =1 {Trường này} other {Các trường này}} được hiển thị bên dưới nhưng có thể không chỉnh sửa được cho đến khi được thêm vào mẫu.",
+    "title": "Kho lưu trữ trường hợp thử nghiệm",
+    "folders": "Thư mục",
+    "showDescendants": "Hiển thị tất cả con cháu",
+    "addFolder": "Thêm thư mục",
+    "emptyFolders": "Nhấp vào nút Thêm thư mục ở trên để thêm thư mục đầu tiên.",
+    "selectedAllCases": "{count, plural, =0 {Đã chọn tất cả các trường hợp} one {Đã chọn trường hợp số # trên tất cả các trang} other {Đã chọn trường hợp số # trên tất cả các trang}}",
+    "deselectedAllCases": "Bỏ chọn tất cả các trường hợp trên tất cả các trang.",
+    "selectAllTooltip": "Chọn/Bỏ chọn tất cả các trường hợp trên trang này",
+    "selectAllShiftTooltip": "{count, plural, =0 {Chọn/Bỏ chọn tất cả các trường hợp trên tất cả các trang} one {Chọn/Bỏ chọn # trường hợp trên tất cả các trang} other {Chọn/Bỏ chọn # trường hợp trên tất cả các trang}}",
+    "deselectAllShiftTooltip": "Bỏ chọn/Chọn tất cả các trường hợp trên tất cả các trang.",
+    "shiftClickHint": "Giữ phím Shift để chọn/bỏ chọn tất cả các trang.",
+    "treeView": {
+      "expandAll": "Mở rộng tất cả",
+      "collapseAll": "Thu gọn tất cả",
+      "altKey": "Giữ phím Alt để mở rộng/thu gọn tất cả các phần tử con."
+    },
+    "dragDrop": {
+      "move": "Di chuyển",
+      "copy": "Sao chép",
+      "promptTitle": "Bạn muốn làm gì?",
+      "copying": "Đang sao chép…",
+      "copyComplete": "{count, plural, =1 {Đã sao chép 1 trường hợp vào {folder}} other {Đã sao chép # trường hợp vào {folder}}}{dest, select, samename {} crossProject { trong {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {Đã chuyển 1 trường hợp đến {folder}} other {Đã chuyển # trường hợp đến {folder}}}{dest, select, samename {} crossProject { trong {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Không thể sao chép 1 trường hợp vào {folder}} other {Không thể sao chép # trường hợp vào {folder}}}{dest, select, samename {} crossProject { trong {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Không thể chuyển 1 trường hợp đến {folder}} other {Không thể chuyển # trường hợp đến {folder}}}{dest, select, samename {} crossProject { trong {projectName}} other {}}",
+      "copyAlreadyRunning": "Bản sao khác đang được thực hiện. Vui lòng chờ cho đến khi hoàn tất.",
+      "currentSuffix": "(Hiện hành)",
+      "moveDisabledSameFolder": "Các hồ sơ đã có sẵn trong thư mục này.",
+      "dragPreviewCase": "Trường hợp thử nghiệm",
+      "dragPreviewCount": "{count, plural, =1 {# trường hợp thử nghiệm} other {# các trường hợp thử nghiệm}}",
+      "modifierHintMac": "Nhấn giữ ⇧ để di chuyển hoặc ⌥ để sao chép trong khi kéo chuột để bỏ qua menu này.",
+      "modifierHintWin": "Giữ phím Shift để di chuyển hoặc phím Ctrl để sao chép trong khi kéo chuột để bỏ qua menu này."
+    },
+    "folderActions": {
+      "edit": "Chỉnh sửa thư mục",
+      "delete": "Xóa thư mục",
+      "rename": "Đổi tên thư mục"
+    },
+    "cases": {
+      "filter": "Lọc các trường hợp...",
+      "selectFolder": "Chọn một thư mục để thêm hoặc hiển thị các trường hợp kiểm thử.",
+      "selectCases": "Chọn các trường hợp kiểm thử",
+      "noTestCases": "Không có trường hợp thử nghiệm nào để hiển thị.",
+      "addCase": "Thêm trường hợp",
+      "notFound": "Không tìm thấy trường hợp kiểm thử.",
+      "selectFilter": "Chọn bộ lọc",
+      "testResultHistory": "Lịch sử kết quả kiểm tra",
+      "testResultHistoryDescription": "Xem lịch sử kết quả kiểm thử cho trường hợp kiểm thử này.",
+      "noTestResults": "Không tìm thấy kết quả kiểm thử nào cho trường hợp kiểm thử này.",
+      "unknownRun": "Chạy không xác định",
+      "attempt": "Nỗ lực",
+      "invalidProject": "Dự án không hợp lệ",
+      "noSearchResults": "Không có trường hợp nào phù hợp với tiêu chí tìm kiếm của bạn.",
+      "bulkEdit": "Chỉnh sửa hàng loạt",
+      "createTestRun": "Tạo bản chạy thử nghiệm",
+      "copyMoveToProject": "Sao chép / Di chuyển",
+      "export": "Xuất khẩu",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "Không thể sắp xếp lại các trường hợp kiểm thử trên nhiều trang. Để sắp xếp lại, hãy xem tất cả các trường hợp trên một trang bằng cách chọn 'Tất cả' từ menu kích thước trang hoặc bỏ chọn các trường hợp từ các trang khác. Bạn vẫn có thể kéo các trường hợp đã chọn vào thư mục.",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "Tất cả đều hiển thị ({count})"
+        },
+        "textLongFormat": {
+          "label": "Định dạng văn bản phong phú"
+        },
+        "rowMode": {
+          "label": "Các hàng của trường hợp kiểm thử",
+          "multi": "Một hàng trên mỗi bước"
+        }
+      },
+      "importWizard": {
+        "title": "Nhập các trường hợp kiểm thử",
+        "fields": {
+          "workflowState": "Trạng thái quy trình làm việc",
+          "column": "Cột {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# trường hợp thử nghiệm} other {# các trường hợp thử nghiệm}} đã được nhập thành công"
+        },
+        "errors": {
+          "templateRequired": "Việc chọn mẫu là bắt buộc.",
+          "folderRequired": "Bạn cần chọn thư mục cho vị trí nhập này.",
+          "fileRequired": "Cần có tệp CSV hoặc Markdown.",
+          "markdownParseFailed": "Không thể phân tích cú pháp tệp Markdown.",
+          "markdownLlmFailed": "Tính năng phân tích cú pháp bằng AI không khả dụng, đang sử dụng trình phân tích cú pháp tiêu chuẩn."
+        },
+        "page1": {
+          "fileType": {
+            "label": "Loại tệp",
+            "csv": "CSV",
+            "markdown": "Giảm giá"
+          },
+          "parsingMarkdown": "Đang phân tích tệp markdown...",
+          "useAiParsing": "Sử dụng trí tuệ nhân tạo để hỗ trợ lập bản đồ thực địa.",
+          "importLocation": {
+            "label": "Vị trí nhập khẩu",
+            "singleFolder": "Thêm tất cả các trường hợp vào một thư mục duy nhất.",
+            "rootFolder": "Thêm tất cả các trường hợp và thư mục vào một thư mục gốc (cần thiết lập ánh xạ).",
+            "topLevel": "Thêm tất cả các trường hợp và thư mục vào cấp cao nhất (cần thiết lập sơ đồ)."
+          },
+          "selectFolder": "Chọn thư mục",
+          "selectFolderPlaceholder": "Chọn một thư mục...",
+          "delimiters": {
+            "tab": "Tab"
+          },
+          "hasHeaders": "Hàng đầu tiên chứa tên cột.",
+          "template": "Mẫu trường hợp kho lưu trữ",
+          "rowMode": {
+            "single": "Mỗi hàng là một trường hợp thử nghiệm riêng biệt.",
+            "multi": "Các trường hợp kiểm thử có thể trải rộng trên nhiều hàng."
+          }
+        },
+        "page2": {
+          "title": "Ánh xạ các cột CSV sang các trường",
+          "description": "Bạn có thể ánh xạ từng cột trong tệp CSV đến một trường trong mẫu hoặc chọn bỏ qua bước này.",
+          "ignoreColumn": "Bỏ qua cột",
+          "requiredFieldsWarning": "{count, plural, one {# Trường bắt buộc là} other {# Các trường bắt buộc là}} không được ánh xạ"
+        },
+        "page3": {
+          "title": "Tóm tắt lập bản đồ hiện trường",
+          "mappingSummary": "Tóm tắt bản đồ",
+          "folderSplitMode": {
+            "label": "Chế độ phân cấp thư mục",
+            "plain": "Văn bản thuần túy (không tách chuỗi)",
+            "plainExample": "Ví dụ: 'This/is.a>Folder' → Thư mục đơn có tên 'This/is.a>Folder'",
+            "slash": "Phân tách bằng dấu gạch chéo (/)",
+            "slashExample": "Ví dụ: 'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "Phân tách bởi dấu chấm (.)",
+            "dotExample": "Ví dụ: 'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "Phân tách bằng dấu lớn hơn (>)",
+            "greaterThanExample": "Ví dụ: 'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "Xem trước khi nhập",
+          "showing": "Hiển thị {start}-{end} trong tổng số {total} trường hợp",
+          "case": "Trường hợp {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "Thêm trường hợp kiểm thử",
+      "name": "Tên trường hợp kiểm thử",
+      "namePlaceholder": "Nhập tên trường hợp kiểm thử",
+      "selectTemplate": "Chọn một mẫu",
+      "selectState": "Chọn một tiểu bang",
+      "estimatePlaceholder": "Nhập ước tính",
+      "create": "Tạo trường hợp kiểm thử",
+      "successMessage": "Đã thêm trường hợp kiểm thử mới.",
+      "errorMessage": "Lỗi không xác định khi thêm trường hợp kiểm thử mới"
+    },
+    "columns": {
+      "selectCase": "Chọn trường hợp",
+      "runOrder": "Thứ tự chạy",
+      "lastTestResult": "Kết quả cuối cùng",
+      "testedOn": "Lần kiểm tra cuối cùng"
+    },
+    "actions": {
+      "archive": "Lưu trữ"
+    },
+    "parentFolder": "Thư mục cha",
+    "rootFolder": "Thư mục gốc",
+    "removeParentFolder": "Xóa thư mục cha",
+    "createInSelectedFolder": "Trở về thư mục cha",
+    "deleteCase": {
+      "title": "Xóa trường hợp kiểm thử",
+      "confirmMessageStart": "Bạn có chắc chắn muốn xóa trường hợp kiểm thử này không? ",
+      "confirmMessageEnd": "?",
+      "warning": "Trường hợp thử nghiệm này sẽ bị xóa khỏi dự án. Dữ liệu lịch sử cho trường hợp thử nghiệm này vẫn sẽ được lưu giữ trong dự án, bao gồm cả kết quả.",
+      "activeRunWarningMessage": "Trường hợp kiểm thử này là một phần của {count, plural, =1 {# lần chạy kiểm thử đang hoạt động} other {# các lần chạy kiểm thử đang hoạt động}}. Việc xóa nó sẽ đánh dấu nó là đã bị xóa trong các lần chạy đó."
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Xóa thư mục này cũng sẽ xóa tất cả các thư mục con. Bạn có chắc chắn không?} one {Xóa thư mục này cũng sẽ xóa 1 trường hợp kiểm thử trong thư mục này và tất cả các thư mục con. Bạn có chắc chắn không?} other {Xóa thư mục này cũng sẽ xóa # trường hợp kiểm thử trong thư mục này và tất cả các thư mục con. Bạn có chắc chắn không?}}",
+      "warning": "Thư mục này và tất cả các trường hợp kiểm thử bên trong sẽ bị xóa khỏi dự án. Dữ liệu lịch sử cho các trường hợp kiểm thử này, bao gồm cả kết quả, vẫn sẽ được lưu giữ trong dự án.",
+      "confirm": "Xác nhận xóa thư mục",
+      "success": "Thư mục và tất cả các thư mục con/trường hợp đã được xóa thành công."
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "Tên thư mục đã tồn tại. Vui lòng chọn một tên khác."
+      }
+    },
+    "views": {
+      "byAutomation": "Tự động hóa",
+      "allTemplates": "Tất cả các mẫu",
+      "allStates": "Tất cả các tiểu bang",
+      "allCreators": "Tất cả những người sáng tạo",
+      "allCases": "Tất cả các trường hợp",
+      "allAssignees": "Tất cả người được chỉ định",
+      "anyTag": "Bất kỳ thẻ nào",
+      "noTags": "Không có thẻ",
+      "byTag": "Nhãn",
+      "byIssue": "Vấn đề",
+      "anyIssue": "Bất kỳ vấn đề nào",
+      "noIssues": "Không có vấn đề gì"
+    },
+    "noFoldersTitle": "Chưa có thư mục nào",
+    "noFoldersDescription": "Hãy bắt đầu bằng cách tạo thư mục đầu tiên để sắp xếp các trường hợp kiểm thử của bạn.",
+    "noFoldersOrCasesNoPermission": "Hiện không có thư mục hoặc trường hợp kiểm thử nào để hiển thị.",
+    "createFirstFolder": "Tạo thư mục đầu tiên của bạn",
+    "bulkEdit": {
+      "title": "Chỉnh sửa hàng loạt {count, plural, one {# Trường hợp} other {# Trường hợp}}",
+      "description": "Chỉnh sửa {count, plural, one {# trường hợp đã chọn} other {# trường hợp đã chọn}}. Chọn một trường để bật chế độ chỉnh sửa.",
+      "defineStepsTitle": "Xác định các bước để cập nhật hàng loạt",
+      "saveNewSteps": "Lưu các bước mới",
+      "newStepsDefined": "Các bước mới được xác định ({count}) - Nhấp vào nút để chỉnh sửa",
+      "clearExistingStepsWarning": "Các bậc thang hiện có sẽ bị loại bỏ.",
+      "warnings": {
+        "templateMismatch": {
+          "title": "Nhiều mẫu đã được chọn",
+          "description": "Chỉ có thể chỉnh sửa các trường thông thường khi chọn các trường hợp có mẫu khác nhau. Có thể chỉnh sửa các trường động bằng cách chọn các trường hợp sử dụng cùng một mẫu."
+        },
+        "junitLimitations": {
+          "title": "Những hạn chế của việc chỉnh sửa trường hợp kiểm thử tự động",
+          "description": "Các trường Ước tính và Tự động không thể được chỉnh sửa đối với các trường hợp thử nghiệm được nhập từ kết quả thử nghiệm tự động."
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "Lỗi khi tải trường hợp",
+        "fetchErrorDescription": "Không thể tải dữ liệu cho các trường hợp đã chọn. Vui lòng đóng cửa sổ bật lên và thử lại.",
+        "updateErrorTitle": "Cập nhật thất bại",
+        "updateFailed": "Đã xảy ra lỗi khi lưu thay đổi. Vui lòng kiểm tra lại dữ liệu và thử lại.",
+        "fetchError": "Lỗi khi truy xuất dữ liệu vụ việc."
+      },
+      "success": {
+        "casesUpdated": "Các trường hợp đã được cập nhật thành công."
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "Lỗi xác thực",
+      "stepsCannotBeBulkEdited": "Không thể chỉnh sửa hàng loạt các bước.",
+      "stepsInfoTitle": "Thông tin các bước",
+      "stepsCannotBeBulkEditedInfo": "Không thể chỉnh sửa hàng loạt các bước. Hãy chỉnh sửa từng bước một cách riêng lẻ.",
+      "confirmDeleteCases": "Bạn có chắc chắn muốn xóa {count, plural, one {# trường hợp đã chọn} other {# trường hợp đã chọn}}không? Hành động này không thể hoàn tác.",
+      "replaceAll": "Thay thế tất cả",
+      "searchReplace": "Tìm kiếm và thay thế",
+      "searchFor": "Tìm kiếm",
+      "replaceWith": "Thay thế bằng",
+      "searchText": "Nhập văn bản để tìm kiếm",
+      "replacementText": "Nhập văn bản thay thế",
+      "useRegex": "Sử dụng biểu thức chính quy",
+      "caseSensitive": "phân biệt chữ hoa chữ thường",
+      "regexHint": "Sử dụng .* cho bất kỳ ký tự nào, \\d+ cho số, \\w+ cho từ. Nhóm bắt giữ: (mẫu) sau đó sử dụng $1, $2, v.v.",
+      "preview": "Xem trước",
+      "matches": "các trận đấu",
+      "noMatches": "Không tìm thấy kết quả phù hợp.",
+      "invalidRegexPattern": "Mẫu biểu thức chính quy không hợp lệ",
+      "searchPatternRequired": "Cần có mẫu tìm kiếm.",
+      "stepsSearchReplaceInfo": "Chức năng tìm kiếm và thay thế sẽ được áp dụng cho cả mô tả các bước và kết quả mong đợi."
+    },
+    "exportModal": {
+      "title": "Xuất các trường hợp kiểm thử",
+      "description": "Chọn tùy chọn xuất dữ liệu bên dưới.",
+      "scope": {
+        "selected": "Đã chọn ({count})",
+        "allFiltered": "Tất cả (Chế độ xem hiện tại) ({count})",
+        "allProject": "Tất cả trong Dự án ({count})"
+      },
+      "format": {
+        "label": "Định dạng",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Giảm giá"
+      },
+      "columns": {
+        "all": "Tất cả",
+        "visible": "Dễ thấy"
+      },
+      "delimiter": {
+        "label": "Dấu phân cách",
+        "placeholder": "Chọn dấu phân cách...",
+        "comma": "Dấu phẩy (,)",
+        "semicolon": "Dấu chấm phẩy (;)",
+        "colon": "Dấu hai chấm (:)",
+        "pipe": "Dấu gạch dọc (|)"
+      },
+      "textLongFormat": {
+        "label": "Văn bản định dạng dài"
+      },
+      "attachmentFormat": {
+        "label": "Định dạng tệp đính kèm",
+        "names": "Tên",
+        "json": "JSON",
+        "embedded": "Nhúng hình ảnh"
+      },
+      "stepsFormat": {
+        "label": "Định dạng các bước",
+        "plainText": "Văn bản thuần túy"
+      },
+      "rowMode": {
+        "label": "Số hàng trên mỗi trường hợp",
+        "single": "Một hàng trên mỗi thùng",
+        "multi": "Nhiều hàng trên mỗi bước"
+      },
+      "comingSoon": "Sắp ra mắt",
+      "exporting": "Đang xuất khẩu...",
+      "exportError": "Quá trình xuất dữ liệu thất bại. Vui lòng thử lại."
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "Chuyển đổi các trường hợp kiểm thử đã chọn thành các kịch bản tự động hóa bằng cách sử dụng mẫu hoặc trí tuệ nhân tạo.",
+      "templatePlaceholder": "Chọn một mẫu...",
+      "searchPlaceholder": "Tìm kiếm mẫu...",
+      "noTemplatesFound": "Không tìm thấy mẫu nào.",
+      "outputModeLabel": "Chế độ đầu ra",
+      "outputModeSingle": "Hàng đơn ({count, plural, one {# trường hợp} other {tất cả # trường hợp}})",
+      "outputModeIndividual": "{count, plural, one {Tệp riêng lẻ (.zip)} other {Các tệp riêng lẻ (.zip)}}",
+      "casesToExport": "{count, plural, one {# trường hợp} other {# trường hợp}} để xuất",
+      "exportSuccess": "Quá trình xuất khẩu đã hoàn tất thành công.",
+      "noAvailableTemplates": "Không có mẫu nào khả dụng. Vui lòng liên hệ với quản trị viên."
+    },
+    "aiExport": {
+      "toggleLabel": "Tạo bằng AI",
+      "generating": "Đang tạo...",
+      "generatingProgress": "Tạo trường hợp {current} của {total}...",
+      "generatingBatch": "Tạo {count, plural, one {# trường hợp} other {# trường hợp}} trong một tệp...",
+      "previewTitle": "Xem trước khi xuất",
+      "previewDescription": "{count, plural, one {# tập tin} other {# tập tin}} được tạo",
+      "copySuccess": "Đã sao chép vào clipboard",
+      "fallbackBadge": "Được tạo bằng mẫu (không có AI)",
+      "retryButton": "Thử lại quá trình tạo AI",
+      "aiGenerated": "Được tạo bởi AI",
+      "templateGenerated": "Mẫu được tạo",
+      "truncatedWarning": "Kết quả đầu ra bị cắt ngắn — mô hình đã đạt đến giới hạn token. Hãy thử giảm kích thước lô hoặc tăng Max Output Tokens trong Prompt Config của bạn.",
+      "contextFiles": "{count, plural, one {(# tập tin ngữ cảnh)} other {(# tập tin ngữ cảnh)}}",
+      "noCodeContextHint": "Chưa có kho lưu trữ mã nguồn nào được cấu hình. AI sẽ sử dụng các mẫu khung chuẩn.",
+      "generatingParallelProgress": "Đã tạo {done} trong số {total} tập tin...",
+      "cancelledGeneration": "Đã hủy"
+    },
+    "duplicates": {
+      "findDuplicates": "Tìm các mục trùng lặp",
+      "viewResults": "Xem {count, plural, one {# Kết quả} other {# Kết quả}}",
+      "retryScan": "Thử quét lại",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "Nâng cao hiệu quả với trí tuệ nhân tạo...",
+      "scanComplete": "Phân tích trùng lặp hoàn tất — {count, plural, =0 {không tìm thấy bản sao trùng lặp} one {# tìm thấy bản sao trùng lặp tiềm năng} other {# tìm thấy bản sao trùng lặp tiềm năng}}",
+      "scanFailed": "Phân tích trùng lặp thất bại",
+      "scanFailedDescription": "Đã xảy ra lỗi không mong muốn",
+      "pageTitle": "Ứng viên trùng lặp",
+      "pageDescription": "Xem xét lại các trường hợp kiểm thử trùng lặp tiềm ẩn được tìm thấy trong lần quét gần nhất.",
+      "rescan": "Quét lại",
+      "cancelScan": "Hủy quét",
+      "loading": "Đang tải các ứng viên trùng lặp...",
+      "noDuplicatesFound": "Không tìm thấy bản sao nào",
+      "noDuplicatesDescription": "Lần quét cuối cùng hoàn tất mà không tìm thấy cặp nào trùng khớp.",
+      "loadMore": "Tải thêm",
+      "filterPlaceholder": "Lọc các mục trùng lặp...",
+      "columnConfidence": "Sự tự tin",
+      "columnCaseA": "Trường hợp A",
+      "columnCaseB": "Trường hợp B",
+      "columnMatchedFields": "Các trường khớp",
+      "columnScore": "Điểm",
+      "compareButton": "So sánh",
+      "viewCaseDetails": "Xem chi tiết vụ việc",
+      "selectAll": "Chọn tất cả",
+      "selectRow": "Chọn hàng",
+      "selected": "{count, plural, one {# đã chọn} other {# đã chọn}}",
+      "bulkDismiss": "Không trùng lặp ({count})",
+      "bulkLink": "Liên kết dưới dạng liên quan ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# cặp đôi bị loại bỏ} other {# các cặp đôi bị loại bỏ}}",
+      "bulkLinkSuccess": "{count, plural, one {# cặp liên kết} other {# các cặp liên kết}}",
+      "bulkError": "Một số thao tác đã thất bại. Vui lòng thử lại.",
+      "tableHint": "Nhấp vào một hàng hoặc nút So sánh để xem xét và giải quyết cặp trùng lặp.",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "So sánh các mục có khả năng trùng lặp này và chọn cách giải quyết chúng.",
+      "selectPrimary": "Nhấp vào một trường hợp để chọn nó làm trường hợp chính để hợp nhất.",
+      "selectedAsPrimary": "Được chọn làm Chính",
+      "mergeButton": "Giữ nguyên yếu tố chính",
+      "linkButton": "Liên kết như là liên quan",
+      "dismissButton": "Không phải bản sao",
+      "merging": "Đang hợp nhất...",
+      "linking": "Đang liên kết...",
+      "dismissing": "Sa thải...",
+      "mergeSuccess": "Các trường hợp đã được hợp nhất thành công. {runsTransferred, plural, =0 {Không có lượt chạy thử nào được chuyển} one {# Lượt chạy thử đã được chuyển} other {# Lượt chạy thử đã được chuyển}}.",
+      "linkSuccess": "Các trường hợp được cho là có liên quan.",
+      "dismissSuccess": "Cặp đôi này đã bị loại bỏ. Chúng sẽ không xuất hiện trong các lần quét sau.",
+      "resolveError": "Không thể giải quyết cặp trùng lặp. Vui lòng thử lại.",
+      "loadingDetails": "Đang tải chi tiết đơn hàng...",
+      "caseDetailsError": "Không thể tải chi tiết vụ việc.",
+      "sourceLabel": "Nguồn",
+      "fieldValuesLabel": "Giá trị trường",
+      "lastRunLabel": "Lần chạy cuối",
+      "noFieldValues": "Không có giá trị trường nào",
+      "noLastRun": "Đừng bao giờ chạy",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "Không có thư mục",
+      "duplicateWarning": "Có thể tìm thấy các mục trùng lặp.",
+      "duplicateWarningDescription": "{count, plural, one {# trường hợp hiện có} other {# các trường hợp hiện có}} có thể bao gồm chức năng tương tự",
+      "duplicateWarningReview": "Ôn tập",
+      "importWarning": "Có thể là bản sao trùng lặp",
+      "importWarningTooltip": "Tên trường hợp này tương tự như {count, plural, one {# trường hợp hiện có} other {# các trường hợp hiện có}}: {names}",
+      "importIntraWarning": "Trùng lặp trong quá trình nhập",
+      "importIntraWarningTooltip": "Các hàng {rows} trong lần nhập này có cùng tên hoặc tên rất giống nhau.",
+      "checkingDuplicates": "Kiểm tra các mục trùng lặp..."
+    },
+    "generateTestCases": {
+      "buttonText": "Tạo các trường hợp kiểm thử",
+      "title": "Tạo các trường hợp kiểm thử bằng AI",
+      "description": "Sử dụng trí tuệ nhân tạo để tự động tạo ra các trường hợp kiểm thử toàn diện từ các vấn đề hoặc tài liệu bên ngoài.",
+      "loadingResults": "Đang tải các trường hợp kiểm thử đã tạo...",
+      "generatingPreparing": "Đang chuẩn bị yêu cầu...",
+      "generatingCallingAi": "Đang chờ AI tạo ra các trường hợp thử nghiệm...",
+      "generatingStreaming": "AI đang tạo trường hợp thử nghiệm {count}...",
+      "generatingStreamingPage": "AI đang tạo trường hợp thử nghiệm {count} — trang {current} của {total}: {page}",
+      "generatingProcessing": "Đang xử lý các trường hợp kiểm thử được tạo ra...",
+      "generatingHint": "Quá trình này có thể mất một phút tùy thuộc vào độ phức tạp của tài liệu nguồn.",
+      "steps": {
+        "selectIssue": "Chọn nguồn",
+        "selectTemplate": "Chọn mẫu",
+        "reviewGenerated": "Đánh giá & Nhập khẩu"
+      },
+      "selectSource": {
+        "title": "Chọn nguồn yêu cầu",
+        "description": "Chọn xem bạn muốn tạo các trường hợp kiểm thử từ một vấn đề hay từ một tài liệu yêu cầu.",
+        "folderContextTip": "Các trường hợp kiểm thử hiện có từ \"{folderName}\" và các thư mục cha/con của nó sẽ được sử dụng làm ngữ cảnh để tránh trùng lặp. Hãy chắc chắn rằng bạn đã chọn đúng thư mục trước khi tiếp tục.",
+        "currentFolder": "thư mục hiện tại",
+        "fromIssue": "Từ ấn bản",
+        "fromDocument": "Từ tài liệu",
+        "documentTitle": "Tiêu đề tài liệu",
+        "documentTitlePlaceholder": "Nhập tiêu đề của tài liệu yêu cầu của bạn.",
+        "documentDescription": "Tài liệu yêu cầu",
+        "documentDescriptionPlaceholder": "Hãy dán nội dung tài liệu yêu cầu của bạn vào đây...",
+        "documentPriority": "Ưu tiên (Tùy chọn)",
+        "selectPriority": "Chọn mức độ ưu tiên",
+        "saveDocument": "Lưu yêu cầu tài liệu",
+        "fromUrl": "Từ URL",
+        "recentGenerations": "Các công việc Tạo trường hợp kiểm thử từ URL gần đây",
+        "recentJobInfo": "{pages, plural, one {# trang} other {# trang}}{hasTestCases, select, true { · {testCases, plural, one {# trường hợp thử nghiệm} other {# trường hợp thử nghiệm}}} other {}}",
+        "recentJobHasResults": "Sẵn sàng để xem xét",
+        "recentJobClickToGenerate": "Nhấp chuột để tạo các trường hợp thử nghiệm",
+        "recentJobCrawling": "Đang bò... {pages, plural, one {# trang} other {# trang}} cho đến nay",
+        "removeJobTitle": "Loại bỏ thế hệ",
+        "confirmRemoveJob": "Thao tác này sẽ xóa bộ nhớ cache thu thập dữ liệu và mọi trường hợp kiểm thử đã tạo. Bạn luôn có thể tạo lại từ cùng URL đó.",
+        "loadingRecentJobs": "Đang tải các công việc gần đây...",
+        "urlInput": "URL trang",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "URL này chứa nội dung gì?",
+        "urlModeRequirements": "Yêu cầu",
+        "urlModeRequirementsHint": "Trang này mô tả những gì cần xây dựng.",
+        "urlModeApplication": "Ứng dụng",
+        "urlModeApplicationHint": "Page là ứng dụng cần kiểm tra.",
+        "urlValidationError": "Vui lòng nhập URL hợp lệ bắt đầu bằng http:// hoặc https://",
+        "followLinks": "Theo dõi các liên kết",
+        "followLinksHint": "Chỉ những trang có cùng tên miền với URL bạn nhập mới được hệ thống thu thập thông tin.",
+        "maxDepth": "Độ sâu tối đa",
+        "maxPages": "Số trang tối đa",
+        "crawlProgress": "{current, plural, one {Đã tải trang # cho đến nay...} other {Đã tải trang # cho đến nay...}}",
+        "generatingSinglePage": "Đang tạo các trường hợp kiểm thử...",
+        "generatingSetup": "Đang chuẩn bị tạo các trường hợp kiểm thử...",
+        "robotsSkipped": "{count, plural, one {# trang bị bỏ qua} other {# trang bị bỏ qua}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "Chọn Vấn đề bên ngoài",
+        "description": "Chọn một vấn đề từ hệ thống bên ngoài của bạn (như Jira) để tạo các trường hợp kiểm thử.",
+        "searchButton": "Tìm kiếm các vấn đề"
+      },
+      "selectTemplate": {
+        "title": "Chọn mẫu trường hợp kiểm thử",
+        "description": "Chọn mẫu sẽ được sử dụng để tạo các trường hợp kiểm thử. Trí tuệ nhân tạo sẽ điền các trường thông tin theo mẫu này.",
+        "placeholder": "Chọn một mẫu...",
+        "fieldsDescription": "Chọn những trường thông tin mà AI nên tự động điền. Các trường bắt buộc luôn được bao gồm.",
+        "requiredOnly": "Chỉ cần thiết"
+      },
+      "addNotes": {
+        "title": "Thêm ghi chú và hướng dẫn",
+        "description": "Cung cấp thêm ngữ cảnh và hướng dẫn để giúp AI tạo ra các trường hợp kiểm thử tốt hơn.",
+        "quantity": "Số lượng trường hợp thử nghiệm cần tạo",
+        "placeholder": "Thêm hướng dẫn cụ thể cho việc tạo trường hợp kiểm thử...\n\nVí dụ:\n• Tập trung vào kiểm thử bảo mật\n• Bao gồm các trường hợp ngoại lệ và điều kiện biên\n• Kiểm thử cả trường hợp thành công và lỗi\n• Xem xét các trường hợp trên thiết bị di động và máy tính để bàn\n• Tập trung vào kiểm thử API",
+        "suggestions": "Gợi ý nhanh:",
+        "quantityOptions": {
+          "justOne": "Chỉ một",
+          "couple": "Một cặp (2)",
+          "few": "Một vài (2-3)",
+          "several": "Một số (4-6)",
+          "many": "Nhiều (7-10)",
+          "maximum": "Tối đa"
+        },
+        "suggestionItems": {
+          "security": "Tập trung vào kiểm tra bảo mật",
+          "edgeCases": "Bao gồm cả các trường hợp ngoại lệ",
+          "happyPath": "Chỉ kiểm tra trường hợp thành công",
+          "mobile": "Hãy xem xét các kịch bản trên thiết bị di động",
+          "api": "Tập trung vào kiểm thử API",
+          "accessibility": "Bao gồm các bài kiểm tra khả năng tiếp cận"
+        }
+      },
+      "review": {
+        "title": "Đánh giá các trường hợp kiểm thử được tạo ra",
+        "description": "Xem xét các trường hợp thử nghiệm do AI tạo ra, thực hiện bất kỳ chỉnh sửa cần thiết nào và chọn những trường hợp cần nhập.",
+        "selected": "{count} trong số {total} được chọn",
+        "moreSteps": "... và {count, plural, one {# thêm bước} other {# thêm bước}}",
+        "templateFields": "Các trường mẫu:",
+        "moreFields": "... và {count, plural, one {# thêm trường} other {# thêm trường}}",
+        "crawledUrls": "{count, plural, one {# trang đã được thu thập} other {# trang đã được thu thập}}",
+        "spaWarning": "Trang này có thể yêu cầu hiển thị JavaScript. Kết quả có thể không đầy đủ.",
+        "filterByPage": "Lọc theo trang",
+        "allPages": "Tất cả các trang ({pages, plural, one {# trang} other {# trang}}, {cases, plural, one {# trường hợp} other {# trường hợp}})"
+      },
+      "generatingLegacy": "Tạo các trường hợp thử nghiệm bằng AI...",
+      "expandProgress": "{done} của {total} được tạo ra",
+      "import": "{count, plural, =0 {Nhập các trường hợp kiểm thử} =1 {Nhập 1 trường hợp kiểm thử} other {Nhập # trường hợp kiểm thử}}",
+      "importing": "{count, plural, =0 {Đang nhập các trường hợp kiểm thử...} =1 {Đang nhập 1 trường hợp kiểm thử...} other {Đang nhập # trường hợp kiểm thử...}}",
+      "openInExternalSystem": "Mở trong {provider}",
+      "externalSystem": "Hệ thống bên ngoài",
+      "autoGenerateTags": "Tự động tạo thẻ cho các trường hợp kiểm thử",
+      "success": {
+        "imported": "{count, plural, =1 {Đã nhập thành công 1 trường hợp thử nghiệm} other {Đã nhập thành công # trường hợp thử nghiệm}}"
+      },
+      "importData": {
+        "issueDescription": "Vấn đề bên ngoài phát sinh từ quá trình tạo trường hợp kiểm thử",
+        "generatedFolderName": "Được tạo ra"
+      },
+      "errors": {
+        "generateFailed": "Không thể tạo các trường hợp kiểm thử. Vui lòng thử lại.",
+        "importFailed": "Không thể nhập các trường hợp kiểm thử. Vui lòng thử lại.",
+        "noTestCasesGenerated": "Không có trường hợp kiểm thử nào được tạo ra. Vui lòng thử lại với các dữ liệu đầu vào khác.",
+        "jobNoLongerAvailable": "Thế hệ này không còn khả dụng nữa. Hãy bắt đầu một thế hệ mới từ trình hướng dẫn Tạo trường hợp kiểm thử.",
+        "noAiModel": "Hiện chưa có mô hình AI nào được cấu hình cho dự án này. Vui lòng cấu hình mô hình AI trong cài đặt dự án.",
+        "noIssueSelected": "Vui lòng chọn một vấn đề để tạo các trường hợp kiểm thử.",
+        "noDocumentProvided": "Vui lòng cung cấp chi tiết tài liệu yêu cầu.",
+        "noTemplateSelected": "Vui lòng chọn một mẫu cho các trường hợp kiểm thử.",
+        "noFieldsSelected": "Vui lòng chọn ít nhất một trường để tạo nội dung.",
+        "noTestCasesSelectedForImport": "Vui lòng chọn ít nhất một trường hợp thử nghiệm để nhập.",
+        "templateRequired": "Bạn cần chọn mẫu. Vui lòng quay lại và chọn mẫu.",
+        "repositoryNotFound": "Không tìm thấy kho lưu trữ dự án. Vui lòng liên hệ với quản trị viên của bạn.",
+        "workflowNotConfigured": "Quy trình làm việc của dự án chưa được cấu hình. Vui lòng kiểm tra lại cài đặt dự án.",
+        "authenticationError": "Lỗi xác thực. Vui lòng làm mới trang và thử lại.",
+        "caseCreationFailed": "Không thể tạo trường hợp kiểm thử: {name}",
+        "caseAlreadyExists": "Trường hợp kiểm thử \"{name}\" đã tồn tại trong thư mục này.",
+        "invalidTemplateConfig": "Cấu hình mẫu không hợp lệ cho trường hợp kiểm thử \"{name}\".",
+        "nameTooLong": "Tên trường hợp kiểm thử \"{name}\" quá dài. Vui lòng sử dụng tên ngắn hơn.",
+        "caseCreationError": "Không thể tạo \"{name}\": {error}",
+        "templateNotFound": "Không tìm thấy mẫu đã chọn. Vui lòng làm mới trang và thử lại.",
+        "repositoryConfigError": "Lỗi cấu hình kho lưu trữ dự án. Vui lòng liên hệ với quản trị viên của bạn.",
+        "workflowConfigError": "Lỗi cấu hình quy trình làm việc dự án. Vui lòng kiểm tra lại cài đặt dự án.",
+        "permissionDenied": "Bạn không có quyền tạo các trường hợp kiểm thử trong dự án này.",
+        "validationFailed": "Xác thực dữ liệu thất bại. Vui lòng kiểm tra nội dung trường hợp kiểm thử và thử lại.",
+        "databaseError": "Lỗi kết nối cơ sở dữ liệu. Vui lòng thử lại sau.",
+        "genericImportError": "Nhập khẩu thất bại: {error}",
+        "networkRoutingError": "Lỗi định tuyến mạng hoặc cấu hình máy chủ - nhận được trang lỗi HTML thay vì phản hồi API.",
+        "invalidSourceConfig": "Cấu hình nguồn không hợp lệ",
+        "failedToCreateCaseVersion": "Không thể tạo phiên bản hồ sơ",
+        "noUrlProvided": "Vui lòng nhập URL để tạo các trường hợp kiểm thử từ đó.",
+        "urlFetchFailed": "Không thể tải nội dung từ URL được cung cấp. Vui lòng kiểm tra lại URL và thử lại.",
+        "llm": {
+          "genericTitle": "Lỗi tạo AI",
+          "genericMessage": "Đã xảy ra lỗi khi tạo các trường hợp kiểm thử bằng AI. Vui lòng thử lại hoặc điều chỉnh dữ liệu nhập vào.",
+          "overloaded": {
+            "title": "Dịch vụ tạm thời không khả dụng",
+            "message": "Dịch vụ AI hiện đang có lượng truy cập cao. Vui lòng thử lại sau vài phút."
+          },
+          "quota": {
+            "title": "Đã đạt giới hạn sử dụng",
+            "message": "Bạn đã đạt đến giới hạn sử dụng AI cho khoảng thời gian này. Vui lòng thử lại sau hoặc liên hệ với quản trị viên của bạn."
+          },
+          "timeout": {
+            "title": "Yêu cầu hết thời gian chờ",
+            "message": "Yêu cầu AI mất quá nhiều thời gian để hoàn thành. Điều này có thể xảy ra với các yêu cầu phức tạp hoặc số lượng lớn các trường hợp thử nghiệm."
+          },
+          "network": {
+            "title": "Lỗi mạng",
+            "message": "Không thể kết nối với dịch vụ AI. Vui lòng kiểm tra kết nối internet của bạn và thử lại."
+          },
+          "unauthorized": {
+            "title": "Xác thực dịch vụ AI thất bại",
+            "message": "Dịch vụ AI đã từ chối thông tin đăng nhập của chúng tôi. Quản trị viên cần xem lại khóa API của tích hợp LLM trong cài đặt quản trị."
+          },
+          "forbidden": {
+            "title": "Quyền truy cập dịch vụ AI bị từ chối",
+            "message": "Dịch vụ AI đã từ chối yêu cầu này. Quản trị viên cần xác minh quyền hạn và quyền truy cập dự án của việc tích hợp LLM."
+          },
+          "projectNotFound": {
+            "title": "Không tìm thấy dự án",
+            "message": "Chúng tôi không tìm thấy dự án này, hoặc bạn không có quyền sử dụng công nghệ tạo nội dung bằng AI tại đây."
+          },
+          "noIntegration": {
+            "title": "Không có tích hợp LLM đang hoạt động",
+            "message": "Hiện tại chưa có cấu hình tích hợp LLM nào được thiết lập cho dự án này. Quản trị viên cần kích hoạt tính năng này trong cài đặt quản trị."
+          },
+          "invalidRequest": {
+            "title": "Yêu cầu không hợp lệ",
+            "message": "Yêu cầu tạo bằng AI thiếu thông tin cần thiết. Vui lòng làm mới trang và thử lại."
+          },
+          "retryButton": "Thử lại",
+          "dismissButton": "Miễn nhiệm",
+          "suggestionsHeading": "Gợi ý",
+          "suggestions": {
+            "retryLater": "Hãy thử lại sau vài phút.",
+            "contactAdmin": "Nếu sự cố vẫn tiếp diễn, hãy liên hệ với quản trị viên của bạn.",
+            "checkStatus": "Kiểm tra trạng thái dịch vụ AI",
+            "checkNetwork": "Kiểm tra kết nối internet của bạn"
+          },
+          "timestampLabel": "Đã xảy ra lỗi tại",
+          "showDetails": "Hiển thị chi tiết",
+          "hideDetails": "Ẩn chi tiết",
+          "copyDetails": "Sao chép chi tiết",
+          "detailsCopied": "Chi tiết lỗi đã được sao chép vào clipboard"
+        }
+      },
+      "unsavedEdits": {
+        "title": "Chỉnh sửa chưa lưu",
+        "description": "{count, plural, =1 {Bạn có 1 trường hợp kiểm thử với các chỉnh sửa chưa được lưu.} other {Bạn có # trường hợp kiểm thử với các chỉnh sửa chưa được lưu.}}",
+        "warning": "Nếu bạn tiếp tục mà không lưu, những thay đổi của bạn sẽ bị mất.",
+        "saveAllAndImport": "Lưu tất cả & Nhập",
+        "discardAndImport": "Hủy bỏ chỉnh sửa & Nhập"
+      },
+      "linkedIssuesDroppedTitle": "Một số vấn đề liên quan không được bao gồm.",
+      "linkedIssuesDropped": "{count, plural, =1 {# Vấn đề được liên kết đã bị hủy bỏ} other {# Vấn đề được liên kết đã bị hủy bỏ}} do hạn mức token: {keys}.",
+      "linkedIssuesPreviewHeading": "Các vấn đề liên quan sẽ được bao gồm"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "Thêm thẻ",
+      "title": "Thêm thẻ mới",
+      "fields": {
+        "name_error": "Tên thẻ là bắt buộc"
+      },
+      "errors": {
+        "nameExists": "Thẻ có tên này đã tồn tại."
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "Thẻ có tên này đã tồn tại."
+      }
+    },
+    "filterPlaceholder": "Lọc theo thẻ...",
+    "defaultName": "Thẻ không tên",
+    "noProject": "Không có dự án",
+    "description": "Quản lý và sắp xếp các trường hợp kiểm thử và phiên kiểm thử của bạn bằng thẻ.",
+    "detail": {
+      "title": "Chi tiết thẻ",
+      "filterPlaceholder": "Lọc các mục...",
+      "noResults": "Không tìm thấy mục nào",
+      "noFilterResults": "Không có mục nào phù hợp với bộ lọc hiện tại.",
+      "filters": {
+        "hideCompletedSessions": "Ẩn các phiên đã hoàn thành",
+        "hideCompletedTestRuns": "Ẩn các lần chạy thử nghiệm đã hoàn tất",
+        "caseTypeLabel": "Loại trường hợp",
+        "allCases": "Tất cả"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "Từ khóa tìm kiếm...",
+      "searchOrAddPlaceholder": "Tìm kiếm hoặc thêm thẻ...",
+      "noOptions": "Không có tùy chọn nào"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "Trình xem tệp đính kèm"
+    },
+    "delete": {
+      "confirmMessage": "Bạn có chắc chắn muốn xóa tệp đính kèm này không?",
+      "deferredMessage": "Tệp đính kèm này sẽ bị xóa khi bạn lưu."
+    }
+  },
+  "runs": {
+    "notFound": "Không tìm thấy kết quả chạy thử nghiệm.",
+    "add": {
+      "title": "Thêm Chạy thử",
+      "description": "Thêm một lượt chạy thử nghiệm mới vào dự án.",
+      "success": {
+        "title": "Đã thêm thành công lượt chạy thử nghiệm.",
+        "description": "Quá trình chạy thử nghiệm đã được thêm vào dự án.",
+        "descriptionMultiple": "{count, plural, one {# Đã tạo lượt chạy thử nghiệm} other {# Đã tạo lượt chạy thử nghiệm}} cho '{name}'"
+      },
+      "estimates": {
+        "manual": "Thời gian thao tác bằng tay ước tính",
+        "automated": "Thời gian tự động ước tính",
+        "mixed": "Thời gian ước tính thủ công/tự động"
+      },
+      "creatingProgress": "Đang tạo bản chạy thử nghiệm {current} của {total}..."
+    },
+    "magicSelect": {
+      "title": "Lựa chọn ma thuật",
+      "description": "Lựa chọn trường hợp kiểm thử dựa trên trí tuệ nhân tạo phù hợp với ngữ cảnh chạy thử nghiệm của bạn.",
+      "counting": "Đang tìm kiếm các trường hợp kiểm thử phù hợp...",
+      "reasoning": "Suy luận AI",
+      "reviewSelection": "Xem xét các trường hợp thử nghiệm được đề xuất",
+      "viewSuggested": "Xem các trường hợp được đề xuất",
+      "tokenUsage": "{total} mã thông báo được sử dụng",
+      "noLlmIntegration": "Các tính năng AI yêu cầu tích hợp LLM. Hãy cấu hình tích hợp này trong cài đặt dự án.",
+      "configure": {
+        "title": "Phạm vi trường hợp thử nghiệm",
+        "description": "Đã tìm thấy {count, plural, =1 {# trường hợp thử nghiệm} other {# trường hợp thử nghiệm}} trong kho lưu trữ",
+        "descriptionFiltered": "Đã tìm thấy {count, plural, =1 {# trường hợp kiểm thử có thể liên quan} other {# các trường hợp kiểm thử có thể liên quan}} từ {total, plural, =1 {# tổng cộng} other {# tổng cộng}} trong kho lưu trữ",
+        "noMatchesTitle": "Không tìm thấy trường hợp kiểm thử phù hợp.",
+        "noMatchesDescription": "Tên và mô tả của lần chạy thử nghiệm không khớp với bất kỳ trường hợp thử nghiệm nào. Hãy quay lại bước trước và thêm các chi tiết cụ thể hơn như tên tính năng, tên thành phần hoặc từ khóa xuất hiện trong các trường hợp thử nghiệm của bạn.",
+        "maxResultsTitle": "Số lượng tối đa các trường hợp kiểm thử khớp",
+        "maxResultsDescription": "Tiêu chí tìm kiếm khớp với một số lượng lớn các trường hợp thử nghiệm. Để có kết quả chính xác hơn, hãy quay lại bước trước và thêm thông tin chi tiết cụ thể hơn vào quá trình chạy thử nghiệm.",
+        "batchSize": "Kích thước lô",
+        "batchSizeAll": "Tất cả các trường hợp (yêu cầu đơn lẻ)",
+        "batchSizePercent": "{percent}% ({count} trường hợp)",
+        "requestsNeeded": "{count, plural, =1 {# Yêu cầu AI sẽ được thực hiện} other {# Yêu cầu AI sẽ được thực hiện}}",
+        "batchNote": "Kết quả từ tất cả các đợt sẽ được kết hợp."
+      },
+      "loading": {
+        "batch": "Đang xử lý lô {current} trong số {total}",
+        "analyzing": "Phân tích các trường hợp thử nghiệm...",
+        "progress": "Đã phân tích {analyzed} trong số {total} trường hợp thử nghiệm...",
+        "waitingForAi": "Đang chờ phản hồi từ AI (lô {batch} trong số {total})...",
+        "selectedSoFar": "{count, plural, =1 {# Số trường hợp thử nghiệm đã được chọn cho đến nay} other {# Số trường hợp thử nghiệm đã được chọn cho đến nay}}",
+        "resolving_integration": "Giải quyết vấn đề tích hợp AI...",
+        "fetching_cases": "Đang tải các trường hợp kiểm thử..."
+      },
+      "success": {
+        "title": "Các trường hợp kiểm thử được đề xuất",
+        "description": "{count, plural, =1 {# trường hợp kiểm thử được chọn} other {# các trường hợp kiểm thử được chọn}} dựa trên ngữ cảnh chạy thử của bạn",
+        "linkedCasesAdded": "{count, plural, =1 {# Tự động bao gồm các trường hợp liên kết} other {# Tự động bao gồm các trường hợp liên kết}}",
+        "truncationWarningTitle": "Kết quả sơ bộ",
+        "truncationWarning": "{count, plural, =1 {# lô đã bị cắt bớt} other {# các lô đã bị cắt bớt}} bởi mô hình AI — một số trường hợp thử nghiệm có thể chưa được đánh giá."
+      },
+      "noSuggestions": {
+        "title": "Không có trường hợp kiểm thử phù hợp",
+        "description": "Không có trường hợp thử nghiệm nào đáp ứng tiêu chí. Hãy thử bổ sung thêm ngữ cảnh hoặc làm rõ."
+      },
+      "clarification": {
+        "label": "Thông tin bổ sung (tùy chọn)",
+        "placeholder": "Hãy bổ sung thêm ngữ cảnh để giúp lựa chọn các trường hợp kiểm thử phù hợp...",
+        "refine": "Tinh chỉnh lựa chọn"
+      },
+      "actions": {
+        "start": "Phân tích các trường hợp kiểm thử",
+        "startBatched": "Phân tích các trường hợp kiểm thử ({count, plural, one {# lô} other {# lô}})",
+        "accept": "Thêm vào lựa chọn"
+      },
+      "errors": {
+        "title": "Lựa chọn thất bại",
+        "generic": "Đã xảy ra lỗi khi chọn các trường hợp kiểm thử. Vui lòng thử lại.",
+        "noTestRunName": "Vui lòng nhập tên cho lần chạy thử trước khi sử dụng Magic Select."
+      }
+    },
+    "delete": {
+      "title": "Xóa lần chạy thử nghiệm",
+      "description": "Bạn có chắc chắn muốn xóa lần chạy thử nghiệm này không? Kết quả sẽ được lưu giữ để phân tích lịch sử.",
+      "warning": "Hành động này không thể đảo ngược.",
+      "toast": {
+        "loading": "Đang xóa lần chạy thử nghiệm...",
+        "success": "Quá trình chạy thử nghiệm đã được xóa thành công.",
+        "error": {
+          "title": "Không thể xóa lần chạy thử nghiệm.",
+          "description": "Đã xảy ra lỗi khi xóa lần chạy thử nghiệm."
+        }
+      }
+    },
+    "summary": {
+      "title": "Tóm tắt quá trình chạy thử nghiệm",
+      "description": "Xem bản tóm tắt quá trình chạy thử nghiệm",
+      "activeRunsAndEstTime": "Các đợt chạy đang diễn ra & Thời gian dự kiến",
+      "activeRunsLabel": "Chạy",
+      "totalEstTime": "Tổng thời gian ước tính",
+      "responsibleUsers": "Người dùng có trách nhiệm",
+      "allActiveRuns": "Tất cả các đợt chạy đang diễn ra",
+      "recentResultsTitle": "Kết quả thủ công gần đây",
+      "recentResultsDescription": "Xem kết quả gần đây của đợt chạy thử nghiệm",
+      "recentAutomatedResultsTitle": "Kết quả tự động gần đây",
+      "noRecentAutomatedResults": "Không tìm thấy kết quả tự động gần đây nào.",
+      "recentResultsDateRange": "Khoảng thời gian",
+      "recentResultsElapsed": "Đã trôi qua",
+      "noRecentResults": "Không tìm thấy kết quả gần đây nào.",
+      "completionTrendTitle": "Xu hướng hoàn thành (6 tháng trước)",
+      "workDistributionTitle": "Phân công công việc",
+      "workDistributionDescription": "Ước tính phân bổ công việc theo người được giao.",
+      "noWorkDistributionData": "Hiện không có phiên làm việc nào đang hoạt động với người được chỉ định hoặc ước tính nào để hiển thị."
+    },
+    "details": {
+      "title": "Chi tiết về lần chạy thử nghiệm",
+      "description": "Xem chi tiết về lần chạy thử nghiệm"
+    },
+    "duplicateDialog": {
+      "title": "Chạy thử nghiệm trùng lặp",
+      "description": "Tạo bản sao của lần chạy thử nghiệm <nameStyle>{name}</nameStyle>.",
+      "fields": {
+        "duplicateScope": {
+          "label": "Các trường hợp kiểm thử cần sao chép",
+          "allCases": "Tất cả các trường hợp thử nghiệm",
+          "specificStatuses": "Các trường hợp thử nghiệm với trạng thái cụ thể"
+        },
+        "statusesToInclude": {
+          "label": "Các trường hợp kiểm thử cần bao gồm",
+          "description": "Chọn trạng thái của các trường hợp kiểm thử mà bạn muốn đưa vào lần chạy kiểm thử trùng lặp.",
+          "noStatuses": "Không tìm thấy trạng thái cụ thể nào trong lần chạy thử này, hoặc kết quả vẫn đang tải.",
+          "noStatusesRecorded": "Không có trạng thái cụ thể nào được ghi lại trong lần chạy này. Việc sao chép sẽ bao gồm tất cả các trường hợp thử nghiệm (thường được đánh dấu là 'Chưa được kiểm thử')."
+        },
+        "copyAssignments": {
+          "label": "Phân công trường hợp kiểm thử",
+          "copy": "Sao chép các gán trường hợp kiểm thử hiện có",
+          "assign": "Tất cả các trường hợp thử nghiệm trong lần chạy thử nghiệm trùng lặp sẽ giữ nguyên các thiết lập hiện có của chúng.",
+          "unassign": "Tất cả các trường hợp thử nghiệm trong lần chạy thử nghiệm trùng lặp sẽ được hủy gán."
+        }
+      },
+      "successMessage": "Đã sao chép thành công quá trình chạy thử nghiệm '{name}'.",
+      "errorMessage": "Không thể sao chép quá trình chạy thử nghiệm. Lỗi: {error}"
+    },
+    "filter": {
+      "placeholder": "Chạy thử nghiệm bộ lọc..."
+    },
+    "typeFilter": {
+      "label": "Trình diễn",
+      "both": "Thủ công & Tự động"
+    },
+    "empty": {
+      "noMatchingCompleted": "Không có kết quả chạy thử nào phù hợp với bộ lọc của bạn."
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "Chủ yếu",
+      "projects": "Dự án",
+      "templatesAndFields": "Mẫu & Trường",
+      "fields": "Các cánh đồng",
+      "workflows": "Quy trình làm việc",
+      "statuses": "Trạng thái",
+      "milestoneTypes": "Các loại cột mốc",
+      "configurations": "Cấu hình",
+      "users": "Người dùng",
+      "groups": "Nhóm",
+      "roles": "Vai trò",
+      "tags": "Thẻ",
+      "issues": "Vấn đề",
+      "appConfig": "Cấu hình ứng dụng",
+      "notifications": "Thông báo",
+      "imports": "Nhập dữ liệu",
+      "integrations": "Tích hợp vấn đề",
+      "webhooks": "Webhooks",
+      "llm": "Mô hình AI",
+      "prompts": "Cấu hình nhắc nhở",
+      "exportTemplates": "Mẫu xuất khẩu",
+      "codeRepositories": "Kho lưu trữ mã nguồn",
+      "quickScript": "QuickScript",
+      "sso": "Xác thực",
+      "security": "Bảo vệ",
+      "trash": "Rác",
+      "reports": "Báo cáo",
+      "shares": "Quản lý cổ phần",
+      "elasticsearch": "Công cụ tìm kiếm",
+      "queues": "Hàng đợi công việc",
+      "auditLogs": "Nhật ký kiểm toán",
+      "apiTokens": "Mã thông báo API",
+      "quickscriptTemplates": "Mẫu QuickScript",
+      "testManagement": "Quản lý kiểm thử",
+      "peopleAndAccess": "Con người & Quyền truy cập",
+      "toolsAndIntegrations": "Công cụ & Tích hợp",
+      "system": "Hệ thống"
+    },
+    "imports": {
+      "description": "Tích hợp dữ liệu từ các công cụ quản lý kiểm thử bên ngoài vào TestPlanIt.",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "Tải lên tệp xuất JSON của Testmo để phân tích nội dung và chuẩn bị bản đồ di chuyển của bạn.",
+        "wizard": {
+          "steps": {
+            "upload": "Tải lên xuất khẩu",
+            "analysis": "Phân tích đánh giá",
+            "mapping": "Cấu hình ánh xạ",
+            "import": "Nhập màn hình"
+          },
+          "stepIndicator": "Bước {step} của {total}"
+        },
+        "fileLabel": "Tệp JSON Testmo",
+        "fileHelp": "Chọn tệp xuất JSON mà bạn đã tải xuống từ Testmo.",
+        "analyze": "Phân tích xuất khẩu",
+        "analyzing": "Đang phân tích...",
+        "reset": "Kết quả rõ ràng",
+        "job": {
+          "discoveringDatasets": "Khám phá các tập dữ liệu...",
+          "scanningFile": "Đang quét tập tin xuất testmo...",
+          "datasetsProcessed": "{processed, number} tập dữ liệu{processed, plural, one {} other {s}} đã xử lý",
+          "datasetsProcessedWithTotal": "{processed, number} của {total, number} tập dữ liệu{total, plural, one {} other {s}} đã được xử lý",
+          "rowsProcessed": "{value, number} hàng đã được xử lý",
+          "itemsProcessed": "{processed, number} trong số {total, number} mục đã được xử lý",
+          "analysisInProgress": "Phân tích xuất khẩu…",
+          "cancel": "Hủy nhập khẩu",
+          "cancelRequested": "Yêu cầu hủy",
+          "processingRate": "Tỷ lệ:",
+          "estimatedTimeRemaining": "Thời gian còn lại ước tính:",
+          "datasetsLabel": "Bộ dữ liệu:",
+          "rowsProcessedLabel": "Hàng:"
+        },
+        "summaryHeading": "Tóm tắt xuất khẩu",
+        "summary": {
+          "datasets": "Bộ dữ liệu",
+          "fileName": "Tên tệp",
+          "fileSize": "Kích thước tệp",
+          "analysisTime": "Thời gian phân tích"
+        },
+        "datasetTable": {
+          "name": "Tập dữ liệu",
+          "rows": "Hàng",
+          "samples": "Các mẫu vật được thu thập"
+        },
+        "status": {
+          "truncated": "bị cắt ngắn"
+        },
+        "selectDataset": "Chọn tập dữ liệu",
+        "schema": "Sơ đồ",
+        "samples": "Hàng mẫu",
+        "noSamples": "Không có mẫu nào được thu thập cho tập dữ liệu này.",
+        "mappingHeading": "Cấu hình ánh xạ",
+        "mappingRefresh": "Phân tích làm mới",
+        "mappingDescription": "Xem lại chi tiết phân tích và ánh xạ các thực thể Testmo vào các bản ghi TestPlanIt hiện có, hoặc chọn tạo các bản ghi mới.",
+        "mappingAnalysisError": "Chúng tôi không thể tạo phân tích bản đồ. Hãy thử lại.",
+        "mappingLoading": "Phân tích lập bản đồ tòa nhà…",
+        "mappingSummaryHeading": "Các thực thể được phát hiện",
+        "mappingSummaryPending": "{count, plural, =1 {# đang chờ xử lý} other {# đang chờ xử lý}}",
+        "mappingOutstandingTitle": "Giải quyết các vấn đề lập bản đồ còn tồn đọng",
+        "mappingOutstandingDescription": "Hoàn tất các thiết lập ánh xạ còn lại trước khi bắt đầu nhập dữ liệu.",
+        "mappingOutstandingItem": "{count, plural, =1 {# mục chưa được giải quyết} other {# các mục chưa được giải quyết}} trong {label}",
+        "mappingSummaryTemplateFields": "Các trường mẫu",
+        "mappingDatasetLabels": {
+          "field_values": "Giá trị trường",
+          "repository_case_values": "Giá trị trường hợp kho lưu trữ",
+          "configs": "Cài đặt cấu hình",
+          "session_issues": "Các vấn đề về phiên",
+          "session_tags": "Thẻ phiên",
+          "states": "Trạng thái quy trình làm việc",
+          "statuses": "Trạng thái",
+          "templates": "Mẫu",
+          "template_fields": "Các trường mẫu",
+          "milestone_types": "Các loại cột mốc",
+          "roles": "Vai trò",
+          "users": "Người dùng",
+          "groups": "Nhóm",
+          "user_groups": "Nhóm người dùng",
+          "issue_targets": "Tích hợp vấn đề",
+          "tags": "Thẻ",
+          "sessions": "Phiên họp",
+          "session_results": "Kết quả phiên",
+          "fields": "Các cánh đồng",
+          "projects": "Dự án",
+          "repositories": "Kho lưu trữ",
+          "repository_folders": "Thư mục kho lưu trữ",
+          "repository_cases": "Các trường hợp lưu trữ",
+          "repository_case_steps": "Các bước xử lý trường hợp kho lưu trữ",
+          "repository_case_tags": "Thẻ trường hợp kho lưu trữ",
+          "milestones": "Các cột mốc",
+          "runs": "Chạy thử nghiệm",
+          "run_tests": "Các trường hợp chạy thử nghiệm",
+          "run_results": "Kết quả chạy thử nghiệm",
+          "run_result_steps": "Kết quả bước chạy thử nghiệm",
+          "run_links": "Liên kết chạy thử nghiệm",
+          "run_tags": "Thẻ chạy thử nghiệm",
+          "issues": "Vấn đề",
+          "milestone_issues": "Các vấn đề quan trọng",
+          "repository_case_issues": "Các vấn đề về kho lưu trữ",
+          "run_issues": "Sự cố khi chạy thử nghiệm",
+          "run_result_issues": "Các vấn đề về kết quả chạy thử nghiệm",
+          "session_result_issues": "Các vấn đề về kết quả phiên",
+          "automation_cases": "Các trường hợp tự động hóa",
+          "automation_runs": "Tự động hóa chạy",
+          "automation_run_tests": "Chạy thử nghiệm tự động",
+          "automation_run_test_fields": "Các trường kiểm thử chạy tự động",
+          "automation_run_links": "Liên kết chạy tự động hóa",
+          "automation_run_tags": "Thẻ chạy tự động",
+          "session_values": "Giá trị phiên"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "Xem lại các trạng thái quy trình làm việc để lập bản đồ hoặc tạo các quy trình làm việc TestPlanIt.",
+          "statuses": "Cấu hình cách các trạng thái của Testmo được ánh xạ tới các trạng thái của TestPlanIt.",
+          "templates": "Xem lại các định nghĩa mẫu được nhập từ Testmo.",
+          "template_fields": "Kiểm tra định nghĩa các trường mẫu có trong tệp xuất.",
+          "fields": "Xem lại các bản ghi trường tùy chỉnh đã được xuất từ Testmo.",
+          "field_values": "Kiểm tra định nghĩa giá trị trường được ghi lại trong quá trình xuất dữ liệu.",
+          "milestone_types": "Kiểm tra các định nghĩa loại mốc quan trọng được ghi lại trong dữ liệu xuất.",
+          "roles": "Xem lại định nghĩa vai trò để hiểu rõ quyền hạn trong Testmo.",
+          "users": "Xem các tài khoản người dùng được phát hiện trong dữ liệu xuất của Testmo.",
+          "groups": "Xem lại các bài tập nhóm được giao từ Testmo.",
+          "configs": "Ánh xạ tên cấu hình với các danh mục và biến thể của TestPlanIt.",
+          "tags": "Kiểm tra các giá trị thẻ xuất hiện trong dữ liệu Testmo.",
+          "repository_case_values": "Chọn nhiều giá trị được gán cho các trường hợp kiểm thử.",
+          "sessions": "Các phiên luôn được tạo dưới dạng phiên mới.",
+          "session_results": "Kết quả phiên được liên kết với các phiên.",
+          "session_issues": "Các vấn đề về phiên làm việc có liên quan đến chính các phiên làm việc đó.",
+          "session_tags": "Thẻ phiên được liên kết với các phiên.",
+          "issue_targets": "Ánh xạ các mục tiêu vấn đề của Testmo với các tích hợp của TestPlanIt (Jira, GitHub, v.v.)."
+        },
+        "mappingDatasetDefaultDescription": "Đã phát hiện đánh giá {dataset} trong quá trình xuất Testmo.",
+        "mappingDatasetCount": "{count, number} bản ghi{count, plural, one {} other {s}} được phát hiện",
+        "mappingDatasetNoEntitiesTitle": "Không có gì để lập bản đồ",
+        "mappingDatasetNoEntitiesDescription": "Bộ dữ liệu này không cần ánh xạ. Hãy chuyển sang bộ dữ liệu tiếp theo khi bạn đã sẵn sàng.",
+        "mappingDatasetUnsupportedTitle": "Không cần lập bản đồ",
+        "mappingDatasetUnsupportedDescription": "Các bản ghi này sẽ được tự động nhập và kết nối với các bản ghi liên quan trong TestPlanIt. Không cần phải thực hiện việc đối chiếu thủ công.",
+        "mappingDatasetEmptyTitle": "Không có bộ dữ liệu nào được lưu giữ.",
+        "mappingDatasetEmptyDescription": "Quá trình phân tích không lưu giữ bất kỳ tập dữ liệu nào để cấu hình. Vui lòng tải lên một bản xuất khác nếu bạn cần thêm dữ liệu.",
+        "importProgressTitle": "Tiến độ nhập khẩu",
+        "importProgressDescription": "{count, plural, =0 {Tất cả bản ghi đã được nhập từ các thực thể được theo dõi.} =1 {Còn lại 1 bản ghi từ các thực thể được theo dõi.} other {Số bản ghi còn lại từ các thực thể được theo dõi.}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {Không còn bản ghi nào} =1 {Còn lại 1 bản ghi} other {Còn lại # bản ghi}}",
+        "importProgressProcessed": "{processed, number}/{total, number} bản ghi được nhập",
+        "importProgressAria": "{percent}% nhập khẩu hoàn tất",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "Tổng thời gian:",
+        "activityLogTitle": "Hoạt động nhập khẩu",
+        "activityLogDescription": "Nhật ký chi tiết các bước nhập dữ liệu nền. Dấu thời gian dựa trên múi giờ của máy chủ.",
+        "activitySummaryProcessed": "{count, plural, =1 {# bản ghi đã được xử lý} other {# bản ghi đã được xử lý}}",
+        "activitySummaryCreated": "{count, plural, =1 {# đã tạo} other {# đã tạo}}",
+        "activitySummaryMapped": "{count, plural, =1 {# đã ánh xạ} other {# đã ánh xạ}}",
+        "activitySummaryUnknown": "Bước nhập khẩu",
+        "activityDefaultMessage": "Nhập bản cập nhật",
+        "previousImportsHeading": "Xem lại các lần nhập khẩu trước đó",
+        "previousImportsDescription": "Phân tích tải kết quả từ quá trình nhập dữ liệu hoàn tất để kiểm tra cấu hình hoặc nhật ký hoạt động.",
+        "previousImportsRefresh": "Làm mới danh sách",
+        "previousImportsPlaceholder": "Chọn một lần nhập trước đó",
+        "previousImportsEmpty": "Không tìm thấy dữ liệu nhập trước đó cho tài khoản của bạn.",
+        "previousImportsCreatedLabel": "Tạo: ",
+        "previousImportsFileLabel": "Tài liệu: ",
+        "previousImportsNoFilename": "Tệp không xác định",
+        "jobHistoryLoadFailed": "Chúng tôi không thể tải các công việc đã nhập trước đó.",
+        "jobLoadFailed": "Chúng tôi không thể tải công việc nhập dữ liệu đó.",
+        "uploadProgressAnalyzing": "Tải lên hoàn tất. Đang phân tích tệp…",
+        "uploadProgressComplete": "Quá trình tải lên hoàn tất",
+        "etaLabel": "Thời gian dự kiến hoàn thành: {time}",
+        "startImportButton": "Bắt đầu nhập khẩu",
+        "workflowCreate": {
+          "nameLabel": "Tên quy trình làm việc",
+          "namePlaceholder": "Nhập tên quy trình làm việc",
+          "scopePlaceholder": "Chọn phạm vi",
+          "iconColorLabel": "Biểu tượng & màu sắc",
+          "typeLabel": "Loại quy trình làm việc"
+        },
+        "mappingDatasets": "Các bộ dữ liệu cần được xem xét",
+        "mappingImportConfiguration": "Nhập cấu hình",
+        "mappingExportConfiguration": "Cấu hình xuất",
+        "mappingImportConfigurationFailed": "Chúng tôi không thể nhập tệp cấu hình đó. Vui lòng kiểm tra xem đó có phải là JSON hợp lệ hay không và thử lại.",
+        "mappingInvalidConfiguration": "Cấu hình phải là định dạng JSON hợp lệ.",
+        "mappingSaveFailed": "Không thể lưu cấu hình. Vui lòng thử lại.",
+        "mappingSaveConfiguration": "Lưu cấu hình",
+        "mappingSavingConfiguration": "Đang lưu…",
+        "mappingStartImport": "Bắt đầu nhập dữ liệu nền",
+        "mappingStartingImport": "Bắt đầu nhập khẩu…",
+        "mappingImportFailed": "Không thể bắt đầu quá trình nhập dữ liệu nền. Vui lòng thử lại.",
+        "mappingImportDisabled": "Hãy lưu cấu hình trước khi bắt đầu quá trình nhập dữ liệu nền.",
+        "mappingImportInProgress": "Đang nhập dữ liệu nền",
+        "mappingImportInProgressDescription": "Công cụ nhập dữ liệu đang xử lý cấu hình. Bạn có thể theo dõi trạng thái ở trên.",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# bản ghi} other {# bản ghi}} ",
+          "columnSource": "Thực thể Testmo",
+          "columnSourceDetails": "Chi tiết",
+          "columnSuggestedWorkflowType": "Loại được đề xuất",
+          "columnTarget": "Mục tiêu",
+          "workflowTypeUnknown": "Không phát hiện",
+          "actionMap": "Ánh xạ tới hệ thống hiện có",
+          "actionCreate": "Tạo mới",
+          "workflowTypePlaceholder": "Chọn loại",
+          "noWorkflowsAvailable": "Hiện không có quy trình làm việc nào.",
+          "noStatusesAvailable": "Hiện không có thông tin trạng thái nào.",
+          "noGroupsAvailable": "Hiện không có nhóm nào.",
+          "groupSelectPlaceholder": "Chọn nhóm",
+          "groupNotePlaceholder": "Ghi chú (tùy chọn)",
+          "groupNoteEmpty": "Không có thông tin chi tiết bổ sung nào được cung cấp.",
+          "noUsersAvailable": "Hiện không có người dùng nào.",
+          "userNoExistingTargets": "Hiện không có người dùng nào để lập bản đồ.",
+          "userNamePlaceholder": "Họ và tên đầy đủ",
+          "userAccessPlaceholder": "Chọn cấp độ truy cập",
+          "userRoleUnavailable": "Hiện không có vai trò nào để phân công.",
+          "userPasswordPlaceholder": "Mật khẩu tạm thời",
+          "userPasswordHint": "Cung cấp mật khẩu tạm thời. Người dùng có thể thay đổi mật khẩu sau khi đăng nhập.",
+          "userActiveLabel": "Tài khoản đang hoạt động",
+          "userDisplayFallback": "Người dùng {id}",
+          "userMissingRequired": "Thiếu thông tin cần thiết",
+          "noConfigurationsAvailable": "Không có cấu hình nào khả dụng.",
+          "configurationNoTokens": "Không phát hiện thấy biến thể nào trong cấu hình này.",
+          "configurationNoExistingTargets": "Hiện không có cấu hình nào để ánh xạ.",
+          "configurationNamePlaceholder": "Nhập tên cấu hình",
+          "configurationVariantLabel": "Biến thể {index}",
+          "configurationVariantActionLabel": "Nên xử lý biến thể này như thế nào?",
+          "configurationVariantActionPlaceholder": "Chọn một tùy chọn",
+          "configurationVariantMapOption": "Ánh xạ tới biến thể hiện có",
+          "configurationVariantExistingCategoryOption": "Tạo biến thể trong danh mục hiện có",
+          "configurationVariantNewCategoryOption": "Tạo danh mục và biến thể mới",
+          "configurationVariantSelectLabel": "Chọn biến thể",
+          "configurationVariantNoVariants": "Không có biến thể nào để lập bản đồ.",
+          "configurationVariantCategoryLabel": "Loại",
+          "configurationVariantNameLabel": "Tên biến thể",
+          "configurationVariantNamePlaceholder": "Nhập tên biến thể",
+          "configurationVariantNoCategories": "Hiện không có danh mục nào.",
+          "configurationVariantCategoryNameLabel": "Tên danh mục",
+          "configurationVariantCategoryNamePlaceholder": "Nhập tên danh mục",
+          "noTemplateFieldsAvailable": "Không có trường mẫu nào.",
+          "templateFieldDisplayFallback": "Trường {id}",
+          "templateFieldUnknownTemplate": "Mẫu không xác định",
+          "templateFieldTargetCase": "Trường hợp",
+          "templateFieldTargetResult": "Trường kết quả",
+          "templateFieldSelectPlaceholder": "Chọn trường",
+          "templateFieldNoExistingTargets": "Hiện không có khu vực nào để lập bản đồ.",
+          "templateFieldTypePlaceholder": "Chọn loại trường",
+          "templateFieldRestrictedLabel": "Trường bị hạn chế",
+          "templateFieldOptionsLabel": "Tùy chọn thả xuống",
+          "templateFieldOptionsPlaceholder": "Nhập một lựa chọn trên mỗi dòng.",
+          "templateFieldOptionsHint": "Phân tách mỗi lựa chọn bằng một dòng mới.",
+          "templateFieldOptionsListLabel": "Tùy chọn",
+          "templateFieldOptionsCheckedLabel": "Được chọn mặc định",
+          "templateFieldOptionsMinValueLabel": "Giá trị tối thiểu",
+          "templateFieldOptionsMaxValueLabel": "Giá trị tối đa",
+          "templateFieldOptionsMinIntegerLabel": "Số nguyên tối thiểu",
+          "templateFieldOptionsMaxIntegerLabel": "Số nguyên tối đa",
+          "templateFieldNewFieldSummaryTitle": "Chi tiết trường mới",
+          "templateFieldNewFieldSummaryDescription": "Hãy xem lại các giá trị sẽ được sử dụng để tạo trường TestPlanIt này.",
+          "templateFieldConfigureFieldButton": "Cấu hình chi tiết",
+          "templateFieldEditFieldButton": "Chỉnh sửa chi tiết",
+          "templateFieldSummaryMissingValue": "Chưa được thiết lập",
+          "templateFieldSummaryMissingDetailsHint": "Vui lòng cung cấp thông tin chi tiết về trường mới trước khi tiếp tục.",
+          "templateFieldModalSaveButton": "Lưu chi tiết",
+          "templateFieldTargetTypeLabel": "Loại mục tiêu",
+          "templateFieldTypeMismatchWarning": "Loại trường đã chọn {target} không khớp với loại trường Testmo {source}.",
+          "templateFieldDuplicateTargetWarning": "Mục tiêu đã chọn đã được ánh xạ tới một trường Testmo khác. Vui lòng chọn một mục tiêu khác.",
+          "templateFieldTargetAlreadyUsed": "Đã được lập bản đồ",
+          "templateFieldMappedSummary": "Được ánh xạ tới {name} ({type})",
+          "templateFieldIssueMissingTarget": "Chọn một lĩnh vực mục tiêu.",
+          "templateFieldIssueMissingDetails": "Vui lòng cung cấp tên hiển thị, tên hệ thống và loại trường trước khi tiếp tục.",
+          "noTemplatesAvailable": "Hiện không có mẫu nào.",
+          "templateColumnFields": "Các cánh đồng",
+          "templateFieldStatusMapped": "Đã lập bản đồ",
+          "templateFieldStatusCreate": "Tạo trường mới",
+          "templateFieldStatusMissing": "Chưa được lập bản đồ",
+          "templateFieldStatusMismatch": "Sai lệch mục tiêu",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# trường case} other {# trường case}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# trường kết quả} other {# các trường kết quả}}",
+          "templateMapLabel": "Ánh xạ tới mẫu hiện có",
+          "templateCreateLabel": "Tạo mẫu mới",
+          "templateNoMatchingTargets": "Không tìm thấy mẫu phù hợp.",
+          "templateNewNameLabel": "Tên mẫu",
+          "templateMapHintIncomplete": "Trước khi ánh xạ tất cả các trường của Testmo vào các trường dữ liệu và kết quả hiện có, hãy ánh xạ chúng vào một mẫu có sẵn.",
+          "templateMapHintDuplicate": "Mỗi trường trong Testmo phải tương ứng với một trường duy nhất trong TestPlanIt.",
+          "templateMapHintNoMatch": "Không có mẫu nào hiện có sử dụng cùng một tập hợp các trường.",
+          "templateMapHintAlreadyMapped": "Tất cả các mẫu phù hợp đã được ánh xạ. Hãy xóa các ánh xạ khác trước khi tiếp tục.",
+          "templateIssueNoSelection": "Chọn một mẫu có sẵn để ánh xạ.",
+          "templateIssueTargetConflict": "Một mẫu khác đã được ánh xạ tới mục tiêu này.",
+          "templateIssueFieldErrors": "Giải quyết các trường mẫu được đánh dấu.",
+          "templateTargetFieldsMismatch": "Các trường không khớp với mẫu này.",
+          "templateTargetNoLongerMatching": "Các trường thông tin không còn khớp với mẫu này nữa.",
+          "noRolesAvailable": "Hiện không có vị trí nào trống.",
+          "roleSelectPlaceholder": "Chọn vai trò",
+          "roleNameLabel": "Tên vai trò",
+          "roleNamePlaceholder": "Nhập tên vai trò",
+          "rolePermissionsEmpty": "Chưa có quyền nào được chỉ định.",
+          "rolePermissionAddEdit": "Thêm/Chỉnh sửa",
+          "noMilestoneTypesAvailable": "Không có loại mốc thời gian nào khả dụng.",
+          "milestoneSelectPlaceholder": "Chọn loại mốc thời gian",
+          "milestoneNamePlaceholder": "Nhập tên loại mốc thời gian",
+          "milestoneDefaultLabel": "Loại mốc mặc định",
+          "milestoneIconRequired": "Chọn một biểu tượng",
+          "statusColorPlaceholder": "Mã màu hex (tùy chọn)",
+          "issueTargetSelectPlaceholder": "Chọn tích hợp...",
+          "noIssueTargetsAvailable": "Không có tích hợp vấn đề nào khả dụng",
+          "issueTargetNamePlaceholder": "Tên tích hợp...",
+          "templateFieldsHeading": "Các trường mẫu",
+          "roleAreaColumn": "Khu vực",
+          "workflowSelectPlaceholder": "Chọn quy trình làm việc",
+          "statusSelectPlaceholder": "Chọn trạng thái",
+          "statusNamePlaceholder": "Nhập tên trạng thái",
+          "statusSystemNamePlaceholder": "Nhập tên hệ thống",
+          "labelSystemName": "Tên hệ thống",
+          "groupNamePlaceholder": "Nhập tên nhóm",
+          "configurationNameLabel": "Tên cấu hình",
+          "userSelectPlaceholder": "Chọn người dùng",
+          "userApiLabel": "Người dùng API",
+          "templateCaseFieldsLabel": "Trường hợp",
+          "templateResultFieldsLabel": "Các trường kết quả",
+          "templateNoFieldsPlaceholder": "Hiện chưa có trường nào được cấu hình cho mẫu này.",
+          "templateTargetAlreadyUsed": "Mục tiêu đã được ánh xạ tới một mẫu khác.",
+          "templateFieldRequiredLabel": "Trường bắt buộc",
+          "templateFieldOptionsDefaultValueLabel": "Giá trị mặc định",
+          "templateFieldOptionsInitialHeightLabel": "Chiều cao ban đầu",
+          "templateFieldTemplateLabelSingular": "bản mẫu",
+          "templateFieldTemplateLabelPlural": "mẫu",
+          "templateFieldTargetGroupCase": "Trường hợp",
+          "templateFieldTargetGroupResult": "Các trường kết quả",
+          "columnAction": "Hoạt động"
+        },
+        "nextSteps": "Sau khi quá trình nhập dữ liệu nền hoàn tất, bạn có thể xem lại dữ liệu đã được di chuyển từ các dự án đích.",
+        "nextStepsDescription": "Quá trình nhập dữ liệu nền diễn ra bất đồng bộ. Bạn có thể theo dõi trạng thái ở trên hoặc làm mới trang để xem cập nhật."
+      },
+      "comingSoon": {
+        "description": "Việc nhập dữ liệu từ TestRail, Zephyr và các công cụ khác đang nằm trong kế hoạch phát triển."
+      },
+      "errors": {
+        "fileRequired": "Vui lòng chọn tệp JSON xuất của Testmo trước khi phân tích.",
+        "uploadFailed": "Chúng tôi không thể tải tệp xuất lên bộ nhớ. Vui lòng thử lại.",
+        "analysisFailed": "Chúng tôi không thể phân tích dữ liệu xuất khẩu đó. Vui lòng kiểm tra lại tệp và thử lại."
+      }
+    },
+    "sso": {
+      "description": "Quản lý cài đặt xác thực và bảo mật",
+      "sections": {
+        "providers": {
+          "title": "Nhà cung cấp đăng nhập",
+          "description": "Cấu hình cách người dùng có thể đăng nhập vào ứng dụng của bạn."
+        },
+        "security": {
+          "title": "Bảo vệ",
+          "description": "Cấu hình các chính sách bảo mật cho việc xác thực"
+        }
+      },
+      "globalSettings": {
+        "title": "Cài đặt SSO toàn cầu",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "Bật hoặc tắt xác thực Google OAuth"
+        },
+        "samlProvider": {
+          "title": "Nhà cung cấp SAML",
+          "description": "Bật hoặc tắt xác thực SAML"
+        },
+        "apple": {
+          "title": "Đăng nhập bằng Apple",
+          "description": "Bật hoặc tắt xác thực Đăng nhập bằng Apple"
+        },
+        "microsoft": {
+          "title": "Đăng nhập một lần của Microsoft",
+          "description": "Bật hoặc tắt xác thực Microsoft (Azure AD / Entra ID)"
+        },
+        "magicLink": {
+          "title": "Xác thực liên kết ma thuật",
+          "description": "Bật hoặc tắt xác thực qua email không cần mật khẩu"
+        },
+        "forceSso": {
+          "title": "Buộc đăng nhập SSO",
+          "description": "Vô hiệu hóa đăng nhập bằng email và yêu cầu người dùng sử dụng SSO."
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "Yêu cầu xác thực hai yếu tố (2FA) khi đăng nhập bằng mật khẩu.",
+            "description": "Người dùng đăng nhập bằng email/mật khẩu phải thiết lập và sử dụng xác thực hai yếu tố."
+          },
+          "forceAllLogins": {
+            "title": "Yêu cầu xác thực hai yếu tố (2FA) cho tất cả các lần đăng nhập.",
+            "description": "Tất cả người dùng phải xác thực bằng xác thực hai yếu tố (2FA) sau khi đăng nhập, bao gồm cả người dùng SSO."
+          }
+        }
+      },
+      "providers": {
+        "configure": "Cấu hình SAML",
+        "delete": "Xóa nhà cung cấp",
+        "entryPoint": "Điểm vào: ",
+        "autoProvision": "Tự động cấp phép: ",
+        "defaultAccess": "Quyền truy cập mặc định: ",
+        "configurationMessage": "Cấu hình SAML chưa được thiết lập. Nhấp vào nút cài đặt để cấu hình."
+      },
+      "samlConfiguration": {
+        "title": "Cấu hình nhà cung cấp SAML",
+        "backButton": "Quay lại trang Nhà cung cấp SSO",
+        "description": "Cấu hình cài đặt SAML cho {name}",
+        "samlSettings": {
+          "title": "Cài đặt SAML",
+          "description": "Cấu hình cài đặt nhà cung cấp danh tính SAML của bạn",
+          "ssoUrl": "URL SSO (Điểm truy cập)",
+          "entityId": "Mã định danh tổ chức (Người phát hành)",
+          "certificate": "Chứng chỉ X.509",
+          "callbackUrl": "URL gọi lại",
+          "logoutUrl": "URL đăng xuất (Tùy chọn)"
+        },
+        "userProvisioning": {
+          "title": "Cấp phép người dùng",
+          "description": "Cấu hình cách tạo và phân bổ người dùng.",
+          "autoProvision": "Tự động cấp phát tài khoản cho người dùng mới",
+          "defaultAccess": "Quyền truy cập hệ thống mặc định dành cho người dùng mới",
+          "accessDescription": "Người dùng mới sẽ được chỉ định vai trò mặc định từ cơ sở dữ liệu và cấp độ truy cập hệ thống này."
+        },
+        "attributeMapping": {
+          "title": "Ánh xạ thuộc tính",
+          "description": "Ánh xạ các thuộc tính SAML tới các trường người dùng",
+          "email": "Thuộc tính email",
+          "displayName": "Thuộc tính tên hiển thị",
+          "userId": "Thuộc tính ID người dùng",
+          "firstName": "Thuộc tính Tên (Tùy chọn)",
+          "lastName": "Thuộc tính Họ (Tùy chọn)",
+          "groups": "Thuộc tính nhóm (Tùy chọn)"
+        }
+      },
+      "messages": {
+        "googleEnabled": "Đã bật Google OAuth",
+        "googleDisabled": "Google OAuth đã bị vô hiệu hóa",
+        "googleCreated": "Nhà cung cấp OAuth của Google đã được tạo.",
+        "googleUpdateFailed": "Không thể cập nhật Google OAuth.",
+        "samlCreated": "Nhà cung cấp SAML đã được tạo",
+        "createFailed": "Không thể tạo nhà cung cấp",
+        "deleted": "Nhà cung cấp đã bị xóa",
+        "deleteFailed": "Không thể xóa nhà cung cấp",
+        "enabled": "Nhà cung cấp đã kích hoạt",
+        "disabled": "Nhà cung cấp đã bị vô hiệu hóa",
+        "updateFailed": "Không thể cập nhật nhà cung cấp",
+        "forceSsoEnabled": "Buộc bật SSO trên toàn cầu",
+        "forceSsoDisabled": "Buộc sử dụng SSO đã bị vô hiệu hóa trên toàn cầu.",
+        "forceSsoUpdateFailed": "Không thể cập nhật cài đặt SSO bắt buộc.",
+        "force2FANonSSOEnabled": "Cần xác thực hai yếu tố để đăng nhập bằng mật khẩu.",
+        "force2FANonSSODisabled": "Không còn yêu cầu xác thực hai yếu tố đối với việc đăng nhập bằng mật khẩu.",
+        "force2FAAllLoginsEnabled": "Yêu cầu xác thực hai yếu tố cho tất cả các lần đăng nhập.",
+        "force2FAAllLoginsDisabled": "Xác thực hai yếu tố không còn bắt buộc đối với tất cả các lần đăng nhập.",
+        "force2FAUpdateFailed": "Không thể cập nhật cài đặt xác thực hai yếu tố.",
+        "configUpdated": "Cấu hình SAML đã được cập nhật",
+        "configCreated": "Cấu hình SAML đã được tạo",
+        "configSaveFailed": "Không thể lưu cấu hình SAML.",
+        "googleConfigSaved": "Cấu hình Google OAuth đã được lưu thành công.",
+        "googleConfigFailed": "Không thể lưu cấu hình",
+        "appleEnabled": "Đăng nhập bằng Apple đã được bật.",
+        "appleDisabled": "Đăng nhập bằng Apple đã bị vô hiệu hóa",
+        "appleCreated": "Nhà cung cấp đăng nhập Apple đã được tạo.",
+        "appleConfigSaved": "Cấu hình đăng nhập Apple đã được lưu thành công.",
+        "appleConfigFailed": "Không thể lưu cấu hình Đăng nhập Apple.",
+        "appleUpdateFailed": "Không thể cập nhật nhà cung cấp đăng nhập Apple.",
+        "microsoftEnabled": "Đã bật SSO của Microsoft",
+        "microsoftDisabled": "Microsoft SSO đã bị vô hiệu hóa",
+        "microsoftCreated": "Nhà cung cấp SSO của Microsoft đã được tạo.",
+        "microsoftConfigSaved": "Cấu hình SSO của Microsoft đã được lưu thành công.",
+        "microsoftConfigFailed": "Không thể lưu cấu hình Microsoft SSO.",
+        "microsoftUpdateFailed": "Không thể cập nhật nhà cung cấp SSO của Microsoft.",
+        "magicLinkEnabled": "Xác thực Magic Link đã được kích hoạt.",
+        "magicLinkDisabled": "Xác thực Magic Link đã bị vô hiệu hóa",
+        "magicLinkCreated": "Nhà cung cấp Magic Link đã tạo ra",
+        "magicLinkUpdateFailed": "Không thể cập nhật nhà cung cấp Magic Link.",
+        "samlConfigSaved": "Cấu hình SAML đã được lưu thành công.",
+        "configureFirst": "Vui lòng cấu hình nhà cung cấp trước khi kích hoạt nó.",
+        "domainRestrictionEnabled": "Đã bật hạn chế tên miền email.",
+        "domainRestrictionDisabled": "Hạn chế tên miền email đã bị vô hiệu hóa.",
+        "domainRestrictionUpdateFailed": "Không thể cập nhật cài đặt hạn chế tên miền.",
+        "domainRequired": "Vui lòng nhập tên miền",
+        "invalidDomain": "Vui lòng nhập một tên miền hợp lệ (ví dụ: example.com)",
+        "domainAdded": "Tên miền đã được thêm thành công.",
+        "domainExists": "Tên miền này đã có trong danh sách được cho phép.",
+        "domainAddFailed": "Thêm tên miền không thành công",
+        "domainEnabled": "Tên miền đã được kích hoạt",
+        "domainDisabled": "Tên miền đã bị vô hiệu hóa",
+        "domainUpdateFailed": "Không thể cập nhật tên miền.",
+        "domainDeleted": "Tên miền đã được xóa thành công",
+        "domainDeleteFailed": "Không thể xóa tên miền",
+        "defaultAccessUpdated": "Cấp độ truy cập mặc định đã được cập nhật",
+        "defaultAccessUpdateFailed": "Không thể cập nhật cấp độ truy cập mặc định.",
+        "emailVerificationEnabled": "Hiện tại, người dùng mới bắt buộc phải xác minh email.",
+        "emailVerificationDisabled": "Việc xác minh email không còn bắt buộc đối với người dùng mới.",
+        "emailVerificationDisabledAndVerified": "Xác minh email đã bị vô hiệu hóa và {count, plural, one {# tài khoản người dùng} other {# tài khoản người dùng}} đã được xác minh",
+        "emailVerificationUpdateFailed": "Không thể cập nhật cài đặt xác minh email.",
+        "emailServerNotConfigured": "Không thể bật xác minh email: Máy chủ email chưa được cấu hình.",
+        "openRegistrationEnabled": "Chức năng tự đăng ký hiện đã được kích hoạt.",
+        "openRegistrationDisabled": "Chức năng tự đăng ký hiện đã bị vô hiệu hóa.",
+        "openRegistrationUpdateFailed": "Không thể cập nhật cài đặt tự đăng ký."
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "Cấu hình Google OAuth",
+          "description": "Thiết lập thông tin xác thực máy khách Google OAuth của bạn. Bạn có thể lấy thông tin này từ Bảng điều khiển Google Cloud.",
+          "clientIdPlaceholder": "ID máy khách OAuth của Google của bạn",
+          "clientSecretPlaceholder": "Mã bí mật máy khách Google OAuth của bạn",
+          "instructions": {
+            "title": "Để có được những thông tin đăng nhập này:",
+            "step1": "Truy cập vào Bảng điều khiển Google Cloud.",
+            "step2": "Chọn dự án của bạn hoặc tạo dự án mới.",
+            "step3": "Kích hoạt API Google+",
+            "step4": "Vào mục Thông tin xác thực và tạo ID máy khách OAuth 2.0.",
+            "step5": "Đặt URI chuyển hướng được ủy quyền thành:"
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "Cả ID khách hàng và mã bí mật khách hàng đều cần thiết."
+          }
+        },
+        "microsoft": {
+          "title": "Cấu hình Microsoft SSO",
+          "description": "Thiết lập thông tin đăng nhập ứng dụng Microsoft Entra ID (Azure AD). Bạn có thể lấy thông tin này từ Cổng thông tin Azure.",
+          "clientIdPlaceholder": "Mã định danh ứng dụng (khách hàng) của bạn",
+          "clientSecretPlaceholder": "Giá trị bí mật của khách hàng của bạn",
+          "tenantId": "Mã số người thuê (Tùy chọn)",
+          "tenantIdPlaceholder": "ID thư mục (người thuê) của bạn",
+          "tenantIdHint": "Để trống nếu muốn sử dụng cho nhiều người dùng (\"chung\"). Đặt thành ID người dùng cụ thể của bạn để chỉ giới hạn cho tổ chức của bạn.",
+          "instructions": {
+            "title": "Để có được những thông tin đăng nhập này:",
+            "step1": "Truy cập Cổng thông tin Azure (portal.azure.com)",
+            "step2": "Truy cập vào Microsoft Entra ID > Đăng ký ứng dụng",
+            "step3": "Đăng ký ứng dụng mới hoặc chọn ứng dụng hiện có",
+            "step4": "Trong mục Chứng chỉ & bí mật, hãy tạo một bí mật khách hàng mới.",
+            "step5": "Thêm URI chuyển hướng sau vào phần Xác thực:"
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "Cả ID khách hàng và mã bí mật khách hàng đều cần thiết."
+          }
+        },
+        "saml": {
+          "description": "Thiết lập cấu hình Nhà cung cấp định danh SAML của bạn. Bạn có thể lấy các thông tin chi tiết này từ Nhà cung cấp định danh SAML của mình.",
+          "entryPoint": "URL điểm truy cập SSO",
+          "issuer": "Bên phát hành (Mã định danh thực thể)",
+          "callbackUrl": "URL ACS (Callback)",
+          "logoutUrl": "URL đăng xuất SLO (Tùy chọn)",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:your-idp:entity-id",
+          "certPlaceholder": "-----BẮT ĐẦU GIẤY CHỨNG NHẬN-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "Để cấu hình SAML:",
+            "step1": "Hãy liên hệ với quản trị viên Nhà cung cấp định danh SAML của bạn.",
+            "step2": "Yêu cầu URL điểm truy cập SSO và ID thực thể.",
+            "step3": "Tải xuống chứng chỉ X.509",
+            "step4": "Hãy cấu hình URL ACS này trong IdP của bạn:"
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "Các thông tin sau đây là bắt buộc: Điểm truy cập, Tổ chức phát hành, Chứng chỉ và URL gọi lại."
+          }
+        },
+        "disableEmailVerification": {
+          "title": "Tắt xác minh email?",
+          "description": "Thao tác này sẽ vô hiệu hóa xác minh email đối với người dùng đăng ký mới và xác minh tất cả các tài khoản hiện có chưa được xác minh.",
+          "warning": "⚠️ Cảnh báo an ninh",
+          "warningPoint1": "Chỉ nên sử dụng cho các cài đặt bảo mật (mạng riêng, VPN hoặc môi trường đáng tin cậy).",
+          "warningPoint2": "Tất cả các tài khoản chưa được xác minh hiện có sẽ được xác minh ngay lập tức và được cấp quyền truy cập hệ thống.",
+          "confirmation": "Bạn có chắc chắn muốn tắt xác minh email và xác minh tất cả tài khoản không?",
+          "confirm": "Vô hiệu hóa và xác minh tất cả",
+          "verifying": "Đang xác minh tài khoản..."
+        }
+      },
+      "status": {
+        "configured": "Đã cấu hình",
+        "setup": "Cài đặt"
+      },
+      "registration": {
+        "title": "Cài đặt đăng ký",
+        "description": "Kiểm soát ai có thể đăng ký tài khoản mới.",
+        "restrictDomains": {
+          "title": "Hạn chế tên miền email",
+          "description": "Chỉ cho phép đăng ký từ các tên miền email cụ thể."
+        },
+        "allowedDomains": {
+          "title": "Các tên miền email được cho phép",
+          "placeholder": "ví dụ.com",
+          "add": "Thêm tên miền",
+          "empty": "Chưa có tên miền nào được cấu hình cho phép. Tất cả các tên miền sẽ bị chặn khi tính năng hạn chế được bật."
+        },
+        "defaultAccess": {
+          "title": "Mức độ truy cập mặc định",
+          "description": "Mức độ truy cập hệ thống được chỉ định cho người dùng mới khi họ đăng ký.",
+          "options": {
+            "NONE": "Không có quyền truy cập - Người dùng không thể truy cập hệ thống cho đến khi quản trị viên cấp quyền.",
+            "USER": "Người dùng - Quyền truy cập người dùng tiêu chuẩn vào các dự án được chỉ định",
+            "PROJECTADMIN": "Quản trị viên dự án - Có khả năng quản lý các dự án được giao.",
+            "ADMIN": "Quản trị viên - Quyền truy cập quản trị hệ thống đầy đủ"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "Yêu cầu xác minh email",
+          "description": "Người dùng phải xác minh địa chỉ email của mình trước khi truy cập vào hệ thống.",
+          "noEmailServerWarning": "Máy chủ email chưa được cấu hình. Chức năng xác thực email tự động bị vô hiệu hóa cho đến khi máy chủ email được thiết lập."
+        },
+        "allowOpenRegistration": {
+          "title": "Cho phép tự đăng ký",
+          "description": "Khi tính năng này bị vô hiệu hóa, người dùng mới không thể đăng ký trực tiếp hoặc tạo tài khoản thông qua SSO. Người dùng hiện tại vẫn có thể đăng nhập."
+        }
+      },
+      "errors": {
+        "invalidProvider": "Nhà cung cấp không hợp lệ hoặc không phải là nhà cung cấp SAML."
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "Lọc các dự án..."
+      },
+      "complete": {
+        "title": "Dự án hoàn chỉnh",
+        "description": "Thao tác này sẽ hoàn tất dự án và ngăn chặn việc bổ sung thêm bất kỳ lần chạy thử nào khác."
+      },
+      "add": {
+        "button": "Thêm dự án",
+        "title": "Thêm dự án mới",
+        "defaultFields": "Mẫu mặc định, loại mốc thời gian mặc định, cùng tất cả quy trình làm việc và trạng thái sẽ được thêm vào dự án khi dự án được tạo.",
+        "selectIssueTracker": "Chọn Trình theo dõi sự cố",
+        "issueTrackerRequired": "Cần có hệ thống theo dõi sự cố."
+      },
+      "wizard": {
+        "title": "Tạo dự án mới",
+        "description": "Thiết lập một dự án mới với tất cả các cấu hình cần thiết.",
+        "steps": {
+          "details": "Chi tiết dự án",
+          "workflows": "Quy trình làm việc, trạng thái và các loại mốc quan trọng",
+          "integrations": "Tích hợp",
+          "permissions": "Người dùng & Quyền hạn"
+        },
+        "labels": {
+          "selected": "Đã chọn",
+          "statuses": "Trạng thái kiểm thử",
+          "issueTrackers": "Công cụ theo dõi sự cố"
+        },
+        "placeholders": {
+          "projectName": "Nhập tên dự án",
+          "selectDefaultAccess": "Chọn loại truy cập mặc định"
+        },
+        "descriptions": {
+          "templates": "Hãy chọn ít nhất một mẫu để định nghĩa cấu trúc các trường hợp kiểm thử trong dự án này.",
+          "workflows": "Thiết lập quy trình làm việc, trạng thái và loại mốc thời gian để quản lý các hoạt động dự án.",
+          "integrations": "Tùy chọn: Kết nối các công cụ theo dõi sự cố bên ngoài và mô hình AI để tăng cường chức năng.",
+          "noIntegrations": "Hiện tại chưa có tích hợp nào được cấu hình. Bạn có thể bỏ qua bước này hoặc cấu hình tích hợp sau.",
+          "aiModels": "Kích hoạt các mô hình AI để tạo trường hợp thử nghiệm và đưa ra các đề xuất thông minh.",
+          "permissions": "Cấu hình quyền truy cập người dùng và quyền nhóm cho dự án này.",
+          "milestoneTypes": "Chọn các loại mốc quan trọng để theo dõi tiến độ dự án và thời hạn."
+        },
+        "actions": {
+          "selectDefault": "Sử dụng mặc định",
+          "create": "Tạo dự án",
+          "creating": "Đang tạo dự án..."
+        },
+        "errors": {
+          "nameRequired": "Tên dự án là bắt buộc",
+          "validationFailed": "Không thể xác thực tên dự án. Vui lòng thử lại.",
+          "templateRequired": "Ít nhất một mẫu phải được chọn.",
+          "workflowRequired": "Ít nhất một quy trình làm việc phải được lựa chọn.",
+          "statusRequired": "Phải chọn ít nhất một trạng thái.",
+          "roleRequired": "Vui lòng chọn vai trò khi sử dụng loại truy cập 'Vai trò cụ thể'.",
+          "creationFailed": "Không thể tạo dự án. Vui lòng thử lại."
+        },
+        "success": {
+          "created": "Dự án đã được tạo thành công"
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa dự án",
+        "labels": {
+          "groupProjectAccess": "Truy cập dự án nhóm",
+          "groupPermissions": "Quyền nhóm",
+          "userPermissions": "Quyền của người dùng",
+          "noEffect": "Không có tác dụng",
+          "access": {
+            "groupsGlobalRole": "Vai trò toàn cầu của Tập đoàn",
+            "groupDefault": "Nhóm mặc định",
+            "groupSpecificRole": "Vai trò cụ thể của nhóm",
+            "groupProjectDefault": "Dự án nhóm mặc định",
+            "groupProjectNoAccess": "Dự án nhóm Không được phép truy cập",
+            "groupProjectSpecificRole": "Vai trò cụ thể trong dự án nhóm",
+            "effectiveAccess": "Tiếp cận hiệu quả"
+          },
+          "accessHints": {
+            "noAccess": "Người dùng sẽ không có quyền truy cập vào dự án này trừ khi được cấp phép rõ ràng thông qua việc chỉ định trực tiếp hoặc tư cách thành viên nhóm.",
+            "globalRole": "Tất cả người dùng có quyền truy cập trang web đều có thể xem dự án này. Quyền hạn của họ được xác định bởi vai trò được chỉ định toàn cầu.",
+            "specificRole": "Người dùng không được cấp quyền truy cập tự động. Quyền truy cập phải được cấp thông qua việc chỉ định người dùng trực tiếp hoặc tư cách thành viên nhóm. Người dùng được chỉ định thông qua nhóm sẽ sử dụng vai trò này trừ khi bị ghi đè bởi việc chỉ định trực tiếp."
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "Chọn quyền truy cập mặc định",
+          "groupPermissionsUI": "Giao diện quản lý quyền nhóm sẽ được đặt ở đây...",
+          "userPermissionsUI": "Giao diện quản lý quyền người dùng sẽ được đặt ở đây...",
+          "selectAccess": "Chọn quyền truy cập...",
+          "selectRole": "Chọn vai trò...",
+          "searchUsersToAdd": "Tìm kiếm người dùng để thêm..."
+        },
+        "tableHeaders": {
+          "globalRole": "Vai trò toàn cầu",
+          "projectAccess": "Dự án Access"
+        },
+        "messages": {
+          "noUsersAssigned": "Không có người dùng nào được chỉ định quyền cụ thể.",
+          "noGroupsFound": "Không tìm thấy nhóm nào."
+        },
+        "actions": {
+          "removeUser": "Xóa người dùng"
+        },
+        "loadingUserPermissions": "Đang tải quyền người dùng..."
+      },
+      "delete": {
+        "title": "Xóa dự án",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa dự án này không?"
+      }
+    },
+    "templates": {
+      "description": "Quản lý các mẫu và trường kiểm thử",
+      "help": {
+        "caseFields": "Các trường hợp xác định các thuộc tính và dữ liệu có thể được thu thập cho mỗi trường hợp kiểm thử trong kho lưu trữ. Chúng cho phép bạn tùy chỉnh thông tin trường hợp kiểm thử vượt ra ngoài các trường tiêu chuẩn.",
+        "resultFields": "Các trường kết quả xác định dữ liệu bổ sung có thể được thu thập khi ghi lại kết quả kiểm thử. Chúng cho phép bạn theo dõi thông tin tùy chỉnh cụ thể liên quan đến kết quả thực thi kiểm thử."
+      },
+      "confirmSetAsDefault": "Đặt làm mẫu mặc định",
+      "confirmSetAsDefaultDescription": "Bạn có chắc chắn muốn đặt mẫu này làm mẫu mặc định không?",
+      "confirmSetAsDefaultProjects": "Mẫu này sẽ được thêm vào tất cả các dự án.",
+      "add": {
+        "button": "Thêm mẫu",
+        "title": "Thêm mẫu mới",
+        "defaultTemplateHint": "Mẫu này sẽ được áp dụng cho tất cả các dự án."
+      },
+      "edit": {
+        "title": "Chỉnh sửa mẫu"
+      },
+      "delete": {
+        "title": "Xóa mẫu",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa mẫu <strong>{name}</strong> không?",
+        "warning": "Tất cả các trường hợp thử nghiệm và phiên khám phá hiện đang sử dụng mẫu này sẽ tự động được gán lại cho mẫu mặc định.",
+        "errors": {
+          "defaultTemplateNotFound": "Không tìm thấy mẫu mặc định. Không thể tiếp tục xóa.",
+          "unknown": "Đã xảy ra lỗi không xác định trong quá trình xóa mẫu."
+        }
+      },
+      "caseFields": {
+        "description": "Quản lý các trường dữ liệu",
+        "add": {
+          "button": "Thêm trường hợp",
+          "title": "Thêm trường dữ liệu mới"
+        },
+        "edit": {
+          "title": "Chỉnh sửa trường hợp"
+        },
+        "delete": {
+          "title": "Xóa trường hợp",
+          "confirmMessage": "Bạn có chắc chắn muốn xóa trường Thông tin vụ việc này không?",
+          "warning": "Trường Case Field sẽ bị xóa khỏi mọi mẫu. Thao tác này không thể hoàn tác."
+        }
+      },
+      "resultFields": {
+        "description": "Quản lý các trường kết quả",
+        "add": {
+          "button": "Thêm trường kết quả",
+          "title": "Thêm trường kết quả mới"
+        },
+        "edit": {
+          "title": "Chỉnh sửa trường kết quả"
+        },
+        "delete": {
+          "title": "Xóa trường kết quả",
+          "confirmMessage": "Bạn có chắc chắn muốn xóa <strong>{name}</strong> không?",
+          "warning": "Trường Kết quả sẽ bị xóa khỏi mọi Mẫu. Hành động này không thể hoàn tác."
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "Kho lưu trữ mã nguồn",
+      "description": "Quản lý các kết nối kho mã nguồn cho ngữ cảnh QuickScript.",
+      "addRepository": "Thêm kho lưu trữ",
+      "noRepos": {
+        "title": "Chưa có kho lưu trữ mã nào được cấu hình.",
+        "description": "Kết nối kho lưu trữ Git để cung cấp ngữ cảnh tệp cho việc tạo xuất dữ liệu kiểm thử dựa trên trí tuệ nhân tạo."
+      },
+      "delete": {
+        "title": "Xóa kho lưu trữ",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa <strong>{name}</strong>không? Hành động này không thể hoàn tác.",
+        "fallbackName": "kho lưu trữ này"
+      },
+      "testConnection": "Kiểm tra kết nối",
+      "connectionSuccess": "Kết nối thành công",
+      "connectionFailed": "Kết nối thất bại",
+      "networkError": "Lỗi mạng",
+      "editTitle": "Chỉnh sửa kho mã nguồn",
+      "addTitle": "Thêm kho mã nguồn",
+      "repositoryUpdated": "Kho lưu trữ đã được cập nhật",
+      "repositoryCreated": "Kho lưu trữ đã được tạo",
+      "saveFailed": "Không thể lưu kho lưu trữ",
+      "namePlaceholder": "Kho lưu trữ của tôi",
+      "selectProvider": "Chọn nhà cung cấp",
+      "httpWarning": "URL này sử dụng giao thức HTTP. Thông tin đăng nhập sẽ được gửi dưới dạng văn bản thuần. Hãy sử dụng HTTPS để có kết nối an toàn."
+    },
+    "exportTemplates": {
+      "title": "Mẫu QuickScript",
+      "description": "Quản lý các mẫu được QuickScript sử dụng để chuyển đổi các trường hợp kiểm thử thành kịch bản tự động hóa.",
+      "confirmSetAsDefault": "Đặt làm mẫu xuất mặc định",
+      "confirmSetAsDefaultDescription": "Bạn có chắc chắn muốn đặt mẫu này làm mặc định không? Mẫu này sẽ được chọn sẵn khi người dùng xuất các trường hợp kiểm thử.",
+      "fields": {
+        "category": "Loại",
+        "framework": "Khung",
+        "fileExtension": "Phần mở rộng tệp",
+        "headerBody": "Mẫu tiêu đề",
+        "templateBody": "Thân mẫu",
+        "footerBody": "Mẫu chân trang",
+        "validation": {
+          "categoryRequired": "Thể loại là bắt buộc.",
+          "frameworkRequired": "Cần có khung cấu trúc.",
+          "templateBodyRequired": "Nội dung mẫu là bắt buộc.",
+          "fileExtensionRequired": "Tệp tin phải có phần mở rộng.",
+          "languageRequired": "Yêu cầu về ngôn ngữ."
+        },
+        "placeholders": {
+          "name": "Ví dụ: Nhà viết kịch (TypeScript)",
+          "description": "Ví dụ: Tạo các đoạn mã kiểm thử Playwright.",
+          "category": "Ví dụ: Trình duyệt E2E",
+          "framework": "Ví dụ: Nhà viết kịch",
+          "fileExtension": "ví dụ: .spec.ts",
+          "language": "ví dụ, bản thảo",
+          "headerBody": "Tùy chọn. Nội dung chỉ được hiển thị một lần ở đầu trang (ví dụ: các câu lệnh nhập khẩu).",
+          "templateBody": "Nhập mẫu ria mép...\n\nCác biến có sẵn:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nPhần các bước:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nTrường tùy chỉnh:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "Tùy chọn. Nội dung chỉ được hiển thị một lần ở cuối (ví dụ: mã đóng)."
+        },
+        "combobox": {
+          "typeNew": "Nhập giá trị mới"
+        }
+      },
+      "add": {
+        "button": "Thêm mẫu QuickScript",
+        "title": "Thêm mẫu QuickScript mới"
+      },
+      "edit": {
+        "title": "Chỉnh sửa mẫu QuickScript"
+      },
+      "delete": {
+        "title": "Xóa mẫu QuickScript",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa mẫu QuickScript <strong>{name}</strong> không?"
+      },
+      "preview": {
+        "title": "Xem trước (dữ liệu giả lập)",
+        "empty": "Nhập nội dung mẫu để xem bản xem trước.",
+        "error": "Lỗi khi hiển thị mẫu. Hãy kiểm tra cú pháp Mustache của bạn."
+      },
+      "filterPlaceholder": "Các mẫu lọc...",
+      "noResults": "Không có mẫu nào phù hợp với bộ lọc của bạn.",
+      "templateCount": "{count, plural, one {# mẫu} other {# mẫu}}",
+      "allFrameworks": "Tất cả các khung phần mềm",
+      "allFileExtensions": "Tất cả các phần mở rộng",
+      "allLanguages": "Tất cả các ngôn ngữ",
+      "showEnabled": "Chỉ được kích hoạt",
+      "showAll": "Tất cả",
+      "variableInserter": {
+        "placeholder": "Chèn biến...",
+        "groups": {
+          "customFields": "Trường tùy chỉnh"
+        },
+        "stepsBlock": "Khối bậc thang"
+      }
+    },
+    "users": {
+      "showInactive": "Hiển thị trạng thái không hoạt động",
+      "add": {
+        "button": "Thêm người dùng",
+        "title": "Thêm người dùng mới",
+        "fields": {
+          "email_invalid": "Địa chỉ email không hợp lệ",
+          "password_error": "Cần có mật khẩu.",
+          "confirmPassword_error": "Cần xác nhận mật khẩu.",
+          "passwordOptionalHelp": "Để trống nếu muốn người dùng đăng nhập bằng liên kết ảo hoặc SSO."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa người dùng"
+      },
+      "delete": {
+        "title": "Xóa người dùng"
+      },
+      "restore": {
+        "title": "Khôi phục người dùng đã xóa",
+        "description": "Đã tìm thấy người dùng đã bị xóa với địa chỉ email {email} . Bạn có muốn khôi phục người dùng này không?",
+        "confirm": "Khôi phục người dùng"
+      },
+      "forcePasswordChange": "Buộc thay đổi mật khẩu",
+      "revokePassword": "Thu hồi mật khẩu",
+      "forcePasswordChangeDialogTitle": "Buộc thay đổi mật khẩu",
+      "forcePasswordChangeDialogDescription": "Điều này sẽ yêu cầu {name} phải thay đổi mật khẩu của họ trong lần đăng nhập tiếp theo.",
+      "revokePasswordDialogTitle": "Thu hồi mật khẩu",
+      "revokePasswordDialogDescription": "Thao tác này sẽ ngay lập tức vô hiệu hóa mật khẩu của {name}. Họ sẽ cần sử dụng phương thức đăng nhập khác.",
+      "confirmAction": "Xác nhận",
+      "forcePasswordChangeSuccess": "Cần thay đổi mật khẩu cho {name}",
+      "forcePasswordChangeFailed": "Không thể buộc thay đổi mật khẩu.",
+      "revokePasswordSuccess": "Mật khẩu đã bị thu hồi cho {name}",
+      "revokePasswordFailed": "Không thể thu hồi mật khẩu."
+    },
+    "security": {
+      "title": "Bảo vệ",
+      "description": "Cấu hình chính sách mật khẩu, cài đặt khóa tài khoản và các hành động thực thi.",
+      "passwordPolicyTitle": "Chính sách mật khẩu",
+      "passwordPolicyDescription": "Đặt ra các yêu cầu đối với mật khẩu người dùng.",
+      "lockoutPolicyTitle": "Chính sách khóa cửa",
+      "lockoutPolicyDescription": "Cấu hình khóa tài khoản sau các lần đăng nhập không thành công.",
+      "enforcementTitle": "Các biện pháp thực thi",
+      "enforcementDescription": "Buộc thay đổi mật khẩu đối với người dùng sử dụng thông tin đăng nhập.",
+      "minPasswordLengthLabel": "Độ dài mật khẩu tối thiểu",
+      "minPasswordLengthDescription": "Mật khẩu phải có ít nhất số ký tự này (8-128)",
+      "requireUppercaseLabel": "Yêu cầu viết hoa",
+      "requireLowercaseLabel": "Yêu cầu viết chữ thường",
+      "requireNumbersLabel": "Yêu cầu số",
+      "requiredSpecialCharsLabel": "Các ký tự đặc biệt bắt buộc",
+      "requiredSpecialCharsDescription": "Để trống nếu muốn vô hiệu hóa. Nhập các ký tự cần hiển thị (ví dụ: !@#$)",
+      "passwordHistoryDepthLabel": "Độ sâu lịch sử mật khẩu",
+      "passwordHistoryDepthDescription": "Ngăn chặn việc sử dụng lại N mật khẩu gần nhất (0 = đã tắt)",
+      "passwordExpirationDaysLabel": "Thời hạn hiệu lực mật khẩu (ngày)",
+      "passwordExpirationDaysDescription": "Buộc thay đổi mật khẩu sau N ngày (0 = vô hiệu hóa)",
+      "lockoutThresholdLabel": "Ngưỡng khóa",
+      "lockoutThresholdDescription": "Số lần đăng nhập thất bại trước khi tài khoản bị khóa (tối thiểu 1)",
+      "lockoutDurationMinutesLabel": "Thời gian khóa (phút)",
+      "lockoutDurationMinutesDescription": "Thời gian tài khoản bị khóa (tối thiểu 1 ngày)",
+      "saveChanges": "Lưu thay đổi",
+      "forceAllUsers": "Buộc tất cả người dùng phải thay đổi mật khẩu.",
+      "forceAllUsersDialogTitle": "Buộc thay đổi mật khẩu cho tất cả người dùng",
+      "forceAllUsersDialogDescription": "Điều này sẽ yêu cầu {count} người dùng dựa trên thông tin đăng nhập phải thay đổi mật khẩu của họ trong lần đăng nhập tiếp theo.",
+      "forceAllUsersDialogWarning": "Hành động này không thể đảo ngược.",
+      "forceAllUsersDialogConfirm": "Thay đổi bắt buộc",
+      "saved": "Cài đặt bảo mật đã được lưu",
+      "saveFailed": "Không thể lưu cài đặt bảo mật.",
+      "forceAllSuccess": "Người dùng {count} cần thay đổi mật khẩu.",
+      "forceAllFailed": "Không thể buộc thay đổi mật khẩu."
+    },
+    "apiTokens": {
+      "description": "Xem và quản lý mã thông báo API cho tất cả người dùng. Thu hồi mã thông báo nếu có vấn đề về bảo mật.",
+      "filterPlaceholder": "Lọc theo tên token hoặc người dùng...",
+      "showInactive": "Chương trình đã bị thu hồi",
+      "noTokens": "Chưa có mã thông báo API nào được tạo.",
+      "columns": {
+        "lastUsed": "Lần sử dụng cuối cùng",
+        "expires": "Hết hạn"
+      },
+      "status": {
+        "revoked": "Đã bị thu hồi",
+        "expired": "Hết hạn"
+      },
+      "noExpiry": "Không hết hạn",
+      "revokeToken": "Thu hồi mã thông báo",
+      "revokeConfirmTitle": "Thu hồi mã thông báo API",
+      "revokeConfirmMessage": "Bạn có chắc chắn muốn thu hồi mã thông báo API này không? Hành động này không thể hoàn tác.",
+      "revokeConfirmDescription": "Mã thông báo \"{name}\" thuộc về {user} sẽ bị thu hồi ngay lập tức và không thể được sử dụng để truy cập API nữa.",
+      "revokeSuccess": "Mã thông báo API đã được thu hồi thành công",
+      "revokeError": "Không thể thu hồi mã thông báo API.",
+      "revokeAllTokens": "Thu hồi tất cả mã thông báo",
+      "revokeAllTitle": "Thu hồi tất cả mã thông báo API",
+      "revokeAllDescription": "Thao tác này sẽ ngay lập tức thu hồi TẤT CẢ các mã thông báo API đang hoạt động của tất cả người dùng. Hành động này không thể hoàn tác và có thể làm gián đoạn các quy trình tự động.",
+      "revokeAllConfirm": "Nhập \"REVOKE ALL\" để xác nhận",
+      "revokeAllPlaceholder": "HỦY BỎ TẤT CẢ",
+      "revokeAllSuccess": "Tất cả mã thông báo API đã bị thu hồi.",
+      "revokeAllError": "Không thể thu hồi tất cả mã thông báo."
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "Đã xảy ra lỗi trong quá trình tạo thẻ."
+        }
+      },
+      "delete": {
+        "title": "Xóa thẻ",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa thẻ này không?",
+        "warning": "Thẻ này sẽ bị xóa khỏi tất cả các trường hợp kiểm thử và phiên làm việc.",
+        "errors": {
+          "unknown": "Đã xảy ra lỗi khi xóa thẻ."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa thẻ"
+      }
+    },
+    "workflows": {
+      "description": "Quản lý quy trình làm việc của trường hợp kiểm thử",
+      "add": {
+        "button": "Thêm quy trình làm việc",
+        "title": "Thêm quy trình làm việc mới",
+        "defaultHelp": "Đặt làm quy trình làm việc mặc định cho các trường hợp kiểm thử mới.",
+        "scopeLabel": "Phạm vi quy trình làm việc",
+        "errors": {
+          "nameExists": "Một quy trình làm việc với tên này đã tồn tại."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa quy trình làm việc",
+        "lastWorkflowTypeWarning": "Đây là loại quy trình công việc cuối cùng. Ít nhất một loại quy trình công việc phải được kích hoạt.",
+        "errors": {
+          "nameRequired": "Tên quy trình làm việc là bắt buộc",
+          "unknownWorkflow": "Quy trình làm việc không xác định"
+        }
+      },
+      "delete": {
+        "title": "Xóa quy trình làm việc",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa quy trình làm việc này không?"
+      },
+      "setDefault": {
+        "title": "Thiết lập quy trình làm việc mặc định",
+        "confirmMessage": "Bạn có chắc chắn muốn đặt quy trình làm việc này làm mặc định không?",
+        "description": "Quy trình này sẽ được áp dụng cho tất cả các dự án."
+      }
+    },
+    "roles": {
+      "description": "Xác định các hành động mà người dùng có thể thực hiện bằng cách bật/tắt quyền truy cập cho từng khu vực ứng dụng.",
+      "filterPlaceholder": "Lọc theo vai trò...",
+      "add": {
+        "button": "Thêm vai trò",
+        "title": "Thêm vai trò mới",
+        "fields": {
+          "name_error": "Tên vai trò là bắt buộc"
+        },
+        "errors": {
+          "nameExists": "Một vị trí có tên này đã tồn tại."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa vai trò",
+        "permissionsTitle": "Quyền hạn",
+        "areaHeader": "Lĩnh vực ứng dụng"
+      },
+      "delete": {
+        "title": "Xóa vai trò",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa vai trò này không?",
+        "warning": "Thao tác này không thể hoàn tác. Người dùng có vai trò này sẽ được chỉ định vai trò mặc định.",
+        "errors": {
+          "defaultNotFound": "Không thể xóa vai trò mặc định"
+        }
+      }
+    },
+    "statuses": {
+      "description": "Quản lý trạng thái kiểm thử",
+      "add": {
+        "button": "Thêm trạng thái",
+        "title": "Thêm trạng thái mới",
+        "systemNameHelp": "Tên hệ thống xác định trạng thái này. Không thể thay đổi sau khi tạo.",
+        "aliasesHelp": "Danh sách bí danh được phân tách bằng dấu phẩy",
+        "errors": {
+          "nameExists": "Trạng thái có tên này đã tồn tại.",
+          "systemNameEmpty": "Tên hệ thống là bắt buộc",
+          "systemNameInvalid": "Tên hệ thống phải là ký tự chữ và số.",
+          "aliasesInvalid": "Tên bí danh phải là ký tự chữ và số.",
+          "missingColor": "Không tìm thấy màu sắc. Vui lòng chọn màu khác."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa trạng thái",
+        "systemNameHelp": "Tên hệ thống xác định trạng thái này cho các quy trình tự động. Không thể thay đổi sau khi tạo.",
+        "unmodifiableHelp": "Trạng thái 'chưa được kiểm thử' là trạng thái hệ thống và không thể thay đổi.",
+        "untestedHelp": "Tên gọi 'chưa được kiểm thử' được dành riêng cho trạng thái hệ thống và không thể sử dụng.",
+        "success": "Trạng thái đã được cập nhật thành công."
+      },
+      "delete": {
+        "title": "Xóa trạng thái",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa trạng thái <strong>{name}</strong> không?",
+        "errors": {
+          "inUse": "Trạng thái này đang được sử dụng và không thể xóa.",
+          "defaultNotFound": "Không tìm thấy trạng thái mặc định"
+        },
+        "success": "Trạng thái đã được xóa thành công"
+      },
+      "fields": {
+        "final": "Cuối cùng",
+        "system": "Trạng thái hệ thống",
+        "forTestCase": "Đối với trường hợp thử nghiệm",
+        "forTestRun": "Để chạy thử",
+        "forSession": "Cho phiên họp",
+        "color": "Màu sắc"
+      }
+    },
+    "appConfig": {
+      "description": "Quản lý cấu hình ứng dụng toàn cầu",
+      "addConfig": "Thêm cấu hình ứng dụng",
+      "editConfig": "Chỉnh sửa cấu hình ứng dụng",
+      "keyPlaceholder": "Nhập khóa cấu hình...",
+      "valuePlaceholder": "Nhập giá trị JSON...",
+      "currentTranslation": "Bản dịch hiện tại",
+      "filterPlaceholder": "Lọc theo từ khóa...",
+      "errors": {
+        "keyRequired": "Cần có chìa khóa.",
+        "invalidJson": "Định dạng JSON không hợp lệ"
+      },
+      "configKeys": {
+        "project_docs_default": "Tài liệu dự án mặc định"
+      }
+    },
+    "configurations": {
+      "description": "Cấu hình là sự kết hợp của các danh mục và biến thể được sử dụng để xác định môi trường thử nghiệm. Ví dụ: Hệ điều hành/Trình duyệt, Máy chủ thử nghiệm, Ngôn ngữ, v.v.",
+      "addConfiguration": "Thêm cấu hình",
+      "editConfiguration": "Chỉnh sửa cấu hình",
+      "filterPlaceholder": "Cấu hình bộ lọc...",
+      "categories": {
+        "title": "Thể loại",
+        "description": "Quản lý các danh mục toàn cầu",
+        "editCategory": "Chỉnh sửa danh mục",
+        "selectCategory": "Chọn danh mục",
+        "filterPlaceholder": "Lọc theo danh mục...",
+        "add": {
+          "title": "Thêm danh mục mới"
+        },
+        "delete": {
+          "confirmMessage": "Bạn có chắc chắn muốn xóa danh mục này không?",
+          "deleteCategory": "Xóa danh mục",
+          "deleteCategoryConfirm": "Bạn có chắc chắn muốn xóa danh mục <strong>{name}</strong> không?",
+          "deleteCategoryWarning": "Thao tác này sẽ xóa danh mục và tất cả các biến thể liên quan."
+        },
+        "disable": {
+          "confirmDisableTitle": "Vô hiệu hóa biến thể",
+          "confirmDisableDescription": "Bạn có chắc chắn muốn vô hiệu hóa biến thể này không?"
+        }
+      },
+      "combinations": {
+        "title": "Sự kết hợp",
+        "description": "Quản lý các tổ hợp toàn cầu",
+        "addCombination": "Thêm tổ hợp",
+        "editCombination": "Chỉnh sửa kết hợp",
+        "selectCombination": "Chọn tổ hợp",
+        "selectCombinationDescription": "Chọn một tổ hợp các biến thể để thêm vào cấu hình.",
+        "allExist": "Tất cả các tổ hợp đều đã tồn tại.",
+        "selectAtLeast": "Vui lòng chọn ít nhất một sự kết hợp."
+      },
+      "delete": {
+        "title": "Xóa cấu hình",
+        "message": "Bạn có chắc chắn muốn xóa cấu hình <strong>{name}</strong> không?",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa cấu hình này không?"
+      },
+      "variants": {
+        "edit": {
+          "title": "Chỉnh sửa biến thể"
+        },
+        "delete": {
+          "title": "Xóa biến thể",
+          "message": "Bạn có chắc chắn muốn xóa biến thể <strong>{name}</strong> không?",
+          "confirmMessage": "Bạn có chắc chắn muốn xóa biến thể này không?",
+          "suggestion": "Hãy cân nhắc việc vô hiệu hóa biến thể đó."
+        },
+        "selection": {
+          "title": "Chọn biến thể",
+          "description": "Chọn các biến thể bạn muốn thêm vào cấu hình."
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "Tổ chức người dùng thành các Nhóm để phân quyền truy cập và vai trò dự án hàng loạt."
+      },
+      "filterPlaceholder": "Nhóm lọc...",
+      "add": {
+        "button": "Thêm nhóm",
+        "title": "Thêm nhóm mới",
+        "errors": {
+          "nameExists": "Đã có một nhóm với tên này tồn tại."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa nhóm"
+      },
+      "delete": {
+        "deleteGroup": "Xóa nhóm",
+        "deleteGroupDescription": "Thao tác này sẽ xóa nhóm và tất cả người dùng liên kết với nhóm đó.",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa nhóm này không?"
+      },
+      "noUsersSelected": "Chưa có người dùng nào được chọn.",
+      "noUsersAssigned": "Hiện chưa có người dùng nào được chỉ định vào nhóm này."
+    },
+    "milestones": {
+      "description": "Quản lý các loại mốc thời gian",
+      "filterPlaceholder": "Lọc theo loại mốc thời gian...",
+      "addMilestones": "Thêm hàng loạt mốc thời gian",
+      "confirmDefault": "Xác nhận mặc định",
+      "confirmDefaultDescription": "Bạn có chắc chắn muốn đặt Loại Mốc quan trọng này làm Mặc định không?",
+      "warning": "Loại mốc quan trọng này sẽ được thêm vào tất cả các dự án.",
+      "wizard": {
+        "selectProjects": "Chọn dự án",
+        "projectsSelected": "{count, plural, =0 {Chưa có dự án nào được chọn} one {# dự án đã được chọn} other {# dự án đã được chọn}}",
+        "createMilestone": "Tạo cột mốc",
+        "noCommonTypesTitle": "Không có loại mốc chung nào",
+        "noCommonTypesDescription": "Các dự án đã chọn không có bất kỳ loại mốc quan trọng nào chung. Vui lòng đảm bảo tất cả các dự án đã chọn đều có ít nhất một loại mốc quan trọng chung, hoặc chọn các dự án khác nhau."
+      },
+      "add": {
+        "button": "Thêm loại mốc",
+        "title": "Thêm loại mốc mới",
+        "errors": {
+          "nameExists": "Một loại cột mốc có tên này đã tồn tại."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa loại mốc"
+      },
+      "delete": {
+        "title": "Xóa loại mốc",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa Loại mốc quan trọng này không?"
+      }
+    },
+    "issue_config": {
+      "link_title": "Công cụ theo dõi sự cố liên kết",
+      "link_description": "Cấu hình URL cơ sở cho các sự cố được liên kết thủ công. Khi liên kết một sự cố chỉ bằng ID bên ngoài, URL cơ sở này sẽ được thêm vào đầu để tạo liên kết đầy đủ.",
+      "filter": {
+        "show_inactive": "Hiển thị các cấu hình không hoạt động",
+        "search_placeholder": "Lọc theo tên cấu hình..."
+      },
+      "base_url": "URL cơ sở",
+      "link_update_success": "Cấu hình liên kết đã được cập nhật thành công.",
+      "link_update_error": "Không thể cập nhật cấu hình liên kết.",
+      "description": "Cấu hình tích hợp với các hệ thống theo dõi sự cố bên ngoài.",
+      "delete": {
+        "title": "Xóa cấu hình sự cố",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa cấu hình <bold>{name}</bold> không?",
+        "warning": "Thao tác này không thể hoàn tác. Bất kỳ dự án nào hiện đang được gán cho trình theo dõi này sẽ được gán lại cho trình theo dõi mặc định. Hãy cân nhắc việc vô hiệu hóa cấu hình này.",
+        "cannotDeleteDefault": "Không thể xóa trình theo dõi sự cố mặc định.",
+        "noDefaultFound": "Không thể xóa: Không tìm thấy trình theo dõi sự cố mặc định nào để gán lại dự án."
+      },
+      "add": {
+        "title": "Thêm Trình theo dõi sự cố",
+        "description": "Tạo cấu hình mới cho hệ thống theo dõi sự cố.",
+        "name": "Tên cấu hình",
+        "name_placeholder": "Ví dụ: Liên kết dự án Jira",
+        "system_type": "Loại hệ thống",
+        "select_system_type": "Chọn loại hệ thống",
+        "base_url": "URL cơ sở bao gồm cả phần giữ chỗ cho vấn đề",
+        "base_url_placeholder": "ví dụ: https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "Cấu hình sự cố đã được tạo thành công",
+        "create_error": "Lỗi khi tạo cấu hình sự cố",
+        "setDefaultWarning": "Việc đặt mục này làm mặc định sẽ xóa trạng thái mặc định khỏi cấu hình mặc định hiện tại."
+      },
+      "edit": {
+        "title": "Chỉnh sửa Trình theo dõi sự cố",
+        "description": "Cập nhật chi tiết cấu hình cho vấn đề này.",
+        "name_placeholder": "Nhập tên cấu hình",
+        "select_project": "Chọn dự án...",
+        "update_success": "Cấu hình sự cố đã được cập nhật thành công.",
+        "update_error": "Không thể cập nhật cấu hình sự cố.",
+        "edit_not_supported": "Hiện tại, việc chỉnh sửa cấu hình cho loại hệ thống này chưa được hỗ trợ."
+      }
+    },
+    "issues": {
+      "description": "Quản lý các vấn đề cho trình theo dõi sự cố này",
+      "filterPlaceholder": "Các vấn đề về bộ lọc...",
+      "add": {
+        "button": "Thêm vấn đề",
+        "title": "Thêm vấn đề mới"
+      },
+      "edit": {
+        "title": "Chỉnh sửa vấn đề"
+      },
+      "delete": {
+        "title": "Xóa sự cố",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa vấn đề \"{name} \" không?"
+      },
+      "syncIssue": "Sự cố đồng bộ hóa từ hệ thống bên ngoài",
+      "syncSuccess": "Sự cố đã được đồng bộ hóa thành công.",
+      "syncSuccessDescription": "Vấn đề \"{name}\" đã được cập nhật với thông tin mới nhất từ hệ thống bên ngoài.",
+      "syncError": "Lỗi đồng bộ hóa",
+      "syncErrorDescription": "Không thể đồng bộ hóa vấn đề. Vui lòng thử lại sau."
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "Liên kết dự án",
+        "milestoneLinks": "Liên kết cột mốc",
+        "icons": "Biểu tượng",
+        "fieldOptions": "Tùy chọn trường",
+        "configCategories": "Danh mục cấu hình",
+        "configVariants": "Các biến thể cấu hình",
+        "repositories": "Kho lưu trữ",
+        "repositoryFolders": "Thư mục kho lưu trữ",
+        "repositoryCaseLinks": "Liên kết trường hợp kho lưu trữ",
+        "repositoryCaseVersions": "Các phiên bản trường hợp kho lưu trữ",
+        "testRunStepResults": "Kết quả các bước chạy thử nghiệm",
+        "issueConfigs": "Cấu hình sự cố",
+        "sharedStepGroups": "Nhóm bước chung"
+      },
+      "table": {
+        "title": "Đã xóa {itemType}",
+        "loading": "Đang tải đã xóa {itemType}...",
+        "error": "Lỗi khi tải đã xóa {itemType}: {message}",
+        "noItems": "Không tìm thấy {itemType} đã bị xóa.",
+        "noResults": "Không tìm thấy {itemType} đã xóa phù hợp với tìm kiếm của bạn cho \"{query}\".",
+        "restoreConfirmationMessage": "Bạn có chắc chắn muốn khôi phục hàng này từ bảng {itemType} không? Dữ liệu liên quan cũng có thể được khôi phục.",
+        "purgeConfirmationMessage": "Bạn có chắc chắn muốn xóa vĩnh viễn hàng này khỏi bảng {itemType} không? Thao tác này không thể hoàn tác và có thể xóa dữ liệu liên quan."
+      }
+    },
+    "notifications": {
+      "title": "Quản lý thông báo",
+      "description": "Thiết lập tùy chọn thông báo mặc định (người dùng có thể thay đổi) và gửi Thông báo Hệ thống.",
+      "defaultMode": {
+        "label": "Chế độ thông báo mặc định",
+        "inApp": "Chỉ có trong ứng dụng",
+        "inAppEmailImmediate": "Trong ứng dụng + Email (Ngay lập tức)",
+        "inAppEmailDaily": "Trong ứng dụng + Email (Tóm tắt hàng ngày)"
+      },
+      "options": {
+        "title": "Các tùy chọn thông báo khả dụng",
+        "inApp": {
+          "label": "Thông báo trong ứng dụng",
+          "description": "Hiển thị thông báo trong ứng dụng"
+        },
+        "emailImmediate": {
+          "label": "Email ngay lập tức",
+          "description": "Gửi thông báo qua email ngay lập tức khi có sự kiện xảy ra."
+        },
+        "emailDaily": {
+          "label": "Bản tóm tắt email hàng ngày",
+          "description": "Gửi bản tóm tắt thông báo hàng ngày qua email."
+        }
+      },
+      "save": "Lưu cài đặt",
+      "success": {
+        "title": "Cài đặt đã được lưu",
+        "description": "Cài đặt thông báo đã được cập nhật thành công."
+      },
+      "error": {
+        "description": "Không thể lưu cài đặt thông báo."
+      },
+      "systemNotification": {
+        "title": "Thông báo hệ thống",
+        "description": "Gửi thông báo quan trọng đến tất cả người dùng.",
+        "titlePlaceholder": "Nhập tiêu đề thông báo...",
+        "messagePlaceholder": "Nhập tin nhắn thông báo...",
+        "send": "Gửi thông báo",
+        "success": {
+          "title": "Thông báo đã được gửi",
+          "description": "Thông báo hệ thống đã được gửi đến {count, plural, one {# người dùng} other {# người dùng}}"
+        },
+        "error": {
+          "description": "Không thể gửi thông báo hệ thống.",
+          "emptyFields": "Vui lòng cung cấp cả tiêu đề và nội dung tin nhắn."
+        },
+        "history": {
+          "title": "Lịch sử thông báo",
+          "sentBy": "Được gửi bởi",
+          "sentAt": "Đã gửi lúc",
+          "empty": "Chưa có thông báo hệ thống nào được gửi đi."
+        }
+      }
+    },
+    "integrations": {
+      "description": "Quản lý các tích hợp của bên thứ ba để theo dõi sự cố",
+      "list": {
+        "title": "Các tích hợp vấn đề đã được cấu hình",
+        "description": "Xem và quản lý các tích hợp sự cố đã cấu hình của bạn."
+      },
+      "empty": {
+        "message": "Chưa có vấn đề nào được cấu hình tích hợp."
+      },
+      "addIntegration": "Thêm tích hợp sự cố",
+      "allIntegrations": "Tất cả các tích hợp vấn đề",
+      "manageDescription": "Cấu hình và quản lý các tích hợp vấn đề dịch vụ bên ngoài của bạn.",
+      "status": {
+        "active": "Tích cực",
+        "inactive": "Không hoạt động"
+      },
+      "connectedProjects": "Các dự án liên kết",
+      "noIntegrations": "Không có vấn đề nào được cấu hình tích hợp",
+      "testConnection": "Kiểm tra kết nối",
+      "testSuccess": "Kết nối thành công",
+      "testSuccessDescription": "Việc tích hợp vấn đề đã được cấu hình và kết nối đúng cách.",
+      "testFailed": "Kết nối thất bại",
+      "testFailedDescription": "Không thể kết nối với dịch vụ bên ngoài",
+      "testError": "Lỗi kiểm thử",
+      "testErrorDescription": "Đã xảy ra lỗi trong quá trình kiểm tra kết nối.",
+      "syncInProgress": "Lỗi đồng bộ hóa...",
+      "syncIntegration": "Đồng bộ hóa tất cả các sự cố từ quá trình tích hợp sự cố.",
+      "syncSuccess": "Đã xếp hàng đồng bộ",
+      "syncSuccessDescription": "Các vấn đề từ \"{name}\" đang được đồng bộ hóa trong nền. Quá trình này có thể mất vài phút. Bảng sẽ tự động cập nhật khi hoàn tất.",
+      "syncError": "Đồng bộ hóa thất bại",
+      "syncErrorDescription": "Không thể xếp hàng công việc đồng bộ cho sự cố tích hợp này. Vui lòng thử lại sau.",
+      "delete": {
+        "confirmMessage": "Bạn có chắc chắn muốn xóa tích hợp sự cố \"{name} \" không?",
+        "warning": "Thao tác này sẽ loại bỏ sự cố tích hợp và ngắt kết nối nó khỏi tất cả các dự án. Hành động này không thể hoàn tác.",
+        "warningTitle": "Hành động này sẽ:",
+        "warning1": "Xóa vĩnh viễn cấu hình tích hợp sự cố và thông tin đăng nhập",
+        "warning2": "Ngắt kết nối tất cả các mã thông báo xác thực người dùng cho việc tích hợp sự cố này.",
+        "warning3": "Giữ nguyên tất cả các vấn đề được liên kết trong cơ sở dữ liệu (các vấn đề sẽ bị hủy liên kết).",
+        "warning4": "Trước tiên, cần loại bỏ sự cố tích hợp khỏi tất cả các dự án."
+      },
+      "deleteSuccess": "Sự cố tích hợp đã bị xóa",
+      "deleteSuccessDescription": "Sự cố tích hợp đã được khắc phục thành công.",
+      "deleteError": "Xóa lỗi",
+      "add": {
+        "description": "Cấu hình tích hợp vấn đề mới với dịch vụ bên ngoài",
+        "selectType": "Chọn loại tích hợp sự cố",
+        "typeDescription": "Chọn loại dịch vụ bạn muốn tích hợp",
+        "successMessage": "Quá trình tích hợp sự cố đã được tạo thành công.",
+        "successDescription": "Việc tích hợp vấn đề đã được cấu hình và sẵn sàng sử dụng.",
+        "simple_url": {
+          "name": "URL đơn giản",
+          "description": "Tính năng theo dõi sự cố cơ bản với các mẫu URL tùy chỉnh"
+        },
+        "jira": {
+          "name": "Jira",
+          "description": "Kết nối với Atlassian Jira để theo dõi sự cố và quản lý dự án."
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "Kết nối với GitHub để theo dõi sự cố."
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "Kết nối với GitLab để theo dõi lỗi và yêu cầu hợp nhất."
+        },
+        "gitea": {
+          "name": "Gitea / Forgejo / Gogs",
+          "description": "Kết nối với máy chủ Gitea, Forgejo hoặc Gogs tự lưu trữ để theo dõi sự cố."
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "Kết nối với Azure DevOps để theo dõi các hạng mục công việc."
+        }
+      },
+      "filterPlaceholder": "Tích hợp bộ lọc...",
+      "table": {
+        "lastSync": "Lần đồng bộ cuối cùng",
+        "empty": "Không tìm thấy vấn đề tích hợp nào.",
+        "loading": "Đang tải các tích hợp vấn đề...",
+        "configure": "Cấu hình"
+      },
+      "edit": {
+        "description": "Cập nhật cài đặt và cấu hình tích hợp sự cố",
+        "successMessage": "Quá trình tích hợp vấn đề đã được cập nhật thành công.",
+        "successDescription": "Các cài đặt tích hợp sự cố đã được lưu."
+      },
+      "editIntegration": "Chỉnh sửa tích hợp vấn đề",
+      "saveIntegration": "Lưu tích hợp vấn đề",
+      "deleteIntegration": "Xóa tích hợp sự cố",
+      "config": {
+        "name": "Tên tích hợp vấn đề",
+        "namePlaceholder": "Nhập tên cho sự tích hợp vấn đề này.",
+        "nameHelp": "Một tên gọi mô tả để xác định sự tích hợp vấn đề này",
+        "authType": "Loại xác thực",
+        "authTypeHelp": "Chọn cách xác thực với dịch vụ bên ngoài",
+        "emailPlaceholder": "your-email@example.com",
+        "emailHelp": "Địa chỉ email tài khoản của bạn",
+        "apiToken": "Mã thông báo API",
+        "apiTokenPlaceholder": "Nhập mã thông báo API của bạn",
+        "apiTokenHelp": "Tạo mã thông báo API từ cài đặt tài khoản của bạn",
+        "jiraUrl": "URL Jira",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "URL của phiên bản Jira của bạn",
+        "clientId": "Mã khách hàng",
+        "clientIdPlaceholder": "Nhập ID máy khách OAuth của bạn",
+        "clientIdHelp": "Mã định danh khách hàng (Client ID) từ ứng dụng OAuth của bạn",
+        "clientSecret": "Bí mật khách hàng",
+        "clientSecretPlaceholder": "Nhập mã bí mật máy khách OAuth của bạn.",
+        "clientSecretHelp": "Mã bí mật khách hàng từ ứng dụng OAuth của bạn",
+        "cloudId": "ID đám mây",
+        "cloudIdPlaceholder": "Nhập ID Atlassian Cloud của bạn",
+        "cloudIdHelp": "Mã định danh (ID) của phiên bản Atlassian Cloud của bạn (có trong URL Jira của bạn)",
+        "apiUrl": "URL API",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "URL cơ sở cho API dịch vụ",
+        "personalAccessTokenPlaceholder": "Nhập mã truy cập cá nhân của bạn",
+        "personalAccessTokenHelp": "Mã truy cập cá nhân với các quyền phù hợp",
+        "apiKeyPlaceholder": "Nhập khóa API của bạn",
+        "apiKeyHelp": "Khóa API để xác thực",
+        "baseUrl": "Mẫu URL",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "Mẫu URL cho các vấn đề. Sử dụng {issueId} làm chỗ giữ chỗ",
+        "organizationUrl": "URL của tổ chức",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "URL tổ chức Azure DevOps của bạn",
+        "projectPath": "Đường dẫn dự án",
+        "projectPathPlaceholder": "nhóm/tiểu nhóm/dự án",
+        "projectPathHelp": "Đường dẫn đầy đủ đến dự án GitLab của bạn (ví dụ: mygroup/myproject)",
+        "instanceUrl": "URL phiên bản",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "URL của máy chủ ảo tự lưu trữ của bạn. Để trống nếu muốn sử dụng gitlab.com",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "Người sở hữu",
+        "ownerPlaceholder": "tên người dùng hoặc tổ chức",
+        "ownerHelp": "Người dùng hoặc tổ chức Gitea sở hữu kho lưu trữ",
+        "repo": "Kho lưu trữ",
+        "repoPlaceholder": "tên kho lưu trữ",
+        "repoHelp": "Tên của kho lưu trữ Gitea",
+        "encrypted": "Đã mã hóa",
+        "encryptedHelp": "Trường này được mã hóa và lưu trữ an toàn.",
+        "changeCredential": "Thay đổi",
+        "apiKeyWarningTitle": "Thông báo xác thực khóa API",
+        "apiKeyWarningDescription": "Khi sử dụng xác thực bằng khóa API, người báo cáo sự cố được xác định tự động:",
+        "apiKeyWarningPoint1": "Nếu địa chỉ email TestPlanIt của bạn trùng khớp với địa chỉ email người dùng Jira, bạn sẽ được chỉ định làm người báo cáo.",
+        "apiKeyWarningPoint2": "Nếu không tìm thấy địa chỉ email trùng khớp, tên TestPlanIt của bạn sẽ được đối chiếu với tên hiển thị trên Jira.",
+        "apiKeyWarningPoint3": "Nếu không tìm thấy kết quả phù hợp, chủ sở hữu khóa API sẽ được đặt làm người báo cáo.",
+        "forgeApiKeyLabel": "Khóa API Forge",
+        "forgeApiKeyDescription": "Được ứng dụng Atlassian Forge sử dụng để xác thực các yêu cầu từ bảng quản lý sự cố Jira. Tạo khóa tại đây và dán vào cài đặt ứng dụng Forge của bạn.",
+        "forgeApiKeyPlaceholder": "Nhấp vào Tạo để tạo khóa API.",
+        "forgeApiKeyGenerate": "Phát ra",
+        "forgeApiKeyCopy": "Sao chép",
+        "forgeApiKeyCopied": "Đã sao chép",
+        "platform": "Nền tảng",
+        "platformPlaceholder": "Chọn nền tảng...",
+        "platformGitea": "Gitea",
+        "platformForgejo": "Forgejo",
+        "platformGogs": "Gogs"
+      },
+      "authType": {
+        "api_key": "Khóa API",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "Mã truy cập cá nhân"
+      },
+      "validation": {
+        "nameRequired": "Tên tích hợp sự cố là bắt buộc",
+        "clientIdRequired": "Cần có ID khách hàng.",
+        "clientSecretRequired": "Mã bí mật khách hàng là bắt buộc",
+        "cloudIdRequired": "Cần có ID đám mây.",
+        "apiUrlRequired": "Cần có URL API.",
+        "tokenRequired": "Cần có Mã truy cập cá nhân.",
+        "apiKeyRequired": "Cần có khóa API."
+      },
+      "errors": {
+        "updateFailed": "Không thể cập nhật tích hợp sự cố",
+        "testFailed": "Kiểm tra kết nối thất bại",
+        "nameExists": "Đã có một vấn đề tích hợp với tên này tồn tại.",
+        "createFailed": "Không thể tạo tích hợp sự cố",
+        "deleteFailed": "Không thể xóa tích hợp sự cố"
+      },
+      "confirmDelete": {
+        "message": "Bạn có chắc chắn muốn xóa tích hợp sự cố \"{name} \" không?",
+        "warning": "Thao tác này sẽ loại bỏ sự cố tích hợp và ngắt kết nối nó khỏi tất cả các dự án. Hành động này không thể hoàn tác."
+      },
+      "form": {
+        "success": "Quá trình tích hợp sự cố đã được lưu thành công.",
+        "successDescription": "Việc tích hợp vấn đề đã được cấu hình và sẵn sàng sử dụng.",
+        "testing": "Đang kiểm tra kết nối..."
+      },
+      "oauth": {
+        "connectAccount": "Kết nối tài khoản",
+        "connected": "Đã kết nối",
+        "notConnected": "Không kết nối",
+        "authDescription": "Bạn cần xác thực với {provider} để sử dụng tính năng tích hợp này.",
+        "authError": "Xác thực thất bại",
+        "authErrorDescription": "Không thể xác thực với dịch vụ bên ngoài"
+      }
+    },
+    "llm": {
+      "addIntegration": "Thêm mô hình AI",
+      "filterPlaceholder": "Lọc các mô hình AI...",
+      "testAll": "Kiểm tra tất cả các kết nối",
+      "connectionTestComplete": "Kiểm tra kết nối hoàn tất",
+      "allIntegrationsTested": "Tất cả các kết nối mô hình AI đã được kiểm tra.",
+      "failedToTestConnections": "Không thể kiểm tra một số kết nối.",
+      "notConfigured": "Chưa được cấu hình",
+      "defaultModel": "Mẫu đã chọn",
+      "budgetUsage": "Mức sử dụng (Tháng này)",
+      "noBudget": "Không có ngân sách nào được thiết lập.",
+      "streaming": "Phát trực tuyến",
+      "add": {
+        "title": "Thêm tích hợp mô hình AI",
+        "description": "Thiết lập mô hình AI mới cho tổ chức của bạn",
+        "integrationNamePlaceholder": "Nhập tên cho sự tích hợp này...",
+        "selectProvider": "Chọn nhà cung cấp",
+        "openai": "OpenAI",
+        "anthropic": "Nhân loại",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "customLlm": "LLM tùy chỉnh",
+        "apiKeyPlaceholder": "Nhập khóa API của bạn...",
+        "apiKeyDescription": "Khóa API của bạn để xác thực với nhà cung cấp",
+        "endpoint": "URL điểm cuối",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "Mẹo: Nếu sử dụng proxy (ví dụ: LiteLLM), hãy thử thêm /v1 vào cuối URL điểm cuối của bạn.",
+        "deploymentName": "Tên triển khai",
+        "deploymentNamePlaceholder": "Nhập tên triển khai...",
+        "deploymentNameDescription": "Tên triển khai Azure OpenAI",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, v.v.",
+        "defaultModelDescription": "Mô hình được sử dụng mặc định",
+        "maxTokensPerRequest": "Số lượng token tối đa cho mỗi yêu cầu",
+        "maxRequestsPerMinute": "Số lượng yêu cầu tối đa mỗi phút",
+        "costPerInputToken": "Chi phí cho mỗi 1 triệu mã thông báo đầu vào ($)",
+        "costPerOutputToken": "Chi phí cho mỗi 1 triệu token đầu ra ($)",
+        "monthlyBudget": "Ngân sách hàng tháng ($)",
+        "monthlyBudgetPlaceholder": "100.00",
+        "monthlyBudgetDescription": "Mục tiêu chi tiêu tùy chọn cho thông báo (không chặn việc sử dụng)",
+        "billingPeriodStartDay": "Ngày bắt đầu kỳ thanh toán",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "Ngày trong tháng (1-31) khi kỳ thanh toán của bạn bắt đầu. Các giá trị 29-31 sử dụng ngày cuối cùng của các tháng ngắn hơn.",
+        "defaultTemperature": "Nhiệt độ mặc định",
+        "defaultMaxTokens": "Số lượng token tối đa mặc định",
+        "timeout": "Thời gian chờ yêu cầu (ms)",
+        "timeoutDescription": "Thời gian chờ tối đa để nhận phản hồi từ mô hình AI (5000-600000ms). Không áp dụng cho các yêu cầu truyền phát trực tuyến.",
+        "streamingEnabled": "Bật tính năng phát trực tuyến",
+        "streamingEnabledDescription": "Cho phép truyền phát phản hồi theo thời gian thực",
+        "setAsDefault": "Đặt làm mặc định",
+        "setAsDefaultDescription": "Hãy sử dụng mô hình này làm mô hình AI mặc định cho tổ chức.",
+        "fetchingModels": "Đang tải mô hình...",
+        "failedToFetchModels": "Không thể tải các mô hình khả dụng",
+        "selectModel": "Chọn một mẫu",
+        "connectionSuccessfulDescription": "Kết nối mô hình AI đã được xác minh và đang hoạt động chính xác.",
+        "failedToConnect": "Không thể kết nối với nhà cung cấp mô hình AI.",
+        "integrationCreated": "Quá trình tích hợp mô hình AI đã được thực hiện thành công.",
+        "failedToCreate": "Không thể tạo tích hợp mô hình AI.",
+        "validation": {
+          "nameRequired": "Tên tích hợp là bắt buộc",
+          "nameUnique": "Một sự tích hợp với tên gọi này đã tồn tại.",
+          "defaultModelRequired": "Cần có mô hình mặc định."
+        }
+      },
+      "edit": {
+        "title": "Chỉnh sửa tích hợp mô hình AI",
+        "description": "Cập nhật cấu hình cho việc tích hợp mô hình AI này.",
+        "statusDescription": "Cho phép hoặc vô hiệu hóa tính năng tích hợp này.",
+        "apiKeyPlaceholder": "Nhập khóa API mới để cập nhật...",
+        "update": "Cập nhật",
+        "integrationUpdated": "Quá trình tích hợp mô hình AI đã được cập nhật thành công.",
+        "failedToUpdate": "Không thể cập nhật tích hợp mô hình AI.",
+        "validation": {
+          "nameRequired": "Tên tích hợp là bắt buộc",
+          "nameUnique": "Một sự tích hợp với tên gọi này đã tồn tại.",
+          "defaultModelRequired": "Cần có mô hình mặc định."
+        }
+      },
+      "sections": {
+        "provider": "Nhà cung cấp",
+        "costAndBudget": "Chi phí & Ngân sách",
+        "advanced": "Trình độ cao"
+      },
+      "delete": {
+        "title": "Xóa tích hợp mô hình AI",
+        "description": "Bạn có chắc chắn muốn xóa tích hợp mô hình AI này không? Thao tác này sẽ xóa nó khỏi tất cả các dự án và không thể hoàn tác.",
+        "integrationDeletedSuccess": "Quá trình tích hợp mô hình AI đã được xóa thành công.",
+        "failedToDeleteIntegration": "Không thể xóa tích hợp mô hình AI.",
+        "cannotDeleteDefault": "Không thể xóa mô hình AI mặc định. Hãy thiết lập một mô hình khác làm mặc định trước."
+      },
+      "validation": {
+        "defaultModelRequired": "Cần có mô hình mặc định."
+      },
+      "test": {
+        "title": "Kiểm thử tích hợp mô hình AI",
+        "description": "Kiểm tra kết nối và chức năng của {name}",
+        "connectionStatus": "Trạng thái kết nối",
+        "connectionStatusDescription": "Kiểm tra xem mô hình AI có thể truy cập được hay không.",
+        "retest": "Kiểm tra lại kết nối",
+        "connectionSuccessfulDescription": "Mô hình AI dễ truy cập và phản hồi chính xác.",
+        "failedToConnect": "Không thể kết nối với mô hình AI.",
+        "errorTestingConnection": "Đã xảy ra lỗi trong quá trình kiểm tra kết nối.",
+        "testMessage": "Thông báo thử nghiệm",
+        "testMessagePlaceholder": "Nhập tin nhắn bạn muốn gửi đến mô hình AI...",
+        "sendTestMessage": "Gửi tin nhắn thử nghiệm",
+        "response": "Phản ứng",
+        "testSuccessful": "Kiểm tra thành công",
+        "responseReceived": "Phản hồi đã được nhận thành công (Chi phí: ${cost})",
+        "testFailed": "Kiểm tra thất bại",
+        "failedToGetResponse": "Không nhận được phản hồi từ mô hình AI.",
+        "failedToSendMessage": "Không thể gửi tin nhắn thử nghiệm.",
+        "defaultTestMessage": "Chào bạn! Vui lòng phản hồi ngắn gọn để xác nhận rằng bạn đang làm việc đúng cách."
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "Việc thiết lập ngân sách hàng tháng không ngăn cản việc sử dụng LLM vượt quá ngân sách đó. Giới hạn ngân sách chỉ mang tính chất tham khảo để quản trị viên đưa ra quyết định.",
+        "budgetDisclaimerShort": "Các giới hạn ngân sách chỉ mang tính chất tham khảo và không ngăn cản việc sử dụng.",
+        "spendLabel": "Chi tiêu tháng hiện tại",
+        "spendOfBudget": "{currentSpend} của {budgetLimit}",
+        "overBudget": "Vượt ngân sách",
+        "budgetPercentage": "{percentage}% ngân sách đã sử dụng",
+        "spendReset": "Chi tiêu tháng hiện tại đã được đặt lại."
+      }
+    },
+    "prompts": {
+      "title": "Cấu hình nhắc nhở",
+      "description": "Quản lý các mẫu lời nhắc AI cho các tính năng khác nhau",
+      "addPromptConfig": "Thêm cấu hình nhắc nhở",
+      "filterPlaceholder": "Cấu hình nhắc lọc...",
+      "features": "Đặc trưng",
+      "featureCount": "{count, plural, one {# tính năng} other {# tính năng}}",
+      "llmIntegration": "Tích hợp LLM",
+      "modelOverride": "Ghi đè mô hình",
+      "llmIntegrationPlaceholder": "Dự án mặc định",
+      "modelOverridePlaceholder": "Tích hợp mặc định",
+      "projectDefault": "Dự án mặc định (xóa)",
+      "integrationDefault": "Tích hợp mặc định (xóa)",
+      "systemPrompt": "Lời nhắc hệ thống",
+      "userPrompt": "Lời nhắc người dùng",
+      "temperature": "Nhiệt độ",
+      "maxOutputTokens": "Số lượng token đầu ra tối đa",
+      "variables": "Biến số",
+      "insertVariable": "Chèn biến",
+      "noConfigs": "Không tìm thấy cấu hình nhắc nhở nào. Thêm cấu hình đầu tiên của bạn để bắt đầu.",
+      "add": {
+        "title": "Thêm cấu hình nhắc nhở",
+        "description": "Tạo cấu hình nhắc nhở AI mới với các lời nhắc cho từng tính năng. Các thiết lập mặc định đã được áp dụng tự động."
+      },
+      "edit": {
+        "title": "Chỉnh sửa cấu hình lời nhắc",
+        "description": "Cập nhật cấu hình lời nhắc AI này"
+      },
+      "delete": {
+        "title": "Xóa cấu hình nhắc nhở",
+        "confirmMessage": "Bạn có chắc chắn muốn xóa <strong>{name}</strong>không? Các dự án sử dụng lời nhắc này sẽ quay lại cài đặt mặc định của hệ thống.",
+        "warning": "Thao tác này không thể hoàn tác. Tất cả các dự án sử dụng cấu hình này sẽ trở về cấu hình nhắc lệnh mặc định."
+      },
+      "llmColumn": "Thạc sĩ Luật",
+      "mixedLlms": "{count} LLMs",
+      "cannotDeleteDefault": "Không thể xóa cấu hình lời nhắc mặc định. Hãy thiết lập một cấu hình khác làm mặc định trước.",
+      "defaultChanged": "Cấu hình lời nhắc mặc định đã được cập nhật thành công.",
+      "featureLabels": {
+        "markdown_parsing": "Phân tích cú pháp trường hợp kiểm thử Markdown",
+        "test_case_generation": "Tạo trường hợp kiểm thử",
+        "magic_select_cases": "Lựa chọn trường hợp kiểm thử thông minh",
+        "editor_assistant": "Trợ lý biên tập viên",
+        "llm_test": "Kiểm tra kết nối LLM",
+        "export_code_generation": "Tạo mã xuất khẩu",
+        "auto_tag": "Đề xuất thẻ AI",
+        "duplicate_detection": "Phát hiện trùng lặp",
+        "generate_from_url": "Tạo các trường hợp kiểm thử từ URL (Yêu cầu)",
+        "generate_from_url_app": "Tạo trường hợp kiểm thử từ URL (Kiểm thử ứng dụng)"
+      }
+    },
+    "elasticsearch": {
+      "title": "Quản lý Elasticsearch",
+      "description": "Quản lý việc lập chỉ mục và bảo trì công cụ tìm kiếm",
+      "status": {
+        "title": "Trạng thái Elasticsearch",
+        "description": "Tình trạng kết nối và sức khỏe hiện tại của công cụ tìm kiếm",
+        "checking": "Đang kiểm tra trạng thái...",
+        "disconnected": "Đã ngắt kết nối",
+        "nodes": "Các nút",
+        "indices": "Chỉ số",
+        "documents": "tài liệu",
+        "error": {
+          "title": "Lỗi kết nối",
+          "description": "Không thể kết nối với dịch vụ Elasticsearch"
+        }
+      },
+      "settings": {
+        "description": "Cấu hình các thiết lập Elasticsearch cho quá trình triển khai của bạn",
+        "numberOfReplicas": "Số lượng bản sao",
+        "replicasHelp": "Đặt thành 0 cho cụm một nút, 1 trở lên cho cụm nhiều nút có tính năng dự phòng.",
+        "savedDescription": "Cấu hình đã được lưu vào cơ sở dữ liệu.",
+        "updated": "Chỉ số được cập nhật",
+        "updatedDescription": "Tất cả các chỉ mục hiện có đã được cập nhật với cài đặt sao chép mới.",
+        "error": "Lỗi khi lưu cài đặt",
+        "errorDescription": "Không thể lưu cấu hình. Vui lòng thử lại.",
+        "note": {
+          "description": "Các thay đổi sẽ được áp dụng ngay lập tức cho các chỉ mục mới. Các chỉ mục hiện có sẽ được cập nhật khi bạn lưu. Đặt số bản sao về 0 để giải quyết trạng thái VÀNG trên các cụm máy chủ đơn nút."
+        }
+      },
+      "reindex": {
+        "title": "Lập chỉ mục lại dữ liệu",
+        "description": "Xây dựng lại chỉ mục tìm kiếm để cải thiện hiệu suất tìm kiếm",
+        "entities": {
+          "all": "Tất cả các thực thể"
+        },
+        "button": {
+          "start": "Bắt đầu lập chỉ mục lại",
+          "indexing": "Đang lập chỉ mục..."
+        },
+        "warning": {
+          "title": "Quan trọng",
+          "description": "Quá trình lập chỉ mục lại có thể mất vài phút tùy thuộc vào dung lượng dữ liệu. Chức năng tìm kiếm có thể bị hạn chế trong quá trình này."
+        },
+        "complete": {
+          "title": "Hoàn tất lập chỉ mục",
+          "description": "Tất cả các thực thể được chọn đã được lập chỉ mục lại thành công."
+        },
+        "success": {
+          "title": "Lập chỉ mục lại thành công",
+          "description": "{count, plural, one {# tài liệu} other {# tài liệu}} đã được lập chỉ mục thành công"
+        },
+        "error": {
+          "title": "Lập chỉ mục lại thất bại",
+          "description": "Đã xảy ra lỗi trong quá trình lập chỉ mục lại. Vui lòng thử lại."
+        }
+      }
+    },
+    "queues": {
+      "title": "Hàng đợi tác vụ nền",
+      "description": "Theo dõi và quản lý hàng đợi xử lý tác vụ nền.",
+      "queueNames": {
+        "forecast-updates": "Cập nhật dự báo",
+        "emails": "Hàng đợi email",
+        "issue-sync": "Vấn đề đồng bộ hóa",
+        "testmo-imports": "Nhập khẩu Testmo",
+        "elasticsearch-reindex": "Lập chỉ mục lại Elasticsearch",
+        "audit-logs": "Nhật ký kiểm toán",
+        "budget-alerts": "Cảnh báo ngân sách",
+        "auto-tag": "Tự động gắn thẻ bằng AI",
+        "repo-cache": "Bộ nhớ đệm kho lưu trữ",
+        "copy-move": "Sao chép & Di chuyển",
+        "duplicate-scan": "Quét bản sao",
+        "magic-select": "Lựa chọn ma thuật",
+        "step-scan": "Quét trình tự bước"
+      },
+      "status": {
+        "paused": "Tạm dừng",
+        "idle": "Không hoạt động"
+      },
+      "table": {
+        "queue": "Hàng đợi",
+        "concurrency": "Đồng thời",
+        "waiting": "Chờ",
+        "failed": "Thất bại"
+      },
+      "concurrency": {
+        "title": "Đồng thời của người lao động",
+        "description": "Tham số đồng thời (Concurrency) kiểm soát số lượng công việc mà mỗi worker xử lý cùng lúc. Giá trị cao hơn có thể cải thiện thông lượng nhưng sử dụng nhiều tài nguyên hệ thống hơn (CPU và bộ nhớ).",
+        "configureTitle": "Cấu hình đồng thời",
+        "configureDescription": "Để điều chỉnh số lượng tiến trình xử lý đồng thời, hãy thiết lập các biến môi trường và khởi động lại các tiến trình con. Xem tài liệu để biết thêm chi tiết.",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Nhập khẩu Testmo (mặc định: 1, tốn nhiều bộ nhớ)",
+          "SYNC_CONCURRENCY": "Đồng bộ hóa vấn đề (mặc định: 2, tốn nhiều tài nguyên I/O)",
+          "EMAIL_CONCURRENCY": "Gửi email (mặc định: 3, tốn nhiều tài nguyên I/O)",
+          "NOTIFICATION_CONCURRENCY": "Thông báo (mặc định: 5, chế độ nhẹ)",
+          "FORECAST_CONCURRENCY": "Cập nhật dự báo (mặc định: 5, tốn nhiều tài nguyên CPU)"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "Tạm dừng hàng đợi",
+          "confirmDescription": "Điều này sẽ ngăn chặn việc xử lý các công việc mới. Các công việc đang hoạt động sẽ tiếp tục được xử lý cho đến khi hoàn thành."
+        },
+        "resume": {
+          "confirmTitle": "Tiếp tục hàng đợi",
+          "confirmDescription": "Điều này sẽ cho phép hàng đợi xử lý các công việc đang chờ."
+        },
+        "clean": {
+          "confirmTitle": "Hàng đợi sạch",
+          "confirmDescription": "Thao tác này sẽ xóa các công việc đã hoàn thành và các công việc thất bại khỏi hàng đợi. Hành động này không thể hoàn tác."
+        },
+        "drain": {
+          "confirmTitle": "Hàng đợi thoát nước",
+          "confirmDescription": "Thao tác này sẽ xóa tất cả các công việc đang chờ khỏi hàng đợi. Các công việc đang hoạt động sẽ tiếp tục cho đến khi hoàn thành. Hành động này không thể hoàn tác."
+        },
+        "obliterate": {
+          "confirmTitle": "Xóa hàng đợi",
+          "confirmDescription": "Thao tác này sẽ xóa hoàn toàn hàng đợi, loại bỏ tất cả các công việc bất kể trạng thái. Hành động này không thể hoàn tác và chỉ nên được sử dụng trong trường hợp khẩn cấp."
+        },
+        "warning": "Cảnh báo",
+        "irreversible": "Thao tác này không thể hoàn tác. Vui lòng xác nhận bạn muốn tiếp tục."
+      },
+      "success": {
+        "actionCompleted": "Hành động đã hoàn tất",
+        "queuePaused": "Hàng đợi đã tạm dừng",
+        "queueResumed": "Hàng đợi đã được khôi phục.",
+        "queueCleaned": "Hàng đợi đã được dọn dẹp.",
+        "queueDrained": "Hàng đợi đã được giải tỏa.",
+        "queueObliterated": "Hàng đợi đã bị xóa bỏ."
+      },
+      "error": {
+        "loadFailed": "Không thể tải hàng đợi",
+        "actionFailed": "Hành động thất bại"
+      },
+      "jobs": {
+        "title": "Công việc xếp hàng",
+        "description": "Xem và quản lý từng công việc trong hàng đợi",
+        "noJobs": "Không tìm thấy việc làm nào trong hàng đợi này.",
+        "table": {
+          "id": "Mã số công việc",
+          "name": "Tên công việc",
+          "attempts": "Những nỗ lực"
+        },
+        "details": {
+          "title": "Chi tiết công việc",
+          "failedReason": "Lý do thất bại",
+          "stacktrace": "Dấu vết ngăn xếp",
+          "data": "Dữ liệu việc làm",
+          "returnValue": "Giá trị trả về",
+          "options": "Các lựa chọn nghề nghiệp",
+          "processed": "Đã xử lý",
+          "finished": "Hoàn thành"
+        },
+        "success": {
+          "actionCompleted": "Thao tác công việc đã hoàn tất",
+          "jobRetried": "Công việc đã được thử lại.",
+          "jobPromoted": "Công việc đã được thăng chức",
+          "jobRemoved": "Công việc đã bị hủy bỏ"
+        },
+        "error": {
+          "loadFailed": "Không thể tải các tác vụ",
+          "actionFailed": "Hành động công việc đã thất bại"
+        },
+        "forceRemove": {
+          "title": "Buộc xóa công việc",
+          "question": "Bạn có muốn buộc xóa công việc này không?",
+          "warning": "Thao tác này sẽ cố gắng xóa nó nhiều lần với độ trễ. Lưu ý: Nếu công việc thực sự bị khóa bởi một tiến trình đang chạy, nó vẫn có thể thất bại.",
+          "confirm": "Buộc gỡ bỏ"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "Xem nhật ký kiểm toán toàn hệ thống để theo dõi bảo mật và tuân thủ.",
+      "filterPlaceholder": "Tìm kiếm theo thực thể, người dùng hoặc hành động...",
+      "filterAction": "Hoạt động",
+      "filterEntityType": "Loại thực thể",
+      "allActions": "Tất cả các hành động",
+      "allEntityTypes": "Tất cả các loại thực thể",
+      "showing": "Hiển thị các mục từ {start} đến {end} trong tổng số {total} mục",
+      "viewDetails": "Xem chi tiết",
+      "detailTitle": "Chi tiết nhật ký kiểm toán",
+      "userInfo": "Thông tin người dùng",
+      "changes": "Thay đổi",
+      "metadata": "Siêu dữ liệu",
+      "oldValue": "Cũ",
+      "newValue": "Mới",
+      "columns": {
+        "timestamp": "Dấu thời gian",
+        "entityId": "ID thực thể",
+        "entityName": "Tên thực thể",
+        "userId": "ID người dùng",
+        "ipAddress": "Địa chỉ IP",
+        "userAgent": "Tác nhân người dùng"
+      },
+      "exportCsv": "Xuất CSV",
+      "timeRange": "Khoảng thời gian",
+      "timeRangeOptions": {
+        "last24h": "24 giờ qua",
+        "last7d": "7 ngày qua",
+        "last30d": "30 ngày qua",
+        "last90d": "90 ngày qua",
+        "allTime": "Mọi thời đại"
+      },
+      "systemActor": "Hệ thống",
+      "systemActorTooltip": "Hành động này được thực hiện bởi hệ thống, không phải bởi người dùng đã đăng nhập."
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "Không có thông báo",
+      "aria": {
+        "notifications": "Thông báo ({count} chưa đọc)"
+      },
+      "actions": {
+        "markRead": "Đánh dấu là đã đọc",
+        "markUnread": "Đánh dấu là chưa đọc",
+        "markAllRead": "Đánh dấu tất cả là đã đọc",
+        "deleteAll": "Xóa tất cả"
+      },
+      "success": {
+        "deleted": "Thông báo đã bị xóa",
+        "markedAllRead": "Tất cả thông báo đã được đánh dấu là đã đọc",
+        "deletedAll": "Tất cả thông báo đã bị xóa"
+      },
+      "error": {
+        "markRead": "Không thể đánh dấu là đã đọc",
+        "markUnread": "Không thể đánh dấu là chưa đọc",
+        "delete": "Không thể xóa thông báo",
+        "markAllRead": "Không thể đánh dấu tất cả là đã đọc",
+        "deleteAll": "Không thể xóa thông báo"
+      },
+      "deleteAllDialog": {
+        "title": "Xóa tất cả thông báo?",
+        "description": "Thao tác này sẽ xóa vĩnh viễn tất cả thông báo của bạn. Không thể hoàn tác hành động này.",
+        "confirm": "Xóa tất cả"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "Bài tập trường hợp kiểm thử mới",
+        "multipleTestCaseAssignmentTitle": "Nhiều trường hợp kiểm thử được chỉ định",
+        "sessionAssignmentTitle": "Phân công nhiệm vụ mới cho kỳ học",
+        "commentMentionTitle": "Bạn được nhắc đến trong một bình luận.",
+        "systemAnnouncementTitle": "Thông báo hệ thống",
+        "assignedTestCase": "được giao cho bạn trường hợp thử nghiệm",
+        "assignedMultipleTestCases": "Đã giao cho bạn {count, plural, one {# trường hợp kiểm thử} other {# trường hợp kiểm thử}}",
+        "assignedSession": "đã chỉ định bạn tham gia buổi họp",
+        "mentionedYouInComment": "Tôi đã nhắc đến bạn trong một bình luận trên",
+        "inProject": "trong dự án",
+        "testRun": "Chạy thử nghiệm:",
+        "casesInProject": "{count, plural, =1 {# trường hợp} other {# trường hợp}} trong",
+        "sentBy": "Được gửi bởi {name}",
+        "milestoneDueSoonTitle": "Cột mốc quan trọng sắp đạt được",
+        "milestoneOverdueTitle": "Cột mốc bị trì hoãn",
+        "milestoneDueSoon": "Mốc thời gian \"{milestoneName}\" trong dự án \"{projectName}\" sẽ đến hạn vào ngày {dueDate}.",
+        "milestoneOverdue": "Mốc thời gian \"{milestoneName}\" trong dự án \"{projectName}\" đến hạn vào ngày {dueDate} và hiện đã quá hạn.",
+        "milestoneNotificationReason": "Bạn nhận được thông báo này vì bạn đã tham gia vào công việc liên quan đến cột mốc này (chạy thử nghiệm, các buổi làm việc hoặc với tư cách là người tạo cột mốc).",
+        "milestoneNotificationContinue": "Bạn sẽ tiếp tục nhận được lời nhắc hàng ngày cho đến khi cột mốc này được đánh dấu là hoàn thành.",
+        "shareLinkAccessedTitle": "Đã truy cập liên kết chia sẻ",
+        "shareLinkAccessedAnonymousViewer": "Người nào đó",
+        "shareLinkAccessedMessage": "{viewer} đã xem báo cáo được chia sẻ của bạn: \"{shareTitle}\"",
+        "viewedYourSharedLink": "đã xem liên kết được chia sẻ của bạn",
+        "viewedAt": "Đã xem vào lúc",
+        "budgetDisclaimer": "Các giới hạn ngân sách chỉ mang tính chất tham khảo và không ngăn cản việc sử dụng.",
+        "llmBudgetExceededTitle": "Ngân sách chương trình LLM đã bị vượt quá.",
+        "llmBudgetThresholdTitle": "Ngân sách LLM {threshold}% Đã sử dụng",
+        "llmBudgetExceededMessage": "{providerName} đã vượt quá ngân sách hàng tháng: {spend} đã chi tiêu trong số {budget} ngân sách.",
+        "llmBudgetThresholdMessage": "{providerName} đã sử dụng {threshold}% ngân sách hàng tháng của mình: {spend} trong số {budget}.",
+        "userRegisteredTitle": "Đăng ký người dùng mới",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) đã đăng ký qua SSO",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) đã đăng ký thông qua mẫu đăng ký",
+        "viewUserList": "Xem danh sách người dùng",
+        "reviewGeneratedCases": "Xem xét các trường hợp kiểm thử được tạo ra",
+        "generateFromUrlCompleteTitle": "Các trang đã được thu thập thông tin thành công",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# trang} other {# trang}} được thu thập từ {url} trong dự án \"{projectName}\". Nhấp vào để xem lại và tạo các trường hợp kiểm thử.",
+        "generateFromUrlFailedTitle": "Quá trình thu thập dữ liệu URL thất bại"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "Các vấn đề về tìm kiếm hoặc liên kết...",
+        "create_label": "Vấn đề liên kết \"{name}\""
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "Nhập tóm tắt sự cố"
+        },
+        "fields": {
+          "name": {
+            "label": "Bản tóm tắt"
+          },
+          "description": {
+            "placeholder": "Hãy mô tả vấn đề...",
+            "helper": "Hãy cung cấp thông tin chi tiết về vấn đề này."
+          },
+          "project": {
+            "helper": "Chọn dự án trong trình theo dõi sự cố bên ngoài"
+          }
+        },
+        "loading_metadata": "Đang tải cài đặt tích hợp...",
+        "errors": {
+          "creation_failed": "Không thể tạo sự cố. Vui lòng thử lại."
+        },
+        "success": {
+          "created": "Sự cố đã được tạo thành công",
+          "external_created": "Sự cố đã được tạo và liên kết với trình theo dõi bên ngoài."
+        },
+        "warnings": {
+          "external_failed": "Sự cố được tạo cục bộ nhưng không thể đồng bộ với trình theo dõi bên ngoài."
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "Bạn cần kết nối tài khoản của mình với {integrationName} để tạo sự cố."
+      },
+      "search_issues_dialog": {
+        "title": "Các vấn đề về tìm kiếm và liên kết",
+        "placeholder": "Tìm kiếm các vấn đề...",
+        "searching": "Đang tìm kiếm...",
+        "searchError": "Không tìm thấy vấn đề",
+        "linkButton": "Liên kết",
+        "linkedCount": "{count, plural, one {# vấn đề} other {# vấn đề}} được liên kết"
+      }
+    },
+    "copyMove": {
+      "title": "Sao chép / Di chuyển vào Dự án",
+      "step1Desc": "Chọn dự án và thư mục mục tiêu cho các trường hợp kiểm thử.",
+      "step2Desc": "Chọn phương thức hoạt động và kiểm tra khả năng tương thích.",
+      "step3Desc": "Theo dõi tiến độ và đánh giá kết quả.",
+      "targetProject": "Dự án mục tiêu",
+      "searchProjects": "Tìm kiếm các dự án...",
+      "loadingProjects": "Đang tải dự án...",
+      "noProjectsFound": "Không tìm thấy dự án nào.",
+      "completed": "(Hoàn thành)",
+      "targetFolder": "Thư mục đích",
+      "newFolderPlaceholder": "Tên thư mục mới...",
+      "operation": "Hoạt động",
+      "operationCopy": "Sao chép",
+      "operationCopyDesc": "Tạo bản sao của (các) trường hợp đã chọn trong dự án đích. Bản gốc vẫn không thay đổi.",
+      "operationMove": "Di chuyển",
+      "operationMoveDesc": "Di chuyển (các) trường hợp đã chọn đến dự án đích. Các trường hợp gốc sẽ bị xóa khỏi nguồn.",
+      "checkingCompatibility": "Kiểm tra khả năng tương thích...",
+      "noTargetWriteAccess": "Bạn không có quyền ghi vào dự án mục tiêu.",
+      "noSourceUpdateAccess": "Bạn không có quyền chỉnh sửa dự án nguồn để di chuyển các trường hợp.",
+      "templateMismatch": "Mẫu không khớp",
+      "autoAssignTemplates": "Tự động gán các mẫu bị thiếu cho dự án mục tiêu",
+      "templatesMayNotDisplay": "Các mẫu bị thiếu sẽ không có sẵn trong dự án đích. Các trường hợp sẽ được sao chép nhưng các trường từ các mẫu đó có thể không hiển thị chính xác.",
+      "workflowFallback": "Một số trạng thái quy trình làm việc không khả dụng trong dự án đích. Trong những trường hợp này, hệ thống sẽ sử dụng trạng thái mặc định của dự án đích.",
+      "default": "(mặc định)",
+      "conflicts": "Áp dụng cho mọi xung đột:",
+      "conflictSkip": "Nhảy",
+      "conflictRename": "Đổi tên",
+      "sharedStepGroups": "Khi các nhóm bước dùng chung đã tồn tại trong mục tiêu:",
+      "sharedStepGroupReuse": "Tái sử dụng những thứ hiện có",
+      "sharedStepGroupReuseDesc": "Các trường hợp sẽ tham chiếu đến nhóm bước chung hiện có.",
+      "sharedStepGroupCreateNew": "Tạo mới",
+      "sharedStepGroupCreateNewDesc": "Một nhóm bước chung mới sẽ được tạo.",
+      "go": "Đi",
+      "processing": "Xử lý...",
+      "progressText": "{processed} trong số {total} trường hợp đã được xử lý",
+      "successCount": "{count} trường hợp {operation}thành công",
+      "skipped": "Đã bỏ qua: {count}",
+      "droppedLinks": "Các liên kết giữa các dự án đã bị xóa: {count}",
+      "errorCount": "{count} trường hợp thất bại",
+      "viewInTargetProject": "Xem trong dự án mục tiêu",
+      "failed": "Thất bại",
+      "folderMode": "Thư mục \"{folderName}\" — {caseCount, plural, one {# trường hợp} other {# trường hợp}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "Các vấn đề liên quan",
+    "linkedIssuesDescription": "Các vấn đề liên quan đến mặt hàng này",
+    "refreshed": "Các số báo đã được cập nhật",
+    "refreshedDescription": "Danh sách các vấn đề liên quan đã được cập nhật.",
+    "unlinked": "Vấn đề chưa được liên kết",
+    "unlinkedDescription": "Vấn đề này đã được xóa khỏi mục này.",
+    "linked": "Vấn đề liên quan",
+    "linkedDescription": "Vấn đề này có liên quan đến mặt hàng này.",
+    "searchAndLink": "Tìm kiếm và Liên kết",
+    "createAndLink": "Tạo và liên kết",
+    "noLinkedIssues": "Không có vấn đề liên quan",
+    "viewExternal": "Xem trong {provider}",
+    "unlink": "Hủy liên kết",
+    "linkError": "Không thể liên kết",
+    "linkExternalIssue": "Liên kết {provider} Vấn đề",
+    "linkIssue": "Vấn đề liên kết",
+    "addIssue": "Thêm vấn đề",
+    "unlinkError": "Không thể hủy liên kết",
+    "noIssuesFound": "Không phát hiện vấn đề nào.",
+    "startTypingToSearch": "Bắt đầu gõ để tìm kiếm các vấn đề",
+    "selectedCount": "{count} đã chọn",
+    "confirmSelection": "Xác nhận lựa chọn",
+    "alreadyLinked": "Đã được liên kết",
+    "authenticate": "Xác thực",
+    "authenticationRequired": "Yêu cầu xác thực",
+    "authenticationDescription": "Bạn cần xác thực với {provider} để tìm kiếm sự cố.",
+    "searchIn": "Tìm kiếm trong {provider}",
+    "searchPlaceholder": "Các vấn đề tìm kiếm...",
+    "searchIssues": "Các vấn đề tìm kiếm",
+    "searchIssuesDescription": "Tìm kiếm các vấn đề nội bộ có liên quan đến mục này.",
+    "searchExternalDescription": "Tìm kiếm {provider} vấn đề để liên kết đến mục này.",
+    "error": "Lỗi khi tải",
+    "errorDescription": "Không thể tải thông tin. Vui lòng thử lại.",
+    "selectIssues": "Chọn các vấn đề",
+    "authRequiredDescription": "Vui lòng xác thực bằng {provider} để tìm kiếm sự cố",
+    "integrationNotConfigured": "Tích hợp chưa được cấu hình",
+    "integrationNotConfiguredDescription": "Việc tích hợp này chưa được cấu hình hoàn chỉnh. Vui lòng liên hệ với quản trị viên dự án của bạn để cấu hình dự án bên ngoài trong cài đặt dự án.",
+    "createIssue": "Tạo sự cố",
+    "createNewIssue": "Tạo sự cố mới",
+    "createIssueDescription": "Tạo một vấn đề mới",
+    "createIssueDescriptionWithIntegration": "Tạo sự cố mới bằng cách sử dụng {provider}",
+    "createIssueDescriptionSimpleUrl": "Tạo một vấn đề nội bộ mới (Tích hợp URL đơn giản)",
+    "creatingWith": "Tạo sự cố với {provider}",
+    "authenticatedAndReady": "Đã xác thực và sẵn sàng tạo vấn đề.",
+    "created": "Sự cố đã được tạo",
+    "createdInExternal": "Sự cố được tạo trong {provider}",
+    "createdInternal": "Sự cố được tạo cục bộ",
+    "createdInternalSimpleUrl": "Sự cố này được tạo nội bộ và có thể được liên kết thông qua URL đơn giản.",
+    "createError": "Không thể tạo sự cố",
+    "useIntegration": "Sử dụng {provider}",
+    "useIntegrationDescription": "Tạo sự cố trên hệ thống bên ngoài",
+    "externalProject": "Dự án bên ngoài",
+    "selectProject": "Chọn dự án",
+    "issueType": "Loại sự cố",
+    "selectIssueType": "Chọn loại sự cố",
+    "noIssueTypes": "Không có loại sự cố nào.",
+    "priorityUrgent": "Cấp bách",
+    "additionalFields": "Các trường bổ sung",
+    "createIssueInJira": "Tạo sự cố trong Jira",
+    "createIssueInJiraDescription": "Sử dụng giao diện của Jira để tạo một sự cố mới với tất cả các trường và tùy chọn có sẵn.",
+    "createIssueInJiraFallbackDescription": "Mở Jira trong một tab mới để tạo sự cố với thông tin đã được điền sẵn.",
+    "jiraIframeError": "Không thể tải giao diện Jira. Vui lòng thử mở trong một tab mới.",
+    "jiraIframeFallback": "Vì lý do bảo mật, Jira yêu cầu mở trong một tab mới. Nhấp vào nút bên dưới để tạo sự cố của bạn.",
+    "jiraFallbackNote": "Sau khi tạo sự cố trong Jira, hãy quay lại đây để tiếp tục liên kết sự cố đó với trường hợp kiểm thử của bạn.",
+    "openInNewTab": "Mở trong tab mới",
+    "jiraIframeNote": "Sau khi tạo sự cố trong Jira, bạn có thể đóng hộp thoại này và làm mới danh sách sự cố.",
+    "fillInRequiredFields": "Hãy điền đầy đủ các trường bắt buộc để tạo vấn đề mới.",
+    "failedToFetchFields": "Không thể lấy các trường thông tin sự cố từ Jira.",
+    "enterSummary": "Hãy tóm tắt ngắn gọn vấn đề.",
+    "enterDescription": "Hãy nhập mô tả chi tiết về vấn đề.",
+    "failedToCreateIssue": "Không thể tạo sự cố trong Jira.",
+    "issueCreatedDescription": "Vấn đề {key} đã được tạo thành công",
+    "addLabel": "Thêm nhãn và nhấn Enter.",
+    "labelHint": "Khoảng trắng sẽ được thay thế bằng dấu gạch ngang.",
+    "labelFormatNote": "Nhãn không được chứa khoảng trắng. Khoảng trắng sẽ tự động được thay thế bằng dấu gạch ngang.",
+    "enterIssueKey": "Nhập mã số sự cố (ví dụ: PROJ-123)",
+    "issueLinkHelp": "Nhập mã số của một vấn đề hiện có để liên kết.",
+    "searchForIssue": "Tìm kiếm vấn đề cần liên kết",
+    "searchUsers": "Tìm kiếm người dùng",
+    "noTeamsAvailable": "Hiện không có đội nào.",
+    "filterAll": "Tất cả",
+    "fanOutPartialFailure": "Không thể truy cập {count} dự án. Hiển thị kết quả từ {successCount} dự án.",
+    "projectSelectorLabel": "Dự án",
+    "searchFailedTitle": "Tìm kiếm thất bại"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "Xem và quản lý tất cả các vấn đề.",
+      "filterPlaceholder": "Lọc các vấn đề theo tên..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "Tài liệu",
+      "Milestones": "Các cột mốc",
+      "TestCaseRepository": "Kho lưu trữ trường hợp thử nghiệm",
+      "TestCaseRestrictedFields": "Các trường bị hạn chế của trường hợp kiểm thử",
+      "TestRuns": "Chạy thử nghiệm",
+      "ClosedTestRuns": "Các lần chạy thử nghiệm đã đóng",
+      "TestRunResults": "Kết quả chạy thử nghiệm",
+      "TestRunResultRestrictedFields": "Kết quả chạy thử nghiệm - Các trường bị hạn chế",
+      "Sessions": "Phiên họp",
+      "SessionsRestrictedFields": "Các trường bị hạn chế của phiên",
+      "ClosedSessions": "Phiên họp kín",
+      "SessionResults": "Kết quả phiên họp",
+      "Tags": "Thẻ",
+      "SharedSteps": "Các bước chung",
+      "Issues": "Vấn đề",
+      "IssueIntegration": "Tích hợp vấn đề",
+      "Forecasting": "Dự báo",
+      "Reporting": "Báo cáo",
+      "Settings": "Cài đặt"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "Chưa bắt đầu",
+      "IN_PROGRESS": "Đang tiến hành",
+      "DONE": "Xong"
+    }
+  },
+  "charts": {
+    "average": "Trung bình",
+    "count": "Số lượng: {count}",
+    "percent": "Phần trăm: {percent}%",
+    "completed": "Đã hoàn thành: {count}",
+    "durationRange": "Thời lượng: {from}giây - {to}giây",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# trường hợp thử nghiệm} other {# các trường hợp thử nghiệm}}",
+    "estimate": "Est: {value}",
+    "partOf": "(Một phần của {parent})",
+    "status": "Trạng thái: {status}"
+  },
+  "linkedCases": {
+    "title": "Các trường hợp kiểm thử được liên kết",
+    "addLink": "Thêm liên kết",
+    "addLinkedTestCase": "Thêm trường hợp kiểm thử được liên kết",
+    "testCase": "Trường hợp thử nghiệm",
+    "linkType": "Loại liên kết",
+    "noLinkedCases": "Không có trường hợp kiểm thử nào được liên kết.",
+    "linkedBy": "Liên kết bởi",
+    "on": "Liên kết tại",
+    "alreadyLinked": "Vụ việc này đã có liên hệ với nhau.",
+    "cannotLinkSelf": "Không thể liên kết một vụ việc với chính nó.",
+    "circularLink": "Đã phát hiện liên kết vòng lặp.",
+    "failedToCreate": "Không thể tạo liên kết.",
+    "confirmRemoveLink": "Bạn có chắc chắn muốn xóa liên kết này không?",
+    "DEPENDS_ON": "Sự phụ thuộc",
+    "DUPLICATED_FROM": "Sao chép từ",
+    "SAME_TEST_DIFFERENT_SOURCE": "Cùng một bài kiểm tra (Nguồn khác nhau)",
+    "status": "Tình trạng mới nhất",
+    "at": "Đã thực thi"
+  },
+  "ganttTooltip": {
+    "task": "Nhiệm vụ",
+    "group": "Chạy/Phiên:",
+    "project": "Dự án:",
+    "starts": "Bắt đầu:",
+    "scheduledCompletion": "Dự kiến hoàn thành:",
+    "estWorkEffort": "Ước tính khối lượng công việc:",
+    "noTasks": "Không có nhiệm vụ nào để hiển thị trên biểu đồ Gantt."
+  },
+  "help": {
+    "project": {
+      "name": "## Tên Dự án\nMã định danh duy nhất cho dự án của bạn.\n\n- Phải là duy nhất trong tất cả các dự án\n- Được sử dụng trong điều hướng và báo cáo\n- Nên rõ ràng và mô tả\n- Giúp các thành viên nhóm xác định phạm vi dự án",
+      "description": "## Mô tả dự án\nThông tin chi tiết bổ sung về mục đích và phạm vi của dự án.\n\n- Không bắt buộc nhưng được khuyến nghị\n- Giúp các thành viên nhóm hiểu rõ mục tiêu dự án\n- Có thể bao gồm các mục tiêu hoặc yêu cầu chính\n- Giới hạn 256 ký tự",
+      "icon": "## Biểu tượng Dự án\nMột dấu hiệu trực quan cho dự án của bạn.\n\n- Giúp nhanh chóng xác định dự án trong danh sách và bảng điều khiển\n- Chọn từ nhiều biểu tượng được xác định trước\n- Có thể thay đổi bất cứ lúc nào\n- Hiển thị trong điều hướng dự án và báo cáo",
+      "completed": "## Trạng thái dự án\nCho biết dự án đang hoạt động hay đã hoàn thành.\n\n- Các dự án đang hoạt động có thể được thử nghiệm và cập nhật\n- Các dự án đã hoàn thành chỉ có thể đọc\n- Ảnh hưởng đến khả năng hiển thị dự án trên bảng điều khiển\n- Có thể được hoàn tác nếu cần",
+      "completedAt": "## Ngày hoàn thành\nNgày dự án được đánh dấu là hoàn thành.\n\n- Tự động thiết lập khi đánh dấu dự án là hoàn thành\n- Được sử dụng để báo cáo và theo dõi\n- Giúp duy trì lịch sử dự án\n- Có thể được sửa đổi nếu cần",
+      "defaultAccess": "## Quyền truy cập mặc định của dự án\nXác định quyền truy cập mặc định cho người dùng và nhóm trong dự án này. Có thể ghi đè các quyền này cho từng người dùng hoặc từng nhóm.",
+      "issueTracker": "## Cấu hình Trình theo dõi Sự cố\nChọn cấu hình trình theo dõi sự cố sẽ được sử dụng để quản lý các sự cố liên quan đến dự án này."
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## Dự án bên ngoài\nChọn dự án hoặc kho lưu trữ trong hệ thống bên ngoài để liên kết với dự án TestPlanIt này.\n\n- Các sự cố được tạo từ TestPlanIt sẽ được tạo trong dự án này\n- Cho phép tích hợp theo dõi sự cố giữa các hệ thống\n- Phải có quyền phù hợp trong hệ thống bên ngoài",
+          "defaultIssueTypeHelp": "## Loại sự cố mặc định\nLoại sự cố sẽ được chọn trước khi tạo sự cố mới từ TestPlanIt.\n\n- Tiết kiệm thời gian bằng cách mặc định chọn loại sự cố phổ biến nhất của bạn\n- Có thể được ghi đè khi tạo các sự cố riêng lẻ\n- Phải là loại sự cố hợp lệ cho dự án bên ngoài đã chọn\n- Cập nhật mục này nếu quy trình làm việc của bạn thay đổi",
+          "automaticSyncHelp": "## Đồng bộ tự động\nCho phép tự động đồng bộ trạng thái sự cố giữa TestPlanIt và hệ thống bên ngoài.\n\n- Các sự cố liên kết với trường hợp kiểm thử sẽ tự động cập nhật trạng thái của chúng\n- Giúp duy trì tính nhất quán trong việc theo dõi sự cố trên các hệ thống\n- Có thể làm tăng mức sử dụng API với dịch vụ bên ngoài\n- Có thể tắt nếu muốn điều khiển thủ công"
+        }
+      }
+    },
+    "user": {
+      "name": "## Tên người dùng\nTên đầy đủ của người dùng.\n\n- Được sử dụng để nhận dạng trong toàn hệ thống\n- Hiển thị trong các nhiệm vụ và báo cáo\n- Phải là duy nhất cho mỗi người dùng",
+      "email": "## Địa chỉ Email\nĐịa chỉ email của người dùng để truy cập tài khoản.\n\n- Dùng để đăng nhập hệ thống\n- Phải là địa chỉ duy nhất cho mỗi người dùng\n- Dùng để nhận thông báo hệ thống",
+      "password": "## Mật khẩu\nMật khẩu tài khoản của người dùng.\n\n- Tùy chọn khi cấu hình phương thức đăng nhập không cần mật khẩu (nhà cung cấp SSO Magic Link hoặc máy chủ email) — để trống nếu muốn yêu cầu đăng nhập qua Magic Link hoặc SSO\n- Khi được cung cấp, phải đáp ứng chính sách mật khẩu được thiết lập trong **Quản trị → Bảo mật** (độ dài tối thiểu và loại ký tự)\n- Được sử dụng để truy cập tài khoản an toàn\n- Nên được giữ bí mật",
+      "token": "## Mã xác minh\nNhập mã bạn nhận được trong email để xác minh tài khoản. Nếu bạn không có mã, bạn có thể yêu cầu mã mới.",
+      "confirmPassword": "## Xác nhận mật khẩu\nNhập lại mật khẩu để đảm bảo bạn đã nhập đúng.\n\n- Phải khớp chính xác với mật khẩu\n- Giúp tránh lỗi đánh máy\n- Chỉ bắt buộc khi nhập mật khẩu — để trống nếu trường mật khẩu trống",
+      "access": "## Cấp độ truy cập hệ thống\nXác định quyền hạn của người dùng trên toàn hệ thống.\n\n- **Quản trị viên:** Truy cập và cấu hình hệ thống đầy đủ\n- **Quản trị viên dự án:** Có thể quản lý các dự án được giao\n- **Người dùng:** Truy cập tiêu chuẩn vào các dự án được giao\n- **Không có quyền:** Chỉ có thể xem bảng điều khiển của họ",
+      "role": "## Vai trò hệ thống\nVai trò này xác định quyền truy cập dự án mặc định của người dùng.\n\n- Xác định cấp độ truy cập mặc định cho các dự án\n- Có thể được tùy chỉnh trong Quản trị vai trò\n- Ảnh hưởng đến các tính năng và khả năng có sẵn",
+      "active": "## Trạng thái hoạt động\nKiểm soát việc người dùng có thể truy cập hệ thống hay không.\n\n- Người dùng đang hoạt động có thể đăng nhập và truy cập các tài nguyên được chỉ định.\n- Người dùng không hoạt động không thể đăng nhập nhưng dữ liệu của họ vẫn được lưu giữ.\n  - Sử dụng tùy chọn này để tạm thời vô hiệu hóa quyền truy cập mà không xóa tài khoản.",
+      "api": "## Truy cập API\nCho phép truy cập lập trình vào hệ thống thông qua các điểm cuối API.\n\n- Cho phép tích hợp với các công cụ bên ngoài và tự động hóa\n- Yêu cầu xác thực bằng khóa API\n- Chịu sự giới hạn về số lượng yêu cầu và kiểm soát truy cập",
+      "projects": "## Phân công dự án\nChọn các dự án mà người dùng này có thể truy cập.\n\n- Kiểm soát các dự án hiển thị trên bảng điều khiển của người dùng\n- Bắt buộc để tham gia dự án\n- Có thể được quản trị viên chỉnh sửa sau\n- Sử dụng \"Chọn tất cả\" để nhanh chóng phân công tất cả các dự án có sẵn",
+      "groups": "## Phân công nhóm\nChọn nhóm mà người dùng này thuộc về.\n\n- Nhóm giúp tổ chức người dùng và quyền hạn\n- Người dùng kế thừa quyền hạn từ nhóm của họ\n- Đơn giản hóa việc quản lý quyền truy cập\n- Có thể được quản trị viên chỉnh sửa sau này",
+      "itemsPerPage": "## Số mục trên mỗi trang\nĐiều khiển số lượng mục mặc định hiển thị trong bảng và danh sách.\n\n- Ảnh hưởng đến tất cả các chế độ xem phân trang trong ứng dụng\n- Có thể thay đổi bất cứ lúc nào\n- Giúp quản lý các tập dữ liệu lớn một cách hiệu quả\n- Các tùy chọn có sẵn: 10, 25, 50 hoặc 100 mục",
+      "dateFormat": "## Định dạng ngày tháng\nĐặt định dạng hiển thị ngày tháng ưa thích của bạn.\n\n- Được áp dụng nhất quán trên toàn ứng dụng\n- Giúp đảm bảo độ chính xác khi diễn giải ngày tháng\n- Thay đổi có hiệu lực ngay lập tức\n- Các ví dụ hiển thị trong menu thả xuống phản ánh định dạng thực tế",
+      "timeFormat": "## Định dạng thời gian\nThiết lập định dạng hiển thị thời gian ưa thích của bạn.\n\n- Chọn giữa định dạng 12 giờ và 24 giờ\n- Được áp dụng nhất quán trên toàn ứng dụng\n- Thay đổi có hiệu lực ngay lập tức\n- Các ví dụ hiển thị trong menu thả xuống phản ánh định dạng thực tế",
+      "timezone": "## Múi giờ\nĐặt múi giờ ưa thích của bạn cho việc hiển thị ngày và giờ.\n\n- Được áp dụng nhất quán trên toàn bộ ứng dụng",
+      "theme": "## Chủ đề\nChọn chủ đề hình ảnh ưa thích cho ứng dụng.\n\n- **Hệ thống:** Tự động phù hợp với chủ đề hệ điều hành của bạn\n- **Sáng:** Giao diện sạch sẽ, tươi sáng để sử dụng ban ngày\n- **Tối:** Chế độ tối thân thiện với mắt cho môi trường thiếu sáng\n- **Xanh lá cây, Cam, Tím:** Thêm chút màu sắc vui tươi!",
+      "locale": "## Ngôn ngữ\nChọn ngôn ngữ bạn muốn sử dụng cho giao diện ứng dụng.\n\n- Thay đổi tất cả văn bản, nhãn và thông báo sang ngôn ngữ bạn đã chọn\n- Định dạng ngày và giờ được điều chỉnh cho phù hợp với quy ước khu vực\n- Có hiệu lực ngay lập tức mà không cần làm mới trang\n- Các ngôn ngữ khả dụng phụ thuộc vào các bản dịch đã được cài đặt",
+      "notificationMode": "## Tùy chọn thông báo\nĐiều chỉnh cách bạn nhận thông báo về nhiệm vụ và cập nhật công việc.\n\n- **Sử dụng cài đặt chung:** Tuân theo cài đặt mặc định của hệ thống do quản trị viên thiết lập\n- **Không có thông báo:** Tắt tất cả thông báo\n- **Chỉ trong ứng dụng:** Chỉ nhận thông báo trong ứng dụng\n- **Trong ứng dụng + Email (Ngay lập tức):** Nhận cả thông báo trong ứng dụng và cảnh báo email ngay lập tức\n- **Trong ứng dụng + Email (Tóm tắt hàng ngày):** Nhận thông báo trong ứng dụng và tóm tắt email hàng ngày\n\nBạn có thể thay đổi tùy chọn này bất cứ lúc nào để phù hợp với quy trình làm việc của mình."
+    },
+    "milestone": {
+      "name": "## Tên Mốc quan trọng\nMột tên rõ ràng, mô tả xác định mốc quan trọng này trong dự án của bạn.\n\n- Nên là duy nhất và có ý nghĩa\n- Giúp các thành viên nhóm nhanh chóng hiểu mục đích của mốc quan trọng\n- Được sử dụng trong báo cáo và theo dõi dự án",
+      "type": "## Loại cột mốc\nPhân loại cột mốc và xác định hình thức cũng như hành vi của nó.\n\n- Các loại khác nhau có thể có quy trình làm việc khác nhau\n- Giúp sắp xếp và lọc các cột mốc\n- Có thể ảnh hưởng đến báo cáo và theo dõi",
+      "started": "## Trạng thái Bắt đầu\nCho biết công việc trên mốc thời gian này đã bắt đầu.\n\n- Đánh dấu mốc thời gian là đang tiến hành\n- Tự động cập nhật ngày bắt đầu thực tế khi được bật\n- Ảnh hưởng đến tiến độ dự án và theo dõi tiến độ",
+      "completed": "## Trạng thái Hoàn thành\nCho biết công việc trên mốc này đã hoàn thành.\n\n- Đánh dấu mốc là đã hoàn thành\n- Tự động cập nhật ngày hoàn thành thực tế\n- Được sử dụng để theo dõi tiến độ và báo cáo\n- Ảnh hưởng đến các mốc phụ thuộc và tiến độ dự án",
+      "startDate": "## Ngày bắt đầu dự kiến\nNgày dự kiến bắt đầu công việc cho mốc thời gian này.\n\n- Hỗ trợ lập kế hoạch và lên lịch dự án\n- Được sử dụng để dự báo tiến độ\n- Hỗ trợ lập kế hoạch phân bổ nguồn lực",
+      "dueDate": "## Ngày đến hạn\nNgày mục tiêu để hoàn thành cột mốc này.\n\n- Đặt ra kỳ vọng về thời hạn\n- Được sử dụng để lập kế hoạch tiến độ dự án\n- Giúp theo dõi tiến độ cột mốc so với lịch trình",
+      "parent": "## Mốc quan trọng cha\nLiên kết mốc quan trọng này với mốc quan trọng cha, tạo thành một hệ thống phân cấp.\n\n- Tổ chức các mốc quan trọng thành các nhóm logic\n- Hiển thị các mối quan hệ và sự phụ thuộc\n- Giúp theo dõi tiến độ của các sáng kiến lớn hơn",
+      "description": "## Mô tả\nThông tin chi tiết về mục đích, yêu cầu và phạm vi của cột mốc.\n\n- Cung cấp bối cảnh cho các thành viên nhóm\n- Ghi lại các yêu cầu và mục tiêu chính\n- Hỗ trợ sự hợp tác và thống nhất",
+      "documentation": "## Tài liệu\nThông tin chi tiết bổ sung, tài liệu tham khảo và tài liệu hỗ trợ.\n\n- Thông số kỹ thuật\n- Tài liệu thiết kế\n- Tài liệu tham khảo bên ngoài\n- Biên bản cuộc họp và quyết định",
+      "automaticCompletion": "## Tự động hoàn thành khi đến hạn\nTự động đánh dấu mốc này là đã hoàn thành khi đến hạn.\n\n- Mốc sẽ được hoàn thành vào thời gian đã lên lịch vào ngày đến hạn\n- Hữu ích cho các mốc có giới hạn thời gian, cần được đóng lại bất kể trạng thái hoàn thành\n- Có thể bị ghi đè bằng cách hoàn thành mốc thủ công trước ngày đến hạn\n- Yêu cầu phải đặt ngày đến hạn",
+      "notifyDaysBefore": "## Thông báo trước ngày đến hạn\nGửi thông báo cho các thành viên nhóm được chỉ định khi ngày đến hạn của mốc thời gian sắp đến.\n\n- Bật để kích hoạt thông báo, tắt để vô hiệu hóa\n- Nhập số ngày trước ngày đến hạn để bắt đầu gửi lời nhắc\n- Thông báo được gửi đến người dùng được chỉ định cho các lần chạy thử nghiệm và phiên trong mốc thời gian này\n- Các mốc thời gian quá hạn sẽ tiếp tục gửi lời nhắc cho đến khi hoàn thành"
+    },
+    "session": {
+      "name": "## Tên phiên\nMột tên rõ ràng, mô tả mục đích của phiên kiểm thử.\n\n- Nên là duy nhất và có ý nghĩa\n- Giúp các thành viên nhóm hiểu được điều gì đang được kiểm thử\n- Được sử dụng trong báo cáo và theo dõi",
+      "template": "## Mẫu\nMẫu xác định cấu trúc và nội dung của phiên kiểm thử của bạn.\n\n- Cung cấp định dạng nhất quán cho tài liệu kiểm thử\n- Bao gồm các phần và trường được xác định trước\n- Giúp duy trì các tiêu chuẩn kiểm thử trong toàn bộ dự án của bạn",
+      "configuration": "## Cấu hình\nMôi trường hoặc thiết lập cụ thể cần thiết cho phiên kiểm thử này.\n\n- Môi trường kiểm thử (ví dụ: Staging, Production)\n- Cấu hình hoặc cài đặt đặc biệt\n- Dữ liệu hoặc điều kiện kiểm thử cần thiết",
+      "milestone": "## Mốc quan trọng\nLiên kết phiên này với một mốc quan trọng của dự án.\n\n- Giúp theo dõi tiến độ kiểm thử hướng tới mục tiêu dự án\n- Nhóm các phiên kiểm thử có liên quan\n- Hỗ trợ báo cáo dựa trên mốc quan trọng",
+      "description": "## Mô tả\nTổng quan ngắn gọn về nội dung của phiên kiểm thử này.\n\n- Các khu vực hoặc tính năng chính đang được kiểm thử\n- Bối cảnh hoặc thông tin quan trọng\n- Các lưu ý hoặc yêu cầu đặc biệt",
+      "mission": "## Nhiệm vụ\nNhiệm vụ xác định các mục tiêu cụ thể cho phiên thử nghiệm này.\n\n- Bạn đang thử nghiệm cái gì?\n- Các lĩnh vực trọng tâm chính là gì?\n- Kết quả mong đợi là gì?\n\nMột nhiệm vụ rõ ràng giúp việc thử nghiệm tập trung và hiệu quả hơn.",
+      "estimate": "## Ước tính thời gian\nThời gian ước tính để hoàn thành phiên kiểm tra này.\n\nVí dụ:\n- \"30 phút\" cho 30 phút\n- \"1 giờ 30 phút\" cho 1 giờ 30 phút\n- \"2 ngày\" cho 2 ngày\n- \"1 tuần\" cho 1 tuần",
+      "elapsed": "## Thời gian đã trôi qua\nThời gian thực tế đã dành cho phiên thử nghiệm này.\n\nVí dụ:\n- \"45m\" cho 45 phút\n- \"2h 15m\" cho 2 giờ 15 phút\n- \"3 ngày\" cho 3 ngày\n\nTheo dõi thời gian chính xác để cải thiện các ước tính trong tương lai.",
+      "state": "## Trạng thái quy trình làm việc\nTrạng thái hiện tại của phiên kiểm thử này trong quy trình làm việc của bạn.\n\n- Giúp theo dõi tiến độ phiên\n- Hỗ trợ quản lý quy trình làm việc\n- Được sử dụng để báo cáo và theo dõi",
+      "assignedTo": "## Người được giao nhiệm vụ\nThành viên nhóm chịu trách nhiệm thực hiện phiên kiểm thử này.\n\n- Xác định người thực hiện kiểm thử\n- Hỗ trợ quản lý tài nguyên\n- Hỗ trợ trách nhiệm giải trình và theo dõi",
+      "tags": "## Thẻ\nTừ khóa hoặc nhãn giúp phân loại và sắp xếp các phiên kiểm thử.\n\n- Giúp dễ dàng tìm kiếm các phiên\n- Nhóm các hoạt động kiểm thử có liên quan\n- Hỗ trợ lọc và báo cáo",
+      "attachments": "## Tệp đính kèm\nCác tệp, ảnh chụp màn hình hoặc các tài liệu khác liên quan đến phiên thử nghiệm này.\n\n- Tệp dữ liệu thử nghiệm\n- Ảnh chụp màn hình hoặc bản ghi\n- Tài liệu hỗ trợ\n- Tài liệu tham khảo",
+      "issues": "## Vấn đề\nLiên kết các vấn đề liên quan đến phiên này."
+    },
+    "testRun": {
+      "name": "## Tên Lần Chạy Thử Nghiệm\nNhập một tên mô tả cho lần chạy thử nghiệm này để dễ dàng nhận dạng sau này.",
+      "description": "## Mô tả\nCung cấp bản tóm tắt ngắn gọn hoặc ghi chú về lần chạy thử nghiệm này.",
+      "configuration": "## Cấu hình\nChọn một hoặc nhiều cấu hình (ví dụ: môi trường, trình duyệt, thiết bị) mà theo đó các lần chạy thử nghiệm sẽ được thực hiện. Việc chọn nhiều cấu hình sẽ tạo ra các lần chạy thử nghiệm riêng biệt cho mỗi cấu hình.",
+      "milestone": "## Mốc quan trọng\nLiên kết lần chạy thử nghiệm này với một mốc quan trọng cụ thể của dự án để theo dõi tiến độ hướng tới các mục tiêu lớn hơn.",
+      "docs": "## Tài liệu\nBao gồm bất kỳ tài liệu, liên kết hoặc ghi chú chi tiết nào có liên quan cho lần chạy thử nghiệm này.",
+      "state": "## Trạng thái\nCho biết trạng thái hiện tại hoặc kết quả của lần chạy thử nghiệm này theo quy trình làm việc của dự án.",
+      "tags": "## Thẻ\nÁp dụng các thẻ liên quan để phân loại và lọc kết quả chạy thử nghiệm này.",
+      "issues": "## Vấn đề\nLiên kết bất kỳ vấn đề liên quan nào (lỗi, nhiệm vụ, v.v.) với lần chạy thử nghiệm này.",
+      "attachments": "## Tệp đính kèm\nVui lòng tải lên bất kỳ tệp hỗ trợ, ảnh chụp màn hình hoặc nhật ký nào liên quan đến lần chạy thử nghiệm này.",
+      "duplicate": {
+        "statusesToInclude": "## Các trạng thái cần bao gồm\nChọn các trạng thái của trường hợp kiểm thử mà bạn muốn bao gồm trong lần chạy kiểm thử trùng lặp.",
+        "copyAssignments": "## Sao chép phân công\nNếu được bật, các phân công của các trường hợp kiểm thử sẽ được sao chép sang lần chạy kiểm thử trùng lặp."
+      }
+    },
+    "appConfig": {
+      "key": "## Khóa\nMã định danh duy nhất cho cấu hình này.",
+      "value": "## Giá trị\nGiá trị của cấu hình này."
+    },
+    "milestoneType": {
+      "icon": "## Biểu tượng Loại Mốc quan trọng\nBiểu tượng trực quan cho loại mốc quan trọng này.\n\n- Giúp nhanh chóng xác định loại mốc quan trọng trong danh sách và bảng điều khiển\n- Chọn từ nhiều biểu tượng được xác định trước\n- Có thể thay đổi bất cứ lúc nào\n- Hiển thị trong điều hướng dự án và báo cáo",
+      "name": "## Tên Loại Mốc Quan Trọng\nMột tên rõ ràng, mô tả xác định loại mốc quan trọng này trong dự án của bạn.\n\n- Giúp các thành viên nhóm nhanh chóng hiểu mục đích của loại mốc quan trọng này.\n- Được sử dụng trong báo cáo và theo dõi dự án.",
+      "isDefault": "## Loại mốc mặc định\nCho biết liệu loại mốc này có phải là loại mặc định cho dự án của bạn hay không.\n\n- Loại mốc mặc định được chọn trước cho các mốc mới\n- Có thể thay đổi bất cứ lúc nào",
+      "projects": "## Các Dự Án Liên Kết\nChọn các dự án mà loại mốc này sẽ khả dụng.\n\n- Nếu không có dự án nào được chọn, loại mốc này sẽ khả dụng trên toàn cầu.\n- Việc gán cho các dự án cụ thể sẽ giới hạn việc sử dụng chỉ cho các dự án đó."
+    },
+    "tag": {
+      "name": "## Tên Thẻ\nMột tên hoặc từ khóa rõ ràng, ngắn gọn, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp các thành viên nhóm nhanh chóng tìm thấy các trường hợp kiểm thử, các lần chạy thử nghiệm và các phiên liên quan."
+    },
+    "role": {
+      "name": "## Tên vai trò\nMột tên hoặc từ khóa rõ ràng, ngắn gọn, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp các thành viên nhóm nhanh chóng tìm thấy các trường hợp kiểm thử, các lần chạy thử nghiệm và các phiên liên quan.",
+      "isDefault": "## Vai trò mặc định\nCho biết liệu vai trò này có phải là vai trò mặc định cho dự án của bạn hay không.\n\n- Vai trò mặc định được chọn sẵn cho người dùng mới\n- Có thể thay đổi bất cứ lúc nào",
+      "permissions": {
+        "canAddEdit": "## Thêm/Chỉnh sửa\nCho biết liệu vai trò này có thể thêm và chỉnh sửa khu vực ứng dụng liên quan hay không.",
+        "canDelete": "## Xóa\nCho biết liệu vai trò này có thể xóa khu vực ứng dụng liên quan hay không.",
+        "canClose": "## Đóng\nCho biết liệu vai trò này có thể đóng khu vực ứng dụng liên quan hay không."
+      }
+    },
+    "group": {
+      "name": "## Tên Nhóm\nMột tên hoặc từ khóa rõ ràng, ngắn gọn, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp các thành viên nhóm nhanh chóng tìm thấy các trường hợp kiểm thử, các lần chạy thử nghiệm và các phiên liên quan.",
+      "users": "## Người dùng\nCho biết những người dùng được chỉ định vào nhóm này."
+    },
+    "template": {
+      "name": "## Tên mẫu\nMột tên duy nhất và mô tả cho mẫu này (ví dụ: 'Trường hợp kiểm thử tiêu chuẩn', 'Kết quả kiểm thử API').",
+      "isEnabled": "## Đã bật\nNếu được chọn, mẫu này sẽ có sẵn để lựa chọn khi tạo trường hợp kiểm thử mới hoặc xác định cấu trúc chạy kiểm thử. Nếu một mẫu được đặt là 'Mặc định', nó cũng phải được 'Bật'.",
+      "isDefault": "## Mặc định\nNếu được chọn, mẫu này sẽ tự động được chọn cho các dự án mới hoặc làm mặc định cho tất cả các dự án nếu không có mẫu mặc định cụ thể nào được thiết lập cho dự án. Chỉ có một mẫu có thể là mặc định cho tất cả các dự án. Việc bật tùy chọn này sẽ vô hiệu hóa bất kỳ mẫu nào khác hiện đang được đặt làm mặc định.",
+      "caseFields": "## Trường dữ liệu kiểm thử\nChọn và sắp xếp các trường tùy chỉnh sẽ có sẵn khi tạo hoặc chỉnh sửa trường hợp kiểm thử bằng mẫu này.\n\n- Thêm các trường từ menu thả xuống để đưa chúng vào mẫu\n- Kéo và thả để sắp xếp lại thứ tự các trường\n- Thứ tự xác định cách các trường hiển thị trong biểu mẫu\n- Chỉ các trường dữ liệu kiểm thử đã được kích hoạt mới có thể được chọn\n- Các trường dữ liệu kiểm thử xác định cấu trúc và dữ liệu được thu thập cho các trường hợp kiểm thử",
+      "resultFields": "## Các trường kết quả\nChọn và sắp xếp các trường tùy chỉnh sẽ hiển thị khi thêm kết quả kiểm thử bằng mẫu này.\n\n- Thêm các trường từ menu thả xuống để đưa chúng vào mẫu\n- Kéo và thả để sắp xếp lại các trường\n- Thứ tự sẽ xác định cách các trường hiển thị khi nhập kết quả kiểm thử\n- Chỉ các trường kết quả được kích hoạt mới có thể được chọn\n- Các trường kết quả ghi lại dữ liệu bổ sung cụ thể cho kết quả thực thi kiểm thử",
+      "projects": "## Các Dự Án Liên Kết\nChọn các dự án mà mẫu này sẽ khả dụng. Nếu không có dự án nào được chọn, mẫu sẽ khả dụng trên toàn cầu. Việc gán mẫu cho các dự án cụ thể sẽ giới hạn việc sử dụng mẫu chỉ trong các dự án đó."
+    },
+    "llm": {
+      "name": "## Tên tích hợp\nNhãn mô tả cho tích hợp LLM này.\n\n- Được sử dụng để xác định nó trong danh sách và cài đặt\n- Ví dụ: \"OpenAI GPT-4o\" hoặc \"Ollama nội bộ\"",
+      "provider": "## Nhà cung cấp\nDịch vụ LLM hỗ trợ tích hợp này.\n\n- Xác định giao thức API và các mô hình khả dụng\n- Không thể thay đổi sau khi tạo",
+      "apiKey": "## Khóa API\nKhóa xác thực của bạn cho API của nhà cung cấp LLM.\n\n- Lấy khóa này từ bảng điều khiển dành cho nhà phát triển của nhà cung cấp\n- Được mã hóa và không bao giờ hiển thị sau khi lưu\n- Không bắt buộc đối với Ollama (triển khai cục bộ)",
+      "endpoint": "## Điểm cuối API\nURL cơ sở cho API của nhà cung cấp LLM.\n\n- Để trống đối với OpenAI, Anthropic và Gemini — URL chính thức sẽ được sử dụng tự động\n- Bắt buộc đối với Ollama (ví dụ: `http://localhost:11434`), Azure OpenAI và LLM tùy chỉnh\n- Tùy chọn đối với bất kỳ nhà cung cấp nào — trỏ đến một proxy tương thích với OpenAI (ví dụ: LiteLLM) bằng cách nhập URL của nó\n- **Các địa chỉ riêng tư/nội bộ** (localhost, 127.0.0.1, địa chỉ IP riêng, siêu dữ liệu đám mây) bị chặn trừ khi được cho phép rõ ràng thông qua biến môi trường `ALLOWED_PRIVATE_HOSTS`",
+      "deploymentName": "## Tên triển khai Azure\nTên của triển khai mô hình Azure OpenAI của bạn.\n\n- Được tìm thấy trong Azure OpenAI Studio trong mục Triển khai\n- Khác với tên mô hình — ví dụ: `my-gpt4-deploy` tương ứng với `gpt-4`\n- Chỉ bắt buộc đối với Azure OpenAI",
+      "defaultModel": "## Mô hình mặc định\nMô hình được sử dụng cho các yêu cầu AI với tích hợp này.\n\n- Đối với OpenAI, Anthropic và Gemini — các mô hình có sẵn được tự động lấy từ khóa API của bạn\n- Đảm bảo mô hình đã được kích hoạt trong tài khoản nhà cung cấp của bạn\n- Ví dụ: `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`",
+      "maxTokensPerRequest": "## Số Token Tối Đa Mỗi Yêu Cầu\nGiới hạn tối đa cho số token đầu ra của bất kỳ yêu cầu nào.\n\n- Các yêu cầu vượt quá giới hạn này sẽ bị từ chối với lỗi trước khi đạt đến LLM\n- Đặt giá trị này thành dung lượng token đầu ra tối đa thực tế của mô hình\n- Ví dụ: `16384` cho GPT-4o, `8192` cho Claude 3.5 Sonnet\n- Đặt giá trị này quá thấp sẽ khiến các tính năng AI bị lỗi hoặc tạo ra đầu ra bị cắt ngắn",
+      "defaultMaxTokens": "## Số Token Tối Đa Mặc Định\nGiới hạn token đầu ra **dự phòng** được sử dụng khi yêu cầu không chỉ định giới hạn riêng.\n\n- Mỗi tính năng AI (tạo kiểm thử, xuất mã, v.v.) đặt giới hạn riêng trong **Quản trị → Cấu hình lời nhắc**\n- Giá trị này chỉ được sử dụng làm giá trị dự phòng cho các tính năng không có giới hạn cụ thể được cấu hình\n- Nên nhỏ hơn hoặc bằng Số Token Tối Đa Mỗi Yêu Cầu",
+      "maxRequestsPerMinute": "## Số lượng yêu cầu tối đa mỗi phút\nGiới hạn số lượng cuộc gọi API có thể được thực hiện đến nhà cung cấp này mỗi phút.\n\n- Đặt để phù hợp với giới hạn tốc độ của gói dịch vụ của nhà cung cấp\n- Các yêu cầu vượt quá sẽ được xếp vào hàng đợi, không bị từ chối\n- Kiểm tra tài liệu của nhà cung cấp để biết giới hạn của gói dịch vụ của bạn",
+      "costPerInputToken": "## Chi phí mỗi Token đầu vào (USD)\nChi phí bằng USD cho mỗi token đầu vào (lời nhắc) được gửi đến mô hình.\n\n- Được sử dụng để theo dõi chi phí và cảnh báo ngân sách\n- Tìm thông tin này trên trang giá của nhà cung cấp\n- Ví dụ: `0.000005` = 5 USD cho mỗi triệu token đầu vào",
+      "costPerOutputToken": "## Chi phí trên mỗi Token đầu ra (USD)\nChi phí bằng USD cho mỗi token đầu ra (hoàn thành) được tạo ra bởi mô hình.\n\n- Thường cao hơn chi phí token đầu vào\n- Được sử dụng để theo dõi chi phí và cảnh báo ngân sách\n- Ví dụ: `0.000015` = 15 USD cho mỗi triệu token đầu ra",
+      "monthlyBudget": "## Ngân sách hàng tháng (USD)\nMục tiêu chi tiêu tùy chọn cho tích hợp này.\n\n- Đặt thành `0` để tắt theo dõi ngân sách\n- Ngân sách chỉ mang tính chất **thông tin** — nó không chặn việc sử dụng LLM\n- Bạn sẽ nhận được thông báo khi đạt 80%, 90% và 100% ngân sách\n- Chi phí được tính toán dựa trên tỷ giá mỗi token ở trên",
+      "billingPeriodStartDay": "## Ngày bắt đầu kỳ thanh toán\nNgày trong tháng (1–31) khi kỳ thanh toán của bạn bắt đầu.\n\n- Mặc định là `1` tương ứng với tháng dương lịch\n- Đặt thành `15` cho chu kỳ từ ngày 15 đến ngày 15 (ví dụ: để khớp với ngày hóa đơn của nhà cung cấp)\n- Các giá trị `29–31` tự động giới hạn ở ngày cuối cùng của các tháng ngắn hơn (tháng 2 trong năm không nhuận, v.v.)\n- Ảnh hưởng đến cửa sổ chi tiêu **Ngân sách hàng tháng** và hành động **Đặt lại chi tiêu**",
+      "defaultTemperature": "## Nhiệt độ mặc định\nĐiều khiển tính ngẫu nhiên của phản hồi mô hình (0–2).\n\n- **0:** Xác định — đầu ra giống hệt nhau cho cùng một đầu vào\n- **0.3:** Tập trung — được khuyến nghị để tạo kiểm thử và xuất mã\n- **1+:** Sáng tạo — phản hồi đa dạng hơn\n- Các tính năng riêng lẻ có thể ghi đè cài đặt này trong Cấu hình lời nhắc",
+      "timeout": "## Thời gian chờ yêu cầu (ms)\nThời gian chờ phản hồi trước khi yêu cầu bị hủy.\n\n- Giá trị tính bằng mili giây (ví dụ: `30000` = 30 giây)\n- Các yêu cầu truyền tải dữ liệu (ví dụ: xem trước xuất mã) sẽ bỏ qua thời gian chờ này\n- Tăng giá trị cho các mô hình chậm hoặc lớn\n- Phạm vi: 5.000 – 600.000 ms",
+      "streamingEnabled": "## Bật tính năng truyền phát trực tuyến\nTruyền phát phản hồi từng token một thay vì chờ toàn bộ kết quả.\n\n- Bắt buộc để xem trước mã theo thời gian thực trong cửa sổ Xuất\n- Giảm độ trễ cảm nhận đối với các phản hồi dài\n- Được khuyến nghị cho tất cả các nhà cung cấp được hỗ trợ",
+      "isDefault": "## Đặt làm tích hợp mặc định\nĐặt tích hợp này làm mặc định cho tất cả các tính năng AI.\n\n- Chỉ có thể đặt một tích hợp làm mặc định tại một thời điểm\n- Các tính năng không được cấu hình nhà cung cấp cụ thể sẽ sử dụng nhà cung cấp mặc định\n- Có thể thay đổi bất cứ lúc nào"
+    },
+    "integration": {
+      "name": "## Tên Tích hợp\nMột tên mô tả để xác định tích hợp này trên toàn hệ thống.\n\n- Phải là duy nhất để phân biệt với các tích hợp khác\n- Được sử dụng trong cài đặt và cấu hình dự án\n- Nên chỉ rõ dịch vụ và mục đích",
+      "authType": "## Loại xác thực\nChọn cách xác thực với dịch vụ bên ngoài.\n\n- **Khóa API:** Xác thực đơn giản bằng email và mã thông báo API\n- **OAuth 2.0:** Xác thực an toàn bằng quy trình OAuth\n- **Mã thông báo truy cập cá nhân:** Xác thực trực tiếp dựa trên mã thông báo",
+      "email": "## Địa chỉ Email\nĐịa chỉ email tài khoản của bạn cho dịch vụ bên ngoài.\n\n- Được sử dụng để xác thực khóa API\n- Phải trùng khớp với tài khoản đã tạo mã thông báo API\n- Bắt buộc đối với Jira và các dịch vụ tương tự",
+      "apiToken": "## Mã thông báo API\nTạo mã thông báo API từ cài đặt tài khoản của bạn trong dịch vụ bên ngoài.\n\n- Thường được tìm thấy trong Cài đặt tài khoản → Bảo mật → Mã thông báo API\n- Cung cấp quyền truy cập an toàn mà không cần tiết lộ mật khẩu của bạn\n- Có thể bị thu hồi và tạo lại khi cần",
+      "jiraUrl": "## URL Jira\nURL cơ sở của phiên bản Jira của bạn.\n\n- Định dạng: https://your-site.atlassian.net\n- Không bao gồm /browse hoặc các đường dẫn khác\n- Phải có thể truy cập được từ máy chủ này",
+      "clientId": "## ID máy khách OAuth\nID máy khách từ cấu hình ứng dụng OAuth của bạn.\n\n- Được tạo trong bảng điều khiển dành cho nhà phát triển của dịch vụ bên ngoài\n- Được sử dụng để xác định ứng dụng của bạn trong quá trình OAuth\n- An toàn để chia sẻ trong các tệp cấu hình",
+      "clientSecret": "## Mã bí mật máy khách OAuth\nMã bí mật máy khách từ cấu hình ứng dụng OAuth của bạn.\n\n- Được tạo cùng với ID máy khách\n- Phải được giữ bí mật và an toàn\n- Được sử dụng để xác thực ứng dụng của bạn",
+      "personalAccessToken": "## Mã truy cập cá nhân\nMã truy cập cá nhân với các quyền phù hợp cho dịch vụ bên ngoài.\n\n- Được tạo trong cài đặt tài khoản của bạn\n- Nên có quyền đọc và ghi\n- An toàn hơn xác thực bằng mật khẩu",
+      "baseUrl": "## Mẫu URL\nMẫu URL để liên kết đến các vấn đề bên ngoài.\n\n- Sử dụng '{issueId}' làm chỗ giữ chỗ cho mã định danh vấn đề\n- Ví dụ: https://example.com/issues/'{issueId}'\n- Được sử dụng cho các tích hợp dựa trên URL đơn giản",
+      "organizationUrl": "## URL Tổ chức\nURL tổ chức Azure DevOps của bạn.\n\n- Định dạng: https://dev.azure.com/your-org\n- Phải có thể truy cập được từ máy chủ này\n- Được sử dụng để truy cập API Azure DevOps",
+      "apiKey": "## Khóa API\nKhóa API dùng để xác thực với dịch vụ bên ngoài.\n\n- Được tạo trong cài đặt API của dịch vụ\n- Cung cấp quyền truy cập lập trình vào dịch vụ\n- Bảo mật và thay đổi thường xuyên",
+      "forgeApiKey": "## Khóa API Forge\nĐược sử dụng để xác thực ứng dụng Atlassian Forge khi ứng dụng này lấy dữ liệu kiểm thử từ các vấn đề Jira của bạn.\n\n- Nhấp vào Tạo để tạo khóa mới\n- Sao chép khóa và dán vào cài đặt ứng dụng Forge trong Jira (Quản lý ứng dụng → Cài đặt TestPlanIt)\n- Việc tạo lại sẽ vô hiệu hóa khóa trước đó",
+      "owner": "## Chủ sở hữu / Không gian tên\nNgười dùng hoặc tổ chức sở hữu kho lưu trữ.\n\n- Đối với GitHub/GitLab: tên người dùng hoặc tên tổ chức\n- Đối với Gitea/Forgejo/Gogs: tên người dùng hoặc nhóm\n- Ví dụ: my-org hoặc my-username",
+      "repo": "## Tên kho lưu trữ\nTên của kho lưu trữ để liên kết các vấn đề.\n\n- Tên kho lưu trữ chính xác (không phải URL đầy đủ)\n- Ví dụ: my-project\n- Phải có thể truy cập được bằng thông tin đăng nhập được cung cấp",
+      "instanceUrl": "## URL phiên bản\nURL cơ sở của phiên bản tự lưu trữ của bạn.\n\n- Định dạng: https://git.example.com\n- Không bao gồm dấu gạch chéo hoặc đường dẫn ở cuối\n- Phải có thể truy cập được từ máy chủ này",
+      "projectPath": "## Đường dẫn dự án\nĐường dẫn đầy đủ đến dự án GitLab của bạn.\n\n- Định dạng: namespace/project hoặc group/subgroup/project\n- Ví dụ: my-org/my-project\n- Tìm thấy trong URL dự án: gitlab.com/namespace/project",
+      "platform": "## Nền tảng\nNền tảng Git tự lưu trữ mà bạn đang kết nối.\n\n- **Gitea**: các phiên bản dựa trên gitea.io\n- **Forgejo**: các phiên bản dựa trên forgejo.org (phiên bản phân nhánh của Gitea)\n- **Gogs**: các phiên bản dựa trên gogs.io\n\nĐiều này kiểm soát biểu tượng nào được hiển thị và có thể ảnh hưởng đến khả năng tương thích API."
+    },
+    "config": {
+      "name": "## Tên Cấu hình\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp mô tả các tổ hợp biến thể tạo nên Cấu hình (ví dụ: \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", v.v.)."
+    },
+    "configCategory": {
+      "name": "## Tên Danh mục\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp sắp xếp các biến thể (ví dụ: Chrome, Firefox, Safari, Edge, v.v.) vào các danh mục (ví dụ: Trình duyệt)."
+    },
+    "configVariant": {
+      "name": "## Tên Biến thể\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp mô tả biến thể là một phần của môi trường thử nghiệm (ví dụ: Chrome, Safari, Windows 10, Windows 11, macOS 15.5, v.v.)."
+    },
+    "issueConfig": {
+      "name": "## Tên Cấu Hình Sự Cố\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp mô tả cấu hình sự cố (ví dụ: Jira, GitHub, v.v.).",
+      "baseUrl": "## URL cơ sở\nURL cơ sở cho cấu hình sự cố bao gồm cả phần giữ chỗ sự cố (ví dụ: https://your-jira-instance.atlassian.net/browse/'{issueId}').",
+      "systemType": "## Loại hệ thống\nLoại hệ thống theo dõi sự cố (ví dụ: LINK Jira, v.v.).",
+      "isActive": "## Hoạt động\nCho biết cấu hình sự cố này có đang hoạt động hay không.",
+      "isDefault": "## Mặc định\nCho biết cấu hình vấn đề này có phải là mặc định cho dự án của bạn hay không.\n\n- Cấu hình vấn đề mặc định được chọn trước cho các vấn đề mới\n- Có thể thay đổi bất cứ lúc nào",
+      "projects": "## Dự án\nCho biết các dự án được gán cho cấu hình sự cố này."
+    },
+    "issue": {
+      "name": "## Tên sự cố\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp mô tả sự cố (ví dụ: \"Sự cố 123\", \"Lỗi 456\", v.v.).",
+      "title": "## Tiêu đề vấn đề\nMột tiêu đề dễ đọc, mô tả vấn đề.\n\n- Cung cấp ngữ cảnh về nội dung của vấn đề\n- Được hiển thị trong danh sách và bảng tổng hợp vấn đề\n- Cần rõ ràng và mang tính mô tả",
+      "externalKey": "## Khóa bên ngoài\nKhóa hoặc mã định danh duy nhất từ hệ thống theo dõi sự cố bên ngoài.\n\n- Đối với JIRA: Mã sự cố như \"PROJ-123\"\n- Đối với GitHub: Số sự cố như \"456\"\n- Đối với Azure DevOps: ID mục công việc\n- Tự động tạo URL bên ngoài khi lưu",
+      "externalId": "## Mã định danh bên ngoài\nMã định danh duy nhất cho vấn đề này trong hệ thống theo dõi sự cố (ví dụ: \"Issue-123\", \"Bug456\", v.v.).\n\n- Mã này được sử dụng làm chỗ giữ chỗ cho sự cố trong URL cơ sở.",
+      "description": "## Mô tả\nTổng quan ngắn gọn về nội dung của vấn đề này.\n\n- Các lĩnh vực hoặc tính năng chính đang được kiểm thử\n- Bối cảnh hoặc thông tin quan trọng\n- Các lưu ý hoặc yêu cầu đặc biệt",
+      "project": "## Dự án\nDự án mà vấn đề này liên quan đến.\n\n- Các vấn đề có thể được liên kết với các trường hợp kiểm thử trên nhiều dự án\n- Việc thiết lập một dự án chính giúp sắp xếp các vấn đề\n- Có thể để trống đối với các vấn đề liên quan đến nhiều dự án",
+      "state": "## Trạng thái\nCho biết trạng thái hiện tại hoặc kết quả của vấn đề này theo quy trình làm việc của dự án.",
+      "tags": "## Thẻ\nÁp dụng các thẻ liên quan để phân loại và lọc vấn đề này.",
+      "issues": "## Vấn đề\nLiên kết bất kỳ vấn đề liên quan nào (lỗi, nhiệm vụ, v.v.) với vấn đề này."
+    },
+    "status": {
+      "name": "## Tên trạng thái\nMột tên rõ ràng, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp mô tả trạng thái kết quả kiểm thử (ví dụ: Đã đạt, Thất bại, Bị chặn, v.v.).",
+      "color": "## Màu sắc\nMàu sắc của trạng thái này.",
+      "systemName": "## Tên Hệ Thống\nTên của trạng thái được hệ thống phụ trợ sử dụng (ví dụ: truy vấn cơ sở dữ liệu, báo cáo, v.v.).",
+      "aliases": "## Tên gọi khác\nTên gọi bổ sung hoặc từ đồng nghĩa cho trạng thái này, có thể được sử dụng để liên kết các trạng thái hệ thống bên ngoài với trạng thái này.",
+      "enabled": "## Đã bật\nCho biết trạng thái này có được bật hay không.",
+      "isEnabled": "## Đã bật\nCho biết trạng thái này có được bật và sẵn sàng sử dụng hay không.\n\n- Khi được bật, trạng thái này có thể được chọn khi ghi lại kết quả kiểm tra.\n- Các trạng thái bị tắt sẽ bị ẩn khỏi lựa chọn nhưng vẫn được lưu giữ trong kết quả hiện có.",
+      "success": "## Thành công\nCho biết trạng thái này có phải là trạng thái thành công hay không.",
+      "isSuccess": "## Trạng thái Thành công\nCho biết trạng thái này có thể hiện kết quả kiểm tra thành công hay không.\n\n- Trạng thái thành công góp phần vào chỉ số tỷ lệ đạt\n- Được sử dụng trong báo cáo và phân tích để theo dõi hiệu quả kiểm tra",
+      "completed": "## Đã hoàn thành\nCho biết trạng thái này có phải là trạng thái đã hoàn thành hay không.",
+      "isCompleted": "## Trạng thái Hoàn thành\nCho biết trạng thái này có biểu thị việc thực thi kiểm thử đã hoàn tất hay không.\n\n- Trạng thái Hoàn thành cho biết bài kiểm thử đã chạy xong.\n- Được sử dụng để tính toán tỷ lệ hoàn thành và theo dõi tiến độ.",
+      "failure": "## Thất bại\nCho biết trạng thái này có phải là trạng thái thất bại hay không.",
+      "isFailure": "## Trạng thái lỗi\nCho biết trạng thái này có biểu thị kết quả kiểm tra thất bại hay không.\n\n- Trạng thái lỗi góp phần vào các chỉ số tỷ lệ lỗi\n- Được sử dụng trong báo cáo và phân tích để xác định các vấn đề",
+      "scope": "## Phạm vi\nCho biết phạm vi của trạng thái này (Chạy thử nghiệm, Phiên, Tự động hóa).",
+      "projects": "## Dự án\nCho biết các dự án có thể sử dụng trạng thái này."
+    },
+    "workflow": {
+      "scope": "## Phạm vi\nCho biết phạm vi của quy trình công việc này (Chạy thử nghiệm, Phiên, Tự động hóa).\n\n- Không thể thay đổi sau khi quy trình công việc được tạo.",
+      "iconColor": "## Biểu tượng/Màu sắc\nBiểu tượng và màu sắc cho quy trình làm việc này.",
+      "name": "## Tên\nMột tên rõ ràng, mô tả được sử dụng cho tất cả các dự án.\n\n- Giúp mô tả quy trình làm việc (ví dụ: \"Bản nháp\", \"Đang xem xét\", \"Đang hoạt động\", v.v.).",
+      "workflowType": "## Loại\nLoại quy trình công việc (Chưa bắt đầu, Đang tiến hành, Đã hoàn thành).",
+      "type": "## Loại quy trình công việc\nDanh mục trạng thái quy trình công việc (Chưa bắt đầu, Đang tiến hành, Đã hoàn thành).\n\n- Xác định cách trạng thái này ảnh hưởng đến việc theo dõi tiến độ\n- Trạng thái Chưa bắt đầu cho biết công việc chưa được bắt đầu\n- Trạng thái Đang tiến hành cho thấy công việc đang được thực hiện\n- Trạng thái Đã hoàn thành đánh dấu công việc đã hoàn thành",
+      "isDefault": "## Mặc định\nCho biết liệu quy trình làm việc này có phải là mặc định cho dự án của bạn hay không.\n\n- Quy trình làm việc mặc định được chọn trước cho các lần chạy thử nghiệm, phiên và tự động hóa mới.",
+      "isEnabled": "## Đã bật\nCho biết liệu quy trình làm việc này có được bật hay không.",
+      "isActive": "## Hoạt động\nCho biết trạng thái quy trình công việc này có đang hoạt động và sẵn sàng sử dụng hay không.\n\n- Các quy trình công việc đang hoạt động có thể được chọn khi cập nhật các lần chạy thử nghiệm, phiên hoặc tự động hóa.\n- Các quy trình công việc không hoạt động sẽ bị ẩn khỏi lựa chọn nhưng vẫn được lưu giữ trong các mục hiện có.",
+      "projects": "## Dự án\nCho biết các dự án có thể sử dụng quy trình làm việc này."
+    },
+    "testResult": {
+      "status": "## Trạng thái\nChọn trạng thái tổng thể của quá trình thực thi kiểm thử. Trạng thái bạn chọn có thể ảnh hưởng đến các chỉ số và báo cáo của dự án.",
+      "elapsedTime": "## Thời gian thực hiện\nNhập tổng thời gian cần thiết để thực thi trường hợp kiểm thử này. Bạn có thể sử dụng các đơn vị như **s** cho giây, **m** cho phút, **h** cho giờ (ví dụ: 30s, 5m, 1h 20m).",
+      "resultData": "## Chi tiết kết quả\nCung cấp các ghi chú chi tiết, quan sát hoặc bất kỳ dữ liệu liên quan nào khác về quá trình thực hiện kiểm thử tổng thể. Điều này có thể bao gồm chi tiết thiết lập, các bước đã thực hiện nếu có sự sai lệch so với kế hoạch hoặc các nhận xét chung.",
+      "evidence": "## Bằng chứng/Tệp đính kèm\nTải lên bất kỳ tệp nào (ví dụ: ảnh chụp màn hình, nhật ký, tệp dữ liệu) dùng làm bằng chứng cho kết quả kiểm tra này. Các tệp đính kèm này sẽ được liên kết với kết quả cụ thể này.",
+      "issues": "## Các vấn đề được liên kết\nLiên kết bất kỳ vấn đề nào từ hệ thống theo dõi vấn đề tích hợp của bạn có liên quan đến kết quả kiểm thử này. Điều này giúp theo dõi các lỗi hoặc nhiệm vụ liên quan đến kết quả của bài kiểm thử này.",
+      "stepStatus": "## Trạng thái bước\nChọn trạng thái cho bước kiểm thử cụ thể này. Điều này cho phép theo dõi tiến độ chi tiết trong một trường hợp kiểm thử duy nhất.",
+      "stepElapsedTime": "## Thời gian thực hiện bước\nNhập thời gian cần thiết để thực hiện bước cụ thể này. Sử dụng các đơn vị như **giây**, **phút**, **giờ** (ví dụ: 10 giây, 2 phút). Phần này là tùy chọn.",
+      "stepNotes": "## Ghi chú bước\nThêm bất kỳ ghi chú, quan sát hoặc dữ liệu nào cụ thể liên quan đến việc thực hiện bước kiểm thử này.",
+      "stepIssues": "## Các vấn đề liên quan đến bước\nLiên kết các vấn đề từ trình theo dõi sự cố của bạn có liên quan cụ thể đến kết quả hoặc quan sát của bước kiểm thử này."
+    },
+    "case": {
+      "name": "## Tên trường hợp kiểm thử\nMột tên rõ ràng, mô tả cho trường hợp kiểm thử.",
+      "state": "## Trạng thái\nCho biết trạng thái quy trình công việc hiện tại của trường hợp này.",
+      "template": "## Mẫu\nChọn mẫu mà trường hợp này sẽ sử dụng cho các trường dữ liệu và trường kết quả.",
+      "estimate": "## Ước tính\nThời gian ước tính được nhập thủ công để hoàn thành trường hợp kiểm thử này.",
+      "automated": "## Tự động\nCho biết trường hợp kiểm thử này có được tự động hóa hay không.",
+      "tags": "## Thẻ\nÁp dụng các thẻ liên quan để phân loại và lọc trường hợp này.",
+      "issues": "## Vấn đề\nLiên kết bất kỳ vấn đề liên quan nào (lỗi, nhiệm vụ, v.v.) với trường hợp này."
+    },
+    "folder": {
+      "name": "## Tên thư mục\nMột tên rõ ràng, mô tả cho thư mục.",
+      "documentation": "## Tài liệu\nThông tin chi tiết bổ sung, tài liệu tham khảo và tài liệu hỗ trợ."
+    },
+    "bulkEdit": {
+      "name": "## Tên\nMột tên rõ ràng, mô tả cho các trường hợp thử nghiệm.",
+      "state": "## Trạng thái\nCho biết trạng thái quy trình công việc hiện tại của các trường hợp kiểm thử này.",
+      "estimate": "## Ước tính\nThời gian ước tính được nhập thủ công để hoàn thành mỗi trường hợp kiểm thử này.",
+      "automated": "## Tự động\nCho biết liệu các trường hợp kiểm thử này có được tự động hóa hay không.",
+      "tags": "## Thẻ\nÁp dụng các thẻ liên quan để phân loại và lọc các trường hợp thử nghiệm này.",
+      "issues": "## Vấn đề\nLiên kết bất kỳ vấn đề liên quan nào (lỗi, nhiệm vụ, v.v.) với các trường hợp kiểm thử này."
+    },
+    "caseField": {
+      "displayName": "## Tên hiển thị\nĐây là tên dễ đọc cho trường sẽ được hiển thị cho người dùng trong các biểu mẫu và chế độ xem. Hãy đặt tên rõ ràng và mô tả.",
+      "systemName": "## Tên Hệ Thống\nMột mã định danh duy nhất cho trường này được hệ thống sử dụng nội bộ (ví dụ: trong các cuộc gọi API, truy vấn cơ sở dữ liệu). Mã này sẽ được tự động tạo từ Tên Hiển Thị nhưng có thể được tùy chỉnh. Phải bắt đầu bằng một chữ cái. Chỉ có thể chứa chữ cái, số và dấu gạch dưới (không có khoảng trắng hoặc ký tự đặc biệt).",
+      "hint": "## Văn bản gợi ý (Tùy chọn)\nCung cấp hướng dẫn ngắn gọn hoặc ví dụ sẽ xuất hiện bên dưới trường để hướng dẫn người dùng. Điều này có thể làm rõ đầu vào hoặc định dạng dự kiến.",
+      "enabled": "## Đã bật\nXác định xem trường này có hoạt động và có sẵn để sử dụng trong các mẫu và trường hợp kiểm thử hay không. Các trường bị vô hiệu hóa sẽ bị ẩn và dữ liệu của chúng được lưu giữ nhưng không được sử dụng.",
+      "required": "## Bắt buộc\nNếu được chọn, người dùng phải cung cấp giá trị cho trường này khi tạo hoặc chỉnh sửa trường hợp kiểm thử bằng cách sử dụng mẫu có chứa trường này.",
+      "restricted": "## Hạn chế\nNếu được chọn, chỉ những người dùng có quyền đặc biệt (ví dụ: Quản trị viên cấp cao hoặc những người có quyền 'Trường bị hạn chế của trường hợp') mới có thể chỉnh sửa giá trị của trường này sau khi trường hợp được tạo. Người dùng khác sẽ chỉ thấy trường này ở chế độ chỉ đọc. Điều này hữu ích cho các trường như 'Người xem xét' hoặc 'Ngày phê duyệt' mà người dùng thông thường không nên thay đổi sau một giai đoạn nhất định.",
+      "fieldType": "## Loại trường\nXác định loại dữ liệu mà trường này sẽ lưu trữ và cách hiển thị (ví dụ: Văn bản, Số, Ngày, Danh sách thả xuống). Loại trường không thể thay đổi sau khi tạo.",
+      "defaultValue": "## Giá trị mặc định (Tùy chọn)\nĐặt giá trị được điền sẵn cho trường này. Đối với loại 'Hộp kiểm', hãy sử dụng 'true' hoặc 'false'. Đối với 'Thả xuống' hoặc 'Chọn nhiều', điều này thường đề cập đến ID của (các) tùy chọn mặc định. Đối với các loại khác, đó là văn bản/số mặc định theo nghĩa đen. Điều này có thể được ghi đè khi trường được thêm vào mẫu.",
+      "isChecked": "## Trạng thái mặc định (cho hộp kiểm)\nXác định xem hộp kiểm có nên được chọn mặc định khi tạo một mục mới (ví dụ: trường hợp thử nghiệm) hay không.",
+      "minValue": "## Giá trị tối thiểu (cho Số/Số nguyên)\nĐặt giá trị số nhỏ nhất được phép cho trường này. Cả Giá trị tối thiểu và Giá trị tối đa phải được đặt nếu một trong hai được sử dụng.",
+      "maxValue": "## Giá trị tối đa (cho Số/Số nguyên)\nĐặt giá trị số lớn nhất được phép cho trường này. Cả Giá trị tối thiểu và Giá trị tối đa phải được đặt nếu một trong hai được sử dụng.",
+      "initialHeight": "## Chiều cao ban đầu (cho văn bản dài)\nChỉ định chiều cao hiển thị ban đầu (tính bằng pixel) cho các trường trình soạn thảo văn bản đa dạng. Điều này giúp kiểm soát bố cục biểu mẫu cho các trường nhập văn bản dài hơn.",
+      "dropdownOptions": "## Tùy chọn (cho menu thả xuống/chọn nhiều mục)\nXác định danh sách các lựa chọn có sẵn. Bạn có thể sắp xếp lại thứ tự các tùy chọn, đặt mặc định và bật/tắt từng tùy chọn riêng lẻ."
+    },
+    "resultField": {
+      "displayName": "## Tên hiển thị\nĐây là tên dễ đọc cho trường sẽ được hiển thị cho người dùng khi nhập kết quả kiểm tra. Hãy đặt tên rõ ràng và mô tả.",
+      "systemName": "## Tên Hệ Thống\nMột mã định danh duy nhất cho trường này được hệ thống sử dụng nội bộ (ví dụ: trong các cuộc gọi API, truy vấn cơ sở dữ liệu). Mã này sẽ được tự động tạo từ Tên Hiển Thị nhưng có thể được tùy chỉnh.\n- Phải bắt đầu bằng một chữ cái.\n- Chỉ có thể chứa chữ cái, số và dấu gạch dưới (không có khoảng trắng hoặc ký tự đặc biệt).",
+      "hint": "## Văn bản gợi ý (Tùy chọn)\nCung cấp hướng dẫn ngắn gọn hoặc ví dụ sẽ xuất hiện bên dưới trường để hướng dẫn người dùng. Điều này có thể làm rõ đầu vào hoặc định dạng dự kiến khi nhập dữ liệu kết quả.",
+      "enabled": "## Đã bật\nXác định xem trường này có hoạt động và có sẵn để sử dụng trong các mẫu khi nhập kết quả kiểm tra hay không. Các trường bị vô hiệu hóa sẽ bị ẩn và dữ liệu của chúng được lưu giữ nhưng không được sử dụng.",
+      "required": "## Bắt buộc\nNếu được chọn, người dùng phải cung cấp giá trị cho trường này khi thêm kết quả kiểm tra bằng cách sử dụng mẫu có chứa trường này.",
+      "restricted": "## Hạn chế\nNếu được chọn, chỉ những người dùng có quyền đặc biệt (ví dụ: Quản trị viên cấp cao hoặc những người có quyền 'Trường bị hạn chế trong kết quả chạy thử') mới có thể chỉnh sửa giá trị của trường này sau khi kết quả được gửi. Những người dùng khác sẽ chỉ thấy trường này ở chế độ chỉ đọc.",
+      "fieldType": "## Loại trường\nXác định loại dữ liệu mà trường này sẽ lưu trữ và cách hiển thị kết quả kiểm tra (ví dụ: Văn bản, Số, Ngày, Danh sách thả xuống). Loại trường không thể thay đổi sau khi tạo.",
+      "defaultValue": "## Giá trị mặc định (Tùy chọn)\nĐặt giá trị được điền sẵn cho trường này khi thêm kết quả kiểm tra mới. Đối với loại 'Hộp kiểm', hãy sử dụng 'true' hoặc 'false'. Đối với 'Thả xuống' hoặc 'Chọn nhiều', điều này thường đề cập đến ID của (các) tùy chọn mặc định. Đối với các loại khác, đó là văn bản/số mặc định theo nghĩa đen.",
+      "isChecked": "## Trạng thái mặc định (cho hộp kiểm)\nXác định xem hộp kiểm có nên được chọn mặc định khi thêm kết quả kiểm tra mới hay không.",
+      "minValue": "## Giá trị tối thiểu (cho Số/Số nguyên)\nĐặt giá trị số nhỏ nhất được phép cho trường này khi nhập dữ liệu kết quả. Cả Giá trị tối thiểu và Giá trị tối đa phải được đặt nếu chỉ sử dụng một trong hai.",
+      "maxValue": "## Giá trị tối đa (cho Số/Số nguyên)\nĐặt giá trị số lớn nhất được phép cho trường này khi nhập dữ liệu kết quả. Cả Giá trị tối thiểu và Giá trị tối đa phải được đặt nếu chỉ sử dụng một trong hai.",
+      "initialHeight": "## Chiều cao ban đầu (cho văn bản dài)\nChỉ định chiều cao hiển thị ban đầu (tính bằng pixel) cho các trường trình soạn thảo văn bản đa dạng được sử dụng trong kết quả. Điều này giúp kiểm soát bố cục biểu mẫu cho các trường nhập văn bản dài hơn.",
+      "dropdownOptions": "## Tùy chọn (cho Menu thả xuống/Chọn nhiều)\nXác định danh sách các lựa chọn có sẵn khi nhập dữ liệu kết quả. Bạn có thể sắp xếp lại các tùy chọn, đặt mặc định và bật/tắt từng tùy chọn riêng lẻ."
+    },
+    "exportModal": {
+      "scope": "## Phạm vi xuất\nXác định các trường hợp kiểm thử nào sẽ được bao gồm trong quá trình xuất:\n- **Đã chọn:** Chỉ xuất các trường hợp kiểm thử mà bạn đã chọn rõ ràng trong bảng.\n- **Tất cả đã lọc:** Xuất tất cả các trường hợp kiểm thử khớp với tiêu chí lọc hiện tại trong bảng, ngay cả khi không phải tất cả đều hiển thị trên trang.\n- **Tất cả dự án:** Xuất mọi trường hợp kiểm thử trong dự án hiện tại, bỏ qua mọi lựa chọn hoặc bộ lọc.",
+      "format": "## Định dạng xuất\nChọn định dạng tệp cho dữ liệu xuất của bạn.\n- **CSV (Giá trị được phân tách bằng dấu phẩy):** Một tệp văn bản thuần túy phù hợp với bảng tính (Excel, Google Sheets) và các công cụ phân tích dữ liệu. Chức năng xuất PDF sẽ được bổ sung trong bản phát hành sau.",
+      "columns": "## Các cột cần xuất (Chỉ CSV)\nXác định các cột dữ liệu nào sẽ được bao gồm cho mỗi trường hợp kiểm thử:\n- **Tất cả các cột:** Xuất tất cả các trường dữ liệu có sẵn cho các trường hợp kiểm thử, bao gồm cả các trường tùy chỉnh từ mẫu của chúng.\n- **Các cột hiển thị:** Chỉ xuất các cột hiện đang hiển thị trong bảng trường hợp kiểm thử.",
+      "delimiter": "## Dấu phân cách CSV (Chỉ dành cho CSV)\nChọn ký tự được sử dụng để phân tách các giá trị trong tệp CSV. Thông dụng nhất là dấu phẩy. Sử dụng dấu phân cách khác nếu dữ liệu của bạn chứa dấu phẩy trong các trường văn bản (ví dụ: dấu chấm phẩy).",
+      "textLongFormat": "## Định dạng trường văn bản dài (Chỉ CSV)\nXác định cách xuất các trường văn bản đa dạng (như 'Mô tả' hoặc các trường 'Văn bản dài' tùy chỉnh):\n- **JSON:** Xuất nội dung dưới dạng chuỗi JSON, giữ nguyên tất cả định dạng (in đậm, danh sách, v.v.). Đây là lựa chọn tốt nhất để nhập lại hoặc xử lý bằng lập trình.\n- **Văn bản thuần túy:** Xuất nội dung dưới dạng văn bản thuần túy, loại bỏ định dạng. Điều này giúp dễ đọc hơn trong các trình xem văn bản đơn giản.",
+      "stepsFormat": "## Định dạng các bước (Chỉ CSV)\nXác định cách xuất các bước kiểm thử (bao gồm cả kết quả mong đợi):\n- **JSON:** Xuất các bước dưới dạng mảng JSON các đối tượng, giữ nguyên cấu trúc và văn bản định dạng. Thích hợp cho việc nhập lại hoặc phân tích chi tiết.\n- **Văn bản thuần túy:** Xuất các bước ở định dạng văn bản thuần túy đơn giản, dễ đọc, với mỗi bước và kết quả mong đợi trên một dòng mới.",
+      "rowMode": "## Chế độ hàng (Chỉ CSV)\nXác định cách hiển thị các trường đa giá trị (như Thẻ hoặc trường tùy chỉnh Chọn nhiều) và các Bước:\n- **Một hàng cho mỗi trường hợp:** Mỗi trường hợp kiểm thử là một hàng duy nhất. Các trường đa giá trị và các bước sẽ được thu gọn vào các ô tương ứng (thường là JSON hoặc văn bản được nối).\n- **Nhiều hàng cho mỗi trường hợp:** Một trường hợp kiểm thử có thể trải rộng trên nhiều hàng nếu nó có nhiều thẻ, giá trị chọn nhiều hoặc bước. Mỗi giá trị/bước duy nhất cho các trường đó sẽ tạo ra một hàng mới, với dữ liệu trường hợp khác được lặp lại. Điều này hữu ích cho việc phân tích chi tiết hoặc xoay trục.",
+      "attachmentFormat": "## Định dạng thông tin tệp đính kèm (Chỉ CSV)\nXác định cách xuất thông tin về tệp đính kèm:\n- **JSON:** Xuất chi tiết tệp đính kèm (như tên tệp, URL, kích thước) dưới dạng mảng JSON. Định dạng này đầy đủ thông tin nhưng khó đọc hơn khi xuất trực tiếp ra CSV.\n- **Chỉ tên tệp:** Xuất danh sách tên tệp đính kèm được phân tách bằng dấu phẩy. Đơn giản hơn để tra cứu nhanh."
+    },
+    "reportMetrics": {
+      "count": "## Số lượng kết quả kiểm thử\nSố lượng kết quả chạy thử trong nhóm này.",
+      "passRate": "## Tỷ lệ đậu\nTỷ lệ kết quả trong nhóm này đạt trạng thái đậu.",
+      "avgElapsed": "## Thời gian trung bình đã trôi qua\nThời gian trung bình đã trôi qua cho các kết quả trong nhóm này.",
+      "sumElapsed": "## Tổng thời gian đã trôi qua\nTổng thời gian đã trôi qua cho các kết quả trong nhóm này.",
+      "executionCount": "## Số lần thực thi kiểm thử\nTổng số lần thực thi kiểm thử đã thực hiện.",
+      "testCaseCount": "## Số lượng trường hợp kiểm thử\nTổng số trường hợp kiểm thử trong nhóm này.",
+      "testRunCount": "## Số lần chạy thử nghiệm\nTổng số lần chạy thử nghiệm trong nhóm này.",
+      "automationRate": "## Tỷ lệ tự động hóa\nPhần trăm các trường hợp kiểm thử được tự động hóa.",
+      "averageSteps": "## Số bước trung bình trên mỗi trường hợp\nSố bước trung bình trên mỗi trường hợp kiểm thử.",
+      "automatedCount": "## Các trường hợp tự động\nSố lượng các trường hợp kiểm thử tự động.",
+      "manualCount": "## Các trường hợp kiểm thử thủ công\nSố lượng trường hợp kiểm thử thủ công.",
+      "totalSteps": "## Tổng số bước\nTổng số bước kiểm thử trên tất cả các trường hợp.",
+      "createdCaseCount": "## Các trường hợp kiểm thử đã tạo\nSố lượng trường hợp kiểm thử được tạo trong khoảng thời gian này.",
+      "sessionResultCount": "## Kết quả phiên\nSố lượng kết quả kiểm tra phiên.",
+      "sessionCount": "## Số lượng phiên\nTổng số phiên thử nghiệm.",
+      "activeSessions": "## Phiên hoạt động\nSố lượng phiên hiện đang hoạt động (isActive = true).",
+      "milestoneCompletion": "## Hoàn thành cột mốc\nTỷ lệ phần trăm các trường hợp kiểm thử được hoàn thành trong các cột mốc. Được tính bằng (kết quả kiểm thử đã hoàn thành / tổng số trường hợp kiểm thử trong các lần chạy kiểm thử) × 100.",
+      "averageTimeSpent": "## Thời gian trung bình dành cho các hoạt động\nThời gian trung bình dành cho các hoạt động.",
+      "sessionParticipation": "## Mức độ tham gia phiên kiểm tra\nMức độ tham gia vào các phiên kiểm tra.",
+      "lastActiveDate": "## Ngày hoạt động gần nhất\nNgày hoạt động gần đây nhất.",
+      "averageAge": "## Tuổi trung bình\nTuổi trung bình của các mặt hàng tính bằng ngày.",
+      "issueCount": "## Số lượng sự cố\nTổng số sự cố đã được theo dõi.",
+      "milestoneCount": "## Số lượng cột mốc\nTổng số cột mốc.",
+      "milestoneCompletionRate": "## Tỷ lệ hoàn thành cột mốc\nPhần trăm các cột mốc đã hoàn thành.",
+      "averageMilestoneDuration": "## Thời gian trung bình hoàn thành các mốc quan trọng\nThời gian trung bình hoàn thành các mốc quan trọng tính bằng ngày."
+    },
+    "reportDimensions": {
+      "user": "## Kích thước người dùng\nNhóm kết quả theo người dùng đã thực hiện các bài kiểm tra hoặc được chỉ định cho các mục.",
+      "status": "## Kích thước trạng thái\nNhóm kết quả theo trạng thái thực thi kiểm thử (ví dụ: Đã vượt qua, Thất bại, Bị chặn).",
+      "project": "## Kích thước dự án\nNhóm kết quả theo dự án để phân tích liên dự án.",
+      "testRun": "## Kích thước Chạy thử nghiệm\nNhóm kết quả theo lần chạy thử nghiệm chứa các trường hợp thử nghiệm đã thực thi.",
+      "testCase": "## Kích thước trường hợp kiểm thử\nNhóm kết quả theo từng trường hợp kiểm thử riêng lẻ để phân tích chi tiết.",
+      "milestone": "## Kích thước cột mốc\nNhóm kết quả theo các cột mốc dự án để theo dõi tiến độ đạt được mục tiêu.",
+      "configuration": "## Kích thước cấu hình\nNhóm kết quả theo cấu hình môi trường kiểm thử (ví dụ: trình duyệt, hệ điều hành).",
+      "template": "## Kích thước mẫu\nNhóm kết quả theo mẫu được sử dụng cho cấu trúc trường hợp kiểm thử.",
+      "creator": "## Kích thước người tạo\nNhóm kết quả theo người dùng đã tạo các trường hợp thử nghiệm hoặc các lần chạy thử nghiệm.",
+      "state": "## Kích thước trạng thái\nNhóm kết quả theo trạng thái quy trình làm việc (ví dụ: Bản nháp, Đang hoạt động, Đã hoàn thành).",
+      "role": "## Chiều vai trò\nNhóm kết quả theo vai trò người dùng để phân tích quyền truy cập và trách nhiệm.",
+      "group": "## Kích thước nhóm\nNhóm kết quả theo nhóm người dùng. Người dùng có thể thuộc nhiều nhóm, vì vậy các hoạt động sẽ được tính cho mỗi nhóm mà người dùng thuộc về.",
+      "folder": "## Kích thước thư mục\nNhóm kết quả theo cấu trúc thư mục kho lưu trữ để phân tích tổ chức.",
+      "session": "## Kích thước phiên\nNhóm kết quả theo các phiên kiểm thử để phân tích dựa trên phiên.",
+      "assignedTo": "## Kích thước được chỉ định cho\nNhóm kết quả theo người dùng được chỉ định để thực hiện hoặc quản lý các mục.",
+      "issueType": "## Kích thước loại sự cố\nNhóm kết quả theo loại sự cố được theo dõi (ví dụ: Lỗi, Nhiệm vụ, Câu chuyện, Cải tiến).",
+      "issueTracker": "## Kích thước Trình theo dõi Sự cố\nNhóm kết quả theo tích hợp theo dõi sự cố được sử dụng (ví dụ: Jira, GitHub Issues, Azure DevOps).",
+      "issueStatus": "## Kích thước trạng thái sự cố\nNhóm kết quả theo trạng thái hiện tại của sự cố (ví dụ: Đang mở, Đang xử lý, Đã giải quyết, Đã đóng).",
+      "priority": "## Chiều ưu tiên\nNhóm kết quả theo mức độ ưu tiên của vấn đề (ví dụ: Cao, Trung bình, Thấp).",
+      "source": "## Kích thước nguồn\nNhóm kết quả theo nguồn thực thi kiểm thử (ví dụ: Thủ công, JUnit, API).",
+      "date": "## Chiều dữ liệu theo ngày\nNhóm kết quả theo ngày để phân tích và theo dõi xu hướng dựa trên thời gian."
+    },
+    "reportBuilder": {
+      "dimensions": "## Kích thước\nChọn các kích thước bạn muốn phân tích trong báo cáo. Kích thước là các thuộc tính phân loại dữ liệu của bạn, chẳng hạn như Ngày, Người dùng, Trạng thái, v.v. Bạn có thể kéo để sắp xếp lại thứ tự chúng.",
+      "metrics": "## Số liệu\nChọn các số liệu bạn muốn đo trong báo cáo. Số liệu là các phép đo định lượng được suy ra từ dữ liệu của bạn, chẳng hạn như Số kết quả kiểm tra, Tỷ lệ đạt, Thời gian trung bình, v.v. Bạn có thể kéo để sắp xếp lại thứ tự chúng.",
+      "dateRange": "## Phạm vi ngày\nLọc dữ liệu báo cáo của bạn theo một khoảng thời gian cụ thể. Bạn có thể chọn từ các phạm vi được xác định trước như '7 ngày gần đây' hoặc 'Tháng trước', hoặc xác định phạm vi ngày tùy chỉnh. Bộ lọc này áp dụng cho trường ngày liên quan cho từng loại báo cáo (ví dụ: ngày thực hiện cho kết quả kiểm thử, ngày tạo cho trường hợp kiểm thử)."
+    },
+    "codeRepository": {
+      "name": "## Tên kho lưu trữ\nTên hiển thị thân thiện cho kết nối kho lưu trữ này.\n\n- Được sử dụng để xác định nó trong cài đặt ngữ cảnh mã dự án.\n- Không cần phải trùng khớp với tên kho lưu trữ trên nhà cung cấp.",
+      "provider": "## Nhà cung cấp Git\nNền tảng lưu trữ kho lưu trữ này.\n\n- **GitHub** — github.com (đám mây hoặc doanh nghiệp)\n- **GitLab** — gitlab.com hoặc tự lưu trữ\n- **Bitbucket Cloud** — bitbucket.org (chỉ đám mây)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — máy chủ Git tự lưu trữ với API tương thích",
+      "githubToken": "## Mã truy cập cá nhân\nMã GitHub có quyền **Đọc nội dung**.\n\nTạo mã tại: GitHub → Cài đặt hồ sơ → Cài đặt nhà phát triển → Mã truy cập cá nhân → Mã chi tiết.",
+      "owner": "## Chủ sở hữu\nTổ chức hoặc tài khoản người dùng GitHub sở hữu kho lưu trữ.\n\n- Ví dụ: `myorg` hoặc `myusername`\n- Đây là phân đoạn đường dẫn đầu tiên trong URL kho lưu trữ của bạn trên github.com",
+      "repo": "## Kho lưu trữ\nTên kho lưu trữ, không có tiền tố chủ sở hữu.\n\n- Ví dụ: `my-repo` (không phải `myorg/my-repo`)\n- Đây là đoạn đường dẫn thứ hai trong URL kho lưu trữ của bạn trên github.com",
+      "gitlabToken": "## Mã truy cập cá nhân\nMã GitLab có phạm vi **read_api** và **read_repository**.\n\nTạo mã này tại: GitLab → Cài đặt người dùng → Mã truy cập.",
+      "projectPath": "## ID hoặc Đường dẫn Dự án\nID dự án dạng số hoặc đường dẫn đầy đủ của không gian tên.\n\n- Ví dụ đường dẫn: `myorg/my-project`\n- Ví dụ ID: `12345678`\n- Tìm thấy trong GitLab tại Cài đặt → Chung.",
+      "baseUrl": "## URL GitLab\nĐể trống nếu muốn sử dụng gitlab.com. Đối với các phiên bản tự lưu trữ, hãy nhập URL GitLab của bạn.\n\n- Ví dụ: `https://gitlab.example.com`",
+      "bitbucketEmail": "## Email tài khoản Atlassian\nĐịa chỉ email liên kết với tài khoản Atlassian của bạn.\n\n- Đây là email bạn dùng để đăng nhập vào Bitbucket Cloud.",
+      "bitbucketApiToken": "## Mã thông báo API\nMã thông báo API của Bitbucket với phạm vi **Kho lưu trữ: Đọc**.\n\nTạo mã thông báo tại: Bitbucket → Cài đặt cá nhân → Mã thông báo API.\n\n> Atlassian đã loại bỏ mật khẩu ứng dụng và thay thế bằng mã thông báo API.",
+      "workspace": "## Không gian làm việc\nĐường dẫn không gian làm việc từ URL Bitbucket của bạn.\n\n- Ví dụ: `myworkspace` từ `bitbucket.org/myworkspace`",
+      "repoSlug": "## Slug của kho lưu trữ\nMã định danh của kho lưu trữ từ URL của nó.\n\n- Ví dụ: `my-repo` từ `bitbucket.org/myworkspace/my-repo`",
+      "azureToken": "## Mã truy cập cá nhân\nMã PAT của Azure DevOps với quyền **Đọc mã**.\n\nTạo mã này tại: Azure DevOps → Cài đặt người dùng → Mã truy cập cá nhân.",
+      "organizationUrl": "## URL Tổ chức\nURL tổ chức Azure DevOps của bạn.\n\n- Ví dụ: `https://dev.azure.com/myorg`",
+      "project": "## Tên Dự án\nTên của dự án Azure DevOps chứa kho lưu trữ.\n\n- Được tìm thấy là phân đoạn đường dẫn thứ ba trong URL Azure DevOps của bạn sau tên tổ chức.",
+      "azureRepoId": "## Tên hoặc ID kho lưu trữ\nTên hoặc GUID của kho lưu trữ trong dự án Azure DevOps.\n\n- Ví dụ: `my-repo`",
+      "giteaToken": "## Mã truy cập cá nhân\nMã này có quyền đọc kho lưu trữ.\n\nBạn có thể tạo mã này tại: Quản trị trang web → Ứng dụng, hoặc Cài đặt người dùng → Ứng dụng.\n\n- Hoạt động với Gitea, Forgejo, Gogs và bất kỳ máy chủ nào cung cấp API tương thích.",
+      "giteaBaseUrl": "## URL máy chủ\nURL cơ sở của máy chủ Git tự lưu trữ của bạn.\n\n- Ví dụ: `https://gitea.example.com`\n- Phải bao gồm giao thức (khuyến nghị sử dụng https://)\n- Hoạt động với Gitea, Forgejo, Gogs và các máy chủ khác có API REST `/api/v1/` tương thích với Gitea",
+      "giteaOwner": "## Chủ sở hữu\nTổ chức hoặc tài khoản người dùng sở hữu kho lưu trữ.\n\n- Ví dụ: `myorg` hoặc `myusername`\n- Đây là phân đoạn đường dẫn đầu tiên trong URL kho lưu trữ của bạn",
+      "giteaRepo": "## Kho lưu trữ\nTên kho lưu trữ, không có tiền tố chủ sở hữu.\n\n- Ví dụ: `my-repo` (không phải `myorg/my-repo`)"
+    },
+    "promptConfig": {
+      "name": "## Tên cấu hình\nMột tên duy nhất, mô tả rõ ràng cho cấu hình nhắc nhở này.\n\n- Được sử dụng để xác định cấu hình khi gán nó cho một dự án (ví dụ: \"GPT-4o Prompts\", \"Conservative Prompts\").",
+      "description": "## Mô tả\nBản tóm tắt tùy chọn về những điểm khác biệt của cấu hình này.\n\n- Giúp quản trị viên hiểu mục đích một cách nhanh chóng (ví dụ: \"Nhiệt độ thấp hơn sẽ nhắc nhở về đầu ra xác định\").",
+      "isActive": "## Kích hoạt\nKhi được kích hoạt, cấu hình này có thể được sử dụng bởi các dự án.\n\n- Các cấu hình không hoạt động sẽ bị ẩn khỏi menu thả xuống phân công dự án.\n- Cấu hình mặc định không thể bị vô hiệu hóa.",
+      "isDefault": "## Cấu hình mặc định\nKhi được bật, cấu hình này sẽ được sử dụng bởi bất kỳ dự án nào chưa được gán cấu hình cụ thể.\n\n- Chỉ có thể có một cấu hình mặc định tại một thời điểm.\n- Việc thiết lập cấu hình mặc định mới sẽ tự động hủy bỏ cấu hình trước đó.",
+      "systemPrompt": "## Lời nhắc hệ thống\nCác hướng dẫn được gửi đến mô hình AI trước khi người dùng nhập bất kỳ dữ liệu nào. Xác định vai trò, định dạng đầu ra và các ràng buộc của mô hình.\n\n- Hỗ trợ các ký tự giữ chỗ ngoặc kép (ví dụ: FRAMEWORK, LANGUAGE, CASE_NAME) được thay thế trong thời gian chạy.\n- Các thay đổi ở đây sẽ ảnh hưởng đến mọi dự án sử dụng cấu hình này.",
+      "userPrompt": "## Lời nhắc người dùng\nTin nhắn được gửi đến AI thay mặt người dùng. Để trống nếu tính năng này tự động tạo tin nhắn của người dùng hoàn toàn bằng mã.\n\n- Hỗ trợ các ký tự giữ chỗ dạng dấu ngoặc kép (ví dụ: ISSUE_TITLE, CASE_NAME, CODE_CONTEXT) được thay thế trong quá trình chạy.\n- Các ký tự giữ chỗ khả dụng cho mỗi tính năng được liệt kê trong phần Biến bên dưới.",
+      "temperature": "## Nhiệt độ\nĐiều khiển tính ngẫu nhiên của đầu ra AI. Phạm vi: 0–2.\n\n- **0.0–0.3** — Có tính xác định cao, tốt nhất cho đầu ra có cấu trúc (JSON, mã).\n- **0.4–0.7** — Cân bằng, tốt cho việc tạo trường hợp thử nghiệm.\n- **0.8–2.0** — Sáng tạo và đa dạng hơn, phù hợp với văn bản mở.",
+      "maxOutputTokens": "## Số lượng Token đầu ra tối đa\nSố lượng token tối đa mà mô hình sẽ tạo ra trong một phản hồi duy nhất.\n\n- Giá trị cao hơn cho phép phản hồi dài hơn nhưng làm tăng chi phí và độ trễ.\n- Phạm vi điển hình: 2048 cho văn bản ngắn, 4096 cho tạo mã, 6000+ cho đầu ra đa trường hợp."
+    },
+    "menu": {
+      "startTour": "Chuyến tham quan chào mừng có hướng dẫn",
+      "startProjectTour": "Chuyến tham quan dự án",
+      "startAdminTour": "Chuyến tham quan dành cho quản trị viên",
+      "startDemoProjectTour": "Giới thiệu dự án mẫu"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "Chào mừng bạn đến với TestPlanIt!",
+          "content": "Hãy cùng điểm qua nhanh các tính năng chính của TestPlan để giúp bạn bắt đầu quy trình kiểm thử của mình."
+        },
+        "projects": {
+          "content": "Bạn có thể truy cập tất cả các dự án kiểm thử của mình từ đây. Mỗi dự án bao gồm các trường hợp kiểm thử, các lần chạy và các tính năng cộng tác nhóm."
+        },
+        "project": {
+          "title": "Thẻ dự án",
+          "content": "Nhấp vào thẻ dự án để xem chi tiết. Chọn \"Hướng dẫn tham quan dự án\" từ menu trợ giúp để xem hướng dẫn chi tiết về các tính năng của dự án."
+        },
+        "globalFeatures": {
+          "title": "Tính năng toàn cầu",
+          "content": "Quản lý thẻ để phân loại, theo dõi sự cố trên các dự án và quản lý người dùng với quyền truy cập dựa trên vai trò."
+        },
+        "search": {
+          "content": "Tìm kiếm theo ngữ cảnh dựa trên trang hiện tại của bạn. Nhanh chóng tìm các trường hợp kiểm thử, lần chạy, sự cố hoặc bất kỳ nội dung nào. Sử dụng Cmd+K (hoặc Ctrl+K) để truy cập tức thì."
+        },
+        "help": {
+          "title": "Trợ giúp & Hỗ trợ",
+          "content": "Bạn có thể truy cập hướng dẫn tham quan này bất cứ lúc nào hoặc xem tài liệu hướng dẫn chi tiết của chúng tôi để được hỗ trợ đầy đủ."
+        },
+        "notifications": {
+          "content": "Luôn cập nhật thông tin về việc hoàn thành chạy thử nghiệm, cập nhật sự cố và hoạt động của nhóm. Thiết lập tùy chọn trong cài đặt tài khoản của bạn."
+        },
+        "account": {
+          "title": "Menu Tài khoản",
+          "content": "Tùy chỉnh hồ sơ, tùy chọn thông báo và cài đặt tài khoản của bạn. Chuyển đổi giữa chủ đề sáng và tối."
+        },
+        "assignments": {
+          "content": "Xem các trường hợp kiểm thử và các lần chạy được giao cho bạn trên tất cả các dự án. Đây là bảng điều khiển cá nhân của bạn để theo dõi công việc kiểm thử."
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "Công cụ chọn dự án",
+          "content": "Chuyển đổi nhanh chóng giữa các dự án bằng menu thả xuống này. Xem chi tiết dự án và truy cập cài đặt chung cho toàn dự án."
+        },
+        "projectSections": {
+          "title": "Các phần của dự án",
+          "content": "Bạn có thể điều hướng qua mục Tổng quan để xem bảng điều khiển dự án, mục Tài liệu để xem hướng dẫn dự án và mục Các mốc quan trọng để theo dõi tiến độ."
+        },
+        "repository": {
+          "content": "Quản lý các trường hợp kiểm thử, sắp xếp chúng vào các thư mục và tạo các kịch bản kiểm thử mới để đảm bảo phạm vi kiểm thử toàn diện."
+        },
+        "repositoryPanels": {
+          "title": "Bảng điều khiển bên trái kho lưu trữ",
+          "content": "Bảng điều khiển bên trái hiển thị cấu trúc thư mục và cây thư mục trường hợp kiểm thử của bạn. Sử dụng bộ chọn chế độ xem để chuyển đổi giữa các chế độ xem tổ chức khác nhau."
+        },
+        "repositoryRightPanel": {
+          "title": "Bảng điều khiển bên phải kho lưu trữ",
+          "content": "Bảng điều khiển bên phải hiển thị chi tiết trường hợp kiểm thử, kết quả thực thi và cung cấp các thao tác để tạo trường hợp kiểm thử mới hoặc nhập các trường hợp hiện có."
+        },
+        "sharedSteps": {
+          "title": "Các bước chung",
+          "content": "Xác định các nhóm bước có thể tái sử dụng và tham chiếu từ nhiều trường hợp kiểm thử khác nhau. Giữ cho các bước kiểm thử của bạn tuân thủ nguyên tắc DRY (Don't Repeat Yourself) và nhất quán."
+        },
+        "testRuns": {
+          "content": "Thực hiện các đợt chạy thử nghiệm theo kế hoạch, theo dõi tiến độ và quản lý việc phân công thử nghiệm cho toàn bộ nhóm. Xem kết quả thực hiện chi tiết."
+        },
+        "testRunsPage": {
+          "title": "Bảng điều khiển Chạy thử nghiệm",
+          "content": "Đây là trang Chạy thử nghiệm, nơi bạn có thể tạo các lần chạy thử nghiệm mới, theo dõi tiến độ thực thi, xem kết quả và quản lý việc phân công thử nghiệm. Theo dõi các hoạt động thử nghiệm của nhóm bạn từ một vị trí tập trung duy nhất."
+        },
+        "sessions": {
+          "title": "Phiên thảo luận thăm dò",
+          "content": "Ghi chép lại các buổi thử nghiệm thăm dò, thu thập kết quả và theo dõi thời gian dành cho các hoạt động thử nghiệm ngẫu nhiên."
+        },
+        "sessionsPage": {
+          "title": "Bảng điều khiển các phiên khám phá",
+          "content": "Đây là trang Phiên làm việc, nơi bạn có thể tạo và quản lý các phiên kiểm thử thăm dò. Ghi lại kết quả, theo dõi thời gian đã sử dụng và lưu giữ hồ sơ về tất cả các hoạt động kiểm thử ngẫu nhiên để có phạm vi kiểm thử tốt hơn."
+        },
+        "tags": {
+          "title": "Quản lý thẻ",
+          "content": "Sắp xếp và phân loại các trường hợp kiểm thử của bạn bằng cách sử dụng thẻ. Tạo thẻ tùy chỉnh để cải thiện việc sắp xếp và lọc các trường hợp kiểm thử."
+        },
+        "issues": {
+          "title": "Theo dõi sự cố",
+          "content": "Theo dõi và quản lý các sự cố phát hiện trong quá trình thử nghiệm. Liên kết các sự cố với các trường hợp thử nghiệm và tích hợp với các hệ thống theo dõi lỗi bên ngoài."
+        },
+        "reports": {
+          "title": "Báo cáo & Phân tích",
+          "content": "Tạo báo cáo và phân tích toàn diện cho dự án của bạn. Xem phạm vi kiểm thử, xu hướng thực thi, chỉ số hiệu suất nhóm và tạo báo cáo tùy chỉnh cho các bên liên quan."
+        },
+        "settings": {
+          "title": "Cài đặt dự án",
+          "content": "Từ đây, bạn có thể quản lý các tích hợp cấp dự án, cấu hình mô hình AI và các liên kết chia sẻ."
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "Chào mừng đến với Trang quản trị",
+          "content": "Hãy cùng khám phá các tính năng quản trị của TestPlanIt. Quản lý dự án, người dùng, cấu hình và cài đặt hệ thống từ bảng điều khiển quản trị tập trung này."
+        },
+        "projects": {
+          "title": "Quản lý dự án",
+          "content": "Quản lý tất cả các dự án trong tổ chức của bạn. Tạo, cấu hình và lưu trữ dự án. Thiết lập quyền và kiểm soát truy cập cho toàn bộ dự án."
+        },
+        "templatesAndFields": {
+          "content": "Tạo và quản lý các mẫu trường hợp kiểm thử và các trường tùy chỉnh. Xác định loại trường, quy tắc xác thực và sắp xếp các mẫu để đảm bảo cấu trúc trường hợp kiểm thử nhất quán trên các dự án."
+        },
+        "workflows": {
+          "title": "Quản lý quy trình làm việc",
+          "content": "Xác định quy trình làm việc và chuyển đổi trạng thái của trường hợp kiểm thử. Cấu hình cách các trường hợp kiểm thử tiến triển qua các trạng thái khác nhau như Bản nháp, Đang xem xét và Đã phê duyệt."
+        },
+        "statuses": {
+          "title": "Trạng thái kết quả xét nghiệm",
+          "content": "Cấu hình các trạng thái kết quả kiểm tra có sẵn như Đạt, Không đạt, Bị chặn và Bỏ qua. Thiết lập các trạng thái tùy chỉnh và xác định hành vi cũng như hình thức hiển thị của chúng."
+        },
+        "milestones": {
+          "content": "Xác định các loại mốc quan trọng để theo dõi dự án. Cấu hình các loại bản phát hành, danh mục sprint và các phân loại mốc quan trọng khác của dự án."
+        },
+        "configurations": {
+          "title": "Cấu hình kiểm thử",
+          "content": "Quản lý cấu hình và môi trường kiểm thử. Thiết lập các tổ hợp trình duyệt, loại thiết bị, hệ điều hành và các ngữ cảnh thực thi kiểm thử khác."
+        },
+        "users": {
+          "title": "Quản lý người dùng",
+          "content": "Quản lý tài khoản người dùng, quyền hạn và cấp độ truy cập. Tạo người dùng mới, phân công vai trò và cấu hình cài đặt xác thực."
+        },
+        "groups": {
+          "title": "Quản lý nhóm",
+          "content": "Tổ chức người dùng thành các nhóm để quản lý quyền dễ dàng hơn. Tạo các nhóm theo phòng ban, nhóm dự án và nhóm truy cập dựa trên vai trò."
+        },
+        "roles": {
+          "title": "Quản lý vai trò",
+          "content": "Xác định vai trò và quyền hạn của người dùng. Cấu hình các hành động mà các vai trò khác nhau có thể thực hiện trong các dự án và quản trị hệ thống."
+        },
+        "tags": {
+          "title": "Thẻ toàn cầu",
+          "content": "Quản lý các thẻ trên toàn tổ chức để phân loại các trường hợp thử nghiệm, dự án và các thực thể khác. Tạo hệ thống phân cấp thẻ và chuẩn hóa việc gắn thẻ trên các dự án."
+        },
+        "reports": {
+          "content": "Tạo báo cáo bao quát nhiều dự án. Phân tích xu hướng, chỉ số hiệu suất và hiệu quả kiểm thử của tổ chức trên toàn bộ không gian làm việc của bạn."
+        },
+        "notifications": {
+          "title": "Cài đặt thông báo",
+          "content": "Cấu hình tùy chọn thông báo toàn hệ thống. Thiết lập mẫu email, quy tắc thông báo và cài đặt mặc định cho thông báo người dùng."
+        },
+        "integrations": {
+          "title": "Tích hợp hệ thống",
+          "content": "Quản lý các tích hợp bên thứ ba và kết nối API. Cấu hình tích hợp Jira, GitHub và các công cụ bên ngoài khác cho tổ chức của bạn."
+        },
+        "llm": {
+          "title": "Cấu hình AI",
+          "content": "Cấu hình các mô hình AI và cài đặt để tạo trường hợp kiểm thử tự động và các tính năng thông minh. Quản lý khóa API và tùy chọn mô hình."
+        },
+        "sso": {
+          "title": "Đăng nhập một lần",
+          "content": "Cấu hình các nhà cung cấp SSO và phương thức xác thực. Thiết lập tích hợp SAML, OAuth và các nhà cung cấp danh tính khác để truy cập người dùng liền mạch."
+        },
+        "appConfig": {
+          "content": "Quản lý cài đặt ứng dụng toàn cầu và tùy chọn hệ thống. Cấu hình giá trị mặc định, công tắc tính năng và hành vi trên toàn hệ thống."
+        },
+        "trash": {
+          "title": "Thùng rác hệ thống",
+          "content": "Xem và quản lý các mục đã xóa trên tất cả các dự án. Khôi phục nội dung bị xóa nhầm hoặc xóa vĩnh viễn các mục khỏi hệ thống."
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "Chào mừng bạn đến với Dự án Demo",
+          "content": "Dự án này đã được tải sẵn dữ liệu mẫu. Chúng ta hãy cùng nhau tìm hiểu các tính năng chính. Sử dụng menu thả xuống này để chuyển đổi giữa các dự án."
+        },
+        "overview": {
+          "title": "Tổng quan dự án",
+          "content": "Tổng quan là bảng điều khiển dự án của bạn. Nó hiển thị tiến độ các mốc quan trọng và tóm tắt các trường hợp kiểm thử, các lần chạy đang hoạt động, các phiên và các thẻ."
+        },
+        "documentation": {
+          "title": "Tài liệu",
+          "content": "Mỗi dự án đều có một trang tài liệu. Hãy sử dụng nó để ghi lại kế hoạch kiểm thử, ghi chú dự án hoặc liên kết đến các nguồn tài nguyên bên ngoài."
+        },
+        "documentationContent": {
+          "title": "Trình soạn thảo văn bản đa dạng",
+          "content": "Tài liệu hỗ trợ định dạng văn bản phong phú với tiêu đề, danh sách, liên kết và hình ảnh. Hãy thử chỉnh sửa trang này để xem cách hoạt động."
+        },
+        "milestones": {
+          "title": "Các cột mốc",
+          "content": "Theo dõi quá trình kiểm thử của bạn so với các sprint, bản phát hành và các mục tiêu khác. Liên kết các lần chạy thử nghiệm và các phiên kiểm thử với các mốc thời gian để theo dõi tiến độ."
+        },
+        "milestonesPage": {
+          "title": "Dòng thời gian các mốc quan trọng",
+          "content": "Xem tất cả các mốc quan trọng của dự án này. Mỗi mốc quan trọng hiển thị trạng thái và tiến độ hoàn thành."
+        },
+        "repository": {
+          "title": "Kho lưu trữ trường hợp thử nghiệm",
+          "content": "Sắp xếp các trường hợp kiểm thử vào các thư mục với các trường, bước và mức độ ưu tiên tùy chỉnh. Xem các thư mục mẫu để biết cách các trường hợp được cấu trúc."
+        },
+        "repositoryPanels": {
+          "title": "Thư mục & Hộp đựng",
+          "content": "Khung bên trái hiển thị các thư mục. Nhấp vào một thư mục để xem các trường hợp kiểm thử của nó. Mỗi trường hợp đều có các bước, mô tả và các tham chiếu bước chung."
+        },
+        "repositoryCases": {
+          "title": "Các trường hợp thử nghiệm",
+          "content": "Tại đây, bạn có thể thấy các trường hợp kiểm thử cho thư mục đã chọn. Mỗi hàng hiển thị tên trường hợp, mức độ ưu tiên và các trường tùy chỉnh. Nhấp vào một trường hợp để xem chi tiết đầy đủ và các bước thực hiện."
+        },
+        "sharedSteps": {
+          "title": "Các bước chung",
+          "content": "Xác định các nhóm bước có thể tái sử dụng, có thể được tham chiếu từ nhiều trường hợp kiểm thử khác nhau. Điều này giúp các bước chung được nhất quán và dễ bảo trì."
+        },
+        "sharedStepsPage": {
+          "title": "Nhóm bước chung",
+          "content": "Mỗi nhóm chứa một tập hợp các bước được sắp xếp theo thứ tự. Hãy tham chiếu chúng từ bất kỳ trường hợp kiểm thử nào để giữ cho các bước của bạn tuân thủ nguyên tắc DRY (Don't Repeat Yourself) và nhất quán."
+        },
+        "testRuns": {
+          "title": "Chạy thử nghiệm",
+          "content": "Tạo các lượt chạy thử nghiệm để thực hiện các trường hợp và ghi lại kết quả. Gán các lượt chạy cho các mốc thời gian và theo dõi tiến độ đạt/không đạt."
+        },
+        "testRunsPage": {
+          "title": "Kết quả chạy thử nghiệm",
+          "content": "Xem kết quả và tiến độ chạy thử nghiệm. Mỗi lần chạy hiển thị trạng thái, mốc thời gian được chỉ định và phân tích kết quả đạt/không đạt."
+        },
+        "sessions": {
+          "title": "Phiên thảo luận thăm dò",
+          "content": "Ghi lại quá trình kiểm thử ngẫu nhiên bằng phương pháp kiểm thử dựa trên phiên. Ghi nhận kết quả, gán trạng thái và theo dõi thời gian thực hiện."
+        },
+        "sessionsPage": {
+          "title": "Kết quả phiên họp",
+          "content": "Mỗi phiên đều bao gồm các phát hiện chi tiết, trạng thái và ghi chú. Nhấp vào một phiên để xem kết quả."
+        },
+        "tags": {
+          "title": "Thẻ",
+          "content": "Thẻ (Tags) giúp sắp xếp và lọc các trường hợp kiểm thử, lượt chạy và phiên kiểm thử. Hãy xem các thẻ mẫu để hiểu cách chúng phân loại nội dung."
+        },
+        "tagsPage": {
+          "title": "Quản lý thẻ",
+          "content": "Bạn có thể tạo, chỉnh sửa và gán thẻ từ đây. Sử dụng thẻ để nhóm và lọc nội dung trong toàn bộ dự án của mình."
+        },
+        "issues": {
+          "title": "Vấn đề",
+          "content": "Theo dõi các lỗi và khiếm khuyết được tìm thấy trong quá trình thử nghiệm. Các vấn đề có thể được liên kết với kết quả chạy thử nghiệm thất bại và các phát hiện trong phiên để đảm bảo khả năng truy vết đầy đủ."
+        },
+        "issuesPage": {
+          "title": "Trình theo dõi sự cố",
+          "content": "Xem các ví dụ về sự cố liên quan đến kết quả không thành công. Các sự cố có thể được truy vết ngược lại đến lần chạy thử nghiệm hoặc phiên tìm kiếm đã phát hiện ra chúng."
+        },
+        "reports": {
+          "title": "Báo cáo & Phân tích",
+          "content": "Tạo báo cáo về độ bao phủ kiểm thử, xu hướng thực thi và hiệu suất nhóm. Sử dụng các báo cáo có sẵn hoặc tạo báo cáo tùy chỉnh cho các bên liên quan."
+        },
+        "settings": {
+          "title": "Cài đặt dự án",
+          "content": "Từ đây, bạn có thể quản lý các tích hợp cấp dự án, cấu hình mô hình AI và các liên kết chia sẻ."
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "Tạo và quản lý các báo cáo liên dự án."
+      },
+      "reportsTabDescription": "Xem và phân tích các báo cáo được tạo sẵn cho dự án của bạn.",
+      "reportType": "Loại báo cáo",
+      "selectReportType": "Chọn loại báo cáo",
+      "selectReport": "Chọn báo cáo",
+      "dimensions": "Kích thước",
+      "dimensionsSubtitle": "Kích thước (kéo để sắp xếp lại, thêm bên dưới)",
+      "metrics": "Số liệu",
+      "addDimension": "Thêm chiều sâu...",
+      "addMetric": "Thêm số liệu...",
+      "runReport": "Chạy báo cáo",
+      "noResultsFound": "Không tìm thấy kết quả nào.",
+      "selectAtLeastOneDimensionAndMetric": "Hãy chọn ít nhất một chiều và một chỉ số.",
+      "noDataMatchingCriteria": "Không tìm thấy dữ liệu nào phù hợp với các chiều và chỉ số đã chọn.",
+      "noDataMatchingCriteriaWithDateFilter": "Không tìm thấy dữ liệu nào phù hợp với các chiều và chỉ số đã chọn. Hãy thử điều chỉnh bộ lọc phạm vi ngày.",
+      "noDataAvailable": "Không có dữ liệu nào cho báo cáo này.",
+      "generatedAt": "Báo cáo được tạo tại",
+      "crossProjectAnalytics": "Phân tích và báo cáo liên dự án",
+      "unauthorizedAdmin": "Không được phép: Cần quyền truy cập quản trị viên.",
+      "title": "Trình tạo báo cáo",
+      "description": "Tạo báo cáo tùy chỉnh để phân tích dữ liệu dự án của bạn.",
+      "crossProjectDescription": "Phân tích dữ liệu trên tất cả các dự án trong không gian làm việc của bạn.",
+      "selectDimensions": "Chọn kích thước...",
+      "selectMetrics": "Chọn các chỉ số...",
+      "dimensionOrder": "Thứ tự kích thước",
+      "metricOrder": "Thứ tự theo hệ mét",
+      "filtersDescription": "Lọc dữ liệu báo cáo theo các tiêu chí cụ thể.",
+      "activeFilters": "Bộ lọc đang hoạt động:",
+      "priorityFilterPlaceholder": "Chọn các giá trị ưu tiên (hoặc để trống nếu muốn chọn tất cả)",
+      "dateRange": {
+        "selectDateRange": "Chọn phạm vi ngày",
+        "chooseStartDate": "Chọn ngày bắt đầu",
+        "chooseEndDate": "Chọn ngày kết thúc",
+        "categories": {
+          "day": "Ngày",
+          "week": "Tuần",
+          "month": "Tháng",
+          "quarter": "Một phần tư",
+          "year": "Năm"
+        },
+        "today": "Hôm nay",
+        "yesterday": "Hôm qua",
+        "last7Days": "7 ngày qua",
+        "last30Days": "30 ngày qua",
+        "thisWeek": "Tuần này",
+        "lastWeek": "Tuần trước",
+        "last2Weeks": "Hai tuần qua",
+        "thisMonth": "Tháng này",
+        "lastMonth": "Tháng trước",
+        "last3Months": "3 tháng qua",
+        "thisQuarter": "Quý này",
+        "lastQuarter": "Quý cuối cùng",
+        "thisYear": "Năm nay",
+        "lastYear": "Năm ngoái",
+        "last12Months": "12 tháng qua",
+        "allTime": "Mọi thời đại",
+        "custom": "Khoảng thời gian tùy chỉnh"
+      },
+      "dateGrouping": {
+        "label": "Nhóm theo",
+        "daily": "Hằng ngày",
+        "weekly": "Hàng tuần",
+        "monthly": "Hàng tháng",
+        "quarterly": "Hàng quý",
+        "annually": "Hàng năm"
+      },
+      "filters": {
+        "selectFilter": "Chọn loại bộ lọc",
+        "allProjects": "Tất cả các dự án"
+      },
+      "errors": {
+        "failedToLoadMetadata": "Không thể tải siêu dữ liệu báo cáo",
+        "failedToRunReport": "Không thể chạy báo cáo.",
+        "atLeastOneDimensionRequired": "Ít nhất phải có một chiều.",
+        "atLeastOneMetricRequired": "Ít nhất một chỉ số phải được chỉ định.",
+        "invalidCombinationDateLastActive": "Chỉ số 'Ngày hoạt động cuối cùng' không thể kết hợp với chiều dữ liệu 'Ngày hoạt động'.",
+        "lastActiveDateOnlyWithUser": "Chỉ số 'Ngày hoạt động cuối cùng' chỉ có thể được sử dụng với chiều dữ liệu 'Người dùng'.",
+        "invalidDimensionCombination": "Kích thước '{dim1}' và '{dim2}' không thể được sử dụng cùng nhau trong báo cáo Thực thi Kiểm thử.",
+        "startDateRequiredWithEndDate": "Ngày bắt đầu là bắt buộc khi ngày kết thúc được chỉ định.",
+        "endDateMustBeAfterStartDate": "Ngày kết thúc phải sau hoặc bằng ngày bắt đầu."
+      },
+      "chartDataTruncated": {
+        "title": "Dữ liệu biểu đồ bị cắt bớt",
+        "message": "Hiển thị {shown} trong số {total} điểm dữ liệu để dễ đọc. Sử dụng bộ lọc hoặc phạm vi ngày để thu hẹp kết quả, hoặc xem toàn bộ dữ liệu trong bảng Kết quả bên dưới."
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "Báo cáo thực thi kiểm thử",
+          "description": "Phân tích kết quả kiểm tra, tỷ lệ đạt và các chỉ số thực hiện."
+        },
+        "repositoryStats": {
+          "label": "Thống kê kho lưu trữ",
+          "description": "Thống kê trường hợp thử nghiệm, độ bao phủ và tình trạng của kho lưu trữ"
+        },
+        "userEngagement": {
+          "label": "Tương tác người dùng",
+          "description": "Phân tích hoạt động, năng suất và khối lượng công việc của người dùng"
+        },
+        "projectHealth": {
+          "label": "Dự án Sức khỏe",
+          "description": "Tiến độ dự án, các mốc quan trọng và tình trạng hoàn thành"
+        },
+        "sessionAnalysis": {
+          "label": "Phân tích phiên",
+          "description": "Số liệu về việc hoàn thành phiên, thời lượng và bài tập"
+        },
+        "issueTracking": {
+          "label": "Theo dõi sự cố",
+          "description": "Phân tích tác động, giải quyết vấn đề và quá trình phát sinh vấn đề."
+        },
+        "automationTrends": {
+          "label": "Xu hướng tự động hóa",
+          "description": "Theo dõi tiến độ tự động hóa hàng tuần theo mức độ ưu tiên"
+        },
+        "flakyTests": {
+          "label": "Các bài kiểm tra không ổn định",
+          "description": "Xác định các bài kiểm tra có kết quả đạt/không đạt không nhất quán."
+        },
+        "testCaseHealth": {
+          "label": "Trường hợp thử nghiệm về sức khỏe",
+          "description": "Xác định các trường hợp kiểm thử lỗi thời, bị hỏng hoặc đáng ngờ dựa trên các mẫu thực thi."
+        },
+        "issueTestCoverage": {
+          "label": "Vấn đề về phạm vi kiểm thử",
+          "description": "Xem các vấn đề liên quan cùng với các trường hợp kiểm thử được liên kết và trạng thái thực thi mới nhất."
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "Các lần chạy liên tiếp gần nhất",
+        "consecutiveRunsHelp": "Số lần thực thi kiểm thử gần đây cần phân tích (5-30). Kết quả có trạng thái 'chưa kiểm thử' sẽ bị loại trừ.",
+        "flipThreshold": "Số lần lật tối thiểu",
+        "flipThresholdHelp": "Số lượng tối thiểu các lần chuyển đổi thành công/thất bại cần thiết để được coi là không ổn định.",
+        "flips": "Lật",
+        "lastNResults": "Kết quả cuối cùng {count, plural, one {# Kết quả} other {# Kết quả}}",
+        "newest": "Mới",
+        "oldest": "Cũ",
+        "noFlakyTests": "Không tìm thấy bài kiểm tra không ổn định nào phù hợp với tiêu chí.",
+        "includeFilter": "Bao gồm",
+        "testRunDeleted": "Quá trình chạy thử nghiệm đã bị xóa.",
+        "chart": {
+          "highPriority": "Cần được chú ý",
+          "lowPriority": "Ưu tiên thấp hơn",
+          "recencyAxis": "Thất bại gần đây",
+          "flipsAxis": "Số lần lật",
+          "oldFailures": "Lớn hơn",
+          "recentFailures": "Gần đây",
+          "failureRate": "Tỷ lệ hỏng hóc",
+          "recency": "Điểm gần đây",
+          "backlogTitle": "Các xét nghiệm có mức độ ưu tiên thấp hơn",
+          "backlogDescription": "{count, plural, one {# kiểm tra lỗi bổ sung} other {# kiểm tra lỗi bổ sung}} không hiển thị"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "Ổn định sau (ngày)",
+        "staleDaysThresholdHelp": "Số ngày không thực thi trước khi một bài kiểm tra được coi là lỗi thời (7-90).",
+        "minExecutions": "Số lần thực thi tối thiểu cho mỗi tỷ lệ",
+        "minExecutionsHelp": "Số lần thực hiện tối thiểu cần thiết để tính toán số liệu thống kê tỷ lệ đạt yêu cầu có ý nghĩa (3-20).",
+        "lookbackDays": "Thời kỳ xem xét lại",
+        "lookbackDaysHelp": "Số ngày để phân tích lịch sử thực thi (30-365).",
+        "includeFilter": "Bao gồm",
+        "staleFilter": "Sự cũ kỹ",
+        "stale": "Cũ",
+        "notStale": "Không bị ôi thiu",
+        "status": "Tình trạng sức khỏe",
+        "healthScore": "Điểm",
+        "lastExecuted": "Lần thực thi cuối cùng",
+        "executions": "Thực thi",
+        "passRate": "Tỷ lệ đậu",
+        "passCount": "Vượt qua",
+        "failCount": "Thất bại",
+        "never": "Không bao giờ",
+        "daysSince": "Số ngày kể từ khi hành quyết",
+        "count": "Đếm",
+        "totalTests": "các trường hợp thử nghiệm",
+        "noData": "Không tìm thấy trường hợp thử nghiệm nào.",
+        "noExecutedTests": "Không có bài kiểm tra nào được thực thi để hiển thị.",
+        "healthStatus": {
+          "healthy": "Khỏe mạnh",
+          "stale": "Cũ",
+          "neverExecuted": "Không bao giờ bị hành quyết",
+          "alwaysPassing": "Luôn luôn đi ngang qua",
+          "alwaysFailing": "Luôn luôn thất bại"
+        },
+        "chart": {
+          "distribution": "Phân phối trạng thái",
+          "healthyRecent": "Khỏe mạnh & Mới đây",
+          "unhealthyStale": "Cần được chú ý",
+          "daysAxis": "Số ngày kể từ lần hành quyết cuối cùng",
+          "healthScoreAxis": "Điểm sức khỏe"
+        },
+        "stats": {
+          "totalTests": "Tổng số bài kiểm tra",
+          "needsAttention": "Cần được chú ý",
+          "needsAttentionTooltip": "Luôn thất bại + Không bao giờ được thực thi + Các bài kiểm tra lỗi thời",
+          "healthy": "Khỏe mạnh",
+          "healthyTooltip": "Khỏe mạnh + Luôn vượt qua các bài kiểm tra",
+          "avgScore": "Điểm sức khỏe trung bình"
+        },
+        "healthScoreTooltip": {
+          "title": "Điểm số bắt đầu từ 100, các điểm bị trừ:",
+          "neverExecuted": "Chưa từng được thực thi: -50",
+          "stale90": "Không chạy trong hơn 90 ngày: -40",
+          "stale60": "Không chạy trong hơn 60 ngày: -25",
+          "stale30": "Không chạy trong hơn 30 ngày: -10",
+          "alwaysPassing": "Luôn luôn đạt điểm đậu (100%): -5",
+          "alwaysFailing": "Luôn thất bại (0%): -30",
+          "lowPassRate": "Tỷ lệ đậu thấp (<50%): -20",
+          "lowExecutions": "Ít lần thực thi (<3): -10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "Chế độ xem",
+        "summaryView": "Tóm tắt (theo từng vấn đề)",
+        "detailView": "Chi tiết (theo từng trường hợp thử nghiệm)",
+        "issue": "Vấn đề",
+        "testCase": "Trường hợp thử nghiệm",
+        "testCases": "{count, plural, =1 {Trường hợp thử nghiệm} other {Các trường hợp thử nghiệm}}",
+        "issueStatus": "Trạng thái",
+        "priority": "Sự ưu tiên",
+        "linkedTests": "Các bài kiểm tra liên kết",
+        "testResults": "Kết quả (Đạt/Theo dõi/Không xác định)",
+        "passRate": "Tỷ lệ đậu",
+        "passed": "Đi qua",
+        "failed": "Thất bại",
+        "lastStatus": "Trạng thái cuối cùng",
+        "lastExecuted": "Lần thực thi cuối cùng",
+        "notTested": "Chưa được kiểm tra",
+        "noData": "Không phát hiện vấn đề nào với các trường hợp kiểm thử được liên kết.",
+        "noIssuesNeedingAttention": "Tất cả các vấn đề đều đã được kiểm tra đạt yêu cầu - tuyệt vời!",
+        "stats": {
+          "totalIssues": "Tổng số vấn đề",
+          "issuesWithFailures": "Với những thất bại",
+          "issuesWithFailuresTooltip": "Có vấn đề với ít nhất một trường hợp kiểm thử thất bại.",
+          "issuesWithUntested": "Chưa được kiểm thử",
+          "issuesWithUntestedTooltip": "Có vấn đề với ít nhất một trường hợp kiểm thử chưa được thực thi.",
+          "issuesAllPassing": "Tất cả đều trôi qua",
+          "overallPassRate": "Tỷ lệ đậu",
+          "numberOfIssues": "Số lượng vấn đề"
+        },
+        "charts": {
+          "passRateDistribution": "Phân bố tỷ lệ đỗ bài kiểm tra",
+          "linkedTestCases": "Số lượng trường hợp kiểm thử được liên kết",
+          "untestedTestCases": "Số lượng trường hợp kiểm thử chưa được kiểm thử",
+          "testCoverageVsExecution": "Độ phủ kiểm thử so với trạng thái thực thi"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "Thực thi kiểm thử liên dự án",
+          "description": "Phân tích kết quả kiểm tra, tỷ lệ đạt và các chỉ số thực hiện trên tất cả các dự án."
+        },
+        "repositoryStats": {
+          "label": "Thống kê kho lưu trữ liên dự án",
+          "description": "Thống kê trường hợp kiểm thử, độ bao phủ và tình trạng kho lưu trữ trên các dự án."
+        },
+        "userEngagement": {
+          "label": "Tương tác người dùng giữa các dự án",
+          "description": "Phân tích hoạt động, năng suất và khối lượng công việc của người dùng trên các dự án."
+        },
+        "issueTracking": {
+          "label": "Theo dõi vấn đề giữa các dự án",
+          "description": "Việc tạo lập, giải quyết và phân tích tác động của các vấn đề trong các dự án."
+        },
+        "automationTrends": {
+          "label": "Xu hướng tự động hóa xuyên dự án",
+          "description": "Theo dõi tiến độ tự động hóa hàng tuần theo mức độ ưu tiên trên các dự án."
+        },
+        "flakyTests": {
+          "label": "Kiểm thử lỗi không ổn định giữa các dự án",
+          "description": "Xác định các bài kiểm tra có kết quả đạt/không đạt không nhất quán giữa các dự án."
+        },
+        "testCaseHealth": {
+          "label": "Kiểm thử sức khỏe giữa các dự án",
+          "description": "Xác định các trường hợp kiểm thử lỗi thời, bị hỏng hoặc đáng ngờ trong các dự án."
+        },
+        "issueTestCoverage": {
+          "label": "Độ phủ kiểm thử vấn đề xuyên dự án",
+          "description": "Xem các vấn đề liên quan đến các trường hợp kiểm thử được liên kết và trạng thái thực thi mới nhất trên các dự án."
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "Chỉ Quản trị viên dự án và Quản trị viên mới có thể truy cập báo cáo dự án.",
+      "projectIdRequired": "Cần có mã số dự án.",
+      "missingRequiredFields": "Thiếu các trường bắt buộc",
+      "unsupportedDimension": "Kích thước không được hỗ trợ: {dimension}",
+      "unsupportedMetric": "Chỉ số đo không được hỗ trợ: {metric}",
+      "atLeastOneDimensionMetricRequired": "Cần ít nhất một chiều và một chỉ số đo.",
+      "atLeastOneMetricRequired": "Ít nhất một chỉ số phải được chỉ định.",
+      "projectDimensionsMetricsRequired": "Cần có ID dự án, kích thước và số liệu.",
+      "unsupportedDimensions": "Kích thước không được hỗ trợ: {dimensions}",
+      "unsupportedMetrics": "Các chỉ số không được hỗ trợ: {metrics}",
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn."
+    },
+    "dimensions": {
+      "project": "Dự án",
+      "status": "Trạng thái",
+      "user": "Người dùng",
+      "executor": "Người thi hành án",
+      "assignedTo": "Được giao cho",
+      "configuration": "Cấu hình",
+      "date": "Ngày",
+      "executionDate": "Ngày thực hiện",
+      "creationDate": "Ngày tạo",
+      "activityDate": "Ngày hoạt động",
+      "testRun": "Chạy thử nghiệm",
+      "testCase": "Trường hợp thử nghiệm",
+      "milestone": "Cột mốc",
+      "template": "Bản mẫu",
+      "creator": "Người sáng tạo",
+      "state": "Tình trạng",
+      "source": "Nguồn",
+      "folder": "Thư mục",
+      "group": "Nhóm",
+      "role": "Vai trò",
+      "session": "Phiên họp",
+      "weekEnding": "Tuần kết thúc",
+      "period": "Giai đoạn",
+      "priority": "Sự ưu tiên",
+      "automationStatus": "Trạng thái tự động hóa",
+      "issueType": "Loại sự cố",
+      "issueTracker": "Trình theo dõi sự cố",
+      "issueStatus": "Trạng thái vấn đề"
+    },
+    "metrics": {
+      "testResults": "Kết quả kiểm tra",
+      "testResultCount": "Số kết quả xét nghiệm",
+      "passRate": "Tỷ lệ đậu (%)",
+      "avgElapsed": "Thời gian trung bình đã trôi qua",
+      "avgElapsedTime": "Thời gian trung bình đã trôi qua",
+      "totalElapsedTime": "Tổng thời gian đã trôi qua",
+      "testRunCount": "Số lần chạy thử nghiệm",
+      "testCaseCount": "Số lượng trường hợp kiểm thử",
+      "automationRate": "Tỷ lệ tự động hóa (%)",
+      "avgStepsPerCase": "Số bước trung bình mỗi trường hợp",
+      "averageSteps": "Số bước trung bình mỗi trường hợp",
+      "automatedCount": "Các trường hợp tự động",
+      "manualCount": "Hộp đựng thủ công",
+      "totalCount": "Tổng số ca",
+      "totalSteps": "Tổng số bước",
+      "executionCount": "Thực thi kiểm thử",
+      "createdCaseCount": "Số lượng trường hợp kiểm thử đã tạo",
+      "sessionResultCount": "Số lượng kết quả phiên",
+      "caseCreations": "Các trường hợp đã được tạo",
+      "sessionParticipation": "Tham gia phiên họp",
+      "averageElapsed": "Thời gian trung bình cho mỗi lần thực thi",
+      "lastActiveDate": "Ngày hoạt động cuối cùng",
+      "issueCount": "Số lượng phát hành",
+      "averageAge": "Tuổi trung bình (ngày)",
+      "sessionCount": "Số phiên",
+      "activeSessions": "Phiên hoạt động",
+      "averageTimeSpent": "Thời gian trung bình dành ra (phút)",
+      "milestoneCount": "Số lượng cột mốc",
+      "milestoneCompletionRate": "Tỷ lệ hoàn thành cột mốc (%)",
+      "averageMilestoneDuration": "Thời gian hoàn thành trung bình (ngày)",
+      "totalMilestones": "Tổng số mốc quan trọng",
+      "activeMilestones": "Các cột mốc quan trọng",
+      "milestoneCompletion": "Tỷ lệ hoàn thành cột mốc (%)",
+      "averageDuration": "Thời gian trung bình",
+      "totalDuration": "Tổng thời lượng"
+    },
+    "drillDown": {
+      "title": "Hồ sơ chi tiết",
+      "loading": "Đang tải hồ sơ...",
+      "loadingMore": "Đang tải thêm...",
+      "noRecords": "Không tìm thấy hồ sơ nào.",
+      "error": "Không thể tải bản ghi",
+      "recordCount": "{count} {count, plural, =1 {bản ghi} other {các bản ghi}}",
+      "allRecords": "Tất cả hồ sơ",
+      "allLoaded": "Tất cả bản ghi đã được tải"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "Chia sẻ",
+      "dialogTitle": "Chia sẻ báo cáo",
+      "dialogDescription": "Tạo liên kết chia sẻ hoặc quản lý các liên kết báo cáo đã chia sẻ hiện có.",
+      "tabs": {
+        "create": "Tạo Chia sẻ",
+        "list": "Cổ phần của tôi"
+      },
+      "shareMode": {
+        "label": "Chế độ chia sẻ",
+        "authenticated": {
+          "title": "Đã xác thực (yêu cầu đăng nhập)",
+          "description": "Chỉ những người dùng đã đăng nhập và có quyền truy cập vào dự án này mới có thể xem được.",
+          "descriptionCrossProject": "Chỉ những người dùng đã đăng nhập và có quyền quản trị mới có thể xem."
+        },
+        "passwordProtected": {
+          "title": "Được bảo vệ bằng mật khẩu",
+          "description": "Bất kỳ ai có liên kết và mật khẩu đều có thể xem. Người dùng đã đăng nhập và có quyền truy cập dự án sẽ bỏ qua bước nhập mật khẩu.",
+          "descriptionCrossProject": "Bất kỳ ai có liên kết và mật khẩu đều có thể xem. Người dùng đã đăng nhập với quyền quản trị viên sẽ bỏ qua bước nhập mật khẩu."
+        },
+        "public": {
+          "title": "Công khai (bất kỳ ai có liên kết)",
+          "description": "Bất kỳ ai có đường dẫn đều có thể xem báo cáo này mà không cần đăng nhập."
+        }
+      },
+      "expiration": {
+        "label": "Hạn sử dụng",
+        "noExpiration": "Không có hạn sử dụng",
+        "expiresAtMidnight": "Liên kết sẽ hết hạn vào cuối ngày đã chọn (theo giờ địa phương của bạn)."
+      },
+      "notifyOnView": {
+        "label": "Thông báo cho tôi khi có người xem liên kết này",
+        "description": "Bạn sẽ nhận được thông báo khi liên kết chia sẻ được truy cập, tùy thuộc vào tùy chọn thông báo của bạn."
+      },
+      "title": {
+        "placeholder": "Ví dụ: Báo cáo thực thi kiểm thử",
+        "leaveEmptyToUse": "Để trống khi sử dụng:"
+      },
+      "description": {
+        "placeholder": "Thêm mô tả cho báo cáo được chia sẻ này..."
+      },
+      "actions": {
+        "createShareLink": "Tạo liên kết chia sẻ",
+        "creating": "Đang tạo..."
+      },
+      "errors": {
+        "loginRequired": "Bạn phải đăng nhập để tạo liên kết chia sẻ.",
+        "createFailed": "Không thể tạo liên kết chia sẻ",
+        "genericError": "Đã xảy ra lỗi không xác định"
+      },
+      "status": {
+        "revoked": {
+          "title": "Liên kết chia sẻ đã bị thu hồi",
+          "description": "Liên kết chia sẻ này đã bị thu hồi và không còn truy cập được nữa."
+        },
+        "expired": {
+          "title": "Liên kết chia sẻ đã hết hạn",
+          "description": "Liên kết chia sẻ này đã hết hạn và không còn truy cập được nữa."
+        }
+      },
+      "footer": {
+        "poweredBy": "Được cung cấp bởi"
+      },
+      "manageShares": {
+        "title": "Quản lý cổ phần",
+        "description": "Xem và quản lý tất cả các liên kết chia sẻ cho dự án này.",
+        "adminTitle": "Quản lý tất cả cổ phần",
+        "adminDescription": "Xem và quản lý các liên kết chia sẻ trên tất cả các dự án."
+      },
+      "shareList": {
+        "columns": {
+          "mode": "Cách thức",
+          "views": "Lượt xem",
+          "expires": "Hết hạn"
+        },
+        "status": {
+          "revoked": "Đã bị thu hồi",
+          "expired": "Hết hạn"
+        },
+        "notifications": {
+          "enabled": "TRÊN",
+          "disabled": "Tắt"
+        },
+        "empty": {
+          "title": "Chưa có liên kết chia sẻ nào được tạo.",
+          "description": "Hãy tạo liên kết chia sẻ đầu tiên của bạn để bắt đầu."
+        },
+        "defaultTitle": "{entityType} chia sẻ",
+        "noProject": "Liên dự án",
+        "actions": {
+          "copyLink": "Sao chép liên kết",
+          "revoke": "Thu hồi"
+        },
+        "revokeDialog": {
+          "title": "Thu hồi liên kết chia sẻ?",
+          "description": "Thao tác này sẽ ngay lập tức thu hồi liên kết chia sẻ. Bất kỳ ai cố gắng truy cập sẽ thấy thông báo lỗi. Hành động này không thể hoàn tác.",
+          "confirm": "Thu hồi liên kết",
+          "revoking": "Đang thu hồi..."
+        },
+        "deleteDialog": {
+          "title": "Xóa liên kết chia sẻ?",
+          "description": "Thao tác này sẽ xóa vĩnh viễn liên kết chia sẻ. Nếu liên kết hiện đang hoạt động, nó sẽ hết hạn ngay lập tức và không thể truy cập được nữa. Hành động này không thể hoàn tác.",
+          "confirm": "Xóa liên kết"
+        },
+        "toast": {
+          "linkCopied": "Đã sao chép liên kết!",
+          "linkCopiedDescription": "Liên kết chia sẻ đã được sao chép vào khay nhớ tạm của bạn.",
+          "copyFailed": "Không thể sao chép",
+          "copyFailedDescription": "Vui lòng sao chép đường dẫn theo cách thủ công.",
+          "linkRevoked": "Liên kết chia sẻ đã bị thu hồi",
+          "linkRevokedDescription": "Liên kết chia sẻ đã bị thu hồi và không còn truy cập được nữa.",
+          "revokeFailed": "Không thể thu hồi",
+          "revokeFailedDescription": "Đã xảy ra lỗi khi thu hồi liên kết chia sẻ.",
+          "notificationsEnabled": "Thông báo đã được bật",
+          "notificationsEnabledDescription": "Bạn sẽ nhận được thông báo khi ai đó xem liên kết chia sẻ này.",
+          "notificationsDisabled": "Thông báo đã bị vô hiệu hóa",
+          "notificationsDisabledDescription": "Bạn sẽ không nhận được thông báo khi ai đó xem liên kết chia sẻ này.",
+          "notificationUpdateFailed": "Không thể cập nhật thông báo",
+          "notificationUpdateFailedDescription": "Đã xảy ra lỗi trong quá trình cập nhật cài đặt thông báo.",
+          "linkDeleted": "Liên kết chia sẻ đã bị xóa",
+          "linkDeletedDescription": "Liên kết chia sẻ đã bị xóa và sẽ không còn xuất hiện trong danh sách của bạn nữa.",
+          "deleteFailed": "Không thể xóa",
+          "deleteFailedDescription": "Đã xảy ra lỗi khi xóa liên kết chia sẻ."
+        }
+      },
+      "created": {
+        "title": "Đã tạo liên kết chia sẻ!",
+        "description": "Liên kết chia sẻ của bạn đã sẵn sàng. Sao chép và chia sẻ với người khác.",
+        "shareLink": "Chia sẻ liên kết",
+        "copy": "Sao chép",
+        "openInNewTab": "Mở trong tab mới",
+        "metadata": {
+          "mode": "Cách thức",
+          "expires": "Hết hạn",
+          "views": "Lượt xem"
+        },
+        "warnings": {
+          "publicLink": "Liên kết công khai:",
+          "publicLinkDescription": "Bất kỳ ai có liên kết này đều có thể truy cập báo cáo mà không cần xác thực.",
+          "expiresSoon": "Liên kết này sẽ hết hạn vào cuối"
+        },
+        "actions": {
+          "createAnother": "Tạo thêm một cái nữa"
+        }
+      },
+      "editDialog": {
+        "title": "Chỉnh sửa liên kết chia sẻ",
+        "description": "Cập nhật cài đặt cho liên kết chia sẻ này.",
+        "passwordExists": "Liên kết chia sẻ này đã có mật khẩu. Hãy để trống ô mật khẩu để giữ nguyên mật khẩu hiện có.",
+        "passwordPlaceholder": "Để trống nếu muốn giữ nguyên mật khẩu hiện có."
+      }
+    },
+    "passwordDialog": {
+      "title": "Cần có mật khẩu",
+      "description": "Nội dung được chia sẻ từ <strong>{projectName}</strong> được bảo vệ bằng mật khẩu. Vui lòng nhập mật khẩu để tiếp tục.",
+      "passwordPlaceholder": "Nhập mật khẩu",
+      "showPassword": "Hiển thị mật khẩu",
+      "hidePassword": "Ẩn mật khẩu",
+      "verifying": "Đang xác minh...",
+      "errors": {
+        "emptyPassword": "Vui lòng nhập mật khẩu",
+        "tooManyAttempts": "Quá nhiều lần thử không thành công. Vui lòng thử lại sau{resetAt, select, null {} other { vào lúc {resetAt}}}.",
+        "genericError": "Đã xảy ra lỗi. Vui lòng thử lại."
+      },
+      "attempts": {
+        "noAttemptsRemaining": "Không còn lượt thử nào nữa. Vui lòng thử lại sau.",
+        "attemptsRemaining": "{count, plural, =1 {1 lần thử} other {Số lần thử còn lại}}"
+      }
+    },
+    "sharedReport": {
+      "loading": "Đang tải báo cáo...",
+      "errors": {
+        "onlyReportSharing": "Hiện tại, chỉ có tính năng chia sẻ báo cáo được triển khai.",
+        "failedToLoad": "Không thể tải dữ liệu báo cáo."
+      },
+      "defaultTitle": "Báo cáo được chia sẻ",
+      "fromProject": "Từ dự án:",
+      "dateRange": "Khoảng thời gian:",
+      "readOnlyNotice": "Đây là chế độ xem chia sẻ chỉ đọc.",
+      "viewCount": "{count, plural, =1 {1 lượt xem} other {# lượt xem}}",
+      "viewInFullApp": "Xem trong ứng dụng đầy đủ",
+      "pagination": {
+        "showing": "Đang hiển thị",
+        "of": "của",
+        "results": "kết quả"
+      }
+    },
+    "authBypass": {
+      "title": "Bạn có quyền truy cập vào dự án này.",
+      "description": "Xem với tư cách {userName} có quyền truy cập vào {projectName}.",
+      "viewInApp": "Xem ứng dụng đầy đủ"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "Lọc các bước được chia sẻ...",
+    "noGroups": "Không tìm thấy bước nào được chia sẻ.",
+    "noTestCases": "Không có trường hợp kiểm thử nào sử dụng nhóm bước chung này.",
+    "selectGroupPrompt": "Chọn một nhóm bước chung để xem các bước trong nhóm đó.",
+    "deleteTitle": "Xóa nhóm bước dùng chung?",
+    "deleteDescription": "Bạn có chắc chắn muốn xóa nhóm bước dùng chung này không? Các bước sẽ bị xóa khỏi tất cả các trường hợp kiểm thử sử dụng chúng.",
+    "saveSuccess": "Các bước chia sẻ đã được cập nhật thành công.",
+    "saveError": "Đã xảy ra lỗi khi lưu các bước được chia sẻ.",
+    "stepsCount": "{count, plural, one {# bước} other {# các bước}}",
+    "testCasesUsing": "{count, plural, one {# trường hợp thử nghiệm} other {# các trường hợp thử nghiệm}}",
+    "importWizard": {
+      "title": "Nhập các bước được chia sẻ",
+      "fields": {
+        "order": "Đặt hàng",
+        "stepNumber": "Bước chân #",
+        "stepContent": "Nội dung bước",
+        "expectedResultContent": "Nội dung kết quả dự kiến",
+        "combinedStepData": "Dữ liệu bước kết hợp",
+        "stepsData": "Dữ liệu các bước"
+      },
+      "success": {
+        "description": "{count, plural, one {# bước chung} other {# các bước chung}} đã nhập thành công"
+      },
+      "errors": {
+        "parseFailed": "Không thể phân tích cú pháp tệp CSV.",
+        "validationFailed": "Xác thực thất bại",
+        "validationDescription": "{count, plural, one {# lỗi xác thực} other {# lỗi xác thực}} đã tìm thấy",
+        "importFailed": "Nhập khẩu thất bại",
+        "fileRequired": "Cần có một tệp CSV."
+      },
+      "page1": {
+        "title": "Tải lên tệp và cấu hình",
+        "selectedFile": "Tệp đã chọn",
+        "delimiter": "Dấu phân cách trường",
+        "delimiters": {
+          "tab": "Tab (\\t)"
+        },
+        "hasHeaders": "Hàng đầu tiên chứa tiêu đề cột.",
+        "encoding": "Mã hóa tập tin",
+        "rowMode": {
+          "label": "Chế độ hàng",
+          "single": "Một hàng trên mỗi bước chung",
+          "multi": "Nhiều hàng cho các bước chung phức tạp"
+        }
+      },
+      "page2": {
+        "title": "Ánh xạ các cột CSV với các trường bước dùng chung",
+        "description": "Ánh xạ các cột trong tệp CSV của bạn với các trường bước chung. Các trường bắt buộc phải được ánh xạ.",
+        "ignoreColumn": "Bỏ qua cột này",
+        "requiredFieldsWarning": "{count, plural, one {# Trường bắt buộc là} other {# Các trường bắt buộc là}} chưa được ánh xạ. Vui lòng ánh xạ tất cả các trường bắt buộc để tiếp tục."
+      },
+      "page3": {
+        "title": "Xem trước dữ liệu nhập",
+        "showing": "Hiển thị các bước được chia sẻ từ {start} đến {end} trong tổng số {total} bước được chia sẻ",
+        "step": "Bước chung {number}",
+        "noValue": "(trống)"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "Thêm thủ công",
+      "description": "Tạo nhóm bước chung mới với chức năng nhập liệu thủ công.",
+      "groupNamePlaceholder": "Nhập tên cho nhóm bước chung này.",
+      "success": "Các bước chia sẻ đã được tạo thành công",
+      "errors": {
+        "groupNameRequired": "Tên nhóm là bắt buộc",
+        "stepsRequired": "Ít nhất cần phải thực hiện một bước.",
+        "saveFailed": "Không thể lưu các bước đã chia sẻ"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "Trình tự các bước trùng lặp",
+      "pageDescription": "Xem xét các chuỗi bước trùng khớp giữa các trường hợp thử nghiệm. Chuyển đổi các kết quả trùng khớp thành các nhóm Bước chung hoặc loại bỏ các kết quả dương tính giả.",
+      "noResultsFound": "Không tìm thấy trình tự bước trùng lặp nào.",
+      "noResultsDescription": "Chạy quét để phát hiện các chuỗi bước lặp lại trong các trường hợp thử nghiệm của bạn.",
+      "filterPlaceholder": "Lọc theo tên vụ việc...",
+      "selected": "{count, plural, one {# đã chọn} other {# đã chọn}}",
+      "bulkDismiss": "Bỏ qua ({count})",
+      "bulkDismissSuccess": "{count, plural, one {# trận đấu bị hủy bỏ} other {# các trận đấu bị hủy bỏ}}",
+      "bulkError": "Một số thao tác đã thất bại. Vui lòng thử lại.",
+      "tableHint": "Nhấp vào một hàng để xem trước các bước đã khớp. Chọn các hàng có hộp kiểm để thực hiện các thao tác hàng loạt.",
+      "columns": {
+        "matchedSteps": "Các bước phù hợp",
+        "casesCount": "Các trường hợp",
+        "review": "Ôn tập"
+      },
+      "scanning": "Đang quét...",
+      "scanComplete": "{count, plural, one {# tìm thấy kết quả phù hợp} other {# tìm thấy kết quả phù hợp}}",
+      "scanFailed": "Quét thất bại",
+      "scanFailedDescription": "Đã xảy ra lỗi trong quá trình quét. Vui lòng thử lại.",
+      "cancelScan": "Hủy quét",
+      "findStepDuplicates": "Tìm các bước trùng lặp",
+      "rescan": "Quét",
+      "viewResults": "Xem kết quả ({count})",
+      "retryScan": "Thử quét lại",
+      "dialog": {
+        "title": "Chuyển đổi sang các bước được chia sẻ",
+        "previewTitle": "Trình tự bước phù hợp",
+        "casesTitle": "Các trường hợp kiểm thử bị ảnh hưởng",
+        "casesDescription": "Bỏ chọn các trường hợp bạn muốn loại trừ khỏi quá trình chuyển đổi.",
+        "nameLabel": "Tên nhóm bước chung",
+        "namePlaceholder": "Nhập tên cho nhóm bước chung...",
+        "converting": "Đang chuyển đổi...",
+        "dismissMatch": "Bỏ qua trận đấu",
+        "dismissing": "Sa thải...",
+        "convertSuccess": "Nhóm bước chung đã được tạo thành công!",
+        "convertError": "Quá trình chuyển đổi thất bại. Vui lòng thử lại.",
+        "dismissSuccess": "Trận đấu kết thúc.",
+        "dismissError": "Không thể đóng. Vui lòng thử lại.",
+        "viewSharedStep": "Xem Nhóm Bước Chung",
+        "skippedWarning": "{count, plural, one {# trường hợp đã bị bỏ qua} other {# trường hợp đã bị bỏ qua}} (cũ hoặc đã được chuyển đổi).",
+        "noCasesSelected": "Chọn ít nhất một trường hợp để chuyển đổi.",
+        "selectAll": "Chọn tất cả"
+      }
+    },
+    "findStepDuplicates": "Tìm các mục trùng lặp"
+  },
+  "search": {
+    "title": "Tìm kiếm",
+    "placeholder": {
+      "thisProject": "Tìm kiếm trong dự án này...",
+      "allProjects": "Tìm kiếm trên tất cả các dự án..."
+    },
+    "currentProjectOnly": "Chỉ dành cho dự án hiện tại",
+    "allTypes": "Tất cả các loại",
+    "entityTypes": {
+      "repositoryCase": "Các trường hợp lưu trữ"
+    },
+    "results": {
+      "tryAdjusting": "Hãy thử điều chỉnh các từ khóa tìm kiếm hoặc bộ lọc của bạn.",
+      "searchingFor": "Đang tìm kiếm",
+      "within": "ở trong",
+      "currentProject": "dự án hiện tại",
+      "page": "Trang"
+    },
+    "errors": {
+      "searchFailed": "Tìm kiếm không thành công. Vui lòng thử lại.",
+      "tryAgain": "Hãy thử lại"
+    },
+    "startTyping": "Bắt đầu nhập để tìm kiếm",
+    "typesSelected": "{count, plural, one {# loại} other {# loại}}",
+    "customFieldFilters": "Bộ lọc trường tùy chỉnh",
+    "customFiltersApplied": "bộ lọc tùy chỉnh",
+    "customFields": "Trường tùy chỉnh",
+    "addFilter": "Thêm bộ lọc",
+    "filter": "Lọc",
+    "noCustomFilters": "Không có bộ lọc trường tùy chỉnh nào được áp dụng.",
+    "selectDate": "Chọn ngày",
+    "selectOption": "Chọn tùy chọn",
+    "selectOptions": "Chọn tùy chọn",
+    "operators": {
+      "equals": "Bằng nhau",
+      "not_equals": "Không bằng",
+      "contains": "Chứa",
+      "not_contains": "Không chứa",
+      "starts_with": "Bắt đầu với",
+      "ends_with": "Kết thúc bằng",
+      "gt": "Lớn hơn",
+      "lt": "Ít hơn",
+      "gte": "Lớn hơn hoặc bằng",
+      "lte": "Nhỏ hơn hoặc bằng",
+      "between": "Giữa",
+      "in": "TRONG",
+      "not_in": "Không có trong",
+      "exists": "Tồn tại",
+      "not_exists": "Không tồn tại"
+    },
+    "help": {
+      "exactPhrases": "Cụm từ chính xác",
+      "exactPhrasesDesc": "Đặt các thuật ngữ trong dấu ngoặc kép để khớp chính xác với các cụm từ:",
+      "proximity": "Tìm kiếm theo khoảng cách",
+      "proximityDesc": "các từ nằm trong phạm vi N vị trí của nhau",
+      "booleanOperators": "Toán tử Boolean",
+      "andDesc": "cả hai điều khoản phải khớp nhau",
+      "orDesc": "Cả hai thuật ngữ đều có thể phù hợp.",
+      "notDesc": "loại trừ kết quả có chứa điều khoản",
+      "prefixDesc": "yêu cầu hoặc loại trừ một điều khoản",
+      "groupingDesc": "nhóm các thuật ngữ cho các truy vấn phức tạp",
+      "wildcards": "Wildcards",
+      "wildcardMultiDesc": "phù hợp với bất kỳ ký tự nào",
+      "wildcardSingleDesc": "khớp với một ký tự đơn",
+      "fuzzyMatching": "Ghép nối mờ",
+      "fuzzyDesc": "Tìm các thuật ngữ tương tự để giúp sửa lỗi chính tả.",
+      "defaultBehavior": "Nhiều từ khóa sử dụng toán tử OR theo mặc định. Kết quả khớp với tên sẽ được xếp hạng cao nhất.",
+      "fullSyntaxLink": "Tài liệu tham khảo đầy đủ về cú pháp truy vấn Lucene."
+    },
+    "filters": {
+      "title": "Bộ lọc nâng cao",
+      "active": "bộ lọc đang hoạt động",
+      "activeCount": "{count, plural, =0 {Không có bộ lọc} one {# bộ lọc} other {# bộ lọc}} đang hoạt động",
+      "apply": "Áp dụng bộ lọc",
+      "common": "Bộ lọc thông dụng",
+      "entitySpecific": "Bộ lọc theo loại",
+      "searchPlaceholder": "Các tùy chọn bộ lọc tìm kiếm...",
+      "states": "Trạng thái quy trình làm việc",
+      "createdAt": "Ngày tạo",
+      "updatedAt": "Ngày cập nhật",
+      "completedAt": "Ngày hoàn thành",
+      "from": "Từ",
+      "to": "ĐẾN",
+      "testRunType": "Loại chạy thử nghiệm",
+      "regular": "Thường xuyên",
+      "junit": "JUnit",
+      "automatedOnly": "Chỉ tự động",
+      "archivedOnly": "Chỉ được lưu trữ",
+      "completedOnly": "Chỉ hoàn thành",
+      "manualOnly": "Chỉ có chế độ thủ công",
+      "estimateRange": "Phạm vi ước tính",
+      "elapsedRange": "Khoảng thời gian đã trôi qua",
+      "minValue": "Tối thiểu",
+      "maxValue": "Tối đa",
+      "hasExternalId": "Có ID bên ngoài",
+      "dueDateRange": "Khoảng thời gian đến hạn",
+      "hasParent": "Đã đạt được cột mốc quan trọng của cha mẹ",
+      "milestoneType": "Loại cột mốc",
+      "minutes": "phút",
+      "hours": "giờ",
+      "days": "ngày",
+      "searchingIn": "Tìm kiếm trong",
+      "includeDeleted": "Bao gồm các mục đã xóa",
+      "filterActive": "Bộ lọc đang hoạt động:",
+      "applyFilter": "Áp dụng bộ lọc",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "Giá trị đầu tiên phải nhỏ hơn giá trị thứ hai.",
+        "firstDateMustBeBeforeSecond": "Buổi hẹn hò đầu tiên phải diễn ra trước buổi hẹn hò thứ hai."
+      },
+      "link": {
+        "domainHelp": "Chỉ nhập tên miền (ví dụ: \"github.com\" hoặc \"example.org\")"
+      }
+    }
+  },
+  "email": {
+    "greeting": "Xin chào,",
+    "greetingWithName": "Chào {name},",
+    "notification": {
+      "intro": "Bạn có thông báo mới:",
+      "viewDetails": "Xem chi tiết",
+      "viewAll": "Xem tất cả thông báo"
+    },
+    "digest": {
+      "intro": "Dưới đây là bản tóm tắt thông báo hàng ngày từ TestPlanIt:",
+      "viewDetails": "Xem chi tiết",
+      "viewAll": "Xem tất cả thông báo",
+      "noNotifications": "Hôm nay bạn không nhận được thông báo mới nào.",
+      "footer": "Bạn nhận được email này vì bạn đã bật thông báo tóm tắt hàng ngày. Bạn có thể thay đổi tùy chọn thông báo của mình trong phần cài đặt.",
+      "profileSettings": "cài đặt hồ sơ"
+    },
+    "footer": {
+      "sentBy": "Email này được gửi bởi",
+      "unsubscribe": "Hủy đăng ký",
+      "managePreferences": "Quản lý tùy chọn",
+      "allRightsReserved": "Bản quyền đã được bảo lưu."
+    },
+    "magicLink": {
+      "subject": "Đăng nhập vào TestPlanIt",
+      "heading": "Đăng nhập vào TestPlanIt",
+      "intro": "Nhấp vào nút bên dưới để đăng nhập:",
+      "signInButton": "Đăng nhập",
+      "copyPasteIntro": "Hoặc sao chép và dán liên kết này vào trình duyệt của bạn:",
+      "disclaimer": "Nếu bạn không yêu cầu nhận email này, bạn có thể bỏ qua nó một cách an toàn.",
+      "textBody": "Đăng nhập vào TestPlanIt\n\nNhấp vào liên kết bên dưới để đăng nhập:\n{url}\n\nNếu bạn không yêu cầu nhận email này, bạn có thể bỏ qua nó."
+    }
+  },
+  "comments": {
+    "title": "Bình luận",
+    "placeholder": "Hãy viết bình luận... (sử dụng @ để nhắc đến người dùng)",
+    "editPlaceholder": "Chỉnh sửa bình luận của bạn...",
+    "postComment": "Đăng bình luận",
+    "noComments": "Chưa có bình luận nào. Hãy là người đầu tiên bình luận!",
+    "edited": "đã chỉnh sửa",
+    "confirmDelete": "Bạn có chắc chắn muốn xóa bình luận này không? Hành động này không thể hoàn tác.",
+    "deleteDialog": {
+      "title": "Xóa bình luận"
+    },
+    "errors": {
+      "createFailed": "Không thể tạo bình luận. Vui lòng thử lại.",
+      "updateFailed": "Cập nhật bình luận không thành công. Vui lòng thử lại.",
+      "deleteFailed": "Không thể xóa bình luận. Vui lòng thử lại.",
+      "loadFailed": "Không thể tải bình luận. Vui lòng thử lại."
+    },
+    "mentions": {
+      "notAMember": "Không phải là thành viên dự án",
+      "noUsersFound": "Không tìm thấy người dùng nào"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "Thời gian dùng thử kết thúc sau {count, plural, =1 {1 ngày} other {# ngày}}",
+    "expiresT oday": "Thời gian dùng thử kết thúc hôm nay.",
+    "expired": "{count, plural, =1 {Thời gian dùng thử đã hết hạn cách đây 1 ngày} other {Thời gian dùng thử đã hết hạn cách đây # ngày}}",
+    "contactSales": "Liên hệ bộ phận bán hàng"
+  },
+  "feedback": {
+    "sheetTitle": "Chia sẻ phản hồi của bạn",
+    "sheetDescription": "Hãy giúp chúng tôi cải thiện TestPlanIt bằng cách chia sẻ kinh nghiệm của bạn.",
+    "bannerMessage": "Quá trình thử nghiệm của bạn diễn ra thế nào? Chúng tôi rất muốn nghe ý kiến của bạn.",
+    "menuItem": "Chia sẻ phản hồi"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "Thẻ AI",
+      "tagAll": "Gắn thẻ tất cả",
+      "aiAutoTag": "Thẻ tự động",
+      "tagActions": "Hành động gắn thẻ",
+      "startTagging": "Bắt đầu gắn thẻ",
+      "selectEntityType": "Chọn loại thực thể",
+      "selectProject": "Chọn một dự án",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {Trường hợp thử nghiệm} other {Các trường hợp thử nghiệm}}",
+        "testRun": "{count, plural, one {Chạy thử nghiệm} other {Các lần chạy thử nghiệm}}",
+        "session": "{count, plural, one {Phiên} other {Các phiên}}"
+      }
+    },
+    "review": {
+      "title": "Đề xuất thẻ đánh giá",
+      "description": "Nhấp vào các thẻ để bật/tắt trạng thái chấp nhận. Nhấp đúp chuột để chỉnh sửa tên thẻ.",
+      "selectEntity": "Chọn một đối tượng để xem các gợi ý gắn thẻ.",
+      "noTagsSelected": "Chưa có thẻ nào được chọn",
+      "footerSummary": "{assignCount, plural, one {# thẻ} other {# thẻ}} sẽ được gán, {newCount, plural, one {# thẻ mới} other {# thẻ mới}} sẽ được tạo",
+      "footerAssignCount": "{assignCount, plural, one {# thẻ} other {# thẻ}} sẽ được gán",
+      "footerNewCount": "{newCount, plural, one {# thẻ mới} other {# các thẻ mới}} sẽ được tạo",
+      "newTagsPopoverTitle": "Các thẻ mới để tạo",
+      "applying": "Đang áp dụng...",
+      "applySuccess": "{tagCount, plural, one {# thẻ} other {# thẻ}} được áp dụng cho {entityCount, plural, one {# thực thể} other {# thực thể}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# thẻ} other {# thẻ}} được áp dụng cho {entityCount, plural, one {# thực thể} other {# thực thể}}, {newCount, plural, one {# thẻ mới} other {# thẻ mới}} được tạo",
+      "applyError": "Không thể áp dụng thẻ. Vui lòng thử lại.",
+      "suggestedTags": "Thẻ đề xuất",
+      "noSuggestions": "Trí tuệ nhân tạo không thể tạo ra bất kỳ thẻ nào.",
+      "alreadyApplied": "Đã nộp đơn",
+      "filterEntities": "Lọc các thực thể...",
+      "noEntitiesMatch": "Không có thực thể nào phù hợp với tìm kiếm của bạn.",
+      "tagCount": "{count, plural, one {# thẻ} other {# thẻ}}",
+      "noTags": "không có",
+      "failed": "Thất bại",
+      "analysisFailed": "Không thể phân tích thực thể này.",
+      "responseTruncated": "Phản hồi bị cắt ngắn — hãy tăng số lượng Token đầu ra tối đa trong cài đặt LLM.",
+      "tooltipExisting": "Thẻ hiện có",
+      "tooltipNew": "Thẻ mới — sẽ được tạo",
+      "tooltipAssign": "Gán thẻ hiện có",
+      "toggleFailed": "Hiển thị/ẩn các thực thể bị lỗi",
+      "showFailed": "Hiển thị thất bại"
+    },
+    "progress": {
+      "starting": "Bắt đầu phân tích...",
+      "analyzed": "Đã phân tích các thực thể {analyzed}/{total}",
+      "sizing": "Đang tìm kích thước lô tối ưu (thử {size} thực thể)...",
+      "streaming": "Đã nhận phản hồi AI ({analyzed}/{total} thực thể đã hoàn thành)...",
+      "finalizing": "Đang chuẩn bị kết quả...",
+      "complete": "Phân tích hoàn tất",
+      "reviewSuggestions": "Đề xuất đánh giá",
+      "failed": "Phân tích thất bại"
+    },
+    "wizard": {
+      "description": "Trí tuệ nhân tạo (AI) sẽ phân tích toàn bộ các trường hợp thử nghiệm, các lần chạy thử nghiệm và các phiên làm việc của dự án để đề xuất các thẻ liên quan dựa trên nội dung của chúng.",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "Bắt đầu phân tích",
+      "untaggedOnly": "Chỉ phân tích các bản ghi không có thẻ hiện có.",
+      "allowNewTags": "Cho phép tạo thẻ mới",
+      "noLlmConfigured": "(Chưa cấu hình LLM)",
+      "analyzingDescription": "Trí tuệ nhân tạo đang phân tích các thực thể của bạn và tạo ra các đề xuất thẻ. Quá trình này có thể mất một chút thời gian."
+    },
+    "entityDetail": {
+      "customFields": "Trường tùy chỉnh",
+      "noDetails": "Không có thêm thông tin chi tiết nào khác.",
+      "openInNewTab": "Mở trong tab mới"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "Rất yếu",
+    "weak": "Yếu đuối",
+    "fair": "Hội chợ",
+    "good": "Tốt",
+    "strong": "Mạnh",
+    "minLength": "Ít nhất {count} ký tự",
+    "uppercase": "Ít nhất một chữ cái viết hoa",
+    "lowercase": "Ít nhất một chữ cái viết thường",
+    "numbers": "Ít nhất một số",
+    "specialChars": "Ký tự đặc biệt từ: {chars}",
+    "history": "Mật khẩu này đã được sử dụng trong {depth} lần gần đây nhất của bạn."
+  },
+  "TrialExpired": {
+    "title": "Thời gian dùng thử của bạn đã hết hạn.",
+    "description": "Cảm ơn bạn đã dùng thử TestPlanIt! Thời gian dùng thử của bạn đã kết thúc và phiên bản này không còn truy cập được nữa.",
+    "nextSteps": "Để tiếp tục sử dụng TestPlanIt và truy cập dữ liệu kiểm thử của bạn, vui lòng liên hệ với đội ngũ bán hàng của chúng tôi.",
+    "pricingPlans": "Các gói giá",
+    "dataRetention": "Dữ liệu kiểm tra của bạn đã được lưu trữ an toàn và sẽ có sẵn khi bạn nâng cấp tài khoản."
+  }
+}

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "姓名",
+    "cancel": "取消",
+    "dismiss": "解雇",
+    "of": "的",
+    "on": "在",
+    "at": "在",
+    "in": "在",
+    "add": "添加",
+    "never": "绝不",
+    "select": "选择...",
+    "file": "文件",
+    "selectMultiple": "选择多个...",
+    "searchUsers": "搜索用户...",
+    "searchCases": "{count, plural, =0 {搜索案例} one {搜索案例数} other {搜索案例数}}",
+    "searchProjects": "{count, plural, =0 {搜索项目} one {搜索项目数量} other {搜索项目数量}}",
+    "searchTags": "搜索标签...",
+    "searchRuns": "{count, plural, =0 {搜索测试运行次数} one {搜索测试运行次数} other {搜索测试运行次数}}",
+    "searchSessions": "{count, plural, =0 {搜索会话} one {搜索会话数} other {搜索会话数}}",
+    "search": "搜索...",
+    "defaultOption": "默认选项",
+    "yes": "是的",
+    "no": "不",
+    "updated": "更新",
+    "groupedBy": "按以下方式分组",
+    "lastEditedBy": "最后编辑于",
+    "actions": {
+      "edit": "编辑",
+      "save": "节省",
+      "delete": "删除",
+      "create": "创造",
+      "submit": "提交",
+      "close": "关闭",
+      "done": "完毕",
+      "verify": "核实",
+      "signIn": "登入",
+      "signOut": "登出",
+      "signUp": "报名",
+      "resend": "重新发送",
+      "deleting": "正在删除……",
+      "next": "下一个",
+      "previous": "以前的",
+      "finish": "结束",
+      "download": "下载",
+      "apply": "申请",
+      "confirm": "确认",
+      "confirmDelete": "确认删除",
+      "saveChanges": "保存更改",
+      "saving": "保存...",
+      "submitting": "正在提交……",
+      "start": "开始",
+      "pause": "暂停",
+      "reset": "重置",
+      "copy": "复制",
+      "copyLink": "复制链接",
+      "copied": "已复制！",
+      "complete": "完全的",
+      "back": "后退",
+      "clear": "清除",
+      "expand": "扩张",
+      "collapse": "坍塌",
+      "addResult": "添加结果",
+      "passAndNext": "下一个",
+      "viewInRepository": "在存储库中查看",
+      "resultAdded": "测试结果已添加",
+      "resultAddedDescription": "测试结果已成功添加。",
+      "resultUpdated": "测试结果已更新",
+      "resultDeleted": "测试结果已删除",
+      "deleteResult": "删除测试结果",
+      "deleteResultConfirmation": "您确定要删除此测试结果吗？此操作无法撤销。",
+      "editResult": "编辑测试结果",
+      "resultDetails": "结果详情",
+      "actionsLabel": "行动",
+      "assign": "分配",
+      "assignSelected": "分配 {count, plural, one {# 情况} other {# 情况}}",
+      "refresh": "刷新",
+      "addResultSelected": "将结果添加到 {count, plural, one {# 情况} other {# 情况}}",
+      "resultsAdded": "{count, plural, one {# 结果} other {# 结果}} 添加",
+      "resultsAddedDescription": "{count, plural, one {结果已添加到 # 个测试用例} other {结果已添加到 # 个测试用例}} 成功",
+      "addingResultsToMultiple": "将结果添加到 {count, plural, one {# 测试用例} other {# 测试用例}}",
+      "addedToTestRun": "已添加到测试运行",
+      "addedToTestRunDescription": "测试用例已添加到测试运行中。",
+      "noAvailableTestRuns": "所有正在进行的测试运行均已包含此测试用例。",
+      "resultUpdateError": "测试结果更新失败",
+      "resultDeleteError": "删除测试结果失败",
+      "selectStatus": "选择状态",
+      "addToTestRun": "添加到测试运行",
+      "status": "地位",
+      "resultDetailsPlaceholder": "请输入结果详情……",
+      "selectAll": "全选",
+      "deselectAll": "取消选择所有",
+      "clearAll": "全部清除",
+      "selectFile": "选择文件",
+      "restore": "恢复",
+      "purge": "清除",
+      "previousCase": "前例",
+      "nextCase": "下一个案例",
+      "startTesting": "开始测试",
+      "expandLeftPanel": "展开左侧面板",
+      "collapseLeftPanel": "折叠左侧面板",
+      "expandRightPanel": "展开右侧面板",
+      "collapseRightPanel": "折叠右侧面板",
+      "createTag": "创建标签“{name}”",
+      "noTagsFound": "未找到标签",
+      "duplicate": "复制",
+      "exportPdf": "导出PDF",
+      "exportingPdf": "出口...",
+      "change": "改变",
+      "viewAll": "查看全部",
+      "undo": "撤销",
+      "undoDelete": "撤销删除",
+      "automated": {
+        "details": "自动化测试详情",
+        "message": "信息",
+        "line": "线",
+        "testSuite": "测试套件："
+      },
+      "junit": {
+        "details": "自动化测试结果详情",
+        "import": {
+          "title": "导入测试结果",
+          "description": "上传测试结果文件以导入到新的测试运行中。支持 JUnit、TestNG、xUnit、NUnit、MSTest、Mocha 和 Cucumber 格式。",
+          "testRun": {
+            "label": "测试运行",
+            "placeholder": "选择一次测试运行"
+          },
+          "file": {
+            "label": "测试结果文件"
+          },
+          "import": "进口",
+          "selectFolder": "选择一个文件夹",
+          "createNewFolder": "创建新文件夹",
+          "createNewFolderNamed": "创建新文件夹： {name}",
+          "progress": {
+            "initializing": "正在初始化导入...",
+            "validating": "正在验证输入数据……",
+            "creatingRun": "正在创建测试运行...",
+            "fetchingTemplate": "正在获取模板数据...",
+            "countingTests": "正在处理来自 {files} 个文件的 {count} 个测试用例...",
+            "parsingFile": "正在解析文件 {current} ，该文件属于 {total}...",
+            "processingSuite": "处理套件： {name}",
+            "processingCase": "正在处理测试用例 {current} 的 {total}...",
+            "finalizing": "正在完成导入……",
+            "completed": "导入成功！",
+            "errorParsing": "解析文件 {index}时出错： {error}",
+            "skippingFile": "跳过无效文件 {index}"
+          },
+          "error": {
+            "title": "导入错误",
+            "importFailed": "导入测试结果失败，请重试。"
+          },
+          "success": {
+            "title": "导入成功",
+            "description": "测试结果已成功导入。"
+          },
+          "fileRequired": "请至少上传一份检测结果文件。"
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "结果格式",
+            "placeholder": "选择格式"
+          }
+        }
+      },
+      "confirmRestoreTitle": "确认恢复",
+      "confirmPurgeTitle": "确认清除",
+      "remove": "消除",
+      "reconfigure": "重新配置并重试"
+    },
+    "permissions": {
+      "addEdit": "添加/编辑"
+    },
+    "auth": {
+      "internal": "电子邮件/密码",
+      "sso": "仅限单点登录",
+      "both": "电子邮件和单点登录"
+    },
+    "status": {
+      "deleted": "已删除",
+      "disabled": "已禁用",
+      "noCustomFieldData": "没有其他细节。",
+      "pending": "待办的",
+      "uploading": "正在上传...",
+      "notApplicable": "不适用",
+      "redirecting": "正在重定向...",
+      "pendingDelete": "将被删除",
+      "pendingChanges": "待定变更",
+      "importing": "输入...",
+      "addingTestCases": "添加测试用例……"
+    },
+    "priority": {
+      "low": "低的",
+      "medium": "中等的",
+      "high": "高的"
+    },
+    "filters": {
+      "allStatuses": "所有状态",
+      "allPriorities": "所有优先事项"
+    },
+    "fields": {
+      "groupName": "组名",
+      "users": "用户",
+      "mixed": "所有值",
+      "type": "类型",
+      "default": "默认",
+      "enabled": "已启用",
+      "projects": "项目",
+      "iconColor": "图标/颜色",
+      "selectWorkflow": "选择工作流程",
+      "icon": "图标",
+      "systemName": "系统名称",
+      "aliases": "别名",
+      "scope": "范围",
+      "success": "成功",
+      "failure": "失败",
+      "completed": "完全的",
+      "elapsed": "经过时间",
+      "totalElapsed": "总经过时间",
+      "totalEstimate": "预计剩余时间",
+      "completionRate": "完成率",
+      "attachments": "附件",
+      "documentation": "文档",
+      "state": "状态",
+      "configuration": "配置",
+      "configurations": "配置",
+      "milestone": "里程碑",
+      "tags": "标签",
+      "createdBy": "创建者",
+      "description": "描述",
+      "description_placeholder": "添加描述……",
+      "testCases": "测试用例",
+      "sessions": "会议",
+      "sharedSteps": "共同步骤",
+      "email": "电子邮件",
+      "password": "密码",
+      "confirmPassword": "确认密码",
+      "token": "令牌",
+      "access": "使用权",
+      "avatar": "阿凡达",
+      "steps": "步骤",
+      "step": "步",
+      "expectedResult": "预期结果",
+      "notes": "笔记",
+      "estimate": "估计",
+      "date": "日期",
+      "size": "尺寸",
+      "created": "创建",
+      "template": "模板",
+      "mission": "使命",
+      "assignedTo": "分配给",
+      "executedBy": "执行人",
+      "optional": "选修的",
+      "role": "角色",
+      "defaultRole": "默认角色",
+      "systemAccess": "系统访问",
+      "authMethod": "身份验证方法",
+      "dateCreated": "创建日期",
+      "apiUser": "API 用户",
+      "unverified": "未经证实",
+      "selfRegistered": "自行注册",
+      "role_placeholder": "选择角色",
+      "usersCreated": "用户创建",
+      "groups": "团体",
+      "apiAccess": "API 访问",
+      "requiredForAdmin": "管理员需要",
+      "account": "帐户",
+      "accountHistory": "账户历史记录",
+      "activity": "活动",
+      "lastActive": "最后活跃时间",
+      "theme": "主题",
+      "locale": "语言",
+      "timezone": "时区",
+      "itemsPerPage": "每页项目数",
+      "notificationMode": "通知",
+      "value": "价值",
+      "key": "钥匙",
+      "configurationDetails": "配置详情",
+      "isActive": "积极的",
+      "members": "成员",
+      "milestoneTypes": "里程碑类型",
+      "milestones": "里程碑",
+      "createdAt": "创建于",
+      "completedOn": "已完成",
+      "variants": "变体",
+      "emailVerified": "电子邮件已验证",
+      "issueTracker": "问题跟踪器",
+      "caseFields": "案例字段",
+      "resultFields": "结果字段",
+      "displayName": "显示名称",
+      "hint": "暗示",
+      "required": "必需的",
+      "restricted": "受限制的",
+      "fieldType": "字段类型",
+      "templates": "模板",
+      "started": "开始",
+      "startDate": "开始日期",
+      "automated": "自动化",
+      "manual": "手动的",
+      "notAutomated": "非自动化",
+      "testRuns": "测试运行",
+      "title": "标题",
+      "project": "项目",
+      "priority": "优先事项",
+      "integration": "一体化",
+      "lastSyncedAt": "上次同步",
+      "externalKey": "外部密钥",
+      "initialHeight": "初始高度",
+      "minValue": "最小值",
+      "maxValue": "最大值",
+      "minIntegerValue": "最小整数值",
+      "maxIntegerValue": "最大整数值",
+      "defaultValue": "默认值",
+      "checked": "已检查",
+      "version": "版本",
+      "issues": "问题",
+      "internalIssues": "内部问题",
+      "externalIssues": "{provider} 问题",
+      "data": "数据",
+      "note": "笔记",
+      "externalId": "外部标识",
+      "forecast": "预报",
+      "forecastManual": "预测手册",
+      "forecastAutomated": "预测自动化",
+      "executedAt": "执行于",
+      "className": "班级",
+      "suiteName": "套房",
+      "duration": "期间",
+      "session": "会议",
+      "charter": "宪章",
+      "summary": "概括",
+      "progress": "进步",
+      "assertions": "断言",
+      "properties": "特性",
+      "systemOutput": "测试用例日志",
+      "systemError": "系统错误",
+      "resultStatus": "结果",
+      "links": "链接",
+      "id": "ID",
+      "JUNIT": "JUnit 导入",
+      "API": "API",
+      "folder": "文件夹",
+      "parentFolder": "新案例的父文件夹",
+      "multipleValues": "多个值",
+      "provider": "提供者",
+      "updatedAt": "更新于",
+      "tools": "工具",
+      "codeRepository": "代码库",
+      "aiModels": "默认LLM",
+      "configKeys": {
+        "edit_results_duration": "编辑结果持续时间",
+        "project_docs_default": "项目文档默认",
+        "notificationSettings": "通知全局设置",
+        "elasticsearch_replicas": "Elasticsearch 副本"
+      },
+      "options": {
+        "label": "标签",
+        "validation": {
+          "empty": "选项不能为空。",
+          "invalidChars": "选项包含无效字符：“{char}”",
+          "duplicate": "选项必须唯一",
+          "systemNameError": "系统名称无效",
+          "initialHeightMax": "初始高度不能大于 600px。",
+          "displayNameRequiredResult": "请输入结果字段的显示名称。",
+          "displayNameRequiredCase": "输入案例字段的显示名称。",
+          "minValueMaxValue": "最小值必须小于最大值，如果设置了其中一个值，则两者都必须设置。",
+          "minMaxValueInteger": "最小整数值必须小于最大整数值，如果设置了其中一个，则两者都必须设置。",
+          "systemNameRequired": "系统名称不能为空。",
+          "systemNameRegex": "系统名称必须以字母开头，并且只能包含字母、数字和下划线。",
+          "fieldTypeRequired": "字段类型为必填项。"
+        }
+      },
+      "placeholders": {
+        "key": "回车键",
+        "value": "输入数值",
+        "addVariant": "添加变体",
+        "addCategory": "添加类别",
+        "displayName": "输入显示名称",
+        "systemName": "输入系统名称",
+        "hint": "输入提示"
+      },
+      "hints": {
+        "systemName": "系统名称必须唯一，且只能包含字母、数字和下划线。",
+        "fieldType": "（字段类型一旦创建便无法更改）"
+      },
+      "validation": {
+        "nameRequired": "姓名（必填）",
+        "stateRequired": "州政府要求",
+        "urlRequired": "必须提供网址",
+        "invalidUrl": "无效的 URL 格式"
+      }
+    },
+    "filter": {
+      "placeholder": "筛选 {item}..."
+    },
+    "access": {
+      "admin": "行政",
+      "projectAdmin": "项目管理员",
+      "user": "用户",
+      "none": "没有任何"
+    },
+    "validation": {
+      "required": "请输入 {field}",
+      "invalidDuration": "请输入有效时长",
+      "maxDuration": "持续时间不得超过 {max} 分钟",
+      "minLength": "{field} 必须至少包含 {min} 个字符",
+      "emailFormat": "电子邮件格式无效",
+      "passwordMatch": "密码必须匹配",
+      "unique": "{field} 必须唯一",
+      "roleRequired": "需要此职位",
+      "nameMinLength": "名称必须至少包含 2 个字符",
+      "invalidDurationFormat": "时长格式无效。请尝试 30 分钟、1 周或 1 小时 25 分钟等格式。"
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "确认 {action}",
+        "message": "你确定要 {action}吗？"
+      },
+      "confirmDelete": {
+        "description": "您确定要删除此项目吗？此操作无法撤销。"
+      },
+      "assign": {
+        "title": "分配测试用例",
+        "description": "将测试用例“{testCase}”分配给用户",
+        "selectUser": "选择用户"
+      },
+      "assignBulk": {
+        "title": "批量分配测试用例",
+        "description": "将 {count, plural, one {# 选定的测试用例} other {# 选定的测试用例}} 分配给用户"
+      },
+      "complete": {
+        "title": "完成测试运行",
+        "description": "您确定要完成此次测试运行吗？",
+        "warning": "测试运行完成后将无法修改。",
+        "apple": {
+          "title": "配置 Apple 登录",
+          "description": "设置您的 Apple 登录凭证。您可以从 Apple 开发者门户获取这些凭证。",
+          "clientId": "服务 ID",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "团队 ID",
+          "teamIdPlaceholder": "您的 10 位字符团队 ID",
+          "keyId": "密钥 ID",
+          "keyIdPlaceholder": "您的 10 位字符密钥 ID",
+          "privateKey": "私钥",
+          "privateKeyPlaceholder": "请在此处粘贴您的 .p8 私钥内容",
+          "instructions": {
+            "title": "安装说明：",
+            "step1": "前往 Apple 开发者门户",
+            "step2": "创建服务 ID 并配置“使用 Apple 登录”",
+            "step3": "创建用于通过 Apple 登录的密钥",
+            "step4": "下载 .p8 私钥文件",
+            "step5": "添加以下重定向 URL："
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "所有字段均为必填项"
+          }
+        }
+      },
+      "delete": {
+        "title": "删除 {item}",
+        "description": "您确定要删除 {name}吗？",
+        "warning": "此操作无法撤销。它将永久删除 {item}。"
+      }
+    },
+    "messages": {
+      "deleteSuccess": "项目已成功删除",
+      "deleteError": "删除项目时发生错误",
+      "moveSuccess": "物品已成功移动",
+      "moveError": "移动物品时发生错误",
+      "updateSuccess": "项目已成功更新",
+      "updateError": "更新项目时发生错误",
+      "linkCopied": "链接已复制到剪贴板",
+      "copyFailed": "复制链接到剪贴板失败",
+      "created": "测试运行已成功创建",
+      "createdDescription": "测试运行已创建，现在可在测试运行列表中查看。",
+      "createError": "发生未知错误，请重试。",
+      "emptyActive": "没有正在进行的测试运行。",
+      "emptyCompleted": "未完成任何测试运行",
+      "projectUpdated": "项目已成功更新",
+      "projectUpdateError": "更新项目时发生错误",
+      "noProjects": "未找到项目"
+    },
+    "placeholders": {
+      "email": "电子邮件",
+      "name": "输入姓名",
+      "mission": "请描述您的任务……",
+      "selectMilestone": "选择里程碑",
+      "selectStatus": "选择状态",
+      "selectTemplate": "选择模板",
+      "duration": "例如 1 小时 30 分钟或 90 分钟",
+      "docs": "添加文档……",
+      "select": "选择",
+      "selectState": "选择州",
+      "selectConfiguration": "选择配置",
+      "selectConfigurations": "选择配置",
+      "selectOption": "选择一个选项",
+      "date": "选择日期",
+      "selectEncoding": "选择编码方式...",
+      "selectATemplate": "选择一个模板……",
+      "selectVersion": "选择版本",
+      "selectAModel": "选择型号",
+      "selectWorkflowType": "选择工作流程类型",
+      "addAnOption": "添加一个选项",
+      "addADescription": "添加描述……",
+      "optionalDescription": "可选描述……",
+      "projectNotes": "项目笔记……",
+      "filterByName": "按名称筛选...",
+      "filterByValue": "按值筛选...",
+      "selectOperator": "选择运算符",
+      "searchIcons": "搜索图标……",
+      "value": "价值",
+      "stepCount": "步数",
+      "enterText": "请输入文字...",
+      "enterUrl": "输入网址",
+      "issueIdExample": "第123期",
+      "selectPriorityValuesOrEmpty": "选择优先级值（或留空表示全部不选）"
+    },
+    "errors": {
+      "error": "错误",
+      "somethingWentWrong": "发生意外错误，请稍后重试。",
+      "emailRequired": "请输入您的电子邮件地址。",
+      "emailInvalid": "这是一个无效的电子邮件地址。",
+      "passwordRequired": "需要输入密码。",
+      "confirmPasswordRequired": "请确认您的密码。",
+      "passwordDoesNotMeetPolicy": "密码不符合安全要求。",
+      "passwordsDoNotMatch": "密码不匹配",
+      "nameRequired": "请输入您的全名",
+      "duplicate": "请选择一个独一无二的名字。",
+      "userExists": "用户已存在。",
+      "unknown": "发生未知错误。",
+      "invalidCredentials": "用户名或密码无效",
+      "projectNotFound": "项目未找到",
+      "projectNotFoundDescription": "您要查找的项目不存在，或者您没有访问权限。",
+      "tokenRequired": "请输入您的电子邮件验证码或点击电子邮件中的链接。",
+      "noSuccessStatus": "未选择成功状态",
+      "missingTestRunCase": "测试运行用例 ID 缺失",
+      "fieldRequired": "此字段是必需的",
+      "projectNameExists": "已存在一个同名项目",
+      "defaultNotFound": "未找到默认值",
+      "emailExists": "已存在使用此电子邮件地址的用户",
+      "nameExists": "已存在同名用户",
+      "duplicateValue": "该值已被使用",
+      "unauthorized": "您无权执行此操作。",
+      "accessDenied": "拒绝访问",
+      "sessionNotFound": "未找到会话或会话无效。",
+      "issueTrackerNotConfigured": "此项目未配置问题跟踪系统。",
+      "noUserSession": "未找到用户会话",
+      "noProjectId": "未找到项目 ID",
+      "unknownErrorWithMessage": "发生未知错误。 {message}",
+      "unauthenticated": "用户未通过身份验证。",
+      "fetchFailed": "数据获取失败，请稍后再试。",
+      "unsupportedFieldType": "不支持的字段类型",
+      "notAuthenticated": {
+        "title": "未经认证",
+        "message": "您必须登录才能执行此操作。"
+      },
+      "failedToFetchAssignments": {
+        "title": "获取任务失败",
+        "message": "获取作业失败，请稍后再试。"
+      },
+      "issueManagement": {
+        "linkedSuccess": "问题链接成功",
+        "linkError": "链接问题错误",
+        "unlinkedSuccess": "问题已成功解除关联",
+        "unlinkError": "取消链接问题出错",
+        "noActiveIntegration": "未找到此项目的活动集成"
+      },
+      "roleRequiredForSpecificRole": "当访问类型为特定角色时，需要提供角色信息。",
+      "projectCreationFailed": "项目创建失败，未返回 ID。",
+      "invalidRoleId": "无效的角色 ID",
+      "workflowStateExists": "工作流状态已存在。请选择一个新名称。",
+      "failedToLoadCaseData": "案例数据加载失败，无法保存。",
+      "atLeastOneTagRequired": "至少需要一个标签",
+      "atLeastOneIssueRequired": "至少需要一期",
+      "atLeastOneOptionRequired": "至少要选择一个选项",
+      "valueRequired": "需要值",
+      "contentRequired": "内容为必填项",
+      "invalidContentFormat": "无效的内容格式",
+      "caseNameRequired": "请输入测试用例的名称",
+      "caseStateRequired": "请选择一个州",
+      "caseFolderRequired": "请选择一个文件夹。",
+      "estimateTooLarge": "估算值过大",
+      "estimateRequiredValid": "需要提供预估时间，且预估时间必须有效（例如，1小时30分钟）。",
+      "invalidDurationOrExceedsMax": "时长格式无效或超过最大限制（例如，1小时30分钟）",
+      "configurationNameExists": "配置名称已存在，请选择其他名称。",
+      "variantNameExists": "该变体名称已存在，请选择其他名称。",
+      "categoryNameExists": "类别名称已存在，请选择其他名称。",
+      "workflowStateNameExists": "工作流状态名称已存在。请选择其他名称。",
+      "folderNameRequired": "请输入文件夹名称",
+      "folderNameRequiredEnter": "请输入文件夹名称。",
+      "workflowStateNameRequired": "请输入工作流状态的名称",
+      "roleNameEmpty": "角色名称不能为空",
+      "groupNameRequired": "组名称为必填项",
+      "templateNameRequired": "请输入模板名称",
+      "caseStateInvalid": "请选择一个有效的州/省",
+      "caseTemplateRequired": "请选择模板",
+      "invalidContent": "无效内容",
+      "milestoneNameRequired": "请输入里程碑的名称",
+      "milestoneTypeRequired": "请选择里程碑类型",
+      "testRunNameMinLength": "名称必须至少包含 2 个字符。",
+      "stateRequiredDot": "必须填写州名。",
+      "milestoneTypeNameMinLength": "里程碑类型名称必须至少包含 2 个字符。",
+      "projectNameRequired": "项目名称（必填）",
+      "workflowScopeRequired": "请为该州选择一个工作流程。",
+      "workflowTypeRequired": "请选择工作流程类型",
+      "newTestCaseAdded": "新增测试用例",
+      "repositoryDeleted": "存储库已删除",
+      "failedToDeleteRepository": "删除存储库失败",
+      "permissionDenied": "您没有权限访问此页面。",
+      "resultSubmitPermissionDenied": "您无法提交此案例的结果。请联系项目管理员将其分配给您。",
+      "noModelsFound": "未找到模型",
+      "failedToFetchModels": "获取模型失败",
+      "failedToCopyToClipboard": "复制到剪贴板失败",
+      "failedToLoadJobResults": "加载作业结果失败",
+      "failedToUpdateRepositoryStatus": "更新存储库状态失败"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "仪表板",
+      "twoFactorVerification": "双因素验证",
+      "changePassword": "更改密码",
+      "twoFactorSetup": "双因素设置",
+      "signUp": "报名",
+      "signIn": "登入",
+      "verifyEmail": "验证电子邮件",
+      "trialExpired": "试用期已结束",
+      "linkSsoAccount": "关联 SSO 帐户",
+      "userProfile": "用户个人资料",
+      "users": "用户",
+      "issues": "问题",
+      "tags": "标签",
+      "tagDetails": "标签详情",
+      "aiModels": "人工智能模型",
+      "integrations": "集成",
+      "quickscript": "QuickScript",
+      "webhooks": "网络钩子",
+      "shares": "股票",
+      "repository": "存储库",
+      "testCaseVersion": "测试用例版本",
+      "duplicateTestCases": "重复的测试用例",
+      "documentation": "文档",
+      "sharedSteps": "共同步骤",
+      "stepDuplicates": "步骤重复",
+      "sessions": "会议",
+      "sessionVersion": "会话版本",
+      "milestones": "里程碑",
+      "testRuns": "测试运行",
+      "reports": "报告",
+      "adminSamlConfig": "管理员 - SAML 配置",
+      "apiDocumentation": "API 文档",
+      "sharedContent": "共享内容"
+    },
+    "aria": {
+      "userMenu": "用户菜单",
+      "search": "搜索",
+      "helpMenu": "帮助菜单",
+      "help": "帮助",
+      "grouped": "分组",
+      "group": "团体",
+      "selectAll": "全选",
+      "selectRow": "选择行",
+      "removeIssue": "问题",
+      "selectDeselectAllAddEdit": "全选/取消全选 添加/编辑",
+      "selectDeselectAllDelete": "全选/取消全选 删除",
+      "selectDeselectAllClose": "全选/取消全选 关闭",
+      "clearFilter": "清除过滤器",
+      "olderVersion": "旧版本",
+      "newerVersion": "新版本",
+      "deletedUser": "已删除用户",
+      "restrictedField": "受限字段",
+      "backToTestCase": "返回测试用例"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# 项目} other {# 项目集}}",
+      "templates": "模板和字段",
+      "workflows": "工作流程",
+      "statuses": "状态",
+      "roles": "角色",
+      "unknownRole": "未知角色",
+      "unknownGroup": "未知团体",
+      "file": "文件",
+      "files": "文件",
+      "existingAttachments": "现有附件",
+      "new": "新的",
+      "noElapsedTime": "未记录时间",
+      "untested": "未经测试",
+      "noResults": "无结果",
+      "resultsWithNoElapsedTime": "未记录结果所需时间",
+      "total": "全部的",
+      "noCases": "没有测试用例",
+      "unknown": "未知",
+      "selectedTestCases": "选定的测试用例",
+      "editToModifyCasesTitle": "此列表无法修改。",
+      "editToModifyCases": "编辑测试运行，然后单击“选定的测试用例”来修改列表。",
+      "noTestCasesSelected": "未选择任何测试用例",
+      "editToSelectTestCases": "编辑测试运行以选择测试用例。",
+      "casesInRun": "{count, plural, =0 {测试运行中没有测试用例} =1 {测试运行中有 1 个测试用例} other {测试运行中有 # 个测试用例}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 个唯一案例} other {唯一案例数}} 跨越 {configCount, plural, =1 {1 个配置} other {配置数}} （总案例数{totalCount}）",
+      "viewTestRunDetails": "查看测试运行详情",
+      "sortByStatus": "按状态分组",
+      "sortByDate": "按日期排序",
+      "testRuns": "{count, plural, =0 {无测试运行} =1 {1 次测试运行} other {# 次测试运行}}",
+      "sessions": "{count, plural, =0 {无会话} =1 {1 个会话} other {# 个会话}}",
+      "noOptions": "暂无选项",
+      "multiConfiguration": "属于多配置组",
+      "otherConfigurations": "其他配置",
+      "selected": "已选择： {count}",
+      "defaultProjectAccess": "默认项目访问权限",
+      "defaultAccessType": "默认访问类型",
+      "assignedUsersCount": "{count, plural, =0 {未分配用户} =1 {已分配用户数} other {已分配用户数}}",
+      "successRate": "成功率",
+      "unassigned": "未分配",
+      "testRunName": "测试运行名称",
+      "estimatesEllipsis": "估算……",
+      "access": {
+        "noAccess": "无访问权限",
+        "globalRole": "使用全局角色",
+        "specificRole": "具体角色",
+        "projectDefault": "项目默认值",
+        "usersGlobalRole": "用户的全局角色"
+      },
+      "unknownUser": "未知用户",
+      "unknownProject": "未知项目",
+      "unknownTag": "未知标签",
+      "filesSelectedForUpload": "{count, plural, =1 {已选择 1 个文件进行上传} other {已选择 # 个文件进行上传}}"
+    },
+    "empty": {
+      "description": "无描述",
+      "documentation": "无文档",
+      "childMilestones": "没有儿童里程碑",
+      "sessions": "无会议",
+      "activeSessions": "没有正在进行的会话",
+      "completedSessions": "没有已完成的会话",
+      "testCase": "未找到测试用例",
+      "noTestCasesOrSessions": "未找到测试用例或会话",
+      "noTestCasesSessionsOrRuns": "未找到测试用例、会话或运行。"
+    },
+    "or": "或者",
+    "for": "为了",
+    "and": "和",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt 标志",
+      "tagline": "尝试一切"
+    },
+    "table": {
+      "columns": {
+        "columns": "列",
+        "required": "（必需的）"
+      },
+      "filter": "筛选列表...",
+      "selectNone": "选择“无”",
+      "sort": "排序列",
+      "sortAscending": "按升序排列",
+      "sortDescending": "按降序排列",
+      "sortNone": "未分类",
+      "resize": "调整列宽"
+    },
+    "pagination": {
+      "selectPage": "选择页面",
+      "morePages": "更多页面",
+      "goToPrevious": "返回上一页",
+      "goToNext": "前往下一页",
+      "all": "所有项目",
+      "entries": "{count, plural, =1 {# 件数} other {# 件数}}",
+      "pageSize": "页面大小",
+      "showing": "显示",
+      "total": "总计 {count, plural, =1 {# 件数} other {# 件数}}",
+      "filtered": "已筛选",
+      "pageOfPages": "第 {current} 页，共 {total} 页"
+    },
+    "upload": {
+      "title": "上传新的个人资料图片",
+      "description": "拖放图片或点击下方按钮选择文件。",
+      "attachments": {
+        "title": "上传附件",
+        "description": "拖放文件或点击下方按钮选择文件。",
+        "selectFiles": "{count, plural, =0 {选择文件} one {已选文件数：1} other {已选文件数：#}}",
+        "selectFile": "{count, plural, =0 {选择文件} other {已选择 1 个文件}}",
+        "filesSelected": "{count, plural, one {已选择 1 个文件} other {已选择 # 个文件}}",
+        "addMoreFiles": "添加更多文件...",
+        "replaceFile": "替换文件...",
+        "invalidFileType": "文件类型无效。仅允许使用 {types} 文件。",
+        "altText": {
+          "emoji": "表情符号"
+        },
+        "count": "{count, plural, =1 {# 文件} other {# 文件集}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "拖放 CSV 文件以导入测试用例",
+      "dropToImportTestResults": "将文件拖放到指定位置以导入测试结果",
+      "supportedCsvFormats": "支持格式：.csv",
+      "supportedResultFormats": "支持的文件格式：.xml、.trx、.json",
+      "unsupportedFileType": "不支持的文件类型。预期格式： {expected}",
+      "noFilesDetected": "未检测到 Drop 文件夹中的任何文件。"
+    },
+    "editor": {
+      "setColor": "设置颜色",
+      "enterUrl": "请输入包含 https:// 的网址。",
+      "uploadFile": "上传文件",
+      "video": {
+        "controls": "视频播放器控制"
+      },
+      "image": {
+        "alignLeft": "左对齐",
+        "alignCenter": "居中对齐",
+        "alignRight": "右对齐",
+        "sizeSmall": "小型",
+        "sizeMedium": "中号",
+        "sizeLarge": "大号",
+        "sizeFull": "全宽",
+        "resetSize": "恢复原大小",
+        "rotate": "旋转90°",
+        "delete": "删除图片"
+      },
+      "table": {
+        "insertTable": "插入表",
+        "headerRow": "标题行",
+        "addColumnBefore": "在前面添加列",
+        "addColumnAfter": "在后面添加列",
+        "deleteColumn": "删除列",
+        "addRowBefore": "在前面添加一行",
+        "addRowAfter": "在后面添加行",
+        "deleteRow": "删除行",
+        "deleteTable": "删除表"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "在下方添加段落",
+        "clearFormatting": "清晰的格式",
+        "copyToClipboard": "复制到剪贴板"
+      },
+      "textMenu": {
+        "bold": "大胆的",
+        "italic": "斜体",
+        "underline": "强调",
+        "strikethrough": "删除线",
+        "code": "代码",
+        "codeBlock": "代码块",
+        "highlightText": "高亮文本",
+        "textColor": "文本颜色",
+        "moreOptions": "更多选项",
+        "subscript": "下标",
+        "superscript": "上标",
+        "alignLeft": "左对齐",
+        "alignCenter": "居中对齐",
+        "alignRight": "右对齐",
+        "justify": "证明合法",
+        "setLink": "设置链接",
+        "editLink": "编辑链接",
+        "removeLink": "移除链接",
+        "resetColorToDefault": "重置颜色为默认值"
+      }
+    },
+    "ai": {
+      "title": "人工智能写作助手",
+      "improveWriting": "提高写作能力",
+      "makeShorter": "缩短",
+      "makeLonger": "延长",
+      "fixGrammar": "修改语法",
+      "changeTone": "改变音调",
+      "professional": "专业的",
+      "casual": "随意的",
+      "formal": "正式的",
+      "translate": "翻译",
+      "english": "英语",
+      "spanish": "西班牙语",
+      "french": "法语",
+      "summarize": "总结",
+      "addExamples": "添加示例",
+      "originalText": "原文",
+      "suggestion": "人工智能建议",
+      "generating": "正在生成建议……",
+      "noSuggestion": "尚未生成任何建议。",
+      "acceptSuggestion": "接受建议",
+      "errors": {
+        "contentBlocked": "内容已被安全过滤器屏蔽。请尝试使用不同的措辞重新表述您的请求。",
+        "emptyContent": "人工智能无法生成响应。请尝试重新措辞或稍后再试。",
+        "maxTokens": "人工智能的回复过长，已被截断。请尝试使用更简短的请求或要求更简洁的回复。",
+        "rateLimit": "由于速率限制，AI 服务暂时无法使用。请稍后再试。",
+        "accessDenied": "您没有权限在此项目中使用人工智能功能。",
+        "generic": "抱歉，处理您的请求时出错。"
+      }
+    },
+    "by": "经过",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "目录",
+        "emptyMessage": "开始向文档添加标题 …"
+      },
+      "carousel": {
+        "previousSlide": "上一张幻灯片",
+        "nextSlide": "下一张幻灯片"
+      },
+      "dialog": {
+        "toggleFullScreen": "切换全屏"
+      },
+      "command": {
+        "title": "命令菜单",
+        "description": "搜索并执行命令"
+      },
+      "breadcrumb": {
+        "more": "更多的"
+      },
+      "clickToViewDetails": "点击查看详情",
+      "clickToExpand": "点击展开",
+      "clickToCollapse": "点击收起",
+      "search": {
+        "filters": "过滤器",
+        "noResultsFound": "未找到结果",
+        "loadingProjects": "正在加载项目...",
+        "noProjectsFound": "未找到项目。",
+        "viewAllProjects": "查看所有项目",
+        "states": "各州",
+        "automationStatus": "自动化状态",
+        "parent": "父母"
+      },
+      "issues": {
+        "errorLoadingDetails": "加载问题详情时出错： ",
+        "updated": "更新： ",
+        "openInJira": "在 Jira 中打开",
+        "openInExternalSystem": "打开方式 {provider}",
+        "assignee": "受让人",
+        "status": "地位： ",
+        "clickToOpenInNewTab": "点击在新标签页中打开",
+        "url": "网址： ",
+        "externalId": "外部 ID： ",
+        "viewIn": "查看",
+        "fieldType": "字段类型： ",
+        "richTextContent": "富文本内容",
+        "invalidContent": "无效内容",
+        "fieldInformation": "现场信息"
+      },
+      "onboarding": {
+        "skipTour": "跳过行程"
+      },
+      "charts": {
+        "resultsDistribution": "结果分布",
+        "statusTimeline": "状态时间表",
+        "testDurationHistogram": "测试时长直方图",
+        "zoomDonutChart": "缩放甜甜圈图",
+        "zoomStatusTimeline": "Zoom 状态时间线",
+        "zoomHistogramChart": "缩放直方图",
+        "duration": "持续时间： {seconds} 秒",
+        "durationLabel": "期间"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "正在加载问题跟踪信息……",
+      "enterDocumentation": "请输入文档……",
+      "noAutomatedTestResults": "本次运行未找到自动测试结果。"
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {分钟} other {分钟}}",
+      "seconds": "{count, plural, =1 {秒} other {秒}}"
+    },
+    "units": {
+      "time": "时间"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {情况} other {情况}}",
+      "result": "{count, plural, =1 {结果} other {结果}}",
+      "run": "{count, plural, =1 {运行} other {运行}}",
+      "comment": "{count, plural, =1 {{count} 评论} other {{count} 评论}}"
+    },
+    "success": {
+      "assigned": "测试用例已成功分配",
+      "unassigned": "测试用例已成功取消分配。",
+      "bulkAssigned": "{count, plural, one {# 测试用例} other {# 测试用例}} 已成功分配",
+      "bulkUnassigned": "{count, plural, one {# 测试用例} other {# 测试用例}} 已成功取消分配"
+    },
+    "tabs": {
+      "general": "一般的",
+      "settings": "设置"
+    },
+    "selectFilter": "请选择筛选条件以查看测试用例。",
+    "invalidProject": "项目ID无效。",
+    "visualization": "可视化",
+    "results": "结果",
+    "loading": "加载中..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "创建新帐户",
+      "sso": {
+        "title": "使用 SSO 登录",
+        "googleOAuth": "继续使用 Google",
+        "apple": "继续使用 Apple",
+        "microsoft": "继续使用 Microsoft",
+        "samlProvider": "使用 {name}登录",
+        "magicLink": "使用 Magic Link 登录",
+        "emailLogin": "继续通过电子邮件"
+      },
+      "magicLink": {
+        "description": "请输入您的电子邮件地址，我们将向您发送一个安全链接以供登录。无需密码。您必须已拥有一个帐户。",
+        "emailPlaceholder": "请输入您的邮箱",
+        "sendLink": "发送魔法链接",
+        "sending": "正在发送...",
+        "checkEmail": "请查看您的电子邮件",
+        "success": "如果您有账户，我们已向您的邮箱 {email} 发送了一个魔法链接。点击邮件中的链接即可登录。",
+        "error": "发送魔法链接失败，请重试。",
+        "backToSignIn": "返回登录页面"
+      },
+      "twoFactor": {
+        "title": "双因素身份验证",
+        "description": "输入身份验证器应用程序中的 6 位验证码，或使用备用验证码。"
+      },
+      "troubleSigningIn": "登录遇到问题？",
+      "contactAdmin": "请联系系统管理员"
+    },
+    "errors": {
+      "accessDenied": "访问被拒绝。您的帐户可能已停用或您没有登录权限。",
+      "configuration": "服务器配置存在问题。",
+      "verification": "验证令牌已过期或已被使用。",
+      "invalid2FACode": "验证码无效，请重试。",
+      "twoFactorTokenRequired": "需要令牌",
+      "verificationCodeRequired": "需要验证码"
+    },
+    "signup": {
+      "description": "请输入您的信息以注册新帐户。",
+      "signIn": "登录您现有的帐户。",
+      "registrationDisabled": "请联系管理员创建账户。",
+      "errors": {
+        "emailRequired": "必须提供电子邮件地址",
+        "passwordRequired": "密码不符合安全要求",
+        "confirmPasswordRequired": "需要确认密码",
+        "passwordsDoNotMatch": "密码不匹配",
+        "domainRestricted": "注册仅限已批准的电子邮件域名。如果您认为此信息有误，请联系您的管理员。"
+      }
+    },
+    "verifyEmail": {
+      "title": "验证电子邮件",
+      "loading": "正在验证电子邮件...",
+      "success": "邮箱已成功验证",
+      "error": "电子邮件验证失败",
+      "expired": "验证链接已过期",
+      "invalid": "无效的验证链接",
+      "alreadyVerified": "邮箱已验证",
+      "toast": {
+        "verifySuccess": {
+          "description": "您现在可以登录您的账户了。"
+        },
+        "verifyError": {
+          "description": "验证电子邮件时出错"
+        },
+        "resendSuccess": {
+          "title": "已发送邮件验证链接",
+          "description": "请查收您的电子邮件，其中包含验证链接。"
+        },
+        "resendError": {
+          "title": "发送邮件验证链接失败",
+          "description": "发送电子邮件验证链接时发生错误。"
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "设置双因素身份验证",
+      "description": "您的组织需要启用双因素身份验证。请进行设置以继续。",
+      "backupDescription": "继续操作前，请保存您的备份代码。",
+      "required": "根据贵组织的安全策略，需要启用双因素身份验证。",
+      "loading": "准备设置……",
+      "manualEntry": "或者手动输入此代码：",
+      "verifyLabel": "验证码",
+      "verify": "验证并启用",
+      "backupCodesInfo": "请将这些代码保存在安全的地方。如果您丢失了验证器设备，可以使用这些代码访问您的帐户。",
+      "copyCodes": "复制所有代码",
+      "continue": "继续登录"
+    },
+    "twoFactorVerify": {
+      "title": "验证您的身份",
+      "description": "请输入身份验证器应用程序中显示的 6 位验证码以继续。",
+      "backupCodeLabel": "备份代码",
+      "backupCodeHint": "您还可以输入一个 8 位字符的备用代码。",
+      "useAuthenticator": "请改用验证码",
+      "useBackupCode": "改用备用代码",
+      "signOut": "退出登录并使用其他帐户"
+    },
+    "forceChangePassword": {
+      "title": "更改密码",
+      "adminDescription": "管理员要求您更改密码。",
+      "expiredDescription": "您的密码已过期。请设置新密码以继续。",
+      "newPasswordLabel": "新密码",
+      "confirmPasswordLabel": "确认新密码",
+      "submitButton": "更改密码",
+      "signOut": "退出登录",
+      "passwordsMustMatch": "密码不匹配。",
+      "passwordRequired": "需要输入密码。",
+      "genericError": "发生错误，请重试。",
+      "policyTitle": "密码要求：",
+      "policyMinLength": "至少 {count} 个字符",
+      "policyUppercase": "至少包含一个大写字母",
+      "policyLowercase": "至少包含一个小写字母",
+      "policyNumbers": "至少一个数字",
+      "policySpecialChars": "至少包含一个特殊字符（{chars}）"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "关联 SSO 帐户",
+      "description": "将您的帐户与单点登录提供商关联",
+      "availableProviders": "可用的单点登录提供商",
+      "linkWithGoogle": "与谷歌链接",
+      "linkWithSaml": "链接至 {name}",
+      "accountLinked": "账户已成功关联",
+      "linkingFailed": "账户关联失败",
+      "noProvidersAvailable": "目前没有可用于连接的单点登录 (SSO) 提供商。",
+      "linkingInfo": "关联单点登录 (SSO) 提供商后，您可以使用该提供商而非密码登录。您现有的帐户数据将保持不变。",
+      "signInWithGoogle": "使用 Google 登录",
+      "enterpriseSamlSso": "企业级 SAML 单点登录",
+      "linkProvider": "链接提供商",
+      "linking": "正在连接……",
+      "noProvidersContactAdmin": "目前没有可用的单点登录 (SSO) 提供商。请联系您的管理员。"
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "仪表板",
+      "admin": "行政",
+      "profile": "轮廓"
+    },
+    "admin": {
+      "crossProjectReports": "跨项目报告"
+    },
+    "projects": {
+      "sections": {
+        "management": "管理"
+      },
+      "menu": {
+        "repository": "存储库",
+        "runs": "测试运行及结果"
+      },
+      "dropdown": {
+        "selectProject": "选择一个项目",
+        "selectProjectAriaLabel": "选择项目 {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "项目 ID： {id}",
+      "active": "项目正在进行中",
+      "completed": "项目已完成"
+    },
+    "overview": {
+      "title": "概述",
+      "currentMilestones": "当前里程碑",
+      "seeAllMilestones": "{count, plural, =1 {查看里程碑 # 里程碑} other {查看所有里程碑 # 里程碑}}",
+      "seeAllTestCases": "{count, plural, =1 {查看 # 测试用例} other {查看所有 # 测试用例}}",
+      "latestTestCases": "最新测试用例",
+      "createdOn": "创建于",
+      "seeAllTags": "查看所有标签",
+      "seeAllActiveSessions": "{count, plural, =1 {查看当前会话数} other {查看所有当前会话数}}",
+      "latestSessions": "最新会话",
+      "activeTestRuns": "正在进行的测试运行",
+      "seeAllActiveTestRuns": "{count, plural, =1 {查看当前运行的测试次数} other {查看所有当前运行的测试次数}}",
+      "latestTestRuns": "最新测试运行",
+      "testCaseBreakdown": "测试用例分解",
+      "noTestCases": "项目仓库为空。请使用仓库添加测试用例。",
+      "noTestCasesPrefix": "项目仓库为空。请使用以下命令添加测试用例：",
+      "noTestCasesLink": "存储库"
+    },
+    "icon": {
+      "upload": {
+        "title": "上传项目图标",
+        "description": "上传一张最大 4MB 的正方形图片（宽高比 1:1）。",
+        "errors": {
+          "invalidFileType": "仅允许上传图像文件。",
+          "fileTooLarge": "文件太大。最大大小为 {size}。"
+        }
+      }
+    },
+    "settings": {
+      "description": "管理 {projectName}的设置",
+      "moreSettingsComingSoon": "更多设置即将推出",
+      "moreSettingsDescription": "更多项目配置选项将在未来的更新中在此处提供。",
+      "integrations": {
+        "description": "管理此项目的第三方问题集成",
+        "availableIntegrations": "可用的问题集成",
+        "availableDescription": "选择一个问题集成方案来连接到此项目",
+        "configuredIntegration": "配置集成",
+        "noIntegrationAssigned": "未分配集成问题",
+        "noIntegrationDescription": "从可用选项中选择一个问题集成方案即可开始。",
+        "selectIntegration": "选择要配置的问题集成",
+        "integration": {
+          "assignError": "分配问题集成失败",
+          "updateSuccess": "集成设置已更新",
+          "updateError": "问题集成设置更新失败",
+          "removeError": "移除问题集成失败",
+          "removeIntegration": "移除集成",
+          "confirmRemove": "确认移除",
+          "authDescription": "您需要使用 {provider} 进行身份验证才能使用此问题集成",
+          "authenticating": "正在验证……",
+          "authSuccess": "身份验证成功",
+          "selectProject": "选择 {provider} 项目",
+          "selectProjectPlaceholder": "选择要链接的项目",
+          "linkedProject": "关联项目",
+          "loadProjectsError": "项目加载失败",
+          "settingsSaved": "集成设置已成功保存",
+          "saveSettingsError": "问题集成设置保存失败",
+          "authorizationRequired": "需要授权",
+          "authenticationError": "身份验证失败，请重试。",
+          "authorizationRequiredDescription": "您需要授权此问题集成才能访问外部项目",
+          "authorizationMessage": "请授权问题集成继续进行。",
+          "authorizeIntegration": "授权 {name}",
+          "integrationSettings": "{name} 设置",
+          "integrationSettingsDescription": "为该项目配置问题集成设置",
+          "selectExternalProject": "选择外部项目",
+          "refreshProjects": "刷新项目",
+          "defaultIssueType": "默认问题类型",
+          "selectDefaultIssueType": "选择默认问题类型",
+          "defaultIssueTypeDescription": "创建新问题时，此问题类型将被预先选中。",
+          "issueTypePlaceholder": "例如：缺陷、任务、故事",
+          "defaultComponent": "默认组件",
+          "componentPlaceholder": "例如，前端、后端",
+          "automaticSync": "自动同步",
+          "automaticSyncDescription": "自动同步TestPlanIt与外部系统之间的问题",
+          "simpleUrlDescription": "此问题集成使用简单的 URL 模式链接到外部问题。问题将使用配置的 URL 模式在新标签页中打开。",
+          "externalProjectHelp": "这将设置从 TestPlanIt 创建新问题的默认项目。您仍然可以链接和同步来自其他外部项目的问题——每个问题都跟踪其自身的源项目。",
+          "linkedProjects": "链接的外部项目",
+          "linkedProjectsDescription": "通过此集成连接的外部项目",
+          "noLinkedProjects": "没有链接外部项目",
+          "noLinkedProjectsDescription": "添加外部项目以启用问题搜索和同步。",
+          "addProjects": "添加项目",
+          "addSelected": "添加所选内容",
+          "setAsDefault": "设置为默认值",
+          "removeProject": "移除项目",
+          "removeProjectConfirmation": "移除此项目将停止同步其中的问题。之前同步的问题不会被删除。是否继续？",
+          "removeProjectWebhookCascadeBullet": "该项目的入站 webhook 也将被移除。",
+          "keepProject": "保持项目",
+          "defaultIndicator": "默认",
+          "syncStatusSyncing": "同步",
+          "syncStatusCompleted": "已同步",
+          "syncStatusError": "同步错误",
+          "fanOutPartialFailure": "无法访问 {count} 个项目。正在显示 {successCount} 个项目的结果。",
+          "projectSelectorLabel": "项目",
+          "defaultIssueTypeHelp": "使用 TestPlanIt 创建新问题时，系统会自动选择此问题类型。如果您经常创建相同类型的问题，这将节省时间。",
+          "automaticSyncHelp": "启用此功能后，当外部系统（通过 Webhook）检测到更改时，问题将自动同步。您也可以随时手动同步。",
+          "removeWarningTitle": "移除此集成问题将导致：",
+          "removeWarning1": "断开所有与此问题集成相关的问题（问题仍保留在数据库中）",
+          "removeWarning2": "移除此项目的所有问题集成特定设置",
+          "removeWarning3": "如果想再次使用此问题集成，则需要重新配置。",
+          "removeWarning4": "移除为此集成配置的入站 Webhook",
+          "switchIntegration": "交换机集成",
+          "switchWarningTitle": "切换到不同的AI模型将：",
+          "switchWarning1": "断开当前与问题集成关联的所有问题",
+          "switchWarning2": "保留数据库中的问题（它们将不再关联）",
+          "switchWarning3": "将当前问题集成配置替换为新的配置。",
+          "switchWarning4": "移除为当前集成配置的入站 Webhook"
+        },
+        "integrationAssigned": "集成任务已成功分配",
+        "integrationAssignError": "未能将问题集成分配给项目",
+        "integrationRemoved": "集成已成功移除",
+        "integrationRemoveError": "未能从项目中移除问题集成",
+        "add": {
+          "jira": {
+            "description": "将您的 Jira 帐户连接到 TestPlanIt，即可直接从 TestPlanIt 管理问题。"
+          },
+          "simple_url": {
+            "description": "连接到第三方系统进行问题跟踪。"
+          },
+          "github": {
+            "description": "连接到 GitHub 以进行问题跟踪和代码库管理。"
+          },
+          "gitlab": {
+            "description": "连接到 GitLab 以跟踪问题和合并请求。"
+          },
+          "gitea": {
+            "description": "连接到自托管的 Gitea、Forgejo 或 Gogs 实例进行问题跟踪。"
+          },
+          "azure_devops": {
+            "description": "连接到 Azure DevOps 以跟踪工作项。"
+          }
+        }
+      },
+      "webhooks": {
+        "description": "配置入站 Webhook 以保持关联问题同步。",
+        "inboundDescription": "配置入站 Webhook 以保持关联问题同步。",
+        "outboundDescription": "配置出站 webhook，将 TestPlanIt 事件发送到 Slack 或任何 HMAC 签名的 URL。",
+        "directionInbound": "入境",
+        "directionOutbound": "出站",
+        "inboundAddButtonAllConfigured": "入站适配器已配置完成。",
+        "inboundAddButtonNoIntegration": "在添加入站 webhook 之前，请先为该项目分配一个问题集成。",
+        "inboundEmptyWithIntegration": "未配置任何入站 Webhook。 <link>添加一个</link> 以接收来自您分配的问题集成的更新。",
+        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "deliveriesEmptyNoConfigs": "目前还没有 webhook 发送——请在其他标签页上创建入站或出站 webhook 以开始接收它们。",
+        "noConfig": "未配置 webhook",
+        "createButton": "创建 webhook",
+        "url": "Webhook URL",
+        "urlHelp": "将此 URL 粘贴到问题跟踪器的 webhook 配置中。",
+        "secret": "Webhook 秘密",
+        "secretHelp": "将此密钥粘贴到问题跟踪器的 webhook 配置中。",
+        "revealedShownOnceWarning": "立即复制下面的网址和密钥——它们只会显示一次，以后无法找回。",
+        "secretMasked": "隐藏 — 旋转查看",
+        "rotateSecret": "旋转秘密",
+        "rotateConfirmTitle": "轮换 webhook 密钥？",
+        "rotateConfirm": "轮换密钥将使问题跟踪器端的当前配置失效，直到您在那里更新配置为止。是否继续？",
+        "isActive": "已启用",
+        "deleteConfirmTitle": "删除 webhook 配置？",
+        "deleteConfirm": "删除此 webhook 配置？入站邮件将被拒绝。",
+        "sendTest": "发送测试 webhook",
+        "testSuccess": "测试 webhook 已接受（HTTP {statusCode}，结果： {outcome}）",
+        "testFailure": "测试 webhook 失败（HTTP {statusCode}）： {error}",
+        "saveError": "保存 webhook 配置失败",
+        "lastReceived": "最后收到： {timestamp}",
+        "lastReceivedLabel": "上次收到时间：",
+        "lastReceivedNever": "尚未发货",
+        "copyUrl": "复制 webhook URL",
+        "copySecret": "复制 webhook 密钥",
+        "urlCopied": "Webhook URL 已复制到剪贴板",
+        "secretCopied": "Webook 密钥已复制到剪贴板",
+        "nextSteps": "接下来：将这些信息粘贴到问题跟踪器的 webhook 配置中，然后点击下方的“发送测试 webhook”来验证流程。保存密钥后，点击“完成”——密钥将无法再次显示。",
+        "revealDone": "完毕",
+        "pageTitle": "网络钩子",
+        "inboundTab": "入境",
+        "outboundTab": "出站",
+        "outboundEmpty": "未配置任何出站 Webhook。请添加一个 Webhook，以便将 TestPlanIt 事件发送到 Slack 或任何经过 HMAC 签名的 URL。",
+        "outboundAddButton": "添加出站 webhook",
+        "outboundCreateTitle": "新增出站 webhook",
+        "outboundCreateName": "姓名",
+        "outboundCreateNameHelp": "为该目标位置添加一个标签，例如“工程 Slack”。",
+        "outboundCreateNamePlaceholder": "工程 Slack",
+        "outboundCreateNameRequired": "姓名为必填项。",
+        "outboundCreateUrlRequired": "必须提供网址。",
+        "outboundCreateUrlInvalid": "请输入有效的网址（https://example.com/...）。",
+        "outboundCreateUrlMustUseHttps": "URL必须使用HTTPS",
+        "outboundNameLabel": "姓名",
+        "outboundUnnamedConfig": "（未命名的 webhook）",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "目标 URL。Slack 传入 webhook URL 会自动检测。",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "检测到：Slack",
+        "outboundDetectedHmac": "检测到：通用 HMAC",
+        "adapterLabelSlack": "松弛",
+        "adapterLabelGenericHmac": "通用 HMAC webhook",
+        "outboundCreateSubscriptionsTitle": "订阅",
+        "outboundCreateSubscriptionsHelp": "选择哪些事件会触发到此目标位置。您可以稍后更改这些设置。",
+        "outboundSubsTestRunsAndSessions": "测试运行和会话",
+        "outboundSubsTestRuns": "测试运行",
+        "outboundSubsSessions": "会议",
+        "eventVerbs": {
+          "duplicated": "重复",
+          "stateChanged": "状态已改变",
+          "resultAdded": "结果已添加"
+        },
+        "events": {
+          "testRunCreated": "创建测试运行",
+          "testRunStateChanged": "测试运行状态已更改",
+          "testRunCompleted": "测试运行完成",
+          "testRunDuplicated": "重复测试运行",
+          "testRunResultAdded": "测试运行结果已添加",
+          "sessionCreated": "会话已创建",
+          "sessionStateChanged": "会话状态已更改",
+          "sessionCompleted": "会议结束",
+          "sessionDuplicated": "会话重复",
+          "sessionResultAdded": "会话结果已添加",
+          "issueCreated": "问题已创建",
+          "issueUpdated": "问题已更新",
+          "issueDeleted": "问题已删除",
+          "caseCreated": "案件已创建",
+          "caseUpdated": "案件更新",
+          "caseDeleted": "案件已删除",
+          "jiraIssueCreated": "Jira 问题已创建",
+          "jiraIssueUpdated": "Jira 问题已更新",
+          "jiraIssueDeleted": "Jira 问题已删除",
+          "githubIssues": "GitHub 问题活动",
+          "githubPullRequest": "GitHub 拉取请求",
+          "githubPush": "GitHub推送",
+          "githubIssueComment": "GitHub 问题评论",
+          "adoWorkitemCreated": "创建 Azure DevOps 工作项",
+          "adoWorkitemUpdated": "Azure DevOps 工作项已更新",
+          "adoWorkitemDeleted": "Azure DevOps 工作项已删除",
+          "webhookTest": "测试活动"
+        },
+        "outboundSubsIssues": "问题",
+        "outboundSubsCases": "案例",
+        "outboundSubsSelectAll": "请选中此部分中的所有内容",
+        "outboundCreateSubmit": "创建 webhook",
+        "outboundCreateCancel": "取消",
+        "outboundCreateSuccess": "已创建出站 webhook。",
+        "outboundCreateError": "创建出站 webhook 失败。",
+        "outboundUrlLabel": "目标网址",
+        "outboundActiveToggle": "积极的",
+        "outboundSlackHint": "这个网址很敏感——任何拥有它的人都可以向你的频道发布内容。",
+        "outboundHmacSecretsTitle": "签署秘密",
+        "outboundHmacActiveSecret": "积极的",
+        "outboundHmacInactiveSecret": "非活跃状态",
+        "outboundHmacRetiringSecret": "退休",
+        "outboundHmacAutoRetireIn": "自动退休，剩余天数 {days} 天",
+        "outboundHmacRotateButton": "旋转秘密",
+        "outboundHmacExtendButton": "延长7天",
+        "outboundHmacRetireNowButton": "现在就退休",
+        "outboundRotateConfirmTitle": "轮换签名密钥？",
+        "outboundRotateConfirm": "系统会生成一个新的活动密钥。之前的密钥将继续有效签名 7 天，在此期间消费者会进行更新。",
+        "outboundRotateSuccess": "密钥已轮换。新的明文如下所示。",
+        "outboundRotateError": "密钥轮换失败。",
+        "outboundRetireConfirmTitle": "现在就此保密吗？",
+        "outboundRetireConfirm": "退役的密钥将立即停止签名。仍在使用旧密钥的用户将拒绝新的有效载荷。",
+        "outboundRetireSuccess": "秘密退休了。",
+        "outboundRetireError": "未能成功退休。",
+        "outboundExtendSuccess": "自动退休期限延长7天。",
+        "outboundExtendError": "扩展密钥失败。",
+        "outboundSendTestButton": "发送测试事件",
+        "outboundSendTestQueued": "测试事件已排队——请检查消息的目标位置。",
+        "outboundSendTestError": "测试事件排队失败。",
+        "outboundDeleteButton": "删除 webhook",
+        "outboundDeleteConfirmTitle": "删除出站 webhook？",
+        "outboundDeleteConfirm": "所有发往该目的地的后续事件立即停止发射。",
+        "outboundDeleteSuccess": "Webhook 已删除。",
+        "outboundDeleteError": "删除 webhook 失败。",
+        "outboundSecretCopy": "复制秘密",
+        "outboundSecretShownOnce": "现在就把这个秘密记下来——它不能再被人知道了。",
+        "outboundSecretDone": "完毕",
+        "inboundAddButton": "添加入站 webhook",
+        "inboundChooserTitle": "选择适配器",
+        "inboundChooserDescription": "选择将向 TestPlanIt 发送 Webhook 的问题跟踪系统。每个项目可以有一个 Jira、一个 GitHub 和一个 Azure DevOps 入站 Webhook。",
+        "inboundChooserJira": "吉拉",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "吉特亚",
+        "inboundChooserAlreadyConfigured": "已配置",
+        "inboundChooserSubmit": "继续",
+        "inboundChooserCancel": "取消",
+        "inboundEmpty": "未配置入站 Webhook。请添加一个以接收来自 Jira、GitHub、GitLab、Gitea 或 Azure DevOps 的问题更新。",
+        "inboundJiraTitle": "Jira 入站 webhook",
+        "inboundGithubTitle": "GitHub 入站 webhook",
+        "inboundGithubScopeHint": "GitHub <code>issues</code> events 会更新关联的 TestPlanIt 问题。Pull request 和 issue comment 事件已接受，但目前不会更新问题。",
+        "inboundGitlabTitle": "GitLab 入站 webhook",
+        "inboundGitlabScopeHint": "GitLab <code>Issue Hook</code> 事件会更新关联的 TestPlanIt 问题。其他事件类型也会被接受，但不会更新问题。",
+        "inboundGiteaTitle": "Gitea 入站 webhook",
+        "inboundGiteaScopeHint": "Gitea <code>issues</code> events 会更新关联的 TestPlanIt 问题。其他事件类型也会被接受，但不会更新问题。",
+        "inboundAdoTitle": "Azure DevOps 入站 Webhook",
+        "inboundAdoScopeHint": "Azure DevOps <code>工作项已更新</code> 事件会更新关联的 TestPlanIt 问题。其他事件也会被接受，但不会更新问题。",
+        "inboundAdoUsername": "用户名",
+        "inboundAdoPassword": "密码",
+        "inboundAdoUsernamePlaceholder": "服务帐户",
+        "inboundAdoUsernameHelp": "已在 Azure DevOps 服务钩子端进行配置。TestPlanIt 通过 HTTP 基本身份验证对其进行验证。",
+        "inboundAdoPasswordHelp": "静态存储时采用加密方式。同时，也请在 Azure DevOps 服务钩子端保存此值。",
+        "inboundAdoResourceDetailsHint": "配置 Azure DevOps 服务钩子时，将“要发送的资源详细信息”设置为“全部”，以便将 System.State 包含在有效负载中。",
+        "setupStepsTitle": "设置步骤",
+        "setupStepsJiraStep1": "在 Jira 中，转到“设置”→“系统”→“WebHooks”（或您的 Jira 管理员的 webhook 配置页面）。",
+        "setupStepsJiraStep2": "点击“创建 Webhook”。将以下 URL 粘贴到 URL 字段中，将密钥粘贴到密钥字段中。",
+        "setupStepsJiraStep3": "在“问题相关事件”下，选中“已更新”，以便发送问题状态更改。",
+        "setupStepsJiraStep4": "保存 webhook。使用下面的“发送测试 webhook”来验证管道。",
+        "setupStepsGithubStep1": "在您的 GitHub 存储库中，转到“设置”→“Webhooks”→“添加 webhook”。",
+        "setupStepsGithubStep2": "将以下 URL 粘贴到“有效负载 URL”字段中。将内容类型设置为 application/json。",
+        "setupStepsGithubStep3": "将以下秘密粘贴到“秘密”字段中。",
+        "setupStepsGithubStep4": "选择“让我选择单个事件”，然后勾选“问题”。",
+        "setupStepsGithubStep5": "点击“添加 webhook”。使用下面的“发送测试 webhook”来验证管道。",
+        "setupStepsAdoStep1": "在 Azure DevOps 项目中，转到项目设置 → 服务挂钩 → 创建订阅。",
+        "setupStepsAdoStep2": "选择“Web Hooks”作为服务。将触发器设置为“工作项已更新”。",
+        "setupStepsAdoStep3": "将要发送的资源详细信息设置为“全部”，以便包含 System.State。",
+        "setupStepsAdoStep4": "将下方网址粘贴到网址栏中。将基本身份验证的用户名和密码设置为您上方输入的值。",
+        "setupStepsAdoStep5": "保存订阅。使用下面的“发送测试 webhook”来验证管道。",
+        "setupStepsGitlabStep1": "在 GitLab 中，转到您的项目 → 设置 → Webhooks。",
+        "setupStepsGitlabStep2": "将下方网址粘贴到网址栏中。将下方密钥粘贴到密钥令牌栏中。",
+        "setupStepsGitlabStep3": "在“触发器”下，选中“问题事件”。",
+        "setupStepsGitlabStep4": "点击“添加 webhook”。使用下面的“发送测试 webhook”来验证管道。",
+        "setupStepsGiteaStep1": "在 Gitea 中，转到您的存储库 → 设置 → Webhooks。",
+        "setupStepsGiteaStep2": "点击“添加 Webhook”，然后选择“Gitea”。",
+        "setupStepsGiteaStep3": "将下方 URL 粘贴到“目标 URL”字段中。将下方密钥粘贴到“密钥”字段中。",
+        "setupStepsGiteaStep4": "在“触发条件”下，选择“问题”。",
+        "setupStepsGiteaStep5": "点击“添加 Webhook”。使用下面的“发送测试 Webhook”来验证管道。",
+        "deliveriesTab": "送货",
+        "filterConfigPlaceholder": "所有 webhook",
+        "filterStatusAll": "全部",
+        "filterStatusFailed": "失败的",
+        "filterStatusSuccess": "成功",
+        "filterSinceDefault": "自…",
+        "filterUntilDefault": "直到…",
+        "filterReset": "重置筛选器",
+        "filterBulkReplayButton": "批量重放 {count} 出站失败",
+        "filterBulkReplayHidden": "所有可见的故障都发生在入站端——请重新触发上游事件。",
+        "deliveriesEmpty": "没有符合这些筛选条件的订单。",
+        "deliveriesResetFilters": "重置筛选器",
+        "deliveriesLoadMore": "加载更多",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "事件",
+        "tableHeaderStatus": "地位",
+        "tableHeaderError": "错误",
+        "tableHeaderReceivedAt": "已收到",
+        "tableHeaderAttempt": "试图",
+        "tableHeaderDirection": "方向",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "查看详情",
+        "drawerTitle": "配送详情",
+        "drawerLabelEvent": "事件",
+        "drawerLabelDirection": "方向",
+        "drawerLabelStatusCode": "状态码",
+        "drawerLabelLatency": "延迟",
+        "drawerLatencyValue": "{ms} 毫秒",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "错误",
+        "drawerLabelPayloadDigest": "有效载荷摘要",
+        "drawerLabelEventId": "事件 ID",
+        "drawerLabelAttempt": "试图",
+        "drawerLabelReceivedAt": "收到于",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "{id} 的回放",
+        "drawerReplayButton": "重播此球",
+        "drawerInboundReplayNotSupported": "入库交付无法重现——请重新触发上游事件。",
+        "replayConfirmTitle": "重播这次投篮？",
+        "replayConfirm": "这将触发一个真正的 {direction} {adapterType} 请求。",
+        "replayAction": "重播",
+        "bulkReplayConfirmTitle": "重放出站失败？",
+        "bulkReplayConfirm": "重放 {count} 个出站失败到 {configName}？这将触发 {count} 个真正的 HTTP 请求。",
+        "bulkReplayCapExceeded": "批量重放每次最多只能发送 100 条消息。可以缩小筛选范围或按顺序运行。目前， {count} 将被重放。",
+        "bulkReplayAction": "重播 {count}",
+        "healthBadge": {
+          "HEALTHY": "健康",
+          "DEGRADED": "降级",
+          "DISABLED": "已禁用"
+        },
+        "healthTooltipHealthy": "上次成功： {lastSuccessAt}",
+        "healthTooltipDegraded": "连续失败次数 {count} · 最后一次失败时间为 {lastFailureAt}",
+        "healthTooltipDisabled": "连续失败 10 次后禁用 · {lastFailureAt}",
+        "activityLabel": "配送活动",
+        "activityLastDispatched": "最后发货",
+        "activityLastSuccess": "最后成功",
+        "activityLastFailure": "最后一次失败",
+        "activityNever": "绝不",
+        "reEnable": "重新启用",
+        "reEnableConfirmTitle": "重新启用此 webhook？",
+        "reEnableConfirm": "请确认上游问题已修复后再重新启用。webhook 将立即恢复发送。",
+        "toastReplaySuccess": "重放已排队",
+        "toastReplayFailed": "重放失败： {error}",
+        "toastReplayInboundNotSupported": "入库货物无法重现。",
+        "toastBulkReplaySuccess": "批量重放开始 · 批次 {batchId}",
+        "toastBulkReplayFailed": "批量重放失败： {error}",
+        "toastReEnableSuccess": "Webhook 已重新启用",
+        "toastReEnableFailed": "重新启用失败： {error}"
+      },
+      "aiModels": {
+        "description": "配置人工智能模型以实现智能测试用例生成和分析",
+        "availableModels": "项目默认值",
+        "availableModelsDescription": "从系统管理员配置的模型中选择一个默认的 AI 模型用于此项目。",
+        "currentModelSettings": "当前模型设置",
+        "currentModelDescription": "当前激活的 AI 模型配置详情： {name}",
+        "noModelsAvailable": "目前没有可用的AI模型。请联系您的系统管理员，为您的组织配置AI模型。",
+        "monthlyBudget": "每月预算",
+        "model": "模型",
+        "budget": "预算",
+        "streamingTooltip": "启用实时响应流",
+        "systemDefault": "系统默认设置",
+        "setAsDefault": "设置为默认值",
+        "clearDefault": "清除默认设置",
+        "useForProject": "用于项目",
+        "removeModel": "清除默认设置",
+        "removeWarningTitle": "清除默认AI模型将：",
+        "removeWarning1": "除非已配置每个功能的单独设置，否则禁用 AI 驱动的功能。",
+        "removeWarning2": "移除用于测试用例生成和分析的备用模型",
+        "switchModel": "更改默认值",
+        "switchWarningTitle": "更改默认AI模型将：",
+        "switchWarning1": "改变本项目中人工智能功能的行为方式",
+        "switchWarning2": "可能会影响生成内容的质量和风格。",
+        "modelAssigned": "本项目默认AI模型集",
+        "modelAssignError": "设置默认AI模型失败",
+        "modelRemoved": "默认AI模型已清除",
+        "modelRemoveError": "清除默认AI模型失败",
+        "confirmRemove": "您确定要将“{name}”清除为该项目的默认值吗？",
+        "confirmSwitch": "您确定要将默认值从“{from}”更改为“{to}”吗？",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/月"
+        },
+        "promptConfig": "提示配置",
+        "promptConfigDescription": "选择此项目要使用的 AI 提示配置。",
+        "useSystemDefault": "使用系统默认值",
+        "promptConfigChanged": "提示符配置已成功更新。",
+        "featureOverrides": {
+          "title": "每个特征的 LLM 覆盖",
+          "description": "针对特定 AI 功能，覆盖默认的 LLM 集成。覆盖操作在解析链中优先级最高。",
+          "feature": "特征",
+          "override": "覆盖",
+          "effectiveLlm": "有效的LLM",
+          "source": "来源",
+          "noOverride": "无覆盖",
+          "noLlm": "无LLM（已禁用）",
+          "disabledOverride": "已禁用（覆盖）",
+          "projectOverride": "项目覆盖",
+          "promptConfig": "提示配置",
+          "noLlmConfigured": "未配置LLM",
+          "selectIntegration": "选择集成方式...",
+          "overrideSaved": "功能覆盖已保存",
+          "overrideCleared": "功能覆盖已清除",
+          "overrideError": "保存功能覆盖失败"
+        }
+      },
+      "shares": {
+        "title": "管理股份",
+        "description": "查看和管理此项目的所有共享链接"
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "启用 QuickScript 并连接代码库，以进行 AI 辅助测试生成。",
+        "enableLabel": "启用 QuickScript",
+        "enableDescription": " 允许团队成员使用 QuickScript 将测试用例转换为自动化脚本。",
+        "enabledToast": "已启用 QuickScript",
+        "disabledToast": "QuickScript 已禁用",
+        "noRepos": {
+          "title": "未配置任何代码仓库",
+          "adminDescription": "在为此项目配置代码上下文之前，请先建立存储库连接。",
+          "adminLink": "前往代码仓库",
+          "userDescription": "请联系系统管理员设置代码库连接。"
+        },
+        "repository": {
+          "title": "代码库",
+          "description": "选择用于 AI 环境的代码存储库",
+          "placeholder": "选择一个代码仓库……",
+          "branchLabel": "分支",
+          "branchPlaceholder": "留空则使用仓库默认分支"
+        },
+        "pathPatterns": {
+          "title": "路径模式",
+          "description": "指定要包含的文件。每一行都包含一个基本路径和一个 glob 模式。例如：`path=tests/e2e/pages + pattern=*` 直接包含该文件夹中的所有文件；`path=src + pattern=**/*.test.ts` 递归包含所有测试文件。",
+          "pathLabel": "小路",
+          "pathPlaceholder": "测试/端到端/页面",
+          "patternLabel": "图案",
+          "addPath": "添加路径",
+          "previewFiles": "预览文件",
+          "scanningRepo": "正在扫描存储库文件… ({seconds}s)",
+          "files": "{count, plural, one {# 文件} other {# 文件集}}",
+          "truncatedBadge": "结果可能不完整（受提供商限制）",
+          "exceedsLimit": "总大小超出 AI 上下文限制 {overflow}。导出过程中，文件会根据与待导出测试用例的相关性进行排序——相关性最高的文件优先导出，当达到预算上限时，相关性较低的文件将被跳过。如果您希望更精确地控制要导出的文件，请缩小路径模式。"
+        },
+        "preview": {
+          "resolvingBranch": "正在解析分支…",
+          "scanningFiles": "正在扫描 {scope}… 中的文件",
+          "scanningFilesCount": "正在扫描 {scope}… 中的文件（已找到{count}）",
+          "filtering": "对 {count} 个文件和… 个文件应用过滤器"
+        },
+        "cache": {
+          "title": "缓存设置",
+          "description": "Valkey 会缓存文件，以便在 AI 生成过程中快速访问。",
+          "enableLabel": "启用文件缓存",
+          "disabledWarning": "文件缓存已禁用。导出时，代码库文件将直接从您的代码提供商处获取，不会存储在 TestPlanIt 中。AI 驱动的 QuickScript 仍将包含代码上下文，但每次导出都会向您的代码库发出实时请求。",
+          "ttlLabel": "缓存持续时间（天）",
+          "statusTitle": "缓存状态",
+          "refreshButton": "刷新缓存",
+          "listingFiles": "文件列表…",
+          "cachingFiles": "缓存 {count} 个文件…",
+          "statusNeverFetched": "从未获取",
+          "statusPending": "令人耳目一新……",
+          "lastFetched": "最后获取时间",
+          "filesCached": "文件已缓存",
+          "totalSize": "总尺寸"
+        },
+        "save": "保存配置",
+        "saved": "代码上下文配置已保存",
+        "saveError": "配置保存失败",
+        "listError": "无法列出存储库文件",
+        "contentsError": "文件内容缓存失败",
+        "networkError": "缓存刷新期间出现网络错误",
+        "refreshSuccess": "缓存已刷新： {fileCount} 个文件（已缓存{contentCached} 个内容）",
+        "refreshRateLimited": "缓存已刷新：列出了 {fileCount} 个文件，缓存了 {contentCached}/{fileCount} 个内容（速率受限——请再次刷新以完成）",
+        "validation": {
+          "pathRequired": "路径是必需的",
+          "patternRequired": "需要图案",
+          "repositoryRequired": "需要存储库",
+          "pathPatternRequired": "至少需要一种路径模式"
+        },
+        "exportTemplates": {
+          "title": "导出模板",
+          "description": "为该项目分配导出模板。只有分配的模板才会显示在导出对话框中。",
+          "noTemplates": "未启用任何导出模板。请联系您的系统管理员。",
+          "assignedLabel": "已分配模板",
+          "selectPlaceholder": "选择要分配的模板……",
+          "defaultLabel": "默认模板",
+          "defaultPlaceholder": "无（使用全局默认值）",
+          "assigned": "已分配",
+          "save": "保存模板作业",
+          "saved": "模板分配已保存",
+          "saveError": "模板分配保存失败"
+        },
+        "disconnect": "断开存储库",
+        "confirmDisconnect": "您确定要断开“{name}”与此项目的连接吗？",
+        "disconnectWarningTitle": "断开此存储库的连接将导致：",
+        "disconnectWarning1": "删除所有缓存的存储库文件",
+        "disconnectWarning2": "移除路径模式和分支配置",
+        "disconnectWarning3": "停止在 AI 生成的导出文件中包含代码上下文",
+        "disconnectSuccess": "代码库已断开连接",
+        "disconnectError": "断开代码库连接失败"
+      }
+    }
+  },
+  "milestones": {
+    "title": "里程碑详情",
+    "fields": {
+      "parent": "家长里程碑",
+      "dueDate": "到期日",
+      "automaticCompletion": "截止日期自动完成",
+      "notifyDaysBefore": "提前几天通知到期日",
+      "notifyDaysBeforeValue": "截止日期前通知 {count, plural, one {# 天} other {# 天}}",
+      "dueDateNotifications": "到期日通知"
+    },
+    "labels": {
+      "childMilestones": "儿童成长里程碑"
+    },
+    "placeholders": {
+      "description": "请输入里程碑描述……",
+      "documentation": "提交里程碑文档……",
+      "selectType": "选择里程碑类型...",
+      "selectParent": "选择家长里程碑..."
+    },
+    "empty": {
+      "active": "暂无活动里程碑",
+      "completed": "未完成任何里程碑",
+      "description": "未提供描述",
+      "documentation": "未提供任何文件。",
+      "testRuns": "没有测试运行",
+      "forecasts": "暂无预测数据"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "尚未开始",
+      "IN_PROGRESS": "进行中",
+      "STOPPED": "停止",
+      "BLOCKED": "已屏蔽",
+      "CANCELLED": "取消",
+      "unscheduled": "非计划",
+      "upcoming": "即将推出",
+      "delayed": "延迟",
+      "pastDue": "逾期",
+      "started": "开始",
+      "completed": "完全的"
+    },
+    "status": {
+      "stop": "停止",
+      "reopen": "重新开放"
+    },
+    "dates": {
+      "pickStartDate": "选择开始日期",
+      "pickCompletionDate": "拣货完成日期",
+      "selectDate": "选择日期...",
+      "completionWarning": "警告：这将把该里程碑标记为已完成"
+    },
+    "toast": {
+      "deleted": "里程碑 {name} 已删除",
+      "updated": "里程碑已更新",
+      "updateFailed": "里程碑更新失败",
+      "completed": "里程碑“{name}”已完成。",
+      "completedWithDependencies": "里程碑及其依赖项均已成功完成。"
+    },
+    "errors": {
+      "nameExists": "已存在一个同名的里程碑",
+      "nameRequired": "里程碑名称为必填项",
+      "notFound": "未找到里程碑"
+    },
+    "actions": {
+      "add": "添加里程碑"
+    },
+    "delete": {
+      "title": "删除里程碑",
+      "confirmMessage": "您确定要删除里程碑 {name}吗？",
+      "warning": "此里程碑将从项目中移除。该里程碑的历史数据仍将保留在项目中。",
+      "toast": {
+        "loading": "删除里程碑……",
+        "success": "里程碑已成功删除",
+        "error": {
+          "title": "删除里程碑失败",
+          "description": "删除里程碑时发生错误"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "确认里程碑完成情况",
+      "confirmDescription": "完成此里程碑也将完成以下相关事项：",
+      "impactActiveTestRuns": "{count, plural, one {# 正在进行的测试运行} other {# 正在进行的运行}}",
+      "impactActiveSessions": "{count, plural, one {# 当前会话数} other {# 当前会话数}}",
+      "impactDescendantMilestones": "{count, plural, one {# 后代里程碑} other {# 后代里程碑}}",
+      "completeTestRunsLabel": "完成关联测试运行（{count, plural, one {# 活动} other {# 活动}}）",
+      "completeSessionsLabel": "已完成关联会话（{count, plural, one {# 活跃} other {# 活跃}}）",
+      "testRunStateLabel": "测试运行完成状态",
+      "sessionStateLabel": "会话完成状态",
+      "itemsRemaining": "以下项目将继续有效：",
+      "processing": "加工...",
+      "confirmAndCompleteAll": "确认并完成所有"
+    },
+    "notifications": {
+      "dueSoon": "里程碑“{name}”将于 {dueDate}到期。",
+      "overdue": "里程碑“{name}”应于 {dueDate}日到期。"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {会话} other {会话}}",
+    "labels": {
+      "totalElapsed": "花费时间",
+      "remaining": "剩余： {time}",
+      "overtime": "超过估计值： {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "没有符合您筛选条件的已完成会话。"
+    },
+    "filter": {
+      "placeholder": "筛选会话..."
+    },
+    "actions": {
+      "add": "添加会话",
+      "create": "创建新会话",
+      "edit": "编辑会话",
+      "complete": "完整会话",
+      "delete": "删除会话",
+      "viewSessionDetails": "查看会话"
+    },
+    "noMilestone": "没有里程碑",
+    "completeDialog": {
+      "noWorkflowsConfigured": "此项目未配置任何完成工作流程。请在管理设置中配置工作流程以启用会话完成功能。"
+    },
+    "messages": {
+      "createSuccess": "会话创建成功",
+      "createSuccessMultiple": "{count} 会话创建成功",
+      "duplicateSuccess": "会话已成功复制",
+      "duplicateSuccessMultiple": "{count} 会话已成功复制"
+    },
+    "duplicateDialog": {
+      "title": "重复会话",
+      "description": "创建会话 <nameStyle>{name}</nameStyle> 的副本，包含所有元数据，但不包含任何结果。"
+    },
+    "errors": {
+      "failedToCreate": "创建新会话失败",
+      "failedToCreateVersion": "创建会话版本失败",
+      "nameAlreadyExists": "会话名称已存在。请选择一个新名称。",
+      "createFailed": "创建会话失败",
+      "duplicateFailed": "会话复制失败"
+    },
+    "validation": {
+      "nameMinLength": "名称必须至少包含 2 个字符。",
+      "templateRequired": "请选择模板",
+      "maxDuration": "持续时间必须小于或等于 {max}。"
+    },
+    "placeholders": {
+      "estimate": "预估时间（例如，1小时30分钟）",
+      "elapsed": "经过时间（例如，2天4小时）",
+      "selectUser": "选择用户",
+      "estimateHint": "例如，2小时30分钟",
+      "noEstimate": "未设定估计值"
+    },
+    "delete": {
+      "confirmMessage": "您确定要删除会话 {name}吗？",
+      "warning": "本次会话将从项目中移除。本次会话的历史数据仍将保留在项目中。",
+      "toast": {
+        "loading": "正在删除会话...",
+        "success": "会话已成功删除",
+        "error": {
+          "title": "删除会话失败",
+          "description": "删除会话时发生错误"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "您确定要完成会话 {name}吗？",
+      "warning": "会话结束后，该会话将被永久存档，且无法再进行更新。",
+      "fields": {
+        "completionDate": "完成日期"
+      },
+      "placeholders": {
+        "pickDate": "选择一个日期"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "预计剩余总时间：",
+      "recentResultsTitle": "近期业绩概要",
+      "recentResultsDescription": "会议结果总结。",
+      "noRecentResults": "近期未记录任何会话结果。",
+      "completionTrendTitle": "完成趋势",
+      "completionTrendDescription": "每月完成的课程数量。",
+      "noCompletedRuns": "过去 6 个月内未找到已完成的运行记录。",
+      "completionTrendTitle6Mo": "完成趋势（过去 6 个月）",
+      "noCompletedSessions6Mo": "过去6个月内未完成任何疗程。"
+    },
+    "version": {
+      "title": "会话历史记录视图",
+      "notFound": "未找到会话版本。",
+      "selectVersion": "选择版本",
+      "backToSession": "返回会话",
+      "backToLatest": "返回最新版本",
+      "versionInfo": {
+        "created": "版本 {number} 创建",
+        "latestUpdated": "最新版本 {number} 已更新"
+      },
+      "renderer": {
+        "noEstimate": "暂无估算",
+        "noTimeLogged": "未记录时间",
+        "noContent": "无内容",
+        "currentVersion": "当前版本",
+        "previousVersion": "先前版本"
+      },
+      "diff": {
+        "added": "额外",
+        "removed": "已移除",
+        "changed": "已更改"
+      }
+    },
+    "results": {
+      "section": "会话日志",
+      "add": "添加会话结果",
+      "edit": "编辑会话结果",
+      "editDescription": "对会话结果进行更改，完成后点击保存。",
+      "details": "请在此处输入结果详情……",
+      "noResults": "目前还没有结果。",
+      "noNotes": "此结果未添加任何备注。",
+      "deleteSuccess": "会话结果已成功删除",
+      "deleteError": "删除会话结果失败",
+      "updateSuccess": "会话结果已成功更新",
+      "updateError": "更新会话结果失败",
+      "linkCopied": "会话结果链接已复制到剪贴板",
+      "copyFailed": "复制会话结果链接失败",
+      "confirmDelete": {
+        "title": "删除会话结果",
+        "description": "您确定要删除此会话结果吗？"
+      }
+    },
+    "notFound": "未找到会话"
+  },
+  "home": {
+    "dashboard": {
+      "title": "您的仪表盘",
+      "users": "There {count, plural, =1 {is # User} other {are # Users}}",
+      "yourProjects": "您的项目",
+      "projects": "您有权访问 {count, plural, =1 {# 项目} other {# 项目集}}",
+      "loading": "正在加载仪表盘...",
+      "noItems": "你目前无需处理任何分配给你的任务。",
+      "pendingRuns": "待测试运行",
+      "activeSessions": "活跃会话",
+      "yourActiveSessions": "{count, plural, =0 {无活动会话} =1 {活动会话数} other {活动会话数}}",
+      "yourPendingRuns": "{count, plural, =0 {无待处理的测试运行} =1 {# 活动测试运行} other {# 活动测试运行}}",
+      "yourAssignments": "你的作业",
+      "totalTime": "预计总时间： ",
+      "totalWorkEffort": "总工作量： ",
+      "scheduleSpan": "日程跨度： "
+    },
+    "initialPreferences": {
+      "title": "设置您的偏好",
+      "description": "选择最适合您的默认设置。您可以随时在个人资料中更改这些设置。",
+      "dateFormat": "日期格式",
+      "timeFormat": "时间格式",
+      "timezonePlaceholder": "搜索时区...",
+      "skip": "保留默认设置",
+      "save": "保存偏好设置",
+      "success": "偏好设置已更新",
+      "error": "保存您的偏好设置时出错。"
+    },
+    "noAccess": {
+      "title": "无项目访问权限",
+      "description": "您无权访问此系统中的任何项目。",
+      "contact": "请联系您的系统管理员申请项目访问权限。",
+      "adminAddProject": "添加您的第一个项目即可开始！",
+      "footer": "需要获得访问权限才能查看和参与测试计划活动。"
+    },
+    "noProjectAccess": {
+      "description": "您无权访问此项目。",
+      "contact": "请联系您的项目管理员申请访问权限。"
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# 测试用例} =1 {# 测试用例} other {# 测试用例}}",
+      "activeMilestones": "{count, plural, =0 {# 当前里程碑} =1 {# 当前里程碑} other {# 当前里程碑}}",
+      "activeRuns": "{count, plural, =0 {# 当前运行} =1 {# 当前运行} other {# 当前运行}}",
+      "activeSessions": "{count, plural, =0 {# 当前会话} =1 {# 当前会话} other {# 当前会话}}",
+      "issues": "{count, plural, =0 {# 问题} =1 {# 问题} other {# 问题}}"
+    }
+  },
+  "users": {
+    "description": "管理用户帐户，设置系统访问级别，并分配全局角色。",
+    "filter": "筛选用户...",
+    "profile": {
+      "title": "用户个人资料",
+      "edit": {
+        "title": "编辑个人资料",
+        "timezonePlaceholder": "选择或搜索时区...",
+        "timezoneRequired": "必须填写时区信息。",
+        "avatarUpdated": "头像更新成功。",
+        "avatarUpdateError": "头像更新失败。",
+        "deleteAvatar": "删除头像",
+        "deleteAvatarConfirm": "您确定要删除您的头像吗？",
+        "emailDisabledForSso": "单点登录 (SSO) 帐户的电子邮件地址无法更改。请通过您的身份提供商更新电子邮件地址。",
+        "emailEditableForBoth": "您可以使用邮箱/密码或单点登录 (SSO) 登录。更改邮箱地址只会影响密码验证。",
+        "linkSsoProvider": "链接 SSO 提供商"
+      },
+      "preferences": {
+        "title": "偏好"
+      },
+      "access": {
+        "title": "使用权"
+      },
+      "notifications": {
+        "title": "通知偏好设置",
+        "description": "自定义接收通知的方式",
+        "currentGlobal": "当前全局设置： {mode}",
+        "mode": {
+          "label": "通知模式",
+          "useGlobal": "使用全局设置"
+        },
+        "options": {
+          "title": "其他选项",
+          "email": {
+            "label": "电子邮件通知",
+            "description": "通过电子邮件接收通知"
+          }
+        },
+        "success": {
+          "title": "已保存偏好设置",
+          "description": "您的通知偏好设置已更新"
+        },
+        "error": {
+          "description": "通知偏好设置保存失败"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "更改密码",
+        "setPasswordButtonText": "设置密码",
+        "description": "请输入您当前的密码和新密码以更改您的帐户密码。此操作只会更改您内部管理的密码。如果您通过单点登录 (SSO) 登录，则该密码不会更改。",
+        "setPasswordDescription": "您已通过单点登录 (SSO) 登录，但尚未设置本地密码。请输入新密码以启用帐户的邮箱/密码登录功能。",
+        "currentPasswordLabel": "当前密码",
+        "newPasswordLabel": "新密码",
+        "confirmPasswordLabel": "确认新密码",
+        "validation": {
+          "passwordsDoNotMatch": "新密码不匹配。",
+          "newPasswordTooShort": "新密码不符合安全要求。"
+        },
+        "success": {
+          "passwordChanged": "密码已成功更改。"
+        }
+      },
+      "mentionedComments": {
+        "title": "评论中提到",
+        "description": "在提及你的评论中",
+        "noComments": "目前还没有人提到过你。",
+        "comment": "评论",
+        "showingResults": "显示 {start} - {end} 共 {total}"
+      },
+      "twoFactor": {
+        "enable": "启用双因素身份验证",
+        "disable": "禁用",
+        "disableNotAllowed": "您的组织要求启用双因素身份验证",
+        "ssoBypassNotice": "单点登录 (SSO) 将绕过此双因素身份验证 (2FA) 设置。请联系您的管理员，强制所有登录启用双因素身份验证。",
+        "regenerateCodes": "新代码",
+        "setup": {
+          "description": "使用您的身份验证器应用（例如 Google Authenticator 或 Authy）扫描二维码，然后输入验证码。",
+          "backupCodesTitle": "保存您的备份代码",
+          "done": "我已经保存了我的代码"
+        },
+        "disableConfirm": {
+          "title": "禁用双因素身份验证？",
+          "description": "这将降低您账户的安全性。请输入您当前的双重验证码或备用验证码进行确认。",
+          "placeholder": "输入代码"
+        },
+        "regenerate": {
+          "title": "重新生成备份代码",
+          "description": "这将使您现有的备用验证码失效。请输入您当前的双重验证码以继续。",
+          "confirm": "重新生成代码",
+          "newCodesTitle": "您的新备份代码",
+          "newCodesDescription": "您的旧代码已失效。请将这些新代码保存在安全的地方。"
+        }
+      },
+      "apiTokens": {
+        "description": "API令牌允许外部应用程序和脚本代表您访问TestPlanIt。令牌拥有与您的帐户相同的权限。",
+        "create": "创建令牌",
+        "createTitle": "创建 API 令牌",
+        "createDescription": "创建新的 API 令牌，用于验证外部工具和脚本。",
+        "nameLabel": "令牌名称",
+        "namePlaceholder": "例如，CI/CD 流水线、CLI 工具",
+        "noTokens": "尚未创建任何 API 令牌。",
+        "expiryLabel": "到期日期（可选）",
+        "expiryHint": "无需清洗，不会过期。",
+        "tokenCreated": "令牌已创建",
+        "tokenCreatedDescription": "您的API令牌已成功创建。",
+        "copyWarning": "立即复制此令牌。您将无法再次查看它！",
+        "yourToken": "您的令牌",
+        "deleteTitle": "删除 API 令牌？",
+        "deleteDescription": "此操作无法撤销。任何使用此令牌的应用程序将无法再进行身份验证。",
+        "readOnlyLabel": "只读",
+        "readOnlyDescription": "适用于只能查询数据而不能修改数据的AI代理。",
+        "agentTokenLabel": "标记为代理令牌",
+        "agentTokenDescription": "使用 metadata.source: \"mcp\" 标记审计日志条目，以便管理员可以归因于代理驱动的更改。",
+        "readOnlyBadge": "只读",
+        "agentTokenBadge": "代理令牌",
+        "errors": {
+          "nameRequired": "令牌名称为必填项。"
+        }
+      }
+    },
+    "access": {
+      "guest": "客人"
+    },
+    "avatar": {
+      "update": "更新头像",
+      "remove": "移除头像",
+      "changeProfilePicture": "更改个人资料图片",
+      "notAuthenticated": "您必须登录才能上传头像。"
+    },
+    "deletedUser": "已删除用户"
+  },
+  "userMenu": {
+    "viewProfile": "查看个人资料",
+    "locale": "本地化",
+    "themes": {
+      "light": "光",
+      "dark": "黑暗的",
+      "system": "系统",
+      "green": "绿色的",
+      "purple": "紫色的",
+      "orange": "橙子"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "未找到测试用例版本。",
+      "detailsRegion": "测试用例详情",
+      "metadataRegion": "测试用例元数据",
+      "versionCreated": "版本 {version} 创建",
+      "latestVersionUpdated": "最新版本 {version} 已更新",
+      "historyView": "测试用例历史记录视图"
+    },
+    "fields": {
+      "optionNotFound": "未找到选项",
+      "hasValue": "有价值",
+      "noValue": "无价值",
+      "hasDate": "有日期",
+      "noDate": "无日期",
+      "hasText": "有文本",
+      "noText": "无文本",
+      "hasLink": "有链接",
+      "noLink": "无链接",
+      "hasSteps": "有步骤",
+      "noSteps": "无需步骤",
+      "unchecked": "未检查",
+      "linkedCases": "关联病例",
+      "clickToViewFullContent": "点击查看完整内容"
+    },
+    "steps": {
+      "add": "添加步骤",
+      "addSharedSteps": "添加共享步骤",
+      "delete": "删除步骤",
+      "confirmDelete": "确认删除步骤 {number}？",
+      "createSharedSteps": "创建共享 {number, plural, one {步骤} other {步骤}}",
+      "sharedStepsName": "共享步骤名称",
+      "sharedStepsDescription": "输入您新共享的步骤 {number, plural, one {的名称} other {步骤}}。这将包括 {number, plural, one {# 已选步骤} other {# 已选步骤}}。",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "请选择步骤并输入名称以创建共享步骤。",
+        "failedToCreateSharedStepGroupError": "创建共享步骤失败，请重试。",
+        "sharedStepGroupCreatedSuccess": "共享步骤创建成功！",
+        "genericSharedStepCreationError": "创建共享步骤时发生未知错误。请重试。",
+        "errorCreatingSharedGroup": "创建共享步骤失败，请重试。",
+        "sharedGroupCreatedSuccess": "共享步骤组创建成功！"
+      },
+      "selectSharedStepsTitle": "选择共享步骤",
+      "selectSharedStepsDescription": "选择要添加到测试用例中的共享步骤。",
+      "sharedStepsListPlaceholder": "正在加载共享步骤...",
+      "sharedStepsNamePlaceholder": "输入名称以标识共享步骤",
+      "noSharedStepsFound": "未找到此项目的共享步骤。",
+      "sharedStepGroupTitle": "共享步骤： {name}",
+      "confirmDeleteSharedStepBlock": "您确定要从此测试用例中移除共享步骤块“{name}”吗？这不会删除共享步骤组本身。",
+      "removeBlockButton": "移除障碍",
+      "loadingSharedStepsItems": "正在加载步骤……",
+      "noStepsInSharedGroup": "此共享步骤组为空。",
+      "searchSharedStepsPlaceholder": "选择共享步骤...",
+      "stepsCountLabel": "{count, plural, =0 {# 步骤} =1 {# 步骤} other {# 步骤}}",
+      "reviewSelectedStepsTitle": "回顾选定步骤",
+      "noStepsInSelectedGroup": "所选组没有步骤。",
+      "sharedGroupSuffix": "（共同步骤）",
+      "unnamedSharedGroup": "未命名的共享步骤"
+    },
+    "testCase": {
+      "toggleAutomated": "切换自动测试",
+      "editAttachmentsIndividually": "单独编辑附件。",
+      "automatedStatus": "自动化测试是 {status}"
+    },
+    "templateNotAssignedWarning": "此测试用例使用了模板“{templateName}”，但该模板当前未分配给项目“{projectName}”。您可能需要将此模板分配给该项目，或者修改测试用例以使用其他模板。",
+    "orphanedStepsWarning": "此测试用例包含步骤，但当前模板“{templateName}”不包含“步骤”字段。在测试用例拥有包含“步骤”字段的模板之前，无法编辑步骤。",
+    "orphanedFieldsWarning": "此测试用例包含 {count, plural, =1 {# 字段值} other {# 字段值}} 其中 {count, plural, =1 {是} other {是}} 未包含在当前模板“{templateName}”中。 {count, plural, =1 {此字段是} other {这些字段}} 如下所示，但在添加到模板之前可能无法编辑。",
+    "title": "测试用例库",
+    "folders": "文件夹",
+    "showDescendants": "显示所有后代",
+    "addFolder": "添加文件夹",
+    "emptyFolders": "点击上方的“添加文件夹”按钮，添加第一个文件夹。",
+    "selectedAllCases": "{count, plural, =0 {已选择所有案例} one {已选择所有页面中的案例数} other {已选择所有页面中的案例数}}",
+    "deselectedAllCases": "已取消选择所有页面上的所有案例",
+    "selectAllTooltip": "选中/取消选中此页面上的所有案例",
+    "selectAllShiftTooltip": "{count, plural, =0 {选择/取消选择所有页面上的所有案例} one {选择/取消选择所有页面上的 # 个案例} other {选择/取消选择所有页面上的 # 个案例}}",
+    "deselectAllShiftTooltip": "取消选择/选择所有页面上的所有案例",
+    "shiftClickHint": "按住 Shift 键可选择/取消选择所有页面",
+    "treeView": {
+      "expandAll": "全部展开",
+      "collapseAll": "全部收起",
+      "altKey": "按住 Alt 键展开/折叠所有子项"
+    },
+    "dragDrop": {
+      "move": "移动",
+      "copy": "复制",
+      "promptTitle": "你想做什么？",
+      "copying": "正在复制…",
+      "copyComplete": "{count, plural, =1 {已复制 1 个案例至 {folder}} other {已复制 # 个案例至 {folder}}}{dest, select, samename {} crossProject { 位于 {projectName}} other {}}",
+      "moveComplete": "将 1 个案例移至 {count, plural, =1 {{folder}} other {将 # 个案例移至 {folder}}}{dest, select, samename {} crossProject { 中 {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Failed to copy 1 case to {folder}} other {Failed to copy # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {无法将 1 个案例移动到 {folder}} other {无法将 # 个案例移动到 {folder}}}{dest, select, samename {} crossProject { 中 {projectName}} other {}}",
+      "copyAlreadyRunning": "另一份拷贝正在制作中，请稍候。",
+      "currentSuffix": "（当前的）",
+      "moveDisabledSameFolder": "案例已在此文件夹中",
+      "dragPreviewCase": "测试用例",
+      "dragPreviewCount": "{count, plural, =1 {# 测试用例} other {# 测试用例}}",
+      "modifierHintMac": "按住 ⇧ 移动或按住 ⌥ 复制，拖动即可跳过此菜单。",
+      "modifierHintWin": "按住Shift键移动或按住Ctrl键复制，拖动即可跳过此菜单。"
+    },
+    "folderActions": {
+      "edit": "编辑文件夹",
+      "delete": "删除文件夹",
+      "rename": "重命名文件夹"
+    },
+    "cases": {
+      "filter": "筛选案例...",
+      "selectFolder": "选择要添加或显示测试用例的文件夹。",
+      "selectCases": "选择测试用例",
+      "noTestCases": "没有要显示的测试用例。",
+      "addCase": "添加案例",
+      "notFound": "未找到测试用例。",
+      "selectFilter": "选择筛选器",
+      "testResultHistory": "测试结果历史记录",
+      "testResultHistoryDescription": "查看此测试用例的测试结果历史记录",
+      "noTestResults": "未找到此测试用例的测试结果",
+      "unknownRun": "未知运行",
+      "attempt": "试图",
+      "invalidProject": "无效项目",
+      "noSearchResults": "没有符合您搜索条件的案例。",
+      "bulkEdit": "批量编辑",
+      "createTestRun": "创建测试运行",
+      "copyMoveToProject": "复制/移动",
+      "export": "出口",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "无法跨多个页面重新排列测试用例。要重新排序，请从页面大小菜单中选择“全部”以在一个页面上查看所有用例，或取消选择其他页面上的用例。您仍然可以将选定的用例拖到文件夹中。",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "全部可见（{count}）"
+        },
+        "textLongFormat": {
+          "label": "富文本格式"
+        },
+        "rowMode": {
+          "label": "测试用例行",
+          "multi": "每步单行"
+        }
+      },
+      "importWizard": {
+        "title": "导入测试用例",
+        "fields": {
+          "workflowState": "工作流状态",
+          "column": "列 {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# 测试用例} other {# 测试用例}} 导入成功"
+        },
+        "errors": {
+          "templateRequired": "需要选择模板",
+          "folderRequired": "此导入位置需要选择文件夹。",
+          "fileRequired": "需要 CSV 或 Markdown 文件。",
+          "markdownParseFailed": "解析 Markdown 文件失败",
+          "markdownLlmFailed": "AI解析不可用，使用标准解析器"
+        },
+        "page1": {
+          "fileType": {
+            "label": "文件类型",
+            "csv": "CSV",
+            "markdown": "Markdown"
+          },
+          "parsingMarkdown": "正在解析 Markdown 文件……",
+          "useAiParsing": "利用人工智能辅助进行田间测绘",
+          "importLocation": {
+            "label": "进口地点",
+            "singleFolder": "将所有案例添加到同一个文件夹中",
+            "rootFolder": "将所有案例和文件夹添加到根文件夹（需要映射）",
+            "topLevel": "将所有案例和文件夹添加到顶层（需要映射）"
+          },
+          "selectFolder": "选择文件夹",
+          "selectFolderPlaceholder": "选择一个文件夹……",
+          "delimiters": {
+            "tab": "标签页"
+          },
+          "hasHeaders": "第一行包含列名",
+          "template": "存储库案例模板",
+          "rowMode": {
+            "single": "每一行代表一个测试用例。",
+            "multi": "测试用例可以跨越多行"
+          }
+        },
+        "page2": {
+          "title": "将 CSV 列映射到字段",
+          "description": "将 CSV 文件中的每一列映射到模板中的一个字段，或者选择忽略它。",
+          "ignoreColumn": "忽略列",
+          "requiredFieldsWarning": "{count, plural, one {# 必填字段为} other {# 必填字段为}} 未映射"
+        },
+        "page3": {
+          "title": "田间测绘概要",
+          "mappingSummary": "地图摘要",
+          "folderSplitMode": {
+            "label": "文件夹层级模式",
+            "plain": "纯文本（未分割）",
+            "plainExample": "示例：'This/is.a>Folder' → 名为 'This/is.a>Folder' 的单个文件夹",
+            "slash": "以斜杠 (/) 分隔",
+            "slashExample": "示例：'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "按点号 (.) 分割",
+            "dotExample": "示例：'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "按大于号 (>) 分割",
+            "greaterThanExample": "示例：'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "预览导入",
+          "showing": "显示 {start}-{end} 共 {total} 个案例",
+          "case": "案例 {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "添加测试用例",
+      "name": "测试用例名称",
+      "namePlaceholder": "输入测试用例名称",
+      "selectTemplate": "选择模板",
+      "selectState": "选择一个州",
+      "estimatePlaceholder": "输入估价",
+      "create": "创建测试用例",
+      "successMessage": "新增测试用例",
+      "errorMessage": "添加新测试用例时出现未知错误"
+    },
+    "columns": {
+      "selectCase": "选择个案",
+      "runOrder": "运行顺序",
+      "lastTestResult": "最新结果",
+      "testedOn": "上次测试"
+    },
+    "actions": {
+      "archive": "档案"
+    },
+    "parentFolder": "父文件夹",
+    "rootFolder": "根文件夹",
+    "removeParentFolder": "删除父文件夹",
+    "createInSelectedFolder": "恢复到父文件夹",
+    "deleteCase": {
+      "title": "删除测试用例",
+      "confirmMessageStart": "您确定要删除测试用例吗？ ",
+      "confirmMessageEnd": "？",
+      "warning": "此测试用例将从项目中移除。该测试用例的历史数据（包括结果）仍将保留在项目中。",
+      "activeRunWarningMessage": "此测试用例属于 {count, plural, =1 {# 活动测试运行} other {# 活动测试运行}}。删除它会将这些运行标记为已删除。"
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Deleting this folder will also delete all subfolders. Are you sure?} one {Deleting this folder will also delete 1 test case in this folder and all subfolders. Are you sure?} other {Deleting this folder will also delete # test cases in this folder and all subfolders. Are you sure?}}",
+      "warning": "此文件夹及其所有测试用例将从项目中移除。这些测试用例的历史数据（包括结果）仍将保留在项目中。",
+      "confirm": "确认删除文件夹",
+      "success": "文件夹及其所有子文件夹/案例已成功删除。"
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "文件夹名称已存在，请选择其他名称。"
+      }
+    },
+    "views": {
+      "byAutomation": "自动化",
+      "allTemplates": "所有模板",
+      "allStates": "所有州",
+      "allCreators": "所有创作者",
+      "allCases": "所有案例",
+      "allAssignees": "所有受让人",
+      "anyTag": "任何标签",
+      "noTags": "无标签",
+      "byTag": "标签",
+      "byIssue": "问题",
+      "anyIssue": "任何问题",
+      "noIssues": "没问题"
+    },
+    "noFoldersTitle": "暂无文件夹",
+    "noFoldersDescription": "首先创建你的第一个文件夹来整理你的测试用例。",
+    "noFoldersOrCasesNoPermission": "没有要显示的文件夹或测试用例。",
+    "createFirstFolder": "创建你的第一个文件夹",
+    "bulkEdit": {
+      "title": "批量编辑 {count, plural, one {# 个案例} other {# 个案例}}",
+      "description": "正在编辑 {count, plural, one {# 已选案例} other {# 已选案例}}。选中字段即可启用编辑。",
+      "defineStepsTitle": "定义批量更新步骤",
+      "saveNewSteps": "保存新步骤",
+      "newStepsDefined": "已定义新步骤（{count}） - 点击按钮进行编辑",
+      "clearExistingStepsWarning": "现有步骤将被移除",
+      "warnings": {
+        "templateMismatch": {
+          "title": "已选择多个模板",
+          "description": "当选择使用不同模板的案例时，只能编辑标准字段。如果案例使用相同的模板，则可以编辑动态字段。"
+        },
+        "junitLimitations": {
+          "title": "自动化测试用例编辑的局限性",
+          "description": "从自动化测试结果导入的测试用例的“估算”和“自动化”字段无法修改。"
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "加载案例时出错",
+        "fetchErrorDescription": "无法加载所选案例的数据。请关闭此窗口并重试。",
+        "updateErrorTitle": "更新失败",
+        "updateFailed": "保存更改时出错。请检查数据并重试。",
+        "fetchError": "获取案例数据时出错。"
+      },
+      "success": {
+        "casesUpdated": "病例已成功更新"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "验证错误",
+      "stepsCannotBeBulkEdited": "步骤无法批量编辑",
+      "stepsInfoTitle": "步骤信息",
+      "stepsCannotBeBulkEditedInfo": "步骤无法批量编辑。请逐个编辑各个案例来修改步骤。",
+      "confirmDeleteCases": "您确定要删除 {count, plural, one {# 已选案例} other {# 已选案例}}吗？此操作无法撤销。",
+      "replaceAll": "全部替换",
+      "searchReplace": "搜索和替换",
+      "searchFor": "搜索",
+      "replaceWith": "替换为",
+      "searchText": "输入要搜索的文本",
+      "replacementText": "输入替换文本",
+      "useRegex": "使用正则表达式",
+      "caseSensitive": "区分大小写",
+      "regexHint": "使用 .* 表示任意字符，\\d+ 表示数字，\\w+ 表示单词。捕获组：（模式），然后使用 $1、$2 等。",
+      "preview": "预览",
+      "matches": "比赛",
+      "noMatches": "未找到匹配项",
+      "invalidRegexPattern": "无效的正则表达式模式",
+      "searchPatternRequired": "需要搜索模式",
+      "stepsSearchReplaceInfo": "搜索和替换功能将应用于步骤描述和预期结果。"
+    },
+    "exportModal": {
+      "title": "导出测试用例",
+      "description": "请在下方选择您的导出选项。",
+      "scope": {
+        "selected": "已选择（{count}）",
+        "allFiltered": "全部（当前视图）（{count}）",
+        "allProject": "项目 ({count})"
+      },
+      "format": {
+        "label": "格式",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Markdown"
+      },
+      "columns": {
+        "all": "全部",
+        "visible": "可见的"
+      },
+      "delimiter": {
+        "label": "分隔符",
+        "placeholder": "选择分隔符...",
+        "comma": "逗号（，）",
+        "semicolon": "分号（;）",
+        "colon": "冒号 （：）",
+        "pipe": "竖线 (|)"
+      },
+      "textLongFormat": {
+        "label": "文本长格式"
+      },
+      "attachmentFormat": {
+        "label": "附件格式",
+        "names": "姓名",
+        "json": "JSON",
+        "embedded": "嵌入图片"
+      },
+      "stepsFormat": {
+        "label": "步骤格式",
+        "plainText": "纯文本"
+      },
+      "rowMode": {
+        "label": "每箱行数",
+        "single": "每箱单行",
+        "multi": "每步多行"
+      },
+      "comingSoon": "即将推出",
+      "exporting": "出口...",
+      "exportError": "导出失败，请重试。"
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "使用模板或人工智能将选定的测试用例转换为自动化脚本。",
+      "templatePlaceholder": "选择一个模板……",
+      "searchPlaceholder": "搜索模板...",
+      "noTemplatesFound": "未找到模板。",
+      "outputModeLabel": "输出模式",
+      "outputModeSingle": "单文件（{count, plural, one {# 案例} other {所有 # 案例}}）",
+      "outputModeIndividual": "{count, plural, one {单个文件 (.zip)} other {单个文件 (.zip)}}",
+      "casesToExport": "{count, plural, one {# 情况} other {# 情况}} 导出",
+      "exportSuccess": "导出成功。",
+      "noAvailableTemplates": "没有可用的模板。请联系您的管理员。"
+    },
+    "aiExport": {
+      "toggleLabel": "利用人工智能生成",
+      "generating": "正在生成...",
+      "generatingProgress": "生成 {current} 的 {total} 案例 ...",
+      "generatingBatch": "在一个文件中生成 {count, plural, one {# 个案例} other {# 个案例}}...",
+      "previewTitle": "导出预览",
+      "previewDescription": "{count, plural, one {# 文件} other {# 生成的文件数}}",
+      "copySuccess": "已复制到剪贴板",
+      "fallbackBadge": "使用模板生成（人工智能不可用）",
+      "retryButton": "重试人工智能生成",
+      "aiGenerated": "人工智能生成",
+      "templateGenerated": "模板已生成",
+      "truncatedWarning": "输出被截断——模型已达到令牌限制。请尝试减小批处理大小或在提示配置中增加最大输出令牌数。",
+      "contextFiles": "{count, plural, one {（上下文文件数量）} other {（上下文文件数量）}}",
+      "noCodeContextHint": "未配置代码仓库。人工智能将使用标准框架模式。",
+      "generatingParallelProgress": "已生成 {done} 个文件，共 {total} 个文件...",
+      "cancelledGeneration": "取消"
+    },
+    "duplicates": {
+      "findDuplicates": "查找重复项",
+      "viewResults": "查看 {count, plural, one {# 结果} other {# 结果集}}",
+      "retryScan": "重试扫描",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "利用人工智能提升成果……",
+      "scanComplete": "重复项分析完成 — {count, plural, =0 {未发现重复项} one {发现潜在重复项数量} other {发现潜在重复项数量}}",
+      "scanFailed": "重复分析失败",
+      "scanFailedDescription": "发生意外错误",
+      "pageTitle": "重复候选人",
+      "pageDescription": "查看上次扫描中发现的潜在重复测试用例。",
+      "rescan": "重新扫描",
+      "cancelScan": "取消扫描",
+      "loading": "正在加载重复的候选对象...",
+      "noDuplicatesFound": "未找到重复项",
+      "noDuplicatesDescription": "上次扫描完成，未发现匹配项。",
+      "loadMore": "加载更多",
+      "filterPlaceholder": "过滤重复项...",
+      "columnConfidence": "信心",
+      "columnCaseA": "案例 A",
+      "columnCaseB": "案例 B",
+      "columnMatchedFields": "匹配字段",
+      "columnScore": "分数",
+      "compareButton": "比较",
+      "viewCaseDetails": "查看案件详情",
+      "selectAll": "全选",
+      "selectRow": "选择行",
+      "selected": "{count, plural, one {# 已选择} other {# 已选择}}",
+      "bulkDismiss": "非重复项 ({count})",
+      "bulkLink": "链接为相关（{count}）",
+      "bulkDismissSuccess": "{count, plural, one {# 已解散的配对} other {# 已解散的配对}}",
+      "bulkLinkSuccess": "{count, plural, one {# 配对链接} other {# 配对链接}}",
+      "bulkError": "部分操作失败，请重试。",
+      "tableHint": "单击行或“比较”按钮，查看并解决重复项。",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "比较这些潜在的重复项，并选择如何解决它们。",
+      "selectPrimary": "点击案例即可将其选为主合并案例。",
+      "selectedAsPrimary": "选为主要",
+      "mergeButton": "保持主要",
+      "linkButton": "链接相关",
+      "dismissButton": "非重复项",
+      "merging": "合并中……",
+      "linking": "正在连接……",
+      "dismissing": "解雇……",
+      "mergeSuccess": "案例合并成功。 {runsTransferred, plural, =0 {未传输任何测试运行} one {已传输的测试运行次数} other {已传输的测试运行次数}}。",
+      "linkSuccess": "关联案例。",
+      "dismissSuccess": "该对嫌疑人已被排除。它不会出现在以后的扫描结果中。",
+      "resolveError": "解析重复键值对失败，请重试。",
+      "loadingDetails": "正在加载案件详情……",
+      "caseDetailsError": "案件详情加载失败。",
+      "sourceLabel": "来源",
+      "fieldValuesLabel": "字段值",
+      "lastRunLabel": "最后一次",
+      "noFieldValues": "无字段值",
+      "noLastRun": "永远不要跑",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "没有文件夹",
+      "duplicateWarning": "发现可能重复项",
+      "duplicateWarningDescription": "{count, plural, one {# 现有案例} other {# 现有案例}} 可能涵盖类似功能",
+      "duplicateWarningReview": "审查",
+      "importWarning": "可能重复",
+      "importWarningTooltip": "此案例名称类似于 {count, plural, one {# 现有案例} other {# 现有案例}}: {names}",
+      "importIntraWarning": "导入过程中出现重复项",
+      "importIntraWarningTooltip": "此导入中的行 {rows} 具有相同或非常相似的名称",
+      "checkingDuplicates": "正在检查重复项……"
+    },
+    "generateTestCases": {
+      "buttonText": "生成测试用例",
+      "title": "利用人工智能生成测试用例",
+      "description": "利用人工智能技术，根据外部问题或文档自动生成全面的测试用例。",
+      "loadingResults": "正在加载生成的测试用例...",
+      "generatingPreparing": "正在准备请求……",
+      "generatingCallingAi": "等待人工智能生成测试用例……",
+      "generatingStreaming": "AI正在生成测试用例 {count}...",
+      "generatingStreamingPage": "AI 正在生成测试用例 {count} — 第 {current} 页，共 {total}页： {page}",
+      "generatingProcessing": "正在处理生成的测试用例……",
+      "generatingHint": "这可能需要一分钟，具体取决于您的原始资料的复杂程度。",
+      "steps": {
+        "selectIssue": "选择来源",
+        "selectTemplate": "选择模板",
+        "reviewGenerated": "审核与导入"
+      },
+      "selectSource": {
+        "title": "选择需求来源",
+        "description": "选择是从问题文档还是需求文档生成测试用例。",
+        "folderContextTip": "为避免重复，系统将使用“{folderName}”及其父/子文件夹中的现有测试用例作为上下文。请确保在继续操作前已选择正确的文件夹。",
+        "currentFolder": "当前文件夹",
+        "fromIssue": "期刊",
+        "fromDocument": "从文档",
+        "documentTitle": "文件标题",
+        "documentTitlePlaceholder": "请输入您的需求文档标题",
+        "documentDescription": "需求文档",
+        "documentDescriptionPlaceholder": "请将需求文档内容粘贴到此处……",
+        "documentPriority": "优先级（可选）",
+        "selectPriority": "选择优先级",
+        "saveDocument": "保存文档要求",
+        "fromUrl": "来自 URL",
+        "recentGenerations": "最近的从 URL 生成测试用例的作业",
+        "recentJobInfo": "{pages, plural, one {# 页数} other {# 页数}}{hasTestCases, select, true { · {testCases, plural, one {# 测试用例} other {# 测试用例}}} other {}}",
+        "recentJobHasResults": "准备审核",
+        "recentJobClickToGenerate": "点击生成测试用例",
+        "recentJobCrawling": "正在爬取... {pages, plural, one {# 页数} other {# 页数}} 目前为止",
+        "removeJobTitle": "移除生成",
+        "confirmRemoveJob": "这将删除缓存的爬虫记录和所有生成的测试用例。您可以随时从同一 URL 重新生成。",
+        "loadingRecentJobs": "正在加载最近的职位...",
+        "urlInput": "页面网址",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "这个网址包含什么内容？",
+        "urlModeRequirements": "要求",
+        "urlModeRequirementsHint": "页面描述了要构建的内容",
+        "urlModeApplication": "应用",
+        "urlModeApplicationHint": "Page 是要测试的应用程序",
+        "urlValidationError": "请输入以 http:// 或 https:// 开头的有效网址。",
+        "followLinks": "点击链接",
+        "followLinksHint": "只会抓取与您输入的网址位于同一域名下的页面。",
+        "maxDepth": "最大深度",
+        "maxPages": "最大页数",
+        "crawlProgress": "{current, plural, one {目前已获取第 # 页...} other {目前已获取第 # 页...}}",
+        "generatingSinglePage": "正在生成测试用例……",
+        "generatingSetup": "准备生成测试用例……",
+        "robotsSkipped": "{count, plural, one {# 跳过的页码} other {# 跳过的页码}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "选择外部问题",
+        "description": "从外部系统（例如 Jira）中选择一个问题来生成测试用例。",
+        "searchButton": "查找问题"
+      },
+      "selectTemplate": {
+        "title": "选择测试用例模板",
+        "description": "选择用于生成测试用例的模板。人工智能将根据此模板填充字段。",
+        "placeholder": "选择一个模板……",
+        "fieldsDescription": "选择人工智能应自动填充的字段。必填字段始终包含在内。",
+        "requiredOnly": "仅需"
+      },
+      "addNotes": {
+        "title": "添加备注和指导",
+        "description": "提供更多背景信息和指导，以帮助人工智能生成更好的测试用例。",
+        "quantity": "要生成的测试用例数量",
+        "placeholder": "添加测试用例生成的具体说明……\n\n例如：\n• 重点关注安全测试\n• 包含边界情况和边缘情况\n• 同时测试正常路径和错误路径\n• 考虑移动端和桌面端场景\n• 重点关注 API 测试",
+        "suggestions": "快速建议：",
+        "quantityOptions": {
+          "justOne": "只有一个",
+          "couple": "一对夫妇（2）",
+          "few": "几个（2-3）",
+          "several": "若干（4-6）",
+          "many": "许多（7-10）",
+          "maximum": "最大限度"
+        },
+        "suggestionItems": {
+          "security": "重点进行安全测试",
+          "edgeCases": "包括极端情况",
+          "happyPath": "仅测试正常路径",
+          "mobile": "考虑移动场景",
+          "api": "专注于 API 测试",
+          "accessibility": "包含无障碍测试"
+        }
+      },
+      "review": {
+        "title": "审查生成的测试用例",
+        "description": "查看 AI 生成的测试用例，进行必要的修改，并选择要导入的用例。",
+        "selected": "已选择 {count} 中的 {total}",
+        "moreSteps": "……以及 {count, plural, one {# 更多步骤} other {# 更多步骤}}",
+        "templateFields": "模板字段：",
+        "moreFields": "……以及 {count, plural, one {# 更多字段} other {# 更多字段}}",
+        "crawledUrls": "{count, plural, one {# 已抓取页面数} other {# 已抓取页数}}",
+        "spaWarning": "此页面可能需要 JavaScript 渲染。结果可能不完整。",
+        "filterByPage": "按页面筛选",
+        "allPages": "所有页面（{pages, plural, one {# 页} other {# 页数}}, {cases, plural, one {# 案例} other {# 案例数}}）"
+      },
+      "generatingLegacy": "利用人工智能生成测试用例……",
+      "expandProgress": "{done} 中的 {total} 生成",
+      "import": "{count, plural, =0 {导入测试用例} =1 {导入 1 个测试用例} other {导入 # 个测试用例}}",
+      "importing": "{count, plural, =0 {正在导入测试用例...} =1 {正在导入 1 个测试用例...} other {正在导入 # 个测试用例...}}",
+      "openInExternalSystem": "打开方式 {provider}",
+      "externalSystem": "外部系统",
+      "autoGenerateTags": "自动为测试用例生成标签",
+      "success": {
+        "imported": "{count, plural, =1 {成功导入 1 个测试用例} other {成功导入 # 个测试用例}}"
+      },
+      "importData": {
+        "issueDescription": "与测试用例生成相关的外部问题",
+        "generatedFolderName": "生成"
+      },
+      "errors": {
+        "generateFailed": "测试用例生成失败，请重试。",
+        "importFailed": "导入测试用例失败，请重试。",
+        "noTestCasesGenerated": "未生成任何测试用例。请使用不同的输入重试。",
+        "jobNoLongerAvailable": "此版本已不再可用。请从“生成测试用例”向导开始新的版本。",
+        "noAiModel": "此项目未配置任何 AI 模型。请在项目设置中配置 AI 模型。",
+        "noIssueSelected": "请选择一个问题以生成测试用例。",
+        "noDocumentProvided": "请提供需求文档的详细信息。",
+        "noTemplateSelected": "请为测试用例选择一个模板。",
+        "noFieldsSelected": "请至少选择一个字段以生成内容。",
+        "noTestCasesSelectedForImport": "请至少选择一个测试用例导入。",
+        "templateRequired": "必须选择模板。请返回并选择模板。",
+        "repositoryNotFound": "项目仓库未找到。请联系管理员。",
+        "workflowNotConfigured": "项目工作流程未配置。请检查项目设置。",
+        "authenticationError": "身份验证错误。请刷新页面后重试。",
+        "caseCreationFailed": "创建测试用例失败： {name}",
+        "caseAlreadyExists": "此文件夹中已存在测试用例“{name}”。",
+        "invalidTemplateConfig": "测试用例“{name}”的模板配置无效。",
+        "nameTooLong": "测试用例名称“{name}”过长，请使用较短的名称。",
+        "caseCreationError": "创建“{name}”失败： {error}",
+        "templateNotFound": "找不到所选模板。请刷新页面重试。",
+        "repositoryConfigError": "项目仓库配置错误。请联系您的管理员。",
+        "workflowConfigError": "项目工作流程配置错误。请检查项目设置。",
+        "permissionDenied": "您没有权限在此项目中创建测试用例。",
+        "validationFailed": "数据验证失败。请检查测试用例内容并重试。",
+        "databaseError": "数据库连接错误，请稍后再试。",
+        "genericImportError": "导入失败： {error}",
+        "networkRoutingError": "网络路由或服务器配置问题 - 收到的是 HTML 错误页面而不是 API 响应",
+        "invalidSourceConfig": "无效的源配置",
+        "failedToCreateCaseVersion": "创建案例版本失败",
+        "noUrlProvided": "请输入要从中生成测试用例的 URL",
+        "urlFetchFailed": "无法从提供的URL获取内容。请检查URL并重试。",
+        "llm": {
+          "genericTitle": "AI生成误差",
+          "genericMessage": "使用 AI 生成测试用例时出错。请重试或调整您的输入。",
+          "overloaded": {
+            "title": "服务暂时不可用",
+            "message": "人工智能服务目前访问量较大，请稍后再试。"
+          },
+          "quota": {
+            "title": "使用次数已达上限",
+            "message": "您已达到本时段的AI使用限额。请稍后再试或联系您的管理员。"
+          },
+          "timeout": {
+            "title": "请求超时",
+            "message": "AI请求耗时过长。这可能是由于需求复杂或测试用例数量庞大造成的。"
+          },
+          "network": {
+            "title": "网络错误",
+            "message": "无法连接到人工智能服务。请检查您的网络连接并重试。"
+          },
+          "unauthorized": {
+            "title": "AI服务认证失败",
+            "message": "AI 服务拒绝了我们的凭证。管理员需要在管理设置中查看 LLM 集成的 API 密钥。"
+          },
+          "forbidden": {
+            "title": "AI 服务访问被拒绝",
+            "message": "AI 服务拒绝了此请求。管理员需要验证 LLM 集成的权限和项目访问权限。"
+          },
+          "projectNotFound": {
+            "title": "项目未找到",
+            "message": "我们找不到这个项目，或者您没有在此处使用人工智能生成技术的许可。"
+          },
+          "noIntegration": {
+            "title": "无活跃LLM集成",
+            "message": "此项目未配置任何有效的 LLM 集成。管理员需要在管理设置中启用它。"
+          },
+          "invalidRequest": {
+            "title": "无效请求",
+            "message": "AI生成请求缺少必要信息。请刷新页面后重试。"
+          },
+          "retryButton": "重试",
+          "dismissButton": "解雇",
+          "suggestionsHeading": "建议",
+          "suggestions": {
+            "retryLater": "几分钟后再试。",
+            "contactAdmin": "如果问题仍然存在，请联系您的管理员。",
+            "checkStatus": "检查人工智能服务状态",
+            "checkNetwork": "请检查您的网络连接"
+          },
+          "timestampLabel": "发生错误",
+          "showDetails": "显示详情",
+          "hideDetails": "隐藏详情",
+          "copyDetails": "复制详情",
+          "detailsCopied": "错误详情已复制到剪贴板"
+        }
+      },
+      "unsavedEdits": {
+        "title": "未保存的编辑",
+        "description": "{count, plural, =1 {您有 1 个测试用例存在未保存的编辑。} other {您有 # 个测试用例存在未保存的编辑。}}",
+        "warning": "如果您在不保存的情况下继续操作，您的更改将会丢失。",
+        "saveAllAndImport": "全部保存并导入",
+        "discardAndImport": "放弃编辑并导入"
+      },
+      "linkedIssuesDroppedTitle": "部分相关问题未包含在内。",
+      "linkedIssuesDropped": "{count, plural, =1 {# 关联的问题已被删除} other {# 关联的问题已被删除}} 由于代币预算： {keys}。",
+      "linkedIssuesPreviewHeading": "将会包含的相关问题"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "添加标签",
+      "title": "添加新标签",
+      "fields": {
+        "name_error": "标签名称为必填项"
+      },
+      "errors": {
+        "nameExists": "已存在同名标签"
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "已存在同名标签"
+      }
+    },
+    "filterPlaceholder": "筛选标签...",
+    "defaultName": "未命名标签",
+    "noProject": "无项目",
+    "description": "使用标签管理和组织您的测试用例和会话",
+    "detail": {
+      "title": "标签详情",
+      "filterPlaceholder": "筛选项目...",
+      "noResults": "未找到任何物品",
+      "noFilterResults": "没有符合当前筛选条件的商品。",
+      "filters": {
+        "hideCompletedSessions": "隐藏已完成的会话",
+        "hideCompletedTestRuns": "隐藏已完成的测试运行",
+        "caseTypeLabel": "案件类型",
+        "allCases": "全部"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "搜索标签...",
+      "searchOrAddPlaceholder": "搜索或添加标签……",
+      "noOptions": "没有选项"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "附件查看器"
+    },
+    "delete": {
+      "confirmMessage": "您确定要删除此附件吗？",
+      "deferredMessage": "保存时，此附件将被删除。"
+    }
+  },
+  "runs": {
+    "notFound": "未找到测试运行。",
+    "add": {
+      "title": "添加测试运行",
+      "description": "向项目中添加一个新的测试运行",
+      "success": {
+        "title": "测试运行已成功添加",
+        "description": "测试运行已添加到项目中。",
+        "descriptionMultiple": "{count, plural, one {# 已为 '{name}' 创建} other {# 已为 '{name}' 创建}}"
+      },
+      "estimates": {
+        "manual": "预计人工时间",
+        "automated": "预计自动完成时间",
+        "mixed": "预计手动/自动时间"
+      },
+      "creatingProgress": "创建测试运行 {current} ，测试运行为 {total}..."
+    },
+    "magicSelect": {
+      "title": "魔法选择",
+      "description": "基于测试运行上下文的 AI 驱动的测试用例选择",
+      "counting": "正在寻找相关的测试用例……",
+      "reasoning": "人工智能推理",
+      "reviewSelection": "审查建议的测试用例",
+      "viewSuggested": "查看推荐案例",
+      "tokenUsage": "使用的 {total} 令牌",
+      "noLlmIntegration": "AI 功能需要与 LLM 集成。请在项目设置中进行配置。",
+      "configure": {
+        "title": "测试用例范围",
+        "description": "在仓库中找到 {count, plural, =1 {# 测试用例} other {# 测试用例}}",
+        "descriptionFiltered": "找到 {count, plural, =1 {# 个可能相关的测试用例} other {# 个可能相关的测试用例}} 来自 {total, plural, =1 {# 总计} other {# 仓库中总计}}",
+        "noMatchesTitle": "未找到匹配的测试用例",
+        "noMatchesDescription": "测试运行名称和描述与任何测试用例都不匹配。请返回上一步，添加更具体的详细信息，例如功能名称、组件名称或测试用例中出现的关键字。",
+        "maxResultsTitle": "最大测试用例匹配数",
+        "maxResultsDescription": "搜索条件匹配了大量测试用例。为了获得更精准的结果，请返回上一步，为测试运行添加更具体的详细信息。",
+        "batchSize": "批量大小",
+        "batchSizeAll": "所有案例（单个请求）",
+        "batchSizePercent": "{percent}% ({count} 个案例)",
+        "requestsNeeded": "{count, plural, =1 {# 将发出 AI 请求} other {# 将发出 AI 请求}}",
+        "batchNote": "所有批次的结果将合并。"
+      },
+      "loading": {
+        "batch": "正在处理批次 {current} ，共 {total}",
+        "analyzing": "分析测试用例……",
+        "progress": "分析了 {analyzed} 个测试用例中的 {total} 个测试用例……",
+        "waitingForAi": "正在等待 AI 响应（批次 {batch} ，共 {total} 批次）...",
+        "selectedSoFar": "{count, plural, =1 {# 目前已选择的测试用例数} other {# 目前已选择的测试用例数}}",
+        "resolving_integration": "解决人工智能集成问题……",
+        "fetching_cases": "正在获取测试用例..."
+      },
+      "success": {
+        "title": "建议的测试用例",
+        "description": "{count, plural, =1 {# 已选择测试用例} other {# 已选择测试用例}} 根据您的测试运行上下文",
+        "linkedCasesAdded": "{count, plural, =1 {# 关联案例自动包含} other {# 关联案例自动包含}}",
+        "truncationWarningTitle": "部分结果",
+        "truncationWarning": "{count, plural, =1 {# 批次被截断} other {# 批次被截断}} 由 AI 模型截断 — 某些测试用例可能未被评估。"
+      },
+      "noSuggestions": {
+        "title": "没有匹配的测试用例",
+        "description": "没有测试用例符合要求。请尝试添加更多上下文或说明。"
+      },
+      "clarification": {
+        "label": "补充信息（可选）",
+        "placeholder": "添加更多上下文信息，以帮助选择相关的测试用例……",
+        "refine": "优化选择"
+      },
+      "actions": {
+        "start": "分析测试用例",
+        "startBatched": "分析测试用例（{count, plural, one {# 批次} other {# 批次数}}）",
+        "accept": "添加到选择"
+      },
+      "errors": {
+        "title": "选择失败",
+        "generic": "选择测试用例时出错，请重试。",
+        "noTestRunName": "请在使用 Magic Select 之前输入测试运行名称。"
+      }
+    },
+    "delete": {
+      "title": "删除测试运行",
+      "description": "您确定要删除此次测试运行吗？结果将保留以供历史分析。",
+      "warning": "此操作无法撤销。",
+      "toast": {
+        "loading": "删除测试运行...",
+        "success": "测试运行已成功删除",
+        "error": {
+          "title": "删除测试运行失败",
+          "description": "删除测试运行时发生错误"
+        }
+      }
+    },
+    "summary": {
+      "title": "测试运行总结",
+      "description": "查看测试运行摘要",
+      "activeRunsAndEstTime": "活跃运行次数及预计时间",
+      "activeRunsLabel": "跑",
+      "totalEstTime": "预计总时间",
+      "responsibleUsers": "负责任的用户",
+      "allActiveRuns": "所有正在进行的运行",
+      "recentResultsTitle": "近期手动结果",
+      "recentResultsDescription": "查看测试运行的最新结果",
+      "recentAutomatedResultsTitle": "近期自动结果",
+      "noRecentAutomatedResults": "未找到最近的自动搜索结果。",
+      "recentResultsDateRange": "日期范围",
+      "recentResultsElapsed": "过去",
+      "noRecentResults": "未找到近期结果。",
+      "completionTrendTitle": "完成趋势（过去 6 个月）",
+      "workDistributionTitle": "工作分配",
+      "workDistributionDescription": "按受让人估算的工作分配。",
+      "noWorkDistributionData": "没有正在进行的、有指派对象或预估时间的会话可供显示。"
+    },
+    "details": {
+      "title": "测试运行详情",
+      "description": "查看测试运行详情"
+    },
+    "duplicateDialog": {
+      "title": "重复测试运行",
+      "description": "创建测试运行的副本 <nameStyle>{name}</nameStyle>。",
+      "fields": {
+        "duplicateScope": {
+          "label": "待复现的测试用例",
+          "allCases": "所有测试用例",
+          "specificStatuses": "具有特定状态的测试用例"
+        },
+        "statusesToInclude": {
+          "label": "测试用例包括",
+          "description": "选择要包含在重复测试运行中的测试用例的状态。",
+          "noStatuses": "本次测试运行未发现任何特定状态，或结果仍在加载中。",
+          "noStatusesRecorded": "本次运行未记录任何具体状态。复制操作将包含所有测试用例（通常标记为“未测试”）。"
+        },
+        "copyAssignments": {
+          "label": "测试用例分配",
+          "copy": "复制现有测试用例分配",
+          "assign": "重复测试运行中的所有测试用例将保留其现有分配。",
+          "unassign": "重复测试运行中的所有测试用例都将被取消分配。"
+        }
+      },
+      "successMessage": "测试运行“{name}”已成功复制。",
+      "errorMessage": "测试运行失败。错误： {error}"
+    },
+    "filter": {
+      "placeholder": "过滤器测试运行..."
+    },
+    "typeFilter": {
+      "label": "展示",
+      "both": "手动和自动"
+    },
+    "empty": {
+      "noMatchingCompleted": "没有符合您筛选条件的已完成测试运行。"
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "主要的",
+      "projects": "项目",
+      "templatesAndFields": "模板和字段",
+      "fields": "田野",
+      "workflows": "工作流程",
+      "statuses": "状态",
+      "milestoneTypes": "里程碑类型",
+      "configurations": "配置",
+      "users": "用户",
+      "groups": "团体",
+      "roles": "角色",
+      "tags": "标签",
+      "issues": "问题",
+      "appConfig": "应用程序配置",
+      "notifications": "通知",
+      "imports": "数据导入",
+      "integrations": "问题整合",
+      "webhooks": "网络钩子",
+      "llm": "人工智能模型",
+      "prompts": "提示配置",
+      "exportTemplates": "导出模板",
+      "codeRepositories": "代码库",
+      "quickScript": "QuickScript",
+      "sso": "验证",
+      "security": "安全",
+      "trash": "垃圾",
+      "reports": "报告",
+      "shares": "管理股份",
+      "elasticsearch": "搜索引擎",
+      "queues": "作业队列",
+      "auditLogs": "审计日志",
+      "apiTokens": "API令牌",
+      "quickscriptTemplates": "QuickScript模板",
+      "testManagement": "测试管理",
+      "peopleAndAccess": "人员与通道",
+      "toolsAndIntegrations": "工具与集成",
+      "system": "系统"
+    },
+    "imports": {
+      "description": "将外部测试管理工具中的数据导入TestPlanIt。",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "上传 Testmo JSON 导出文件以分析其内容并准备迁移映射。",
+        "wizard": {
+          "steps": {
+            "upload": "上传导出",
+            "analysis": "综述分析",
+            "mapping": "配置映射",
+            "import": "监控导入"
+          },
+          "stepIndicator": "步骤 {step} 的 {total}"
+        },
+        "fileLabel": "Testmo JSON 文件",
+        "fileHelp": "选择您从 Testmo 下载的 JSON 导出文件。",
+        "analyze": "分析导出",
+        "analyzing": "分析中……",
+        "reset": "结果清晰",
+        "job": {
+          "discoveringDatasets": "发现数据集……",
+          "scanningFile": "正在扫描 testmo 导出文件...",
+          "datasetsProcessed": "{processed, number} 数据集{processed, plural, one {} other {s}} 已处理",
+          "datasetsProcessedWithTotal": "{processed, number} 的 {total, number} 数据集{total, plural, one {} other {s}} 已处理",
+          "rowsProcessed": "已处理 {value, number} 行",
+          "itemsProcessed": "已处理 {processed, number} 项中的 {total, number} 项",
+          "analysisInProgress": "分析导出…",
+          "cancel": "取消导入",
+          "cancelRequested": "取消请求",
+          "processingRate": "速度：",
+          "estimatedTimeRemaining": "预计剩余时间：",
+          "datasetsLabel": "数据集：",
+          "rowsProcessedLabel": "行："
+        },
+        "summaryHeading": "导出摘要",
+        "summary": {
+          "datasets": "数据集",
+          "fileName": "文件名",
+          "fileSize": "文件大小",
+          "analysisTime": "分析时间"
+        },
+        "datasetTable": {
+          "name": "数据集",
+          "rows": "行",
+          "samples": "采集的样本"
+        },
+        "status": {
+          "truncated": "截断"
+        },
+        "selectDataset": "选择数据集",
+        "schema": "模式",
+        "samples": "示例行",
+        "noSamples": "该数据集未采集到任何样本。",
+        "mappingHeading": "映射配置",
+        "mappingRefresh": "刷新分析",
+        "mappingDescription": "查看分析详情并将 Testmo 实体映射到现有的 TestPlanIt 记录，或者选择创建新记录。",
+        "mappingAnalysisError": "我们无法生成映射分析。请重试。",
+        "mappingLoading": "建筑测绘分析…",
+        "mappingSummaryHeading": "检测到的实体",
+        "mappingSummaryPending": "{count, plural, =1 {# 待处理} other {# 待处理}}",
+        "mappingOutstandingTitle": "解决未决映射问题",
+        "mappingOutstandingDescription": "在开始导入之前，请完成剩余的映射。",
+        "mappingOutstandingItem": "{count, plural, =1 {# 未解决项} other {# 未解决项}} 在 {label}",
+        "mappingSummaryTemplateFields": "模板字段",
+        "mappingDatasetLabels": {
+          "field_values": "字段值",
+          "repository_case_values": "存储库案例值",
+          "configs": "配置设置",
+          "session_issues": "会议问题",
+          "session_tags": "会话标签",
+          "states": "工作流状态",
+          "statuses": "状态",
+          "templates": "模板",
+          "template_fields": "模板字段",
+          "milestone_types": "里程碑类型",
+          "roles": "角色",
+          "users": "用户",
+          "groups": "团体",
+          "user_groups": "用户组",
+          "issue_targets": "问题集成",
+          "tags": "标签",
+          "sessions": "会议",
+          "session_results": "会议结果",
+          "fields": "田野",
+          "projects": "项目",
+          "repositories": "存储库",
+          "repository_folders": "存储库文件夹",
+          "repository_cases": "存储库案例",
+          "repository_case_steps": "存储库案例步骤",
+          "repository_case_tags": "存储库案例标签",
+          "milestones": "里程碑",
+          "runs": "测试运行",
+          "run_tests": "测试运行用例",
+          "run_results": "测试运行结果",
+          "run_result_steps": "测试运行步骤结果",
+          "run_links": "测试运行链接",
+          "run_tags": "测试运行标签",
+          "issues": "问题",
+          "milestone_issues": "里程碑问题",
+          "repository_case_issues": "存储库案例问题",
+          "run_issues": "测试运行问题",
+          "run_result_issues": "测试运行结果问题",
+          "session_result_issues": "会议结果问题",
+          "automation_cases": "自动化案例",
+          "automation_runs": "自动化运行",
+          "automation_run_tests": "自动化运行测试",
+          "automation_run_test_fields": "自动化运行测试字段",
+          "automation_run_links": "自动化运行链接",
+          "automation_run_tags": "自动化运行标签",
+          "session_values": "会话值"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "查看工作流状态，以映射或创建 TestPlanIt 工作流。",
+          "statuses": "配置 Testmo 状态如何映射到 TestPlanIt 状态。",
+          "templates": "审核从 Testmo 导入的模板定义。",
+          "template_fields": "检查导出文件中包含的模板字段定义。",
+          "fields": "查看从 Testmo 导出的自定义字段记录。",
+          "field_values": "检查导出文件中捕获的字段值定义。",
+          "milestone_types": "检查导出文件中捕获的里程碑类型定义。",
+          "roles": "查看角色定义以了解Testmo权限。",
+          "users": "查看Testmo导出文件中检测到的用户帐户。",
+          "groups": "复习从 Testmo 继承下来的小组作业。",
+          "configs": "将配置名称映射到 TestPlanIt 类别和变体。",
+          "tags": "检查Testmo数据中出现的标签值。",
+          "repository_case_values": "分配给测试用例的多选值。",
+          "sessions": "会话始终作为新会话创建。",
+          "session_results": "会话结果与会话相关联。",
+          "session_issues": "会话问题与会话相关。",
+          "session_tags": "会话标签与会话相关联。",
+          "issue_targets": "将 Testmo 问题目标映射到 TestPlanIt 集成（Jira、GitHub 等）。"
+        },
+        "mappingDatasetDefaultDescription": "在 Testmo 导出中检测到评论 {dataset} 。",
+        "mappingDatasetCount": "{count, number} 记录{count, plural, one {} other {s}} 检测到",
+        "mappingDatasetNoEntitiesTitle": "地图上没有任何东西。",
+        "mappingDatasetNoEntitiesDescription": "此数据集无需映射。准备就绪后，请继续处理下一个数据集。",
+        "mappingDatasetUnsupportedTitle": "无需映射",
+        "mappingDatasetUnsupportedDescription": "这些记录将自动导入并连接到TestPlanIt中的相关记录。无需手动映射。",
+        "mappingDatasetEmptyTitle": "未保存任何数据集",
+        "mappingDatasetEmptyDescription": "分析过程中未保留任何用于配置的数据集。如果您需要其他数据，请上传其他导出文件。",
+        "importProgressTitle": "导入进度",
+        "importProgressDescription": "{count, plural, =0 {所有已导入的记录（涵盖所有跟踪实体）。} =1 {已导入的记录（涵盖所有跟踪实体）。} other {已导入的记录（涵盖所有跟踪实体）。}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {无剩余记录} =1 {剩余 1 条记录} other {剩余记录数}}",
+        "importProgressProcessed": "{processed, number}/{total, number} 记录已导入",
+        "importProgressAria": "{percent}导入完成百分比",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "总耗时：",
+        "activityLogTitle": "进口活动",
+        "activityLogDescription": "后台导入步骤的详细日志。时间戳基于服务器时区。",
+        "activitySummaryProcessed": "{count, plural, =1 {# 已处理记录数} other {# 已处理记录数}}",
+        "activitySummaryCreated": "{count, plural, =1 {# 创建} other {# 创建}}",
+        "activitySummaryMapped": "{count, plural, =1 {# 已映射} other {# 已映射}}",
+        "activitySummaryUnknown": "导入步骤",
+        "activityDefaultMessage": "导入更新",
+        "previousImportsHeading": "查看之前的进口记录",
+        "previousImportsDescription": "从已完成的导入中加载分析结果，以检查配置或活动日志。",
+        "previousImportsRefresh": "刷新列表",
+        "previousImportsPlaceholder": "选择之前的导入",
+        "previousImportsEmpty": "未找到您账户之前的任何导入记录。",
+        "previousImportsCreatedLabel": "创建时间： ",
+        "previousImportsFileLabel": "文件： ",
+        "previousImportsNoFilename": "未知文件",
+        "jobHistoryLoadFailed": "我们无法加载之前导入的作业。",
+        "jobLoadFailed": "我们无法加载该导入作业。",
+        "uploadProgressAnalyzing": "上传完成。正在分析文件…",
+        "uploadProgressComplete": "上传完成",
+        "etaLabel": "预计到达时间： {time}",
+        "startImportButton": "开始导入",
+        "workflowCreate": {
+          "nameLabel": "工作流名称",
+          "namePlaceholder": "输入工作流名称",
+          "scopePlaceholder": "选择范围",
+          "iconColorLabel": "图标和颜色",
+          "typeLabel": "工作流程类型"
+        },
+        "mappingDatasets": "需要审核的数据集",
+        "mappingImportConfiguration": "导入配置",
+        "mappingExportConfiguration": "导出配置",
+        "mappingImportConfigurationFailed": "我们无法导入该配置文件。请确认其为有效的 JSON 格式，然后重试。",
+        "mappingInvalidConfiguration": "配置必须为有效的JSON格式。",
+        "mappingSaveFailed": "配置保存失败，请重试。",
+        "mappingSaveConfiguration": "保存配置",
+        "mappingSavingConfiguration": "正在保存…",
+        "mappingStartImport": "开始后台导入",
+        "mappingStartingImport": "开始导入…",
+        "mappingImportFailed": "后台导入失败，请稍后再试。",
+        "mappingImportDisabled": "启动后台导入前请保存配置。",
+        "mappingImportInProgress": "后台导入进行中",
+        "mappingImportInProgressDescription": "导入进程正在处理配置。您可以在上方监控状态。",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# 记录} other {# 记录}} ",
+          "columnSource": "Testmo实体",
+          "columnSourceDetails": "细节",
+          "columnSuggestedWorkflowType": "建议类型",
+          "columnTarget": "目标",
+          "workflowTypeUnknown": "未检测到",
+          "actionMap": "映射到现有",
+          "actionCreate": "创建新的",
+          "workflowTypePlaceholder": "选择类型",
+          "noWorkflowsAvailable": "暂无可用工作流程。",
+          "noStatusesAvailable": "暂无状态信息。",
+          "noGroupsAvailable": "暂无可用群组。",
+          "groupSelectPlaceholder": "选择组",
+          "groupNotePlaceholder": "备注（可选）",
+          "groupNoteEmpty": "未提供更多细节。",
+          "noUsersAvailable": "没有可用用户。",
+          "userNoExistingTargets": "没有可用于映射的用户。",
+          "userNamePlaceholder": "姓名",
+          "userAccessPlaceholder": "选择访问级别",
+          "userRoleUnavailable": "暂无可分配的角色。",
+          "userPasswordPlaceholder": "临时密码",
+          "userPasswordHint": "提供一个临时密码。用户登录后可以更改密码。",
+          "userActiveLabel": "活跃账户",
+          "userDisplayFallback": "用户 {id}",
+          "userMissingRequired": "缺少必要信息",
+          "noConfigurationsAvailable": "暂无可用配置。",
+          "configurationNoTokens": "在此配置中未检测到任何变异体。",
+          "configurationNoExistingTargets": "没有可映射的配置。",
+          "configurationNamePlaceholder": "输入配置名称",
+          "configurationVariantLabel": "变体 {index}",
+          "configurationVariantActionLabel": "应该如何处理这种变体？",
+          "configurationVariantActionPlaceholder": "选择一个选项",
+          "configurationVariantMapOption": "映射到现有变体",
+          "configurationVariantExistingCategoryOption": "在现有类别中创建变体",
+          "configurationVariantNewCategoryOption": "创建新类别和变体",
+          "configurationVariantSelectLabel": "选择变体",
+          "configurationVariantNoVariants": "没有可供映射的变体。",
+          "configurationVariantCategoryLabel": "类别",
+          "configurationVariantNameLabel": "变体名称",
+          "configurationVariantNamePlaceholder": "输入变体名称",
+          "configurationVariantNoCategories": "暂无分类。",
+          "configurationVariantCategoryNameLabel": "类别名称",
+          "configurationVariantCategoryNamePlaceholder": "输入类别名称",
+          "noTemplateFieldsAvailable": "没有可用的模板字段。",
+          "templateFieldDisplayFallback": "字段 {id}",
+          "templateFieldUnknownTemplate": "未知模板",
+          "templateFieldTargetCase": "案例字段",
+          "templateFieldTargetResult": "结果字段",
+          "templateFieldSelectPlaceholder": "选择字段",
+          "templateFieldNoExistingTargets": "没有可映射的字段。",
+          "templateFieldTypePlaceholder": "选择字段类型",
+          "templateFieldRestrictedLabel": "受限字段",
+          "templateFieldOptionsLabel": "下拉选项",
+          "templateFieldOptionsPlaceholder": "每行输入一个选项",
+          "templateFieldOptionsHint": "每个选项之间用新行隔开。",
+          "templateFieldOptionsListLabel": "选项",
+          "templateFieldOptionsCheckedLabel": "默认选中",
+          "templateFieldOptionsMinValueLabel": "最小值",
+          "templateFieldOptionsMaxValueLabel": "最大值",
+          "templateFieldOptionsMinIntegerLabel": "最小整数",
+          "templateFieldOptionsMaxIntegerLabel": "最大整数",
+          "templateFieldNewFieldSummaryTitle": "新字段详情",
+          "templateFieldNewFieldSummaryDescription": "查看将用于创建此 TestPlanIt 字段的值。",
+          "templateFieldConfigureFieldButton": "配置详细信息",
+          "templateFieldEditFieldButton": "编辑详情",
+          "templateFieldSummaryMissingValue": "未设置",
+          "templateFieldSummaryMissingDetailsHint": "请先提供新字段的详细信息再继续。",
+          "templateFieldModalSaveButton": "保存详细信息",
+          "templateFieldTargetTypeLabel": "目标类型",
+          "templateFieldTypeMismatchWarning": "所选字段类型 {target} 与 Testmo 字段类型 {source}不匹配。",
+          "templateFieldDuplicateTargetWarning": "所选目标已映射到另一个 Testmo 字段。请选择其他目标。",
+          "templateFieldTargetAlreadyUsed": "已映射",
+          "templateFieldMappedSummary": "映射到 {name} ({type})",
+          "templateFieldIssueMissingTarget": "选择目标字段。",
+          "templateFieldIssueMissingDetails": "请先提供显示名称、系统名称和字段类型，然后再继续。",
+          "noTemplatesAvailable": "暂无模板可用。",
+          "templateColumnFields": "田野",
+          "templateFieldStatusMapped": "已映射",
+          "templateFieldStatusCreate": "创建新字段",
+          "templateFieldStatusMissing": "未映射",
+          "templateFieldStatusMismatch": "目标错配",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# 案例字段} other {# 案例字段}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# 结果字段} other {# 结果字段}}",
+          "templateMapLabel": "映射到现有模板",
+          "templateCreateLabel": "创建新模板",
+          "templateNoMatchingTargets": "没有匹配的模板。",
+          "templateNewNameLabel": "模板名称",
+          "templateMapHintIncomplete": "在映射到现有模板之前，先将所有 Testmo 字段映射到现有案例和结果字段。",
+          "templateMapHintDuplicate": "每个 Testmo 字段都必须映射到一个唯一的 TestPlanIt 字段。",
+          "templateMapHintNoMatch": "没有现有模板使用相同的字段集。",
+          "templateMapHintAlreadyMapped": "所有匹配的模板都已映射。请先清除其他映射，然后再继续。",
+          "templateIssueNoSelection": "选择现有模板进行映射。",
+          "templateIssueTargetConflict": "另一个模板已经映射到此目标。",
+          "templateIssueFieldErrors": "解析高亮显示的模板字段。",
+          "templateTargetFieldsMismatch": "字段与此模板不匹配。",
+          "templateTargetNoLongerMatching": "字段不再符合此模板。",
+          "noRolesAvailable": "暂无空缺职位。",
+          "roleSelectPlaceholder": "选择角色",
+          "roleNameLabel": "角色名称",
+          "roleNamePlaceholder": "请输入角色名称",
+          "rolePermissionsEmpty": "未分配任何权限",
+          "rolePermissionAddEdit": "添加/编辑",
+          "noMilestoneTypesAvailable": "暂无里程碑类型。",
+          "milestoneSelectPlaceholder": "选择里程碑类型",
+          "milestoneNamePlaceholder": "输入里程碑类型名称",
+          "milestoneDefaultLabel": "默认里程碑类型",
+          "milestoneIconRequired": "选择一个图标",
+          "statusColorPlaceholder": "颜色十六进制代码（可选）",
+          "issueTargetSelectPlaceholder": "选择集成方式...",
+          "noIssueTargetsAvailable": "目前没有可用的集成方案。",
+          "issueTargetNamePlaceholder": "集成名称...",
+          "templateFieldsHeading": "模板字段",
+          "roleAreaColumn": "区域",
+          "workflowSelectPlaceholder": "选择工作流程",
+          "statusSelectPlaceholder": "选择状态",
+          "statusNamePlaceholder": "输入状态名称",
+          "statusSystemNamePlaceholder": "请输入系统名称",
+          "labelSystemName": "系统名称",
+          "groupNamePlaceholder": "请输入组名",
+          "configurationNameLabel": "配置名称",
+          "userSelectPlaceholder": "选择用户",
+          "userApiLabel": "API 用户",
+          "templateCaseFieldsLabel": "案例字段",
+          "templateResultFieldsLabel": "结果字段",
+          "templateNoFieldsPlaceholder": "此模板未配置任何字段。",
+          "templateTargetAlreadyUsed": "目标已映射到另一个模板。",
+          "templateFieldRequiredLabel": "必填字段",
+          "templateFieldOptionsDefaultValueLabel": "默认值",
+          "templateFieldOptionsInitialHeightLabel": "初始高度",
+          "templateFieldTemplateLabelSingular": "模板",
+          "templateFieldTemplateLabelPlural": "模板",
+          "templateFieldTargetGroupCase": "案例字段",
+          "templateFieldTargetGroupResult": "结果字段",
+          "columnAction": "行动"
+        },
+        "nextSteps": "后台导入完成后，您可以查看从目标项目迁移的数据。",
+        "nextStepsDescription": "后台导入是异步运行的。您可以监控上方的状态或刷新页面查看更新。"
+      },
+      "comingSoon": {
+        "description": "导入 TestRail、Zephyr 和其他工具的功能已列入开发计划。"
+      },
+      "errors": {
+        "fileRequired": "请在分析前选择Testmo导出JSON文件。",
+        "uploadFailed": "导出文件上传失败，请重试。",
+        "analysisFailed": "我们无法分析该导出文件。请检查文件并重试。"
+      }
+    },
+    "sso": {
+      "description": "管理身份验证和安全设置",
+      "sections": {
+        "providers": {
+          "title": "登录提供商",
+          "description": "配置用户如何登录您的应用程序"
+        },
+        "security": {
+          "title": "安全",
+          "description": "配置身份验证的安全策略"
+        }
+      },
+      "globalSettings": {
+        "title": "全局 SSO 设置",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "启用或禁用 Google OAuth 身份验证"
+        },
+        "samlProvider": {
+          "title": "SAML 提供商",
+          "description": "启用或禁用 SAML 身份验证"
+        },
+        "apple": {
+          "title": "Apple 登录",
+          "description": "启用或禁用 Apple 登录身份验证"
+        },
+        "microsoft": {
+          "title": "Microsoft SSO",
+          "description": "启用或禁用 Microsoft（Azure AD / Entra ID）身份验证"
+        },
+        "magicLink": {
+          "title": "魔法链接认证",
+          "description": "启用或禁用基于电子邮件的无密码身份验证"
+        },
+        "forceSso": {
+          "title": "强制 SSO 登录",
+          "description": "禁用电子邮件登录，要求用户使用单点登录 (SSO)。"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "密码登录需要启用双因素身份验证",
+            "description": "使用邮箱/密码登录的用户必须设置并使用双因素身份验证"
+          },
+          "forceAllLogins": {
+            "title": "所有登录均需启用双因素身份验证",
+            "description": "所有用户（包括单点登录用户）登录后都必须进行双因素身份验证。"
+          }
+        }
+      },
+      "providers": {
+        "configure": "配置 SAML",
+        "delete": "删除提供商",
+        "entryPoint": "入口点： ",
+        "autoProvision": "自动配置： ",
+        "defaultAccess": "默认访问权限： ",
+        "configurationMessage": "SAML配置尚未设置。请点击设置按钮进行配置。"
+      },
+      "samlConfiguration": {
+        "title": "配置 SAML 提供程序",
+        "backButton": "返回 SSO 提供商",
+        "description": "配置 {name}的 SAML 设置",
+        "samlSettings": {
+          "title": "SAML 设置",
+          "description": "配置您的 SAML 身份提供程序设置",
+          "ssoUrl": "单点登录 URL（入口点）",
+          "entityId": "实体 ID（发行方）",
+          "certificate": "X.509证书",
+          "callbackUrl": "回调 URL",
+          "logoutUrl": "注销网址（可选）"
+        },
+        "userProvisioning": {
+          "title": "用户配置",
+          "description": "配置用户创建和映射方式",
+          "autoProvision": "自动配置新用户",
+          "defaultAccess": "新用户的默认系统访问权限",
+          "accessDescription": "新用户将被分配数据库中的默认角色和系统访问级别。"
+        },
+        "attributeMapping": {
+          "title": "属性映射",
+          "description": "将 SAML 属性映射到用户字段",
+          "email": "电子邮件属性",
+          "displayName": "显示名称属性",
+          "userId": "用户 ID 属性",
+          "firstName": "名字属性（可选）",
+          "lastName": "姓氏属性（可选）",
+          "groups": "分组属性（可选）"
+        }
+      },
+      "messages": {
+        "googleEnabled": "已启用 Google OAuth",
+        "googleDisabled": "Google OAuth 已禁用",
+        "googleCreated": "Google OAuth 提供程序创建",
+        "googleUpdateFailed": "Google OAuth 更新失败",
+        "samlCreated": "SAML 提供程序创建",
+        "createFailed": "创建提供者失败",
+        "deleted": "提供商已删除",
+        "deleteFailed": "删除提供商失败",
+        "enabled": "提供商已启用",
+        "disabled": "提供商已禁用",
+        "updateFailed": "更新提供商失败",
+        "forceSsoEnabled": "全球强制启用 SSO",
+        "forceSsoDisabled": "强制全局禁用 SSO",
+        "forceSsoUpdateFailed": "更新强制 SSO 设置失败",
+        "force2FANonSSOEnabled": "密码登录需要双因素身份验证",
+        "force2FANonSSODisabled": "密码登录不再需要双因素认证",
+        "force2FAAllLoginsEnabled": "所有登录都需要双因素身份验证",
+        "force2FAAllLoginsDisabled": "不再需要所有登录都进行双因素身份验证",
+        "force2FAUpdateFailed": "双因素身份验证设置更新失败",
+        "configUpdated": "SAML 配置已更新",
+        "configCreated": "SAML 配置已创建",
+        "configSaveFailed": "保存 SAML 配置失败",
+        "googleConfigSaved": "Google OAuth 配置已成功保存",
+        "googleConfigFailed": "配置保存失败",
+        "appleEnabled": "已启用 Apple 登录",
+        "appleDisabled": "已禁用 Apple 登录",
+        "appleCreated": "Apple 登录提供商创建",
+        "appleConfigSaved": "Apple 登录配置已成功保存",
+        "appleConfigFailed": "保存 Apple 登录配置失败",
+        "appleUpdateFailed": "更新 Apple 登录提供程序失败",
+        "microsoftEnabled": "已启用 Microsoft SSO",
+        "microsoftDisabled": "已禁用 Microsoft SSO",
+        "microsoftCreated": "Microsoft SSO 提供程序创建",
+        "microsoftConfigSaved": "Microsoft SSO 配置已成功保存",
+        "microsoftConfigFailed": "保存 Microsoft SSO 配置失败",
+        "microsoftUpdateFailed": "更新 Microsoft SSO 提供程序失败",
+        "magicLinkEnabled": "已启用 Magic Link 身份验证",
+        "magicLinkDisabled": "Magic Link 身份验证已禁用",
+        "magicLinkCreated": "Magic Link 提供商创建",
+        "magicLinkUpdateFailed": "更新 Magic Link 提供程序失败",
+        "samlConfigSaved": "SAML 配置已成功保存",
+        "configureFirst": "请先配置提供程序，然后再启用它。",
+        "domainRestrictionEnabled": "已启用电子邮件域限制",
+        "domainRestrictionDisabled": "电子邮件域名限制已禁用",
+        "domainRestrictionUpdateFailed": "更新域限制设置失败",
+        "domainRequired": "请输入域名",
+        "invalidDomain": "请输入有效的域名（例如 example.com）",
+        "domainAdded": "域名已成功添加。",
+        "domainExists": "该域名已在允许列表中",
+        "domainAddFailed": "添加域名失败",
+        "domainEnabled": "域已启用",
+        "domainDisabled": "域已禁用",
+        "domainUpdateFailed": "更新域名失败",
+        "domainDeleted": "域名已成功移除",
+        "domainDeleteFailed": "删除域名失败",
+        "defaultAccessUpdated": "默认访问级别已更新",
+        "defaultAccessUpdateFailed": "更新默认访问级别失败",
+        "emailVerificationEnabled": "新用户现在需要进行电子邮件验证。",
+        "emailVerificationDisabled": "新用户不再需要进行电子邮件验证。",
+        "emailVerificationDisabledAndVerified": "Email verification disabled and {count, plural, one {# user account} other {# user accounts}} verified",
+        "emailVerificationUpdateFailed": "电子邮件验证设置更新失败",
+        "emailServerNotConfigured": "无法启用电子邮件验证：电子邮件服务器未配置",
+        "openRegistrationEnabled": "自助注册功能现已启用。",
+        "openRegistrationDisabled": "自助注册功能现已关闭",
+        "openRegistrationUpdateFailed": "更新自助注册设置失败"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "配置 Google OAuth",
+          "description": "设置您的 Google OAuth 客户端凭据。您可以从 Google Cloud 控制台获取这些凭据。",
+          "clientIdPlaceholder": "您的 Google OAuth 客户端 ID",
+          "clientSecretPlaceholder": "您的 Google OAuth 客户端密钥",
+          "instructions": {
+            "title": "获取这些凭证：",
+            "step1": "前往 Google Cloud 控制台",
+            "step2": "选择您的项目或创建一个新项目",
+            "step3": "启用 Google+ API",
+            "step4": "转到“凭据”并创建 OAuth 2.0 客户端 ID",
+            "step5": "将授权重定向 URI 设置为："
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "客户端 ID 和客户端密钥都需要"
+          }
+        },
+        "microsoft": {
+          "title": "配置 Microsoft SSO",
+          "description": "设置您的 Microsoft Entra ID（Azure AD）应用程序凭据。您可以从 Azure 门户获取这些凭据。",
+          "clientIdPlaceholder": "您的应用程序（客户端）ID",
+          "clientSecretPlaceholder": "您的客户秘密价值",
+          "tenantId": "租户 ID（可选）",
+          "tenantIdPlaceholder": "您的目录（租户）ID",
+          "tenantIdHint": "留空表示多租户（“公共”）。设置为您的特定租户 ID 则仅限您的组织使用。",
+          "instructions": {
+            "title": "获取这些凭证：",
+            "step1": "访问 Azure 门户 (portal.azure.com)",
+            "step2": "导航至 Microsoft Entra ID > 应用注册",
+            "step3": "注册新应用或选择现有应用",
+            "step4": "在“证书和密钥”下，创建一个新的客户端密钥",
+            "step5": "在身份验证下添加以下重定向 URI："
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "客户端 ID 和客户端密钥都需要"
+          }
+        },
+        "saml": {
+          "description": "设置您的 SAML 身份提供商配置。您可以从您的 SAML 身份提供商处获取这些详细信息。",
+          "entryPoint": "SSO入口点URL",
+          "issuer": "发行人（实体 ID）",
+          "callbackUrl": "ACS（回调）URL",
+          "logoutUrl": "SLO 注销 URL（可选）",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:你的身份提供商:实体ID",
+          "certPlaceholder": "-----开始证书-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "配置 SAML：",
+            "step1": "请联系您的 SAML 身份提供商管理员",
+            "step2": "请求 SSO 入口点 URL 和实体 ID",
+            "step3": "下载 X.509 证书",
+            "step4": "在您的身份提供商 (IdP) 中配置此 ACS URL："
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "入口点、颁发者、证书和回调 URL 是必需的。"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "禁用电子邮件验证？",
+          "description": "这将禁用新用户注册的电子邮件验证，并验证所有现有的未验证帐户。",
+          "warning": "⚠️ 安全警告",
+          "warningPoint1": "仅推荐用于安全安装环境（私有网络、VPN 或可信环境）",
+          "warningPoint2": "所有现有的未验证帐户将立即得到验证，并被授予系统访问权限。",
+          "confirmation": "您确定要禁用电子邮件验证并验证所有帐户吗？",
+          "confirm": "禁用并验证所有",
+          "verifying": "正在验证账户……"
+        }
+      },
+      "status": {
+        "configured": "已配置",
+        "setup": "设置"
+      },
+      "registration": {
+        "title": "注册设置",
+        "description": "控制谁可以注册新帐户",
+        "restrictDomains": {
+          "title": "限制电子邮件域名",
+          "description": "仅允许来自特定电子邮件域名的注册。"
+        },
+        "allowedDomains": {
+          "title": "允许的电子邮件域名",
+          "placeholder": "example.com",
+          "add": "添加域名",
+          "empty": "未配置任何允许的域名。启用限制后，所有域名都将被阻止。"
+        },
+        "defaultAccess": {
+          "title": "默认访问级别",
+          "description": "新用户注册时分配的系统访问级别",
+          "options": {
+            "NONE": "无访问权限 - 用户必须经管理员授予权限后才能访问系统。",
+            "USER": "用户 - 标准用户权限，可访问已分配的项目",
+            "PROJECTADMIN": "项目管理员 - 可以管理分配给他们的项目",
+            "ADMIN": "管理员 - 完全系统管理权限"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "需要电子邮件验证",
+          "description": "用户必须先验证其电子邮件地址才能访问系统。",
+          "noEmailServerWarning": "邮件服务器尚未配置。邮件验证功能将自动禁用，直到邮件服务器设置完成。"
+        },
+        "allowOpenRegistration": {
+          "title": "允许自助注册",
+          "description": "禁用此功能后，新用户无法直接注册或通过单点登录 (SSO) 创建帐户。现有用户仍然可以登录。"
+        }
+      },
+      "errors": {
+        "invalidProvider": "无效的提供商或不是 SAML 提供商。"
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "筛选项目..."
+      },
+      "complete": {
+        "title": "完整项目",
+        "description": "此操作将完成项目，并阻止添加任何其他测试运行。"
+      },
+      "add": {
+        "button": "添加项目",
+        "title": "添加新项目",
+        "defaultFields": "创建项目时，将向项目中添加默认模板、默认里程碑类型以及所有工作流程和状态。",
+        "selectIssueTracker": "选择问题跟踪器",
+        "issueTrackerRequired": "需要问题跟踪系统。"
+      },
+      "wizard": {
+        "title": "创建新项目",
+        "description": "创建一个包含所有必要配置的新项目",
+        "steps": {
+          "details": "项目详情",
+          "workflows": "工作流程、状态和里程碑类型",
+          "integrations": "集成",
+          "permissions": "用户与权限"
+        },
+        "labels": {
+          "selected": "已选",
+          "statuses": "测试状态",
+          "issueTrackers": "问题跟踪器"
+        },
+        "placeholders": {
+          "projectName": "输入项目名称",
+          "selectDefaultAccess": "选择默认访问类型"
+        },
+        "descriptions": {
+          "templates": "请选择至少一个模板来定义本项目中的测试用例结构。",
+          "workflows": "配置工作流程、状态和里程碑类型，以管理项目活动。",
+          "integrations": "可选：连接外部问题跟踪器和人工智能模型，以增强功能。",
+          "noIntegrations": "目前尚未配置任何集成。您可以跳过此步骤或稍后配置集成。",
+          "aiModels": "启用人工智能模型，用于生成测试用例和提供智能建议。",
+          "permissions": "配置此项目的用户访问权限和组权限。",
+          "milestoneTypes": "选择里程碑类型以跟踪项目进度和截止日期。"
+        },
+        "actions": {
+          "selectDefault": "使用默认值",
+          "create": "创建项目",
+          "creating": "创建项目..."
+        },
+        "errors": {
+          "nameRequired": "项目名称（必填）",
+          "validationFailed": "项目名称验证失败，请重试。",
+          "templateRequired": "至少要选择一个模板",
+          "workflowRequired": "必须至少选择一个工作流程",
+          "statusRequired": "必须至少选择一种状态",
+          "roleRequired": "使用“特定角色”访问类型时，请选择角色。",
+          "creationFailed": "项目创建失败，请重试。"
+        },
+        "success": {
+          "created": "项目创建成功"
+        }
+      },
+      "edit": {
+        "title": "编辑项目",
+        "labels": {
+          "groupProjectAccess": "小组项目访问权限",
+          "groupPermissions": "群组权限",
+          "userPermissions": "用户权限",
+          "noEffect": "无影响",
+          "access": {
+            "groupsGlobalRole": "集团的全球角色",
+            "groupDefault": "组默认值",
+            "groupSpecificRole": "特定角色",
+            "groupProjectDefault": "小组项目默认设置",
+            "groupProjectNoAccess": "小组项目无访问权限",
+            "groupProjectSpecificRole": "小组项目特定角色",
+            "effectiveAccess": "有效获取"
+          },
+          "accessHints": {
+            "noAccess": "除非通过直接分配或加入群组等方式明确授予权限，否则用户将无法访问此项目。",
+            "globalRole": "所有拥有网站访问权限的用户均可查看此项目。他们的权限取决于其全局分配的角色。",
+            "specificRole": "用户不会自动获得访问权限。访问权限必须通过直接用户分配或组成员身份授予。通过组分配的用户将使用此角色，除非被直接分配覆盖。"
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "选择默认访问权限",
+          "groupPermissionsUI": "群组权限管理界面将放在这里……",
+          "userPermissionsUI": "用户权限管理界面将放在这里……",
+          "selectAccess": "选择访问权限...",
+          "selectRole": "选择角色...",
+          "searchUsersToAdd": "搜索要添加的用户..."
+        },
+        "tableHeaders": {
+          "globalRole": "全球角色",
+          "projectAccess": "项目访问"
+        },
+        "messages": {
+          "noUsersAssigned": "没有用户被分配任何特定权限。",
+          "noGroupsFound": "未找到群组。"
+        },
+        "actions": {
+          "removeUser": "移除用户"
+        },
+        "loadingUserPermissions": "正在加载用户权限..."
+      },
+      "delete": {
+        "title": "删除项目",
+        "confirmMessage": "您确定要删除此项目吗？"
+      }
+    },
+    "templates": {
+      "description": "管理测试用例模板和字段",
+      "help": {
+        "caseFields": "用例字段定义了存储库中每个测试用例可以捕获的属性和数据。它们允许您在标准字段之外自定义测试用例信息。",
+        "resultFields": "结果字段定义了在记录测试结果时可以捕获的其他数据。它们允许您跟踪特定于测试执行结果的自定义信息。"
+      },
+      "confirmSetAsDefault": "设置为默认模板",
+      "confirmSetAsDefaultDescription": "您确定要将此模板设置为默认模板吗？",
+      "confirmSetAsDefaultProjects": "此模板将添加到所有项目中。",
+      "add": {
+        "button": "添加模板",
+        "title": "添加新模板",
+        "defaultTemplateHint": "此模板将分配给所有项目。"
+      },
+      "edit": {
+        "title": "编辑模板"
+      },
+      "delete": {
+        "title": "删除模板",
+        "confirmMessage": "您确定要删除 <strong>{name}</strong> 模板吗？",
+        "warning": "当前使用此模板的所有测试用例和探索性会话将自动重新分配给默认模板。",
+        "errors": {
+          "defaultTemplateNotFound": "未找到默认模板。删除操作无法进行。",
+          "unknown": "删除模板时发生未知错误。"
+        }
+      },
+      "caseFields": {
+        "description": "管理案例字段",
+        "add": {
+          "button": "添加个案字段",
+          "title": "添加新案例字段"
+        },
+        "edit": {
+          "title": "编辑案例字段"
+        },
+        "delete": {
+          "title": "删除个案字段",
+          "confirmMessage": "您确定要删除此案例字段吗？",
+          "warning": "案例字段将从所有模板中移除。此操作无法撤销。"
+        }
+      },
+      "resultFields": {
+        "description": "管理结果字段",
+        "add": {
+          "button": "添加结果字段",
+          "title": "添加新结果字段"
+        },
+        "edit": {
+          "title": "编辑结果字段"
+        },
+        "delete": {
+          "title": "删除结果字段",
+          "confirmMessage": "您确定要删除 <strong>{name}</strong>吗？",
+          "warning": "结果字段将从所有模板中移除。此操作无法撤销。"
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "代码库",
+      "description": "管理 QuickScript 上下文的代码库连接。",
+      "addRepository": "添加存储库",
+      "noRepos": {
+        "title": "未配置任何代码仓库",
+        "description": "连接 Git 存储库，为 AI 驱动的测试导出生成提供文件上下文。"
+      },
+      "delete": {
+        "title": "删除存储库",
+        "confirmMessage": "您确定要删除 <strong>{name}</strong>吗？此操作无法撤销。",
+        "fallbackName": "此仓库"
+      },
+      "testConnection": "测试连接",
+      "connectionSuccess": "连接成功",
+      "connectionFailed": "连接失败",
+      "networkError": "网络错误",
+      "editTitle": "编辑代码库",
+      "addTitle": "添加代码库",
+      "repositoryUpdated": "存储库已更新",
+      "repositoryCreated": "已创建存储库",
+      "saveFailed": "保存存储库失败",
+      "namePlaceholder": "我的仓库",
+      "selectProvider": "选择提供商",
+      "httpWarning": "此网址使用 HTTP 协议。凭据将以明文形式发送。请使用 HTTPS 协议以确保连接安全。"
+    },
+    "exportTemplates": {
+      "title": "QuickScript模板",
+      "description": "管理 QuickScript 用于将测试用例转换为自动化脚本的模板。",
+      "confirmSetAsDefault": "设置为默认导出模板",
+      "confirmSetAsDefaultDescription": "您确定要将此模板设置为默认模板吗？用户导出测试用例时，它将被预先选中。",
+      "fields": {
+        "category": "类别",
+        "framework": "框架",
+        "fileExtension": "文件扩展名",
+        "headerBody": "页眉模板",
+        "templateBody": "模板主体",
+        "footerBody": "页脚模板",
+        "validation": {
+          "categoryRequired": "类别为必填项。",
+          "frameworkRequired": "需要框架。",
+          "templateBodyRequired": "必须填写模板正文。",
+          "fileExtensionRequired": "必须提供文件扩展名。",
+          "languageRequired": "需要掌握相关语言。"
+        },
+        "placeholders": {
+          "name": "例如，剧作家（TypeScript）",
+          "description": "例如，生成 Playwright 测试存根",
+          "category": "例如，浏览器端到端",
+          "framework": "例如，剧作家",
+          "fileExtension": "例如，.spec.ts",
+          "language": "例如，TypeScript",
+          "headerBody": "可选。内容会在顶部渲染一次（例如，导入语句）。",
+          "templateBody": "输入胡子模板...\n\n可用变量：\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\n步骤部分：\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\n自定义字段：\n'{{fields.fieldSystemName}}'",
+          "footerBody": "可选。内容在底部渲染一次（例如，结束代码）。"
+        },
+        "combobox": {
+          "typeNew": "输入新值"
+        }
+      },
+      "add": {
+        "button": "添加 QuickScript 模板",
+        "title": "添加新的 QuickScript 模板"
+      },
+      "edit": {
+        "title": "编辑 QuickScript 模板"
+      },
+      "delete": {
+        "title": "删除快速脚本模板",
+        "confirmMessage": "您确定要删除 <strong>{name}</strong> QuickScript 模板吗？"
+      },
+      "preview": {
+        "title": "预览（模拟数据）",
+        "empty": "输入模板正文以查看预览。",
+        "error": "模板渲染出错。请检查您的 Mustache 语法。"
+      },
+      "filterPlaceholder": "筛选模板...",
+      "noResults": "没有符合您筛选条件的模板。",
+      "templateCount": "{count, plural, one {# 模板} other {# 模板集}}",
+      "allFrameworks": "所有框架",
+      "allFileExtensions": "所有扩展",
+      "allLanguages": "所有语言",
+      "showEnabled": "仅启用",
+      "showAll": "全部",
+      "variableInserter": {
+        "placeholder": "插入变量...",
+        "groups": {
+          "customFields": "自定义字段"
+        },
+        "stepsBlock": "步骤阻塞"
+      }
+    },
+    "users": {
+      "showInactive": "显示非活动状态",
+      "add": {
+        "button": "添加用户",
+        "title": "添加新用户",
+        "fields": {
+          "email_invalid": "无效的电子邮件地址",
+          "password_error": "需要密码",
+          "confirmPassword_error": "需要确认密码",
+          "passwordOptionalHelp": "留空则要求用户通过魔法链接或单点登录登录。"
+        }
+      },
+      "edit": {
+        "title": "编辑用户"
+      },
+      "delete": {
+        "title": "删除用户"
+      },
+      "restore": {
+        "title": "恢复已删除用户",
+        "description": "已找到电子邮件地址为 {email} 的已删除用户。您是否要恢复此用户？",
+        "confirm": "恢复用户"
+      },
+      "forcePasswordChange": "强制更改密码",
+      "revokePassword": "撤销密码",
+      "forcePasswordChangeDialogTitle": "强制更改密码",
+      "forcePasswordChangeDialogDescription": "这将要求 {name} 在下次登录时更改密码。",
+      "revokePasswordDialogTitle": "撤销密码",
+      "revokePasswordDialogDescription": "这将立即使 {name}的密码失效。他们需要使用其他登录方式。",
+      "confirmAction": "确认",
+      "forcePasswordChangeSuccess": "{name} 需要更改密码",
+      "forcePasswordChangeFailed": "强制更改密码失败",
+      "revokePasswordSuccess": "密码已撤销 {name}",
+      "revokePasswordFailed": "撤销密码失败"
+    },
+    "security": {
+      "title": "安全",
+      "description": "配置密码策略、锁定设置和强制执行措施",
+      "passwordPolicyTitle": "密码策略",
+      "passwordPolicyDescription": "设置用户密码要求",
+      "lockoutPolicyTitle": "锁定政策",
+      "lockoutPolicyDescription": "配置登录失败后账户锁定",
+      "enforcementTitle": "执法行动",
+      "enforcementDescription": "强制基于凭证的用户更改密码",
+      "minPasswordLengthLabel": "密码最小长度",
+      "minPasswordLengthDescription": "密码长度必须至少为以下字符数（8-128）",
+      "requireUppercaseLabel": "必须使用大写字母",
+      "requireLowercaseLabel": "必须使用小写字母",
+      "requireNumbersLabel": "需要数字",
+      "requiredSpecialCharsLabel": "必需特殊字符",
+      "requiredSpecialCharsDescription": "留空则禁用。请输入必须显示的字符（例如 !@#$）",
+      "passwordHistoryDepthLabel": "密码历史记录深度",
+      "passwordHistoryDepthDescription": "禁止重复使用最近 N 个密码（0 = 已禁用）",
+      "passwordExpirationDaysLabel": "密码过期时间（天）",
+      "passwordExpirationDaysDescription": "强制密码更改时间（N 天后生效，0 表示禁用）",
+      "lockoutThresholdLabel": "锁定阈值",
+      "lockoutThresholdDescription": "账户被锁定前的失败尝试次数（最少 1 次）",
+      "lockoutDurationMinutesLabel": "锁定持续时间（分钟）",
+      "lockoutDurationMinutesDescription": "账户锁定时长（最少 1 小时）",
+      "saveChanges": "保存更改",
+      "forceAllUsers": "强制所有用户更改密码",
+      "forceAllUsersDialogTitle": "强制所有用户更改密码",
+      "forceAllUsersDialogDescription": "这将要求 {count} 基于凭证的用户在下次登录时更改密码。",
+      "forceAllUsersDialogWarning": "此操作无法撤销。",
+      "forceAllUsersDialogConfirm": "力变化",
+      "saved": "已保存安全设置",
+      "saveFailed": "保存安全设置失败",
+      "forceAllSuccess": "{count} 用户需要更改密码",
+      "forceAllFailed": "强制更改密码失败"
+    },
+    "apiTokens": {
+      "description": "查看和管理所有用户的 API 令牌。如有安全隐患，可撤销令牌。",
+      "filterPlaceholder": "按令牌名称或用户筛选...",
+      "showInactive": "显示撤销",
+      "noTokens": "尚未创建任何 API 令牌。",
+      "columns": {
+        "lastUsed": "上次使用",
+        "expires": "过期"
+      },
+      "status": {
+        "revoked": "撤销",
+        "expired": "已到期"
+      },
+      "noExpiry": "无有效期",
+      "revokeToken": "撤销令牌",
+      "revokeConfirmTitle": "撤销 API 令牌",
+      "revokeConfirmMessage": "您确定要撤销此 API 令牌吗？此操作无法撤销。",
+      "revokeConfirmDescription": "属于 {user} 的令牌“{name}”将被立即撤销，并且不能再用于 API 访问。",
+      "revokeSuccess": "API令牌已成功撤销",
+      "revokeError": "撤销 API 令牌失败",
+      "revokeAllTokens": "撤销所有代币",
+      "revokeAllTitle": "撤销所有 API 令牌",
+      "revokeAllDescription": "这将立即撤销所有用户的所有有效 API 令牌。此操作无法撤销，并且可能会中断自动化工作流程。",
+      "revokeAllConfirm": "输入“全部撤销”以确认",
+      "revokeAllPlaceholder": "撤销所有",
+      "revokeAllSuccess": "所有API令牌均已被撤销。",
+      "revokeAllError": "撤销所有令牌失败"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "创建标签时发生错误"
+        }
+      },
+      "delete": {
+        "title": "删除标签",
+        "confirmMessage": "您确定要删除此标签吗？",
+        "warning": "此标签将从所有测试用例和会话中移除。",
+        "errors": {
+          "unknown": "删除标签时发生错误"
+        }
+      },
+      "edit": {
+        "title": "编辑标签"
+      }
+    },
+    "workflows": {
+      "description": "管理测试用例工作流程",
+      "add": {
+        "button": "添加工作流",
+        "title": "添加新工作流程",
+        "defaultHelp": "设置为新测试用例的默认工作流程",
+        "scopeLabel": "工作流程范围",
+        "errors": {
+          "nameExists": "已存在同名的工作流"
+        }
+      },
+      "edit": {
+        "title": "编辑工作流程",
+        "lastWorkflowTypeWarning": "这是最后一种工作流类型。必须至少启用一种工作流类型。",
+        "errors": {
+          "nameRequired": "工作流名称为必填项",
+          "unknownWorkflow": "未知工作流程"
+        }
+      },
+      "delete": {
+        "title": "删除工作流",
+        "confirmMessage": "您确定要删除此工作流程吗？"
+      },
+      "setDefault": {
+        "title": "设置默认工作流程",
+        "confirmMessage": "您确定要将此工作流程设置为默认工作流程吗？",
+        "description": "此工作流程将添加到所有项目中。"
+      }
+    },
+    "roles": {
+      "description": "通过切换每个应用程序区域的权限，定义用户可以执行的操作。",
+      "filterPlaceholder": "筛选角色...",
+      "add": {
+        "button": "添加角色",
+        "title": "添加新角色",
+        "fields": {
+          "name_error": "角色名称为必填项"
+        },
+        "errors": {
+          "nameExists": "已存在同名角色"
+        }
+      },
+      "edit": {
+        "title": "编辑角色",
+        "permissionsTitle": "权限",
+        "areaHeader": "应用领域"
+      },
+      "delete": {
+        "title": "删除角色",
+        "confirmMessage": "您确定要删除此角色吗？",
+        "warning": "此操作无法撤销。具有此角色的用户将被分配到默认角色。",
+        "errors": {
+          "defaultNotFound": "无法删除默认角色"
+        }
+      }
+    },
+    "statuses": {
+      "description": "管理测试状态",
+      "add": {
+        "button": "添加状态",
+        "title": "添加新状态",
+        "systemNameHelp": "系统名称用于标识此状态。创建后无法更改。",
+        "aliasesHelp": "以逗号分隔的别名列表",
+        "errors": {
+          "nameExists": "已存在同名状态",
+          "systemNameEmpty": "系统名称为必填项",
+          "systemNameInvalid": "系统名称必须为字母数字格式",
+          "aliasesInvalid": "别名必须包含字母和数字。",
+          "missingColor": "未找到该颜色。请选择其他颜色。"
+        }
+      },
+      "edit": {
+        "title": "编辑状态",
+        "systemNameHelp": "系统名称用于标识自动化流程的此状态。创建后无法更改。",
+        "unmodifiableHelp": "“未测试”状态是系统状态，无法修改。",
+        "untestedHelp": "“未测试”这个名称保留用于系统状态，不能使用。",
+        "success": "状态已成功更新"
+      },
+      "delete": {
+        "title": "删除状态",
+        "confirmMessage": "您确定要删除状态 <strong>{name}</strong>吗？",
+        "errors": {
+          "inUse": "此状态正在使用中，无法删除",
+          "defaultNotFound": "未找到默认状态"
+        },
+        "success": "状态已成功删除"
+      },
+      "fields": {
+        "final": "最终的",
+        "system": "系统状态",
+        "forTestCase": "测试用例",
+        "forTestRun": "测试运行",
+        "forSession": "会议期间",
+        "color": "颜色"
+      }
+    },
+    "appConfig": {
+      "description": "管理全局应用程序配置",
+      "addConfig": "添加应用程序配置",
+      "editConfig": "编辑应用程序配置",
+      "keyPlaceholder": "请输入配置密钥...",
+      "valuePlaceholder": "请输入JSON值...",
+      "currentTranslation": "当前翻译",
+      "filterPlaceholder": "按关键词筛选...",
+      "errors": {
+        "keyRequired": "需要钥匙",
+        "invalidJson": "无效的 JSON 格式"
+      },
+      "configKeys": {
+        "project_docs_default": "项目文档默认"
+      }
+    },
+    "configurations": {
+      "description": "配置是用于定义测试环境的各种类别和变体的组合。例如，操作系统/浏览器、测试服务器、语言等。",
+      "addConfiguration": "添加配置",
+      "editConfiguration": "编辑配置",
+      "filterPlaceholder": "过滤器配置...",
+      "categories": {
+        "title": "类别",
+        "description": "管理全球类别",
+        "editCategory": "编辑类别",
+        "selectCategory": "选择类别",
+        "filterPlaceholder": "筛选类别...",
+        "add": {
+          "title": "添加新类别"
+        },
+        "delete": {
+          "confirmMessage": "您确定要删除此类别吗？",
+          "deleteCategory": "删除类别",
+          "deleteCategoryConfirm": "您确定要删除类别 <strong>{name}</strong>吗？",
+          "deleteCategoryWarning": "此操作将删除该类别及其所有关联变体。"
+        },
+        "disable": {
+          "confirmDisableTitle": "禁用变体",
+          "confirmDisableDescription": "您确定要禁用此变体吗？"
+        }
+      },
+      "combinations": {
+        "title": "组合",
+        "description": "管理全局组合",
+        "addCombination": "添加组合",
+        "editCombination": "编辑组合",
+        "selectCombination": "选择组合",
+        "selectCombinationDescription": "选择要添加到配置中的变体组合。",
+        "allExist": "所有组合都已存在。",
+        "selectAtLeast": "请至少选择一种组合。"
+      },
+      "delete": {
+        "title": "删除配置",
+        "message": "您确定要删除配置 <strong>{name}</strong>吗？",
+        "confirmMessage": "您确定要删除此配置吗？"
+      },
+      "variants": {
+        "edit": {
+          "title": "编辑变体"
+        },
+        "delete": {
+          "title": "删除变体",
+          "message": "您确定要删除变体 <strong>{name}</strong>吗？",
+          "confirmMessage": "您确定要删除此版本吗？",
+          "suggestion": "考虑禁用该变体。"
+        },
+        "selection": {
+          "title": "选择变体",
+          "description": "选择要添加到配置中的变体。"
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "将用户组织成组，以便批量分配项目访问权限和角色。"
+      },
+      "filterPlaceholder": "筛选组...",
+      "add": {
+        "button": "添加组",
+        "title": "添加新组",
+        "errors": {
+          "nameExists": "已存在同名组织"
+        }
+      },
+      "edit": {
+        "title": "编辑组"
+      },
+      "delete": {
+        "deleteGroup": "删除组",
+        "deleteGroupDescription": "此操作将删除该群组及其所有关联用户。",
+        "confirmMessage": "您确定要删除此群组吗？"
+      },
+      "noUsersSelected": "暂无用户选择。",
+      "noUsersAssigned": "此组暂无用户。"
+    },
+    "milestones": {
+      "description": "管理里程碑类型",
+      "filterPlaceholder": "筛选里程碑类型……",
+      "addMilestones": "批量添加里程碑",
+      "confirmDefault": "确认默认设置",
+      "confirmDefaultDescription": "您确定要将此里程碑类型设置为默认值吗？",
+      "warning": "此里程碑类型将添加到所有项目中。",
+      "wizard": {
+        "selectProjects": "选择项目",
+        "projectsSelected": "{count, plural, =0 {未选择任何项目} one {已选择项目数} other {已选择项目数}}",
+        "createMilestone": "创建里程碑",
+        "noCommonTypesTitle": "没有常见的里程碑类型",
+        "noCommonTypesDescription": "所选项目之间没有任何共同的里程碑类型。请确保所有选定项目至少有一个共同的里程碑类型，或者选择其他项目。"
+      },
+      "add": {
+        "button": "添加里程碑类型",
+        "title": "新增里程碑类型",
+        "errors": {
+          "nameExists": "已存在同名的里程碑类型"
+        }
+      },
+      "edit": {
+        "title": "编辑里程碑类型"
+      },
+      "delete": {
+        "title": "删除里程碑类型",
+        "confirmMessage": "您确定要删除此里程碑类型吗？"
+      }
+    },
+    "issue_config": {
+      "link_title": "链接问题跟踪器",
+      "link_description": "配置手动链接问题的基本 URL。当仅使用外部 ID 链接问题时，此基本 URL 将添加到完整链接的前面。",
+      "filter": {
+        "show_inactive": "显示非活动配置",
+        "search_placeholder": "按配置名称筛选..."
+      },
+      "base_url": "基本 URL",
+      "link_update_success": "链路配置已成功更新",
+      "link_update_error": "链路配置更新失败",
+      "description": "配置与外部问题跟踪系统的集成。",
+      "delete": {
+        "title": "删除问题配置",
+        "confirmMessage": "您确定要删除配置 <bold>{name}</bold>吗？",
+        "warning": "此操作无法撤销。当前分配给此跟踪器的所有项目都将被重新分配给默认跟踪器。建议您考虑停用此配置。",
+        "cannotDeleteDefault": "默认问题跟踪器无法删除。",
+        "noDefaultFound": "无法删除：未找到可重新分配项目的默认问题跟踪器。"
+      },
+      "add": {
+        "title": "添加问题跟踪器",
+        "description": "为问题跟踪系统创建新配置。",
+        "name": "配置名称",
+        "name_placeholder": "例如，Jira 项目链接",
+        "system_type": "系统类型",
+        "select_system_type": "选择系统类型",
+        "base_url": "包含问题占位符的基本 URL",
+        "base_url_placeholder": "例如，https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "问题配置已成功创建",
+        "create_error": "创建问题配置时出错",
+        "setDefaultWarning": "将此项设置为默认值将从当前默认配置中移除默认状态。"
+      },
+      "edit": {
+        "title": "编辑问题跟踪器",
+        "description": "更新此问题配置的详细信息。",
+        "name_placeholder": "输入配置名称",
+        "select_project": "选择项目……",
+        "update_success": "问题配置已成功更新",
+        "update_error": "更新问题配置失败",
+        "edit_not_supported": "目前不支持编辑此系统类型的配置。"
+      }
+    },
+    "issues": {
+      "description": "管理此问题跟踪器的问题",
+      "filterPlaceholder": "过滤器问题……",
+      "add": {
+        "button": "添加问题",
+        "title": "添加新问题"
+      },
+      "edit": {
+        "title": "编辑问题"
+      },
+      "delete": {
+        "title": "删除问题",
+        "confirmMessage": "您确定要删除问题“{name}”吗？"
+      },
+      "syncIssue": "来自外部系统的同步问题",
+      "syncSuccess": "问题已成功同步",
+      "syncSuccessDescription": "问题“{name}”已使用来自外部系统的最新信息进行更新。",
+      "syncError": "同步问题失败",
+      "syncErrorDescription": "问题同步失败，请稍后再试。"
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "项目链接",
+        "milestoneLinks": "里程碑链接",
+        "icons": "图标",
+        "fieldOptions": "字段选项",
+        "configCategories": "配置类别",
+        "configVariants": "配置变体",
+        "repositories": "存储库",
+        "repositoryFolders": "存储库文件夹",
+        "repositoryCaseLinks": "案例库链接",
+        "repositoryCaseVersions": "存储库案例版本",
+        "testRunStepResults": "测试运行步骤结果",
+        "issueConfigs": "问题配置",
+        "sharedStepGroups": "共同步骤小组"
+      },
+      "table": {
+        "title": "已删除 {itemType}",
+        "loading": "正在加载已删除的 {itemType}...",
+        "error": "加载已删除的 {itemType}: {message}时出错",
+        "noItems": "未找到已删除的 {itemType} 。",
+        "noResults": "没有找到与您的搜索“{query}”匹配的已删除的 {itemType} 。",
+        "restoreConfirmationMessage": "您确定要从 {itemType} 表中恢复此行吗？关联数据也可能会恢复。",
+        "purgeConfirmationMessage": "您确定要从 {itemType} 表中永久删除此行吗？此操作无法撤销，并且可能会删除关联数据。"
+      }
+    },
+    "notifications": {
+      "title": "通知管理",
+      "description": "设置默认通知偏好设置（用户可以覆盖），并发送系统通知。",
+      "defaultMode": {
+        "label": "默认通知模式",
+        "inApp": "仅限应用内购买",
+        "inAppEmailImmediate": "应用内 + 电子邮件（立即）",
+        "inAppEmailDaily": "应用内 + 电子邮件（每日摘要）"
+      },
+      "options": {
+        "title": "可用的通知选项",
+        "inApp": {
+          "label": "应用内通知",
+          "description": "在应用内显示通知"
+        },
+        "emailImmediate": {
+          "label": "立即发送电子邮件",
+          "description": "事件发生时立即发送电子邮件通知"
+        },
+        "emailDaily": {
+          "label": "每日邮件摘要",
+          "description": "每日通过电子邮件发送通知摘要"
+        }
+      },
+      "save": "保存设置",
+      "success": {
+        "title": "设置已保存",
+        "description": "通知设置已成功更新"
+      },
+      "error": {
+        "description": "通知设置保存失败"
+      },
+      "systemNotification": {
+        "title": "系统通知",
+        "description": "向所有用户发送重要公告",
+        "titlePlaceholder": "请输入通知标题...",
+        "messagePlaceholder": "输入通知消息...",
+        "send": "发送通知",
+        "success": {
+          "title": "已发送通知",
+          "description": "系统通知已发送至 {count, plural, one {# 用户} other {# 用户组}}"
+        },
+        "error": {
+          "description": "发送系统通知失败",
+          "emptyFields": "请提供标题和正文。"
+        },
+        "history": {
+          "title": "通知历史记录",
+          "sentBy": "发送者",
+          "sentAt": "发送于",
+          "empty": "尚未发送任何系统通知。"
+        }
+      }
+    },
+    "integrations": {
+      "description": "管理用于问题跟踪的第三方集成",
+      "list": {
+        "title": "已配置的问题集成",
+        "description": "查看和管理您已配置的问题集成"
+      },
+      "empty": {
+        "message": "尚未配置任何问题集成"
+      },
+      "addIntegration": "添加问题集成",
+      "allIntegrations": "所有问题集成",
+      "manageDescription": "配置和管理您的外部服务集成问题",
+      "status": {
+        "active": "积极的",
+        "inactive": "非活跃状态"
+      },
+      "connectedProjects": "关联项目",
+      "noIntegrations": "未配置任何问题集成",
+      "testConnection": "测试连接",
+      "testSuccess": "连接成功",
+      "testSuccessDescription": "问题集成已正确配置并连接",
+      "testFailed": "连接失败",
+      "testFailedDescription": "无法连接到外部服务",
+      "testError": "测试错误",
+      "testErrorDescription": "测试连接时发生错误",
+      "syncInProgress": "同步问题……",
+      "syncIntegration": "同步问题集成中的所有问题",
+      "syncSuccess": "同步已排队",
+      "syncSuccessDescription": "来自“{name}”的问题正在后台同步。这可能需要一些时间。同步完成后，表格将自动更新。",
+      "syncError": "同步失败",
+      "syncErrorDescription": "无法为此集成问题添加同步任务。请稍后重试。",
+      "delete": {
+        "confirmMessage": "您确定要删除问题集成“{name}”吗？",
+        "warning": "这将移除问题集成并将其与所有项目断开连接。此操作无法撤销。",
+        "warningTitle": "此操作将：",
+        "warning1": "永久删除问题集成配置和凭据",
+        "warning2": "断开此问题集成的所有用户身份验证令牌",
+        "warning3": "保留数据库中所有已链接的问题（问题将取消链接）。",
+        "warning4": "首先需要从所有项目中移除该问题集成。"
+      },
+      "deleteSuccess": "问题集成已删除",
+      "deleteSuccessDescription": "问题集成已成功移除。",
+      "deleteError": "删除错误",
+      "add": {
+        "description": "配置与外部服务的新问题集成",
+        "selectType": "选择问题集成类型",
+        "typeDescription": "选择您要集成的服务类型",
+        "successMessage": "问题集成已成功创建",
+        "successDescription": "问题集成已配置完成，可以开始使用了。",
+        "simple_url": {
+          "name": "简单网址",
+          "description": "使用自定义 URL 模式进行基本问题跟踪"
+        },
+        "jira": {
+          "name": "吉拉",
+          "description": "连接到 Atlassian Jira 进行问题跟踪和项目管理"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "连接到 GitHub 以进行问题跟踪"
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "连接到 GitLab 以跟踪问题和合并请求"
+        },
+        "gitea": {
+          "name": "吉特亚/福尔格约/戈格斯",
+          "description": "连接到自托管的 Gitea、Forgejo 或 Gogs 实例以进行问题跟踪"
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "连接到 Azure DevOps 以跟踪工作项"
+        }
+      },
+      "filterPlaceholder": "过滤器集成……",
+      "table": {
+        "lastSync": "上次同步",
+        "empty": "未发现集成问题",
+        "loading": "正在加载问题集成...",
+        "configure": "配置"
+      },
+      "edit": {
+        "description": "更新问题集成设置和配置",
+        "successMessage": "问题集成已成功更新",
+        "successDescription": "问题集成设置已保存"
+      },
+      "editIntegration": "编辑问题集成",
+      "saveIntegration": "保存问题集成",
+      "deleteIntegration": "删除问题集成",
+      "config": {
+        "name": "问题集成名称",
+        "namePlaceholder": "请为此问题集成输入名称",
+        "nameHelp": "用于识别此问题集成的描述性名称",
+        "authType": "身份验证类型",
+        "authTypeHelp": "选择如何通过外部服务进行身份验证",
+        "emailPlaceholder": "您的邮箱地址@example.com",
+        "emailHelp": "您的帐户电子邮件地址",
+        "apiToken": "API令牌",
+        "apiTokenPlaceholder": "请输入您的 API 令牌",
+        "apiTokenHelp": "从您的帐户设置中生成 API 令牌",
+        "jiraUrl": "Jira URL",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "您的 Jira 实例的 URL",
+        "clientId": "客户ID",
+        "clientIdPlaceholder": "请输入您的 OAuth 客户端 ID",
+        "clientIdHelp": "来自您的 OAuth 应用程序的客户端 ID",
+        "clientSecret": "客户机密",
+        "clientSecretPlaceholder": "请输入您的 OAuth 客户端密钥",
+        "clientSecretHelp": "来自您的 OAuth 应用程序的客户端密钥",
+        "cloudId": "Cloud ID",
+        "cloudIdPlaceholder": "请输入您的 Atlassian 云 ID",
+        "cloudIdHelp": "您的 Atlassian Cloud 实例 ID（可在您的 Jira URL 中找到）",
+        "apiUrl": "API URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "服务 API 的基本 URL",
+        "personalAccessTokenPlaceholder": "请输入您的个人访问令牌",
+        "personalAccessTokenHelp": "具有相应权限的个人访问令牌",
+        "apiKeyPlaceholder": "请输入您的 API 密钥",
+        "apiKeyHelp": "用于身份验证的 API 密钥",
+        "baseUrl": "URL模式",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "问题 URL 格式。使用 {issueId} 作为占位符",
+        "organizationUrl": "组织网址",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "您的 Azure DevOps 组织 URL",
+        "projectPath": "项目路径",
+        "projectPathPlaceholder": "小组/子小组/项目",
+        "projectPathHelp": "您的 GitLab 项目的完整路径（例如 mygroup/myproject）",
+        "instanceUrl": "实例 URL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "自托管实例的 URL。留空则使用 gitlab.com。",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "所有者",
+        "ownerPlaceholder": "用户名或组织",
+        "ownerHelp": "拥有该仓库的 Gitea 用户或组织",
+        "repo": "存储库",
+        "repoPlaceholder": "仓库名称",
+        "repoHelp": "Gitea 仓库的名称",
+        "encrypted": "加密",
+        "encryptedHelp": "该字段已加密并安全存储。",
+        "changeCredential": "改变",
+        "apiKeyWarningTitle": "API密钥认证通知",
+        "apiKeyWarningDescription": "使用 API 密钥认证时，问题报告者会自动确定：",
+        "apiKeyWarningPoint1": "如果您的 TestPlanIt 邮箱地址与 Jira 用户邮箱地址匹配，您将被设置为报告人。",
+        "apiKeyWarningPoint2": "如果没有匹配的电子邮件地址，您的 TestPlanIt 名称将与 Jira 显示名称进行匹配。",
+        "apiKeyWarningPoint3": "如果未找到匹配项，则将 API 密钥所有者设置为报告者。",
+        "forgeApiKeyLabel": "Forge API 密钥",
+        "forgeApiKeyDescription": "Atlassian Forge 应用使用此密钥来验证来自 Jira 问题面板的请求。请在此处生成密钥并将其粘贴到 Forge 应用设置中。",
+        "forgeApiKeyPlaceholder": "点击“生成”按钮创建 API 密钥",
+        "forgeApiKeyGenerate": "产生",
+        "forgeApiKeyCopy": "复制",
+        "forgeApiKeyCopied": "已复制",
+        "platform": "平台",
+        "platformPlaceholder": "选择平台...",
+        "platformGitea": "吉特亚",
+        "platformForgejo": "福尔热",
+        "platformGogs": "戈格斯"
+      },
+      "authType": {
+        "api_key": "API密钥",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "个人访问令牌"
+      },
+      "validation": {
+        "nameRequired": "问题集成名称为必填项",
+        "clientIdRequired": "需要客户端 ID",
+        "clientSecretRequired": "需要客户端密钥",
+        "cloudIdRequired": "需要 Cloud ID",
+        "apiUrlRequired": "需要提供 API URL",
+        "tokenRequired": "需要个人访问令牌",
+        "apiKeyRequired": "需要 API 密钥"
+      },
+      "errors": {
+        "updateFailed": "问题集成更新失败",
+        "testFailed": "连接测试失败",
+        "nameExists": "已存在一个名称相同的集成问题",
+        "createFailed": "创建问题集成失败",
+        "deleteFailed": "删除问题集成失败"
+      },
+      "confirmDelete": {
+        "message": "您确定要删除问题集成“{name}”吗？",
+        "warning": "这将移除问题集成并将其与所有项目断开连接。此操作无法撤销。"
+      },
+      "form": {
+        "success": "问题集成已成功保存",
+        "successDescription": "问题集成已配置完成，可以开始使用了。",
+        "testing": "正在测试连接..."
+      },
+      "oauth": {
+        "connectAccount": "连接帐户",
+        "connected": "已连接",
+        "notConnected": "未连接",
+        "authDescription": "您需要使用 {provider} 进行身份验证才能使用此集成",
+        "authError": "身份验证失败",
+        "authErrorDescription": "无法通过外部服务进行身份验证"
+      }
+    },
+    "llm": {
+      "addIntegration": "添加人工智能模型",
+      "filterPlaceholder": "过滤人工智能模型……",
+      "testAll": "测试所有连接",
+      "connectionTestComplete": "连接测试完成",
+      "allIntegrationsTested": "所有人工智能模型连接均已测试",
+      "failedToTestConnections": "部分连接测试失败",
+      "notConfigured": "未配置",
+      "defaultModel": "选定型号",
+      "budgetUsage": "本月使用量",
+      "noBudget": "无预算集",
+      "streaming": "流媒体",
+      "add": {
+        "title": "添加人工智能模型集成",
+        "description": "为您的组织配置一个新的人工智能模型",
+        "integrationNamePlaceholder": "请输入此集成的名称……",
+        "selectProvider": "选择服务提供商",
+        "openai": "OpenAI",
+        "anthropic": "人类学",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "奥拉玛",
+        "customLlm": "定制LLM",
+        "apiKeyPlaceholder": "请输入您的 API 密钥...",
+        "apiKeyDescription": "您用于向提供商进行身份验证的 API 密钥",
+        "endpoint": "端点 URL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "提示：如果使用代理（例如 LiteLLM），请尝试在端点 URL 的末尾添加 /v1。",
+        "deploymentName": "部署名称",
+        "deploymentNamePlaceholder": "请输入部署名称...",
+        "deploymentNameDescription": "Azure OpenAI 部署名称",
+        "defaultModelPlaceholder": "gpt-4o、claude-3-5-sonnet-20241022 等。",
+        "defaultModelDescription": "默认使用的模型",
+        "maxTokensPerRequest": "每次请求的最大令牌数",
+        "maxRequestsPerMinute": "每分钟最大请求数",
+        "costPerInputToken": "每百万个输入代币的成本（美元）",
+        "costPerOutputToken": "每百万个输出代币的成本（美元）",
+        "monthlyBudget": "每月预算（美元）",
+        "monthlyBudgetPlaceholder": "100.00",
+        "monthlyBudgetDescription": "可选的通知消费目标（不会限制使用）",
+        "billingPeriodStartDay": "计费周期起始日",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "账单周期开始的日期（1-31）。29-31 使用的是较短月份的最后一天。",
+        "defaultTemperature": "默认温度",
+        "defaultMaxTokens": "默认最大令牌数",
+        "timeout": "请求超时时间（毫秒）",
+        "timeoutDescription": "等待 AI 模型响应的最长时间（5000-600000 毫秒）。不适用于流式请求。",
+        "streamingEnabled": "启用流媒体",
+        "streamingEnabledDescription": "允许实时响应流",
+        "setAsDefault": "设置为默认值",
+        "setAsDefaultDescription": "将此模型用作组织的默认人工智能模型。",
+        "fetchingModels": "正在获取模型...",
+        "failedToFetchModels": "获取可用模型失败",
+        "selectModel": "选择型号",
+        "connectionSuccessfulDescription": "AI模型连接已验证，运行正常。",
+        "failedToConnect": "无法连接到 AI 模型提供商",
+        "integrationCreated": "AI模型集成已成功创建",
+        "failedToCreate": "创建 AI 模型集成失败",
+        "validation": {
+          "nameRequired": "集成名称为必填项",
+          "nameUnique": "已存在同名集成",
+          "defaultModelRequired": "需要默认模型"
+        }
+      },
+      "edit": {
+        "title": "编辑 AI 模型集成",
+        "description": "更新此 AI 模型集成的配置",
+        "statusDescription": "启用或禁用此集成",
+        "apiKeyPlaceholder": "请输入新的 API 密钥进行更新...",
+        "update": "更新",
+        "integrationUpdated": "AI模型集成已成功更新",
+        "failedToUpdate": "AI模型集成更新失败",
+        "validation": {
+          "nameRequired": "集成名称为必填项",
+          "nameUnique": "已存在同名集成",
+          "defaultModelRequired": "需要默认模型"
+        }
+      },
+      "sections": {
+        "provider": "提供者",
+        "costAndBudget": "成本与预算",
+        "advanced": "先进的"
+      },
+      "delete": {
+        "title": "删除 AI 模型集成",
+        "description": "您确定要删除此AI模型集成吗？此操作会将其从所有项目中移除，且无法撤销。",
+        "integrationDeletedSuccess": "AI模型集成已成功删除",
+        "failedToDeleteIntegration": "删除 AI 模型集成失败",
+        "cannotDeleteDefault": "无法删除默认AI模型。请先将另一个模型设置为默认模型。"
+      },
+      "validation": {
+        "defaultModelRequired": "需要默认模型"
+      },
+      "test": {
+        "title": "测试人工智能模型集成",
+        "description": "测试 {name}的连接和功能",
+        "connectionStatus": "连接状态",
+        "connectionStatusDescription": "检查人工智能模型是否可访问",
+        "retest": "重新测试连接",
+        "connectionSuccessfulDescription": "AI模型可访问且响应正确。",
+        "failedToConnect": "连接人工智能模型失败",
+        "errorTestingConnection": "测试连接时发生错误",
+        "testMessage": "测试消息",
+        "testMessagePlaceholder": "请输入要发送给人工智能模型的消息……",
+        "sendTestMessage": "发送测试消息",
+        "response": "回复",
+        "testSuccessful": "测试成功",
+        "responseReceived": "已成功收到响应（成本： ${cost}）",
+        "testFailed": "测试失败",
+        "failedToGetResponse": "未能从人工智能模型获得响应",
+        "failedToSendMessage": "发送测试消息失败",
+        "defaultTestMessage": "您好！请简要确认您的工作一切正常。"
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "设定月度预算并不能阻止LLM的使用超出预算。预算限制仅供管理员决策参考。",
+        "budgetDisclaimerShort": "预算限制仅供参考，不会限制使用。",
+        "spendLabel": "本月支出",
+        "spendOfBudget": "{currentSpend} 的 {budgetLimit}",
+        "overBudget": "超出预算",
+        "budgetPercentage": "{percentage}已用预算百分比",
+        "spendReset": "本月支出已重置"
+      }
+    },
+    "prompts": {
+      "title": "提示配置",
+      "description": "管理不同功能的 AI 提示模板",
+      "addPromptConfig": "添加提示配置",
+      "filterPlaceholder": "筛选提示配置...",
+      "features": "特征",
+      "featureCount": "{count, plural, one {# 功能} other {# 功能}}",
+      "llmIntegration": "LLM整合",
+      "modelOverride": "模型覆盖",
+      "llmIntegrationPlaceholder": "项目默认值",
+      "modelOverridePlaceholder": "集成默认值",
+      "projectDefault": "项目默认值（清除）",
+      "integrationDefault": "集成默认值（清除）",
+      "systemPrompt": "系统提示",
+      "userPrompt": "用户提示",
+      "temperature": "温度",
+      "maxOutputTokens": "最大输出令牌",
+      "variables": "变量",
+      "insertVariable": "插入变量",
+      "noConfigs": "未找到任何配置。请添加您的第一个配置以开始使用。",
+      "add": {
+        "title": "添加提示配置",
+        "description": "创建一个新的AI提示配置，为每个功能添加提示。默认值已自动应用。"
+      },
+      "edit": {
+        "title": "编辑提示配置",
+        "description": "更新此 AI 提示配置"
+      },
+      "delete": {
+        "title": "删除提示配置",
+        "confirmMessage": "您确定要删除 <strong>{name}</strong>吗？使用此提示的项目将回退到系统默认值。",
+        "warning": "此操作无法撤销。所有使用此配置的项目都将恢复为默认提示配置。"
+      },
+      "llmColumn": "法学硕士",
+      "mixedLlms": "{count} 法学硕士",
+      "cannotDeleteDefault": "无法删除默认提示符配置。请先将另一个配置设为默认值。",
+      "defaultChanged": "默认提示符配置已成功更新。",
+      "featureLabels": {
+        "markdown_parsing": "Markdown 测试用例解析",
+        "test_case_generation": "测试用例生成",
+        "magic_select_cases": "智能测试用例选择",
+        "editor_assistant": "编辑写作助理",
+        "llm_test": "LLM 连接测试",
+        "export_code_generation": "导出代码生成",
+        "auto_tag": "AI标签建议",
+        "duplicate_detection": "重复检测",
+        "generate_from_url": "根据 URL 生成测试用例（需求）",
+        "generate_from_url_app": "从 URL 生成测试用例（应用程序测试）"
+      }
+    },
+    "elasticsearch": {
+      "title": "Elasticsearch 管理",
+      "description": "管理搜索引擎索引和维护",
+      "status": {
+        "title": "Elasticsearch 状态",
+        "description": "搜索引擎的当前连接和运行状况",
+        "checking": "正在检查状态……",
+        "disconnected": "断开连接",
+        "nodes": "节点",
+        "indices": "指数",
+        "documents": "文档",
+        "error": {
+          "title": "连接错误",
+          "description": "无法连接到 Elasticsearch 服务"
+        }
+      },
+      "settings": {
+        "description": "配置 Elasticsearch 设置以进行部署",
+        "numberOfReplicas": "副本数量",
+        "replicasHelp": "单节点集群设为 0，多节点冗余集群设为 1 或更高。",
+        "savedDescription": "配置已保存到数据库",
+        "updated": "指数已更新",
+        "updatedDescription": "所有现有索引均已使用新的副本设置进行更新。",
+        "error": "保存设置时出错",
+        "errorDescription": "配置保存失败，请重试。",
+        "note": {
+          "description": "更改会立即应用于新创建的索引。现有索引会在保存时更新。将副本数设置为 0 可以解决单节点集群上的黄色状态问题。"
+        }
+      },
+      "reindex": {
+        "title": "重新索引数据",
+        "description": "重建搜索索引以提高搜索性能",
+        "entities": {
+          "all": "所有实体"
+        },
+        "button": {
+          "start": "开始重新索引",
+          "indexing": "正在建立索引……"
+        },
+        "warning": {
+          "title": "重要的",
+          "description": "重新索引可能需要几分钟时间，具体时间取决于数据量。在此过程中，搜索功能可能会受到限制。"
+        },
+        "complete": {
+          "title": "重新索引完成",
+          "description": "所有选定的实体均已成功重新索引。"
+        },
+        "success": {
+          "title": "重新索引成功",
+          "description": "{count, plural, one {# 文档} other {# 文档}} 索引成功"
+        },
+        "error": {
+          "title": "重新索引失败",
+          "description": "重新索引时发生错误，请重试。"
+        }
+      }
+    },
+    "queues": {
+      "title": "后台作业队列",
+      "description": "监控和管理后台作业处理队列",
+      "queueNames": {
+        "forecast-updates": "预测更新",
+        "emails": "电子邮件队列",
+        "issue-sync": "问题同步",
+        "testmo-imports": "Testmo Imports",
+        "elasticsearch-reindex": "Elasticsearch 重新索引",
+        "audit-logs": "审计日志",
+        "budget-alerts": "预算警报",
+        "auto-tag": "AI自动标签",
+        "repo-cache": "存储库缓存",
+        "copy-move": "复制和移动",
+        "duplicate-scan": "重复扫描",
+        "magic-select": "魔法选择",
+        "step-scan": "步进序列扫描"
+      },
+      "status": {
+        "paused": "暂停",
+        "idle": "闲置的"
+      },
+      "table": {
+        "queue": "队列",
+        "concurrency": "并发性",
+        "waiting": "等待",
+        "failed": "失败的"
+      },
+      "concurrency": {
+        "title": "工作并发",
+        "description": "并发性控制每个工作进程同时处理的作业数量。更高的并发性可以提高吞吐量，但会占用更多系统资源（CPU 和内存）。",
+        "configureTitle": "配置并发性",
+        "configureDescription": "要调整并发数，请设置环境变量并重启工作进程。详情请参阅文档。",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo 导入（默认值：1，占用大量内存）",
+          "SYNC_CONCURRENCY": "问题同步（默认值：2，I/O密集型）",
+          "EMAIL_CONCURRENCY": "电子邮件发送（默认值：3，I/O密集型）",
+          "NOTIFICATION_CONCURRENCY": "通知（默认值：5，轻量级）",
+          "FORECAST_CONCURRENCY": "预测更新（默认值：5，CPU密集型）"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "暂停队列",
+          "confirmDescription": "这将阻止新任务的处理。正在进行的任务将继续完成。"
+        },
+        "resume": {
+          "confirmTitle": "恢复队列",
+          "confirmDescription": "这将允许队列处理等待中的作业。"
+        },
+        "clean": {
+          "confirmTitle": "清理队列",
+          "confirmDescription": "这将从队列中移除已完成和失败的任务。此操作无法撤销。"
+        },
+        "drain": {
+          "confirmTitle": "排水队列",
+          "confirmDescription": "这将从队列中移除所有等待中的任务。正在进行的任务将继续完成。此操作无法撤销。"
+        },
+        "obliterate": {
+          "confirmTitle": "删除队列",
+          "confirmDescription": "这将彻底清空队列，删除所有任务，无论其状态如何。此操作无法撤销，仅应在紧急情况下使用。"
+        },
+        "warning": "警告",
+        "irreversible": "此操作无法撤销。请确认是否继续。"
+      },
+      "success": {
+        "actionCompleted": "操作完成",
+        "queuePaused": "队列已暂停",
+        "queueResumed": "队列已恢复。",
+        "queueCleaned": "队列已清理完毕",
+        "queueDrained": "队列已清空",
+        "queueObliterated": "队列已被删除"
+      },
+      "error": {
+        "loadFailed": "队列加载失败",
+        "actionFailed": "操作失败"
+      },
+      "jobs": {
+        "title": "排队作业",
+        "description": "查看和管理队列中的各个作业",
+        "noJobs": "此队列中未找到任何任务",
+        "table": {
+          "id": "职位编号",
+          "name": "职位名称",
+          "attempts": "尝试"
+        },
+        "details": {
+          "title": "职位详情",
+          "failedReason": "失败原因",
+          "stacktrace": "堆栈跟踪",
+          "data": "工作数据",
+          "returnValue": "返回值",
+          "options": "工作选择",
+          "processed": "已处理",
+          "finished": "完成的"
+        },
+        "success": {
+          "actionCompleted": "工作操作已完成",
+          "jobRetried": "任务已重试",
+          "jobPromoted": "职位已晋升",
+          "jobRemoved": "职位已移除"
+        },
+        "error": {
+          "loadFailed": "加载作业失败",
+          "actionFailed": "作业操作失败"
+        },
+        "forceRemove": {
+          "title": "强制删除职位",
+          "question": "你想强制删除这个职位吗？",
+          "warning": "这将尝试多次移除该任务，每次移除操作都会有延迟。注意：如果该任务确实被正在运行的工作进程锁定，则移除操作仍可能失败。",
+          "confirm": "强制移除"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "查看系统范围内的审计跟踪，以进行安全性和合规性跟踪",
+      "filterPlaceholder": "按实体、用户或操作搜索……",
+      "filterAction": "行动",
+      "filterEntityType": "实体类型",
+      "allActions": "所有操作",
+      "allEntityTypes": "所有实体类型",
+      "showing": "显示 {start} 到 {end} 共 {total} 条记录",
+      "viewDetails": "查看详情",
+      "detailTitle": "审计日志详情",
+      "userInfo": "用户信息",
+      "changes": "变化",
+      "metadata": "元数据",
+      "oldValue": "老的",
+      "newValue": "新的",
+      "columns": {
+        "timestamp": "时间戳",
+        "entityId": "实体 ID",
+        "entityName": "实体名称",
+        "userId": "用户身份",
+        "ipAddress": "IP地址",
+        "userAgent": "用户代理"
+      },
+      "exportCsv": "导出 CSV 文件",
+      "timeRange": "时间范围",
+      "timeRangeOptions": {
+        "last24h": "过去24小时",
+        "last7d": "过去7天",
+        "last30d": "过去30天",
+        "last90d": "过去90天",
+        "allTime": "所有时间"
+      },
+      "systemActor": "系统",
+      "systemActorTooltip": "系统执行的操作，而非登录用户执行的操作。"
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "无通知",
+      "aria": {
+        "notifications": "通知（{count} 未读）"
+      },
+      "actions": {
+        "markRead": "标记为已读",
+        "markUnread": "标记为未读",
+        "markAllRead": "全部标记为已读",
+        "deleteAll": "全部删除"
+      },
+      "success": {
+        "deleted": "通知已删除",
+        "markedAllRead": "所有标记为已读的通知",
+        "deletedAll": "所有通知已删除"
+      },
+      "error": {
+        "markRead": "标记为已读失败",
+        "markUnread": "标记为未读失败",
+        "delete": "删除通知失败",
+        "markAllRead": "未能将所有内容标记为已读",
+        "deleteAll": "删除通知失败"
+      },
+      "deleteAllDialog": {
+        "title": "删除所有通知？",
+        "description": "这将永久删除您的所有通知。此操作无法撤销。",
+        "confirm": "全部删除"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "新的测试用例分配",
+        "multipleTestCaseAssignmentTitle": "已分配多个测试用例",
+        "sessionAssignmentTitle": "新会话分配",
+        "commentMentionTitle": "你被评论中提到了。",
+        "systemAnnouncementTitle": "系统公告",
+        "assignedTestCase": "已分配您执行测试用例",
+        "assignedMultipleTestCases": "分配给你的测试用例数： {count, plural, one {# 测试用例数：} other {# 测试用例数：}}",
+        "assignedSession": "已将您分配到会话",
+        "mentionedYouInComment": "在评论中提到了你",
+        "inProject": "项目",
+        "testRun": "测试运行：",
+        "casesInProject": "{count, plural, =1 {# 案例} other {# 案例}}",
+        "sentBy": "发送者： {name}",
+        "milestoneDueSoonTitle": "里程碑即将到来",
+        "milestoneOverdueTitle": "里程碑逾期",
+        "milestoneDueSoon": "项目“{projectName}”中的里程碑“{milestoneName}”将于 {dueDate}到期。",
+        "milestoneOverdue": "项目“{projectName}”中的里程碑“{milestoneName}”原定于 {dueDate} 到期，现已逾期。",
+        "milestoneNotificationReason": "您收到此通知是因为您参与了与此里程碑相关的工作（测试运行、会议或作为里程碑创建者）。",
+        "milestoneNotificationContinue": "您将持续收到每日提醒，直到此里程碑被标记为完成。",
+        "shareLinkAccessedTitle": "分享链接已访问",
+        "shareLinkAccessedAnonymousViewer": "某人",
+        "shareLinkAccessedMessage": "{viewer} 查看了您共享的报告：\"{shareTitle}\"",
+        "viewedYourSharedLink": "我已查看您分享的链接",
+        "viewedAt": "查看于",
+        "budgetDisclaimer": "预算限制仅供参考，并不妨碍实际使用。",
+        "llmBudgetExceededTitle": "法学硕士预算超支",
+        "llmBudgetThresholdTitle": "LLM 预算 {threshold}已用百分比",
+        "llmBudgetExceededMessage": "{providerName} 已超出其月度预算： {spend} 已花费 {budget} 预算。",
+        "llmBudgetThresholdMessage": "{providerName} 已使用其每月预算的 {threshold}%： {spend} 的 {budget}。",
+        "userRegisteredTitle": "新用户注册",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) 已通过 SSO 注册",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) 已通过注册表单注册",
+        "viewUserList": "查看用户列表",
+        "reviewGeneratedCases": "审查生成的测试用例",
+        "generateFromUrlCompleteTitle": "页面抓取成功",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# 页} other {# 页数}} 已从项目“{projectName}中的 {url} 爬取。点击查看并生成测试用例。",
+        "generateFromUrlFailedTitle": "URL 爬取失败"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "搜索或链接问题……",
+        "create_label": "链接问题“{name}”"
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "输入问题摘要"
+        },
+        "fields": {
+          "name": {
+            "label": "概括"
+          },
+          "description": {
+            "placeholder": "请描述一下问题……",
+            "helper": "请提供有关该问题的详细信息。"
+          },
+          "project": {
+            "helper": "在外部问题跟踪器中选择项目"
+          }
+        },
+        "loading_metadata": "正在加载集成设置...",
+        "errors": {
+          "creation_failed": "创建问题失败，请重试。"
+        },
+        "success": {
+          "created": "问题已成功创建",
+          "external_created": "问题已创建并链接到外部跟踪器"
+        },
+        "warnings": {
+          "external_failed": "问题已在本地创建，但无法与外部跟踪器同步。"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "您需要将您的帐户连接到 {integrationName} 才能创建问题。"
+      },
+      "search_issues_dialog": {
+        "title": "搜索和链接问题",
+        "placeholder": "查找问题...",
+        "searching": "正在搜索……",
+        "searchError": "搜索问题失败",
+        "linkButton": "关联",
+        "linkedCount": "{count, plural, one {# 问题} other {# 问题}} 链接"
+      }
+    },
+    "copyMove": {
+      "title": "复制/移动到项目",
+      "step1Desc": "选择测试用例的目标项目和文件夹。",
+      "step2Desc": "选择操作并检查兼容性。",
+      "step3Desc": "跟踪进度并审查结果。",
+      "targetProject": "目标项目",
+      "searchProjects": "搜索项目...",
+      "loadingProjects": "正在加载项目...",
+      "noProjectsFound": "未找到项目。",
+      "completed": "（完全的）",
+      "targetFolder": "目标文件夹",
+      "newFolderPlaceholder": "新文件夹名称...",
+      "operation": "手术",
+      "operationCopy": "复制",
+      "operationCopyDesc": "在目标项目中创建所选案例的副本。原始案例保持不变。",
+      "operationMove": "移动",
+      "operationMoveDesc": "将选定的案例移动到目标项目。原始案例将从源项目中删除。",
+      "checkingCompatibility": "正在检查兼容性……",
+      "noTargetWriteAccess": "您没有目标项目的写入权限。",
+      "noSourceUpdateAccess": "您没有源项目的编辑权限，无法移动案例。",
+      "templateMismatch": "模板不匹配",
+      "autoAssignTemplates": "自动将缺失的模板分配给目标项目",
+      "templatesMayNotDisplay": "目标项目中将无法使用缺失的模板。案例将被复制，但模板中的字段可能无法正确显示。",
+      "workflowFallback": "目标项目中某些工作流状态不可用。这些情况下将使用目标项目的默认状态。",
+      "default": "（默认）",
+      "conflicts": "适用于所有冲突：",
+      "conflictSkip": "跳过",
+      "conflictRename": "重命名",
+      "sharedStepGroups": "当目标系统中已存在共享步骤组时：",
+      "sharedStepGroupReuse": "重复利用现有",
+      "sharedStepGroupReuseDesc": "案例将参考现有的共享步骤组。",
+      "sharedStepGroupCreateNew": "创建新的",
+      "sharedStepGroupCreateNewDesc": "将创建一个新的共享步骤组。",
+      "go": "去",
+      "processing": "加工...",
+      "progressText": "已处理案例数：{processed} / {total}",
+      "successCount": "{count} 案例 {operation}d 成功",
+      "skipped": "已跳过： {count}",
+      "droppedLinks": "跨项目链接已删除： {count}",
+      "errorCount": "{count} 案例失败",
+      "viewInTargetProject": "在目标项目中查看",
+      "failed": "失败的",
+      "folderMode": "文件夹“{folderName}” — {caseCount, plural, one {# 案例} other {# 案例}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "相关问题",
+    "linkedIssuesDescription": "与此项目相关的问题",
+    "refreshed": "问题已更新",
+    "refreshedDescription": "相关问题列表已更新",
+    "unlinked": "问题未关联",
+    "unlinkedDescription": "该问题已从此项目中移除。",
+    "linked": "相关问题",
+    "linkedDescription": "该问题与此项目有关",
+    "searchAndLink": "搜索和链接",
+    "createAndLink": "创建和链接",
+    "noLinkedIssues": "没有相关问题",
+    "viewExternal": "在 {provider}中查看",
+    "unlink": "取消链接",
+    "linkError": "链接问题失败",
+    "linkExternalIssue": "链接 {provider} 问题",
+    "linkIssue": "链接问题",
+    "addIssue": "添加问题",
+    "unlinkError": "取消链接问题失败",
+    "noIssuesFound": "未发现问题",
+    "startTypingToSearch": "开始输入以搜索问题",
+    "selectedCount": "{count} 已选择",
+    "confirmSelection": "确认选择",
+    "alreadyLinked": "已链接",
+    "authenticate": "认证",
+    "authenticationRequired": "需要身份验证",
+    "authenticationDescription": "您需要使用 {provider} 进行身份验证才能搜索问题。",
+    "searchIn": "在 {provider}中搜索",
+    "searchPlaceholder": "搜索问题……",
+    "searchIssues": "搜索问题",
+    "searchIssuesDescription": "查找与此项目相关的内部问题。",
+    "searchExternalDescription": "搜索 {provider} 个问题以链接到此项目。",
+    "error": "加载问题错误",
+    "errorDescription": "问题加载失败，请重试。",
+    "selectIssues": "选择问题",
+    "authRequiredDescription": "请使用 {provider} 进行身份验证以搜索问题",
+    "integrationNotConfigured": "集成未配置",
+    "integrationNotConfiguredDescription": "此集成尚未完全配置。请联系您的项目管理员，以便在项目设置中配置外部项目。",
+    "createIssue": "创建问题",
+    "createNewIssue": "创建新问题",
+    "createIssueDescription": "创建新问题",
+    "createIssueDescriptionWithIntegration": "使用 {provider}创建新问题",
+    "createIssueDescriptionSimpleUrl": "创建新的内部问题（简单 URL 集成）",
+    "creatingWith": "创建问题 {provider}",
+    "authenticatedAndReady": "已通过身份验证，可以创建问题。",
+    "created": "问题已创建",
+    "createdInExternal": "问题创建于 {provider}",
+    "createdInternal": "本地创建的问题",
+    "createdInternalSimpleUrl": "此问题已在内部创建，可通过简单 URL 链接。",
+    "createError": "创建问题失败",
+    "useIntegration": "使用 {provider}",
+    "useIntegrationDescription": "在外部系统中创建问题",
+    "externalProject": "外部项目",
+    "selectProject": "选择项目",
+    "issueType": "问题类型",
+    "selectIssueType": "选择问题类型",
+    "noIssueTypes": "暂无问题类型",
+    "priorityUrgent": "紧迫的",
+    "additionalFields": "附加字段",
+    "createIssueInJira": "在 Jira 中创建问题",
+    "createIssueInJiraDescription": "使用 Jira 的界面创建一个包含所有可用字段和选项的新问题",
+    "createIssueInJiraFallbackDescription": "在新标签页中打开 Jira，即可创建带有预填信息的议题。",
+    "jiraIframeError": "无法加载 Jira 界面。请尝试在新标签页中打开。",
+    "jiraIframeFallback": "出于安全考虑，Jira 需要新标签页中打开。请点击下方按钮创建您的问题。",
+    "jiraFallbackNote": "在 Jira 中创建问题后，返回此处继续将其链接到您的测试用例。",
+    "openInNewTab": "在新标签页中打开",
+    "jiraIframeNote": "在 Jira 中创建问题后，您可以关闭此对话框并刷新问题列表。",
+    "fillInRequiredFields": "填写必填字段以创建新问题",
+    "failedToFetchFields": "无法从 Jira 获取问题字段",
+    "enterSummary": "请简要概述该问题。",
+    "enterDescription": "请详细描述问题。",
+    "failedToCreateIssue": "在 Jira 中创建问题失败",
+    "issueCreatedDescription": "问题 {key} 已成功创建",
+    "addLabel": "添加标签并按 Enter 键",
+    "labelHint": "空格将被替换为连字符。",
+    "labelFormatNote": "标签中不能包含空格。空格将被自动替换为连字符。",
+    "enterIssueKey": "输入问题编号（例如，PROJ-123）",
+    "issueLinkHelp": "输入现有问题的键值以进行链接",
+    "searchForIssue": "查找要链接的问题",
+    "searchUsers": "搜索用户",
+    "noTeamsAvailable": "暂无球队",
+    "filterAll": "全部",
+    "fanOutPartialFailure": "无法访问 {count} 个项目。正在显示 {successCount} 个项目的结果。",
+    "projectSelectorLabel": "项目",
+    "searchFailedTitle": "搜索失败"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "浏览和管理所有问题。",
+      "filterPlaceholder": "按名称筛选问题..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "文档",
+      "Milestones": "里程碑",
+      "TestCaseRepository": "测试用例库",
+      "TestCaseRestrictedFields": "测试用例受限字段",
+      "TestRuns": "测试运行",
+      "ClosedTestRuns": "封闭式测试运行",
+      "TestRunResults": "测试运行结果",
+      "TestRunResultRestrictedFields": "测试运行结果受限字段",
+      "Sessions": "会议",
+      "SessionsRestrictedFields": "会话受限字段",
+      "ClosedSessions": "闭门会议",
+      "SessionResults": "会议结果",
+      "Tags": "标签",
+      "SharedSteps": "共同步骤",
+      "Issues": "问题",
+      "IssueIntegration": "问题整合",
+      "Forecasting": "预测",
+      "Reporting": "报告",
+      "Settings": "设置"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "尚未开始",
+      "IN_PROGRESS": "进行中",
+      "DONE": "完毕"
+    }
+  },
+  "charts": {
+    "average": "平均的",
+    "count": "计数： {count}",
+    "percent": "百分比： {percent}%",
+    "completed": "已完成： {count}",
+    "durationRange": "持续时间： {from}秒 - {to}秒",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# 测试用例} other {# 测试用例}}",
+    "estimate": "估计： {value}",
+    "partOf": "（ {parent}的一部分）",
+    "status": "状态： {status}"
+  },
+  "linkedCases": {
+    "title": "关联测试用例",
+    "addLink": "添加链接",
+    "addLinkedTestCase": "添加关联测试用例",
+    "testCase": "测试用例",
+    "linkType": "链接类型",
+    "noLinkedCases": "没有关联的测试用例。",
+    "linkedBy": "链接",
+    "on": "链接",
+    "alreadyLinked": "此案已关联。",
+    "cannotLinkSelf": "无法将案件与其自身关联。",
+    "circularLink": "检测到环状链接。",
+    "failedToCreate": "链接创建失败。",
+    "confirmRemoveLink": "您确定要删除此链接吗？",
+    "DEPENDS_ON": "依赖性",
+    "DUPLICATED_FROM": "复制自",
+    "SAME_TEST_DIFFERENT_SOURCE": "相同的测试（不同来源）",
+    "status": "最新状态",
+    "at": "已执行"
+  },
+  "ganttTooltip": {
+    "task": "任务",
+    "group": "运行/会话：",
+    "project": "项目：",
+    "starts": "开始：",
+    "scheduledCompletion": "预计完工日期：",
+    "estWorkEffort": "预计工作量：",
+    "noTasks": "甘特图中没有要显示的任务。"
+  },
+  "help": {
+    "project": {
+      "name": "## 项目名称\n项目的唯一标识符。\n\n- 必须在所有项目中唯一\n- 用于导航和报告\n- 应清晰且具有描述性\n- 帮助团队成员识别项目范围",
+      "description": "## 项目描述\n项目目的和范围的更多详细信息。\n\n- 可选，但建议填写\n- 帮助团队成员理解项目目标\n- 可包含关键目标或需求\n- 限 256 个字符",
+      "icon": "## 项目图标\n项目的视觉标识符。\n\n- 有助于在列表和仪表盘中快速识别项目\n- 可从各种预定义图标中选择\n- 可随时更改\n- 显示在项目导航和报告中",
+      "completed": "## 项目状态\n指示项目是处于活动状态还是已完成状态。\n\n- 活动项目可用于测试和更新。\n- 已完成项目为只读。\n- 影响项目在仪表盘中的可见性。\n- 如有需要，可以撤销此设置。",
+      "completedAt": "## 完成日期\n项目标记为完成的日期。\n\n- 在将项目标记为完成时自动设置\n- 用于报告和跟踪\n- 有助于维护项目历史记录\n- 可根据需要进行修改",
+      "defaultAccess": "## 默认项目访问权限\n定义此项目中用户和组的默认访问权限。可以针对每个用户或每个组进行覆盖。",
+      "issueTracker": "## 问题跟踪器配置\n选择用于管理与此项目相关的问题的跟踪器配置。"
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## 外部项目\n选择要与此 TestPlanIt 项目关联的外部系统中的项目或存储库。\n\n- 从 TestPlanIt 创建的问题将在此项目中创建。\n- 启用系统间的问题跟踪集成。\n- 必须在外部系统中拥有相应的权限。",
+          "defaultIssueTypeHelp": "## 默认问题类型\n从 TestPlanIt 创建新问题时将预先选择的问题类型。\n\n- 默认为最常用的问题类型，节省时间。\n- 创建单个问题时可以覆盖此设置。\n- 必须是所选外部项目的有效问题类型。\n- 如果您的工作流程发生更改，请更新此设置。",
+          "automaticSyncHelp": "## 自动同步\n启用 TestPlanIt 与外部系统之间的问题状态自动同步。\n\n- 与测试用例关联的问题将自动更新其状态。\n- 有助于保持跨系统问题跟踪的一致性。\n- 可能会增加外部服务的 API 使用量。\n- 如果更喜欢手动控制，可以禁用此功能。"
+        }
+      }
+    },
+    "user": {
+      "name": "## 用户名\n用户的全名。\n\n- 用于系统内的身份识别\n- 显示在任务分配和报告中\n- 每个用户的用户名必须唯一",
+      "email": "## 电子邮件地址\n用户用于访问帐户的电子邮件地址。\n\n- 用于系统登录\n- 每个用户必须使用唯一的电子邮件地址\n- 用于系统通知",
+      "password": "## 密码\n用户帐户密码。\n\n- 如果配置了无密码登录方式（Magic Link SSO 提供商或电子邮件服务器），则此项为可选 — 留空则必须通过 Magic Link 或 SSO 登录。\n- 如果提供，则必须满足“管理 → 安全”中设置的密码策略（最小长度和字符类别）。\n- 用于安全帐户访问。\n- 应保密。",
+      "token": "## 验证令牌\n输入您在电子邮件中收到的令牌以验证您的帐户。如果您没有令牌，可以申请一个新的。",
+      "confirmPassword": "## 确认密码\n请重新输入密码，确保输入正确。\n\n- 必须与密码完全一致。\n- 有助于防止输入错误。\n- 仅当输入密码时需要填写 — 如果密码字段为空，则留空。",
+      "access": "## 系统访问级别\n决定用户的系统级权限。\n\n- **管理员：** 完全系统访问权限和配置权限\n- **项目管理员：** 可以管理分配的项目\n- **用户：** 对分配的项目具有标准访问权限\n- **无：** 只能查看其仪表板",
+      "role": "## 系统角色\n此角色决定用户的默认项目权限。\n\n- 定义项目的默认访问级别\n- 可在角色管理中进行自定义\n- 影响可用功能和权限",
+      "active": "## 活动状态\n控制用户是否可以访问系统。\n\n- 活动用户可以登录并访问其分配的资源。\n- 非活动用户无法登录，但其数据将被保留。\n  - 使用此选项可暂时禁用访问权限，而不会删除帐户。",
+      "api": "## API 访问\n允许通过 API 端点以编程方式访问系统。\n\n- 允许与外部工具和自动化集成\n- 需要 API 密钥身份验证\n- 受速率限制和访问控制",
+      "projects": "## 项目分配\n选择此用户可以访问的项目。\n\n- 控制哪些项目显示在用户的仪表板中。\n- 项目参与的必要条件。\n- 管理员可以稍后修改。\n- 使用“全选”快速分配所有可用项目。",
+      "groups": "## 分组\n选择此用户所属的组。\n\n- 分组有助于组织用户和权限。\n- 用户继承其所属组的权限。\n- 简化访问管理。\n- 管理员稍后可以修改。",
+      "itemsPerPage": "## 每页显示项目数\n控制表格和列表中显示的默认项目数。\n\n- 影响应用程序中所有分页视图\n- 可随时更改\n- 有助于高效管理大型数据集\n- 可选值：10、25、50 或 100 项",
+      "dateFormat": "## 日期格式\n设置您首选的日期显示格式。\n\n- 在整个应用程序中统一应用\n- 有助于确保日期解读的准确性\n- 更改立即生效\n- 下拉菜单中显示的示例反映了实际格式",
+      "timeFormat": "## 时间格式\n设置您首选的时间显示格式。\n\n- 选择 12 小时制或 24 小时制\n- 在整个应用程序中统一应用\n- 更改立即生效\n- 下拉菜单中显示的示例反映了实际格式",
+      "timezone": "## 时区\n设置日期和时间显示的首选时区。\n\n- 在整个应用程序中统一应用",
+      "theme": "## 主题\n选择您喜欢的应用程序视觉主题。\n\n- **系统：** 自动匹配您的操作系统主题\n- **浅色：** 简洁明亮的界面，适合白天使用\n- **深色：** 护眼深色模式，适合光线较暗的环境\n- **绿色、橙色、紫色：** 充满活力的色彩！",
+      "locale": "## 语言\n选择您偏好的应用程序界面语言。\n\n- 将所有文本、标签和消息更改为您选择的语言\n- 日期和时间格式将自动调整以符合区域惯例\n- 立即生效，无需刷新页面\n- 可用语言取决于已安装的翻译",
+      "notificationMode": "## 通知偏好设置\n控制您接收工作任务和更新通知的方式。\n\n- **使用全局设置：** 遵循管理员设置的系统默认值。\n- **无通知：** 禁用所有通知。\n- **仅限应用内：** 仅在应用内接收通知。\n- **应用内通知 + 电子邮件（立即）：** 同时接收应用内通知和电子邮件提醒。\n- **应用内通知 + 电子邮件（每日摘要）：** 接收应用内通知和每日电子邮件摘要。\n\n您可以随时更改此偏好设置以适应您的工作流程。"
+    },
+    "milestone": {
+      "name": "## 里程碑名称\n一个清晰、描述性的名称，用于标识项目中的此里程碑。\n\n- 应具有唯一性和意义\n- 帮助团队成员快速理解里程碑的目的\n- 用于报告和项目跟踪",
+      "type": "## 里程碑类型\n对里程碑进行分类，并决定其外观和行为。\n\n- 不同类型的里程碑可能具有不同的工作流程。\n- 有助于组织和筛选里程碑。\n- 可能会影响报告和跟踪。",
+      "started": "## 开始状态\n表示此里程碑的工作已开始。\n\n- 将里程碑标记为进行中。\n- 切换后自动更新实际开始日期。\n- 影响项目时间表和进度跟踪。",
+      "completed": "## 完成状态\n表示此里程碑的工作已完成。\n\n- 将里程碑标记为已完成。\n- 自动更新实际完成日期。\n- 用于进度跟踪和报告。\n- 影响依赖里程碑和项目时间表。",
+      "startDate": "## 计划开始日期\n此里程碑预计开始工作的日期。\n\n- 有助于项目规划和进度安排\n- 用于时间线预测\n- 支持资源分配规划",
+      "dueDate": "## 截止日期\n完成此里程碑的目标日期。\n\n- 设定截止日期预期\n- 用于项目时间表规划\n- 帮助跟踪里程碑进度与计划的对比情况",
+      "parent": "## 父级里程碑\n将此里程碑链接到父级里程碑，从而创建层级结构。\n\n- 将里程碑组织成逻辑组。\n- 显示依赖关系。\n- 帮助跟踪大型项目的进展。",
+      "description": "## 描述\n里程碑的目的、要求和范围的详细信息。\n\n- 为团队成员提供背景信息\n- 记录关键要求和目标\n- 支持协作和目标一致性",
+      "documentation": "## 文档\n更多详情、参考资料和支持材料。\n\n- 技术规范\n- 设计文档\n- 外部参考资料\n- 会议记录和决议",
+      "automaticCompletion": "## 截止日期自动完成\n当里程碑的截止日期到来时，会自动将其标记为已完成。\n\n- 里程碑将在截止日期当天按计划时间完成。\n- 适用于无论完成状态如何都应关闭的限时里程碑。\n- 可以通过在截止日期前手动完成里程碑来覆盖此设置。\n- 需要设置截止日期。",
+      "notifyDaysBefore": "## 截止日期前通知\n当里程碑截止日期临近时，向指定的团队成员发送通知。\n\n- 开启此开关以启用通知，关闭此开关以禁用通知。\n- 输入截止日期前开始发送提醒的天数。\n- 通知将发送给分配到此里程碑内测试运行和会话的用户。\n- 逾期里程碑将持续发送提醒，直至完成。"
+    },
+    "session": {
+      "name": "## 会话名称\n一个清晰、描述性的名称，用于明确测试会话的目的。\n\n- 应唯一且有意义\n- 帮助团队成员了解测试内容\n- 用于报告和跟踪",
+      "template": "## 模板\n模板定义了测试会话的结构和内容。\n\n- 为测试文档提供一致的格式\n- 包含预定义的部分和字段\n- 有助于在整个项目中维护测试标准",
+      "configuration": "## 配置\n此测试会话所需的特定环境或设置。\n\n- 测试环境（例如，预发布环境、生产环境）\n- 特殊配置或设置\n- 所需的测试数据或条件",
+      "milestone": "## 里程碑\n将此会话与项目里程碑关联。\n\n- 帮助跟踪测试进度，以实现项目目标。\n- 将相关的测试会话分组。\n- 支持基于里程碑的报告。",
+      "description": "## 描述\n本次测试内容的简要概述。\n\n- 测试的关键领域或功能\n- 重要背景信息\n- 特殊注意事项或要求",
+      "mission": "## 任务\n任务定义了本次测试的具体目标和目的。\n\n- 你要测试什么？\n- 重点关注哪些方面？\n- 预期结果是什么？\n\n清晰的任务有助于保持测试的专注性和高效性。",
+      "estimate": "## 时间预估\n完成本次测试的预计时间。\n\n例如：\n- \"30m\" 表示 30 分钟\n- \"1h 30m\" 表示 1 小时 30 分钟\n- \"2 days\" 表示 2 天\n- \"1 week\" 表示 1 周",
+      "elapsed": "## 已用时间\n本次测试实际耗时。\n\n例如：\n- “45m” 表示 45 分钟\n- “2h 15m” 表示 2 小时 15 分钟\n- “3 days” 表示 3 天\n\n准确记录时间有助于改进未来的估算。",
+      "state": "## 工作流状态\n此测试会话在工作流中的当前状态。\n\n- 帮助跟踪会话进度\n- 支持工作流管理\n- 用于报告和跟踪",
+      "assignedTo": "## 分配给\n负责执行本次测试的团队成员。\n\n- 确定测试执行人\n- 协助资源管理\n- 支持问责和跟踪",
+      "tags": "## 标签\n用于对测试会话进行分类和组织的关键词或标签。\n\n- 便于查找会话\n- 将相关的测试活动分组\n- 支持筛选和报告",
+      "attachments": "## 附件\n与本次测试相关的文档、屏幕截图或其他文件。\n\n- 测试数据文件\n- 屏幕截图或录像\n- 支持文档\n- 参考资料",
+      "issues": "## 问题\n将相关问题链接到本次会议。"
+    },
+    "testRun": {
+      "name": "## 测试运行名称\n输入此测试运行的描述性名称，以便以后轻松识别。",
+      "description": "## 描述\n提供有关本次测试运行的简要总结或说明。",
+      "configuration": "## 配置\n选择一个或多个配置（例如，环境、浏览器、设备），测试运行将在这些配置下执行。选择多个配置将为每个配置创建单独的测试运行。",
+      "milestone": "## 里程碑\n将此测试运行与特定的项目里程碑关联起来，以跟踪实现更大目标的进展。",
+      "docs": "## 文档\n包含本次测试运行的任何相关文档、链接或详细注释。",
+      "state": "## 状态\n根据项目的工作流程，指示此测试运行的当前状态或结果。",
+      "tags": "## 标签\n应用相关标签对本次测试运行进行分类和筛选。",
+      "issues": "## 问题\n将任何相关问题（错误、任务等）链接到此测试运行。",
+      "attachments": "## 附件\n上传与本次测试运行相关的任何支持文件、屏幕截图或日志。",
+      "duplicate": {
+        "statusesToInclude": "## 要包含的状态\n选择要包含在重复测试运行中的测试用例的状态。",
+        "copyAssignments": "## 复制分配\n如果启用，测试用例的分配将被复制到复制的测试运行中。"
+      }
+    },
+    "appConfig": {
+      "key": "## 键\n此配置的唯一标识符。",
+      "value": "## 值\n此配置的值。"
+    },
+    "milestoneType": {
+      "icon": "## 里程碑类型图标\n此里程碑类型的视觉标识符。\n\n- 有助于在列表和仪表盘中快速识别里程碑类型\n- 可从各种预定义图标中选择\n- 可随时更改\n- 显示在项目导航和报告中",
+      "name": "## 里程碑类型名称\n一个清晰、描述性的名称，用于标识项目中的此里程碑类型。\n\n- 帮助团队成员快速理解里程碑类型的用途\n- 用于报告和项目跟踪",
+      "isDefault": "## 默认里程碑类型\n指示此里程碑类型是否为项目的默认类型。\n\n- 默认里程碑类型已预先选择，适用于新里程碑。\n- 可随时更改。",
+      "projects": "## 关联项目\n选择此里程碑类型将适用于哪些项目。\n\n- 如果未选择任何项目，则里程碑类型将全局可用。\n- 分配给特定项目后，其使用范围将仅限于这些项目。"
+    },
+    "tag": {
+      "name": "## 标签名称\n一个清晰、简洁、描述性的名称或关键词，用于所有项目。\n\n- 帮助团队成员快速找到相关的测试用例、测试运行和会话。"
+    },
+    "role": {
+      "name": "## 角色名称\n一个清晰、简洁、描述性的名称或关键词，用于所有项目。\n\n- 帮助团队成员快速找到相关的测试用例、测试运行和会话。",
+      "isDefault": "## 默认角色\n指示此角色是否为项目的默认角色。\n\n- 默认角色已预先为新用户选择。\n- 可随时更改。",
+      "permissions": {
+        "canAddEdit": "## 添加/编辑\n指示此角色是否可以添加和编辑相关的应用程序区域。",
+        "canDelete": "## 删除\n指示此角色是否可以删除相关的应用程序区域。",
+        "canClose": "## 关闭\n指示此角色是否可以关闭相关的应用程序区域。"
+      }
+    },
+    "group": {
+      "name": "## 组名称\n一个清晰、简洁、描述性的名称或关键词，用于所有项目。\n\n- 帮助团队成员快速找到相关的测试用例、测试运行和会话。",
+      "users": "## 用户\n表示分配给此组的用户。"
+    },
+    "template": {
+      "name": "## 模板名称\n此模板的唯一描述性名称（例如，“标准测试用例”、“API 测试结果”）。",
+      "isEnabled": "## 已启用\n如果选中，则在创建新测试用例或定义测试运行结构时可以选择此模板。如果模板设置为“默认”，则也必须将其设置为“已启用”。",
+      "isDefault": "## 默认值\n如果选中此项，则新项目将自动选择此模板；如果未设置项目特定的默认值，则此模板将作为所有项目的默认模板。所有项目只能有一个默认模板。启用此选项将禁用当前设置为默认模板的任何其他模板。",
+      "caseFields": "## 用例字段\n选择并排序使用此模板创建或编辑测试用例时可用的自定义字段。\n\n- 从下拉列表中添加字段以将其包含在模板中。\n- 拖放以重新排序字段。\n- 顺序决定字段在表单中的显示方式。\n- 只有已启用的用例字段才可供选择。\n- 用例字段定义测试用例的结构和捕获的数据。",
+      "resultFields": "## 结果字段\n选择并排序使用此模板添加测试结果时可用的自定义字段。\n\n- 从下拉列表中添加字段以将其包含在模板中。\n- 拖放以重新排序字段。\n- 顺序决定输入测试结果时字段的显示方式。\n- 只有已启用的结果字段才可供选择。\n- 结果字段捕获特定于测试执行结果的其他数据。",
+      "projects": "## 关联项目\n选择此模板将适用于哪些项目。如果未选择任何项目，则该模板将全局可用。将模板分配给特定项目后，其使用范围将仅限于这些项目。"
+    },
+    "llm": {
+      "name": "## 集成名称\n此 LLM 集成的描述性标签。\n\n- 用于在列表和设置中标识它。\n- 例如：“OpenAI GPT-4o”或“内部 Ollama”。",
+      "provider": "## 提供商\n为该集成提供支持的 LLM 服务。\n\n- 确定 API 协议和可用模型。\n- 创建后无法更改。",
+      "apiKey": "## API 密钥\n您的 LLM 提供商 API 的身份验证密钥。\n\n- 从提供商的开发者控制台获取。\n- 保存后将保持加密状态，不会显示。\n- Ollama（本地部署）不需要此密钥。",
+      "endpoint": "## API 端点\nLLM 提供商 API 的基本 URL。\n\n- OpenAI、Anthropic 和 Gemini 留空 — 系统会自动使用官方 URL。\n- Ollama（例如 `http://localhost:11434`）、Azure OpenAI 和自定义 LLM 为必填项。\n- 所有提供商均为可选 — 通过输入 URL 指向 OpenAI 兼容的代理（例如 LiteLLM）。\n- **私有/内部地址**（localhost、127.0.0.1、私有 IP、云元数据）将被阻止，除非通过 `ALLOWED_PRIVATE_HOSTS` 环境变量显式允许。",
+      "deploymentName": "## Azure 部署名称\n您的 Azure OpenAI 模型部署的名称。\n\n- 在 Azure OpenAI Studio 的“部署”下找到。\n- 与模型名称不同，例如 `my-gpt4-deploy` 映射到 `gpt-4`。\n- 仅 Azure OpenAI 需要。",
+      "defaultModel": "## 默认模型\n此集成用于 AI 请求的模型。\n\n- 对于 OpenAI、Anthropic 和 Gemini — 可用模型将根据您的 API 密钥自动获取。\n- 请确保已在您的提供商帐户中启用该模型。\n- 例如：`gpt-4o`、`claude-3-5-sonnet-20241022`、`gemini-1.5-pro`",
+      "maxTokensPerRequest": "## 每次请求的最大令牌数\n单个请求输出令牌数的**硬性上限**。\n\n- 超过此值的请求会在到达 LLM 之前被**拒绝并返回错误**。\n- 将此值设置为模型的实际最大输出令牌容量。\n- 例如：GPT-4o 为 `16384`，Claude 3.5 Sonnet 为 `8192`。\n- 此值设置过低会导致 AI 功能失效或生成截断的输出。",
+      "defaultMaxTokens": "## 默认最大令牌数\n当请求未指定自身令牌数限制时，使用此**备用**输出令牌数限制。\n\n- 每个 AI 功能（测试生成、代码导出等）在**管理 → 提示配置**中设置自己的限制。\n- 此值仅用作未配置特定限制的功能的备用值。\n- 应≤每个请求的最大令牌数。",
+      "maxRequestsPerMinute": "## 每分钟最大请求数\n限制每分钟可向此提供商发出的 API 调用次数。\n\n- 设置以匹配您的提供商套餐的速率限制。\n- 超出限制的请求将被排队，不会被拒绝。\n- 请查看您的提供商文档以了解您的套餐限制。",
+      "costPerInputToken": "## 每个输入令牌的成本（美元）\n发送到模型的每个输入（提示）令牌的成本（以美元计）。\n\n- 用于成本跟踪和预算提醒。\n- 可在服务提供商的定价页面找到。\n- 例如：`0.000005` = 每百万个输入令牌 5 美元",
+      "costPerOutputToken": "## 每个输出代币的成本（美元）\n模型生成的每个输出（完成）代币的成本（以美元计）。\n\n- 通常高于输入代币的成本\n- 用于成本跟踪和预算提醒\n- 例如：`0.000015` = 每百万个输出代币 15 美元",
+      "monthlyBudget": "## 月度预算（美元）\n此集成的可选支出目标。\n\n- 设置为 `0` 可禁用预算跟踪。\n- 预算仅供参考，不会影响 LLM 的使用。\n- 您将在达到预算的 80%、90% 和 100% 时收到通知。\n- 费用按上述每个代币的价格计算。",
+      "billingPeriodStartDay": "## 账单周期起始日\n账单周期开始的日期（1-31）。\n\n- 默认值 `1` 与日历月一致。\n- 设置为 `15` 表示每月 15 日到 15 日的周期（例如，与您的供应商发票日期一致）。\n- 值 `29-31` 会自动锁定到较短月份的最后一天（例如，非闰年的 2 月）。\n- 影响**月度预算**支出窗口和**重置支出**操作。",
+      "defaultTemperature": "## 默认温度\n控制模型响应的随机性（0-2）。\n\n- **0:** 确定性 — 相同输入输出相同\n- **0.3:** 聚焦 — 推荐用于测试生成和代码输出\n- **1+:** 创造性 — 响应更加多样化\n- 单个功能可以在提示配置中覆盖此设置",
+      "timeout": "## 请求超时 (毫秒)\n请求被取消前等待响应的时间。\n\n- 值以毫秒为单位（例如 `30000` = 30 秒）\n- 流式请求（例如代码导出预览）忽略此超时\n- 对于运行缓慢或模型较大的请求，增加此超时时间\n- 范围：5,000 – 600,000 毫秒",
+      "streamingEnabled": "## 启用流式传输\n逐个令牌地传输响应，而不是等待完整输出。\n\n- 导出模态框中实时代码预览所必需。\n- 降低长时间响应的感知延迟。\n- 建议所有受支持的提供商启用。",
+      "isDefault": "## 设置为默认集成\n将此集成设置为所有 AI 功能的默认集成。\n\n- 一次只能有一个集成设置为默认集成。\n- 未配置特定提供商的功能将使用默认集成。\n- 可随时更改。"
+    },
+    "integration": {
+      "name": "## 集成名称\n用于在整个系统中标识此集成的描述性名称。\n\n- 必须唯一，以便与其他集成区分开来。\n- 用于项目设置和配置。\n- 应清晰地表明服务和用途。",
+      "authType": "## 身份验证类型\n选择如何与外部服务进行身份验证。\n\n- **API 密钥：** 使用电子邮件和 API 令牌进行简单身份验证\n- **OAuth 2.0：** 使用 OAuth 流程进行安全身份验证\n- **个人访问令牌：** 基于令牌的直接身份验证",
+      "email": "## 电子邮件地址\n您的外部服务帐户电子邮件地址。\n\n- 用于 API 密钥身份验证\n- 必须与生成 API 令牌的帐户匹配\n- Jira 和类似服务必需",
+      "apiToken": "## API 令牌\n在外部服务的帐户设置中生成 API 令牌。\n\n- 通常位于“帐户设置”→“安全”→“API 令牌”中。\n- 提供安全访问，无需暴露您的密码。\n- 可根据需要撤销和重新生成。",
+      "jiraUrl": "## Jira URL\n您的 Jira 实例的基本 URL。\n\n- 格式：https://your-site.atlassian.net\n- 请勿包含 /browse 或其他路径\n- 必须可从此服务器访问",
+      "clientId": "## OAuth 客户端 ID\n来自您的 OAuth 应用程序配置的客户端 ID。\n\n- 在外部服务的开发者控制台中创建。\n- 用于在 OAuth 流程中识别您的应用程序。\n- 可以安全地在配置文件中共享。",
+      "clientSecret": "## OAuth 客户端密钥\n来自您的 OAuth 应用程序配置的客户端密钥。\n\n- 与客户端 ID 一起创建\n- 必须保密且安全\n- 用于验证您的应用程序",
+      "personalAccessToken": "## 个人访问令牌\n具有访问外部服务相应权限的个人访问令牌。\n\n- 在您的帐户设置中生成\n- 应具有读写权限\n- 比密码验证更安全",
+      "baseUrl": "## URL 模式\n用于链接到外部问题的 URL 模式。\n\n- 使用 '{issueId}' 作为问题标识符的占位符。\n- 例如：https://example.com/issues/'。{issueId}'。\n- 用于简单的基于 URL 的集成。",
+      "organizationUrl": "## 组织 URL\n您的 Azure DevOps 组织 URL。\n\n- 格式：https://dev.azure.com/your-org\n- 必须可从此服务器访问\n- 用于访问 Azure DevOps API",
+      "apiKey": "## API 密钥\n用于外部服务身份验证的 API 密钥。\n\n- 在服务的 API 设置中生成\n- 提供对服务的编程访问权限\n- 妥善保管并定期轮换",
+      "forgeApiKey": "## Forge API 密钥\n用于在 Atlassian Forge 应用从 Jira 问题中获取测试数据时对其进行身份验证。\n\n- 点击“生成”按钮创建新密钥。\n- 复制密钥并将其粘贴到 Jira 中的 Forge 应用设置中（管理应用 → TestPlanIt 设置）。\n- 重新生成密钥将使之前的密钥失效。",
+      "owner": "## 所有者/命名空间\n拥有该仓库的用户或组织。\n\n- 对于 GitHub/GitLab：用户名或组织名称\n- 对于 Gitea/Forgejo/Gogs：用户或组名称\n- 例如：my-org 或 my-username",
+      "repo": "## 仓库名称\n要链接问题的仓库名称。\n\n- 确切的仓库名称（非完整 URL）\n- 例如：my-project\n- 必须可以使用提供的凭据访问。",
+      "instanceUrl": "## 实例 URL\n自托管实例的基本 URL。\n\n- 格式：https://git.example.com\n- 请勿包含尾部斜杠或路径\n- 必须可从此服务器访问",
+      "projectPath": "## 项目路径\nGitLab 项目的完整路径。\n\n- 格式：命名空间/项目 或 组/子组/项目\n- 例如：my-org/my-project\n- 可在项目 URL 中找到：gitlab.com/namespace/project",
+      "platform": "## 平台\n您正在连接的自托管 Git 平台。\n\n- **Gitea**：基于 gitea.io 的实例\n- **Forgejo**：基于 forgejo.org 的实例（Gitea 的分支）\n- **Gogs**：基于 gogs.io 的实例\n\n此设置控制显示的图标，并可能影响 API 兼容性。"
+    },
+    "config": {
+      "name": "## 配置名称\n一个清晰、描述性的名称，在所有项目中使用。\n\n- 有助于描述构成配置的变体组合（例如“Chrome，Windows 10”、“Safari/macOS 15.5”、“Edge/Windows 11”等）。"
+    },
+    "configCategory": {
+      "name": "## 类别名称\n一个清晰、描述性的名称，用于所有项目。\n\n- 有助于将变体（例如 Chrome、Firefox、Safari、Edge 等）组织到类别（例如浏览器）中。"
+    },
+    "configVariant": {
+      "name": "## 变体名称\n一个清晰、描述性的名称，在所有项目中使用。\n\n- 有助于描述测试环境（例如 Chrome、Safari、Windows 10、Windows 11、macOS 15.5 等）中的变体。"
+    },
+    "issueConfig": {
+      "name": "## 问题配置名称\n一个清晰、描述性的名称，在所有项目中使用。\n\n- 有助于描述问题配置（例如 Jira、GitHub 等）。",
+      "baseUrl": "## 基本 URL\n问题配置的基本 URL，包括问题占位符（例如 https://your-jira-instance.atlassian.net/browse/'{issueId}'）。",
+      "systemType": "## 系统类型\n问题跟踪系统的类型（例如 LINK Jira 等）。",
+      "isActive": "## 活动\n指示此问题配置是否处于活动状态。",
+      "isDefault": "## 默认值\n指示此问题配置是否为项目的默认配置。\n\n- 默认问题配置已预先选中，适用于新问题。\n- 可随时更改。",
+      "projects": "## 项目\n指示分配给此问题配置的项目。"
+    },
+    "issue": {
+      "name": "## 问题名称\n一个清晰、描述性的名称，在所有项目中使用。\n\n- 有助于描述问题（例如“问题 123”、“错误 456”等）。",
+      "title": "## 问题标题\n一个易于理解的标题，用于描述问题。\n\n- 提供问题相关的背景信息\n- 显示在列表和问题展示中\n- 应清晰明了且具有描述性",
+      "externalKey": "## 外部密钥\n来自外部问题跟踪系统的唯一密钥或标识符。\n\n- 对于 JIRA：问题密钥，例如“PROJ-123”\n- 对于 GitHub：问题编号，例如“456”\n- 对于 Azure DevOps：工作项 ID\n- 保存时自动生成外部 URL",
+      "externalId": "## 外部 ID\n此问题在问题跟踪系统中的唯一标识符（例如“Issue-123”、“Bug456”等）。\n\n- 这用作基本 URL 中的问题占位符。",
+      "description": "## 描述\n本期内容的简要概述。\n\n- 正在测试的关键领域或功能\n- 重要的背景信息\n- 特殊考虑或要求",
+      "project": "## 项目\n此问题关联的项目。\n\n- 问题可以链接到多个项目的测试用例。\n- 设置主项目有助于组织问题。\n- 可以留空，表示跨项目问题。",
+      "state": "## 状态\n根据项目的工作流程，指示此问题的当前状态或结果。",
+      "tags": "## 标签\n应用相关标签来对此问题进行分类和筛选。",
+      "issues": "## 问题\n将任何相关问题（错误、任务等）链接到此问题。"
+    },
+    "status": {
+      "name": "## 状态名称\n一个清晰、描述性的名称，在所有项目中使用。\n\n- 用于描述测试结果状态（例如通过、失败、阻塞等）。",
+      "color": "## 颜色\n此状态的颜色。",
+      "systemName": "## 系统名称\n后端系统使用的状态名称（例如数据库查询、报告等）。",
+      "aliases": "## 别名\n此状态的其他名称或同义词，可用于将外部系统状态链接到此状态。",
+      "enabled": "## 已启用\n指示此状态是否已启用。",
+      "isEnabled": "## 已启用\n指示此状态是否已启用并可供使用。\n\n- 启用后，可在记录测试结果时选择此状态。\n- 禁用状态将隐藏，但会保留在现有结果中。",
+      "success": "## 成功\n指示此状态是否为成功状态。",
+      "isSuccess": "## 成功状态\n指示此状态是否代表测试成功。\n\n- 成功状态计入通过率指标。\n- 用于报告和分析，以跟踪测试效果。",
+      "completed": "## 已完成\n指示此状态是否为已完成状态。",
+      "isCompleted": "## 完成状态\n指示此状态是否表示测试执行已完成。\n\n- 完成状态表示测试已运行完毕。\n- 用于计算完成率和进度跟踪",
+      "failure": "## 失败\n指示此状态是否为失败状态。",
+      "isFailure": "## 失败状态\n指示此状态是否代表测试失败。\n\n- 失败状态会影响失败率指标。\n- 用于报告和分析，以识别问题。",
+      "scope": "## 范围\n指示此状态的范围（测试运行、会话、自动化）。",
+      "projects": "## 项目\n指示可以使用此状态的项目。"
+    },
+    "workflow": {
+      "scope": "## 范围\n指示此工作流的范围（测试运行、会话、自动化）。\n\n- 工作流创建后无法更改。",
+      "iconColor": "## 图标/颜色\n此工作流程的图标和颜色。",
+      "name": "## 名称\n一个清晰、描述性的名称，用于所有项目。\n\n- 有助于描述工作流程（例如“草稿”、“审核中”、“进行中”等）。",
+      "workflowType": "## 类型\n工作流类型（未开始、进行中、已完成）。",
+      "type": "## 工作流类型\n工作流状态的类别（未开始、进行中、已完成）。\n\n- 决定此状态如何影响进度跟踪\n- “未开始”状态表示工作尚未开始\n- “进行中”状态表示正在进行的工作\n- “已完成”状态表示工作已完成",
+      "isDefault": "## 默认值\n指示此工作流程是否为项目的默认工作流程。\n\n- 默认工作流程已预先选中，用于新的测试运行、会话和自动化。",
+      "isEnabled": "## 已启用\n指示此工作流程是否已启用。",
+      "isActive": "## 活动\n指示此工作流状态是否处于活动状态且可供使用。\n\n- 更新测试运行、会话或自动化时，可以选择活动工作流。\n- 非活动工作流将隐藏，但会保留在现有项中。",
+      "projects": "## 项目\n指示可以使用此工作流程的项目。"
+    },
+    "testResult": {
+      "status": "## 状态\n选择测试执行的总体状态。您选择的状态可能会影响项目指标和报告。",
+      "elapsedTime": "## 运行时间\n输入执行此测试用例所花费的总时间。您可以使用 **s** 表示秒，**m** 表示分钟，**h** 表示小时（例如，30s、5m、1h 20m）。",
+      "resultData": "## 结果详情\n提供有关整个测试执行的详细笔记、观察结果或任何其他相关数据。这可以包括设置详情、偏离计划时所采取的步骤或一般性评论。",
+      "evidence": "## 证据/附件\n上传任何可作为本次测试结果证据的文件（例如，屏幕截图、日志、数据文件）。这些附件将与本次测试结果关联。",
+      "issues": "## 关联问题\n将集成问题跟踪系统中与此测试结果相关的任何问题链接起来。这有助于跟踪与此测试结果相关的缺陷或任务。",
+      "stepStatus": "## 步骤状态\n选择此特定测试步骤的状态。这允许对单个测试用例中的进度进行精细跟踪。",
+      "stepElapsedTime": "## 步骤耗时\n输入执行此特定步骤所花费的时间。使用 **s**、**m**、**h** 等单位（例如，10 秒、2 分钟）。此项为可选。",
+      "stepNotes": "## 步骤说明\n添加与执行此测试步骤相关的任何说明、观察结果或数据。",
+      "stepIssues": "## 步骤关联问题\n链接问题跟踪器中与此测试步骤的结果或观察结果相关的问题。"
+    },
+    "case": {
+      "name": "## 测试用例名称\n测试用例的清晰、描述性名称。",
+      "state": "## 状态\n指示此案例的当前工作流状态。",
+      "template": "## 模板\n选择此案例将用于案例字段和结果字段的模板。",
+      "estimate": "## 估算\n手动输入的完成此测试用例的估计时间。",
+      "automated": "## 自动化\n指示此测试用例是否为自动化测试。",
+      "tags": "## 标签\n应用相关标签对该案例进行分类和筛选。",
+      "issues": "## 问题\n将任何相关问题（错误、任务等）链接到此案例。"
+    },
+    "folder": {
+      "name": "## 文件夹名称\n文件夹的清晰、描述性名称。",
+      "documentation": "## 文档\n更多细节、参考资料和支持材料。"
+    },
+    "bulkEdit": {
+      "name": "## 名称\n测试用例的清晰、描述性名称。",
+      "state": "## 状态\n指示这些测试用例的当前工作流状态。",
+      "estimate": "## 估算\n手动输入完成每个测试用例的预计时间。",
+      "automated": "## 自动化\n指示这些测试用例是否是自动化的。",
+      "tags": "## 标签\n应用相关标签对这些测试用例进行分类和筛选。",
+      "issues": "## 问题\n将任何相关问题（错误、任务等）链接到这些测试用例。"
+    },
+    "caseField": {
+      "displayName": "## 显示名称\n这是将在表单和视图中向用户显示的字段的易读名称。请确保名称清晰明了且具有描述性。",
+      "systemName": "## 系统名称\n此字段在系统内部使用的唯一标识符（例如，在 API 调用、数据库查询中）。它将根据显示名称自动生成，但可以自定义。必须以字母开头。只能包含字母、数字和下划线（不能包含空格或特殊字符）。",
+      "hint": "## 提示文本（可选）\n提供简短的说明或示例，显示在字段下方，以指导用户。这可以阐明预期的输入或格式。",
+      "enabled": "## 启用\n确定此字段是否处于活动状态，并可在模板和测试用例中使用。禁用的字段将被隐藏，其数据将被保留但不使用。",
+      "required": "## 必填\n如果选中，则用户在使用包含此字段的模板创建或编辑测试用例时，必须为此字段提供值。",
+      "restricted": "## 受限\n如果选中此项，则只有拥有特殊权限的用户（例如超级管理员或拥有“案例受限字段”权限的用户）才能在案例创建后编辑此字段的值。其他用户将只能看到此字段。这对于“审核人”或“批准日期”等字段非常有用，这些字段在特定阶段之后不应由普通用户更改。",
+      "fieldType": "## 字段类型\n决定此字段将存储的数据类型及其显示方式（例如，文本、数字、日期、下拉列表）。字段类型创建后无法更改。",
+      "defaultValue": "## 默认值（可选）\n为该字段设置预填充值。对于“复选框”类型，请使用“true”或“false”。对于“下拉列表”或“多选”类型，这通常指的是默认选项的 ID。对于其他类型，它是默认文本/数字。将字段添加到模板时，可以覆盖此值。",
+      "isChecked": "## 默认状态（复选框）\n确定在创建新项目（例如，测试用例）时是否应默认选中复选框。",
+      "minValue": "## 最小值（适用于数字/整数）\n设置此字段允许的最小数值。如果使用最小值或最大值，则必须同时设置两者。",
+      "maxValue": "## 最大值（适用于数字/整数）\n设置此字段允许的最大数值。如果使用最小值或最大值，则必须同时设置两者。",
+      "initialHeight": "## 初始高度（适用于长文本）\n指定富文本编辑器字段的初始显示高度（以像素为单位）。这有助于控制较长文本输入的表单布局。",
+      "dropdownOptions": "## 选项（下拉列表/多选列表）\n定义可供选择的选项列表。您可以重新排列选项顺序、设置默认值以及启用/禁用单个选项。"
+    },
+    "resultField": {
+      "displayName": "## 显示名称\n这是用户输入测试结果时将显示的字段的易读名称。请确保名称清晰明了且具有描述性。",
+      "systemName": "## 系统名称\n此字段的唯一标识符，供系统内部使用（例如，在 API 调用、数据库查询中）。它将根据显示名称自动生成，但可以自定义。\n- 必须以字母开头。\n- 只能包含字母、数字和下划线（不能包含空格或特殊字符）。",
+      "hint": "## 提示文本（可选）\n提供简短的说明或示例，显示在字段下方，以指导用户。这可以明确输入结果数据时的预期内容或格式。",
+      "enabled": "## 启用\n确定此字段是否处于活动状态，以及在输入测试结果时是否可在模板中使用。禁用的字段将被隐藏，其数据将被保留但不使用。",
+      "required": "## 必填\n如果选中，则用户在使用包含此字段的模板添加测试结果时，必须为此字段提供值。",
+      "restricted": "## 受限\n如果选中此项，则只有拥有特殊权限的用户（例如，超级管理员或拥有“测试运行结果受限字段”权限的用户）才能在提交结果后编辑此字段的值。其他用户将只能读取此字段的值。",
+      "fieldType": "## 字段类型\n决定此字段将存储的数据类型以及测试结果的显示方式（例如，文本、数字、日期、下拉列表）。字段类型创建后无法更改。",
+      "defaultValue": "## 默认值（可选）\n添加新的测试结果时，请为此字段设置预填充值。对于“复选框”类型，请使用“true”或“false”。对于“下拉列表”或“多选”类型，此值通常指的是默认选项的 ID。对于其他类型，此值为默认文本/数字。",
+      "isChecked": "## 默认状态（复选框）\n确定添加新测试结果时是否应默认选中复选框。",
+      "minValue": "## 最小值（适用于数字/整数）\n设置输入结果数据时此字段允许的最小数值。如果使用最小值或最大值，则必须同时设置两者。",
+      "maxValue": "## 最大值（适用于数字/整数）\n设置输入结果数据时此字段允许的最大数值。如果使用最小值或最大值，则必须同时设置两者。",
+      "initialHeight": "## 初始高度（适用于长文本）\n指定结果中使用的富文本编辑器字段的初始显示高度（以像素为单位）。这有助于控制较长文本输入的表单布局。",
+      "dropdownOptions": "## 选项（下拉列表/多选列表）\n定义输入结果数据时可供选择的选项列表。您可以重新排列选项顺序、设置默认值以及启用/禁用单个选项。"
+    },
+    "exportModal": {
+      "scope": "## 导出范围\n决定哪些测试用例包含在导出文件中：\n- **已选：** 仅导出您在表格中明确选择的测试用例。\n- **全部筛选：** 导出所有符合表格中当前筛选条件的测试用例，即使并非所有测试用例当前都显示在页面上。\n- **所有项目：** 导出当前项目中的所有测试用例，忽略任何选择或筛选条件。",
+      "format": "## 导出格式\n选择导出文件格式。\n- **CSV（逗号分隔值）：** 纯文本文件，适用于电子表格（Excel、Google Sheets）和数据分析工具。PDF 导出功能计划在未来的版本中推出。",
+      "columns": "## 要导出的列（仅限 CSV）\n确定每个测试用例将包含哪些数据列：\n- **所有列：** 导出测试用例的所有可用数据字段，包括其模板中的自定义字段。\n- **可见列：** 仅导出测试用例表中当前可见的列。",
+      "delimiter": "## CSV 分隔符（仅限 CSV）\n选择用于分隔 CSV 文件中值的字符。最常用的是逗号。如果您的数据在文本字段中包含逗号，请使用其他分隔符（例如，分号）。",
+      "textLongFormat": "## 长文本字段格式（仅限 CSV）\n确定富文本字段（例如“描述”或自定义“长文本”字段）的导出方式：\n- **JSON：** 将内容导出为 JSON 字符串，保留所有格式（粗体、列表等）。这最适合重新导入或程序化处理。\n- **纯文本：** 将内容导出为纯文本，去除格式。这在纯文本查看器中更易于阅读。",
+      "stepsFormat": "## 步骤格式（仅限 CSV）\n确定测试步骤（包括预期结果）的导出方式：\n- **JSON：** 将步骤导出为 JSON 对象数组，保留结构和丰富的文本信息。适用于重新导入或进行详细分析。\n- **纯文本：** 将步骤导出为简洁易读的纯文本格式，每个步骤和预期结果都位于新的一行。",
+      "rowMode": "## 行模式（仅限 CSV）\n决定多值字段（例如标签或多选自定义字段）和步骤的表示方式：\n- **每个用例单行：**每个测试用例占一行。多值字段和步骤将被压缩到各自的单元格中（通常以 JSON 或拼接文本的形式）。\n- **每个用例多行：**如果一个测试用例包含多个标签、多选值或步骤，则可以跨越多行。此类字段的每个唯一值/步骤都将创建一个新行，其他用例数据则重复显示。这对于详细分析或透视非常有用。",
+      "attachmentFormat": "## 附件信息格式（仅限 CSV）\n确定附件信息的导出方式：\n- **JSON：** 将附件详细信息（例如文件名、URL、大小）导出为 JSON 数组。这种方式信息全面，但直接在 CSV 文件中阅读起来不太方便。\n- **仅文件名：** 导出以逗号分隔的附件文件名列表。这种方式更简洁，便于快速查找。"
+    },
+    "reportMetrics": {
+      "count": "## 测试结果计数\n此组中的测试运行结果数量。",
+      "passRate": "## 通过率\n此组结果中通过状态的比例。",
+      "avgElapsed": "## 平均耗时\n此组结果的平均耗时。",
+      "sumElapsed": "## 总耗时\n此组结果的耗时总和。",
+      "executionCount": "## 测试执行\n已执行的测试总次数。",
+      "testCaseCount": "## 测试用例计数\n此组中的测试用例总数。",
+      "testRunCount": "## 测试运行次数\n此组中的测试运行总数。",
+      "automationRate": "## 自动化率\n自动化测试用例的百分比。",
+      "averageSteps": "## 每个测试用例的平均步骤数\n每个测试用例的平均步骤数。",
+      "automatedCount": "## 自动化测试用例\n自动化测试用例的数量。",
+      "manualCount": "## 手动测试用例\n手动测试用例的数量。",
+      "totalSteps": "## 总步骤数\n所有案例的测试步骤总数。",
+      "createdCaseCount": "## 创建的测试用例\n此期间创建的测试用例数量。",
+      "sessionResultCount": "## 会话结果\n会话测试结果数量。",
+      "sessionCount": "## 会话计数\n测试会话总数。",
+      "activeSessions": "## 活动会话\n当前处于活动状态的会话数（isActive = true）。",
+      "milestoneCompletion": "## 里程碑完成度\n里程碑中已完成的测试用例百分比。计算方法为（已完成的测试结果 / 测试运行中的测试用例总数）× 100。",
+      "averageTimeSpent": "## 平均花费时间\n各项活动的平均花费时间。",
+      "sessionParticipation": "## 会话参与度\n测试会话的参与程度。",
+      "lastActiveDate": "## 最后活跃日期\n最近一次活动日期。",
+      "averageAge": "## 平均年龄\n物品的平均年龄（天）。",
+      "issueCount": "## 问题计数\n跟踪的问题总数。",
+      "milestoneCount": "## 里程碑数量\n里程碑总数。",
+      "milestoneCompletionRate": "## 里程碑完成率\n已完成里程碑的百分比。",
+      "averageMilestoneDuration": "## 平均里程碑持续时间\n里程碑的平均持续时间（以天为单位）。"
+    },
+    "reportDimensions": {
+      "user": "## 用户维度\n按执行测试或分配给项目的用户对结果进行分组。",
+      "status": "## 状态维度\n按测试执行状态（例如，通过、失败、阻塞）对结果进行分组。",
+      "project": "## 项目维度\n按项目对结果进行分组，以便进行跨项目分析。",
+      "testRun": "## 测试运行维度\n按包含已执行测试用例的测试运行对结果进行分组。",
+      "testCase": "## 测试用例维度\n按各个测试用例对结果进行分组，以便进行详细分析。",
+      "milestone": "## 里程碑维度\n按项目里程碑对结果进行分组，以跟踪目标的进展情况。",
+      "configuration": "## 配置维度\n按测试环境配置（例如，浏览器、操作系统）对结果进行分组。",
+      "template": "## 模板维度\n按用于测试用例结构的模板对结果进行分组。",
+      "creator": "## 创建者维度\n按创建测试用例或测试运行的用户对结果进行分组。",
+      "state": "## 状态维度\n按工作流状态（例如，草稿、进行中、已完成）对结果进行分组。",
+      "role": "## 角色维度\n按用户角色对结果进行分组，以进行访问权限和责任分析。",
+      "group": "## 分组维度\n按用户组对结果进行分组。用户可以属于多个组，因此用户所属的每个组都会统计其活动。",
+      "folder": "## 文件夹维度\n按存储库文件夹结构对结果进行分组，以便进行组织分析。",
+      "session": "## 会话维度\n按测试会话对结果进行分组，以便进行基于会话的分析。",
+      "assignedTo": "## 分配给维度\n按分配给执行或管理项目的用户对结果进行分组。",
+      "issueType": "## 问题类型维度\n按跟踪的问题类型（例如，缺陷、任务、故事、增强）对结果进行分组。",
+      "issueTracker": "## 问题跟踪器维度\n按使用的问题跟踪集成（例如，Jira、GitHub Issues、Azure DevOps）对结果进行分组。",
+      "issueStatus": "## 问题状态维度\n按问题的当前状态（例如，打开、进行中、已解决、已关闭）对结果进行分组。",
+      "priority": "## 优先级维度\n按问题优先级（例如，高、中、低）对结果进行分组。",
+      "source": "## 源维度\n按测试执行的来源（例如，手动、JUnit、API）对结果进行分组。",
+      "date": "## 日期维度\n按日期对结果进行分组，以便进行基于时间的分析和趋势分析。"
+    },
+    "reportBuilder": {
+      "dimensions": "## 维度\n选择要在报告中分析的维度。维度是用于对数据进行分类的属性，例如日期、用户、状态等。您可以拖动来重新排序。",
+      "metrics": "## 指标\n选择您希望在报告中衡量的指标。指标是从您的数据中提取的定量测量值，例如测试结果计数、通过率、平均耗时等。您可以拖动它们来重新排序。",
+      "dateRange": "## 日期范围\n按特定时间段筛选报告数据。您可以从预定义的范围（例如“最近 7 天”或“上个月”）中选择，也可以定义自定义日期范围。此筛选器适用于每种报告类型的相关日期字段（例如，测试结果的执行日期，测试用例的创建日期）。"
+    },
+    "codeRepository": {
+      "name": "## 存储库名称\n此存储库连接的友好显示名称。\n\n- 用于在项目代码上下文设置中标识它。\n- 不需要与提供程序上的存储库名称匹配。",
+      "provider": "## Git 提供商\n托管此代码库的平台。\n\n- **GitHub** — github.com（云端或企业版）\n- **GitLab** — gitlab.com 或自托管\n- **Bitbucket Cloud** — bitbucket.org（仅限云端）\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — 具有兼容 API 的自托管 Git 服务器",
+      "githubToken": "## 个人访问令牌\n具有 **Contents: Read** 权限的 GitHub 令牌。\n\n在以下位置生成：GitHub → 个人资料设置 → 开发者设置 → 个人访问令牌 → 细粒度令牌。",
+      "owner": "## 所有者\n拥有该仓库的 GitHub 组织或用户帐户。\n\n- 例如：`myorg` 或 `myusername`\n- 这是您在 github.com 上的仓库 URL 中的第一个路径段。",
+      "repo": "## 仓库\n仓库名称，不包含所有者前缀。\n\n- 例如：`my-repo`（而非 `myorg/my-repo`）\n- 这是您在 github.com 上的仓库 URL 中的第二个路径段。",
+      "gitlabToken": "## 个人访问令牌\n具有 **read_api** 和 **read_repository** 权限的 GitLab 令牌。\n\n在以下位置生成：GitLab → 用户设置 → 访问令牌。",
+      "projectPath": "## 项目 ID 或路径\n数字项目 ID 或完整的命名空间路径。\n\n- 示例路径：`myorg/my-project`\n- 示例 ID：`12345678`\n- 在 GitLab 的“设置”→“常规”下找到。",
+      "baseUrl": "## GitLab URL\n留空则使用 gitlab.com。对于自托管实例，请输入您的 GitLab URL。\n\n- 例如：`https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian 帐户电子邮件\n与您的 Atlassian 帐户关联的电子邮件地址。\n\n- 这是您用于登录 Bitbucket Cloud 的电子邮件。",
+      "bitbucketApiToken": "## API 令牌\n具有 **Repositories: Read** 权限的 Bitbucket API 令牌。\n\n在以下位置创建：Bitbucket → 个人设置 → API 令牌。\n\n> Atlassian 已弃用应用密码，转而使用 API 令牌。",
+      "workspace": "## 工作区\n来自您的 Bitbucket URL 的工作区别名。\n\n- 例如：`bitbucket.org/myworkspace` 中的 `myworkspace`",
+      "repoSlug": "## 仓库别名\n仓库 URL 中的标识符。\n\n- 例如：`bitbucket.org/myworkspace/my-repo` 中的 `my-repo`",
+      "azureToken": "## 个人访问令牌\n具有**代码（读取）**权限的 Azure DevOps 个人访问令牌。\n\n在以下位置创建：Azure DevOps → 用户设置 → 个人访问令牌。",
+      "organizationUrl": "## 组织 URL\n您的 Azure DevOps 组织 URL。\n\n- 例如：`https://dev.azure.com/myorg`",
+      "project": "## 项目名称\n包含存储库的 Azure DevOps 项目的名称。\n\n- 位于 Azure DevOps URL 中组织名称之后的第三个路径段。",
+      "azureRepoId": "## 存储库名称或 ID\nAzure DevOps 项目中的存储库名称或 GUID。\n\n- 例如：`my-repo`",
+      "giteaToken": "## 个人访问令牌\n具有仓库读取权限的令牌。\n\n在以下位置生成：站点管理 → 应用程序，或用户设置 → 应用程序。\n\n- 适用于 Gitea、Forgejo、Gogs 以及任何提供兼容 API 的服务器。",
+      "giteaBaseUrl": "## 服务器 URL\n自托管 Git 服务器的基本 URL。\n\n- 例如：`https://gitea.example.com`\n- 必须包含协议（推荐使用 https://）\n- 适用于 Gitea、Forgejo、Gogs 以及其他具有与 Gitea 兼容的 `/api/v1/` REST API 的服务器",
+      "giteaOwner": "## 所有者\n拥有此存储库的组织或用户帐户。\n\n- 例如：`myorg` 或 `myusername`\n- 这是存储库 URL 中的第一个路径段",
+      "giteaRepo": "## 仓库\n仓库名称，不包含所有者前缀。\n\n- 例如：`my-repo`（而非 `myorg/my-repo`）"
+    },
+    "promptConfig": {
+      "name": "## 配置名称\n此提示配置的唯一描述性名称。\n\n- 用于在将配置分配给项目时标识该配置（例如“GPT-4o 提示”、“保守提示”）。",
+      "description": "## 描述\n可选的摘要，用于说明此配置的独特之处。\n\n- 帮助管理员一目了然地了解其用途（例如“降低温度提示以实现确定性输出”）。",
+      "isActive": "## 启用\n启用后，此配置可供项目使用。\n\n- 未启用的配置将从项目分配下拉菜单中隐藏。\n- 默认配置无法停用。",
+      "isDefault": "## 默认配置\n启用后，任何未分配特定配置的项目都将使用此配置。\n\n- 一次只能有一个配置作为默认配置。\n- 设置新的默认配置会自动取消之前的默认配置。",
+      "systemPrompt": "## 系统提示\n在用户输入任何内容之前发送给 AI 模型的指令。定义模型的角色、输出格式和约束。\n\n- 支持双花括号占位符（例如 FRAMEWORK、LANGUAGE、CASE_NAME），这些占位符会在运行时进行替换。\n- 此处所做的更改会影响使用此配置的所有项目。",
+      "userPrompt": "## 用户提示\n代表用户发送给 AI 的消息。如果该功能完全通过代码构建用户消息，则留空。\n\n- 支持双花括号占位符（例如 ISSUE_TITLE、CASE_NAME、CODE_CONTEXT），这些占位符会在运行时进行替换。\n- 每个功能可用的占位符列于下方的“变量”部分。",
+      "temperature": "## 温度\n控制 AI 输出的随机性。范围：0–2。\n\n- **0.0–0.3** — 高度确定性，最适合结构化输出（JSON、代码）。\n- **0.4–0.7** — 平衡，适合生成测试用例。\n- **0.8–2.0** — 更具创造性和多样性，适合开放式文本。",
+      "maxOutputTokens": "## 最大输出词元数\n模型在单个响应中生成的最大词元数。\n\n- 更高的值允许更长的响应，但会增加成本和延迟。\n- 典型范围：短文本为 2048，代码生成为 4096，多大小写输出为 6000 以上。"
+    },
+    "menu": {
+      "startTour": "导览欢迎之旅",
+      "startProjectTour": "项目参观",
+      "startAdminTour": "管理员巡视",
+      "startDemoProjectTour": "演示项目参观"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "欢迎使用 TestPlanIt！",
+          "content": "让我们快速浏览一下 TestPlanIt 的主要功能，以帮助您开始测试工作流程。"
+        },
+        "projects": {
+          "content": "从这里可以访问您的所有测试项目。每个项目都包含测试用例、运行次数和团队协作功能。"
+        },
+        "project": {
+          "title": "项目卡",
+          "content": "点击项目卡片即可查看其详细信息。从帮助菜单中选择“项目导览”，即可获得项目功能导览。"
+        },
+        "globalFeatures": {
+          "title": "全球专题",
+          "content": "管理标签以进行分类，跟踪跨项目的问题，并使用基于角色的访问控制来管理用户。"
+        },
+        "search": {
+          "content": "基于当前页面的上下文搜索。快速查找测试用例、运行结果、问题或任何内容。使用 Cmd+K（或 Ctrl+K）即可快速访问。"
+        },
+        "help": {
+          "title": "帮助与支持",
+          "content": "您可以随时访问此导览，或访问我们的完整文档获取详细帮助。"
+        },
+        "notifications": {
+          "content": "随时了解测试运行完成情况、问题更新和团队活动。请在您的帐户设置中配置偏好设置。"
+        },
+        "account": {
+          "title": "账户菜单",
+          "content": "自定义个人资料、通知偏好设置和帐户设置。切换浅色和深色主题。"
+        },
+        "assignments": {
+          "content": "查看分配给您的所有项目的测试用例和运行情况。这是您的个人仪表盘，用于跟踪您的测试工作。"
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "项目选择器",
+          "content": "使用此下拉菜单可快速切换项目。查看项目详情并访问项目全局设置。"
+        },
+        "projectSections": {
+          "title": "项目章节",
+          "content": "通过“概览”查看项目仪表盘，“文档”查看项目指南，“里程碑”查看项目进度跟踪。"
+        },
+        "repository": {
+          "content": "管理您的测试用例，将它们整理到文件夹中，并创建新的测试场景以实现全面的测试覆盖。"
+        },
+        "repositoryPanels": {
+          "title": "存储库左侧面板",
+          "content": "左侧面板显示文件夹结构和测试用例树。使用视图选择器可在不同的组织视图之间切换。"
+        },
+        "repositoryRightPanel": {
+          "title": "存储库右侧面板",
+          "content": "右侧面板显示测试用例详情、执行结果，并提供创建新测试用例或导入现有测试用例的操作。"
+        },
+        "sharedSteps": {
+          "title": "共同步骤",
+          "content": "定义可重用的步骤组，以便多个测试用例可以引用它们。保持测试步骤的简洁性和一致性。"
+        },
+        "testRuns": {
+          "content": "执行计划的测试运行，跟踪进度，并管理团队内的测试任务分配。查看详细的执行结果。"
+        },
+        "testRunsPage": {
+          "title": "测试运行仪表盘",
+          "content": "这是“测试运行”页面，您可以在这里创建新的测试运行、监控执行进度、查看结果以及管理测试任务。在一个中心位置跟踪团队的测试活动。"
+        },
+        "sessions": {
+          "title": "探索性会议",
+          "content": "记录探索性测试过程，收集测试结果，并跟踪临时测试活动所花费的时间。"
+        },
+        "sessionsPage": {
+          "title": "探索性会议仪表盘",
+          "content": "这是“会话”页面，您可以在这里创建和管理探索性测试会话。记录测试结果、跟踪测试时间，并维护所有临时测试活动的记录，以提高测试覆盖率。"
+        },
+        "tags": {
+          "title": "标签管理",
+          "content": "使用标签整理和分类测试用例。创建自定义标签，以改进测试用例的组织和筛选。"
+        },
+        "issues": {
+          "title": "问题跟踪",
+          "content": "跟踪和管理测试过程中发现的问题。将问题与测试用例关联，并与外部缺陷跟踪系统集成。"
+        },
+        "reports": {
+          "title": "报告与分析",
+          "content": "为您的项目生成全面的报告和分析。查看测试覆盖率、执行趋势、团队绩效指标，并为利益相关者创建自定义报告。"
+        },
+        "settings": {
+          "title": "项目设置",
+          "content": "从这里管理项目级集成、AI 模型配置和共享链接。"
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "欢迎使用管理员控制功能",
+          "content": "通过引导式教程了解 TestPlanIt 的管理功能。您可以通过此中央管理面板管理项目、用户、配置和系统设置。"
+        },
+        "projects": {
+          "title": "项目管理",
+          "content": "管理组织内的所有项目。创建、配置和归档项目。设置项目范围的权限和访问控制。"
+        },
+        "templatesAndFields": {
+          "content": "创建和管理测试用例模板和自定义字段。定义字段类型、验证规则，并组织模板，以确保跨项目的测试用例结构一致。"
+        },
+        "workflows": {
+          "title": "工作流管理",
+          "content": "定义测试用例工作流程和状态转换。配置测试用例如何经历不同的状态，例如草稿、审核和批准。"
+        },
+        "statuses": {
+          "title": "测试结果状态",
+          "content": "配置可用的测试结果状态，例如通过、失败、已阻止和跳过。设置自定义状态并定义其行为和外观。"
+        },
+        "milestones": {
+          "content": "定义项目跟踪的里程碑类型。配置发布类型、迭代类别和其他项目里程碑分类。"
+        },
+        "configurations": {
+          "title": "测试配置",
+          "content": "管理测试配置和环境。设置浏览器组合、设备类型、操作系统和其他测试执行上下文。"
+        },
+        "users": {
+          "title": "用户管理",
+          "content": "管理用户帐户、权限和访问级别。创建新用户、分配角色并配置身份验证设置。"
+        },
+        "groups": {
+          "title": "集团管理",
+          "content": "将用户分组，以便更轻松地管理权限。创建部门组、项目团队和基于角色的访问组。"
+        },
+        "roles": {
+          "title": "角色管理",
+          "content": "定义用户角色和权限。配置不同角色在项目和系统管理中可以执行的操作。"
+        },
+        "tags": {
+          "title": "全局标签",
+          "content": "管理组织范围内的标签，用于对测试用例、项目和其他实体进行分类。创建标签层级结构，并规范跨项目的标签使用。"
+        },
+        "reports": {
+          "content": "生成跨多个项目的报告。分析整个工作空间内的趋势、绩效指标和组织测试有效性。"
+        },
+        "notifications": {
+          "title": "通知设置",
+          "content": "配置系统级通知偏好设置。设置用户通知的电子邮件模板、通知规则和默认设置。"
+        },
+        "integrations": {
+          "title": "系统集成",
+          "content": "管理第三方集成和 API 连接。为您的组织配置 Jira、GitHub 和其他外部工具集成。"
+        },
+        "llm": {
+          "title": "AI配置",
+          "content": "配置用于自动生成测试用例和智能功能的AI模型和设置。管理API密钥和模型偏好设置。"
+        },
+        "sso": {
+          "title": "单点登录",
+          "content": "配置单点登录 (SSO) 提供商和身份验证方法。设置 SAML、OAuth 和其他身份提供商集成，以实现无缝用户访问。"
+        },
+        "appConfig": {
+          "content": "管理全局应用程序设置和系统偏好设置。配置默认值、功能开关和系统级行为。"
+        },
+        "trash": {
+          "title": "系统垃圾",
+          "content": "查看和管理所有项目中已删除的项目。恢复意外删除的内容或从系统中永久清除项目。"
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "欢迎来到演示项目",
+          "content": "本项目已预加载示例数据。让我们一起来了解一下主要功能。使用此下拉菜单可在项目之间切换。"
+        },
+        "overview": {
+          "title": "项目概述",
+          "content": "概览页面是您的项目仪表盘。它显示里程碑进度以及测试用例、正在进行的运行、会话和标签的摘要。"
+        },
+        "documentation": {
+          "title": "文档",
+          "content": "每个项目都有一个文档页面。你可以用它来记录测试计划、项目笔记或外部资源链接。"
+        },
+        "documentationContent": {
+          "title": "富文本编辑器",
+          "content": "文档支持富文本格式，包括标题、列表、链接和图片。您可以尝试编辑此页面，看看效果如何。"
+        },
+        "milestones": {
+          "title": "里程碑",
+          "content": "根据迭代、版本发布和其他目标跟踪测试进度。将测试运行和会话与里程碑关联起来，以便跟踪进度。"
+        },
+        "milestonesPage": {
+          "title": "里程碑时间表",
+          "content": "查看此项目的所有里程碑。每个里程碑都显示了其状态和完成进度。"
+        },
+        "repository": {
+          "title": "测试用例库",
+          "content": "将测试用例整理到带有自定义字段、步骤和优先级的文件夹中。浏览示例文件夹，了解用例的结构。"
+        },
+        "repositoryPanels": {
+          "title": "文件夹和箱子",
+          "content": "左侧面板显示文件夹。点击文件夹即可查看其测试用例。每个用例都包含步骤、描述和共享步骤引用。"
+        },
+        "repositoryCases": {
+          "title": "测试用例",
+          "content": "这里显示所选文件夹的测试用例。每一行都显示用例名称、优先级和自定义字段。点击用例即可查看其完整详情和步骤。"
+        },
+        "sharedSteps": {
+          "title": "共同步骤",
+          "content": "定义可重用的步骤组，以便多个测试用例可以引用这些步骤。这样可以保持常用步骤的一致性，并便于维护。"
+        },
+        "sharedStepsPage": {
+          "title": "共同步骤小组",
+          "content": "每个步骤组都包含一系列有序的步骤。在任何测试用例中引用这些步骤，以保持步骤的简洁性和一致性。"
+        },
+        "testRuns": {
+          "title": "测试运行",
+          "content": "创建测试运行以执行用例并记录结果。将运行分配到里程碑并跟踪通过/失败进度。"
+        },
+        "testRunsPage": {
+          "title": "测试运行结果",
+          "content": "查看测试运行结果和进度。每次运行都会显示其状态、指定的里程碑以及通过/失败的详细情况。"
+        },
+        "sessions": {
+          "title": "探索性会议",
+          "content": "利用基于会话的测试来捕获临时测试结果。记录测试结果，分配状态，并跟踪所花费的时间。"
+        },
+        "sessionsPage": {
+          "title": "会议结果",
+          "content": "每次会话都包含详细的分析结果、状态和备注。点击会话即可查看结果。"
+        },
+        "tags": {
+          "title": "标签",
+          "content": "标签有助于组织和筛选测试用例、运行和会话。浏览示例标签，了解它们如何对内容进行分类。"
+        },
+        "tagsPage": {
+          "title": "标签管理",
+          "content": "您可以在这里创建、编辑和分配标签。使用标签对项目中的内容进行分组和筛选。"
+        },
+        "issues": {
+          "title": "问题",
+          "content": "跟踪测试过程中发现的错误和缺陷。问题可以与失败的测试运行结果和会话发现关联起来，从而实现完全可追溯性。"
+        },
+        "issuesPage": {
+          "title": "问题跟踪器",
+          "content": "查看与失败结果相关的示例问题。这些问题可以追溯到发现它们的测试运行或会话。"
+        },
+        "reports": {
+          "title": "报告与分析",
+          "content": "生成测试覆盖率、执行趋势和团队绩效报告。可以使用预置报告，也可以为利益相关者创建自定义报告。"
+        },
+        "settings": {
+          "title": "项目设置",
+          "content": "从这里管理项目级集成、AI 模型配置和共享链接。"
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "创建和管理跨项目报告"
+      },
+      "reportsTabDescription": "查看和分析您项目的预置报告。",
+      "reportType": "报告类型",
+      "selectReportType": "选择报告类型",
+      "selectReport": "选择报告",
+      "dimensions": "方面",
+      "dimensionsSubtitle": "尺寸（拖动重新排序，在下方添加）",
+      "metrics": "指标",
+      "addDimension": "添加维度……",
+      "addMetric": "添加指标……",
+      "runReport": "运行报告",
+      "noResultsFound": "未找到结果。",
+      "selectAtLeastOneDimensionAndMetric": "至少选择一个维度和一个指标。",
+      "noDataMatchingCriteria": "未找到与所选维度和指标匹配的数据。",
+      "noDataMatchingCriteriaWithDateFilter": "未找到符合所选维度和指标的数据。请尝试调整日期范围筛选器。",
+      "noDataAvailable": "本报告暂无可用数据。",
+      "generatedAt": "报告生成于",
+      "crossProjectAnalytics": "跨项目分析与报告",
+      "unauthorizedAdmin": "未经授权：需要管理员权限。",
+      "title": "报表生成器",
+      "description": "构建自定义报告以分析项目数据",
+      "crossProjectDescription": "分析工作区中所有项目的数据",
+      "selectDimensions": "选择尺寸...",
+      "selectMetrics": "选择指标……",
+      "dimensionOrder": "尺寸顺序",
+      "metricOrder": "公制顺序",
+      "filtersDescription": "按特定条件筛选报告数据",
+      "activeFilters": "启用筛选器：",
+      "priorityFilterPlaceholder": "选择优先级值（或留空表示全部不选）",
+      "dateRange": {
+        "selectDateRange": "选择日期范围",
+        "chooseStartDate": "选择开始日期",
+        "chooseEndDate": "选择结束日期",
+        "categories": {
+          "day": "天",
+          "week": "星期",
+          "month": "月",
+          "quarter": "四分之一",
+          "year": "年"
+        },
+        "today": "今天",
+        "yesterday": "昨天",
+        "last7Days": "过去7天",
+        "last30Days": "过去30天",
+        "thisWeek": "本星期",
+        "lastWeek": "上星期",
+        "last2Weeks": "过去两周",
+        "thisMonth": "本月",
+        "lastMonth": "上个月",
+        "last3Months": "过去三个月",
+        "thisQuarter": "本季度",
+        "lastQuarter": "上个季度",
+        "thisYear": "今年",
+        "lastYear": "去年",
+        "last12Months": "过去12个月",
+        "allTime": "所有时间",
+        "custom": "自定义日期范围"
+      },
+      "dateGrouping": {
+        "label": "按分组",
+        "daily": "日常的",
+        "weekly": "每周",
+        "monthly": "月度",
+        "quarterly": "季刊",
+        "annually": "每年"
+      },
+      "filters": {
+        "selectFilter": "选择筛选类型",
+        "allProjects": "所有项目"
+      },
+      "errors": {
+        "failedToLoadMetadata": "报告元数据加载失败",
+        "failedToRunReport": "报告运行失败",
+        "atLeastOneDimensionRequired": "至少需要一个维度。",
+        "atLeastOneMetricRequired": "至少需要指定一个指标。",
+        "invalidCombinationDateLastActive": "“上次活动日期”指标不能与“活动日期”维度合并。",
+        "lastActiveDateOnlyWithUser": "“上次活动日期”指标只能与“用户”维度一起使用。",
+        "invalidDimensionCombination": "在测试执行报告中，不能同时使用“{dim1}”和“{dim2}”维度。",
+        "startDateRequiredWithEndDate": "当指定结束日期时，必须同时指定开始日期。",
+        "endDateMustBeAfterStartDate": "结束日期必须晚于或等于开始日期。"
+      },
+      "chartDataTruncated": {
+        "title": "图表数据已截断",
+        "message": "为了便于阅读，仅显示 {shown} 个数据点，共 {total} 个数据点。您可以使用筛选器或日期范围来缩小搜索结果范围，或在下方的结果表格中查看完整数据。"
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "测试执行报告",
+          "description": "分析测试结果、通过率和执行指标"
+        },
+        "repositoryStats": {
+          "label": "存储库统计信息",
+          "description": "测试用例统计信息、覆盖率和存储库健康状况"
+        },
+        "userEngagement": {
+          "label": "用户参与度",
+          "description": "用户活动、生产力和工作量分析"
+        },
+        "projectHealth": {
+          "label": "项目健康",
+          "description": "项目进度、里程碑和完成状态"
+        },
+        "sessionAnalysis": {
+          "label": "会话分析",
+          "description": "会话完成情况、持续时间和作业指标"
+        },
+        "issueTracking": {
+          "label": "问题跟踪",
+          "description": "问题产生、解决和影响分析"
+        },
+        "automationTrends": {
+          "label": "自动化趋势",
+          "description": "按优先级每周跟踪自动化进度"
+        },
+        "flakyTests": {
+          "label": "不稳定的测试",
+          "description": "找出结果不一致的测试（通过/失败）。"
+        },
+        "testCaseHealth": {
+          "label": "测试案例健康状况",
+          "description": "根据执行模式识别过时、损坏或可疑的测试用例"
+        },
+        "issueTestCoverage": {
+          "label": "问题测试覆盖率",
+          "description": "查看问题及其关联的测试用例和最新执行状态"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "最近连续运行",
+        "consecutiveRunsHelp": "待分析的近期测试执行次数（5-30）。状态为“未测试”的结果将被排除在外。",
+        "flipThreshold": "最少翻转次数",
+        "flipThresholdHelp": "达到最低通过/失败转换次数才算不稳定。",
+        "flips": "翻转",
+        "lastNResults": "最后 {count, plural, one {# 结果} other {# 结果集}}",
+        "newest": "新的",
+        "oldest": "老的",
+        "noFlakyTests": "未发现符合标准的不合格测试",
+        "includeFilter": "包括",
+        "testRunDeleted": "测试运行已被删除",
+        "chart": {
+          "highPriority": "需要关注",
+          "lowPriority": "优先级较低",
+          "recencyAxis": "近期失败",
+          "flipsAxis": "翻转次数",
+          "oldFailures": "老年人",
+          "recentFailures": "最近的",
+          "failureRate": "故障率",
+          "recency": "近期得分",
+          "backlogTitle": "低优先级测试",
+          "backlogDescription": "{count, plural, one {# 额外的不稳定测试} other {# 额外的不稳定测试}} 未显示"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "过期（天后）",
+        "staleDaysThresholdHelp": "测试未执行的天数（7-90）被视为过期。",
+        "minExecutions": "最低执行次数",
+        "minExecutionsHelp": "计算有意义的通过率统计数据所需的最少执行次数（3-20）。",
+        "lookbackDays": "回顾期",
+        "lookbackDaysHelp": "分析执行历史的天数（30-365）。",
+        "includeFilter": "包括",
+        "staleFilter": "陈旧",
+        "stale": "陈旧",
+        "notStale": "未过期",
+        "status": "健康状况",
+        "healthScore": "分数",
+        "lastExecuted": "最后执行",
+        "executions": "执行",
+        "passRate": "通过率",
+        "passCount": "通行证",
+        "failCount": "失败",
+        "never": "绝不",
+        "daysSince": "执行完毕至今已过去数天",
+        "count": "数数",
+        "totalTests": "测试用例",
+        "noData": "未找到测试用例",
+        "noExecutedTests": "没有已执行的测试要显示",
+        "healthStatus": {
+          "healthy": "健康",
+          "stale": "陈旧",
+          "neverExecuted": "从未执行",
+          "alwaysPassing": "总是通过",
+          "alwaysFailing": "总是失败"
+        },
+        "chart": {
+          "distribution": "状态分布",
+          "healthyRecent": "健康与近期",
+          "unhealthyStale": "需要关注",
+          "daysAxis": "自上次执行以来的天数",
+          "healthScoreAxis": "健康评分"
+        },
+        "stats": {
+          "totalTests": "总测试次数",
+          "needsAttention": "需要关注",
+          "needsAttentionTooltip": "总是失败 + 从未执行 + 过时的测试",
+          "healthy": "健康",
+          "healthyTooltip": "健康 + 每次测试都通过",
+          "avgScore": "平均健康评分"
+        },
+        "healthScoreTooltip": {
+          "title": "初始分数为100分，扣分项：",
+          "neverExecuted": "从未执行：-50",
+          "stale90": "超过 90 天未运行：-40",
+          "stale60": "超过 60 天未运行：-25",
+          "stale30": "超过 30 天未运行：-10",
+          "alwaysPassing": "始终通过（100%）：-5",
+          "alwaysFailing": "始终失败 (0%)：-30",
+          "lowPassRate": "低通过率（<50%）：-20",
+          "lowExecutions": "执行次数少（<3）：-10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "查看模式",
+        "summaryView": "摘要（按期）",
+        "detailView": "详细信息（按测试用例）",
+        "issue": "问题",
+        "testCase": "测试用例",
+        "testCases": "{count, plural, =1 {测试用例} other {测试用例}}",
+        "issueStatus": "地位",
+        "priority": "优先事项",
+        "linkedTests": "关联测试",
+        "testResults": "结果（合格/不合格/待定）",
+        "passRate": "通过率",
+        "passed": "通过",
+        "failed": "失败的",
+        "lastStatus": "最新状态",
+        "lastExecuted": "最后执行",
+        "notTested": "未经测试",
+        "noData": "未发现关联测试用例存在问题。",
+        "noIssuesNeedingAttention": "所有问题都通过了测试——干得好！",
+        "stats": {
+          "totalIssues": "总期数",
+          "issuesWithFailures": "失败",
+          "issuesWithFailuresTooltip": "至少有一个测试用例失败，存在问题",
+          "issuesWithUntested": "未经测试",
+          "issuesWithUntestedTooltip": "至少有一个尚未执行的测试用例存在问题。",
+          "issuesAllPassing": "全部通过",
+          "overallPassRate": "通过率",
+          "numberOfIssues": "问题数量"
+        },
+        "charts": {
+          "passRateDistribution": "考试通过率分布",
+          "linkedTestCases": "关联测试用例数量",
+          "untestedTestCases": "未测试用例数量",
+          "testCoverageVsExecution": "测试覆盖率与执行状态"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "跨项目测试执行",
+          "description": "分析所有项目的测试结果、通过率和执行指标"
+        },
+        "repositoryStats": {
+          "label": "跨项目存储库统计信息",
+          "description": "项目间的测试用例统计、覆盖率和代码库健康状况"
+        },
+        "userEngagement": {
+          "label": "跨项目用户参与",
+          "description": "跨项目的用户活动、生产力和工作量分析"
+        },
+        "issueTracking": {
+          "label": "跨项目问题跟踪",
+          "description": "项目间的问题产生、解决和影响分析"
+        },
+        "automationTrends": {
+          "label": "跨项目自动化趋势",
+          "description": "按优先级逐周跟踪各项目的自动化进度"
+        },
+        "flakyTests": {
+          "label": "跨项目不稳定的测试",
+          "description": "识别项目中通过/失败结果不一致的测试"
+        },
+        "testCaseHealth": {
+          "label": "跨项目测试用例健康状况",
+          "description": "识别项目中的过时、损坏或可疑的测试用例"
+        },
+        "issueTestCoverage": {
+          "label": "跨项目问题测试覆盖率",
+          "description": "查看项目中的问题及其关联的测试用例和最新执行状态"
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "只有项目管理员和管理员才能访问项目报告。",
+      "projectIdRequired": "项目 ID 为必填项",
+      "missingRequiredFields": "缺少必填字段",
+      "unsupportedDimension": "不支持的维度： {dimension}",
+      "unsupportedMetric": "不支持的度量： {metric}",
+      "atLeastOneDimensionMetricRequired": "至少需要一个维度和一个度量",
+      "atLeastOneMetricRequired": "必须指定至少一项指标。",
+      "projectDimensionsMetricsRequired": "需要项目 ID、维度和指标。",
+      "unsupportedDimensions": "不支持的维度： {dimensions}",
+      "unsupportedMetrics": "不支持的度量值： {metrics}",
+      "unexpectedError": "发生意外错误。"
+    },
+    "dimensions": {
+      "project": "项目",
+      "status": "地位",
+      "user": "用户",
+      "executor": "执行人",
+      "assignedTo": "分配给",
+      "configuration": "配置",
+      "date": "日期",
+      "executionDate": "执行日期",
+      "creationDate": "创建日期",
+      "activityDate": "活动日期",
+      "testRun": "测试运行",
+      "testCase": "测试用例",
+      "milestone": "里程碑",
+      "template": "模板",
+      "creator": "创作者",
+      "state": "状态",
+      "source": "来源",
+      "folder": "文件夹",
+      "group": "团体",
+      "role": "角色",
+      "session": "会议",
+      "weekEnding": "一周结束",
+      "period": "时期",
+      "priority": "优先事项",
+      "automationStatus": "自动化状态",
+      "issueType": "问题类型",
+      "issueTracker": "问题跟踪器",
+      "issueStatus": "问题状态"
+    },
+    "metrics": {
+      "testResults": "测试结果",
+      "testResultCount": "检测结果计数",
+      "passRate": "通过率（%）",
+      "avgElapsed": "平均经过时间",
+      "avgElapsedTime": "平均经过时间",
+      "totalElapsedTime": "总经过时间",
+      "testRunCount": "测试运行次数",
+      "testCaseCount": "测试用例数量",
+      "automationRate": "自动化率（%）",
+      "avgStepsPerCase": "每例平均步骤",
+      "averageSteps": "每例平均步数",
+      "automatedCount": "自动化案件",
+      "manualCount": "手动案例",
+      "totalCount": "病例总数",
+      "totalSteps": "总步数",
+      "executionCount": "测试执行",
+      "createdCaseCount": "已创建的测试用例数量",
+      "sessionResultCount": "会话结果计数",
+      "caseCreations": "创建案例",
+      "sessionParticipation": "会议参与",
+      "averageElapsed": "每次执行的平均时间",
+      "lastActiveDate": "最后活跃日期",
+      "issueCount": "问题数量",
+      "averageAge": "平均年龄（天）",
+      "sessionCount": "会话数",
+      "activeSessions": "活跃会话",
+      "averageTimeSpent": "平均花费时间（分钟）",
+      "milestoneCount": "里程碑计数",
+      "milestoneCompletionRate": "里程碑完成率（%）",
+      "averageMilestoneDuration": "平均里程碑持续时间（天）",
+      "totalMilestones": "总里程碑",
+      "activeMilestones": "活跃里程碑",
+      "milestoneCompletion": "里程碑完成率（%）",
+      "averageDuration": "平均持续时间",
+      "totalDuration": "总时长"
+    },
+    "drillDown": {
+      "title": "详细记录",
+      "loading": "正在加载记录...",
+      "loadingMore": "加载中……",
+      "noRecords": "未找到记录",
+      "error": "记录加载失败",
+      "recordCount": "{count} {count, plural, =1 {记录} other {记录}}",
+      "allRecords": "所有记录",
+      "allLoaded": "所有记录已加载"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "分享",
+      "dialogTitle": "分享报告",
+      "dialogDescription": "创建可共享链接或管理现有共享报告链接。",
+      "tabs": {
+        "create": "创建共享",
+        "list": "我的股票"
+      },
+      "shareMode": {
+        "label": "分享模式",
+        "authenticated": {
+          "title": "已验证（需要登录）",
+          "description": "只有已登录且有权访问此项目的用户才能查看。",
+          "descriptionCrossProject": "只有拥有管理员权限的登录用户才能查看。"
+        },
+        "passwordProtected": {
+          "title": "密码保护",
+          "description": "任何拥有链接和密码的人都可以查看。已登录并拥有项目访问权限的用户无需密码。",
+          "descriptionCrossProject": "任何拥有链接和密码的人都可以查看。已登录并拥有管理员权限的用户无需密码。"
+        },
+        "public": {
+          "title": "公开（任何拥有链接的人）",
+          "description": "任何拥有该链接的人无需登录即可查看此报告。"
+        }
+      },
+      "expiration": {
+        "label": "到期日",
+        "noExpiration": "无有效期",
+        "expiresAtMidnight": "链接将于所选日期结束时失效（以您当地时间为准）。"
+      },
+      "notifyOnView": {
+        "label": "有人查看此链接时通知我",
+        "description": "根据您的通知偏好设置，当有人访问分享链接时，您将收到通知。"
+      },
+      "title": {
+        "placeholder": "例如，测试执行报告",
+        "leaveEmptyToUse": "留空备用："
+      },
+      "description": {
+        "placeholder": "为这份共享报告添加描述……"
+      },
+      "actions": {
+        "createShareLink": "创建共享链接",
+        "creating": "正在创建……"
+      },
+      "errors": {
+        "loginRequired": "您必须登录才能创建分享链接",
+        "createFailed": "创建共享链接失败",
+        "genericError": "发生未知错误"
+      },
+      "status": {
+        "revoked": {
+          "title": "分享链接已撤销",
+          "description": "此分享链接已被撤销，无法再访问。"
+        },
+        "expired": {
+          "title": "分享链接已过期",
+          "description": "此分享链接已过期，无法再访问。"
+        }
+      },
+      "footer": {
+        "poweredBy": "供电"
+      },
+      "manageShares": {
+        "title": "管理股份",
+        "description": "查看和管理此项目的所有共享链接",
+        "adminTitle": "管理所有股份",
+        "adminDescription": "查看所有项目中的共享链接"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "模式",
+          "views": "浏览量",
+          "expires": "过期"
+        },
+        "status": {
+          "revoked": "撤销",
+          "expired": "已到期"
+        },
+        "notifications": {
+          "enabled": "在",
+          "disabled": "离开"
+        },
+        "empty": {
+          "title": "尚未创建任何分享链接。",
+          "description": "创建你的第一个分享链接即可开始。"
+        },
+        "defaultTitle": "{entityType} 分享",
+        "noProject": "跨项目",
+        "actions": {
+          "copyLink": "复制链接",
+          "revoke": "撤销"
+        },
+        "revokeDialog": {
+          "title": "撤销分享链接？",
+          "description": "这将立即撤销分享链接。任何尝试访问该链接的人都会看到错误信息。此操作无法撤销。",
+          "confirm": "撤销链接",
+          "revoking": "撤销……"
+        },
+        "deleteDialog": {
+          "title": "删除分享链接？",
+          "description": "这将永久删除分享链接。如果该链接当前处于活动状态，它将立即失效且无法再访问。此操作无法撤销。",
+          "confirm": "删除链接"
+        },
+        "toast": {
+          "linkCopied": "链接已复制！",
+          "linkCopiedDescription": "分享链接已复制到剪贴板。",
+          "copyFailed": "复制失败",
+          "copyFailedDescription": "请手动复制链接。",
+          "linkRevoked": "分享链接已撤销",
+          "linkRevokedDescription": "分享链接已被撤销，无法再访问。",
+          "revokeFailed": "撤销失败",
+          "revokeFailedDescription": "撤销共享链接时发生错误。",
+          "notificationsEnabled": "已启用通知",
+          "notificationsEnabledDescription": "当有人查看此分享链接时，您将收到通知。",
+          "notificationsDisabled": "通知已禁用",
+          "notificationsDisabledDescription": "当有人查看此分享链接时，您不会收到通知。",
+          "notificationUpdateFailed": "更新通知失败",
+          "notificationUpdateFailedDescription": "更新通知设置时发生错误。",
+          "linkDeleted": "分享链接已删除",
+          "linkDeletedDescription": "分享链接已被删除，将不再显示在您的列表中。",
+          "deleteFailed": "删除失败",
+          "deleteFailedDescription": "删除分享链接时出错。"
+        }
+      },
+      "created": {
+        "title": "分享链接已创建！",
+        "description": "您的分享链接已准备就绪。复制并分享给其他人即可。",
+        "shareLink": "分享链接",
+        "copy": "复制",
+        "openInNewTab": "在新标签页中打开",
+        "metadata": {
+          "mode": "模式",
+          "expires": "过期",
+          "views": "浏览量"
+        },
+        "warnings": {
+          "publicLink": "公开链接：",
+          "publicLinkDescription": "拥有此链接的人无需身份验证即可访问该报告。",
+          "expiresSoon": "此链接将于月底失效"
+        },
+        "actions": {
+          "createAnother": "创建另一个"
+        }
+      },
+      "editDialog": {
+        "title": "编辑分享链接",
+        "description": "更新此分享链接的设置。",
+        "passwordExists": "此分享链接已设置密码。请将密码字段留空以保留现有密码。",
+        "passwordPlaceholder": "留空以保留现有密码"
+      }
+    },
+    "passwordDialog": {
+      "title": "需要密码",
+      "description": "来自 <strong>{projectName}</strong> 的共享内容受密码保护。请输入密码以继续。",
+      "passwordPlaceholder": "输入密码",
+      "showPassword": "显示密码",
+      "hidePassword": "隐藏密码",
+      "verifying": "正在核实……",
+      "errors": {
+        "emptyPassword": "请输入密码",
+        "tooManyAttempts": "Too many failed attempts. Please try again later{resetAt, select, null {} other { at {resetAt}}}.",
+        "genericError": "发生错误，请重试。"
+      },
+      "attempts": {
+        "noAttemptsRemaining": "尝试次数已用完，请稍后再试。",
+        "attemptsRemaining": "{count, plural, =1 {1 次尝试} other {# 次尝试}} 剩余。"
+      }
+    },
+    "sharedReport": {
+      "loading": "正在加载报告……",
+      "errors": {
+        "onlyReportSharing": "目前仅实现了报告共享功能。",
+        "failedToLoad": "报告数据加载失败"
+      },
+      "defaultTitle": "共享报告",
+      "fromProject": "来自项目：",
+      "dateRange": "日期范围：",
+      "readOnlyNotice": "这是一个只读共享视图",
+      "viewCount": "{count, plural, =1 {1 次浏览} other {# 次浏览}}",
+      "viewInFullApp": "查看完整应用",
+      "pagination": {
+        "showing": "显示",
+        "of": "的",
+        "results": "结果"
+      }
+    },
+    "authBypass": {
+      "title": "您有权访问此项目",
+      "description": "以 {userName} 身份查看，并可访问 {projectName}。",
+      "viewInApp": "查看完整应用"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "筛选共享步骤...",
+    "noGroups": "未找到共享步骤。",
+    "noTestCases": "没有测试用例使用此共享步骤组。",
+    "selectGroupPrompt": "选择共享步骤组以查看其步骤。",
+    "deleteTitle": "删除共享步骤组？",
+    "deleteDescription": "您确定要删除此共享步骤组吗？删除后，所有使用这些步骤的测试用例中的步骤都将被移除。",
+    "saveSuccess": "共享步骤已成功更新。",
+    "saveError": "保存共享步骤时发生错误。",
+    "stepsCount": "{count, plural, one {# 步骤} other {# 步骤}}",
+    "testCasesUsing": "{count, plural, one {# 测试用例} other {# 测试用例}}",
+    "importWizard": {
+      "title": "导入共享步骤",
+      "fields": {
+        "order": "命令",
+        "stepNumber": "步 ＃",
+        "stepContent": "步骤内容",
+        "expectedResultContent": "预期结果内容",
+        "combinedStepData": "组合步数据",
+        "stepsData": "步骤数据"
+      },
+      "success": {
+        "description": "{count, plural, one {# 共享步骤} other {# 共享步骤}} 导入成功"
+      },
+      "errors": {
+        "parseFailed": "解析 CSV 文件失败",
+        "validationFailed": "验证失败",
+        "validationDescription": "{count, plural, one {# 验证错误} other {# 发现验证错误}}",
+        "importFailed": "导入失败",
+        "fileRequired": "需要一个 CSV 文件。"
+      },
+      "page1": {
+        "title": "上传文件和配置",
+        "selectedFile": "选定文件",
+        "delimiter": "字段分隔符",
+        "delimiters": {
+          "tab": "Tab (\\t)"
+        },
+        "hasHeaders": "第一行包含列标题。",
+        "encoding": "文件编码",
+        "rowMode": {
+          "label": "行模式",
+          "single": "每个共享步骤一行",
+          "multi": "复杂共享步骤的多行"
+        }
+      },
+      "page2": {
+        "title": "将 CSV 列映射到共享步骤字段",
+        "description": "将您的 CSV 列映射到共享步骤字段。必填字段必须映射。",
+        "ignoreColumn": "忽略此列",
+        "requiredFieldsWarning": "{count, plural, one {# 必填字段} other {# 必填字段}} 未映射。请映射所有必填字段以继续。"
+      },
+      "page3": {
+        "title": "预览导入数据",
+        "showing": "显示 {start} 到 {end} 共 {total} 个共享步骤",
+        "step": "共享步骤 {number}",
+        "noValue": "（空的）"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "手动添加",
+      "description": "创建一个新的共享步骤组（手动输入）",
+      "groupNamePlaceholder": "请输入此共享步骤组的名称",
+      "success": "共享步骤已成功创建",
+      "errors": {
+        "groupNameRequired": "组名必填",
+        "stepsRequired": "至少需要一步。",
+        "saveFailed": "保存共享步骤失败"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "步骤序列重复",
+      "pageDescription": "检查测试用例中匹配的步骤序列。将匹配项转换为共享步骤组，或排除误报。",
+      "noResultsFound": "未发现重复步骤。",
+      "noResultsDescription": "运行扫描以检测测试用例中重复的步骤序列。",
+      "filterPlaceholder": "按案例名称筛选...",
+      "selected": "{count, plural, one {# 已选择} other {# 已选择}}",
+      "bulkDismiss": "解雇（{count}）",
+      "bulkDismissSuccess": "{count, plural, one {# 比赛已取消} other {# 比赛已取消}}",
+      "bulkError": "部分操作失败，请重试。",
+      "tableHint": "点击行可预览匹配的步骤。选中带有复选框的行可进行批量操作。",
+      "columns": {
+        "matchedSteps": "匹配步骤",
+        "casesCount": "案例",
+        "review": "审查"
+      },
+      "scanning": "扫描...",
+      "scanComplete": "{count, plural, one {# 找到匹配项} other {# 找到匹配项}}",
+      "scanFailed": "扫描失败",
+      "scanFailedDescription": "扫描过程中发生错误，请重试。",
+      "cancelScan": "取消扫描",
+      "findStepDuplicates": "查找重复步骤",
+      "rescan": "扫描",
+      "viewResults": "查看结果 ({count})",
+      "retryScan": "重试扫描",
+      "dialog": {
+        "title": "转换为共享步骤",
+        "previewTitle": "匹配步骤序列",
+        "casesTitle": "受影响的测试用例",
+        "casesDescription": "取消勾选要从转换中排除的案例。",
+        "nameLabel": "共享步骤组名称",
+        "namePlaceholder": "请输入共享步骤组的名称……",
+        "converting": "正在转换...",
+        "dismissMatch": "取消比赛",
+        "dismissing": "解雇……",
+        "convertSuccess": "共享步骤组创建成功！",
+        "convertError": "转换失败，请重试。",
+        "dismissSuccess": "比赛结束。",
+        "dismissError": "关闭失败，请重试。",
+        "viewSharedStep": "查看共享步骤组",
+        "skippedWarning": "{count, plural, one {# 跳过案例} other {# 跳过案例}} （已过时或已转换）。",
+        "noCasesSelected": "至少选择一个案例进行转换。",
+        "selectAll": "全选"
+      }
+    },
+    "findStepDuplicates": "查找重复项"
+  },
+  "search": {
+    "title": "搜索",
+    "placeholder": {
+      "thisProject": "在此项目中搜索……",
+      "allProjects": "搜索所有项目……"
+    },
+    "currentProjectOnly": "仅限当前项目",
+    "allTypes": "所有类型",
+    "entityTypes": {
+      "repositoryCase": "存储库案例"
+    },
+    "results": {
+      "tryAdjusting": "尝试调整搜索词或筛选条件。",
+      "searchingFor": "正在寻找",
+      "within": "之内",
+      "currentProject": "当前项目",
+      "page": "页"
+    },
+    "errors": {
+      "searchFailed": "搜索失败，请重试。",
+      "tryAgain": "再试一次"
+    },
+    "startTyping": "开始输入以进行搜索",
+    "typesSelected": "{count, plural, one {# 类型} other {# 类型们}}",
+    "customFieldFilters": "自定义字段筛选器",
+    "customFiltersApplied": "自定义过滤器",
+    "customFields": "自定义字段",
+    "addFilter": "添加筛选器",
+    "filter": "筛选",
+    "noCustomFilters": "未应用自定义字段筛选器",
+    "selectDate": "选择日期",
+    "selectOption": "选择选项",
+    "selectOptions": "选择选项",
+    "operators": {
+      "equals": "等于",
+      "not_equals": "不等于",
+      "contains": "包含",
+      "not_contains": "不含",
+      "starts_with": "以……开始",
+      "ends_with": "以……结尾",
+      "gt": "大于",
+      "lt": "少于",
+      "gte": "大于或等于",
+      "lte": "小于或等于",
+      "between": "之间",
+      "in": "在",
+      "not_in": "不在",
+      "exists": "存在",
+      "not_exists": "不存在"
+    },
+    "help": {
+      "exactPhrases": "确切短语",
+      "exactPhrasesDesc": "将词语用引号括起来，以匹配完整的短语：",
+      "proximity": "近距离搜索",
+      "proximityDesc": "彼此相距 N 个位置的单词",
+      "booleanOperators": "布尔运算符",
+      "andDesc": "这两个术语必须匹配",
+      "orDesc": "这两个术语都可以匹配",
+      "notDesc": "排除包含该术语的结果",
+      "prefixDesc": "要求或排除某个条款",
+      "groupingDesc": "复杂查询的分组术语",
+      "wildcards": "外卡",
+      "wildcardMultiDesc": "匹配任何字符",
+      "wildcardSingleDesc": "匹配单个字符",
+      "fuzzyMatching": "模糊匹配",
+      "fuzzyDesc": "查找相似词以帮助纠正拼写错误。",
+      "defaultBehavior": "多个词语默认使用“或”运算符。与名称完全匹配的结果排名最高。",
+      "fullSyntaxLink": "Lucene 查询语法完整参考"
+    },
+    "filters": {
+      "title": "高级筛选器",
+      "active": "过滤器已激活",
+      "activeCount": "{count, plural, =0 {无过滤器} one {# 过滤器} other {# 过滤器}} 已启用",
+      "apply": "应用筛选条件",
+      "common": "常用过滤器",
+      "entitySpecific": "类型特定筛选器",
+      "searchPlaceholder": "搜索筛选选项……",
+      "states": "工作流状态",
+      "createdAt": "创建日期",
+      "updatedAt": "更新日期",
+      "completedAt": "完成日期",
+      "from": "从",
+      "to": "到",
+      "testRunType": "测试运行类型",
+      "regular": "常规的",
+      "junit": "JUnit",
+      "automatedOnly": "仅限自动",
+      "archivedOnly": "仅存档",
+      "completedOnly": "仅完成",
+      "manualOnly": "仅限手动",
+      "estimateRange": "估算范围",
+      "elapsedRange": "经过时间范围",
+      "minValue": "敏",
+      "maxValue": "最大限度",
+      "hasExternalId": "具有外部 ID",
+      "dueDateRange": "到期日范围",
+      "hasParent": "具有父级里程碑",
+      "milestoneType": "里程碑类型",
+      "minutes": "分钟",
+      "hours": "小时",
+      "days": "天",
+      "searchingIn": "搜索",
+      "includeDeleted": "包括已删除的项目",
+      "filterActive": "筛选器已启用：",
+      "applyFilter": "应用筛选器",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "第一个值必须小于第二个值",
+        "firstDateMustBeBeforeSecond": "第一次约会必须在第二次约会之前。"
+      },
+      "link": {
+        "domainHelp": "只需输入域名（例如，“github.com”或“example.org”）"
+      }
+    }
+  },
+  "email": {
+    "greeting": "你好，",
+    "greetingWithName": "嗨 {name}，",
+    "notification": {
+      "intro": "您收到一条新通知：",
+      "viewDetails": "查看详情",
+      "viewAll": "查看所有通知"
+    },
+    "digest": {
+      "intro": "以下是您每日收到的来自 TestPlanIt 的通知摘要：",
+      "viewDetails": "查看详情",
+      "viewAll": "查看所有通知",
+      "noNotifications": "您今天没有任何新通知。",
+      "footer": "您收到此邮件是因为您已启用每日摘要通知。您可以在设置中更改通知偏好。",
+      "profileSettings": "个人资料设置"
+    },
+    "footer": {
+      "sentBy": "这封邮件由……发送",
+      "unsubscribe": "取消订阅",
+      "managePreferences": "管理偏好设置",
+      "allRightsReserved": "版权所有。"
+    },
+    "magicLink": {
+      "subject": "登录 TestPlanIt",
+      "heading": "登录 TestPlanIt",
+      "intro": "点击下方按钮登录：",
+      "signInButton": "登入",
+      "copyPasteIntro": "或者复制此链接并粘贴到浏览器中：",
+      "disclaimer": "如果您没有请求收到这封邮件，您可以忽略它。",
+      "textBody": "登录 TestPlanIt\n\n点击以下链接登录：\n{url}\n\n如果您没有请求此电子邮件，则可以忽略它。"
+    }
+  },
+  "comments": {
+    "title": "评论",
+    "placeholder": "请留言……（使用@提及用户）",
+    "editPlaceholder": "编辑您的评论……",
+    "postComment": "发表评论",
+    "noComments": "目前还没有评论。快来发表你的第一个评论吧！",
+    "edited": "编辑",
+    "confirmDelete": "您确定要删除此评论吗？此操作无法撤销。",
+    "deleteDialog": {
+      "title": "删除评论"
+    },
+    "errors": {
+      "createFailed": "创建评论失败，请重试。",
+      "updateFailed": "评论更新失败，请重试。",
+      "deleteFailed": "删除评论失败，请重试。",
+      "loadFailed": "评论加载失败，请重试。"
+    },
+    "mentions": {
+      "notAMember": "非项目成员",
+      "noUsersFound": "未找到用户"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "审判将于 {count, plural, =1 {1天} other {#天}}结束",
+    "expiresT oday": "试用期今天到期",
+    "expired": "{count, plural, =1 {试用期已于 1 天前过期} other {试用期已于 # 天前过期}}",
+    "contactSales": "联系销售"
+  },
+  "feedback": {
+    "sheetTitle": "分享您的反馈",
+    "sheetDescription": "请分享您的使用体验，帮助我们改进 TestPlanIt。",
+    "bannerMessage": "你的庭审进行得怎么样？我们很想听听你的想法。",
+    "menuItem": "分享反馈"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "AI标签",
+      "tagAll": "全部标记",
+      "aiAutoTag": "自动标签",
+      "tagActions": "标签操作",
+      "startTagging": "开始标记",
+      "selectEntityType": "选择实体类型",
+      "selectProject": "选择一个项目",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {测试用例} other {测试用例}}",
+        "testRun": "{count, plural, one {测试运行} other {测试运行}}",
+        "session": "{count, plural, one {会话} other {会话}}"
+      }
+    },
+    "review": {
+      "title": "评论标签建议",
+      "description": "点击标签可切换是否接受标签。双击可编辑标签名称。",
+      "selectEntity": "选择一个实体以查看标签建议。",
+      "noTagsSelected": "未选择任何标签",
+      "footerSummary": "{assignCount, plural, one {# 标签} other {# 标签}} 将被分配， {newCount, plural, one {# 新标签} other {# 新标签}} 将被创建",
+      "footerAssignCount": "{assignCount, plural, one {# 标签} other {# 标签}} 将被分配",
+      "footerNewCount": "{newCount, plural, one {# 新标签} other {# 新标签}} 将创建",
+      "newTagsPopoverTitle": "要创建的新标签",
+      "applying": "正在申请……",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}, {newCount, plural, one {# new tag} other {# new tags}} created",
+      "applyError": "标签应用失败，请重试。",
+      "suggestedTags": "建议标签",
+      "noSuggestions": "人工智能无法生成任何标签。",
+      "alreadyApplied": "已申请",
+      "filterEntities": "筛选实体...",
+      "noEntitiesMatch": "没有符合您搜索条件的实体。",
+      "tagCount": "{count, plural, one {# 标签} other {# 标签}}",
+      "noTags": "没有任何",
+      "failed": "失败的",
+      "analysisFailed": "无法分析此实体",
+      "responseTruncated": "响应被截断——请在 LLM 设置中增加最大输出令牌数",
+      "tooltipExisting": "现有标签",
+      "tooltipNew": "将创建新标签",
+      "tooltipAssign": "分配现有标签",
+      "toggleFailed": "显示/隐藏失败的实体",
+      "showFailed": "显示失败"
+    },
+    "progress": {
+      "starting": "开始分析……",
+      "analyzed": "分析了 {analyzed}/{total} 个实体",
+      "sizing": "寻找最佳批次大小（尝试 {size} 个实体）...",
+      "streaming": "正在接收 AI 响应（{analyzed}/{total} 个实体已完成）……",
+      "finalizing": "正在准备结果……",
+      "complete": "分析完成",
+      "reviewSuggestions": "评论建议",
+      "failed": "分析失败"
+    },
+    "wizard": {
+      "description": "AI 将分析您整个项目的测试用例、测试运行和会话，并根据其内容建议相关的标签。",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "开始分析",
+      "untaggedOnly": "仅分析没有现有标签的记录",
+      "allowNewTags": "允许创建新标签",
+      "noLlmConfigured": "（未配置LLM）",
+      "analyzingDescription": "AI正在分析您的实体并生成标签建议。这可能需要一些时间。"
+    },
+    "entityDetail": {
+      "customFields": "自定义字段",
+      "noDetails": "暂无更多详情。",
+      "openInNewTab": "在新标签页中打开"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "非常弱",
+    "weak": "虚弱的",
+    "fair": "公平的",
+    "good": "好的",
+    "strong": "强的",
+    "minLength": "至少 {count} 个字符",
+    "uppercase": "至少包含一个大写字母",
+    "lowercase": "至少包含一个小写字母",
+    "numbers": "至少一个数字",
+    "specialChars": "特殊字符来自： {chars}",
+    "history": "此密码曾用于您最近的 {depth} 个密码中。"
+  },
+  "TrialExpired": {
+    "title": "您的试用期已结束。",
+    "description": "感谢您试用TestPlanIt！您的试用期已结束，此实例已无法访问。",
+    "nextSteps": "如需继续使用 TestPlanIt 并访问您的测试数据，请联系我们的销售团队。",
+    "pricingPlans": "定价方案",
+    "dataRetention": "您的测试数据已安全存储，升级帐户后即可访问。"
+  }
+}

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -1,0 +1,6850 @@
+{
+  "common": {
+    "name": "姓名",
+    "cancel": "取消",
+    "dismiss": "解僱",
+    "of": "的",
+    "on": "在",
+    "at": "在",
+    "in": "在",
+    "add": "添加",
+    "never": "絕不",
+    "select": "選擇...",
+    "file": "文件",
+    "selectMultiple": "選擇多個...",
+    "searchUsers": "搜尋用戶...",
+    "searchCases": "{count, plural, =0 {Search cases} one {Search # case} other {Search # cases}}",
+    "searchProjects": "{count, plural, =0 {Search projects} one {Search # project} other {Search # projects}}",
+    "searchTags": "搜尋標籤...",
+    "searchRuns": "{count, plural, =0 {Search test runs} one {Search # test run} other {Search # test runs}}",
+    "searchSessions": "{count, plural, =0 {搜尋會話數} one {搜尋會話數} other {搜尋會話數}}",
+    "search": "搜尋...",
+    "defaultOption": "預設選項",
+    "yes": "是的",
+    "no": "不",
+    "updated": "更新",
+    "groupedBy": "按以下方式分組",
+    "lastEditedBy": "最後編輯於",
+    "actions": {
+      "edit": "編輯",
+      "save": "節省",
+      "delete": "刪除",
+      "create": "創造",
+      "submit": "提交",
+      "close": "關閉",
+      "done": "完畢",
+      "verify": "核實",
+      "signIn": "登入",
+      "signOut": "登出",
+      "signUp": "報名",
+      "resend": "重新發送",
+      "deleting": "正在刪除…",
+      "next": "下一個",
+      "previous": "以前的",
+      "finish": "結束",
+      "download": "下載",
+      "apply": "申請",
+      "confirm": "確認",
+      "confirmDelete": "確認刪除",
+      "saveChanges": "儲存變更",
+      "saving": "儲存...",
+      "submitting": "正在提交…",
+      "start": "開始",
+      "pause": "暫停",
+      "reset": "重置",
+      "copy": "複製",
+      "copyLink": "複製連結",
+      "copied": "已複製！",
+      "complete": "完全的",
+      "back": "後退",
+      "clear": "清除",
+      "expand": "擴張",
+      "collapse": "坍塌",
+      "addResult": "新增結果",
+      "passAndNext": "下一個",
+      "viewInRepository": "在儲存庫中查看",
+      "resultAdded": "測試結果已新增",
+      "resultAddedDescription": "測試結果已成功新增。",
+      "resultUpdated": "測試結果已更新",
+      "resultDeleted": "測試結果已刪除",
+      "deleteResult": "刪除測試結果",
+      "deleteResultConfirmation": "您確定要刪除此測試結果嗎？此操作無法撤銷。",
+      "editResult": "編輯測試結果",
+      "resultDetails": "結果詳情",
+      "actionsLabel": "行動",
+      "assign": "分配",
+      "assignSelected": "分配 {count, plural, one {# 情況} other {# 情況}}",
+      "refresh": "重新整理",
+      "addResultSelected": "將結果加到 {count, plural, one {# 情況} other {# 情況}}",
+      "resultsAdded": "{count, plural, one {# 結果} other {# 結果}} 添加",
+      "resultsAddedDescription": "{count, plural, one {結果已新增至 # 個測試案例} other {結果已新增至 # 個測試案例}} 成功",
+      "addingResultsToMultiple": "將結果加入 {count, plural, one {# 測試案例} other {# 測試案例}}",
+      "addedToTestRun": "已新增至測試運行",
+      "addedToTestRunDescription": "測試用例已新增至測試運行。",
+      "noAvailableTestRuns": "所有正在進行的測試運行均已包含此測試案例。",
+      "resultUpdateError": "測試結果更新失敗",
+      "resultDeleteError": "刪除測試結果失敗",
+      "selectStatus": "選擇狀態",
+      "addToTestRun": "新增到測試運行",
+      "status": "地位",
+      "resultDetailsPlaceholder": "請輸入結果詳情…",
+      "selectAll": "全選",
+      "deselectAll": "取消選擇所有",
+      "clearAll": "全部清除",
+      "selectFile": "選擇文件",
+      "restore": "恢復",
+      "purge": "清除",
+      "previousCase": "前例",
+      "nextCase": "下一個案例",
+      "startTesting": "開始測試",
+      "expandLeftPanel": "展開左側面板",
+      "collapseLeftPanel": "折疊左側面板",
+      "expandRightPanel": "展開右側面板",
+      "collapseRightPanel": "折疊右側面板",
+      "createTag": "建立標籤“{name}”",
+      "noTagsFound": "未找到標籤",
+      "duplicate": "複製",
+      "exportPdf": "匯出PDF",
+      "exportingPdf": "出口...",
+      "change": "改變",
+      "viewAll": "看全部",
+      "undo": "撤銷",
+      "undoDelete": "撤銷刪除",
+      "automated": {
+        "details": "自動化測試詳情",
+        "message": "訊息",
+        "line": "線",
+        "testSuite": "測試套件："
+      },
+      "junit": {
+        "details": "自動化測試結果詳情",
+        "import": {
+          "title": "導入測試結果",
+          "description": "上傳測試結果檔案以匯入到新的測試運行中。支援 JUnit、TestNG、xUnit、NUnit、MSTest、Mocha 和 Cucumber 格式。",
+          "testRun": {
+            "label": "測試運行",
+            "placeholder": "選擇一次測試運行"
+          },
+          "file": {
+            "label": "測試結果文件"
+          },
+          "import": "進口",
+          "selectFolder": "選擇一個資料夾",
+          "createNewFolder": "建立新資料夾",
+          "createNewFolderNamed": "建立新資料夾： {name}",
+          "progress": {
+            "initializing": "正在初始化導入...",
+            "validating": "正在驗證輸入資料…",
+            "creatingRun": "正在建立測試運行...",
+            "fetchingTemplate": "正在取得範本資料...",
+            "countingTests": "正在處理來自 {files} 個檔案的 {count} 個測試案例...",
+            "parsingFile": "正在解析檔案 {current} ，該檔案屬於 {total}...",
+            "processingSuite": "處理套件： {name}",
+            "processingCase": "正在處理測試案例 {current} ，此測試案例屬於 {total}...",
+            "finalizing": "正在完成導入…",
+            "completed": "導入成功！",
+            "errorParsing": "解析檔 {index}時發生錯誤： {error}",
+            "skippingFile": "跳過無效檔案 {index}"
+          },
+          "error": {
+            "title": "導入錯誤",
+            "importFailed": "導入測試結果失敗，請重試。"
+          },
+          "success": {
+            "title": "導入成功",
+            "description": "測試結果已成功導入。"
+          },
+          "fileRequired": "請至少上傳一份檢測結果檔。"
+        }
+      },
+      "testResults": {
+        "import": {
+          "format": {
+            "label": "結果格式",
+            "placeholder": "選擇格式"
+          }
+        }
+      },
+      "confirmRestoreTitle": "確認恢復",
+      "confirmPurgeTitle": "確認清除",
+      "remove": "消除",
+      "reconfigure": "重新配置並重試"
+    },
+    "permissions": {
+      "addEdit": "新增/編輯"
+    },
+    "auth": {
+      "internal": "電子郵件/密碼",
+      "sso": "限單一登入",
+      "both": "電子郵件和單一登入"
+    },
+    "status": {
+      "deleted": "已刪除",
+      "disabled": "已停用",
+      "noCustomFieldData": "沒有其他細節。",
+      "pending": "待辦的",
+      "uploading": "正在上傳...",
+      "notApplicable": "不適用",
+      "redirecting": "正在重定向...",
+      "pendingDelete": "將被刪除",
+      "pendingChanges": "待定變更",
+      "importing": "輸入...",
+      "addingTestCases": "添加測試用例…"
+    },
+    "priority": {
+      "low": "低的",
+      "medium": "中等的",
+      "high": "高的"
+    },
+    "filters": {
+      "allStatuses": "所有狀態",
+      "allPriorities": "所有優先事項"
+    },
+    "fields": {
+      "groupName": "組名",
+      "users": "使用者",
+      "mixed": "所有值",
+      "type": "類型",
+      "default": "預設",
+      "enabled": "已啟用",
+      "projects": "專案",
+      "iconColor": "圖示/顏色",
+      "selectWorkflow": "選擇工作流程",
+      "icon": "圖示",
+      "systemName": "系統名稱",
+      "aliases": "別名",
+      "scope": "範圍",
+      "success": "成功",
+      "failure": "失敗",
+      "completed": "完全的",
+      "elapsed": "經過時間",
+      "totalElapsed": "總經過時間",
+      "totalEstimate": "預計剩餘時間",
+      "completionRate": "完成率",
+      "attachments": "附件",
+      "documentation": "文件",
+      "state": "狀態",
+      "configuration": "配置",
+      "configurations": "配置",
+      "milestone": "里程碑",
+      "tags": "標籤",
+      "createdBy": "創建者",
+      "description": "描述",
+      "description_placeholder": "添加描述…",
+      "testCases": "測試用例",
+      "sessions": "會議",
+      "sharedSteps": "共同步驟",
+      "email": "電子郵件",
+      "password": "密碼",
+      "confirmPassword": "確認密碼",
+      "token": "令牌",
+      "access": "使用權",
+      "avatar": "阿凡達",
+      "steps": "步驟",
+      "step": "步",
+      "expectedResult": "預期結果",
+      "notes": "筆記",
+      "estimate": "估計",
+      "date": "日期",
+      "size": "尺寸",
+      "created": "創建",
+      "template": "範本",
+      "mission": "使命",
+      "assignedTo": "分配給",
+      "executedBy": "執行人",
+      "optional": "選修的",
+      "role": "角色",
+      "defaultRole": "預設角色",
+      "systemAccess": "系統訪問",
+      "authMethod": "身份驗證方法",
+      "dateCreated": "建立日期",
+      "apiUser": "API 使用者",
+      "unverified": "未經證實",
+      "selfRegistered": "自行註冊",
+      "role_placeholder": "選擇角色",
+      "usersCreated": "使用者創建",
+      "groups": "團體",
+      "apiAccess": "API 存取",
+      "requiredForAdmin": "管理員需要",
+      "account": "帳戶",
+      "accountHistory": "帳戶歷史記錄",
+      "activity": "活動",
+      "lastActive": "最後活躍時間",
+      "theme": "主題",
+      "locale": "語言",
+      "timezone": "時區",
+      "itemsPerPage": "每頁項目數",
+      "notificationMode": "通知",
+      "value": "價值",
+      "key": "鑰匙",
+      "configurationDetails": "配置詳情",
+      "isActive": "積極的",
+      "members": "成員",
+      "milestoneTypes": "里程碑類型",
+      "milestones": "里程碑",
+      "createdAt": "創建於",
+      "completedOn": "已完成",
+      "variants": "變體",
+      "emailVerified": "電子郵件已驗證",
+      "issueTracker": "問題追蹤器",
+      "caseFields": "案例字段",
+      "resultFields": "結果字段",
+      "displayName": "顯示名稱",
+      "hint": "暗示",
+      "required": "必需的",
+      "restricted": "受限制的",
+      "fieldType": "字段類型",
+      "templates": "範本",
+      "started": "開始",
+      "startDate": "開始日期",
+      "automated": "自動化",
+      "manual": "手動的",
+      "notAutomated": "非自動化",
+      "testRuns": "測試運行",
+      "title": "標題",
+      "project": "專案",
+      "priority": "優先事項",
+      "integration": "一體化",
+      "lastSyncedAt": "上次同步",
+      "externalKey": "外部密鑰",
+      "initialHeight": "初始高度",
+      "minValue": "最小值",
+      "maxValue": "最大值",
+      "minIntegerValue": "最小整數值",
+      "maxIntegerValue": "最大整數值",
+      "defaultValue": "預設值",
+      "checked": "已檢查",
+      "version": "版本",
+      "issues": "問題",
+      "internalIssues": "內部問題",
+      "externalIssues": "{provider} 問題",
+      "data": "數據",
+      "note": "筆記",
+      "externalId": "外部標識",
+      "forecast": "預報",
+      "forecastManual": "預測手冊",
+      "forecastAutomated": "預測自動化",
+      "executedAt": "執行於",
+      "className": "班級",
+      "suiteName": "套房",
+      "duration": "期間",
+      "session": "會議",
+      "charter": "憲章",
+      "summary": "概括",
+      "progress": "進步",
+      "assertions": "斷言",
+      "properties": "特性",
+      "systemOutput": "測試用例日誌",
+      "systemError": "系統錯誤",
+      "resultStatus": "結果",
+      "links": "連結",
+      "id": "ID",
+      "JUNIT": "JUnit 導入",
+      "API": "API",
+      "folder": "資料夾",
+      "parentFolder": "新案例的父資料夾",
+      "multipleValues": "多個值",
+      "provider": "提供者",
+      "updatedAt": "更新於",
+      "tools": "工具",
+      "codeRepository": "程式碼庫",
+      "aiModels": "預設LLM",
+      "configKeys": {
+        "edit_results_duration": "編輯結果持續時間",
+        "project_docs_default": "專案文件預設",
+        "notificationSettings": "通知全域設定",
+        "elasticsearch_replicas": "Elasticsearch 副本"
+      },
+      "options": {
+        "label": "標籤",
+        "validation": {
+          "empty": "選項不能為空。",
+          "invalidChars": "選項包含無效字元：“{char}”",
+          "duplicate": "選項必須唯一",
+          "systemNameError": "系統名稱無效",
+          "initialHeightMax": "初始高度不能大於 600px。",
+          "displayNameRequiredResult": "請輸入結果欄位的顯示名稱。",
+          "displayNameRequiredCase": "輸入案例欄位的顯示名稱。",
+          "minValueMaxValue": "最小值必須小於最大值，如果設定了其中一個值，則兩者都必須設定。",
+          "minMaxValueInteger": "最小整數值必須小於最大整數值，如果設定了其中一個，則兩者都必須設定。",
+          "systemNameRequired": "系統名稱不能為空。",
+          "systemNameRegex": "系統名稱必須以字母開頭，並且只能包含字母、數字和底線。",
+          "fieldTypeRequired": "欄位類型為必填項。"
+        }
+      },
+      "placeholders": {
+        "key": "回車鍵",
+        "value": "輸入數值",
+        "addVariant": "添加變體",
+        "addCategory": "新增類別",
+        "displayName": "輸入顯示名稱",
+        "systemName": "輸入系統名稱",
+        "hint": "輸入提示"
+      },
+      "hints": {
+        "systemName": "系統名稱必須唯一，且只能包含字母、數字和底線。",
+        "fieldType": "（欄位類型一旦建立便無法變更）"
+      },
+      "validation": {
+        "nameRequired": "姓名（必填）",
+        "stateRequired": "州政府要求",
+        "urlRequired": "必須提供網址",
+        "invalidUrl": "無效的 URL 格式"
+      }
+    },
+    "filter": {
+      "placeholder": "篩檢 {item}..."
+    },
+    "access": {
+      "admin": "行政",
+      "projectAdmin": "專案管理員",
+      "user": "使用者",
+      "none": "沒有任何"
+    },
+    "validation": {
+      "required": "請輸入 {field}",
+      "invalidDuration": "請輸入有效時長",
+      "maxDuration": "持續時間不得超過 {max} 分鐘",
+      "minLength": "{field} 必須至少包含 {min} 個字符",
+      "emailFormat": "電子郵件格式無效",
+      "passwordMatch": "密碼必須匹配",
+      "unique": "{field} 必須唯一",
+      "roleRequired": "需要此職位",
+      "nameMinLength": "名稱必須至少包含 2 個字符",
+      "invalidDurationFormat": "時長格式無效。請嘗試 30 分鐘、1 週或 1 小時 25 分鐘等格式。"
+    },
+    "dialogs": {
+      "confirmAction": {
+        "title": "確認 {action}",
+        "message": "你確定要 {action}嗎？"
+      },
+      "confirmDelete": {
+        "description": "您確定要刪除此項目嗎？此操作無法撤銷。"
+      },
+      "assign": {
+        "title": "分配測試用例",
+        "description": "將測試案例「{testCase}」指派給用戶",
+        "selectUser": "選擇用戶"
+      },
+      "assignBulk": {
+        "title": "批量分配測試用例",
+        "description": "將 {count, plural, one {# 選取的測試案例} other {# 選取的測試案例}} 指派給用戶"
+      },
+      "complete": {
+        "title": "完成測試運行",
+        "description": "您確定要完成此測試運行嗎？",
+        "warning": "測試運行完成後將無法修改。",
+        "apple": {
+          "title": "配置 Apple 登入",
+          "description": "設定您的 Apple 登入憑證。您可以從 Apple 開發者入口網站取得這些憑證。",
+          "clientId": "服務 ID",
+          "clientIdPlaceholder": "com.example.service",
+          "teamId": "團隊 ID",
+          "teamIdPlaceholder": "您的 10 位元字元團隊 ID",
+          "keyId": "密鑰 ID",
+          "keyIdPlaceholder": "您的 10 位元字元密鑰 ID",
+          "privateKey": "私鑰",
+          "privateKeyPlaceholder": "請在此處貼上您的 .p8 私鑰內容",
+          "instructions": {
+            "title": "安裝說明：",
+            "step1": "前往 Apple 開發者門戶",
+            "step2": "建立服務 ID 並配置“使用 Apple 登入”",
+            "step3": "建立用於透過 Apple 登入的金鑰",
+            "step4": "下載 .p8 私鑰文件",
+            "step5": "新增以下重定向 URL："
+          },
+          "redirectUri": "/api/auth/callback/apple",
+          "validation": {
+            "allRequired": "所有欄位均為必填項"
+          }
+        }
+      },
+      "delete": {
+        "title": "刪除 {item}",
+        "description": "您確定要刪除 {name} 嗎？",
+        "warning": "此操作無法撤銷。它將永久刪除 {item}。"
+      }
+    },
+    "messages": {
+      "deleteSuccess": "項目已成功刪除",
+      "deleteError": "刪除項目時發生錯誤",
+      "moveSuccess": "物品已成功移動",
+      "moveError": "移動物品時發生錯誤",
+      "updateSuccess": "專案已成功更新",
+      "updateError": "更新項目時發生錯誤",
+      "linkCopied": "連結已複製到剪貼簿",
+      "copyFailed": "複製連結到剪貼簿失敗",
+      "created": "測試運行已成功創建",
+      "createdDescription": "測試運行已創建，現在可在測試運行清單中查看。",
+      "createError": "發生未知錯誤，請重試。",
+      "emptyActive": "沒有正在進行的測試運行。",
+      "emptyCompleted": "未完成任何測試運行",
+      "projectUpdated": "專案已成功更新",
+      "projectUpdateError": "更新項目時發生錯誤",
+      "noProjects": "未找到項目"
+    },
+    "placeholders": {
+      "email": "電子郵件",
+      "name": "輸入姓名",
+      "mission": "請描述您的任務…",
+      "selectMilestone": "選擇里程碑",
+      "selectStatus": "選擇狀態",
+      "selectTemplate": "選擇模板",
+      "duration": "例如 1 小時 30 分鐘或 90 分鐘",
+      "docs": "新增文件…",
+      "select": "選擇",
+      "selectState": "選擇州",
+      "selectConfiguration": "選擇配置",
+      "selectConfigurations": "選擇配置",
+      "selectOption": "選擇一個選項",
+      "date": "選擇日期",
+      "selectEncoding": "選擇編碼方式...",
+      "selectATemplate": "選擇一個模板…",
+      "selectVersion": "選擇版本",
+      "selectAModel": "選擇型號",
+      "selectWorkflowType": "選擇工作流程類型",
+      "addAnOption": "新增一個選項",
+      "addADescription": "添加描述…",
+      "optionalDescription": "可選描述…",
+      "projectNotes": "項目筆記…",
+      "filterByName": "按名稱篩選...",
+      "filterByValue": "按值篩選...",
+      "selectOperator": "選擇運算符",
+      "searchIcons": "搜尋圖示…",
+      "value": "價值",
+      "stepCount": "步數",
+      "enterText": "請輸入文字...",
+      "enterUrl": "輸入網址",
+      "issueIdExample": "第123期",
+      "selectPriorityValuesOrEmpty": "選擇優先值（或留空表示全部不選）"
+    },
+    "errors": {
+      "error": "錯誤",
+      "somethingWentWrong": "發生意外錯誤，請稍後重試。",
+      "emailRequired": "請輸入您的電子郵件地址。",
+      "emailInvalid": "這是一個無效的電子郵件地址。",
+      "passwordRequired": "需要輸入密碼。",
+      "confirmPasswordRequired": "請確認您的密碼。",
+      "passwordDoesNotMeetPolicy": "密碼不符合安全要求。",
+      "passwordsDoNotMatch": "密碼不匹配",
+      "nameRequired": "請輸入您的全名",
+      "duplicate": "請選擇一個獨一無二的名字。",
+      "userExists": "用戶已存在。",
+      "unknown": "發生未知錯誤。",
+      "invalidCredentials": "使用者名稱或密碼無效",
+      "projectNotFound": "項目未找到",
+      "projectNotFoundDescription": "您要尋找的項目不存在，或者您沒有存取權限。",
+      "tokenRequired": "請輸入您的電子郵件驗證碼或點擊電子郵件中的連結。",
+      "noSuccessStatus": "未選擇成功狀態",
+      "missingTestRunCase": "測試運行用例 ID 缺失",
+      "fieldRequired": "此欄位是必需的",
+      "projectNameExists": "已存在一個同名項目",
+      "defaultNotFound": "未找到預設值",
+      "emailExists": "已存在使用此電子郵件地址的用戶",
+      "nameExists": "已存在同名用戶",
+      "duplicateValue": "該值已被使用",
+      "unauthorized": "您無權執行此操作。",
+      "accessDenied": "拒絕訪問",
+      "sessionNotFound": "未找到會話或會話無效。",
+      "issueTrackerNotConfigured": "此項目未配置問題追蹤系統。",
+      "noUserSession": "未找到使用者會話",
+      "noProjectId": "未找到項目 ID",
+      "unknownErrorWithMessage": "發生未知錯誤。 {message}",
+      "unauthenticated": "用戶未通過身份驗證。",
+      "fetchFailed": "數據獲取失敗，請稍後再試。",
+      "unsupportedFieldType": "不支援的欄位類型",
+      "notAuthenticated": {
+        "title": "未經認證",
+        "message": "您必須登入才能執行此操作。"
+      },
+      "failedToFetchAssignments": {
+        "title": "取得任務失敗",
+        "message": "取得作業失敗，請稍後再試。"
+      },
+      "issueManagement": {
+        "linkedSuccess": "問題連結成功",
+        "linkError": "連結問題錯誤",
+        "unlinkedSuccess": "問題已成功解除關聯",
+        "unlinkError": "取消連結問題出錯",
+        "noActiveIntegration": "未找到此項目的活動集成"
+      },
+      "roleRequiredForSpecificRole": "當存取類型為特定角色時，需要提供角色資訊。",
+      "projectCreationFailed": "專案建立失敗，未傳回 ID。",
+      "invalidRoleId": "無效的角色 ID",
+      "workflowStateExists": "工作流程狀態已存在。請選擇一個新名稱。",
+      "failedToLoadCaseData": "案例資料載入失敗，無法儲存。",
+      "atLeastOneTagRequired": "至少需要一個標籤",
+      "atLeastOneIssueRequired": "至少需要一期",
+      "atLeastOneOptionRequired": "至少要選擇一個選項",
+      "valueRequired": "需要值",
+      "contentRequired": "內容為必填項",
+      "invalidContentFormat": "無效的內容格式",
+      "caseNameRequired": "請輸入測試案例的名稱",
+      "caseStateRequired": "請選擇一個州",
+      "caseFolderRequired": "請選擇一個資料夾。",
+      "estimateTooLarge": "估算值過大",
+      "estimateRequiredValid": "需要提供預估時間，且預估時間必須有效（例如，1小時30分鐘）。",
+      "invalidDurationOrExceedsMax": "時長格式無效或超過最大限制（例如，1小時30分鐘）",
+      "configurationNameExists": "配置名稱已存在，請選擇其他名稱。",
+      "variantNameExists": "該變體名稱已存在，請選擇其他名稱。",
+      "categoryNameExists": "類別名稱已存在，請選擇其他名稱。",
+      "workflowStateNameExists": "工作流程狀態名稱已存在。請選擇其他名稱。",
+      "folderNameRequired": "請輸入資料夾名稱",
+      "folderNameRequiredEnter": "請輸入資料夾名稱。",
+      "workflowStateNameRequired": "請輸入工作流程狀態的名稱",
+      "roleNameEmpty": "角色名稱不能為空",
+      "groupNameRequired": "群組名稱為必填項",
+      "templateNameRequired": "請輸入範本名稱",
+      "caseStateInvalid": "請選擇一個有效的州/省",
+      "caseTemplateRequired": "請選擇模板",
+      "invalidContent": "無效內容",
+      "milestoneNameRequired": "請輸入里程碑的名稱",
+      "milestoneTypeRequired": "請選擇里程碑類型",
+      "testRunNameMinLength": "名稱必須至少包含 2 個字元。",
+      "stateRequiredDot": "必須填寫州名。",
+      "milestoneTypeNameMinLength": "里程碑類型名稱必須至少包含 2 個字元。",
+      "projectNameRequired": "項目名稱（必填）",
+      "workflowScopeRequired": "請為該州選擇一個工作流程。",
+      "workflowTypeRequired": "請選擇工作流程類型",
+      "newTestCaseAdded": "新增測試案例",
+      "repositoryDeleted": "儲存庫已刪除",
+      "failedToDeleteRepository": "刪除儲存庫失敗",
+      "permissionDenied": "您沒有權限存取此頁面。",
+      "resultSubmitPermissionDenied": "您無法提交此案例的結果。請聯絡專案管理員將其分配給您。",
+      "noModelsFound": "未找到模型",
+      "failedToFetchModels": "取得模型失敗",
+      "failedToCopyToClipboard": "複製到剪貼簿失敗",
+      "failedToLoadJobResults": "載入作業結果失敗",
+      "failedToUpdateRepositoryStatus": "更新儲存庫狀態失敗"
+    },
+    "pageTitles": {
+      "appName": "TestPlanIt",
+      "dashboard": "儀表板",
+      "twoFactorVerification": "雙重驗證",
+      "changePassword": "更改密碼",
+      "twoFactorSetup": "雙因素設定",
+      "signUp": "報名",
+      "signIn": "登入",
+      "verifyEmail": "驗證電子郵件",
+      "trialExpired": "試用期已結束",
+      "linkSsoAccount": "關聯 SSO 帳戶",
+      "userProfile": "用戶個人資料",
+      "users": "使用者",
+      "issues": "問題",
+      "tags": "標籤",
+      "tagDetails": "標籤詳情",
+      "aiModels": "人工智慧模型",
+      "integrations": "整合",
+      "quickscript": "QuickScript",
+      "webhooks": "網路鉤子",
+      "shares": "股票",
+      "repository": "儲存庫",
+      "testCaseVersion": "測試用例版本",
+      "duplicateTestCases": "重複的測試案例",
+      "documentation": "文件",
+      "sharedSteps": "共同步驟",
+      "stepDuplicates": "步驟重複",
+      "sessions": "會議",
+      "sessionVersion": "會話版本",
+      "milestones": "里程碑",
+      "testRuns": "測試運行",
+      "reports": "報告",
+      "adminSamlConfig": "管理員 - SAML 配置",
+      "apiDocumentation": "API 文件",
+      "sharedContent": "分享內容"
+    },
+    "aria": {
+      "userMenu": "使用者選單",
+      "search": "搜尋",
+      "helpMenu": "幫助菜單",
+      "help": "幫助",
+      "grouped": "分組",
+      "group": "團體",
+      "selectAll": "全選",
+      "selectRow": "選擇行",
+      "removeIssue": "問題",
+      "selectDeselectAllAddEdit": "全選/取消全選 新增/編輯",
+      "selectDeselectAllDelete": "全選/取消全選 刪除",
+      "selectDeselectAllClose": "全選/取消全選 關閉",
+      "clearFilter": "清除過濾器",
+      "olderVersion": "舊版",
+      "newerVersion": "新版本",
+      "deletedUser": "已刪除用戶",
+      "restrictedField": "受限字段",
+      "backToTestCase": "返回測試用例"
+    },
+    "labels": {
+      "projects": "{count, plural, =1 {# 項目} other {# 項目集}}",
+      "templates": "模板和字段",
+      "workflows": "工作流程",
+      "statuses": "狀態",
+      "roles": "角色",
+      "unknownRole": "未知角色",
+      "unknownGroup": "未知團體",
+      "file": "文件",
+      "files": "文件",
+      "existingAttachments": "現有附件",
+      "new": "新的",
+      "noElapsedTime": "未記錄時間",
+      "untested": "未經測試",
+      "noResults": "無結果",
+      "resultsWithNoElapsedTime": "未記錄結果所需時間",
+      "total": "全部的",
+      "noCases": "沒有測試用例",
+      "unknown": "未知",
+      "selectedTestCases": "選定的測試用例",
+      "editToModifyCasesTitle": "此清單無法修改。",
+      "editToModifyCases": "編輯測試運行，然後按一下「選定的測試案例」來修改清單。",
+      "noTestCasesSelected": "未選擇任何測試用例",
+      "editToSelectTestCases": "編輯測試運行以選擇測試案例。",
+      "casesInRun": "{count, plural, =0 {No Test Cases in the Test Run} =1 {1 Test Case in the Test Run} other {# Test Cases in the Test Run}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Unique Case} other {# Unique Cases}} across {configCount, plural, =1 {1 Configuration} other {# Configurations}} ({totalCount} total cases)",
+      "viewTestRunDetails": "查看測試運行詳情",
+      "sortByStatus": "按狀態分組",
+      "sortByDate": "按日期排序",
+      "testRuns": "{count, plural, =0 {No Test Runs} =1 {1 Test Run} other {# Test Runs}}",
+      "sessions": "{count, plural, =0 {No Sessions} =1 {1 Session} other {# Sessions}}",
+      "noOptions": "暫無選項",
+      "multiConfiguration": "屬於多配置組",
+      "otherConfigurations": "其他配置",
+      "selected": "已選擇： {count}",
+      "defaultProjectAccess": "預設項目存取權限",
+      "defaultAccessType": "預設存取類型",
+      "assignedUsersCount": "{count, plural, =0 {No Users Assigned} =1 {# User Assigned} other {# Users Assigned}}",
+      "successRate": "成功率",
+      "unassigned": "未分配",
+      "testRunName": "測試運行名稱",
+      "estimatesEllipsis": "估算…",
+      "access": {
+        "noAccess": "無訪問權限",
+        "globalRole": "使用全域角色",
+        "specificRole": "具體角色",
+        "projectDefault": "項目預設值",
+        "usersGlobalRole": "使用者的全域角色"
+      },
+      "unknownUser": "未知用戶",
+      "unknownProject": "未知項目",
+      "unknownTag": "未知標籤",
+      "filesSelectedForUpload": "{count, plural, =1 {選擇 1 個檔案上傳} other {已選擇 # 個檔案上傳}}"
+    },
+    "empty": {
+      "description": "無描述",
+      "documentation": "無文件",
+      "childMilestones": "沒有兒童里程碑",
+      "sessions": "無會議",
+      "activeSessions": "沒有正在進行的會話",
+      "completedSessions": "沒有已完成的會話",
+      "testCase": "未找到測試用例",
+      "noTestCasesOrSessions": "未找到測試案例或會話",
+      "noTestCasesSessionsOrRuns": "未找到測試案例、會話或運行。"
+    },
+    "or": "或者",
+    "for": "為了",
+    "and": "和",
+    "branding": {
+      "name": "TestPlanIt",
+      "logoAlt": "TestPlanIt 標誌",
+      "tagline": "嘗試一切事物"
+    },
+    "table": {
+      "columns": {
+        "columns": "列",
+        "required": "（必需的）"
+      },
+      "filter": "篩選列表...",
+      "selectNone": "選擇“無”",
+      "sort": "排序列",
+      "sortAscending": "按升序排列",
+      "sortDescending": "按降序排列",
+      "sortNone": "未分類",
+      "resize": "調整列寬"
+    },
+    "pagination": {
+      "selectPage": "選擇頁面",
+      "morePages": "更多頁面",
+      "goToPrevious": "回上一頁",
+      "goToNext": "前往下一頁",
+      "all": "所有項目",
+      "entries": "{count, plural, =1 {# 件數} other {# 件數}}",
+      "pageSize": "頁面大小",
+      "showing": "顯示",
+      "total": "總計 {count, plural, =1 {# 件數} other {# 件數}}",
+      "filtered": "已篩選",
+      "pageOfPages": "第 {current} 頁，共 {total} 頁"
+    },
+    "upload": {
+      "title": "上傳新的個人資料圖片",
+      "description": "拖放圖片或點擊下方按鈕選擇檔案。",
+      "attachments": {
+        "title": "上傳附件",
+        "description": "拖放檔案或點擊下方按鈕選擇檔案。",
+        "selectFiles": "{count, plural, =0 {選擇檔案} one {已選檔案 1 個} other {已選檔案數量 ~<[⌇⌇3⌇⌇⌇]>~ 已選檔案數}}",
+        "selectFile": "{count, plural, =0 {選取檔案} other {選取 1 個檔案}}",
+        "filesSelected": "{count, plural, one {已選取 1 個檔案} other {已選取 # 個檔案}}",
+        "addMoreFiles": "新增更多檔案...",
+        "replaceFile": "替換檔案...",
+        "invalidFileType": "文件類型無效。僅允許使用 {types} 檔案。",
+        "altText": {
+          "emoji": "表情符號"
+        },
+        "count": "{count, plural, =1 {# 文件} other {# 文件集}}"
+      }
+    },
+    "fileDropZone": {
+      "dropToImportTestCases": "拖放 CSV 檔案以匯入測試案例",
+      "dropToImportTestResults": "將檔案拖曳到指定位置以匯入測試結果",
+      "supportedCsvFormats": "支援格式：.csv",
+      "supportedResultFormats": "支援的檔案格式：.xml、.trx、.json",
+      "unsupportedFileType": "不支援的文件類型。預期格式： {expected}",
+      "noFilesDetected": "未偵測到 Drop 資料夾中的任何檔案。"
+    },
+    "editor": {
+      "setColor": "設定顏色",
+      "enterUrl": "請輸入包含 https:// 的網址。",
+      "uploadFile": "上傳文件",
+      "video": {
+        "controls": "視訊播放器控制"
+      },
+      "image": {
+        "alignLeft": "左對齊",
+        "alignCenter": "居中對齊",
+        "alignRight": "右對齊",
+        "sizeSmall": "小型",
+        "sizeMedium": "中號",
+        "sizeLarge": "大號",
+        "sizeFull": "全寬",
+        "resetSize": "恢復原大小",
+        "rotate": "旋轉90°",
+        "delete": "刪除圖片"
+      },
+      "table": {
+        "insertTable": "插入表",
+        "headerRow": "標題行",
+        "addColumnBefore": "在前面新增列",
+        "addColumnAfter": "在後面新增列",
+        "deleteColumn": "刪除列",
+        "addRowBefore": "在前面新增一行",
+        "addRowAfter": "在後面加入行",
+        "deleteRow": "刪除行",
+        "deleteTable": "刪除表"
+      },
+      "contentMenu": {
+        "addParagraphBelow": "在下方加入段落",
+        "clearFormatting": "清晰的格式",
+        "copyToClipboard": "複製到剪貼簿"
+      },
+      "textMenu": {
+        "bold": "大膽的",
+        "italic": "斜體",
+        "underline": "強調",
+        "strikethrough": "刪除線",
+        "code": "程式碼",
+        "codeBlock": "程式碼區塊",
+        "highlightText": "高亮文字",
+        "textColor": "文字顏色",
+        "moreOptions": "更多選項",
+        "subscript": "下標",
+        "superscript": "上標",
+        "alignLeft": "左對齊",
+        "alignCenter": "居中對齊",
+        "alignRight": "右對齊",
+        "justify": "證明合法",
+        "setLink": "設定連結",
+        "editLink": "編輯連結",
+        "removeLink": "移除連結",
+        "resetColorToDefault": "重設顏色為預設值"
+      }
+    },
+    "ai": {
+      "title": "人工智慧寫作助手",
+      "improveWriting": "提升寫作能力",
+      "makeShorter": "縮短",
+      "makeLonger": "延長",
+      "fixGrammar": "修改語法",
+      "changeTone": "改變音調",
+      "professional": "專業的",
+      "casual": "隨意的",
+      "formal": "正式的",
+      "translate": "翻譯",
+      "english": "英語",
+      "spanish": "西班牙語",
+      "french": "法語",
+      "summarize": "總結",
+      "addExamples": "新增範例",
+      "originalText": "原文",
+      "suggestion": "人工智慧建議",
+      "generating": "正在生成建議…",
+      "noSuggestion": "尚未產生任何建議。",
+      "acceptSuggestion": "接受建議",
+      "errors": {
+        "contentBlocked": "內容已被安全過濾器屏蔽。請嘗試使用不同的措詞重新表達您的請求。",
+        "emptyContent": "人工智慧無法產生響應。請嘗試重新措詞或稍後再試。",
+        "maxTokens": "人工智慧的回覆過長，已被截斷。請嘗試使用更短的請求或要求更簡潔的回覆。",
+        "rateLimit": "由於速率限制，AI 服務暫時無法使用。請稍後再試。",
+        "accessDenied": "您沒有權限在此專案中使用人工智慧功能。",
+        "generic": "抱歉，處理您的請求時出錯。"
+      }
+    },
+    "by": "經過",
+    "version": {
+      "prefix": "v"
+    },
+    "ui": {
+      "tableOfContents": {
+        "title": "目錄",
+        "emptyMessage": "開始在文件中加入標題 …"
+      },
+      "carousel": {
+        "previousSlide": "上一張投影片",
+        "nextSlide": "下一張投影片"
+      },
+      "dialog": {
+        "toggleFullScreen": "切換全螢幕"
+      },
+      "command": {
+        "title": "命令選單",
+        "description": "搜尋並執行命令"
+      },
+      "breadcrumb": {
+        "more": "更多的"
+      },
+      "clickToViewDetails": "點擊看詳情",
+      "clickToExpand": "點擊展開",
+      "clickToCollapse": "點擊收起",
+      "search": {
+        "filters": "過濾器",
+        "noResultsFound": "未找到結果",
+        "loadingProjects": "正在加載項目...",
+        "noProjectsFound": "未找到項目。",
+        "viewAllProjects": "查看所有項目",
+        "states": "各州",
+        "automationStatus": "自動化狀態",
+        "parent": "父母"
+      },
+      "issues": {
+        "errorLoadingDetails": "載入問題詳情時發生錯誤： ",
+        "updated": "更新： ",
+        "openInJira": "在 Jira 中打開",
+        "openInExternalSystem": "開啟方式 {provider}",
+        "assignee": "受讓人",
+        "status": "地位： ",
+        "clickToOpenInNewTab": "點選在新分頁中開啟",
+        "url": "網址： ",
+        "externalId": "外部 ID： ",
+        "viewIn": "查看",
+        "fieldType": "字段類型： ",
+        "richTextContent": "富文本內容",
+        "invalidContent": "無效內容",
+        "fieldInformation": "現場資訊"
+      },
+      "onboarding": {
+        "skipTour": "跳過行程"
+      },
+      "charts": {
+        "resultsDistribution": "結果分佈",
+        "statusTimeline": "狀態時間表",
+        "testDurationHistogram": "測試時長直方圖",
+        "zoomDonutChart": "縮放甜甜圈圖",
+        "zoomStatusTimeline": "Zoom 狀態時間軸",
+        "zoomHistogramChart": "縮放直方圖",
+        "duration": "持續時間： {seconds} 秒",
+        "durationLabel": "期間"
+      },
+      "import": {
+        "encoding": {
+          "utf8": "UTF-8",
+          "iso88591": "ISO-8859-1",
+          "iso885915": "ISO-8859-15",
+          "windows1252": "Windows-1252"
+        }
+      },
+      "loadingIssueTracker": "正在加載問題追蹤資訊…",
+      "enterDocumentation": "請輸入文件…",
+      "noAutomatedTestResults": "本次運行未找到自動測試結果。"
+    },
+    "time": {
+      "minutes": "{count, plural, =1 {分} other {分鐘}}",
+      "seconds": "{count, plural, =1 {秒} other {秒}}"
+    },
+    "units": {
+      "time": "時間"
+    },
+    "plural": {
+      "case": "{count, plural, =1 {情況} other {情況}}",
+      "result": "{count, plural, =1 {結果} other {結果}}",
+      "run": "{count, plural, =1 {運行} other {運行}}",
+      "comment": "{count, plural, =1 {{count} comment} other {{count} comments}}"
+    },
+    "success": {
+      "assigned": "測試用例已成功分配",
+      "unassigned": "測試用例已成功取消分配。",
+      "bulkAssigned": "{count, plural, one {# 測試案例} other {# 測試案例}} 已成功分配",
+      "bulkUnassigned": "{count, plural, one {# 測試案例} other {# 測試案例}} 已成功取消分配"
+    },
+    "tabs": {
+      "general": "一般的",
+      "settings": "設定"
+    },
+    "selectFilter": "請選擇篩選條件以查看測試案例。",
+    "invalidProject": "項目ID無效。",
+    "visualization": "視覺化",
+    "results": "結果",
+    "loading": "載入中..."
+  },
+  "auth": {
+    "signin": {
+      "createAccount": "建立新帳戶",
+      "sso": {
+        "title": "使用 SSO 登入",
+        "googleOAuth": "繼續使用 Google",
+        "apple": "繼續使用 Apple",
+        "microsoft": "繼續使用 Microsoft",
+        "samlProvider": "使用 {name} 登入",
+        "magicLink": "使用 Magic Link 登入",
+        "emailLogin": "繼續透過電子郵件"
+      },
+      "magicLink": {
+        "description": "請輸入您的電子郵件地址，我們將向您發送安全連結以供登入。無需密碼。您必須已擁有一個帳戶。",
+        "emailPlaceholder": "請輸入您的信箱",
+        "sendLink": "發送魔法連結",
+        "sending": "正在發送...",
+        "checkEmail": "請查看您的電子郵件",
+        "success": "如果您有帳戶，我們已向您的郵箱 {email} 發送了一個魔法連結。點擊郵件中的連結即可登入。",
+        "error": "發送魔法連結失敗，請重試。",
+        "backToSignIn": "返回登入頁面"
+      },
+      "twoFactor": {
+        "title": "雙重身份驗證",
+        "description": "輸入身份驗證器應用程式中的 6 位元驗證碼，或使用備用驗證碼。"
+      },
+      "troubleSigningIn": "登入遇到問題？",
+      "contactAdmin": "請聯絡系統管理員"
+    },
+    "errors": {
+      "accessDenied": "訪問被拒絕。您的帳戶可能已停用或您沒有登入權限。",
+      "configuration": "伺服器配置存在問題。",
+      "verification": "驗證令牌已過期或已被使用。",
+      "invalid2FACode": "驗證碼無效，請重試。",
+      "twoFactorTokenRequired": "需要令牌",
+      "verificationCodeRequired": "需要驗證碼"
+    },
+    "signup": {
+      "description": "請輸入您的資訊以註冊新帳戶。",
+      "signIn": "登入您現有的帳戶。",
+      "registrationDisabled": "請聯絡管理員建立帳戶。",
+      "errors": {
+        "emailRequired": "必須提供電子郵件地址",
+        "passwordRequired": "密碼不符合安全要求",
+        "confirmPasswordRequired": "需要確認密碼",
+        "passwordsDoNotMatch": "密碼不匹配",
+        "domainRestricted": "註冊僅限已核准的電子郵件網域。如果您認為此資訊有誤，請聯絡您的管理員。"
+      }
+    },
+    "verifyEmail": {
+      "title": "驗證電子郵件",
+      "loading": "正在驗證電子郵件...",
+      "success": "郵箱已成功驗證",
+      "error": "電子郵件驗證失敗",
+      "expired": "驗證連結已過期",
+      "invalid": "無效的驗證鏈接",
+      "alreadyVerified": "郵箱已驗證",
+      "toast": {
+        "verifySuccess": {
+          "description": "您現在可以登入您的帳戶了。"
+        },
+        "verifyError": {
+          "description": "驗證電子郵件時發生錯誤"
+        },
+        "resendSuccess": {
+          "title": "已發送郵件驗證鏈接",
+          "description": "請查收您的電子郵件，其中包含驗證連結。"
+        },
+        "resendError": {
+          "title": "發送郵件驗證連結失敗",
+          "description": "發送電子郵件驗證連結時發生錯誤。"
+        }
+      }
+    },
+    "twoFactorSetup": {
+      "title": "設定雙重認證",
+      "description": "您的組織需要啟用雙重認證。請進行設定以繼續。",
+      "backupDescription": "繼續操作前，請儲存您的備份代碼。",
+      "required": "根據貴組織的安全策略，需要啟用雙重認證。",
+      "loading": "準備設定…",
+      "manualEntry": "或手動輸入此代碼：",
+      "verifyLabel": "驗證碼",
+      "verify": "驗證並啟用",
+      "backupCodesInfo": "請將這些代碼保存在安全的地方。如果您遺失了驗證器設備，可以使用這些代碼存取您的帳戶。",
+      "copyCodes": "複製所有程式碼",
+      "continue": "繼續登入"
+    },
+    "twoFactorVerify": {
+      "title": "驗證您的身份",
+      "description": "請輸入身份驗證器應用程式中顯示的 6 位元驗證碼以繼續。",
+      "backupCodeLabel": "備份程式碼",
+      "backupCodeHint": "您也可以輸入一個 8 位元字元的備用代碼。",
+      "useAuthenticator": "請改用驗證碼",
+      "useBackupCode": "改用備用代碼",
+      "signOut": "登出登入並使用其他帳戶"
+    },
+    "forceChangePassword": {
+      "title": "更改密碼",
+      "adminDescription": "管理員要求您更改密碼。",
+      "expiredDescription": "您的密碼已過期。請設定新密碼以繼續。",
+      "newPasswordLabel": "新密碼",
+      "confirmPasswordLabel": "確認新密碼",
+      "submitButton": "更改密碼",
+      "signOut": "登出登入",
+      "passwordsMustMatch": "密碼不符。",
+      "passwordRequired": "需要輸入密碼。",
+      "genericError": "發生錯誤，請重試。",
+      "policyTitle": "密碼要求：",
+      "policyMinLength": "至少 {count} 個字符",
+      "policyUppercase": "至少包含一個大寫字母",
+      "policyLowercase": "至少包含一個小寫字母",
+      "policyNumbers": "至少一個數字",
+      "policySpecialChars": "至少包含一個特殊字元（{chars}）"
+    }
+  },
+  "account": {
+    "linkSso": {
+      "title": "關聯 SSO 帳戶",
+      "description": "將您的帳戶與單一登入提供者關聯",
+      "availableProviders": "可用的單一登入提供者",
+      "linkWithGoogle": "與谷歌連結",
+      "linkWithSaml": "連結至 {name}",
+      "accountLinked": "帳戶已成功關聯",
+      "linkingFailed": "帳戶關聯失敗",
+      "noProvidersAvailable": "目前沒有可用於連線的單一登入 (SSO) 提供者。",
+      "linkingInfo": "關聯單一登入 (SSO) 提供者後，您可以使用該提供者而非密碼登入。您現有的帳戶資料將保持不變。",
+      "signInWithGoogle": "使用 Google 登入",
+      "enterpriseSamlSso": "企業級 SAML 單一登入",
+      "linkProvider": "連結提供者",
+      "linking": "正在連接…",
+      "noProvidersContactAdmin": "目前沒有可用的單一登入 (SSO) 提供者。請聯絡您的管理員。"
+    }
+  },
+  "navigation": {
+    "menu": {
+      "dashboard": "儀表板",
+      "admin": "行政",
+      "profile": "輪廓"
+    },
+    "admin": {
+      "crossProjectReports": "跨專案報告"
+    },
+    "projects": {
+      "sections": {
+        "management": "管理"
+      },
+      "menu": {
+        "repository": "儲存庫",
+        "runs": "測試運行及結果"
+      },
+      "dropdown": {
+        "selectProject": "選擇一個項目",
+        "selectProjectAriaLabel": "選擇項目 {name}"
+      }
+    }
+  },
+  "projects": {
+    "status": {
+      "id": "項目 ID： {id}",
+      "active": "項目正在進行中",
+      "completed": "項目已完成"
+    },
+    "overview": {
+      "title": "概述",
+      "currentMilestones": "目前里程碑",
+      "seeAllMilestones": "{count, plural, =1 {看里程碑 # 里程碑} other {看全部里程碑 # 里程碑}}",
+      "seeAllTestCases": "{count, plural, =1 {查看 # 測試案例} other {看全部 # 測試案例}}",
+      "latestTestCases": "最新測試案例",
+      "createdOn": "創建於",
+      "seeAllTags": "查看所有標籤",
+      "seeAllActiveSessions": "{count, plural, =1 {看目前會話數} other {查看所有目前會話數}}",
+      "latestSessions": "最新會話",
+      "activeTestRuns": "正在進行的測試運行",
+      "seeAllActiveTestRuns": "{count, plural, =1 {查看目前運行的測試次數} other {查看所有目前運行的測試次數}}",
+      "latestTestRuns": "最新測試運行",
+      "testCaseBreakdown": "測試用例分解",
+      "noTestCases": "專案倉庫為空。請使用倉庫新增測試案例。",
+      "noTestCasesPrefix": "專案倉庫為空。請使用以下命令新增測試案例：",
+      "noTestCasesLink": "儲存庫"
+    },
+    "icon": {
+      "upload": {
+        "title": "上傳項目圖標",
+        "description": "上傳一張最大 4MB 的正方形圖片（寬高比 1:1）。",
+        "errors": {
+          "invalidFileType": "僅允許上傳圖像檔案。",
+          "fileTooLarge": "文件過大。最大大小為 {size}。"
+        }
+      }
+    },
+    "settings": {
+      "description": "管理 {projectName} 的設定",
+      "moreSettingsComingSoon": "更多設定即將推出",
+      "moreSettingsDescription": "更多項目配置選項將在未來的更新中在此處提供。",
+      "integrations": {
+        "description": "管理此項目的第三方問題集成",
+        "availableIntegrations": "可用的問題集成",
+        "availableDescription": "選擇一個問題整合方案來連接到此項目",
+        "configuredIntegration": "配置集成",
+        "noIntegrationAssigned": "未分配整合問題",
+        "noIntegrationDescription": "從可用選項中選擇一個問題整合方案即可開始。",
+        "selectIntegration": "選擇要配置的問題集成",
+        "integration": {
+          "assignError": "分配問題整合失敗",
+          "updateSuccess": "整合設定已更新",
+          "updateError": "問題整合設定更新失敗",
+          "removeError": "移除問題整合失敗",
+          "removeIntegration": "移除集成",
+          "confirmRemove": "確認移除",
+          "authDescription": "您需要使用 {provider} 進行身份驗證才能使用此問題集成",
+          "authenticating": "正在驗證…",
+          "authSuccess": "身份驗證成功",
+          "selectProject": "選擇 {provider} 項目",
+          "selectProjectPlaceholder": "選擇要連結的項目",
+          "linkedProject": "關聯項目",
+          "loadProjectsError": "專案載入失敗",
+          "settingsSaved": "整合設定已成功儲存",
+          "saveSettingsError": "問題整合設定保存失敗",
+          "authorizationRequired": "需要授權",
+          "authenticationError": "身份驗證失敗，請重試。",
+          "authorizationRequiredDescription": "您需要授權此問題整合才能存取外部項目",
+          "authorizationMessage": "請授權問題整合繼續進行。",
+          "authorizeIntegration": "授權 {name}",
+          "integrationSettings": "{name} 設定",
+          "integrationSettingsDescription": "為該專案配置問題整合設置",
+          "selectExternalProject": "選擇外部項目",
+          "refreshProjects": "重新整理項目",
+          "defaultIssueType": "預設問題類型",
+          "selectDefaultIssueType": "選擇預設問題類型",
+          "defaultIssueTypeDescription": "建立新問題時，此問題類型將預先選取。",
+          "issueTypePlaceholder": "例如：缺陷、任務、故事",
+          "defaultComponent": "預設組件",
+          "componentPlaceholder": "例如，前端、後端",
+          "automaticSync": "自動同步",
+          "automaticSyncDescription": "自動同步TestPlanIt與外部系統之間的問題",
+          "simpleUrlDescription": "此問題整合使用簡單的 URL 模式連結到外部問題。問題將使用配置的 URL 模式在新標籤頁中開啟。",
+          "externalProjectHelp": "這將設定從 TestPlanIt 建立新問題的預設項目。您仍然可以連結和同步來自其他外部項目的問題——每個問題都追蹤其自身的來源項目。",
+          "linkedProjects": "連結的外部項目",
+          "linkedProjectsDescription": "透過此整合連接的外部項目",
+          "noLinkedProjects": "沒有連結外部項目",
+          "noLinkedProjectsDescription": "新增外部項目以啟用問題搜尋和同步。",
+          "addProjects": "新增項目",
+          "addSelected": "新增所選內容",
+          "setAsDefault": "設定為預設值",
+          "removeProject": "移除項目",
+          "removeProjectConfirmation": "移除此項目將停止同步其中的問題。之前同步的問題不會刪除。是否繼續？",
+          "removeProjectWebhookCascadeBullet": "該項目的入站 webhook 也將被移除。",
+          "keepProject": "保持項目",
+          "defaultIndicator": "預設",
+          "syncStatusSyncing": "同步",
+          "syncStatusCompleted": "已同步",
+          "syncStatusError": "同步錯誤",
+          "fanOutPartialFailure": "無法存取 {count} 個項目。正在顯示 {successCount} 個項目的結果。",
+          "projectSelectorLabel": "專案",
+          "defaultIssueTypeHelp": "使用 TestPlanIt 建立新問題時，系統會自動選擇此問題類型。如果您經常創建相同類型的問題，這將節省時間。",
+          "automaticSyncHelp": "啟用此功能後，當外部系統（透過 Webhook）偵測到變更時，問題將自動同步。您也可以隨時手動同步。",
+          "removeWarningTitle": "移除此整合問題將導致：",
+          "removeWarning1": "中斷所有與此問題整合相關的問題（問題仍保留在資料庫中）",
+          "removeWarning2": "移除此項目的所有問題整合特定設置",
+          "removeWarning3": "如果想再次使用此問題集成，則需要重新配置。",
+          "removeWarning4": "移除為此整合配置的入站 Webhook",
+          "switchIntegration": "交換器集成",
+          "switchWarningTitle": "切換到不同的AI模型將會帶來以下後果：",
+          "switchWarning1": "斷開當前與問題整合關聯的所有問題",
+          "switchWarning2": "保留資料庫中的問題（它們將不再關聯）",
+          "switchWarning3": "將當前問題整合配置替換為新的配置。",
+          "switchWarning4": "移除為目前整合配置的入站 Webhook"
+        },
+        "integrationAssigned": "整合任務已成功分配",
+        "integrationAssignError": "未能將問題整合分配給項目",
+        "integrationRemoved": "整合已成功移除",
+        "integrationRemoveError": "未能從專案中移除問題集成",
+        "add": {
+          "jira": {
+            "description": "將您的 Jira 帳戶連接到 TestPlanIt，即可直接從 TestPlanIt 管理問題。"
+          },
+          "simple_url": {
+            "description": "連接到第三方系統進行問題追蹤。"
+          },
+          "github": {
+            "description": "連接到 GitHub 以進行問題追蹤和程式碼庫管理。"
+          },
+          "gitlab": {
+            "description": "連接到 GitLab 以追蹤問題和合併請求。"
+          },
+          "gitea": {
+            "description": "連接到自架的 Gitea、Forgejo 或 Gogs 實例進行問題追蹤。"
+          },
+          "azure_devops": {
+            "description": "連接到 Azure DevOps 以追蹤工作項目。"
+          }
+        }
+      },
+      "webhooks": {
+        "description": "配置入站 Webhook 以保持關聯問題同步。",
+        "inboundDescription": "配置入站 Webhook 以保持關聯問題同步。",
+        "outboundDescription": "設定出站 webhook，將 TestPlanIt 事件傳送至 Slack 或任何 HMAC 簽章的 URL。",
+        "directionInbound": "入境",
+        "directionOutbound": "出站",
+        "inboundAddButtonAllConfigured": "入站適配器已配置完成。",
+        "inboundAddButtonNoIntegration": "在新增入站 webhook 之前，請先為該專案指派一個問題整合。",
+        "inboundEmptyWithIntegration": "未配置任何入站 Webhook。 <link>新增一個</link> 以接收來自您指派的問題整合的更新。",
+        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "deliveriesEmptyNoConfigs": "目前還沒有 webhook 發送——請在其他標籤頁上建立入站或出站 webhook 以開始接收它們。",
+        "noConfig": "未配置 webhook",
+        "createButton": "創建 webhook",
+        "url": "Webhook URL",
+        "urlHelp": "將此 URL 貼到問題追蹤器的 webhook 設定中。",
+        "secret": "Webhook 秘密",
+        "secretHelp": "將此密鑰貼上到問題追蹤器的 webhook 配置中。",
+        "revealedShownOnceWarning": "立即複製下面的網址和金鑰——它們只會顯示一次，以後無法找回。",
+        "secretMasked": "隱藏 — 旋轉查看",
+        "rotateSecret": "旋轉秘密",
+        "rotateConfirmTitle": "輪換 webhook 密鑰？",
+        "rotateConfirm": "輪換密鑰將使問題追蹤器端的當前配置失效，直到您在那裡更新配置為止。是否繼續？",
+        "isActive": "已啟用",
+        "deleteConfirmTitle": "刪除 webhook 配置？",
+        "deleteConfirm": "刪除此 webhook 配置？入站郵件將被拒絕。",
+        "sendTest": "發送測試 webhook",
+        "testSuccess": "測試 webhook 已接受（HTTP {statusCode}，結果： {outcome}）",
+        "testFailure": "測試 webhook 失敗（HTTP {statusCode}）： {error}",
+        "saveError": "儲存 webhook 設定失敗",
+        "lastReceived": "最後收到： {timestamp}",
+        "lastReceivedLabel": "上次收到時間：",
+        "lastReceivedNever": "尚未出貨",
+        "copyUrl": "複製 webhook URL",
+        "copySecret": "複製 webhook 金鑰",
+        "urlCopied": "Webhook URL 已複製到剪貼簿",
+        "secretCopied": "Webook 金鑰已複製到剪貼簿",
+        "nextSteps": "接下來：將這些資訊貼到問題追蹤器的 webhook 設定中，然後點擊下方的「傳送測試 webhook」來驗證流程。儲存密鑰後，點擊「完成」－密鑰將無法再次顯示。",
+        "revealDone": "完畢",
+        "pageTitle": "網路鉤子",
+        "inboundTab": "入境",
+        "outboundTab": "出站",
+        "outboundEmpty": "未配置任何出站 Webhook。請新增一個 Webhook，以便將 TestPlanIt 事件傳送到 Slack 或任何經過 HMAC 簽署的 URL。",
+        "outboundAddButton": "新增出站 webhook",
+        "outboundCreateTitle": "新增出站 webhook",
+        "outboundCreateName": "姓名",
+        "outboundCreateNameHelp": "此目標位置的標籤，例如「工程 Slack」。",
+        "outboundCreateNamePlaceholder": "工程 Slack",
+        "outboundCreateNameRequired": "姓名為必填項。",
+        "outboundCreateUrlRequired": "必須提供網址。",
+        "outboundCreateUrlInvalid": "請輸入有效的網址（https://example.com/...）。",
+        "outboundCreateUrlMustUseHttps": "URL必須使用HTTPS",
+        "outboundNameLabel": "姓名",
+        "outboundUnnamedConfig": "（未命名的 webhook）",
+        "outboundCreateUrl": "URL",
+        "outboundCreateUrlHelp": "目標 URL。 Slack 傳入 webhook URL 會自動偵測。",
+        "outboundCreateUrlPlaceholder": "https://hooks.slack.com/services/...",
+        "outboundDetectedSlack": "偵測到：Slack",
+        "outboundDetectedHmac": "偵測到：通用 HMAC",
+        "adapterLabelSlack": "鬆弛",
+        "adapterLabelGenericHmac": "通用 HMAC webhook",
+        "outboundCreateSubscriptionsTitle": "訂閱",
+        "outboundCreateSubscriptionsHelp": "選擇哪些事件會傳送到此目標位置。您可以稍後變更這些設定。",
+        "outboundSubsTestRunsAndSessions": "測試運行和會話",
+        "outboundSubsTestRuns": "測試運行",
+        "outboundSubsSessions": "會議",
+        "eventVerbs": {
+          "duplicated": "重複",
+          "stateChanged": "狀態已改變",
+          "resultAdded": "結果已新增"
+        },
+        "events": {
+          "testRunCreated": "建立測試運行",
+          "testRunStateChanged": "測試運行狀態已更改",
+          "testRunCompleted": "測試運行完成",
+          "testRunDuplicated": "重複測試運行",
+          "testRunResultAdded": "測試運行結果已新增",
+          "sessionCreated": "會話已建立",
+          "sessionStateChanged": "會話狀態已更改",
+          "sessionCompleted": "會議結束",
+          "sessionDuplicated": "會話重複",
+          "sessionResultAdded": "會話結果已新增",
+          "issueCreated": "問題已建立",
+          "issueUpdated": "問題已更新",
+          "issueDeleted": "問題已刪除",
+          "caseCreated": "案件已創建",
+          "caseUpdated": "案件更新",
+          "caseDeleted": "案件已刪除",
+          "jiraIssueCreated": "Jira 問題已創建",
+          "jiraIssueUpdated": "Jira 問題已更新",
+          "jiraIssueDeleted": "Jira 問題已刪除",
+          "githubIssues": "GitHub 問題活動",
+          "githubPullRequest": "GitHub 拉取請求",
+          "githubPush": "GitHub推播",
+          "githubIssueComment": "GitHub 問題評論",
+          "adoWorkitemCreated": "建立 Azure DevOps 工作項",
+          "adoWorkitemUpdated": "Azure DevOps 工作項目已更新",
+          "adoWorkitemDeleted": "Azure DevOps 工作項目已刪除",
+          "webhookTest": "測試活動"
+        },
+        "outboundSubsIssues": "問題",
+        "outboundSubsCases": "案例",
+        "outboundSubsSelectAll": "請選取此部分中的所有內容",
+        "outboundCreateSubmit": "創建 webhook",
+        "outboundCreateCancel": "取消",
+        "outboundCreateSuccess": "已建立出站 webhook。",
+        "outboundCreateError": "建立出站 webhook 失敗。",
+        "outboundUrlLabel": "目標網址",
+        "outboundActiveToggle": "積極的",
+        "outboundSlackHint": "這個網址很敏感——任何擁有它的人都可以向你的頻道發佈內容。",
+        "outboundHmacSecretsTitle": "簽署秘密",
+        "outboundHmacActiveSecret": "積極的",
+        "outboundHmacInactiveSecret": "非活躍狀態",
+        "outboundHmacRetiringSecret": "退休",
+        "outboundHmacAutoRetireIn": "自動退休，剩餘天數 {days} 天",
+        "outboundHmacRotateButton": "旋轉秘密",
+        "outboundHmacExtendButton": "延長7天",
+        "outboundHmacRetireNowButton": "現在就退休",
+        "outboundRotateConfirmTitle": "輪換簽名金鑰？",
+        "outboundRotateConfirm": "系統會產生一個新的活動密鑰。先前的金鑰將繼續有效 7 天，直到使用者完成更新。",
+        "outboundRotateSuccess": "密鑰已輪換。新的明文如下圖所示。",
+        "outboundRotateError": "密鑰輪換失敗。",
+        "outboundRetireConfirmTitle": "現在就此保密嗎？",
+        "outboundRetireConfirm": "退役的金鑰將立即停止簽署。仍在使用舊密鑰的用戶將拒絕新的有效載荷。",
+        "outboundRetireSuccess": "秘密退休了。",
+        "outboundRetireError": "未能成功退休。",
+        "outboundExtendSuccess": "自動退休期間延長7天。",
+        "outboundExtendError": "擴展密鑰失敗。",
+        "outboundSendTestButton": "發送測試事件",
+        "outboundSendTestQueued": "測試事件已排隊－請檢查訊息的目標位置。",
+        "outboundSendTestError": "測試事件排隊失敗。",
+        "outboundDeleteButton": "刪除 webhook",
+        "outboundDeleteConfirmTitle": "刪除出站 webhook？",
+        "outboundDeleteConfirm": "所有發送到該目的地的後續事件立即停止發射。",
+        "outboundDeleteSuccess": "Webhook 已刪除。",
+        "outboundDeleteError": "刪除 webhook 失敗。",
+        "outboundSecretCopy": "複製秘密",
+        "outboundSecretShownOnce": "現在就把這個秘密記下來──它不能再被人知道了。",
+        "outboundSecretDone": "完畢",
+        "inboundAddButton": "新增入站 webhook",
+        "inboundChooserTitle": "選擇適配器",
+        "inboundChooserDescription": "選擇將向 TestPlanIt 發送 Webhook 的問題追蹤系統。每個專案可以有一個 Jira、一個 GitHub 和一個 Azure DevOps 入站 Webhook。",
+        "inboundChooserJira": "吉拉",
+        "inboundChooserGithub": "GitHub",
+        "inboundChooserAdo": "Azure DevOps",
+        "inboundChooserGitlab": "GitLab",
+        "inboundChooserGitea": "吉特亞",
+        "inboundChooserAlreadyConfigured": "已配置",
+        "inboundChooserSubmit": "繼續",
+        "inboundChooserCancel": "取消",
+        "inboundEmpty": "未配置入站 Webhook。請新增一個以接收來自 Jira、GitHub、GitLab、Gitea 或 Azure DevOps 的問題更新。",
+        "inboundJiraTitle": "Jira 入站 webhook",
+        "inboundGithubTitle": "GitHub 入站 webhook",
+        "inboundGithubScopeHint": "GitHub <code>issues</code> events 會更新相關的 TestPlanIt 問題。 Pull request 和 issue comment 事件已被接受，但目前不會更新問題。",
+        "inboundGitlabTitle": "GitLab 入站 webhook",
+        "inboundGitlabScopeHint": "GitLab <code>Issue Hook</code> 事件會更新相關的 TestPlanIt 問題。其他事件類型也會被接受，但不會更新問題。",
+        "inboundGiteaTitle": "Gitea 入站 webhook",
+        "inboundGiteaScopeHint": "Gitea <code>issues</code> events 會更新相關的 TestPlanIt 問題。其他事件類型也會被接受，但不會更新問題。",
+        "inboundAdoTitle": "Azure DevOps 入站 Webhook",
+        "inboundAdoScopeHint": "Azure DevOps <code>工作項目已更新</code> 事件會更新相關的 TestPlanIt 問題。其他事件也會被接受，但不會更新問題。",
+        "inboundAdoUsername": "使用者名稱",
+        "inboundAdoPassword": "密碼",
+        "inboundAdoUsernamePlaceholder": "服務帳戶",
+        "inboundAdoUsernameHelp": "已在 Azure DevOps 服務鉤子端進行設定。 TestPlanIt 透過 HTTP 基本驗證對其進行驗證。",
+        "inboundAdoPasswordHelp": "靜態儲存時採用加密方式。同時，也請在 Azure DevOps 服務鉤子端中儲存此值。",
+        "inboundAdoResourceDetailsHint": "配置 Azure DevOps 服務鉤子時，將“要傳送的資源詳細資料”設為“全部”，以便將 System.State 包含在有效負載中。",
+        "setupStepsTitle": "設定步驟",
+        "setupStepsJiraStep1": "在 Jira 中，前往「設定」→「系統」→「WebHooks」（或您的 Jira 管理員的 webhook 設定頁面）。",
+        "setupStepsJiraStep2": "點擊「建立 Webhook」。將以下 URL 貼到 URL 欄位中，將金鑰貼到金鑰欄位中。",
+        "setupStepsJiraStep3": "在“問題相關事件”下，選取“已更新”，以便傳送問題狀態變更。",
+        "setupStepsJiraStep4": "保存 webhook。使用下面的「發送測試 webhook」來驗證管道。",
+        "setupStepsGithubStep1": "在您的 GitHub 儲存庫中，前往「設定」→「Webhooks」→「新增 webhook」。",
+        "setupStepsGithubStep2": "將以下 URL 貼到「有效負載 URL」欄位中。將內容類型設定為 application/json。",
+        "setupStepsGithubStep3": "將以下秘密貼到「秘密」欄位中。",
+        "setupStepsGithubStep4": "選擇“讓我選擇單一事件”，然後勾選“問題”。",
+        "setupStepsGithubStep5": "點選「新增 webhook」。使用下面的「發送測試 webhook」來驗證管道。",
+        "setupStepsAdoStep1": "在 Azure DevOps 專案中，前往「專案設定」→「服務掛鉤」→「建立訂閱」。",
+        "setupStepsAdoStep2": "選擇“Web Hooks”作為服務。將觸發器設定為「工作項目已更新」。",
+        "setupStepsAdoStep3": "將要傳送的資源詳細資訊設為“全部”，以便包含 System.State。",
+        "setupStepsAdoStep4": "將以下網址貼到網址列。將基本驗證的使用者名稱和密碼設定為您上面輸入的值。",
+        "setupStepsAdoStep5": "保存訂閱。使用下面的「發送測試 webhook」來驗證管道。",
+        "setupStepsGitlabStep1": "在 GitLab 中，前往您的專案 → 設定 → Webhooks。",
+        "setupStepsGitlabStep2": "將下方網址貼到網址列。將下方密鑰貼到密鑰令牌欄中。",
+        "setupStepsGitlabStep3": "在“觸發器”下，選取“問題事件”。",
+        "setupStepsGitlabStep4": "點選「新增 webhook」。使用下面的「發送測試 webhook」來驗證管道。",
+        "setupStepsGiteaStep1": "在 Gitea 中，前往您的儲存庫 → 設定 → Webhooks。",
+        "setupStepsGiteaStep2": "點擊“新增 Webhook”，然後選擇“Gitea”。",
+        "setupStepsGiteaStep3": "將下方 URL 貼到「目標 URL」欄位中。將下方密鑰貼到「密鑰」欄位中。",
+        "setupStepsGiteaStep4": "在“觸發條件”下，選擇“問題”。",
+        "setupStepsGiteaStep5": "點擊“新增 Webhook”。使用下面的「發送測試 Webhook」來驗證管道。",
+        "deliveriesTab": "送貨",
+        "filterConfigPlaceholder": "所有 webhook",
+        "filterStatusAll": "全部",
+        "filterStatusFailed": "失敗的",
+        "filterStatusSuccess": "成功",
+        "filterSinceDefault": "自…",
+        "filterUntilDefault": "直到…",
+        "filterReset": "重置篩選器",
+        "filterBulkReplayButton": "批量重播 {count} 出站失敗",
+        "filterBulkReplayHidden": "所有可見的故障都發生在入站端—請重新觸發上游事件。",
+        "deliveriesEmpty": "沒有符合這些篩選條件的訂單。",
+        "deliveriesResetFilters": "重置篩選器",
+        "deliveriesLoadMore": "加載更多",
+        "tableHeaderConfig": "Webhook",
+        "tableHeaderEvent": "事件",
+        "tableHeaderStatus": "地位",
+        "tableHeaderError": "錯誤",
+        "tableHeaderReceivedAt": "已收到",
+        "tableHeaderAttempt": "試圖",
+        "tableHeaderDirection": "方向",
+        "tableHeaderActions": "",
+        "tableActionViewDetails": "看詳情",
+        "drawerTitle": "外送詳情",
+        "drawerLabelEvent": "事件",
+        "drawerLabelDirection": "方向",
+        "drawerLabelStatusCode": "狀態碼",
+        "drawerLabelLatency": "延遲",
+        "drawerLatencyValue": "{ms} 毫秒",
+        "drawerLatencyUnknown": "—",
+        "drawerLabelError": "錯誤",
+        "drawerLabelPayloadDigest": "有效載荷摘要",
+        "drawerLabelEventId": "事件 ID",
+        "drawerLabelAttempt": "試圖",
+        "drawerLabelReceivedAt": "收到於",
+        "drawerNoError": "—",
+        "drawerReplayedFrom": "{id} 的回放",
+        "drawerReplayButton": "重播此球",
+        "drawerInboundReplayNotSupported": "入庫交付無法重現－請重新觸發上游事件。",
+        "replayConfirmTitle": "重播這次投籃？",
+        "replayConfirm": "這將觸發一個真正的 {direction} {adapterType} 請求。",
+        "replayAction": "重播",
+        "bulkReplayConfirmTitle": "重播站失敗？",
+        "bulkReplayConfirm": "重播 {count} 個出站失敗到 {configName}？這將觸發 {count} 個真正的 HTTP 請求。",
+        "bulkReplayCapExceeded": "大量重播每次最多只能發送 100 則訊息。可以縮小篩選範圍或依序運行。目前， {count} 將被重播。",
+        "bulkReplayAction": "重播 {count}",
+        "healthBadge": {
+          "HEALTHY": "健康",
+          "DEGRADED": "降級",
+          "DISABLED": "已停用"
+        },
+        "healthTooltipHealthy": "上次成功： {lastSuccessAt}",
+        "healthTooltipDegraded": "連續失敗次數 {count} · 最後失敗時間為 {lastFailureAt}",
+        "healthTooltipDisabled": "連續失敗 10 次後停用 · {lastFailureAt}",
+        "activityLabel": "配送活動",
+        "activityLastDispatched": "最後出貨",
+        "activityLastSuccess": "最後成功",
+        "activityLastFailure": "最後一次失敗",
+        "activityNever": "絕不",
+        "reEnable": "重新啟用",
+        "reEnableConfirmTitle": "重新啟用此 webhook？",
+        "reEnableConfirm": "請確認上游問題已修復後再重新啟用。 webhook 將立即恢復發送。",
+        "toastReplaySuccess": "重播已排隊",
+        "toastReplayFailed": "重播失敗： {error}",
+        "toastReplayInboundNotSupported": "入庫貨物無法重現。",
+        "toastBulkReplaySuccess": "大量重播開始 · 批次 {batchId}",
+        "toastBulkReplayFailed": "批量重播失敗： {error}",
+        "toastReEnableSuccess": "Webhook 已重新啟用",
+        "toastReEnableFailed": "重新啟用失敗： {error}"
+      },
+      "aiModels": {
+        "description": "配置人工智慧模型以實現智慧測試用例生成和分析",
+        "availableModels": "項目預設值",
+        "availableModelsDescription": "從系統管理員配置的模型中選擇一個預設的 AI 模型用於此專案。",
+        "currentModelSettings": "目前模型設定",
+        "currentModelDescription": "目前啟動的 AI 模型配置詳情： {name}",
+        "noModelsAvailable": "目前沒有可用的AI模型。請聯絡您的系統管理員，為您的組織配置AI模型。",
+        "monthlyBudget": "每月預算",
+        "model": "模型",
+        "budget": "預算",
+        "streamingTooltip": "啟用即時響應流",
+        "systemDefault": "系統預設設定",
+        "setAsDefault": "設定為預設值",
+        "clearDefault": "清除預設設定",
+        "useForProject": "用於專案",
+        "removeModel": "清除預設設定",
+        "removeWarningTitle": "清除預設AI模型將：",
+        "removeWarning1": "除非已配置每個功能的單獨設置，否則禁用 AI 驅動的功能。",
+        "removeWarning2": "移除用於測試用例產生和分析的備用模型",
+        "switchModel": "更改預設值",
+        "switchWarningTitle": "更改預設AI模型將：",
+        "switchWarning1": "改變本項目中人工智慧功能的行為方式",
+        "switchWarning2": "可能會影響生成內容的品質和風格。",
+        "modelAssigned": "本項目預設AI模型集",
+        "modelAssignError": "設定預設AI模型失敗",
+        "modelRemoved": "預設AI模型已清除",
+        "modelRemoveError": "清除預設AI模型失敗",
+        "confirmRemove": "您確定要將「{name}」清除為該專案的預設值嗎？",
+        "confirmSwitch": "您確定要將預設值從“{from}”變更為“{to}”嗎？",
+        "currency": {
+          "dollar": "$",
+          "perMonth": "/月"
+        },
+        "promptConfig": "提示配置",
+        "promptConfigDescription": "選擇此項目要使用的 AI 提示配置。",
+        "useSystemDefault": "使用系統預設值",
+        "promptConfigChanged": "提示符號配置已成功更新。",
+        "featureOverrides": {
+          "title": "每個特徵的 LLM 覆蓋",
+          "description": "針對特定 AI 功能，覆蓋預設的 LLM 整合。覆蓋操作在解析鏈中優先權最高。",
+          "feature": "特徵",
+          "override": "覆蓋",
+          "effectiveLlm": "有效的LLM",
+          "source": "來源",
+          "noOverride": "無覆蓋",
+          "noLlm": "無LLM（已停用）",
+          "disabledOverride": "已禁用（覆蓋）",
+          "projectOverride": "項目覆蓋",
+          "promptConfig": "提示配置",
+          "noLlmConfigured": "未配置LLM",
+          "selectIntegration": "選擇集成方式...",
+          "overrideSaved": "功能覆蓋已儲存",
+          "overrideCleared": "功能覆蓋已清除",
+          "overrideError": "保存功能覆蓋失敗"
+        }
+      },
+      "shares": {
+        "title": "管理股份",
+        "description": "查看和管理此項目的所有共享鏈接"
+      },
+      "quickScript": {
+        "title": "QuickScript",
+        "description": "啟用 QuickScript 並連接程式碼庫，以進行 AI 輔助測試產生。",
+        "enableLabel": "啟用 QuickScript",
+        "enableDescription": " 允許團隊成員使用 QuickScript 將測試案例轉換為自動化腳本。",
+        "enabledToast": "已啟用 QuickScript",
+        "disabledToast": "QuickScript 已停用",
+        "noRepos": {
+          "title": "未配置任何代碼倉庫",
+          "adminDescription": "在為此項目配置程式碼上下文之前，請先建立儲存庫連線。",
+          "adminLink": "前往代碼倉庫",
+          "userDescription": "請聯絡系統管理員設定程式碼庫連線。"
+        },
+        "repository": {
+          "title": "程式碼庫",
+          "description": "選擇用於 AI 環境的程式碼儲存庫",
+          "placeholder": "選擇一個代碼倉庫…",
+          "branchLabel": "分支",
+          "branchPlaceholder": "留空則使用倉庫預設分支"
+        },
+        "pathPatterns": {
+          "title": "路徑模式",
+          "description": "指定要包含的檔案。每一行都包含一個基本路徑和一個 glob 模式。例如：`path=tests/e2e/pages + pattern=*` 直接包含該資料夾中的所有檔案；`path=src + pattern=**/*.test.ts` 遞歸包含所有測試檔案。",
+          "pathLabel": "小路",
+          "pathPlaceholder": "測試/端到端/頁面",
+          "patternLabel": "圖案",
+          "addPath": "新增路徑",
+          "previewFiles": "預覽文件",
+          "scanningRepo": "正在掃描儲存庫檔案… ({seconds}s)",
+          "files": "{count, plural, one {# 文件} other {# 文件集}}",
+          "truncatedBadge": "結果可能不完整（受提供者限制）",
+          "exceedsLimit": "總大小超出 AI 情境限制 {overflow}。在匯出過程中，文件會根據與待匯出測試案例的相關性進行排序——相關性最高的文件優先導出，當達到預算上限時，相關性較低的文件將被跳過。如果您希望更精確地控制要匯出的文件，請縮小路徑模式。"
+        },
+        "preview": {
+          "resolvingBranch": "正在解析分支…",
+          "scanningFiles": "正在掃描 {scope}… 中的文件",
+          "scanningFilesCount": "正在掃描 {scope}… 中的檔案（已找到{count}）",
+          "filtering": "對 {count} 個檔案和… 個檔案套用過濾器"
+        },
+        "cache": {
+          "title": "快取設定",
+          "description": "Valkey 會快取文件，以便在 AI 生成過程中快速存取。",
+          "enableLabel": "啟用檔案快取",
+          "disabledWarning": "文件緩存已禁用。匯出時，程式碼庫檔案將直接從您的程式碼提供者取得，不會儲存在 TestPlanIt 中。 AI 驅動的 QuickScript 仍將包含程式碼上下文，但每次匯出都會向您的程式碼庫發出即時請求。",
+          "ttlLabel": "快取持續時間（天）",
+          "statusTitle": "快取狀態",
+          "refreshButton": "刷新快取",
+          "listingFiles": "文件列表…",
+          "cachingFiles": "快取 {count} 個檔案…",
+          "statusNeverFetched": "從未獲取",
+          "statusPending": "令人耳目一新…",
+          "lastFetched": "最後獲取時間",
+          "filesCached": "文件已快取",
+          "totalSize": "總尺寸"
+        },
+        "save": "儲存配置",
+        "saved": "程式碼上下文配置已儲存",
+        "saveError": "配置保存失敗",
+        "listError": "無法列出儲存庫文件",
+        "contentsError": "文件內容快取失敗",
+        "networkError": "快取刷新期間出現網路錯誤",
+        "refreshSuccess": "快取已刷新： {fileCount} 個檔案（已快取{contentCached} 個內容）",
+        "refreshRateLimited": "快取已刷新：列出了 {fileCount} 個文件，快取了 {contentCached}/{fileCount} 個內容（速率受限——請再次刷新以完成）",
+        "validation": {
+          "pathRequired": "路徑是必需的",
+          "patternRequired": "需要圖案",
+          "repositoryRequired": "需要儲存庫",
+          "pathPatternRequired": "至少需要一種路徑模式"
+        },
+        "exportTemplates": {
+          "title": "匯出模板",
+          "description": "為該項目分配導出模板。只有指派的範本才會顯示在匯出對話方塊中。",
+          "noTemplates": "未啟用任何匯出模板。請聯絡您的系統管理員。",
+          "assignedLabel": "已指派模板",
+          "selectPlaceholder": "選擇要分配的模板…",
+          "defaultLabel": "預設模板",
+          "defaultPlaceholder": "無（使用全域預設值）",
+          "assigned": "已分配",
+          "save": "儲存範本作業",
+          "saved": "模板分配已儲存",
+          "saveError": "模板分配保存失敗"
+        },
+        "disconnect": "斷開儲存庫",
+        "confirmDisconnect": "您確定要中斷「{name}」與此項目的連線嗎？",
+        "disconnectWarningTitle": "斷開此存儲庫的連接將導致：",
+        "disconnectWarning1": "刪除所有快取的儲存庫文件",
+        "disconnectWarning2": "移除路徑模式和分支配置",
+        "disconnectWarning3": "停止在 AI 產生的匯出檔案中包含程式碼上下文",
+        "disconnectSuccess": "程式碼庫已斷開連接",
+        "disconnectError": "斷開程式碼庫連線失敗"
+      }
+    }
+  },
+  "milestones": {
+    "title": "里程碑詳情",
+    "fields": {
+      "parent": "家長里程碑",
+      "dueDate": "到期日",
+      "automaticCompletion": "截止日期自動完成",
+      "notifyDaysBefore": "提前幾天通知到期日",
+      "notifyDaysBeforeValue": "截止日期前通知 {count, plural, one {# 天} other {# 天}}",
+      "dueDateNotifications": "到期日通知"
+    },
+    "labels": {
+      "childMilestones": "兒童成長里程碑"
+    },
+    "placeholders": {
+      "description": "請輸入里程碑描述…",
+      "documentation": "提交里程碑文檔…",
+      "selectType": "選擇里程碑類型...",
+      "selectParent": "選擇家長里程碑..."
+    },
+    "empty": {
+      "active": "暫無活動里程碑",
+      "completed": "暫無已完成的里程碑",
+      "description": "未提供描述",
+      "documentation": "未提供任何文件。",
+      "testRuns": "沒有測試運行",
+      "forecasts": "暫無預測數據"
+    },
+    "statusLabels": {
+      "NOT_STARTED": "尚未開始",
+      "IN_PROGRESS": "進行中",
+      "STOPPED": "停止",
+      "BLOCKED": "已屏蔽",
+      "CANCELLED": "取消",
+      "unscheduled": "非計劃性",
+      "upcoming": "即將推出",
+      "delayed": "延遲",
+      "pastDue": "逾期",
+      "started": "開始",
+      "completed": "完全的"
+    },
+    "status": {
+      "stop": "停止",
+      "reopen": "重新開放"
+    },
+    "dates": {
+      "pickStartDate": "選擇開始日期",
+      "pickCompletionDate": "揀貨完成日期",
+      "selectDate": "選擇日期...",
+      "completionWarning": "警告：這將標記該里程碑已完成"
+    },
+    "toast": {
+      "deleted": "里程碑 {name} 已刪除",
+      "updated": "里程碑已更新",
+      "updateFailed": "里程碑更新失敗",
+      "completed": "里程碑「{name}」已完成。",
+      "completedWithDependencies": "里程碑及其相依性均已成功完成。"
+    },
+    "errors": {
+      "nameExists": "已存在一個以此命名的里程碑",
+      "nameRequired": "里程碑名稱為必填項",
+      "notFound": "未找到里程碑"
+    },
+    "actions": {
+      "add": "新增里程碑"
+    },
+    "delete": {
+      "title": "刪除里程碑",
+      "confirmMessage": "您確定要刪除里程碑 {name} 嗎？",
+      "warning": "此里程碑將從專案中移除。該里程碑的歷史數據仍將保留在專案中。",
+      "toast": {
+        "loading": "刪除里程碑…",
+        "success": "里程碑已成功刪除",
+        "error": {
+          "title": "刪除里程碑失敗",
+          "description": "刪除里程碑時發生錯誤"
+        }
+      }
+    },
+    "completeDialog": {
+      "confirmTitle": "確認里程碑完成情況",
+      "confirmDescription": "完成此里程碑也將完成以下相關事項：",
+      "impactActiveTestRuns": "{count, plural, one {# 目前測試運行} other {# 目前運行次數}}",
+      "impactActiveSessions": "{count, plural, one {# 目前會話數} other {# 目前會話數}}",
+      "impactDescendantMilestones": "{count, plural, one {# 後里程碑} other {# 後位里程碑}}",
+      "completeTestRunsLabel": "完成相關測試運行（{count, plural, one {# 活動} other {# 活動}}）",
+      "completeSessionsLabel": "已完成關聯會話（{count, plural, one {# 活躍} other {# 活躍}}）",
+      "testRunStateLabel": "測試運行完成狀態",
+      "sessionStateLabel": "會話完成狀態",
+      "itemsRemaining": "以下項目將繼續有效：",
+      "processing": "加工...",
+      "confirmAndCompleteAll": "確認並完成所有"
+    },
+    "notifications": {
+      "dueSoon": "里程碑「{name}」將於 {dueDate}到期。",
+      "overdue": "里程碑「{name}」應於 {dueDate}日到期。"
+    }
+  },
+  "sessions": {
+    "title": "{count, plural, =1 {會話} other {會話}}",
+    "labels": {
+      "totalElapsed": "花費時間",
+      "remaining": "剩餘： {time}",
+      "overtime": "超出估計值： {time}"
+    },
+    "empty": {
+      "noMatchingCompleted": "沒有符合您篩選條件的已完成會話。"
+    },
+    "filter": {
+      "placeholder": "篩選會話..."
+    },
+    "actions": {
+      "add": "新增會話",
+      "create": "建立新會話",
+      "edit": "編輯會話",
+      "complete": "完整會話",
+      "delete": "刪除會話",
+      "viewSessionDetails": "查看會話"
+    },
+    "noMilestone": "沒有里程碑",
+    "completeDialog": {
+      "noWorkflowsConfigured": "此項目未配置任何完成工作流程。請在管理設定中配置工作流程以啟用會話完成功能。"
+    },
+    "messages": {
+      "createSuccess": "會話創建成功",
+      "createSuccessMultiple": "{count} 會話建立成功",
+      "duplicateSuccess": "會話已成功複製",
+      "duplicateSuccessMultiple": "{count} 會話已成功複製"
+    },
+    "duplicateDialog": {
+      "title": "重複會話",
+      "description": "建立會話 <nameStyle>{name}</nameStyle> 的副本，包含所有元數據，但不包含任何結果。"
+    },
+    "errors": {
+      "failedToCreate": "建立新會話失敗",
+      "failedToCreateVersion": "建立會話版本失敗",
+      "nameAlreadyExists": "會話名稱已存在。請選擇一個新名稱。",
+      "createFailed": "建立會話失敗",
+      "duplicateFailed": "會話複製失敗"
+    },
+    "validation": {
+      "nameMinLength": "名稱必須至少包含 2 個字元。",
+      "templateRequired": "請選擇模板",
+      "maxDuration": "持續時間必須小於或等於 {max}。"
+    },
+    "placeholders": {
+      "estimate": "預估時間（例如，1小時30分鐘）",
+      "elapsed": "經過時間（例如，2天4小時）",
+      "selectUser": "選擇用戶",
+      "estimateHint": "例如，2小時30分鐘",
+      "noEstimate": "未設定估計值"
+    },
+    "delete": {
+      "confirmMessage": "您確定要刪除會話 {name} 嗎？",
+      "warning": "本次會話將從項目中移除。本次會話的歷史資料仍將保留在專案中。",
+      "toast": {
+        "loading": "正在刪除會話...",
+        "success": "會話已成功刪除",
+        "error": {
+          "title": "刪除會話失敗",
+          "description": "刪除會話時發生錯誤"
+        }
+      }
+    },
+    "complete": {
+      "confirmMessage": "您確定要完成會話 {name}嗎？",
+      "warning": "會話結束後，該會話將永久存檔，且無法再進行更新。",
+      "fields": {
+        "completionDate": "完成日期"
+      },
+      "placeholders": {
+        "pickDate": "選擇日期"
+      }
+    },
+    "summary": {
+      "workDistributionDescription": "預計剩餘總時間：",
+      "recentResultsTitle": "近期業績概要",
+      "recentResultsDescription": "會議結果總結。",
+      "noRecentResults": "近期未記錄任何會話結果。",
+      "completionTrendTitle": "完成趨勢",
+      "completionTrendDescription": "每月完成的課程數。",
+      "noCompletedRuns": "過去 6 個月內未找到已完成的運行記錄。",
+      "completionTrendTitle6Mo": "完成趨勢（過去 6 個月）",
+      "noCompletedSessions6Mo": "過去6個月內未完成任何療程。"
+    },
+    "version": {
+      "title": "會話歷史記錄視圖",
+      "notFound": "未找到會話版本。",
+      "selectVersion": "選擇版本",
+      "backToSession": "返回會話",
+      "backToLatest": "返回最新版本",
+      "versionInfo": {
+        "created": "版本 {number} 創建",
+        "latestUpdated": "最新版本 {number} 已更新"
+      },
+      "renderer": {
+        "noEstimate": "暫無估算",
+        "noTimeLogged": "未記錄時間",
+        "noContent": "無內容",
+        "currentVersion": "目前版本",
+        "previousVersion": "先前版本"
+      },
+      "diff": {
+        "added": "額外",
+        "removed": "已移除",
+        "changed": "已更改"
+      }
+    },
+    "results": {
+      "section": "會話日誌",
+      "add": "新增會話結果",
+      "edit": "編輯會話結果",
+      "editDescription": "對會話結果進行更改，完成後點選儲存。",
+      "details": "請在此輸入結果詳情…",
+      "noResults": "目前還沒有結果。",
+      "noNotes": "此結果未新增任何備註。",
+      "deleteSuccess": "會話結果已成功刪除",
+      "deleteError": "刪除會話結果失敗",
+      "updateSuccess": "會話結果已成功更新",
+      "updateError": "更新會話結果失敗",
+      "linkCopied": "會話結果連結已複製到剪貼簿",
+      "copyFailed": "複製會話結果連結失敗",
+      "confirmDelete": {
+        "title": "刪除會話結果",
+        "description": "您確定要刪除此會話結果嗎？"
+      }
+    },
+    "notFound": "未找到會話"
+  },
+  "home": {
+    "dashboard": {
+      "title": "您的儀錶板",
+      "users": "There {count, plural, =1 {is # User} other {are # Users}}",
+      "yourProjects": "您的專案",
+      "projects": "您有權存取 {count, plural, =1 {# 項目} other {# 項目集}}",
+      "loading": "正在加載儀錶板...",
+      "noItems": "你目前無需處理任何分配給你的任務。",
+      "pendingRuns": "待測試運行",
+      "activeSessions": "活躍會話",
+      "yourActiveSessions": "{count, plural, =0 {無活動會話} =1 {活動會話數} other {活動會話數}}",
+      "yourPendingRuns": "{count, plural, =0 {No Pending Test Runs} =1 {# Active Test Run} other {# Active Test Runs}}",
+      "yourAssignments": "你的作業",
+      "totalTime": "預計總時間： ",
+      "totalWorkEffort": "總工作量： ",
+      "scheduleSpan": "日程跨度： "
+    },
+    "initialPreferences": {
+      "title": "設定您的偏好",
+      "description": "選擇最適合您的預設設定。您可以隨時在個人資料中變更這些設定。",
+      "dateFormat": "日期格式",
+      "timeFormat": "時間格式",
+      "timezonePlaceholder": "搜尋時區...",
+      "skip": "保留預設設定",
+      "save": "儲存偏好設定",
+      "success": "偏好設定已更新",
+      "error": "儲存您的偏好設定時出錯。"
+    },
+    "noAccess": {
+      "title": "無項目存取權限",
+      "description": "您無權存取此系統中的任何項目。",
+      "contact": "請聯絡您的系統管理員申請專案存取權限。",
+      "adminAddProject": "添加您的第一個項目即可開始！",
+      "footer": "需要獲得存取權限才能查看和參與測試計劃活動。"
+    },
+    "noProjectAccess": {
+      "description": "您無權存取此項目。",
+      "contact": "請聯絡您的專案管理員申請存取權限。"
+    },
+    "counts": {
+      "testCases": "{count, plural, =0 {# Test Cases} =1 {# Test Case} other {# Test Cases}}",
+      "activeMilestones": "{count, plural, =0 {# Active Milestones} =1 {# Active Milestone} other {# Active Milestones}}",
+      "activeRuns": "{count, plural, =0 {# Active Runs} =1 {# Active Run} other {# Active Runs}}",
+      "activeSessions": "{count, plural, =0 {# Active Sessions} =1 {# Active Session} other {# Active Sessions}}",
+      "issues": "{count, plural, =0 {# 問題} =1 {# 問題} other {# 問題}}"
+    }
+  },
+  "users": {
+    "description": "管理使用者帳戶，設定係統存取級別，並指派全域角色。",
+    "filter": "篩選用戶...",
+    "profile": {
+      "title": "用戶個人資料",
+      "edit": {
+        "title": "編輯個人資料",
+        "timezonePlaceholder": "選擇或搜尋時區...",
+        "timezoneRequired": "必須填寫時區資訊。",
+        "avatarUpdated": "頭像更新成功。",
+        "avatarUpdateError": "頭像更新失敗。",
+        "deleteAvatar": "刪除頭像",
+        "deleteAvatarConfirm": "您確定要刪除您的頭像嗎？",
+        "emailDisabledForSso": "單一登入 (SSO) 帳戶的電子郵件地址無法變更。請透過您的身分提供者更新電子郵件地址。",
+        "emailEditableForBoth": "您可以使用郵件信箱/密碼或單一登入 (SSO) 登入。更改郵箱地址只會影響密碼驗證。",
+        "linkSsoProvider": "連結 SSO 提供者"
+      },
+      "preferences": {
+        "title": "偏好"
+      },
+      "access": {
+        "title": "使用權"
+      },
+      "notifications": {
+        "title": "通知偏好設定",
+        "description": "自訂接收通知的方式",
+        "currentGlobal": "目前全域設定： {mode}",
+        "mode": {
+          "label": "通知模式",
+          "useGlobal": "使用全域設定"
+        },
+        "options": {
+          "title": "其他選項",
+          "email": {
+            "label": "電子郵件通知",
+            "description": "透過電子郵件接收通知"
+          }
+        },
+        "success": {
+          "title": "已儲存偏好設定",
+          "description": "您的通知偏好設定已更新"
+        },
+        "error": {
+          "description": "通知偏好設定保存失敗"
+        }
+      },
+      "changePasswordModal": {
+        "buttonText": "更改密碼",
+        "setPasswordButtonText": "設定密碼",
+        "description": "請輸入您目前的密碼和新密碼以變更您的帳戶密碼。此操作只會更改您內部管理的密碼。如果您透過單一登入 (SSO) 登入，則該密碼不會變更。",
+        "setPasswordDescription": "您已透過單一登入 (SSO) 登錄，但尚未設定本機密碼。請輸入新密碼以啟用帳戶的郵件信箱/密碼登入功能。",
+        "currentPasswordLabel": "目前密碼",
+        "newPasswordLabel": "新密碼",
+        "confirmPasswordLabel": "確認新密碼",
+        "validation": {
+          "passwordsDoNotMatch": "新密碼不符。",
+          "newPasswordTooShort": "新密碼不符合安全要求。"
+        },
+        "success": {
+          "passwordChanged": "密碼已成功更改。"
+        }
+      },
+      "mentionedComments": {
+        "title": "評論中提到",
+        "description": "在提及你的評論中",
+        "noComments": "目前還沒有人提到過你。",
+        "comment": "評論",
+        "showingResults": "顯示 {start} - {end} 共 {total}"
+      },
+      "twoFactor": {
+        "enable": "啟用雙重認證",
+        "disable": "停用",
+        "disableNotAllowed": "您的組織要求啟用雙重認證",
+        "ssoBypassNotice": "單一登入 (SSO) 將繞過此雙重認證 (2FA) 設定。請聯絡您的管理員，強制所有登入啟用雙重認證。",
+        "regenerateCodes": "新程式碼",
+        "setup": {
+          "description": "使用您的身份驗證器應用程式（例如 Google Authenticator 或 Authy）掃描二維碼，然後輸入驗證碼。",
+          "backupCodesTitle": "保存您的備份代碼",
+          "done": "我已經儲存了我的程式碼"
+        },
+        "disableConfirm": {
+          "title": "禁用雙重認證？",
+          "description": "這將降低您帳戶的安全性。請輸入您目前的雙重驗證碼或備用驗證碼進行確認。",
+          "placeholder": "輸入代碼"
+        },
+        "regenerate": {
+          "title": "重新產生備份程式碼",
+          "description": "這將使您現有的備用驗證碼失效。請輸入您目前的雙重驗證碼以繼續。",
+          "confirm": "重新產生程式碼",
+          "newCodesTitle": "您的新備份代碼",
+          "newCodesDescription": "您的舊代碼已失效。請將這些新程式碼保存在安全的地方。"
+        }
+      },
+      "apiTokens": {
+        "description": "API令牌允許外部應用程式和腳本代表您存取TestPlanIt。令牌擁有與您的帳戶相同的權限。",
+        "create": "創建令牌",
+        "createTitle": "建立 API 令牌",
+        "createDescription": "建立新的 API 令牌，用於驗證外部工具和腳本。",
+        "nameLabel": "令牌名稱",
+        "namePlaceholder": "例如，CI/CD 管線、CLI 工具",
+        "noTokens": "尚未建立任何 API 令牌。",
+        "expiryLabel": "到期日期（可選）",
+        "expiryHint": "無需清洗，不會過期。",
+        "tokenCreated": "令牌已建立",
+        "tokenCreatedDescription": "您的API令牌已成功建立。",
+        "copyWarning": "立即複製此令牌。您將無法再次查看它！",
+        "yourToken": "您的令牌",
+        "deleteTitle": "刪除 API 令牌？",
+        "deleteDescription": "此操作無法撤銷。任何使用此令牌的應用程式將無法再進行身份驗證。",
+        "readOnlyLabel": "只讀",
+        "readOnlyDescription": "適用於只能查詢資料而不能修改資料的AI代理。",
+        "agentTokenLabel": "標記為代理令牌",
+        "agentTokenDescription": "使用 metadata.source: \"mcp\" 標記稽核日誌條目，以便管理員可以歸因於代理程式驅動的變更。",
+        "readOnlyBadge": "只讀",
+        "agentTokenBadge": "代理令牌",
+        "errors": {
+          "nameRequired": "令牌名稱為必填項。"
+        }
+      }
+    },
+    "access": {
+      "guest": "客人"
+    },
+    "avatar": {
+      "update": "更新頭像",
+      "remove": "移除頭像",
+      "changeProfilePicture": "更換頭像",
+      "notAuthenticated": "您必須登入才能上傳頭像。"
+    },
+    "deletedUser": "已刪除用戶"
+  },
+  "userMenu": {
+    "viewProfile": "查看個人資料",
+    "locale": "在地化",
+    "themes": {
+      "light": "光",
+      "dark": "黑暗的",
+      "system": "系統",
+      "green": "綠色的",
+      "purple": "紫色的",
+      "orange": "橘子"
+    }
+  },
+  "repository": {
+    "version": {
+      "notFound": "未找到測試用例版本。",
+      "detailsRegion": "測試用例詳情",
+      "metadataRegion": "測試用例元數據",
+      "versionCreated": "版本 {version} 創建",
+      "latestVersionUpdated": "最新版本 {version} 已更新",
+      "historyView": "測試用例歷史記錄視圖"
+    },
+    "fields": {
+      "optionNotFound": "未找到選項",
+      "hasValue": "有價值",
+      "noValue": "無價值",
+      "hasDate": "有日期",
+      "noDate": "無日期",
+      "hasText": "有文字",
+      "noText": "無文字",
+      "hasLink": "有連結",
+      "noLink": "無連結",
+      "hasSteps": "有步驟",
+      "noSteps": "無需步驟",
+      "unchecked": "未檢查",
+      "linkedCases": "關聯病例",
+      "clickToViewFullContent": "點擊看完整內容"
+    },
+    "steps": {
+      "add": "新增步驟",
+      "addSharedSteps": "新增共享步驟",
+      "delete": "刪除步驟",
+      "confirmDelete": "確認刪除步驟 {number}？",
+      "createSharedSteps": "建立共享 {number, plural, one {步驟} other {步驟}}",
+      "sharedStepsName": "共享步驟名稱",
+      "sharedStepsDescription": "輸入您新分享的步驟 {number, plural, one {的名稱} other {步驟}}。這將包括 {number, plural, one {# 已選步驟} other {# 已選步驟}}。",
+      "notifications": {
+        "noStepsSelectedOrNameEmptyWarning": "請選擇步驟並輸入名稱以建立共用步驟。",
+        "failedToCreateSharedStepGroupError": "建立共用步驟失敗，請重試。",
+        "sharedStepGroupCreatedSuccess": "共享步驟創建成功！",
+        "genericSharedStepCreationError": "建立共用步驟時發生未知錯誤。請重試。",
+        "errorCreatingSharedGroup": "建立共用步驟失敗，請重試。",
+        "sharedGroupCreatedSuccess": "共享步驟組創建成功！"
+      },
+      "selectSharedStepsTitle": "選擇共享步驟",
+      "selectSharedStepsDescription": "選擇要新增至測試案例中的共用步驟。",
+      "sharedStepsListPlaceholder": "正在加載共享步驟...",
+      "sharedStepsNamePlaceholder": "輸入名稱以標識共享步驟",
+      "noSharedStepsFound": "未找到此項目的共用步驟。",
+      "sharedStepGroupTitle": "共享步驟： {name}",
+      "confirmDeleteSharedStepBlock": "您確定要從此測試案例中移除共享步驟區塊「{name}」嗎？這不會刪除共用步驟組本身。",
+      "removeBlockButton": "移除障礙物",
+      "loadingSharedStepsItems": "正在加載步驟…",
+      "noStepsInSharedGroup": "此共用步驟群組為空。",
+      "searchSharedStepsPlaceholder": "選擇共享步驟...",
+      "stepsCountLabel": "{count, plural, =0 {# 步驟} =1 {# 步驟} other {# 步驟}}",
+      "reviewSelectedStepsTitle": "回顧選定步驟",
+      "noStepsInSelectedGroup": "所選組沒有步驟。",
+      "sharedGroupSuffix": "（共同步驟）",
+      "unnamedSharedGroup": "未命名的共享步驟"
+    },
+    "testCase": {
+      "toggleAutomated": "切換自動測試",
+      "editAttachmentsIndividually": "單獨編輯附件。",
+      "automatedStatus": "自動化測試是 {status}"
+    },
+    "templateNotAssignedWarning": "此測試案例使用了範本“{templateName}”，但該範本目前未指派給專案“{projectName}”。您可能需要將此範本指派給項目，或修改測試案例以使用其他範本。",
+    "orphanedStepsWarning": "此測試案例包含步驟，但目前範本「{templateName}」不包含「步驟」欄位。在測試案例擁有包含「步驟」欄位的範本之前，無法編輯步驟。",
+    "orphanedFieldsWarning": "This test case has {count, plural, =1 {# field value} other {# field values}} that {count, plural, =1 {is} other {are}} not included in the current template \"{templateName}\". {count, plural, =1 {This field is} other {These fields are}} shown below but may not be editable until added to the template.",
+    "title": "測試用例庫",
+    "folders": "資料夾",
+    "showDescendants": "顯示所有後代",
+    "addFolder": "新增資料夾",
+    "emptyFolders": "點擊上方的「新增資料夾」按鈕，新增第一個資料夾。",
+    "selectedAllCases": "{count, plural, =0 {Selected all cases} one {Selected # case across all pages} other {Selected # cases across all pages}}",
+    "deselectedAllCases": "已取消選擇所有頁面上的所有案例",
+    "selectAllTooltip": "選取/取消選取此頁面上的所有案例",
+    "selectAllShiftTooltip": "{count, plural, =0 {Select/Deselect all cases across all pages} one {Select/Deselect # case across all pages} other {Select/Deselect # cases across all pages}}",
+    "deselectAllShiftTooltip": "取消選擇/選擇所有頁面上的所有案例",
+    "shiftClickHint": "按住 Shift 鍵可選擇/取消選擇所有頁面",
+    "treeView": {
+      "expandAll": "全部展開",
+      "collapseAll": "全部收起",
+      "altKey": "按住 Alt 鍵展開/折疊所有子項"
+    },
+    "dragDrop": {
+      "move": "移動",
+      "copy": "複製",
+      "promptTitle": "你想做什麼？",
+      "copying": "正在複製…",
+      "copyComplete": "{count, plural, =1 {Copied 1 case to {folder}} other {Copied # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {Moved 1 case to {folder}} other {Moved # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Failed to copy 1 case to {folder}} other {Failed to copy # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Failed to move 1 case to {folder}} other {Failed to move # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyAlreadyRunning": "另一份拷貝正在處理中，請稍候。",
+      "currentSuffix": "（當前的）",
+      "moveDisabledSameFolder": "案例已在此資料夾中",
+      "dragPreviewCase": "測試用例",
+      "dragPreviewCount": "{count, plural, =1 {# 測試案例} other {# 測試案例}}",
+      "modifierHintMac": "按住 ⇧ 移動或按住 ⌥ 複製，拖曳即可跳過此選單。",
+      "modifierHintWin": "按住Shift鍵移動或按住Ctrl鍵複製，拖曳即可跳過此選單。"
+    },
+    "folderActions": {
+      "edit": "編輯資料夾",
+      "delete": "刪除資料夾",
+      "rename": "重新命名資料夾"
+    },
+    "cases": {
+      "filter": "篩選案例...",
+      "selectFolder": "選擇要新增或顯示測試案例的資料夾。",
+      "selectCases": "選擇測試用例",
+      "noTestCases": "沒有要顯示的測試案例。",
+      "addCase": "新增案例",
+      "notFound": "未找到測試用例。",
+      "selectFilter": "選擇篩選器",
+      "testResultHistory": "測試結果歷史記錄",
+      "testResultHistoryDescription": "查看此測試案例的測試結果歷史記錄",
+      "noTestResults": "未找到此測試案例的測試結果",
+      "unknownRun": "未知運行",
+      "attempt": "試圖",
+      "invalidProject": "無效項目",
+      "noSearchResults": "沒有符合您搜尋條件的案例。",
+      "bulkEdit": "批次編輯",
+      "createTestRun": "建立測試運行",
+      "copyMoveToProject": "複製/移動",
+      "export": "出口",
+      "quickScript": "QuickScript",
+      "cannotReorderAcrossPages": "無法跨多個頁面重新排列測試案例。若要重新排序，請從頁面大小選單中選擇「全部」以在一個頁面上查看所有用例，或取消選擇其他頁面上的用例。您仍然可以將選定的用例拖曳到資料夾中。",
+      "exportModal": {
+        "scope": {
+          "allFiltered": "全部可見（{count}）"
+        },
+        "textLongFormat": {
+          "label": "富文本格式"
+        },
+        "rowMode": {
+          "label": "測試用例行",
+          "multi": "每步單行"
+        }
+      },
+      "importWizard": {
+        "title": "導入測試用例",
+        "fields": {
+          "workflowState": "工作流程狀態",
+          "column": "列 {number}"
+        },
+        "success": {
+          "description": "{count, plural, one {# 測試案例} other {# 測試案例}} 匯入成功"
+        },
+        "errors": {
+          "templateRequired": "需要選擇模板",
+          "folderRequired": "此導入位置需要選擇資料夾。",
+          "fileRequired": "需要 CSV 或 Markdown 檔案。",
+          "markdownParseFailed": "解析 Markdown 文件失敗",
+          "markdownLlmFailed": "AI解析不可用，使用標準解析器"
+        },
+        "page1": {
+          "fileType": {
+            "label": "文件類型",
+            "csv": "CSV",
+            "markdown": "Markdown"
+          },
+          "parsingMarkdown": "正在解析 Markdown 文件…",
+          "useAiParsing": "利用人工智慧輔助進行田間測繪",
+          "importLocation": {
+            "label": "進口地點",
+            "singleFolder": "將所有案例新增到同一個資料夾中",
+            "rootFolder": "將所有案例和資料夾新增至根資料夾（需要映射）",
+            "topLevel": "將所有案例和資料夾新增至頂層（需要映射）"
+          },
+          "selectFolder": "選擇資料夾",
+          "selectFolderPlaceholder": "選擇一個資料夾…",
+          "delimiters": {
+            "tab": "標籤頁"
+          },
+          "hasHeaders": "第一行包含列名",
+          "template": "儲存庫案例模板",
+          "rowMode": {
+            "single": "每一行代表一個測試用例。",
+            "multi": "測試用例可以跨越多行"
+          }
+        },
+        "page2": {
+          "title": "將 CSV 欄位對應到字段",
+          "description": "將 CSV 檔案中的每一列對應到範本中的一個字段，或選擇忽略它。",
+          "ignoreColumn": "忽略列",
+          "requiredFieldsWarning": "{count, plural, one {# 必填欄位為} other {# 必填欄位為}} 未對映"
+        },
+        "page3": {
+          "title": "田間測繪概要",
+          "mappingSummary": "地圖摘要",
+          "folderSplitMode": {
+            "label": "資料夾層級模式",
+            "plain": "純文字（未分割）",
+            "plainExample": "範例：'This/is.a>Folder' → 名為 'This/is.a>Folder' 的單一資料夾",
+            "slash": "以斜線 (/) 分隔",
+            "slashExample": "例：'This/is.a>Folder' → 'This' > 'is.a>Folder'",
+            "dot": "依點號 (.) 分割",
+            "dotExample": "例：'This/is.a>Folder' → 'This/is' > 'a>Folder'",
+            "greaterThan": "以大於號 (>) 分割",
+            "greaterThanExample": "例：'This/is.a>Folder' → 'This/is.a' > 'Folder'"
+          }
+        },
+        "page4": {
+          "title": "預覽導入",
+          "showing": "顯示 {start}-{end} 共 {total} 個案",
+          "case": "案例 {number}"
+        }
+      }
+    },
+    "addCase": {
+      "title": "新增測試用例",
+      "name": "測試用例名稱",
+      "namePlaceholder": "輸入測試案例名稱",
+      "selectTemplate": "選擇模板",
+      "selectState": "選擇一個州",
+      "estimatePlaceholder": "輸入估價",
+      "create": "建立測試用例",
+      "successMessage": "新增測試案例",
+      "errorMessage": "新增測試用例時出現未知錯誤"
+    },
+    "columns": {
+      "selectCase": "選擇個案",
+      "runOrder": "運行順序",
+      "lastTestResult": "最新結果",
+      "testedOn": "上次測試"
+    },
+    "actions": {
+      "archive": "檔案"
+    },
+    "parentFolder": "父資料夾",
+    "rootFolder": "根資料夾",
+    "removeParentFolder": "刪除父資料夾",
+    "createInSelectedFolder": "恢復到父資料夾",
+    "deleteCase": {
+      "title": "刪除測試用例",
+      "confirmMessageStart": "您確定要刪除測試案例嗎？ ",
+      "confirmMessageEnd": "？",
+      "warning": "此測試用例將從項目中移除。此測試案例的歷史資料（包括結果）仍將保留在專案中。",
+      "activeRunWarningMessage": "此測試案例屬於 {count, plural, =1 {# 活動測試運行} other {# 活動測試運行}}。刪除它會將這些運行標記為已刪除。"
+    },
+    "deleteFolder": {
+      "confirmMessage": "{count, plural, =0 {Deleting this folder will also delete all subfolders. Are you sure?} one {Deleting this folder will also delete 1 test case in this folder and all subfolders. Are you sure?} other {Deleting this folder will also delete # test cases in this folder and all subfolders. Are you sure?}}",
+      "warning": "此資料夾及其所有測試案例將從專案中移除。這些測試案例的歷史資料（包括結果）仍將保留在專案中。",
+      "confirm": "確認刪除資料夾",
+      "success": "資料夾及其所有子資料夾/案例已成功刪除。"
+    },
+    "editFolder": {
+      "errors": {
+        "nameExists": "資料夾名稱已存在，請選擇其他名稱。"
+      }
+    },
+    "views": {
+      "byAutomation": "自動化",
+      "allTemplates": "所有模板",
+      "allStates": "所有州",
+      "allCreators": "所有創作者",
+      "allCases": "所有案例",
+      "allAssignees": "所有受讓人",
+      "anyTag": "任何標籤",
+      "noTags": "無標籤",
+      "byTag": "標籤",
+      "byIssue": "問題",
+      "anyIssue": "任何問題",
+      "noIssues": "沒問題"
+    },
+    "noFoldersTitle": "暫無資料夾",
+    "noFoldersDescription": "首先創建你的第一個資料夾來整理你的測試案例。",
+    "noFoldersOrCasesNoPermission": "沒有要顯示的資料夾或測試案例。",
+    "createFirstFolder": "創建你的第一個資料夾",
+    "bulkEdit": {
+      "title": "大量編輯 {count, plural, one {# 個案} other {# 個案}}",
+      "description": "正在編輯 {count, plural, one {# 已選案例} other {# 已選案例}}。選取欄位即可啟用編輯。",
+      "defineStepsTitle": "定義批次更新步驟",
+      "saveNewSteps": "儲存新步驟",
+      "newStepsDefined": "已定義新步驟（{count}） - 點選按鈕進行編輯",
+      "clearExistingStepsWarning": "現有步驟將被移除",
+      "warnings": {
+        "templateMismatch": {
+          "title": "已選擇多個模板",
+          "description": "當選擇使用不同模板的案例時，只能編輯標準欄位。選擇使用相同範本的案例時，可以編輯動態欄位。"
+        },
+        "junitLimitations": {
+          "title": "自動化測試用例編輯的局限性",
+          "description": "從自動化測試結果匯入的測試案例的「估算」和「自動化」欄位無法修改。"
+        }
+      },
+      "errors": {
+        "fetchErrorTitle": "載入案例時出錯",
+        "fetchErrorDescription": "無法載入所選案例的資料。請關閉此視窗並重試。",
+        "updateErrorTitle": "更新失敗",
+        "updateFailed": "儲存變更時發生錯誤。請檢查數據並重試。",
+        "fetchError": "取得案例數據時出錯。"
+      },
+      "success": {
+        "casesUpdated": "病例已成功更新"
+      },
+      "placeholders": {
+        "various": "<various values>"
+      },
+      "validationError": "驗證錯誤",
+      "stepsCannotBeBulkEdited": "步驟無法批次編輯",
+      "stepsInfoTitle": "步驟資訊",
+      "stepsCannotBeBulkEditedInfo": "步驟無法批次編輯。請逐一編輯各個案例來修改步驟。",
+      "confirmDeleteCases": "您確定要刪除 {count, plural, one {# 已選案例} other {# 已選案例}}嗎？此操作無法撤銷。",
+      "replaceAll": "全部替換",
+      "searchReplace": "搜尋和替換",
+      "searchFor": "搜尋",
+      "replaceWith": "替換為",
+      "searchText": "輸入要搜尋的文字",
+      "replacementText": "輸入替換文字",
+      "useRegex": "使用正規表示式",
+      "caseSensitive": "區分大小寫",
+      "regexHint": "使用 .* 表示任意字符，\\d+ 表示數字，\\w+ 表示單字。捕獲組：（模式），然後使用 $1、$2 等。",
+      "preview": "預覽",
+      "matches": "比賽",
+      "noMatches": "未找到匹配項",
+      "invalidRegexPattern": "無效的正規表示式模式",
+      "searchPatternRequired": "需要搜尋模式",
+      "stepsSearchReplaceInfo": "搜尋和取代功能將應用於步驟描述和預期結果。"
+    },
+    "exportModal": {
+      "title": "匯出測試用例",
+      "description": "請在下方選擇您的匯出選項。",
+      "scope": {
+        "selected": "已選擇（{count}）",
+        "allFiltered": "全部（目前視圖）（{count}）",
+        "allProject": "項目中的所有項目（{count}）"
+      },
+      "format": {
+        "label": "格式",
+        "csv": "CSV",
+        "pdf": "PDF",
+        "markdown": "Markdown"
+      },
+      "columns": {
+        "all": "全部",
+        "visible": "可見的"
+      },
+      "delimiter": {
+        "label": "分隔符",
+        "placeholder": "選擇分隔符號...",
+        "comma": "逗號（，）",
+        "semicolon": "分號（;）",
+        "colon": "冒號 （：）",
+        "pipe": "豎線 (|)"
+      },
+      "textLongFormat": {
+        "label": "文字長格式"
+      },
+      "attachmentFormat": {
+        "label": "附件格式",
+        "names": "姓名",
+        "json": "JSON",
+        "embedded": "嵌入圖片"
+      },
+      "stepsFormat": {
+        "label": "步驟格式",
+        "plainText": "純文字"
+      },
+      "rowMode": {
+        "label": "每箱行數",
+        "single": "每箱單行",
+        "multi": "每步多行"
+      },
+      "comingSoon": "即將推出",
+      "exporting": "出口...",
+      "exportError": "匯出失敗，請重試。"
+    },
+    "quickScript": {
+      "title": "QuickScript",
+      "description": "使用範本或人工智慧將選定的測試案例轉換為自動化腳本。",
+      "templatePlaceholder": "選擇一個模板…",
+      "searchPlaceholder": "搜尋模板...",
+      "noTemplatesFound": "未找到模板。",
+      "outputModeLabel": "輸出模式",
+      "outputModeSingle": "單一文件（{count, plural, one {# 案例} other {所有 # 案例}}）",
+      "outputModeIndividual": "{count, plural, one {單一檔案 (.zip)} other {單一檔案 (.zip)}}",
+      "casesToExport": "{count, plural, one {# 情況} other {# 情況}} 匯出",
+      "exportSuccess": "匯出成功。",
+      "noAvailableTemplates": "沒有可用的模板。請聯絡您的管理員。"
+    },
+    "aiExport": {
+      "toggleLabel": "利用人工智慧生成",
+      "generating": "正在生成...",
+      "generatingProgress": "生成 {current} 的 {total} 案例 ...",
+      "generatingBatch": "在一個檔案中產生 {count, plural, one {# 個案例} other {# 個案例}}...",
+      "previewTitle": "導出預覽",
+      "previewDescription": "{count, plural, one {# 檔} other {# 產生的檔案數}}",
+      "copySuccess": "已複製到剪貼簿",
+      "fallbackBadge": "使用模板生成（人工智慧不可用）",
+      "retryButton": "重試人工智慧生成",
+      "aiGenerated": "人工智慧生成",
+      "templateGenerated": "模板已生成",
+      "truncatedWarning": "輸出被截斷——模型已達到令牌限制。請嘗試減小批次大小或在提示配置中增加最大輸出令牌數。",
+      "contextFiles": "{count, plural, one {（上下文文件數）} other {（上下文文件數）}}",
+      "noCodeContextHint": "未配置代碼倉庫。人工智慧將使用標準框架模式。",
+      "generatingParallelProgress": "已產生 {done} 個文件，共 {total} 個檔案...",
+      "cancelledGeneration": "取消"
+    },
+    "duplicates": {
+      "findDuplicates": "尋找重複項",
+      "viewResults": "看 {count, plural, one {# 結果} other {# 結果集}}",
+      "retryScan": "重試掃描",
+      "analyzing": "{analyzed}/{total}",
+      "aiAnalyzing": "利用人工智慧提升成果…",
+      "scanComplete": "Duplicate analysis complete — {count, plural, =0 {no duplicates found} one {# potential duplicate found} other {# potential duplicates found}}",
+      "scanFailed": "重複分析失敗",
+      "scanFailedDescription": "發生意外錯誤",
+      "pageTitle": "重複候選人",
+      "pageDescription": "查看上次掃描中發現的潛在重複測試案例。",
+      "rescan": "重新掃描",
+      "cancelScan": "取消掃描",
+      "loading": "正在載入重複的候選對象...",
+      "noDuplicatesFound": "未找到重複項",
+      "noDuplicatesDescription": "上次掃描完成，未發現匹配項。",
+      "loadMore": "加載更多",
+      "filterPlaceholder": "過濾重複項...",
+      "columnConfidence": "信心",
+      "columnCaseA": "案例 A",
+      "columnCaseB": "案例 B",
+      "columnMatchedFields": "匹配字段",
+      "columnScore": "分數",
+      "compareButton": "比較",
+      "viewCaseDetails": "查看案件詳情",
+      "selectAll": "全選",
+      "selectRow": "選擇行",
+      "selected": "{count, plural, one {# 已選擇} other {# 已選擇}}",
+      "bulkDismiss": "非重複項 ({count})",
+      "bulkLink": "連結為相關（{count}）",
+      "bulkDismissSuccess": "{count, plural, one {# 已解散的配對} other {# 已解散的配對}}",
+      "bulkLinkSuccess": "{count, plural, one {# 配對連結} other {# 配對連結}}",
+      "bulkError": "部分操作失敗，請重試。",
+      "tableHint": "點選行或“比較”按鈕，查看並解決重複項。",
+      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonDescription": "比較這些潛在的重複項，並選擇如何解決它們。",
+      "selectPrimary": "點擊案例即可選為主合併案例。",
+      "selectedAsPrimary": "選為主要",
+      "mergeButton": "保持主要",
+      "linkButton": "連結相關",
+      "dismissButton": "非重複項",
+      "merging": "合併中…",
+      "linking": "正在連接…",
+      "dismissing": "解僱…",
+      "mergeSuccess": "Cases merged successfully. {runsTransferred, plural, =0 {No test runs transferred} one {# test run transferred} other {# test runs transferred}}.",
+      "linkSuccess": "關聯案例。",
+      "dismissSuccess": "該對嫌疑人已被排除。它不會出現在以後的掃描結果中。",
+      "resolveError": "解析重複鍵值對失敗，請重試。",
+      "loadingDetails": "正在加載案件詳情…",
+      "caseDetailsError": "案件詳情加載失敗。",
+      "sourceLabel": "來源",
+      "fieldValuesLabel": "欄位值",
+      "lastRunLabel": "最後一次",
+      "noFieldValues": "無字段值",
+      "noLastRun": "永遠不要跑",
+      "stepExpectedResult": "{step} → {result}",
+      "runStatusDate": "{status} — {date}",
+      "noFolder": "沒有資料夾",
+      "duplicateWarning": "發現可能重複項",
+      "duplicateWarningDescription": "{count, plural, one {# 現有案例} other {# 現有案例}} 可能涵蓋類似功能",
+      "duplicateWarningReview": "審查",
+      "importWarning": "可能重複",
+      "importWarningTooltip": "This case name is similar to {count, plural, one {# existing case} other {# existing cases}}: {names}",
+      "importIntraWarning": "導入過程中出現重複項",
+      "importIntraWarningTooltip": "此匯入中的行 {rows} 具有相同或非常相似的名稱",
+      "checkingDuplicates": "正在檢查重複…"
+    },
+    "generateTestCases": {
+      "buttonText": "產生測試用例",
+      "title": "利用人工智慧產生測試用例",
+      "description": "利用人工智慧技術，根據外部問題或文件自動產生全面的測試案例。",
+      "loadingResults": "正在載入產生的測試用例...",
+      "generatingPreparing": "正在準備請求…",
+      "generatingCallingAi": "等待人工智慧產生測試用例…",
+      "generatingStreaming": "AI正在產生測試用例 {count}...",
+      "generatingStreamingPage": "AI 正在產生測試案例 {count} — 第 {current} 頁，共 {total}頁： {page}",
+      "generatingProcessing": "正在處理產生的測試用例…",
+      "generatingHint": "這可能需要一分鐘，具體取決於來源材料的複雜程度。",
+      "steps": {
+        "selectIssue": "選擇來源",
+        "selectTemplate": "選擇模板",
+        "reviewGenerated": "審核與導入"
+      },
+      "selectSource": {
+        "title": "選擇需求來源",
+        "description": "選擇是從問題文件還是需求文件產生測試案例。",
+        "folderContextTip": "為避免重複，系統將使用「{folderName}」及其父/子資料夾中的現有測試案例作為上下文。請確保在繼續操作前已選擇正確的資料夾。",
+        "currentFolder": "目前資料夾",
+        "fromIssue": "期刊",
+        "fromDocument": "從文件",
+        "documentTitle": "文件標題",
+        "documentTitlePlaceholder": "請輸入您的需求文件標題",
+        "documentDescription": "需求文件",
+        "documentDescriptionPlaceholder": "請將需求文件內容貼到此處…",
+        "documentPriority": "優先權（可選）",
+        "selectPriority": "選擇優先級",
+        "saveDocument": "儲存文件要求",
+        "fromUrl": "來自 URL",
+        "recentGenerations": "最近的從 URL 產生測試案例的作業",
+        "recentJobInfo": "{pages, plural, one {# page} other {# pages}}{hasTestCases, select, true { · {testCases, plural, one {# test case} other {# test cases}}} other {}}",
+        "recentJobHasResults": "準備審核",
+        "recentJobClickToGenerate": "點擊產生測試用例",
+        "recentJobCrawling": "正在爬取... {pages, plural, one {# 頁數} other {# 頁數}} 目前為止",
+        "removeJobTitle": "移除生成",
+        "confirmRemoveJob": "這將刪除快取的爬蟲記錄和所有產生的測試案例。您可以隨時從同一 URL 重新產生。",
+        "loadingRecentJobs": "正在加載最近的職位...",
+        "urlInput": "頁面網址",
+        "urlInputPlaceholder": "https://example.com/docs",
+        "urlMode": "這個網址包含什麼內容？",
+        "urlModeRequirements": "要求",
+        "urlModeRequirementsHint": "頁面描述了要建立的內容",
+        "urlModeApplication": "應用",
+        "urlModeApplicationHint": "Page 是要測試的應用程式",
+        "urlValidationError": "請輸入以 http:// 或 https:// 開頭的有效網址。",
+        "followLinks": "點擊連結",
+        "followLinksHint": "只會抓取與您輸入的網址位於同一網域下的頁面。",
+        "maxDepth": "最大深度",
+        "maxPages": "最大頁數",
+        "crawlProgress": "{current, plural, one {目前已取得第 # 頁...} other {目前已取得第 # 頁...}}",
+        "generatingSinglePage": "正在產生測試用例…",
+        "generatingSetup": "準備產生測試用例…",
+        "robotsSkipped": "{count, plural, one {# 跳過的頁碼} other {# 跳過的頁碼}} (robots.txt)"
+      },
+      "selectIssue": {
+        "title": "選擇外部問題",
+        "description": "從外部系統（例如 Jira）中選擇一個問題來產生測試案例。",
+        "searchButton": "尋找問題"
+      },
+      "selectTemplate": {
+        "title": "選擇測試用例模板",
+        "description": "選擇用於產生測試案例的範本。人工智慧將根據此模板填充欄位。",
+        "placeholder": "選擇一個模板…",
+        "fieldsDescription": "選擇人工智慧應自動填入的欄位。必填欄位始終包含在內。",
+        "requiredOnly": "僅需"
+      },
+      "addNotes": {
+        "title": "添加備註和指導",
+        "description": "提供更多背景資訊和指導，以幫助人工智慧產生更好的測試案例。",
+        "quantity": "要產生的測試用例數量",
+        "placeholder": "Add specific instructions for test case generation...\n\nFor example:\n• Focus on security testing\n• Include edge cases and boundary conditions\n• Test both happy path and error scenarios\n• Consider mobile and desktop scenarios\n• Focus on API testing",
+        "suggestions": "快速建議：",
+        "quantityOptions": {
+          "justOne": "只有一個",
+          "couple": "一對夫婦（2）",
+          "few": "幾（2-3）",
+          "several": "若干（4-6）",
+          "many": "許多（7-10）",
+          "maximum": "最大限度"
+        },
+        "suggestionItems": {
+          "security": "重點進行安全測試",
+          "edgeCases": "包括極端情況",
+          "happyPath": "僅測試正常路徑",
+          "mobile": "考慮移動場景",
+          "api": "專注於 API 測試",
+          "accessibility": "包含無障礙測試"
+        }
+      },
+      "review": {
+        "title": "審查產生的測試用例",
+        "description": "查看 AI 產生的測試案例，進行必要的修改，並選擇要匯入的用例。",
+        "selected": "{count} 中的 {total} 已選擇",
+        "moreSteps": "……以及 {count, plural, one {# 更多步驟} other {# 更多步驟}}",
+        "templateFields": "模板欄位：",
+        "moreFields": "……以及 {count, plural, one {# 更多欄位} other {# 更多欄位}}",
+        "crawledUrls": "{count, plural, one {# 已抓取頁數} other {# 已抓取頁數}}",
+        "spaWarning": "此頁面可能需要 JavaScript 渲染。結果可能不完整。",
+        "filterByPage": "按頁面篩選",
+        "allPages": "All pages ({pages, plural, one {# page} other {# pages}}, {cases, plural, one {# case} other {# cases}})"
+      },
+      "generatingLegacy": "利用人工智慧產生測試用例…",
+      "expandProgress": "{done} 中的 {total} 生成",
+      "import": "{count, plural, =0 {Import Test Cases} =1 {Import 1 Test Case} other {Import # Test Cases}}",
+      "importing": "{count, plural, =0 {Importing Test Cases...} =1 {Importing 1 Test Case...} other {Importing # Test Cases...}}",
+      "openInExternalSystem": "開啟方式 {provider}",
+      "externalSystem": "外部系統",
+      "autoGenerateTags": "自動為測試用例產生標籤",
+      "success": {
+        "imported": "{count, plural, =1 {成功匯入 1 個測試案例} other {成功匯入 # 個測試案例}}"
+      },
+      "importData": {
+        "issueDescription": "與測試用例產生相關的外部問題",
+        "generatedFolderName": "產生"
+      },
+      "errors": {
+        "generateFailed": "測試用例產生失敗，請重試。",
+        "importFailed": "導入測試用例失敗，請重試。",
+        "noTestCasesGenerated": "未產生任何測試用例。請使用不同的輸入重試。",
+        "jobNoLongerAvailable": "此版本已不再可用。請從「產生測試案例」精靈開始新的版本。",
+        "noAiModel": "此項目未配置任何 AI 模型。請在專案設定中配置 AI 模型。",
+        "noIssueSelected": "請選擇一個問題以產生測試案例。",
+        "noDocumentProvided": "請提供需求文件的詳細資訊。",
+        "noTemplateSelected": "請為測試案例選擇一個模板。",
+        "noFieldsSelected": "請至少選擇一個欄位以產生內容。",
+        "noTestCasesSelectedForImport": "請至少選擇一個測試用例導入。",
+        "templateRequired": "必須選擇模板。請返回並選擇模板。",
+        "repositoryNotFound": "項目倉庫未找到。請聯絡管理員。",
+        "workflowNotConfigured": "專案工作流程未配置。請檢查項目設定。",
+        "authenticationError": "身份驗證錯誤。請刷新頁面後重試。",
+        "caseCreationFailed": "建立測試案例失敗： {name}",
+        "caseAlreadyExists": "此資料夾中已存在測試案例「{name}」。",
+        "invalidTemplateConfig": "測試案例「{name}」的範本配置無效。",
+        "nameTooLong": "測試案例名稱「{name}」過長，請使用較短的名稱。",
+        "caseCreationError": "創造「{name}」失敗： {error}",
+        "templateNotFound": "找不到所選模板。請刷新頁面重試。",
+        "repositoryConfigError": "專案倉庫配置錯誤。請聯絡您的管理員。",
+        "workflowConfigError": "專案工作流程配置錯誤。請檢查項目設定。",
+        "permissionDenied": "您沒有權限在此專案中建立測試案例。",
+        "validationFailed": "數據驗證失敗。請檢查測試用例內容並重試。",
+        "databaseError": "資料庫連線錯誤，請稍後再試。",
+        "genericImportError": "導入失敗： {error}",
+        "networkRoutingError": "網路路由或伺服器設定問題 - 收到的是 HTML 錯誤頁面而不是 API 回應",
+        "invalidSourceConfig": "無效的來源配置",
+        "failedToCreateCaseVersion": "建立案例版本失敗",
+        "noUrlProvided": "請輸入要從中產生測試案例的 URL",
+        "urlFetchFailed": "無法從提供的URL取得內容。請檢查URL並重試。",
+        "llm": {
+          "genericTitle": "AI產生誤差",
+          "genericMessage": "使用 AI 產生測試用例時發生錯誤。請重試或調整您的輸入。",
+          "overloaded": {
+            "title": "服務暫時無法使用",
+            "message": "人工智慧服務目前訪問量較大，請稍後再試。"
+          },
+          "quota": {
+            "title": "使用次數已達上限",
+            "message": "您已達到本時段的AI使用限額。請稍後再試或聯絡您的管理員。"
+          },
+          "timeout": {
+            "title": "請求超時",
+            "message": "AI請求耗時過長。這可能是由於需求複雜或測試案例數量龐大所造成的。"
+          },
+          "network": {
+            "title": "網路錯誤",
+            "message": "無法連接到人工智慧服務。請檢查您的網路連線並重試。"
+          },
+          "unauthorized": {
+            "title": "AI服務認證失敗",
+            "message": "AI 服務拒絕了我們的憑證。管理員需要在管理設定中查看 LLM 整合的 API 金鑰。"
+          },
+          "forbidden": {
+            "title": "AI 服務存取被拒絕",
+            "message": "AI 服務拒絕了此請求。管理員需要驗證 LLM 整合的權限和專案存取權限。"
+          },
+          "projectNotFound": {
+            "title": "項目未找到",
+            "message": "我們找不到這個項目，或者您沒有在此處使用人工智慧生成技術的許可。"
+          },
+          "noIntegration": {
+            "title": "無活躍LLM集成",
+            "message": "此項目未配置任何有效的 LLM 整合。管理員需要在管理設定中啟用它。"
+          },
+          "invalidRequest": {
+            "title": "無效請求",
+            "message": "AI產生請求缺少必要資訊。請刷新頁面後重試。"
+          },
+          "retryButton": "重試",
+          "dismissButton": "解僱",
+          "suggestionsHeading": "建議",
+          "suggestions": {
+            "retryLater": "幾分鐘後再試。",
+            "contactAdmin": "如果問題仍然存在，請聯絡您的管理員。",
+            "checkStatus": "檢查人工智慧服務狀態",
+            "checkNetwork": "請檢查您的網路連接"
+          },
+          "timestampLabel": "發生錯誤",
+          "showDetails": "顯示詳情",
+          "hideDetails": "隱藏詳情",
+          "copyDetails": "複製詳情",
+          "detailsCopied": "錯誤詳情已複製到剪貼簿"
+        }
+      },
+      "unsavedEdits": {
+        "title": "未儲存的編輯",
+        "description": "{count, plural, =1 {您有 1 個測試案例存在未儲存的編輯。} other {您有 # 個測試案例存在未儲存的編輯。}}",
+        "warning": "如果您在不儲存的情況下繼續操作，您的變更將會遺失。",
+        "saveAllAndImport": "全部儲存並導入",
+        "discardAndImport": "放棄編輯並導入"
+      },
+      "linkedIssuesDroppedTitle": "部分相關問題未包含在內。",
+      "linkedIssuesDropped": "{count, plural, =1 {# linked issue was dropped} other {# linked issues were dropped}} due to token budget: {keys}.",
+      "linkedIssuesPreviewHeading": "將會包含的相關問題"
+    }
+  },
+  "tags": {
+    "add": {
+      "button": "添加標籤",
+      "title": "新增標籤",
+      "fields": {
+        "name_error": "標籤名稱為必填項"
+      },
+      "errors": {
+        "nameExists": "已存在同名標籤"
+      }
+    },
+    "edit": {
+      "errors": {
+        "nameExists": "已存在同名標籤"
+      }
+    },
+    "filterPlaceholder": "篩選標籤...",
+    "defaultName": "未命名標籤",
+    "noProject": "無專案",
+    "description": "使用標籤管理和組織您的測試案例和會話",
+    "detail": {
+      "title": "標籤詳情",
+      "filterPlaceholder": "篩選項目...",
+      "noResults": "未找到任何物品",
+      "noFilterResults": "沒有符合目前篩選條件的商品。",
+      "filters": {
+        "hideCompletedSessions": "隱藏已完成的會話",
+        "hideCompletedTestRuns": "隱藏已完成的測試運行",
+        "caseTypeLabel": "案件類型",
+        "allCases": "全部"
+      }
+    },
+    "manageTags": {
+      "searchPlaceholder": "搜尋標籤...",
+      "searchOrAddPlaceholder": "搜尋或新增標籤…",
+      "noOptions": "沒有選項"
+    }
+  },
+  "attachments": {
+    "viewer": {
+      "title": "附件檢視器"
+    },
+    "delete": {
+      "confirmMessage": "您確定要刪除此附件嗎？",
+      "deferredMessage": "儲存時，此附件將被刪除。"
+    }
+  },
+  "runs": {
+    "notFound": "未找到測試運行。",
+    "add": {
+      "title": "新增測試運行",
+      "description": "在專案中新增一個新的測試運行",
+      "success": {
+        "title": "測試運行已成功添加",
+        "description": "測試運行已新增至專案。",
+        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for '{name}'"
+      },
+      "estimates": {
+        "manual": "預計人工時間",
+        "automated": "預計自動完成時間",
+        "mixed": "預計手動/自動時間"
+      },
+      "creatingProgress": "建立測試運行 {current} ，測試運行為 {total}..."
+    },
+    "magicSelect": {
+      "title": "魔法選擇",
+      "description": "基於測試運行上下文的 AI 驅動的測試案例選擇",
+      "counting": "正在尋找相關的測試案例…",
+      "reasoning": "人工智慧推理",
+      "reviewSelection": "審查建議的測試案例",
+      "viewSuggested": "查看推薦案例",
+      "tokenUsage": "使用的 {total} 令牌",
+      "noLlmIntegration": "AI 功能需要與 LLM 整合。請在項目設定中進行配置。",
+      "configure": {
+        "title": "測試用例範圍",
+        "description": "在倉庫中找到 {count, plural, =1 {# 測試案例} other {# 測試案例}}",
+        "descriptionFiltered": "Found {count, plural, =1 {# possibly relevant test case} other {# possibly relevant test cases}} from {total, plural, =1 {# total} other {# total}} in the repository",
+        "noMatchesTitle": "未找到符合的測試案例",
+        "noMatchesDescription": "測試運行名稱和描述與任何測試案例都不符。請返回上一步，添加更具體的詳細信息，例如功能名稱、組件名稱或測試案例中出現的關鍵字。",
+        "maxResultsTitle": "最大測試案例匹配數",
+        "maxResultsDescription": "搜尋條件匹配了大量測試案例。為了獲得更精準的結果，請回到上一步，為測試運行添加更具體的詳細資訊。",
+        "batchSize": "批量大小",
+        "batchSizeAll": "所有案例（單一請求）",
+        "batchSizePercent": "{percent}% ({count} 個案)",
+        "requestsNeeded": "{count, plural, =1 {# 會發出 AI 請求} other {# 將發出 AI 請求}}",
+        "batchNote": "所有批次的結果將合併。"
+      },
+      "loading": {
+        "batch": "正在處理批次 {current} ，共 {total}",
+        "analyzing": "分析測試用例…",
+        "progress": "分析了 {analyzed} 個測試案例中的 {total} 個測試案例…",
+        "waitingForAi": "正在等待 AI 回應（批次 {batch} ，共 {total} 批次）...",
+        "selectedSoFar": "{count, plural, =1 {# 目前已選取的測試案例數} other {# 目前已選取的測試案例數}}",
+        "resolving_integration": "解決人工智慧整合問題…",
+        "fetching_cases": "正在獲取測試案例..."
+      },
+      "success": {
+        "title": "建議的測試用例",
+        "description": "{count, plural, =1 {# 已選擇測試案例} other {# 已選擇測試案例}} 根據您的測試運行上下文",
+        "linkedCasesAdded": "{count, plural, =1 {# 關聯案例自動包含} other {# 關聯案例自動包含}}",
+        "truncationWarningTitle": "部分結果",
+        "truncationWarning": "{count, plural, =1 {# 批次被截斷} other {# 批次被截斷}} 由 AI 模型截斷 — 某些測試案例可能未被評估。"
+      },
+      "noSuggestions": {
+        "title": "沒有匹配的測試用例",
+        "description": "沒有測試用例符合要求。請嘗試新增更多上下文或說明。"
+      },
+      "clarification": {
+        "label": "補充資訊（可選）",
+        "placeholder": "添加更多上下文信息，以幫助選擇相關的測試案例…",
+        "refine": "優化選擇"
+      },
+      "actions": {
+        "start": "分析測試用例",
+        "startBatched": "分析測試案例（{count, plural, one {# 批次} other {# 批次數}}）",
+        "accept": "新增到選擇"
+      },
+      "errors": {
+        "title": "選擇失敗",
+        "generic": "選擇測試用例時出錯，請重試。",
+        "noTestRunName": "請在使用 Magic Select 之前輸入測試運行名稱。"
+      }
+    },
+    "delete": {
+      "title": "刪除測試運行",
+      "description": "您確定要刪除此次測試運行嗎？結果將保留以供歷史分析。",
+      "warning": "此操作無法撤銷。",
+      "toast": {
+        "loading": "刪除測試運行...",
+        "success": "測試運行已成功刪除",
+        "error": {
+          "title": "刪除測試運行失敗",
+          "description": "刪除測試運行時發生錯誤"
+        }
+      }
+    },
+    "summary": {
+      "title": "測試運行總結",
+      "description": "查看測試運行摘要",
+      "activeRunsAndEstTime": "活躍運行次數及預計時間",
+      "activeRunsLabel": "跑",
+      "totalEstTime": "預計總時間",
+      "responsibleUsers": "負責任的用戶",
+      "allActiveRuns": "所有正在進行的運行",
+      "recentResultsTitle": "近期手動結果",
+      "recentResultsDescription": "查看測試運行的最新結果",
+      "recentAutomatedResultsTitle": "近期自動結果",
+      "noRecentAutomatedResults": "未找到最近的自動搜尋結果。",
+      "recentResultsDateRange": "日期範圍",
+      "recentResultsElapsed": "過去",
+      "noRecentResults": "未找到最新結果。",
+      "completionTrendTitle": "完成趨勢（過去 6 個月）",
+      "workDistributionTitle": "工作分配",
+      "workDistributionDescription": "受讓人的預計工作分配。",
+      "noWorkDistributionData": "沒有正在進行的、有指派物件或預估時間的會話可供顯示。"
+    },
+    "details": {
+      "title": "測試運行詳情",
+      "description": "查看測試運行詳情"
+    },
+    "duplicateDialog": {
+      "title": "重複測試運行",
+      "description": "建立測試運行的副本 <nameStyle>{name}</nameStyle>。",
+      "fields": {
+        "duplicateScope": {
+          "label": "待復現的測試案例",
+          "allCases": "所有測試用例",
+          "specificStatuses": "具有特定狀態的測試案例"
+        },
+        "statusesToInclude": {
+          "label": "測試用例包括",
+          "description": "選擇要包含在重複測試運行中的測試案例的狀態。",
+          "noStatuses": "本次測試運行未發現任何特定狀態，或結果仍在載入中。",
+          "noStatusesRecorded": "本次運行未記錄任何具體狀態。複製操作將包含所有測試案例（通常標記為“未測試”）。"
+        },
+        "copyAssignments": {
+          "label": "測試用例分配",
+          "copy": "複製現有測試用例分配",
+          "assign": "重複測試運行中的所有測試案例將保留其現有分配。",
+          "unassign": "重複測試運行中的所有測試案例都將被取消分配。"
+        }
+      },
+      "successMessage": "測試運行“{name}”已成功複製。",
+      "errorMessage": "測試運行失敗。錯誤： {error}"
+    },
+    "filter": {
+      "placeholder": "過濾器測試運行..."
+    },
+    "typeFilter": {
+      "label": "展示",
+      "both": "手動和自動"
+    },
+    "empty": {
+      "noMatchingCompleted": "沒有符合您篩選條件的已完成測試運行。"
+    }
+  },
+  "admin": {
+    "menu": {
+      "header": "主要的",
+      "projects": "專案",
+      "templatesAndFields": "模板和字段",
+      "fields": "田野",
+      "workflows": "工作流程",
+      "statuses": "狀態",
+      "milestoneTypes": "里程碑類型",
+      "configurations": "配置",
+      "users": "使用者",
+      "groups": "團體",
+      "roles": "角色",
+      "tags": "標籤",
+      "issues": "問題",
+      "appConfig": "應用程式配置",
+      "notifications": "通知",
+      "imports": "數據導入",
+      "integrations": "問題整合",
+      "webhooks": "網路鉤子",
+      "llm": "人工智慧模型",
+      "prompts": "提示配置",
+      "exportTemplates": "匯出模板",
+      "codeRepositories": "程式碼庫",
+      "quickScript": "QuickScript",
+      "sso": "驗證",
+      "security": "安全",
+      "trash": "垃圾",
+      "reports": "報告",
+      "shares": "管理股份",
+      "elasticsearch": "搜尋引擎",
+      "queues": "作業佇列",
+      "auditLogs": "審計日誌",
+      "apiTokens": "API令牌",
+      "quickscriptTemplates": "QuickScript模板",
+      "testManagement": "測試管理",
+      "peopleAndAccess": "人員與通道",
+      "toolsAndIntegrations": "工具與集成",
+      "system": "系統"
+    },
+    "imports": {
+      "description": "將外部測試管理工具中的資料匯入TestPlanIt。",
+      "tabs": {
+        "testmoJson": "Testmo JSON"
+      },
+      "testmo": {
+        "intro": "上傳 Testmo JSON 匯出檔案以分析其內容並準備遷移映射。",
+        "wizard": {
+          "steps": {
+            "upload": "上傳導出",
+            "analysis": "綜述分析",
+            "mapping": "配置映射",
+            "import": "監控導入"
+          },
+          "stepIndicator": "步驟 {step} 的 {total}"
+        },
+        "fileLabel": "Testmo JSON 文件",
+        "fileHelp": "選擇您從 Testmo 下載的 JSON 匯出檔案。",
+        "analyze": "分析導出",
+        "analyzing": "分析中…",
+        "reset": "結果清晰",
+        "job": {
+          "discoveringDatasets": "發現數據集…",
+          "scanningFile": "正在掃描 testmo 匯出檔案...",
+          "datasetsProcessed": "{processed, number} 資料集{processed, plural, one {} other {s}} 已處理",
+          "datasetsProcessedWithTotal": "{processed, number} of {total, number} dataset{total, plural, one {} other {s}} processed",
+          "rowsProcessed": "{value, number} 行已處理",
+          "itemsProcessed": "已處理 {processed, number} 項中的 {total, number} 項",
+          "analysisInProgress": "分析導出…",
+          "cancel": "取消導入",
+          "cancelRequested": "取消請求",
+          "processingRate": "速度：",
+          "estimatedTimeRemaining": "預計剩餘時間：",
+          "datasetsLabel": "數據集：",
+          "rowsProcessedLabel": "行："
+        },
+        "summaryHeading": "導出摘要",
+        "summary": {
+          "datasets": "數據集",
+          "fileName": "檔案名稱",
+          "fileSize": "文件大小",
+          "analysisTime": "分析時間"
+        },
+        "datasetTable": {
+          "name": "數據集",
+          "rows": "列",
+          "samples": "採集的樣本"
+        },
+        "status": {
+          "truncated": "截斷"
+        },
+        "selectDataset": "選擇資料集",
+        "schema": "模式",
+        "samples": "範例行",
+        "noSamples": "該資料集未採集到任何樣本。",
+        "mappingHeading": "映射配置",
+        "mappingRefresh": "重新整理分析",
+        "mappingDescription": "查看分析詳情並將 Testmo 實體對應到現有的 TestPlanIt 記錄，或選擇建立新記錄。",
+        "mappingAnalysisError": "我們無法產生映射分析。請重試。",
+        "mappingLoading": "建築測繪分析…",
+        "mappingSummaryHeading": "偵測到的實體",
+        "mappingSummaryPending": "{count, plural, =1 {# 待處理} other {# 待處理}}",
+        "mappingOutstandingTitle": "解決未解決的映射問題",
+        "mappingOutstandingDescription": "在開始導入之前，請完成剩餘的映射。",
+        "mappingOutstandingItem": "{count, plural, =1 {# 未解決方案} other {# 未解決方案}} 在 {label}",
+        "mappingSummaryTemplateFields": "模板字段",
+        "mappingDatasetLabels": {
+          "field_values": "欄位值",
+          "repository_case_values": "儲存庫案例值",
+          "configs": "配置設定",
+          "session_issues": "會議問題",
+          "session_tags": "會話標籤",
+          "states": "工作流程狀態",
+          "statuses": "狀態",
+          "templates": "範本",
+          "template_fields": "模板字段",
+          "milestone_types": "里程碑類型",
+          "roles": "角色",
+          "users": "使用者",
+          "groups": "團體",
+          "user_groups": "使用者群組",
+          "issue_targets": "問題集成",
+          "tags": "標籤",
+          "sessions": "會議",
+          "session_results": "會議結果",
+          "fields": "田野",
+          "projects": "專案",
+          "repositories": "儲存庫",
+          "repository_folders": "儲存庫資料夾",
+          "repository_cases": "儲存庫案例",
+          "repository_case_steps": "儲存庫案例步驟",
+          "repository_case_tags": "儲存庫案例標籤",
+          "milestones": "里程碑",
+          "runs": "測試運行",
+          "run_tests": "測試運行用例",
+          "run_results": "測試運行結果",
+          "run_result_steps": "測試運行步驟結果",
+          "run_links": "測試運行連結",
+          "run_tags": "測試運行標籤",
+          "issues": "問題",
+          "milestone_issues": "里程碑問題",
+          "repository_case_issues": "儲存庫案例問題",
+          "run_issues": "測試運行問題",
+          "run_result_issues": "測試運行結果問題",
+          "session_result_issues": "會話結果問題",
+          "automation_cases": "自動化案例",
+          "automation_runs": "自動化運行",
+          "automation_run_tests": "自動化運行測試",
+          "automation_run_test_fields": "自動化運行測試字段",
+          "automation_run_links": "自動化運行連結",
+          "automation_run_tags": "自動化運作標籤",
+          "session_values": "會話值"
+        },
+        "mappingDatasetDescriptions": {
+          "states": "查看工作流程狀態，以對應或建立 TestPlanIt 工作流程。",
+          "statuses": "配置 Testmo 狀態如何對應到 TestPlanIt 狀態。",
+          "templates": "審核從 Testmo 匯入的模板定義。",
+          "template_fields": "檢查匯出文件中包含的範本欄位定義。",
+          "fields": "查看從 Testmo 匯出的自訂欄位記錄。",
+          "field_values": "檢查匯出檔案中捕獲的欄位值定義。",
+          "milestone_types": "檢查匯出檔案中擷取的里程碑類型定義。",
+          "roles": "查看角色定義以了解Testmo權限。",
+          "users": "查看Testmo匯出檔案中偵測到的使用者帳戶。",
+          "groups": "複習從 Testmo 繼承下來的小組作業。",
+          "configs": "將組態名稱對應到 TestPlanIt 類別和變體。",
+          "tags": "檢查Testmo資料中出現的標籤值。",
+          "repository_case_values": "分配給測試案例的多選值。",
+          "sessions": "會話始終作為新會話建立。",
+          "session_results": "會話結果與會話相關聯。",
+          "session_issues": "會話問題與會話相關。",
+          "session_tags": "會話標籤與會話相關聯。",
+          "issue_targets": "將 Testmo 問題目標對應到 TestPlanIt 整合（Jira、GitHub 等）。"
+        },
+        "mappingDatasetDefaultDescription": "在 Testmo 匯出中偵測到評論 {dataset}。",
+        "mappingDatasetCount": "{count, number} 記錄{count, plural, one {} other {s}} 檢測到",
+        "mappingDatasetNoEntitiesTitle": "地圖上沒有任何東西。",
+        "mappingDatasetNoEntitiesDescription": "此資料集無需映射。準備好後，請繼續處理下一個資料集。",
+        "mappingDatasetUnsupportedTitle": "無需映射",
+        "mappingDatasetUnsupportedDescription": "這些記錄將自動匯入並連接到TestPlanIt中的相關記錄。無需手動映射。",
+        "mappingDatasetEmptyTitle": "未保存任何資料集",
+        "mappingDatasetEmptyDescription": "分析過程中未保留任何用於配置的資料集。如果您需要其他數據，請上傳其他匯出檔案。",
+        "importProgressTitle": "導入進度",
+        "importProgressDescription": "{count, plural, =0 {所有已匯入的記錄（涵蓋所有追蹤實體）。} =1 {已匯入的記錄（涵蓋所有追蹤實體）共 1 個。} other {已匯入的記錄（涵蓋所有追蹤實體）共 7 個。}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {No remaining records} =1 {1 record remaining} other {# records remaining}}",
+        "importProgressProcessed": "{processed, number}/{total, number} 記錄已匯入",
+        "importProgressAria": "{percent}匯入完成百分比",
+        "importProgressPercentLabel": "{percent}%",
+        "importDurationLabel": "總耗時：",
+        "activityLogTitle": "進口活動",
+        "activityLogDescription": "後台匯入步驟的詳細日誌。時間戳基於伺服器時區。",
+        "activitySummaryProcessed": "{count, plural, =1 {# 已處理記錄數} other {# 已處理記錄數}}",
+        "activitySummaryCreated": "{count, plural, =1 {# 建立} other {# 建立}}",
+        "activitySummaryMapped": "{count, plural, =1 {# 已映射} other {# 已映射}}",
+        "activitySummaryUnknown": "導入步驟",
+        "activityDefaultMessage": "導入更新",
+        "previousImportsHeading": "查看先前的進口記錄",
+        "previousImportsDescription": "從已完成的匯入中載入分析結果，以檢查配置或活動日誌。",
+        "previousImportsRefresh": "重新整理清單",
+        "previousImportsPlaceholder": "選擇之前的導入",
+        "previousImportsEmpty": "未找到您帳戶之前的任何匯入記錄。",
+        "previousImportsCreatedLabel": "創建時間： ",
+        "previousImportsFileLabel": "文件： ",
+        "previousImportsNoFilename": "未知文件",
+        "jobHistoryLoadFailed": "我們無法載入之前導入的作業。",
+        "jobLoadFailed": "我們無法載入該導入作業。",
+        "uploadProgressAnalyzing": "上傳完成。正在分析文件…",
+        "uploadProgressComplete": "上傳完成",
+        "etaLabel": "預計抵達時間： {time}",
+        "startImportButton": "開始導入",
+        "workflowCreate": {
+          "nameLabel": "工作流程名稱",
+          "namePlaceholder": "輸入工作流程名稱",
+          "scopePlaceholder": "選擇範圍",
+          "iconColorLabel": "圖示和顏色",
+          "typeLabel": "工作流程類型"
+        },
+        "mappingDatasets": "需要審核的資料集",
+        "mappingImportConfiguration": "導入配置",
+        "mappingExportConfiguration": "匯出配置",
+        "mappingImportConfigurationFailed": "我們無法導入該設定檔。請確認其為有效的 JSON 格式，然後再試一次。",
+        "mappingInvalidConfiguration": "配置必須為有效的JSON格式。",
+        "mappingSaveFailed": "配置儲存失敗，請重試。",
+        "mappingSaveConfiguration": "儲存配置",
+        "mappingSavingConfiguration": "正在儲存…",
+        "mappingStartImport": "開始後台導入",
+        "mappingStartingImport": "開始導入…",
+        "mappingImportFailed": "後台導入失敗，請稍後再試。",
+        "mappingImportDisabled": "啟動後台導入前請儲存配置。",
+        "mappingImportInProgress": "後台導入進行中",
+        "mappingImportInProgressDescription": "導入進程正在處理配置。您可以在上方監控狀態。",
+        "mapping": {
+          "datasetTotalLabel": "{count, plural, =1 {# 記錄} other {# 記錄}} ",
+          "columnSource": "Testmo實體",
+          "columnSourceDetails": "細節",
+          "columnSuggestedWorkflowType": "建議類型",
+          "columnTarget": "目標",
+          "workflowTypeUnknown": "未檢測到",
+          "actionMap": "映射到現有",
+          "actionCreate": "創建新的",
+          "workflowTypePlaceholder": "選擇類型",
+          "noWorkflowsAvailable": "暫無可用工作流程。",
+          "noStatusesAvailable": "暫無狀態資訊。",
+          "noGroupsAvailable": "暫無可用群組。",
+          "groupSelectPlaceholder": "選擇組",
+          "groupNotePlaceholder": "備註（可選）",
+          "groupNoteEmpty": "未提供更多細節。",
+          "noUsersAvailable": "沒有可用用戶。",
+          "userNoExistingTargets": "沒有可用於映射的使用者。",
+          "userNamePlaceholder": "姓名",
+          "userAccessPlaceholder": "選擇訪問級別",
+          "userRoleUnavailable": "暫無可分配的角色。",
+          "userPasswordPlaceholder": "臨時密碼",
+          "userPasswordHint": "提供一個臨時密碼。使用者登入後可以更改密碼。",
+          "userActiveLabel": "活躍帳戶",
+          "userDisplayFallback": "用戶 {id}",
+          "userMissingRequired": "缺少必要資訊",
+          "noConfigurationsAvailable": "暫無可用配置。",
+          "configurationNoTokens": "在此配置中未檢測到任何變異體。",
+          "configurationNoExistingTargets": "沒有可映射的配置。",
+          "configurationNamePlaceholder": "輸入配置名稱",
+          "configurationVariantLabel": "變異 {index}",
+          "configurationVariantActionLabel": "應該如何處理這種變體？",
+          "configurationVariantActionPlaceholder": "選擇一個選項",
+          "configurationVariantMapOption": "映射到現有變體",
+          "configurationVariantExistingCategoryOption": "在現有類別中建立變體",
+          "configurationVariantNewCategoryOption": "建立新類別和變體",
+          "configurationVariantSelectLabel": "選擇變體",
+          "configurationVariantNoVariants": "沒有可供映射的變體。",
+          "configurationVariantCategoryLabel": "類別",
+          "configurationVariantNameLabel": "變體名稱",
+          "configurationVariantNamePlaceholder": "輸入變體名稱",
+          "configurationVariantNoCategories": "暫無分類。",
+          "configurationVariantCategoryNameLabel": "類別名稱",
+          "configurationVariantCategoryNamePlaceholder": "輸入類別名稱",
+          "noTemplateFieldsAvailable": "沒有可用的模板欄位。",
+          "templateFieldDisplayFallback": "字段 {id}",
+          "templateFieldUnknownTemplate": "未知模板",
+          "templateFieldTargetCase": "案例字段",
+          "templateFieldTargetResult": "結果字段",
+          "templateFieldSelectPlaceholder": "選擇字段",
+          "templateFieldNoExistingTargets": "沒有可對應的字段。",
+          "templateFieldTypePlaceholder": "選擇字段類型",
+          "templateFieldRestrictedLabel": "受限字段",
+          "templateFieldOptionsLabel": "下拉選項",
+          "templateFieldOptionsPlaceholder": "每行輸入一個選項",
+          "templateFieldOptionsHint": "每個選項之間以新行隔開。",
+          "templateFieldOptionsListLabel": "選項",
+          "templateFieldOptionsCheckedLabel": "預設選取",
+          "templateFieldOptionsMinValueLabel": "最小值",
+          "templateFieldOptionsMaxValueLabel": "最大值",
+          "templateFieldOptionsMinIntegerLabel": "最小整數",
+          "templateFieldOptionsMaxIntegerLabel": "最大整數",
+          "templateFieldNewFieldSummaryTitle": "新欄位詳情",
+          "templateFieldNewFieldSummaryDescription": "查看將用於建立此 TestPlanIt 欄位的值。",
+          "templateFieldConfigureFieldButton": "配置詳細信息",
+          "templateFieldEditFieldButton": "編輯詳情",
+          "templateFieldSummaryMissingValue": "未設定",
+          "templateFieldSummaryMissingDetailsHint": "請先提供新欄位的詳細資訊再繼續。",
+          "templateFieldModalSaveButton": "儲存詳細信息",
+          "templateFieldTargetTypeLabel": "目標類型",
+          "templateFieldTypeMismatchWarning": "所選欄位類型 {target} 與 Testmo 欄位類型 {source} 不符。",
+          "templateFieldDuplicateTargetWarning": "所選目標已對應到另一個 Testmo 欄位。請選擇其他目標。",
+          "templateFieldTargetAlreadyUsed": "已對應",
+          "templateFieldMappedSummary": "映射到 {name} ({type})",
+          "templateFieldIssueMissingTarget": "選擇目標欄位。",
+          "templateFieldIssueMissingDetails": "請先提供顯示名稱、系統名稱和欄位類型，然後再繼續。",
+          "noTemplatesAvailable": "暫無模板可用。",
+          "templateColumnFields": "田野",
+          "templateFieldStatusMapped": "已對應",
+          "templateFieldStatusCreate": "建立新字段",
+          "templateFieldStatusMissing": "未映射",
+          "templateFieldStatusMismatch": "目標錯配",
+          "templateCaseFieldCountBadge": "{count, plural, =1 {# 案例欄位} other {# 案例欄位}}",
+          "templateResultFieldCountBadge": "{count, plural, =1 {# 結果欄位} other {# 結果欄位}}",
+          "templateMapLabel": "映射到現有模板",
+          "templateCreateLabel": "建立新模板",
+          "templateNoMatchingTargets": "沒有匹配的模板。",
+          "templateNewNameLabel": "模板名稱",
+          "templateMapHintIncomplete": "在對應到現有範本之前，先將所有 Testmo 欄位對應到現有案例和結果欄位。",
+          "templateMapHintDuplicate": "每個 Testmo 欄位都必須對應到一個唯一的 TestPlanIt 欄位。",
+          "templateMapHintNoMatch": "沒有現有範本使用相同的欄位集。",
+          "templateMapHintAlreadyMapped": "所有符合的模板都已映射。請先清除其他映射，然後再繼續。",
+          "templateIssueNoSelection": "選擇現有範本進行映射。",
+          "templateIssueTargetConflict": "另一個模板已經映射到此目標。",
+          "templateIssueFieldErrors": "解析高亮顯示的模板欄位。",
+          "templateTargetFieldsMismatch": "欄位與此模板不符。",
+          "templateTargetNoLongerMatching": "欄位不再符合此模板。",
+          "noRolesAvailable": "暫無空缺職位。",
+          "roleSelectPlaceholder": "選擇角色",
+          "roleNameLabel": "角色名稱",
+          "roleNamePlaceholder": "請輸入角色名稱",
+          "rolePermissionsEmpty": "未分配任何權限",
+          "rolePermissionAddEdit": "新增/編輯",
+          "noMilestoneTypesAvailable": "暫無里程碑類型。",
+          "milestoneSelectPlaceholder": "選擇里程碑類型",
+          "milestoneNamePlaceholder": "輸入里程碑類型名稱",
+          "milestoneDefaultLabel": "預設里程碑類型",
+          "milestoneIconRequired": "選擇一個圖標",
+          "statusColorPlaceholder": "顏色十六進位代碼（可選）",
+          "issueTargetSelectPlaceholder": "選擇集成方式...",
+          "noIssueTargetsAvailable": "目前沒有可用的整合方案。",
+          "issueTargetNamePlaceholder": "整合名稱...",
+          "templateFieldsHeading": "模板字段",
+          "roleAreaColumn": "區域",
+          "workflowSelectPlaceholder": "選擇工作流程",
+          "statusSelectPlaceholder": "選擇狀態",
+          "statusNamePlaceholder": "輸入狀態名稱",
+          "statusSystemNamePlaceholder": "請輸入系統名稱",
+          "labelSystemName": "系統名稱",
+          "groupNamePlaceholder": "請輸入群組名",
+          "configurationNameLabel": "配置名稱",
+          "userSelectPlaceholder": "選擇用戶",
+          "userApiLabel": "API 使用者",
+          "templateCaseFieldsLabel": "案例字段",
+          "templateResultFieldsLabel": "結果字段",
+          "templateNoFieldsPlaceholder": "此模板未配置任何欄位。",
+          "templateTargetAlreadyUsed": "目標已映射到另一個模板。",
+          "templateFieldRequiredLabel": "必填字段",
+          "templateFieldOptionsDefaultValueLabel": "預設值",
+          "templateFieldOptionsInitialHeightLabel": "初始高度",
+          "templateFieldTemplateLabelSingular": "範本",
+          "templateFieldTemplateLabelPlural": "範本",
+          "templateFieldTargetGroupCase": "案例字段",
+          "templateFieldTargetGroupResult": "結果字段",
+          "columnAction": "行動"
+        },
+        "nextSteps": "後台匯入完成後，您可以查看從目標專案遷移的資料。",
+        "nextStepsDescription": "後台導入是異步運行的。您可以監控上方的狀態或刷新頁面查看更新。"
+      },
+      "comingSoon": {
+        "description": "導入 TestRail、Zephyr 和其他工具的功能已列入開發計劃。"
+      },
+      "errors": {
+        "fileRequired": "請在分析前選擇Testmo導出JSON檔。",
+        "uploadFailed": "匯出檔案上傳失敗，請重試。",
+        "analysisFailed": "我們無法分析該匯出文件。請檢查文件並重試。"
+      }
+    },
+    "sso": {
+      "description": "管理身份驗證和安全性設定",
+      "sections": {
+        "providers": {
+          "title": "登入提供者",
+          "description": "配置使用者如何登入您的應用程式"
+        },
+        "security": {
+          "title": "安全",
+          "description": "配置身份驗證的安全性策略"
+        }
+      },
+      "globalSettings": {
+        "title": "全域 SSO 設定",
+        "googleOAuth": {
+          "title": "Google OAuth",
+          "description": "啟用或停用 Google OAuth 身份驗證"
+        },
+        "samlProvider": {
+          "title": "SAML 提供者",
+          "description": "啟用或停用 SAML 身份驗證"
+        },
+        "apple": {
+          "title": "Apple 登入",
+          "description": "啟用或停用 Apple 登入身份驗證"
+        },
+        "microsoft": {
+          "title": "Microsoft SSO",
+          "description": "啟用或停用 Microsoft（Azure AD / Entra ID）身份驗證"
+        },
+        "magicLink": {
+          "title": "魔法連結認證",
+          "description": "啟用或停用基於電子郵件的無密碼身份驗證"
+        },
+        "forceSso": {
+          "title": "強制 SSO 登入",
+          "description": "停用電子郵件登錄，要求使用者使用單一登入 (SSO)。"
+        },
+        "twoFactor": {
+          "forceNonSSO": {
+            "title": "密碼登入需要啟用雙重認證",
+            "description": "使用郵箱/密碼登入的使用者必須設定並使用雙重認證"
+          },
+          "forceAllLogins": {
+            "title": "所有登入均需啟用雙重認證",
+            "description": "所有使用者（包括單一登入使用者）登入後都必須進行雙重認證。"
+          }
+        }
+      },
+      "providers": {
+        "configure": "配置 SAML",
+        "delete": "刪除提供者",
+        "entryPoint": "入口點： ",
+        "autoProvision": "自動配置： ",
+        "defaultAccess": "預設存取權限： ",
+        "configurationMessage": "SAML配置尚未設定。請點選設定按鈕進行配置。"
+      },
+      "samlConfiguration": {
+        "title": "配置 SAML 提供者",
+        "backButton": "返回 SSO 提供者",
+        "description": "配置 {name} 的 SAML 設定",
+        "samlSettings": {
+          "title": "SAML 設定",
+          "description": "配置您的 SAML 身分提供者設置",
+          "ssoUrl": "單一登入 URL（入口點）",
+          "entityId": "實體 ID（發行商）",
+          "certificate": "X.509證書",
+          "callbackUrl": "回呼 URL",
+          "logoutUrl": "註銷網址（可選）"
+        },
+        "userProvisioning": {
+          "title": "使用者配置",
+          "description": "配置使用者建立和映射方式",
+          "autoProvision": "自動配置新用戶",
+          "defaultAccess": "新用戶的預設系統存取權限",
+          "accessDescription": "新用戶將被指派資料庫中的預設角色和系統存取等級。"
+        },
+        "attributeMapping": {
+          "title": "屬性映射",
+          "description": "將 SAML 屬性對應到使用者字段",
+          "email": "電子郵件屬性",
+          "displayName": "顯示名稱屬性",
+          "userId": "使用者 ID 屬性",
+          "firstName": "名字屬性（可選）",
+          "lastName": "姓氏屬性（可選）",
+          "groups": "分組屬性（可選）"
+        }
+      },
+      "messages": {
+        "googleEnabled": "已啟用 Google OAuth",
+        "googleDisabled": "Google OAuth 已停用",
+        "googleCreated": "Google OAuth 提供者創建",
+        "googleUpdateFailed": "Google OAuth 更新失敗",
+        "samlCreated": "SAML 提供者建立",
+        "createFailed": "創建提供者失敗",
+        "deleted": "提供者已刪除",
+        "deleteFailed": "刪除提供者失敗",
+        "enabled": "提供者已啟用",
+        "disabled": "提供者已禁用",
+        "updateFailed": "更新提供者失敗",
+        "forceSsoEnabled": "全球強制啟用 SSO",
+        "forceSsoDisabled": "強制全域禁用 SSO",
+        "forceSsoUpdateFailed": "更新強制 SSO 設定失敗",
+        "force2FANonSSOEnabled": "密碼登入需要雙重認證",
+        "force2FANonSSODisabled": "密碼登入不再需要雙重認證",
+        "force2FAAllLoginsEnabled": "所有登入都需要雙重認證",
+        "force2FAAllLoginsDisabled": "不再需要所有登入進行雙重認證",
+        "force2FAUpdateFailed": "雙重認證設定更新失敗",
+        "configUpdated": "SAML 設定已更新",
+        "configCreated": "SAML 設定已建立",
+        "configSaveFailed": "儲存 SAML 設定失敗",
+        "googleConfigSaved": "Google OAuth 配置已成功儲存",
+        "googleConfigFailed": "配置保存失敗",
+        "appleEnabled": "已啟用 Apple 登入",
+        "appleDisabled": "已停用 Apple 登入",
+        "appleCreated": "Apple 登入提供者創建",
+        "appleConfigSaved": "Apple 登入配置已成功儲存",
+        "appleConfigFailed": "儲存 Apple 登入設定失敗",
+        "appleUpdateFailed": "更新 Apple 登入提供者失敗",
+        "microsoftEnabled": "已啟用 Microsoft SSO",
+        "microsoftDisabled": "已停用 Microsoft SSO",
+        "microsoftCreated": "Microsoft SSO 提供者建立",
+        "microsoftConfigSaved": "Microsoft SSO 設定已成功儲存",
+        "microsoftConfigFailed": "儲存 Microsoft SSO 設定失敗",
+        "microsoftUpdateFailed": "更新 Microsoft SSO 提供者失敗",
+        "magicLinkEnabled": "已啟用 Magic Link 身份驗證",
+        "magicLinkDisabled": "Magic Link 身份驗證已停用",
+        "magicLinkCreated": "Magic Link 提供者創建",
+        "magicLinkUpdateFailed": "更新 Magic Link 提供者失敗",
+        "samlConfigSaved": "SAML 設定已成功儲存",
+        "configureFirst": "請先配置提供程序，然後再啟用它。",
+        "domainRestrictionEnabled": "已啟用電子郵件網域限制",
+        "domainRestrictionDisabled": "電子郵件網域限制已停用",
+        "domainRestrictionUpdateFailed": "更新域限制設定失敗",
+        "domainRequired": "請輸入域名",
+        "invalidDomain": "請輸入有效的網域名稱（例如 example.com）",
+        "domainAdded": "域名已成功新增。",
+        "domainExists": "該域名已在允許清單中",
+        "domainAddFailed": "新增域名失敗",
+        "domainEnabled": "網域已啟用",
+        "domainDisabled": "網域已停用",
+        "domainUpdateFailed": "更新網域失敗",
+        "domainDeleted": "域名已成功移除",
+        "domainDeleteFailed": "刪除網域失敗",
+        "defaultAccessUpdated": "預設存取等級已更新",
+        "defaultAccessUpdateFailed": "更新預設存取等級失敗",
+        "emailVerificationEnabled": "新用戶現在需要進行電子郵件驗證。",
+        "emailVerificationDisabled": "新用戶不再需要進行電子郵件驗證。",
+        "emailVerificationDisabledAndVerified": "Email verification disabled and {count, plural, one {# user account} other {# user accounts}} verified",
+        "emailVerificationUpdateFailed": "電子郵件驗證設定更新失敗",
+        "emailServerNotConfigured": "無法啟用電子郵件驗證：電子郵件伺服器未配置",
+        "openRegistrationEnabled": "自助註冊功能現已啟用。",
+        "openRegistrationDisabled": "自助註冊功能現已關閉",
+        "openRegistrationUpdateFailed": "更新自助註冊設定失敗"
+      },
+      "dialogs": {
+        "googleOAuth": {
+          "title": "配置 Google OAuth",
+          "description": "設定您的 Google OAuth 用戶端憑證。您可以從 Google Cloud 控制台取得這些憑證。",
+          "clientIdPlaceholder": "您的 Google OAuth 用戶端 ID",
+          "clientSecretPlaceholder": "您的 Google OAuth 用戶端金鑰",
+          "instructions": {
+            "title": "取得這些憑證：",
+            "step1": "前往 Google Cloud 控制台",
+            "step2": "選擇您的專案或建立一個新項目",
+            "step3": "啟用 Google+ API",
+            "step4": "前往「憑證」並建立 OAuth 2.0 用戶端 ID",
+            "step5": "將授權重定向 URI 設定為："
+          },
+          "redirectUri": "/api/auth/callback/google",
+          "validation": {
+            "bothRequired": "客戶端 ID 和客戶端金鑰都需要"
+          }
+        },
+        "microsoft": {
+          "title": "設定 Microsoft SSO",
+          "description": "設定您的 Microsoft Entra ID（Azure AD）應用程式憑證。您可以從 Azure 入口網站取得這些憑證。",
+          "clientIdPlaceholder": "您的應用程式（客戶端）ID",
+          "clientSecretPlaceholder": "您的客戶秘密價值",
+          "tenantId": "租戶 ID（可選）",
+          "tenantIdPlaceholder": "您的目錄（租戶）ID",
+          "tenantIdHint": "留空表示多租戶（“公共”）。設定為您的特定租戶 ID 則僅限您的組織使用。",
+          "instructions": {
+            "title": "取得這些憑證：",
+            "step1": "造訪 Azure 入口網站 (portal.azure.com)",
+            "step2": "導覽至 Microsoft Entra ID > 應用程式註冊",
+            "step3": "註冊新應用程式或選擇現有應用",
+            "step4": "在「憑證和金鑰」下，建立一個新的客戶端金鑰",
+            "step5": "在身份驗證下新增以下重定向 URI："
+          },
+          "redirectUri": "/api/auth/callback/azure-ad",
+          "validation": {
+            "bothRequired": "客戶端 ID 和客戶端金鑰都需要"
+          }
+        },
+        "saml": {
+          "description": "設定您的 SAML 身分提供者配置。您可以從您的 SAML 身分提供者取得這些詳細資訊。",
+          "entryPoint": "SSO入口點URL",
+          "issuer": "發行人（實體 ID）",
+          "callbackUrl": "ACS（回呼）URL",
+          "logoutUrl": "SLO 登出 URL（可選）",
+          "entryPointPlaceholder": "https://your-idp.com/sso/saml",
+          "issuerPlaceholder": "urn:你的身分提供者:實體ID",
+          "certPlaceholder": "-----開始憑證-----...",
+          "logoutUrlPlaceholder": "https://your-idp.com/slo/saml",
+          "instructions": {
+            "title": "配置 SAML：",
+            "step1": "請聯絡您的 SAML 身分提供者管理員",
+            "step2": "請求 SSO 入口點 URL 和實體 ID",
+            "step3": "下載 X.509 證書",
+            "step4": "在您的身分提供者 (IdP) 中設定此 ACS URL："
+          },
+          "redirectUri": "/api/auth/callback/saml",
+          "validation": {
+            "allRequired": "入口點、頒發者、憑證和回呼 URL 是必要的。"
+          }
+        },
+        "disableEmailVerification": {
+          "title": "禁用電子郵件驗證？",
+          "description": "這將停用新用戶註冊的電子郵件驗證，並驗證所有現有的未驗證帳戶。",
+          "warning": "⚠️ 安全警告",
+          "warningPoint1": "僅建議用於安全安裝環境（私有網路、VPN 或可信任環境）",
+          "warningPoint2": "所有現有的未驗證帳戶將立即驗證並被授予系統存取權限",
+          "confirmation": "您確定要停用電子郵件驗證並驗證所有帳戶嗎？",
+          "confirm": "禁用並驗證所有",
+          "verifying": "正在驗證帳戶…"
+        }
+      },
+      "status": {
+        "configured": "已配置",
+        "setup": "設定"
+      },
+      "registration": {
+        "title": "註冊設定",
+        "description": "控制誰可以註冊新帳戶",
+        "restrictDomains": {
+          "title": "限制電子郵件域名",
+          "description": "僅允許來自特定電子郵件網域的註冊。"
+        },
+        "allowedDomains": {
+          "title": "允許的電子郵件域名",
+          "placeholder": "example.com",
+          "add": "新增域名",
+          "empty": "未配置任何允許的網域名稱。啟用限制後，所有網域都將被封鎖。"
+        },
+        "defaultAccess": {
+          "title": "預設訪問級別",
+          "description": "新用戶註冊時分配的系統存取級別",
+          "options": {
+            "NONE": "無存取權限 - 使用者必須經管理員授予權限後才能存取系統。",
+            "USER": "使用者 - 標準使用者權限，可存取已指派的項目",
+            "PROJECTADMIN": "專案管理員 - 可以管理分配給他們的項目",
+            "ADMIN": "管理員 - 完全系統管理權限"
+          }
+        },
+        "requireEmailVerification": {
+          "title": "需要電子郵件驗證",
+          "description": "使用者必須先驗證其電子郵件地址才能存取系統。",
+          "noEmailServerWarning": "郵件伺服器尚未配置。郵件驗證功能將自動停用，直到郵件伺服器設定完成。"
+        },
+        "allowOpenRegistration": {
+          "title": "允許自助註冊",
+          "description": "停用此功能後，新使用者無法直接註冊或透過單一登入 (SSO) 建立帳戶。現有用戶仍然可以登入。"
+        }
+      },
+      "errors": {
+        "invalidProvider": "無效的提供者或不是 SAML 提供者。"
+      }
+    },
+    "projects": {
+      "filter": {
+        "placeholder": "篩選項目..."
+      },
+      "complete": {
+        "title": "完整項目",
+        "description": "此操作將完成項目，並阻止新增任何其他測試運行。"
+      },
+      "add": {
+        "button": "新增項目",
+        "title": "新增項目",
+        "defaultFields": "建立專案時，將向專案中新增預設範本、預設里程碑類型以及所有工作流程和狀態。",
+        "selectIssueTracker": "選擇問題追蹤器",
+        "issueTrackerRequired": "需要問題追蹤系統。"
+      },
+      "wizard": {
+        "title": "建立新專案",
+        "description": "建立一個包含所有必要配置的新項目",
+        "steps": {
+          "details": "項目詳情",
+          "workflows": "工作流程、狀態和里程碑類型",
+          "integrations": "整合",
+          "permissions": "使用者與權限"
+        },
+        "labels": {
+          "selected": "已選",
+          "statuses": "測試狀態",
+          "issueTrackers": "問題追蹤器"
+        },
+        "placeholders": {
+          "projectName": "輸入項目名稱",
+          "selectDefaultAccess": "選擇預設存取類型"
+        },
+        "descriptions": {
+          "templates": "請選擇至少一個範本來定義本項目中的測試案例結構。",
+          "workflows": "配置工作流程、狀態和里程碑類型，以管理專案活動。",
+          "integrations": "可選：連接外部問題追蹤器和人工智慧模型，以增強功能。",
+          "noIntegrations": "目前尚未配置任何整合。您可以跳過此步驟或稍後配置整合。",
+          "aiModels": "啟用人工智慧模型，用於產生測試用例和提供智慧建議。",
+          "permissions": "配置此項目的使用者存取權限和群組權限。",
+          "milestoneTypes": "選擇里程碑類型以追蹤專案進度和截止日期。"
+        },
+        "actions": {
+          "selectDefault": "使用預設值",
+          "create": "創建專案",
+          "creating": "建立項目..."
+        },
+        "errors": {
+          "nameRequired": "項目名稱（必填）",
+          "validationFailed": "專案名稱驗證失敗，請重試。",
+          "templateRequired": "至少要選擇一個模板",
+          "workflowRequired": "必須至少選擇一個工作流程",
+          "statusRequired": "必須至少選擇一種狀態",
+          "roleRequired": "使用「特定角色」存取類型時，請選擇角色。",
+          "creationFailed": "專案建立失敗，請重試。"
+        },
+        "success": {
+          "created": "專案創建成功"
+        }
+      },
+      "edit": {
+        "title": "編輯項目",
+        "labels": {
+          "groupProjectAccess": "小組專案存取權限",
+          "groupPermissions": "群組權限",
+          "userPermissions": "使用者權限",
+          "noEffect": "無影響",
+          "access": {
+            "groupsGlobalRole": "集團的全球角色",
+            "groupDefault": "群組預設值",
+            "groupSpecificRole": "特定角色",
+            "groupProjectDefault": "小組項目預設設定",
+            "groupProjectNoAccess": "小組項目無訪問權限",
+            "groupProjectSpecificRole": "小組專案特定角色",
+            "effectiveAccess": "有效獲取"
+          },
+          "accessHints": {
+            "noAccess": "除非透過直接分配或加入群組等方式明確授予權限，否則使用者將無法存取此項目。",
+            "globalRole": "所有擁有網站存取權限的使用者均可查看此項目。他們的權限取決於其全域分配的角色。",
+            "specificRole": "使用者不會自動獲得存取權限。存取權限必須透過直接使用者指派或群組成員身分授予。透過群組指派的使用者將使用此角色，除非直接被指派覆蓋。"
+          }
+        },
+        "placeholders": {
+          "selectDefaultAccess": "選擇預設存取權限",
+          "groupPermissionsUI": "群組權限管理介面放在這裡…",
+          "userPermissionsUI": "使用者權限管理介面將會放在這裡…",
+          "selectAccess": "選擇存取權限...",
+          "selectRole": "選擇角色...",
+          "searchUsersToAdd": "搜尋要新增的用戶..."
+        },
+        "tableHeaders": {
+          "globalRole": "全球角色",
+          "projectAccess": "項目訪問"
+        },
+        "messages": {
+          "noUsersAssigned": "沒有使用者被指派任何特定權限。",
+          "noGroupsFound": "未找到群組。"
+        },
+        "actions": {
+          "removeUser": "移除用戶"
+        },
+        "loadingUserPermissions": "正在載入使用者權限..."
+      },
+      "delete": {
+        "title": "刪除項目",
+        "confirmMessage": "您確定要刪除此項目嗎？"
+      }
+    },
+    "templates": {
+      "description": "管理測試用例模板和字段",
+      "help": {
+        "caseFields": "用例欄位定義了儲存庫中每個測試案例可以擷取的屬性和資料。它們允許您在標準欄位之外自訂測試用例資訊。",
+        "resultFields": "結果欄位定義了在記錄測試結果時可以擷取的其他資料。它們允許您追蹤特定於測試執行結果的自訂資訊。"
+      },
+      "confirmSetAsDefault": "設定為預設模板",
+      "confirmSetAsDefaultDescription": "您確定要將此範本設定為預設範本嗎？",
+      "confirmSetAsDefaultProjects": "此模板將會新增至所有項目。",
+      "add": {
+        "button": "新增模板",
+        "title": "新增模板",
+        "defaultTemplateHint": "此範本將指派給所有項目。"
+      },
+      "edit": {
+        "title": "編輯模板"
+      },
+      "delete": {
+        "title": "刪除模板",
+        "confirmMessage": "您確定要刪除 <strong>{name}</strong> 範本嗎？",
+        "warning": "目前使用此範本的所有測試案例和探索性會話將自動重新指派給預設範本。",
+        "errors": {
+          "defaultTemplateNotFound": "未找到預設模板。刪除操作無法進行。",
+          "unknown": "刪除模板時發生未知錯誤。"
+        }
+      },
+      "caseFields": {
+        "description": "管理案例字段",
+        "add": {
+          "button": "新增案例字段",
+          "title": "新增案例字段"
+        },
+        "edit": {
+          "title": "編輯案例字段"
+        },
+        "delete": {
+          "title": "刪除個案字段",
+          "confirmMessage": "您確定要刪除此案例欄位嗎？",
+          "warning": "案例欄位將從所有模板中移除。此操作無法撤銷。"
+        }
+      },
+      "resultFields": {
+        "description": "管理結果字段",
+        "add": {
+          "button": "新增結果字段",
+          "title": "新增結果字段"
+        },
+        "edit": {
+          "title": "編輯結果字段"
+        },
+        "delete": {
+          "title": "刪除結果字段",
+          "confirmMessage": "您確定要刪除 <strong>{name}</strong> 嗎？",
+          "warning": "結果欄位將從所有模板中移除。此操作無法撤銷。"
+        }
+      }
+    },
+    "codeRepositories": {
+      "title": "程式碼庫",
+      "description": "管理 QuickScript 上下文的程式碼庫連線。",
+      "addRepository": "新增儲存庫",
+      "noRepos": {
+        "title": "未配置任何代碼倉庫",
+        "description": "連接 Git 儲存庫，為 AI 驅動的測試匯出產生提供文件上下文。"
+      },
+      "delete": {
+        "title": "刪除儲存庫",
+        "confirmMessage": "您確定要刪除 <strong>{name}</strong>嗎？此操作無法撤銷。",
+        "fallbackName": "此倉庫"
+      },
+      "testConnection": "測試連接",
+      "connectionSuccess": "連線成功",
+      "connectionFailed": "連線失敗",
+      "networkError": "網路錯誤",
+      "editTitle": "編輯程式碼庫",
+      "addTitle": "新增程式碼庫",
+      "repositoryUpdated": "儲存庫已更新",
+      "repositoryCreated": "已建立儲存庫",
+      "saveFailed": "保存儲存庫失敗",
+      "namePlaceholder": "我的倉庫",
+      "selectProvider": "選擇提供者",
+      "httpWarning": "此網址使用 HTTP 協定。憑證將以明文形式發送。請使用 HTTPS 協定以確保連線安全。"
+    },
+    "exportTemplates": {
+      "title": "QuickScript模板",
+      "description": "管理 QuickScript 用於將測試案例轉換為自動化腳本的範本。",
+      "confirmSetAsDefault": "設定為預設導出模板",
+      "confirmSetAsDefaultDescription": "您確定要將此範本設定為預設範本嗎？當使用者匯出測試案例時，它將被預先選取。",
+      "fields": {
+        "category": "類別",
+        "framework": "框架",
+        "fileExtension": "檔案副檔名",
+        "headerBody": "頁眉模板",
+        "templateBody": "模板主體",
+        "footerBody": "頁尾模板",
+        "validation": {
+          "categoryRequired": "類別為必填項。",
+          "frameworkRequired": "需要框架。",
+          "templateBodyRequired": "必須填寫模板正文。",
+          "fileExtensionRequired": "必須提供檔案副檔名。",
+          "languageRequired": "需要掌握相關語言。"
+        },
+        "placeholders": {
+          "name": "例如，劇作家（TypeScript）",
+          "description": "例如，產生 Playwright 測試存根",
+          "category": "例如，瀏覽器端到端",
+          "framework": "例如，劇作家",
+          "fileExtension": "例如，.spec.ts",
+          "language": "例如，TypeScript",
+          "headerBody": "可選。內容會在頂部渲染一次（例如，導入語句）。",
+          "templateBody": "Enter Mustache template...\n\nAvailable variables:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSteps section:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nCustom fields:\n'{{fields.fieldSystemName}}'",
+          "footerBody": "可選。內容在底部渲染一次（例如，結束程式碼）。"
+        },
+        "combobox": {
+          "typeNew": "輸入新值"
+        }
+      },
+      "add": {
+        "button": "新增 QuickScript 模板",
+        "title": "新增新的 QuickScript 模板"
+      },
+      "edit": {
+        "title": "編輯 QuickScript 模板"
+      },
+      "delete": {
+        "title": "刪除快速腳本模板",
+        "confirmMessage": "您確定要刪除 <strong>{name}</strong> QuickScript 範本嗎？"
+      },
+      "preview": {
+        "title": "預覽（模擬數據）",
+        "empty": "輸入模板正文以查看預覽。",
+        "error": "模板渲染出錯。請檢查您的 Mustache 語法。"
+      },
+      "filterPlaceholder": "篩選模板...",
+      "noResults": "沒有符合您篩選條件的範本。",
+      "templateCount": "{count, plural, one {# 模板} other {# 模板集}}",
+      "allFrameworks": "所有框架",
+      "allFileExtensions": "所有擴充",
+      "allLanguages": "所有語言",
+      "showEnabled": "僅啟用",
+      "showAll": "全部",
+      "variableInserter": {
+        "placeholder": "插入變數...",
+        "groups": {
+          "customFields": "自訂字段"
+        },
+        "stepsBlock": "步驟阻塞"
+      }
+    },
+    "users": {
+      "showInactive": "顯示非活動狀態",
+      "add": {
+        "button": "新增用戶",
+        "title": "新增用戶",
+        "fields": {
+          "email_invalid": "無效的電子郵件地址",
+          "password_error": "需要密碼",
+          "confirmPassword_error": "需要確認密碼",
+          "passwordOptionalHelp": "留空則要求使用者透過魔法連結或單一登入登入。"
+        }
+      },
+      "edit": {
+        "title": "編輯使用者"
+      },
+      "delete": {
+        "title": "刪除用戶"
+      },
+      "restore": {
+        "title": "恢復已刪除用戶",
+        "description": "已找到電子郵件地址為 {email} 的已刪除使用者。您是否要恢復此用戶？",
+        "confirm": "恢復用戶"
+      },
+      "forcePasswordChange": "強制更改密碼",
+      "revokePassword": "撤銷密碼",
+      "forcePasswordChangeDialogTitle": "強制更改密碼",
+      "forcePasswordChangeDialogDescription": "這將要求 {name} 在下次登入時變更密碼。",
+      "revokePasswordDialogTitle": "撤銷密碼",
+      "revokePasswordDialogDescription": "這將立即使 {name}的密碼失效。他們需要使用其他登入方式。",
+      "confirmAction": "確認",
+      "forcePasswordChangeSuccess": "{name} 需要更改密碼",
+      "forcePasswordChangeFailed": "強制更改密碼失敗",
+      "revokePasswordSuccess": "密碼已撤銷 {name}",
+      "revokePasswordFailed": "撤銷密碼失敗"
+    },
+    "security": {
+      "title": "安全",
+      "description": "配置密碼策略、鎖定設定和強制執行措施",
+      "passwordPolicyTitle": "密碼原則",
+      "passwordPolicyDescription": "設定用戶密碼要求",
+      "lockoutPolicyTitle": "鎖定政策",
+      "lockoutPolicyDescription": "配置登入失敗後帳戶鎖定",
+      "enforcementTitle": "執法行動",
+      "enforcementDescription": "強制基於憑證的使用者更改密碼",
+      "minPasswordLengthLabel": "密碼最小長度",
+      "minPasswordLengthDescription": "密碼長度必須至少為以下字元數（8-128）",
+      "requireUppercaseLabel": "必須使用大寫字母",
+      "requireLowercaseLabel": "必須使用小寫字母",
+      "requireNumbersLabel": "需要數字",
+      "requiredSpecialCharsLabel": "必需特殊字符",
+      "requiredSpecialCharsDescription": "留空則禁用。請輸入必須顯示的字元（例如 !@#$）",
+      "passwordHistoryDepthLabel": "密碼歷史記錄深度",
+      "passwordHistoryDepthDescription": "禁止重複使用最近 N 個密碼（0 = 已停用）",
+      "passwordExpirationDaysLabel": "密碼過期時間（天）",
+      "passwordExpirationDaysDescription": "強制密碼更改時間（N 天後生效，0 表示停用）",
+      "lockoutThresholdLabel": "鎖定閾值",
+      "lockoutThresholdDescription": "帳戶被鎖定前的失敗嘗試次數（最少 1 次）",
+      "lockoutDurationMinutesLabel": "鎖定持續時間（分鐘）",
+      "lockoutDurationMinutesDescription": "帳戶鎖定時長（最少 1 小時）",
+      "saveChanges": "儲存變更",
+      "forceAllUsers": "強制所有使用者更改密碼",
+      "forceAllUsersDialogTitle": "強制所有使用者更改密碼",
+      "forceAllUsersDialogDescription": "這將要求 {count} 基於憑證的使用者在下次登入時變更密碼。",
+      "forceAllUsersDialogWarning": "此操作無法撤銷。",
+      "forceAllUsersDialogConfirm": "力變化",
+      "saved": "已儲存安全設定",
+      "saveFailed": "儲存安全設定失敗",
+      "forceAllSuccess": "{count} 使用者需要更改密碼",
+      "forceAllFailed": "強制更改密碼失敗"
+    },
+    "apiTokens": {
+      "description": "查看和管理所有使用者的 API 令牌。如有安全隱患，可撤銷令牌。",
+      "filterPlaceholder": "按令牌名稱或使用者篩選...",
+      "showInactive": "顯示撤銷",
+      "noTokens": "尚未建立任何 API 令牌。",
+      "columns": {
+        "lastUsed": "上次使用",
+        "expires": "過期"
+      },
+      "status": {
+        "revoked": "撤銷",
+        "expired": "已到期"
+      },
+      "noExpiry": "無有效期限",
+      "revokeToken": "撤銷令牌",
+      "revokeConfirmTitle": "撤銷 API 令牌",
+      "revokeConfirmMessage": "您確定要撤銷此 API 令牌嗎？此操作無法撤銷。",
+      "revokeConfirmDescription": "屬於 {user} 的令牌「{name}」將會立即撤銷，並且不能再用於 API 存取。",
+      "revokeSuccess": "API令牌已成功撤銷",
+      "revokeError": "撤銷 API 令牌失敗",
+      "revokeAllTokens": "撤銷所有代幣",
+      "revokeAllTitle": "撤銷所有 API 令牌",
+      "revokeAllDescription": "這將立即撤銷所有使用者的所有有效 API 令牌。此操作無法撤銷，並且可能中斷自動化工作流程。",
+      "revokeAllConfirm": "輸入“REVOKE ALL”進行確認",
+      "revokeAllPlaceholder": "撤銷所有",
+      "revokeAllSuccess": "所有API令牌均已撤銷。",
+      "revokeAllError": "撤銷所有令牌失敗"
+    },
+    "tags": {
+      "add": {
+        "errors": {
+          "unknown": "建立標籤時發生錯誤"
+        }
+      },
+      "delete": {
+        "title": "刪除標籤",
+        "confirmMessage": "您確定要刪除此標籤嗎？",
+        "warning": "此標籤將從所有測試案例和會話中移除。",
+        "errors": {
+          "unknown": "刪除標籤時發生錯誤"
+        }
+      },
+      "edit": {
+        "title": "編輯標籤"
+      }
+    },
+    "workflows": {
+      "description": "管理測試用例工作流程",
+      "add": {
+        "button": "新增工作流程",
+        "title": "新增工作流程",
+        "defaultHelp": "設定為新測試案例的預設工作流程",
+        "scopeLabel": "工作流程範圍",
+        "errors": {
+          "nameExists": "已存在同名的工作流程"
+        }
+      },
+      "edit": {
+        "title": "編輯工作流程",
+        "lastWorkflowTypeWarning": "這是最後一種工作流程類型。必須至少啟用一種工作流程類型。",
+        "errors": {
+          "nameRequired": "工作流程名稱為必填項",
+          "unknownWorkflow": "未知工作流程"
+        }
+      },
+      "delete": {
+        "title": "刪除工作流程",
+        "confirmMessage": "您確定要刪除此工作流程嗎？"
+      },
+      "setDefault": {
+        "title": "設定預設工作流程",
+        "confirmMessage": "您確定要將此工作流程設定為預設工作流程嗎？",
+        "description": "此工作流程將會新增至所有項目。"
+      }
+    },
+    "roles": {
+      "description": "透過切換每個應用程式區域的權限，定義使用者可以執行哪些操作。",
+      "filterPlaceholder": "篩選角色...",
+      "add": {
+        "button": "添加角色",
+        "title": "新增角色",
+        "fields": {
+          "name_error": "角色名稱為必填項"
+        },
+        "errors": {
+          "nameExists": "已存在同名角色"
+        }
+      },
+      "edit": {
+        "title": "編輯角色",
+        "permissionsTitle": "權限",
+        "areaHeader": "應用領域"
+      },
+      "delete": {
+        "title": "刪除角色",
+        "confirmMessage": "您確定要刪除此角色嗎？",
+        "warning": "此操作無法撤銷。具有此角色的使用者將被指派到預設角色。",
+        "errors": {
+          "defaultNotFound": "無法刪除預設角色"
+        }
+      }
+    },
+    "statuses": {
+      "description": "管理測試狀態",
+      "add": {
+        "button": "新增狀態",
+        "title": "新增狀態",
+        "systemNameHelp": "系統名稱用於標識此狀態。創建後無法更改。",
+        "aliasesHelp": "以逗號分隔的別名列表",
+        "errors": {
+          "nameExists": "已存在同名狀態",
+          "systemNameEmpty": "系統名稱為必填項",
+          "systemNameInvalid": "系統名稱必須為字母數字格式",
+          "aliasesInvalid": "別名必須包含字母和數字。",
+          "missingColor": "未找到該顏色。請選擇其他顏色。"
+        }
+      },
+      "edit": {
+        "title": "編輯狀態",
+        "systemNameHelp": "系統名稱用於標識自動化流程的此狀態。創建後無法更改。",
+        "unmodifiableHelp": "“未測試”狀態是系統狀態，無法修改。",
+        "untestedHelp": "“未測試”這個名稱保留用於系統狀態，不能使用。",
+        "success": "狀態已成功更新"
+      },
+      "delete": {
+        "title": "刪除狀態",
+        "confirmMessage": "您確定要刪除狀態 <strong>{name}</strong> 嗎？",
+        "errors": {
+          "inUse": "此狀態正在使用中，無法刪除",
+          "defaultNotFound": "未找到預設狀態"
+        },
+        "success": "狀態已成功刪除"
+      },
+      "fields": {
+        "final": "最終的",
+        "system": "系統狀態",
+        "forTestCase": "測試用例",
+        "forTestRun": "測試運行",
+        "forSession": "會議期間",
+        "color": "顏色"
+      }
+    },
+    "appConfig": {
+      "description": "管理全域應用程式配置",
+      "addConfig": "新增應用程式配置",
+      "editConfig": "編輯應用程式配置",
+      "keyPlaceholder": "請輸入配置密鑰...",
+      "valuePlaceholder": "請輸入JSON值...",
+      "currentTranslation": "目前翻譯",
+      "filterPlaceholder": "按關鍵字篩選...",
+      "errors": {
+        "keyRequired": "需要鑰匙",
+        "invalidJson": "無效的 JSON 格式"
+      },
+      "configKeys": {
+        "project_docs_default": "專案文件預設"
+      }
+    },
+    "configurations": {
+      "description": "配置是用於定義測試環境的類別和變體的組合。例如，作業系統/瀏覽器、測試伺服器、語言等。",
+      "addConfiguration": "新增配置",
+      "editConfiguration": "編輯配置",
+      "filterPlaceholder": "過濾器配置...",
+      "categories": {
+        "title": "類別",
+        "description": "管理全球類別",
+        "editCategory": "編輯類別",
+        "selectCategory": "選擇類別",
+        "filterPlaceholder": "篩選類別...",
+        "add": {
+          "title": "新增類別"
+        },
+        "delete": {
+          "confirmMessage": "您確定要刪除此類別嗎？",
+          "deleteCategory": "刪除類別",
+          "deleteCategoryConfirm": "您確定要刪除類別 <strong>{name}</strong> 嗎？",
+          "deleteCategoryWarning": "此操作將刪除該類別及其所有關聯變體。"
+        },
+        "disable": {
+          "confirmDisableTitle": "停用變體",
+          "confirmDisableDescription": "您確定要停用此變體嗎？"
+        }
+      },
+      "combinations": {
+        "title": "組合",
+        "description": "管理全域組合",
+        "addCombination": "新增組合",
+        "editCombination": "編輯組合",
+        "selectCombination": "選擇組合",
+        "selectCombinationDescription": "選擇要新增至配置中的變體組合。",
+        "allExist": "所有組合都已存在。",
+        "selectAtLeast": "請至少選擇一種組合。"
+      },
+      "delete": {
+        "title": "刪除配置",
+        "message": "您確定要刪除設定 <strong>{name}</strong> 嗎？",
+        "confirmMessage": "您確定要刪除此配置嗎？"
+      },
+      "variants": {
+        "edit": {
+          "title": "編輯變體"
+        },
+        "delete": {
+          "title": "刪除變體",
+          "message": "您確定要刪除變體 <strong>{name}</strong> 嗎？",
+          "confirmMessage": "您確定要刪除此版本嗎？",
+          "suggestion": "考慮禁用該變體。"
+        },
+        "selection": {
+          "title": "選擇變體",
+          "description": "選擇要新增至配置中的變體。"
+        }
+      }
+    },
+    "groups": {
+      "description": {
+        "groupInfo": "將使用者組織成群組，以便大量分配項目存取權限和角色。"
+      },
+      "filterPlaceholder": "篩選組...",
+      "add": {
+        "button": "新增群組",
+        "title": "新增群組",
+        "errors": {
+          "nameExists": "已存在同名組織"
+        }
+      },
+      "edit": {
+        "title": "編輯群組"
+      },
+      "delete": {
+        "deleteGroup": "刪除群組",
+        "deleteGroupDescription": "此操作將刪除該群組及其所有關聯使用者。",
+        "confirmMessage": "您確定要刪除此群組嗎？"
+      },
+      "noUsersSelected": "暫無用戶選擇。",
+      "noUsersAssigned": "此群組暫無使用者。"
+    },
+    "milestones": {
+      "description": "管理里程碑類型",
+      "filterPlaceholder": "篩選里程碑類型…",
+      "addMilestones": "批量新增里程碑",
+      "confirmDefault": "確認預設設定",
+      "confirmDefaultDescription": "您確定要將此里程碑類型設為預設值嗎？",
+      "warning": "此里程碑類型將會新增至所有項目。",
+      "wizard": {
+        "selectProjects": "選擇項目",
+        "projectsSelected": "{count, plural, =0 {No projects selected} one {# project selected} other {# projects selected}}",
+        "createMilestone": "創建里程碑",
+        "noCommonTypesTitle": "沒有常見的里程碑類型",
+        "noCommonTypesDescription": "所選項目之間沒有任何共同的里程碑類型。請確保所有選定項目至少有一個共同的里程碑類型，或選擇其他項目。"
+      },
+      "add": {
+        "button": "新增里程碑類型",
+        "title": "新增里程碑類型",
+        "errors": {
+          "nameExists": "已存在同名的里程碑類型"
+        }
+      },
+      "edit": {
+        "title": "編輯里程碑類型"
+      },
+      "delete": {
+        "title": "刪除里程碑類型",
+        "confirmMessage": "您確定要刪除此里程碑類型嗎？"
+      }
+    },
+    "issue_config": {
+      "link_title": "連結問題追蹤器",
+      "link_description": "配置手動連結問題的基本 URL。當僅使用外部 ID 連結問題時，此基本 URL 將會新增至完整連結的前面。",
+      "filter": {
+        "show_inactive": "顯示非活動配置",
+        "search_placeholder": "按配置名稱篩選..."
+      },
+      "base_url": "基本 URL",
+      "link_update_success": "鏈路配置已成功更新",
+      "link_update_error": "鏈路配置更新失敗",
+      "description": "配置與外部問題追蹤系統的整合。",
+      "delete": {
+        "title": "刪除問題配置",
+        "confirmMessage": "您確定要刪除設定 <bold>{name}</bold> 嗎？",
+        "warning": "此操作無法撤銷。目前指派給此追蹤器的所有項目都將重新指派給預設追蹤器。建議您考慮停用此配置。",
+        "cannotDeleteDefault": "預設問題追蹤器無法刪除。",
+        "noDefaultFound": "無法刪除：未找到可重新分配項目的預設問題追蹤器。"
+      },
+      "add": {
+        "title": "新增問題追蹤器",
+        "description": "為問題追蹤系統建立新配置。",
+        "name": "配置名稱",
+        "name_placeholder": "例如，Jira 專案鏈接",
+        "system_type": "系統類型",
+        "select_system_type": "選擇系統類型",
+        "base_url": "包含問題佔位符的基本 URL",
+        "base_url_placeholder": "例如，https://your-tracker.com/issues/'{issueId}'",
+        "create_success": "問題配置已成功創建",
+        "create_error": "建立問題配置時出錯",
+        "setDefaultWarning": "將此項目設為預設值將從目前預設配置中移除預設狀態。"
+      },
+      "edit": {
+        "title": "編輯問題追蹤器",
+        "description": "更新此問題配置的詳細資訊。",
+        "name_placeholder": "輸入配置名稱",
+        "select_project": "選擇項目...",
+        "update_success": "問題配置已成功更新",
+        "update_error": "更新問題配置失敗",
+        "edit_not_supported": "目前不支援編輯此系統類型的配置。"
+      }
+    },
+    "issues": {
+      "description": "管理此問題追蹤器的問題",
+      "filterPlaceholder": "過濾器問題…",
+      "add": {
+        "button": "添加問題",
+        "title": "新增問題"
+      },
+      "edit": {
+        "title": "編輯問題"
+      },
+      "delete": {
+        "title": "刪除問題",
+        "confirmMessage": "您確定要刪除問題「{name}」嗎？"
+      },
+      "syncIssue": "來自外部系統的同步問題",
+      "syncSuccess": "問題已成功同步",
+      "syncSuccessDescription": "問題「{name}」已使用外部系統的最新資訊進行更新。",
+      "syncError": "同步問題失敗",
+      "syncErrorDescription": "問題同步失敗，請稍後再試。"
+    },
+    "trash": {
+      "itemTypes": {
+        "projectLinks": "項目連結",
+        "milestoneLinks": "里程碑連結",
+        "icons": "圖示",
+        "fieldOptions": "字段選項",
+        "configCategories": "配置類別",
+        "configVariants": "配置變體",
+        "repositories": "儲存庫",
+        "repositoryFolders": "儲存庫資料夾",
+        "repositoryCaseLinks": "案例庫連結",
+        "repositoryCaseVersions": "儲存庫案例版本",
+        "testRunStepResults": "測試運行步驟結果",
+        "issueConfigs": "問題配置",
+        "sharedStepGroups": "共同步驟小組"
+      },
+      "table": {
+        "title": "已刪除 {itemType}",
+        "loading": "正在載入已刪除的 {itemType}...",
+        "error": "載入已刪除的 {itemType}: {message} 時發生錯誤",
+        "noItems": "未找到已刪除的 {itemType}。",
+        "noResults": "沒有找到與您的搜尋「{query}」相符的已刪除的 {itemType}。",
+        "restoreConfirmationMessage": "您確定要從 {itemType} 表格中還原此行嗎？關聯資料也可能會恢復。",
+        "purgeConfirmationMessage": "您確定要從 {itemType} 表格中永久刪除此行嗎？此操作無法撤銷，並且可能會刪除關聯資料。"
+      }
+    },
+    "notifications": {
+      "title": "通知管理",
+      "description": "設定預設通知偏好設定（使用者可以覆蓋），並發送系統通知。",
+      "defaultMode": {
+        "label": "預設通知模式",
+        "inApp": "限應用程式內購買",
+        "inAppEmailImmediate": "應用程式內 + 電子郵件（立即）",
+        "inAppEmailDaily": "應用程式內 + 電子郵件（每日摘要）"
+      },
+      "options": {
+        "title": "可用的通知選項",
+        "inApp": {
+          "label": "應用程式內通知",
+          "description": "在應用程式內顯示通知"
+        },
+        "emailImmediate": {
+          "label": "立即發送電子郵件",
+          "description": "事件發生時立即發送電子郵件通知"
+        },
+        "emailDaily": {
+          "label": "每日郵件摘要",
+          "description": "每日透過電子郵件發送通知摘要"
+        }
+      },
+      "save": "儲存設定",
+      "success": {
+        "title": "設定已儲存",
+        "description": "通知設定已成功更新"
+      },
+      "error": {
+        "description": "通知設定保存失敗"
+      },
+      "systemNotification": {
+        "title": "系統通知",
+        "description": "向所有用戶發送重要公告",
+        "titlePlaceholder": "請輸入通知標題...",
+        "messagePlaceholder": "輸入通知訊息...",
+        "send": "發送通知",
+        "success": {
+          "title": "已發送通知",
+          "description": "系統通知已寄至 {count, plural, one {# 使用者} other {# 使用者群組}}"
+        },
+        "error": {
+          "description": "發送系統通知失敗",
+          "emptyFields": "請提供標題和內文。"
+        },
+        "history": {
+          "title": "通知歷史記錄",
+          "sentBy": "發送者",
+          "sentAt": "發送於",
+          "empty": "尚未發送任何系統通知。"
+        }
+      }
+    },
+    "integrations": {
+      "description": "管理用於問題追蹤的第三方集成",
+      "list": {
+        "title": "已配置的問題集成",
+        "description": "查看和管理您已配置的問題集成"
+      },
+      "empty": {
+        "message": "尚未配置任何問題集成"
+      },
+      "addIntegration": "添加問題集成",
+      "allIntegrations": "所有問題集成",
+      "manageDescription": "配置和管理您的外部服務整合問題",
+      "status": {
+        "active": "積極的",
+        "inactive": "非活躍狀態"
+      },
+      "connectedProjects": "關聯項目",
+      "noIntegrations": "未配置任何問題集成",
+      "testConnection": "測試連接",
+      "testSuccess": "連線成功",
+      "testSuccessDescription": "問題集成已正確配置並連接",
+      "testFailed": "連線失敗",
+      "testFailedDescription": "無法連線到外部服務",
+      "testError": "測試錯誤",
+      "testErrorDescription": "測試連線時發生錯誤",
+      "syncInProgress": "同步問題…",
+      "syncIntegration": "同步問題整合中的所有問題",
+      "syncSuccess": "同步已排隊",
+      "syncSuccessDescription": "來自「{name}」的問題正在後台同步。這可能需要一些時間。同步完成後，表格將自動更新。",
+      "syncError": "同步失敗",
+      "syncErrorDescription": "無法為此整合問題新增同步任務。請稍後重試。",
+      "delete": {
+        "confirmMessage": "您確定要刪除問題整合「{name}」嗎？",
+        "warning": "這將移除問題整合並將其與所有專案斷開連接。此操作無法撤銷。",
+        "warningTitle": "此操作將：",
+        "warning1": "永久刪除問題整合配置和憑證",
+        "warning2": "斷開此問題整合的所有使用者身份驗證令牌",
+        "warning3": "保留資料庫中所有已連結的問題（問題將取消連結）。",
+        "warning4": "首先需要從所有專案中移除該問題整合。"
+      },
+      "deleteSuccess": "問題整合已刪除",
+      "deleteSuccessDescription": "問題整合已成功移除。",
+      "deleteError": "刪除錯誤",
+      "add": {
+        "description": "配置與外部服務的新問題集成",
+        "selectType": "選擇問題整合類型",
+        "typeDescription": "選擇您要整合的服務類型",
+        "successMessage": "問題整合已成功創建",
+        "successDescription": "問題整合已配置完成，可以開始使用了。",
+        "simple_url": {
+          "name": "簡單網址",
+          "description": "使用自訂 URL 模式進行基本問題跟踪"
+        },
+        "jira": {
+          "name": "吉拉",
+          "description": "連接到 Atlassian Jira 進行問題追蹤和專案管理"
+        },
+        "github": {
+          "name": "GitHub",
+          "description": "連接到 GitHub 以進行問題追蹤"
+        },
+        "gitlab": {
+          "name": "GitLab",
+          "description": "連接到 GitLab 以追蹤問題和合併請求"
+        },
+        "gitea": {
+          "name": "吉特亞/福爾格約/戈格斯",
+          "description": "連接到自架的 Gitea、Forgejo 或 Gogs 實例以進行問題跟踪"
+        },
+        "azureDevops": {
+          "name": "Azure DevOps",
+          "description": "連接到 Azure DevOps 以追蹤工作項"
+        }
+      },
+      "filterPlaceholder": "過濾器整合…",
+      "table": {
+        "lastSync": "上次同步",
+        "empty": "未發現整合問題",
+        "loading": "正在加載問題集成...",
+        "configure": "配置"
+      },
+      "edit": {
+        "description": "更新問題整合設定和配置",
+        "successMessage": "問題整合已成功更新",
+        "successDescription": "問題整合設定已儲存"
+      },
+      "editIntegration": "編輯問題集成",
+      "saveIntegration": "保存問題集成",
+      "deleteIntegration": "刪除問題集成",
+      "config": {
+        "name": "問題整合名稱",
+        "namePlaceholder": "請為此問題整合輸入名稱",
+        "nameHelp": "用於識別此問題整合的描述性名稱",
+        "authType": "身份驗證類型",
+        "authTypeHelp": "選擇如何透過外部服務進行身份驗證",
+        "emailPlaceholder": "您的郵件地址@example.com",
+        "emailHelp": "您的帳戶電子郵件地址",
+        "apiToken": "API令牌",
+        "apiTokenPlaceholder": "請輸入您的 API 令牌",
+        "apiTokenHelp": "從您的帳戶設定中產生 API 令牌",
+        "jiraUrl": "Jira URL",
+        "jiraUrlPlaceholder": "https://your-site.atlassian.net",
+        "jiraUrlHelp": "您的 Jira 實例的 URL",
+        "clientId": "客戶ID",
+        "clientIdPlaceholder": "請輸入您的 OAuth 用戶端 ID",
+        "clientIdHelp": "來自您的 OAuth 應用程式的用戶端 ID",
+        "clientSecret": "客戶機密",
+        "clientSecretPlaceholder": "請輸入您的 OAuth 用戶端金鑰",
+        "clientSecretHelp": "來自您的 OAuth 應用程式的用戶端金鑰",
+        "cloudId": "Cloud ID",
+        "cloudIdPlaceholder": "請輸入您的 Atlassian 雲端 ID",
+        "cloudIdHelp": "您的 Atlassian Cloud 實例 ID（可在您的 Jira URL 中找到）",
+        "apiUrl": "API URL",
+        "apiUrlPlaceholder": "https://api.example.com",
+        "apiUrlHelp": "服務 API 的基本 URL",
+        "personalAccessTokenPlaceholder": "請輸入您的個人存取令牌",
+        "personalAccessTokenHelp": "具有相應權限的個人存取權令牌",
+        "apiKeyPlaceholder": "請輸入您的 API 金鑰",
+        "apiKeyHelp": "用於身份驗證的 API 金鑰",
+        "baseUrl": "URL模式",
+        "baseUrlPlaceholder": "https://example.com/issues/'{issueId}'",
+        "baseUrlHelp": "問題 URL 格式。使用 {issueId} 作為佔位符",
+        "organizationUrl": "組織網址",
+        "organizationUrlPlaceholder": "https://dev.azure.com/your-org",
+        "organizationUrlHelp": "您的 Azure DevOps 組織 URL",
+        "projectPath": "專案路徑",
+        "projectPathPlaceholder": "小組/子小組/項目",
+        "projectPathHelp": "您的 GitLab 專案的完整路徑（例如 mygroup/myproject）",
+        "instanceUrl": "實例 URL",
+        "instanceUrlPlaceholder": "https://gitlab.example.com",
+        "instanceUrlHelp": "自託管執行個體的 URL。留空則使用 gitlab.com。",
+        "giteaInstanceUrlPlaceholder": "https://gitea.example.com",
+        "owner": "擁有者",
+        "ownerPlaceholder": "使用者名稱或組織",
+        "ownerHelp": "擁有該倉庫的 Gitea 使用者或組織",
+        "repo": "儲存庫",
+        "repoPlaceholder": "倉庫名稱",
+        "repoHelp": "Gitea 倉庫的名稱",
+        "encrypted": "加密",
+        "encryptedHelp": "該欄位已加密並安全儲存。",
+        "changeCredential": "改變",
+        "apiKeyWarningTitle": "API金鑰認證通知",
+        "apiKeyWarningDescription": "使用 API 金鑰認證時，問題報告者會自動決定：",
+        "apiKeyWarningPoint1": "如果您的 TestPlanIt 信箱位址與 Jira 使用者信箱位址相符，您將被設定為報告人。",
+        "apiKeyWarningPoint2": "如果沒有相符的電子郵件地址，您的 TestPlanIt 名稱將與 Jira 顯示名稱相符。",
+        "apiKeyWarningPoint3": "如果未找到符合項，則將 API 金鑰擁有者設定為報告者。",
+        "forgeApiKeyLabel": "Forge API 金鑰",
+        "forgeApiKeyDescription": "Atlassian Forge 應用程式使用此金鑰來驗證來自 Jira 問題面板的請求。請在此處產生金鑰並將其貼到 Forge 應用程式設定中。",
+        "forgeApiKeyPlaceholder": "點選「產生」按鈕建立 API 金鑰",
+        "forgeApiKeyGenerate": "產生",
+        "forgeApiKeyCopy": "複製",
+        "forgeApiKeyCopied": "已複製",
+        "platform": "平台",
+        "platformPlaceholder": "選擇平台...",
+        "platformGitea": "吉特亞",
+        "platformForgejo": "福爾熱",
+        "platformGogs": "戈格斯"
+      },
+      "authType": {
+        "api_key": "API金鑰",
+        "oauth2": "OAuth 2.0",
+        "personal_access_token": "個人訪問令牌"
+      },
+      "validation": {
+        "nameRequired": "問題整合名稱為必填項",
+        "clientIdRequired": "需要客戶端 ID",
+        "clientSecretRequired": "需要客戶端密鑰",
+        "cloudIdRequired": "需要 Cloud ID",
+        "apiUrlRequired": "需要提供 API URL",
+        "tokenRequired": "需要個人存取權令牌",
+        "apiKeyRequired": "需要 API 金鑰"
+      },
+      "errors": {
+        "updateFailed": "問題整合更新失敗",
+        "testFailed": "連線測試失敗",
+        "nameExists": "已存在一個名稱相同的整合問題",
+        "createFailed": "創建問題整合失敗",
+        "deleteFailed": "刪除問題整合失敗"
+      },
+      "confirmDelete": {
+        "message": "您確定要刪除問題整合「{name}」嗎？",
+        "warning": "這將移除問題整合並將其與所有專案斷開連接。此操作無法撤銷。"
+      },
+      "form": {
+        "success": "問題整合已成功保存",
+        "successDescription": "問題整合已配置完成，可以開始使用了。",
+        "testing": "正在測試連接..."
+      },
+      "oauth": {
+        "connectAccount": "連結帳戶",
+        "connected": "已連接",
+        "notConnected": "未連接",
+        "authDescription": "您需要使用 {provider} 進行身份驗證才能使用此集成",
+        "authError": "身份驗證失敗",
+        "authErrorDescription": "無法透過外部服務進行身份驗證"
+      }
+    },
+    "llm": {
+      "addIntegration": "新增人工智慧模型",
+      "filterPlaceholder": "過濾人工智慧模型…",
+      "testAll": "測試所有連接",
+      "connectionTestComplete": "連線測試完成",
+      "allIntegrationsTested": "所有人工智慧模型連接均已測試",
+      "failedToTestConnections": "部分連線測試失敗",
+      "notConfigured": "未配置",
+      "defaultModel": "選定型號",
+      "budgetUsage": "本月使用量",
+      "noBudget": "無預算集",
+      "streaming": "串流媒體",
+      "add": {
+        "title": "添加人工智慧模型集成",
+        "description": "為您的組織配置一個新的人工智慧模型",
+        "integrationNamePlaceholder": "請輸入此整合的名稱…",
+        "selectProvider": "選擇服務提供者",
+        "openai": "OpenAI",
+        "anthropic": "人類學",
+        "azureOpenai": "Azure OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "奧拉瑪",
+        "customLlm": "定制LLM",
+        "apiKeyPlaceholder": "請輸入您的 API 金鑰...",
+        "apiKeyDescription": "您用於向提供者進行身份驗證的 API 金鑰",
+        "endpoint": "端點 URL",
+        "endpointPlaceholder": "https://api.provider.com/v1",
+        "endpointV1Hint": "提示：如果使用代理程式（例如 LiteLLM），請嘗試在端點 URL 的末端新增 /v1。",
+        "deploymentName": "部署名稱",
+        "deploymentNamePlaceholder": "請輸入部署名稱...",
+        "deploymentNameDescription": "Azure OpenAI 部署名稱",
+        "defaultModelPlaceholder": "gpt-4o、claude-3-5-sonnet-20241022 等。",
+        "defaultModelDescription": "預設使用的模型",
+        "maxTokensPerRequest": "每次請求的最大令牌數",
+        "maxRequestsPerMinute": "每分鐘最大請求數",
+        "costPerInputToken": "每百萬個輸入代幣的成本（美元）",
+        "costPerOutputToken": "每百萬個輸出代幣的成本（美元）",
+        "monthlyBudget": "每月預算（美元）",
+        "monthlyBudgetPlaceholder": "100.00",
+        "monthlyBudgetDescription": "可選的通知消費目標（不會限制使用）",
+        "billingPeriodStartDay": "計費週期起始日",
+        "billingPeriodStartDayPlaceholder": "1",
+        "billingPeriodStartDayDescription": "帳單週期開始的日期（1-31）。 29-31 使用的是較短月份的最後一天。",
+        "defaultTemperature": "預設溫度",
+        "defaultMaxTokens": "預設最大令牌數",
+        "timeout": "請求超時時間（毫秒）",
+        "timeoutDescription": "等待 AI 模型響應的最長時間（5000-600000 毫秒）。不適用於串流請求。",
+        "streamingEnabled": "啟用串流媒體",
+        "streamingEnabledDescription": "允許即時響應流",
+        "setAsDefault": "設定為預設值",
+        "setAsDefaultDescription": "將此模型用作組織的預設人工智慧模型。",
+        "fetchingModels": "正在取得模型...",
+        "failedToFetchModels": "取得可用模型失敗",
+        "selectModel": "選擇型號",
+        "connectionSuccessfulDescription": "AI模型連線已驗證，運作正常。",
+        "failedToConnect": "無法連接 AI 模型提供商",
+        "integrationCreated": "AI模型整合已成功創建",
+        "failedToCreate": "建立 AI 模型整合失敗",
+        "validation": {
+          "nameRequired": "整合名稱為必填項",
+          "nameUnique": "已存在同名集成",
+          "defaultModelRequired": "需要預設模型"
+        }
+      },
+      "edit": {
+        "title": "編輯 AI 模型集成",
+        "description": "更新此 AI 模型整合的配置",
+        "statusDescription": "啟用或停用此集成",
+        "apiKeyPlaceholder": "請輸入新的 API 金鑰進行更新...",
+        "update": "更新",
+        "integrationUpdated": "AI模型整合已成功更新",
+        "failedToUpdate": "AI模型整合更新失敗",
+        "validation": {
+          "nameRequired": "整合名稱為必填項",
+          "nameUnique": "已存在同名集成",
+          "defaultModelRequired": "需要預設模型"
+        }
+      },
+      "sections": {
+        "provider": "提供者",
+        "costAndBudget": "成本與預算",
+        "advanced": "先進的"
+      },
+      "delete": {
+        "title": "刪除 AI 模型集成",
+        "description": "您確定要刪除此AI模型整合嗎？此操作會將其從所有項目中移除，且無法撤銷。",
+        "integrationDeletedSuccess": "AI模型整合已成功刪除",
+        "failedToDeleteIntegration": "刪除 AI 模型整合失敗",
+        "cannotDeleteDefault": "無法刪除預設AI模型。請先將另一個模型設定為預設模型。"
+      },
+      "validation": {
+        "defaultModelRequired": "需要預設模型"
+      },
+      "test": {
+        "title": "測試人工智慧模型集成",
+        "description": "測試 {name} 的連接與功能",
+        "connectionStatus": "連線狀態",
+        "connectionStatusDescription": "檢查人工智慧模型是否可存取",
+        "retest": "重新測試連接",
+        "connectionSuccessfulDescription": "AI模型可存取且響應正確。",
+        "failedToConnect": "連結人工智慧模型失敗",
+        "errorTestingConnection": "測試連線時發生錯誤",
+        "testMessage": "測試訊息",
+        "testMessagePlaceholder": "請輸入要傳送給人工智慧模型的訊息…",
+        "sendTestMessage": "發送測試訊息",
+        "response": "回覆",
+        "testSuccessful": "測試成功",
+        "responseReceived": "已成功收到回應（成本： ${cost}）",
+        "testFailed": "測試失敗",
+        "failedToGetResponse": "未能從人工智慧模型獲得回應",
+        "failedToSendMessage": "發送測試訊息失敗",
+        "defaultTestMessage": "您好！請簡要確認您的工作一切正常。"
+      },
+      "budgetAlert": {
+        "budgetDisclaimer": "設定每月預算並不能阻止LLM的使用超出預算。預算限制僅供管理員決策參考。",
+        "budgetDisclaimerShort": "預算限制僅供參考，不會限制使用。",
+        "spendLabel": "本月支出",
+        "spendOfBudget": "{currentSpend} 的 {budgetLimit}",
+        "overBudget": "超出預算",
+        "budgetPercentage": "{percentage}已用預算百分比",
+        "spendReset": "本月支出已重置"
+      }
+    },
+    "prompts": {
+      "title": "提示配置",
+      "description": "管理不同功能的 AI 提示模板",
+      "addPromptConfig": "新增提示配置",
+      "filterPlaceholder": "篩選提示配置...",
+      "features": "特徵",
+      "featureCount": "{count, plural, one {# 功能} other {# 功能}}",
+      "llmIntegration": "LLM整合",
+      "modelOverride": "模型覆蓋",
+      "llmIntegrationPlaceholder": "項目預設值",
+      "modelOverridePlaceholder": "整合預設值",
+      "projectDefault": "項目預設值（清除）",
+      "integrationDefault": "整合預設值（清除）",
+      "systemPrompt": "系統提示",
+      "userPrompt": "使用者提示",
+      "temperature": "溫度",
+      "maxOutputTokens": "最大輸出令牌",
+      "variables": "變數",
+      "insertVariable": "插入變數",
+      "noConfigs": "未找到任何配置。請新增您的第一個配置以開始使用。",
+      "add": {
+        "title": "新增提示配置",
+        "description": "建立一個新的AI提示配置，為每個功能新增提示。預設值已自動套用。"
+      },
+      "edit": {
+        "title": "編輯提示配置",
+        "description": "更新此 AI 提示配置"
+      },
+      "delete": {
+        "title": "刪除提示配置",
+        "confirmMessage": "您確定要刪除 <strong>{name}</strong>嗎？使用此提示的項目將回退到系統預設值。",
+        "warning": "此操作無法撤銷。所有使用此配置的項目都將恢復為預設提示配置。"
+      },
+      "llmColumn": "法學碩士",
+      "mixedLlms": "{count} 法學碩士",
+      "cannotDeleteDefault": "無法刪除預設提示符配置。請先將另一個配置設為預設值。",
+      "defaultChanged": "預設提示符號配置已成功更新。",
+      "featureLabels": {
+        "markdown_parsing": "Markdown 測試用例解析",
+        "test_case_generation": "測試用例生成",
+        "magic_select_cases": "智慧測試用例選擇",
+        "editor_assistant": "編輯寫作助理",
+        "llm_test": "LLM 連線測試",
+        "export_code_generation": "匯出程式碼生成",
+        "auto_tag": "AI標籤建議",
+        "duplicate_detection": "重複檢測",
+        "generate_from_url": "根據 URL 產生測試案例（需求）",
+        "generate_from_url_app": "從 URL 產生測試用例（應用程式測試）"
+      }
+    },
+    "elasticsearch": {
+      "title": "Elasticsearch 管理",
+      "description": "管理搜尋引擎索引和維護",
+      "status": {
+        "title": "Elasticsearch 狀態",
+        "description": "搜尋引擎的當前連線和運作狀況",
+        "checking": "正在檢查狀態…",
+        "disconnected": "斷開連接",
+        "nodes": "節點",
+        "indices": "指數",
+        "documents": "文件",
+        "error": {
+          "title": "連線錯誤",
+          "description": "無法連線到 Elasticsearch 服務"
+        }
+      },
+      "settings": {
+        "description": "配置 Elasticsearch 設定以進行部署",
+        "numberOfReplicas": "副本數量",
+        "replicasHelp": "單節點叢集設為 0，多節點冗餘叢集設為 1 或更高。",
+        "savedDescription": "配置已儲存到資料庫",
+        "updated": "指數已更新",
+        "updatedDescription": "所有現有索引均已使用新的副本設定進行更新。",
+        "error": "儲存設定時出錯",
+        "errorDescription": "配置儲存失敗，請重試。",
+        "note": {
+          "description": "變更會立即套用至新建立的索引。現有索引會在儲存時更新。將副本數設為 0 可以解決單節點叢集上的黃色狀態問題。"
+        }
+      },
+      "reindex": {
+        "title": "重新索引數據",
+        "description": "重建搜尋索引以提高搜尋效能",
+        "entities": {
+          "all": "所有實體"
+        },
+        "button": {
+          "start": "開始重新索引",
+          "indexing": "正在建立索引…"
+        },
+        "warning": {
+          "title": "重要的",
+          "description": "重新索引可能需要幾分鐘時間，具體時間取決於資料量。在此過程中，搜尋功能可能會受到限制。"
+        },
+        "complete": {
+          "title": "重新索引完成",
+          "description": "所有選定的實體均已成功重新索引。"
+        },
+        "success": {
+          "title": "重新索引成功",
+          "description": "{count, plural, one {# 文件} other {# 文檔}} 索引成功"
+        },
+        "error": {
+          "title": "重新索引失敗",
+          "description": "重新索引時發生錯誤，請重試。"
+        }
+      }
+    },
+    "queues": {
+      "title": "後台作業佇列",
+      "description": "監控和管理後台作業處理佇列",
+      "queueNames": {
+        "forecast-updates": "預測更新",
+        "emails": "電子郵件佇列",
+        "issue-sync": "問題同步",
+        "testmo-imports": "Testmo Imports",
+        "elasticsearch-reindex": "Elasticsearch 重新索引",
+        "audit-logs": "審計日誌",
+        "budget-alerts": "預算警報",
+        "auto-tag": "AI自動標籤",
+        "repo-cache": "儲存庫快取",
+        "copy-move": "複製和移動",
+        "duplicate-scan": "重複掃描",
+        "magic-select": "魔法選擇",
+        "step-scan": "步進序列掃描"
+      },
+      "status": {
+        "paused": "暫停",
+        "idle": "閒置的"
+      },
+      "table": {
+        "queue": "佇列",
+        "concurrency": "並發性",
+        "waiting": "等待",
+        "failed": "失敗的"
+      },
+      "concurrency": {
+        "title": "工作並行",
+        "description": "並發性控制每個工作進程同時處理的作業數量。更高的並發性可以提高吞吐量，但會佔用更多系統資源（CPU 和記憶體）。",
+        "configureTitle": "配置並發性",
+        "configureDescription": "若要調整並發數，請設定環境變數並重新啟動工作進程。詳情請參閱文件。",
+        "envVars": {
+          "TESTMO_IMPORT_CONCURRENCY": "Testmo 匯入（預設值：1，佔用大量記憶體）",
+          "SYNC_CONCURRENCY": "問題同步（預設值：2，I/O密集型）",
+          "EMAIL_CONCURRENCY": "電子郵件發送（預設值：3，I/O密集型）",
+          "NOTIFICATION_CONCURRENCY": "通知（預設值：5，輕量級）",
+          "FORECAST_CONCURRENCY": "預測更新（預設值：5，CPU密集型）"
+        }
+      },
+      "actions": {
+        "pause": {
+          "confirmTitle": "暫停隊列",
+          "confirmDescription": "這將阻止新任務的處理。正在進行的任務將繼續完成。"
+        },
+        "resume": {
+          "confirmTitle": "恢復佇列",
+          "confirmDescription": "這將允許佇列處理等待中的作業。"
+        },
+        "clean": {
+          "confirmTitle": "清理隊列",
+          "confirmDescription": "這將從佇列中移除已完成和失敗的任務。此操作無法撤銷。"
+        },
+        "drain": {
+          "confirmTitle": "排水隊列",
+          "confirmDescription": "這將從佇列中移除所有等待中的任務。正在進行的任務將繼續完成。此操作無法撤銷。"
+        },
+        "obliterate": {
+          "confirmTitle": "刪除佇列",
+          "confirmDescription": "這將徹底清空佇列，刪除所有任務，無論其狀態為何。此操作無法撤銷，僅應在緊急情況下使用。"
+        },
+        "warning": "警告",
+        "irreversible": "此操作無法撤銷。請確認是否繼續。"
+      },
+      "success": {
+        "actionCompleted": "操作完成",
+        "queuePaused": "隊列已暫停",
+        "queueResumed": "隊列已恢復。",
+        "queueCleaned": "隊列已清理完畢",
+        "queueDrained": "隊列已清空",
+        "queueObliterated": "隊列已刪除"
+      },
+      "error": {
+        "loadFailed": "隊列載入失敗",
+        "actionFailed": "操作失敗"
+      },
+      "jobs": {
+        "title": "排隊作業",
+        "description": "查看和管理佇列中的各個作業",
+        "noJobs": "此佇列中未找到任何任務",
+        "table": {
+          "id": "職位編號",
+          "name": "職位名稱",
+          "attempts": "嘗試"
+        },
+        "details": {
+          "title": "職位詳情",
+          "failedReason": "失敗原因",
+          "stacktrace": "堆疊追蹤",
+          "data": "工作數據",
+          "returnValue": "傳回值",
+          "options": "工作選擇",
+          "processed": "已處理",
+          "finished": "完成的"
+        },
+        "success": {
+          "actionCompleted": "工作操作已完成",
+          "jobRetried": "任務已重試",
+          "jobPromoted": "職位已晉升",
+          "jobRemoved": "職位已移除"
+        },
+        "error": {
+          "loadFailed": "載入作業失敗",
+          "actionFailed": "作業操作失敗"
+        },
+        "forceRemove": {
+          "title": "強制刪除職位",
+          "question": "你想強制刪除這個職缺嗎？",
+          "warning": "這將嘗試多次移除該任務，每次移除操作都會有延遲。注意：如果該任務確實被正在執行的工作進程鎖定，則移除操作仍可能失敗。",
+          "confirm": "強制移除"
+        }
+      }
+    },
+    "auditLogs": {
+      "description": "查看系統範圍內的審計跟踪，以進行安全性和合規性跟踪",
+      "filterPlaceholder": "按實體、使用者或操作搜尋…",
+      "filterAction": "行動",
+      "filterEntityType": "實體類型",
+      "allActions": "所有操作",
+      "allEntityTypes": "所有實體類型",
+      "showing": "顯示 {start} 到 {end} 共 {total} 筆記錄",
+      "viewDetails": "看詳情",
+      "detailTitle": "審計日誌詳情",
+      "userInfo": "使用者資訊",
+      "changes": "變化",
+      "metadata": "元數據",
+      "oldValue": "老的",
+      "newValue": "新的",
+      "columns": {
+        "timestamp": "時間戳",
+        "entityId": "實體 ID",
+        "entityName": "實體名稱",
+        "userId": "使用者身分",
+        "ipAddress": "IP位址",
+        "userAgent": "使用者代理"
+      },
+      "exportCsv": "匯出 CSV 文件",
+      "timeRange": "時間範圍",
+      "timeRangeOptions": {
+        "last24h": "過去24小時",
+        "last7d": "過去7天",
+        "last30d": "過去30天",
+        "last90d": "過去90天",
+        "allTime": "所有時間"
+      },
+      "systemActor": "系統",
+      "systemActorTooltip": "系統執行的操作，而非登入使用者執行的操作。"
+    }
+  },
+  "components": {
+    "notifications": {
+      "empty": "無通知",
+      "aria": {
+        "notifications": "通知（{count} 未讀）"
+      },
+      "actions": {
+        "markRead": "標記為已讀",
+        "markUnread": "標記為未讀",
+        "markAllRead": "全部標記為已讀",
+        "deleteAll": "全部刪除"
+      },
+      "success": {
+        "deleted": "通知已刪除",
+        "markedAllRead": "所有標記為已讀的通知",
+        "deletedAll": "所有通知已刪除"
+      },
+      "error": {
+        "markRead": "標記為已讀失敗",
+        "markUnread": "標記為未讀失敗",
+        "delete": "刪除通知失敗",
+        "markAllRead": "未能將所有內容標記為已讀",
+        "deleteAll": "刪除通知失敗"
+      },
+      "deleteAllDialog": {
+        "title": "刪除所有通知？",
+        "description": "這將永久刪除您的所有通知。此操作無法撤銷。",
+        "confirm": "全部刪除"
+      },
+      "content": {
+        "testCaseAssignmentTitle": "新的測試用例分配",
+        "multipleTestCaseAssignmentTitle": "已分配多個測試案例",
+        "sessionAssignmentTitle": "新會話分配",
+        "commentMentionTitle": "你被評論中提到了。",
+        "systemAnnouncementTitle": "系統公告",
+        "assignedTestCase": "已指派您執行測試案例",
+        "assignedMultipleTestCases": "分配給你的測試案例數： {count, plural, one {# 測試案例數：} other {# 測試案例數：}}",
+        "assignedSession": "已將您指派到會話",
+        "mentionedYouInComment": "在評論中提到了你",
+        "inProject": "專案",
+        "testRun": "測試運行：",
+        "casesInProject": "{count, plural, =1 {# 案例} other {# 案例}}",
+        "sentBy": "發送者： {name}",
+        "milestoneDueSoonTitle": "里程碑即將到來",
+        "milestoneOverdueTitle": "里程碑逾期",
+        "milestoneDueSoon": "項目「{projectName}」中的里程碑「{milestoneName}」將於 {dueDate}到期。",
+        "milestoneOverdue": "項目「{projectName}」中的里程碑「{milestoneName}」原定於 {dueDate} 到期，現已逾期。",
+        "milestoneNotificationReason": "您收到此通知是因為您參與了與此里程碑相關的工作（測試運行、會議或作為里程碑創建者）。",
+        "milestoneNotificationContinue": "您將持續收到每日提醒，直到此里程碑被標記為完成。",
+        "shareLinkAccessedTitle": "分享連結已訪問",
+        "shareLinkAccessedAnonymousViewer": "某人",
+        "shareLinkAccessedMessage": "{viewer} 檢視了您分享的報告：\"{shareTitle}\"",
+        "viewedYourSharedLink": "我已查看您分享的鏈接",
+        "viewedAt": "查看於",
+        "budgetDisclaimer": "預算限制僅供參考，不妨礙實際使用。",
+        "llmBudgetExceededTitle": "法學碩士預算超支",
+        "llmBudgetThresholdTitle": "LLM 預算 {threshold}已使用百分比",
+        "llmBudgetExceededMessage": "{providerName} 已超出其月度預算： {spend} 已花費 {budget} 預算。",
+        "llmBudgetThresholdMessage": "{providerName} 已使用其每月預算的 {threshold}%： {spend} 的 {budget}。",
+        "userRegisteredTitle": "新用戶註冊",
+        "userRegisteredMessageSso": "{userName} ({userEmail}) 已透過 SSO 註冊",
+        "userRegisteredMessageForm": "{userName} ({userEmail}) 已透過註冊表單註冊",
+        "viewUserList": "查看使用者列表",
+        "reviewGeneratedCases": "審查產生的測試用例",
+        "generateFromUrlCompleteTitle": "頁面抓取成功",
+        "generateFromUrlCompleteMessage": "{pages, plural, one {# page} other {# pages}} crawled from {url} in project \"{projectName}\". Click to review and generate test cases.",
+        "generateFromUrlFailedTitle": "URL 抓取失敗"
+      }
+    },
+    "issues": {
+      "manage_issues": {
+        "placeholder": "搜尋或連結問題…",
+        "create_label": "連結問題“{name}"
+      },
+      "create_issue_dialog": {
+        "placeholders": {
+          "name": "輸入問題摘要"
+        },
+        "fields": {
+          "name": {
+            "label": "概括"
+          },
+          "description": {
+            "placeholder": "請描述一下問題…",
+            "helper": "請提供有關該問題的詳細資訊。"
+          },
+          "project": {
+            "helper": "在外部問題追蹤器中選擇項目"
+          }
+        },
+        "loading_metadata": "正在加載集成設定...",
+        "errors": {
+          "creation_failed": "建立問題失敗，請重試。"
+        },
+        "success": {
+          "created": "問題已成功創建",
+          "external_created": "問題已建立並連結到外部追蹤器"
+        },
+        "warnings": {
+          "external_failed": "問題已在本地創建，但無法與外部追蹤器同步。"
+        }
+      },
+      "integration_auth_prompt": {
+        "description": "您需要將您的帳戶連接到 {integrationName} 才能建立問題。"
+      },
+      "search_issues_dialog": {
+        "title": "搜尋和連結問題",
+        "placeholder": "尋找問題...",
+        "searching": "正在搜尋…",
+        "searchError": "搜尋問題失敗",
+        "linkButton": "關聯",
+        "linkedCount": "{count, plural, one {# 問題} other {# 問題}} 鏈接"
+      }
+    },
+    "copyMove": {
+      "title": "複製/移動到項目",
+      "step1Desc": "選擇測試案例的目標項目和資料夾。",
+      "step2Desc": "選擇操作並檢查相容性。",
+      "step3Desc": "追蹤進度並審查結果。",
+      "targetProject": "目標專案",
+      "searchProjects": "搜尋項目...",
+      "loadingProjects": "正在加載項目...",
+      "noProjectsFound": "未找到項目。",
+      "completed": "（完全的）",
+      "targetFolder": "目標資料夾",
+      "newFolderPlaceholder": "新資料夾名稱...",
+      "operation": "手術",
+      "operationCopy": "複製",
+      "operationCopyDesc": "在目標專案中建立所選案例的副本。原始案例保持不變。",
+      "operationMove": "移動",
+      "operationMoveDesc": "將選定的案例移至目標項目。原始案例將從來源項目中刪除。",
+      "checkingCompatibility": "正在檢查相容性…",
+      "noTargetWriteAccess": "您沒有目標項目的寫入權限。",
+      "noSourceUpdateAccess": "您沒有來源項目的編輯權限，無法移動案例。",
+      "templateMismatch": "模板不匹配",
+      "autoAssignTemplates": "自動將缺少的模板分配給目標項目",
+      "templatesMayNotDisplay": "目標項目中將無法使用缺少的模板。案例將被複製，但模板中的欄位可能無法正確顯示。",
+      "workflowFallback": "目標項目中某些工作流程狀態不可用。這些情況下將使用目標項目的預設狀態。",
+      "default": "(預設)",
+      "conflicts": "適用於所有衝突：",
+      "conflictSkip": "跳過",
+      "conflictRename": "重新命名",
+      "sharedStepGroups": "當目標系統中已存在共用步驟群組時：",
+      "sharedStepGroupReuse": "重複利用現有",
+      "sharedStepGroupReuseDesc": "案例將參考現有的共享步驟組。",
+      "sharedStepGroupCreateNew": "創建新的",
+      "sharedStepGroupCreateNewDesc": "將建立一個新的共享步驟組。",
+      "go": "去",
+      "processing": "加工...",
+      "progressText": "已處理個案數：{processed} / {total}",
+      "successCount": "{count} 案例 {operation}d 成功",
+      "skipped": "已跳過： {count}",
+      "droppedLinks": "跨項目連結已刪除： {count}",
+      "errorCount": "{count} 個案失敗",
+      "viewInTargetProject": "在目標項目中查看",
+      "failed": "失敗的",
+      "folderMode": "資料夾「{folderName}」 — {caseCount, plural, one {# 案例} other {# 案例}}"
+    }
+  },
+  "issues": {
+    "linkedIssues": "相關問題",
+    "linkedIssuesDescription": "與此項目相關的問題",
+    "refreshed": "問題已更新",
+    "refreshedDescription": "相關問題清單已更新",
+    "unlinked": "問題未關聯",
+    "unlinkedDescription": "該問題已從此項目中移除。",
+    "linked": "相關問題",
+    "linkedDescription": "該問題與此項目有關",
+    "searchAndLink": "搜尋和連結",
+    "createAndLink": "創建和連結",
+    "noLinkedIssues": "沒有相關問題",
+    "viewExternal": "在 {provider}中查看",
+    "unlink": "取消連結",
+    "linkError": "連結問題失敗",
+    "linkExternalIssue": "連結 {provider} 問題",
+    "linkIssue": "連結問題",
+    "addIssue": "添加問題",
+    "unlinkError": "取消連結問題失敗",
+    "noIssuesFound": "未發現問題",
+    "startTypingToSearch": "開始輸入以搜尋問題",
+    "selectedCount": "{count} 已選擇",
+    "confirmSelection": "確認選擇",
+    "alreadyLinked": "已連結",
+    "authenticate": "認證",
+    "authenticationRequired": "需要身份驗證",
+    "authenticationDescription": "您需要使用 {provider} 進行身份驗證才能搜尋問題。",
+    "searchIn": "在 {provider} 中搜尋",
+    "searchPlaceholder": "搜尋問題…",
+    "searchIssues": "搜尋問題",
+    "searchIssuesDescription": "尋找與此項目相關的內部問題。",
+    "searchExternalDescription": "搜尋 {provider} 個問題以連結到此項目。",
+    "error": "載入問題錯誤",
+    "errorDescription": "問題載入失敗，請重試。",
+    "selectIssues": "選擇問題",
+    "authRequiredDescription": "請使用 {provider} 進行身份驗證以搜尋問題",
+    "integrationNotConfigured": "整合未配置",
+    "integrationNotConfiguredDescription": "此整合尚未完全配置。請聯絡您的專案管理員，以便在專案設定中設定外部項目。",
+    "createIssue": "創建問題",
+    "createNewIssue": "建立新問題",
+    "createIssueDescription": "建立新問題",
+    "createIssueDescriptionWithIntegration": "使用 {provider} 建立新問題",
+    "createIssueDescriptionSimpleUrl": "建立新的內部問題（簡單 URL 整合）",
+    "creatingWith": "創建問題 {provider}",
+    "authenticatedAndReady": "已通過身份驗證，可以建立問題。",
+    "created": "問題已建立",
+    "createdInExternal": "問題創建於 {provider}",
+    "createdInternal": "本地創建的問題",
+    "createdInternalSimpleUrl": "此問題已在內部創建，可透過簡單 URL 連結。",
+    "createError": "創建問題失敗",
+    "useIntegration": "使用 {provider}",
+    "useIntegrationDescription": "在外部系統中建立問題",
+    "externalProject": "外部專案",
+    "selectProject": "選擇項目",
+    "issueType": "問題類型",
+    "selectIssueType": "選擇問題類型",
+    "noIssueTypes": "暫無問題類型",
+    "priorityUrgent": "緊迫的",
+    "additionalFields": "附加字段",
+    "createIssueInJira": "在 Jira 中創建問題",
+    "createIssueInJiraDescription": "使用 Jira 的介面建立一個包含所有可用欄位和選項的新問題",
+    "createIssueInJiraFallbackDescription": "在新分頁中開啟 Jira，即可建立預先填入資訊的議題。",
+    "jiraIframeError": "無法載入 Jira 介面。請嘗試在新分頁中開啟。",
+    "jiraIframeFallback": "出於安全考慮，Jira 需要新標籤頁中開啟。請點擊下方按鈕建立您的問題。",
+    "jiraFallbackNote": "在 Jira 中創建問題後，請返回此處繼續將其連結到您的測試案例。",
+    "openInNewTab": "在新分頁中開啟",
+    "jiraIframeNote": "在 Jira 中建立問題後，您可以關閉此對話方塊並刷新問題清單。",
+    "fillInRequiredFields": "填寫必填欄位以建立新問題",
+    "failedToFetchFields": "無法從 Jira 取得問題字段",
+    "enterSummary": "請簡要概述該問題。",
+    "enterDescription": "請詳細描述問題。",
+    "failedToCreateIssue": "在 Jira 中創建問題失敗",
+    "issueCreatedDescription": "問題 {key} 已成功創建",
+    "addLabel": "新增標籤並按 Enter 鍵",
+    "labelHint": "空格將被替換為連字號。",
+    "labelFormatNote": "標籤中不能包含空格。空格將自動替換為連字號。",
+    "enterIssueKey": "輸入問題編號（例如，PROJ-123）",
+    "issueLinkHelp": "輸入現有問題的鍵值以進行鏈接",
+    "searchForIssue": "尋找要連結的問題",
+    "searchUsers": "搜尋用戶",
+    "noTeamsAvailable": "暫無球隊",
+    "filterAll": "全部",
+    "fanOutPartialFailure": "無法存取 {count} 個項目。正在顯示 {successCount} 個項目的結果。",
+    "projectSelectorLabel": "專案",
+    "searchFailedTitle": "搜尋失敗"
+  },
+  "Pages": {
+    "Issues": {
+      "description": "瀏覽和管理所有問題。",
+      "filterPlaceholder": "按名稱篩選問題..."
+    }
+  },
+  "enums": {
+    "ApplicationArea": {
+      "Documentation": "文件",
+      "Milestones": "里程碑",
+      "TestCaseRepository": "測試用例庫",
+      "TestCaseRestrictedFields": "測試用例受限字段",
+      "TestRuns": "測試運行",
+      "ClosedTestRuns": "封閉式測試運行",
+      "TestRunResults": "測試運行結果",
+      "TestRunResultRestrictedFields": "測試運行結果受限字段",
+      "Sessions": "會議",
+      "SessionsRestrictedFields": "會話受限字段",
+      "ClosedSessions": "閉門會議",
+      "SessionResults": "會議結果",
+      "Tags": "標籤",
+      "SharedSteps": "共同步驟",
+      "Issues": "問題",
+      "IssueIntegration": "問題整合",
+      "Forecasting": "預測",
+      "Reporting": "報告",
+      "Settings": "設定"
+    },
+    "WorkflowType": {
+      "NOT_STARTED": "尚未開始",
+      "IN_PROGRESS": "進行中",
+      "DONE": "完畢"
+    }
+  },
+  "charts": {
+    "average": "平均的",
+    "count": "數： {count}",
+    "percent": "百分比： {percent}%",
+    "completed": "已完成： {count}",
+    "durationRange": "持續時間： {from}秒 - {to}秒",
+    "seconds": "{seconds}s",
+    "testCases": "{count, plural, one {# 測試案例} other {# 測試案例}}",
+    "estimate": "估計： {value}",
+    "partOf": "（ {parent}的一部份）",
+    "status": "狀態： {status}"
+  },
+  "linkedCases": {
+    "title": "關聯測試用例",
+    "addLink": "添加連結",
+    "addLinkedTestCase": "新增關聯測試用例",
+    "testCase": "測試用例",
+    "linkType": "連結類型",
+    "noLinkedCases": "沒有關聯的測試用例。",
+    "linkedBy": "連結",
+    "on": "連結",
+    "alreadyLinked": "此案已關聯。",
+    "cannotLinkSelf": "無法將案件與其自身關聯。",
+    "circularLink": "偵測到環狀連結。",
+    "failedToCreate": "連結建立失敗。",
+    "confirmRemoveLink": "您確定要刪除此連結嗎？",
+    "DEPENDS_ON": "依賴性",
+    "DUPLICATED_FROM": "複製自",
+    "SAME_TEST_DIFFERENT_SOURCE": "相同的測試（不同來源）",
+    "status": "最新狀態",
+    "at": "已執行"
+  },
+  "ganttTooltip": {
+    "task": "任務",
+    "group": "運行/會話：",
+    "project": "專案:",
+    "starts": "開始：",
+    "scheduledCompletion": "預計完工日期：",
+    "estWorkEffort": "預計工作量：",
+    "noTasks": "甘特圖中沒有要顯示的任務。"
+  },
+  "help": {
+    "project": {
+      "name": "## Project Name\nThe unique identifier for your project.\n\n- Must be unique across all projects\n- Used in navigation and reports\n- Should be clear and descriptive\n- Helps team members identify the project scope",
+      "description": "## Project Description\nAdditional details about the project's purpose and scope.\n\n- Optional but recommended\n- Helps team members understand project goals\n- Can include key objectives or requirements\n- Limited to 256 characters",
+      "icon": "## Project Icon\nA visual identifier for your project.\n\n- Helps quickly identify the project in lists and dashboards\n- Choose from a variety of predefined icons\n- Can be changed at any time\n- Appears in project navigation and reports",
+      "completed": "## Project Status\nIndicates whether the project is active or completed.\n\n- Active projects are available for testing and updates\n- Completed projects are read-only\n- Affects project visibility in dashboards\n- Can be reversed if needed",
+      "completedAt": "## Completion Date\nThe date when the project was marked as completed.\n\n- Automatically set when marking a project as completed\n- Used for reporting and tracking\n- Helps maintain project history\n- Can be modified if needed",
+      "defaultAccess": "## 預設項目存取權限\n定義此項目中使用者和群組的預設存取權限。可以針對每個使用者或每個群組進行覆蓋。",
+      "issueTracker": "## 問題追蹤器配置\n選擇用於管理與此項目相關的問題的追蹤器配置。"
+    },
+    "projects": {
+      "settings": {
+        "integrations": {
+          "externalProjectHelp": "## 外部項目\n選擇要與此 TestPlanIt 項目關聯的外部系統中的項目或儲存庫。\n\n- 從 TestPlanIt 建立的問題將在此專案中建立。\n- 啟用系統間的問題追蹤整合。\n- 必須在外部系統中擁有對應的權限。",
+          "defaultIssueTypeHelp": "## 預設問題類型\n從 TestPlanIt 建立新問題時將預先選擇的問題類型。\n\n- 預設為最常用的問題類型，節省時間。\n- 建立單一問題時可以覆寫此設定。\n- 必須是所選外部項目的有效問題類型。\n- 如果您的工作流程發生更改，請更新此設定。",
+          "automaticSyncHelp": "## 自動同步\n啟用 TestPlanIt 與外部系統之間的問題狀態自動同步。\n\n- 與測試案例關聯的問題將自動更新其狀態。\n- 有助於維持跨系統問題追蹤的一致性。\n- 可能會增加外部服務的 API 使用量。\n- 如果偏好手動控制，可以停用此功能。"
+        }
+      }
+    },
+    "user": {
+      "name": "## 使用者名稱\n使用者的全名。\n\n- 用於系統內的識別\n- 顯示在任務分配和報告中\n- 每個使用者的使用者名稱必須唯一",
+      "email": "## 電子郵件地址\n使用者用於存取帳戶的電子郵件地址。\n\n- 用於系統登入\n- 每個使用者必須使用唯一的電子郵件地址\n- 用於系統通知",
+      "password": "## 密碼\n使用者帳號密碼。\n\n- 如果設定了無密碼登入方式（Magic Link SSO 提供者或電子郵件伺服器），則此項目為可選 — 留空則必須透過 Magic Link 或 SSO 登入。\n- 如果提供，則必須符合「管理 → 安全性」中設定的密碼策略（最小長度和字元類別）。\n- 用於安全帳戶存取。\n- 應保密。",
+      "token": "## 驗證令牌\n輸入您在電子郵件中收到的令牌以驗證您的帳戶。如果您沒有令牌，可以申請一個新的。",
+      "confirmPassword": "## 確認密碼\n請重新輸入密碼，並確保輸入正確。\n\n- 必須與密碼完全一致。\n- 有助於防止輸入錯誤。\n- 僅當輸入密碼時需要填寫 — 若密碼欄位為空，則留空。",
+      "access": "## System Access Level\nDetermines the user's system-wide permissions.\n\n- **Admin:** Full system access and configuration\n- **Project Admin:** Can manage assigned projects\n- **User:** Standard access to assigned projects\n- **None:** Can only view their dashboard",
+      "role": "## 系統角色\n此角色決定使用者的預設項目權限。\n\n- 定義項目的預設存取等級。\n- 可在角色管理中自訂。\n- 影響可用功能和權限。",
+      "active": "## 活動狀態\n控制使用者是否可以存取系統。\n\n- 活動使用者可以登入並存取其指派的資源。\n- 非活動用戶無法登錄，但其資料將會保留。\n  - 使用此選項可暫時停用存取權限，而不會刪除帳戶。",
+      "api": "## API 存取\n允許透過 API 端點以程式設計方式存取系統。\n\n- 允許與外部工具和自動化整合。\n- 需要 API 金鑰驗證。\n- 受速率限制和存取控制。",
+      "projects": "## 項目分配\n選擇此使用者可以存取的項目。\n\n- 控制哪些項目顯示在使用者的儀表板中。\n- 專案參與的必要條件。\n- 管理者可以稍後修改。\n- 使用「全選」快速指派所有可用項目。",
+      "groups": "## 分組分配\n選取此使用者所屬的群組。\n\n- 分組有助於組織使用者和權限。\n- 使用者繼承其所屬群組的權限。\n- 簡化存取管理。\n- 管理員稍後可以修改。",
+      "itemsPerPage": "## Items Per Page\nControls the default number of items shown in tables and lists.\n\n- Affects all paginated views in the application\n- Can be changed at any time\n- Helps manage large data sets efficiently\n- Available options: 10, 25, 50, or 100 items",
+      "dateFormat": "## Date Format\nSets your preferred date display format.\n\n- Applied consistently across the application\n- Helps ensure date interpretation accuracy\n- Changes take effect immediately\n- Examples shown in the dropdown reflect the actual format",
+      "timeFormat": "## Time Format\nSets your preferred time display format.\n\n- Choose between 12-hour and 24-hour formats\n- Applied consistently across the application\n- Changes take effect immediately\n- Examples shown in the dropdown reflect the actual format",
+      "timezone": "## 時區\n設定日期和時間顯示的首選時區。\n\n- 在整個應用程式中統一應用",
+      "theme": "## Theme\nChoose your preferred visual theme for the application.\n\n- **System:** Automatically matches your operating system theme\n- **Light:** Clean, bright interface for daytime use\n- **Dark:** Eye-friendly dark mode for low-light environments\n- **Green, Orange, Purple:** A fun pop of color!",
+      "locale": "## Language\nSelect your preferred language for the application interface.\n\n- Changes all text, labels, and messages to your chosen language\n- Date and time formats adjust to match regional conventions\n- Takes effect immediately without requiring a page refresh\n- Available languages depend on installed translations",
+      "notificationMode": "## Notification Preferences\nControls how you receive notifications for work assignments and updates.\n\n- **Use Global Settings:** Follow the system default set by administrators\n- **No Notifications:** Disable all notifications\n- **In-App Only:** Receive notifications only within the application\n- **In-App + Email (Immediate):** Get both in-app notifications and immediate email alerts\n- **In-App + Email (Daily Digest):** Get in-app notifications and a daily email summary\n\nYou can change this preference at any time to suit your workflow."
+    },
+    "milestone": {
+      "name": "## 里程碑名稱\n一個清晰、描述性的名稱，用於標識專案中的此里程碑。\n\n- 應具有唯一性和意義\n- 幫助團隊成員快速理解里程碑的目的\n- 用於報告和專案追蹤",
+      "type": "## 里程碑類型\n將里程碑分類，並決定其外觀和行為。\n\n- 不同類型的里程碑可能有不同的工作流程。\n- 有助於組織和篩選里程碑。\n- 可能會影響報告和追蹤。",
+      "started": "## 開始狀態\n表示此里程碑的工作已開始。\n\n- 將里程碑標記為進行中。\n- 切換後自動更新實際開始日期。\n- 影響專案時程和進度追蹤。",
+      "completed": "## 完成狀態\n表示此里程碑的工作已完成。\n\n- 將里程碑標記為已完成。\n- 自動更新實際完成日期。\n- 用於進度追蹤和報告。\n- 影響依賴里程碑與專案時程。",
+      "startDate": "## 計畫開始日期\n此里程碑預計開始工作的日期。\n\n- 有助於專案規劃與進度安排\n- 用於時間軸預測\n- 支援資源分配規劃",
+      "dueDate": "## 截止日期\n完成此里程碑的目標日期。\n\n- 設定截止日期預期\n- 用於專案時程規劃\n- 協助追蹤里程碑進度與計畫的偏差",
+      "parent": "## 父級里程碑\n將此里程碑連結到父級里程碑，從而建立層級結構。\n\n- 將里程碑組織成邏輯群組。\n- 顯示依賴關係。\n- 協助追蹤大型專案的進度。",
+      "description": "## 描述\n里程碑的目的、要求和範圍的詳細資訊。\n\n- 提供團隊成員背景資訊\n- 記錄關鍵要求和目標\n- 支援協作和目標一致性",
+      "documentation": "## 文件\n更多詳情、參考資料和支援資料。\n\n- 技術規格\n- 設計文件\n- 外部參考資料\n- 會議記錄與決議",
+      "automaticCompletion": "## 截止日期自動完成\n當里程碑的截止日期到來時，會自動標記為已完成。\n\n- 里程碑將在截止日期當天按計畫時間完成。\n- 適用於無論完成狀態如何都應關閉的限時里程碑。\n- 可以透過在截止日期前手動完成里程碑來覆蓋此設定。\n- 需要設定截止日期。",
+      "notifyDaysBefore": "## 截止日期前通知\n當里程碑截止日期臨近時，向指定的團隊成員發送通知。\n\n- 開啟此開關以啟用通知，關閉此開關以停用通知。\n- 輸入截止日期前開始發送提醒的天數。\n- 通知將傳送給指派到此里程碑內測試運行和會話的使用者。\n- 逾期里程碑將持續傳送提醒，直至完成。"
+    },
+    "session": {
+      "name": "## 會話名稱\n一個清晰、描述性的名稱，用於明確測試會話的目的。\n\n- 應唯一且有意義。\n- 幫助團隊成員了解測驗內容。\n- 用於報告和追蹤。",
+      "template": "## 範本\n範本定義了測驗會話的結構和內容。\n\n- 為測試文件提供一致的格式\n- 包含預先定義的部分和欄位\n- 有助於在整個專案中維護測試標準",
+      "configuration": "## 設定\n此測試會話所需的特定環境或設定。\n\n- 測試環境（例如，預發布環境、生產環境）\n- 特殊配置或設定\n- 所需的測試資料或條件",
+      "milestone": "## 里程碑\n將此會話與專案里程碑關聯。\n\n- 協助追蹤測試進度，以達成專案目標。\n- 將相關的測驗會話分組。\n- 支援基於里程碑的報告。",
+      "description": "## 描述\n本測試內容的簡要概述。\n\n- 測試的關鍵領域或功能\n- 重要的背景資訊\n- 特殊注意事項或要求",
+      "mission": "## 任務\n任務定義了本次測驗的具體目標和目的。\n\n- 你要測試什麼？\n- 重點在於哪些面向？\n- 預期結果是什麼？\n\n清晰的任務有助於維持測驗的專注性和高效率。",
+      "estimate": "## Time Estimate\nEstimated time to complete this testing session.\n\nExamples:\n- \"30m\" for 30 minutes\n- \"1h 30m\" for 1 hour and 30 minutes\n- \"2 days\" for 2 days\n- \"1 week\" for 1 week",
+      "elapsed": "## Elapsed Time\nThe actual time spent on this testing session.\n\nExamples:\n- \"45m\" for 45 minutes\n- \"2h 15m\" for 2 hours and 15 minutes\n- \"3 days\" for 3 days\n\nTrack time accurately to improve future estimates.",
+      "state": "## 工作流程狀態\n此測試工作階段在您工作流程中的目前狀態。\n\n- 幫助追蹤會話進度\n- 支援工作流程管理\n- 用於報告和追蹤",
+      "assignedTo": "## 指派給\n負責執行本次測試的團隊成員。\n\n- 確定測試執行人\n- 協助資源管理\n- 支持問責和跟踪",
+      "tags": "## 標籤\n用於對測試會話進行分類和組織的關鍵字或標籤。\n\n- 方便尋找會話\n- 將相關的測試活動分組\n- 支援篩選和報告",
+      "attachments": "## 附件\n與本測試相關的文件、螢幕截圖或其他文件。\n\n- 測試資料檔案\n- 螢幕截圖或錄影\n- 支援文件\n- 參考資料",
+      "issues": "## 問題\n將相關問題連結到本次會議。"
+    },
+    "testRun": {
+      "name": "## 測試運行名稱\n輸入此測試運行的描述性名稱，以便日後輕鬆識別。",
+      "description": "## 說明\n提供有關本測試運行的簡要總結或說明。",
+      "configuration": "## 配置\n選擇一個或多個配置（例如，環境、瀏覽器、設備），測試運行將在這些配置下執行。選擇多個配置將為每個配置建立單獨的測試運行。",
+      "milestone": "## 里程碑\n將此測試運行與特定的專案里程碑關聯起來，以追蹤實現更大目標的進度。",
+      "docs": "## 文件\n包含本測試運行的任何相關文件、連結或詳細註解。",
+      "state": "## 狀態\n根據專案的工作流程，指示此測試運行的目前狀態或結果。",
+      "tags": "## 標籤\n應用相關標籤對本次測試運行進行分類和篩選。",
+      "issues": "## 問題\n將任何相關問題（錯誤、任務等）連結到此測試運行。",
+      "attachments": "## 附件\n上傳與本測試運行相關的任何支援檔案、螢幕截圖或日誌。",
+      "duplicate": {
+        "statusesToInclude": "## 要包含的狀態\n選擇要包含在重複測試運行中的測試案例的狀態。",
+        "copyAssignments": "## 複製分配\n如果啟用，測試案例的分配將複製到複製的測試運行中。"
+      }
+    },
+    "appConfig": {
+      "key": "## 鍵\n此配置的唯一識別碼。",
+      "value": "## 值\n此配置的值。"
+    },
+    "milestoneType": {
+      "icon": "## Milestone Type Icon\nA visual identifier for this milestone type.\n\n- Helps quickly identify the milestone type in lists and dashboards\n- Choose from a variety of predefined icons\n- Can be changed at any time\n- Appears in project navigation and reports",
+      "name": "## 里程碑類型名稱\n一個清晰、描述性的名稱，用於標識專案中的此里程碑類型。\n\n- 幫助團隊成員快速理解里程碑類型的用途。\n- 用於報告和專案追蹤。",
+      "isDefault": "## 預設里程碑類型\n指示此里程碑類型是否為專案的預設類型。\n\n- 預設里程碑類型已預先選擇，適用於新里程碑。\n- 可隨時變更。",
+      "projects": "## 關聯項目\n選擇此里程碑類型將適用於哪些項目。\n\n- 如果未選擇任何項目，則里程碑類型將全域可用。\n- 指派給特定項目後，其使用範圍將僅限於這些項目。"
+    },
+    "tag": {
+      "name": "## 標籤名稱\n一個清晰、簡潔、描述性的名稱或關鍵字，用於所有項目。\n\n- 幫助團隊成員快速找到相關的測試案例、測試運行和會話。"
+    },
+    "role": {
+      "name": "## 角色名稱\n一個清晰、簡潔、描述性的名稱或關鍵字，用於所有項目。\n\n- 幫助團隊成員快速找到相關的測試案例、測試運行和會話。",
+      "isDefault": "## 預設角色\n指示此角色是否為專案的預設角色。\n\n- 預設角色已預先為新使用者選擇。\n- 可隨時變更。",
+      "permissions": {
+        "canAddEdit": "## 新增/編輯\n指示此角色是否可以新增和編輯相關的應用程式區域。",
+        "canDelete": "## 刪除\n指示此角色是否可以刪除相關的應用程式區域。",
+        "canClose": "## 關閉\n指示此角色是否可以關閉相關的應用程式區域。"
+      }
+    },
+    "group": {
+      "name": "## 群組名稱\n一個清晰、簡潔、描述性的名稱或關鍵字，用於所有項目。\n\n- 幫助團隊成員快速找到相關的測試案例、測試運行和會話。",
+      "users": "## 使用者\n表示指派給此群組的使用者。"
+    },
+    "template": {
+      "name": "## 範本名稱\n此範本的唯一描述性名稱（例如，「標準測試案例」、「API 測試結果」）。",
+      "isEnabled": "## 已啟用\n如果選中，則在建立新測試案例或定義測試運行結構時，可以選擇此範本。如果範本設為“預設”，則也必須將其設為“已啟用”。",
+      "isDefault": "## 預設值\n如果選取此項，則新項目將自動選擇此範本；如果未設定項目特定的預設值，則此範本將作為所有項目的預設範本。所有項目只能有一個預設模板。啟用此選項將停用目前設定為預設範本的任何其他範本。",
+      "caseFields": "## 使用案例欄位\n選擇並排序使用此範本建立或編輯測試案例時可用的自訂欄位。\n\n- 從下拉清單中新增欄位以將其包含在範本中。\n- 拖曳以重新排序欄位。\n- 順序決定欄位在表單中的顯示方式。\n- 只有已啟用的使用案例欄位才可供選擇。\n- 用例欄位定義測試用例的結構和擷取的資料。",
+      "resultFields": "## 結果欄位\n選擇並排序使用此範本新增測試結果時可用的自訂欄位。\n\n- 從下拉清單中新增欄位以將其包含在範本中。\n- 拖曳以重新排序欄位。\n- 順序決定輸入測試結果時欄位的顯示方式。\n- 只有已啟用的結果欄位才可供選擇。\n- 結果欄位擷取特定於測試執行結果的其他資料。",
+      "projects": "## 關聯項目\n選擇此範本將適用於哪些項目。如果未選擇任何項目，則該範本將全域可用。將範本指派給特定項目後，其使用範圍將僅限於這些項目。"
+    },
+    "llm": {
+      "name": "## 整合名稱\n此 LLM 整合的描述性標籤。\n\n- 用於在清單和設定中標識它。\n- 例如：「OpenAI GPT-4o」或「內部 Ollama」。",
+      "provider": "## 提供者\n為此整合提供支援的 LLM 服務。\n\n- 確定 API 協定和可用模型。\n- 建立後無法變更。",
+      "apiKey": "## API 金鑰\n您的 LLM 提供者 API 的驗證金鑰。\n\n- 從提供者的開發者控制台取得。\n- 儲存後將保持加密狀態，不會顯示。\n- Ollama（本地部署）不需要此金鑰。",
+      "endpoint": "## API 端點\nLLM 提供者 API 的基本 URL。\n\n- OpenAI、Anthropic 和 Gemini 留空 — 系統會自動使用官方 URL。\n- Ollama（例如 `http://localhost:11434`）、Azure OpenAI 和自訂 LLM 為必填項。\n- 所有提供者均為可選 — 透過輸入 URL 指向 OpenAI 相容的代理程式（例如 LiteLLM）。\n- **私有/內部位址**（localhost、127.0.0.1、私人 IP、雲元資料）將被阻止，除非透過 `ALLOWED_PRIVATE_HOSTS` 環境變數明確允許。",
+      "deploymentName": "## Azure 部署名稱\n您的 Azure OpenAI 模式部署的名稱。\n\n- 在 Azure OpenAI Studio 的「部署」下找到。\n- 與模型名稱不同，例如 `my-gpt4-deploy` 對應到 `gpt-4`。\n- 僅 Azure OpenAI 需要。",
+      "defaultModel": "## 預設模型\n此整合用於 AI 請求的模型。\n\n- 對於 OpenAI、Anthropic 和 Gemini — 可用模型將根據您的 API 金鑰自動取得。\n- 請確保已在您的提供者帳戶中啟用該模型。\n- 例如：`gpt-4o`、`claude-3-5-sonnet-20241022`、`gemini-1.5-pro`",
+      "maxTokensPerRequest": "## 每次請求的最大令牌數\n單一請求輸出令牌數的**硬性上限**。\n\n- 超過此值的請求會在到達 LLM 之前被**拒絕並傳回錯誤**。\n- 將此值設定為模型的實際最大輸出令牌容量。\n- 例如：GPT-4o 為 `16384`，Claude 3.5 Sonnet 為 `8192`。\n- 此值設定過低會導致 AI 功能失效或產生截斷的輸出。",
+      "defaultMaxTokens": "## 預設最大令牌數\n當請求未指定自身令牌數限制時，使用此**備用**輸出令牌數限制。\n\n- 每個 AI 功能（測試產生、程式碼匯出等）在**管理 → 提示設定**中設定自己的限制。\n- 此值僅用作未配置特定限制的功能的備用值。\n- 應≤每個請求的最大令牌數。",
+      "maxRequestsPerMinute": "## 每分鐘最大請求數\n限制每分鐘可向此提供者發出的 API 呼叫次數。\n\n- 設定以符合您的供應商套餐的速率限制。\n- 超出限制的請求將被排隊，不會被拒絕。\n- 請查看您的提供者文件以了解您的套餐限制。",
+      "costPerInputToken": "## 每個輸入令牌的成本（美元）\n發送到模型的每個輸入（提示）令牌的成本（以美元計）。\n\n- 用於成本追蹤和預算提醒。\n- 可在服務提供者的定價頁面找到。\n- 例如：`0.000005` = 每百萬個輸入令牌 5 美元",
+      "costPerOutputToken": "## 每個輸出代幣的成本（美元）\n模型產生的每個輸出（完成）代幣的成本（以美元計）。\n\n- 通常高於輸入代幣的成本\n- 通常高於輸入代幣的成本 \n - 用於成本追蹤與預算提醒\n- 例如：`0.000015` = 每百萬個輸出代幣 155 美元",
+      "monthlyBudget": "## 每月預算（美元）\n此整合的選用支出目標。\n\n- 設定為 `0` 可停用預算追蹤。\n- 預算僅供參考，不會影響 LLM 的使用。\n- 您將在達到預算的 80%、90% 和 100% 時收到通知。\n- 費用是根據上述每個代幣的價格計算。",
+      "billingPeriodStartDay": "## 帳單週期起始日\n帳單週期開始的日期（1-31）。\n\n- 預設值 `1` 與日曆月一致。\n- 設定為 `15` 表示每月 15 日至 15 日的週期（例如，與您的供應商發票日期一致）。\n- 值 `29-31` 會自動鎖定到較短月份的最後一天（例如，非閏年的 2 月）。\n- 影響**月度預算**支出窗口和**重置支出**操作。",
+      "defaultTemperature": "## Default Temperature\nControls the randomness of model responses (0–2).\n\n- **0:** Deterministic — identical output for the same input\n- **0.3:** Focused — recommended for test generation and code output\n- **1+:** Creative — more varied responses\n- Individual features can override this in Prompt Config",
+      "timeout": "## Request Timeout (ms)\nHow long to wait for a response before the request is cancelled.\n\n- Value is in milliseconds (e.g. `30000` = 30 seconds)\n- Streaming requests (e.g. code export preview) ignore this timeout\n- Increase for slow or large models\n- Range: 5,000 – 600,000 ms",
+      "streamingEnabled": "## 啟用串流\n逐一令牌地傳輸回應，而不是等待完整輸出。\n\n- 匯出模態方塊中即時程式碼預覽所必需。\n- 降低長時間反應的感知延遲。\n- 建議所有支援的供應商啟用。",
+      "isDefault": "## 設定為預設整合\n將此整合設為所有 AI 功能的預設整合。\n\n- 一次只能有一個整合設定為預設整合。\n- 未配置特定提供者的功能將使用預設整合。\n- 可隨時變更。"
+    },
+    "integration": {
+      "name": "## 整合名稱\n用於在整個系統中標識此整合的描述性名稱。\n\n- 必須唯一，以便與其他整合區分開來。\n- 用於專案設定與設定。\n- 應清楚地表明服務和用途。",
+      "authType": "## Authentication Type\nChoose how to authenticate with the external service.\n\n- **API Key:** Simple authentication using email and API token\n- **OAuth 2.0:** Secure authentication using OAuth flow\n- **Personal Access Token:** Direct token-based authentication",
+      "email": "## 電子郵件地址\n您的外部服務帳號電子郵件地址。\n\n- 用於 API 金鑰驗證\n- 必須與產生 API 令牌的帳戶匹配\n- Jira 和類似服務必需",
+      "apiToken": "## API 令牌\n在外部服務的帳戶設定中產生 API 令牌。\n\n- 通常位於「帳號設定」→「安全性」→「API 令牌」中。\n- 提供安全訪問，無需暴露您的密碼。\n- 可依需要撤銷和重新產生。",
+      "jiraUrl": "## Jira URL\n您的 Jira 實例的基本 URL。\n\n- 格式：https://your-site.atlassian.net\n- 請勿包含 /browse 或其他路徑\n- 請勿從此存取伺服器",
+      "clientId": "## OAuth 用戶端 ID\n來自您的 OAuth 應用程式設定的客戶端 ID。\n\n- 在外部服務的開發者控制台中建立。\n- 用於在 OAuth 流程中識別您的應用程式。\n- 可以安全地在設定檔中共用。",
+      "clientSecret": "## OAuth 用戶端金鑰\n來自您的 OAuth 應用程式設定的用戶端金鑰。\n\n- 與客戶端 ID 一起建立\n- 必須保密且安全\n- 用於驗證您的應用程式",
+      "personalAccessToken": "## 個人存取權杖\n具有存取外部服務對應權限的個人存取權令牌。\n\n- 在您的帳戶設定中產生\n- 應具有讀寫權限\n- 比密碼驗證更安全",
+      "baseUrl": "## URL 模式\n用於連結到外部問題的 URL 模式。\n\n- 使用 '{issueId}' 作為問題標識符的佔位符。\n- 例如：https://example.com/issues/'。{issueId}'。\n- 用於簡單的 URL 為基礎的整合。",
+      "organizationUrl": "## 組織 URL\n您的 Azure DevOps 組織 URL。\n\n- 格式：https://dev.azure.com/your-org\n- 必須可從此伺服器存取\n- 用於存取 Azure DevOps API",
+      "apiKey": "## API 金鑰\n用於外部服務驗證的 API 金鑰。\n\n- 在服務的 API 設定中產生\n- 提供對服務的程式存取權\n- 妥善保管並定期輪調",
+      "forgeApiKey": "## Forge API 金鑰\n用於在 Atlassian Forge 應用程式從 Jira 問題中取得測試資料時對其進行驗證。\n\n- 點選「產生」按鈕建立新金鑰。\n- 複製金鑰並將其貼上到 Jira 中的 Forge 應用程式設定中（管理應用程式 → TestPlanIt 設定）。\n- 重新產生金鑰將使先前的金鑰失效。",
+      "owner": "## 擁有者/命名空間\n擁有該倉庫的使用者或組織。\n\n- 對於 GitHub/GitLab：使用者名稱或組織名稱\n- 對於 Gitea/Forgejo/Gogs：使用者或群組名稱\n例如：my-org 或 - 例如",
+      "repo": "## 倉庫名稱\n要連結問題的倉庫名稱。\n\n- 確切的倉庫名稱（非完整 URL）\n- 例如：my-project\n- 必須可以使用提供的憑證存取。",
+      "instanceUrl": "## 實例 URL\n自託管執行個體的基本 URL。\n\n- 格式：https://git.example.com\n- 請勿包含尾部斜線或路徑\n- 請勿從此伺服器存取",
+      "projectPath": "## 專案路徑\nGitLab 專案的完整路徑。\n\n- 格式：命名空間/專案 或 群組/子群組/專案\n- 例如：my-org/my-project\n- 在專案中可找到專案可在專案.",
+      "platform": "## Platform\nThe self-hosted Git platform you are connecting to.\n\n- **Gitea**: gitea.io-based instances\n- **Forgejo**: forgejo.org-based instances (Gitea fork)\n- **Gogs**: gogs.io-based instances\n\nThis controls which icon is shown and may affect API compatibility."
+    },
+    "config": {
+      "name": "## 設定名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 有助於描述構成配置的變體組合（例如「Chrome，Windows 10」、「Safari/macOS 15.5」、「Edge/Windows 11」等）。"
+    },
+    "configCategory": {
+      "name": "## 類別名稱\n一個清晰、描述性的名稱，用於所有項目。\n\n- 有助於將變體（例如 Chrome、Firefox、Safari、Edge 等）組織到類別（例如瀏覽器）中。"
+    },
+    "configVariant": {
+      "name": "## 變體名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 有助於描述測試環境（例如 Chrome、Safari、Windows 10、Windows 11、macOS 15.5 等）中的變體。"
+    },
+    "issueConfig": {
+      "name": "## 問題配置名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 有助於描述問題配置（例如 Jira、GitHub 等）。",
+      "baseUrl": "## 基本 URL\n問題配置的基本 URL，包括問題佔位符（例如 https://your-jira-instance.atlassian.net/browse/'{issueId}')。",
+      "systemType": "## 系統類型\n問題追蹤系統的類型（例如 LINK Jira 等）。",
+      "isActive": "## 活動\n指示此問題配置是否處於作用中狀態。",
+      "isDefault": "## 預設值\n指示此問題配置是否為專案的預設配置。\n\n- 預設問題配置已預先選中，適用於新問題。\n- 可隨時變更。",
+      "projects": "## 項目\n指示指派給此問題配置的項目。"
+    },
+    "issue": {
+      "name": "## 問題名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 有助於描述問題（例如「問題 123」、「錯誤 456」等）。",
+      "title": "## 問題標題\n一個易於理解的標題，用來描述問題。\n\n- 提供問題相關的背景資訊。\n- 顯示在清單和問題展示中。\n- 應清晰明了且具描述性。",
+      "externalKey": "## External Key\nThe unique key or identifier from the external issue tracking system.\n\n- For JIRA: Issue key like \"PROJ-123\"\n- For GitHub: Issue number like \"456\"\n- For Azure DevOps: Work item ID\n- Automatically generates the external URL when saved",
+      "externalId": "## 外部 ID\n此問題在問題追蹤系統中的唯一識別碼（例如「Issue-123」、「Bug456」等）。\n\n- 這用作基本 URL 中的問題佔位符。",
+      "description": "## 描述\n本期內容的簡要概述。\n\n- 正在測試的關鍵領域或功能\n- 重要的背景資訊\n- 特殊考慮或要求",
+      "project": "## 項目\n此問題相關的項目。\n\n- 問題可以連結到多個專案的測試案例。\n- 設定主項目有助於組織問題。\n- 可以留空，表示跨專案問題。",
+      "state": "## 狀態\n根據專案的工作流程，指示此問題的當前狀態或結果。",
+      "tags": "## 標籤\n應用相關標籤對此問題進行分類與篩選。",
+      "issues": "## 問題\n將任何相關問題（錯誤、任務等）連結到此問題。"
+    },
+    "status": {
+      "name": "## 狀態名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 用來描述測試結果狀態（例如通過、失敗、阻斷等）。",
+      "color": "## 顏色\n此狀態的顏色。",
+      "systemName": "## 系統名稱\n後端系統所使用的狀態名稱（例如資料庫查詢、報告等）。",
+      "aliases": "## 別名\n此狀態的其他名稱或同義詞，可用來將外部系統狀態連結到此狀態。",
+      "enabled": "## 已啟用\n指示此狀態是否已啟用。",
+      "isEnabled": "## 已啟用\n指示此狀態是否已啟用並可供使用。\n\n- 啟用後，可在記錄測試結果時選擇此狀態。\n- 停用狀態將會隱藏，但會保留在現有結果中。",
+      "success": "## 成功\n指示此狀態是否為成功狀態。",
+      "isSuccess": "## 成功狀態\n指示此狀態是否代表測試成功。\n\n- 成功狀態計入通過率指標。\n- 用於報告和分析，以追蹤測試效果。",
+      "completed": "## 已完成\n指示此狀態是否為已完成狀態。",
+      "isCompleted": "## 完成狀態\n指示此狀態是否表示測試執行已完成。\n\n- 完成狀態表示測試已運作完畢。\n- 用於計算完成率和進度跟踪",
+      "failure": "## 失敗\n指示此狀態是否為失敗狀態。",
+      "isFailure": "## 失敗狀態\n指示此狀態是否代表測試失敗。\n\n- 失敗狀態會影響失敗率指標。\n- 用於報告和分析，以識別問題。",
+      "scope": "## 範圍\n指示此狀態的範圍（測試運行、會話、自動化）。",
+      "projects": "## 項目\n指示可以使用此狀態的項目。"
+    },
+    "workflow": {
+      "scope": "## 範圍\n指示此工作流程的範圍（測試運行、會話、自動化）。\n\n- 工作流程建立後無法變更。",
+      "iconColor": "## 圖示/顏色\n此工作流程的圖示和顏色。",
+      "name": "## 名稱\n一個清晰、描述性的名稱，用於所有項目。\n\n- 有助於描述工作流程（例如「草稿」、「審核中」、「進行中」等）。",
+      "workflowType": "## 類型\n工作流程類型（未開始、進行中、已完成）。",
+      "type": "## Workflow Type\nThe category of workflow state (Not Started, In Progress, Completed).\n\n- Determines how this state affects progress tracking\n- Not Started states indicate work hasn't begun\n- In Progress states show active work\n- Completed states mark finished work",
+      "isDefault": "## 預設值\n指示此工作流程是否為專案的預設工作流程。\n\n- 預設工作流程已預先選中，用於新的測試運行、會話和自動化。",
+      "isEnabled": "## 已啟用\n指示此工作流程是否已啟用。",
+      "isActive": "## 活動\n指示此工作流程狀態是否處於作用中且可供使用。\n\n- 更新測試運行、會話或自動化時，可以選擇活動工作流程。\n- 非活動工作流程將會隱藏，但會保留在現有項目中。",
+      "projects": "## 項目\n指示可以使用此工作流程的項目。"
+    },
+    "testResult": {
+      "status": "## 狀態\n選擇測試執行的總體狀態。您選擇的狀態可能會影響專案指標和報告。",
+      "elapsedTime": "## 經過時間\n輸入執行此測試案例所花費的總時間。您可以使用 **s** 表示秒，**m** 表示分鐘，**h** 表示小時（例如，30s、5m、1h 20m）。",
+      "resultData": "## 結果詳情\n提供有關整個測試執行的詳細筆記、觀察結果或任何其他相關資料。這可以包括設定詳情、偏離計畫時所採取的步驟或一般性評論。",
+      "evidence": "## 證據/附件\n上傳任何可作為本次測試結果證據的文件（例如，螢幕截圖、日誌、資料檔案）。這些附件將與本次測試結果關聯。",
+      "issues": "## 關聯問題\n連結整合問題追蹤系統中與此測試結果相關的任何問題。這有助於追蹤與此測試結果相關的缺陷或任務。",
+      "stepStatus": "## 步驟狀態\n選擇此特定測試步驟的狀態。這允許對單一測試案例中的進度進行精細追蹤。",
+      "stepElapsedTime": "## 步驟耗時\n輸入執行此特定步驟所花費的時間。使用 **s**、**m**、**h** 等單位（例如，10 秒、2 分鐘）。此項為可選。",
+      "stepNotes": "## 步驟說明\n新增與執行此測試步驟相關的任何說明、觀察結果或資料。",
+      "stepIssues": "## 步驟關聯問題\n連結問題追蹤器中與此測試步驟的結果或觀察結果相關的具體問題。"
+    },
+    "case": {
+      "name": "## 測試案例名稱\n測試案例的清晰、描述性名稱。",
+      "state": "## 狀態\n指示此案例的目前工作流程狀態。",
+      "template": "## 範本\n選擇此案例將用於案例欄位和結果欄位的範本。",
+      "estimate": "## 估算\n手動輸入的完成此測試案例的估計時間。",
+      "automated": "## 自動化\n指示此測試案例是否為自動化測試。",
+      "tags": "## 標籤\n應用相關標籤對此案例進行分類與篩選。",
+      "issues": "## 問題\n將任何相關問題（錯誤、任務等）連結到此案例。"
+    },
+    "folder": {
+      "name": "## 資料夾名稱\n資料夾的清晰、描述性名稱。",
+      "documentation": "## 文件\n更多細節、參考資料和支援資料。"
+    },
+    "bulkEdit": {
+      "name": "## 名稱\n測試案例的清晰、描述性名稱。",
+      "state": "## 狀態\n指示這些測試案例的目前工作流程狀態。",
+      "estimate": "## 估算\n手動輸入完成每個測試案例的估計時間。",
+      "automated": "## 自動化\n指示這些測試案例是否是自動化的。",
+      "tags": "## 標籤\n應用相關標籤對這些測試案例進行分類和篩選。",
+      "issues": "## 問題\n將任何相關問題（錯誤、任務等）連結到這些測試案例。"
+    },
+    "caseField": {
+      "displayName": "## 顯示名稱\n這是將在表單和檢視中向使用者顯示的欄位的易讀名稱。請確保名稱清晰明了且具有描述性。",
+      "systemName": "## 系統名稱\n此欄位的唯一標識符，供系統內部使用（例如，在 API 呼叫、資料庫查詢中）。它將根據顯示名稱自動生成，但可以自訂。必須以字母開頭。只能包含字母、數字和底線（不能包含空格或特殊字元）。",
+      "hint": "## 提示文字（選用）\n提供簡短的說明或範例，顯示在欄位下方，以指導使用者。這可以闡明預期的輸入或格式。",
+      "enabled": "## 啟用\n決定此欄位是否處於活動狀態，並可在範本和測試案例中使用。禁用的欄位將被隱藏，其資料將被保留但不使用。",
+      "required": "## 必填\n如果選中，則在使用包含此欄位的範本建立或編輯測試案例時，使用者必須為此欄位提供值。",
+      "restricted": "## 受限\n如果選取此項，則只有擁有特殊權限的使用者（例如超級管理員或擁有「案例受限欄位」權限的使用者）才能在案例建立後編輯此欄位的值。其他用戶將只能讀取此欄位。這對於「審核者」或「批准日期」等欄位非常有用，這些欄位在特定階段之後不應由普通使用者變更。",
+      "fieldType": "## 欄位類型\n決定此欄位將儲存的資料類型及其顯示方式（例如，文字、數字、日期、下拉式清單）。字段類型創建後無法更改。",
+      "defaultValue": "## 預設值（可選）\n為該欄位設定預填值。對於“複選框”類型，請使用“true”或“false”。對於「下拉清單」或「多重選擇」類型，這通常指的是預設選項的 ID。對於其他類型，它是預設文字/數字。將欄位新增至範本時，可以覆寫此值。",
+      "isChecked": "## 預設狀態（複選框）\n決定在建立新專案（例如，測試案例）時是否應預設選取核取方塊。",
+      "minValue": "## 最小值（適用於數字/整數）\n設定此欄位允許的最小數值。如果使用最小值或最大值，則必須同時設定兩者。",
+      "maxValue": "## 最大值（適用於數字/整數）\n設定此欄位允許的最大數值。如果使用最小值或最大值，則必須同時設定兩者。",
+      "initialHeight": "## 初始高度（適用於長文字）\n指定富文本編輯器欄位的初始顯示高度（以像素為單位）。這有助於控制較長文字輸入的表單佈局。",
+      "dropdownOptions": "## 選項（下拉清單/多選清單）\n定義可供選擇的選項清單。您可以重新排列選項順序、設定預設值以及啟用/停用單一選項。"
+    },
+    "resultField": {
+      "displayName": "## 顯示名稱\n這是使用者輸入測試結果時將顯示的欄位的易讀名稱。請確保名稱清晰明了且具有描述性。",
+      "systemName": "## 系統名稱\n此欄位的唯一標識符，供系統內部使用（例如，在 API 呼叫、資料庫查詢中）。它將根據顯示名稱自動生成，但可以自訂。\n- 必須以字母開頭。\n- 只能包含字母、數字和底線（不能包含空格或特殊字元）。",
+      "hint": "## 提示文字（選用）\n提供簡短的說明或範例，顯示在欄位下方，以指導使用者。這可以明確輸入結果資料時的預期內容或格式。",
+      "enabled": "## 啟用\n決定此欄位是否處於作用中狀態，以及在輸入測試結果時是否可在範本中使用。禁用的欄位將被隱藏，其資料將被保留但不使用。",
+      "required": "## 必填\n如果選中，則使用者在使用包含此欄位的範本新增測試結果時，必須為此欄位提供值。",
+      "restricted": "## 受限\n如果選取此項，則只有擁有特殊權限的使用者（例如，超級管理員或擁有「測試執行結果受限欄位」權限的使用者）才能在提交結果後編輯此欄位的值。其他用戶將只能讀取此欄位的值。",
+      "fieldType": "## 欄位類型\n決定此欄位將儲存的資料類型以及測試結果的顯示方式（例如，文字、數字、日期、下拉式清單）。字段類型創建後無法更改。",
+      "defaultValue": "## 預設值（可選）\n新增新的測試結果時，請為此欄位設定預先填入值。對於“複選框”類型，請使用“true”或“false”。對於「下拉清單」或「多重選擇」類型，此值通常指的是預設選項的 ID。對於其他類型，此值即為預設文字/數字。",
+      "isChecked": "## 預設狀態（複選框）\n確定新增測試結果時是否應預設選取核取方塊。",
+      "minValue": "## 最小值（適用於數字/整數）\n設定輸入結果資料時此欄位允許的最小數值。如果使用最小值或最大值，則必須同時設定兩者。",
+      "maxValue": "## 最大值（適用於數字/整數）\n設定輸入結果資料時此欄位允許的最大數值。如果使用最小值或最大值，則必須同時設定兩者。",
+      "initialHeight": "## 初始高度（適用於長文本）\n指定結果中使用的富文本編輯器欄位的初始顯示高度（以像素為單位）。這有助於控制較長文字輸入的表單佈局。",
+      "dropdownOptions": "## 選項（下拉清單/多選清單）\n定義輸入結果資料時可供選擇的選項清單。您可以重新排列選項順序、設定預設值以及啟用/停用單一選項。"
+    },
+    "exportModal": {
+      "scope": "## 匯出範圍\n決定哪些測試案例包含在匯出中：\n- **已選取：** 僅匯出您在表格中明確選擇的測試案例。\n- **全部篩選：** 匯出所有符合表格中目前篩選條件的測試案例，即使並非所有測試案例目前都顯示在頁面上。\n- **所有項目：** 匯出目前專案中的所有測試案例，忽略任何選擇或篩選條件。",
+      "format": "## 匯出格式\n選擇匯出檔案格式。\n- **CSV（逗號分隔值）：** 適用於電子表格（Excel、Google Sheets）和資料分析工具的純文字檔案。 PDF 匯出功能計劃在未來的版本中推出。",
+      "columns": "## 要匯出的欄位（僅限 CSV）\n決定每個測試案例要包含哪些資料列：\n- **所有欄位：** 匯出測試案例的所有可用資料欄位，包括其範本中的自訂欄位。\n- **可見列：** 僅匯出測試案例表中目前可見的欄位。",
+      "delimiter": "## CSV 分隔符號（僅限 CSV）\n選擇用於分隔 CSV 檔案中值的字元。最常用的是逗號。如果您的資料在文字欄位中包含逗號，請使用其他分隔符號（例如，分號）。",
+      "textLongFormat": "## 長文本欄位格式（僅限 CSV）\n決定富文本欄位（例如「說明」或自訂「長文字」欄位）的匯出方式：\n- **JSON：** 將內容匯出為 JSON 字串，保留所有格式清單等）。這最適合重新導入或程序化處理。\n- **純文字：** 將內容匯出為純文本，移除格式。這在純文字檢視器中更易於閱讀。",
+      "stepsFormat": "## 步驟格式（僅限 CSV）\n確定測試步驟（包括預期結果）的匯出方式：\n- **JSON：** 將步驟匯出為 JSON 物件陣列，保留結構和豐富的文字資訊。適用於重新匯入或進行詳細分析。\n- **純文字：** 將步驟匯出為簡潔易讀的純文字格式，每個步驟及其預期結果分別位於新的一行。",
+      "rowMode": "## 行模式（僅限 CSV）\n決定多值欄位（例如標籤或多選自訂欄位）和步驟的表示方式：\n- **每個使用案例單行：** 每個測試案例佔一行。多值欄位和步驟將被壓縮到各自的儲存格中（通常以 JSON 或拼接文字的形式）。\n- **每個案例多行：** 如果一個測試案例包含多個標籤、多選值或步驟，則可以跨越多行。此類欄位的每個唯一值/步驟都會建立一個新行，其他用例資料則重複顯示。這對於詳細分析或透視非常有用。",
+      "attachmentFormat": "## 附件資訊格式（僅限 CSV）\n決定附件資訊的匯出方式：\n- **JSON：** 將附件詳細資料（例如檔案名稱、URL、大小）匯出為 JSON 陣列。這種方式資訊全面，但直接在 CSV 檔案中閱讀起來不太方便。\n- **僅檔案名稱：** 匯出以逗號分隔的附件檔案名稱清單。這種方式更簡潔，方便快速找到。"
+    },
+    "reportMetrics": {
+      "count": "## 測試結果計數\n此組中的測試運行結果數。",
+      "passRate": "## 通過率\n此組結果中通過狀態的比例。",
+      "avgElapsed": "## 平均耗時\n此組結果的平均耗時。",
+      "sumElapsed": "## 總耗時\n此組結果的耗時總和。",
+      "executionCount": "## 測試執行\n執行的測試總次數。",
+      "testCaseCount": "## 測試案例計數\n此組中的測試案例總數。",
+      "testRunCount": "## 測試運行次數\n此組的測試運行總數。",
+      "automationRate": "## 自動化率\n自動化測試案例的百分比。",
+      "averageSteps": "## 每個測試案例的平均步驟數\n每個測試案例的平均步驟數。",
+      "automatedCount": "## 自動化測試案例\n自動化測試案例的數量。",
+      "manualCount": "## 手動測試案例\n手動測試案例的數量。",
+      "totalSteps": "## 總步驟數\n所有個案的測試步驟總數。",
+      "createdCaseCount": "## 建立的測試案例\n此期間建立的測試案例數量。",
+      "sessionResultCount": "## 會話結果\n會話測試結果數。",
+      "sessionCount": "## 會話計數\n測試會話總數。",
+      "activeSessions": "## 活動會話\n目前處於活動狀態的會話數（isActive = true）。",
+      "milestoneCompletion": "## 里程碑完成度\n里程碑中已完成的測試案例百分比。計算方法為（已完成的測試結果 / 測試運行中的測試案例總數）× 100。",
+      "averageTimeSpent": "## 平均花費時間\n各項活動的平均花費時間。",
+      "sessionParticipation": "## 會話參與度\n測試會話的參與程度。",
+      "lastActiveDate": "## 最後活躍日期\n最近一次活動日期。",
+      "averageAge": "## 平均年齡\n物品的平均年齡（天）。",
+      "issueCount": "## 問題計數\n追蹤的總問題數。",
+      "milestoneCount": "## 里程碑數\n里程碑總數。",
+      "milestoneCompletionRate": "## 里程碑完成率\n已完成里程碑的百分比。",
+      "averageMilestoneDuration": "## 平均里程碑持續時間\n里程碑的平均持續時間（以天為單位）。"
+    },
+    "reportDimensions": {
+      "user": "## 使用者維度\n依執行測試或指派給專案的使用者將結果分組。",
+      "status": "## 狀態維度\n依測試執行狀態（例如，透過、失敗、阻斷）將結果分組。",
+      "project": "## 項目維度\n依項目將結果分組，以便進行跨項目分析。",
+      "testRun": "## 測試運行維度\n依包含已執行測試案例的測試運行將結果分組。",
+      "testCase": "## 測試案例維度\n將結果依個別測試案例分組，以便進行詳細分析。",
+      "milestone": "## 里程碑維度\n依專案里程碑將結果分組，以追蹤目標的進度。",
+      "configuration": "## 設定維度\n依測試環境配置（例如，瀏覽器、作業系統）將結果分組。",
+      "template": "## 範本維度\n依用於測試案例結構的範本將結果分組。",
+      "creator": "## 建立者維度\n依建立測試案例或測試運行的使用者將結果分組。",
+      "state": "## 狀態維度\n依工作流程狀態（例如，草稿、進行中、已完成）將結果分組。",
+      "role": "## 角色維度\n將結果依使用者角色分組，以進行存取權限和責任分析。",
+      "group": "## 分組維度\n依使用者群組分組結果。使用者可以屬於多個群組，因此使用者所屬的每個群組都會統計其活動。",
+      "folder": "## 資料夾維度\n依儲存庫資料夾結構將結果分組，以便進行組織分析。",
+      "session": "## 會話維度\n依測試會話將結果分組，以便進行基於會話的分析。",
+      "assignedTo": "## 指派給維度\n將結果依指派給執行或管理專案的使用者分組。",
+      "issueType": "## 問題類型維度\n依追蹤的問題類型（例如，缺陷、任務、故事、增強）將結果分組。",
+      "issueTracker": "## 問題追蹤器維度\n依使用的問題追蹤整合（例如，Jira、GitHub Issues、Azure DevOps）將結果分組。",
+      "issueStatus": "## 問題狀態維度\n依問題的目前狀態（例如，開啟、進行中、已解決、已關閉）將結果分組。",
+      "priority": "## 優先權維度\n依問題優先順序（例如，高、中、低）將結果分組。",
+      "source": "## 來源維度\n依測試執行的來源（例如，手動、JUnit、API）將結果分組。",
+      "date": "## 日期維度\n將結果依日期分組，以便進行基於時間的分析和趨勢分析。"
+    },
+    "reportBuilder": {
+      "dimensions": "## 維度\n選擇要在報告中分析的維度。維度是用於對資料進行分類的屬性，例如日期、使用者、狀態等。您可以拖曳來重新排序。",
+      "metrics": "## 指標\n選擇您希望在報告中衡量的指標。指標是從您的數據中提取的定量測量值，例如測試結果計數、通過率、平均耗時等。您可以拖曳它們來重新排序。",
+      "dateRange": "## 日期範圍\n依特定時段篩選報告資料。您可以從預先定義的範圍中選擇，例如“最近 7 天”或“上個月”，也可以定義自訂日期範圍。此篩選器適用於每種報表類型的相關日期欄位（例如，測試結果的執行日期，測試案例的建立日期）。"
+    },
+    "codeRepository": {
+      "name": "## 儲存庫名稱\n此儲存庫連接的友善顯示名稱。\n\n- 用於在項目代碼上下文設定中標識它。\n- 不需要與提供者上的儲存庫名稱相符。",
+      "provider": "## Git Provider\nThe platform hosting this repository.\n\n- **GitHub** — github.com (cloud or Enterprise)\n- **GitLab** — gitlab.com or self-hosted\n- **Bitbucket Cloud** — bitbucket.org (cloud only)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — self-hosted Git servers with compatible APIs",
+      "githubToken": "## 個人存取令牌\n具有 **Contents: Read** 權限的 GitHub 令牌。\n\n在下列位置產生：GitHub → 個人資料設定 → 開發者設定 → 個人存取權令牌 → 細粒度令牌。",
+      "owner": "## 所有者\n擁有該倉庫的 GitHub 組織或使用者帳戶。\n\n- 例如：`myorg` 或 `myusername`\n- 這是您在 github.com 上的倉庫 URL 中的第一個路徑段。",
+      "repo": "## 倉庫\n倉庫名稱，不包含所有者前綴。\n\n- 例如：`my-repo`（而非 `myorg/my-repo`）\n- 這是您在 github.com 上的倉庫 URL 中的第二個路徑段。",
+      "gitlabToken": "## 個人存取令牌\n具有 **read_api** 和 **read_repository** 權限的 GitLab 令牌。\n\n在下列位置產生：GitLab → 使用者設定 → 存取權令牌。",
+      "projectPath": "## 專案 ID 或路徑\n數位項目 ID 或完整的命名空間路徑。\n\n- 範例路徑：`myorg/my-project`\n- 範例 ID：`12345678`\n- 在 GitLab 常規的「設定」下找到。",
+      "baseUrl": "## GitLab URL\n留空則使用 gitlab.com。對於自託管實例，請輸入您的 GitLab URL。\n\n- 例如：`https://gitlab.example.com`",
+      "bitbucketEmail": "## Atlassian 帳號電子郵件\n與您的 Atlassian 帳號關聯的電子郵件地址。\n\n- 這是您用來登入 Bitbucket Cloud 的電子郵件。",
+      "bitbucketApiToken": "## API 令牌\n具有 **Repositories: Read** 權限的 Bitbucket API 令牌。\n\n在下列位置建立：Bitbucket → 個人設定 → API 令牌。\n\n> Atlassian 已棄用應用程式密碼，改用 API 令牌。",
+      "workspace": "## 工作區\n來自您的 Bitbucket URL 的工作區別名稱。\n\n- 例如：`bitbucket.org/myworkspace` 中的 `myworkspace`",
+      "repoSlug": "## 倉庫別名\n倉庫 URL 中的識別碼。\n\n- 例如：`bitbucket.org/myworkspace/my-repo` 中的 `my-repo`",
+      "azureToken": "## 個人存取權杖\n具有**代碼（讀取）**權限的 Azure DevOps 個人存取權杖。\n\n在下列位置建立：Azure DevOps → 使用者設定 → 個人存取權令牌。",
+      "organizationUrl": "## 組織 URL\n您的 Azure DevOps 組織 URL。\n\n- 例如：`https://dev.azure.com/myorg`",
+      "project": "## 專案名稱\n包含儲存庫的 Azure DevOps 專案的名稱。\n\n- 位於 Azure DevOps URL 中組織名稱之後的第三個路徑段。",
+      "azureRepoId": "## 儲存庫名稱或 ID\nAzure DevOps 專案中的儲存庫名稱或 GUID。\n\n- 例如：`my-repo`",
+      "giteaToken": "## 個人存取權杖\n具有倉庫讀取權限的令牌。\n\n在下列位置產生：網站管理 → 應用程序，或使用者設定 → 應用程式。\n\n- 適用於 Gitea、Forgejo、Gogs 以及任何提供相容 API 的伺服器。",
+      "giteaBaseUrl": "## 伺服器 URL\n自託管 Git 伺服器的基本 URL。\n\n- 例如：`https://gitea.example.com`\n- 必須包含協定（建議使用 https://）\n- 適用於 Gitea、Forgejo、Gogs",
+      "giteaOwner": "## 擁有者\n擁有此儲存庫的組織或使用者帳戶。\n\n- 例如：`myorg` 或 `myusername`\n- 這是儲存庫 URL 中的第一個路徑段",
+      "giteaRepo": "## 倉庫\n倉庫名稱，不包含所有者前綴。\n\n- 例如：`my-repo`（而非 `myorg/my-repo`）"
+    },
+    "promptConfig": {
+      "name": "## 設定名稱\n此提示配置的唯一描述性名稱。\n\n- 用於將配置指派給項目時標識該配置（例如「GPT-4o 提示」、「保守提示」）。",
+      "description": "## 描述\n可選的摘要，用於說明此配置的獨特之處。\n\n- 幫助管理員一目了然地了解其用途（例如「降低溫度提示以實現確定性輸出」）。",
+      "isActive": "## 啟用\n啟用後，此設定可供專案使用。\n\n- 未啟用的設定將從項目分配下拉式功能表中隱藏。\n- 預設設定無法停用。",
+      "isDefault": "## 預設配置\n啟用後，任何未指派特定配置的項目都將使用此配置。\n\n- 一次只能有一個配置作為預設配置。\n- 設定新的預設設定會自動取消先前的預設設定。",
+      "systemPrompt": "## 系統提示\n在使用者輸入任何內容之前發送給 AI 模型的指令。定義模型的角色、輸出格式和限制條件。\n\n- 支援雙花括號佔位符（例如 FRAMEWORK、LANGUAGE、CASE_NAME），這些佔位符會在運行時進行替換。\n- 此處所做的變更會影響使用此配置的所有項目。",
+      "userPrompt": "## 使用者提示\n代表使用者傳送給 AI 的訊息。如果該功能完全透過程式碼建立使用者訊息，則留空。\n\n- 支援雙花括號佔位符（例如 ISSUE_TITLE、CASE_NAME、CODE_CONTEXT），這些佔位符會在運行時進行替換。\n- 每個功能可用的佔位符列於下方的「變數」部分。",
+      "temperature": "## 溫度\n控制 AI 輸出的隨機性。範圍：0–2。\n\n- **0.0–0.3** — 高度確定性，最適合結構化輸出（JSON、程式碼）。\n- **0.4–0.7** — 平衡，適合產生測試案例。\n- **0.8–2.0** — 更具創造性和多樣性，適合開放式文字。",
+      "maxOutputTokens": "## 最大輸出詞元數\n模型在單一回應中產生的最大詞元數。\n\n- 更高的值允許更長的反應，但會增加成本和延遲。\n- 典型範圍：短文字為 2048，程式碼產生為 4096，多大小寫輸出為 6000 以上。"
+    },
+    "menu": {
+      "startTour": "導覽歡迎之旅",
+      "startProjectTour": "項目參觀",
+      "startAdminTour": "管理員巡視",
+      "startDemoProjectTour": "演示項目參觀"
+    },
+    "tour": {
+      "mainTour": {
+        "welcome": {
+          "title": "歡迎使用 TestPlanIt！",
+          "content": "讓我們快速瀏覽一下 TestPlanIt 的主要功能，以幫助您開始測試工作流程。"
+        },
+        "projects": {
+          "content": "從這裡可以存取您的所有測試項目。每個專案都包含測試案例、運行次數和團隊協作功能。"
+        },
+        "project": {
+          "title": "專案卡",
+          "content": "點擊項目卡片即可查看其詳細資訊。從說明選單中選擇“專案導覽”，即可獲得專案功能導覽。"
+        },
+        "globalFeatures": {
+          "title": "全球專題",
+          "content": "管理標籤以進行分類，追蹤跨專案的問題，並使用基於角色的存取控制來管理使用者。"
+        },
+        "search": {
+          "content": "基於目前頁面的上下文搜尋。快速尋找測試案例、運行結果、問題或任何內容。使用 Cmd+K（或 Ctrl+K）即可快速存取。"
+        },
+        "help": {
+          "title": "幫助與支持",
+          "content": "您可以隨時存取此導覽，或造訪我們的完整文件以取得詳細協助。"
+        },
+        "notifications": {
+          "content": "隨時了解測試運行完成情況、問題更新和團隊活動。請在您的帳戶設定中配置偏好設定。"
+        },
+        "account": {
+          "title": "帳戶選單",
+          "content": "自訂個人資料、通知偏好設定和帳戶設定。切換淺色和深色主題。"
+        },
+        "assignments": {
+          "content": "查看分配給您的所有專案的測試案例和運行情況。這是您的個人儀錶板，用於追蹤您的測試工作。"
+        }
+      },
+      "projectTour": {
+        "projectSelector": {
+          "title": "項目選擇器",
+          "content": "使用此下拉式選單可快速切換項目。查看項目詳情並造訪項目全域設定。"
+        },
+        "projectSections": {
+          "title": "專案章節",
+          "content": "透過「概覽」檢視專案儀表板，「文件」檢視專案指南，「里程碑」檢視專案進度追蹤。"
+        },
+        "repository": {
+          "content": "管理您的測試案例，將它們整理到資料夾中，並建立新的測試場景以實現全面的測試覆蓋。"
+        },
+        "repositoryPanels": {
+          "title": "存儲庫左側面板",
+          "content": "左側面板顯示資料夾結構和測試案例樹。使用視圖選擇器可在不同的組織視圖之間切換。"
+        },
+        "repositoryRightPanel": {
+          "title": "存儲庫右側面板",
+          "content": "右側面板顯示測試案例詳情、執行結果，並提供建立新測試案例或匯入現有測試案例的操作。"
+        },
+        "sharedSteps": {
+          "title": "共同步驟",
+          "content": "定義可重複使用的步驟組，以便多個測試案例可以引用它們。保持測試步驟的簡潔性和一致性。"
+        },
+        "testRuns": {
+          "content": "執行計畫的測試運行，追蹤進度，並管理團隊內的測試任務分配。查看詳細的執行結果。"
+        },
+        "testRunsPage": {
+          "title": "測試運行儀表板",
+          "content": "這是「測試運行」頁面，您可以在這裡建立新的測試運行、監控執行進度、查看結果以及管理測試任務。在一個中心位置追蹤團隊的測試活動。"
+        },
+        "sessions": {
+          "title": "探索性會議",
+          "content": "記錄探索性測試過程，收集測試結果，並追蹤臨時測試活動所花費的時間。"
+        },
+        "sessionsPage": {
+          "title": "探索性會議儀錶盤",
+          "content": "這是「會話」頁面，您可以在這裡建立和管理探索性測試會話。記錄測試結果、追蹤測試時間，並維護所有臨時測試活動的記錄，以提高測試覆蓋率。"
+        },
+        "tags": {
+          "title": "標籤管理",
+          "content": "使用標籤整理和分類測試案例。建立自訂標籤，以改善測試案例的組織和篩選。"
+        },
+        "issues": {
+          "title": "問題追蹤",
+          "content": "追蹤和管理測試過程中發現的問題。將問題與測試案例關聯，並與外部缺陷追蹤系統整合。"
+        },
+        "reports": {
+          "title": "報告與分析",
+          "content": "為您的專案產生全面的報告和分析。查看測試覆蓋率、執行趨勢、團隊績效指標，並為利害關係人建立自訂報告。"
+        },
+        "settings": {
+          "title": "項目設定",
+          "content": "從這裡管理專案級整合、AI 模型配置和共享連結。"
+        }
+      },
+      "adminTour": {
+        "welcome": {
+          "title": "歡迎使用管理員控制功能",
+          "content": "透過引導式教學了解 TestPlanIt 的管理功能。您可以透過此中央管理面板管理專案、使用者、配置和系統設定。"
+        },
+        "projects": {
+          "title": "專案管理",
+          "content": "管理組織內的所有專案。建立、配置和歸檔項目。設定專案範圍的權限和存取控制。"
+        },
+        "templatesAndFields": {
+          "content": "建立和管理測試用例範本和自訂欄位。定義欄位類型、驗證規則，並組織模板，以確保跨專案的測試案例結構一致。"
+        },
+        "workflows": {
+          "title": "工作流程管理",
+          "content": "定義測試案例工作流程和狀態轉換。配置測試案例如何經歷不同的狀態，例如草稿、審核和批准。"
+        },
+        "statuses": {
+          "title": "測試結果狀態",
+          "content": "配置可用的測試結果狀態，例如通過、失敗、已封鎖和跳過。設定自訂狀態並定義其行為和外觀。"
+        },
+        "milestones": {
+          "content": "定義專案追蹤的里程碑類型。配置發布類型、迭代類別和其他項目里程碑分類。"
+        },
+        "configurations": {
+          "title": "測試配置",
+          "content": "管理測試配置和環境。設定瀏覽器組合、裝置類型、作業系統和其他測試執行上下文。"
+        },
+        "users": {
+          "title": "使用者管理",
+          "content": "管理使用者帳戶、權限和存取等級。建立新使用者、指派角色並配置身份驗證設定。"
+        },
+        "groups": {
+          "title": "集團管理",
+          "content": "將使用者分組，以便更輕鬆地管理權限。建立部門群組、專案團隊和基於角色的存取群組。"
+        },
+        "roles": {
+          "title": "角色管理",
+          "content": "定義使用者角色和權限。配置不同角色在專案和系統管理中可以執行的操作。"
+        },
+        "tags": {
+          "title": "全域標籤",
+          "content": "管理組織範圍內的標籤，用於對測試案例、專案和其他實體進行分類。建立標籤層級結構，並規範跨專案的標籤使用。"
+        },
+        "reports": {
+          "content": "產生跨多個項目的報告。分析整個工作空間內的趨勢、績效指標和組織測試有效性。"
+        },
+        "notifications": {
+          "title": "通知設定",
+          "content": "配置係統級通知偏好設定。設定使用者通知的電子郵件範本、通知規則和預設設定。"
+        },
+        "integrations": {
+          "title": "系統整合",
+          "content": "管理第三方整合和 API 連接。為您的組織配置 Jira、GitHub 和其他外部工具整合。"
+        },
+        "llm": {
+          "title": "AI配置",
+          "content": "配置用於自動產生測試案例和智慧功能的AI模型和設定。管理API金鑰和模型偏好設定。"
+        },
+        "sso": {
+          "title": "單一登入",
+          "content": "設定單一登入 (SSO) 提供者和身分驗證方法。設定 SAML、OAuth 和其他身分提供者集成，以實現無縫用戶存取。"
+        },
+        "appConfig": {
+          "content": "管理全域應用程式設定和系統偏好設定。配置預設值、功能開關和系統級行為。"
+        },
+        "trash": {
+          "title": "系統垃圾",
+          "content": "查看和管理所有項目中已刪除的項目。恢復意外刪除的內容或從系統中永久清除項目。"
+        }
+      },
+      "demoProjectTour": {
+        "projectSelector": {
+          "title": "歡迎來到示範項目",
+          "content": "本項目已預先載入範例資料。讓我們一起來了解一下主要功能。使用此下拉式選單可在項目之間切換。"
+        },
+        "overview": {
+          "title": "項目概述",
+          "content": "概覽頁面是您的專案儀表板。它顯示里程碑進度以及測試案例、正在進行的運行、會話和標籤的摘要。"
+        },
+        "documentation": {
+          "title": "文件",
+          "content": "每個項目都有一個文件頁面。你可以用它來記錄測試計劃、專案筆記或外部資源連結。"
+        },
+        "documentationContent": {
+          "title": "富文本編輯器",
+          "content": "文件支援富文本格式，包括標題、清單、連結和圖片。您可以嘗試編輯此頁面，看看效果如何。"
+        },
+        "milestones": {
+          "title": "里程碑",
+          "content": "根據迭代、版本發布和其他目標追蹤測試進度。將測試運行和會話與里程碑關聯起來，以便追蹤進度。"
+        },
+        "milestonesPage": {
+          "title": "里程碑時間表",
+          "content": "查看此專案的所有里程碑。每個里程碑都顯示了其狀態和完成進度。"
+        },
+        "repository": {
+          "title": "測試用例庫",
+          "content": "將測試案例整理到帶有自訂欄位、步驟和優先順序的資料夾中。瀏覽範例資料夾，了解用例的結構。"
+        },
+        "repositoryPanels": {
+          "title": "文件夾和箱子",
+          "content": "左側面板顯示資料夾。點擊資料夾即可查看其中的測試案例。每個用例都包含步驟、描述和共用步驟引用。"
+        },
+        "repositoryCases": {
+          "title": "測試用例",
+          "content": "這裡顯示所選資料夾的測試案例。每一行都顯示用例名稱、優先權和自訂欄位。點擊用例即可查看其完整詳情和步驟。"
+        },
+        "sharedSteps": {
+          "title": "共同步驟",
+          "content": "定義可重複使用的步驟組，供多個測試案例引用。這樣可以保持常用步驟的一致性，以便於維護。"
+        },
+        "sharedStepsPage": {
+          "title": "共同步驟小組",
+          "content": "每個步驟組都包含一系列有順序的步驟。在任何測試案例中引用這些步驟，以保持步驟的簡潔性和一致性。"
+        },
+        "testRuns": {
+          "title": "測試運行",
+          "content": "建立測試運行以執行用例並記錄結果。將運行分配到里程碑並追蹤通過/失敗進度。"
+        },
+        "testRunsPage": {
+          "title": "測試運行結果",
+          "content": "查看測試運行結果和進度。每次運行都會顯示其狀態、指定的里程碑以及通過/失敗的詳細情況。"
+        },
+        "sessions": {
+          "title": "探索性會議",
+          "content": "利用基於會話的測試來捕獲臨時測試結果。記錄測試結果，分配狀態，並追蹤所花費的時間。"
+        },
+        "sessionsPage": {
+          "title": "會議結果",
+          "content": "每次會話都包含詳細的分析結果、狀態和備註。點擊會話即可查看結果。"
+        },
+        "tags": {
+          "title": "標籤",
+          "content": "標籤有助於組織和篩選測試案例、運行和會話。瀏覽範例標籤，了解它們如何對內容進行分類。"
+        },
+        "tagsPage": {
+          "title": "標籤管理",
+          "content": "您可以在這裡建立、編輯和指派標籤。使用標籤對項目中的內容進行分組和篩選。"
+        },
+        "issues": {
+          "title": "問題",
+          "content": "追蹤測試過程中發現的錯誤和缺陷。問題可以與失敗的測試運行結果和會話發現關聯起來，從而實現完全可追溯性。"
+        },
+        "issuesPage": {
+          "title": "問題追蹤器",
+          "content": "查看與失敗結果相關的範例問題。這些問題可以追溯到發現它們的測試運行或會話。"
+        },
+        "reports": {
+          "title": "報告與分析",
+          "content": "產生測試覆蓋率、執行趨勢和團隊績效報告。可以使用預置報告，也可以為利害關係人建立自訂報告。"
+        },
+        "settings": {
+          "title": "項目設定",
+          "content": "從這裡管理專案級整合、AI 模型配置和共享連結。"
+        }
+      }
+    }
+  },
+  "reports": {
+    "ui": {
+      "crossProjectReports": {
+        "description": "建立和管理跨專案報告"
+      },
+      "reportsTabDescription": "查看和分析您項目的預置報告。",
+      "reportType": "報告類型",
+      "selectReportType": "選擇報告類型",
+      "selectReport": "選擇報告",
+      "dimensions": "方面",
+      "dimensionsSubtitle": "尺寸（拖曳重新排序，在下方新增）",
+      "metrics": "指標",
+      "addDimension": "添加維度…",
+      "addMetric": "添加指標…",
+      "runReport": "運行報告",
+      "noResultsFound": "未找到結果。",
+      "selectAtLeastOneDimensionAndMetric": "至少選擇一個維度和一個指標。",
+      "noDataMatchingCriteria": "未找到與所選維度和指標相符的資料。",
+      "noDataMatchingCriteriaWithDateFilter": "未找到符合所選維度和指標的資料。請嘗試調整日期範圍篩選器。",
+      "noDataAvailable": "本報告暫無可用數據。",
+      "generatedAt": "報告生成於",
+      "crossProjectAnalytics": "跨專案分析與報告",
+      "unauthorizedAdmin": "未經授權：需要管理員權限。",
+      "title": "報表產生器",
+      "description": "建立自訂報告以分析專案數據",
+      "crossProjectDescription": "分析工作區中所有項目的數據",
+      "selectDimensions": "選擇尺寸...",
+      "selectMetrics": "選擇指標…",
+      "dimensionOrder": "尺寸順序",
+      "metricOrder": "公制順序",
+      "filtersDescription": "依特定條件篩選報告數據",
+      "activeFilters": "啟用篩選器：",
+      "priorityFilterPlaceholder": "選擇優先值（或留空表示全部不選）",
+      "dateRange": {
+        "selectDateRange": "選擇日期範圍",
+        "chooseStartDate": "選擇開始日期",
+        "chooseEndDate": "選擇結束日期",
+        "categories": {
+          "day": "天",
+          "week": "星期",
+          "month": "月",
+          "quarter": "四分之一",
+          "year": "年"
+        },
+        "today": "今天",
+        "yesterday": "昨天",
+        "last7Days": "過去7天",
+        "last30Days": "過去30天",
+        "thisWeek": "本星期",
+        "lastWeek": "上個星期",
+        "last2Weeks": "過去兩週",
+        "thisMonth": "本月",
+        "lastMonth": "上個月",
+        "last3Months": "過去三個月",
+        "thisQuarter": "本季",
+        "lastQuarter": "上季",
+        "thisYear": "今年",
+        "lastYear": "去年",
+        "last12Months": "過去12個月",
+        "allTime": "所有時間",
+        "custom": "自訂日期範圍"
+      },
+      "dateGrouping": {
+        "label": "按分組",
+        "daily": "日常的",
+        "weekly": "每週",
+        "monthly": "每月",
+        "quarterly": "季刊",
+        "annually": "每年"
+      },
+      "filters": {
+        "selectFilter": "選擇篩選類型",
+        "allProjects": "所有項目"
+      },
+      "errors": {
+        "failedToLoadMetadata": "報告元資料載入失敗",
+        "failedToRunReport": "報告運行失敗",
+        "atLeastOneDimensionRequired": "至少需要一個維度。",
+        "atLeastOneMetricRequired": "至少需要指定一個指標。",
+        "invalidCombinationDateLastActive": "「上次活動日期」指標不能與「活動日期」維度合併。",
+        "lastActiveDateOnlyWithUser": "「上次活動日期」指標只能與「使用者」維度一起使用。",
+        "invalidDimensionCombination": "在測試執行報告中，不能同時使用「{dim1}」和「{dim2}」維度。",
+        "startDateRequiredWithEndDate": "當指定結束日期時，必須同時指定開始日期。",
+        "endDateMustBeAfterStartDate": "結束日期必須晚於或等於開始日期。"
+      },
+      "chartDataTruncated": {
+        "title": "圖表資料已截斷",
+        "message": "為了方便閱讀，僅顯示 {shown} 個資料點，共 {total} 個資料點。您可以使用篩選器或日期範圍來縮小搜尋結果範圍，或在下方的結果表格中查看完整資料。"
+      },
+      "reportTypes": {
+        "testExecution": {
+          "label": "測試執行報告",
+          "description": "分析測試結果、通過率和執行指標"
+        },
+        "repositoryStats": {
+          "label": "儲存庫統計訊息",
+          "description": "測試案例統計資料、覆蓋率和儲存庫健康狀況"
+        },
+        "userEngagement": {
+          "label": "用戶參與度",
+          "description": "使用者活動、生產力和工作量分析"
+        },
+        "projectHealth": {
+          "label": "項目健康",
+          "description": "專案進度、里程碑和完成狀態"
+        },
+        "sessionAnalysis": {
+          "label": "會話分析",
+          "description": "會話完成狀況、持續時間和作業指標"
+        },
+        "issueTracking": {
+          "label": "問題追蹤",
+          "description": "問題產生、解決與影響分析"
+        },
+        "automationTrends": {
+          "label": "自動化趨勢",
+          "description": "按優先順序每週追蹤自動化進度"
+        },
+        "flakyTests": {
+          "label": "不穩定的測試",
+          "description": "找出結果不一致的測試（通過/失敗）。"
+        },
+        "testCaseHealth": {
+          "label": "測試案例健康狀況",
+          "description": "根據執行模式識別過時、損壞或可疑的測試案例"
+        },
+        "issueTestCoverage": {
+          "label": "問題測試覆蓋率",
+          "description": "查看問題及其關聯的測試案例和最新執行狀態"
+        }
+      },
+      "flakyTests": {
+        "consecutiveRuns": "最近連續運行",
+        "consecutiveRunsHelp": "待分析的近期測試執行次數（5-30）。狀態為「未測試」的結果將被排除在外。",
+        "flipThreshold": "最少翻轉次數",
+        "flipThresholdHelp": "達到最低通過/失敗轉換次數才算不穩定。",
+        "flips": "翻轉",
+        "lastNResults": "最後 {count, plural, one {# 結果} other {# 結果集}}",
+        "newest": "新的",
+        "oldest": "老的",
+        "noFlakyTests": "未發現符合標準的不合格測試",
+        "includeFilter": "包括",
+        "testRunDeleted": "測試運行已刪除",
+        "chart": {
+          "highPriority": "需要關注",
+          "lowPriority": "優先順序較低",
+          "recencyAxis": "近期失敗",
+          "flipsAxis": "翻轉次數",
+          "oldFailures": "老年人",
+          "recentFailures": "最近的",
+          "failureRate": "故障率",
+          "recency": "近期得分",
+          "backlogTitle": "低優先級測試",
+          "backlogDescription": "{count, plural, one {# 額外的不穩定測試} other {# 額外的不穩定測試}} 未顯示"
+        }
+      },
+      "testCaseHealth": {
+        "staleDaysThreshold": "過期（天后）",
+        "staleDaysThresholdHelp": "測試未執行的天數（7-90）被視為過期。",
+        "minExecutions": "最低執行次數",
+        "minExecutionsHelp": "計算有意義的通過率統計資料所需的最少執行次數（3-20）。",
+        "lookbackDays": "回顧期",
+        "lookbackDaysHelp": "分析執行歷史的天數（30-365）。",
+        "includeFilter": "包括",
+        "staleFilter": "陳舊",
+        "stale": "陳舊",
+        "notStale": "未過期",
+        "status": "健康狀況",
+        "healthScore": "分數",
+        "lastExecuted": "最後執行",
+        "executions": "執行",
+        "passRate": "通過率",
+        "passCount": "通行證",
+        "failCount": "失敗",
+        "never": "絕不",
+        "daysSince": "執行完畢至今已過數天",
+        "count": "數數",
+        "totalTests": "測試用例",
+        "noData": "未找到測試用例",
+        "noExecutedTests": "沒有已執行的測試要顯示",
+        "healthStatus": {
+          "healthy": "健康",
+          "stale": "陳舊",
+          "neverExecuted": "從未執行",
+          "alwaysPassing": "總是透過",
+          "alwaysFailing": "總是失敗"
+        },
+        "chart": {
+          "distribution": "狀態分佈",
+          "healthyRecent": "健康與近期",
+          "unhealthyStale": "需要關注",
+          "daysAxis": "自上次執行以來的天數",
+          "healthScoreAxis": "健康評分"
+        },
+        "stats": {
+          "totalTests": "總測試次數",
+          "needsAttention": "需要關注",
+          "needsAttentionTooltip": "總是失敗 + 從未執行 + 過時的測試",
+          "healthy": "健康",
+          "healthyTooltip": "健康 + 每次測試都通過",
+          "avgScore": "平均健康評分"
+        },
+        "healthScoreTooltip": {
+          "title": "初始分數為100分，扣分項：",
+          "neverExecuted": "從未執行：-50",
+          "stale90": "超過 90 天未運行：-40",
+          "stale60": "超過 60 天未運行：-25",
+          "stale30": "超過 30 天未運行：-10",
+          "alwaysPassing": "始終通過（100%）：-5",
+          "alwaysFailing": "始終失敗 (0%)：-30",
+          "lowPassRate": "低通過率（<50%）：-20",
+          "lowExecutions": "執行次數少（<3）：-10"
+        }
+      },
+      "issueTestCoverage": {
+        "viewMode": "查看模式",
+        "summaryView": "摘要（按期）",
+        "detailView": "詳細資訊（按測試用例）",
+        "issue": "問題",
+        "testCase": "測試用例",
+        "testCases": "{count, plural, =1 {測試案例} other {測試案例}}",
+        "issueStatus": "地位",
+        "priority": "優先事項",
+        "linkedTests": "關聯測試",
+        "testResults": "結果（合格/不合格/待定）",
+        "passRate": "通過率",
+        "passed": "透過",
+        "failed": "失敗的",
+        "lastStatus": "最新狀態",
+        "lastExecuted": "最後執行",
+        "notTested": "未經測試",
+        "noData": "未發現關聯測試用例有問題。",
+        "noIssuesNeedingAttention": "所有問題都通過了測試——幹得好！",
+        "stats": {
+          "totalIssues": "總期數",
+          "issuesWithFailures": "失敗",
+          "issuesWithFailuresTooltip": "至少有一個測試案例失敗，有問題",
+          "issuesWithUntested": "未經測試",
+          "issuesWithUntestedTooltip": "至少有一個尚未執行的測試案例有問題。",
+          "issuesAllPassing": "全部透過",
+          "overallPassRate": "通過率",
+          "numberOfIssues": "問題數量"
+        },
+        "charts": {
+          "passRateDistribution": "考試通過率分佈",
+          "linkedTestCases": "關聯測試用例數量",
+          "untestedTestCases": "未測試用例數量",
+          "testCoverageVsExecution": "測試覆蓋率與執行狀態"
+        }
+      },
+      "crossProjectReportTypes": {
+        "testExecution": {
+          "label": "跨專案測試執行",
+          "description": "分析所有項目的測試結果、通過率和執行指標"
+        },
+        "repositoryStats": {
+          "label": "跨專案儲存庫統計訊息",
+          "description": "項目間的測試案例統計、覆蓋率和程式碼庫健康狀況"
+        },
+        "userEngagement": {
+          "label": "跨專案用戶參與",
+          "description": "跨專案的使用者活動、生產力和工作量分析"
+        },
+        "issueTracking": {
+          "label": "跨專案問題追蹤",
+          "description": "項目間的問題產生、解決與影響分析"
+        },
+        "automationTrends": {
+          "label": "跨專案自動化趨勢",
+          "description": "按優先順序逐週追蹤各專案的自動化進度"
+        },
+        "flakyTests": {
+          "label": "跨項目不穩定的測試",
+          "description": "識別專案中通過/失敗結果不一致的測試"
+        },
+        "testCaseHealth": {
+          "label": "跨專案測試用例健康狀況",
+          "description": "識別專案中的過時、損壞或可疑的測試案例"
+        },
+        "issueTestCoverage": {
+          "label": "跨專案問題測試覆蓋率",
+          "description": "查看專案中的問題及其關聯的測試案例和最新執行狀態"
+        }
+      }
+    },
+    "errors": {
+      "adminOnly": "只有專案管理員和管理員才能存取專案報告。",
+      "projectIdRequired": "項目 ID 為必填項",
+      "missingRequiredFields": "缺少必填字段",
+      "unsupportedDimension": "不支持的維度： {dimension}",
+      "unsupportedMetric": "不支援的測量： {metric}",
+      "atLeastOneDimensionMetricRequired": "至少需要一個維度和一個度量",
+      "atLeastOneMetricRequired": "必須指定至少一項指標。",
+      "projectDimensionsMetricsRequired": "需要項目 ID、維度和指標。",
+      "unsupportedDimensions": "不支持的維度： {dimensions}",
+      "unsupportedMetrics": "不支持的指標： {metrics}",
+      "unexpectedError": "發生意外錯誤。"
+    },
+    "dimensions": {
+      "project": "專案",
+      "status": "地位",
+      "user": "使用者",
+      "executor": "執行人",
+      "assignedTo": "分配給",
+      "configuration": "配置",
+      "date": "日期",
+      "executionDate": "執行日期",
+      "creationDate": "建立日期",
+      "activityDate": "活動日期",
+      "testRun": "測試運行",
+      "testCase": "測試用例",
+      "milestone": "里程碑",
+      "template": "範本",
+      "creator": "創作者",
+      "state": "狀態",
+      "source": "來源",
+      "folder": "資料夾",
+      "group": "團體",
+      "role": "角色",
+      "session": "會議",
+      "weekEnding": "一週結束",
+      "period": "時期",
+      "priority": "優先事項",
+      "automationStatus": "自動化狀態",
+      "issueType": "問題類型",
+      "issueTracker": "問題追蹤器",
+      "issueStatus": "問題狀態"
+    },
+    "metrics": {
+      "testResults": "測試結果",
+      "testResultCount": "檢測結果計數",
+      "passRate": "通過率（%）",
+      "avgElapsed": "平均經過時間",
+      "avgElapsedTime": "平均經過時間",
+      "totalElapsedTime": "總經過時間",
+      "testRunCount": "測試運行次數",
+      "testCaseCount": "測試用例數量",
+      "automationRate": "自動化率（%）",
+      "avgStepsPerCase": "每例平均步驟",
+      "averageSteps": "每例平均步數",
+      "automatedCount": "自動化案件",
+      "manualCount": "手動案例",
+      "totalCount": "病例總數",
+      "totalSteps": "總步數",
+      "executionCount": "測試執行",
+      "createdCaseCount": "已建立的測試案例數量",
+      "sessionResultCount": "會話結果計數",
+      "caseCreations": "創建案例",
+      "sessionParticipation": "會議參與",
+      "averageElapsed": "每次執行的平均時間",
+      "lastActiveDate": "最後活躍日期",
+      "issueCount": "問題數量",
+      "averageAge": "平均年齡（天）",
+      "sessionCount": "會話數",
+      "activeSessions": "活躍會話",
+      "averageTimeSpent": "平均花費時間（分鐘）",
+      "milestoneCount": "里程碑計數",
+      "milestoneCompletionRate": "里程碑完成率（%）",
+      "averageMilestoneDuration": "平均里程碑持續時間（天）",
+      "totalMilestones": "總里程碑",
+      "activeMilestones": "活躍里程碑",
+      "milestoneCompletion": "里程碑完成率（%）",
+      "averageDuration": "平均持續時間",
+      "totalDuration": "總時長"
+    },
+    "drillDown": {
+      "title": "詳細記錄",
+      "loading": "正在加載記錄...",
+      "loadingMore": "載入中……",
+      "noRecords": "未找到記錄",
+      "error": "記錄載入失敗",
+      "recordCount": "{count} {count, plural, =1 {記錄} other {記錄}}",
+      "allRecords": "所有記錄",
+      "allLoaded": "所有記錄已加載"
+    },
+    "defaultValues": {
+      "noData": "-"
+    },
+    "shareDialog": {
+      "shareButton": "分享",
+      "dialogTitle": "分享報告",
+      "dialogDescription": "建立可共享連結或管理現有共享報告連結。",
+      "tabs": {
+        "create": "建立共享",
+        "list": "我的股票"
+      },
+      "shareMode": {
+        "label": "分享模式",
+        "authenticated": {
+          "title": "已驗證（需要登入）",
+          "description": "只有已登入且有權存取此項目的使用者才能查看。",
+          "descriptionCrossProject": "只有擁有管理員權限的登入使用者才能查看。"
+        },
+        "passwordProtected": {
+          "title": "密碼保護",
+          "description": "任何擁有連結和密碼的人都可以查看。已登入並擁有項目存取權限的使用者無需密碼。",
+          "descriptionCrossProject": "任何擁有連結和密碼的人都可以查看。已登入並擁有管理員權限的使用者無需密碼。"
+        },
+        "public": {
+          "title": "公開（任何擁有連結的人）",
+          "description": "任何擁有該連結的人無需登入即可查看此報告。"
+        }
+      },
+      "expiration": {
+        "label": "到期日",
+        "noExpiration": "無有效期限",
+        "expiresAtMidnight": "連結將於所選日期結束時失效（以您當地時間為準）。"
+      },
+      "notifyOnView": {
+        "label": "有人查看此連結時通知我",
+        "description": "根據您的通知偏好設置，當有人造訪分享連結時，您將收到通知。"
+      },
+      "title": {
+        "placeholder": "例如，測試執行報告",
+        "leaveEmptyToUse": "留空備用："
+      },
+      "description": {
+        "placeholder": "為這份共享報告添加描述…"
+      },
+      "actions": {
+        "createShareLink": "建立共享連結",
+        "creating": "正在創建…"
+      },
+      "errors": {
+        "loginRequired": "您必須登入才能建立分享連結",
+        "createFailed": "建立共享連結失敗",
+        "genericError": "發生未知錯誤"
+      },
+      "status": {
+        "revoked": {
+          "title": "分享連結已撤銷",
+          "description": "此分享連結已撤銷，無法再存取。"
+        },
+        "expired": {
+          "title": "分享連結已過期",
+          "description": "此分享連結已過期，無法再造訪。"
+        }
+      },
+      "footer": {
+        "poweredBy": "供電"
+      },
+      "manageShares": {
+        "title": "管理股份",
+        "description": "查看和管理此項目的所有共享鏈接",
+        "adminTitle": "管理所有股份",
+        "adminDescription": "查看所有項目中的共享鏈接"
+      },
+      "shareList": {
+        "columns": {
+          "mode": "模式",
+          "views": "瀏覽量",
+          "expires": "過期"
+        },
+        "status": {
+          "revoked": "撤銷",
+          "expired": "已到期"
+        },
+        "notifications": {
+          "enabled": "在",
+          "disabled": "離開"
+        },
+        "empty": {
+          "title": "尚未建立任何分享連結。",
+          "description": "創建你的第一個分享連結即可開始。"
+        },
+        "defaultTitle": "{entityType} 分享",
+        "noProject": "跨專案",
+        "actions": {
+          "copyLink": "複製連結",
+          "revoke": "撤銷"
+        },
+        "revokeDialog": {
+          "title": "撤銷分享連結？",
+          "description": "這將立即撤銷分享連結。任何嘗試訪問該連結的人都會看到錯誤訊息。此操作無法撤銷。",
+          "confirm": "撤銷連結",
+          "revoking": "撤銷…"
+        },
+        "deleteDialog": {
+          "title": "刪除分享連結？",
+          "description": "這將永久刪除分享連結。如果該連結目前處於活動狀態，它將立即失效且無法再存取。此操作無法撤銷。",
+          "confirm": "刪除連結"
+        },
+        "toast": {
+          "linkCopied": "連結已複製！",
+          "linkCopiedDescription": "分享連結已複製到剪貼簿。",
+          "copyFailed": "複製失敗",
+          "copyFailedDescription": "請手動複製連結。",
+          "linkRevoked": "分享連結已撤銷",
+          "linkRevokedDescription": "分享連結已被撤銷，無法再存取。",
+          "revokeFailed": "撤銷失敗",
+          "revokeFailedDescription": "撤銷共用連結時發生錯誤。",
+          "notificationsEnabled": "已啟用通知",
+          "notificationsEnabledDescription": "當有人查看此分享連結時，您將收到通知。",
+          "notificationsDisabled": "通知已禁用",
+          "notificationsDisabledDescription": "當有人查看此分享連結時，您不會收到通知。",
+          "notificationUpdateFailed": "更新通知失敗",
+          "notificationUpdateFailedDescription": "更新通知設定時發生錯誤。",
+          "linkDeleted": "分享連結已刪除",
+          "linkDeletedDescription": "分享連結已被刪除，將不再顯示在您的清單中。",
+          "deleteFailed": "刪除失敗",
+          "deleteFailedDescription": "刪除分享連結時發生錯誤。"
+        }
+      },
+      "created": {
+        "title": "分享連結已建立！",
+        "description": "您的分享連結已準備就緒。複製並分享給其他人即可。",
+        "shareLink": "分享連結",
+        "copy": "複製",
+        "openInNewTab": "在新分頁中開啟",
+        "metadata": {
+          "mode": "模式",
+          "expires": "過期",
+          "views": "瀏覽量"
+        },
+        "warnings": {
+          "publicLink": "公開連結：",
+          "publicLinkDescription": "擁有此連結的人無需身份驗證即可存取該報告。",
+          "expiresSoon": "此連結將於月底失效"
+        },
+        "actions": {
+          "createAnother": "創建另一個"
+        }
+      },
+      "editDialog": {
+        "title": "編輯分享連結",
+        "description": "更新此分享連結的設定。",
+        "passwordExists": "此分享連結已設定密碼。請將密碼欄位留空以保留現有密碼。",
+        "passwordPlaceholder": "留空以保留現有密碼"
+      }
+    },
+    "passwordDialog": {
+      "title": "需要密碼",
+      "description": "來自 <strong>{projectName}</strong> 的共享內容受密碼保護。請輸入密碼以繼續。",
+      "passwordPlaceholder": "輸入密碼",
+      "showPassword": "顯示密碼",
+      "hidePassword": "隱藏密碼",
+      "verifying": "正在核實…",
+      "errors": {
+        "emptyPassword": "請輸入密碼",
+        "tooManyAttempts": "Too many failed attempts. Please try again later{resetAt, select, null {} other { at {resetAt}}}.",
+        "genericError": "發生錯誤，請重試。"
+      },
+      "attempts": {
+        "noAttemptsRemaining": "嘗試次數已用完，請稍後再試。",
+        "attemptsRemaining": "{count, plural, =1 {1 次嘗試} other {# 次嘗試}} 剩餘。"
+      }
+    },
+    "sharedReport": {
+      "loading": "正在載入報告…",
+      "errors": {
+        "onlyReportSharing": "目前僅實現了報告共享功能。",
+        "failedToLoad": "報告資料載入失敗"
+      },
+      "defaultTitle": "共享報告",
+      "fromProject": "來自項目：",
+      "dateRange": "日期範圍：",
+      "readOnlyNotice": "這是一個唯讀共享視圖",
+      "viewCount": "{count, plural, =1 {1 瀏覽} other {# 瀏覽}}",
+      "viewInFullApp": "看完整應用",
+      "pagination": {
+        "showing": "顯示",
+        "of": "的",
+        "results": "結果"
+      }
+    },
+    "authBypass": {
+      "title": "您有權存取此項目",
+      "description": "以 {userName} 身份查看，並可訪問 {projectName}。",
+      "viewInApp": "看完整應用"
+    }
+  },
+  "sharedSteps": {
+    "filterPlaceholder": "篩選分享步驟...",
+    "noGroups": "未找到共享步驟。",
+    "noTestCases": "沒有測試案例使用此共享步驟組。",
+    "selectGroupPrompt": "選擇共用步驟群組以查看其步驟。",
+    "deleteTitle": "刪除共享步驟組？",
+    "deleteDescription": "您確定要刪除此共用步驟組嗎？刪除後，所有使用這些步驟的測試案例中的步驟都將被移除。",
+    "saveSuccess": "共享步驟已成功更新。",
+    "saveError": "儲存共用步驟時發生錯誤。",
+    "stepsCount": "{count, plural, one {# 步驟} other {# 步驟}}",
+    "testCasesUsing": "{count, plural, one {# 測試案例} other {# 測試案例}}",
+    "importWizard": {
+      "title": "導入共享步驟",
+      "fields": {
+        "order": "命令",
+        "stepNumber": "步 ＃",
+        "stepContent": "步驟內容",
+        "expectedResultContent": "預期結果內容",
+        "combinedStepData": "組合步數據",
+        "stepsData": "步驟數據"
+      },
+      "success": {
+        "description": "{count, plural, one {# 共享步驟} other {# 共享步驟}} 匯入成功"
+      },
+      "errors": {
+        "parseFailed": "解析 CSV 檔案失敗",
+        "validationFailed": "驗證失敗",
+        "validationDescription": "{count, plural, one {# 驗證錯誤} other {# 發現驗證錯誤}}",
+        "importFailed": "導入失敗",
+        "fileRequired": "需要一個 CSV 檔案。"
+      },
+      "page1": {
+        "title": "上傳檔案和配置",
+        "selectedFile": "已選文件",
+        "delimiter": "字段分隔符",
+        "delimiters": {
+          "tab": "Tab (\\t)"
+        },
+        "hasHeaders": "第一行包含列標題。",
+        "encoding": "文件編碼",
+        "rowMode": {
+          "label": "行模式",
+          "single": "每個共享步驟一行",
+          "multi": "複雜共享步驟的多行"
+        }
+      },
+      "page2": {
+        "title": "將 CSV 列對應到共用步驟字段",
+        "description": "將您的 CSV 欄位對應到共用步驟欄位。必填欄位必須對應。",
+        "ignoreColumn": "忽略此列",
+        "requiredFieldsWarning": "{count, plural, one {# 必填欄位} other {# 必填欄位}} 未對映。請映射所有必填欄位以繼續。"
+      },
+      "page3": {
+        "title": "預覽導入數據",
+        "showing": "顯示 {start} 到 {end} 共 {total} 個共享步驟",
+        "step": "共享步驟 {number}",
+        "noValue": "（空的）"
+      }
+    },
+    "manualEntry": {
+      "buttonLabel": "手動新增",
+      "description": "建立一個新的共享步驟組（手動輸入）",
+      "groupNamePlaceholder": "請輸入此共用步驟組的名稱",
+      "success": "共享步驟已成功創建",
+      "errors": {
+        "groupNameRequired": "組名必填",
+        "stepsRequired": "至少需要一步。",
+        "saveFailed": "儲存分享步驟失敗"
+      }
+    },
+    "stepDuplicates": {
+      "pageTitle": "步驟序列重複",
+      "pageDescription": "檢查測試案例中符合的步驟序列。將符合項目轉換為共用步驟群組，或排除誤報。",
+      "noResultsFound": "未發現重複步驟。",
+      "noResultsDescription": "執行掃描以檢測測試案例中重複的步驟序列。",
+      "filterPlaceholder": "按案例名稱篩選...",
+      "selected": "{count, plural, one {# 已選擇} other {# 已選擇}}",
+      "bulkDismiss": "解僱（{count}）",
+      "bulkDismissSuccess": "{count, plural, one {# 比賽已取消} other {# 比賽已取消}}",
+      "bulkError": "部分操作失敗，請重試。",
+      "tableHint": "點選行可預覽配對的步驟。選取具有複選框的行可進行批次操作。",
+      "columns": {
+        "matchedSteps": "配對步驟",
+        "casesCount": "案例",
+        "review": "審查"
+      },
+      "scanning": "掃描...",
+      "scanComplete": "{count, plural, one {# 找出符合項} other {# 找出符合項}}",
+      "scanFailed": "掃描失敗",
+      "scanFailedDescription": "掃描過程中發生錯誤，請重試。",
+      "cancelScan": "取消掃描",
+      "findStepDuplicates": "尋找重複步驟",
+      "rescan": "掃描",
+      "viewResults": "查看結果 ({count})",
+      "retryScan": "重試掃描",
+      "dialog": {
+        "title": "轉換為共用步驟",
+        "previewTitle": "匹配步驟序列",
+        "casesTitle": "受影響的測試案例",
+        "casesDescription": "取消勾選要從轉換中排除的案例。",
+        "nameLabel": "共享步驟組名稱",
+        "namePlaceholder": "請輸入共享步驟組的名稱…",
+        "converting": "正在轉換...",
+        "dismissMatch": "取消比賽",
+        "dismissing": "解僱…",
+        "convertSuccess": "共享步驟組創建成功！",
+        "convertError": "轉換失敗，請重試。",
+        "dismissSuccess": "比賽結束。",
+        "dismissError": "關閉失敗，請重試。",
+        "viewSharedStep": "查看共享步驟組",
+        "skippedWarning": "{count, plural, one {# 跳過案例} other {# 跳過案例}} （已過時或已轉換）。",
+        "noCasesSelected": "至少選擇一個案例進行轉換。",
+        "selectAll": "全選"
+      }
+    },
+    "findStepDuplicates": "尋找重複項"
+  },
+  "search": {
+    "title": "搜尋",
+    "placeholder": {
+      "thisProject": "在此項目中搜尋…",
+      "allProjects": "搜尋所有項目…"
+    },
+    "currentProjectOnly": "僅限當前項目",
+    "allTypes": "所有類型",
+    "entityTypes": {
+      "repositoryCase": "儲存庫案例"
+    },
+    "results": {
+      "tryAdjusting": "嘗試調整搜尋詞或篩選條件。",
+      "searchingFor": "正在尋找",
+      "within": "之內",
+      "currentProject": "目前專案",
+      "page": "頁"
+    },
+    "errors": {
+      "searchFailed": "搜尋失敗，請重試。",
+      "tryAgain": "再試一次"
+    },
+    "startTyping": "開始輸入以進行搜尋",
+    "typesSelected": "{count, plural, one {# 模式} other {# 類型}}",
+    "customFieldFilters": "自訂欄位篩選器",
+    "customFiltersApplied": "自訂過濾器",
+    "customFields": "自訂字段",
+    "addFilter": "新增篩選器",
+    "filter": "篩選",
+    "noCustomFilters": "未套用自訂欄位篩選器",
+    "selectDate": "選擇日期",
+    "selectOption": "選擇選項",
+    "selectOptions": "選擇選項",
+    "operators": {
+      "equals": "等於",
+      "not_equals": "不等於",
+      "contains": "包含",
+      "not_contains": "不含",
+      "starts_with": "以……開始",
+      "ends_with": "以……結尾",
+      "gt": "大於",
+      "lt": "少於",
+      "gte": "大於或等於",
+      "lte": "小於或等於",
+      "between": "之間",
+      "in": "在",
+      "not_in": "不在",
+      "exists": "存在",
+      "not_exists": "不存在"
+    },
+    "help": {
+      "exactPhrases": "確切短語",
+      "exactPhrasesDesc": "將字詞用引號括起來，以符合完整的短語：",
+      "proximity": "近距離搜尋",
+      "proximityDesc": "彼此相距 N 個位置的單字",
+      "booleanOperators": "布林運算符",
+      "andDesc": "這兩個術語必須匹配",
+      "orDesc": "這兩個術語都可以匹配",
+      "notDesc": "排除包含該術語的結果",
+      "prefixDesc": "要求或排除某個條款",
+      "groupingDesc": "複雜查詢的分組術語",
+      "wildcards": "外卡",
+      "wildcardMultiDesc": "匹配任何字符",
+      "wildcardSingleDesc": "匹配單一字符",
+      "fuzzyMatching": "模糊匹配",
+      "fuzzyDesc": "尋找相似單字以幫助糾正拼字錯誤",
+      "defaultBehavior": "多個詞語預設使用“或”運算符。與名稱完全匹配的結果排名最高。",
+      "fullSyntaxLink": "Lucene 查詢語法完整參考"
+    },
+    "filters": {
+      "title": "進階篩選器",
+      "active": "過濾器已激活",
+      "activeCount": "{count, plural, =0 {No filters} one {# filter} other {# filters}} active",
+      "apply": "應用篩選條件",
+      "common": "常用過濾器",
+      "entitySpecific": "類型特定篩選器",
+      "searchPlaceholder": "搜尋篩選選項…",
+      "states": "工作流程狀態",
+      "createdAt": "建立日期",
+      "updatedAt": "更新日期",
+      "completedAt": "完成日期",
+      "from": "從",
+      "to": "到",
+      "testRunType": "測試運行類型",
+      "regular": "常規的",
+      "junit": "JUnit",
+      "automatedOnly": "僅限自動",
+      "archivedOnly": "僅存檔",
+      "completedOnly": "僅完成",
+      "manualOnly": "限手動",
+      "estimateRange": "估算範圍",
+      "elapsedRange": "經過時間範圍",
+      "minValue": "敏感",
+      "maxValue": "最大限度",
+      "hasExternalId": "具有外部 ID",
+      "dueDateRange": "到期日範圍",
+      "hasParent": "具有父級里程碑",
+      "milestoneType": "里程碑類型",
+      "minutes": "分分鐘",
+      "hours": "小時",
+      "days": "天",
+      "searchingIn": "搜尋",
+      "includeDeleted": "包括已刪除的項目",
+      "filterActive": "篩選器已啟用：",
+      "applyFilter": "應用篩選器",
+      "validation": {
+        "firstValueMustBeLessThanSecond": "第一個值必須小於第二個值",
+        "firstDateMustBeBeforeSecond": "第一次約會必須在第二次約會之前。"
+      },
+      "link": {
+        "domainHelp": "只需輸入網域名稱（例如，“github.com”或“example.org”）"
+      }
+    }
+  },
+  "email": {
+    "greeting": "你好，",
+    "greetingWithName": "嗨 {name}，",
+    "notification": {
+      "intro": "您收到一則新通知：",
+      "viewDetails": "看詳情",
+      "viewAll": "查看所有通知"
+    },
+    "digest": {
+      "intro": "以下是您每日收到的來自 TestPlanIt 的通知摘要：",
+      "viewDetails": "看詳情",
+      "viewAll": "查看所有通知",
+      "noNotifications": "您今天沒有任何新通知。",
+      "footer": "您收到此郵件是因為您已啟用每日摘要通知。您可以在設定中變更通知偏好。",
+      "profileSettings": "個人資料設定"
+    },
+    "footer": {
+      "sentBy": "這封郵件由…發送",
+      "unsubscribe": "取消訂閱",
+      "managePreferences": "管理偏好設定",
+      "allRightsReserved": "版權所有。"
+    },
+    "magicLink": {
+      "subject": "登入 TestPlanIt",
+      "heading": "登入 TestPlanIt",
+      "intro": "點擊下方按鈕登入：",
+      "signInButton": "登入",
+      "copyPasteIntro": "或複製此連結並貼上到瀏覽器中：",
+      "disclaimer": "如果您沒有要求收到這封郵件，您可以忽略它。",
+      "textBody": "登入 TestPlanIt\n\n點擊以下連結登入：\n{url}\n\n如果您沒有要求此電子郵件，則可以忽略它。"
+    }
+  },
+  "comments": {
+    "title": "評論",
+    "placeholder": "請留言…（使用@提及用戶）",
+    "editPlaceholder": "編輯您的評論…",
+    "postComment": "發表評論",
+    "noComments": "目前還沒有評論。快來發表你的第一個評論吧！",
+    "edited": "編輯",
+    "confirmDelete": "您確定要刪除此評論嗎？此操作無法撤銷。",
+    "deleteDialog": {
+      "title": "刪除評論"
+    },
+    "errors": {
+      "createFailed": "建立評論失敗，請重試。",
+      "updateFailed": "評論更新失敗，請重試。",
+      "deleteFailed": "刪除評論失敗，請重試。",
+      "loadFailed": "評論加載失敗，請重試。"
+    },
+    "mentions": {
+      "notAMember": "非專案成員",
+      "noUsersFound": "未找到用戶"
+    }
+  },
+  "Trial": {
+    "daysRemaining": "審判將於 {count, plural, =1 {1天} other {#天}}結束",
+    "expiresT oday": "試用期今天到期",
+    "expired": "{count, plural, =1 {試用期已於 1 天前過期} other {試用期已於 # 天前過期}}",
+    "contactSales": "聯繫銷售"
+  },
+  "feedback": {
+    "sheetTitle": "分享您的回饋",
+    "sheetDescription": "請分享您的使用體驗，幫助我們改善 TestPlanIt。",
+    "bannerMessage": "你的庭審進行得怎麼樣？我們很想聽聽你的想法。",
+    "menuItem": "分享回饋"
+  },
+  "autoTag": {
+    "actions": {
+      "aiTag": "AI標籤",
+      "tagAll": "全部標記",
+      "aiAutoTag": "自動標籤",
+      "tagActions": "標籤操作",
+      "startTagging": "開始標記",
+      "selectEntityType": "選擇實體類型",
+      "selectProject": "選擇一個項目",
+      "entityTypes": {
+        "repositoryCase": "{count, plural, one {測試案例} other {測試案例}}",
+        "testRun": "{count, plural, one {測試運行} other {測試運行}}",
+        "session": "{count, plural, one {會話} other {會話}}"
+      }
+    },
+    "review": {
+      "title": "評論標籤建議",
+      "description": "點擊標籤可切換是否接受標籤。雙擊可編輯標籤名稱。",
+      "selectEntity": "選擇一個實體以查看標籤建議。",
+      "noTagsSelected": "未選擇任何標籤",
+      "footerSummary": "{assignCount, plural, one {# tag} other {# tags}} will be assigned, {newCount, plural, one {# new tag} other {# new tags}} will be created",
+      "footerAssignCount": "{assignCount, plural, one {# 標籤} other {# 標籤}} 將會被分配",
+      "footerNewCount": "{newCount, plural, one {# 新標籤} other {# 新標籤}} 將創建",
+      "newTagsPopoverTitle": "要建立的新標籤",
+      "applying": "正在申請…",
+      "applySuccess": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}",
+      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}, {newCount, plural, one {# new tag} other {# new tags}} created",
+      "applyError": "標籤應用程式失敗，請重試。",
+      "suggestedTags": "建議標籤",
+      "noSuggestions": "人工智慧無法產生任何標籤。",
+      "alreadyApplied": "已申請",
+      "filterEntities": "篩選實體...",
+      "noEntitiesMatch": "沒有符合您搜尋條件的實體。",
+      "tagCount": "{count, plural, one {# 標籤} other {# 標籤}}",
+      "noTags": "沒有任何",
+      "failed": "失敗的",
+      "analysisFailed": "無法分析此實體",
+      "responseTruncated": "回應被截斷－請在 LLM 設定中增加最大輸出令牌數",
+      "tooltipExisting": "現有標籤",
+      "tooltipNew": "將建立新標籤",
+      "tooltipAssign": "分配現有標籤",
+      "toggleFailed": "顯示/隱藏失敗的實體",
+      "showFailed": "顯示失敗"
+    },
+    "progress": {
+      "starting": "開始分析…",
+      "analyzed": "分析了 {analyzed}/{total} 個實體",
+      "sizing": "尋找最佳批次大小（嘗試 {size} 個實體）...",
+      "streaming": "正在接收 AI 回應（{analyzed}/{total} 個實體已完成）…",
+      "finalizing": "正在準備結果…",
+      "complete": "分析完成",
+      "reviewSuggestions": "評論建議",
+      "failed": "分析失敗"
+    },
+    "wizard": {
+      "description": "AI 將分析您整個專案的測試案例、測試運行和會話，並根據其內容建議相關的標籤。",
+      "entityLine": "{count} {type}",
+      "startAnalysis": "開始分析",
+      "untaggedOnly": "僅分析沒有現有標籤的記錄",
+      "allowNewTags": "允許建立新標籤",
+      "noLlmConfigured": "（未配置LLM）",
+      "analyzingDescription": "AI正在分析您的實體並產生標籤建議。這可能需要一些時間。"
+    },
+    "entityDetail": {
+      "customFields": "自訂字段",
+      "noDetails": "暫無更多詳情。",
+      "openInNewTab": "在新分頁中開啟"
+    }
+  },
+  "passwordStrength": {
+    "veryWeak": "非常弱",
+    "weak": "虛弱的",
+    "fair": "公平的",
+    "good": "好的",
+    "strong": "強的",
+    "minLength": "至少 {count} 個字符",
+    "uppercase": "至少包含一個大寫字母",
+    "lowercase": "至少包含一個小寫字母",
+    "numbers": "至少一個數字",
+    "specialChars": "特殊字元來自： {chars}",
+    "history": "此密碼曾用於您最近的 {depth} 個密碼中。"
+  },
+  "TrialExpired": {
+    "title": "您的試用期已結束。",
+    "description": "感謝您試用TestPlanIt！您的試用期已結束，此執行個體已無法存取。",
+    "nextSteps": "如需繼續使用 TestPlanIt 並存取您的測試數據，請聯絡我們的銷售團隊。",
+    "pricingPlans": "定價方案",
+    "dataRetention": "您的測試資料已安全存儲，升級帳戶後即可存取。"
+  }
+}

--- a/testplanit/next.config.ts
+++ b/testplanit/next.config.ts
@@ -1,32 +1,31 @@
 import path from "path";
-import { fileURLToPath } from "url";
+import type { NextConfig } from "next";
+import type { RemotePattern } from "next/dist/shared/lib/image-config";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin({
-  locales: ["en-US", "es-ES", "fr-FR"],
-  defaultLocale: "en-US",
   requestConfig: "./i18n/request.ts",
-  createMessagesDeclaration: {
-    path: "./messages/en-US.json",
-    makeParamsOptional: true,
+  experimental: {
+    createMessagesDeclaration: "./messages/en-US.json",
   },
 });
 
 // Helper function to extract hostname and port from URL
-const parseUrlForPattern = (url) => {
+const parseUrlForPattern = (url: string) => {
   try {
     const parsed = new URL(url);
-    return {
-      protocol: parsed.protocol.replace(":", ""),
-      hostname: parsed.hostname,
-      port: parsed.port || "",
-    };
+    const protocol = parsed.protocol.replace(":", "") as "http" | "https";
+    return { protocol, hostname: parsed.hostname, port: parsed.port || "" };
   } catch {
     return null;
   }
 };
 
-const addUploadPatternsForUrl = (patterns, url, uploadPaths) => {
+const addUploadPatternsForUrl = (
+  patterns: RemotePattern[],
+  url: string | undefined,
+  uploadPaths: string[]
+) => {
   if (!url) {
     return;
   }
@@ -43,7 +42,7 @@ const addUploadPatternsForUrl = (patterns, url, uploadPaths) => {
 
 // Build dynamic remote patterns based on environment configuration
 const buildDynamicRemotePatterns = () => {
-  const dynamicPatterns = [];
+  const dynamicPatterns: RemotePattern[] = [];
   const bucketName = process.env.AWS_BUCKET_NAME || "testplanit";
 
   const uploadPaths = [
@@ -82,7 +81,7 @@ const buildDynamicRemotePatterns = () => {
   if (baseDomain) {
     uploadPaths.forEach((pathname) => {
       dynamicPatterns.push({
-        protocol: "https",
+        protocol: "https" as const,
         hostname: `*.${baseDomain}`,
         port: "",
         pathname,
@@ -93,8 +92,7 @@ const buildDynamicRemotePatterns = () => {
   return dynamicPatterns;
 };
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
   output: "standalone",
   turbopack: {
     resolveAlias: {
@@ -111,10 +109,7 @@ const nextConfig = {
     "jspdf",
     "fflate",
   ],
-  outputFileTracingRoot: path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../"
-  ),
+  outputFileTracingRoot: path.join(__dirname, "../"),
   experimental: {
     // Limit number of workers to reduce memory usage during build
     workerThreads: false,

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "audit:coverage": "tsx scripts/audit-coverage.ts",
     "generate": "NODE_OPTIONS='--max-old-space-size=12288' zenstack generate && prisma db push",
+    "generate:dev": "NODE_OPTIONS='--max-old-space-size=12288' zenstack generate && dotenv -e .env.development -- prisma db push",
     "build": "node scripts/generate-version.js && node scripts/fix-zenstack-symlink.js && pnpm build:workers && next build",
     "build:workers": "node scripts/build-workers.js",
     "dev": "next dev",

--- a/testplanit/prisma/schema.prisma
+++ b/testplanit/prisma/schema.prisma
@@ -32,7 +32,17 @@ enum ItemsPerPage {
 enum Locale {
   en_US
   es_ES
+  de_DE
   fr_FR
+  it_IT
+  nl_NL
+  pl_PL
+  pt_BR
+  vi_VN
+  zh_CN
+  zh_TW
+  ja_JP
+  ko_KR
 }
 
 enum DateFormat {

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -242,7 +242,17 @@ enum ItemsPerPage {
 enum Locale {
     en_US
     es_ES
+    de_DE
     fr_FR
+    it_IT
+    nl_NL
+    pl_PL
+    pt_BR
+    vi_VN
+    zh_CN
+    zh_TW
+    ja_JP
+    ko_KR
 
     @@deny('all', !auth())
     @@allow('update', auth().access == 'ADMIN')

--- a/testplanit/utils/locales.test.ts
+++ b/testplanit/utils/locales.test.ts
@@ -1,6 +1,8 @@
 import { enUS } from "date-fns/locale/en-US";
 import { es } from "date-fns/locale/es";
 import { fr } from "date-fns/locale/fr";
+import { it as itLocale } from "date-fns/locale/it";
+import { de } from "date-fns/locale/de";
 import { describe, expect, it } from "vitest";
 import { getDateFnsLocale } from "./locales";
 
@@ -9,6 +11,8 @@ describe("getDateFnsLocale", () => {
     expect(getDateFnsLocale("en-US")).toBe(enUS);
     expect(getDateFnsLocale("es-ES")).toBe(es);
     expect(getDateFnsLocale("fr-FR")).toBe(fr);
+    expect(getDateFnsLocale("it-IT")).toBe(itLocale);
+    expect(getDateFnsLocale("de-DE")).toBe(de);
   });
 
   it("should return the default locale (enUS) for unknown locales", () => {

--- a/testplanit/utils/locales.ts
+++ b/testplanit/utils/locales.ts
@@ -1,15 +1,8 @@
-import { Locale } from "date-fns";
-import { enUS } from "date-fns/locale/en-US";
-import { es } from "date-fns/locale/es";
-import { fr } from "date-fns/locale/fr";
+import { type Locale } from "date-fns";
 
-// Map next-intl locales to date-fns locales
-const localeMap: Record<string, Locale> = {
-  "en-US": enUS,
-  "es-ES": es,
-  "fr-FR": fr,
-};
+import { dateFnsLocaleMap, dateFnsLocaleFor } from "~/i18n/dateFnsLocales";
 
-export const getDateFnsLocale = (locale: string): Locale => {
-  return localeMap[locale] || enUS; // Default to English if locale not found
-};
+export const getDateFnsLocale = (locale: string): Locale =>
+  dateFnsLocaleFor(locale);
+
+export { dateFnsLocaleMap };


### PR DESCRIPTION
## Description

Expands UI language support from 3 languages (English, Spanish, French) to 13, adding German, Italian, Dutch, Polish, Portuguese (Brazil), Vietnamese, Chinese Simplified, Chinese Traditional, Japanese, and Korean.

Introduces a single source of truth for supported locales so adding a new language in the future requires changes to exactly two files (i18n/navigation.ts and i18n/dateFnsLocales.ts) plus running pnpm generate:dev and pnpm crowdin:sync.

Key changes:
- i18n/navigation.ts — canonical locale list and display names (endonym order, CJK at end)
- i18n/dateFnsLocales.ts — date-fns locale map with coverage guard test
- next.config.mjs converted to next.config.ts to import from TS source
- schema.zmodel / prisma/schema.prisma — 10 new Locale enum values
- crowdin.yml — all 12 non-English language mappings configured
- lib/server-date-formatter.ts — locale-specific "at" word for datetime strings
- components/onboarding/InitialPreferencesDialog.tsx — fixed: locale change now sets NEXT_LOCALE cookie and reloads so the language switch takes effect immediately
- Fixed TestPlanIt brand name casing across all locale message files (was being mangled by machine translation)
- Docs and blog post updated

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — i18n/dateFnsLocales.test.ts includes a coverage guard that fails if a locale is added to navigation.ts without a date-fns mapping
- [x] Manual testing — switched between all 13 languages via Profile > Preferences; verified locale change in initial preferences dialog takes effect on reload

**Test Configuration:**
- OS: macOS
- Browser: Chrome
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the CLA (https://testplanit.com/cla)

## Additional Notes

Translations are managed via Crowdin. The TestPlanIt brand name has been added to the Crowdin glossary as Do Not Translate to prevent machine translation from altering it in future syncs.

To add a new language in the future:
1. Add the locale to i18n/navigation.ts (locale array + display name)
2. Add the date-fns mapping to i18n/dateFnsLocales.ts
3. Run pnpm generate:dev
4. Add the language in Crowdin and run pnpm crowdin:sync