### PR TITLE
fix(ci): pull --rebase before pushing in Crowdin sync workflow

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -58,5 +58,6 @@ jobs:
             echo "Locale files already up to date, nothing to commit"
           else
             git commit -m "chore(i18n): sync locale files [skip ci]"
+            git pull --rebase origin main
             git push
           fi


### PR DESCRIPTION
## Description

Fixes the Crowdin sync workflow failing to push when another commit lands on `main` while the job is running. Adding `git pull --rebase origin main` before `git push` resolves the divergence instead of erroring out.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Observed failure in run [25810455525](https://github.com/TestPlanIt/testplanit/actions/runs/25810455525/job/75824991692)
- Fix: rebase onto current main before pushing so concurrent commits don't block the sync

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code