### PR TITLE
fix(tests): add useExecutionLogColumns mock to ReportRenderer test

### DIFF
--- a/testplanit/components/reports/ReportRenderer.test.tsx
+++ b/testplanit/components/reports/ReportRenderer.test.tsx
@@ -8,6 +8,7 @@ const {
   mockFlakyTestsColumns,
   mockTestCaseHealthColumns,
   mockIssueTestCoverageColumns,
+  mockExecutionLogColumns,
 } = vi.hoisted(() => {
   const col = (id: string) => ({
     id,
@@ -21,6 +22,7 @@ const {
     mockFlakyTestsColumns: [col("testName"), col("flipCount")],
     mockTestCaseHealthColumns: [col("testCase"), col("health")],
     mockIssueTestCoverageColumns: [col("issue"), col("coverage")],
+    mockExecutionLogColumns: [col("testCaseName"), col("statusName")],
   };
 });
 
@@ -48,6 +50,10 @@ vi.mock("~/hooks/useTestCaseHealthColumns", () => ({
 
 vi.mock("~/hooks/useIssueTestCoverageColumns", () => ({
   useIssueTestCoverageSummaryColumns: () => mockIssueTestCoverageColumns,
+}));
+
+vi.mock("~/hooks/useExecutionLogColumns", () => ({
+  useExecutionLogColumns: () => mockExecutionLogColumns,
 }));
 
 // Mock DataTable to render data rows for inspection


### PR DESCRIPTION
## Description

The Execution Log report (shipped in v0.27.5) broke the `ReportRenderer.test.tsx` suite. `useExecutionLogColumns` imports `TestRunNameDisplay`, which imports from `~/lib/navigation`, which requires a `redirect` export that is not present in the test's `next/navigation` mock.

Fix: mock `useExecutionLogColumns` directly in the test file, matching the pattern already used for all other column hooks (`useReportColumns`, `useAutomationTrendsColumns`, `useFlakyTestsColumns`, etc.).

## Related Issue

Broken by the execution log commit that landed directly on main (v0.27.5).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `pnpm test run components/reports/ReportRenderer.test.tsx` now passes (8/8 tests)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code