### PR TITLE
ci: upgrade docker/setup-buildx-action from v3 to v4

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo "REPO_LC=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
@@ -74,7 +74,7 @@ jobs:
         docker context use colima
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       run: echo "REPO_LC=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
@@ -132,7 +132,7 @@ jobs:
         docker context use colima
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
@@ -270,7 +270,7 @@ jobs:
       run: echo "REPO_LC=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
@@ -333,7 +333,7 @@ jobs:
         docker context use colima
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4


### PR DESCRIPTION
## Description

Upgrades `docker/setup-buildx-action` from `v3` to `v4` in `release.yml` and `docs-release.yml`. v3 runs on Node.js 20 which GitHub is deprecating on Actions runners — forced migration to Node.js 24 begins June 2, 2026.

6 occurrences updated across both workflow files.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- No logic changes, only action version pin updated
- v4.0.0 is the current latest release of the action

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code