### PR TITLE
fix(ci): use RELEASE_PLEASE_TOKEN in Crowdin sync to bypass branch protection

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -58,5 +58,6 @@ jobs:
             echo "Locale files already up to date, nothing to commit"
           else
             git commit -m "chore(i18n): sync locale files [skip ci]"
+            git pull --rebase origin main
             git push
           fi

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Install Crowdin CLI
         run: npm install -g @crowdin/cli@4


### PR DESCRIPTION
## Description

The Crowdin sync workflow was still failing after the rebase fix (#307) — `GITHUB_TOKEN` for `github-actions[bot]` cannot bypass branch protection rules, so the push to main is rejected.

`RELEASE_PLEASE_TOKEN` is a PAT already present in repo secrets that has bypass permissions, used by the semantic-release workflow for exactly this reason. Switching the checkout token to `RELEASE_PLEASE_TOKEN` gives the workflow the credentials it needs to push directly to main.

## Related Issue

Follow-up to #307.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Semantic release workflow uses the same token for the same purpose and pushes to main successfully

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code