### PR TITLE
enhancement(audit): harden audit-context plumbing

### DIFF
--- a/testplanit/app/api/auth/[...nextauth]/route.ts
+++ b/testplanit/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,9 @@
 import NextAuth from "next-auth";
 import { cookies } from "next/headers";
+import {
+  extractAuditContextFromHeaders,
+  runWithAuditContext,
+} from "~/lib/auditContext";
 import { getAuthOptions } from "~/server/auth";
 
 /**
@@ -50,7 +54,11 @@ export async function GET(
     params: await context.params,
   };
 
-  return handler(req, resolvedContext);
+  // Seed the audit-context ALS frame so signIn/signOut callbacks in
+  // server/auth.ts inherit ipAddress/userAgent/requestId for LOGIN /
+  // LOGIN_FAILED audit rows.
+  const auditCtx = extractAuditContextFromHeaders(req.headers);
+  return runWithAuditContext(auditCtx, () => handler(req, resolvedContext));
 }
 
 export async function POST(
@@ -65,5 +73,6 @@ export async function POST(
     params: await context.params,
   };
 
-  return handler(req, resolvedContext);
+  const auditCtx = extractAuditContextFromHeaders(req.headers);
+  return runWithAuditContext(auditCtx, () => handler(req, resolvedContext));
 }

--- a/testplanit/lib/auditContext.ts
+++ b/testplanit/lib/auditContext.ts
@@ -57,18 +57,10 @@ export const auditContextStorage = new AsyncLocalStorage<AuditContext>();
 
 /**
  * Get the current audit context from AsyncLocalStorage.
- * If not in AsyncLocalStorage context, falls back to global context.
  * Returns undefined if not within a request context.
  */
 export function getAuditContext(): AuditContext | undefined {
-  // First try AsyncLocalStorage
-  const stored = auditContextStorage.getStore();
-  if (stored) {
-    return stored;
-  }
-
-  // Fall back to global context (set by API routes)
-  return globalFallbackContext;
+  return auditContextStorage.getStore();
 }
 
 /**
@@ -88,37 +80,6 @@ export function updateAuditContext(updates: Partial<AuditContext>): void {
   if (current) {
     Object.assign(current, updates);
   }
-}
-
-/**
- * Global fallback context for when AsyncLocalStorage is not available.
- * This is used in API routes where we can't wrap the entire request
- * in a runWithAuditContext call.
- * Note: This is a simple fallback and may not be perfectly isolated
- * across concurrent requests, but provides basic context for audit logs.
- */
-let globalFallbackContext: AuditContext | undefined;
-
-/**
- * Set the audit context directly (fallback for when AsyncLocalStorage isn't available).
- * Used in API routes that can't use runWithAuditContext.
- */
-export function setAuditContext(context: AuditContext): void {
-  // First try to update existing AsyncLocalStorage context
-  const current = auditContextStorage.getStore();
-  if (current) {
-    Object.assign(current, context);
-  } else {
-    // Fall back to global context for API routes
-    globalFallbackContext = context;
-  }
-}
-
-/**
- * Get the fallback context when AsyncLocalStorage context is not available.
- */
-export function getFallbackContext(): AuditContext | undefined {
-  return globalFallbackContext;
 }
 
 /**

--- a/testplanit/lib/auditContextWrappers.test.ts
+++ b/testplanit/lib/auditContextWrappers.test.ts
@@ -178,13 +178,8 @@ describe("enrichFromApiAuth", () => {
         userName: "Orphan",
       })
     ).not.toThrow();
-    // getAuditContext may return the globalFallbackContext singleton if
-    // some other test set it; the invariant we care about here is that
-    // enrichFromApiAuth itself doesn't create a frame. Confirm that via
-    // the ALS store directly.
-    // Note: we don't assert getAuditContext() === undefined because
-    // auditContext.ts's getAuditContext falls back to globalFallbackContext.
-    // The behavioral contract is "doesn't throw"; anything else is
-    // delegated to updateAuditContext's existing semantics.
+    // The behavioral contract is "doesn't throw" — enrichFromApiAuth must
+    // not create its own ALS frame; anything else is delegated to
+    // updateAuditContext's existing semantics.
   });
 });


### PR DESCRIPTION
## Description

Two small audit-log enhancements:

1. **Remove unused global fallback audit context.** `globalFallbackContext`, `setAuditContext`, and `getFallbackContext` in `lib/auditContext.ts` had zero non-test callers. Every audit-emitting code path now flows through the AsyncLocalStorage frame seeded by `withAuditContext` / `withActionAuditContext`. The dead code is gone and `getAuditContext` now just returns the ALS store directly.

2. **Enrich NextAuth events with request actor context.** Wrapped the `[...nextauth]` GET/POST handlers in `runWithAuditContext`. The `signIn` / `signOut` callbacks in `server/auth.ts` now run inside an ALS frame seeded with the request's `ipAddress`, `userAgent`, and `requestId`. Persisted audit rows for `LOGIN`, `LOGIN_FAILED`, `ACCOUNT_LOCKED`, `ACCOUNT_UNLOCKED`, and `TWO_FACTOR_VERIFIED` events previously had these fields `null`; downstream code (`captureAuditEvent` → `auditLogWorker`) already reads from the ALS frame, so this is a single-point fix.

## Related Issue

N/A (cleanup + audit-log follow-ups from v0.22.1).

## Type of Change

- [x] Refactoring (no functional changes) — dead-code removal
- [x] Bug fix (non-breaking change that fixes an issue) — missing actor enrichment on auth audit rows

## How Has This Been Tested?

- [x] Unit tests — `lib/auditContext`, `lib/auditContextWrappers`, `workers/auditLogWorker` suites pass (24 tests)
- [x] Full suite — `pnpm precommit` (lint + format:check + 6743 tests) green

**Test Configuration:**
- OS: macOS (Darwin 25.4.0)
- Node version: per `package.json` engines

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes