### PR TITLE
fix(i18n): add Turkish (tr-TR) and Russian (ru-RU) locale support

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -83,7 +83,7 @@ Yes, TestPlanIt integrates with various LLM providers including OpenAI, Azure Op
 
 ### Does TestPlanIt support multiple languages?
 
-The TestPlanIt interface supports 13 languages: English (US), Deutsch (German), Español (Spanish), Français (French), Italiano (Italian), Nederlands (Dutch), Polski (Polish), Português (Portuguese Brazil), Tiếng Việt (Vietnamese), 中文简体 (Chinese Simplified), 中文繁體 (Chinese Traditional), 日本語 (Japanese), and 한국어 (Korean). Contributions for additional languages are welcome.
+The TestPlanIt interface supports 15 languages: English (US), Deutsch (German), Español (Spanish), Français (French), Italiano (Italian), Nederlands (Dutch), Polski (Polish), Português (Portuguese Brazil), Türkçe (Turkish), Tiếng Việt (Vietnamese), Русский (Russian), 中文简体 (Chinese Simplified), 中文繁體 (Chinese Traditional), 日本語 (Japanese), and 한국어 (Korean). Contributions for additional languages are welcome.
 
 ## Administration
 

--- a/docs/docs/user-guide/user-profile.md
+++ b/docs/docs/user-guide/user-profile.md
@@ -64,7 +64,7 @@ When viewing your own profile, you can view and edit these preferences:
 #### Display Preferences
 
 - **Theme**: Choose from Light, Dark, System, Green, Orange, or Purple themes (with color indicators)
-- **Locale**: Language preference (English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Vietnamese, Chinese Simplified, Chinese Traditional, Japanese, Korean)
+- **Locale**: Language preference (English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Turkish, Vietnamese, Russian, Chinese Simplified, Chinese Traditional, Japanese, Korean)
 - **Items Per Page**: Number of items to show in paginated tables (10, 25, 50, 100)
 
 #### Date & Time Formatting

--- a/testplanit/app/api/users/[userId]/route.ts
+++ b/testplanit/app/api/users/[userId]/route.ts
@@ -1,5 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod/v4";
+import {
+  Access,
+  DateFormat,
+  ItemsPerPage,
+  Locale,
+  NotificationMode,
+  Theme,
+  TimeFormat,
+} from "@prisma/client";
 import { prisma } from "~/lib/prisma";
 import { getServerAuthSession } from "~/server/auth";
 import { invalidateSessionUserCache } from "~/lib/session-cache";
@@ -24,55 +33,17 @@ const updateUserSchema = z.object({
   isApi: z.boolean().optional(),
   isDeleted: z.boolean().optional(),
   image: z.string().nullable().optional(),
-  access: z.enum(["NONE", "USER", "PROJECTADMIN", "ADMIN"]).optional(),
+  access: z.enum(Access).optional(),
   roleId: z.number().int().optional(),
   userPreferences: z
     .object({
-      theme: z
-        .enum(["Light", "Dark", "System", "Green", "Orange", "Purple"])
-        .optional(),
-      locale: z
-        .enum([
-          "en_US",
-          "es_ES",
-          "fr_FR",
-          "it_IT",
-          "de_DE",
-          "nl_NL",
-          "pl_PL",
-          "pt_BR",
-          "vi_VN",
-          "zh_CN",
-          "zh_TW",
-          "ja_JP",
-          "ko_KR",
-        ])
-        .optional(),
-      itemsPerPage: z.enum(["P10", "P25", "P50", "P100", "P250"]).optional(),
-      dateFormat: z
-        .enum([
-          "MM_DD_YYYY_SLASH",
-          "MM_DD_YYYY_DASH",
-          "DD_MM_YYYY_SLASH",
-          "DD_MM_YYYY_DASH",
-          "YYYY_MM_DD",
-          "MMM_D_YYYY",
-          "D_MMM_YYYY",
-        ])
-        .optional(),
-      timeFormat: z
-        .enum(["HH_MM", "HH_MM_A", "HH_MM_Z", "HH_MM_Z_A"])
-        .optional(),
+      theme: z.enum(Theme).optional(),
+      locale: z.enum(Locale).optional(),
+      itemsPerPage: z.enum(ItemsPerPage).optional(),
+      dateFormat: z.enum(DateFormat).optional(),
+      timeFormat: z.enum(TimeFormat).optional(),
       timezone: z.string().optional(),
-      notificationMode: z
-        .enum([
-          "NONE",
-          "USE_GLOBAL",
-          "IN_APP",
-          "IN_APP_EMAIL_IMMEDIATE",
-          "IN_APP_EMAIL_DAILY",
-        ])
-        .optional(),
+      notificationMode: z.enum(NotificationMode).optional(),
       emailNotifications: z.boolean().optional(),
       inAppNotifications: z.boolean().optional(),
     })

--- a/testplanit/crowdin.yml
+++ b/testplanit/crowdin.yml
@@ -16,6 +16,8 @@ files:
         nl: "nl-NL"
         pl: "pl-PL"
         pt-BR: "pt-BR"
+        ru: "ru-RU"
+        tr: "tr-TR"
         vi: "vi-VN"
         zh-CN: "zh-CN"
         zh-TW: "zh-TW"

--- a/testplanit/i18n/dateFnsLocales.ts
+++ b/testplanit/i18n/dateFnsLocales.ts
@@ -7,6 +7,8 @@ import { it } from "date-fns/locale/it";
 import { nl } from "date-fns/locale/nl";
 import { pl } from "date-fns/locale/pl";
 import { ptBR } from "date-fns/locale/pt-BR";
+import { ru } from "date-fns/locale/ru";
+import { tr } from "date-fns/locale/tr";
 import { vi } from "date-fns/locale/vi";
 import { zhCN } from "date-fns/locale/zh-CN";
 import { zhTW } from "date-fns/locale/zh-TW";
@@ -24,6 +26,8 @@ export const dateFnsLocaleMap: Record<string, Locale> = {
   "nl-NL": nl,
   "pl-PL": pl,
   "pt-BR": ptBR,
+  "tr-TR": tr,
+  "ru-RU": ru,
   "vi-VN": vi,
   "zh-CN": zhCN,
   "zh-TW": zhTW,

--- a/testplanit/i18n/navigation.ts
+++ b/testplanit/i18n/navigation.ts
@@ -1,5 +1,5 @@
 // Ordered alphabetically by each language's native name (endonym).
-// Latin-script languages first, CJK at the end (no universal alpha order).
+// Latin-script languages first, then Cyrillic, then CJK (no universal alpha order).
 export const locales = [
   "de-DE",
   "en-US",
@@ -9,7 +9,9 @@ export const locales = [
   "nl-NL",
   "pl-PL",
   "pt-BR",
+  "tr-TR",
   "vi-VN",
+  "ru-RU",
   "zh-CN",
   "zh-TW",
   "ja-JP",
@@ -29,7 +31,9 @@ export const languageNames: Record<string, string> = {
   "nl-NL": "Nederlands (Nederland)",
   "pl-PL": "Polski (Polska)",
   "pt-BR": "Português (Brasil)",
+  "tr-TR": "Türkçe (Türkiye)",
   "vi-VN": "Tiếng Việt",
+  "ru-RU": "Русский (Россия)",
   "zh-CN": "中文（简体）",
   "zh-TW": "中文（繁體）",
   "ja-JP": "日本語",

--- a/testplanit/prisma/schema.prisma
+++ b/testplanit/prisma/schema.prisma
@@ -38,7 +38,9 @@ enum Locale {
   nl_NL
   pl_PL
   pt_BR
+  tr_TR
   vi_VN
+  ru_RU
   zh_CN
   zh_TW
   ja_JP

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -248,7 +248,9 @@ enum Locale {
     nl_NL
     pl_PL
     pt_BR
+    tr_TR
     vi_VN
+    ru_RU
     zh_CN
     zh_TW
     ja_JP


### PR DESCRIPTION
## Description

Adds Turkish (`tr-TR`) and Russian (`ru-RU`) UI locales. Crowdin project has already been updated to source translations for both languages; this PR wires them into the app so they appear in the locale picker and resolve correctly at runtime.

**App wiring**

- `schema.zmodel` — added `tr_TR` and `ru_RU` to the `Locale` enum
- `i18n/navigation.ts` — registered `tr-TR` and `ru-RU` in `locales` and `languageNames` (Türkçe (Türkiye), Русский (Россия))
- `i18n/dateFnsLocales.ts` — imported and mapped `tr` and `ru` from `date-fns/locale`
- `crowdin.yml` — added `tr` → `tr-TR` and `ru` → `ru-RU` language mappings
- `messages/tr-TR.json` and `messages/ru-RU.json` — seeded from `en-US.json` (Crowdin will populate via `pnpm crowdin:sync`)

**Schema refactor (drive-by)**

- `app/api/users/[userId]/route.ts` — replaced hardcoded Zod enum lists with `z.enum(PrismaEnum)` for `access`, `theme`, `locale`, `itemsPerPage`, `dateFormat`, `timeFormat`, and `notificationMode`. The hardcoded `locale` enum was the source of a 400 on profile saves before this fix — future enum additions only require updating `schema.zmodel` + `pnpm generate`.

**Docs**

- `docs/docs/faq.md` — 13 → 15 languages, added Türkçe and Русский inline
- `docs/docs/user-guide/user-profile.md` — added Turkish and Russian to the locale list

## Related Issue

None — direct user request.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (Zod enum derivation from Prisma client)

## Testing

- [x] `dateFnsLocales.test.ts` loop test auto-covers tr-TR and ru-RU (asserts every `locales[]` entry exists in `dateFnsLocaleMap`)
- [x] Existing `proxy.test.ts`, `server-translations.test.ts`, and component tests are isolated from the locale list — no updates needed
- [ ] After merge: run `pnpm crowdin:sync` to populate `tr-TR.json` and `ru-RU.json` with real translations
- [ ] After merge: verify locale picker in user profile shows both new options

## Checklist

- [x] Followed code style and conventions
- [x] No hardcoded UI strings
- [x] No `.planning/` references in code or commit
- [x] No flaky tests introduced
- [x] Schema regenerated via `pnpm generate` (Prisma + ZenStack hooks)
