### PR TITLE
fix(access): grant test-run and session update access to group/default-role users

### DIFF
--- a/testplanit/__tests__/integration/testrun-group-permission-update.test.ts
+++ b/testplanit/__tests__/integration/testrun-group-permission-update.test.ts
@@ -1,0 +1,235 @@
+// Regression test for the test-run / session @@allow('update,delete', ...)
+// rules. Before the fix, the rules omitted group-assigned access paths, so a
+// user whose only permission flowed through a Group with a role that had
+// TestRuns.canAddEdit could not edit a test run created by another user.
+//
+// This test asserts the positive case: User B, granted access purely via a
+// Group with SPECIFIC_ROLE, can update a TestRun created by User A.
+//
+// Run via:
+//   cd testplanit && RUN_DB_INTEGRATION=1 pnpm test testrun-group-permission-update --run
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PrismaClient, WorkflowScope } from "@prisma/client";
+import { enhance } from "@zenstackhq/runtime";
+
+const RUN_INTEGRATION = process.env.RUN_DB_INTEGRATION === "1";
+const HAS_DB_URL = Boolean(process.env.DATABASE_URL);
+const describeIntegration =
+  RUN_INTEGRATION && HAS_DB_URL ? describe : describe.skip;
+
+const prisma = new PrismaClient();
+const RUN_TAG = `tr-grp-${Date.now()}`;
+
+type AuthUser = Awaited<ReturnType<typeof fetchAuthUser>>;
+
+async function fetchAuthUser(userId: string) {
+  return prisma.user.findUniqueOrThrow({
+    where: { id: userId },
+    include: { role: { include: { rolePermissions: true } } },
+  });
+}
+
+interface Fixture {
+  project: { id: number };
+  testRun: { id: number };
+  groupMember: AuthUser;
+  outsider: AuthUser;
+}
+
+let fixture: Fixture | null = null;
+
+async function setupFixture(): Promise<Fixture> {
+  const userRole = await prisma.roles.findFirst({ where: { name: "user" } });
+  if (!userRole) {
+    throw new Error(
+      "Dev DB missing seeded `user` role. Run `pnpm tsx prisma/seed.ts` first."
+    );
+  }
+  const runWorkflow = await prisma.workflows.findFirst({
+    where: { scope: WorkflowScope.RUNS, isDeleted: false, isEnabled: true },
+  });
+  if (!runWorkflow) {
+    throw new Error("Dev DB missing RUNS-scoped Workflows row.");
+  }
+
+  // A custom role granting TestRuns.canAddEdit (so we exercise the
+  // rolePermissions[area == 'TestRuns' && canAddEdit] branch, not the
+  // role.name == 'Project Admin' short-circuit).
+  const editorRole = await prisma.roles.create({
+    data: {
+      name: `${RUN_TAG}-runEditor`,
+      rolePermissions: {
+        create: [{ area: "TestRuns", canAddEdit: true, canDelete: false }],
+      },
+    },
+  });
+
+  // Creator of the project + test run.
+  const creatorCreated = await prisma.user.create({
+    data: {
+      email: `${RUN_TAG}-creator@example.test`,
+      name: `${RUN_TAG} Creator`,
+      access: "USER",
+      roleId: userRole.id,
+    },
+  });
+
+  // The user whose only path to the project is group membership.
+  const groupMemberCreated = await prisma.user.create({
+    data: {
+      email: `${RUN_TAG}-groupMember@example.test`,
+      name: `${RUN_TAG} Group Member`,
+      access: "USER",
+      roleId: userRole.id,
+    },
+  });
+
+  // Negative control: not in the group, not the creator, no direct perms.
+  const outsiderCreated = await prisma.user.create({
+    data: {
+      email: `${RUN_TAG}-outsider@example.test`,
+      name: `${RUN_TAG} Outsider`,
+      access: "USER",
+      roleId: userRole.id,
+    },
+  });
+
+  const groupMember = await fetchAuthUser(groupMemberCreated.id);
+  const outsider = await fetchAuthUser(outsiderCreated.id);
+
+  const project = await prisma.projects.create({
+    data: {
+      name: `${RUN_TAG}-project`,
+      createdBy: creatorCreated.id,
+      defaultAccessType: "SPECIFIC_ROLE",
+      defaultRoleId: userRole.id,
+    },
+  });
+
+  const group = await prisma.groups.create({
+    data: {
+      name: `${RUN_TAG}-group`,
+      assignedUsers: { create: [{ userId: groupMember.id }] },
+    },
+  });
+
+  await prisma.groupProjectPermission.create({
+    data: {
+      groupId: group.id,
+      projectId: project.id,
+      accessType: "SPECIFIC_ROLE",
+      roleId: editorRole.id,
+    },
+  });
+
+  const testRun = await prisma.testRuns.create({
+    data: {
+      projectId: project.id,
+      name: `${RUN_TAG}-run`,
+      stateId: runWorkflow.id,
+      createdById: creatorCreated.id,
+    },
+  });
+
+  return {
+    project: { id: project.id },
+    testRun: { id: testRun.id },
+    groupMember,
+    outsider,
+  };
+}
+
+async function cleanupFixture(f: Fixture | null): Promise<void> {
+  if (!f) return;
+  const safe = async (op: () => Promise<unknown>): Promise<void> => {
+    try {
+      await op();
+    } catch {
+      /* best-effort */
+    }
+  };
+
+  await safe(() =>
+    prisma.testRuns.updateMany({
+      where: { name: { startsWith: RUN_TAG } },
+      data: { isDeleted: true },
+    })
+  );
+  await safe(() =>
+    prisma.groupProjectPermission.deleteMany({
+      where: { project: { name: { startsWith: RUN_TAG } } },
+    })
+  );
+  await safe(() =>
+    prisma.groupAssignment.deleteMany({
+      where: { group: { name: { startsWith: RUN_TAG } } },
+    })
+  );
+  await safe(() =>
+    prisma.groups.updateMany({
+      where: { name: { startsWith: RUN_TAG } },
+      data: { isDeleted: true },
+    })
+  );
+  await safe(() =>
+    prisma.rolePermission.deleteMany({
+      where: { role: { name: { startsWith: RUN_TAG } } },
+    })
+  );
+  await safe(() =>
+    prisma.roles.updateMany({
+      where: { name: { startsWith: RUN_TAG } },
+      data: { isDeleted: true },
+    })
+  );
+  await safe(() =>
+    prisma.projects.updateMany({
+      where: { name: { startsWith: RUN_TAG } },
+      data: { isDeleted: true },
+    })
+  );
+  await safe(() =>
+    prisma.user.updateMany({
+      where: { email: { startsWith: RUN_TAG } },
+      data: { isDeleted: true, isActive: false },
+    })
+  );
+}
+
+beforeAll(async () => {
+  if (!RUN_INTEGRATION || !HAS_DB_URL) return;
+  fixture = await setupFixture();
+}, 30_000);
+
+afterAll(async () => {
+  if (!RUN_INTEGRATION || !HAS_DB_URL) return;
+  await cleanupFixture(fixture);
+  await prisma.$disconnect();
+}, 30_000);
+
+describeIntegration("TestRun update via group-assigned SPECIFIC_ROLE", () => {
+  it("allows a user whose only access is through a group with TestRuns.canAddEdit to update a TestRun created by someone else", async () => {
+    if (!fixture) throw new Error("fixture not initialized");
+    const enhancedDb = enhance(prisma, { user: fixture.groupMember });
+
+    const updated = await enhancedDb.testRuns.update({
+      where: { id: fixture.testRun.id },
+      data: { name: `${RUN_TAG}-renamed-by-group-member` },
+    });
+
+    expect(updated.name).toBe(`${RUN_TAG}-renamed-by-group-member`);
+  });
+
+  it("denies an outsider with no group, no direct permission, and no global role on the project", async () => {
+    if (!fixture) throw new Error("fixture not initialized");
+    const enhancedDb = enhance(prisma, { user: fixture.outsider });
+
+    await expect(
+      enhancedDb.testRuns.update({
+        where: { id: fixture.testRun.id },
+        data: { name: `${RUN_TAG}-should-not-stick` },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -1645,16 +1645,33 @@ model RepositoryCaseVersions {
          project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
     )
 
-    // Create/update/delete access for users with repository permissions
+    // Create/update/delete access based on role permissions
     @@allow('create,update,delete',
         project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                 (role.name == 'Project Admin' ||
                                  role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])] ||
+    // User with GLOBAL_ROLE access type (use their global role)
+        project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                auth().role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
         project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
         project.groupPermissions?[group.assignedUsers?[user == auth()] &&
                                   accessType == 'SPECIFIC_ROLE' &&
-                                  role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]]
+                                  role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                  accessType == 'GLOBAL_ROLE' &&
+                                  auth().role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (project.assignedUsers?[user == auth()] &&
+         project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2062,14 +2079,34 @@ model Sessions {
                                   role.rolePermissions?[area == 'Sessions' && canAddEdit]]
     )
 
-    // Update/delete access
+    // Update/delete access based on role permissions
     @@allow('update,delete',
         auth().id == createdById ||
         project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                 (role.name == 'Project Admin' ||
                                  role.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)])] ||
-        project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                auth().role.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)]] ||
+    // System PROJECTADMIN assigned to project
+        project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                  accessType == 'SPECIFIC_ROLE' &&
+                                  role.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)]] ||
+    // Group with GLOBAL_ROLE access type
+        project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                  accessType == 'GLOBAL_ROLE' &&
+                                  auth().role.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (project.assignedUsers?[user == auth()] &&
+         project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2144,12 +2181,34 @@ model SessionResults {
          session.project.defaultRole.rolePermissions?[area == 'SessionResults' && canAddEdit])
     )
 
-    // Update/delete access
+    // Update/delete access based on role permissions
     @@allow('update,delete',
         auth().id == createdById ||
         session.project.creator == auth() ||
-        session.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' && role.name == 'Project Admin'] ||
-        session.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with SPECIFIC_ROLE access type
+        session.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
+                                         (role.name == 'Project Admin' ||
+                                          role.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)])] ||
+    // User with GLOBAL_ROLE access type (use their global role)
+        session.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                         auth().role.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)]] ||
+    // System PROJECTADMIN assigned to project
+        session.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        session.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'SPECIFIC_ROLE' &&
+                                          role.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)]] ||
+    // Group with GLOBAL_ROLE access type
+        session.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'GLOBAL_ROLE' &&
+                                          auth().role.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (session.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (session.project.assignedUsers?[user == auth()] &&
+         session.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         session.project.defaultRole.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2278,10 +2337,30 @@ model SessionFieldValues {
     // Create/update/delete access inherits from session permissions
     @@allow('create,update,delete',
         session.project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         session.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                         (role.name == 'Project Admin' ||
                                          role.rolePermissions?[area == 'Sessions' && canAddEdit])] ||
-        session.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        session.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                        auth().role.rolePermissions?[area == 'Sessions' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
+        session.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        session.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'SPECIFIC_ROLE' &&
+                                          role.rolePermissions?[area == 'Sessions' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        session.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'GLOBAL_ROLE' &&
+                                          auth().role.rolePermissions?[area == 'Sessions' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (session.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'Sessions' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (session.project.assignedUsers?[user == auth()] &&
+         session.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         session.project.defaultRole.rolePermissions?[area == 'Sessions' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2359,14 +2438,34 @@ model TestRuns {
                                   role.rolePermissions?[area == 'TestRuns' && canAddEdit]]
     )
 
-    // Update/delete access
+    // Update/delete access based on role permissions
     @@allow('update,delete',
         auth().id == createdById ||
         project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                 (role.name == 'Project Admin' ||
                                  role.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)])] ||
-        project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                auth().role.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)]] ||
+    // System PROJECTADMIN assigned to project
+        project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                  accessType == 'SPECIFIC_ROLE' &&
+                                  role.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)]] ||
+    // Group with GLOBAL_ROLE access type
+        project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                  accessType == 'GLOBAL_ROLE' &&
+                                  auth().role.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (project.assignedUsers?[user == auth()] &&
+         project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2469,15 +2568,35 @@ model TestRunCases {
          testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit])
     )
 
-    // Update access - creator, assignee, or admin
+    // Update access - creator, assignee, or users with test run permissions
     @@allow('update',
         auth().id == testRun.createdById ||
         auth().id == assignedToId ||
         testRun.project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                          (role.name == 'Project Admin' ||
                                           role.rolePermissions?[area == 'TestRuns' && canAddEdit])] ||
-        testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                         auth().role.rolePermissions?[area == 'TestRuns' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
+        testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'SPECIFIC_ROLE' &&
+                                          role.rolePermissions?[area == 'TestRuns' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'GLOBAL_ROLE' &&
+                                          auth().role.rolePermissions?[area == 'TestRuns' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRuns' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (testRun.project.assignedUsers?[user == auth()] &&
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2541,10 +2660,30 @@ model TestRunResults {
     @@allow('create,update',
         auth().id == executedById ||
         testRun.project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                          (role.name == 'Project Admin' ||
                                           role.rolePermissions?[area == 'TestRunResults' && canAddEdit])] ||
-        testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
+        testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'SPECIFIC_ROLE' &&
+                                          role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                          accessType == 'GLOBAL_ROLE' &&
+                                          auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (testRun.project.assignedUsers?[user == auth()] &&
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2595,10 +2734,30 @@ model TestRunStepResults {
     @@allow('create,update',
         auth().id == testRunResult.executedById ||
         testRunResult.testRun.project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         testRunResult.testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                                        (role.name == 'Project Admin' ||
                                                         role.rolePermissions?[area == 'TestRunResults' && canAddEdit])] ||
-        testRunResult.testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        testRunResult.testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                                       auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
+        testRunResult.testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        testRunResult.testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                                        accessType == 'SPECIFIC_ROLE' &&
+                                                        role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        testRunResult.testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                                        accessType == 'GLOBAL_ROLE' &&
+                                                        auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (testRunResult.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (testRunResult.testRun.project.assignedUsers?[user == auth()] &&
+         testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRunResult.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')
@@ -2678,10 +2837,30 @@ model TestRunCaseIteration {
     @@allow('update',
         auth().id == assignedToId ||
         testRunCase.testRun.project.creator == auth() ||
+    // User with SPECIFIC_ROLE access type
         testRunCase.testRun.project.userPermissions?[user == auth() && accessType == 'SPECIFIC_ROLE' &&
                                                      (role.name == 'Project Admin' ||
                                                       role.rolePermissions?[area == 'TestRunResults' && canAddEdit])] ||
-        testRunCase.testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN']
+    // User with GLOBAL_ROLE access type (use their global role)
+        testRunCase.testRun.project.userPermissions?[user == auth() && accessType == 'GLOBAL_ROLE' &&
+                                                     auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // System PROJECTADMIN assigned to project
+        testRunCase.testRun.project.assignedUsers?[user == auth() && auth().access == 'PROJECTADMIN'] ||
+    // Group with SPECIFIC_ROLE access type
+        testRunCase.testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                                      accessType == 'SPECIFIC_ROLE' &&
+                                                      role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Group with GLOBAL_ROLE access type
+        testRunCase.testRun.project.groupPermissions?[group.assignedUsers?[user == auth()] &&
+                                                      accessType == 'GLOBAL_ROLE' &&
+                                                      auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]] ||
+    // Project default GLOBAL_ROLE - user's global role has permission
+        (testRunCase.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE' &&
+         auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Project default SPECIFIC_ROLE - project's default role has permission
+        (testRunCase.testRun.project.assignedUsers?[user == auth()] &&
+         testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRunCase.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
     @@allow('all', auth().access == 'ADMIN')


### PR DESCRIPTION
## Description

The ZenStack `@@allow('update,delete', …)` rules on `TestRuns`, `Sessions`, `SessionResults`, `SessionFieldValues`, `TestRunCases`, `TestRunResults`, `TestRunStepResults`, `TestRunCaseIteration`, and `RepositoryCaseVersions` were missing access branches that the corresponding `create` rules already had.

Symptom: a user whose project access flowed through a Group, a project-default role, or a Global role with `TestRuns.canAddEdit` / `Sessions.canAddEdit` / `TestRunResults.canAddEdit` could create the entity but could not edit one they didn't personally create. The client surfaced the policy denial as the generic "An error occurred while fetching the data." message.

This PR mirrors the 8-branch project-permission pattern already established on `RepositoryCases` so update/delete checks see the same access paths as create:

- Direct user with `SPECIFIC_ROLE`
- Direct user with `GLOBAL_ROLE`
- System `PROJECTADMIN`
- Group member with `SPECIFIC_ROLE`
- Group member with `GLOBAL_ROLE`
- Project default `GLOBAL_ROLE`
- Project default `SPECIFIC_ROLE`
- System `ADMIN` (already present via catch-all)

`SessionResults` had an extra narrowing — its direct-user branch only checked `role.name == 'Project Admin'` and skipped `rolePermissions[area == 'SessionResults' && canAddEdit]`. That branch is now broadened to match the rest of the file.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Manual testing

New live-DB integration test [`testplanit/__tests__/integration/testrun-group-permission-update.test.ts`](testplanit/__tests__/integration/testrun-group-permission-update.test.ts) builds a fixture with a user whose only path to a project is through a Group with a `SPECIFIC_ROLE` granting `TestRuns.canAddEdit`, then verifies that user can update a TestRun created by someone else. A negative-control case confirms a true outsider is still denied. Run via:

```bash
cd testplanit && RUN_DB_INTEGRATION=1 pnpm test testrun-group-permission-update --run
```

Full suite (`pnpm precommit`) — 7381 passed, 81 skipped, 0 failed.

**Test Configuration:**
- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

`SessionVersions` was left alone — it has no `update`/`delete` rule at all, which appears intentional (versions are immutable snapshots). Worth confirming, but it isn't part of this bug class.

`TestRunResults`, `TestRunStepResults`, and `TestRunCaseIteration` similarly have no explicit `delete` rule — only the `@@allow('all', auth().access == 'ADMIN')` catch-all permits deletion. That's preserved here, since restricting non-admin deletion of execution history looks deliberate. Easy to add an explicit delete rule later if that turns out to be unintentional.