### PR TITLE
fix(llm): surface details on test-case generation parse failures

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -2758,8 +2758,11 @@ export function GenerateTestCasesWizard({
 
       if (!outlineRes.ok) {
         const errData = await outlineRes.json().catch(() => ({}));
+        // Pass the whole payload through so the toast handler picks up
+        // `details`, `suggestions`, and `code` — not just the headline.
         throw new Error(
           JSON.stringify({
+            ...errData,
             message:
               errData.error || t("generateTestCases.errors.generateFailed"),
           })

--- a/testplanit/app/api/llm/generate-test-cases/expand/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/expand/route.ts
@@ -273,10 +273,33 @@ export async function POST(req: NextRequest) {
         );
 
         if (parseError || testCases.length === 0) {
+          if (parseError) {
+            console.error("\n=== EXPAND PARSE ERROR ===");
+            console.error("User error:", parseError.userError);
+            console.error("Raw error:", parseError.errorMessage);
+            console.error("Finish reason:", finishReason ?? "<none>");
+            console.error("Response length:", parseError.responseLength);
+            console.error("Seems truncated:", parseError.seemsTruncated);
+            console.error("Response preview:", parseError.responsePreview);
+          }
           send(controller, {
             type: "error",
             code: "generic" satisfies LlmStreamErrorCode,
             message: parseError?.userError ?? "No test case generated",
+            details: parseError
+              ? parseError.seemsTruncated
+                ? `Response appears truncated${
+                    finishReason === "length"
+                      ? " (hit the max-tokens limit)"
+                      : ""
+                  } at ${parseError.responseLength} chars.`
+                : `Parser error: ${parseError.errorMessage}`
+              : "The model returned no test case content.",
+            suggestions: parseError?.userSuggestions,
+            finishReason,
+            responsePreview: parseError?.responsePreview,
+            responseLength: parseError?.responseLength,
+            seemsTruncated: parseError?.seemsTruncated,
           });
           return;
         }

--- a/testplanit/app/api/llm/generate-test-cases/outline/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/outline/route.ts
@@ -141,22 +141,62 @@ export async function POST(request: NextRequest) {
     });
 
     const raw = response.content.trim();
+    const finishReason = response.finishReason;
     let parsed: { outlines: TestCaseOutline[] };
 
     try {
       const jsonMatch = raw.match(/\{[\s\S]*\}/);
       if (!jsonMatch) throw new Error("No JSON found in response");
       parsed = JSON.parse(jsonMatch[0]);
-    } catch {
+    } catch (parseError) {
+      const errMsg =
+        parseError instanceof Error ? parseError.message : String(parseError);
+      const responseLength = raw.length;
+      const responsePreview = raw.slice(0, 500);
+
+      console.error("\n=== OUTLINE PARSE ERROR ===");
+      console.error("Parse error:", errMsg);
+      console.error("Finish reason:", finishReason ?? "<none>");
+      console.error("Response length:", responseLength);
+      console.error("Response preview:", responsePreview);
+
+      const { code, details, suggestions } = classifyOutlineParseFailure({
+        raw,
+        finishReason,
+        errMsg,
+      });
+
       return NextResponse.json(
-        { error: "Failed to parse outline response from LLM" },
+        {
+          error: "Failed to parse outline response from LLM",
+          code,
+          details,
+          suggestions,
+          finishReason,
+          responseLength,
+          responsePreview,
+        },
         { status: 500 }
       );
     }
 
     if (!Array.isArray(parsed.outlines) || parsed.outlines.length === 0) {
+      console.error("\n=== OUTLINE EMPTY RESPONSE ===");
+      console.error("Finish reason:", finishReason ?? "<none>");
+      console.error("Parsed response:", JSON.stringify(parsed).slice(0, 500));
       return NextResponse.json(
-        { error: "LLM returned no outlines" },
+        {
+          error: "LLM returned no outlines",
+          code: "generic",
+          details:
+            "The model returned valid JSON but the outlines array was empty.",
+          suggestions: [
+            "Try regenerating — this is often transient",
+            "Refine the issue description or testing guidance",
+            "Try a different model or temperature in LLM settings",
+          ],
+          finishReason,
+        },
         { status: 500 }
       );
     }
@@ -172,4 +212,77 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+function classifyOutlineParseFailure(input: {
+  raw: string;
+  finishReason: string | undefined;
+  errMsg: string;
+}): { code: string; details: string; suggestions: string[] } {
+  const { raw, finishReason, errMsg } = input;
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return {
+      code: "generic",
+      details:
+        "The model returned an empty response. This is usually transient or a connectivity issue with the provider.",
+      suggestions: [
+        "Try again — empty responses are typically transient",
+        "Check the LLM integration's status page",
+        "Verify the model and API key in LLM settings",
+      ],
+    };
+  }
+
+  if (
+    finishReason === "length" ||
+    errMsg.includes("Unexpected end") ||
+    (!trimmed.endsWith("}") && !trimmed.endsWith("]"))
+  ) {
+    return {
+      code: "generic",
+      details: `The model's response was cut off before it finished${
+        finishReason === "length" ? " (hit the max-tokens limit)" : ""
+      }. The JSON was incomplete and could not be parsed.`,
+      suggestions: [
+        'Try a smaller quantity (e.g. "Few" instead of "Many")',
+        "Shorten the issue description or testing guidance",
+        "Raise the model's max-output-tokens in LLM settings",
+      ],
+    };
+  }
+
+  const refusalMarkers = [
+    "i cannot",
+    "i can't",
+    "i am unable",
+    "i'm unable",
+    "i'm not able",
+    "sorry,",
+    "as an ai",
+  ];
+  const lower = trimmed.toLowerCase();
+  if (refusalMarkers.some((m) => lower.includes(m)) && !lower.includes("{")) {
+    return {
+      code: "generic",
+      details:
+        "The model returned a refusal or explanatory text instead of JSON. The issue content may have triggered safety filters or the prompt may be unclear.",
+      suggestions: [
+        "Rephrase the issue description or testing guidance",
+        "Try a different model — providers have different safety thresholds",
+        "Remove any content that might look like instructions to the model",
+      ],
+    };
+  }
+
+  return {
+    code: "generic",
+    details: `The model returned text but its JSON could not be parsed (${errMsg}). The response preview is included for debugging.`,
+    suggestions: [
+      "Try again — JSON-format slips are often transient",
+      "Switch to a model with stronger JSON adherence (e.g. with native JSON mode)",
+      "Check server logs for the full raw response",
+    ],
+  };
 }


### PR DESCRIPTION
## Description

When the AI test-case generation flow fails to parse an LLM response, the user was shown an opaque "Failed to parse outline response from LLM" toast and the server logged nothing — so there was no way to tell whether the model was overloaded, hit the token cap, refused, or returned malformed JSON. This change makes those failures self-describing on both the server and the user-facing toast, without changing parser behavior.

What changed:

- **Outline route** ([`testplanit/app/api/llm/generate-test-cases/outline/route.ts`](testplanit/app/api/llm/generate-test-cases/outline/route.ts)) — the parse-failure catch now binds the error and logs the raw response preview, `finishReason`, length, and the parser's error message. The HTTP 500 response includes `details`, `suggestions`, `finishReason`, `responseLength`, and `responsePreview`. A small classifier picks one of empty / truncated / refusal / malformed and supplies tailored suggestions. The "empty outlines array" branch gets the same treatment.
- **Expand route** ([`testplanit/app/api/llm/generate-test-cases/expand/route.ts`](testplanit/app/api/llm/generate-test-cases/expand/route.ts)) — `parseAndValidateTestCases` already produces a rich `parseError` (`userSuggestions`, `seemsTruncated`, `responsePreview`, `responseLength`), but the SSE error event only forwarded `userError`. The full diagnostic block is now both logged and sent over the wire.
- **Wizard** ([`testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx`](testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx)) — the outline-failure branch was only forwarding `{ message }`; it now spreads the full `errData` so the existing `enhancedError` toast handler picks up `details`, `suggestions`, and `code`.

## Related Issue

N/A — reactive hardening after a transient LLM failure produced an undiagnosable error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — full vitest suite passes (476 files, 7381 tests).
- [x] Manual testing — verified the rename/branch state, ran \`pnpm precommit\` (lint + format:check + tests) and \`pnpm type-check\`, both clean.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

No tests added — this is purely a diagnostics/messaging change with no behavioral change to the parser or the LLM call. The failure-classification heuristics are intentionally string-pattern-based (no fancy NLP) and only used to pick the suggestion bullet list shown in the toast.