### PR TITLE
chore(ci): fix Dependabot workspace handling for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
+  # Single npm entry for the pnpm workspace. The root pnpm-lock.yaml is the
+  # source of truth for testplanit, cli, packages/*, docs, and forge-app —
+  # per-subdirectory entries produced stale-lockfile PRs because Dependabot's
+  # per-subdir mode doesn't update the shared root lockfile.
   - package-ecosystem: "npm"
-    directory: "/testplanit"
+    directory: "/"
     schedule:
       interval: "weekly"
     ignore:
@@ -19,36 +23,6 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-resizable-panels"
         update-types: ["version-update:semver-major"]
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-        exclude-patterns:
-          - "@types/node"
-      minor-and-patch:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/api"
-    schedule:
-      interval: "weekly"
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-        exclude-patterns:
-          - "@types/node"
-      minor-and-patch:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "npm"
-    directory: "/cli"
-    schedule:
-      interval: "weekly"
     groups:
       dev-dependencies:
         dependency-type: "development"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Verify workspace lockfile mirror
+        # testplanit/pnpm-lock.yaml is a load-bearing byte-for-byte duplicate
+        # of the root pnpm-lock.yaml — the testplanit Dockerfile copies it
+        # from its build context. Fail loudly when they diverge (typically
+        # after a Dependabot bump) so the mirror is fixed before merge.
+        run: diff -q pnpm-lock.yaml testplanit/pnpm-lock.yaml
+
       - name: Install dependencies
         run: |
           cd testplanit
@@ -62,17 +69,12 @@ jobs:
           cd testplanit
           pnpm test run
 
-      - name: Install packages dependencies
-        run: pnpm install --frozen-lockfile
-        working-directory: packages/api
-
+      # packages/api and cli are pnpm workspace members — they were already
+      # installed by the workspace-aware install above. No second install
+      # step needed.
       - name: Run packages unit tests
         run: pnpm test run
         working-directory: packages/api
-
-      - name: Install CLI dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        working-directory: cli
 
       - name: Run CLI unit tests
         run: pnpm test


### PR DESCRIPTION
## Description

Dependabot PRs against this repo have been failing every run with `ERR_PNPM_OUTDATED_LOCKFILE`. The cause is a mismatch between how Dependabot was configured and how this workspace is actually laid out, plus a redundant CI step that turned the mismatch into a hard failure:

- `pnpm-workspace.yaml` declares a single workspace at the repo root covering `testplanit`, `cli`, `packages/*`, `docs`, and `forge-app`. There is one root `pnpm-lock.yaml`; `packages/api/` and `cli/` have no lockfile of their own.
- `.github/dependabot.yml` had three separate `npm` ecosystem entries (`/testplanit`, `/packages/api`, `/cli`). Dependabot's per-subdirectory mode bumped each subdir's `package.json` but did not update the shared root lockfile.
- `.github/workflows/ci.yml` then ran `pnpm install --frozen-lockfile` from inside `packages/api` and `cli`, which failed loudly on the stale lockfile. Those steps were also redundant: the first install from `testplanit/` is workspace-aware and already covers every member.

What this PR changes:

1. **dependabot.yml** — collapses the three `npm` entries into one with `directory: "/"`. Modern Dependabot detects pnpm workspaces and updates the shared root `pnpm-lock.yaml` in a single PR. All existing ignore rules and groups are preserved.
2. **ci.yml** — drops the redundant `pnpm install --frozen-lockfile` steps for `packages/api` and `cli`; keeps the `pnpm test` steps. Workspace members are already installed by the first install.
3. **ci.yml** — adds an early `diff -q pnpm-lock.yaml testplanit/pnpm-lock.yaml` guard. `testplanit/pnpm-lock.yaml` is a load-bearing byte-for-byte duplicate of the root lockfile because `testplanit/Dockerfile` copies the lockfile from its build context. The guard makes the duplicate explicit: a Dependabot bump updates the root lockfile only, so the maintainer mirrors with `cp pnpm-lock.yaml testplanit/pnpm-lock.yaml` before merging.

After this lands, the three currently-open broken Dependabot PRs (#324, #325, #326) should be closed — they'll be superseded by the next clean Dependabot run from the consolidated `/` entry.

## Related Issue

N/A — reactive fix after every Dependabot PR has been failing CI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing — confirmed root and `testplanit/` lockfiles are byte-identical (`diff -q` succeeds); validated both YAML files parse cleanly; verified the workspace layout (`pnpm-workspace.yaml` includes `testplanit`, `cli`, `packages/*`) so the workspace-aware install genuinely covers all members the dropped install steps used to cover.
- [ ] Unit tests — not applicable (CI / Dependabot config only).
- [ ] Integration tests — not applicable.
- [ ] E2E tests — not applicable.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, ARM)
- Node version: project default
- pnpm version: 9 (matches CI)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

This is a `chore(ci)` rather than `fix(...)` so release-please will not bump the published version — there is no behavior change for users.

The lockfile-mirror guard is intentionally simple (one `diff` step) rather than an auto-sync workflow. Auto-sync on Dependabot PRs is possible but requires PAT-based write-back, which is more surface area than this problem warrants. If the manual `cp` step becomes a chore in practice, we can revisit.
