### PR TITLE
fix(export): include expectedResult content in test case exports

### DIFF
--- a/testplanit/components/TestResultHistory.test.tsx
+++ b/testplanit/components/TestResultHistory.test.tsx
@@ -434,6 +434,67 @@ describe("TestResultHistory", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders expectedResult when step text is empty (regression)", async () => {
+    const user = userEvent.setup();
+    const expectedResultDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Verify login succeeds" }],
+        },
+      ],
+    };
+    const resultWithSteps = {
+      ...mockManualResult,
+      id: 2,
+      stepResults: [
+        {
+          id: 901,
+          stepStatus: { name: "Passed", color: { value: "#22C55E" } },
+          notes: null,
+          evidence: null,
+          elapsed: 0,
+          sharedStepItemId: null,
+          step: {
+            id: 401,
+            step: { type: "doc", content: [{ type: "paragraph" }] },
+            // Steps.expectedResult is a Json? scalar — not a nested relation
+            expectedResult: expectedResultDoc,
+            sharedStepGroupId: null,
+            sharedStepGroup: null,
+          },
+          issues: [],
+        },
+      ],
+    };
+    const testCaseWithStepResults = {
+      ...mockTestCase,
+      testRuns: [
+        {
+          ...mockTestCase.testRuns[0],
+          results: [resultWithSteps],
+        },
+      ],
+      junitResults: [],
+    };
+    mockUseFindFirstRepositoryCases.mockReturnValue({
+      data: testCaseWithStepResults,
+      isLoading: false,
+    });
+
+    renderWithQueryClient(<TestResultHistory {...defaultProps} />);
+
+    await user.click(screen.getByTestId("expand-result-manual-2"));
+
+    const editorContents = screen
+      .getAllByTestId("tiptap-editor")
+      .map((el) => el.textContent ?? "");
+    expect(
+      editorContents.some((text) => text.includes("Verify login succeeds"))
+    ).toBe(true);
+  });
+
   it("hides Add to Test Run button when user lacks permission", () => {
     const testCaseNoResults = {
       ...mockTestCase,

--- a/testplanit/components/TestResultHistory.tsx
+++ b/testplanit/components/TestResultHistory.tsx
@@ -139,7 +139,7 @@ interface ManualTestResult extends UnifiedTestResultBase {
     step: {
       id: number;
       step: JsonValue;
-      expectedResult: { expectedResult: JsonValue } | null;
+      expectedResult: JsonValue;
       sharedStepGroupId?: number | null;
       sharedStepGroup?: { name: string | null } | null;
     };
@@ -473,14 +473,11 @@ const StepResultsDisplay = ({
             let expectedResultContent;
             try {
               expectedResultContent = stepResult.step.expectedResult
-                ?.expectedResult
-                ? typeof stepResult.step.expectedResult.expectedResult ===
-                  "string"
-                  ? JSON.parse(stepResult.step.expectedResult.expectedResult)
-                  : stepResult.step.expectedResult.expectedResult
+                ? typeof stepResult.step.expectedResult === "string"
+                  ? JSON.parse(stepResult.step.expectedResult)
+                  : stepResult.step.expectedResult
                 : emptyEditorContent;
             } catch {
-              // console.warn("Error parsing expected result content:", error);
               expectedResultContent = emptyEditorContent;
             }
 
@@ -1407,6 +1404,7 @@ export default function TestResultHistory({
                           variant="ghost"
                           size="icon"
                           className="h-6 w-6"
+                          data-testid={`expand-result-${result.displayId}`}
                           onClick={() => toggleExpanded(result.displayId)}
                         >
                           {isExpanded ? (

--- a/testplanit/hooks/useExportData.test.tsx
+++ b/testplanit/hooks/useExportData.test.tsx
@@ -62,7 +62,7 @@ type SampleDataType = {
   steps?: {
     id: number;
     step: any;
-    expectedResult?: { expectedResult: any; isDeleted?: boolean };
+    expectedResult?: any;
     isDeleted?: boolean;
   }[];
   attachments?: {
@@ -187,15 +187,13 @@ const sampleData: SampleDataType[] = [
           ],
         },
         expectedResult: {
-          expectedResult: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: "Result 1 content" }],
-              },
-            ],
-          },
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Result 1 content" }],
+            },
+          ],
         },
         isDeleted: false,
       },
@@ -738,6 +736,68 @@ describe("useExportData", () => {
     expect(unparsedData[0]["Expected Result"]).toBe("Result 1 content");
     expect(unparsedData[1]["Step Content"]).toBe("Step 2 content");
     expect(unparsedData[1]["Expected Result"]).toBe("");
+  });
+
+  it("should include expectedResult when the step text is empty (regression)", async () => {
+    mockExtractText.mockImplementation((node) => {
+      if (node?.content?.[0]?.content?.[0]?.text) {
+        return node.content[0].content[0].text;
+      }
+      return "";
+    });
+    const caseWithEmptyStep: SampleDataType = {
+      id: 99,
+      name: "Empty Step Case",
+      steps: [
+        {
+          id: 901,
+          step: { type: "doc", content: [{ type: "paragraph" }] },
+          expectedResult: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Expected only" }],
+              },
+            ],
+          },
+          isDeleted: false,
+        },
+      ],
+    };
+    const { result } = renderExportHook({
+      selectedIds: [99],
+      currentData: [caseWithEmptyStep],
+    });
+    mockFetchAllData.mockResolvedValueOnce([caseWithEmptyStep]);
+
+    const multiOptions: ExportOptions = {
+      format: "csv",
+      scope: "selected",
+      columns: "all",
+      delimiter: ",",
+      rowMode: "multi",
+      stepsFormat: "plainText",
+      textLongFormat: "json",
+      attachmentFormat: "json",
+    };
+    await act(async () => {
+      await result.current.handleExport(multiOptions);
+    });
+    const multiRows = mockUnparse.mock.calls[0][0];
+    expect(multiRows).toHaveLength(1);
+    expect(multiRows[0]["Step Content"]).toBe("");
+    expect(multiRows[0]["Expected Result"]).toBe("Expected only");
+
+    mockUnparse.mockClear();
+    mockFetchAllData.mockResolvedValueOnce([caseWithEmptyStep]);
+    await act(async () => {
+      await result.current.handleExport({ ...multiOptions, rowMode: "single" });
+    });
+    const singleRow = mockUnparse.mock.calls[0][0];
+    expect(singleRow[0]["Steps Data"]).toBe(
+      "Expected Result 1:\nExpected only"
+    );
   });
 
   // --- Add tests for attachmentFormat, textLongFormat, custom fields, delimiters, etc. ---

--- a/testplanit/hooks/useExportData.ts
+++ b/testplanit/hooks/useExportData.ts
@@ -392,10 +392,7 @@ export function useExportData<
     steps?: {
       id: number;
       step: any;
-      expectedResult?: {
-        expectedResult: any;
-        isDeleted?: boolean;
-      } | null;
+      expectedResult?: any;
       isDeleted?: boolean;
     }[];
     attachments?: any[];
@@ -563,13 +560,9 @@ export function useExportData<
                   activeSteps.map((step, index) => ({
                     stepNumber: index + 1,
                     step: formatStepContent(step.step, "json"),
-                    expectedResult:
-                      !step.expectedResult || step.expectedResult.isDeleted
-                        ? null
-                        : formatStepContent(
-                            step.expectedResult.expectedResult,
-                            "json"
-                          ),
+                    expectedResult: !step.expectedResult
+                      ? null
+                      : formatStepContent(step.expectedResult, "json"),
                   })) || [];
                 combinedStepData = JSON.stringify(stepsArray);
               } else {
@@ -580,14 +573,12 @@ export function useExportData<
                         step.step,
                         effectiveOptions.stepsFormat
                       );
-                      // Check isDeleted before formatting expectedResult
-                      const expectedText =
-                        !step.expectedResult || step.expectedResult.isDeleted
-                          ? ""
-                          : formatStepContent(
-                              step.expectedResult.expectedResult,
-                              effectiveOptions.stepsFormat
-                            );
+                      const expectedText = !step.expectedResult
+                        ? ""
+                        : formatStepContent(
+                            step.expectedResult,
+                            effectiveOptions.stepsFormat
+                          );
                       const stepStr = stepText
                         ? `Step ${index + 1}:\n${stepText}`
                         : "";
@@ -633,14 +624,12 @@ export function useExportData<
                     step.step,
                     effectiveOptions.stepsFormat
                   );
-                  // Check isDeleted before formatting expectedResult
-                  const expectedResultContent =
-                    !step.expectedResult || step.expectedResult.isDeleted
-                      ? ""
-                      : formatStepContent(
-                          step.expectedResult.expectedResult,
-                          effectiveOptions.stepsFormat
-                        );
+                  const expectedResultContent = !step.expectedResult
+                    ? ""
+                    : formatStepContent(
+                        step.expectedResult,
+                        effectiveOptions.stepsFormat
+                      );
                   if (index === 0) {
                     multiRows.push({
                       formatted: formatItemData(


### PR DESCRIPTION
## Description

Test case exports were silently dropping every step's expected-result text. The bug was most visible when the step body was also empty — the export row appeared blank — but it affected all exports.

**Root cause:** `Steps.expectedResult` is a `Json?` scalar on the `Steps` model (Tiptap doc), but the export hook and the step result history panel were reading it as a nested relation via `step.expectedResult.expectedResult` / `step.expectedResult.isDeleted`. Both accessors always resolved to `undefined`, so `formatStepContent(undefined, …)` returned `""`.

**Changes:**
- `hooks/useExportData.ts` — fix three call sites (single-row JSON, single-row plain/markdown, multi-row) to read `step.expectedResult` directly. Also corrects the generic type constraint that declared the wrong shape.
- `components/TestResultHistory.tsx` — same fix in the per-result step history panel, plus correct the inline type annotation. Adds a `data-testid` on the row-expand chevron so the regression test can target it.
- `hooks/useExportData.test.tsx` — fixes the existing fixture, which was encoding the broken nested shape, and adds a regression test asserting expected-result text reaches the output when the step body is empty (covering both `single` and `multi` row modes).
- `components/TestResultHistory.test.tsx` — adds a regression test that mounts the component, expands a row, and asserts the expected-result text reaches the rendered Tiptap editor.

## Related Issue

N/A (customer-reported regression)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — `pnpm test --run hooks/useExportData.test.tsx components/TestResultHistory.test.tsx` (33/33 pass)
- [x] Full suite — `pnpm precommit` (lint + format:check + 7,383/7,464 pass)
- [x] Type check — `pnpm type-check` clean

**Test Configuration:**
- OS: macOS (darwin)
- Node version: as per repo `.nvmrc`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes