### PR TITLE
fix(import): round-trip support for labeled + multi-row CSV step exports

### DIFF
--- a/testplanit/app/api/repository/import/route.test.ts
+++ b/testplanit/app/api/repository/import/route.test.ts
@@ -859,6 +859,50 @@ describe("CSV Import API Route", () => {
       });
     });
 
+    it("imports multi-row CSV by collapsing continuation rows into one case (regression)", async () => {
+      const file = [
+        "ID,Name,Description,Step #,Step Content,Expected Result",
+        "1,Login flow,Verify login,1,Open login page,Login form renders",
+        "1,Login flow,,2,Enter credentials,Dashboard appears",
+        "1,Login flow,,3,Click logout,Login page returns",
+        "2,Password reset,Verify reset email,1,Click forgot password,Reset email sent",
+      ].join("\n");
+
+      const request = createRequest({
+        projectId: 1,
+        file,
+        delimiter: ",",
+        hasHeaders: true,
+        encoding: "UTF-8",
+        templateId: 1,
+        importLocation: "single_folder",
+        folderId: 1,
+        rowMode: "multi",
+        fieldMappings: [
+          { csvColumn: "ID", templateField: "id" },
+          { csvColumn: "Name", templateField: "name" },
+          { csvColumn: "Description", templateField: "description" },
+        ],
+      });
+
+      const response = await POST(request);
+      const result = await parseSSEResponse(response);
+
+      expect(result.complete).toBeDefined();
+      // Two cases (Login flow + Password reset), four steps total (3 + 1)
+      expect(mockEnhancedDb.repositoryCases.create).toHaveBeenCalledTimes(2);
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledTimes(4);
+      // Each created step has both fields populated
+      for (const call of mockEnhancedDb.steps.create.mock.calls) {
+        expect(call[0].data.step).toEqual(
+          expect.objectContaining({ type: "doc" })
+        );
+        expect(call[0].data.expectedResult).toEqual(
+          expect.objectContaining({ type: "doc" })
+        );
+      }
+    });
+
     it("imports test cases with workflow state", async () => {
       mockEnhancedDb.workflows.findFirst.mockImplementation(({ where }) => {
         if (where.name === "In Progress") {

--- a/testplanit/app/api/repository/import/route.test.ts
+++ b/testplanit/app/api/repository/import/route.test.ts
@@ -815,6 +815,50 @@ describe("CSV Import API Route", () => {
       });
     });
 
+    it("imports labeled-format Steps cell as a single step + expected result (regression)", async () => {
+      // Verbatim shape of the cell produced by the CSV exporter in single-row
+      // plainText mode. Customer reported the labeled lines were being split
+      // into four separate Steps rows on re-import.
+      const cell = [
+        "Step 1:",
+        "Navigate to the Tasks Page",
+        "Expected Result 1:",
+        'Verify ""My Open Tasks"" on the Tasks page has been updated to ""Your Open Tasks""',
+      ].join("\n");
+      const file =
+        "Name,Description,Steps Data\n" +
+        `Verify task page text,Test Description,"${cell.replace(/"/g, '""')}"`;
+
+      const request = createRequest({
+        projectId: 1,
+        file,
+        delimiter: ",",
+        hasHeaders: true,
+        encoding: "UTF-8",
+        templateId: 1,
+        importLocation: "single_folder",
+        folderId: 1,
+        fieldMappings: [
+          { csvColumn: "Name", templateField: "name" },
+          { csvColumn: "Description", templateField: "description" },
+          { csvColumn: "Steps Data", templateField: "steps" },
+        ],
+      });
+
+      const response = await POST(request);
+      const result = await parseSSEResponse(response);
+
+      expect(result.complete).toBeDefined();
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledTimes(1);
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          step: expect.objectContaining({ type: "doc" }),
+          expectedResult: expect.objectContaining({ type: "doc" }),
+          order: 0,
+        }),
+      });
+    });
+
     it("imports test cases with workflow state", async () => {
       mockEnhancedDb.workflows.findFirst.mockImplementation(({ where }) => {
         if (where.name === "In Progress") {

--- a/testplanit/app/api/repository/import/route.ts
+++ b/testplanit/app/api/repository/import/route.ts
@@ -24,6 +24,7 @@ import {
   parseLabeledSteps,
   tryParseJsonSteps,
 } from "~/lib/utils/parseExportedSteps";
+import { aggregateMultiRowSteps } from "~/lib/utils/aggregateMultiRowSteps";
 
 function parseTags(value: any): string[] {
   if (!value) return [];
@@ -296,6 +297,11 @@ export const POST = withAuditContext(async (request: NextRequest) => {
 
           rows = parseResult.data as any[];
         }
+
+        if (body.rowMode === "multi") {
+          rows = aggregateMultiRowSteps(rows, body.fieldMappings);
+        }
+
         const errors: ImportError[] = [];
         const casesToImport: any[] = [];
 
@@ -405,6 +411,16 @@ export const POST = withAuditContext(async (request: NextRequest) => {
                 }
               }
             }
+          }
+
+          if (Array.isArray(row._aggregatedSteps)) {
+            caseData.steps = row._aggregatedSteps.map((s: any) => ({
+              step: ensureTipTapJSON(s.step),
+              expectedResult: s.expectedResult
+                ? ensureTipTapJSON(s.expectedResult)
+                : null,
+              order: s.order,
+            }));
           }
 
           // Validate required fields

--- a/testplanit/app/api/repository/import/route.ts
+++ b/testplanit/app/api/repository/import/route.ts
@@ -19,6 +19,11 @@ import { db } from "~/server/db";
 import { syncRepositoryCaseToElasticsearch } from "~/services/repositoryCaseSync";
 import { getElasticsearchClient } from "~/services/elasticsearchService";
 import { ensureTipTapJSON } from "~/utils/tiptapConversion";
+import {
+  hasLabeledStepFormat,
+  parseLabeledSteps,
+  tryParseJsonSteps,
+} from "~/lib/utils/parseExportedSteps";
 
 function parseTags(value: any): string[] {
   if (!value) return [];
@@ -1076,16 +1081,35 @@ function validateFieldValue(
         throw new Error(`Invalid URL: ${value}`);
       }
 
-    case "Steps":
-      // Parse pipe-separated format: "1. Step text | Expected result"
+    case "Steps": {
       const stepsText = value.toString();
+
+      const jsonParsed = tryParseJsonSteps(stepsText);
+      if (jsonParsed) {
+        return jsonParsed.map((s) => ({
+          step: ensureTipTapJSON(s.step),
+          expectedResult: s.expectedResult
+            ? ensureTipTapJSON(s.expectedResult)
+            : null,
+          order: s.order,
+        }));
+      }
+
+      if (hasLabeledStepFormat(stepsText)) {
+        return parseLabeledSteps(stepsText).map((s) => ({
+          step: ensureTipTapJSON(s.step),
+          expectedResult: s.expectedResult
+            ? ensureTipTapJSON(s.expectedResult)
+            : null,
+          order: s.order,
+        }));
+      }
+
+      // Legacy: one step per line, pipe-separated "1. Step | Expected"
       const lines = stepsText.split(/\n/).filter((line: string) => line.trim());
 
       return lines.map((line: string, index: number) => {
-        // Remove step number prefix if present (e.g., "1. ", "2. ")
         const withoutNumber = line.replace(/^\d+\.\s*/, "").trim();
-
-        // Split by pipe to get step and expected result
         const parts = withoutNumber.split("|").map((p: string) => p.trim());
         const stepText = parts[0] || "";
         const expectedResultText = parts[1] || null;
@@ -1098,6 +1122,7 @@ function validateFieldValue(
           order: index,
         };
       });
+    }
 
     default:
       return value;

--- a/testplanit/app/api/shared-steps/import/route.ts
+++ b/testplanit/app/api/shared-steps/import/route.ts
@@ -11,6 +11,10 @@ import {
   convertTextToTipTapJSON,
   ensureTipTapJSON,
 } from "~/utils/tiptapConversion";
+import {
+  parseLabeledSteps,
+  tryParseJsonSteps,
+} from "~/lib/utils/parseExportedSteps";
 
 // Helper function to safely parse JSON
 const safeJsonParse = (jsonString: any, defaultValue: any = null): any => {
@@ -23,81 +27,28 @@ const safeJsonParse = (jsonString: any, defaultValue: any = null): any => {
   }
 };
 
-// Helper function to extract text from TipTap JSON
-const extractTextFromTipTap = (jsonContent: any): string => {
-  if (!jsonContent) return "";
-
-  if (typeof jsonContent === "string") {
-    // Try to parse as JSON first
-    const parsed = safeJsonParse(jsonContent);
-    if (typeof parsed === "string") return parsed;
-    jsonContent = parsed;
-  }
-
-  if (jsonContent.text && typeof jsonContent.text === "string") {
-    return jsonContent.text;
-  }
-
-  if (jsonContent.content && Array.isArray(jsonContent.content)) {
-    return jsonContent.content.map(extractTextFromTipTap).join("");
-  }
-
-  return "";
-};
-
-// Parse combined step data (single row mode with all steps in one field)
 const parseCombinedStepData = (
   combinedData: string,
   _rowMode: string
 ): Array<{ step: string; expectedResult?: string; order: number }> => {
   if (!combinedData || combinedData.trim() === "") return [];
 
-  try {
-    // Try to parse as JSON first (export format)
-    const parsed = safeJsonParse(combinedData);
-    if (Array.isArray(parsed)) {
-      return parsed.map((item, index) => ({
-        step:
-          typeof item.step === "string"
-            ? item.step
-            : extractTextFromTipTap(item.step),
-        expectedResult: item.expectedResult
-          ? typeof item.expectedResult === "string"
-            ? item.expectedResult
-            : extractTextFromTipTap(item.expectedResult)
-          : undefined,
-        order: item.stepNumber || index,
-      }));
-    }
-  } catch {
-    // Fall back to plain text parsing
+  const jsonParsed = tryParseJsonSteps(combinedData);
+  if (jsonParsed) {
+    return jsonParsed.map((s) => ({
+      step: s.step,
+      expectedResult: s.expectedResult || undefined,
+      order: s.order,
+    }));
   }
 
-  // Parse plain text format
-  const steps: Array<{ step: string; expectedResult?: string; order: number }> =
-    [];
-  const sections = combinedData
-    .split("---")
-    .map((s) => s.trim())
-    .filter((s) => s);
-
-  for (let i = 0; i < sections.length; i++) {
-    const section = sections[i];
-    const stepMatch = section.match(
-      /Step \d+:\s*(.*?)(?=Expected Result \d+:|$)/s
-    );
-    const expectedMatch = section.match(/Expected Result \d+:\s*(.*?)$/s);
-
-    if (stepMatch) {
-      steps.push({
-        step: stepMatch[1].trim(),
-        expectedResult: expectedMatch ? expectedMatch[1].trim() : undefined,
-        order: i,
-      });
-    }
-  }
-
-  return steps;
+  return parseLabeledSteps(combinedData)
+    .filter((s) => s.step || s.expectedResult)
+    .map((s) => ({
+      step: s.step,
+      expectedResult: s.expectedResult || undefined,
+      order: s.order,
+    }));
 };
 
 interface FieldMapping {

--- a/testplanit/lib/utils/aggregateMultiRowSteps.test.ts
+++ b/testplanit/lib/utils/aggregateMultiRowSteps.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { aggregateMultiRowSteps } from "./aggregateMultiRowSteps";
+
+describe("aggregateMultiRowSteps", () => {
+  it("collapses continuation rows into the head row's _aggregatedSteps", () => {
+    const rows = [
+      {
+        ID: "1",
+        Name: "Login flow",
+        Description: "Verify login",
+        "Step #": "1",
+        "Step Content": "Open login page",
+        "Expected Result": "Login form renders",
+      },
+      {
+        ID: "1",
+        Name: "Login flow",
+        Description: "",
+        "Step #": "2",
+        "Step Content": "Enter credentials",
+        "Expected Result": "Dashboard appears",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+      { csvColumn: "Description", templateField: "description" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].Description).toBe("Verify login");
+    expect(result[0]._aggregatedSteps).toEqual([
+      {
+        step: "Open login page",
+        expectedResult: "Login form renders",
+        order: 0,
+      },
+      {
+        step: "Enter credentials",
+        expectedResult: "Dashboard appears",
+        order: 1,
+      },
+    ]);
+  });
+
+  it("starts a new aggregated case when ID changes", () => {
+    const rows = [
+      {
+        ID: "1",
+        Name: "Case A",
+        "Step #": "1",
+        "Step Content": "A step 1",
+        "Expected Result": "A result 1",
+      },
+      {
+        ID: "1",
+        Name: "Case A",
+        "Step #": "2",
+        "Step Content": "A step 2",
+        "Expected Result": "",
+      },
+      {
+        ID: "2",
+        Name: "Case B",
+        "Step #": "1",
+        "Step Content": "B step 1",
+        "Expected Result": "B result 1",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]._aggregatedSteps).toHaveLength(2);
+    expect(result[1]._aggregatedSteps).toHaveLength(1);
+    expect(result[1]._aggregatedSteps[0].step).toBe("B step 1");
+  });
+
+  it("groups by Name when no ID column is mapped", () => {
+    const rows = [
+      {
+        Name: "Case A",
+        "Step #": "1",
+        "Step Content": "A1",
+        "Expected Result": "",
+      },
+      {
+        Name: "Case A",
+        "Step #": "2",
+        "Step Content": "A2",
+        "Expected Result": "",
+      },
+      {
+        Name: "Case B",
+        "Step #": "1",
+        "Step Content": "B1",
+        "Expected Result": "",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].Name).toBe("Case A");
+    expect(result[0]._aggregatedSteps).toHaveLength(2);
+    expect(result[1].Name).toBe("Case B");
+  });
+
+  it("preserves expected-result-only continuation rows", () => {
+    const rows = [
+      {
+        ID: "1",
+        Name: "x",
+        "Step #": "1",
+        "Step Content": "Open page",
+        "Expected Result": "",
+      },
+      {
+        ID: "1",
+        Name: "x",
+        "Step #": "2",
+        "Step Content": "",
+        "Expected Result": "Banner is hidden",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._aggregatedSteps).toEqual([
+      { step: "Open page", expectedResult: "", order: 0 },
+      { step: "", expectedResult: "Banner is hidden", order: 1 },
+    ]);
+  });
+
+  it("skips continuation rows with no step content and no expected result", () => {
+    const rows = [
+      {
+        ID: "1",
+        Name: "x",
+        "Step #": "1",
+        "Step Content": "Step",
+        "Expected Result": "",
+      },
+      {
+        ID: "1",
+        Name: "x",
+        "Step #": "",
+        "Step Content": "",
+        "Expected Result": "",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._aggregatedSteps).toHaveLength(1);
+  });
+
+  it("returns input unchanged when no step columns are present", () => {
+    const rows = [{ ID: "1", Name: "x", Description: "y" }];
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+    expect(result).toBe(rows);
+  });
+
+  it("returns input unchanged for empty input", () => {
+    expect(aggregateMultiRowSteps([], [])).toEqual([]);
+  });
+
+  it("uses row-order fallback when Step # is missing", () => {
+    const rows = [
+      {
+        ID: "1",
+        Name: "x",
+        "Step Content": "First",
+        "Expected Result": "",
+      },
+      {
+        ID: "1",
+        Name: "x",
+        "Step Content": "Second",
+        "Expected Result": "",
+      },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+    ]);
+
+    expect(result[0]._aggregatedSteps).toEqual([
+      { step: "First", expectedResult: "", order: 0 },
+      { step: "Second", expectedResult: "", order: 1 },
+    ]);
+  });
+});

--- a/testplanit/lib/utils/aggregateMultiRowSteps.ts
+++ b/testplanit/lib/utils/aggregateMultiRowSteps.ts
@@ -1,0 +1,119 @@
+export interface MultiRowFieldMapping {
+  csvColumn: string;
+  templateField: string | null;
+}
+
+export interface AggregatedStep {
+  step: string;
+  expectedResult: string;
+  order: number;
+}
+
+// CSV column names emitted by the exporter in multi-row mode.
+const STEP_CONTENT_COLUMNS = ["Step Content"];
+const EXPECTED_RESULT_COLUMNS = ["Expected Result"];
+const STEP_NUMBER_COLUMNS = ["Step #", "Step Number"];
+
+function findColumn(row: any, candidates: string[]): string | null {
+  if (!row || typeof row !== "object") return null;
+  for (const candidate of candidates) {
+    if (Object.prototype.hasOwnProperty.call(row, candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function nonEmpty(v: any): boolean {
+  return v != null && v.toString().trim() !== "";
+}
+
+function toKey(v: any): string | null {
+  if (v == null) return null;
+  const s = v.toString().trim();
+  return s ? s : null;
+}
+
+function parseStepOrder(raw: any, fallback: number): number {
+  if (raw == null) return fallback;
+  const n = parseInt(raw.toString(), 10);
+  return Number.isFinite(n) ? n - 1 : fallback;
+}
+
+/**
+ * Collapses an exporter-style multi-row CSV (one row per step, with `Step #`,
+ * `Step Content`, `Expected Result` columns) into one row per case. The head
+ * row keeps all its existing fields; continuation rows are absorbed into the
+ * head row's `_aggregatedSteps` array.
+ *
+ * A row is considered a continuation when it shares the same value as the
+ * previous head row in the `id`-mapped column (or, if no id mapping, the
+ * `name`-mapped column). Rows that don't match any previous head become new
+ * head rows.
+ *
+ * If no step-content / expected-result column is present, the input is
+ * returned unchanged.
+ */
+export function aggregateMultiRowSteps(
+  rows: any[],
+  fieldMappings: MultiRowFieldMapping[]
+): any[] {
+  if (!Array.isArray(rows) || rows.length === 0) return rows;
+
+  const stepContentCol = findColumn(rows[0], STEP_CONTENT_COLUMNS);
+  const expectedCol = findColumn(rows[0], EXPECTED_RESULT_COLUMNS);
+  const stepNumberCol = findColumn(rows[0], STEP_NUMBER_COLUMNS);
+
+  if (!stepContentCol && !expectedCol) return rows;
+
+  const idMapping = fieldMappings.find((m) => m.templateField === "id");
+  const nameMapping = fieldMappings.find((m) => m.templateField === "name");
+
+  const aggregated: any[] = [];
+
+  for (const row of rows) {
+    const id = idMapping ? toKey(row[idMapping.csvColumn]) : null;
+    const name = nameMapping ? toKey(row[nameMapping.csvColumn]) : null;
+
+    const stepText = stepContentCol ? row[stepContentCol] : "";
+    const expectedText = expectedCol ? row[expectedCol] : "";
+    const stepNumRaw = stepNumberCol ? row[stepNumberCol] : "";
+    const hasStep = nonEmpty(stepText) || nonEmpty(expectedText);
+
+    const prev = aggregated[aggregated.length - 1];
+    const prevId = prev && idMapping ? toKey(prev[idMapping.csvColumn]) : null;
+    const prevName =
+      prev && nameMapping ? toKey(prev[nameMapping.csvColumn]) : null;
+
+    const isContinuation =
+      prev &&
+      ((id != null && id === prevId) ||
+        (id == null && name != null && name === prevName));
+
+    if (isContinuation) {
+      if (hasStep) {
+        if (!prev._aggregatedSteps) prev._aggregatedSteps = [];
+        prev._aggregatedSteps.push({
+          step: (stepText ?? "").toString(),
+          expectedResult: (expectedText ?? "").toString(),
+          order: parseStepOrder(stepNumRaw, prev._aggregatedSteps.length),
+        });
+      }
+      continue;
+    }
+
+    const newRow: any = { ...row };
+    if (hasStep) {
+      newRow._aggregatedSteps = [
+        {
+          step: (stepText ?? "").toString(),
+          expectedResult: (expectedText ?? "").toString(),
+          order: parseStepOrder(stepNumRaw, 0),
+        },
+      ];
+    }
+    aggregated.push(newRow);
+  }
+
+  return aggregated;
+}

--- a/testplanit/lib/utils/parseExportedSteps.test.ts
+++ b/testplanit/lib/utils/parseExportedSteps.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasLabeledStepFormat,
+  parseLabeledSteps,
+  tryParseJsonSteps,
+} from "./parseExportedSteps";
+
+describe("hasLabeledStepFormat", () => {
+  it("detects exporter output with both labels", () => {
+    expect(
+      hasLabeledStepFormat("Step 1:\nDo a thing\nExpected Result 1:\nResult")
+    ).toBe(true);
+  });
+
+  it("detects exporter output with only a step label", () => {
+    expect(hasLabeledStepFormat("Step 1:\nDo a thing")).toBe(true);
+  });
+
+  it("detects exporter output with only an expected-result label", () => {
+    expect(hasLabeledStepFormat("Expected Result 1:\nVerify thing")).toBe(true);
+  });
+
+  it("rejects legacy pipe-per-line format", () => {
+    expect(hasLabeledStepFormat("Step 1 | Result 1\nStep 2 | Result 2")).toBe(
+      false
+    );
+  });
+
+  it("rejects bare plain text", () => {
+    expect(hasLabeledStepFormat("Simple step text")).toBe(false);
+  });
+});
+
+describe("parseLabeledSteps", () => {
+  it("parses the customer-reported single-step cell verbatim", () => {
+    const cell = [
+      "Step 1:",
+      "Navigate to the Tasks Page",
+      "Expected Result 1:",
+      'Verify "My Open Tasks" on the Tasks page has been updated to "Your Open Tasks"',
+    ].join("\n");
+
+    const result = parseLabeledSteps(cell);
+
+    expect(result).toEqual([
+      {
+        step: "Navigate to the Tasks Page",
+        expectedResult:
+          'Verify "My Open Tasks" on the Tasks page has been updated to "Your Open Tasks"',
+        order: 0,
+      },
+    ]);
+  });
+
+  it("parses multiple step blocks separated by --- lines", () => {
+    const cell = [
+      "Step 1:",
+      "Open login page",
+      "Expected Result 1:",
+      "Login page renders",
+      "---",
+      "Step 2:",
+      "Enter credentials",
+      "Expected Result 2:",
+      "Dashboard appears",
+    ].join("\n");
+
+    expect(parseLabeledSteps(cell)).toEqual([
+      {
+        step: "Open login page",
+        expectedResult: "Login page renders",
+        order: 0,
+      },
+      {
+        step: "Enter credentials",
+        expectedResult: "Dashboard appears",
+        order: 1,
+      },
+    ]);
+  });
+
+  it("preserves expected result when step body is empty", () => {
+    const cell = ["Expected Result 1:", "Verify the banner is hidden"].join(
+      "\n"
+    );
+
+    expect(parseLabeledSteps(cell)).toEqual([
+      {
+        step: "",
+        expectedResult: "Verify the banner is hidden",
+        order: 0,
+      },
+    ]);
+  });
+
+  it("preserves multi-line step body", () => {
+    const cell = [
+      "Step 1:",
+      "Line one of the step",
+      "Line two of the step",
+      "Expected Result 1:",
+      "Result body",
+    ].join("\n");
+
+    expect(parseLabeledSteps(cell)).toEqual([
+      {
+        step: "Line one of the step\nLine two of the step",
+        expectedResult: "Result body",
+        order: 0,
+      },
+    ]);
+  });
+
+  it("handles step with no expected result", () => {
+    const cell = ["Step 1:", "Just a step"].join("\n");
+
+    expect(parseLabeledSteps(cell)).toEqual([
+      { step: "Just a step", expectedResult: "", order: 0 },
+    ]);
+  });
+
+  it("normalizes CRLF line endings", () => {
+    const cell = "Step 1:\r\nDo a thing\r\nExpected Result 1:\r\nResult";
+
+    expect(parseLabeledSteps(cell)).toEqual([
+      { step: "Do a thing", expectedResult: "Result", order: 0 },
+    ]);
+  });
+
+  it("treats a block with no labels as a bare step body", () => {
+    expect(parseLabeledSteps("Plain step text")).toEqual([
+      { step: "Plain step text", expectedResult: "", order: 0 },
+    ]);
+  });
+});
+
+describe("tryParseJsonSteps", () => {
+  it("parses string step + expectedResult entries from the JSON export", () => {
+    const json = JSON.stringify([
+      { stepNumber: 1, step: "Open page", expectedResult: "Page loads" },
+      { stepNumber: 2, step: "Click button", expectedResult: "Modal opens" },
+    ]);
+
+    expect(tryParseJsonSteps(json)).toEqual([
+      { step: "Open page", expectedResult: "Page loads", order: 0 },
+      { step: "Click button", expectedResult: "Modal opens", order: 1 },
+    ]);
+  });
+
+  it("extracts text from Tiptap-shaped step/expectedResult values", () => {
+    const doc = (text: string) => ({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+    });
+    const json = JSON.stringify([
+      { stepNumber: 1, step: doc("Body"), expectedResult: doc("Result") },
+    ]);
+
+    expect(tryParseJsonSteps(json)).toEqual([
+      { step: "Body", expectedResult: "Result", order: 0 },
+    ]);
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(tryParseJsonSteps("Step 1:\nx")).toBeNull();
+  });
+
+  it("returns null for JSON that isn't an array", () => {
+    expect(tryParseJsonSteps('{"step":"x"}')).toBeNull();
+  });
+});

--- a/testplanit/lib/utils/parseExportedSteps.ts
+++ b/testplanit/lib/utils/parseExportedSteps.ts
@@ -1,0 +1,93 @@
+import { extractTextFromNode } from "~/utils/extractTextFromJson";
+
+export interface ParsedExportedStep {
+  step: string;
+  expectedResult: string;
+  order: number;
+}
+
+const LABEL_LINE_RE = /^(Step|Expected Result)\s+\d+:\s*$/m;
+const LABEL_LINE_RE_G = /^(Step|Expected Result)\s+\d+:\s*$/gm;
+const BLOCK_SEPARATOR_RE = /\n[ \t]*---[ \t]*\n/;
+
+export function hasLabeledStepFormat(text: string): boolean {
+  return LABEL_LINE_RE.test(text);
+}
+
+export function parseLabeledSteps(text: string): ParsedExportedStep[] {
+  const normalized = text.replace(/\r\n?/g, "\n");
+  const blocks = normalized.split(BLOCK_SEPARATOR_RE);
+
+  return blocks.map((rawBlock, index) => {
+    const block = rawBlock.trim();
+    if (!block) {
+      return { step: "", expectedResult: "", order: index };
+    }
+
+    const labels: Array<{
+      kind: "step" | "expected";
+      labelStart: number;
+      labelEnd: number;
+    }> = [];
+    const re = new RegExp(LABEL_LINE_RE_G.source, "gm");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(block)) !== null) {
+      labels.push({
+        kind: m[1] === "Step" ? "step" : "expected",
+        labelStart: m.index,
+        labelEnd: m.index + m[0].length,
+      });
+    }
+
+    let stepText = "";
+    let expectedText = "";
+
+    if (labels.length === 0) {
+      stepText = block;
+    } else {
+      for (let i = 0; i < labels.length; i++) {
+        const start = labels[i].labelEnd;
+        const end =
+          i + 1 < labels.length ? labels[i + 1].labelStart : block.length;
+        const content = block.slice(start, end).trim();
+        if (labels[i].kind === "step") {
+          stepText = content;
+        } else {
+          expectedText = content;
+        }
+      }
+    }
+
+    return { step: stepText, expectedResult: expectedText, order: index };
+  });
+}
+
+export function tryParseJsonSteps(text: string): ParsedExportedStep[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  return parsed.map((item: any, index) => {
+    const stepValue = item?.step;
+    const expectedValue = item?.expectedResult;
+    const orderRaw = item?.stepNumber;
+    return {
+      step:
+        typeof stepValue === "string"
+          ? stepValue
+          : extractTextFromNode(stepValue),
+      expectedResult:
+        typeof expectedValue === "string"
+          ? expectedValue
+          : extractTextFromNode(expectedValue),
+      order:
+        typeof orderRaw === "number" && Number.isFinite(orderRaw)
+          ? orderRaw - 1
+          : index,
+    };
+  });
+}


### PR DESCRIPTION
## Description

Two related fixes that make the CSV exporter's output round-trip cleanly through the test case importer. Customer reported the bugs in sequence — first the labeled single-row format produced 4 stray Steps rows per case; then we noticed multi-row mode didn't round-trip at all.

### Commit 1: Labeled single-row format (`Step N:` / `Expected Result N:`)

The test case importer at `app/api/repository/import/route.ts` only knew the legacy pipe-per-line shape (`1. Step | Result`). The exporter, in single-row plainText/markdown mode, produces:

```
Step 1:
<step body>
Expected Result 1:
<expected body>
---
Step 2:
...
```

The importer split this by `\n`, treated every non-empty line as its own step, and persisted each one to the `Steps` table.

**Changes:**
- New shared parser `lib/utils/parseExportedSteps.ts` with `hasLabeledStepFormat`, `parseLabeledSteps`, and `tryParseJsonSteps`. Handles the labeled multi-line format and the JSON-array format from the exporter.
- `app/api/repository/import/route.ts` Steps cell parser now tries JSON → labeled → legacy pipe in order. Legacy callers continue to work; existing tests unchanged.
- `app/api/shared-steps/import/route.ts` adopts the shared parser, replacing a near-duplicate inline parser that silently dropped entries when the step body was empty (`if (stepMatch) push` — an expected-result-only step lost its content).

### Commit 2: Multi-row CSV mode (`Step #`, `Step Content`, `Expected Result` columns)

The exporter's multi-row mode emits one row per step, with continuation rows sharing the same `ID`/`Name` as the head row and all other fields blank. The importer was processing every CSV row as a separate test case, so a single N-step case round-tripped into N single-step cases.

**Changes:**
- New `lib/utils/aggregateMultiRowSteps.ts` collapses continuation rows into the head row's `_aggregatedSteps` array. Groups by mapped `id` column when present, falls back to mapped `name` column.
- Server invokes the aggregator only when `rowMode: "multi"`; when present, each head row's `_aggregatedSteps` overrides `caseData.steps` after the field-mapping loop.
- No wizard UI changes required — `rowMode` was already plumbed through and `Step #`/`Step Content`/`Expected Result` columns are read directly from the row data, so unmapped columns in the wizard still work.

## Related Issue

N/A (customer-reported round-trip regression)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — shared parser extraction

## How Has This Been Tested?

- [x] Unit tests:
  - `lib/utils/parseExportedSteps.test.ts` — 16 tests (customer's verbatim cell, multi-step blocks, empty-step + expected-only, CRLF normalization, JSON shape, legacy format rejection)
  - `lib/utils/aggregateMultiRowSteps.test.ts` — 8 tests (continuation grouping by ID, fallback to Name, expected-only continuation rows, blank-row skip, missing Step # fallback, no-step-column passthrough)
- [x] Integration tests in `app/api/repository/import/route.test.ts`:
  - Customer's verbatim labeled-cell single-row CSV → asserts one `steps.create` call with both `step` and `expectedResult` populated
  - 2-case / 4-step multi-row CSV → asserts two `repositoryCases.create` calls and four `steps.create` calls with both fields populated on every step
- [x] Full suite — `pnpm precommit` (lint + format:check + 7,409/7,490 pass)
- [x] Type check — `pnpm type-check` clean

**Test Configuration:**
- OS: macOS (darwin)
- Node version: as per repo `.nvmrc`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
