### PR TITLE
fix(llm): honor configured max-output-tokens in outline endpoint

### DIFF
--- a/testplanit/app/api/llm/generate-test-cases/outline/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/outline/route.ts
@@ -109,12 +109,15 @@ export async function POST(request: NextRequest) {
     const systemPrompt = buildOutlineSystemPrompt(quantity);
     const userPrompt = buildOutlineUserPrompt(issue, context);
 
-    let maxTokens = resolvedPrompt.maxOutputTokens ?? 1024;
+    let maxTokens = resolvedPrompt.maxOutputTokens ?? 2048;
     const providerConfig = await (prisma as any).llmProviderConfig.findFirst({
       where: { llmIntegrationId: resolved.integrationId },
     });
     if (providerConfig) {
-      maxTokens = Math.min(providerConfig.defaultMaxTokens ?? 1024, 1024);
+      maxTokens =
+        providerConfig.defaultMaxTokens ??
+        resolvedPrompt.maxOutputTokens ??
+        2048;
     }
 
     const llmRequest: LlmRequest = {


### PR DESCRIPTION
## Description

The two-phase test-case generation outline route silently capped `maxTokens` at 1024:

```ts
let maxTokens = resolvedPrompt.maxOutputTokens ?? 1024;
const providerConfig = await (prisma as any).llmProviderConfig.findFirst({ ... });
if (providerConfig) {
  maxTokens = Math.min(providerConfig.defaultMaxTokens ?? 1024, 1024);
}
```

The `Math.min(..., 1024)` overrode whatever value the user set in LLM settings. When a user requested "Many" outlines, the response often exceeded 1024 tokens, causing the JSON to truncate mid-array. The resulting parse error (improved in #327) suggested *"Raise the model's max-output-tokens in LLM settings"* — a setting the route ignored.

This PR:

- Drops the hard 1024 ceiling; honors `providerConfig.defaultMaxTokens` and falls back to `resolvedPrompt.maxOutputTokens`, matching the resolution order already used by the `/expand` route.
- Bumps the no-config fallback from 1024 → 2048 so "Many" outlines fit out of the box. Outlines are titles + summaries only, much smaller than the expand route's 4096 default.

The cap has been there since the two-phase split in #304; #327 only made the symptom user-visible.

## Related Issue

N/A — surfaced via user report after #327 added parse-failure diagnostics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS: macOS (darwin 25.4.0)
- Browser (if applicable): N/A (server-side route)
- Node version: project pinned

Reproduced the truncation locally with "Many" outlines hitting `finishReason: length` at ~4400 chars; after the fix, `defaultMaxTokens` configured in LLM settings is honored and the response completes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Heads up: `main` currently has unrelated TypeScript errors in `ImportCasesWizard.tsx` introduced by #332. Those are not from this change and will need a separate fix for CI to go green here.
