### PR TITLE
fix(webhooks): skip tenant key fetch for retire-expired-secrets cron

### DIFF
--- a/testplanit/workers/webhookDispatchWorker.dispatch.test.ts
+++ b/testplanit/workers/webhookDispatchWorker.dispatch.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// This suite exercises the REAL withTenantContext wrapper (not the passthrough
+// stub used in webhookDispatchWorker.test.ts) so it can assert the key-fetch
+// behaviour of the queue-level `dispatch` wrapper. The seam under test:
+// retire-expired-secrets must bypass the tenant ENCRYPTION_KEY fetch, while
+// ordinary dispatch jobs must still trigger it.
+
+const mockGetTenantEncryptionKey = vi.fn().mockResolvedValue("test-key");
+vi.mock("../lib/tenantSecrets", () => ({
+  getTenantEncryptionKey: (...args: unknown[]) =>
+    mockGetTenantEncryptionKey(...args),
+}));
+
+vi.mock("../lib/multiTenantPrisma", () => ({
+  validateMultiTenantJobData: vi.fn(),
+  getPrismaClientForJob: vi.fn().mockReturnValue({ __mock: "prisma" }),
+  isMultiTenantMode: vi.fn().mockReturnValue(false),
+  disconnectAllTenantClients: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockDispatchWebhook = vi.fn().mockResolvedValue({
+  outcome: "success",
+  statusCode: 200,
+  deliveryId: "d1",
+});
+vi.mock("../lib/webhooks/dispatch", () => ({
+  dispatchWebhook: (...args: unknown[]) => mockDispatchWebhook(...args),
+}));
+
+const mockRetireExpiredSecrets = vi.fn().mockResolvedValue({ retiredCount: 0 });
+vi.mock("../lib/webhooks/secret-rotation", () => ({
+  retireExpiredSecrets: (...args: unknown[]) =>
+    mockRetireExpiredSecrets(...args),
+}));
+
+vi.mock("../lib/webhooks/health", () => ({
+  transition: vi.fn().mockResolvedValue({ from: "HEALTHY", to: "HEALTHY" }),
+}));
+
+vi.mock("../lib/valkey", () => ({ default: null }));
+
+// NOTE: ../lib/tenantContext is intentionally NOT mocked — we want the real
+// runWithTenantContext → getTenantEncryptionKey path.
+
+import { dispatch } from "./webhookDispatchWorker";
+
+function buildJob(opts: {
+  name?: string;
+  tenantId?: string;
+  data?: Record<string, unknown>;
+}) {
+  return {
+    id: "job-1",
+    name: opts.name,
+    attemptsMade: 0,
+    data: opts.data ?? { tenantId: opts.tenantId },
+  } as any;
+}
+
+describe("webhookDispatchWorker.dispatch — tenant key-fetch routing", () => {
+  beforeEach(() => {
+    mockGetTenantEncryptionKey.mockClear();
+    mockDispatchWebhook.mockClear();
+    mockRetireExpiredSecrets.mockClear();
+  });
+
+  it("retire-expired-secrets job does NOT fetch the tenant encryption key (the K8s secrets call that fails/retries for unprovisioned tenants)", async () => {
+    const job = buildJob({
+      name: "retire-expired-secrets",
+      tenantId: "tenant-A",
+    });
+
+    await dispatch(job);
+
+    expect(mockGetTenantEncryptionKey).not.toHaveBeenCalled();
+    expect(mockRetireExpiredSecrets).toHaveBeenCalledTimes(1);
+    expect(mockDispatchWebhook).not.toHaveBeenCalled();
+  });
+
+  it("ordinary dispatch job DOES fetch the tenant encryption key via withTenantContext", async () => {
+    const job = buildJob({
+      data: {
+        outboxEventId: "ev1",
+        webhookConfigId: "c1",
+        attempt: 1,
+        tenantId: "tenant-A",
+      },
+    });
+
+    await dispatch(job);
+
+    expect(mockGetTenantEncryptionKey).toHaveBeenCalledTimes(1);
+    expect(mockGetTenantEncryptionKey).toHaveBeenCalledWith("tenant-A");
+    expect(mockDispatchWebhook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/testplanit/workers/webhookDispatchWorker.ts
+++ b/testplanit/workers/webhookDispatchWorker.ts
@@ -84,6 +84,22 @@ const processor = async (job: Job<DispatchJobData | { tenantId?: string }>) => {
   }
 };
 
+// Queue-level dispatch wrapper. retire-expired-secrets resolves its own
+// tenant-scoped Prisma client from job.data and decrypts nothing, so it must
+// NOT go through withTenantContext: that wrapper eagerly fetches the tenant
+// ENCRYPTION_KEY from the Kubernetes secrets API for every job with a
+// tenantId. For this cron the key is unnecessary, and the fetch throws (then
+// retries forever) for tenants whose secret is absent or unreadable. All
+// other jobs still run inside tenant context.
+const contextAwareProcessor = withTenantContext(processor);
+
+export const dispatch = (
+  job: Job<DispatchJobData | { tenantId?: string }>
+): Promise<unknown> =>
+  job.name === "retire-expired-secrets"
+    ? processor(job)
+    : contextAwareProcessor(job);
+
 export async function handleCompleted(
   job: Job,
   result?: { outcome?: string } | null
@@ -141,26 +157,22 @@ const startWorker = async () => {
     console.log("[WebhookDispatchWorker] Starting in SINGLE-TENANT mode");
   }
   if (valkeyConnection) {
-    worker = new Worker(
-      WEBHOOK_DISPATCH_QUEUE_NAME,
-      withTenantContext(processor),
-      {
-        connection: valkeyConnection as any,
-        concurrency: parseInt(
-          process.env.WEBHOOK_DISPATCH_CONCURRENCY || "5",
-          10
-        ),
-        // Retry curve — strategy MUST live on Worker.settings (not Queue).
-        // BullMQ 5.x signature: (attemptsMade, type?, err?, job?) => number | Promise<number>.
-        // The `attemptsMade` here is `job.attemptsMade + 1` per BullMQ source
-        // (the 1-indexed "next attempt about to start"). retryDelayForAttempt
-        // is also 1-indexed — direct passthrough works.
-        settings: {
-          backoffStrategy: (attemptsMade: number) =>
-            retryDelayForAttempt(attemptsMade),
-        },
-      }
-    );
+    worker = new Worker(WEBHOOK_DISPATCH_QUEUE_NAME, dispatch, {
+      connection: valkeyConnection as any,
+      concurrency: parseInt(
+        process.env.WEBHOOK_DISPATCH_CONCURRENCY || "5",
+        10
+      ),
+      // Retry curve — strategy MUST live on Worker.settings (not Queue).
+      // BullMQ 5.x signature: (attemptsMade, type?, err?, job?) => number | Promise<number>.
+      // The `attemptsMade` here is `job.attemptsMade + 1` per BullMQ source
+      // (the 1-indexed "next attempt about to start"). retryDelayForAttempt
+      // is also 1-indexed — direct passthrough works.
+      settings: {
+        backoffStrategy: (attemptsMade: number) =>
+          retryDelayForAttempt(attemptsMade),
+      },
+    });
     worker.on("completed", (job, result) => {
       // handleCompleted writes lastSuccessAt + resets consecutiveFailureCount
       // + flips DEGRADED/DISABLED → HEALTHY via lib/webhooks/health.transition.


### PR DESCRIPTION
## Description

The daily `retire-expired-secrets` cron ran inside `withTenantContext`, which
eagerly fetches the per-tenant `ENCRYPTION_KEY` from the Kubernetes secrets API
*before* the job processor runs. For tenants whose secret is missing (404) or
unreadable (403), that fetch threw and the job retried indefinitely — even
though this cron never decrypts anything and resolves its own tenant-scoped
Prisma client directly from the job data.

This routes the retire job around `withTenantContext` via a small queue-level
`dispatch` wrapper, so it no longer makes the Kubernetes call at all. The fix
removes the failing call entirely rather than swallowing the error, so the
retry noise stops for every tenant — including unprovisioned/forbidden ones.
All other jobs still run inside tenant context as before.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Added `webhookDispatchWorker.dispatch.test.ts`, which exercises the **real**
`withTenantContext` (the existing suite stubs it to a passthrough) and asserts:
the retire job does **not** trigger the tenant key fetch, while an ordinary
dispatch job still does. Full suite passes locally (7431 passed), with ESLint,
Prettier, and project-wide `tsc --noEmit` clean.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: (project default)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

A secondary cleanup is available but intentionally **not** included: the
scheduler registers this cron for every tenant regardless of whether they have
any webhooks. With the Kubernetes call removed, that's harmless (a no-op
`updateMany` returning 0), so filtering it would be pure overhead. Happy to add
it in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)