### PR TITLE
chore(lint): remove unused eslint-disable directives

### DIFF
--- a/testplanit/app/[locale]/admin/llm/page.tsx
+++ b/testplanit/app/[locale]/admin/llm/page.tsx
@@ -288,7 +288,6 @@ function LlmIntegrationList() {
   const [deletingIntegration, setDeletingIntegration] =
     useState<ExtendedLlmIntegration | null>(null);
 
-  // eslint-disable-next-line react-hooks/refs
   const columns = useColumns(
     userPreferences,
     handleToggle,

--- a/testplanit/app/[locale]/admin/projects/page.tsx
+++ b/testplanit/app/[locale]/admin/projects/page.tsx
@@ -432,7 +432,7 @@ function ProjectAdmin() {
 
   const columns: CustomColumnDef<ExtendedProjects>[] = useColumns(
     userPreferences,
-    // eslint-disable-next-line react-hooks/refs
+
     handleToggleCompleted,
     handleOpenEditModal,
     tCommon,

--- a/testplanit/app/[locale]/admin/prompts/page.tsx
+++ b/testplanit/app/[locale]/admin/prompts/page.tsx
@@ -217,7 +217,7 @@ function PromptConfigList() {
 
   const columns = useColumns(
     userPreferences,
-    // eslint-disable-next-line react-hooks/refs
+
     handleToggleDefault,
     tCommon,
     t,

--- a/testplanit/app/[locale]/admin/roles/page.tsx
+++ b/testplanit/app/[locale]/admin/roles/page.tsx
@@ -204,7 +204,6 @@ function RoleList() {
   );
 
   const columns = useColumns(
-    // eslint-disable-next-line react-hooks/refs
     handleToggleDefault,
     tCommon,
     setEditingRole,

--- a/testplanit/app/api/mcp/milestones-descendants/route.test.ts
+++ b/testplanit/app/api/mcp/milestones-descendants/route.test.ts
@@ -26,7 +26,6 @@ vi.mock("~/lib/auth/utils", () => ({
 // export chain (WR-03). Stored on globalThis because `vi.mock` factories
 // are hoisted above top-level `let`/`const` declarations.
 declare global {
-  // eslint-disable-next-line no-var
   var __auditContextTracker: { calls: number; handler: unknown } | undefined;
 }
 vi.mock("~/lib/auditContextWrappers", () => {

--- a/testplanit/e2e/tests/mcp/cases.spec.ts
+++ b/testplanit/e2e/tests/mcp/cases.spec.ts
@@ -283,7 +283,6 @@ test.describe("MCP test-case CRUD lifecycle (Phase 6)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "Phase 8 REPO-02 maintenance smoke: project has 0 automated:true cases — filter shape verified, row-shape assertion skipped"
       );

--- a/testplanit/e2e/tests/mcp/code-repositories.spec.ts
+++ b/testplanit/e2e/tests/mcp/code-repositories.spec.ts
@@ -132,7 +132,6 @@ test.describe("MCP code-repositories read (Phase 8 REPO-01)", () => {
     expect(Array.isArray(body.data)).toBe(true);
 
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "REPO-01 skipped: seed has 0 ProjectCodeRepositoryConfig rows"
       );

--- a/testplanit/e2e/tests/mcp/issue-impact.spec.ts
+++ b/testplanit/e2e/tests/mcp/issue-impact.spec.ts
@@ -138,7 +138,6 @@ test.describe("MCP issue-impact chain (Phase 7 EXEC-06)", () => {
     baseURL,
   }) => {
     if (ctx.issueId === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-06 chain skipped: seed has no Issue linked to a project's RepositoryCases"
       );
@@ -167,7 +166,6 @@ test.describe("MCP issue-impact chain (Phase 7 EXEC-06)", () => {
     expect(Array.isArray(casesBody.data)).toBe(true);
 
     if (casesBody.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-06 partial: issue has 0 linked RepositoryCases (access policy may have filtered)"
       );
@@ -213,7 +211,6 @@ test.describe("MCP issue-impact chain (Phase 7 EXEC-06)", () => {
     expect(Array.isArray(resultsBody.data)).toBe(true);
 
     if (resultsBody.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-06 partial: linked cases have 0 TestRunResults yet — chain shape verified but executedBy assertion skipped"
       );

--- a/testplanit/e2e/tests/mcp/issues.spec.ts
+++ b/testplanit/e2e/tests/mcp/issues.spec.ts
@@ -150,7 +150,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
       ctx.issueExternalKey === null ||
       ctx.issueExternalSystem === null
     ) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE-01 skipped: seed has no Issue with externalKey + integration.provider in this project"
       );
@@ -204,7 +203,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE-02: seed project has 0 Issues — order assertion skipped"
       );
@@ -225,7 +223,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     baseURL,
   }) => {
     if (ctx.issueId === null) {
-      // eslint-disable-next-line no-console
       console.warn("ISSUE-03 skipped: seed has 0 Issues in project");
       return;
     }
@@ -289,7 +286,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     // Overflow detection probe: if any one array is exactly 101 the MCP tool
     // would surface truncated:true. We document it but do not require it.
     if (data.repositoryCases.length === 101) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE-03: linkedCases overflow probe HIT (>= 100 — MCP would surface truncated)"
       );
@@ -303,7 +299,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     baseURL,
   }) => {
     if (ctx.issueId === null) {
-      // eslint-disable-next-line no-console
       console.warn("ISSUE-04 outbound skipped: seed has 0 Issues");
       return;
     }
@@ -327,7 +322,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE-04 outbound: issue has 0 linked cases (or filtered by access policy)"
       );
@@ -339,7 +333,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     baseURL,
   }) => {
     if (ctx.caseIdLinkedToAnyIssue === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE-04 inbound skipped: no RepositoryCase has any Issue link in this project"
       );
@@ -380,7 +373,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
       ctx.issueExternalSystem === null ||
       ctx.issueId === null
     ) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE chain skipped: seed has no Issue with externalKey + integration.provider in this project"
       );
@@ -430,7 +422,6 @@ test.describe("MCP issue read tools (Phase 8 ISSUE-01..04)", () => {
     const casesBody = await casesR.json();
     expect(Array.isArray(casesBody.data)).toBe(true);
     if (casesBody.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "ISSUE chain partial: issue has 0 linked RepositoryCases — chain shape verified, non-empty assertion skipped"
       );

--- a/testplanit/e2e/tests/mcp/repository-case-links.spec.ts
+++ b/testplanit/e2e/tests/mcp/repository-case-links.spec.ts
@@ -137,7 +137,6 @@ test.describe("MCP repository case links read (Phase 8 REPO-05)", () => {
     baseURL,
   }) => {
     if (ctx.linkId === null || ctx.caseAId === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "REPO-05 caseId mode skipped: seed has no RepositoryCaseLink in this project"
       );
@@ -184,7 +183,6 @@ test.describe("MCP repository case links read (Phase 8 REPO-05)", () => {
     baseURL,
   }) => {
     if (ctx.caseAId === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "REPO-05 caseAId mode skipped: seed has no RepositoryCaseLink"
       );
@@ -216,7 +214,6 @@ test.describe("MCP repository case links read (Phase 8 REPO-05)", () => {
     baseURL,
   }) => {
     if (ctx.caseBId === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "REPO-05 caseBId mode skipped: seed has no RepositoryCaseLink"
       );
@@ -248,7 +245,6 @@ test.describe("MCP repository case links read (Phase 8 REPO-05)", () => {
     baseURL,
   }) => {
     if (ctx.linkType === null || ctx.caseAId === null) {
-      // eslint-disable-next-line no-console
       console.warn("REPO-05 linkType skipped: seed has no RepositoryCaseLink");
       return;
     }

--- a/testplanit/e2e/tests/mcp/runs.spec.ts
+++ b/testplanit/e2e/tests/mcp/runs.spec.ts
@@ -314,7 +314,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-01 part A: seed project has 0 TestRuns — RPC accepts the query shape but returned empty"
       );
@@ -338,7 +337,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     );
 
     if (list.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-01 list-row statusCounts assertion skipped: seed project has 0 runs"
       );
@@ -382,7 +380,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.runId === null) {
-      // eslint-disable-next-line no-console
       console.warn("EXEC-02 skipped: seed project has 0 TestRuns");
       return;
     }
@@ -463,7 +460,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
         _count: { id: number };
       }>;
     if (groups.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-02 partial: run has 0 TestRunCases — rollup assertion skipped"
       );
@@ -488,7 +484,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.runId === null) {
-      // eslint-disable-next-line no-console
       console.warn("EXEC-03 skipped: seed project has 0 TestRuns");
       return;
     }
@@ -509,7 +504,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-03 partial: run has 0 TestRunCases — row-shape assertion skipped"
       );
@@ -530,7 +524,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.runId === null) {
-      // eslint-disable-next-line no-console
       console.warn("EXEC-04 skipped: seed project has 0 TestRuns");
       return;
     }
@@ -551,7 +544,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-04 partial: run has 0 TestRunResults — row-shape assertion skipped"
       );
@@ -572,7 +564,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.testRunResultId === null) {
-      // eslint-disable-next-line no-console
       console.warn("EXEC-05 skipped: seed has 0 TestRunResults");
       return;
     }
@@ -638,7 +629,6 @@ test.describe("MCP test-run read tools (Phase 7 EXEC-01..05)", () => {
     expect(data.id).toBe(ctx.testRunResultId);
     expect(Array.isArray(data.stepResults)).toBe(true);
     if (data.stepResults.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "EXEC-05 partial: result has 0 stepResults — R2/D7-08 assertions skipped"
       );

--- a/testplanit/e2e/tests/mcp/sessions.spec.ts
+++ b/testplanit/e2e/tests/mcp/sessions.spec.ts
@@ -131,7 +131,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "SESS-01: seed project has 0 Sessions — row-shape assertion skipped"
       );
@@ -151,7 +150,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.sessionId === null) {
-      // eslint-disable-next-line no-console
       console.warn("SESS-02 skipped: seed project has 0 Sessions");
       return;
     }
@@ -212,7 +210,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.sessionId === null) {
-      // eslint-disable-next-line no-console
       console.warn("SESS-03 skipped: seed project has 0 Sessions");
       return;
     }
@@ -265,7 +262,7 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     } else {
       // Host accepted but presumably ignored. R4 is still enforced at the MCP
       // input schema (07-05 plan). Document and move on.
-      // eslint-disable-next-line no-console
+
       console.warn(
         "SESS-03: host accepted unknown `testCaseId` filter on sessionResults; R4 enforced at MCP input-schema layer"
       );
@@ -279,7 +276,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.sessionResultId === null) {
-      // eslint-disable-next-line no-console
       console.warn("SESS-04 skipped: seed has 0 SessionResults");
       return;
     }
@@ -331,7 +327,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.sessionId === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "SESS-05 sessionId mode skipped: seed project has 0 Sessions"
       );
@@ -360,7 +355,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     const body = await r.json();
     expect(Array.isArray(body.data)).toBe(true);
     if (body.data.length === 0) {
-      // eslint-disable-next-line no-console
       console.warn(
         "SESS-05 sessionId mode: session has 0 linked issues — row-shape skipped"
       );
@@ -374,7 +368,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     baseURL,
   }) => {
     if (ctx.issueId === null) {
-      // eslint-disable-next-line no-console
       console.warn("SESS-05 issueId mode skipped: seed has 0 Issues");
       return;
     }
@@ -415,7 +408,6 @@ test.describe("MCP session read tools (Phase 7 SESS-01..05)", () => {
     expect(r.status()).toBe(200);
     const data = (await r.json()).data;
     if (data === null) {
-      // eslint-disable-next-line no-console
       console.warn(
         "SESS-05 issueId mode: issue not accessible to this token — skipped"
       );


### PR DESCRIPTION
## Description

ESLint's `reportUnusedDisableDirectives` was reporting 42 stale suppression comments (`react-hooks/refs` and `no-console`) that no longer correspond to any reported problem. This removes them via the directive-only autofix (`eslint --fix --fix-type directive`) and reformats the affected lines. No logic changes.

This brings the project's lint warnings from 97 down to 55. The remaining 55 are React Compiler advisories (`incompatible-library`, `preserve-manual-memoization`) and `react-hooks/exhaustive-deps` — intentionally left out of this PR as they require code-level judgment rather than a mechanical sweep.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Full precommit gate passes: ESLint + `tsc --noEmit` clean, Prettier clean, and the full unit suite (7431 passed). The change only deletes dead suppression comments, so there is no runtime impact.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
