### PR TITLE
fix(deps): bump ws to >=8.20.1 (CVE-2026-45736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
             "systeminformation": "^5.31.1",
             "qs": ">=6.15.2",
             "brace-expansion@5": ">=5.0.6",
+            "ws@8": ">=8.20.1",
             "@modelcontextprotocol/sdk": ">=1.26.0",
             "preact": ">=10.28.2",
             "@remix-run/router": ">=1.23.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   systeminformation: ^5.31.1
   qs: '>=6.15.2'
   brace-expansion@5: '>=5.0.6'
+  ws@8: '>=8.20.1'
   '@modelcontextprotocol/sdk': '>=1.26.0'
   preact: '>=10.28.2'
   '@remix-run/router': '>=1.23.2'
@@ -14719,7 +14720,7 @@ packages:
     resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: '>=8.20.1'
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -18735,18 +18736,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -40356,7 +40345,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.7.2
       vizion: 2.2.1
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       pm2-sysmonit: 1.2.8
     transitivePeerDependencies:
@@ -44753,8 +44742,6 @@ snapshots:
       typedarray-to-buffer: 3.1.5
 
   ws@7.5.10: {}
-
-  ws@8.20.0: {}
 
   ws@8.20.1: {}
 

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -397,6 +397,7 @@
     "systeminformation": "^5.31.1",
     "qs": ">=6.15.2",
     "brace-expansion@5": ">=5.0.6",
+    "ws@8": ">=8.20.1",
     "@modelcontextprotocol/sdk": ">=1.26.0",
     "preact": ">=10.28.2",
     "@remix-run/router": ">=1.23.2",

--- a/testplanit/pnpm-lock.yaml
+++ b/testplanit/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   systeminformation: ^5.31.1
   qs: '>=6.15.2'
   brace-expansion@5: '>=5.0.6'
+  ws@8: '>=8.20.1'
   '@modelcontextprotocol/sdk': '>=1.26.0'
   preact: '>=10.28.2'
   '@remix-run/router': '>=1.23.2'
@@ -14719,7 +14720,7 @@ packages:
     resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: '>=8.20.1'
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -18735,18 +18736,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -40356,7 +40345,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.7.2
       vizion: 2.2.1
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       pm2-sysmonit: 1.2.8
     transitivePeerDependencies:
@@ -44753,8 +44742,6 @@ snapshots:
       typedarray-to-buffer: 3.1.5
 
   ws@7.5.10: {}
-
-  ws@8.20.0: {}
 
   ws@8.20.1: {}
 


### PR DESCRIPTION
## Description

Closes the open `ws` Dependabot advisories — #403 (root `pnpm-lock.yaml`) and #397 (`testplanit/pnpm-lock.yaml`), the same advisory reported once per lockfile.

- **GHSA-58qx-3vcg-4xpx / CVE-2026-45736** — `ws` uninitialized memory disclosure, vulnerable `>=8.0.0 <8.20.1`, patched in **8.20.1**.

Adds a version-scoped `ws@8: >=8.20.1` pnpm override (mirrored in the root `pnpm.overrides` and `testplanit`'s `overrides` block) to lift the lone vulnerable transitive `ws@8.20.0` to `8.20.1`. The `ws@8` key leaves the unrelated `ws@7.5.10` line untouched (it is outside the vulnerable range). The regenerated lockfile is synced to the `testplanit/` build-context copy.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Full precommit gate passes: ESLint + `tsc --noEmit` clean, Prettier clean, full unit suite (7431 passed). Verified the regenerated lockfile resolves `ws@8.20.1` (the vulnerable `8.20.0` is gone) and the `ws@7.5.10` line is unchanged.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
