### PR TITLE
fix(mcp): honor customField value filter in cases_list

### DIFF
--- a/packages/mcp-server/src/tools/cases/list.test.ts
+++ b/packages/mcp-server/src/tools/cases/list.test.ts
@@ -154,27 +154,87 @@ describe("registerCasesList", () => {
     });
   });
 
-  it("BL-02: customField filter rejects unsupported `value` key (additionalProperties)", async () => {
+  it("filter: customField {name,value} resolves a Dropdown value to an option-id equals filter", async () => {
+    const priorityDropdown = {
+      id: 50,
+      displayName: "Priority",
+      type: { type: "Dropdown" },
+      fieldOptions: [
+        { fieldOption: { id: 99, name: "High" } },
+        { fieldOption: { id: 98, name: "Low" } },
+      ],
+    };
+    // First call: resolveCustomFields -> caseFields.findMany. Second: the list.
+    mockZenstack
+      .mockResolvedValueOnce([priorityDropdown])
+      .mockResolvedValueOnce([]);
+    const { client } = await setupClient();
+    await client.callTool({
+      name: "testplanit_cases_list",
+      arguments: {
+        projectId: 7,
+        customField: { name: "Priority", value: "High" },
+      },
+    });
+    const where = getLastCallBody()?.where as Record<string, unknown>;
+    expect(where.caseFieldValues).toEqual({
+      some: { fieldId: 50, value: { equals: 99 } },
+    });
+  });
+
+  it("filter: customField {name,value:[...]} resolves a Multi-Select to an array_contains filter", async () => {
+    const components = {
+      id: 60,
+      displayName: "Components",
+      type: { type: "Multi-Select" },
+      fieldOptions: [
+        { fieldOption: { id: 11, name: "Auth" } },
+        { fieldOption: { id: 12, name: "Billing" } },
+      ],
+    };
+    mockZenstack.mockResolvedValueOnce([components]).mockResolvedValueOnce([]);
+    const { client } = await setupClient();
+    await client.callTool({
+      name: "testplanit_cases_list",
+      arguments: {
+        projectId: 7,
+        customField: { name: "Components", value: ["Auth"] },
+      },
+    });
+    const where = getLastCallBody()?.where as Record<string, unknown>;
+    expect(where.caseFieldValues).toEqual({
+      some: { fieldId: 60, value: { array_contains: [11] } },
+    });
+  });
+
+  it("filter: customField {name,value} with an unknown field returns an error, not unfiltered results", async () => {
+    // resolveCustomFields -> caseFields.findMany finds no match -> throws 422.
     mockZenstack.mockResolvedValueOnce([]);
     const { client } = await setupClient();
-    // Zod object schemas are strict by default — passing an unknown
-    // `value` key surfaces a validation error rather than being silently
-    // swallowed (the prior bug).
     const result = await client.callTool({
       name: "testplanit_cases_list",
-      arguments: { projectId: 7, customField: { name: "Priority", value: "High" } },
+      arguments: {
+        projectId: 7,
+        customField: { name: "DoesNotExist", value: "x" },
+      },
     });
-    // The MCP framework returns isError:true with the Zod validation message
-    // when the input is rejected. Accept either an isError result or a
-    // successful call where the unknown key was stripped — what we care
-    // about is that `value` is NOT silently included in the where clause.
-    if (!result.isError) {
-      const body = getLastCallBody();
-      const where = body?.where as Record<string, unknown>;
-      expect(where.caseFieldValues).toEqual({
-        some: { field: { displayName: "Priority" } },
-      });
-    }
+    expect(result.isError).toBeTruthy();
+    // The list query must never run with a dropped/ignored filter.
+    expect(mockZenstack).toHaveBeenCalledTimes(1);
+  });
+
+  it("#333: customField rejects unknown keys (strict schema) instead of silently dropping them", async () => {
+    const { client } = await setupClient();
+    const result = await client.callTool({
+      name: "testplanit_cases_list",
+      arguments: {
+        projectId: 7,
+        customField: { name: "Priority", bogus: "High" },
+      },
+    });
+    expect(result.isError).toBeTruthy();
+    // Strict-object validation fails before the handler runs — no query fired.
+    expect(mockZenstack).not.toHaveBeenCalled();
   });
 
   it("pagination: default limit=25, take=26, no cursor in body", async () => {

--- a/packages/mcp-server/src/tools/cases/list.ts
+++ b/packages/mcp-server/src/tools/cases/list.ts
@@ -4,6 +4,7 @@ import * as z from "zod/v4";
 import { zenstack } from "../../api.js";
 import type { EnvConfig } from "../../env.js";
 import { mapHttpErrorToToolResult } from "../../errors.js";
+import { resolveCustomFields } from "./customFields.js";
 import { mapCaseRow } from "./shared.js";
 
 export interface CasesListDeps {
@@ -82,7 +83,7 @@ export function registerCasesList(server: McpServer, deps: CasesListDeps): void 
     "testplanit_cases_list",
     {
       description:
-        "List test cases scoped to a project. Filters: folderId, tagIds, name (case-insensitive substring), stateId, customField (by display name), issueId (linked Issue numeric id — see issues_list for resolution from external keys). Cursor pagination via the `cursor` returned in `nextCursor`. (per CASE-01 + EXEC-06 chain via D7-03) " +
+        "List test cases scoped to a project. Filters: folderId, tagIds, name (case-insensitive substring), stateId, customField, issueId (linked Issue numeric id — see issues_list for resolution from external keys). customField takes {name} to match cases that have the field set, or {name, value} to match by value (Dropdown/Multi-Select accept the option name or id; an unknown field name or option returns a validation error rather than unfiltered results). Cursor pagination via the `cursor` returned in `nextCursor`. (per CASE-01 + EXEC-06 chain via D7-03) " +
         "Phase-8 maintenance filters: automated (user-controlled flag), source (single or array of RepositoryCaseSource), repositoryId, hasNeverExecuted (no junitResults AND no TestRunResults via TestRunCases), staleSinceUpdate (handler-side post-filter — bounded scan of POST_FILTER_SCAN_CAP=400; surfaces truncated:true when scan cap hit), updatedAfter/updatedBefore (filter via the repositoryCaseVersions relation since RepositoryCases has no updatedAt column). Each row carries lastUpdatedAt and latestResult (union of latest junitResults / TestRunResults). " +
         "Creator and date filters: creatorIds (array of user ids — matches any; deliberately array-shaped while runs_list/sessions_list use single-string createdById), from/to (ISO 8601 createdAt range).",
       inputSchema: {
@@ -91,17 +92,23 @@ export function registerCasesList(server: McpServer, deps: CasesListDeps): void 
         tagIds: z.array(z.number().int().positive()).optional(),
         name: z.string().min(1).optional(),
         stateId: z.number().int().positive().optional(),
-        // BL-02: only `name` is supported. Value-equality on the Json?
-        // `caseFieldValues.value` column is unreliable across field types
-        // (Dropdown stores option IDs, Multi-Select stores arrays, Text
-        // stores strings). Silently swallowing an agent-supplied `value`
-        // (the prior behavior) would let the agent act on incorrect data.
-        // Dropping it from the schema makes the unsupported dimension
-        // explicit; agents that need value filtering should call
-        // testplanit_cases_get on candidate IDs and filter locally.
+        // `{ name }` alone matches cases that have the field set (presence).
+        // `{ name, value }` filters by value: resolveCustomFields canonicalizes
+        // the value the same way the write path stores it (Dropdown/Multi-Select
+        // option name -> option id), so the equality check matches what is
+        // actually persisted in caseFieldValues.value. strictObject rejects any
+        // other key with a validation error instead of silently dropping it.
         customField: z
-          .object({
+          .strictObject({
             name: z.string().min(1),
+            value: z
+              .union([
+                z.string(),
+                z.number(),
+                z.boolean(),
+                z.array(z.union([z.string(), z.number()])),
+              ])
+              .optional(),
           })
           .optional(),
         // D7-03: filter cases linked to a specific issue. Pass the internal
@@ -151,9 +158,32 @@ export function registerCasesList(server: McpServer, deps: CasesListDeps): void 
         }
         if (input.stateId !== undefined) where.stateId = input.stateId;
         if (input.customField) {
-          where.caseFieldValues = {
-            some: { field: { displayName: input.customField.name } },
-          };
+          if (input.customField.value === undefined) {
+            // Presence filter — cases that have this field set (any value).
+            where.caseFieldValues = {
+              some: { field: { displayName: input.customField.name } },
+            };
+          } else {
+            // Value filter — resolve {name, value} to the canonical
+            // {fieldId, value} the write path persists. resolveCustomFields
+            // throws 422 for unknown/ambiguous fields and invalid option
+            // values, so an unmatched filter surfaces an error rather than
+            // returning unfiltered results. It returns exactly one entry per
+            // input key or throws, so [resolved] is always defined here.
+            const [resolved] = await resolveCustomFields(
+              { [input.customField.name]: input.customField.value },
+              deps.env,
+            );
+            const canonical = resolved!.value as Prisma.InputJsonValue;
+            where.caseFieldValues = {
+              some: {
+                fieldId: resolved!.fieldId,
+                value: Array.isArray(resolved!.value)
+                  ? { array_contains: canonical }
+                  : { equals: canonical },
+              },
+            };
+          }
         }
         if (input.issueId !== undefined) {
           // D7-03: RepositoryCases.issues is many-to-many to Issue. Filtering


### PR DESCRIPTION
## Description

`testplanit_cases_list` accepted a `customField` argument but only filtered by field **presence** (`displayName`), and the Zod object **silently stripped** any `value` key. So `{ name: "Priority", value: "High" }` returned every case that had a Priority set — regardless of value — which is why the reporter saw a mix of High/Low/Medium in the results. The published JSON schema even advertised `additionalProperties: true`, actively inviting clients to pass `value`.

This change:

- **Implements value filtering.** `{ name, value }` now resolves through the existing `resolveCustomFields` helper — the same canonicalization the create/update **write path** uses — so Dropdown/Multi-Select option *names* resolve to the option *ids* actually persisted in `caseFieldValues.value`, and the equality check matches what is stored. Dropdown/scalar types → `{ equals }`, Multi-Select → `{ array_contains }`. `{ name }` alone keeps the presence-only behavior.
- **Makes the schema strict** (`strictObject`), so unknown keys are rejected with a validation error instead of being silently dropped. The published JSON schema becomes `additionalProperties: false`.
- **Surfaces a 422** for an unknown/ambiguous field name or an invalid option value, rather than returning unfiltered results.

Reusing the write-path resolver is what makes value-equality reliable here — we filter on exactly the representation the write path persists — which addresses the original `BL-02` concern that prompted value filtering to be dropped.

## Related Issue

Fixes #333

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Added/updated tests in `list.test.ts`: Dropdown value resolves to an option-id `equals` filter, Multi-Select resolves to `array_contains`, an unknown field name returns an error (and never fires an unfiltered query), and a strict-schema unknown key is rejected before the handler runs. Full `@testplanit/mcp-server` suite passes (626 tests), `tsc --noEmit` clean, `tsup` build succeeds.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
