### PR TITLE
chore(ci): publish packages via npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -74,6 +74,12 @@ jobs:
           pnpm --filter "@testplanit/wdio-reporter" build
           pnpm --filter "@testplanit/mcp-server" build
 
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1. Node 24 ships
+      # npm 11.x, but pin to latest so the OIDC handshake can't silently fall
+      # back to anonymous auth — the cause of E404 on scoped-package publishes.
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
@@ -85,8 +91,8 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN — publishing authenticates via OIDC trusted publishing
+          # (id-token: write above + the trusted publisher configured on npm).
 
       - name: Summary
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Description

Switches the package release workflow from `NPM_TOKEN` auth to **npm trusted publishing (OIDC)**.

The `0.1.1` publish of `@testplanit/mcp-server` failed with `E404` because the CI `NPM_TOKEN` lacked write access to that (newer) package. Rather than re-scope a token, this moves publishing to tokenless OIDC, which authenticates via the workflow's existing `id-token: write` and a trusted publisher configured on npm — nothing to expire or re-scope as new `@testplanit/*` packages are added.

Changes to `.github/workflows/packages-release.yml`:

- **Drop `NPM_TOKEN` / `NODE_AUTH_TOKEN`** from the changesets publish step, so npm authenticates via OIDC instead of a token.
- **Pin `npm@latest` before publishing.** Trusted publishing requires npm CLI ≥ 11.5.1; on older npm the OIDC handshake silently falls back to anonymous auth — the documented cause of `E404` on scoped-package publishes. The runner is on Node 24 (npm 11.x); this is belt-and-suspenders.

## Prerequisite (done outside this PR)

A trusted publisher must be configured on npmjs.com for each `@testplanit/*` package:
- **Organization or user:** `TestPlanIt`
- **Repository:** `testplanit`
- **Workflow filename:** `packages-release.yml`
- **Allowed actions:** `npm publish`

(`@testplanit/mcp-server` is the one currently blocked on a `0.1.1` publish.)

## Related Issue

Unblocks the npm release of the #333 fix (already merged; `main` is at `0.1.1`, just not yet on npm).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

CI-only change. YAML validated locally. End-to-end verification is the dispatch of `packages-release.yml` after merge: with `main` at `0.1.1` (not yet on npm), `changeset publish` will publish it via OIDC. If OIDC misbehaves, the fallback is a correctly-scoped `NPM_TOKEN` (no code revert needed beyond restoring the env).

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 24 (runner) / npm ≥ 11.5.1

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

After this lands and the publish succeeds, npm publishing access can optionally be locked down (npm package **Settings → Publishing access → "Require two-factor authentication and disallow tokens"**) so only OIDC works. The now-unused `NPM_TOKEN` secret can also be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
