### PR TITLE
enhancement(audit): audit all admin configuration changes

### DIFF
--- a/docs/docs/user-guide/audit-logs.md
+++ b/docs/docs/user-guide/audit-logs.md
@@ -114,14 +114,18 @@ Only users with administrative privileges can access the audit log viewer.
 
 ## Tracked Entities
 
-The following entity types are tracked in the audit log:
+All administrator-managed configuration changes are tracked, alongside the core
+test, project, and user entities. The following entity types are recorded in the
+audit log:
 
 - **Test Management**: Test Cases, Test Runs, Test Run Cases, Test Results, Sessions, Shared Steps
 - **Project Management**: Projects, Milestones, Issues, Tags
-- **User Management**: Users, Groups, Permissions
-- **Security**: API Tokens
-- **Configuration**: SSO Providers, Email Domains, App Config
-- **Integrations**: Integrations, Project Integrations, Prompt Configurations
+- **User Management**: Users, Groups, Group Assignments, Roles, Role Permissions, Project Assignments, Permissions
+- **Security**: API Tokens, SSO Providers, SAML Configuration, Email Domains
+- **Workspace Configuration**: Workflows, Statuses, Configurations (Categories & Variants), Milestone Types, Project Status / Workflow / Milestone-Type Assignments
+- **Fields & Templates**: Case Fields, Result Fields, Field Options, Templates, Export Templates
+- **System Configuration**: App Config
+- **AI & Integrations**: Integrations, Project Integrations, Prompt Configurations, LLM Integrations, LLM Provider & Feature Configurations, Ollama Model Registry, Code Repositories
 - **Content**: Comments, Attachments
 
 ## Filtering Audit Logs

--- a/testplanit/app/api/admin/tags/create/route.ts
+++ b/testplanit/app/api/admin/tags/create/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod/v4";
 import { Prisma } from "@prisma/client";
 import { prisma } from "~/lib/prisma";
+import { withAuditContext } from "~/lib/auditContextWrappers";
 import { getServerAuthSession } from "~/server/auth";
 
 /**
@@ -38,7 +39,11 @@ const createSchema = z.object({
   name: z.string().min(1),
 });
 
-export async function POST(req: NextRequest) {
+// Wrapped in withAuditContext so the audit entry emitted by the prisma.tags
+// create hook carries the actor: the wrapper seeds the ALS frame and the
+// NextAuth session callback (fired by getServerAuthSession below) enriches it
+// with userId/userEmail/userName. Without the frame that enrichment is a no-op.
+export const POST = withAuditContext(async (req: NextRequest) => {
   const session = await getServerAuthSession();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -127,4 +132,4 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/testplanit/app/api/model/[...path]/route.test.ts
+++ b/testplanit/app/api/model/[...path]/route.test.ts
@@ -1,5 +1,9 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AUDITED_CONFIG_MODELS,
+  ENTITY_NAME_FIELDS,
+} from "~/lib/services/auditLog";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hoisted mocks for the chokepoint route-level mode:read enforcement tests
@@ -63,9 +67,17 @@ vi.mock("~/lib/access-fast-path", () => ({
   tryFastPathCreate: vi.fn(async () => null),
 }));
 
-vi.mock("~/lib/services/auditLog", () => ({
-  captureAuditEvent: vi.fn(async () => undefined),
-}));
+vi.mock("~/lib/services/auditLog", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/lib/services/auditLog")>();
+  // Keep the real AUDITED_CONFIG_MODELS / ENTITY_NAME_FIELDS / calculateDiff
+  // (consumed at module load to build the route's audit maps); only the
+  // queue-backed emitter is stubbed.
+  return {
+    ...actual,
+    captureAuditEvent: vi.fn(async () => undefined),
+  };
+});
 
 vi.mock("~/lib/services/reviewGate", () => ({
   assertReviewGatePasses: vi.fn(async () => null),
@@ -130,6 +142,10 @@ const AUDITED_ENTITIES = new Set([
   "comment",
   "attachment",
   "apiToken",
+  // Admin-config catalog + access models — mirror the route, which spreads the
+  // shared source so the two cannot drift. Guards that every config model is
+  // audited canonically on the RPC path.
+  ...AUDITED_CONFIG_MODELS.map((c) => c.accessor),
 ]);
 
 // Replicate getAuditAction
@@ -174,6 +190,12 @@ function extractEntityName(
     allowedEmailDomain: "domain",
     appConfig: "key",
     apiToken: "name",
+    ...Object.fromEntries(
+      AUDITED_CONFIG_MODELS.flatMap((c) => {
+        const f = ENTITY_NAME_FIELDS[c.entityType];
+        return f ? [[c.accessor, f] as const] : [];
+      })
+    ),
   };
 
   const field = nameFields[entityType];
@@ -223,6 +245,9 @@ const entityTypeMap: Record<string, string> = {
   comment: "Comment",
   attachment: "Attachment",
   apiToken: "ApiToken",
+  ...Object.fromEntries(
+    AUDITED_CONFIG_MODELS.map((c) => [c.accessor, c.entityType])
+  ),
 };
 
 describe("ZenStack API Route Audit Interception", () => {
@@ -262,6 +287,31 @@ describe("ZenStack API Route Audit Interception", () => {
       expect(AUDITED_ENTITIES.has("verificationToken")).toBe(false);
       expect(AUDITED_ENTITIES.has("session")).toBe(false);
       expect(AUDITED_ENTITIES.has("account")).toBe(false);
+    });
+
+    it("audits every admin-config model on the RPC path", () => {
+      // The canonical fix: each config model must be in the route's audited
+      // set so the post-RPC shim emits the single full-diff row (the $extends
+      // hook is suppressed for these on the RPC path). Spot-check the catalog,
+      // access-join, and project-scoped-join categories.
+      for (const accessor of [
+        "workflows",
+        "status",
+        "configurations",
+        "roles",
+        "tags",
+        "caseFields",
+        "samlConfiguration",
+        "rolePermission",
+        "groupAssignment",
+        "projectStatusAssignment",
+      ]) {
+        expect(AUDITED_ENTITIES.has(accessor)).toBe(true);
+      }
+      // Exhaustive: nothing in the shared source is missing from the set.
+      for (const cfg of AUDITED_CONFIG_MODELS) {
+        expect(AUDITED_ENTITIES.has(cfg.accessor)).toBe(true);
+      }
     });
   });
 
@@ -428,6 +478,32 @@ describe("ZenStack API Route Audit Interception", () => {
       expect(
         extractEntityName("attachment", { id: 1, filename: "test.pdf" })
       ).toBeUndefined();
+    });
+
+    it("resolves names for admin-config catalog models", () => {
+      expect(
+        extractEntityName("workflows", { id: 1, name: "Release Flow" })
+      ).toBe("Release Flow");
+      expect(
+        extractEntityName("caseFields", { id: 1, displayName: "Priority" })
+      ).toBe("Priority");
+      expect(
+        extractEntityName("samlConfiguration", {
+          id: "c1",
+          issuer: "https://idp.example.com",
+        })
+      ).toBe("https://idp.example.com");
+    });
+
+    it("resolves composite names for admin-config join models", () => {
+      // Join tables lack a scalar id; the shim derives a readable name from the
+      // composite key (mirrors the audit entry's entityName).
+      expect(
+        extractEntityName("rolePermission", { roleId: 75, area: "TestRuns" })
+      ).toBe("75:TestRuns");
+      expect(
+        extractEntityName("groupAssignment", { userId: "u1", groupId: 3 })
+      ).toBe("u1:3");
     });
 
     it("should return undefined for null result", () => {

--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -16,8 +16,10 @@ import {
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import { prisma } from "~/lib/prisma";
 import {
+  AUDITED_CONFIG_MODELS,
   calculateDiff,
   captureAuditEvent,
+  ENTITY_NAME_FIELDS,
   type AuditEvent,
 } from "~/lib/services/auditLog";
 import {
@@ -191,7 +193,27 @@ const AUDITED_ENTITIES = new Set([
   // decide paths emit REVIEW_REQUESTED / REVIEW_APPROVED / etc. from their
   // own action handlers.
   "reviewRequest",
+  // Admin-config catalog + access models. Audited canonically here on the RPC
+  // path (the dominant admin mutation path); the lib/prisma.ts `$extends` hooks
+  // cover non-RPC paths (workers, custom routes, direct prisma) and are
+  // suppressed on this path via suppressEntityAudit to avoid a double, partial
+  // (`select:{id:true}`-shaped) generic row. Driven from AUDITED_CONFIG_MODELS.
+  ...AUDITED_CONFIG_MODELS.map((c) => c.accessor),
 ]);
+
+// Derived from AUDITED_CONFIG_MODELS so the shim's entity-type and display-name
+// lookups stay in sync with the single source of truth in auditLog.ts.
+const CONFIG_ENTITY_TYPE_BY_ACCESSOR: Record<string, string> =
+  Object.fromEntries(
+    AUDITED_CONFIG_MODELS.map((c) => [c.accessor, c.entityType])
+  );
+const CONFIG_NAME_FIELD_BY_ACCESSOR: Record<string, string | string[]> =
+  Object.fromEntries(
+    AUDITED_CONFIG_MODELS.flatMap((c) => {
+      const field = ENTITY_NAME_FIELDS[c.entityType];
+      return field ? [[c.accessor, field] as const] : [];
+    })
+  );
 
 // Map ZenStack operations to audit actions
 function getAuditAction(operation: string): AuditAction | null {
@@ -235,6 +257,7 @@ function extractEntityName(
     allowedEmailDomain: "domain",
     appConfig: "key",
     apiToken: "name",
+    ...CONFIG_NAME_FIELD_BY_ACCESSOR,
   };
 
   const field = nameFields[entityType];
@@ -805,8 +828,21 @@ async function innerHandler(
     // copies the parent's identity/correlation fields so they remain visible
     // to audit code paths inside the RPC handler.
     const parentAuditCtx = getAuditContext() ?? {};
+    // Suppress the lib/prisma.ts `$extends` generic entity-audit emission for
+    // models this route audits canonically below (AUDITED_ENTITIES). On the RPC
+    // path the `$extends` hook only sees a partial `select:{id:true}` row, so
+    // letting it emit would add a second, malformed audit record. Scoped to the
+    // audited set so hooked-but-not-shimmed models keep their hook-side audit.
+    const auditedByShim =
+      isMutation &&
+      parsedPath !== null &&
+      AUDITED_ENTITIES.has(parsedPath.model);
     let response = await runWithAuditContext(
-      { ...parentAuditCtx, suppressWebhooks: true },
+      {
+        ...parentAuditCtx,
+        suppressWebhooks: true,
+        suppressEntityAudit: auditedByShim,
+      },
       async () => {
         let r = await tryFastPathCreate({
           parsedPath,
@@ -1299,6 +1335,7 @@ async function innerHandler(
               attachment: "Attachment",
               apiToken: "ApiToken",
               reviewRequest: "ReviewRequest",
+              ...CONFIG_ENTITY_TYPE_BY_ACCESSOR,
             };
 
             // Special handling for API token operations - use specific audit actions

--- a/testplanit/lib/auditContext.ts
+++ b/testplanit/lib/auditContext.ts
@@ -46,6 +46,18 @@ export interface AuditContext {
    * Defaults to undefined (= no suppression) so existing callers are unchanged.
    */
   suppressWebhooks?: boolean;
+  /**
+   * Suppression hatch for the generic entity-audit helpers (auditCreate/
+   * auditUpdate/auditDelete and the auditBulk* variants) emitted by the
+   * lib/prisma.ts `$extends` hooks. The ZenStack RPC route sets this for
+   * mutations it audits canonically via its own post-RPC shim, so the
+   * `$extends` hook does not double-emit a (partial, `select:{id:true}`-shaped)
+   * generic row on that path. Specialized helpers (auditRoleChange,
+   * auditSsoConfigChange, etc.) are intentionally NOT gated. Defaults to
+   * undefined (= no suppression); non-RPC paths (workers, custom routes,
+   * direct prisma) leave it unset so the hooks audit normally.
+   */
+  suppressEntityAudit?: boolean;
 }
 
 /**

--- a/testplanit/lib/prisma.config-audit.test.ts
+++ b/testplanit/lib/prisma.config-audit.test.ts
@@ -1,0 +1,273 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AUDITED_CONFIG_MODELS,
+  ENTITY_NAME_FIELDS,
+  type AuditEvent,
+} from "./services/auditLog";
+import {
+  buildConfigAuditHooks,
+  type ConfigAuditDelegate,
+} from "./services/configAuditHooks";
+
+// Intercept at the queue boundary so the real auditCreate/auditUpdate/
+// auditDelete diff + entityId logic runs (mirrors lib/services/auditLog.test.ts).
+const mocks = vi.hoisted(() => ({
+  mockQueue: { add: vi.fn() },
+  // Mutable so a test can flip suppressEntityAudit on the current frame.
+  currentContext: {
+    userId: "ctx-user",
+    userEmail: "ctx@example.com",
+    userName: "Ctx User",
+    ipAddress: "127.0.0.1",
+    userAgent: "vitest",
+    requestId: "req-test",
+  } as Record<string, unknown>,
+}));
+vi.mock("./queues", () => ({
+  getAuditLogQueue: vi.fn(() => mocks.mockQueue),
+}));
+vi.mock("./auditContext", () => ({
+  getAuditContext: vi.fn(() => mocks.currentContext),
+  SYSTEM_ACTOR_ID: "__system__",
+}));
+vi.mock("./multiTenantPrisma", () => ({
+  isMultiTenantMode: vi.fn(() => false),
+  getCurrentTenantId: vi.fn(() => undefined),
+}));
+
+function lastEvent(): AuditEvent {
+  const calls = mocks.mockQueue.add.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return (calls[calls.length - 1][1] as { event: AuditEvent }).event;
+}
+
+const noopDelegate: ConfigAuditDelegate = {
+  findUnique: vi.fn().mockResolvedValue(null),
+};
+
+const findCfg = (entityType: string) => {
+  const cfg = AUDITED_CONFIG_MODELS.find((c) => c.entityType === entityType);
+  if (!cfg) throw new Error(`missing config model: ${entityType}`);
+  return cfg;
+};
+
+describe("admin-config audit sweep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete mocks.currentContext.suppressEntityAudit;
+  });
+
+  // The chief risk: a mistyped accessor is silent dead code because the
+  // $extends block is cast `as any`. Validate every accessor against the
+  // schema (source of truth) and every entityType against ENTITY_NAME_FIELDS.
+  describe("wiring guard", () => {
+    const schema = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../schema.zmodel"),
+      "utf8"
+    );
+    const modelNames = new Set(
+      [...schema.matchAll(/^\s*model\s+(\w+)\b/gm)].map((m) => m[1])
+    );
+    const toAccessor = (name: string) =>
+      name.charAt(0).toLowerCase() + name.slice(1);
+    const validAccessors = new Set([...modelNames].map(toAccessor));
+
+    it("has at least the models named in the RFI plus the broader sweep", () => {
+      expect(AUDITED_CONFIG_MODELS.length).toBeGreaterThanOrEqual(28);
+    });
+
+    it.each(AUDITED_CONFIG_MODELS)(
+      "$entityType: accessor maps to a real model and has a name field",
+      (cfg) => {
+        expect(modelNames.has(cfg.entityType)).toBe(true);
+        expect(validAccessors.has(cfg.accessor)).toBe(true);
+        expect(toAccessor(cfg.entityType)).toBe(cfg.accessor);
+        expect(ENTITY_NAME_FIELDS[cfg.entityType]).toBeDefined();
+      }
+    );
+
+    it("has unique accessors (no duplicate hook keys)", () => {
+      const accessors = AUDITED_CONFIG_MODELS.map((c) => c.accessor);
+      expect(new Set(accessors).size).toBe(accessors.length);
+    });
+  });
+
+  describe("catalog hooks", () => {
+    it("create emits CREATE with entityType, id and name", async () => {
+      const hooks = buildConfigAuditHooks(findCfg("Workflows"), noopDelegate);
+      await hooks.create({
+        args: { data: { name: "Release" } },
+        query: async () => ({ id: 7, name: "Release" }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("CREATE");
+      expect(ev.entityType).toBe("Workflows");
+      expect(ev.entityId).toBe("7");
+      expect(ev.entityName).toBe("Release");
+    });
+
+    it("update emits UPDATE with the changed field", async () => {
+      const delegate: ConfigAuditDelegate = {
+        findUnique: vi.fn().mockResolvedValue({ id: 7, name: "Old" }),
+      };
+      const hooks = buildConfigAuditHooks(findCfg("Status"), delegate);
+      await hooks.update({
+        args: { where: { id: 7 } },
+        query: async () => ({ id: 7, name: "New" }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("UPDATE");
+      expect(ev.entityType).toBe("Status");
+      expect(ev.changes?.name).toEqual({ old: "Old", new: "New" });
+    });
+
+    it("update with no field change emits nothing", async () => {
+      const delegate: ConfigAuditDelegate = {
+        findUnique: vi.fn().mockResolvedValue({ id: 7, name: "Same" }),
+      };
+      const hooks = buildConfigAuditHooks(findCfg("Tags"), delegate);
+      await hooks.update({
+        args: { where: { id: 7 } },
+        query: async () => ({ id: 7, name: "Same" }),
+      });
+      expect(mocks.mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("delete emits DELETE captured from the pre-mutation row", async () => {
+      const delegate: ConfigAuditDelegate = {
+        findUnique: vi.fn().mockResolvedValue({ id: 9, name: "Gone" }),
+      };
+      const hooks = buildConfigAuditHooks(
+        findCfg("SamlConfiguration"),
+        delegate
+      );
+      await hooks.delete({
+        args: { where: { id: 9 } },
+        query: async () => ({ id: 9 }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("DELETE");
+      expect(ev.entityType).toBe("SamlConfiguration");
+      expect(ev.entityId).toBe("9");
+    });
+
+    it("forwards projectId only for project-scoped models", async () => {
+      const scoped = buildConfigAuditHooks(
+        findCfg("LlmFeatureConfig"),
+        noopDelegate
+      );
+      await scoped.create({
+        args: {},
+        query: async () => ({ id: "c1", feature: "gen", projectId: 42 }),
+      });
+      expect(lastEvent().projectId).toBe(42);
+
+      vi.clearAllMocks();
+      const unscoped = buildConfigAuditHooks(
+        findCfg("Workflows"),
+        noopDelegate
+      );
+      await unscoped.create({
+        args: {},
+        query: async () => ({ id: 1, name: "X", projectId: 99 }),
+      });
+      expect(lastEvent().projectId).toBeUndefined();
+    });
+
+    it("does not expose bulk hooks", () => {
+      const hooks = buildConfigAuditHooks(findCfg("Workflows"), noopDelegate);
+      expect(hooks.createMany).toBeUndefined();
+      expect(hooks.deleteMany).toBeUndefined();
+    });
+  });
+
+  describe("join hooks", () => {
+    it("derives entityId from the composite key when there is no scalar id", async () => {
+      const hooks = buildConfigAuditHooks(
+        findCfg("GroupAssignment"),
+        noopDelegate
+      );
+      await hooks.create({
+        args: { data: { userId: "u1", groupId: 3 } },
+        query: async () => ({ userId: "u1", groupId: 3 }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("CREATE");
+      expect(ev.entityType).toBe("GroupAssignment");
+      expect(ev.entityId).toBe("u1:3");
+    });
+
+    it("createMany emits BULK_CREATE", async () => {
+      const hooks = buildConfigAuditHooks(
+        findCfg("ProjectStatusAssignment"),
+        noopDelegate
+      );
+      await hooks.createMany({
+        args: { data: [{ statusId: 1, projectId: 5 }] },
+        query: async () => ({ count: 3 }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("BULK_CREATE");
+      expect(ev.entityType).toBe("ProjectStatusAssignment");
+      expect(ev.projectId).toBe(5);
+    });
+
+    it("deleteMany emits BULK_DELETE", async () => {
+      const hooks = buildConfigAuditHooks(
+        findCfg("RolePermission"),
+        noopDelegate
+      );
+      await hooks.deleteMany({
+        args: { where: { roleId: 2 } },
+        query: async () => ({ count: 4 }),
+      });
+      const ev = lastEvent();
+      expect(ev.action).toBe("BULK_DELETE");
+      expect(ev.entityType).toBe("RolePermission");
+    });
+  });
+
+  // When the ZenStack RPC route sets suppressEntityAudit (it audits canonically
+  // via its own shim), the hook's generic emission must no-op so the entity is
+  // not double-logged with a partial row.
+  describe("suppressEntityAudit", () => {
+    it("no-ops create/update/delete/bulk when the flag is set", async () => {
+      mocks.currentContext.suppressEntityAudit = true;
+      const catalog = buildConfigAuditHooks(findCfg("Workflows"), {
+        findUnique: vi.fn().mockResolvedValue({ id: 7, name: "Old" }),
+      });
+      await catalog.create({
+        args: {},
+        query: async () => ({ id: 7, name: "X" }),
+      });
+      await catalog.update({
+        args: { where: { id: 7 } },
+        query: async () => ({ id: 7, name: "New" }),
+      });
+      await catalog.delete({
+        args: { where: { id: 7 } },
+        query: async () => ({ id: 7 }),
+      });
+      const join = buildConfigAuditHooks(
+        findCfg("RolePermission"),
+        noopDelegate
+      );
+      await join.createMany({ args: {}, query: async () => ({ count: 3 }) });
+      await join.deleteMany({ args: {}, query: async () => ({ count: 3 }) });
+      expect(mocks.mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("still returns the query result while suppressed", async () => {
+      mocks.currentContext.suppressEntityAudit = true;
+      const hooks = buildConfigAuditHooks(findCfg("Workflows"), noopDelegate);
+      const result = await hooks.create({
+        args: {},
+        query: async () => ({ id: 42, name: "X" }),
+      });
+      expect(result).toEqual({ id: 42, name: "X" });
+    });
+  });
+});

--- a/testplanit/lib/prisma.ts
+++ b/testplanit/lib/prisma.ts
@@ -21,7 +21,9 @@ import {
   auditBulkUpdate,
   auditBulkDelete,
   captureAuditEvent,
+  AUDITED_CONFIG_MODELS,
 } from "./services/auditLog";
+import { buildConfigAuditHooks } from "./services/configAuditHooks";
 import { invalidateApiTokenCache } from "./api-token-cache";
 // Plan 02-05 — outbound webhook emitters spliced alongside the existing
 // audit/ES-sync calls. Each emit is bound to a Prisma.TransactionClient
@@ -62,9 +64,24 @@ let dbClient: any;
 function createPrismaClient(errorFormat: "pretty" | "colorless") {
   const baseClient = new PrismaClient({ errorFormat });
 
+  // Generic audit hooks for admin-managed configuration/catalog models. These
+  // models need only audit logging (no Elasticsearch sync, webhook emit, or
+  // transaction wrapping), so a single factory (lib/services/configAuditHooks)
+  // mirrors the per-model pattern used by the hand-written blocks below. The
+  // driving list lives in AUDITED_CONFIG_MODELS (lib/services/auditLog.ts) and
+  // is validated against the datamodel in tests — a mistyped accessor would
+  // otherwise be silent dead code because the `$extends` block is cast `as any`.
+  const configAuditHooks: Record<string, unknown> = Object.fromEntries(
+    AUDITED_CONFIG_MODELS.map((cfg) => [
+      cfg.accessor,
+      buildConfigAuditHooks(cfg, (baseClient as any)[cfg.accessor]),
+    ])
+  );
+
   // Add Elasticsearch sync using client extensions
   const client = baseClient.$extends({
     query: {
+      ...configAuditHooks,
       repositoryCases: {
         // Plan 02-05 Blocker 3 — wrap entity write + emit in an explicit
         // baseClient.$transaction so both commit-or-rollback atomically.

--- a/testplanit/lib/services/auditLog.ts
+++ b/testplanit/lib/services/auditLog.ts
@@ -61,7 +61,150 @@ export const ENTITY_NAME_FIELDS: Record<string, string | string[]> = {
   GroupProjectPermission: ["groupId", "projectId"],
   Account: ["provider", "providerAccountId"],
   UserIntegrationAuth: ["userId", "integrationType"],
+  // Admin-config catalog models (see AUDITED_CONFIG_MODELS below).
+  Workflows: "name",
+  Status: "name",
+  Configurations: "name",
+  ConfigVariants: "name",
+  ConfigCategories: "name",
+  Roles: "name",
+  Tags: "name",
+  Templates: "templateName",
+  CaseExportTemplate: "name",
+  CaseFields: "displayName",
+  ResultFields: "displayName",
+  FieldOptions: "name",
+  MilestoneTypes: "name",
+  Groups: "name",
+  LlmIntegration: "name",
+  CodeRepository: "name",
+  SamlConfiguration: "issuer",
+  LlmProviderConfig: "defaultModel",
+  LlmFeatureConfig: "feature",
+  OllamaModelRegistry: "modelName",
+  // Admin-config join / assignment models (composite keys).
+  RolePermission: ["roleId", "area"],
+  GroupAssignment: ["userId", "groupId"],
+  ProjectAssignment: ["userId", "projectId"],
+  ProjectStatusAssignment: ["statusId", "projectId"],
+  ProjectWorkflowAssignment: ["workflowId", "projectId"],
+  MilestoneTypesAssignment: ["milestoneTypeId", "projectId"],
+  ProjectLlmIntegration: ["llmIntegrationId", "projectId"],
+  ProjectCodeRepositoryConfig: ["repositoryId", "projectId"],
 };
+
+/**
+ * Describes an admin-managed configuration/catalog model whose CRUD should be
+ * audited via the generic hook factory in `lib/prisma.ts`. This array is the
+ * single source of truth for the admin-config audit sweep and is cross-checked
+ * against the live Prisma datamodel in tests so a mistyped `accessor` (the
+ * historical `issue`/`issues` dead-hook bug) fails loudly instead of silently
+ * skipping audit.
+ */
+export interface AuditedConfigModel {
+  /** Audit entityType; must match an ENTITY_NAME_FIELDS key (PascalCase model). */
+  entityType: string;
+  /** Prisma client accessor (camelCase model name) — the `$extends` query key. */
+  accessor: string;
+  /** Forward the row's `projectId` to the audit entry when present. */
+  hasProjectId?: boolean;
+  /**
+   * "catalog" → single-entity models: create + update (also captures the
+   * soft-delete `isDeleted` flip) + upsert + delete.
+   * "join" → assignment/link models the admin UI mutates in bulk
+   * (useCreateMany* / useDeleteMany*); also get createMany + deleteMany, and
+   * derive entityId from their composite key when they lack a scalar `id`.
+   */
+  kind: "catalog" | "join";
+}
+
+export const AUDITED_CONFIG_MODELS: AuditedConfigModel[] = [
+  // Catalog / config models
+  { entityType: "Workflows", accessor: "workflows", kind: "catalog" },
+  { entityType: "Status", accessor: "status", kind: "catalog" },
+  { entityType: "Configurations", accessor: "configurations", kind: "catalog" },
+  { entityType: "ConfigVariants", accessor: "configVariants", kind: "catalog" },
+  {
+    entityType: "ConfigCategories",
+    accessor: "configCategories",
+    kind: "catalog",
+  },
+  { entityType: "Roles", accessor: "roles", kind: "catalog" },
+  { entityType: "Tags", accessor: "tags", kind: "catalog" },
+  { entityType: "Templates", accessor: "templates", kind: "catalog" },
+  {
+    entityType: "CaseExportTemplate",
+    accessor: "caseExportTemplate",
+    kind: "catalog",
+  },
+  { entityType: "CaseFields", accessor: "caseFields", kind: "catalog" },
+  { entityType: "ResultFields", accessor: "resultFields", kind: "catalog" },
+  { entityType: "FieldOptions", accessor: "fieldOptions", kind: "catalog" },
+  { entityType: "MilestoneTypes", accessor: "milestoneTypes", kind: "catalog" },
+  { entityType: "Groups", accessor: "groups", kind: "catalog" },
+  { entityType: "LlmIntegration", accessor: "llmIntegration", kind: "catalog" },
+  { entityType: "CodeRepository", accessor: "codeRepository", kind: "catalog" },
+  {
+    entityType: "SamlConfiguration",
+    accessor: "samlConfiguration",
+    kind: "catalog",
+  },
+  {
+    entityType: "LlmProviderConfig",
+    accessor: "llmProviderConfig",
+    kind: "catalog",
+  },
+  {
+    entityType: "LlmFeatureConfig",
+    accessor: "llmFeatureConfig",
+    hasProjectId: true,
+    kind: "catalog",
+  },
+  {
+    entityType: "OllamaModelRegistry",
+    accessor: "ollamaModelRegistry",
+    kind: "catalog",
+  },
+  // Join / assignment models (access control + project-scoped config links)
+  { entityType: "RolePermission", accessor: "rolePermission", kind: "join" },
+  { entityType: "GroupAssignment", accessor: "groupAssignment", kind: "join" },
+  {
+    entityType: "ProjectAssignment",
+    accessor: "projectAssignment",
+    hasProjectId: true,
+    kind: "join",
+  },
+  {
+    entityType: "ProjectStatusAssignment",
+    accessor: "projectStatusAssignment",
+    hasProjectId: true,
+    kind: "join",
+  },
+  {
+    entityType: "ProjectWorkflowAssignment",
+    accessor: "projectWorkflowAssignment",
+    hasProjectId: true,
+    kind: "join",
+  },
+  {
+    entityType: "MilestoneTypesAssignment",
+    accessor: "milestoneTypesAssignment",
+    hasProjectId: true,
+    kind: "join",
+  },
+  {
+    entityType: "ProjectLlmIntegration",
+    accessor: "projectLlmIntegration",
+    hasProjectId: true,
+    kind: "join",
+  },
+  {
+    entityType: "ProjectCodeRepositoryConfig",
+    accessor: "projectCodeRepositoryConfig",
+    hasProjectId: true,
+    kind: "join",
+  },
+];
 
 /**
  * Fields that should be masked in audit logs for security.
@@ -336,6 +479,17 @@ export async function captureAuditEvent(event: AuditEvent): Promise<void> {
 }
 
 /**
+ * Whether the current request has opted out of generic entity-audit emission
+ * (set by the ZenStack RPC route, which audits canonically via its own shim).
+ * Only the generic CREATE/UPDATE/DELETE + BULK_* helpers honor this; the
+ * specialized semantic helpers (role change, SSO/system config, permission
+ * grant/revoke) intentionally do not.
+ */
+function isEntityAuditSuppressed(): boolean {
+  return getAuditContext()?.suppressEntityAudit === true;
+}
+
+/**
  * Capture a CREATE action audit event.
  */
 export async function auditCreate(
@@ -343,7 +497,13 @@ export async function auditCreate(
   entity: Record<string, unknown>,
   projectId?: number
 ): Promise<void> {
-  const entityId = String(entity.id || entity.key || "unknown");
+  if (isEntityAuditSuppressed()) return;
+  const entityId = String(
+    entity.id ||
+      entity.key ||
+      extractEntityName(entityType, entity) ||
+      "unknown"
+  );
   await captureAuditEvent({
     action: "CREATE",
     entityType,
@@ -363,7 +523,13 @@ export async function auditUpdate(
   newEntity: Record<string, unknown>,
   projectId?: number
 ): Promise<void> {
-  const entityId = String(newEntity.id || newEntity.key || "unknown");
+  if (isEntityAuditSuppressed()) return;
+  const entityId = String(
+    newEntity.id ||
+      newEntity.key ||
+      extractEntityName(entityType, newEntity) ||
+      "unknown"
+  );
   const changes = calculateDiff(oldEntity, newEntity);
 
   // Only log if there are actual changes
@@ -389,7 +555,13 @@ export async function auditDelete(
   entity: Record<string, unknown>,
   projectId?: number
 ): Promise<void> {
-  const entityId = String(entity.id || entity.key || "unknown");
+  if (isEntityAuditSuppressed()) return;
+  const entityId = String(
+    entity.id ||
+      entity.key ||
+      extractEntityName(entityType, entity) ||
+      "unknown"
+  );
   await captureAuditEvent({
     action: "DELETE",
     entityType,
@@ -572,6 +744,7 @@ export async function auditBulkCreate(
   projectId?: number,
   metadata?: Record<string, unknown>
 ): Promise<void> {
+  if (isEntityAuditSuppressed()) return;
   await captureAuditEvent({
     action: "BULK_CREATE",
     entityType,
@@ -594,6 +767,7 @@ export async function auditBulkUpdate(
   where: Record<string, unknown>,
   projectId?: number
 ): Promise<void> {
+  if (isEntityAuditSuppressed()) return;
   await captureAuditEvent({
     action: "BULK_UPDATE",
     entityType,
@@ -616,6 +790,7 @@ export async function auditBulkDelete(
   where: Record<string, unknown>,
   projectId?: number
 ): Promise<void> {
+  if (isEntityAuditSuppressed()) return;
   await captureAuditEvent({
     action: "BULK_DELETE",
     entityType,

--- a/testplanit/lib/services/configAuditHooks.ts
+++ b/testplanit/lib/services/configAuditHooks.ts
@@ -1,0 +1,120 @@
+import {
+  auditBulkCreate,
+  auditBulkDelete,
+  auditCreate,
+  auditDelete,
+  auditUpdate,
+  type AuditedConfigModel,
+} from "./auditLog";
+
+/**
+ * Minimal delegate surface the hooks need to capture pre-mutation state for
+ * update/upsert/delete diffs. Matches the shape of a Prisma model delegate.
+ */
+export interface ConfigAuditDelegate {
+  findUnique(args: { where: unknown }): Promise<Record<string, unknown> | null>;
+}
+
+interface QueryContext {
+  args: any;
+  query: (args: any) => Promise<any>;
+}
+
+type QueryHook = (ctx: QueryContext) => Promise<any>;
+
+/**
+ * Build the standard audit hook set for one admin-config model. Kept free of
+ * any Prisma client coupling (the delegate is injected) so the behavior is
+ * unit-testable without a database. Wired into the `lib/prisma.ts` `$extends`
+ * block, one entry per AUDITED_CONFIG_MODELS row.
+ *
+ * - catalog: create + update + upsert + delete (update captures the
+ *   soft-delete `isDeleted` flip; auditUpdate no-ops when nothing changed).
+ * - join: the above plus createMany + deleteMany for the bulk assignment
+ *   mutations the admin UI issues.
+ */
+export function buildConfigAuditHooks(
+  cfg: AuditedConfigModel,
+  delegate: ConfigAuditDelegate
+): Record<string, QueryHook> {
+  const projectIdOf = (row: any): number | undefined =>
+    cfg.hasProjectId && typeof row?.projectId === "number"
+      ? row.projectId
+      : undefined;
+
+  const hooks: Record<string, QueryHook> = {
+    async create({ args, query }) {
+      const result = await query(args);
+      if (result) {
+        await auditCreate(cfg.entityType, result, projectIdOf(result));
+      }
+      return result;
+    },
+    async update({ args, query }) {
+      const oldEntity = args.where
+        ? await delegate.findUnique({ where: args.where })
+        : null;
+      const result = await query(args);
+      if (result) {
+        await auditUpdate(
+          cfg.entityType,
+          oldEntity,
+          result,
+          projectIdOf(result)
+        );
+      }
+      return result;
+    },
+    async upsert({ args, query }) {
+      const oldEntity = args.where
+        ? await delegate.findUnique({ where: args.where })
+        : null;
+      const result = await query(args);
+      if (result) {
+        if (oldEntity) {
+          await auditUpdate(
+            cfg.entityType,
+            oldEntity,
+            result,
+            projectIdOf(result)
+          );
+        } else {
+          await auditCreate(cfg.entityType, result, projectIdOf(result));
+        }
+      }
+      return result;
+    },
+    async delete({ args, query }) {
+      const oldEntity = args.where
+        ? await delegate.findUnique({ where: args.where })
+        : null;
+      const result = await query(args);
+      if (oldEntity) {
+        await auditDelete(cfg.entityType, oldEntity, projectIdOf(oldEntity));
+      }
+      return result;
+    },
+  };
+
+  if (cfg.kind === "join") {
+    hooks.createMany = async ({ args, query }) => {
+      const result = await query(args);
+      if (result?.count > 0) {
+        const projectId = cfg.hasProjectId
+          ? args.data?.[0]?.projectId
+          : undefined;
+        await auditBulkCreate(cfg.entityType, result.count, projectId);
+      }
+      return result;
+    };
+    hooks.deleteMany = async ({ args, query }) => {
+      const result = await query(args);
+      if (result?.count > 0) {
+        await auditBulkDelete(cfg.entityType, result.count, args.where);
+      }
+      return result;
+    };
+  }
+
+  return hooks;
+}

--- a/testplanit/lib/webhooks/health.test.ts
+++ b/testplanit/lib/webhooks/health.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("~/lib/services/auditLog", () => ({
-  captureAuditEvent: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("~/lib/services/auditLog", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/lib/services/auditLog")>();
+  return {
+    ...actual,
+    captureAuditEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 import { captureAuditEvent } from "~/lib/services/auditLog";
 import { transition } from "./health";

--- a/testplanit/lib/webhooks/replay.test.ts
+++ b/testplanit/lib/webhooks/replay.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("~/lib/services/auditLog", () => ({
-  captureAuditEvent: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("~/lib/services/auditLog", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/lib/services/auditLog")>();
+  return {
+    ...actual,
+    captureAuditEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 const mockQueueAdd = vi.fn();
 const mockGetQueue = vi.fn(() => ({ add: mockQueueAdd }));


### PR DESCRIPTION
## Description

Records create/update/delete for **all administrator-managed configuration and access models** in the audit trail, closing a gap where most admin catalog/config models had unaudited CRUD (the audit-log docs already listed some of these as tracked, so the docs were ahead of the code).

Newly audited:
- **Catalog/config:** Workflows, Statuses, Configurations (+ Variants/Categories), Roles, Tags, Templates, Export Templates, Case Fields, Result Fields, Field Options, Milestone Types, Groups, LLM Integrations, LLM Provider/Feature Config, Ollama Model Registry, Code Repositories, SAML Configuration.
- **Access / assignment models:** Role Permissions, Group Assignments, Project Assignments, Project↔Status/Workflow/Milestone-Type assignments, Project↔LLM-Integration, Project↔Code-Repository config.

Each entry captures who (user, IP, request id), what (entity type/id/name), when, and — for updates/deletes — the field-level before/after diff.

**How it works:** a single source of truth (`AUDITED_CONFIG_MODELS`) drives both mutation paths — the main admin UI path (ZenStack RPC) via the route's canonical post-request audit step, and direct/server-side paths via database-layer (`$extends`) hooks through a shared factory. A new `suppressEntityAudit` context flag (mirroring `suppressWebhooks`) lets the RPC route own the audit so the hook doesn't double-emit a partial row — which also removes a pre-existing duplicate audit row for models that were already audited.

**Known behavior (consistent with existing audited entities):** on the admin-UI (RPC) path, create/upsert entries record who/what/when but not per-field values (full diffs are captured for updates and deletes); bulk operations are recorded as a single `BULK_*` event with a count.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — removes a pre-existing duplicate/partial audit row on the RPC path
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

New tests: a wiring guard cross-checks all 28 config models' accessors against `schema.zmodel` and their name fields (prevents silently-missing coverage), plus factory behavior and suppression tests; the model-route test asserts every config model is in the audited set and resolves catalog + composite-join names. Full suite: 7,929 passing; type-check and lint clean.

Manual: end-to-end in a running stack + DB — confirmed single, correctly-attributed audit rows for create, update, soft-delete, bulk-update, upsert, and bulk-create across catalog models (Tags, Workflows, Roles), an access-join model (Role Permissions → `roleId:area`), and a project-scoped join (Project↔Workflow assignment).

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chromium (admin UI verification)
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- Releases as a **patch** (uses the `enhancement` prefix, not `feat`).
- The user-facing audit-log docs "Tracked Entities" list was updated to reflect full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)