### PR TITLE
enhancement(test-runs): Make completed test runs structurally immutable

### DIFF
--- a/testplanit/app/api/repository/test-runs/[runId]/cases/[caseId]/iterations/bulk-skip/route.ts
+++ b/testplanit/app/api/repository/test-runs/[runId]/cases/[caseId]/iterations/bulk-skip/route.ts
@@ -137,12 +137,24 @@ export async function POST(
       select: {
         id: true,
         testRun: {
-          select: { projectId: true },
+          select: { projectId: true, isCompleted: true },
         },
       },
     });
     if (!runCase) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // A completed run is frozen. The writes below run on the raw client, so
+    // enforce the same lock the ZenStack policy applies to model-API writes.
+    if (runCase.testRun.isCompleted) {
+      return NextResponse.json(
+        {
+          error: "This test run is completed and can no longer be modified",
+          code: "RUN_COMPLETED",
+        },
+        { status: 409 }
+      );
     }
 
     // Validate the chosen status is a Test-Run-scoped status enabled for

--- a/testplanit/app/api/test-runs/edit-result/route.ts
+++ b/testplanit/app/api/test-runs/edit-result/route.ts
@@ -128,6 +128,7 @@ export async function POST(req: NextRequest) {
               select: {
                 createdById: true,
                 projectId: true,
+                isCompleted: true,
                 project: {
                   select: {
                     createdBy: true,
@@ -224,6 +225,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Permission denied", code: "PERMISSION_DENIED" },
         { status: 403 }
+      );
+    }
+
+    // A completed run is frozen: results can no longer be edited. This route
+    // uses the raw client, so it enforces the same lock the ZenStack policy
+    // applies to model-API writes.
+    if (existing.testRunCase.testRun.isCompleted) {
+      return NextResponse.json(
+        {
+          error: "This test run is completed and can no longer be modified",
+          code: "RUN_COMPLETED",
+        },
+        { status: 409 }
       );
     }
 

--- a/testplanit/app/api/test-runs/submit-result/route.test.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.test.ts
@@ -257,6 +257,20 @@ describe("Submit Result API Route", () => {
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
+  it("returns 409 RUN_COMPLETED when the test run is completed", async () => {
+    (prisma.testRunCases.findFirst as any).mockResolvedValue({
+      ...baseRunCase,
+      testRun: { ...baseRunCase.testRun, isCompleted: true },
+    });
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.code).toBe("RUN_COMPLETED");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
   it("submits result and updates test run case atomically when permission is valid", async () => {
     const response = await POST(createRequest(validBody));
     const data = await response.json();

--- a/testplanit/app/api/test-runs/submit-result/route.ts
+++ b/testplanit/app/api/test-runs/submit-result/route.ts
@@ -207,6 +207,7 @@ export async function POST(req: NextRequest) {
             projectId: true,
             createdById: true,
             testRunType: true,
+            isCompleted: true,
             project: {
               select: {
                 createdBy: true,
@@ -314,6 +315,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Permission denied", code: "PERMISSION_DENIED" },
         { status: 403 }
+      );
+    }
+
+    // A completed run is frozen: no recording results. This route uses the
+    // raw client, so it enforces the same lock the ZenStack policy applies to
+    // model-API writes.
+    if (runCase.testRun.isCompleted) {
+      return NextResponse.json(
+        {
+          error: "This test run is completed and can no longer be modified",
+          code: "RUN_COMPLETED",
+        },
+        { status: 409 }
       );
     }
 

--- a/testplanit/e2e/tests/test-runs/completed-run-immutability.spec.ts
+++ b/testplanit/e2e/tests/test-runs/completed-run-immutability.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "../../fixtures";
+
+/**
+ * Completed Test Run immutability (structural)
+ *
+ * Once a run is completed, its composition (test cases) and results are frozen
+ * at the policy layer (ZenStack `@@deny` keyed on `TestRuns.isCompleted`), with
+ * the raw-client result routes enforcing the same lock. This verifies, against
+ * a live database:
+ *  - before completion, adding cases and recording results works;
+ *  - after completion, adding / reordering / removing cases is rejected, and
+ *    recording results (model API and the submit-result route) is rejected;
+ *  - completing and deleting the run still work.
+ *
+ * Model-API calls send `sec-fetch-site: same-origin` (the proxy blocks
+ * header-less calls as external API).
+ */
+const sameOrigin = { "sec-fetch-site": "same-origin" };
+
+test("completed runs structurally reject composition and result changes", async ({
+  api,
+  request,
+  baseURL,
+}) => {
+  const ts = Date.now();
+  const projectId = await api.createProject(`E2E CompletedLock ${ts}`);
+  const folderId = await api.createFolder(projectId, `CL Folder ${ts}`);
+  const case1 = await api.createTestCase(
+    projectId,
+    folderId,
+    `CL Case A ${ts}`
+  );
+  const case2 = await api.createTestCase(
+    projectId,
+    folderId,
+    `CL Case B ${ts}`
+  );
+  const runId = await api.createTestRun(projectId, `CL Run ${ts}`);
+  const passedId = await api.getStatusId("passed");
+
+  // Before completion: adding a case and recording a result both work.
+  const trc1 = await api.addTestCaseToTestRun(runId, case1);
+  await api.createTestResult(runId, trc1, passedId);
+
+  // Complete the run.
+  const complete = await request.patch(`${baseURL}/api/model/testRuns/update`, {
+    headers: sameOrigin,
+    data: {
+      where: { id: runId },
+      data: { isCompleted: true, completedAt: new Date().toISOString() },
+    },
+  });
+  expect(complete.status(), await complete.text()).toBeLessThan(300);
+
+  // Composition is frozen ----------------------------------------------------
+
+  // Add a case (model API create) → policy-denied.
+  await expect(api.addTestCaseToTestRun(runId, case2)).rejects.toThrow();
+
+  // Reorder a case (update order) → policy-denied.
+  const reorder = await request.patch(
+    `${baseURL}/api/model/testRunCases/update`,
+    { headers: sameOrigin, data: { where: { id: trc1 }, data: { order: 5 } } }
+  );
+  expect(reorder.status()).toBeGreaterThanOrEqual(400);
+
+  // Remove a case (soft-delete) → policy-denied.
+  const remove = await request.patch(
+    `${baseURL}/api/model/testRunCases/update`,
+    {
+      headers: sameOrigin,
+      data: { where: { id: trc1 }, data: { isDeleted: true } },
+    }
+  );
+  expect(remove.status()).toBeGreaterThanOrEqual(400);
+
+  // Results are frozen -------------------------------------------------------
+
+  // Recording a result via the model API → policy-denied.
+  await expect(api.createTestResult(runId, trc1, passedId)).rejects.toThrow();
+
+  // Recording via the submit-result route → 409 RUN_COMPLETED.
+  const submit = await request.post(`${baseURL}/api/test-runs/submit-result`, {
+    headers: sameOrigin,
+    data: {
+      testRunId: runId,
+      testRunCaseId: trc1,
+      statusId: passedId,
+      attempt: 2,
+      testRunCaseVersion: 1,
+    },
+  });
+  expect(submit.status()).toBe(409);
+  expect((await submit.json())?.code).toBe("RUN_COMPLETED");
+
+  // Completing-related lifecycle still works: the run can still be deleted.
+  const del = await request.patch(`${baseURL}/api/model/testRuns/update`, {
+    headers: sameOrigin,
+    data: { where: { id: runId }, data: { isDeleted: true } },
+  });
+  expect(del.status(), await del.text()).toBeLessThan(300);
+});

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -2586,6 +2586,11 @@ model TestRunCases {
     @@deny('all', !auth())
     @@deny('all', auth().access == 'NONE')
 
+    // Structural completion lock: once a run is completed its case set is
+    // frozen — no adding, removing, or reordering. There is no in-app reopen;
+    // the only reversal is clearing isCompleted directly in the database.
+    @@deny('create,update,delete', testRun.isCompleted)
+
     // Explicit NO_ACCESS denial
     @@deny('read', testRun.project.userPermissions?[user == auth() && accessType == 'NO_ACCESS'])
 
@@ -2704,6 +2709,10 @@ model TestRunResults {
     @@deny('all', !auth())
     @@deny('all', auth().access == 'NONE')
 
+    // Structural completion lock: results on a completed run are frozen
+    // (no recording or editing). Mirrors the case-level lock on TestRunCases.
+    @@deny('create,update,delete', testRun.isCompleted)
+
     // Explicit NO_ACCESS denial
     @@deny('read', testRun.project.userPermissions?[user == auth() && accessType == 'NO_ACCESS'])
 
@@ -2777,6 +2786,9 @@ model TestRunStepResults {
     @@unique([testRunResultId, stepId, sharedStepItemId], map: "uq_tsr_res_step_shareditem")
     @@deny('all', !auth())
     @@deny('all', auth().access == 'NONE')
+
+    // Structural completion lock: step results on a completed run are frozen.
+    @@deny('create,update,delete', testRunResult.testRun.isCompleted)
 
     // Explicit NO_ACCESS denial
     @@deny('read', testRunResult.testRun.project.userPermissions?[user == auth() && accessType == 'NO_ACCESS'])


### PR DESCRIPTION
## Description

Makes a **completed test run structurally immutable**. Previously, completing a run only hid the edit controls in the UI — the model API / REST / MCP could still add, remove, or reorder its test cases and change its results. This adds policy-layer enforcement so a completed run is genuinely frozen and verifiable in the published schema.

When `TestRuns.isCompleted` is true, a `@@deny('create,update,delete', …)` policy blocks:
- **Composition**: adding, removing (soft-delete), or reordering its `TestRunCases`.
- **Results**: creating/editing/deleting its `TestRunResults` and `TestRunStepResults`.

The result-recording routes that use the raw (non-policy) client — `submit-result`, `edit-result`, and the iteration `bulk-skip` — enforce the same lock and return `409 RUN_COMPLETED`.

This is the structural version of the planned "composition lock," folded into the existing **Completed** concept rather than adding a parallel mechanism — completed runs become frozen evidence, which is a cleaner and stronger story.

**Not changed:** completing a run and deleting a run still work. There is no in-app reopen (completion is already presented as irreversible); the only reversal is clearing `isCompleted` directly in the database for an emergency.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] E2E tests
- [x] Manual testing

Added a unit test (submit-result returns `409 RUN_COMPLETED` for a completed run) and a live E2E (`completed-run-immutability.spec.ts`) that, against a real database: confirms adding cases and recording results work before completion; then, after completion, that adding / reordering / removing cases and recording results (both model API and the submit-result route) are all rejected; and that the run can still be deleted. Ran the result-governance E2E as a regression to confirm normal (non-completed) result flows are unaffected.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chromium
- Node version: 22.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

No new schema fields or migrations — the change is access policies on existing models (compiled by ZenStack). System/background processes that use the raw Prisma client are intentionally unaffected; only user-initiated, policy-enforced and result-route writes are blocked on completed runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
