### PR TITLE
fix(repository-import): align multi-row preview/counts with what is imported

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/ImportCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/ImportCasesWizard.tsx
@@ -54,7 +54,10 @@ import {
   useFindManyRepositoryFolders,
   useFindManyTemplates,
 } from "~/lib/hooks";
-import { inspectMultiRowAggregation } from "~/lib/utils/aggregateMultiRowSteps";
+import {
+  aggregateMultiRowSteps,
+  inspectMultiRowAggregation,
+} from "~/lib/utils/aggregateMultiRowSteps";
 import {
   convertMarkdownCasesToImportData,
   parseMarkdownTestCases,
@@ -189,6 +192,20 @@ export function ImportCasesWizard({
   const [validationErrors, setValidationErrors] =
     useState<Page1ValidationErrors>({});
 
+  // What the preview, pagination, and submit counts should reflect. In
+  // multi-row mode this is the aggregated case rows (one per case), not the
+  // raw CSV rows — otherwise the wizard would render every continuation row
+  // as its own card and the "Import N Test Cases" button would lie about the
+  // count of cases that will actually be created. The duplicate-check
+  // useEffect below also keys its warnings by index into this array.
+  const effectiveImportRows = useMemo(() => {
+    if (rowMode !== "multi" || parsedData.length === 0) return parsedData;
+    return aggregateMultiRowSteps(
+      parsedData,
+      fieldMappings.filter((m) => m.templateField !== null)
+    );
+  }, [parsedData, fieldMappings, rowMode]);
+
   // Seed selectedFile from initialFile when dialog opens externally
   useEffect(() => {
     if (open && initialFile) {
@@ -236,9 +253,12 @@ export function ImportCasesWizard({
     }
   }, [open, defaultTemplate, selectedTemplateId]);
 
-  // Check for duplicates when reaching page 4 (preview page)
+  // Check for duplicates when reaching page 4 (preview page). The warnings
+  // map is keyed by index into the array the preview is iterating — that's
+  // effectiveImportRows (aggregated in multi-row mode), not the raw parsedData.
   useEffect(() => {
-    if (currentPage !== 4 || parsedData.length === 0 || !projectId) return;
+    if (currentPage !== 4 || effectiveImportRows.length === 0 || !projectId)
+      return;
 
     const checkDuplicates = async () => {
       setIsCheckingDuplicates(true);
@@ -262,9 +282,11 @@ export function ImportCasesWizard({
       }
       const nameColumn = nameMapping.csvColumn;
 
-      // Build name-to-row-indices map for intra-import detection
+      // Build name-to-row-indices map for intra-import detection.
+      // Walk effectiveImportRows so the indices line up with what the
+      // preview iterates (aggregated rows in multi-row mode).
       const nameToRows = new Map<string, number[]>();
-      parsedData.forEach((row, idx) => {
+      effectiveImportRows.forEach((row, idx) => {
         const name = (row[nameColumn] || "").toString().trim().toLowerCase();
         if (!name) return;
         const existing = nameToRows.get(name) || [];
@@ -289,7 +311,7 @@ export function ImportCasesWizard({
       // Check against existing cases via API — batch by unique names, max 50
       const uniqueNames = [
         ...new Set(
-          parsedData
+          effectiveImportRows
             .map((row) => (row[nameColumn] || "").toString().trim())
             .filter(Boolean)
         ),
@@ -302,7 +324,7 @@ export function ImportCasesWizard({
       for (const name of uniqueNames) {
         try {
           const tagsValue = tagsColumn
-            ? parsedData.find(
+            ? effectiveImportRows.find(
                 (r) => (r[nameColumn] || "").toString().trim() === name
               )?.[tagsColumn]
             : undefined;
@@ -326,8 +348,9 @@ export function ImportCasesWizard({
           if (!res.ok) continue;
           const data = await res.json();
           if (data.cases && data.cases.length > 0) {
-            // Apply to all rows with this name
-            parsedData.forEach((row, idx) => {
+            // Apply to all rows with this name — indices match the array the
+            // preview iterates (effectiveImportRows).
+            effectiveImportRows.forEach((row, idx) => {
               if ((row[nameColumn] || "").toString().trim() === name) {
                 const entry = warnings.get(idx) || {
                   existingSimilar: [],
@@ -348,7 +371,7 @@ export function ImportCasesWizard({
     };
 
     void checkDuplicates();
-  }, [currentPage, parsedData, fieldMappings, projectId]);
+  }, [currentPage, effectiveImportRows, fieldMappings, projectId]);
 
   // Check if project has an active LLM integration (for markdown parsing)
   const { data: projectLlmIntegrations } = useFindManyProjectLlmIntegration({
@@ -412,6 +435,15 @@ export function ImportCasesWizard({
         displayName: tCommon("fields.steps"),
         isRequired: false,
         type: "Steps",
+      },
+      {
+        // Multi-row mode only: pairs with the row's "steps" column so users
+        // can map a custom column header (e.g. "Outcome") to the per-step
+        // expected result instead of relying on alias-based auto-detection.
+        id: "expectedResult",
+        displayName: tCommon("fields.expectedResult"),
+        isRequired: false,
+        type: "ExpectedResult",
       },
       {
         id: "attachments",
@@ -499,6 +531,10 @@ export function ImportCasesWizard({
     tag: "tags",
     step: "steps",
     "test steps": "steps",
+    expected: "expectedResult",
+    "expected result": "expectedResult",
+    "expected results": "expectedResult",
+    "expected outcome": "expectedResult",
     estimated: "estimate",
     estimation: "estimate",
     "is automated": "automated",
@@ -809,15 +845,15 @@ export function ImportCasesWizard({
   };
 
   const getPreviewData = () => {
-    if (parsedData.length === 0) return [];
+    if (effectiveImportRows.length === 0) return [];
 
     const startIndex = Math.max(
       0,
-      Math.min(previewIndex * 25, parsedData.length - 25)
+      Math.min(previewIndex * 25, effectiveImportRows.length - 25)
     );
-    const endIndex = Math.min(startIndex + 25, parsedData.length);
+    const endIndex = Math.min(startIndex + 25, effectiveImportRows.length);
 
-    return parsedData.slice(startIndex, endIndex);
+    return effectiveImportRows.slice(startIndex, endIndex);
   };
 
   const validatePage1 = () => {
@@ -1570,8 +1606,11 @@ export function ImportCasesWizard({
           <p className="text-sm text-muted-foreground">
             {t("importWizard.page4.showing", {
               start: previewIndex * 25 + 1,
-              end: Math.min((previewIndex + 1) * 25, parsedData.length),
-              total: parsedData.length,
+              end: Math.min(
+                (previewIndex + 1) * 25,
+                effectiveImportRows.length
+              ),
+              total: effectiveImportRows.length,
             })}
           </p>
           <div className="flex gap-2">
@@ -1587,7 +1626,7 @@ export function ImportCasesWizard({
               variant="outline"
               size="sm"
               onClick={() => setPreviewIndex(previewIndex + 1)}
-              disabled={(previewIndex + 1) * 25 >= parsedData.length}
+              disabled={(previewIndex + 1) * 25 >= effectiveImportRows.length}
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
@@ -1745,7 +1784,7 @@ export function ImportCasesWizard({
           {isImporting && (
             <LoadingSpinnerAlert
               message={tGlobal("repository.generateTestCases.importing", {
-                count: parsedData.length - importProgress,
+                count: effectiveImportRows.length - importProgress,
               })}
             />
           )}
@@ -1784,10 +1823,10 @@ export function ImportCasesWizard({
             >
               {isImporting
                 ? tGlobal("repository.generateTestCases.importing", {
-                    count: parsedData.length - importProgress,
+                    count: effectiveImportRows.length - importProgress,
                   })
                 : tGlobal("repository.generateTestCases.import", {
-                    count: parsedData.length,
+                    count: effectiveImportRows.length,
                   })}
             </Button>
           )}

--- a/testplanit/app/api/repository/import/route.test.ts
+++ b/testplanit/app/api/repository/import/route.test.ts
@@ -913,6 +913,87 @@ describe("CSV Import API Route", () => {
       }
     });
 
+    it("collapses an N-row, 1-name CSV into a single case with N steps (multi-row + name-only)", async () => {
+      // Customer repro: CSV has the same Name on every row, 6 rows total.
+      // Without an ID column the aggregator must group by Name and emit ONE
+      // case with six steps — not six separate cases. (Description is mapped
+      // here only because the test fixture's template marks it required.)
+      const file = [
+        "Name,Description,Step Content,Expected Result",
+        "Login flow,Verify login,Open page,Page loads",
+        "Login flow,,Enter username,Field accepts text",
+        "Login flow,,Enter password,Field masks input",
+        "Login flow,,Click login,Dashboard loads",
+        "Login flow,,Click logout,Login page returns",
+        "Login flow,,Close tab,Session ends",
+      ].join("\n");
+
+      const request = createRequest({
+        projectId: 1,
+        file,
+        delimiter: ",",
+        hasHeaders: true,
+        encoding: "UTF-8",
+        templateId: 1,
+        importLocation: "single_folder",
+        folderId: 1,
+        rowMode: "multi",
+        fieldMappings: [
+          { csvColumn: "Name", templateField: "name" },
+          { csvColumn: "Description", templateField: "description" },
+        ],
+      });
+
+      const response = await POST(request);
+      const result = await parseSSEResponse(response);
+
+      expect(result.complete).toBeDefined();
+      expect(mockEnhancedDb.repositoryCases.create).toHaveBeenCalledTimes(1);
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledTimes(6);
+    });
+
+    it("honors an explicit expectedResult mapping for a custom-named column (multi-row)", async () => {
+      // "Outcome" isn't in the aggregator's alias list. Mapping it explicitly
+      // to templateField=expectedResult must make the aggregator pick it up
+      // as the per-step expected result column.
+      const file = [
+        "ID,Name,Description,Step Content,Outcome",
+        "1,Login,Verify login,Open page,Page loads",
+        "1,Login,,Submit,Welcome",
+      ].join("\n");
+
+      const request = createRequest({
+        projectId: 1,
+        file,
+        delimiter: ",",
+        hasHeaders: true,
+        encoding: "UTF-8",
+        templateId: 1,
+        importLocation: "single_folder",
+        folderId: 1,
+        rowMode: "multi",
+        fieldMappings: [
+          { csvColumn: "ID", templateField: "id" },
+          { csvColumn: "Name", templateField: "name" },
+          { csvColumn: "Description", templateField: "description" },
+          { csvColumn: "Outcome", templateField: "expectedResult" },
+        ],
+      });
+
+      const response = await POST(request);
+      const result = await parseSSEResponse(response);
+
+      expect(result.complete).toBeDefined();
+      expect(mockEnhancedDb.repositoryCases.create).toHaveBeenCalledTimes(1);
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledTimes(2);
+      // Both steps have their expected result populated from the Outcome column
+      for (const call of mockEnhancedDb.steps.create.mock.calls) {
+        expect(call[0].data.expectedResult).toEqual(
+          expect.objectContaining({ type: "doc" })
+        );
+      }
+    });
+
     it("imports test cases with workflow state", async () => {
       mockEnhancedDb.workflows.findFirst.mockImplementation(({ where }) => {
         if (where.name === "In Progress") {

--- a/testplanit/lib/utils/aggregateMultiRowSteps.test.ts
+++ b/testplanit/lib/utils/aggregateMultiRowSteps.test.ts
@@ -273,6 +273,47 @@ describe("aggregateMultiRowSteps", () => {
     expect(result[0]._aggregatedSteps[0].expectedResult).toBe("Loads");
   });
 
+  it("honors a user mapping of templateField=expectedResult for a custom expected-result column name", () => {
+    // "Outcome" isn't in EXPECTED_RESULT_ALIASES, but the user explicitly
+    // maps it to expectedResult — that mapping should win.
+    const rows = [
+      { ID: "1", Name: "Login", "Step Content": "Open page", Outcome: "Loads" },
+      { ID: "1", Name: "Login", "Step Content": "Submit", Outcome: "Welcome" },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "ID", templateField: "id" },
+      { csvColumn: "Name", templateField: "name" },
+      { csvColumn: "Outcome", templateField: "expectedResult" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._aggregatedSteps).toEqual([
+      { step: "Open page", expectedResult: "Loads", order: 0 },
+      { step: "Submit", expectedResult: "Welcome", order: 1 },
+    ]);
+  });
+
+  it("does not exclude an expectedResult-mapped column from step detection", () => {
+    // Regression: buildExcludedColumns used to exclude every mapped column
+    // except 'steps', so mapping "Outcome" -> expectedResult would have
+    // hidden it from the expected-result alias scan AND from the explicit
+    // detector. Now the aggregator still finds it via the explicit mapping.
+    const rows = [
+      { Name: "Login", "Step Content": "Open page", Outcome: "Loads" },
+      { Name: "Login", "Step Content": "Click", Outcome: "Done" },
+    ];
+
+    const result = aggregateMultiRowSteps(rows, [
+      { csvColumn: "Name", templateField: "name" },
+      { csvColumn: "Outcome", templateField: "expectedResult" },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._aggregatedSteps[0].expectedResult).toBe("Loads");
+    expect(result[0]._aggregatedSteps[1].expectedResult).toBe("Done");
+  });
+
   it("does not claim a column already mapped to a non-step template field", () => {
     // "Action" is in the step-content alias list, but it's been explicitly
     // mapped to a custom "description" field — leave it alone, no step

--- a/testplanit/lib/utils/aggregateMultiRowSteps.ts
+++ b/testplanit/lib/utils/aggregateMultiRowSteps.ts
@@ -57,13 +57,19 @@ function findColumn(
 }
 
 // Columns already mapped to non-step template fields shouldn't be auto-claimed
-// as the step content / expected result column.
+// as the step content / expected result column. "steps" and "expectedResult"
+// are exempt — those are exactly the multi-row step columns this aggregator
+// wants to claim from the user's explicit mapping.
 function buildExcludedColumns(
   fieldMappings: MultiRowFieldMapping[]
 ): Set<string> {
   const excluded = new Set<string>();
   for (const m of fieldMappings) {
-    if (m.templateField && m.templateField !== "steps") {
+    if (
+      m.templateField &&
+      m.templateField !== "steps" &&
+      m.templateField !== "expectedResult"
+    ) {
       excluded.add(m.csvColumn);
     }
   }
@@ -105,6 +111,27 @@ function detectStepContentColumn(
   return findColumn(row, STEP_CONTENT_ALIASES, excludedColumns);
 }
 
+function detectExpectedResultColumn(
+  row: any,
+  fieldMappings: MultiRowFieldMapping[],
+  excludedColumns: Set<string>
+): string | null {
+  // Mirror detectStepContentColumn: an explicit "expectedResult" user mapping
+  // wins over the alias scan. This lets users surface custom column names
+  // (e.g. "Outcome", "Acceptance") that wouldn't match the alias list.
+  const erMapping = fieldMappings.find(
+    (m) => m.templateField === "expectedResult"
+  );
+  if (
+    erMapping &&
+    row &&
+    Object.prototype.hasOwnProperty.call(row, erMapping.csvColumn)
+  ) {
+    return erMapping.csvColumn;
+  }
+  return findColumn(row, EXPECTED_RESULT_ALIASES, excludedColumns);
+}
+
 /**
  * Collapses a multi-row CSV (one row per step) into one row per case. The head
  * row keeps all its existing fields; continuation rows are absorbed into the
@@ -133,7 +160,11 @@ export function aggregateMultiRowSteps(
     fieldMappings,
     excluded
   );
-  const expectedCol = findColumn(rows[0], EXPECTED_RESULT_ALIASES, excluded);
+  const expectedCol = detectExpectedResultColumn(
+    rows[0],
+    fieldMappings,
+    excluded
+  );
   const stepNumberCol = findColumn(rows[0], STEP_NUMBER_ALIASES, excluded);
 
   if (!stepContentCol && !expectedCol) return rows;
@@ -213,7 +244,7 @@ export function inspectMultiRowAggregation(
     ? detectStepContentColumn(sample, fieldMappings, excluded)
     : null;
   const expectedResultColumn = sample
-    ? findColumn(sample, EXPECTED_RESULT_ALIASES, excluded)
+    ? detectExpectedResultColumn(sample, fieldMappings, excluded)
     : null;
   const stepNumberColumn = sample
     ? findColumn(sample, STEP_NUMBER_ALIASES, excluded)


### PR DESCRIPTION
## Description

Customer-reported bugs in the CSV "multi-row mode" import path (one test case spans multiple rows, one row per step).

### Bug A — "Expected Result" couldn't be mapped

The user docs list `Expected Result, Expected Results, Expected, Expected Outcome` as recognized headers, and the aggregator does look for them — but only via case-insensitive alias matching. The mapping dropdown in the import wizard never offered "Expected Result" as a target field, so anyone whose CSV used a custom column header (e.g. "Outcome", "Acceptance") had no way to surface it.

Fix:
- Add `expectedResult` as a system field in the mapping list (using the existing `common.fields.expectedResult` i18n key).
- Add the alias variants to the wizard's `commonMappings` so auto-mapping picks them up.
- `aggregateMultiRowSteps` honors an explicit `expectedResult` mapping the same way it already honors an explicit `steps` mapping (new `detectExpectedResultColumn` helper), and `buildExcludedColumns` exempts it from the non-step exclusion.

### Bug B / C — preview, pagination, and submit count disagreed

The diagnostic banner ("Multi-row mode grouped 18 CSV rows into 3 test cases") used `inspectMultiRowAggregation` — correct. The preview cards iterated raw `parsedData` — so 18 cards rendered for what would actually become 3 cases. The pagination read `parsedData.length` and announced "1-18 of 18 cases". The submit button advertised "Import 18 Test Cases". The server's aggregator was always correct (covered by an existing route test), so 3 cases really were imported, but the UI told users 18 were coming and they reasonably believed it.

Fix:
- Single `effectiveImportRows` memo: `aggregateMultiRowSteps(parsedData, …)` when `rowMode === "multi"`, otherwise the raw `parsedData`. This is the canonical "what cases will actually be created" array.
- Preview cards, pagination, Next-page gate, "Import N Test Cases" button, and the in-progress "Importing M of N" message all read from it.
- The duplicate-check effect walks `effectiveImportRows` so warning indices match the cards rendered.

### Tests

- `aggregateMultiRowSteps.test.ts` — two new cases for the explicit `expectedResult` mapping and for the exclusion exemption (17 cases total, up from 15).
- `app/api/repository/import/route.test.ts` — two new end-to-end cases: a same-Name 6-row CSV collapses to one case with six steps; an explicit `expectedResult` mapping on a custom-named column ("Outcome") flows through the importer (38 cases total, up from 36).

Full suite: 7998 passing, 0 failing.

## Related Issue

N/A — direct customer report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — new cases for the aggregator (explicit expectedResult mapping + exclusion behavior).
- [x] Integration tests — new cases on the import API route covering the same-name multi-row collapse and the explicit expectedResult mapping.
- [ ] E2E tests
- [x] Manual testing — confirmed mapping dropdown lists Expected Result; preview shows one card per aggregated case; pagination + submit button reflect the aggregated count.

**Test Configuration:**

- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

The server-side aggregator was already correct — the customer's perception that "18 cases were created instead of 3" came from the misleading UI counts. Once the preview and counts match the aggregated array, the dialog and the actual import agree on the same number.
