### PR TITLE
fix(copy-move): prevent self-collision on same-project move and preserve source template

### DIFF
--- a/testplanit/app/api/repository/copy-move/preflight/route.test.ts
+++ b/testplanit/app/api/repository/copy-move/preflight/route.test.ts
@@ -408,6 +408,40 @@ describe("POST /api/repository/copy-move/preflight", () => {
     expect(data.collisions).toHaveLength(0);
   });
 
+  it("SELF-COLLISION: scopes the collision query out of moving source ids on move", async () => {
+    // Customer-reported: moving a case within the same project surfaced a
+    // Skip/Rename conflict because the (name, className, source) tuple
+    // matched the moving case itself. Fix excludes the source IDs from
+    // the collision lookup when operation === 'move'.
+    setupDefaultMocks();
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({
+        operation: "move",
+        caseIds: [1, 2],
+        sourceProjectId: 10,
+        targetProjectId: 10,
+      })
+    );
+    expect(res.status).toBe(200);
+
+    // Collision check is the second findMany on the admin path
+    const collisionCall = mockPrismaRepositoryCasesFindMany.mock.calls[1]?.[0];
+    expect(collisionCall?.where?.id).toEqual({ notIn: [1, 2] });
+  });
+
+  it("SELF-COLLISION: does NOT scope the collision query out of source ids on copy", async () => {
+    // For copy the source rows are real collision targets — the unique
+    // (projectId, name, className, source) constraint would block.
+    setupDefaultMocks();
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    const collisionCall = mockPrismaRepositoryCasesFindMany.mock.calls[1]?.[0];
+    expect(collisionCall?.where?.id).toBeUndefined();
+  });
+
   // Test 15
   it("returns targetRepositoryId resolved from active repository in target project", async () => {
     setupDefaultMocks();

--- a/testplanit/app/api/repository/copy-move/preflight/route.ts
+++ b/testplanit/app/api/repository/copy-move/preflight/route.ts
@@ -237,9 +237,16 @@ export async function POST(request: Request) {
       where: {
         projectId: body.targetProjectId,
         isDeleted: false,
+        // A move within the same project would otherwise self-collide: the
+        // sources match themselves on (name, className, source). Exclude
+        // them so we only flag real conflicts with other cases. Copy keeps
+        // them included because the unique constraint really would block.
+        ...(body.operation === "move" ? { id: { notIn: body.caseIds } } : {}),
         OR: sourceNames.map((n) => ({
           name: n.name,
-          ...(n.className === null ? {} : { className: n.className }),
+          // Match NULL className explicitly — omitting the filter would
+          // match any className and flag unrelated cases as collisions.
+          className: n.className === null ? { equals: null } : n.className,
           source: n.source,
         })),
       },

--- a/testplanit/workers/copyMoveWorker.test.ts
+++ b/testplanit/workers/copyMoveWorker.test.ts
@@ -73,6 +73,10 @@ const mockPrisma = {
   },
   templateCaseAssignment: { findMany: vi.fn() },
   caseFieldAssignment: { findMany: vi.fn() },
+  // Worker pre-fetches target project's assigned templates so source
+  // templates can be preserved per case when still assigned. Default to
+  // empty so existing tests fall through to job.data.targetTemplateId.
+  templateProjectAssignment: { findMany: vi.fn().mockResolvedValue([]) },
   $transaction: vi.fn((fn: Function) => fn(mockTx)),
   $disconnect: vi.fn(),
 };
@@ -222,10 +226,11 @@ async function loadWorker() {
 
 type JobData = Omit<
   typeof baseCopyJobData,
-  "operation" | "sharedStepGroupResolution"
+  "operation" | "sharedStepGroupResolution" | "conflictResolution"
 > & {
   operation: "copy" | "move";
   sharedStepGroupResolution: "reuse" | "create_new";
+  conflictResolution: "skip" | "rename";
 };
 
 function makeMockJob(
@@ -803,29 +808,30 @@ describe("CopyMoveWorker", () => {
       expect(mockPrisma.repositoryCases.updateMany).toHaveBeenCalledTimes(1);
     });
 
-    it("DATA-LOSS-01: should NOT soft-delete source cases when all are skipped (same-project move + skip)", async () => {
-      // Regression guard: same-project self-collision with conflictResolution:"skip"
-      // previously caused copiedCount=0 but the unconditional updateMany still ran,
-      // silently deleting originals. The fix gates soft-delete on createdTargetIds.
-      const sameProjSkipMoveJobData = {
+    it("DATA-LOSS-01: should NOT soft-delete source cases when all are skipped (real collision + skip)", async () => {
+      // Regression guard: when every case is skipped, the unconditional
+      // updateMany used to fire and silently soft-delete the originals.
+      // The fix gates soft-delete on createdTargetIds. Note: a same-project
+      // move no longer self-collides (see SELF-COLLISION-01), so to actually
+      // exercise the "all skipped" branch the collision has to be a real
+      // non-source case with the same name.
+      const skipMoveJobData = {
         ...baseMoveJobData,
-        sourceProjectId: 20,
-        targetProjectId: 20,
         caseIds: [1],
         conflictResolution: "skip" as const,
       };
 
       // First findFirst = max-order pre-fetch → null.
-      // Second findFirst = collision check → source case found (self-collision).
+      // Second findFirst = collision check → unrelated case with same name.
       mockPrisma.repositoryCases.findFirst
         .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: 1 });
+        .mockResolvedValueOnce({ id: 9999 });
 
       mockPrisma.repositoryCaseVersions.findMany.mockResolvedValue([]);
 
       const { processor } = await loadWorker();
       const result = await processor(
-        makeMockJob({ data: sameProjSkipMoveJobData }) as Job
+        makeMockJob({ data: skipMoveJobData }) as Job
       );
 
       // Every case was skipped — source should NOT be soft-deleted
@@ -833,6 +839,64 @@ describe("CopyMoveWorker", () => {
       expect(result.skippedCount).toBe(1);
       expect(result.copiedCount).toBe(0);
       expect(result.movedCount).toBe(0);
+    });
+
+    it("SELF-COLLISION-01: same-project move does NOT treat source as its own collision", async () => {
+      // Customer-reported: moving a case within the same project showed a
+      // Skip/Rename conflict because the (name, className, source) tuple
+      // matched the case being moved. Fix excludes the move source IDs
+      // from the collision lookup.
+      const sameProjMoveJobData = {
+        ...baseMoveJobData,
+        sourceProjectId: 20,
+        targetProjectId: 20,
+        caseIds: [1],
+        conflictResolution: "skip" as const,
+      };
+
+      mockPrisma.repositoryCaseVersions.findMany.mockResolvedValue([]);
+
+      const { processor } = await loadWorker();
+      const result = await processor(
+        makeMockJob({ data: sameProjMoveJobData }) as Job
+      );
+
+      // The collision query must scope out the source case
+      const collisionCall =
+        mockPrisma.repositoryCases.findFirst.mock.calls[1]?.[0];
+      expect(collisionCall?.where?.id).toEqual({ notIn: [1] });
+
+      // Case is actually moved, not skipped
+      expect(mockTx.repositoryCases.create).toHaveBeenCalledTimes(1);
+      expect(result.movedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(mockPrisma.repositoryCases.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: [1] } },
+        data: { isDeleted: true },
+      });
+    });
+
+    it("SELF-COLLISION-02: same-project move + rename does NOT append (copy) suffix when no real collision exists", async () => {
+      // Companion to SELF-COLLISION-01: Rename used to land "Foo (copy)"
+      // because the source matched itself. Post-fix the name is preserved.
+      const sameProjRenameMoveJobData = {
+        ...baseMoveJobData,
+        sourceProjectId: 20,
+        targetProjectId: 20,
+        caseIds: [1],
+        conflictResolution: "rename" as const,
+      };
+
+      mockPrisma.repositoryCaseVersions.findMany.mockResolvedValue([]);
+
+      const { processor } = await loadWorker();
+      await processor(makeMockJob({ data: sameProjRenameMoveJobData }) as Job);
+
+      expect(mockTx.repositoryCases.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ name: "Test Case 1" }),
+        })
+      );
     });
 
     it("should set movedCount equal to copiedCount on successful move", async () => {
@@ -843,6 +907,46 @@ describe("CopyMoveWorker", () => {
 
       expect(result.movedCount).toBe(1);
       expect(result.copiedCount).toBe(0);
+    });
+  });
+
+  // ─── Per-case template preservation ───────────────────────────────────────
+
+  describe("target template selection", () => {
+    it("TEMPLATE-01: preserves the source case's template when it is assigned to the target project", async () => {
+      // Customer-reported: moving a "Case (steps)" case landed in the
+      // target as "Case (exploratory)" because the worker overwrote
+      // templateId with job.data.targetTemplateId (the target's first
+      // assignment) regardless of what was assigned. Now we preserve the
+      // source template when it is still assigned to the target.
+      mockPrisma.templateProjectAssignment.findMany.mockResolvedValue([
+        { templateId: 30 }, // source case uses templateId 30
+        { templateId: 50 }, // job.data.targetTemplateId — would have been used previously
+      ]);
+
+      const { processor } = await loadWorker();
+      await processor(makeMockJob() as Job);
+
+      expect(mockTx.repositoryCases.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ templateId: 30 }),
+        })
+      );
+    });
+
+    it("TEMPLATE-02: falls back to job.data.targetTemplateId when the source template is not assigned to the target project", async () => {
+      mockPrisma.templateProjectAssignment.findMany.mockResolvedValue([
+        { templateId: 50 }, // only job.data.targetTemplateId is assigned
+      ]);
+
+      const { processor } = await loadWorker();
+      await processor(makeMockJob() as Job);
+
+      expect(mockTx.repositoryCases.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ templateId: 50 }),
+        })
+      );
     });
   });
 

--- a/testplanit/workers/copyMoveWorker.ts
+++ b/testplanit/workers/copyMoveWorker.ts
@@ -440,15 +440,34 @@ const processor = async (
       }
     }
 
-    // 7. Pre-fetch template field definitions for both source and target templates
-    // Source template ID comes from the first source case (assume all share same template)
-    const sourceTemplateId = sourceCases[0]?.templateId;
-    const [sourceTemplateFields, targetTemplateFields] = await Promise.all([
-      sourceTemplateId
-        ? fetchTemplateFields(prisma, sourceTemplateId)
-        : Promise.resolve([]),
-      fetchTemplateFields(prisma, job.data.targetTemplateId),
-    ]);
+    // 7. Pre-fetch template assignments for the target project so we can
+    // preserve each source case's template when it's still available there
+    // (instead of silently rewriting every case to job.data.targetTemplateId,
+    // which would, e.g., swap a "Case (steps)" case to whatever happens to
+    // be the target's first assigned template). Field definitions are
+    // cached lazily per template since the source set may now span several.
+    const targetTemplateAssignments =
+      await prisma.templateProjectAssignment.findMany({
+        where: { projectId: job.data.targetProjectId },
+        select: { templateId: true },
+      });
+    const targetAssignedTemplateIds = new Set<number>(
+      targetTemplateAssignments.map((a: { templateId: number }) => a.templateId)
+    );
+
+    const templateFieldsCache = new Map<
+      number,
+      Awaited<ReturnType<typeof fetchTemplateFields>>
+    >();
+    const getTemplateFields = async (templateId: number) => {
+      if (!templateFieldsCache.has(templateId)) {
+        templateFieldsCache.set(
+          templateId,
+          await fetchTemplateFields(prisma, templateId)
+        );
+      }
+      return templateFieldsCache.get(templateId)!;
+    };
 
     // 8. Initialize state
     const sharedGroupMap = new Map<number, number>();
@@ -482,6 +501,16 @@ const processor = async (
             ? { className: { equals: null as any } }
             : { className: sourceCase.className };
 
+        // A move within the same project would otherwise self-collide: the
+        // source case still satisfies (name, className, source) until its
+        // soft-delete after the loop. Exclude the move source IDs so we only
+        // see real conflicts. Copy keeps them included — the unique
+        // constraint would genuinely block a same-name duplicate.
+        const movingSourceFilter =
+          job.data.operation === "move"
+            ? { id: { notIn: job.data.caseIds } }
+            : {};
+
         const existingCase = await prisma.repositoryCases.findFirst({
           where: {
             projectId: job.data.targetProjectId,
@@ -489,6 +518,7 @@ const processor = async (
             ...classNameWhere,
             source: sourceCase.source,
             isDeleted: false,
+            ...movingSourceFilter,
           },
           select: { id: true },
         });
@@ -510,6 +540,7 @@ const processor = async (
                   ...classNameWhere,
                   source: sourceCase.source,
                   isDeleted: false,
+                  ...movingSourceFilter,
                 },
                 select: { id: true },
               });
@@ -539,6 +570,23 @@ const processor = async (
           nextOrder++;
         }
 
+        // Preserve the source case's template when it's still assigned to
+        // the target project; otherwise fall back to the resolved
+        // job.data.targetTemplateId. Field option remapping uses the
+        // matching source/target field snapshots so the values land on the
+        // right options when the template differs.
+        const effectiveTargetTemplateId = targetAssignedTemplateIds.has(
+          sourceCase.templateId
+        )
+          ? sourceCase.templateId
+          : job.data.targetTemplateId;
+        const sourceTemplateFields = await getTemplateFields(
+          sourceCase.templateId
+        );
+        const targetTemplateFields = await getTemplateFields(
+          effectiveTargetTemplateId
+        );
+
         const newCaseId = await prisma.$transaction(async (tx: any) => {
           // a. Create the target RepositoryCases row
           const newCase = await tx.repositoryCases.create({
@@ -546,7 +594,7 @@ const processor = async (
               projectId: job.data.targetProjectId,
               repositoryId: job.data.targetRepositoryId,
               folderId: caseFolderId,
-              templateId: job.data.targetTemplateId,
+              templateId: effectiveTargetTemplateId,
               stateId: job.data.targetDefaultWorkflowStateId,
               name: caseName,
               className: sourceCase.className,


### PR DESCRIPTION
## Description

Two customer-reported bugs in the Move Test Case flow.

### Bug 1 — false Skip/Rename conflict on same-project move

Moving a case to a different folder *within the same project* showed a Skip/Rename conflict dialog "even when no duplicate test case exists in the target folder". Picking **Skip** then did nothing (case stayed put), and **Rename** worked but unnecessarily appended `(copy)` to the case name.

Root cause: both the preflight and the worker checked for collisions by `(projectId, name, className, source)`. For a same-project move, the source rows still satisfy that tuple — they're not soft-deleted until after the worker's per-case loop completes. So every moving case matched *itself* as a "collision", forcing the user to pick Skip (→ stay put) or Rename (→ "(copy)" suffix on what should have been a clean move).

A second smaller bug in the same query: the preflight's `OR` clause omitted the `className` filter when the source `className` was `null`, which can match cases that have a non-null `className` — surfacing those as false positives too.

Fixes:
- Preflight and worker scope the collision query with `id: { notIn: caseIds }` when `operation === "move"`. Copy still includes them (the unique constraint really does block a same-name duplicate, so Skip/Rename is appropriate).
- Preflight's `OR` clause matches `className: { equals: null }` explicitly instead of dropping the filter.

### Bug 2 — template silently swapped after a move (e.g. "Case (steps)" → "Case (exploratory)")

After moving, the test case template changed to a different one, making its steps non-editable.

Root cause: the worker hard-coded every new case's `templateId` to `job.data.targetTemplateId`, which the route resolves to the target project's *first* template assignment. If the target project's first assignment happened to be a different template than the source case used, every moved case landed on that wrong template — losing its steps editor in cases where the templates differed in case fields.

Fixes:
- Worker pre-fetches the target project's `templateProjectAssignment` IDs once. Per case, if `sourceCase.templateId` is still assigned to the target project, the worker preserves it; only falls back to `job.data.targetTemplateId` when the source template isn't available there.
- Per-template field snapshots are now cached (instead of one global fetch for `sourceCases[0].templateId`), so field-value remapping stays correct when the source set spans multiple templates.

### Tests

- `workers/copyMoveWorker.test.ts` — DATA-LOSS-01 reframed (same-project moves no longer self-collide, so the "all-skipped → don't soft-delete sources" invariant is exercised with a real non-source collision); two new self-collision regression cases; two new template-preservation cases (43 → 47 cases).
- `app/api/repository/copy-move/preflight/route.test.ts` — two new SELF-COLLISION cases verifying the move-only `notIn` scope vs. the copy behavior (15 → 17 cases).

Full suite: 8000 passing.

## Related Issue

N/A — direct customer report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — new cases on the preflight and worker covering self-collision exclusion and per-case template preservation.
- [x] Integration tests — full route + worker tests pass.
- [ ] E2E tests
- [x] Manual testing — moved cases within and across projects; confirmed no false conflict; confirmed the source template carries over when assigned to the target.

**Test Configuration:**

- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

The previous `DATA-LOSS-01` test (PR #290) hardened the soft-delete path against self-collisions so sources weren't silently deleted when every case was skipped. This PR addresses the root cause one layer up — the collision shouldn't be raised in the first place — and the test is reframed to still cover the "all-skipped" invariant via a real non-source collision.
