### PR TITLE
enhancement(reports): expand step results in execution log

### DIFF
--- a/docs/docs/user-guide/reporting.md
+++ b/docs/docs/user-guide/reporting.md
@@ -50,6 +50,8 @@ Shows test coverage for issues tracked in integrated systems (Jira, GitHub, Azur
 
 A flat, chronological log of individual test result records. See who executed each test case, when it was executed, which test run it belonged to, and what status was recorded. Useful for audit trails, team activity reviews, and tracking execution patterns over time.
 
+Each row can be expanded to reveal step-level results for that test case execution. Every expected step in the case definition appears as a sub-row — including steps that were not recorded during the run (shown as **Untested**) — with the step action, expected result, per-step status, executed-at timestamp, and duration. Steps that belong to a shared step group are marked with a Shared Step icon and the group name surfaces in a tooltip. Long step or expected-result text is truncated to two lines with the full content (plain text-only) available on hover.
+
 Filters:
 
 - **Date Range** — Limit results to a specific time window

--- a/testplanit/components/reports/ReportRenderer.tsx
+++ b/testplanit/components/reports/ReportRenderer.tsx
@@ -499,6 +499,16 @@ export function ReportRenderer({
               onGroupingChange={onGroupingChange}
               expanded={expanded}
               onExpandedChange={onExpandedChange}
+              getSubRows={
+                isExecutionLog
+                  ? (row: any) => row.steps as any[] | undefined
+                  : undefined
+              }
+              subRowsLabel={
+                isExecutionLog
+                  ? tCommon("fields.steps").toLowerCase()
+                  : undefined
+              }
             />
           </CardContent>
         </Card>

--- a/testplanit/components/tables/DataTable.tsx
+++ b/testplanit/components/tables/DataTable.tsx
@@ -8,6 +8,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Column,
   ColumnDef,
   ColumnPinningState,
@@ -89,6 +95,7 @@ interface DataTableProps<TData extends DataRow, TValue> {
   itemType?: string;
   getSubRows?: (originalRow: TData, index: number) => TData[] | undefined;
   subRowColumns?: ColumnDef<any, any>[];
+  subRowsLabel?: string;
   rowTestIdPrefix?: string;
 }
 
@@ -149,11 +156,13 @@ export function DataTable<TData extends DataRow, TValue>({
   itemType,
   getSubRows,
   subRowColumns: _subRowColumns,
+  subRowsLabel,
   rowTestIdPrefix = "case-row",
 }: DataTableProps<TData, TValue>) {
   const t = useTranslations("common.table");
   const tLabels = useTranslations("common.labels");
   const tCommon = useTranslations("common");
+  const tActions = useTranslations("common.actions");
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -405,28 +414,38 @@ export function DataTable<TData extends DataRow, TValue>({
     () => ({
       id: "expander",
       header: () => null,
-      cell: ({ row }) =>
-        row.getCanExpand() ? (
-          <button
-            {...{
-              onClick: row.getToggleExpandedHandler(),
-              style: { cursor: "pointer" },
-              className: "mr-2",
-            }}
-          >
-            <span
-              className="inline-flex items-center justify-center w-4 transition-transform duration-200"
-              style={{
-                transform: row.getIsExpanded()
-                  ? "rotate(90deg)"
-                  : "rotate(0deg)",
-              }}
-              aria-label={row.getIsExpanded() ? "Collapse" : "Expand"}
-            >
-              {"\u25B6"}
-            </span>
-          </button>
-        ) : null,
+      cell: ({ row }) => {
+        if (!row.getCanExpand()) return null;
+        const isExpanded = row.getIsExpanded();
+        const subRowsCount = row.subRows?.length ?? 0;
+        const tooltipText = isExpanded
+          ? tActions("collapse")
+          : `${tActions("expand")}${subRowsLabel && subRowsCount > 0 ? ` \u2022 ${subRowsCount} ${subRowsLabel}` : ""}`;
+        return (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={row.getToggleExpandedHandler()}
+                  style={{ cursor: "pointer" }}
+                  className="mr-2"
+                  aria-label={tooltipText}
+                >
+                  <span
+                    className="inline-flex items-center justify-center w-4 transition-transform duration-200"
+                    style={{
+                      transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
+                    }}
+                  >
+                    {"\u25B6"}
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{tooltipText}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      },
       size: 24,
       minSize: 24,
       maxSize: 24,
@@ -434,14 +453,14 @@ export function DataTable<TData extends DataRow, TValue>({
       enableHiding: false,
       meta: { isPinned: "left" },
     }),
-    []
+    [tActions, subRowsLabel]
   );
   const finalColumns = useMemo(() => {
-    if (grouping && grouping.length > 0) {
+    if ((grouping && grouping.length > 0) || getSubRows) {
       return [expanderColumn, ...columns];
     }
     return columns;
-  }, [columns, grouping, expanderColumn]);
+  }, [columns, grouping, expanderColumn, getSubRows]);
 
   const table = useReactTable({
     data: localData,
@@ -863,8 +882,9 @@ export function DataTable<TData extends DataRow, TValue>({
                     const { column } = cell;
                     let cellContent: React.ReactNode = null;
                     const _shouldIndent = cellIndex === 0 && isSubRow;
+                    const groupingActive = !!(grouping && grouping.length > 0);
 
-                    if (cell.getIsGrouped()) {
+                    if (groupingActive && cell.getIsGrouped()) {
                       // If grouped, show group label and count
                       // Only show count if there's no custom aggregatedCell (which handles its own display)
                       const showCount = !cell.column.columnDef.aggregatedCell;
@@ -904,14 +924,14 @@ export function DataTable<TData extends DataRow, TValue>({
                           )}
                         </div>
                       );
-                    } else if (cell.getIsAggregated()) {
+                    } else if (groupingActive && cell.getIsAggregated()) {
                       // If aggregated, show aggregate value
                       cellContent = flexRender(
                         cell.column.columnDef.aggregatedCell ??
                           cell.column.columnDef.cell,
                         cell.getContext()
                       );
-                    } else if (cell.getIsPlaceholder()) {
+                    } else if (groupingActive && cell.getIsPlaceholder()) {
                       cellContent = null;
                     } else {
                       cellContent = flexRender(
@@ -924,10 +944,11 @@ export function DataTable<TData extends DataRow, TValue>({
                         key={String(column.id)}
                         style={cellPinningStyleFn(column)}
                         className={`${column.getIsPinned() ? "bg-background shadow-md" : isSelected ? "bg-primary/20" : "bg-primary-foreground/80"} ${
-                          column.getIsPinned() &&
-                          !column.getIsLastColumn(
-                            column.getIsPinned() as "left" | "right"
-                          )
+                          column.id === "expander" ||
+                          (column.getIsPinned() &&
+                            !column.getIsLastColumn(
+                              column.getIsPinned() as "left" | "right"
+                            ))
                             ? "border-r-0"
                             : "border-r border-accent"
                         }`}

--- a/testplanit/hooks/useExecutionLogColumns.tsx
+++ b/testplanit/hooks/useExecutionLogColumns.tsx
@@ -14,86 +14,169 @@ import {
 import { RepositoryCaseSource } from "@prisma/client";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
+import { Layers } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
-import type { ExecutionLogRow } from "~/utils/executionLogUtils";
+import type {
+  ExecutionLogRow,
+  ExecutionLogStepRow,
+} from "~/utils/executionLogUtils";
+
+type ExecutionLogRowOrStep = ExecutionLogRow | ExecutionLogStepRow;
+
+function isStepRow(row: any): row is ExecutionLogStepRow {
+  return row && row.isStep === true;
+}
 
 export function useExecutionLogColumns(
   projectId?: number | string,
   isCrossProject?: boolean
-): ColumnDef<ExecutionLogRow, any>[] {
+): ColumnDef<ExecutionLogRowOrStep, any>[] {
   const t = useTranslations();
   const tCommon = useTranslations("common");
-  const columnHelper = createColumnHelper<ExecutionLogRow>();
+  const columnHelper = createColumnHelper<ExecutionLogRowOrStep>();
 
   return useMemo(() => {
-    const columns: ColumnDef<ExecutionLogRow, any>[] = [];
+    const columns: ColumnDef<ExecutionLogRowOrStep, any>[] = [];
 
     if (isCrossProject) {
       columns.push(
-        columnHelper.accessor((row) => row.project?.name ?? "", {
-          id: "project",
-          header: () => <span>{t("reports.dimensions.project")}</span>,
-          cell: (info) => {
-            const project = info.row.original.project;
-            if (!project)
+        columnHelper.accessor(
+          (row) => (isStepRow(row) ? "" : (row.project?.name ?? "")),
+          {
+            id: "project",
+            header: () => <span>{t("reports.dimensions.project")}</span>,
+            cell: (info) => {
+              const row = info.row.original;
+              if (isStepRow(row)) return null;
+              const project = row.project;
+              if (!project)
+                return (
+                  <span className="text-muted-foreground">
+                    {tCommon("labels.unknown")}
+                  </span>
+                );
               return (
-                <span className="text-muted-foreground">
-                  {tCommon("labels.unknown")}
-                </span>
+                <ProjectNameDisplay
+                  projectName={project.name}
+                  projectId={project.id}
+                  iconUrl={project.iconUrl}
+                  showLink
+                />
               );
-            return (
-              <ProjectNameDisplay
-                projectName={project.name}
-                projectId={project.id}
-                iconUrl={project.iconUrl}
-                showLink
-              />
-            );
-          },
-          enableSorting: true,
-          size: 180,
-          minSize: 120,
-        }) as ColumnDef<ExecutionLogRow, any>
+            },
+            enableSorting: true,
+            size: 180,
+            minSize: 120,
+          }
+        ) as ColumnDef<ExecutionLogRowOrStep, any>
       );
     }
 
     columns.push(
-      columnHelper.accessor("testCaseName", {
-        id: "testCaseName",
-        header: () => <span>{t("reports.dimensions.testCase")}</span>,
-        cell: (info) => {
-          const rowProjectId = info.row.original.project?.id || projectId;
-          return (
-            <CaseDisplay
-              id={info.row.original.testCaseId}
-              name={info.row.original.testCaseName}
-              source={info.row.original.testCaseSource as RepositoryCaseSource}
-              link={
-                rowProjectId
-                  ? `/projects/repository/${rowProjectId}/${info.row.original.testCaseId}`
-                  : undefined
-              }
-              size="medium"
-              maxLines={2}
-            />
-          );
-        },
-        enableSorting: true,
-        size: 320,
-        minSize: 200,
-        maxSize: 800,
-      }) as ColumnDef<ExecutionLogRow, any>
+      columnHelper.accessor(
+        (row) => (isStepRow(row) ? row.stepText : row.testCaseName),
+        {
+          id: "testCaseName",
+          header: () => <span>{t("reports.dimensions.testCase")}</span>,
+          cell: (info) => {
+            const row = info.row.original;
+            if (isStepRow(row)) {
+              return (
+                <div className="pl-6 text-sm space-y-1 py-1">
+                  <div className="flex gap-2 items-start">
+                    <span className="text-muted-foreground shrink-0 inline-flex items-center gap-1">
+                      {row.sharedGroupName && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Layers
+                                size={14}
+                                className="text-primary shrink-0"
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {t("repository.steps.sharedStepGroupTitle", {
+                                name: row.sharedGroupName,
+                              })}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                      {t("common.fields.step")} {row.stepNumber}
+                    </span>
+                    {row.stepText ? (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="line-clamp-2 cursor-default">
+                              {row.stepText}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-md whitespace-pre-wrap">
+                            {row.stepText}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </div>
+                  {row.expectedResult && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground shrink-0">
+                        {t("common.fields.expectedResult")}
+                      </span>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="line-clamp-2 cursor-default">
+                              {row.expectedResult}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-md whitespace-pre-wrap">
+                            {row.expectedResult}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  )}
+                </div>
+              );
+            }
+            const rowProjectId = row.project?.id || projectId;
+            return (
+              <CaseDisplay
+                id={row.testCaseId}
+                name={row.testCaseName}
+                source={row.testCaseSource as RepositoryCaseSource}
+                link={
+                  rowProjectId
+                    ? `/projects/repository/${rowProjectId}/${row.testCaseId}`
+                    : undefined
+                }
+                size="medium"
+                maxLines={2}
+              />
+            );
+          },
+          enableSorting: true,
+          size: 320,
+          minSize: 200,
+          maxSize: 800,
+        }
+      ) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     columns.push(
-      columnHelper.accessor("testRunName", {
+      columnHelper.accessor((row) => (isStepRow(row) ? "" : row.testRunName), {
         id: "testRunName",
         header: () => <span>{t("reports.dimensions.testRun")}</span>,
         cell: (info) => {
-          const { testRunId, testRunName, testRunIsDeleted } =
-            info.row.original;
-          const rowProjectId = info.row.original.project?.id || projectId;
+          const row = info.row.original;
+          if (isStepRow(row)) return null;
+          const { testRunId, testRunName, testRunIsDeleted } = row;
+          const rowProjectId = row.project?.id || projectId;
           return (
             <TestRunNameDisplay
               testRun={{
@@ -110,7 +193,7 @@ export function useExecutionLogColumns(
         size: 240,
         minSize: 150,
         maxSize: 500,
-      }) as ColumnDef<ExecutionLogRow, any>
+      }) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     columns.push(
@@ -119,37 +202,42 @@ export function useExecutionLogColumns(
         header: () => <span>{tCommon("actions.status")}</span>,
         cell: (info) => {
           const { status } = info.row.original;
-          if (!status) return null;
+          if (!status?.name) return null;
           return <StatusDotDisplay name={status.name} color={status.color} />;
         },
         enableSorting: true,
         size: 140,
         minSize: 100,
-      }) as ColumnDef<ExecutionLogRow, any>
+      }) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     columns.push(
-      columnHelper.accessor((row) => row.executedBy?.name ?? "", {
-        id: "executedBy",
-        header: () => <span>{tCommon("fields.executedBy")}</span>,
-        cell: (info) => {
-          const { executedBy } = info.row.original;
-          if (!executedBy?.id)
+      columnHelper.accessor(
+        (row) => (isStepRow(row) ? "" : (row.executedBy?.name ?? "")),
+        {
+          id: "executedBy",
+          header: () => <span>{tCommon("fields.executedBy")}</span>,
+          cell: (info) => {
+            const row = info.row.original;
+            if (isStepRow(row)) return null;
+            const { executedBy } = row;
+            if (!executedBy?.id)
+              return (
+                <span className="text-muted-foreground">
+                  {executedBy?.name || "-"}
+                </span>
+              );
             return (
-              <span className="text-muted-foreground">
-                {executedBy?.name || "-"}
-              </span>
+              <div className="truncate">
+                <UserNameCell userId={executedBy.id} />
+              </div>
             );
-          return (
-            <div className="truncate">
-              <UserNameCell userId={executedBy.id} />
-            </div>
-          );
-        },
-        enableSorting: true,
-        size: 160,
-        minSize: 120,
-      }) as ColumnDef<ExecutionLogRow, any>
+          },
+          enableSorting: true,
+          size: 160,
+          minSize: 120,
+        }
+      ) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     columns.push(
@@ -186,7 +274,7 @@ export function useExecutionLogColumns(
         },
         size: 160,
         minSize: 120,
-      }) as ColumnDef<ExecutionLogRow, any>
+      }) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     columns.push(
@@ -202,7 +290,7 @@ export function useExecutionLogColumns(
         enableSorting: true,
         size: 110,
         minSize: 80,
-      }) as ColumnDef<ExecutionLogRow, any>
+      }) as ColumnDef<ExecutionLogRowOrStep, any>
     );
 
     return columns;

--- a/testplanit/utils/executionLogSlots.test.ts
+++ b/testplanit/utils/executionLogSlots.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExpectedSlotsByCaseId,
+  mergeResultsIntoSlots,
+  tiptapToPlainText,
+  UNTESTED_STATUS,
+  type SharedGroupRow,
+  type SharedItemRow,
+  type StepResultRow,
+  type StepRow,
+} from "./executionLogSlots";
+
+function tiptapDoc(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("tiptapToPlainText", () => {
+  it("returns empty string for null / undefined / empty object", () => {
+    expect(tiptapToPlainText(null)).toBe("");
+    expect(tiptapToPlainText(undefined)).toBe("");
+    expect(tiptapToPlainText({})).toBe("");
+  });
+
+  it("returns empty string when input is a non-string, non-object primitive", () => {
+    expect(tiptapToPlainText(42)).toBe("");
+    expect(tiptapToPlainText(true)).toBe("");
+  });
+
+  it("extracts text from a simple paragraph", () => {
+    expect(tiptapToPlainText(tiptapDoc("Hello"))).toBe("Hello");
+  });
+
+  it("joins text from sibling text nodes with a single space", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Hello" },
+            { type: "text", text: "world" },
+          ],
+        },
+      ],
+    };
+    expect(tiptapToPlainText(doc)).toBe("Hello world");
+  });
+
+  it("ignores nodes without text (e.g. images)", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Before" },
+            { type: "image", attrs: { src: "x.png" } },
+            { type: "text", text: "after" },
+          ],
+        },
+      ],
+    };
+    expect(tiptapToPlainText(doc)).toBe("Before after");
+  });
+
+  it("parses a JSON-encoded string and recurses into it", () => {
+    const json = JSON.stringify(tiptapDoc("Stringified"));
+    expect(tiptapToPlainText(json)).toBe("Stringified");
+  });
+
+  it("falls back to the raw string when JSON parsing fails", () => {
+    expect(tiptapToPlainText("not json")).toBe("not json");
+  });
+});
+
+describe("buildExpectedSlotsByCaseId", () => {
+  it("returns an empty map when there are no case steps", () => {
+    const result = buildExpectedSlotsByCaseId([], [], []);
+    expect(result.size).toBe(0);
+  });
+
+  it("ranks placeholders 1-based by their position in the input order", () => {
+    const caseSteps: StepRow[] = [
+      {
+        id: 100,
+        testCaseId: 1,
+        order: 5, // raw order is arbitrary
+        sharedStepGroupId: null,
+        step: tiptapDoc("first step"),
+        expectedResult: tiptapDoc("first expected"),
+      },
+      {
+        id: 101,
+        testCaseId: 1,
+        order: 10,
+        sharedStepGroupId: null,
+        step: tiptapDoc("second step"),
+        expectedResult: tiptapDoc("second expected"),
+      },
+    ];
+    const slots = buildExpectedSlotsByCaseId(caseSteps, [], []).get(1)!;
+    expect(slots).toHaveLength(2);
+    expect(slots[0]).toMatchObject({
+      key: "100:0",
+      stepNumber: "1",
+      stepText: "first step",
+      expectedResult: "first expected",
+      sharedGroupName: null,
+    });
+    expect(slots[1]).toMatchObject({
+      key: "101:0",
+      stepNumber: "2",
+    });
+  });
+
+  it("expands shared-step placeholders into one slot per item with dotted numbers", () => {
+    const caseSteps: StepRow[] = [
+      {
+        id: 200,
+        testCaseId: 7,
+        order: 0,
+        sharedStepGroupId: 50,
+        step: null,
+        expectedResult: null,
+      },
+      {
+        id: 201,
+        testCaseId: 7,
+        order: 1,
+        sharedStepGroupId: 50,
+        step: null,
+        expectedResult: null,
+      },
+    ];
+    const sharedItems: SharedItemRow[] = [
+      {
+        id: 1,
+        order: 0,
+        sharedStepGroupId: 50,
+        step: tiptapDoc("item one"),
+        expectedResult: tiptapDoc("exp one"),
+      },
+      {
+        id: 2,
+        order: 1,
+        sharedStepGroupId: 50,
+        step: tiptapDoc("item two"),
+        expectedResult: tiptapDoc("exp two"),
+      },
+    ];
+    const sharedGroups: SharedGroupRow[] = [{ id: 50, name: "MyGroup" }];
+
+    const slots = buildExpectedSlotsByCaseId(
+      caseSteps,
+      sharedItems,
+      sharedGroups
+    ).get(7)!;
+    expect(slots.map((s) => s.stepNumber)).toEqual([
+      "1.1",
+      "1.2",
+      "2.1",
+      "2.2",
+    ]);
+    expect(slots.every((s) => s.sharedGroupName === "MyGroup")).toBe(true);
+    expect(slots[0]).toMatchObject({ key: "200:1", stepText: "item one" });
+    expect(slots[3]).toMatchObject({ key: "201:2", stepText: "item two" });
+  });
+
+  it("mixes regular and shared placeholders into a single ordered list", () => {
+    const caseSteps: StepRow[] = [
+      {
+        id: 1,
+        testCaseId: 1,
+        order: 0,
+        sharedStepGroupId: null,
+        step: tiptapDoc("regular A"),
+        expectedResult: null,
+      },
+      {
+        id: 2,
+        testCaseId: 1,
+        order: 1,
+        sharedStepGroupId: 99,
+        step: null,
+        expectedResult: null,
+      },
+      {
+        id: 3,
+        testCaseId: 1,
+        order: 2,
+        sharedStepGroupId: null,
+        step: tiptapDoc("regular B"),
+        expectedResult: null,
+      },
+    ];
+    const sharedItems: SharedItemRow[] = [
+      {
+        id: 10,
+        order: 0,
+        sharedStepGroupId: 99,
+        step: tiptapDoc("shared X"),
+        expectedResult: null,
+      },
+      {
+        id: 11,
+        order: 1,
+        sharedStepGroupId: 99,
+        step: tiptapDoc("shared Y"),
+        expectedResult: null,
+      },
+    ];
+
+    const slots = buildExpectedSlotsByCaseId(caseSteps, sharedItems, [
+      { id: 99, name: "Group" },
+    ]).get(1)!;
+
+    expect(slots.map((s) => s.stepNumber)).toEqual(["1", "2.1", "2.2", "3"]);
+    expect(slots.map((s) => s.stepText)).toEqual([
+      "regular A",
+      "shared X",
+      "shared Y",
+      "regular B",
+    ]);
+    expect(slots[0].sharedGroupName).toBeNull();
+    expect(slots[3].sharedGroupName).toBeNull();
+    expect(slots[1].sharedGroupName).toBe("Group");
+  });
+
+  it("falls back to null group name when no SharedStepGroup row is provided", () => {
+    const caseSteps: StepRow[] = [
+      {
+        id: 1,
+        testCaseId: 1,
+        order: 0,
+        sharedStepGroupId: 42,
+        step: null,
+        expectedResult: null,
+      },
+    ];
+    const sharedItems: SharedItemRow[] = [
+      {
+        id: 1,
+        order: 0,
+        sharedStepGroupId: 42,
+        step: tiptapDoc("only"),
+        expectedResult: null,
+      },
+    ];
+    const slots = buildExpectedSlotsByCaseId(caseSteps, sharedItems, []).get(
+      1
+    )!;
+    expect(slots[0].sharedGroupName).toBeNull();
+  });
+
+  it("handles a shared placeholder whose group has no items by producing zero slots for it", () => {
+    const caseSteps: StepRow[] = [
+      {
+        id: 1,
+        testCaseId: 1,
+        order: 0,
+        sharedStepGroupId: 999,
+        step: null,
+        expectedResult: null,
+      },
+      {
+        id: 2,
+        testCaseId: 1,
+        order: 1,
+        sharedStepGroupId: null,
+        step: tiptapDoc("after"),
+        expectedResult: null,
+      },
+    ];
+    const slots = buildExpectedSlotsByCaseId(caseSteps, [], []).get(1)!;
+    expect(slots).toHaveLength(1);
+    expect(slots[0].stepNumber).toBe("2");
+  });
+});
+
+describe("mergeResultsIntoSlots", () => {
+  const slots = [
+    {
+      key: "100:0",
+      stepNumber: "1",
+      stepText: "step one",
+      expectedResult: "expected one",
+      sharedGroupName: null,
+    },
+    {
+      key: "101:0",
+      stepNumber: "2",
+      stepText: "step two",
+      expectedResult: "expected two",
+      sharedGroupName: null,
+    },
+  ];
+
+  it("renders each slot as Untested when no results exist", () => {
+    const out = mergeResultsIntoSlots(slots, [], 555);
+    expect(out).toHaveLength(2);
+    out.forEach((row, i) => {
+      expect(row.status).toEqual(UNTESTED_STATUS);
+      expect(row.elapsed).toBeNull();
+      expect(row.executedAt).toBeNull();
+      expect(row.id).toBe(`slot-555-${slots[i].key}`);
+    });
+  });
+
+  it("merges a matching result onto its slot and uses the result's id", () => {
+    const result: StepResultRow = {
+      id: 999,
+      stepId: 100,
+      sharedStepItemId: null,
+      elapsed: 12,
+      executedAt: new Date("2025-01-15T10:00:00Z"),
+      stepStatus: { name: "Passed", color: { value: "#2A843F" } },
+    };
+    const out = mergeResultsIntoSlots(slots, [result], 555);
+    expect(out[0]).toMatchObject({
+      id: "step-999",
+      stepNumber: "1",
+      status: { name: "Passed", color: "#2A843F" },
+      elapsed: 12,
+      executedAt: "2025-01-15T10:00:00.000Z",
+    });
+    // slot 2 had no result -> still Untested
+    expect(out[1].status).toEqual(UNTESTED_STATUS);
+    expect(out[1].id).toBe("slot-555-101:0");
+  });
+
+  it("matches by (stepId, sharedStepItemId) — placeholders with the same stepId go to different slots", () => {
+    const sharedSlots = [
+      {
+        key: "200:1",
+        stepNumber: "1.1",
+        stepText: "shared a",
+        expectedResult: "",
+        sharedGroupName: "G",
+      },
+      {
+        key: "200:2",
+        stepNumber: "1.2",
+        stepText: "shared b",
+        expectedResult: "",
+        sharedGroupName: "G",
+      },
+    ];
+    const results: StepResultRow[] = [
+      {
+        id: 1,
+        stepId: 200,
+        sharedStepItemId: 1,
+        elapsed: null,
+        executedAt: null,
+        stepStatus: { name: "Passed", color: { value: "#2A843F" } },
+      },
+      {
+        id: 2,
+        stepId: 200,
+        sharedStepItemId: 2,
+        elapsed: null,
+        executedAt: null,
+        stepStatus: { name: "Failed", color: { value: "#F44B25" } },
+      },
+    ];
+    const out = mergeResultsIntoSlots(sharedSlots, results, 555);
+    expect(out[0].status.name).toBe("Passed");
+    expect(out[1].status.name).toBe("Failed");
+  });
+
+  it("accepts an ISO date string for executedAt and passes it through unchanged", () => {
+    const result: StepResultRow = {
+      id: 1,
+      stepId: 100,
+      sharedStepItemId: null,
+      elapsed: null,
+      executedAt: "2025-03-01T12:00:00.000Z",
+      stepStatus: null,
+    };
+    const out = mergeResultsIntoSlots(slots, [result], 555);
+    expect(out[0].executedAt).toBe("2025-03-01T12:00:00.000Z");
+    // Missing stepStatus -> fall back to Untested name/color
+    expect(out[0].status).toEqual(UNTESTED_STATUS);
+  });
+
+  it("does not match a result for a stepId that exists in another case (no cross-case leakage)", () => {
+    const result: StepResultRow = {
+      id: 999,
+      stepId: 200, // not in our slots
+      sharedStepItemId: null,
+      elapsed: null,
+      executedAt: null,
+      stepStatus: { name: "Passed", color: { value: "#2A843F" } },
+    };
+    const out = mergeResultsIntoSlots(slots, [result], 555);
+    out.forEach((row) => expect(row.status).toEqual(UNTESTED_STATUS));
+  });
+});

--- a/testplanit/utils/executionLogSlots.ts
+++ b/testplanit/utils/executionLogSlots.ts
@@ -1,0 +1,190 @@
+// Pure helpers for the execution-log report. Kept free of server-only imports
+// so they can be unit-tested without pulling in Prisma/auth.
+
+export interface ExecutionLogStepRow {
+  isStep: true;
+  id: string;
+  stepNumber: string;
+  stepText: string;
+  expectedResult: string;
+  sharedGroupName: string | null;
+  status: { name: string; color: string };
+  elapsed: number | null;
+  executedAt: string | null;
+}
+
+// Sentinel used for slots in the case definition that have no
+// TestRunStepResult row recorded yet. The client renders this with the same
+// Untested colour the system uses elsewhere.
+export const UNTESTED_STATUS = { name: "Untested", color: "#B1B2B3" };
+
+export function tiptapToPlainText(doc: unknown): string {
+  if (!doc) return "";
+  if (typeof doc === "string") {
+    try {
+      return tiptapToPlainText(JSON.parse(doc));
+    } catch {
+      return doc;
+    }
+  }
+  if (typeof doc !== "object") return "";
+  const node = doc as { text?: string; content?: unknown[] };
+  if (typeof node.text === "string") return node.text;
+  if (Array.isArray(node.content)) {
+    return node.content
+      .map((child) => tiptapToPlainText(child))
+      .filter(Boolean)
+      .join(" ");
+  }
+  return "";
+}
+
+export interface StepRow {
+  id: number;
+  order: number;
+  testCaseId: number;
+  sharedStepGroupId: number | null;
+  step: unknown;
+  expectedResult: unknown;
+}
+
+export interface SharedItemRow {
+  id: number;
+  order: number;
+  sharedStepGroupId: number;
+  step: unknown;
+  expectedResult: unknown;
+}
+
+export interface SharedGroupRow {
+  id: number;
+  name: string | null;
+}
+
+export interface ExpectedSlot {
+  key: string; // `${stepId}:${sharedItemId | 0}`
+  stepNumber: string;
+  stepText: string;
+  expectedResult: string;
+  sharedGroupName: string | null;
+}
+
+export interface StepResultRow {
+  id: number;
+  stepId: number;
+  sharedStepItemId: number | null;
+  elapsed: number | null;
+  executedAt: Date | string | null;
+  stepStatus: { name: string; color: { value: string } | null } | null;
+}
+
+/**
+ * Builds the canonical step list for each test case, expanding shared step
+ * group placeholders into one row per shared item. Step numbering matches the
+ * case detail page: 1-based sequential rank within the case (caller is
+ * expected to pass steps already ordered by `order` ASC, then `id` ASC), with
+ * dotted `placeholderRank.itemRank` for shared sub-items.
+ */
+export function buildExpectedSlotsByCaseId(
+  caseSteps: StepRow[],
+  sharedItems: SharedItemRow[],
+  sharedGroups: SharedGroupRow[]
+): Map<number, ExpectedSlot[]> {
+  const groupNameById = new Map<number, string>();
+  for (const g of sharedGroups) groupNameById.set(g.id, g.name ?? "");
+
+  const itemsByGroupId = new Map<number, SharedItemRow[]>();
+  for (const item of sharedItems) {
+    if (!itemsByGroupId.has(item.sharedStepGroupId)) {
+      itemsByGroupId.set(item.sharedStepGroupId, []);
+    }
+    itemsByGroupId.get(item.sharedStepGroupId)!.push(item);
+  }
+
+  const stepsByCaseId = new Map<number, StepRow[]>();
+  for (const s of caseSteps) {
+    if (!stepsByCaseId.has(s.testCaseId)) stepsByCaseId.set(s.testCaseId, []);
+    stepsByCaseId.get(s.testCaseId)!.push(s);
+  }
+
+  const slotsByCaseId = new Map<number, ExpectedSlot[]>();
+  for (const [caseId, steps] of stepsByCaseId.entries()) {
+    const slots: ExpectedSlot[] = [];
+    steps.forEach((step, stepIdx) => {
+      const placeholderRank = stepIdx + 1;
+      if (step.sharedStepGroupId != null) {
+        const items = itemsByGroupId.get(step.sharedStepGroupId) ?? [];
+        const groupName = groupNameById.get(step.sharedStepGroupId) ?? null;
+        items.forEach((item, itemIdx) => {
+          const itemRank = itemIdx + 1;
+          slots.push({
+            key: `${step.id}:${item.id}`,
+            stepNumber: `${placeholderRank}.${itemRank}`,
+            stepText: tiptapToPlainText(item.step).trim(),
+            expectedResult: tiptapToPlainText(item.expectedResult).trim(),
+            sharedGroupName: groupName,
+          });
+        });
+      } else {
+        slots.push({
+          key: `${step.id}:0`,
+          stepNumber: `${placeholderRank}`,
+          stepText: tiptapToPlainText(step.step).trim(),
+          expectedResult: tiptapToPlainText(step.expectedResult).trim(),
+          sharedGroupName: null,
+        });
+      }
+    });
+    slotsByCaseId.set(caseId, slots);
+  }
+  return slotsByCaseId;
+}
+
+/**
+ * Merges a test-run's actual step results into the case's expected slot list.
+ * Slots without a matching result render with the Untested sentinel status.
+ */
+export function mergeResultsIntoSlots(
+  expectedSlots: ExpectedSlot[],
+  stepResults: StepResultRow[],
+  testRunResultId: number
+): ExecutionLogStepRow[] {
+  const resultBySlotKey = new Map<string, StepResultRow>();
+  for (const sr of stepResults) {
+    resultBySlotKey.set(`${sr.stepId}:${sr.sharedStepItemId ?? 0}`, sr);
+  }
+  return expectedSlots.map((slot) => {
+    const sr = resultBySlotKey.get(slot.key);
+    if (sr) {
+      return {
+        isStep: true,
+        id: `step-${sr.id}`,
+        stepNumber: slot.stepNumber,
+        stepText: slot.stepText,
+        expectedResult: slot.expectedResult,
+        sharedGroupName: slot.sharedGroupName,
+        status: {
+          name: sr.stepStatus?.name ?? UNTESTED_STATUS.name,
+          color: sr.stepStatus?.color?.value ?? UNTESTED_STATUS.color,
+        },
+        elapsed: sr.elapsed ?? null,
+        executedAt: sr.executedAt
+          ? sr.executedAt instanceof Date
+            ? sr.executedAt.toISOString()
+            : sr.executedAt
+          : null,
+      };
+    }
+    return {
+      isStep: true,
+      id: `slot-${testRunResultId}-${slot.key}`,
+      stepNumber: slot.stepNumber,
+      stepText: slot.stepText,
+      expectedResult: slot.expectedResult,
+      sharedGroupName: slot.sharedGroupName,
+      status: UNTESTED_STATUS,
+      elapsed: null,
+      executedAt: null,
+    };
+  });
+}

--- a/testplanit/utils/executionLogUtils.ts
+++ b/testplanit/utils/executionLogUtils.ts
@@ -3,6 +3,16 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authenticateRequest } from "~/lib/api-token-auth";
 import { authOptions } from "~/server/auth";
+import {
+  buildExpectedSlotsByCaseId,
+  mergeResultsIntoSlots,
+  type ExecutionLogStepRow,
+  type SharedGroupRow,
+  type SharedItemRow,
+  type StepRow,
+} from "./executionLogSlots";
+
+export type { ExecutionLogStepRow } from "./executionLogSlots";
 
 export interface ExecutionLogRow {
   id: number;
@@ -18,6 +28,7 @@ export interface ExecutionLogRow {
   elapsed: number | null;
   testRunCaseVersion: number;
   project?: { id: number; name: string; iconUrl?: string | null };
+  steps?: ExecutionLogStepRow[];
 }
 
 export async function handleExecutionLogPOST(
@@ -116,6 +127,19 @@ export async function handleExecutionLogPOST(
               project: { select: { id: true, name: true, iconUrl: true } },
             },
           },
+          stepResults: {
+            where: { isDeleted: false },
+            select: {
+              id: true,
+              executedAt: true,
+              elapsed: true,
+              stepId: true,
+              sharedStepItemId: true,
+              stepStatus: {
+                select: { name: true, color: { select: { value: true } } },
+              },
+            },
+          },
         },
         orderBy,
         skip,
@@ -144,33 +168,104 @@ export async function handleExecutionLogPOST(
       count: s._count.id,
     }));
 
-    const data: ExecutionLogRow[] = rawResults.map((r: any) => ({
-      id: r.id,
-      testCaseId: r.testRunCase.repositoryCase.id,
-      testCaseName: r.testRunCase.repositoryCase.name,
-      testCaseSource: r.testRunCase.repositoryCase.source,
-      testRunId: r.testRun.id,
-      testRunName: r.testRun.name,
-      testRunIsDeleted: r.testRun.isDeleted,
-      status: {
-        name: r.status.name,
-        color: r.status.color?.value ?? "#6b7280",
-      },
-      executedBy: {
-        id: r.executedBy.id,
-        name: r.executedBy.name,
-      },
-      executedAt: r.executedAt.toISOString(),
-      elapsed: r.elapsed ?? null,
-      testRunCaseVersion: r.testRunCaseVersion,
-      project: r.testRun.project
-        ? {
-            id: r.testRun.project.id,
-            name: r.testRun.project.name,
-            iconUrl: r.testRun.project.iconUrl,
-          }
-        : undefined,
-    }));
+    // Materialise the full step list for every test case in the page so
+    // sub-rows can include slots that have no TestRunStepResult yet (rendered
+    // as Untested). Otherwise the report would silently drop unrecorded steps.
+    const testCaseIds = new Set<number>();
+    for (const r of rawResults as any[]) {
+      testCaseIds.add(r.testRunCase.repositoryCase.id);
+    }
+
+    const caseSteps: StepRow[] =
+      testCaseIds.size > 0
+        ? ((await prisma.steps.findMany({
+            where: {
+              testCaseId: { in: [...testCaseIds] },
+              isDeleted: false,
+            },
+            select: {
+              id: true,
+              order: true,
+              testCaseId: true,
+              sharedStepGroupId: true,
+              step: true,
+              expectedResult: true,
+            },
+            orderBy: [{ order: "asc" }, { id: "asc" }],
+          })) as StepRow[])
+        : [];
+
+    const sharedGroupIds = new Set<number>();
+    for (const s of caseSteps) {
+      if (s.sharedStepGroupId != null) sharedGroupIds.add(s.sharedStepGroupId);
+    }
+
+    const [sharedItems, sharedGroups] = await Promise.all([
+      sharedGroupIds.size > 0
+        ? (prisma.sharedStepItem.findMany({
+            where: { sharedStepGroupId: { in: [...sharedGroupIds] } },
+            select: {
+              id: true,
+              order: true,
+              sharedStepGroupId: true,
+              step: true,
+              expectedResult: true,
+            },
+            orderBy: [{ order: "asc" }, { id: "asc" }],
+          }) as Promise<SharedItemRow[]>)
+        : Promise.resolve<SharedItemRow[]>([]),
+      sharedGroupIds.size > 0
+        ? prisma.sharedStepGroup.findMany({
+            where: { id: { in: [...sharedGroupIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const expectedSlotsByCaseId = buildExpectedSlotsByCaseId(
+      caseSteps,
+      sharedItems,
+      sharedGroups as SharedGroupRow[]
+    );
+
+    const data: ExecutionLogRow[] = rawResults.map((r: any) => {
+      const caseId = r.testRunCase.repositoryCase.id;
+      const expectedSlots = expectedSlotsByCaseId.get(caseId) ?? [];
+      const steps = mergeResultsIntoSlots(
+        expectedSlots,
+        r.stepResults ?? [],
+        r.id
+      );
+
+      return {
+        id: r.id,
+        testCaseId: r.testRunCase.repositoryCase.id,
+        testCaseName: r.testRunCase.repositoryCase.name,
+        testCaseSource: r.testRunCase.repositoryCase.source,
+        testRunId: r.testRun.id,
+        testRunName: r.testRun.name,
+        testRunIsDeleted: r.testRun.isDeleted,
+        status: {
+          name: r.status.name,
+          color: r.status.color?.value ?? "#6b7280",
+        },
+        executedBy: {
+          id: r.executedBy.id,
+          name: r.executedBy.name,
+        },
+        executedAt: r.executedAt.toISOString(),
+        elapsed: r.elapsed ?? null,
+        testRunCaseVersion: r.testRunCaseVersion,
+        project: r.testRun.project
+          ? {
+              id: r.testRun.project.id,
+              name: r.testRun.project.name,
+              iconUrl: r.testRun.project.iconUrl,
+            }
+          : undefined,
+        steps: steps.length > 0 ? steps : undefined,
+      };
+    });
 
     return Response.json({ data, total, statusBreakdown });
   } catch (e: unknown) {


### PR DESCRIPTION
## Description

Each row in the **Execution Log** report is now expandable to reveal step-level results for the test case execution. Every expected step in the case definition appears as a sub-row — including steps that were never recorded during the run (rendered as **Untested**) — with the step action, expected result, per-step status, executed-at, and duration.

Shared step group items are numbered as `N.M` (matching the case detail page) and marked with a Shared Step icon whose tooltip surfaces the group name. Long step / expected-result text is truncated to two lines with the full plain text available on hover.

A small fix in `DataTable` was required to make this work: the grouped / aggregated / placeholder cell branches are now gated on `grouping.length > 0`, so cells in parent rows with sub-rows (but no grouping) render normally instead of being swallowed by the aggregated branch.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests — added `utils/executionLogSlots.test.ts` (18 tests covering tiptap text extraction, slot materialization for regular + shared steps, result-to-slot merging, and Untested fallback)
- [x] Manual testing — verified in Playwright against multiple cases:
  - A case with regular steps and partial results (5 of 10 recorded) → all 10 rows render with the correct 1-based numbering, missing 5 show as Untested
  - A case with 2 shared-step placeholders × 3 items (4 of 6 recorded) → all 6 rows render numbered 1.1–2.3, missing 2 show as Untested, Layers icon + tooltip on every row
- [x] Spot-checked report-builder grouping (test-execution report with `dimensions=status,user`) to confirm the DataTable change didn't regress grouped tables — group rows, aggregated cells, and child rows all render correctly

**Test Configuration:**
- OS: macOS (Darwin 25.4.0)
- Browser: Chrome (via Playwright)
- Node: v24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- `pnpm precommit` passes (8012 / 111 skipped, 0 errors).
- The `Untested` status used for unrecorded slots is a sentinel `{ name: "Untested", color: "#B1B2B3" }` — matches the system colour used elsewhere.