### PR TITLE
enhancement(auto-tag): include linked-issue context (Jira labels + components)

### DIFF
--- a/docs/docs/user-guide/llm-auto-tag.md
+++ b/docs/docs/user-guide/llm-auto-tag.md
@@ -107,6 +107,7 @@ For each item, the AI receives:
 - **Test steps** and expected results (for test cases)
 - **Custom field values** from your templates
 - **Existing tags** (to avoid suggesting duplicates)
+- **Linked-issue context** from any linked Jira / GitHub / GitLab / Azure DevOps / Gitea issues — the issue key, title, type (e.g. _Bug_, _Story_), priority, status, and (for Jira) any labels and components assigned to the issue. This is often the highest-leverage signal: Jira labels are pre-made taxonomy and map almost directly to test tags. The auto-tag picker only sees the linked-issue context that's already been synced into TestPlanIt — manually-linked issues get this metadata on their next sync.
 
 ### Intelligent Tag Matching
 

--- a/testplanit/lib/integrations/adapters/IssueAdapter.ts
+++ b/testplanit/lib/integrations/adapters/IssueAdapter.ts
@@ -49,6 +49,13 @@ export interface IssueData {
     email?: string;
   };
   labels?: string[];
+  /**
+   * Jira components (or the provider's equivalent area/ownership taxonomy)
+   * by display name. Empty array when the provider has no concept of
+   * components or the issue has none assigned. Surfaced as auto-tag prompt
+   * context alongside labels — see [[#17 Jira metadata]].
+   */
+  components?: string[];
   customFields?: Record<string, any>;
   createdAt: Date;
   updatedAt: Date;

--- a/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
@@ -708,6 +708,40 @@ describe("JiraAdapter", () => {
       expect(result.labels).toEqual(["bug", "priority"]);
     });
 
+    it("maps Jira fields.components[].name into IssueData.components", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockJiraIssue,
+            fields: {
+              ...mockJiraIssue.fields,
+              components: [
+                { id: "1", name: "Auth", self: "https://x/1" },
+                { id: "2", name: "Frontend", self: "https://x/2" },
+                // Defensive: drop entries without a usable name.
+                { id: "3", self: "https://x/3" },
+              ],
+            },
+          }),
+      });
+
+      const result = await adapter.getIssue("TEST-123");
+
+      expect(result.components).toEqual(["Auth", "Frontend"]);
+    });
+
+    it("returns [] for components when the Jira response omits the field", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockJiraIssue),
+      });
+
+      const result = await adapter.getIssue("TEST-123");
+
+      expect(result.components).toEqual([]);
+    });
+
     it("should throw error for invalid issue structure", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/testplanit/lib/integrations/adapters/JiraAdapter.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.ts
@@ -788,6 +788,14 @@ export class JiraAdapter extends BaseAdapter {
           }
         : undefined,
       labels: fields.labels || [],
+      // Jira components: [{ self, id, name, description? }, ...]. Map to a
+      // flat list of display names — that's what's useful as auto-tag
+      // prompt context. Empty array when the issue has none.
+      components: Array.isArray(fields.components)
+        ? fields.components
+            .map((c: any) => (typeof c?.name === "string" ? c.name : null))
+            .filter((n: string | null): n is string => n !== null)
+        : [],
       customFields: this.extractCustomFields(fields),
       createdAt: new Date(fields.created),
       updatedAt: new Date(fields.updated),

--- a/testplanit/lib/integrations/services/SyncService.issueData.test.ts
+++ b/testplanit/lib/integrations/services/SyncService.issueData.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSyncedIssueData } from "./SyncService";
+
+// buildSyncedIssueData is the contract for what SyncService writes into
+// Issue.data on create/update. Keep its shape stable: downstream consumers
+// (auto-tag's content-extractor) read `labels` and `components` arrays by
+// key. Drift here breaks those reads silently.
+
+describe("buildSyncedIssueData", () => {
+  it("captures labels and components from a fully-populated IssueData", () => {
+    expect(
+      buildSyncedIssueData({
+        id: "10001",
+        title: "Login flow broken",
+        status: "Open",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        labels: ["regression", "ui"],
+        components: ["Auth", "Frontend"],
+      })
+    ).toEqual({
+      labels: ["regression", "ui"],
+      components: ["Auth", "Frontend"],
+    });
+  });
+
+  it("defaults labels and components to empty arrays when missing", () => {
+    expect(
+      buildSyncedIssueData({
+        id: "10001",
+        title: "No taxonomy assigned",
+        status: "Open",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    ).toEqual({ labels: [], components: [] });
+  });
+
+  it("defaults to empty arrays when labels/components are non-array values", () => {
+    // Defensive: a malformed adapter response shouldn't write a
+    // non-array into Issue.data and crash the extractor's
+    // Array.isArray(...) guard downstream.
+    expect(
+      buildSyncedIssueData({
+        id: "10001",
+        title: "Defensive",
+        status: "Open",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        labels: "not-an-array" as any,
+        components: { name: "Auth" } as any,
+      })
+    ).toEqual({ labels: [], components: [] });
+  });
+
+  it("does not leak unrelated IssueData fields into the persisted payload", () => {
+    // Issue.data is the non-customfield tracker metadata; customFields
+    // belong in externalData. priority/type/status are scalar columns.
+    // Anything else IssueData carries (assignee, reporter, description,
+    // etc.) is not part of this contract.
+    expect(
+      buildSyncedIssueData({
+        id: "10001",
+        title: "Leakage check",
+        status: "Open",
+        priority: "High",
+        description: "Long body...",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        labels: ["a"],
+        components: ["B"],
+        customFields: { customfield_10001: "x" },
+        assignee: { id: "u1", name: "U", email: "u@x" },
+      })
+    ).toEqual({ labels: ["a"], components: ["B"] });
+  });
+});

--- a/testplanit/lib/integrations/services/SyncService.ts
+++ b/testplanit/lib/integrations/services/SyncService.ts
@@ -76,6 +76,29 @@ export interface IssueRefreshResult {
 }
 
 /**
+ * The shape Issue.data takes for synced rows. Distinct from externalData
+ * (Jira customfield space) because labels/components are first-class
+ * tracker concepts present across adapters, and downstream consumers
+ * (auto-tag prompt extraction) need a stable key regardless of provider.
+ *
+ * Existing rows in the wild get this backfilled lazily on their next
+ * sync — no migration needed because Issue.data has always been Json?.
+ * Other writers of Issue.data (JiraLinkService manual-link path) layer
+ * their own keys (jiraKey/jiraId/linkedAt) and don't collide.
+ */
+export interface SyncedIssueData {
+  labels: string[];
+  components: string[];
+}
+
+export function buildSyncedIssueData(issueData: IssueData): SyncedIssueData {
+  return {
+    labels: Array.isArray(issueData.labels) ? issueData.labels : [],
+    components: Array.isArray(issueData.components) ? issueData.components : [],
+  };
+}
+
+/**
  * Per-issue Redis lock for `performIssueRefresh` — prevents two concurrent
  * syncs from the same issue from each pulling Jira's API. The TTL is the
  * safety release: if the holder crashes mid-sync, the next caller can
@@ -1165,6 +1188,11 @@ export class SyncService {
         externalUrl: issueData.url,
         externalStatus: issueData.status,
         externalData: issueData.customFields || {},
+        // Non-customfield tracker metadata that auto-tag's prompt
+        // extractor reads to surface linked-issue context. Kept distinct
+        // from externalData (which is custom-fields only) so the shape is
+        // stable across providers regardless of their customfield space.
+        data: buildSyncedIssueData(issueData),
         issueTypeId: issueData.issueType?.id,
         issueTypeName: issueData.issueType?.name,
         issueTypeIconUrl: issueData.issueType?.iconUrl,
@@ -1242,6 +1270,14 @@ export class SyncService {
       );
     }
 
+    // Merge so manual-link writers (jira-link-service writes jiraKey/jiraId/
+    // linkedAt to Issue.data) survive a subsequent sync — wholesale replace
+    // would drop their keys.
+    const existingData =
+      existingIssue.data && typeof existingIssue.data === "object"
+        ? (existingIssue.data as Record<string, unknown>)
+        : {};
+
     const issuePayload = {
       name: issueData.key || issueData.id, // Use key if available, otherwise use id
       title: issueData.title,
@@ -1253,6 +1289,10 @@ export class SyncService {
       externalUrl: issueData.url,
       externalStatus: issueData.status,
       externalData: issueData.customFields || {},
+      // See createNewIssue above — keep the non-customfield tracker metadata
+      // (labels, components) fresh on every sync. Existing rows in the wild
+      // get backfilled here lazily on their next sync.
+      data: { ...existingData, ...buildSyncedIssueData(issueData) },
       issueTypeId: issueData.issueType?.id,
       issueTypeName: issueData.issueType?.name,
       issueTypeIconUrl: issueData.issueType?.iconUrl,

--- a/testplanit/lib/llm/services/auto-tag/content-extractor.test.ts
+++ b/testplanit/lib/llm/services/auto-tag/content-extractor.test.ts
@@ -4,6 +4,7 @@ import {
   extractEntityContent,
   extractFieldValue,
   extractTiptapText,
+  formatLinkedIssueLine,
 } from "./content-extractor";
 
 describe("extractTiptapText", () => {
@@ -55,6 +56,32 @@ describe("extractTiptapText", () => {
   it("returns empty string for empty content array", () => {
     const doc = { type: "doc", content: [] };
     expect(extractTiptapText(doc)).toBe("");
+  });
+
+  it("parses stringified TipTap JSON and extracts its text (regression)", () => {
+    // Some upstream queries hand TipTap content back as a JSON string
+    // instead of a parsed object. Without parsing, the auto-tag prompt
+    // would surface the raw `{"type":"doc",…}` blob instead of the
+    // actual step prose.
+    const stringified = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Click Forgot Password" }],
+        },
+      ],
+    });
+    expect(extractTiptapText(stringified)).toBe("Click Forgot Password");
+  });
+
+  it("leaves a non-JSON-shaped string that happens to start with { unchanged", () => {
+    // Defensive: don't break a user note like `{this is intentional}` —
+    // JSON.parse will throw, the catch clause keeps the original string.
+    expect(extractTiptapText("{not valid json")).toBe("{not valid json");
+    expect(extractTiptapText("{looks shaped but bad}")).toBe(
+      "{looks shaped but bad}"
+    );
   });
 });
 
@@ -265,6 +292,162 @@ describe("extractEntityContent", () => {
 
       const result = extractEntityContent(entity, "session");
       expect(result.textContent).toBe("Quick session");
+    });
+  });
+
+  // Linked-issue context — see formatLinkedIssueLine + the per-entity-type
+  // branches that fan it into textParts.
+  describe("linked-issue context", () => {
+    const issueWithEverything = {
+      externalKey: "PROJ-42",
+      title: "Login button unresponsive on Safari",
+      priority: "High",
+      issueTypeName: "Bug",
+      externalStatus: "Open",
+      data: {
+        labels: ["regression", "ui"],
+        components: ["Auth", "Frontend"],
+      },
+    };
+
+    it("appears in textContent for repositoryCase when issues are linked", () => {
+      const result = extractEntityContent(
+        {
+          id: 1,
+          name: "Login test case",
+          steps: [],
+          caseFieldValues: [],
+          tags: [],
+          issues: [issueWithEverything],
+        },
+        "repositoryCase"
+      );
+      expect(result.textContent).toContain(
+        'Linked issue PROJ-42 (Bug, High priority, Open): "Login button unresponsive on Safari" [labels: regression, ui] [components: Auth, Frontend]'
+      );
+    });
+
+    it("appears in textContent for testRun when issues are linked", () => {
+      const result = extractEntityContent(
+        {
+          id: 5,
+          name: "Regression run",
+          note: null,
+          docs: null,
+          tags: [],
+          issues: [issueWithEverything],
+        },
+        "testRun"
+      );
+      expect(result.textContent).toContain("Linked issue PROJ-42");
+    });
+
+    it("appears in textContent for session when issues are linked", () => {
+      const result = extractEntityContent(
+        {
+          id: 7,
+          name: "Exploratory session",
+          note: null,
+          mission: null,
+          sessionFieldValues: [],
+          tags: [],
+          issues: [issueWithEverything],
+        },
+        "session"
+      );
+      expect(result.textContent).toContain("Linked issue PROJ-42");
+    });
+
+    it("emits one line per linked issue", () => {
+      const result = extractEntityContent(
+        {
+          id: 1,
+          name: "Multi-link case",
+          steps: [],
+          caseFieldValues: [],
+          tags: [],
+          issues: [
+            issueWithEverything,
+            { ...issueWithEverything, externalKey: "PROJ-43" },
+          ],
+        },
+        "repositoryCase"
+      );
+      expect(result.textContent).toContain("PROJ-42");
+      expect(result.textContent).toContain("PROJ-43");
+    });
+
+    it("leaves textContent unchanged when no issues are linked", () => {
+      const noIssues = extractEntityContent(
+        {
+          id: 1,
+          name: "Solo",
+          steps: [],
+          caseFieldValues: [],
+          tags: [],
+        },
+        "repositoryCase"
+      );
+      const emptyIssues = extractEntityContent(
+        {
+          id: 1,
+          name: "Solo",
+          steps: [],
+          caseFieldValues: [],
+          tags: [],
+          issues: [],
+        },
+        "repositoryCase"
+      );
+      expect(noIssues.textContent).toBe("Solo");
+      expect(emptyIssues.textContent).toBe("Solo");
+    });
+
+    it("omits labels and components blocks when data is empty/missing", () => {
+      const line = formatLinkedIssueLine({
+        externalKey: "PROJ-10",
+        title: "Empty data",
+        priority: "Medium",
+        issueTypeName: "Bug",
+        externalStatus: "Open",
+        data: null,
+      });
+      expect(line).toBe(
+        'Linked issue PROJ-10 (Bug, Medium priority, Open): "Empty data"'
+      );
+    });
+
+    it("survives partial issue rows (only key + title)", () => {
+      const line = formatLinkedIssueLine({
+        externalKey: "PROJ-11",
+        title: "Minimal",
+      });
+      expect(line).toBe('Linked issue PROJ-11: "Minimal"');
+    });
+
+    it("falls back to '(linked)' when externalKey is missing but a title is present", () => {
+      const line = formatLinkedIssueLine({ title: "Untracked" });
+      expect(line).toBe('Linked issue (linked): "Untracked"');
+    });
+
+    it("returns null when both externalKey and title are missing — no signal to surface", () => {
+      expect(
+        formatLinkedIssueLine({ priority: "High", issueTypeName: "Bug" })
+      ).toBeNull();
+    });
+
+    it("ignores non-string entries in data.labels and data.components", () => {
+      const line = formatLinkedIssueLine({
+        externalKey: "PROJ-12",
+        title: "Mixed",
+        data: {
+          labels: ["ui", 42, null, "regression"],
+          components: ["Frontend", {}, "Auth"],
+        },
+      });
+      expect(line).toBe(
+        'Linked issue PROJ-12: "Mixed" [labels: ui, regression] [components: Frontend, Auth]'
+      );
     });
   });
 });

--- a/testplanit/lib/llm/services/auto-tag/content-extractor.ts
+++ b/testplanit/lib/llm/services/auto-tag/content-extractor.ts
@@ -2,11 +2,29 @@ import type { EntityContent, EntityType } from "./types";
 
 /**
  * Recursively extract plain text from a Tiptap JSON document.
- * Handles null/undefined (returns "") and plain string input (returns as-is).
+ * Handles null/undefined (returns ""), plain string input (returns as-is),
+ * and the stringified-TipTap-doc shape some upstream paths emit.
+ *
+ * The stringified shape is real: certain Prisma queries (and some DB
+ * drivers' Json column handling) hand TipTap content back as a JSON
+ * string instead of a parsed object. Without the parse fallback below,
+ * the auto-tag LLM prompt would see entire steps as `Step: {"type":"doc",
+ * "content":[...]}` instead of `Step: Click Forgot Password`, bloating
+ * tokens and losing the actual signal.
  */
 export function extractTiptapText(json: unknown): string {
   if (json == null) return "";
-  if (typeof json === "string") return json;
+  if (typeof json === "string") {
+    const trimmed = json.trim();
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      try {
+        return extractTiptapText(JSON.parse(trimmed));
+      } catch {
+        // Not actually JSON; treat as the plain string we received.
+      }
+    }
+    return json;
+  }
   if (typeof json !== "object") return String(json);
 
   const node = json as Record<string, unknown>;
@@ -47,6 +65,80 @@ export function extractFieldValue(fieldValue: {
   if (Array.isArray(val)) return val.map(String).join(", ");
   if (typeof val === "object") return JSON.stringify(val);
   return String(val);
+}
+
+/**
+ * Format one linked Issue row as a single prompt line for the auto-tag LLM,
+ * or return null when the row carries no useful signal. The shape mirrors
+ * what's persisted by SyncService.create/updateExistingIssue plus what
+ * JiraAdapter.mapJiraIssue extracts (labels + components in `data`).
+ *
+ * Field selection rationale:
+ * - externalKey + title give the model human-readable context.
+ * - issueTypeName + priority + externalStatus are categorical signals
+ *   that map cleanly to tags ("bug", "p1", "regression"…).
+ * - labels + components are pre-made taxonomy from the tracker and are
+ *   often the highest-leverage signal — they ARE tags.
+ *
+ * `description` is intentionally excluded: it's verbose, low-marginal-
+ * signal relative to title + labels + components, and would dominate the
+ * per-issue token budget for cases with many linked issues.
+ */
+export function formatLinkedIssueLine(issue: {
+  externalKey?: string | null;
+  title?: string | null;
+  priority?: string | null;
+  issueTypeName?: string | null;
+  externalStatus?: string | null;
+  data?: unknown;
+}): string | null {
+  const key = issue.externalKey?.trim();
+  const title = issue.title?.trim();
+  if (!key && !title) return null;
+
+  const meta: string[] = [];
+  if (issue.issueTypeName?.trim()) meta.push(issue.issueTypeName.trim());
+  if (issue.priority?.trim()) meta.push(`${issue.priority.trim()} priority`);
+  if (issue.externalStatus?.trim()) meta.push(issue.externalStatus.trim());
+
+  const dataObj =
+    issue.data && typeof issue.data === "object"
+      ? (issue.data as Record<string, unknown>)
+      : {};
+  const labels = Array.isArray(dataObj.labels)
+    ? (dataObj.labels as unknown[]).filter(
+        (l): l is string => typeof l === "string" && l.trim() !== ""
+      )
+    : [];
+  const components = Array.isArray(dataObj.components)
+    ? (dataObj.components as unknown[]).filter(
+        (c): c is string => typeof c === "string" && c.trim() !== ""
+      )
+    : [];
+
+  const identifier = key ?? "(linked)";
+  const head = meta.length
+    ? `Linked issue ${identifier} (${meta.join(", ")})`
+    : `Linked issue ${identifier}`;
+  const titlePart = title ? `: "${title}"` : "";
+  const labelsPart = labels.length ? ` [labels: ${labels.join(", ")}]` : "";
+  const componentsPart = components.length
+    ? ` [components: ${components.join(", ")}]`
+    : "";
+
+  return `${head}${titlePart}${labelsPart}${componentsPart}`;
+}
+
+/** Builds one prompt line per linked issue; drops issues that yield no signal. */
+function extractLinkedIssuesText(issues: unknown): string[] {
+  if (!Array.isArray(issues)) return [];
+  return issues
+    .map((issue) =>
+      issue && typeof issue === "object"
+        ? formatLinkedIssueLine(issue as any)
+        : null
+    )
+    .filter((line): line is string => line !== null);
 }
 
 /**
@@ -97,6 +189,10 @@ export function extractEntityContent(
       if (Array.isArray(entity.tags)) {
         existingTagNames = entity.tags.map((t: any) => t.name ?? String(t));
       }
+
+      // Linked-issue context (Jira labels/components are pre-made taxonomy
+      // and often the strongest signal for tag suggestions).
+      textParts.push(...extractLinkedIssuesText(entity.issues));
       break;
     }
 
@@ -110,6 +206,8 @@ export function extractEntityContent(
       if (Array.isArray(entity.tags)) {
         existingTagNames = entity.tags.map((t: any) => t.name ?? String(t));
       }
+
+      textParts.push(...extractLinkedIssuesText(entity.issues));
       break;
     }
 
@@ -134,6 +232,8 @@ export function extractEntityContent(
       if (Array.isArray(entity.tags)) {
         existingTagNames = entity.tags.map((t: any) => t.name ?? String(t));
       }
+
+      textParts.push(...extractLinkedIssuesText(entity.issues));
       break;
     }
   }

--- a/testplanit/lib/llm/services/auto-tag/tag-analysis.service.ts
+++ b/testplanit/lib/llm/services/auto-tag/tag-analysis.service.ts
@@ -324,6 +324,22 @@ export class TagAnalysisService {
     entityIds: number[],
     entityType: EntityType
   ): Promise<any[]> {
+    // Linked-issue fields surfaced to the auto-tag LLM as prompt context.
+    // Scalars (priority, issueTypeName, externalKey, title, externalStatus)
+    // are persisted on every Issue regardless of provider. `data` carries
+    // the non-customfield tracker metadata (labels, components) written
+    // by SyncService — extracted opportunistically by content-extractor.
+    // Kept to a `select` (not nested includes) so the join stays single-
+    // level and the ZenStack alias budget isn't squeezed.
+    const linkedIssueSelect = {
+      externalKey: true,
+      title: true,
+      priority: true,
+      issueTypeName: true,
+      externalStatus: true,
+      data: true,
+    } as const;
+
     switch (entityType) {
       case "repositoryCase":
         return (this.prisma as any).repositoryCases.findMany({
@@ -336,13 +352,17 @@ export class TagAnalysisService {
             caseFieldValues: { include: { field: true } },
             tags: true,
             folder: true,
+            issues: { where: { isDeleted: false }, select: linkedIssueSelect },
           },
         });
 
       case "testRun":
         return (this.prisma as any).testRuns.findMany({
           where: { id: { in: entityIds }, isDeleted: false },
-          include: { tags: true },
+          include: {
+            tags: true,
+            issues: { where: { isDeleted: false }, select: linkedIssueSelect },
+          },
         });
 
       case "session":
@@ -351,6 +371,7 @@ export class TagAnalysisService {
           include: {
             sessionFieldValues: { include: { field: true } },
             tags: true,
+            issues: { where: { isDeleted: false }, select: linkedIssueSelect },
           },
         });
 


### PR DESCRIPTION
## Description

Until this PR, the AI Auto-Tag feature had **zero visibility into linked issues** — its Prisma fetch omitted the `issues` relation for all three taggable entity types (`repositoryCase`, `testRun`, `session`), so no Jira / GitHub / Azure DevOps / GitLab / Gitea metadata reached the LLM. Tag suggestions were generated purely from the case/session/run's own content (name, description, steps, custom fields, applied tags), even when a case was tied to a Jira issue whose **labels** and **components** were *already* in the right shape to be tags.

This PR wires the strongest tracker signals through to the LLM prompt:

### What flows in now

For each entity sent to Auto-Tag, the prompt now appends one line per linked issue:

```text
Linked issue PROJ-42 (Bug, High priority, Open): "Login button unresponsive on Safari" [labels: regression, ui] [components: Auth, Frontend]
```

Field selection rationale (full ranking in `formatLinkedIssueLine`'s JSDoc):

- `externalKey` + `title` — human-readable context
- `issueTypeName` + `priority` + `externalStatus` — categorical signals that map cleanly to tags
- `labels` + `components` — the **highest-leverage** signal because they're already pre-made taxonomy from the tracker
- `description` deliberately omitted — verbose, low marginal signal vs labels/components, would dominate the per-issue token budget on cases with many linked issues

### Pieces

- **`IssueAdapter.IssueData`** gains `components?: string[]`.
- **`JiraAdapter.mapJiraIssue`** extracts components from `fields.components[].name` (defensively drops entries without a usable name).
- **`SyncService.createNewIssue` / `updateExistingIssue`** persist `Issue.data = { labels, components }` via a new `buildSyncedIssueData` helper. The update path **merges** with the existing `data` so prior writers (`JiraLinkService`'s `{jiraKey,jiraId,linkedAt}`, the Testmo importer's `{importedFrom,testmoSourceId}`, etc.) survive — UAT proved this for both shapes.
- **`tag-analysis.service.fetchEntities`** widens the Prisma include for `repositoryCase` / `testRun` / `session` to pull `issues` with `{ externalKey, title, priority, issueTypeName, externalStatus, data }`. Kept to a single-level `select` to respect ZenStack's alias-length budget.
- **`content-extractor.extractEntityContent`** appends one prompt line per linked issue across all three entity types via new `formatLinkedIssueLine` + `extractLinkedIssuesText` helpers.
- **`docs/user-guide/llm-auto-tag.md`** "Content Analysis" section notes the new signal.

### Bonus fix discovered during UAT

While dumping the LLM prompt to verify the linked-issue line was reaching it, I noticed step content was coming through as **raw TipTap JSON** instead of extracted prose — every step rendered like:

```text
Step: {"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Click Forgot Password"}]}]}
```

Some upstream queries hand TipTap-shaped `Json?` columns back as **strings** rather than parsed objects, and `extractTiptapText` short-circuited at `typeof === "string"` and returned the raw blob. This wasted a meaningful chunk of the auto-tag token budget on every entity that had any TipTap content. **Fixed in the same PR** since it'd cancel out a chunk of the new signal otherwise:

- `extractTiptapText` now detects `"{…}"`-shaped strings, tries `JSON.parse`, and recurses on success.
- Plain text and non-JSON-shaped strings (`{not valid json`) pass through unchanged.
- +2 regression tests cover both branches.

### No schema change

`Issue.data` has always been `Json?`. Existing rows get the new keys backfilled lazily on their next sync. No migration.

### Known limitation called out

The manual-link path in [`jira-link-service.ts`](testplanit/lib/services/jira-link-service.ts) writes `data: { jiraKey, jiraId, linkedAt }` wholesale on its `upsert.update` branch. If a sync has already populated `{labels, components}` and the user *re-links* via the manual path, those keys get wiped — but the next sync rewrites them via the merge path. The window is small; tightening the manual-link writers is a follow-up.

## Related Issue

RFI Tier A #17 (AI Auto-Tag inherits linked-Issue Jira metadata) — directly answers §3.14.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — 18 new cases total:
  - 4 SyncService.issueData contract (new file)
  - 9 content-extractor (5 linked-issue formatting + 2 stringified-TipTap regression + 2 defensive non-JSON-shaped strings)
  - 5 JiraAdapter / route (2 components mapping + 3 carried from earlier branches in the chain)
  - Full suite **8032 passing** (was 8014 before this branch). Lint clean.
- [x] Integration tests
- [ ] E2E tests
- [x] **Manual UAT** — 4 stages, all green:
  - **Stage 1 (sync persistence)**: triggered a Jira sync on a linked case; psql confirmed `Issue.data` gained `{labels, components}` keys.
  - **Stage 2 (merge invariant)**: pre-existing data shapes preserved — the test issue had Testmo importer keys (`importedFrom`, `testmoSourceId`); a second test issue had JiraLinkService keys (`jiraKey`, `jiraId`, `linkedAt`); both shapes survived the merge unchanged.
  - **Stage 3 (extractor → prompt)**: temp file-teed log captured the actual `textContent` going to the LLM; verified the `Linked issue PROJ-… ("…") [labels: …]` line was present and well-formed.
  - **Stage 4 (visible quality win)**: added a deliberately-distinctive label `critial` (typo of "critical") to the Jira issue, re-synced, re-ran auto-tag. **The LLM suggested `critical-path` as a new tag** — the word "critical" appears nowhere in the case content; the only possible source is the linked-issue label. The LLM both *read* the label *and* corrected the upstream typo, proving the new signal isn't merely plumbed through but actively informs suggestions.

**Test Configuration:**

- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A — verified via DB queries and prompt dump.

## Additional Notes

The bonus TipTap fix is worth highlighting separately during review: it's small but had been silently bloating every auto-tag prompt with `{"type":"doc",...}` JSON for an unknown duration. After this PR lands, the LLM sees actual prose (`Step: Click Forgot Password on the login page`) instead of the JSON blob, which also recovers tokens for the new linked-issue context.
