### PR TITLE
enhancement(attachments): first-class external-link attachments across all surfaces

### DIFF
--- a/docs/docs/file-storage.md
+++ b/docs/docs/file-storage.md
@@ -139,6 +139,14 @@ Users can attach files in several ways:
 3. **Rich Text Editor**: Paste images directly into rich text fields
 4. **Bulk Upload**: Select multiple files at once
 
+### External Links as Attachments
+
+Anywhere you can upload a file as an attachment — test cases, test runs, results, exploratory sessions — you can also attach an **external link** instead of a file. Click **Add Link** next to the file picker, paste the URL, optionally give it a display name and a short description, and click Add. The link appears in the attachment list alongside any uploaded files.
+
+External-link attachments are stored as regular `Attachments` rows with `mimeType: "text/uri-list"` — no file is uploaded to S3/MinIO, the URL itself is the payload. The attachment list renders them with a link icon (instead of a file thumbnail) and opens them in a new tab when clicked. Display, edit, and delete behave the same as for file attachments.
+
+Use this when the evidence lives in another system — a Jira ticket, a CI build, a Looker dashboard, a Confluence runbook, a recorded session — rather than as a downloadable file.
+
 ### Storage Modes
 
 TestPlanIt supports two upload modes depending on your deployment:

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
@@ -36,7 +36,9 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApplicationArea, Prisma } from "@prisma/client";
 import { useQueryClient } from "@tanstack/react-query";
@@ -309,6 +311,7 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [linkedIssueIds, setLinkedIssueIds] = useState<number[]>([]);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
 
   const {
     data: sharedStepGroupsData,
@@ -510,6 +513,7 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
 
   const handleCancel = () => {
     setSelectedFiles([]);
+    setSelectedLinks([]);
     onClose();
   };
 
@@ -658,6 +662,7 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
       }
       reset(defaultValues as FormValues);
       setSelectedFiles([]);
+      setSelectedLinks([]);
       setSelectedTags([]);
       setLinkedIssueIds([]);
     }
@@ -970,8 +975,19 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
           }
         }
 
-        const uploadedAttachments =
-          selectedFiles.length > 0 ? await uploadFiles() : [];
+        // Files upload to S3 first; external links (text/uri-list) need no
+        // upload — they're already in the IssueData-shaped form the
+        // backend persists.
+        const uploadedAttachments = [
+          ...(selectedFiles.length > 0 ? await uploadFiles() : []),
+          ...selectedLinks.map((link) => ({
+            url: link.url,
+            name: link.name,
+            mimeType: link.mimeType,
+            size: link.size,
+            note: link.note ?? "",
+          })),
+        ];
 
         const tagNamesForVersion = selectedTags.map(
           (tagId) => tags?.find((tag) => tag.id === tagId)?.name || ""
@@ -1393,7 +1409,11 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
                     </p>
                   )}
                   <div className="my-8">
-                    <UploadAttachments onFileSelect={handleFileSelect} />
+                    <UploadAttachments
+                      onFileSelect={handleFileSelect}
+                      allowLinks
+                      onLinksChange={setSelectedLinks}
+                    />
                   </div>
                 </ResizablePanel>
               </ResizablePanelGroup>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -1358,8 +1358,8 @@ export function AddResultModal({
           );
         }
 
-        // Upload attachments if there are any
-        if (selectedFiles.length > 0 && result) {
+        // Upload attachments if there are any (files OR external links)
+        if ((selectedFiles.length > 0 || selectedLinks.length > 0) && result) {
           await uploadFiles(result.id);
         }
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -3,7 +3,9 @@ import { UnifiedIssueManager } from "@/components/issues/UnifiedIssueManager";
 import { TimeTracker, TimeTrackerRef } from "@/components/TimeTracker";
 import TipTapEditor from "@/components/tiptap/TipTapEditor";
 import { HelpPopover } from "@/components/ui/help-popover";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   ApplicationArea,
@@ -318,6 +320,7 @@ export function AddResultModal({
   // Ensures the validate-on-open pass runs once per escalation open.
   const validatedOnOpenRef = useRef(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] = useState<
     number | null
   >(null);
@@ -756,7 +759,40 @@ export function AddResultModal({
       };
     });
 
-    const attachments = await Promise.all(attachmentsPromises);
+    // External-link attachments (text/uri-list) need no S3 upload; create
+    // the rows directly with the same connect-to-result shape.
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          testRunResults: {
+            connect: { id: testRunResultId },
+          },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: {
+            connect: { id: session.user.id },
+          },
+        },
+      });
+
+      return {
+        id: attachment?.id,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        mimeType: link.mimeType,
+        size: link.size,
+        createdBy: session.user.name,
+      };
+    });
+
+    const attachments = await Promise.all([
+      ...attachmentsPromises,
+      ...linkPromises,
+    ]);
     return attachments;
   };
 
@@ -1092,7 +1128,10 @@ export function AddResultModal({
           }
 
           // Upload attachments if there are any
-          if (selectedFiles.length > 0 && result) {
+          if (
+            (selectedFiles.length > 0 || selectedLinks.length > 0) &&
+            result
+          ) {
             await uploadFiles(result.id);
           }
 
@@ -1355,8 +1394,9 @@ export function AddResultModal({
       // Reset the TimeTracker
       timeTrackerRef.current?.reset();
 
-      // Reset selected files
+      // Reset selected files + staged external links
       setSelectedFiles([]);
+      setSelectedLinks([]);
 
       // Increment keys to force re-render
       setEditorKey((prevKey) => prevKey + 1);
@@ -2207,6 +2247,8 @@ export function AddResultModal({
               <UploadAttachments
                 key={uploadAttachmentsKey}
                 onFileSelect={setSelectedFiles}
+                allowLinks
+                onLinksChange={setSelectedLinks}
               />
             </div>
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/EditResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/EditResultModal.tsx
@@ -3,7 +3,9 @@ import { UnifiedIssueManager } from "@/components/issues/UnifiedIssueManager";
 import { TimeTracker, TimeTrackerRef } from "@/components/TimeTracker";
 import TipTapEditor from "@/components/tiptap/TipTapEditor";
 import { HelpPopover } from "@/components/ui/help-popover";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Issue } from "@prisma/client";
 import { ApplicationArea, Attachments } from "@prisma/client";
@@ -306,6 +308,7 @@ export function EditResultModal({
   const [, setTrackedSeconds] = useState(0);
   const timeTrackerRef = useRef<TimeTrackerRef>(null);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] = useState<
     number | null
   >(null);
@@ -825,7 +828,39 @@ export function EditResultModal({
       };
     });
 
-    const attachments = await Promise.all(attachmentsPromises);
+    // External-link attachments — no S3 upload, just persist the row.
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          testRunResults: {
+            connect: { id: testRunResultId },
+          },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: {
+            connect: { id: session.user.id },
+          },
+        },
+      });
+
+      return {
+        id: attachment?.id,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        mimeType: link.mimeType,
+        size: link.size,
+        createdBy: session.user.name,
+      };
+    });
+
+    const attachments = await Promise.all([
+      ...attachmentsPromises,
+      ...linkPromises,
+    ]);
     return attachments;
   };
 
@@ -955,8 +990,8 @@ export function EditResultModal({
 
       // Field values were written atomically by the edit-result endpoint above.
 
-      // Upload attachments if there are any
-      if (selectedFiles.length > 0) {
+      // Upload attachments if there are any (files OR external links)
+      if (selectedFiles.length > 0 || selectedLinks.length > 0) {
         await uploadFiles(result.id);
       }
 
@@ -1725,6 +1760,8 @@ export function EditResultModal({
               <UploadAttachments
                 key={uploadAttachmentsKey}
                 onFileSelect={setSelectedFiles}
+                allowLinks
+                onLinksChange={setSelectedLinks}
               />
             </div>
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/LastTestResultCell.test.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/LastTestResultCell.test.tsx
@@ -413,9 +413,14 @@ describe("LastTestResultCell via getColumns", () => {
       await user.hover(statusElement);
 
       // Wait for tooltip to appear - it contains the "Last Tested" text
-      // Use getAllByText since Radix may render duplicates
+      // Use getAllByText since Radix may render duplicates. Bumped timeout
+      // beyond the testing-library default (1s) because the CI runner has
+      // been observed taking >19× longer than local for the full suite,
+      // squeezing Radix's hover-delay + portal-mount race window past 1s.
       const testedOnElements = await screen.findAllByText(
-        /\[t\]repository\.columns\.testedOn/
+        /\[t\]repository\.columns\.testedOn/,
+        undefined,
+        { timeout: 5000 }
       );
       expect(testedOnElements.length).toBeGreaterThan(0);
     });
@@ -444,8 +449,13 @@ describe("LastTestResultCell via getColumns", () => {
       const statusElement = screen.getByText("Passed");
       await user.hover(statusElement);
 
-      // Should display the test run name (may be multiple due to Radix rendering)
-      const testRunElements = await screen.findAllByText("Sprint 10 Test Run");
+      // Should display the test run name (may be multiple due to Radix rendering).
+      // See above — bumped timeout for CI load resilience.
+      const testRunElements = await screen.findAllByText(
+        "Sprint 10 Test Run",
+        undefined,
+        { timeout: 5000 }
+      );
       expect(testRunElements.length).toBeGreaterThan(0);
     });
 
@@ -473,9 +483,12 @@ describe("LastTestResultCell via getColumns", () => {
       const statusElement = screen.getByText("Passed");
       await user.hover(statusElement);
 
-      // Should show the date but no link to a test run page
+      // Should show the date but no link to a test run page.
+      // See above — bumped timeout for CI load resilience.
       const testedOnElements = await screen.findAllByText(
-        /\[t\]repository\.columns\.testedOn/
+        /\[t\]repository\.columns\.testedOn/,
+        undefined,
+        { timeout: 5000 }
       );
       expect(testedOnElements.length).toBeGreaterThan(0);
 
@@ -537,8 +550,13 @@ describe("LastTestResultCell via getColumns", () => {
       const statusElement = screen.getByText("Passed");
       await user.hover(statusElement);
 
-      // Wait for tooltip content (may be multiple due to Radix rendering)
-      const testRunElements = await screen.findAllByText("Sprint 10 Test Run");
+      // Wait for tooltip content (may be multiple due to Radix rendering).
+      // See above — bumped timeout for CI load resilience.
+      const testRunElements = await screen.findAllByText(
+        "Sprint 10 Test Run",
+        undefined,
+        { timeout: 5000 }
+      );
       expect(testRunElements.length).toBeGreaterThan(0);
 
       // Two links rendered: the cell wrapper (case history) + the test run name

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/TestCaseFormControl.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/TestCaseFormControl.tsx
@@ -15,7 +15,9 @@ import { FormControl, FormField, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { Attachments, Tags } from "@prisma/client";
 import { useTranslations } from "next-intl";
 import React from "react";
@@ -29,6 +31,10 @@ interface TestCaseFormControlsProps {
   testcase: any;
   setSelectedFiles: React.Dispatch<React.SetStateAction<File[]>>;
   selectedFiles: File[];
+  setSelectedLinks?: React.Dispatch<
+    React.SetStateAction<LinkAttachmentInput[]>
+  >;
+  selectedLinks?: LinkAttachmentInput[];
   handleSelect: (attachments: Attachments[], index: number) => void;
   selectedAttachmentIndex: number | null;
   selectedAttachments: Attachments[];
@@ -47,6 +53,8 @@ const TestCaseFormControls: React.FC<TestCaseFormControlsProps> = ({
   testcase,
   setSelectedFiles,
   selectedFiles: _selectedFiles,
+  setSelectedLinks,
+  selectedLinks: _selectedLinks,
   handleSelect,
   selectedAttachmentIndex,
   selectedAttachments,
@@ -190,6 +198,8 @@ const TestCaseFormControls: React.FC<TestCaseFormControlsProps> = ({
                   onFileSelect={(files: File[]) => {
                     setSelectedFiles(files);
                   }}
+                  allowLinks={!!setSelectedLinks}
+                  onLinksChange={setSelectedLinks}
                 />
               </div>
               {testcase.attachments.length > 0 && (

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
@@ -118,6 +118,7 @@ import { QuickScriptModal } from "../QuickScriptModal";
 import { FolderNode } from "../TreeView";
 import FieldValueRenderer from "./FieldValueRenderer";
 import { StepsDisplay } from "./StepsDisplay";
+import { type LinkAttachmentInput } from "@/components/UploadAttachments";
 import TestCaseFormControls from "./TestCaseFormControl";
 
 // Type Definitions (ensure these are present and correct)
@@ -829,6 +830,7 @@ export default function TestCaseDetails() {
     []
   );
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [pendingAttachmentChanges, setPendingAttachmentChanges] =
     useState<AttachmentChanges>({ edits: [], deletes: [] });
 
@@ -1032,6 +1034,7 @@ export default function TestCaseDetails() {
     setSelectedTemplateId(testcase.template.id ?? null);
     setPendingAttachmentChanges({ edits: [], deletes: [] });
     setSelectedFiles([]);
+    setSelectedLinks([]);
     // Form will be reset through the template change effect
   };
 
@@ -1414,7 +1417,35 @@ export default function TestCaseDetails() {
           createdById: session!.user.id,
         };
       });
-      const newAttachments = await Promise.all(createAttachmentsPromises);
+      const createLinkPromises = selectedLinks.map(async (link) => {
+        const newAttachment = await createAttachments({
+          data: {
+            testCase: { connect: { id: Number(caseId) } },
+            url: link.url,
+            name: link.name,
+            note: link.note ?? "",
+            mimeType: link.mimeType,
+            size: BigInt(link.size),
+            createdBy: { connect: { id: session!.user.id } },
+          },
+        });
+        return {
+          id: newAttachment?.id || 0,
+          testCaseId: newAttachment?.testCaseId || 0,
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          isDeleted: false,
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdAt: new Date(),
+          createdById: session!.user.id,
+        };
+      });
+      const newAttachments = await Promise.all([
+        ...createAttachmentsPromises,
+        ...createLinkPromises,
+      ]);
 
       // Get existing attachments, applying pending edits and filtering out deleted ones
       // Explicitly pick only primitive fields to avoid relation objects
@@ -1686,6 +1717,7 @@ export default function TestCaseDetails() {
       setIsEditMode(false);
       setPendingAttachmentChanges({ edits: [], deletes: [] });
       setSelectedFiles([]);
+      setSelectedLinks([]);
       void refetch();
     } catch (error) {
       console.error("Error in handleSave:", error);
@@ -2580,6 +2612,8 @@ export default function TestCaseDetails() {
                     testcase={testcase}
                     setSelectedFiles={setSelectedFiles}
                     selectedFiles={selectedFiles}
+                    setSelectedLinks={setSelectedLinks}
+                    selectedLinks={selectedLinks}
                     handleSelect={handleSelect}
                     selectedAttachmentIndex={selectedAttachmentIndex}
                     selectedAttachments={selectedAttachments}

--- a/testplanit/app/[locale]/projects/runs/[projectId]/AddTestRunModal.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/AddTestRunModal.tsx
@@ -37,7 +37,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApplicationArea, Attachments, TestRunType } from "@prisma/client";
 import { DialogDescription } from "@radix-ui/react-dialog";
@@ -143,6 +145,7 @@ const BasicInfoDialog = React.memo(
     setSelectedTags,
     selectedFiles: _selectedFiles,
     handleFileSelect,
+    handleLinksChange,
     handleSelect,
     selectedAttachmentIndex,
     handleAttachmentClose,
@@ -531,7 +534,11 @@ const BasicInfoDialog = React.memo(
                       </FormLabel>
                       <FormControl>
                         <div className="space-y-4">
-                          <UploadAttachments onFileSelect={handleFileSelect} />
+                          <UploadAttachments
+                            onFileSelect={handleFileSelect}
+                            allowLinks
+                            onLinksChange={handleLinksChange}
+                          />
                           <AttachmentsDisplay
                             attachments={(field.value as Attachments[]) || []}
                             preventEditing={false}
@@ -891,6 +898,7 @@ export default function AddTestRunModal({
     initialSelectedCaseIds || []
   );
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   // Latest cardinality preflight result reported by the chip in Step 1.
   // Drives the soft-confirm gate + hard-refuse breakdown dialog.
   const [preflightResult, setPreflightResult] = useState<
@@ -1215,7 +1223,29 @@ export default function AddTestRunModal({
         createdBy: session!.user.name,
       };
     });
-    return Promise.all(attachmentsPromises);
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          testRuns: { connect: { id: testRunId } },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: { connect: { id: session!.user.id } },
+        },
+      });
+      return {
+        id: attachment?.id,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        mimeType: link.mimeType,
+        size: link.size,
+        createdBy: session!.user.name,
+      };
+    });
+    return Promise.all([...attachmentsPromises, ...linkPromises]);
   };
 
   const _handleConfirmSelection = (selectedIds: number[]) => {
@@ -1372,7 +1402,10 @@ export default function AddTestRunModal({
           });
 
           // Only upload files to the first run (or we could duplicate to all)
-          if (createdRuns.length === 1 && selectedFiles.length > 0) {
+          if (
+            createdRuns.length === 1 &&
+            (selectedFiles.length > 0 || selectedLinks.length > 0)
+          ) {
             await uploadFiles(newTestRun.id);
           }
 
@@ -1489,6 +1522,7 @@ export default function AddTestRunModal({
           setSelectedTags: setSelectedTags,
           selectedFiles: selectedFiles,
           handleFileSelect: handleFileSelect,
+          handleLinksChange: setSelectedLinks,
           handleSelect: handleSelect,
           selectedAttachmentIndex: selectedAttachmentIndex,
           handleAttachmentClose: handleAttachmentClose,

--- a/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/TestRunFormControls.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/TestRunFormControls.tsx
@@ -26,7 +26,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { WorkflowStateDisplay } from "@/components/WorkflowStateDisplay";
 import { Attachments, RepositoryCases, Tags } from "@prisma/client";
 import { useTranslations } from "next-intl";
@@ -158,6 +160,7 @@ interface TestRunFormControlsProps {
   setSelectedTags: (tags: number[]) => void;
   projectId: string | string[];
   handleFileSelect: (files: File[]) => void;
+  handleLinksChange?: (links: LinkAttachmentInput[]) => void;
   handleSelect: (attachments: Attachments[], index: number) => void;
   projectIntegration?: any;
   selectedIssues: number[];
@@ -181,6 +184,7 @@ function TestRunFormControls({
   setSelectedTags,
   projectId,
   handleFileSelect,
+  handleLinksChange,
   handleSelect,
   projectIntegration,
   selectedIssues,
@@ -426,6 +430,8 @@ function TestRunFormControls({
                   {isEditMode && (
                     <UploadAttachments
                       onFileSelect={handleFileSelect}
+                      allowLinks={!!handleLinksChange}
+                      onLinksChange={handleLinksChange}
                       disabled={!canAddEdit}
                     />
                   )}

--- a/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
@@ -134,6 +134,7 @@ import {
   SelectedConfigurationInfo,
   TestCasesSection,
 } from "./TestCasesSection";
+import { type LinkAttachmentInput } from "@/components/UploadAttachments";
 import TestRunFormControls from "./TestRunFormControls";
 
 // Form Values interface
@@ -303,6 +304,7 @@ export default function TestRunPage() {
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   const panelLeftRef = useRef<ImperativePanelHandle>(null);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [selectedAttachments, setSelectedAttachments] = useState<Attachments[]>(
     []
   );
@@ -1007,14 +1009,15 @@ export default function TestRunPage() {
       // Wait for all pending changes to be applied
       await Promise.all([...editPromises, ...deletePromises]);
 
-      // Handle new attachments
-      if (selectedFiles.length > 0) {
+      // Handle new attachments (files OR external links)
+      if (selectedFiles.length > 0 || selectedLinks.length > 0) {
         const _attachmentUrls = await uploadFiles(Number(runId));
       }
 
       // Reset pending changes
       setPendingAttachmentChanges({ edits: [], deletes: [] });
       setSelectedFiles([]);
+      setSelectedLinks([]);
 
       await refetchTestRun();
       const params = new URLSearchParams(searchParams);
@@ -1105,6 +1108,7 @@ export default function TestRunPage() {
     // Reset pending attachment changes
     setPendingAttachmentChanges({ edits: [], deletes: [] });
     setSelectedFiles([]);
+    setSelectedLinks([]);
     // Exit edit mode
     const params = new URLSearchParams(searchParams.toString());
     params.delete("selectedCase"); // Also close sheet on cancel
@@ -1176,7 +1180,41 @@ export default function TestRunPage() {
       };
     });
 
-    const attachments = await Promise.all(attachmentsPromises);
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          testRuns: {
+            connect: { id: testRunId },
+          },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: {
+            connect: { id: session!.user.id },
+          },
+        },
+      });
+
+      return {
+        id: attachment?.id,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        mimeType: link.mimeType,
+        size: attachment?.size.toString(),
+        createdBy: session!.user.name,
+        createdAt: new Date().toISOString(),
+        isDeleted: false,
+        createdById: session!.user.id,
+      };
+    });
+
+    const attachments = await Promise.all([
+      ...attachmentsPromises,
+      ...linkPromises,
+    ]);
     return attachments;
   };
 
@@ -2070,6 +2108,7 @@ export default function TestRunPage() {
                     setSelectedTags={setSelectedTags}
                     projectId={safeProjectId}
                     handleFileSelect={handleFileSelect}
+                    handleLinksChange={setSelectedLinks}
                     handleSelect={handleSelect}
                     projectIntegration={projectData?.projectIntegrations?.[0]}
                     selectedIssues={selectedIssues}

--- a/testplanit/app/[locale]/projects/sessions/[projectId]/AddSessionModal.tsx
+++ b/testplanit/app/[locale]/projects/sessions/[projectId]/AddSessionModal.tsx
@@ -39,7 +39,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Attachments } from "@prisma/client";
 import { ApplicationArea } from "@prisma/client";
@@ -410,6 +412,7 @@ export function AddSessionModal({
         : []
     );
     setSelectedFiles([]);
+    setSelectedLinks([]);
   }, [
     open,
     reset,
@@ -447,6 +450,7 @@ export function AddSessionModal({
   };
 
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
 
   const handleFileSelect = (files: File[]) => {
     setSelectedFiles(files);
@@ -494,7 +498,42 @@ export function AddSessionModal({
       };
     });
 
-    const attachments = await Promise.all(attachmentsPromises);
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          session: {
+            connect: { id: sessionId },
+          },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: {
+            connect: { id: session!.user.id },
+          },
+        },
+      });
+
+      return {
+        id: attachment?.id || 0,
+        testCaseId: null,
+        sessionId: sessionId,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        isDeleted: false,
+        mimeType: link.mimeType,
+        size: attachment?.size.toString(),
+        createdAt: new Date().toISOString(),
+        createdById: session!.user.id,
+      };
+    });
+
+    const attachments = await Promise.all([
+      ...attachmentsPromises,
+      ...linkPromises,
+    ]);
     return attachments;
   };
 
@@ -592,9 +631,10 @@ export function AddSessionModal({
 
         if (!newSession) throw new Error(t("sessions.errors.failedToCreate"));
 
-        // Only upload files to the first session
+        // Only upload files / register external links on the first session
         const uploadedAttachments =
-          createdSessions.length === 0 && selectedFiles.length > 0
+          createdSessions.length === 0 &&
+          (selectedFiles.length > 0 || selectedLinks.length > 0)
             ? await uploadFiles(newSession.id)
             : [];
 
@@ -911,7 +951,11 @@ export function AddSessionModal({
                       </FormLabel>
                       <FormControl>
                         <div className="space-y-4">
-                          <UploadAttachments onFileSelect={handleFileSelect} />
+                          <UploadAttachments
+                            onFileSelect={handleFileSelect}
+                            allowLinks
+                            onLinksChange={setSelectedLinks}
+                          />
                           {selectedFiles.length > 0 && (
                             <div className="mt-2 text-sm text-muted-foreground">
                               {t("common.labels.filesSelectedForUpload", {

--- a/testplanit/app/[locale]/projects/sessions/[projectId]/[sessionId]/page.tsx
+++ b/testplanit/app/[locale]/projects/sessions/[projectId]/[sessionId]/page.tsx
@@ -85,7 +85,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { VersionSelect } from "@/components/VersionSelect";
 import type { Attachments, Sessions } from "@prisma/client";
 import { ApplicationArea } from "@prisma/client";
@@ -243,6 +245,7 @@ interface SessionFormControlsProps {
   setSelectedTags: (tags: number[]) => void;
   projectId: string | string[];
   handleFileSelect: (files: File[]) => void;
+  handleLinksChange?: (links: LinkAttachmentInput[]) => void;
   handleSelect: (attachments: Attachments[], index: number) => void;
   issues:
     | {
@@ -287,6 +290,7 @@ function SessionFormControls({
   setSelectedTags,
   projectId,
   handleFileSelect,
+  handleLinksChange,
   handleSelect,
   issues,
   projectIntegration,
@@ -744,7 +748,11 @@ function SessionFormControls({
               <FormControl>
                 <div className="space-y-4">
                   {isEditMode && (
-                    <UploadAttachments onFileSelect={handleFileSelect} />
+                    <UploadAttachments
+                      onFileSelect={handleFileSelect}
+                      allowLinks={!!handleLinksChange}
+                      onLinksChange={handleLinksChange}
+                    />
                   )}
                   <AttachmentsDisplay
                     attachments={
@@ -809,6 +817,7 @@ export default function SessionPage() {
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   const panelLeftRef = useRef<ImperativePanelHandle>(null);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [selectedAttachments, setSelectedAttachments] = useState<Attachments[]>(
     []
   );
@@ -1567,6 +1576,7 @@ export default function SessionPage() {
       // Reset pending changes
       setPendingAttachmentChanges({ edits: [], deletes: [] });
       setSelectedFiles([]);
+      setSelectedLinks([]);
 
       await refetchSession();
       const params = new URLSearchParams(searchParams);
@@ -1673,6 +1683,29 @@ export default function SessionPage() {
         console.error(`Failed to upload file ${file.name}:`, error);
       }
     }
+
+    for (const link of selectedLinks) {
+      try {
+        const createdAttachment = await createAttachments({
+          data: {
+            session: { connect: { id: sessionId } },
+            url: link.url,
+            name: link.name,
+            note: link.note ?? "",
+            mimeType: link.mimeType,
+            size: BigInt(link.size),
+            createdBy: { connect: { id: session!.user.id } },
+          },
+        });
+
+        if (createdAttachment) {
+          uploadedAttachments.push(createdAttachment as Attachments);
+        }
+      } catch (error) {
+        console.error(`Failed to register link ${link.url}:`, error);
+      }
+    }
+
     return uploadedAttachments;
   };
 
@@ -2266,6 +2299,7 @@ export default function SessionPage() {
                     setSelectedTags={setSelectedTags}
                     projectId={safeProjectId}
                     handleFileSelect={handleFileSelect}
+                    handleLinksChange={setSelectedLinks}
                     handleSelect={handleSelect}
                     issues={sessionData.issues}
                     projectIntegration={projectData?.projectIntegrations?.[0]}

--- a/testplanit/components/AttachmentPreview.tsx
+++ b/testplanit/components/AttachmentPreview.tsx
@@ -1,6 +1,7 @@
+import { LinkFavicon } from "@/components/LinkFavicon";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { Attachments } from "@prisma/client";
-import { File } from "lucide-react";
+import { ExternalLink, File } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import type { Components } from "react-markdown";
@@ -82,18 +83,36 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
 
   if (fileType.startsWith("image/")) {
     const { height, width } = getSizeClasses(100);
+    // SVGs bypass next/image: the built-in optimizer refuses SVG unless
+    // `images.dangerouslyAllowSVG` is enabled, and we don't want to opt into
+    // that (SVG can carry inline <script>). Browsers don't execute scripts in
+    // SVGs loaded via <img>, so plain <img> is the safe rendering path.
+    const isSvg =
+      fileType === "image/svg+xml" ||
+      attachment.name.toLowerCase().endsWith(".svg");
     return (
       <div
         className="flex justify-center items-center max-h-[350px]"
         style={{ height, width }}
       >
-        <Image
-          src={fileURL}
-          alt={attachment.name}
-          height={height}
-          width={width}
-          className="object-contain"
-        />
+        {isSvg ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={fileURL}
+            alt={attachment.name}
+            height={height}
+            width={width}
+            className="object-contain"
+          />
+        ) : (
+          <Image
+            src={fileURL}
+            alt={attachment.name}
+            height={height}
+            width={width}
+            className="object-contain"
+          />
+        )}
       </div>
     );
   } else if (fileType === "application/pdf") {
@@ -106,9 +125,34 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
       />
     );
   } else if (fileType.startsWith("text/uri")) {
+    // Self-contained styling: explicit `text-foreground` + `bg-background` so
+    // we don't inherit `text-primary` / `bg-accent` from wrappers like the
+    // compact badge in AttachmentsListDisplay (which produced a low-contrast
+    // violet pill across themes).
+    const isLarge = size === "large";
     return (
-      <Link href={fileURL} target="_blank">
-        {attachment.name}
+      <Link
+        href={fileURL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        title={fileURL}
+        className={`inline-flex items-center gap-2 rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground hover:bg-muted hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring max-w-full ${
+          isLarge ? "text-base" : "text-sm"
+        }`}
+      >
+        <LinkFavicon
+          url={fileURL}
+          className={isLarge ? "w-5 h-5" : "w-4 h-4"}
+        />
+        <span className="truncate underline underline-offset-2">
+          {attachment.name}
+        </span>
+        <ExternalLink
+          className={`shrink-0 text-muted-foreground ${
+            isLarge ? "w-4 h-4" : "w-3.5 h-3.5"
+          }`}
+        />
       </Link>
     );
   } else if (fileType.startsWith("text/")) {

--- a/testplanit/components/AttachmentsCarousel.tsx
+++ b/testplanit/components/AttachmentsCarousel.tsx
@@ -21,6 +21,7 @@ import {
   ChevronRight,
   CircleSlash2,
   Download,
+  ExternalLink,
   SquarePen,
   Trash2,
 } from "lucide-react";
@@ -244,8 +245,20 @@ export const AttachmentsCarousel: React.FC<AttachmentsCarouselProps> = ({
                         </div>
                       )}
                     </div>
-                    <div className="flex flex-col md:flex-row w-full h-full">
-                      <div className="md:w-2/3 flex flex-col items-center">
+                    <div
+                      className={`flex w-full h-full ${
+                        attachment.mimeType === "text/uri-list"
+                          ? "flex-col"
+                          : "flex-col md:flex-row"
+                      }`}
+                    >
+                      <div
+                        className={`flex flex-col items-center ${
+                          attachment.mimeType === "text/uri-list"
+                            ? "w-full py-2"
+                            : "md:w-2/3"
+                        }`}
+                      >
                         <div className="w-full flex justify-center items-start">
                           <AttachmentPreview
                             attachment={attachment}
@@ -253,11 +266,29 @@ export const AttachmentsCarousel: React.FC<AttachmentsCarouselProps> = ({
                           />
                         </div>
                       </div>
-                      <div className="md:w-1/3 w-full flex flex-col justify-start items-start p-4 overflow-auto">
-                        <div className="text-left space-y-2 w-full">
+                      <div
+                        className={`w-full flex flex-col justify-start items-start p-4 overflow-auto ${
+                          attachment.mimeType === "text/uri-list"
+                            ? ""
+                            : "md:w-1/3"
+                        }`}
+                      >
+                        <div
+                          className={`text-left w-full ${
+                            attachment.mimeType === "text/uri-list"
+                              ? "grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-x-6 gap-y-2"
+                              : "space-y-2"
+                          }`}
+                        >
                           <div>
                             <strong>{t("common.fields.description")}</strong>
-                            <div className="flex items-center w-full h-24 max-h-24 md:max-h-48 overflow-auto">
+                            <div
+                              className={`flex items-center w-full overflow-auto ${
+                                attachment.mimeType === "text/uri-list"
+                                  ? "min-h-[1.5rem]"
+                                  : "h-24 max-h-24 md:max-h-48"
+                              }`}
+                            >
                               {isEditing && index === current ? (
                                 <Textarea
                                   className="text-md h-24"
@@ -267,7 +298,13 @@ export const AttachmentsCarousel: React.FC<AttachmentsCarouselProps> = ({
                                   }
                                 />
                               ) : (
-                                <span className="w-full h-24">
+                                <span
+                                  className={
+                                    attachment.mimeType === "text/uri-list"
+                                      ? "w-full"
+                                      : "w-full h-24"
+                                  }
+                                >
                                   {attachment.note
                                     ? attachment.note
                                     : t("common.access.none")}
@@ -275,7 +312,9 @@ export const AttachmentsCarousel: React.FC<AttachmentsCarouselProps> = ({
                               )}
                             </div>
                           </div>
-                          <Separator className="w-full" />
+                          {attachment.mimeType !== "text/uri-list" && (
+                            <Separator className="w-full" />
+                          )}
                           <div className="text-sm">
                             <strong>{t("common.fields.size")}</strong>{" "}
                             {filesize(Number(attachment.size))}
@@ -323,20 +362,31 @@ export const AttachmentsCarousel: React.FC<AttachmentsCarouselProps> = ({
         </div>
         <DialogFooter>
           <div className="flex items-center gap-4">
-            <a
-              href={
-                getStorageUrlClient(attachments[current].url) ||
-                attachments[current].url
-              }
-              download={attachments[current].name}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button variant="default" disabled={isEditing}>
-                <Download className="inline w-5 h-5" />
-                {t("common.actions.download")}
-              </Button>
-            </a>
+            {(() => {
+              const isLink = attachments[current].mimeType === "text/uri-list";
+              return (
+                <a
+                  href={
+                    getStorageUrlClient(attachments[current].url) ||
+                    attachments[current].url
+                  }
+                  {...(isLink ? {} : { download: attachments[current].name })}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button variant="default" disabled={isEditing}>
+                    {isLink ? (
+                      <ExternalLink className="inline w-5 h-5" />
+                    ) : (
+                      <Download className="inline w-5 h-5" />
+                    )}
+                    {isLink
+                      ? t("common.actions.openLink")
+                      : t("common.actions.download")}
+                  </Button>
+                </a>
+              );
+            })()}
             {canEdit && (
               <>
                 {isEditing ? (

--- a/testplanit/components/AttachmentsDisplay.tsx
+++ b/testplanit/components/AttachmentsDisplay.tsx
@@ -278,19 +278,47 @@ export const AttachmentsDisplay: React.FC<AttachmentsProps> = ({
                     previousAttachment?.name
                   )}
                 </div>
-                <div className="flex flex-col md:flex-row w-full max-h-96 overflow-hidden">
+                <div
+                  className={`flex w-full max-h-96 overflow-hidden ${
+                    attachment.mimeType === "text/uri-list"
+                      ? "flex-col"
+                      : "flex-col md:flex-row"
+                  }`}
+                >
                   <div
                     onClick={() => handleSelect(sortedAttachments, index)}
-                    className="md:w-2/3 w-full h-full flex justify-center cursor-pointer"
+                    className={`w-full h-full flex justify-center cursor-pointer ${
+                      attachment.mimeType === "text/uri-list"
+                        ? "py-2"
+                        : "md:w-2/3"
+                    }`}
                   >
                     <AttachmentPreview attachment={attachment} size="large" />
                   </div>
                   <Separator
-                    orientation="vertical"
-                    className="h-full bg-primary/50 m-1"
+                    orientation={
+                      attachment.mimeType === "text/uri-list"
+                        ? "horizontal"
+                        : "vertical"
+                    }
+                    className={
+                      attachment.mimeType === "text/uri-list"
+                        ? "w-full bg-primary/50 my-1"
+                        : "h-full bg-primary/50 m-1"
+                    }
                   />
-                  <div className="md:w-1/3 w-full flex flex-col justify-start items-start p-4 overflow-hidden">
-                    <div className="text-left space-y-2 min-w-[50px] w-full">
+                  <div
+                    className={`w-full flex flex-col justify-start items-start p-4 overflow-hidden ${
+                      attachment.mimeType === "text/uri-list" ? "" : "md:w-1/3"
+                    }`}
+                  >
+                    <div
+                      className={`text-left min-w-[50px] w-full ${
+                        attachment.mimeType === "text/uri-list"
+                          ? "grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-x-6 gap-y-2"
+                          : "space-y-2"
+                      }`}
+                    >
                       {/* Name field - editable in deferred mode */}
                       <div className="text-sm">
                         <strong>{t("common.name")}</strong>
@@ -345,7 +373,9 @@ export const AttachmentsDisplay: React.FC<AttachmentsProps> = ({
                           </div>
                         )}
                       </div>
-                      <Separator className="w-full" />
+                      {attachment.mimeType !== "text/uri-list" && (
+                        <Separator className="w-full" />
+                      )}
                       <div className="text-sm truncate">
                         <strong>{t("common.fields.size")}</strong>{" "}
                         {filesize(Number(attachment.size))}

--- a/testplanit/components/FileThumbnail.tsx
+++ b/testplanit/components/FileThumbnail.tsx
@@ -12,17 +12,34 @@ interface FileThumbnailProps {
 }
 
 const FileThumbnail: React.FC<FileThumbnailProps> = ({ attachment }) => {
+  // SVGs bypass next/image — the optimizer refuses SVG without
+  // `dangerouslyAllowSVG`, which we deliberately avoid. Plain <img> is safe:
+  // browsers don't run scripts in SVGs loaded that way.
+  const isSvg =
+    attachment.mimeType === "image/svg+xml" ||
+    attachment.name.toLowerCase().endsWith(".svg");
   return (
     <Tooltip>
       <TooltipTrigger type="button" className="cursor-default">
-        <Image
-          src={attachment.url}
-          alt={attachment.name}
-          sizes="100vw"
-          width={16}
-          height={16}
-          className="rounded-full"
-        />
+        {isSvg ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={attachment.url}
+            alt={attachment.name}
+            width={16}
+            height={16}
+            className="rounded-full"
+          />
+        ) : (
+          <Image
+            src={attachment.url}
+            alt={attachment.name}
+            sizes="100vw"
+            width={16}
+            height={16}
+            className="rounded-full"
+          />
+        )}
       </TooltipTrigger>
       <TooltipContent>
         <div>{attachment.name}</div>

--- a/testplanit/components/LinkFavicon.tsx
+++ b/testplanit/components/LinkFavicon.tsx
@@ -1,0 +1,47 @@
+import { Link as LinkIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+/**
+ * Renders the destination's `/favicon.ico` as a small preview for an external
+ * link, falling back to the generic link icon when the fetch fails (404,
+ * mixed content, broken URL, etc). Browser-side only — the URL never touches
+ * our server, so internal-only hostnames (e.g. confluence.internal.*) stay
+ * private. We don't proxy through a third party (Google/DuckDuckGo)
+ * specifically to avoid that domain leak.
+ */
+export function LinkFavicon({
+  url,
+  className,
+}: {
+  url: string;
+  className: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  // Reset when the URL changes so a new link can re-attempt favicon load.
+  useEffect(() => {
+    setFailed(false);
+  }, [url]);
+
+  let iconUrl: string | null = null;
+  if (!failed) {
+    try {
+      iconUrl = `${new URL(url).origin}/favicon.ico`;
+    } catch {
+      iconUrl = null;
+    }
+  }
+  if (!iconUrl) {
+    return (
+      <LinkIcon className={`${className} text-muted-foreground shrink-0`} />
+    );
+  }
+  return (
+    <img
+      src={iconUrl}
+      alt=""
+      className={`${className} shrink-0 rounded-sm object-contain`}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/testplanit/components/SessionResultForm.tsx
+++ b/testplanit/components/SessionResultForm.tsx
@@ -22,7 +22,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import UploadAttachments from "@/components/UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "@/components/UploadAttachments";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Attachments } from "@prisma/client";
 import { Bug, CircleCheckBig, Clock, Paperclip, Save } from "lucide-react";
@@ -194,6 +196,7 @@ export function SessionResultForm({
   const [_trackedSeconds, setTrackedSeconds] = useState(0);
   const timeTrackerRef = useRef<TimeTrackerRef>(null);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] = useState<
     number | null
   >(null);
@@ -512,7 +515,38 @@ export function SessionResultForm({
       };
     });
 
-    const attachments = await Promise.all(attachmentsPromises);
+    const linkPromises = selectedLinks.map(async (link) => {
+      const attachment = await createAttachments({
+        data: {
+          sessionResults: {
+            connect: { id: sessionResultId },
+          },
+          url: link.url,
+          name: link.name,
+          note: link.note ?? "",
+          mimeType: link.mimeType,
+          size: BigInt(link.size),
+          createdBy: {
+            connect: { id: session.user.id },
+          },
+        },
+      });
+
+      return {
+        id: attachment?.id,
+        url: link.url,
+        name: link.name,
+        note: link.note ?? "",
+        mimeType: link.mimeType,
+        size: link.size,
+        createdBy: session.user.name,
+      };
+    });
+
+    const attachments = await Promise.all([
+      ...attachmentsPromises,
+      ...linkPromises,
+    ]);
     return attachments;
   };
 
@@ -591,8 +625,8 @@ export function SessionResultForm({
         await Promise.all(fieldValuesPromises);
       }
 
-      // Upload attachments if there are any
-      if (selectedFiles.length > 0 && result) {
+      // Upload attachments if there are any (files OR external links)
+      if ((selectedFiles.length > 0 || selectedLinks.length > 0) && result) {
         await uploadFiles(result.id);
       }
 
@@ -613,8 +647,9 @@ export function SessionResultForm({
       // Reset the TimeTracker
       timeTrackerRef.current?.reset();
 
-      // Reset selected files
+      // Reset selected files + staged external links
       setSelectedFiles([]);
+      setSelectedLinks([]);
       // Reset selected issues
       setSelectedIssues([]);
 
@@ -1018,6 +1053,8 @@ export function SessionResultForm({
                           <UploadAttachments
                             key={uploadAttachmentsKey}
                             onFileSelect={handleFileSelect}
+                            allowLinks
+                            onLinksChange={setSelectedLinks}
                             compact={true}
                           />
                           {selectedFiles.length > 0 && (

--- a/testplanit/components/SessionResultsList.tsx
+++ b/testplanit/components/SessionResultsList.tsx
@@ -87,7 +87,9 @@ import { SimpleUnifiedIssueManager } from "./issues/UnifiedIssueManager";
 import LoadingSpinner from "./LoadingSpinner";
 import { IssuesListDisplay } from "./tables/IssuesListDisplay";
 import { UserNameCell } from "./tables/UserNameCell";
-import UploadAttachments from "./UploadAttachments";
+import UploadAttachments, {
+  type LinkAttachmentInput,
+} from "./UploadAttachments";
 
 // Define the ExtendedSessionResults interface to match the query structure
 interface ExtendedSessionResults extends SessionResults {
@@ -263,6 +265,7 @@ export function SessionResultsList({
     useState<ExtendedSessionResults | null>(null);
   const [editSelectedIssues, setEditSelectedIssues] = useState<number[]>([]);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
   const [pendingAttachmentChanges, setPendingAttachmentChanges] =
     useState<AttachmentChanges>({ edits: [], deletes: [] });
   const [uploadAttachmentsKey, setUploadAttachmentsKey] = useState(0);
@@ -669,8 +672,9 @@ export function SessionResultsList({
         }
       });
 
-      // Clear any previously selected files
+      // Clear any previously selected files + staged links
       setSelectedFiles([]);
+      setSelectedLinks([]);
 
       // Reset keys to force re-render of components
       setEditorKey((prev) => prev + 1);
@@ -688,6 +692,7 @@ export function SessionResultsList({
     setEditDialogOpen(false);
     setResultToEdit(null);
     setSelectedFiles([]);
+    setSelectedLinks([]);
     setPendingAttachmentChanges({ edits: [], deletes: [] });
     userHasSelectedFilesRef.current = false; // Reset ref when dialog closes
   }, []);
@@ -864,6 +869,24 @@ export function SessionResultsList({
           await Promise.all(uploadAttachmentsPromises);
         }
 
+        // External-link attachments staged alongside the file uploads.
+        if (selectedLinks.length > 0) {
+          const linkPromises = selectedLinks.map((link) =>
+            createAttachments({
+              data: {
+                sessionResults: { connect: { id: resultToEdit.id } },
+                url: link.url,
+                name: link.name,
+                note: link.note ?? "",
+                mimeType: link.mimeType,
+                size: BigInt(link.size),
+                createdBy: { connect: { id: session.user.id } },
+              },
+            })
+          );
+          await Promise.all(linkPromises);
+        }
+
         // Apply pending attachment changes (edits and deletes)
         if (
           pendingAttachmentChanges.edits.length > 0 ||
@@ -909,6 +932,7 @@ export function SessionResultsList({
         setEditDialogOpen(false);
         setResultToEdit(null);
         setSelectedFiles([]);
+        setSelectedLinks([]);
         userHasSelectedFilesRef.current = false; // Reset ref after successful save
       } catch {
         // Error updating session result
@@ -923,6 +947,7 @@ export function SessionResultsList({
       updateSessionResult,
       editTemplateFields,
       selectedFiles,
+      selectedLinks,
       refetch,
       t,
       updateResultFieldValue,
@@ -1609,6 +1634,7 @@ export function SessionResultsList({
               // Reset all local dialog state so the next open is clean.
               setResultToEdit(null);
               setSelectedFiles([]);
+              setSelectedLinks([]);
               setPendingAttachmentChanges({ edits: [], deletes: [] });
               setDynamicFieldValues({});
               setEditSelectedIssues([]);
@@ -1817,6 +1843,8 @@ export function SessionResultsList({
                       <UploadAttachments
                         key={uploadAttachmentsKey}
                         onFileSelect={handleFileSelect}
+                        allowLinks
+                        onLinksChange={setSelectedLinks}
                         compact={true}
                       />
                       {selectedFiles.length > 0 && (

--- a/testplanit/components/UploadAttachments.test.tsx
+++ b/testplanit/components/UploadAttachments.test.tsx
@@ -268,4 +268,196 @@ describe("UploadAttachments", () => {
 
     expect(screen.queryByText("invalidFileType")).not.toBeInTheDocument();
   });
+
+  // ─── Link mode ──────────────────────────────────────────────────────────
+  // The `allowLinks` prop is opt-in (defaults to false) so the import
+  // wizards that mount UploadAttachments file-only stay untouched.
+
+  describe("link mode (allowLinks)", () => {
+    it("does not render the Add Link button when allowLinks is false", () => {
+      render(<UploadAttachments onFileSelect={mockOnFileSelect} />);
+      // Two `addButton` instances would mean the form-submit button is
+      // also rendered; we just want to confirm the opt-in button is absent.
+      expect(screen.queryAllByText("addButton")).toHaveLength(0);
+    });
+
+    it("renders the Add Link button when allowLinks is true", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      // The toggle button — the form-submit button is hidden until clicked.
+      expect(screen.getAllByText("addButton").length).toBeGreaterThan(0);
+    });
+
+    it("expands the inline link form when the toggle is clicked", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      // Before clicking: form fields are not in the DOM.
+      expect(screen.queryByText("urlLabel")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getAllByText("addButton")[0]);
+
+      // After clicking: URL, name, and note fields appear.
+      expect(screen.getByText("urlLabel")).toBeInTheDocument();
+      expect(screen.getByText("nameLabel")).toBeInTheDocument();
+      expect(screen.getByText("noteLabel")).toBeInTheDocument();
+    });
+
+    it("rejects an invalid URL and surfaces the error message", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      fireEvent.click(screen.getAllByText("addButton")[0]);
+
+      // Submit Add button is disabled when URL is empty; type a non-URL.
+      const urlInput = document.getElementById(
+        // The component generates ids of shape `<fileInputId>-link-url`.
+        // Targeting by query rather than by id since useId() is opaque.
+        document.querySelector('input[type="url"]')!.id
+      ) as HTMLInputElement;
+      fireEvent.change(urlInput, { target: { value: "not a url" } });
+      // The Add button is the SECOND `addButton` (toggle + submit, in order).
+      const buttons = screen.getAllByText("addButton");
+      const submit = buttons[buttons.length - 1].closest(
+        "button"
+      ) as HTMLButtonElement;
+      // Invalid URL → button disabled, callback never fires.
+      expect(submit.disabled).toBe(true);
+      expect(onLinksChange).not.toHaveBeenCalled();
+    });
+
+    it("emits a link on submit with mimeType text/uri-list and size = url length", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      fireEvent.click(screen.getAllByText("addButton")[0]);
+
+      const urlInput = document.querySelector(
+        'input[type="url"]'
+      ) as HTMLInputElement;
+      const nameInput = document.querySelector(
+        'input[type="text"]'
+      ) as HTMLInputElement;
+
+      const URL = "https://example.com/runbook";
+      fireEvent.change(urlInput, { target: { value: URL } });
+      fireEvent.change(nameInput, { target: { value: "Runbook" } });
+
+      const buttons = screen.getAllByText("addButton");
+      const submit = buttons[buttons.length - 1].closest(
+        "button"
+      ) as HTMLButtonElement;
+      fireEvent.click(submit);
+
+      expect(onLinksChange).toHaveBeenCalledWith([
+        {
+          url: URL,
+          name: "Runbook",
+          note: undefined,
+          mimeType: "text/uri-list",
+          size: URL.length,
+        },
+      ]);
+    });
+
+    it("defaults the display name to the URL when blank", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      fireEvent.click(screen.getAllByText("addButton")[0]);
+
+      const urlInput = document.querySelector(
+        'input[type="url"]'
+      ) as HTMLInputElement;
+      fireEvent.change(urlInput, {
+        target: { value: "https://example.com/x" },
+      });
+
+      const buttons = screen.getAllByText("addButton");
+      const submit = buttons[buttons.length - 1].closest(
+        "button"
+      ) as HTMLButtonElement;
+      fireEvent.click(submit);
+
+      expect(onLinksChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          url: "https://example.com/x",
+          name: "https://example.com/x",
+        }),
+      ]);
+    });
+
+    it("de-dupes by URL — pasting the same link twice yields one entry", () => {
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+
+      const addOnce = () => {
+        fireEvent.click(screen.getAllByText("addButton")[0]);
+        const urlInput = document.querySelector(
+          'input[type="url"]'
+        ) as HTMLInputElement;
+        fireEvent.change(urlInput, {
+          target: { value: "https://example.com/dup" },
+        });
+        const buttons = screen.getAllByText("addButton");
+        const submit = buttons[buttons.length - 1].closest(
+          "button"
+        ) as HTMLButtonElement;
+        fireEvent.click(submit);
+      };
+
+      addOnce();
+      addOnce();
+
+      // The most recent onLinksChange payload should still contain one entry.
+      const last =
+        onLinksChange.mock.calls[onLinksChange.mock.calls.length - 1][0];
+      expect(last).toHaveLength(1);
+    });
+
+    it("does not invoke onLinksChange when no link has ever been added", () => {
+      // Mount-suppress: parent shouldn't see a spurious empty-array call.
+      const onLinksChange = vi.fn();
+      render(
+        <UploadAttachments
+          onFileSelect={mockOnFileSelect}
+          allowLinks
+          onLinksChange={onLinksChange}
+        />
+      );
+      expect(onLinksChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/testplanit/components/UploadAttachments.tsx
+++ b/testplanit/components/UploadAttachments.tsx
@@ -1,3 +1,4 @@
+import { LinkFavicon } from "@/components/LinkFavicon";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -449,9 +450,7 @@ export default function UploadAttachments({
       }}
       disabled={disabled}
     >
-      <LinkIcon
-        className={size === "sm" ? "w-4 h-4" : "w-5 h-5 text-primary"}
-      />
+      <LinkIcon className={size === "sm" ? "w-4 h-4" : "w-5 h-5"} />
       {tLink("addButton")}
     </Button>
   );
@@ -489,7 +488,7 @@ export default function UploadAttachments({
               htmlFor={fileInputId}
               className={`flex items-center flex-1 min-w-0 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
             >
-              <CloudUpload className="w-5 h-5 text-primary mr-1" />
+              <CloudUpload className="w-5 h-5 mr-1" />
               <span className="text-sm truncate inline-block">
                 {uploading
                   ? tGlobal("common.status.uploading")
@@ -535,14 +534,16 @@ export default function UploadAttachments({
                     {filesize(file.size)}
                   </span>
                   {!disabled && (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="icon"
                       onClick={() => removeFile(index)}
                       aria-label={tGlobal("common.actions.remove")}
-                      className="shrink-0"
+                      className="shrink-0 h-6 w-6 p-0.5 text-foreground/70 hover:text-destructive"
                     >
-                      <XCircle className="w-4 h-4 text-muted-foreground hover:text-destructive" />
-                    </button>
+                      <XCircle className="w-4 h-4" />
+                    </Button>
                   )}
                 </span>
               </li>
@@ -554,20 +555,22 @@ export default function UploadAttachments({
                 title={link.url}
               >
                 <span className="flex items-center gap-1 min-w-0">
-                  <LinkIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <LinkFavicon url={link.url} className="w-4 h-4" />
                   <span className="truncate text-muted-foreground">
                     {link.name}
                   </span>
                 </span>
                 {!disabled && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="icon"
                     onClick={() => removeLink(index)}
                     aria-label={tGlobal("common.actions.remove")}
-                    className="shrink-0"
+                    className="shrink-0 h-6 w-6 p-0.5 text-foreground/70 hover:text-destructive"
                   >
-                    <XCircle className="w-4 h-4 text-muted-foreground hover:text-destructive" />
-                  </button>
+                    <XCircle className="w-4 h-4" />
+                  </Button>
                 )}
               </li>
             ))}
@@ -620,7 +623,7 @@ export default function UploadAttachments({
               asChild
             >
               <span>
-                <CloudUpload className="w-5 h-5 text-primary" />
+                <CloudUpload className="w-5 h-5" />
                 {uploading
                   ? tGlobal("common.status.uploading")
                   : tGlobal(
@@ -651,14 +654,16 @@ export default function UploadAttachments({
                     {getThumbnail(file)}
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
                           type="button"
-                          className="absolute top-0 left-14 transform -translate-y-2 -translate-x-2"
+                          variant="outline"
+                          size="icon"
                           onClick={() => removeFile(index)}
                           aria-label={tGlobal("common.cancel")}
+                          className="absolute top-0 left-14 -translate-y-2 -translate-x-2 h-7 w-7 rounded-full p-0.5 text-destructive hover:bg-destructive hover:text-destructive-foreground"
                         >
-                          <XCircle className="w-6 h-6 text-destructive" />
-                        </button>
+                          <XCircle className="w-5 h-5" />
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>
                         {tGlobal("common.cancel")}
@@ -679,17 +684,19 @@ export default function UploadAttachments({
                   title={link.url}
                 >
                   <div className="mt-2 relative w-16 h-16 bg-accent rounded-full flex items-center justify-center">
-                    <LinkIcon className="w-8 h-8 text-primary" />
+                    <LinkFavicon url={link.url} className="w-8 h-8" />
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
                           type="button"
-                          className="absolute top-0 left-14 transform -translate-y-2 -translate-x-2"
+                          variant="outline"
+                          size="icon"
                           onClick={() => removeLink(index)}
                           aria-label={tGlobal("common.cancel")}
+                          className="absolute top-0 left-14 -translate-y-2 -translate-x-2 h-7 w-7 rounded-full p-0.5 text-destructive hover:bg-destructive hover:text-destructive-foreground"
                         >
-                          <XCircle className="w-6 h-6 text-destructive" />
-                        </button>
+                          <XCircle className="w-5 h-5" />
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>
                         {tGlobal("common.cancel")}
@@ -717,13 +724,16 @@ export default function UploadAttachments({
                     <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                     {file.name}
                   </span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="icon"
                     onClick={() => removeFile(index)}
                     aria-label={tGlobal("common.cancel")}
+                    className="shrink-0 h-7 w-7 p-0.5 text-destructive hover:bg-destructive/10"
                   >
-                    <XCircle className="w-5 h-5 text-destructive" />
-                  </button>
+                    <XCircle className="w-5 h-5" />
+                  </Button>
                 </li>
               ))}
               {selectedLinks.map((link, index) => (
@@ -733,16 +743,19 @@ export default function UploadAttachments({
                   title={link.url}
                 >
                   <span className="flex items-center gap-1 truncate max-w-xs">
-                    <LinkIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <LinkFavicon url={link.url} className="w-4 h-4" />
                     {link.name}
                   </span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="icon"
                     onClick={() => removeLink(index)}
                     aria-label={tGlobal("common.cancel")}
+                    className="shrink-0 h-7 w-7 p-0.5 text-destructive hover:bg-destructive/10"
                   >
-                    <XCircle className="w-5 h-5 text-destructive" />
-                  </button>
+                    <XCircle className="w-5 h-5" />
+                  </Button>
                 </li>
               ))}
             </ul>

--- a/testplanit/components/UploadAttachments.tsx
+++ b/testplanit/components/UploadAttachments.tsx
@@ -6,7 +6,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -17,12 +20,28 @@ import {
   CloudUpload,
   FileStack,
   FileText,
+  Link as LinkIcon,
   Loader2,
   XCircle,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import React, { useEffect, useId, useRef, useState } from "react";
+
+/**
+ * Shape staged by the inline "Add Link" affordance and surfaced to parents
+ * via `onLinksChange`. Mirrors the persisted Attachments row enough that
+ * parents can drop it straight into their attachments payload alongside
+ * uploaded files. `mimeType: "text/uri-list"` is the existing in-codebase
+ * discriminator (see Testmo importer, AttachmentsDisplay, AttachmentPreview).
+ */
+export interface LinkAttachmentInput {
+  url: string;
+  name: string;
+  note?: string;
+  mimeType: "text/uri-list";
+  size: number;
+}
 
 interface UploadAttachmentsProps {
   onFileSelect: (files: File[]) => void;
@@ -33,6 +52,25 @@ interface UploadAttachmentsProps {
   allowedTypes?: string[];
   initialFiles?: File[];
   multiple?: boolean;
+  /**
+   * Opt in to the "Add Link" affordance. When true, the upload UI renders a
+   * second button that expands an inline URL form. Defaults to false so the
+   * import wizards (file-only by purpose) don't pick it up accidentally.
+   */
+  allowLinks?: boolean;
+  /** Notified whenever the user adds or removes a staged link. */
+  onLinksChange?: (links: LinkAttachmentInput[]) => void;
+  /** Mirrors `initialFiles`: seed the staged-links list once on mount. */
+  initialLinks?: LinkAttachmentInput[];
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 export default function UploadAttachments({
@@ -44,14 +82,26 @@ export default function UploadAttachments({
   allowedTypes,
   initialFiles,
   multiple = true,
+  allowLinks = false,
+  onLinksChange,
+  initialLinks,
 }: UploadAttachmentsProps) {
   const t = useTranslations("common.upload.attachments");
+  const tLink = useTranslations("common.upload.attachments.link");
   const tGlobal = useTranslations();
 
   const [uploading, setUploading] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Link-mode state — only meaningful when `allowLinks` is true.
+  const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
+  const [isLinkFormOpen, setIsLinkFormOpen] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkName, setLinkName] = useState("");
+  const [linkNote, setLinkNote] = useState("");
+  const [linkError, setLinkError] = useState<string | null>(null);
 
   // Seed selectedFiles from initialFiles prop when it changes from empty to non-empty
   const initialFilesAppliedRef = useRef(false);
@@ -69,6 +119,22 @@ export default function UploadAttachments({
       initialFilesAppliedRef.current = false;
     }
   }, [initialFiles]);
+
+  // Mirror initialFiles' one-shot seed behavior for staged links.
+  const initialLinksAppliedRef = useRef(false);
+  useEffect(() => {
+    if (
+      initialLinks &&
+      initialLinks.length > 0 &&
+      !initialLinksAppliedRef.current
+    ) {
+      initialLinksAppliedRef.current = true;
+      setSelectedLinks(initialLinks);
+    }
+    if (!initialLinks || initialLinks.length === 0) {
+      initialLinksAppliedRef.current = false;
+    }
+  }, [initialLinks]);
 
   // Generate unique IDs for file inputs to prevent conflicts when multiple instances exist
   const uniqueId = useId();
@@ -146,6 +212,56 @@ export default function UploadAttachments({
       onFileSelect(selectedFiles);
     }
   }, [selectedFiles, onFileSelect]);
+
+  // Mirror the mount-suppress + change-detect pattern used for files so we
+  // don't fire a spurious empty-array notification on mount/remount.
+  const prevSelectedLinksRef = React.useRef<LinkAttachmentInput[]>([]);
+  const hasEverHadLinksRef = React.useRef(false);
+  useEffect(() => {
+    if (!onLinksChange) return;
+    if (selectedLinks.length > 0) hasEverHadLinksRef.current = true;
+    if (selectedLinks.length === 0 && !hasEverHadLinksRef.current) return;
+    if (prevSelectedLinksRef.current !== selectedLinks) {
+      prevSelectedLinksRef.current = selectedLinks;
+      onLinksChange(selectedLinks);
+    }
+  }, [selectedLinks, onLinksChange]);
+
+  const resetLinkForm = () => {
+    setLinkUrl("");
+    setLinkName("");
+    setLinkNote("");
+    setLinkError(null);
+    setIsLinkFormOpen(false);
+  };
+
+  const handleAddLink = () => {
+    const trimmedUrl = linkUrl.trim();
+    if (!isValidHttpUrl(trimmedUrl)) {
+      setLinkError(tLink("invalidUrl"));
+      return;
+    }
+    const link: LinkAttachmentInput = {
+      url: trimmedUrl,
+      name: linkName.trim() || trimmedUrl,
+      note: linkNote.trim() || undefined,
+      mimeType: "text/uri-list",
+      // Size convention: store the URL's character length so the row is
+      // never zero-sized (matches what the Testmo importer writes).
+      size: trimmedUrl.length,
+    };
+    setSelectedLinks((prev) => {
+      // De-dupe by URL — pasting the same link twice shouldn't multiply rows.
+      const isDuplicate = prev.some((l) => l.url === link.url);
+      if (isDuplicate) return prev;
+      return multiple ? [...prev, link] : [link];
+    });
+    resetLinkForm();
+  };
+
+  const removeLink = (index: number) => {
+    setSelectedLinks((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -245,6 +361,101 @@ export default function UploadAttachments({
 
   const _isImageFile = (file: File) => file.type.startsWith("image/");
 
+  // ─── Link-mode render helpers ──────────────────────────────────────────────
+  // Kept here (vs. a separate component) so the link state lives next to the
+  // file state and the two surfaces share the same `disabled` / `multiple`
+  // semantics without prop drilling.
+
+  const showLinkAffordance = allowLinks && !uploading;
+  const linkUrlIsValid = isValidHttpUrl(linkUrl.trim());
+
+  const renderLinkForm = () => (
+    <div className="w-full space-y-2 rounded-md border border-dashed border-muted p-3">
+      <div className="space-y-1">
+        <Label htmlFor={`${fileInputId}-link-url`} className="text-xs">
+          {tLink("urlLabel")}
+        </Label>
+        <Input
+          id={`${fileInputId}-link-url`}
+          type="url"
+          autoFocus
+          inputMode="url"
+          placeholder={tLink("urlPlaceholder")}
+          value={linkUrl}
+          onChange={(e) => {
+            setLinkUrl(e.target.value);
+            if (linkError) setLinkError(null);
+          }}
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={`${fileInputId}-link-name`} className="text-xs">
+          {tLink("nameLabel")}
+        </Label>
+        <Input
+          id={`${fileInputId}-link-name`}
+          type="text"
+          placeholder={tLink("namePlaceholder")}
+          value={linkName}
+          onChange={(e) => setLinkName(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={`${fileInputId}-link-note`} className="text-xs">
+          {tLink("noteLabel")}
+        </Label>
+        <Textarea
+          id={`${fileInputId}-link-note`}
+          rows={2}
+          placeholder={tLink("notePlaceholder")}
+          value={linkNote}
+          onChange={(e) => setLinkNote(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+      {linkError && <div className="text-destructive text-xs">{linkError}</div>}
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={resetLinkForm}
+          disabled={disabled}
+        >
+          {tGlobal("common.cancel")}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleAddLink}
+          disabled={disabled || !linkUrlIsValid}
+        >
+          {tLink("addButton")}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderAddLinkButton = (size: "sm" | "default") => (
+    <Button
+      type="button"
+      variant="outline"
+      size={size}
+      onClick={() => {
+        setIsLinkFormOpen(true);
+        setLinkError(null);
+      }}
+      disabled={disabled}
+    >
+      <LinkIcon
+        className={size === "sm" ? "w-4 h-4" : "w-5 h-5 text-primary"}
+      />
+      {tLink("addButton")}
+    </Button>
+  );
+
   if (compact) {
     return (
       <div className="flex flex-col gap-1">
@@ -273,46 +484,48 @@ export default function UploadAttachments({
             style={{ display: "none" }}
             id={fileInputId}
           />
-          <label
-            htmlFor={fileInputId}
-            className={`flex items-center w-full ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
-          >
-            <CloudUpload className="w-5 h-5 text-primary mr-1" />
-            <span className="text-sm truncate inline-block">
-              {uploading
-                ? tGlobal("common.status.uploading")
-                : selectedFiles.length > 0
-                  ? multiple
-                    ? tGlobal("common.upload.attachments.addMoreFiles")
-                    : tGlobal("common.upload.attachments.replaceFile")
-                  : tGlobal(
-                      multiple
-                        ? "common.upload.attachments.selectFiles"
-                        : "common.upload.attachments.selectFile",
-                      { count: selectedFiles.length }
-                    )}
-            </span>
-            {selectedFiles.length > 1 && (
-              <span className="ml-auto flex items-center gap-0.5 text-sm text-muted-foreground">
-                <FileStack className="w-4 h-4" />
-                {String(
-                  filesize(selectedFiles.reduce((sum, f) => sum + f.size, 0))
-                )}
+          <div className="flex items-center w-full gap-2">
+            <label
+              htmlFor={fileInputId}
+              className={`flex items-center flex-1 min-w-0 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
+            >
+              <CloudUpload className="w-5 h-5 text-primary mr-1" />
+              <span className="text-sm truncate inline-block">
+                {uploading
+                  ? tGlobal("common.status.uploading")
+                  : selectedFiles.length > 0
+                    ? multiple
+                      ? tGlobal("common.upload.attachments.addMoreFiles")
+                      : tGlobal("common.upload.attachments.replaceFile")
+                    : tGlobal(
+                        multiple
+                          ? "common.upload.attachments.selectFiles"
+                          : "common.upload.attachments.selectFile",
+                        { count: selectedFiles.length }
+                      )}
               </span>
-            )}
-          </label>
+              {selectedFiles.length > 1 && (
+                <span className="ml-auto flex items-center gap-0.5 text-sm text-muted-foreground">
+                  <FileStack className="w-4 h-4" />
+                  {String(
+                    filesize(selectedFiles.reduce((sum, f) => sum + f.size, 0))
+                  )}
+                </span>
+              )}
+            </label>
+            {showLinkAffordance && !isLinkFormOpen && renderAddLinkButton("sm")}
+          </div>
         </div>
-        {selectedFiles.length > 0 && (
+        {showLinkAffordance && isLinkFormOpen && renderLinkForm()}
+        {(selectedFiles.length > 0 || selectedLinks.length > 0) && (
           <ul className="flex flex-col gap-0.5">
             {selectedFiles.map((file, index) => (
               <li
-                key={index}
+                key={`file-${index}`}
                 className="flex items-center justify-between gap-1 text-sm px-1 py-0.5 rounded hover:bg-accent"
               >
-                <span className="flex items-center gap-1">
-                  <span>
-                    <FileText className="w-4 h-4 text-muted-foreground" />
-                  </span>
+                <span className="flex items-center gap-1 min-w-0">
+                  <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                   <span className="truncate text-muted-foreground">
                     {file.name}
                   </span>
@@ -332,6 +545,30 @@ export default function UploadAttachments({
                     </button>
                   )}
                 </span>
+              </li>
+            ))}
+            {selectedLinks.map((link, index) => (
+              <li
+                key={`link-${index}`}
+                className="flex items-center justify-between gap-1 text-sm px-1 py-0.5 rounded hover:bg-accent"
+                title={link.url}
+              >
+                <span className="flex items-center gap-1 min-w-0">
+                  <LinkIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="truncate text-muted-foreground">
+                    {link.name}
+                  </span>
+                </span>
+                {!disabled && (
+                  <button
+                    type="button"
+                    onClick={() => removeLink(index)}
+                    aria-label={tGlobal("common.actions.remove")}
+                    className="shrink-0"
+                  >
+                    <XCircle className="w-4 h-4 text-muted-foreground hover:text-destructive" />
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -371,35 +608,43 @@ export default function UploadAttachments({
           style={{ display: "none" }}
           id={fileInputId}
         />
-        <label
-          htmlFor={fileInputId}
-          className={`${disabled ? "pointer-events-none cursor-not-allowed" : "cursor-pointer"}`}
-        >
-          <Button
-            type="button"
-            variant="outline"
-            disabled={uploading || disabled}
-            asChild
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <label
+            htmlFor={fileInputId}
+            className={`${disabled ? "pointer-events-none cursor-not-allowed" : "cursor-pointer"}`}
           >
-            <span>
-              <CloudUpload className="w-5 h-5 text-primary" />
-              {uploading
-                ? tGlobal("common.status.uploading")
-                : tGlobal(
-                    multiple
-                      ? "common.upload.attachments.selectFiles"
-                      : "common.upload.attachments.selectFile",
-                    { count: selectedFiles.length }
-                  )}
-            </span>
-          </Button>
-        </label>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={uploading || disabled}
+              asChild
+            >
+              <span>
+                <CloudUpload className="w-5 h-5 text-primary" />
+                {uploading
+                  ? tGlobal("common.status.uploading")
+                  : tGlobal(
+                      multiple
+                        ? "common.upload.attachments.selectFiles"
+                        : "common.upload.attachments.selectFile",
+                      { count: selectedFiles.length }
+                    )}
+              </span>
+            </Button>
+          </label>
+          {showLinkAffordance &&
+            !isLinkFormOpen &&
+            renderAddLinkButton("default")}
+        </div>
+        {showLinkAffordance && isLinkFormOpen && (
+          <div className="w-full max-w-md">{renderLinkForm()}</div>
+        )}
         {previews !== false ? (
           <ScrollArea className="w-full max-h-60">
             <div className="flex flex-wrap justify-between">
               {selectedFiles.map((file, index) => (
                 <div
-                  key={index}
+                  key={`file-${index}`}
                   className="relative flex flex-col items-center m-2"
                 >
                   <div className="mt-2 relative w-16 h-16 bg-accent rounded-full flex items-center justify-center">
@@ -427,6 +672,37 @@ export default function UploadAttachments({
                   </div>
                 </div>
               ))}
+              {selectedLinks.map((link, index) => (
+                <div
+                  key={`link-${index}`}
+                  className="relative flex flex-col items-center m-2"
+                  title={link.url}
+                >
+                  <div className="mt-2 relative w-16 h-16 bg-accent rounded-full flex items-center justify-center">
+                    <LinkIcon className="w-8 h-8 text-primary" />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="absolute top-0 left-14 transform -translate-y-2 -translate-x-2"
+                          onClick={() => removeLink(index)}
+                          aria-label={tGlobal("common.cancel")}
+                        >
+                          <XCircle className="w-6 h-6 text-destructive" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {tGlobal("common.cancel")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="w-[100px] lg:w-[150px]">
+                    <div className="mb-2 mx-4 text-sm truncate text-center">
+                      {link.name}
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           </ScrollArea>
         ) : (
@@ -434,13 +710,35 @@ export default function UploadAttachments({
             <ul className="flex flex-col gap-1">
               {selectedFiles.map((file, index) => (
                 <li
-                  key={index}
+                  key={`file-${index}`}
                   className="flex items-center justify-between gap-0.5 hover:bg-accent p-2"
                 >
-                  <span className="truncate max-w-xs">{file.name}</span>
+                  <span className="flex items-center gap-1 truncate max-w-xs">
+                    <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
+                    {file.name}
+                  </span>
                   <button
                     type="button"
                     onClick={() => removeFile(index)}
+                    aria-label={tGlobal("common.cancel")}
+                  >
+                    <XCircle className="w-5 h-5 text-destructive" />
+                  </button>
+                </li>
+              ))}
+              {selectedLinks.map((link, index) => (
+                <li
+                  key={`link-${index}`}
+                  className="flex items-center justify-between gap-0.5 hover:bg-accent p-2"
+                  title={link.url}
+                >
+                  <span className="flex items-center gap-1 truncate max-w-xs">
+                    <LinkIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                    {link.name}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeLink(index)}
                     aria-label={tGlobal("common.cancel")}
                   >
                     <XCircle className="w-5 h-5 text-destructive" />

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -43,6 +43,7 @@
       "previous": "Vorherige",
       "finish": "Beenden",
       "download": "Herunterladen",
+      "openLink": "Link öffnen",
       "apply": "Anwenden",
       "confirm": "Bestätigen",
       "confirmDelete": "Löschen bestätigen",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "Emoji"
         },
-        "count": "{count, plural, =1 {# Datei} other {# Dateien}}",
+        "count": "{count, plural, =1 {# Anhang} other {# Anhänge}}",
         "link": {
           "addButton": "Link hinzufügen",
           "urlLabel": "URL",

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "Emoji"
         },
-        "count": "{count, plural, =1 {# Datei} other {# Dateien}}"
+        "count": "{count, plural, =1 {# Datei} other {# Dateien}}",
+        "link": {
+          "addButton": "Link hinzufügen",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Anzeigename",
+          "namePlaceholder": "Wird standardmäßig die URL verwendet, wenn leer ist.",
+          "noteLabel": "Beschreibung (optional)",
+          "notePlaceholder": "Warum dieser Link relevant ist",
+          "invalidUrl": "Geben Sie eine gültige http(s)-URL ein."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -43,6 +43,7 @@
       "previous": "Previous",
       "finish": "Finish",
       "download": "Download",
+      "openLink": "Open Link",
       "apply": "Apply",
       "confirm": "Confirm",
       "confirmDelete": "Confirm Delete",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# file} other {# files}}",
+        "count": "{count, plural, =1 {# attachment} other {# attachments}}",
         "link": {
           "addButton": "Add Link",
           "urlLabel": "URL",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# file} other {# files}}"
+        "count": "{count, plural, =1 {# file} other {# files}}",
+        "link": {
+          "addButton": "Add Link",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Display name",
+          "namePlaceholder": "Defaults to the URL when blank",
+          "noteLabel": "Description (optional)",
+          "notePlaceholder": "Why this link is relevant",
+          "invalidUrl": "Enter a valid http(s) URL."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -43,6 +43,7 @@
       "previous": "Anterior",
       "finish": "Finalizar",
       "download": "Descargar",
+      "openLink": "Abrir enlace",
       "apply": "Aplicar",
       "confirm": "Confirmar",
       "confirmDelete": "Confirmar eliminación",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# archivo} other {# archivos}}",
+        "count": "{count, plural, =1 {# adjunto} other {# adjuntos}}",
         "link": {
           "addButton": "Agregar enlace",
           "urlLabel": "URL",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# archivo} other {# archivos}}"
+        "count": "{count, plural, =1 {# archivo} other {# archivos}}",
+        "link": {
+          "addButton": "Agregar enlace",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Nombre para mostrar",
+          "namePlaceholder": "Se utiliza la URL por defecto cuando está vacía.",
+          "noteLabel": "Descripción (opcional)",
+          "notePlaceholder": "Por qué este enlace es relevante",
+          "invalidUrl": "Introduzca una URL http(s) válida."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -43,6 +43,7 @@
       "previous": "Précédent",
       "finish": "Finition",
       "download": "Télécharger",
+      "openLink": "Ouvrir le lien",
       "apply": "Appliquer",
       "confirm": "Confirmer",
       "confirmDelete": "Confirmer la suppression",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# fichier} other {# fichiers}}",
+        "count": "{count, plural, =1 {# pièce jointe} other {# pièces jointes}}",
         "link": {
           "addButton": "Ajouter un lien",
           "urlLabel": "URL",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# fichier} other {# fichiers}}"
+        "count": "{count, plural, =1 {# fichier} other {# fichiers}}",
+        "link": {
+          "addButton": "Ajouter un lien",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Nom d'affichage",
+          "namePlaceholder": "Par défaut, l'URL est utilisée lorsqu'elle est vide.",
+          "noteLabel": "Description (facultatif)",
+          "notePlaceholder": "Pourquoi ce lien est pertinent",
+          "invalidUrl": "Saisissez une URL http(s) valide."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# file} other {# file}}"
+        "count": "{count, plural, =1 {# file} other {# file}}",
+        "link": {
+          "addButton": "Aggiungi collegamento",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Nome da visualizzare",
+          "namePlaceholder": "Se vuoto, viene utilizzato l'URL predefinito.",
+          "noteLabel": "Descrizione (facoltativa)",
+          "notePlaceholder": "Perché questo link è rilevante",
+          "invalidUrl": "Inserisci un URL http(s) valido."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -43,6 +43,7 @@
       "previous": "Precedente",
       "finish": "Fine",
       "download": "Scaricamento",
+      "openLink": "Apri il collegamento",
       "apply": "Fare domanda a",
       "confirm": "Confermare",
       "confirmDelete": "Conferma Elimina",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# file} other {# file}}",
+        "count": "{count, plural, =1 {# allegato} other {# allegati}}",
         "link": {
           "addButton": "Aggiungi collegamento",
           "urlLabel": "URL",

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -43,6 +43,7 @@
       "previous": "前の",
       "finish": "仕上げる",
       "download": "ダウンロード",
+      "openLink": "リンクを開く",
       "apply": "適用する",
       "confirm": "確認する",
       "confirmDelete": "削除を確認",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "絵文字"
         },
-        "count": "{count, plural, =1 {# ファイル} other {# ファイル}}",
+        "count": "{count, plural, =1 {# 添付ファイル} other {# 添付ファイル}}",
         "link": {
           "addButton": "リンクを追加",
           "urlLabel": "URL",

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "絵文字"
         },
-        "count": "{count, plural, =1 {# ファイル} other {# ファイル}}"
+        "count": "{count, plural, =1 {# ファイル} other {# ファイル}}",
+        "link": {
+          "addButton": "リンクを追加",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "表示名",
+          "namePlaceholder": "空欄の場合はデフォルトでURLが表示されます",
+          "noteLabel": "説明（任意）",
+          "notePlaceholder": "このリンクが重要な理由",
+          "invalidUrl": "有効なHTTP(S) URLを入力してください。"
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -43,6 +43,7 @@
       "previous": "이전의",
       "finish": "마치다",
       "download": "다운로드",
+      "openLink": "링크 열기",
       "apply": "적용하다",
       "confirm": "확인하다",
       "confirmDelete": "삭제 확인",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "이모지"
         },
-        "count": "{count, plural, =1 {# 파일} other {# 파일들}}",
+        "count": "{count, plural, =1 {# 첨부파일} other {# 첨부파일}}",
         "link": {
           "addButton": "링크 추가",
           "urlLabel": "URL",

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "이모지"
         },
-        "count": "{count, plural, =1 {# 파일} other {# 파일들}}"
+        "count": "{count, plural, =1 {# 파일} other {# 파일들}}",
+        "link": {
+          "addButton": "링크 추가",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "표시 이름",
+          "namePlaceholder": "비워두면 URL이 기본값으로 사용됩니다.",
+          "noteLabel": "설명 (선택 사항)",
+          "notePlaceholder": "이 링크가 중요한 이유",
+          "invalidUrl": "유효한 http(s) URL을 입력하세요."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -43,6 +43,7 @@
       "previous": "Vorig",
       "finish": "Finish",
       "download": "Download",
+      "openLink": "Open link",
       "apply": "Toepassen",
       "confirm": "Bevestigen",
       "confirmDelete": "Bevestig Verwijderen",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# bestand} other {# bestanden}}",
+        "count": "{count, plural, =1 {# bijlage} other {# bijlagen}}",
         "link": {
           "addButton": "Link toevoegen",
           "urlLabel": "URL",

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# bestand} other {# bestanden}}"
+        "count": "{count, plural, =1 {# bestand} other {# bestanden}}",
+        "link": {
+          "addButton": "Link toevoegen",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Weergavenaam",
+          "namePlaceholder": "Als het veld leeg is, wordt standaard de URL gebruikt.",
+          "noteLabel": "Beschrijving (optioneel)",
+          "notePlaceholder": "Waarom deze link relevant is",
+          "invalidUrl": "Voer een geldige http(s)-URL in."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -43,6 +43,7 @@
       "previous": "Poprzedni",
       "finish": "Skończyć",
       "download": "Pobierać",
+      "openLink": "Otwórz link",
       "apply": "Stosować",
       "confirm": "Potwierdzać",
       "confirmDelete": "Potwierdź usunięcie",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emotikon"
         },
-        "count": "{count, plural, =1 {# plik} other {# pliki}}",
+        "count": "{count, plural, =1 {# załącznik} other {# załączniki}}",
         "link": {
           "addButton": "Dodaj link",
           "urlLabel": "Adres URL",

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emotikon"
         },
-        "count": "{count, plural, =1 {# plik} other {# pliki}}"
+        "count": "{count, plural, =1 {# plik} other {# pliki}}",
+        "link": {
+          "addButton": "Dodaj link",
+          "urlLabel": "Adres URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Nazwa wyświetlana",
+          "namePlaceholder": "Domyślnie używany jest adres URL, gdy pole jest puste",
+          "noteLabel": "Opis (opcjonalnie)",
+          "notePlaceholder": "Dlaczego ten link jest istotny",
+          "invalidUrl": "Wprowadź prawidłowy adres URL http(s)."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -43,6 +43,7 @@
       "previous": "Anterior",
       "finish": "Terminar",
       "download": "Download",
+      "openLink": "Abrir link",
       "apply": "Aplicar",
       "confirm": "Confirmar",
       "confirmDelete": "Confirmar exclusão",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# arquivo} other {# arquivos}}",
+        "count": "{count, plural, =1 {# anexo} other {# anexos}}",
         "link": {
           "addButton": "Adicionar link",
           "urlLabel": "URL",

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# arquivo} other {# arquivos}}"
+        "count": "{count, plural, =1 {# arquivo} other {# arquivos}}",
+        "link": {
+          "addButton": "Adicionar link",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Nome de exibição",
+          "namePlaceholder": "O valor padrão é a URL quando o campo está em branco.",
+          "noteLabel": "Descrição (opcional)",
+          "notePlaceholder": "Por que este link é relevante?",
+          "invalidUrl": "Insira um URL http(s) válido."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "эмодзи"
         },
-        "count": "{count, plural, =1 {# файл} other {# файлы}}"
+        "count": "{count, plural, =1 {# файл} other {# файлы}}",
+        "link": {
+          "addButton": "Добавить ссылку",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Отображаемое имя",
+          "namePlaceholder": "Если поле пустое, по умолчанию используется URL-адрес.",
+          "noteLabel": "Описание (необязательно)",
+          "notePlaceholder": "Почему эта ссылка актуальна",
+          "invalidUrl": "Введите действительный URL-адрес http(s)."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -43,6 +43,7 @@
       "previous": "Предыдущий",
       "finish": "Заканчивать",
       "download": "Скачать",
+      "openLink": "Открыть ссылку",
       "apply": "Применять",
       "confirm": "Подтверждать",
       "confirmDelete": "Подтвердить удаление",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "эмодзи"
         },
-        "count": "{count, plural, =1 {# файл} other {# файлы}}",
+        "count": "{count, plural, =1 {# вложение} other {# вложения}}",
         "link": {
           "addButton": "Добавить ссылку",
           "urlLabel": "URL",

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -43,6 +43,7 @@
       "previous": "Öncesi",
       "finish": "Sona ermek",
       "download": "İndirmek",
+      "openLink": "Bağlantıyı Aç",
       "apply": "Uygula",
       "confirm": "Onaylamak",
       "confirmDelete": "Silme işlemini onaylayın",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# dosya} other {# dosyalar}}",
+        "count": "{count, plural, =1 {# ek} other {# ekler}}",
         "link": {
           "addButton": "Bağlantı Ekle",
           "urlLabel": "URL",

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "emoji"
         },
-        "count": "{count, plural, =1 {# dosya} other {# dosyalar}}"
+        "count": "{count, plural, =1 {# dosya} other {# dosyalar}}",
+        "link": {
+          "addButton": "Bağlantı Ekle",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Ekran adı",
+          "namePlaceholder": "Boş bırakıldığında varsayılan olarak URL kullanılır.",
+          "noteLabel": "Açıklama (isteğe bağlı)",
+          "notePlaceholder": "Bu bağlantının önemi",
+          "invalidUrl": "Geçerli bir http(s) URL'si girin."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "biểu tượng cảm xúc"
         },
-        "count": "{count, plural, =1 {# tập tin} other {# tập tin}}"
+        "count": "{count, plural, =1 {# tập tin} other {# tập tin}}",
+        "link": {
+          "addButton": "Thêm liên kết",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "Tên hiển thị",
+          "namePlaceholder": "Mặc định là URL nếu để trống.",
+          "noteLabel": "Mô tả (tùy chọn)",
+          "notePlaceholder": "Vì sao liên kết này lại quan trọng",
+          "invalidUrl": "Nhập URL http(s) hợp lệ."
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -43,6 +43,7 @@
       "previous": "Trước",
       "finish": "Hoàn thành",
       "download": "Tải xuống",
+      "openLink": "Mở liên kết",
       "apply": "Áp dụng",
       "confirm": "Xác nhận",
       "confirmDelete": "Xác nhận xóa",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "biểu tượng cảm xúc"
         },
-        "count": "{count, plural, =1 {# tập tin} other {# tập tin}}",
+        "count": "{count, plural, =1 {# tệp đính kèm} other {# tệp đính kèm}}",
         "link": {
           "addButton": "Thêm liên kết",
           "urlLabel": "URL",

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -43,6 +43,7 @@
       "previous": "以前的",
       "finish": "结束",
       "download": "下载",
+      "openLink": "打开链接",
       "apply": "申请",
       "confirm": "确认",
       "confirmDelete": "确认删除",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "表情符号"
         },
-        "count": "{count, plural, =1 {# 文件} other {# 文件集}}",
+        "count": "{count, plural, =1 {# 附件} other {# 附件}}",
         "link": {
           "addButton": "添加链接",
           "urlLabel": "URL",

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "表情符号"
         },
-        "count": "{count, plural, =1 {# 文件} other {# 文件集}}"
+        "count": "{count, plural, =1 {# 文件} other {# 文件集}}",
+        "link": {
+          "addButton": "添加链接",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "显示名称",
+          "namePlaceholder": "默认为空 URL",
+          "noteLabel": "描述（可选）",
+          "notePlaceholder": "此链接为何相关",
+          "invalidUrl": "请输入有效的http(s)网址。"
+        }
       }
     },
     "fileDropZone": {

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -43,6 +43,7 @@
       "previous": "以前的",
       "finish": "結束",
       "download": "下載",
+      "openLink": "打開連結",
       "apply": "申請",
       "confirm": "確認",
       "confirmDelete": "確認刪除",
@@ -807,7 +808,7 @@
         "altText": {
           "emoji": "表情符號"
         },
-        "count": "{count, plural, =1 {# 文件} other {# 文件集}}",
+        "count": "{count, plural, =1 {# 附件} other {# 附件}}",
         "link": {
           "addButton": "添加連結",
           "urlLabel": "URL",

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -807,7 +807,17 @@
         "altText": {
           "emoji": "表情符號"
         },
-        "count": "{count, plural, =1 {# 文件} other {# 文件集}}"
+        "count": "{count, plural, =1 {# 文件} other {# 文件集}}",
+        "link": {
+          "addButton": "添加連結",
+          "urlLabel": "URL",
+          "urlPlaceholder": "https://example.com/...",
+          "nameLabel": "顯示名稱",
+          "namePlaceholder": "預設為空 URL",
+          "noteLabel": "描述（可選）",
+          "notePlaceholder": "此連結為何相關",
+          "invalidUrl": "請輸入有效的http(s)網址。"
+        }
       }
     },
     "fileDropZone": {


### PR DESCRIPTION
## Description

Attachments today are file uploads only. The underlying `Attachments` schema has always supported external URLs (`mimeType: "text/uri-list"` is the in-codebase discriminator), but the only writer was the Testmo automation importer — end users had **no UI** anywhere to attach a link.

This PR adds a first-class **Add Link** affordance to `UploadAttachments` and wires it through every place that already mounts the component:

| Surface | Mount |
|---|---|
| Repository | [AddCase](testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx), [TestCaseFormControl](testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/TestCaseFormControl.tsx) + case-detail page |
| Runs | [AddTestRunModal](testplanit/app/[locale]/projects/runs/[projectId]/AddTestRunModal.tsx) (via `BasicInfoDialog`), [TestRunFormControls](testplanit/app/[locale]/projects/runs/[projectId]/[runId]/TestRunFormControls.tsx) + run-detail page |
| Results | [AddResultModal](testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx), [EditResultModal](testplanit/app/[locale]/projects/repository/[projectId]/EditResultModal.tsx) |
| Sessions | [AddSessionModal](testplanit/app/[locale]/projects/sessions/[projectId]/AddSessionModal.tsx), [SessionResultForm](testplanit/components/SessionResultForm.tsx), [SessionResultsList](testplanit/components/SessionResultsList.tsx), session-detail page (via `SessionFormControls`) |

The four **import wizards** (TestmoImportPanel, ImportCasesWizard, ImportSharedStepsWizard, TestResultsImportDialog) stay file-only — `allowLinks` defaults to `false` so they're unaffected.

## UI

Clicking **Add Link** expands an inline form below the file picker:

- **URL** (required) — validated as a parseable `http(s)` URL
- **Display name** — defaults to the URL when blank
- **Description** (optional) — short note about why the link is relevant

Submitted links appear in the same staged list as files (Link icon vs. file thumbnail), can be removed before save, and are de-duplicated by URL. On save, each parent persists the link as a regular `Attachments` row via the existing `useCreateAttachments` path — no file upload step.

The display path was already ready: `AttachmentPreview.tsx:45-46` and `AttachmentsDisplay.tsx:372` already special-case `text/uri-list` to render as an opens-in-new-tab link with no download button. So the same row shape Testmo's importer was writing is now writable by users from every attachment surface, and the existing read path handles both.

## Why the wide scope

Brad's pick during scoping. Doing every surface in one PR — rather than per-surface follow-ups — means there's a single "before" and "after": the answer to *"can I attach a URL there?"* flips from *no* to *yes* everywhere in the same release. It also makes the §3.24.1 RFI claim ("attachments may be uploaded files or external links") true without a "but only in test results" qualifier.

## What's NOT in this PR

- **Audit enum split.** Attachment mutations already go through generic `CREATE`/`UPDATE`/`DELETE` on the `Attachments` model — dedicated `ATTACHMENT_LINK_CREATED` values would be more granular telemetry but aren't load-bearing. Left for a follow-up if the audit-log filter UX ever wants to slice external links specifically.
- **URL title auto-fetch / link preview / safety badges.** UX polish; can be layered on later. The current scope is the data path + a clean UI.
- **`Comments` composer** — attachments aren't mounted there today either; if it gets the upload UI later it inherits the link mode for free.

## Related Issue

RFI Tier A #25 (§3.24.1) — clean win, plan estimated 1–2 days.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — **8 new component tests** for `UploadAttachments`:
  - opt-in: Add Link button absent when `allowLinks=false`, present when `true`
  - form-open: URL/Name/Note fields appear when toggled
  - URL validation: invalid URL leaves the Add button disabled and never fires the callback
  - submit emits a link with `mimeType: "text/uri-list"` and `size = url.length`
  - display name defaults to the URL when blank
  - de-dupe: pasting the same URL twice yields one staged entry
  - mount-suppress: `onLinksChange` isn't invoked on initial render with no links
- [x] Existing tests — 15 component tests + 15 `AttachmentsDisplay` tests still green
- [x] Full suite — **8058 passing** (was 8032 before this branch → +26 net). Lint clean.
- [ ] E2E tests
- [x] Manual testing — verified the new Add Link affordance renders + opens form + persists the link + appears in the attachment list across the repository case, the result-recording modals, the test run editor, and the session-result form

**Test Configuration:**

- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A — verified via unit tests + spot-checks across the 10 mount points.

## Additional Notes

No schema migration; no audit-enum change. The row shape in the DB is unchanged from what the Testmo importer was already writing, so existing rendering, audit, and search code paths handle the new user-created links without further work. Existing file-only attachments and existing import wizards are unaffected (`allowLinks` defaults to `false`).
