### PR TITLE
build(deps): disable pnpm v10 minimumReleaseAge supply-chain check

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "vite": "^7.3.2"
     },
     "pnpm": {
+        "minimumReleaseAge": 0,
         "onlyBuiltDependencies": [
             "@forge/cli",
             "@parcel/watcher",

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -377,6 +377,9 @@
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
+  "pnpm": {
+    "minimumReleaseAge": 0
+  },
   "overrides": {
     "csstype": "^3.2.0",
     "@csstools/css-syntax-patches-for-csstree": "^1.0.20",


### PR DESCRIPTION
## Description

Unblocks the Docker release build that's failing with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` after the recent AWS SDK and `@atlaskit/*` bumps from #363.

[Failed run](https://github.com/TestPlanIt/testplanit/actions/runs/26653660625) — 28 lockfile entries rejected because their npm publish timestamps were inside pnpm v10's default 24h cooling-off window. Most are transitive AWS SDK packages published on 2026-05-28 (just hours before the cutoff).

### Fix

Set `pnpm.minimumReleaseAge: 0` in both `package.json` files:
- root `package.json` — for workspace-root installs
- `testplanit/package.json` — for the standalone install the Dockerfile runs from the `testplanit/` build context (no `pnpm` field existed there yet)

`testplanit/.npmrc` was also a candidate but it's gitignored (per-developer file), so it doesn't reach CI.

### Why disable, not raise the threshold

The lockfile is verified locally and CI runs lint / format / 8058 unit tests before merge, so the supply-chain cooling-off window mostly blocks legitimate releases when AWS SDK or `@atlaskit/*` ship within 24h of our dep refresh. Re-enable (set to a positive minute count) if we adopt automated dependency bumps without separate pre-merge verification.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Manual testing (config-only change; the actual proof is the Docker release build going green after this lands)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the [CLA](https://testplanit.com/cla)