### PR TITLE
enhancement(milestones): PDF export from milestone details page

### DIFF
--- a/docs/docs/import-export.md
+++ b/docs/docs/import-export.md
@@ -568,6 +568,8 @@ Common validation errors:
 
 - **Test cases** from the Repository, including all template custom fields and attachment metadata
 - **Test results** from a Test Run, in CSV or PDF
+- **Sessions** as a PDF report from the session details page
+- **Milestone reports** as a PDF from the [milestone details page](./user-guide/projects/milestone-details.md#exporting-to-pdf) — an aggregated, evidence-grade summary of the milestone and its sub-milestones
 - **Audit log** entries from project administration
 
 ### Export Formats
@@ -602,6 +604,12 @@ Common validation errors:
 
 - **Names**: Display attachment file names as text (default for PDF)
 - **Embed Images**: Embed image attachments directly in the PDF document. Non-image files are listed by name. Supported image formats: JPEG, PNG, GIF, WebP, BMP.
+
+:::note Exported PDFs are in English
+
+PDF exports (test case, test run, session, and milestone reports) are generated in **English by design**, regardless of the application's display language. Dates and durations are formatted for your locale, but the document body — titles, section headings, table headers, and field labels — is always English. These documents are intended as canonical, archival evidence artifacts, so their language is kept consistent rather than localized.
+
+:::
 
 ## Integration Examples
 

--- a/docs/docs/user-guide/projects/milestone-details.md
+++ b/docs/docs/user-guide/projects/milestone-details.md
@@ -28,6 +28,7 @@ In the default view mode:
 - All fields are read-only.
 - A **Back Arrow** button in the header navigates back to the main Milestones list.
 - An **Edit** button (icon: SquarePen) is available for users with **ADMIN** or **PROJECTADMIN** access.
+- An **Export PDF** button generates a print/evidence-grade PDF report of the milestone (see [Exporting to PDF](#exporting-to-pdf)).
 - The right panel displays:
   - **Status Badge**: Shows the calculated status (Not Started, In Progress, Completed, Overdue).
   - **Completion Rate**: Displays the percentage of completed test results out of total test cases in test runs associated with this milestone and all descendant milestones.
@@ -54,6 +55,22 @@ Clicking the **Edit** button (or accessing via an edit link) activates Edit Mode
 - **Editing:** Requires the `Add/Edit` permission for the `Milestones` application area. Users without this permission cannot enter edit mode or save changes.
 - **Deleting:** Requires the `Delete` permission for the `Milestones` application area. Users without this permission will not see the Delete button.
 :::
+
+## Exporting to PDF
+
+The **Export PDF** button in the header generates a print- and evidence-grade PDF report of the milestone. Unlike screenshotting the page, the report is laid out aggregate-first, paginates cleanly with table headers that repeat on continuation pages, and stamps every page with a generation header (milestone name, generation date, and the user who produced it) plus a page-numbered footer — so an auditor can see when and by whom the report was produced.
+
+The report aggregates the milestone **and all of its descendant sub-milestones**, and includes:
+
+- **Milestone metadata**: name, status, start/due/created dates, owner, type, and parent path.
+- **Summary**: completion rate, executed vs. total items, total elapsed and estimated time, and a status-count rollup (e.g. Passed / Failed / Blocked).
+- **Contributing Test Runs**: one row per run with its per-status breakdown.
+- **Contributing Sessions**: each session with its latest status.
+- **Sub-milestones**: descendant milestones with their status.
+- **Linked Issues**: issues linked to the contributing runs and sessions.
+- **Review & Approval Decisions**: the decision (approved, rejected, etc.), reviewer, date, and comment for contributing runs and sessions that went through review.
+
+Dates and durations are formatted for your locale. As with the test run and session PDF exports, the document body text is in English by design — see [Exported PDFs are in English](../../import-export.md#pdf-export).
 
 ## Automatic Completion
 

--- a/testplanit/app/[locale]/projects/milestones/[projectId]/[milestoneId]/page.tsx
+++ b/testplanit/app/[locale]/projects/milestones/[projectId]/[milestoneId]/page.tsx
@@ -36,13 +36,14 @@ import {
   CircleCheckBig,
   CircleSlash2,
   Compass,
+  FileDown,
   PlayCircle,
   Save,
   SquarePen,
   Trash2,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { useParams, useSearchParams } from "next/navigation";
 import React, { useEffect, useMemo, useState } from "react";
@@ -54,6 +55,7 @@ import { emptyEditorContent } from "~/app/constants";
 import { isTiptapEmpty } from "~/lib/tiptap/isTiptapEmpty";
 import { CommentsSection } from "~/components/comments/CommentsSection";
 import LoadingSpinner from "~/components/LoadingSpinner";
+import { useExportMilestonePdf } from "~/hooks/pdf/useExportMilestonePdf";
 import { useProjectPermissions } from "~/hooks/useProjectPermissions";
 import {
   useFindFirstMilestones,
@@ -110,6 +112,15 @@ export default function MilestoneDetailsPage() {
   const { resolvedTheme } = useTheme();
 
   const { data: sessionAuth } = useSession();
+  const locale = useLocale();
+
+  const { isExporting: isExportingPdf, handleExport: handleExportPdf } =
+    useExportMilestonePdf({
+      milestoneId: Number(milestoneId),
+      projectId: Number(projectId),
+      locale,
+      generatedByName: sessionAuth?.user?.name,
+    });
 
   const {
     permissions: milestonePermissions,
@@ -544,7 +555,16 @@ export default function MilestoneDetailsPage() {
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)}>
+      <form
+        key={`milestone-form-${isEditMode ? "edit" : "view"}`}
+        onSubmit={(e) => {
+          e.preventDefault();
+          // Ignore stray submits fired while in view mode (e.g. clicking Edit
+          // swaps the trigger for the edit-mode Save button under the cursor).
+          if (!isEditMode) return;
+          void methods.handleSubmit(onSubmit)(e);
+        }}
+      >
         <Card
           className={`group-hover:bg-accent/50 transition-colors ${
             milestone?.isCompleted
@@ -593,6 +613,7 @@ export default function MilestoneDetailsPage() {
                         type="submit"
                         variant="default"
                         disabled={isSubmitting}
+                        data-testid="milestone-save"
                       >
                         <Save className="h-4 w-4" />
                         {isSubmitting
@@ -623,31 +644,57 @@ export default function MilestoneDetailsPage() {
                     )}
                   </>
                 ) : (
-                  showEditButtonPerm && (
-                    <Button
-                      type="button"
-                      onClick={handleEditClick}
-                      variant="secondary"
-                    >
-                      <SquarePen className="h-4 w-4" />
-                      {tCommon("actions.edit")}
-                    </Button>
-                  )
+                  <div className="flex items-center gap-1">
+                    {showEditButtonPerm && (
+                      <Button
+                        type="button"
+                        onClick={handleEditClick}
+                        variant="secondary"
+                        data-testid="milestone-edit"
+                        className="group px-3 hover:px-3 transition-all duration-200 gap-0 hover:gap-2"
+                      >
+                        <SquarePen className="h-4 w-4 shrink-0" />
+                        <span className="max-w-0 overflow-hidden whitespace-nowrap transition-all duration-200 group-hover:max-w-40">
+                          {tCommon("actions.edit")}
+                        </span>
+                      </Button>
+                    )}
+                    {milestone && (
+                      <Button
+                        type="button"
+                        onClick={handleExportPdf}
+                        variant="secondary"
+                        disabled={isExportingPdf}
+                        data-testid="milestone-export-pdf"
+                        className={`group px-3 hover:px-3 transition-all duration-200 gap-0 hover:gap-2 ${
+                          isExportingPdf ? "animate-pulse" : ""
+                        }`}
+                      >
+                        <FileDown className="h-4 w-4 shrink-0" />
+                        <span className="max-w-0 overflow-hidden whitespace-nowrap transition-all duration-200 group-hover:max-w-40">
+                          {isExportingPdf
+                            ? tCommon("actions.exportingPdf")
+                            : tCommon("actions.exportPdf")}
+                        </span>
+                      </Button>
+                    )}
+                    {milestone &&
+                      !milestone.isCompleted &&
+                      canCompleteMilestonePerm && (
+                        <Button
+                          type="button"
+                          onClick={() => setIsCompleteDialogOpen(true)}
+                          variant="secondary"
+                          className="group px-3 hover:px-3 transition-all duration-200 gap-0 hover:gap-2"
+                        >
+                          <CircleCheckBig className="h-4 w-4 shrink-0" />
+                          <span className="max-w-0 overflow-hidden whitespace-nowrap transition-all duration-200 group-hover:max-w-40">
+                            {tCommon("actions.complete")}
+                          </span>
+                        </Button>
+                      )}
+                  </div>
                 )}
-                {!isEditMode &&
-                  milestone &&
-                  !milestone.isCompleted &&
-                  canCompleteMilestonePerm && (
-                    <Button
-                      type="button"
-                      onClick={() => setIsCompleteDialogOpen(true)}
-                      variant="secondary"
-                      className="mt-2"
-                    >
-                      <CircleCheckBig className="h-4 w-4" />
-                      {tCommon("actions.complete")}
-                    </Button>
-                  )}
               </div>
             </div>
           </CardHeader>

--- a/testplanit/app/api/milestones/[milestoneId]/export/route.test.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/export/route.test.ts
@@ -1,0 +1,268 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    milestones: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    reviewRequest: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("~/lib/services/milestoneDescendants", () => ({
+  getAllDescendantMilestoneIds: vi.fn(),
+}));
+
+vi.mock("~/lib/services/milestoneSummary", () => ({
+  getTestRunSegments: vi.fn(),
+  getSessionSegments: vi.fn(),
+  calculateMilestoneCompletion: vi.fn(),
+  getMilestoneLinkedIssues: vi.fn(),
+}));
+
+import { prisma } from "~/lib/prisma";
+import { getAllDescendantMilestoneIds } from "~/lib/services/milestoneDescendants";
+import {
+  calculateMilestoneCompletion,
+  getMilestoneLinkedIssues,
+  getSessionSegments,
+  getTestRunSegments,
+} from "~/lib/services/milestoneSummary";
+import { getServerSession } from "next-auth";
+import { GET } from "./route";
+
+const createRequest = (
+  milestoneId: string
+): [NextRequest, { params: Promise<{ milestoneId: string }> }] => {
+  const req = new NextRequest(
+    `http://localhost/api/milestones/${milestoneId}/export`
+  );
+  const params = { params: Promise.resolve({ milestoneId }) };
+  return [req, params];
+};
+
+const adminSession = {
+  user: { id: "admin-1", name: "Admin", access: "ADMIN" },
+};
+const userSession = { user: { id: "user-1", name: "Reg", access: "USER" } };
+
+const baseMilestone = {
+  id: 1,
+  name: "Release 1.0",
+  projectId: 10,
+  isStarted: true,
+  isCompleted: false,
+  startedAt: new Date("2026-05-01T00:00:00.000Z"),
+  completedAt: null,
+  createdAt: new Date("2026-04-01T00:00:00.000Z"),
+  parentId: null,
+  creator: { name: "Owner" },
+  milestoneType: { name: "Version" },
+};
+
+const testRunSegment = (over: Record<string, unknown> = {}) => ({
+  id: "test-run-1-1-0",
+  type: "test-run" as const,
+  sourceId: 100,
+  sourceName: "Regression Run",
+  statusId: 1,
+  statusName: "Passed",
+  colorValue: "#22c55e",
+  elapsed: 120,
+  estimate: 0,
+  isPending: false,
+  itemCount: 2,
+  statusOrder: 1,
+  ...over,
+});
+
+const sessionSegment = (over: Record<string, unknown> = {}) => ({
+  id: "session-200",
+  type: "session" as const,
+  sourceId: 200,
+  sourceName: "Exploratory",
+  statusId: 5,
+  statusName: "Completed",
+  colorValue: "#22c55e",
+  elapsed: 60,
+  estimate: null,
+  isPending: false,
+  itemCount: 1,
+  statusOrder: 2,
+  ...over,
+});
+
+describe("GET /api/milestones/[milestoneId]/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getAllDescendantMilestoneIds as any).mockResolvedValue([]);
+    (getTestRunSegments as any).mockResolvedValue([]);
+    (getSessionSegments as any).mockResolvedValue([]);
+    (calculateMilestoneCompletion as any).mockResolvedValue(0);
+    (getMilestoneLinkedIssues as any).mockResolvedValue([]);
+    (prisma.milestones.findUnique as any).mockResolvedValue(baseMilestone);
+    (prisma.milestones.findMany as any).mockResolvedValue([]);
+    (prisma.reviewRequest.findMany as any).mockResolvedValue([]);
+  });
+
+  describe("Input validation & auth", () => {
+    it("returns 400 for non-numeric milestoneId", async () => {
+      (getServerSession as any).mockResolvedValue(adminSession);
+      const [req, ctx] = createRequest("not-a-number");
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe("Invalid milestone ID");
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      (getServerSession as any).mockResolvedValue(null);
+      const [req, ctx] = createRequest("1");
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when the milestone does not exist", async () => {
+      (getServerSession as any).mockResolvedValue(adminSession);
+      (prisma.milestones.findUnique as any).mockResolvedValue(null);
+      const [req, ctx] = createRequest("999");
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("Contributors, issues, and review decisions", () => {
+    beforeEach(() => {
+      (getServerSession as any).mockResolvedValue(userSession);
+      (getTestRunSegments as any).mockResolvedValue([
+        testRunSegment(),
+        testRunSegment({
+          id: "test-run-1-2-1",
+          statusName: "Failed",
+          colorValue: "#ef4444",
+          itemCount: 1,
+          isPending: false,
+        }),
+      ]);
+      (getSessionSegments as any).mockResolvedValue([sessionSegment()]);
+      (calculateMilestoneCompletion as any).mockResolvedValue(75);
+      (getMilestoneLinkedIssues as any).mockResolvedValue([
+        {
+          id: 1,
+          name: "BUG-1",
+          title: "Login broken",
+          externalId: null,
+          externalKey: "JIRA-9",
+          externalUrl: null,
+          externalStatus: "Open",
+          data: null,
+          integrationId: null,
+          lastSyncedAt: null,
+          integration: null,
+          projectIds: [10],
+        },
+      ]);
+      (prisma.reviewRequest.findMany as any).mockResolvedValue([
+        {
+          entityType: "RUN",
+          entityId: 100,
+          status: "APPROVED",
+          decidedAt: new Date("2026-05-15T00:00:00.000Z"),
+          decisionComment: "LGTM",
+          decidedBy: { name: "Jane" },
+        },
+      ]);
+    });
+
+    it("rolls up status counts and builds per-run contributors", async () => {
+      const [req, ctx] = createRequest("1");
+      const data = await (await GET(req, ctx)).json();
+
+      expect(data.rollup.completionRate).toBe(75);
+      expect(data.rollup.executedItems).toBe(4); // 2 + 1 (runs) + 1 (session)
+      expect(data.rollup.totalItems).toBe(4);
+      const passed = data.rollup.statusCounts.find(
+        (s: any) => s.statusName === "Passed"
+      );
+      expect(passed.count).toBe(2);
+
+      expect(data.testRuns).toHaveLength(1);
+      expect(data.testRuns[0].id).toBe(100);
+      expect(data.testRuns[0].statusCounts).toHaveLength(2);
+
+      expect(data.sessions).toHaveLength(1);
+      expect(data.sessions[0].id).toBe(200);
+
+      expect(data.issues[0]).toEqual({
+        key: "JIRA-9",
+        title: "Login broken",
+        status: "Open",
+      });
+    });
+
+    it("queries review requests for the contributing runs and sessions and shapes decisions", async () => {
+      const [req, ctx] = createRequest("1");
+      const data = await (await GET(req, ctx)).json();
+
+      const whereArg = (prisma.reviewRequest.findMany as any).mock.calls[0][0]
+        .where;
+      expect(whereArg.projectId).toBe(10);
+      expect(whereArg.isDeleted).toBe(false);
+      expect(whereArg.OR).toEqual([
+        { entityType: "RUN", entityId: { in: [100] } },
+        { entityType: "SESSION", entityId: { in: [200] } },
+      ]);
+
+      expect(data.reviewDecisions).toHaveLength(1);
+      expect(data.reviewDecisions[0]).toMatchObject({
+        entityType: "RUN",
+        entityId: 100,
+        entityName: "Regression Run",
+        status: "APPROVED",
+        decidedByName: "Jane",
+      });
+    });
+  });
+
+  describe("Empty milestone", () => {
+    it("returns empty sections and skips the review query when there is no data", async () => {
+      (getServerSession as any).mockResolvedValue(adminSession);
+
+      const [req, ctx] = createRequest("1");
+      const data = await (await GET(req, ctx)).json();
+
+      expect(data.testRuns).toEqual([]);
+      expect(data.sessions).toEqual([]);
+      expect(data.descendants).toEqual([]);
+      expect(data.issues).toEqual([]);
+      expect(data.reviewDecisions).toEqual([]);
+      expect(prisma.reviewRequest.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Parent path", () => {
+    it("walks the parent chain into a root-first path", async () => {
+      (getServerSession as any).mockResolvedValue(userSession);
+      (prisma.milestones.findUnique as any)
+        .mockResolvedValueOnce({ ...baseMilestone, parentId: 2 }) // the milestone
+        .mockResolvedValueOnce({ name: "Q2", parentId: 3 }) // parent
+        .mockResolvedValueOnce({ name: "FY26", parentId: null }); // grandparent
+
+      const [req, ctx] = createRequest("1");
+      const data = await (await GET(req, ctx)).json();
+
+      expect(data.milestone.parentPath).toEqual(["FY26", "Q2"]);
+    });
+  });
+});

--- a/testplanit/app/api/milestones/[milestoneId]/export/route.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/export/route.ts
@@ -1,0 +1,220 @@
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "~/lib/prisma";
+import {
+  aggregateStatusCounts,
+  groupTestRunContributors,
+  mapSessionContributors,
+  milestoneStatusLabel,
+  shapeReviewDecisions,
+  type MilestoneExportData,
+} from "~/lib/services/milestoneExport";
+import { getAllDescendantMilestoneIds } from "~/lib/services/milestoneDescendants";
+import {
+  calculateMilestoneCompletion,
+  getMilestoneLinkedIssues,
+  getSessionSegments,
+  getTestRunSegments,
+} from "~/lib/services/milestoneSummary";
+import { authOptions } from "~/server/auth";
+
+export type { MilestoneExportData };
+
+/** Walk a milestone's parent chain to build a root-first path of names. */
+async function buildParentPath(parentId: number | null): Promise<string[]> {
+  const path: string[] = [];
+  let current = parentId;
+  // Bound the walk defensively against unexpected cycles.
+  for (let i = 0; i < 25 && current != null; i++) {
+    const parent = await prisma.milestones.findUnique({
+      where: { id: current },
+      select: { name: true, parentId: true },
+    });
+    if (!parent) break;
+    path.unshift(parent.name);
+    current = parent.parentId;
+  }
+  return path;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ milestoneId: string }> }
+) {
+  const { milestoneId: milestoneIdParam } = await params;
+  const milestoneId = Number(milestoneIdParam);
+
+  if (isNaN(milestoneId)) {
+    return NextResponse.json(
+      { error: "Invalid milestone ID" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const milestone = await prisma.milestones.findUnique({
+      where: { id: milestoneId, isDeleted: false },
+      select: {
+        id: true,
+        name: true,
+        projectId: true,
+        isStarted: true,
+        isCompleted: true,
+        startedAt: true,
+        completedAt: true,
+        createdAt: true,
+        parentId: true,
+        creator: { select: { name: true } },
+        milestoneType: { select: { name: true } },
+      },
+    });
+
+    if (!milestone) {
+      return NextResponse.json(
+        { error: "Milestone not found" },
+        { status: 404 }
+      );
+    }
+
+    // Roll up across this milestone and all descendants.
+    const descendantIds = await getAllDescendantMilestoneIds(milestoneId);
+    const allMilestoneIds = [milestoneId, ...descendantIds];
+
+    const [testRunSegments, sessionSegments, completionRate, parentPath] =
+      await Promise.all([
+        getTestRunSegments(allMilestoneIds),
+        getSessionSegments(allMilestoneIds),
+        calculateMilestoneCompletion(allMilestoneIds),
+        buildParentPath(milestone.parentId),
+      ]);
+
+    const allSegments = [...testRunSegments, ...sessionSegments];
+    const totalElapsed = allSegments.reduce(
+      (s, seg) => s + (seg.elapsed || 0),
+      0
+    );
+    const totalEstimate = allSegments.reduce(
+      (s, seg) => s + (seg.estimate || 0),
+      0
+    );
+
+    const rollupCounts = aggregateStatusCounts(allSegments);
+    const testRuns = groupTestRunContributors(testRunSegments);
+    const sessions = mapSessionContributors(sessionSegments);
+
+    const testRunIds = testRuns.map((r) => r.id);
+    const sessionIds = sessions.map((s) => s.id);
+
+    // Descendant sub-milestone metadata for the nesting table.
+    const descendants =
+      descendantIds.length > 0
+        ? (
+            await prisma.milestones.findMany({
+              where: { id: { in: descendantIds }, isDeleted: false },
+              select: {
+                id: true,
+                name: true,
+                isStarted: true,
+                isCompleted: true,
+              },
+              orderBy: { name: "asc" },
+            })
+          ).map((d) => ({
+            id: d.id,
+            name: d.name,
+            status: milestoneStatusLabel(d),
+          }))
+        : [];
+
+    const linkedIssues = await getMilestoneLinkedIssues(
+      testRunIds,
+      sessionIds,
+      milestone.projectId
+    );
+    const issues = linkedIssues.map((issue) => ({
+      key: issue.externalKey || issue.externalId || issue.name,
+      title: issue.title || issue.name,
+      status: issue.externalStatus,
+    }));
+
+    // Review & Approval decisions for the contributing runs and sessions.
+    const entityNameByKey = new Map<string, string>();
+    for (const r of testRuns) entityNameByKey.set(`RUN:${r.id}`, r.name);
+    for (const s of sessions) entityNameByKey.set(`SESSION:${s.id}`, s.name);
+
+    const reviewOr: Array<{
+      entityType: "RUN" | "SESSION";
+      entityId: { in: number[] };
+    }> = [];
+    if (testRunIds.length > 0)
+      reviewOr.push({ entityType: "RUN", entityId: { in: testRunIds } });
+    if (sessionIds.length > 0)
+      reviewOr.push({ entityType: "SESSION", entityId: { in: sessionIds } });
+
+    const reviewRequests =
+      reviewOr.length > 0
+        ? await prisma.reviewRequest.findMany({
+            where: {
+              projectId: milestone.projectId,
+              isDeleted: false,
+              OR: reviewOr,
+            },
+            select: {
+              entityType: true,
+              entityId: true,
+              status: true,
+              decidedAt: true,
+              decisionComment: true,
+              decidedBy: { select: { name: true } },
+            },
+            orderBy: { createdAt: "desc" },
+          })
+        : [];
+    const reviewDecisions = shapeReviewDecisions(
+      reviewRequests,
+      entityNameByKey
+    );
+
+    const response: MilestoneExportData = {
+      milestone: {
+        id: milestone.id,
+        name: milestone.name,
+        status: milestoneStatusLabel(milestone),
+        startedAt: milestone.startedAt?.toISOString() ?? null,
+        completedAt: milestone.completedAt?.toISOString() ?? null,
+        createdAt: milestone.createdAt.toISOString(),
+        ownerName: milestone.creator?.name ?? null,
+        typeName: milestone.milestoneType?.name ?? null,
+        parentPath,
+      },
+      rollup: {
+        totalItems: rollupCounts.totalItems,
+        executedItems: rollupCounts.executedItems,
+        completionRate,
+        totalElapsed,
+        totalEstimate,
+        statusCounts: rollupCounts.statusCounts,
+      },
+      testRuns,
+      sessions,
+      descendants,
+      issues,
+      reviewDecisions,
+      generatedAt: new Date().toISOString(),
+      projectId: milestone.projectId,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error("Milestone export error:", error);
+    return NextResponse.json(
+      { error: "Failed to build milestone export" },
+      { status: 500 }
+    );
+  }
+}

--- a/testplanit/app/api/milestones/[milestoneId]/summary/route.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/summary/route.ts
@@ -2,48 +2,16 @@ import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "~/lib/prisma";
 import { getAllDescendantMilestoneIds } from "~/lib/services/milestoneDescendants";
+import {
+  calculateMilestoneCompletion,
+  getMilestoneLinkedIssues,
+  getSessionSegments,
+  getTestRunSegments,
+  type MilestoneSummaryData,
+} from "~/lib/services/milestoneSummary";
 import { authOptions } from "~/server/auth";
 
-export type MilestoneSummaryData = {
-  milestoneId: number;
-  totalItems: number;
-  completionRate: number;
-  totalElapsed: number;
-  totalEstimate: number;
-  commentsCount: number;
-  segments: Array<{
-    id: string;
-    type: "test-run" | "session";
-    sourceId: number;
-    sourceName: string;
-    statusId: number | null;
-    statusName: string;
-    colorValue: string;
-    elapsed: number | null;
-    estimate: number | null;
-    isPending: boolean;
-    itemCount?: number; // For test runs, number of cases
-    statusOrder: number | null;
-  }>;
-  issues: Array<{
-    id: number;
-    name: string;
-    title: string;
-    externalId: string | null;
-    externalKey: string | null;
-    externalUrl: string | null;
-    externalStatus: string | null;
-    data: any;
-    integrationId: number | null;
-    lastSyncedAt: Date | null;
-    integration: {
-      id: number;
-      provider: string;
-      name: string;
-    } | null;
-    projectIds: number[];
-  }>;
-};
+export type { MilestoneSummaryData };
 
 export async function GET(
   req: NextRequest,
@@ -117,88 +85,13 @@ export async function GET(
     });
 
     // Get all unique issues from test runs and sessions
-    const issueIds = new Set<number>();
     const testRunIds = testRunSegments.map((seg) => seg.sourceId);
     const sessionIds = sessionSegments.map((seg) => seg.sourceId);
-
-    // Fetch test run issues
-    const testRunIssues =
-      testRunIds.length > 0
-        ? await prisma.$queryRaw<
-            Array<{
-              issueId: number;
-            }>
-          >`
-        SELECT DISTINCT "B" as "issueId"
-        FROM "_IssueToTestRuns"
-        WHERE "A" = ANY(${testRunIds}::int[])
-      `
-        : [];
-
-    testRunIssues.forEach((link) => issueIds.add(link.issueId));
-
-    // Fetch session issues (session-level)
-    const sessionIssues =
-      sessionIds.length > 0
-        ? await prisma.$queryRaw<
-            Array<{
-              issueId: number;
-            }>
-          >`
-        SELECT DISTINCT "B" as "issueId"
-        FROM "_IssueToSessions"
-        WHERE "A" = ANY(${sessionIds}::int[])
-      `
-        : [];
-
-    sessionIssues.forEach((link) => issueIds.add(link.issueId));
-
-    // Fetch session result issues
-    const sessionResultIssues =
-      sessionIds.length > 0
-        ? await prisma.$queryRaw<
-            Array<{
-              issueId: number;
-            }>
-          >`
-        SELECT DISTINCT irs."B" as "issueId"
-        FROM "_IssueToSessionResults" irs
-        JOIN "SessionResults" sr ON irs."A" = sr.id
-        WHERE sr."sessionId" = ANY(${sessionIds}::int[])
-          AND sr."isDeleted" = false
-      `
-        : [];
-
-    sessionResultIssues.forEach((link) => issueIds.add(link.issueId));
-
-    // Fetch all unique issues
-    const issues =
-      issueIds.size > 0
-        ? await prisma.issue.findMany({
-            where: {
-              id: { in: Array.from(issueIds) },
-            },
-            select: {
-              id: true,
-              name: true,
-              title: true,
-              externalId: true,
-              externalKey: true,
-              externalUrl: true,
-              externalStatus: true,
-              data: true,
-              integrationId: true,
-              lastSyncedAt: true,
-              integration: {
-                select: {
-                  id: true,
-                  provider: true,
-                  name: true,
-                },
-              },
-            },
-          })
-        : [];
+    const issues = await getMilestoneLinkedIssues(
+      testRunIds,
+      sessionIds,
+      milestone.projectId
+    );
 
     const response: MilestoneSummaryData = {
       milestoneId,
@@ -208,10 +101,7 @@ export async function GET(
       totalEstimate,
       commentsCount,
       segments: allSegments,
-      issues: issues.map((issue) => ({
-        ...issue,
-        projectIds: [milestone.projectId],
-      })),
+      issues,
     };
 
     return NextResponse.json(response);
@@ -222,240 +112,4 @@ export async function GET(
       { status: 500 }
     );
   }
-}
-
-async function calculateMilestoneCompletion(
-  milestoneIds: number[]
-): Promise<number> {
-  // Get total test cases in all test runs for these milestones
-  const totalCasesResult = await prisma.$queryRaw<Array<{ count: bigint }>>`
-    SELECT COUNT(*) as count
-    FROM "TestRunCases" trc
-    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
-    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
-      AND tr."isDeleted" = false
-  `;
-  const totalTestCases = Number(totalCasesResult[0]?.count || 0);
-
-  if (totalTestCases === 0) {
-    return 0;
-  }
-
-  // Get count of completed test cases (where TestRunCases.status.isCompleted = true)
-  const completedCasesResult = await prisma.$queryRaw<Array<{ count: bigint }>>`
-    SELECT COUNT(*) as count
-    FROM "TestRunCases" trc
-    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
-    JOIN "Status" s ON trc."statusId" = s.id
-    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
-      AND tr."isDeleted" = false
-      AND s."isCompleted" = true
-  `;
-  const completedTestCases = Number(completedCasesResult[0]?.count || 0);
-
-  // Calculate percentage, capped at 100%
-  return Math.min((completedTestCases / totalTestCases) * 100, 100);
-}
-
-async function getTestRunSegments(
-  milestoneIds: number[]
-): Promise<MilestoneSummaryData["segments"]> {
-  // Get test runs for this milestone with aggregated case data
-  const testRuns = await prisma.$queryRaw<
-    Array<{
-      testRunId: number;
-      testRunName: string;
-      testRunType: string;
-      totalCases: bigint;
-      totalElapsed: number | null;
-      totalEstimate: number | null;
-      hasPendingCases: boolean;
-      statusId: number | null;
-      statusName: string | null;
-      colorValue: string | null;
-      statusCaseCount: bigint;
-      statusOrder: number | null;
-    }>
-  >`
-    WITH test_run_data AS (
-      SELECT
-        tr.id as "testRunId",
-        tr.name as "testRunName",
-        tr."testRunType",
-        trc."statusId",
-        s.name as "statusName",
-        COALESCE(c.value, '#9ca3af') as "colorValue",
-        s.order as "statusOrder",
-        COUNT(trc.id) as "statusCaseCount",
-        SUM(
-          COALESCE(trr.elapsed, 0) +
-          COALESCE((
-            SELECT SUM(COALESCE(trsr.elapsed, 0))
-            FROM "TestRunStepResults" trsr
-            WHERE trsr."testRunResultId" = trr.id
-          ), 0)
-        ) as "caseElapsed",
-        BOOL_OR(trr.id IS NULL) as "hasPendingCases",
-        SUM(CASE WHEN trr.id IS NULL THEN COALESCE(rc.estimate, 0) ELSE 0 END) as "caseEstimate"
-      FROM "TestRuns" tr
-      JOIN "TestRunCases" trc ON trc."testRunId" = tr.id
-      JOIN "RepositoryCases" rc ON trc."repositoryCaseId" = rc.id
-      LEFT JOIN "TestRunResults" trr ON trr."testRunCaseId" = trc.id AND trr."isDeleted" = false
-      LEFT JOIN "Status" s ON trc."statusId" = s.id
-      LEFT JOIN "Color" c ON s."colorId" = c.id
-      WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
-        AND tr."isDeleted" = false
-      GROUP BY tr.id, tr.name, tr."testRunType", trc."statusId", s.name, c.value, s.order
-    )
-    SELECT
-      "testRunId",
-      "testRunName",
-      "testRunType",
-      COUNT(*) as "totalCases",
-      SUM("caseElapsed") as "totalElapsed",
-      SUM("caseEstimate") as "totalEstimate",
-      BOOL_OR("hasPendingCases") as "hasPendingCases",
-      "statusId",
-      COALESCE("statusName", 'Untested') as "statusName",
-      "colorValue",
-      "statusOrder",
-      SUM("statusCaseCount") as "statusCaseCount"
-    FROM test_run_data
-    GROUP BY "testRunId", "testRunName", "testRunType", "statusId", "statusName", "colorValue", "statusOrder"
-    ORDER BY "testRunId", "statusId" ASC NULLS LAST
-  `;
-
-  // Group test run cases by test run and status
-  const segments: MilestoneSummaryData["segments"] = [];
-  const testRunMap = new Map<
-    number,
-    {
-      name: string;
-      type: string;
-      cases: Array<{
-        statusId: number | null;
-        statusName: string;
-        colorValue: string;
-        count: number;
-        elapsed: number;
-        estimate: number;
-        hasPending: boolean;
-        statusOrder: number | null;
-      }>;
-    }
-  >();
-
-  testRuns.forEach((run) => {
-    if (!testRunMap.has(run.testRunId)) {
-      testRunMap.set(run.testRunId, {
-        name: run.testRunName,
-        type: run.testRunType,
-        cases: [],
-      });
-    }
-    const testRunData = testRunMap.get(run.testRunId)!;
-    testRunData.cases.push({
-      statusId: run.statusId,
-      statusName: run.statusName || "Untested",
-      colorValue: run.colorValue || "#9ca3af",
-      count: Number(run.statusCaseCount),
-      elapsed: Number(run.totalElapsed || 0),
-      estimate: Number(run.totalEstimate || 0),
-      hasPending: run.hasPendingCases,
-      statusOrder: run.statusOrder,
-    });
-  });
-
-  // Create segments for each test run case status
-  testRunMap.forEach((runData, testRunId) => {
-    runData.cases.forEach((caseData, index) => {
-      segments.push({
-        id: `test-run-${testRunId}-${caseData.statusId ?? "null"}-${index}`,
-        type: "test-run",
-        sourceId: testRunId,
-        sourceName: runData.name,
-        statusId: caseData.statusId,
-        statusName: caseData.statusName,
-        colorValue: caseData.colorValue,
-        elapsed: caseData.elapsed,
-        estimate: caseData.estimate,
-        isPending: caseData.hasPending,
-        itemCount: caseData.count,
-        statusOrder: caseData.statusOrder,
-      });
-    });
-  });
-
-  return segments;
-}
-
-async function getSessionSegments(
-  milestoneIds: number[]
-): Promise<MilestoneSummaryData["segments"]> {
-  // Get sessions for this milestone with their latest results
-  const sessions = await prisma.$queryRaw<
-    Array<{
-      sessionId: number;
-      sessionName: string;
-      sessionEstimate: number | null;
-      resultId: number | null;
-      resultCreatedAt: Date | null;
-      resultElapsed: number | null;
-      statusId: number | null;
-      statusName: string | null;
-      colorValue: string | null;
-      statusOrder: number | null;
-    }>
-  >`
-    SELECT
-      s.id as "sessionId",
-      s.name as "sessionName",
-      s.estimate as "sessionEstimate",
-      sr.id as "resultId",
-      sr."createdAt" as "resultCreatedAt",
-      sr.elapsed as "resultElapsed",
-      sr."statusId",
-      st.name as "statusName",
-      COALESCE(c.value, '#9ca3af') as "colorValue",
-      st.order as "statusOrder"
-    FROM "Sessions" s
-    LEFT JOIN LATERAL (
-      SELECT
-        sr2.id,
-        sr2."createdAt",
-        sr2.elapsed,
-        sr2."statusId"
-      FROM "SessionResults" sr2
-      WHERE sr2."sessionId" = s.id
-        AND sr2."isDeleted" = false
-      ORDER BY sr2."createdAt" DESC
-      LIMIT 1
-    ) sr ON true
-    LEFT JOIN "Status" st ON sr."statusId" = st.id
-    LEFT JOIN "Color" c ON st."colorId" = c.id
-    WHERE s."milestoneId" = ANY(${milestoneIds}::int[])
-      AND s."isDeleted" = false
-    ORDER BY s.id
-  `;
-
-  return sessions.map((session) => {
-    const hasPending = session.resultId === null;
-    const firstStatus = session.statusName || "Untested";
-    const firstColor = session.colorValue || "#9ca3af";
-
-    return {
-      id: `session-${session.sessionId}`,
-      type: "session" as const,
-      sourceId: session.sessionId,
-      sourceName: session.sessionName,
-      statusId: session.statusId,
-      statusName: firstStatus,
-      colorValue: firstColor,
-      elapsed: session.resultElapsed,
-      estimate: hasPending ? session.sessionEstimate : null,
-      isPending: hasPending,
-      itemCount: 1,
-      statusOrder: session.statusOrder,
-    };
-  });
 }

--- a/testplanit/e2e/tests/milestones/milestone-edit.spec.ts
+++ b/testplanit/e2e/tests/milestones/milestone-edit.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "../../fixtures";
+
+/**
+ * Regression guard for the milestone details page edit action.
+ *
+ * The header action buttons live inside the milestone <form>. Clicking "Edit"
+ * swaps the trigger for the edit-mode "Save" (type=submit) button at the same
+ * position, which previously let the browser activate that submit button and
+ * fire a stray no-op update — the page would flash into edit mode and
+ * immediately save back to view mode. The form now guards against submits
+ * fired while in view mode and remounts on the mode switch; these tests lock
+ * that behavior in.
+ */
+test.describe("Milestone details — Edit action", () => {
+  const isMilestoneUpdate = (url: string, method: string) =>
+    method === "PUT" && url.includes("/api/model/milestones/update");
+
+  test("clicking Edit enters edit mode without submitting the form", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneEditGuard ${ts}`);
+    const milestoneId = await api.createMilestone(
+      projectId,
+      `Edit Guard ${ts}`
+    );
+
+    await page.goto(`/en-US/projects/milestones/${projectId}/${milestoneId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Count any milestone update calls triggered by clicking Edit.
+    let updateCount = 0;
+    page.on("request", (req) => {
+      if (isMilestoneUpdate(req.url(), req.method())) updateCount++;
+    });
+
+    await page.getByTestId("milestone-edit").click();
+
+    // We should be in edit mode (Save visible) and NO update should have fired.
+    await expect(page.getByTestId("milestone-save")).toBeVisible();
+    expect(updateCount).toBe(0);
+  });
+
+  test("saving in edit mode persists via exactly one update", async ({
+    api,
+    page,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneEditSave ${ts}`);
+    const milestoneId = await api.createMilestone(projectId, `Save ${ts}`);
+
+    await page.goto(`/en-US/projects/milestones/${projectId}/${milestoneId}`);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("milestone-edit").click();
+    await expect(page.getByTestId("milestone-save")).toBeVisible();
+
+    let updateCount = 0;
+    page.on("request", (req) => {
+      if (isMilestoneUpdate(req.url(), req.method())) updateCount++;
+    });
+
+    await page.getByTestId("milestone-save").click();
+
+    // Returns to view mode (Edit visible again) after exactly one update.
+    await expect(page.getByTestId("milestone-edit")).toBeVisible();
+    expect(updateCount).toBe(1);
+  });
+});

--- a/testplanit/e2e/tests/milestones/milestone-export.spec.ts
+++ b/testplanit/e2e/tests/milestones/milestone-export.spec.ts
@@ -1,0 +1,242 @@
+import { PrismaClient } from "@prisma/client";
+import { expect, test } from "../../fixtures";
+import { getProjectWorkflowIds } from "../reviews/helpers";
+
+/**
+ * End-to-end coverage for GET /api/milestones/{id}/export — the data source
+ * behind the milestone PDF. Seeds a milestone tree with every section the
+ * report renders (nested milestones, runs with varied statuses, a session,
+ * a linked issue, and review decisions) and asserts the aggregated snapshot
+ * covers all of them.
+ *
+ * ReviewRequest rows are written directly via Prisma: seeding a decided
+ * request keeps the test independent of the decision endpoint's
+ * eligibility/gate logic (covered by the reviews specs).
+ */
+test.describe("Milestone Export API", () => {
+  let prisma: PrismaClient;
+
+  test.beforeAll(() => {
+    prisma = new PrismaClient();
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("aggregates the full milestone tree across every section", async ({
+    api,
+    request,
+    baseURL,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneExport ${ts}`);
+
+    // grandparent -> parent (the one we export) -> child
+    const grandparentId = await api.createMilestone(projectId, `GP ${ts}`);
+    const parentId = await api.createMilestone(projectId, `Parent ${ts}`, {
+      parentId: grandparentId,
+      isStarted: true,
+    });
+    const childId = await api.createMilestone(projectId, `Child ${ts}`, {
+      parentId,
+    });
+
+    const folderId = await api.getRootFolderId(projectId);
+    const [passed, failed, blocked] = await Promise.all([
+      api.getStatusId("passed"),
+      api.getStatusId("failed"),
+      api.getStatusId("blocked"),
+    ]);
+
+    // Parent milestone run: three cases executed with distinct statuses.
+    const caseIds = await api.createTestCasesBatch(projectId, folderId, [
+      `Case A ${ts}`,
+      `Case B ${ts}`,
+      `Case C ${ts}`,
+    ]);
+    const runId = await api.createTestRun(projectId, `Run ${ts}`, {
+      milestoneId: parentId,
+    });
+    const trcIds = await api.addTestCasesToTestRun(runId, caseIds);
+    const runStatuses = [passed, failed, blocked];
+    for (let i = 0; i < trcIds.length; i++) {
+      // Set the case status (drives the per-status grouping) AND record a
+      // result (so the case counts as executed, not pending).
+      await api.setTestRunCaseStatus(trcIds[i], runStatuses[i]);
+      await api.createTestResult(runId, trcIds[i], runStatuses[i], {
+        elapsed: 1000 * (i + 1),
+      });
+    }
+
+    // Child milestone run: proves descendant roll-up reaches the parent export.
+    const childCaseId = await api.createTestCase(
+      projectId,
+      folderId,
+      `Child Case ${ts}`
+    );
+    const childRunId = await api.createTestRun(projectId, `Child Run ${ts}`, {
+      milestoneId: childId,
+    });
+    const [childTrc] = await api.addTestCasesToTestRun(childRunId, [
+      childCaseId,
+    ]);
+    await api.setTestRunCaseStatus(childTrc, passed);
+    await api.createTestResult(childRunId, childTrc, passed, { elapsed: 800 });
+
+    // Session under the parent.
+    const sessionId = await api.createSession(projectId, `Session ${ts}`, {
+      milestoneId: parentId,
+    });
+
+    // Linked issue on the run.
+    const issueId = await api.createIssue(
+      projectId,
+      `BUG-${ts}`,
+      "Something broke"
+    );
+    const linkRes = await request.patch(`/api/model/testRuns/update`, {
+      data: {
+        where: { id: runId },
+        data: { issues: { connect: { id: issueId } } },
+      },
+    });
+    expect(linkRes.ok()).toBeTruthy();
+
+    // Review decisions: an approved RUN and a pending SESSION.
+    const adminId = await api.getCurrentUserId();
+    const runWf = await getProjectWorkflowIds(
+      request,
+      baseURL!,
+      projectId,
+      "RUNS",
+      2
+    );
+    const sessWf = await getProjectWorkflowIds(
+      request,
+      baseURL!,
+      projectId,
+      "SESSIONS",
+      2
+    );
+    expect(runWf.length).toBeGreaterThanOrEqual(2);
+    expect(sessWf.length).toBeGreaterThanOrEqual(2);
+
+    await prisma.reviewRequest.create({
+      data: {
+        projectId,
+        entityType: "RUN",
+        entityId: runId,
+        fromStateId: runWf[0],
+        toStateId: runWf[1],
+        requestedByUserId: adminId,
+        status: "APPROVED",
+        decidedByUserId: adminId,
+        decidedAt: new Date(),
+        decisionComment: "Ship it",
+      },
+    });
+    await prisma.reviewRequest.create({
+      data: {
+        projectId,
+        entityType: "SESSION",
+        entityId: sessionId,
+        fromStateId: sessWf[0],
+        toStateId: sessWf[1],
+        requestedByUserId: adminId,
+        status: "PENDING",
+      },
+    });
+
+    // --- Call the export endpoint for the PARENT milestone ---
+    const res = await request.get(`/api/milestones/${parentId}/export`);
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+
+    // Milestone metadata + nesting path.
+    expect(data.milestone.id).toBe(parentId);
+    expect(data.milestone.status).toBe("In Progress");
+    expect(data.milestone.parentPath).toEqual([`GP ${ts}`]);
+    expect(data.milestone.ownerName).toBeTruthy();
+    expect(data.milestone.typeName).toBeTruthy();
+    expect(data.projectId).toBe(projectId);
+    expect(data.generatedAt).toBeTruthy();
+
+    // Roll-up spans the parent run (3 cases) + descendant child run (1 case)
+    // + the contributing session (1 item). The session is pending, so it adds
+    // to total but not executed.
+    expect(data.rollup.totalItems).toBe(5);
+    expect(data.rollup.executedItems).toBe(4);
+    expect(data.rollup.completionRate).toBeGreaterThan(0);
+    const rollupTotal = data.rollup.statusCounts.reduce(
+      (sum: number, s: { count: number }) => sum + s.count,
+      0
+    );
+    expect(rollupTotal).toBe(5);
+    expect(data.rollup.statusCounts.length).toBeGreaterThanOrEqual(3);
+
+    // Contributing test runs (parent + child), with per-run breakdown.
+    const runIds = data.testRuns.map((r: { id: number }) => r.id);
+    expect(runIds).toContain(runId);
+    expect(runIds).toContain(childRunId);
+    const parentRun = data.testRuns.find((r: { id: number }) => r.id === runId);
+    expect(parentRun.totalItems).toBe(3);
+    expect(parentRun.executedItems).toBe(3);
+    expect(parentRun.statusCounts.length).toBe(3);
+
+    // Sessions, descendants, issues.
+    expect(data.sessions.map((s: { id: number }) => s.id)).toContain(sessionId);
+    expect(data.descendants.map((d: { id: number }) => d.id)).toContain(
+      childId
+    );
+    expect(
+      data.issues.some((i: { title: string }) => i.title === "Something broke")
+    ).toBe(true);
+
+    // Review & Approval decisions: approved run (with decider) + pending session.
+    const runDecision = data.reviewDecisions.find(
+      (d: { entityType: string; entityId: number }) =>
+        d.entityType === "RUN" && d.entityId === runId
+    );
+    expect(runDecision).toBeTruthy();
+    expect(runDecision.status).toBe("APPROVED");
+    expect(runDecision.decidedByName).toBeTruthy();
+    expect(runDecision.entityName).toBe(`Run ${ts}`);
+
+    const sessionDecision = data.reviewDecisions.find(
+      (d: { entityType: string; entityId: number }) =>
+        d.entityType === "SESSION" && d.entityId === sessionId
+    );
+    expect(sessionDecision).toBeTruthy();
+    expect(sessionDecision.status).toBe("PENDING");
+    expect(sessionDecision.decidedByName).toBeNull();
+  });
+
+  test("returns empty sections for a milestone with no data", async ({
+    api,
+    request,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`MilestoneExportEmpty ${ts}`);
+    const milestoneId = await api.createMilestone(projectId, `Empty ${ts}`);
+
+    const res = await request.get(`/api/milestones/${milestoneId}/export`);
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+
+    expect(data.milestone.id).toBe(milestoneId);
+    expect(data.milestone.status).toBe("Not Started");
+    expect(data.milestone.parentPath).toEqual([]);
+    expect(data.rollup.totalItems).toBe(0);
+    expect(data.testRuns).toEqual([]);
+    expect(data.sessions).toEqual([]);
+    expect(data.descendants).toEqual([]);
+    expect(data.issues).toEqual([]);
+    expect(data.reviewDecisions).toEqual([]);
+  });
+
+  test("returns 404 for a non-existent milestone", async ({ request }) => {
+    const res = await request.get(`/api/milestones/99999999/export`);
+    expect(res.status()).toBe(404);
+  });
+});

--- a/testplanit/hooks/pdf/pdfHelpers.ts
+++ b/testplanit/hooks/pdf/pdfHelpers.ts
@@ -99,6 +99,43 @@ export const PDF_CONFIG = {
   pixelsToMm: 0.264583,
 };
 
+/**
+ * Per-page header/footer metadata for evidence-grade reports. When set via
+ * {@link PdfRenderer.setReportMeta}, every page gets a generation header
+ * (document name + when/by-whom it was produced) on top of the page-number
+ * footer.
+ */
+export type PdfReportMeta = {
+  documentName: string;
+  generatedAt: string;
+  generatedByName?: string | null;
+};
+
+/** A piece of inline text with an optional RGB color (e.g. a status label). */
+export type StatusToken = { text: string; color?: [number, number, number] };
+
+/** A table cell: plain text, or a run of individually-colored status tokens. */
+export type TableCell = string | StatusToken[];
+
+/** Parse a `#rgb`/`#rrggbb` color into an RGB tuple for jsPDF, if valid. */
+export function hexToRgb(
+  hex: string | null | undefined
+): [number, number, number] | undefined {
+  if (!hex) return undefined;
+  let h = hex.trim().replace(/^#/, "");
+  if (h.length === 3)
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return undefined;
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+
 /** Helper class wrapping jsPDF with common rendering operations */
 export class PdfRenderer {
   doc: jsPDF;
@@ -109,6 +146,9 @@ export class PdfRenderer {
   contentWidth: number;
   maxImageWidth: number;
   maxImageHeight: number;
+  /** Top y a fresh page starts at — raised below the header band when meta is set. */
+  topOffset: number;
+  reportMeta: PdfReportMeta | null;
 
   constructor(doc: jsPDF) {
     this.doc = doc;
@@ -118,6 +158,8 @@ export class PdfRenderer {
     this.contentWidth = this.pageWidth - 2 * this.margin;
     this.maxImageWidth = this.contentWidth - 10;
     this.maxImageHeight = PDF_CONFIG.maxImageHeight;
+    this.topOffset = this.margin;
+    this.reportMeta = null;
     this.yPosition = this.margin;
     doc.setCharSpace(0);
   }
@@ -126,7 +168,7 @@ export class PdfRenderer {
   ensureSpace(needed: number) {
     if (this.yPosition > this.pageHeight - needed) {
       this.doc.addPage();
-      this.yPosition = this.margin;
+      this.yPosition = this.topOffset;
     }
   }
 
@@ -369,7 +411,7 @@ export class PdfRenderer {
 
       if (this.yPosition + imgHeightMm + 10 > this.pageHeight - 20) {
         this.doc.addPage();
-        this.yPosition = this.margin;
+        this.yPosition = this.topOffset;
       }
 
       try {
@@ -431,6 +473,276 @@ export class PdfRenderer {
       this.doc.setPage(i);
       this.doc.setFontSize(8);
       this.doc.setFont("helvetica", "normal");
+      this.doc.text(
+        `Page ${i} of ${pageCount}`,
+        this.pageWidth / 2,
+        this.pageHeight - 10,
+        { align: "center" }
+      );
+    }
+  }
+
+  /**
+   * Enable a per-page generation header. Reserves space at the top of every
+   * page so body content does not overlap the header band. Call before
+   * rendering body content; render the header/footer text in a finishing pass
+   * via {@link addHeadersAndFooters}.
+   */
+  setReportMeta(meta: PdfReportMeta) {
+    this.reportMeta = meta;
+    this.topOffset = this.margin + 7;
+    if (this.yPosition < this.topOffset) this.yPosition = this.topOffset;
+  }
+
+  /**
+   * Render a paginated table with a bold header row that repeats at the top of
+   * each continuation page. Columns are sized by relative `width` weights and
+   * cells wrap within their column.
+   */
+  renderTable(opts: {
+    columns: { header: string; width: number; align?: "left" | "right" }[];
+    rows: TableCell[][];
+    fontSize?: number;
+  }) {
+    const { columns, rows } = opts;
+    const fontSize = opts.fontSize ?? 9;
+    const lineHeight = fontSize * 0.45;
+    const cellPadX = 1.5;
+    const cellPadY = 2;
+    const tokenGap = 1.5;
+
+    const totalWeight = columns.reduce((s, c) => s + c.width, 0) || 1;
+    const colWidths = columns.map(
+      (c) => (c.width / totalWeight) * this.contentWidth
+    );
+    const colX: number[] = [];
+    let acc = this.margin;
+    for (const w of colWidths) {
+      colX.push(acc);
+      acc += w;
+    }
+
+    const wrapCell = (text: string, colIndex: number): string[] =>
+      this.doc.splitTextToSize(
+        sanitizeTextForPdf(text ?? ""),
+        Math.max(colWidths[colIndex] - 2 * cellPadX, 6)
+      );
+
+    // Flow colored tokens into lines that fit the column width (tokens never
+    // split mid-word; each keeps its color).
+    const layoutTokens = (
+      tokens: StatusToken[],
+      colIndex: number
+    ): StatusToken[][] => {
+      const avail = Math.max(colWidths[colIndex] - 2 * cellPadX, 6);
+      this.doc.setFontSize(fontSize);
+      this.doc.setFont("helvetica", "normal");
+      const lines: StatusToken[][] = [[]];
+      let curW = 0;
+      for (const tok of tokens) {
+        const text = sanitizeTextForPdf(tok.text);
+        const tw = this.doc.getTextWidth(text);
+        const line = lines[lines.length - 1];
+        const needed = (line.length ? tokenGap : 0) + tw;
+        if (line.length && curW + needed > avail) {
+          lines.push([{ ...tok, text }]);
+          curW = tw;
+        } else {
+          line.push({ ...tok, text });
+          curW += needed;
+        }
+      }
+      return lines;
+    };
+
+    const drawHeaderRow = () => {
+      const headerHeight = lineHeight + 2 * cellPadY;
+      this.doc.setFillColor(240, 240, 240);
+      this.doc.rect(
+        this.margin,
+        this.yPosition,
+        this.contentWidth,
+        headerHeight,
+        "F"
+      );
+      this.doc.setFontSize(fontSize);
+      this.doc.setFont("helvetica", "bold");
+      this.doc.setTextColor(0, 0, 0);
+      columns.forEach((col, i) => {
+        const align = col.align ?? "left";
+        const x =
+          align === "right"
+            ? colX[i] + colWidths[i] - cellPadX
+            : colX[i] + cellPadX;
+        this.doc.text(
+          sanitizeTextForPdf(col.header),
+          x,
+          this.yPosition + cellPadY + lineHeight - 1,
+          {
+            align,
+          }
+        );
+      });
+      this.yPosition += headerHeight;
+      this.doc.setDrawColor(200, 200, 200);
+      this.doc.line(
+        this.margin,
+        this.yPosition,
+        this.margin + this.contentWidth,
+        this.yPosition
+      );
+      this.doc.setFont("helvetica", "normal");
+    };
+
+    this.ensureSpace(30);
+    drawHeaderRow();
+
+    this.doc.setFontSize(fontSize);
+    this.doc.setFont("helvetica", "normal");
+
+    for (const row of rows) {
+      // Lay out every cell up front (text wraps to lines; token cells flow to
+      // lines) so the row height accounts for the tallest cell.
+      const laid = row.map((cell, i) =>
+        Array.isArray(cell)
+          ? { kind: "tokens" as const, lines: layoutTokens(cell, i) }
+          : { kind: "text" as const, lines: wrapCell(cell, i) }
+      );
+      const maxLines = laid.reduce((m, c) => Math.max(m, c.lines.length), 1);
+      const rowHeight = maxLines * lineHeight + 2 * cellPadY;
+
+      // Break to a new page (re-drawing the header) when the row won't fit.
+      if (this.yPosition + rowHeight > this.pageHeight - 18) {
+        this.doc.addPage();
+        this.yPosition = this.topOffset;
+        drawHeaderRow();
+        this.doc.setFontSize(fontSize);
+        this.doc.setFont("helvetica", "normal");
+      }
+
+      const textTop = this.yPosition + cellPadY + lineHeight - 1;
+      laid.forEach((cell, i) => {
+        const align = columns[i]?.align ?? "left";
+        const leftX = colX[i] + cellPadX;
+        if (cell.kind === "text") {
+          const x =
+            align === "right" ? colX[i] + colWidths[i] - cellPadX : leftX;
+          cell.lines.forEach((line, li) => {
+            this.doc.text(String(line), x, textTop + li * lineHeight, {
+              align,
+            });
+          });
+        } else {
+          // Colored tokens are always left-aligned and flow left-to-right.
+          cell.lines.forEach((tokens, li) => {
+            let cx = leftX;
+            const y = textTop + li * lineHeight;
+            for (const tok of tokens) {
+              if (tok.color)
+                this.doc.setTextColor(tok.color[0], tok.color[1], tok.color[2]);
+              else this.doc.setTextColor(0, 0, 0);
+              this.doc.text(tok.text, cx, y);
+              cx += this.doc.getTextWidth(tok.text) + tokenGap;
+            }
+          });
+          this.doc.setTextColor(0, 0, 0);
+        }
+      });
+
+      this.yPosition += rowHeight;
+      this.doc.setDrawColor(230, 230, 230);
+      this.doc.line(
+        this.margin,
+        this.yPosition,
+        this.margin + this.contentWidth,
+        this.yPosition
+      );
+    }
+
+    this.doc.setTextColor(0, 0, 0);
+    this.doc.setFontSize(10);
+    this.yPosition += 4;
+  }
+
+  /**
+   * Render a labeled, color-coded status breakdown (bold label, then each
+   * status token in its own color, flowing across the content width).
+   */
+  renderStatusBreakdown(label: string, tokens: StatusToken[]) {
+    if (tokens.length === 0) return;
+    this.ensureSpace(16);
+    this.doc.setFont("helvetica", "bold");
+    this.doc.setFontSize(10);
+    this.doc.text(`${label}:`, this.margin, this.yPosition);
+    this.yPosition += 5;
+
+    this.doc.setFont("helvetica", "normal");
+    this.doc.setFontSize(9);
+    const lineHeight = 9 * 0.5;
+    const tokenGap = 2;
+    const indent = this.margin + 5;
+    const maxRight = this.pageWidth - this.margin;
+    let cx = indent;
+    for (const tok of tokens) {
+      const text = sanitizeTextForPdf(tok.text);
+      const tw = this.doc.getTextWidth(text);
+      if (cx > indent && cx + tw > maxRight) {
+        this.yPosition += lineHeight;
+        this.ensureSpace(10);
+        cx = indent;
+      }
+      if (tok.color)
+        this.doc.setTextColor(tok.color[0], tok.color[1], tok.color[2]);
+      else this.doc.setTextColor(0, 0, 0);
+      this.doc.text(text, cx, this.yPosition);
+      cx += tw + tokenGap;
+    }
+    this.doc.setTextColor(0, 0, 0);
+    this.doc.setFontSize(10);
+    this.yPosition += 6;
+  }
+
+  /**
+   * Finishing pass: draw the generation header band (when report meta is set)
+   * and a page-numbered footer on every page.
+   */
+  addHeadersAndFooters() {
+    const meta = this.reportMeta;
+    const pageCount = this.doc.getNumberOfPages();
+    for (let i = 1; i <= pageCount; i++) {
+      this.doc.setPage(i);
+
+      if (meta) {
+        this.doc.setFontSize(8);
+        this.doc.setFont("helvetica", "normal");
+        this.doc.setTextColor(120, 120, 120);
+
+        const leftMax = this.contentWidth * 0.55;
+        const left = this.doc.splitTextToSize(
+          sanitizeTextForPdf(meta.documentName),
+          leftMax
+        )[0];
+        this.doc.text(String(left || ""), this.margin, 9);
+
+        const rightText = meta.generatedByName
+          ? `Generated ${meta.generatedAt} by ${meta.generatedByName}`
+          : `Generated ${meta.generatedAt}`;
+        const right = this.doc.splitTextToSize(
+          sanitizeTextForPdf(rightText),
+          this.contentWidth * 0.45
+        )[0];
+        this.doc.text(String(right || ""), this.pageWidth - this.margin, 9, {
+          align: "right",
+        });
+
+        this.doc.setDrawColor(220, 220, 220);
+        this.doc.line(this.margin, 12, this.pageWidth - this.margin, 12);
+        this.doc.setTextColor(0, 0, 0);
+      }
+
+      this.doc.setFontSize(8);
+      this.doc.setFont("helvetica", "normal");
+      this.doc.setTextColor(0, 0, 0);
       this.doc.text(
         `Page ${i} of ${pageCount}`,
         this.pageWidth / 2,

--- a/testplanit/hooks/pdf/useExportMilestonePdf.ts
+++ b/testplanit/hooks/pdf/useExportMilestonePdf.ts
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { logDataExport } from "~/lib/services/auditClient";
+import type { MilestoneExportData } from "~/lib/services/milestoneExport";
+import { toHumanReadable } from "~/utils/duration";
+import { hexToRgb, PdfRenderer, type StatusToken } from "./pdfHelpers";
+
+interface UseExportMilestonePdfProps {
+  milestoneId: number | null | undefined;
+  /** Used for the export audit entry; falls back to the milestone's project. */
+  projectId?: number;
+  locale?: string;
+  /** Current user's display name, stamped into the generation header. */
+  generatedByName?: string | null;
+}
+
+const DECISION_LABELS: Record<string, string> = {
+  PENDING: "Pending",
+  APPROVED: "Approved",
+  CHANGES_REQUESTED: "Changes Requested",
+  REJECTED: "Rejected",
+  CANCELLED: "Cancelled",
+};
+
+export function useExportMilestonePdf({
+  milestoneId,
+  projectId,
+  locale = "en-US",
+  generatedByName,
+}: UseExportMilestonePdfProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    if (!milestoneId) return;
+    setIsExporting(true);
+
+    try {
+      const res = await fetch(`/api/milestones/${milestoneId}/export`);
+      if (!res.ok) {
+        throw new Error(`Export request failed with status ${res.status}`);
+      }
+      const data = (await res.json()) as MilestoneExportData;
+
+      const fmtDate = (iso: string | null) =>
+        iso ? new Date(iso).toLocaleDateString(locale) : "—";
+      const fmtDateTime = (iso: string | null) =>
+        iso ? new Date(iso).toLocaleString(locale) : "—";
+      const fmtDuration = (seconds: number) =>
+        seconds > 0
+          ? toHumanReadable(seconds, { isSeconds: true, locale })
+          : "—";
+      // Color-coded status tokens so statuses are easy to identify, matching
+      // the run/session PDF exports.
+      const statusTokens = (
+        counts: { statusName: string; count: number; colorValue: string }[]
+      ): StatusToken[] =>
+        counts.map((c) => ({
+          text: `${c.statusName}: ${c.count}`,
+          color: hexToRgb(c.colorValue),
+        }));
+
+      const { default: jsPDF } = await import("jspdf");
+      const doc = new jsPDF({
+        orientation: "portrait",
+        unit: "mm",
+        format: "a4",
+      });
+      const pdf = new PdfRenderer(doc);
+
+      const generatedAtLabel = fmtDateTime(data.generatedAt);
+
+      // Enable the per-page header band before rendering body content so the
+      // first page's title clears it; the band itself is drawn in the finishing
+      // pass below.
+      pdf.setReportMeta({
+        documentName: data.milestone.name,
+        generatedAt: generatedAtLabel,
+        generatedByName,
+      });
+
+      // --- Title + generation line ---
+      pdf.renderTitle("Milestone Report");
+      pdf.renderMetaLine(
+        `Generated: ${generatedAtLabel}`,
+        generatedByName ? `By: ${generatedByName}` : undefined
+      );
+      pdf.addSpace(2);
+
+      // --- Milestone metadata ---
+      pdf.renderSectionHeader(data.milestone.name);
+      pdf.renderField("Status", data.milestone.status);
+      pdf.renderField("Type", data.milestone.typeName);
+      pdf.renderField("Owner", data.milestone.ownerName);
+      if (data.milestone.parentPath.length > 0) {
+        pdf.renderField("Path", data.milestone.parentPath.join(" / "));
+      }
+      pdf.renderField("Started", fmtDate(data.milestone.startedAt));
+      pdf.renderField("Completed", fmtDate(data.milestone.completedAt));
+      pdf.renderField("Created", fmtDate(data.milestone.createdAt));
+
+      // --- Aggregate summary (first) ---
+      pdf.renderSectionHeader("Summary");
+      pdf.renderField(
+        "Completion",
+        `${Math.round(data.rollup.completionRate)}%`
+      );
+      pdf.renderField(
+        "Executed",
+        `${data.rollup.executedItems} of ${data.rollup.totalItems}`
+      );
+      pdf.renderField("Total Elapsed", fmtDuration(data.rollup.totalElapsed));
+      pdf.renderField("Total Estimate", fmtDuration(data.rollup.totalEstimate));
+      if (data.rollup.statusCounts.length > 0) {
+        pdf.renderStatusBreakdown(
+          "Status Breakdown",
+          statusTokens(data.rollup.statusCounts)
+        );
+      }
+
+      // --- Contributing test runs ---
+      if (data.testRuns.length > 0) {
+        pdf.renderSectionHeader(
+          `Contributing Test Runs (${data.testRuns.length})`
+        );
+        pdf.renderTable({
+          columns: [
+            { header: "Test Run", width: 3.6 },
+            { header: "Executed", width: 1.4 },
+            { header: "Total", width: 1, align: "right" },
+            { header: "Elapsed", width: 2 },
+            { header: "Status Breakdown", width: 3.6 },
+          ],
+          rows: data.testRuns.map((r) => [
+            r.name,
+            String(r.executedItems),
+            String(r.totalItems),
+            fmtDuration(r.elapsed),
+            statusTokens(r.statusCounts),
+          ]),
+        });
+      }
+
+      // --- Contributing sessions ---
+      if (data.sessions.length > 0) {
+        pdf.renderSectionHeader(
+          `Contributing Sessions (${data.sessions.length})`
+        );
+        pdf.renderTable({
+          columns: [
+            { header: "Session", width: 5 },
+            { header: "Latest Status", width: 2 },
+            { header: "Elapsed", width: 2 },
+          ],
+          rows: data.sessions.map((s) => [
+            s.name,
+            [{ text: s.statusName, color: hexToRgb(s.colorValue) }],
+            fmtDuration(s.elapsed),
+          ]),
+        });
+      }
+
+      // --- Descendant sub-milestones ---
+      if (data.descendants.length > 0) {
+        pdf.renderSectionHeader(`Sub-milestones (${data.descendants.length})`);
+        pdf.renderTable({
+          columns: [
+            { header: "Sub-milestone", width: 5 },
+            { header: "Status", width: 3 },
+          ],
+          rows: data.descendants.map((d) => [d.name, d.status]),
+        });
+      }
+
+      // --- Linked issues ---
+      if (data.issues.length > 0) {
+        pdf.renderSectionHeader(`Linked Issues (${data.issues.length})`);
+        pdf.renderTable({
+          columns: [
+            { header: "Issue", width: 2 },
+            { header: "Title", width: 5 },
+            { header: "Status", width: 2 },
+          ],
+          rows: data.issues.map((i) => [i.key, i.title, i.status ?? "—"]),
+        });
+      }
+
+      // --- Review & Approval decisions ---
+      if (data.reviewDecisions.length > 0) {
+        pdf.renderSectionHeader(
+          `Review & Approval Decisions (${data.reviewDecisions.length})`
+        );
+        pdf.renderTable({
+          columns: [
+            { header: "Item", width: 3 },
+            { header: "Decision", width: 2 },
+            { header: "Decided By", width: 2.5 },
+            { header: "Date", width: 2 },
+            { header: "Comment", width: 4 },
+          ],
+          rows: data.reviewDecisions.map((d) => [
+            d.entityName,
+            DECISION_LABELS[d.status] ?? d.status,
+            d.decidedByName ?? "—",
+            fmtDate(d.decidedAt),
+            d.decisionComment ?? "—",
+          ]),
+        });
+      }
+
+      // --- Per-page header/footer + save ---
+      pdf.addHeadersAndFooters();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      pdf.save(`milestone-export-${timestamp}.pdf`);
+
+      void logDataExport({
+        exportType: "PDF",
+        entityType: "milestone",
+        recordCount: 1,
+        projectId: projectId ?? data.projectId,
+      });
+    } catch (error) {
+      console.error("Milestone PDF export failed:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [milestoneId, projectId, locale, generatedByName]);
+
+  return { isExporting, handleExport };
+}

--- a/testplanit/lib/services/milestoneExport.test.ts
+++ b/testplanit/lib/services/milestoneExport.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import type { MilestoneSegment } from "~/lib/services/milestoneSummary";
+import {
+  aggregateStatusCounts,
+  groupTestRunContributors,
+  mapSessionContributors,
+  milestoneStatusLabel,
+  shapeReviewDecisions,
+} from "./milestoneExport";
+
+const seg = (over: Partial<MilestoneSegment>): MilestoneSegment => ({
+  id: "x",
+  type: "test-run",
+  sourceId: 1,
+  sourceName: "Run A",
+  statusId: 1,
+  statusName: "Passed",
+  colorValue: "#22c55e",
+  elapsed: 0,
+  estimate: 0,
+  isPending: false,
+  itemCount: 1,
+  statusOrder: 1,
+  ...over,
+});
+
+describe("milestoneStatusLabel", () => {
+  it("prefers completed over started", () => {
+    expect(milestoneStatusLabel({ isCompleted: true, isStarted: true })).toBe(
+      "Completed"
+    );
+  });
+  it("reports in-progress when started but not completed", () => {
+    expect(milestoneStatusLabel({ isCompleted: false, isStarted: true })).toBe(
+      "In Progress"
+    );
+  });
+  it("reports not-started otherwise", () => {
+    expect(milestoneStatusLabel({ isCompleted: false, isStarted: false })).toBe(
+      "Not Started"
+    );
+  });
+});
+
+describe("aggregateStatusCounts", () => {
+  it("sums itemCount per status and tallies executed vs total", () => {
+    const result = aggregateStatusCounts([
+      seg({ statusName: "Passed", itemCount: 3, isPending: false }),
+      seg({ statusName: "Failed", itemCount: 2, isPending: false }),
+      seg({ statusName: "Untested", itemCount: 4, isPending: true }),
+    ]);
+    expect(result.totalItems).toBe(9);
+    expect(result.executedItems).toBe(5);
+    const passed = result.statusCounts.find((s) => s.statusName === "Passed");
+    expect(passed?.count).toBe(3);
+  });
+
+  it("merges duplicate status names across segments", () => {
+    const result = aggregateStatusCounts([
+      seg({ statusName: "Passed", itemCount: 2 }),
+      seg({ statusName: "Passed", itemCount: 5 }),
+    ]);
+    expect(result.statusCounts).toHaveLength(1);
+    expect(result.statusCounts[0].count).toBe(7);
+  });
+
+  it("defaults missing itemCount to 1", () => {
+    const result = aggregateStatusCounts([
+      seg({ statusName: "Passed", itemCount: undefined }),
+    ]);
+    expect(result.totalItems).toBe(1);
+  });
+});
+
+describe("groupTestRunContributors", () => {
+  it("groups segments into one row per run with its status breakdown", () => {
+    const runs = groupTestRunContributors([
+      seg({
+        sourceId: 1,
+        sourceName: "Run A",
+        statusName: "Passed",
+        itemCount: 2,
+        elapsed: 120,
+      }),
+      seg({
+        sourceId: 1,
+        sourceName: "Run A",
+        statusName: "Failed",
+        itemCount: 1,
+        isPending: false,
+        elapsed: 60,
+      }),
+      seg({
+        sourceId: 2,
+        sourceName: "Run B",
+        statusName: "Untested",
+        itemCount: 3,
+        isPending: true,
+        elapsed: 0,
+      }),
+    ]);
+    expect(runs).toHaveLength(2);
+    const runA = runs.find((r) => r.id === 1)!;
+    expect(runA.name).toBe("Run A");
+    expect(runA.totalItems).toBe(3);
+    expect(runA.executedItems).toBe(3);
+    expect(runA.elapsed).toBe(180);
+    expect(runA.statusCounts).toHaveLength(2);
+    const runB = runs.find((r) => r.id === 2)!;
+    expect(runB.executedItems).toBe(0);
+  });
+});
+
+describe("mapSessionContributors", () => {
+  it("maps each session segment to a contributor row", () => {
+    const sessions = mapSessionContributors([
+      seg({
+        type: "session",
+        sourceId: 10,
+        sourceName: "Exploratory",
+        statusName: "Completed",
+        isPending: false,
+        elapsed: 90,
+      }),
+    ]);
+    expect(sessions).toEqual([
+      {
+        id: 10,
+        name: "Exploratory",
+        statusName: "Completed",
+        colorValue: "#22c55e",
+        isPending: false,
+        elapsed: 90,
+      },
+    ]);
+  });
+});
+
+describe("shapeReviewDecisions", () => {
+  const names = new Map<string, string>([
+    ["RUN:1", "Q2 Release Regression"],
+    ["SESSION:5", "Smoke Session"],
+  ]);
+
+  it("resolves entity names and decider, drops CASE-scoped requests", () => {
+    const decisions = shapeReviewDecisions(
+      [
+        {
+          entityType: "RUN",
+          entityId: 1,
+          status: "APPROVED",
+          decidedAt: "2026-05-15T00:00:00.000Z",
+          decisionComment: "LGTM",
+          decidedBy: { name: "Jane Doe" },
+        },
+        {
+          entityType: "CASE",
+          entityId: 9,
+          status: "APPROVED",
+          decidedAt: null,
+          decisionComment: null,
+          decidedBy: null,
+        },
+        {
+          entityType: "SESSION",
+          entityId: 5,
+          status: "PENDING",
+          decidedAt: null,
+          decisionComment: null,
+          decidedBy: null,
+        },
+      ],
+      names
+    );
+
+    expect(decisions).toHaveLength(2);
+    const run = decisions.find((d) => d.entityType === "RUN")!;
+    expect(run.entityName).toBe("Q2 Release Regression");
+    expect(run.decidedByName).toBe("Jane Doe");
+    expect(run.decidedAt).toBe("2026-05-15T00:00:00.000Z");
+
+    const session = decisions.find((d) => d.entityType === "SESSION")!;
+    expect(session.entityName).toBe("Smoke Session");
+    expect(session.decidedByName).toBeNull();
+  });
+
+  it("falls back to #id when the name lookup misses", () => {
+    const decisions = shapeReviewDecisions(
+      [
+        {
+          entityType: "RUN",
+          entityId: 99,
+          status: "REJECTED",
+          decidedAt: null,
+          decisionComment: null,
+          decidedBy: null,
+        },
+      ],
+      names
+    );
+    expect(decisions[0].entityName).toBe("#99");
+  });
+});

--- a/testplanit/lib/services/milestoneExport.ts
+++ b/testplanit/lib/services/milestoneExport.ts
@@ -1,0 +1,221 @@
+import type { MilestoneSegment } from "~/lib/services/milestoneSummary";
+
+/**
+ * Pure shaping helpers for the milestone export snapshot.
+ *
+ * This module intentionally has no runtime dependency on Prisma or any
+ * server-only module so the response types can be imported by the client
+ * export hook (`import type`) without bundling server code. The endpoint at
+ * `app/api/milestones/[milestoneId]/export/route.ts` performs the DB reads and
+ * feeds the results through these functions.
+ */
+
+export type MilestoneExportStatusCount = {
+  statusName: string;
+  count: number;
+  colorValue: string;
+};
+
+export type MilestoneExportRollup = {
+  totalItems: number;
+  executedItems: number;
+  completionRate: number;
+  totalElapsed: number;
+  totalEstimate: number;
+  statusCounts: MilestoneExportStatusCount[];
+};
+
+export type MilestoneExportRun = {
+  id: number;
+  name: string;
+  totalItems: number;
+  executedItems: number;
+  /** Total recorded execution time for this run, in seconds. */
+  elapsed: number;
+  statusCounts: MilestoneExportStatusCount[];
+};
+
+export type MilestoneExportSession = {
+  id: number;
+  name: string;
+  statusName: string;
+  colorValue: string;
+  isPending: boolean;
+  /** Recorded execution time for the session's latest result, in seconds. */
+  elapsed: number;
+};
+
+export type MilestoneExportDescendant = {
+  id: number;
+  name: string;
+  status: string;
+};
+
+export type MilestoneExportIssue = {
+  key: string;
+  title: string;
+  status: string | null;
+};
+
+export type MilestoneExportReviewDecision = {
+  entityType: "RUN" | "SESSION";
+  entityId: number;
+  entityName: string;
+  status: string;
+  decidedByName: string | null;
+  decidedAt: string | null;
+  decisionComment: string | null;
+};
+
+export type MilestoneExportData = {
+  milestone: {
+    id: number;
+    name: string;
+    status: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    createdAt: string;
+    ownerName: string | null;
+    typeName: string | null;
+    parentPath: string[];
+  };
+  rollup: MilestoneExportRollup;
+  testRuns: MilestoneExportRun[];
+  sessions: MilestoneExportSession[];
+  descendants: MilestoneExportDescendant[];
+  issues: MilestoneExportIssue[];
+  reviewDecisions: MilestoneExportReviewDecision[];
+  generatedAt: string;
+  projectId: number;
+};
+
+/** Human-readable status for a milestone given its lifecycle flags. */
+export function milestoneStatusLabel(milestone: {
+  isCompleted: boolean;
+  isStarted: boolean;
+}): string {
+  if (milestone.isCompleted) return "Completed";
+  if (milestone.isStarted) return "In Progress";
+  return "Not Started";
+}
+
+type SegmentLike = Pick<
+  MilestoneSegment,
+  "statusName" | "colorValue" | "isPending" | "itemCount"
+>;
+
+/**
+ * Aggregate a flat list of status segments into per-status counts plus
+ * executed/total tallies. Shared by the milestone-wide rollup and per-run
+ * breakdowns (a milestone segment carries `itemCount` cases per status).
+ */
+export function aggregateStatusCounts(segments: SegmentLike[]): {
+  statusCounts: MilestoneExportStatusCount[];
+  totalItems: number;
+  executedItems: number;
+} {
+  const byStatus = new Map<string, MilestoneExportStatusCount>();
+  let totalItems = 0;
+  let executedItems = 0;
+
+  for (const seg of segments) {
+    const count = seg.itemCount ?? 1;
+    totalItems += count;
+    if (!seg.isPending) executedItems += count;
+
+    const existing = byStatus.get(seg.statusName);
+    if (existing) {
+      existing.count += count;
+    } else {
+      byStatus.set(seg.statusName, {
+        statusName: seg.statusName,
+        count,
+        colorValue: seg.colorValue,
+      });
+    }
+  }
+
+  return {
+    statusCounts: Array.from(byStatus.values()),
+    totalItems,
+    executedItems,
+  };
+}
+
+/** Group test-run segments into one contributor row per run. */
+export function groupTestRunContributors(
+  testRunSegments: MilestoneSegment[]
+): MilestoneExportRun[] {
+  const byRun = new Map<
+    number,
+    { name: string; segments: MilestoneSegment[] }
+  >();
+
+  for (const seg of testRunSegments) {
+    const entry = byRun.get(seg.sourceId);
+    if (entry) {
+      entry.segments.push(seg);
+    } else {
+      byRun.set(seg.sourceId, { name: seg.sourceName, segments: [seg] });
+    }
+  }
+
+  return Array.from(byRun.entries()).map(([id, { name, segments }]) => {
+    const { statusCounts, totalItems, executedItems } =
+      aggregateStatusCounts(segments);
+    const elapsed = segments.reduce((sum, seg) => sum + (seg.elapsed ?? 0), 0);
+    return { id, name, totalItems, executedItems, elapsed, statusCounts };
+  });
+}
+
+/** One contributor row per session (sessions carry a single latest status). */
+export function mapSessionContributors(
+  sessionSegments: MilestoneSegment[]
+): MilestoneExportSession[] {
+  return sessionSegments.map((seg) => ({
+    id: seg.sourceId,
+    name: seg.sourceName,
+    statusName: seg.statusName,
+    colorValue: seg.colorValue,
+    isPending: seg.isPending,
+    elapsed: seg.elapsed ?? 0,
+  }));
+}
+
+type ReviewRequestLike = {
+  entityType: "RUN" | "SESSION" | "CASE";
+  entityId: number;
+  status: string;
+  decidedAt: Date | string | null;
+  decisionComment: string | null;
+  decidedBy?: { name: string | null } | null;
+};
+
+/**
+ * Shape review requests for the contributing runs/sessions into decision rows,
+ * resolving each entity's display name from the provided lookup. CASE-scoped
+ * requests are dropped (a milestone aggregates runs and sessions only).
+ */
+export function shapeReviewDecisions(
+  reviewRequests: ReviewRequestLike[],
+  entityNameByKey: Map<string, string>
+): MilestoneExportReviewDecision[] {
+  const toIso = (v: Date | string | null) =>
+    v == null ? null : v instanceof Date ? v.toISOString() : v;
+
+  return reviewRequests
+    .filter((r) => r.entityType === "RUN" || r.entityType === "SESSION")
+    .map((r) => {
+      const entityType = r.entityType as "RUN" | "SESSION";
+      const key = `${entityType}:${r.entityId}`;
+      return {
+        entityType,
+        entityId: r.entityId,
+        entityName: entityNameByKey.get(key) ?? `#${r.entityId}`,
+        status: r.status,
+        decidedByName: r.decidedBy?.name ?? null,
+        decidedAt: toIso(r.decidedAt),
+        decisionComment: r.decisionComment,
+      };
+    });
+}

--- a/testplanit/lib/services/milestoneSummary.ts
+++ b/testplanit/lib/services/milestoneSummary.ts
@@ -1,0 +1,452 @@
+import { prisma } from "~/lib/prisma";
+import { AUTOMATED_TEST_RUN_TYPES } from "~/utils/testResultTypes";
+
+export type MilestoneSegment = {
+  id: string;
+  type: "test-run" | "session";
+  sourceId: number;
+  sourceName: string;
+  statusId: number | null;
+  statusName: string;
+  colorValue: string;
+  elapsed: number | null;
+  estimate: number | null;
+  isPending: boolean;
+  itemCount?: number; // For test runs, number of cases
+  statusOrder: number | null;
+};
+
+export type MilestoneIssue = {
+  id: number;
+  name: string;
+  title: string;
+  externalId: string | null;
+  externalKey: string | null;
+  externalUrl: string | null;
+  externalStatus: string | null;
+  data: any;
+  integrationId: number | null;
+  lastSyncedAt: Date | null;
+  integration: {
+    id: number;
+    provider: string;
+    name: string;
+  } | null;
+  projectIds: number[];
+};
+
+export type MilestoneSummaryData = {
+  milestoneId: number;
+  totalItems: number;
+  completionRate: number;
+  totalElapsed: number;
+  totalEstimate: number;
+  commentsCount: number;
+  segments: MilestoneSegment[];
+  issues: MilestoneIssue[];
+};
+
+export async function calculateMilestoneCompletion(
+  milestoneIds: number[]
+): Promise<number> {
+  // Get total test cases in all test runs for these milestones
+  const totalCasesResult = await prisma.$queryRaw<Array<{ count: bigint }>>`
+    SELECT COUNT(*) as count
+    FROM "TestRunCases" trc
+    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
+    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
+      AND tr."isDeleted" = false
+  `;
+  const totalTestCases = Number(totalCasesResult[0]?.count || 0);
+
+  if (totalTestCases === 0) {
+    return 0;
+  }
+
+  // Get count of completed test cases (where TestRunCases.status.isCompleted = true)
+  const completedCasesResult = await prisma.$queryRaw<Array<{ count: bigint }>>`
+    SELECT COUNT(*) as count
+    FROM "TestRunCases" trc
+    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
+    JOIN "Status" s ON trc."statusId" = s.id
+    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
+      AND tr."isDeleted" = false
+      AND s."isCompleted" = true
+  `;
+  const completedTestCases = Number(completedCasesResult[0]?.count || 0);
+
+  // Calculate percentage, capped at 100%
+  return Math.min((completedTestCases / totalTestCases) * 100, 100);
+}
+
+export async function getTestRunSegments(
+  milestoneIds: number[]
+): Promise<MilestoneSegment[]> {
+  // Split the milestone's runs into manual vs. automated. Automated/imported
+  // runs (JUnit, TestNG, etc.) record their outcomes in JUnitTestResult, not
+  // TestRunResults, so they need a separate aggregation path — otherwise every
+  // automated case looks "pending" with zero elapsed.
+  const runs = await prisma.$queryRaw<
+    Array<{ id: number; testRunType: string }>
+  >`
+    SELECT id, "testRunType"
+    FROM "TestRuns"
+    WHERE "milestoneId" = ANY(${milestoneIds}::int[])
+      AND "isDeleted" = false
+  `;
+  const automatedTypes = new Set<string>(AUTOMATED_TEST_RUN_TYPES);
+  const regularRunIds = runs
+    .filter((r) => !automatedTypes.has(r.testRunType))
+    .map((r) => r.id);
+  const automatedRunIds = runs
+    .filter((r) => automatedTypes.has(r.testRunType))
+    .map((r) => r.id);
+
+  const [manual, automated] = await Promise.all([
+    getManualTestRunSegments(regularRunIds),
+    getAutomatedTestRunSegments(automatedRunIds),
+  ]);
+  return [...manual, ...automated];
+}
+
+async function getManualTestRunSegments(
+  runIds: number[]
+): Promise<MilestoneSegment[]> {
+  if (runIds.length === 0) return [];
+
+  // Get test runs with aggregated case data (manual runs only)
+  const testRuns = await prisma.$queryRaw<
+    Array<{
+      testRunId: number;
+      testRunName: string;
+      testRunType: string;
+      totalCases: bigint;
+      totalElapsed: number | null;
+      totalEstimate: number | null;
+      hasPendingCases: boolean;
+      statusId: number | null;
+      statusName: string | null;
+      colorValue: string | null;
+      statusCaseCount: bigint;
+      statusOrder: number | null;
+    }>
+  >`
+    WITH test_run_data AS (
+      SELECT
+        tr.id as "testRunId",
+        tr.name as "testRunName",
+        tr."testRunType",
+        trc."statusId",
+        s.name as "statusName",
+        COALESCE(c.value, '#9ca3af') as "colorValue",
+        s.order as "statusOrder",
+        COUNT(trc.id) as "statusCaseCount",
+        SUM(
+          COALESCE(trr.elapsed, 0) +
+          COALESCE((
+            SELECT SUM(COALESCE(trsr.elapsed, 0))
+            FROM "TestRunStepResults" trsr
+            WHERE trsr."testRunResultId" = trr.id
+          ), 0)
+        ) as "caseElapsed",
+        BOOL_OR(trr.id IS NULL) as "hasPendingCases",
+        SUM(CASE WHEN trr.id IS NULL THEN COALESCE(rc.estimate, 0) ELSE 0 END) as "caseEstimate"
+      FROM "TestRuns" tr
+      JOIN "TestRunCases" trc ON trc."testRunId" = tr.id
+      JOIN "RepositoryCases" rc ON trc."repositoryCaseId" = rc.id
+      LEFT JOIN "TestRunResults" trr ON trr."testRunCaseId" = trc.id AND trr."isDeleted" = false
+      LEFT JOIN "Status" s ON trc."statusId" = s.id
+      LEFT JOIN "Color" c ON s."colorId" = c.id
+      WHERE tr.id = ANY(${runIds}::int[])
+        AND tr."isDeleted" = false
+      GROUP BY tr.id, tr.name, tr."testRunType", trc."statusId", s.name, c.value, s.order
+    )
+    SELECT
+      "testRunId",
+      "testRunName",
+      "testRunType",
+      COUNT(*) as "totalCases",
+      SUM("caseElapsed") as "totalElapsed",
+      SUM("caseEstimate") as "totalEstimate",
+      BOOL_OR("hasPendingCases") as "hasPendingCases",
+      "statusId",
+      COALESCE("statusName", 'Untested') as "statusName",
+      "colorValue",
+      "statusOrder",
+      SUM("statusCaseCount") as "statusCaseCount"
+    FROM test_run_data
+    GROUP BY "testRunId", "testRunName", "testRunType", "statusId", "statusName", "colorValue", "statusOrder"
+    ORDER BY "testRunId", "statusId" ASC NULLS LAST
+  `;
+
+  // Group test run cases by test run and status
+  const segments: MilestoneSegment[] = [];
+  const testRunMap = new Map<
+    number,
+    {
+      name: string;
+      type: string;
+      cases: Array<{
+        statusId: number | null;
+        statusName: string;
+        colorValue: string;
+        count: number;
+        elapsed: number;
+        estimate: number;
+        hasPending: boolean;
+        statusOrder: number | null;
+      }>;
+    }
+  >();
+
+  testRuns.forEach((run) => {
+    if (!testRunMap.has(run.testRunId)) {
+      testRunMap.set(run.testRunId, {
+        name: run.testRunName,
+        type: run.testRunType,
+        cases: [],
+      });
+    }
+    const testRunData = testRunMap.get(run.testRunId)!;
+    testRunData.cases.push({
+      statusId: run.statusId,
+      statusName: run.statusName || "Untested",
+      colorValue: run.colorValue || "#9ca3af",
+      count: Number(run.statusCaseCount),
+      elapsed: Number(run.totalElapsed || 0),
+      estimate: Number(run.totalEstimate || 0),
+      hasPending: run.hasPendingCases,
+      statusOrder: run.statusOrder,
+    });
+  });
+
+  // Create segments for each test run case status
+  testRunMap.forEach((runData, testRunId) => {
+    runData.cases.forEach((caseData, index) => {
+      segments.push({
+        id: `test-run-${testRunId}-${caseData.statusId ?? "null"}-${index}`,
+        type: "test-run",
+        sourceId: testRunId,
+        sourceName: runData.name,
+        statusId: caseData.statusId,
+        statusName: caseData.statusName,
+        colorValue: caseData.colorValue,
+        elapsed: caseData.elapsed,
+        estimate: caseData.estimate,
+        isPending: caseData.hasPending,
+        itemCount: caseData.count,
+        statusOrder: caseData.statusOrder,
+      });
+    });
+  });
+
+  return segments;
+}
+
+/**
+ * Build status segments for automated/imported runs (JUnit, TestNG, etc.).
+ * Their outcomes live in JUnitTestResult (with `time`), grouped by status —
+ * each result is an executed item, so segments are never pending and their
+ * elapsed comes from the summed result time (same unit the run summary uses).
+ */
+async function getAutomatedTestRunSegments(
+  runIds: number[]
+): Promise<MilestoneSegment[]> {
+  if (runIds.length === 0) return [];
+
+  const rows = await prisma.$queryRaw<
+    Array<{
+      testRunId: number;
+      testRunName: string;
+      statusId: number | null;
+      statusName: string | null;
+      colorValue: string | null;
+      statusOrder: number | null;
+      resultType: string | null;
+      count: bigint;
+      elapsed: number | null;
+    }>
+  >`
+    SELECT
+      su."testRunId" as "testRunId",
+      tr.name as "testRunName",
+      jr."statusId" as "statusId",
+      s.name as "statusName",
+      COALESCE(c.value, '#9ca3af') as "colorValue",
+      s.order as "statusOrder",
+      jr.type as "resultType",
+      COUNT(*) as "count",
+      COALESCE(SUM(jr.time), 0) as "elapsed"
+    FROM "JUnitTestResult" jr
+    JOIN "JUnitTestSuite" su ON jr."testSuiteId" = su.id
+    JOIN "TestRuns" tr ON su."testRunId" = tr.id
+    LEFT JOIN "Status" s ON jr."statusId" = s.id
+    LEFT JOIN "Color" c ON s."colorId" = c.id
+    WHERE su."testRunId" = ANY(${runIds}::int[])
+    GROUP BY su."testRunId", tr.name, jr."statusId", s.name, c.value, s.order, jr.type
+    ORDER BY su."testRunId", jr."statusId" ASC NULLS LAST
+  `;
+
+  return rows.map((row, index) => ({
+    id: `test-run-junit-${row.testRunId}-${row.statusId ?? row.resultType ?? "null"}-${index}`,
+    type: "test-run" as const,
+    sourceId: row.testRunId,
+    sourceName: row.testRunName,
+    statusId: row.statusId,
+    statusName: row.statusName || row.resultType || "Untested",
+    colorValue: row.colorValue || "#9ca3af",
+    elapsed: Number(row.elapsed || 0),
+    estimate: null,
+    isPending: false,
+    itemCount: Number(row.count),
+    statusOrder: row.statusOrder,
+  }));
+}
+
+export async function getSessionSegments(
+  milestoneIds: number[]
+): Promise<MilestoneSegment[]> {
+  // Get sessions for this milestone with their latest results
+  const sessions = await prisma.$queryRaw<
+    Array<{
+      sessionId: number;
+      sessionName: string;
+      sessionEstimate: number | null;
+      resultId: number | null;
+      resultCreatedAt: Date | null;
+      resultElapsed: number | null;
+      statusId: number | null;
+      statusName: string | null;
+      colorValue: string | null;
+      statusOrder: number | null;
+    }>
+  >`
+    SELECT
+      s.id as "sessionId",
+      s.name as "sessionName",
+      s.estimate as "sessionEstimate",
+      sr.id as "resultId",
+      sr."createdAt" as "resultCreatedAt",
+      sr.elapsed as "resultElapsed",
+      sr."statusId",
+      st.name as "statusName",
+      COALESCE(c.value, '#9ca3af') as "colorValue",
+      st.order as "statusOrder"
+    FROM "Sessions" s
+    LEFT JOIN LATERAL (
+      SELECT
+        sr2.id,
+        sr2."createdAt",
+        sr2.elapsed,
+        sr2."statusId"
+      FROM "SessionResults" sr2
+      WHERE sr2."sessionId" = s.id
+        AND sr2."isDeleted" = false
+      ORDER BY sr2."createdAt" DESC
+      LIMIT 1
+    ) sr ON true
+    LEFT JOIN "Status" st ON sr."statusId" = st.id
+    LEFT JOIN "Color" c ON st."colorId" = c.id
+    WHERE s."milestoneId" = ANY(${milestoneIds}::int[])
+      AND s."isDeleted" = false
+    ORDER BY s.id
+  `;
+
+  return sessions.map((session) => {
+    const hasPending = session.resultId === null;
+    const firstStatus = session.statusName || "Untested";
+    const firstColor = session.colorValue || "#9ca3af";
+
+    return {
+      id: `session-${session.sessionId}`,
+      type: "session" as const,
+      sourceId: session.sessionId,
+      sourceName: session.sessionName,
+      statusId: session.statusId,
+      statusName: firstStatus,
+      colorValue: firstColor,
+      elapsed: session.resultElapsed,
+      estimate: hasPending ? session.sessionEstimate : null,
+      isPending: hasPending,
+      itemCount: 1,
+      statusOrder: session.statusOrder,
+    };
+  });
+}
+
+/**
+ * Collect all unique issues linked to a milestone's test runs and sessions
+ * (session-level and session-result-level), returned in the summary shape.
+ */
+export async function getMilestoneLinkedIssues(
+  testRunIds: number[],
+  sessionIds: number[],
+  projectId: number
+): Promise<MilestoneIssue[]> {
+  const issueIds = new Set<number>();
+
+  const testRunIssues =
+    testRunIds.length > 0
+      ? await prisma.$queryRaw<Array<{ issueId: number }>>`
+        SELECT DISTINCT "B" as "issueId"
+        FROM "_IssueToTestRuns"
+        WHERE "A" = ANY(${testRunIds}::int[])
+      `
+      : [];
+  testRunIssues.forEach((link) => issueIds.add(link.issueId));
+
+  const sessionIssues =
+    sessionIds.length > 0
+      ? await prisma.$queryRaw<Array<{ issueId: number }>>`
+        SELECT DISTINCT "B" as "issueId"
+        FROM "_IssueToSessions"
+        WHERE "A" = ANY(${sessionIds}::int[])
+      `
+      : [];
+  sessionIssues.forEach((link) => issueIds.add(link.issueId));
+
+  const sessionResultIssues =
+    sessionIds.length > 0
+      ? await prisma.$queryRaw<Array<{ issueId: number }>>`
+        SELECT DISTINCT irs."B" as "issueId"
+        FROM "_IssueToSessionResults" irs
+        JOIN "SessionResults" sr ON irs."A" = sr.id
+        WHERE sr."sessionId" = ANY(${sessionIds}::int[])
+          AND sr."isDeleted" = false
+      `
+      : [];
+  sessionResultIssues.forEach((link) => issueIds.add(link.issueId));
+
+  const issues =
+    issueIds.size > 0
+      ? await prisma.issue.findMany({
+          where: {
+            id: { in: Array.from(issueIds) },
+          },
+          select: {
+            id: true,
+            name: true,
+            title: true,
+            externalId: true,
+            externalKey: true,
+            externalUrl: true,
+            externalStatus: true,
+            data: true,
+            integrationId: true,
+            lastSyncedAt: true,
+            integration: {
+              select: {
+                id: true,
+                provider: true,
+                name: true,
+              },
+            },
+          },
+        })
+      : [];
+
+  return issues.map((issue) => ({
+    ...issue,
+    projectIds: [projectId],
+  }));
+}


### PR DESCRIPTION
## Description

Adds an evidence-grade **PDF export** to the Milestone Details page (an **Export PDF** button beside Edit/Complete). The report is generated client-side with `jsPDF`, mirroring the existing Test Run / Session PDF exports, and aggregates the milestone **and all descendant sub-milestones**:

- Milestone metadata (status, dates, owner, type, parent path)
- Aggregate summary — completion rate, executed/total, total elapsed & estimate, color-coded status roll-up
- Contributing **Test Runs** and **Sessions** with per-item **Elapsed** and color-coded statuses
- Sub-milestones, Linked Issues, and **Review & Approval Decisions**
- Repeating table headers across page breaks + a per-page generation header/footer (milestone · date · produced-by) for auditability

Data comes from a new `GET /api/milestones/{id}/export` endpoint backed by a shared milestone-summary aggregation (extracted so the on-page summary and the export stay in sync).

Also includes two fixes surfaced along the way:
- **Automated (JUnit) results** are now counted in the milestone roll-up. They live in `JUnitTestResult` (not `TestRunResults`), so they were previously reported as pending with zero elapsed.
- **Milestone edit form** no longer fires a stray no-op save when entering edit mode (guard + form remount, matching the Test Run page).

## Related Issue

N/A

## Type of Change

- [x] Enhancement (non-breaking improvement)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation

## Testing

- New unit tests: `milestoneExport` shaping helpers, `/export` route (auth, 404, contributors, issues, review decisions, parent-path, empty-milestone).
- New E2E specs: `milestone-export` (seeds a nested tree + runs/sessions/issues/reviews, asserts every section) and `milestone-edit` (Edit click doesn't submit; Save still persists once).
- `pnpm precommit` green — lint, type-check, prettier, **8,075 unit tests**.
- Manually verified the live `/export` output against a JUnit-heavy milestone (elapsed/executed now correct) and the rendered PDF formatting (colors, pagination, elapsed columns).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my change works
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (import/export + milestone details guide)
