### PR TITLE
build(deps): disable pnpm minimumReleaseAge in the release Docker build

### DIFF
--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -15,6 +15,11 @@ RUN apk add --no-cache postgresql-client
 RUN apk add --no-cache curl
 # Install pnpm globally
 RUN npm install -g pnpm@latest
+# Disable pnpm v10's minimum-release-age gate (default 24h), which rejects
+# freshly-published lockfile entries. .npmrc is gitignored so it isn't in the
+# build context; write the setting where pnpm reads it. Pre-merge CI is our
+# supply-chain verification.
+RUN echo "minimum-release-age=0" >> .npmrc
 # Copy package files first for better caching
 # COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
 # Install dependencies first
@@ -71,6 +76,8 @@ RUN apk add --no-cache libc6-compat
 RUN apk add --no-cache --virtual .gyp python3 make g++
 RUN npm install -g pnpm@latest
 COPY package.json pnpm-lock.yaml* .npmrc* ./
+# Disable pnpm v10's minimum-release-age gate (see base stage).
+RUN echo "minimum-release-age=0" >> .npmrc
 # Install only production dependencies
 # --ignore-scripts skips postinstall (which needs zenstack, a dev dep)
 RUN pnpm install --prod --ignore-scripts


### PR DESCRIPTION
## Description

The Release **Docker build keeps failing** with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. pnpm v10 (`pnpm@latest` in the Dockerfile) enforces a 24h `minimumReleaseAge` supply-chain gate by default, and #363's dependency refresh pulled several versions published within that window (`ai`, `nodemailer`, `systeminformation`, `@atlaskit/*`, `eslint-module-utils`).

#365 tried to disable the gate via `package.json#pnpm.minimumReleaseAge=0`, but **pnpm v10 does not read that setting from `package.json`** — and the repo's only `.npmrc` (`testplanit/.npmrc`) is gitignored, so it isn't in the Docker build context either. The gate therefore stayed active.

This writes `minimum-release-age=0` into a project `.npmrc` inside each `pnpm install` stage of the Dockerfile — the location pnpm v10 actually honors.

### Verification (pnpm 10.33.2)

```
pnpm config get minimumReleaseAge
  package.json#pnpm      -> undefined   (what #365 used — ignored)
  .npmrc (minimum-release-age=0) -> 0   ✅
```

## Type of Change

- [x] Build/CI fix
- [ ] Bug fix (app)
- [ ] Enhancement
- [ ] Breaking change

Scoped `build(deps)` so it does **not** cut a release. After merge, re-run the **Release** workflow to publish the pending Docker images.

## Testing

- Verified the config mechanism locally on pnpm 10.33.2 (table above).
- The change is confined to the Dockerfile's two `pnpm install` stages; the existing `COPY .npmrc*` is a no-op in CI (file is gitignored).

## Notes / Follow-up

- The `package.json#pnpm.minimumReleaseAge` entries from #365 are left in place as harmless no-ops — happy to remove them in a follow-up if preferred.
- Pre-merge CI (lint + format + 8000+ unit tests) remains the supply-chain verification in lieu of the cooling-off window.
