### PR TITLE
build(deps): pass --config.minimumReleaseAge=0 to pnpm install in Docker build

### DIFF
--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -15,18 +15,18 @@ RUN apk add --no-cache postgresql-client
 RUN apk add --no-cache curl
 # Install pnpm globally
 RUN npm install -g pnpm@latest
-# Disable pnpm v10's minimum-release-age gate (default 24h), which rejects
-# freshly-published lockfile entries. .npmrc is gitignored so it isn't in the
-# build context; write the setting where pnpm reads it. Pre-merge CI is our
-# supply-chain verification.
-RUN echo "minimum-release-age=0" >> .npmrc
 # Copy package files first for better caching
 # COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
-# Install dependencies first
+# Install dependencies first.
+# --config.minimumReleaseAge=0 disables pnpm 11's supply-chain cooling-off gate
+# (default 1440min), which otherwise rejects freshly-published lockfile entries
+# during the release build. pnpm 11 only honors this via the CLI flag or
+# pnpm-workspace.yaml — not .npmrc or package.json#pnpm. Pre-merge CI (lint +
+# format + unit tests) is our supply-chain verification.
 RUN \
     if [ -f yarn.lock ]; then yarn install --frozen-lockfile --ignore-scripts; \
     elif [ -f package-lock.json ]; then npm ci --ignore-scripts; \
-    elif [ -f pnpm-lock.yaml ]; then pnpm i --ignore-scripts; \
+    elif [ -f pnpm-lock.yaml ]; then pnpm i --ignore-scripts --config.minimumReleaseAge=0; \
     else echo "Lockfile not found." && exit 1; \
     fi
 
@@ -76,11 +76,10 @@ RUN apk add --no-cache libc6-compat
 RUN apk add --no-cache --virtual .gyp python3 make g++
 RUN npm install -g pnpm@latest
 COPY package.json pnpm-lock.yaml* .npmrc* ./
-# Disable pnpm v10's minimum-release-age gate (see base stage).
-RUN echo "minimum-release-age=0" >> .npmrc
 # Install only production dependencies
 # --ignore-scripts skips postinstall (which needs zenstack, a dev dep)
-RUN pnpm install --prod --ignore-scripts
+# --config.minimumReleaseAge=0 disables pnpm 11's supply-chain gate (see base stage)
+RUN pnpm install --prod --ignore-scripts --config.minimumReleaseAge=0
 # Rebuild native modules (bcrypt, sharp, etc.) using npm rebuild
 # This avoids pnpm's lifecycle scripts that require dev dependencies
 RUN npm rebuild bcrypt sharp 2>/dev/null || true


### PR DESCRIPTION
## Description

Correct fix for the Release Docker build's `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. Two prior attempts targeted the wrong config location:

- **#365** set `minimumReleaseAge: 0` in `package.json#pnpm` → ignored.
- **#367** wrote `minimum-release-age=0` to `.npmrc` → also ignored by the gate.

`pnpm@latest` is now **v11.5.0**, which enforces `minimumReleaseAge` (default 1440 min) as a **lockfile-verification** step during `pnpm install --prod`, and only reads the setting from the **CLI flag** or **`pnpm-workspace.yaml`** — not `.npmrc` or `package.json#pnpm`.

This passes `--config.minimumReleaseAge=0` directly on both `pnpm install` commands in the Dockerfile (and removes the dead `.npmrc` writes from #367). No new files, no effect on local/dev installs — scoped to the build.

### Verification (reproduced with pnpm 11.5.0, the CI version)

`pnpm install --prod --frozen-lockfile` against a freshly-published dep:

| Disable method | Result |
| --- | --- |
| `.npmrc` `minimum-release-age=0` (#367) | ❌ `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` |
| `pnpm-workspace.yaml` `minimumReleaseAge: 0` | ✅ passes |
| **`--config.minimumReleaseAge=0`** (this PR) | ✅ passes |

## Type of Change

- [x] Build/CI fix

Scoped `build(deps)` → `release: false` (no version bump).

## Testing

- Reproduced the exact CI error locally on pnpm 11.5.0 and confirmed the `--config` flag clears it while `.npmrc` does not (table above).

## Follow-up

After merge: re-point the `v0.32.6` tag to the new commit and re-run the Release workflow to publish the images. The no-op `package.json#pnpm.minimumReleaseAge` entries from #365 can be removed separately.
