### PR TITLE
build(deps): remove dead pnpm.minimumReleaseAge entries from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "vite": "^7.3.2"
     },
     "pnpm": {
-        "minimumReleaseAge": 0,
         "onlyBuiltDependencies": [
             "@forge/cli",
             "@parcel/watcher",

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -377,9 +377,6 @@
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
-  "pnpm": {
-    "minimumReleaseAge": 0
-  },
   "overrides": {
     "csstype": "^3.2.0",
     "@csstools/css-syntax-patches-for-csstree": "^1.0.20",


### PR DESCRIPTION
## Description

Removes the dead `pnpm.minimumReleaseAge` entries from the root and `testplanit/` `package.json` files.

These were added in #365 to disable pnpm's supply-chain cooling-off gate, but **pnpm 11 ignores `minimumReleaseAge` set in `package.json#pnpm`** — the gate is actually handled in the Dockerfile via `ENV PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` (#369). Dropping the no-ops so they don't mislead the next person who goes looking for where the policy is configured.

No behavior change (the settings were already inert).

## Type of Change

- [x] Build/CI cleanup — `build(deps)`, no version bump.

## Testing

- Both files validated as valid JSON; diffs are line-only removals preserving existing formatting; `testplanit/package.json` is Prettier-clean.
