### PR TITLE
feat(export): Data Lake Export endpoints + Webhook Event Catalog

### DIFF
--- a/docs/blog/2026-05-30-data-lake-export.md
+++ b/docs/blog/2026-05-30-data-lake-export.md
@@ -1,0 +1,78 @@
+---
+slug: data-lake-export
+title: 'Stream test data straight into your data lake'
+description: "TestPlanIt's new NDJSON bulk-export endpoints turn test execution into a first-class analytics source for Snowflake, BigQuery, Databricks, and any pipeline that speaks chunked JSON."
+authors: [testplanit]
+tags: [api, data-lake, analytics, integrations]
+---
+
+If your data team treats test execution like any other event stream — coverage trends in Snowflake, defect heatmaps in BigQuery, regression dashboards in Databricks — you've probably written a custom ETL job to scrape pages of paginated JSON out of your test management tool.
+
+We just made that job a one-liner.
+
+<!-- truncate -->
+
+## Three new endpoints, one wire format
+
+TestPlanIt now ships three GET endpoints designed for analytics ingestion:
+
+- `/api/export/test-run-results` — the execution **fact table** (one row per recorded result)
+- `/api/export/repository-cases` — the test-case **dimension table**
+- `/api/export/audit-log` — the **compliance feed** (one row per audited mutation)
+
+Each one streams **NDJSON** (newline-delimited JSON) over HTTP chunked transfer encoding. That's the wire format Spark, Snowflake `COPY INTO`, BigQuery `bq load`, Databricks Auto Loader, Airbyte, Fivetran, Logstash, and Vector all natively understand. No client library, no intermediate parsing, no need to materialize the whole response — your pipeline consumes one record at a time, all the way through.
+
+## What it looks like
+
+Pull every result executed since the last sync:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://testplanit.example.com/api/export/test-run-results?since=2026-05-01T00:00:00Z&pageSize=1000"
+```
+
+The response opens with a manifest line, streams rows, and closes with an end-trailer:
+
+```ndjson
+{"type":"manifest","schemaVersion":1,"resource":"test-run-results","exportedAt":"...","since":"2026-05-01T00:00:00.000Z","pageSize":1000,"projectId":null}
+{"id":12345,"testRunId":42,"testCaseId":200,"statusName":"Passed","isPass":true,"executedAt":"2026-05-30T10:00:00.000Z",...}
+{"id":12346,"testRunId":42,"testCaseId":201,"statusName":"Failed","isPass":false,"executedAt":"2026-05-30T10:00:01.000Z",...}
+...
+{"type":"end","count":1000,"cursor":"eyJrIjoi..."}
+```
+
+The trailer carries a base64url cursor. Hit the same endpoint with `?cursor=<value>` to get the next page. The cursor is `null` when you've exhausted the dataset — that's the signal to stop.
+
+## Stable forward iteration
+
+The cursor encodes the `(executedAt, id)` tuple of the last row. The next page's WHERE clause is **strict-forward** with a tiebreaker:
+
+```sql
+WHERE (executedAt > c.executedAt)
+   OR (executedAt = c.executedAt AND id > c.id)
+```
+
+That's a deliberate choice. Naïve `WHERE executedAt > c.executedAt` skips rows with identical timestamps; `WHERE executedAt >= c.executedAt` duplicates the boundary row. The composite tuple is the only way to walk the table without either. Combined with the indexed sort key, page fetches stay fast at millions of rows.
+
+## Real-time too: the webhook event catalog
+
+For workloads that need push, not pull, TestPlanIt's outbound webhooks fire on every meaningful state change. We now also publish the **catalog** of triggers — `case.created`, `test_run.completed`, `iteration.result.recorded`, `issue.updated`, the whole list — at `/api/webhooks/events`:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://testplanit.example.com/api/webhooks/events?category=test-run"
+```
+
+Drive your downstream subscription config from this catalog. No more reading source to figure out what events exist.
+
+## The architecture pick
+
+We deliberately stopped short of shipping a native Kafka/Kinesis/Pub-Sub producer. The reason: **almost everyone already has a webhook → event-bus bridge** they trust — Kafka Connect REST source, AWS API Gateway → Kinesis Firehose, Google Pub/Sub HTTP push, even a 20-line Vector pipeline. Adding three SDK adapters to TestPlanIt would mean three runbooks, three sets of CVEs, three "why isn't it delivering" failure modes — for ergonomics most of our customers don't need.
+
+What customers DO need is the **format** their data lake speaks and the **schema** of every event. That's what these endpoints give you.
+
+## Try it
+
+The endpoints ship in the next release. To preview today, pull `main` and follow the [Data Lake Export](/docs/data-lake-export) docs page for end-to-end recipes — curl, Python, Spark, Snowflake `COPY INTO`, and Databricks Auto Loader are all covered.
+
+Feedback or a request for a built-in Kafka adapter? We're listening — open a discussion on [GitHub](https://github.com/TestPlanIt/testplanit/discussions) and tell us what you'd want.

--- a/docs/docs/data-lake-export.md
+++ b/docs/docs/data-lake-export.md
@@ -1,0 +1,277 @@
+---
+sidebar_position: 16
+title: Data Lake Export
+---
+
+# Data Lake Export
+
+TestPlanIt ships **streaming NDJSON bulk-export endpoints** for moving test data — execution results, test cases, and the audit log — into Snowflake, BigQuery, Databricks, ClickHouse, or any other analytics platform that consumes NDJSON. Paired with a published **webhook event catalog**, the same data is available as both incremental pull (cursor-paged batch) and real-time push (signed outbound webhooks) so you can mix and match: bulk-load history, then trail with webhooks.
+
+Skim:
+
+- Three GET endpoints under `/api/export/` return **NDJSON over chunked transfer encoding**
+- Each response is one cursor-paged window with a manifest line first and an end-trailer last
+- Pagination is **stable forward iteration** — repeated runs with the same `since` always see new rows, never duplicates, never skipped rows
+- A fourth endpoint, `/api/webhooks/events`, publishes the **catalog of trigger names** TestPlanIt fires on, with payload schemas
+
+## Why NDJSON
+
+NDJSON (newline-delimited JSON) is the de-facto wire format for data-lake ingestion. Each line is a complete JSON record; consumers parse line-by-line without materializing the whole response in memory. Spark, Snowflake `COPY INTO`, BigQuery `bq load`, Databricks Auto Loader, and most generic ETL tools (Airbyte, Fivetran, Logstash, Vector) all read it natively.
+
+Combined with HTTP chunked transfer encoding, this means:
+
+- The **server** never buffers more than one page in memory, regardless of total export size
+- The **consumer** sees the first row within a few hundred milliseconds and can start materializing rows while the database is still scanning
+- A **failed mid-stream** export is obvious: the response ends with an `{"error":"..."}` line instead of an end-trailer
+
+## Endpoints
+
+All three endpoints share the same authentication, query parameters, and response envelope. They differ only in what rows they emit.
+
+### `GET /api/export/test-run-results`
+
+The **fact table** — one row per recorded result, sorted ascending by `executedAt`. This is the high-volume feed: most data-lake pipelines start here.
+
+Each row carries:
+
+```json
+{
+  "id": 12345,
+  "testRunId": 42,
+  "testRunCaseId": 7891,
+  "testCaseId": 200,
+  "projectId": 1,
+  "statusId": 5,
+  "statusName": "Passed",
+  "isPass": true,
+  "isFail": false,
+  "executedAt": "2026-05-30T10:00:00.000Z",
+  "executedById": "cltg18noo0001i7lh4ia312j5",
+  "elapsedMs": 250,
+  "attempt": 1,
+  "iterationId": null,
+  "editedAt": null,
+  "editedById": null
+}
+```
+
+### `GET /api/export/repository-cases`
+
+The **dimension table** — one row per test case, sorted ascending by `createdAt`. Pull this on a longer cadence (nightly, weekly) to rebuild the case lookup table that denormalizes execution facts.
+
+`since` filters by case **creation** time. Cases are versioned (every edit creates a `RepositoryCaseVersions` row) so the natural cadence for catching edits is either:
+
+- **Full refresh** — omit `since`, walk all pages; cheap because cases are typically O(thousands), not O(millions)
+- **Trail via webhooks** — subscribe to `case.updated` and apply diffs to your existing rows
+
+Each row carries:
+
+```json
+{
+  "id": 200,
+  "projectId": 1,
+  "folderId": 50,
+  "templateId": 3,
+  "stateId": 1,
+  "name": "Login with invalid password",
+  "className": null,
+  "source": "MANUAL",
+  "automated": false,
+  "hasParameters": false,
+  "isArchived": false,
+  "estimate": 300,
+  "forecastManual": 280,
+  "forecastAutomated": null,
+  "currentVersion": 4,
+  "createdAt": "2026-03-15T09:27:00.000Z",
+  "creatorId": "cltg18noo0001i7lh4ia312j5"
+}
+```
+
+`currentVersion` increments on every edit. Track it between runs to detect updated cases without parsing the version history.
+
+### `GET /api/export/audit-log`
+
+The **compliance feed** — one row per audited mutation, sorted ascending by `timestamp`. Required for SOX/internal-audit pipelines. **Admin-only** for cross-project; non-admin tokens must supply a `projectId` they have access to.
+
+Each row carries the actor, the entity touched, the action, the before/after diff (when captured), and the metadata blob recorded at the time:
+
+```json
+{
+  "id": "clxyz123abc456",
+  "timestamp": "2026-05-30T10:00:00.000Z",
+  "action": "UPDATE",
+  "entityType": "TestRunResults",
+  "entityId": "42",
+  "entityName": "Smoke test - login",
+  "userId": "cltg18noo0001i7lh4ia312j5",
+  "userEmail": "user@example.com",
+  "userName": "User One",
+  "projectId": 1,
+  "changes": { "statusId": { "old": 3, "new": 5 } },
+  "metadata": { "ip": "10.0.0.42", "ua": "Mozilla/...", "requestId": "..." }
+}
+```
+
+## Query parameters
+
+| Parameter   | Required    | Default | Description                                                                                                                                                    |
+| ----------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `since`     | no          | none    | ISO-8601 timestamp. Only rows with the relevant sort column ≥ `since` are emitted. `executedAt` for results, `createdAt` for cases, `timestamp` for audit log. |
+| `cursor`    | no          | none    | Opaque base64url continuation token from the previous response's end-trailer. Encodes the (sort-key, id) tuple of the last row in the previous page.           |
+| `pageSize`  | no          | 1000    | 1..5000. Values outside the range are silently clamped.                                                                                                        |
+| `projectId` | conditional | none    | Optional for ADMIN tokens, **required** for non-admin tokens. Non-admin tokens must have access to the project they request.                                   |
+
+## Response envelope
+
+Every response is NDJSON: a sequence of JSON objects separated by `\n`. The shape:
+
+```
+{"type":"manifest", ...}                ← first line: per-page metadata
+{"id": ..., ...}                        ← row 1
+{"id": ..., ...}                        ← row 2
+...
+{"type":"end","count":N,"cursor":"..."} ← last line: row count + next cursor
+```
+
+**Manifest:**
+
+```json
+{
+  "type": "manifest",
+  "schemaVersion": 1,
+  "resource": "test-run-results",
+  "exportedAt": "2026-05-30T10:00:00.000Z",
+  "since": "2026-05-01T00:00:00.000Z",
+  "pageSize": 1000,
+  "projectId": null
+}
+```
+
+**End trailer:**
+
+```json
+{ "type": "end", "count": 1000, "cursor": "eyJrIjoi..." }
+```
+
+The trailer's `cursor` is `null` iff the page returned fewer rows than `pageSize` — that's the signal to stop. Otherwise, fire the next request with `?cursor=<value>`.
+
+**Errors mid-stream:** if the database connection drops while emitting rows, the response appends a final `{"error":"..."}` line in place of the end-trailer. Consumers should treat any response that does NOT end with `{"type":"end",...}` as incomplete and retry with the same parameters.
+
+## Authentication
+
+Pass an API token as `Authorization: Bearer <token>`, or include a session cookie (browser-driven). API tokens are the recommended path for ETL pipelines — they're per-user, revocable, and persist across sessions. See [API Tokens](./api-tokens.md) for token issuance.
+
+## Authorization
+
+- **ADMIN tokens**: read across every project. Pass `projectId` to narrow to one.
+- **Non-admin tokens**: must pass `projectId`. The request returns `403` if the user has no access to that project. There is no aggregate "all my projects" mode for non-admins; consumers loop over project IDs explicitly.
+
+## Consumer recipes
+
+### Bash + curl + jq (smoke test)
+
+```bash
+TOKEN="tpi_..."
+BASE="https://your-instance.example.com/api"
+
+# First page
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/export/test-run-results?since=2026-05-01T00:00:00Z&pageSize=100" \
+  > page-1.ndjson
+
+# Extract the cursor from the trailer
+NEXT=$(tail -n1 page-1.ndjson | jq -r '.cursor // empty')
+echo "Next cursor: $NEXT"
+```
+
+### Python (loop to exhaustion)
+
+```python
+import json, requests
+
+TOKEN = "tpi_..."
+BASE = "https://your-instance.example.com/api"
+session = requests.Session()
+session.headers["Authorization"] = f"Bearer {TOKEN}"
+
+cursor = None
+since = "2026-05-01T00:00:00Z"
+all_rows = []
+
+while True:
+    params = {"since": since, "pageSize": 1000}
+    if cursor:
+        params["cursor"] = cursor
+    resp = session.get(f"{BASE}/export/test-run-results", params=params, stream=True)
+    resp.raise_for_status()
+    trailer = None
+    for line in resp.iter_lines():
+        if not line:
+            continue
+        row = json.loads(line)
+        if row.get("type") == "manifest":
+            continue
+        if row.get("type") == "end":
+            trailer = row
+            continue
+        if row.get("error"):
+            raise RuntimeError(f"export failed: {row['error']}")
+        all_rows.append(row)
+    if not trailer or not trailer.get("cursor"):
+        break
+    cursor = trailer["cursor"]
+
+print(f"exported {len(all_rows)} results")
+```
+
+### Spark / Databricks
+
+```python
+# Single-node ingestion; for production use a Bronze/Silver pattern.
+df = (
+  spark.read
+    .option("multiline", "false")
+    .json(f"https://your-instance.example.com/api/export/test-run-results?since={since_iso}",
+          # use a custom HTTP DataSource or wget into DBFS first; Spark .json() doesn't pass Authorization headers natively
+          )
+)
+df.write.mode("append").saveAsTable("bronze.testplanit_results")
+```
+
+In production, prefer pulling into DBFS / S3 / GCS via a scheduled job, then `COPY INTO` from the lake into your warehouse.
+
+### Snowflake (`COPY INTO` from external stage)
+
+```sql
+COPY INTO bronze.testplanit_results
+FROM @testplanit_export/test-run-results/
+FILE_FORMAT = (TYPE = JSON, STRIP_OUTER_ARRAY = FALSE)
+ON_ERROR = 'CONTINUE';
+```
+
+Run a small bridge script (Python, Airflow, anything) to fetch the NDJSON from `/api/export/test-run-results`, drop it into your S3/GCS external stage, then trigger the `COPY INTO`.
+
+## Webhook event catalog
+
+For real-time pushes (rather than polling), TestPlanIt fires signed outbound webhooks on internal triggers. The full list of trigger names is published at `GET /api/webhooks/events`. Optional `?category=` filter restricts to one of: `test-case`, `test-run`, `iteration`, `session`, `issue`, `review`, `system`.
+
+Each catalog entry carries:
+
+```json
+{
+  "name": "test_run.completed",
+  "category": "test-run",
+  "description": "A test run was marked complete (state moved into a terminal state).",
+  "payloadKeys": ["id", "projectId", "completedAt", "summary"]
+}
+```
+
+Use the catalog to drive subscription configuration in your data platform without reading TestPlanIt source. The endpoint is read-only; webhook subscription CRUD lives at `/api/webhooks/configs` (covered in [Webhooks](./user-guide/webhooks.md)).
+
+## Operational notes
+
+- **Performance**: the export endpoints read from the same database as the application but the queries are bounded (`take: pageSize`) and use indexed sort keys, so they don't tank OLTP. Run them off-peak if your instance is volume-sensitive.
+- **Backpressure**: NDJSON streams as fast as the consumer reads. If you suspect overload, lower `pageSize` and the database scan window per request shrinks accordingly.
+- **Soft-deletes**: all three endpoints filter `isDeleted = false`. Soft-deleted rows do not appear in the export; consumers see deletes via `*.deleted` webhook events instead.
+- **Time zone**: every timestamp in the response is UTC, ISO-8601, with millisecond precision. `since` accepts any timezone-qualified ISO-8601 and is normalized to UTC server-side.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -230,6 +230,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'api-reference', // Add api-reference.md
+        'data-lake-export', // NDJSON bulk-export endpoints + webhook event catalog
         'sdk/api-client', // @testplanit/api package
         'sdk/jira-forge-app', // Jira Forge app (Marketplace plugin)
         {

--- a/testplanit/app/api/export/audit-log/route.test.ts
+++ b/testplanit/app/api/export/audit-log/route.test.ts
@@ -1,0 +1,148 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("~/lib/api-token-auth", () => ({ authenticateRequest: vi.fn() }));
+vi.mock("@zenstackhq/runtime", () => ({ enhance: vi.fn() }));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    projects: { findFirst: vi.fn() },
+    auditLog: { findMany: vi.fn() },
+  },
+}));
+
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { GET } from "./route";
+
+async function readNdjson(res: Response): Promise<unknown[]> {
+  const text = await res.text();
+  return text
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function req(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"));
+}
+
+const ADMIN_USER = { userId: "admin-1", access: "ADMIN" } as const;
+const PROJECT_USER = { userId: "user-1", access: null } as const;
+
+function buildAuditRow(id: string, timestamp: Date): unknown {
+  return {
+    id,
+    timestamp,
+    action: "CREATE",
+    entityType: "TestRunResults",
+    entityId: "42",
+    entityName: "Smoke test",
+    userId: "creator-1",
+    userEmail: "c@example.com",
+    userName: "Creator One",
+    projectId: 100,
+    changes: { status: { old: null, new: "PASSED" } },
+    metadata: { ip: "127.0.0.1" },
+  };
+}
+
+describe("GET /api/export/audit-log", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires auth", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: false,
+      error: "Unauthorized",
+      status: 401,
+    });
+    const res = await GET(req("/api/export/audit-log"));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin without projectId", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: PROJECT_USER,
+    });
+    const res = await GET(req("/api/export/audit-log"));
+    expect(res.status).toBe(400);
+  });
+
+  it("enforces project access for non-admin", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: PROJECT_USER,
+    });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+    } as never);
+    vi.mocked(enhance).mockReturnValue({
+      projects: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never);
+    const res = await GET(req("/api/export/audit-log?projectId=100"));
+    expect(res.status).toBe(403);
+  });
+
+  it("streams audit rows with manifest and trailer", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const t1 = new Date("2026-05-01T10:00:00.000Z");
+    vi.mocked(prisma.auditLog.findMany).mockResolvedValue([
+      buildAuditRow("audit-a", t1),
+      buildAuditRow("audit-b", t1),
+    ] as never);
+
+    const res = await GET(req("/api/export/audit-log?pageSize=10"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/x-ndjson; charset=utf-8"
+    );
+
+    const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toMatchObject({
+      type: "manifest",
+      resource: "audit-log",
+    });
+    expect(lines[1]).toMatchObject({
+      id: "audit-a",
+      action: "CREATE",
+      entityType: "TestRunResults",
+      timestamp: t1.toISOString(),
+      changes: { status: { old: null, new: "PASSED" } },
+    });
+    expect(lines[3]).toEqual({ type: "end", count: 2, cursor: null });
+  });
+
+  it("emits a continuation cursor with a string id when the page is full", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const ts = new Date("2026-05-01T00:00:00.000Z");
+    const rows = ["audit-a", "audit-b", "audit-c"].map((id) =>
+      buildAuditRow(id, ts)
+    );
+    vi.mocked(prisma.auditLog.findMany).mockResolvedValue(rows as never);
+
+    const res = await GET(req("/api/export/audit-log?pageSize=3"));
+    const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+    const trailer = lines[lines.length - 1] as {
+      type: string;
+      cursor: string;
+    };
+    const decoded = JSON.parse(
+      Buffer.from(trailer.cursor, "base64url").toString("utf-8")
+    );
+    expect(decoded).toEqual({ k: ts.toISOString(), i: "audit-c" });
+  });
+});

--- a/testplanit/app/api/export/audit-log/route.ts
+++ b/testplanit/app/api/export/audit-log/route.ts
@@ -1,0 +1,168 @@
+/**
+ * Bulk NDJSON export of AuditLog — the compliance / change-history feed.
+ *
+ * Admin-only across all projects; non-admins are gated to the audit rows for
+ * a specific project they have access to (via the enhanced client).
+ *
+ * Sorted by (timestamp asc, id asc) with the standard `since` / `cursor` /
+ * `pageSize` triplet. Each row carries the actor, the entity touched, the
+ * action, the changes diff (when captured), and the metadata blob (IP, UA,
+ * request id) recorded at the time of the event. Schema reference:
+ * `model AuditLog` in schema.zmodel.
+ */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { authOptions } from "~/server/auth";
+import { ndjsonResponse, type PageSource } from "~/lib/export/ndjson";
+import {
+  buildManifest,
+  buildTrailer,
+  cursorWhere,
+  decodeCursor,
+  encodeCursor,
+  parsePageSize,
+  parseSince,
+} from "~/lib/export/queryParams";
+
+interface AuditRow {
+  id: string;
+  timestamp: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  entityName: string | null;
+  userId: string | null;
+  userEmail: string | null;
+  userName: string | null;
+  projectId: number | null;
+  changes: unknown;
+  metadata: unknown;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const auth = await authenticateRequest(request, session);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status ?? 401 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const since = parseSince(url.searchParams.get("since"));
+  const cursor = decodeCursor(url.searchParams.get("cursor"));
+  const pageSize = parsePageSize(url.searchParams.get("pageSize"));
+  const projectIdRaw = url.searchParams.get("projectId");
+  const projectId = projectIdRaw ? Number.parseInt(projectIdRaw, 10) : null;
+
+  const isAdmin = auth.user.access === "ADMIN";
+
+  if (!isAdmin && (projectId === null || Number.isNaN(projectId))) {
+    return NextResponse.json(
+      { error: "projectId is required for non-admin tokens" },
+      { status: 400 }
+    );
+  }
+
+  let reader = prisma as unknown as typeof prisma;
+  if (!isAdmin) {
+    const userRecord = await prisma.user.findUnique({
+      where: { id: auth.user.userId },
+      include: { role: { include: { rolePermissions: true } } },
+    });
+    if (!userRecord) {
+      return NextResponse.json({ error: "User not found" }, { status: 401 });
+    }
+    reader = enhance(prisma, { user: userRecord }) as unknown as typeof prisma;
+
+    const accessible = await reader.projects.findFirst({
+      where: { id: projectId!, isDeleted: false },
+      select: { id: true },
+    });
+    if (!accessible) {
+      return NextResponse.json(
+        { error: "No access to project" },
+        { status: 403 }
+      );
+    }
+  }
+
+  const where: Record<string, unknown> = {};
+  if (projectId !== null && !Number.isNaN(projectId)) {
+    where.projectId = projectId;
+  }
+  if (since) {
+    where.timestamp = { gte: since };
+  }
+  if (cursor) {
+    Object.assign(where, cursorWhere("timestamp", cursor));
+  }
+
+  let exportedCount = 0;
+  let lastRow: AuditRow | null = null;
+
+  const pages: PageSource<AuditRow> = (async function* () {
+    const rows = await reader.auditLog.findMany({
+      where: where as never,
+      orderBy: [{ timestamp: "asc" }, { id: "asc" }],
+      take: pageSize,
+      select: {
+        id: true,
+        timestamp: true,
+        action: true,
+        entityType: true,
+        entityId: true,
+        entityName: true,
+        userId: true,
+        userEmail: true,
+        userName: true,
+        projectId: true,
+        changes: true,
+        metadata: true,
+      },
+    });
+
+    const page: AuditRow[] = rows.map((r) => ({
+      id: r.id,
+      timestamp: r.timestamp.toISOString(),
+      action: r.action,
+      entityType: r.entityType,
+      entityId: r.entityId,
+      entityName: r.entityName,
+      userId: r.userId,
+      userEmail: r.userEmail,
+      userName: r.userName,
+      projectId: r.projectId,
+      changes: r.changes,
+      metadata: r.metadata,
+    }));
+    exportedCount = page.length;
+    lastRow = page[page.length - 1] ?? null;
+    yield page;
+  })();
+
+  const manifest = buildManifest({
+    resource: "audit-log",
+    since,
+    pageSize,
+    projectId,
+  });
+
+  const wrapped: PageSource<AuditRow | Record<string, unknown>> =
+    (async function* () {
+      for await (const page of pages) yield page;
+      let nextCursor: string | null = null;
+      if (exportedCount === pageSize && lastRow !== null) {
+        const row: AuditRow = lastRow;
+        nextCursor = encodeCursor({ k: row.timestamp, i: row.id });
+      }
+      yield [buildTrailer({ count: exportedCount, cursor: nextCursor })];
+    })();
+
+  return ndjsonResponse({ manifest, pages: wrapped });
+}

--- a/testplanit/app/api/export/repository-cases/route.test.ts
+++ b/testplanit/app/api/export/repository-cases/route.test.ts
@@ -1,0 +1,180 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("~/lib/api-token-auth", () => ({ authenticateRequest: vi.fn() }));
+vi.mock("@zenstackhq/runtime", () => ({ enhance: vi.fn() }));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    projects: { findFirst: vi.fn() },
+    repositoryCases: { findMany: vi.fn() },
+  },
+}));
+
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { GET } from "./route";
+
+async function readNdjson(res: Response): Promise<unknown[]> {
+  const text = await res.text();
+  return text
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function req(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"));
+}
+
+const ADMIN_USER = { userId: "admin-1", access: "ADMIN" } as const;
+const PROJECT_USER = { userId: "user-1", access: null } as const;
+
+function buildCaseRow(
+  id: number,
+  createdAt: Date,
+  overrides: Record<string, unknown> = {}
+): unknown {
+  return {
+    id,
+    projectId: 100,
+    folderId: 50,
+    templateId: 3,
+    stateId: 1,
+    name: `Case ${id}`,
+    className: null,
+    source: "MANUAL",
+    automated: false,
+    hasParameters: false,
+    isArchived: false,
+    estimate: null,
+    forecastManual: null,
+    forecastAutomated: null,
+    currentVersion: 1,
+    createdAt,
+    creatorId: "creator-1",
+    ...overrides,
+  };
+}
+
+describe("GET /api/export/repository-cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires auth", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: false,
+      error: "Unauthorized",
+      status: 401,
+    });
+    const res = await GET(req("/api/export/repository-cases"));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin without projectId", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: PROJECT_USER,
+    });
+    const res = await GET(req("/api/export/repository-cases"));
+    expect(res.status).toBe(400);
+  });
+
+  it("enforces project access for non-admin", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: PROJECT_USER,
+    });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+    } as never);
+    vi.mocked(enhance).mockReturnValue({
+      projects: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never);
+    const res = await GET(req("/api/export/repository-cases?projectId=100"));
+    expect(res.status).toBe(403);
+  });
+
+  it("streams cases with manifest and trailer", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const t1 = new Date("2026-05-01T10:00:00.000Z");
+    vi.mocked(prisma.repositoryCases.findMany).mockResolvedValue([
+      buildCaseRow(1, t1, { hasParameters: true }),
+      buildCaseRow(2, t1),
+    ] as never);
+
+    const res = await GET(req("/api/export/repository-cases?pageSize=10"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/x-ndjson; charset=utf-8"
+    );
+
+    const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toMatchObject({
+      type: "manifest",
+      resource: "repository-cases",
+      pageSize: 10,
+    });
+    expect(lines[1]).toMatchObject({
+      id: 1,
+      name: "Case 1",
+      hasParameters: true,
+      createdAt: t1.toISOString(),
+    });
+    expect(lines[3]).toEqual({ type: "end", count: 2, cursor: null });
+  });
+
+  it("emits a continuation cursor when the page fills up", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const ts = new Date("2026-05-01T00:00:00.000Z");
+    const rows = Array.from({ length: 3 }, (_, i) => buildCaseRow(i + 1, ts));
+    vi.mocked(prisma.repositoryCases.findMany).mockResolvedValue(rows as never);
+
+    const res = await GET(req("/api/export/repository-cases?pageSize=3"));
+    const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+    const trailer = lines[lines.length - 1] as {
+      type: string;
+      cursor: string;
+    };
+    const decoded = JSON.parse(
+      Buffer.from(trailer.cursor, "base64url").toString("utf-8")
+    );
+    expect(decoded).toEqual({ k: ts.toISOString(), i: 3 });
+  });
+
+  it("applies projectId filter when admin supplies it", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    vi.mocked(prisma.repositoryCases.findMany).mockResolvedValue([] as never);
+    await GET(req("/api/export/repository-cases?projectId=99"));
+    const call = vi.mocked(prisma.repositoryCases.findMany).mock.calls[0]![0]!;
+    expect((call.where as { projectId: number }).projectId).toBe(99);
+  });
+
+  it("applies the since filter on createdAt", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    vi.mocked(prisma.repositoryCases.findMany).mockResolvedValue([] as never);
+    await GET(req("/api/export/repository-cases?since=2026-01-01T00:00:00Z"));
+    const call = vi.mocked(prisma.repositoryCases.findMany).mock.calls[0]![0]!;
+    expect(
+      (call.where as { createdAt: { gte: Date } }).createdAt.gte.toISOString()
+    ).toBe("2026-01-01T00:00:00.000Z");
+  });
+});

--- a/testplanit/app/api/export/repository-cases/route.ts
+++ b/testplanit/app/api/export/repository-cases/route.ts
@@ -1,0 +1,187 @@
+/**
+ * Bulk NDJSON export of RepositoryCases — the test-case dimension table.
+ *
+ * Companion to /api/export/test-run-results: pull this dimension nightly to
+ * rebuild the case lookup table used to denormalize execution facts.
+ *
+ * Note on incremental capture: RepositoryCases has `createdAt` but no
+ * `updatedAt` (edits are tracked as new rows in RepositoryCaseVersions).
+ * `since` here therefore filters by case CREATION time. Consumers who need
+ * an edit feed should either subscribe to the relevant outbound webhooks,
+ * or run a full refresh (omit `since`) on the cadence appropriate for
+ * dimension churn. `currentVersion` is included in each row so ETL
+ * pipelines can detect updates by tracking version increments between runs.
+ *
+ * Access model and query params match /api/export/test-run-results.
+ */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { authOptions } from "~/server/auth";
+import { ndjsonResponse, type PageSource } from "~/lib/export/ndjson";
+import {
+  buildManifest,
+  buildTrailer,
+  cursorWhere,
+  decodeCursor,
+  encodeCursor,
+  parsePageSize,
+  parseSince,
+} from "~/lib/export/queryParams";
+
+interface CaseRow {
+  id: number;
+  projectId: number;
+  folderId: number;
+  templateId: number;
+  stateId: number;
+  name: string;
+  className: string | null;
+  source: string;
+  automated: boolean;
+  hasParameters: boolean;
+  isArchived: boolean;
+  estimate: number | null;
+  forecastManual: number | null;
+  forecastAutomated: number | null;
+  currentVersion: number;
+  createdAt: string;
+  creatorId: string;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const auth = await authenticateRequest(request, session);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status ?? 401 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const since = parseSince(url.searchParams.get("since"));
+  const cursor = decodeCursor(url.searchParams.get("cursor"));
+  const pageSize = parsePageSize(url.searchParams.get("pageSize"));
+  const projectIdRaw = url.searchParams.get("projectId");
+  const projectId = projectIdRaw ? Number.parseInt(projectIdRaw, 10) : null;
+
+  const isAdmin = auth.user.access === "ADMIN";
+
+  if (!isAdmin && (projectId === null || Number.isNaN(projectId))) {
+    return NextResponse.json(
+      { error: "projectId is required for non-admin tokens" },
+      { status: 400 }
+    );
+  }
+
+  let reader = prisma as unknown as typeof prisma;
+  if (!isAdmin) {
+    const userRecord = await prisma.user.findUnique({
+      where: { id: auth.user.userId },
+      include: { role: { include: { rolePermissions: true } } },
+    });
+    if (!userRecord) {
+      return NextResponse.json({ error: "User not found" }, { status: 401 });
+    }
+    reader = enhance(prisma, { user: userRecord }) as unknown as typeof prisma;
+
+    const accessible = await reader.projects.findFirst({
+      where: { id: projectId!, isDeleted: false },
+      select: { id: true },
+    });
+    if (!accessible) {
+      return NextResponse.json(
+        { error: "No access to project" },
+        { status: 403 }
+      );
+    }
+  }
+
+  const where: Record<string, unknown> = { isDeleted: false };
+  if (projectId !== null && !Number.isNaN(projectId)) {
+    where.projectId = projectId;
+  }
+  if (since) {
+    where.createdAt = { gte: since };
+  }
+  if (cursor) {
+    Object.assign(where, cursorWhere("createdAt", cursor));
+  }
+
+  let exportedCount = 0;
+  let lastRow: CaseRow | null = null;
+
+  const pages: PageSource<CaseRow> = (async function* () {
+    const rows = await reader.repositoryCases.findMany({
+      where: where as never,
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: pageSize,
+      select: {
+        id: true,
+        projectId: true,
+        folderId: true,
+        templateId: true,
+        stateId: true,
+        name: true,
+        className: true,
+        source: true,
+        automated: true,
+        hasParameters: true,
+        isArchived: true,
+        estimate: true,
+        forecastManual: true,
+        forecastAutomated: true,
+        currentVersion: true,
+        createdAt: true,
+        creatorId: true,
+      },
+    });
+
+    const page: CaseRow[] = rows.map((c) => ({
+      id: c.id,
+      projectId: c.projectId,
+      folderId: c.folderId,
+      templateId: c.templateId,
+      stateId: c.stateId,
+      name: c.name,
+      className: c.className,
+      source: c.source,
+      automated: c.automated,
+      hasParameters: c.hasParameters,
+      isArchived: c.isArchived,
+      estimate: c.estimate,
+      forecastManual: c.forecastManual,
+      forecastAutomated: c.forecastAutomated,
+      currentVersion: c.currentVersion,
+      createdAt: c.createdAt.toISOString(),
+      creatorId: c.creatorId,
+    }));
+    exportedCount = page.length;
+    lastRow = page[page.length - 1] ?? null;
+    yield page;
+  })();
+
+  const manifest = buildManifest({
+    resource: "repository-cases",
+    since,
+    pageSize,
+    projectId,
+  });
+
+  const wrapped: PageSource<CaseRow | Record<string, unknown>> =
+    (async function* () {
+      for await (const page of pages) yield page;
+      let nextCursor: string | null = null;
+      if (exportedCount === pageSize && lastRow !== null) {
+        const row: CaseRow = lastRow;
+        nextCursor = encodeCursor({ k: row.createdAt, i: row.id });
+      }
+      yield [buildTrailer({ count: exportedCount, cursor: nextCursor })];
+    })();
+
+  return ndjsonResponse({ manifest, pages: wrapped });
+}

--- a/testplanit/app/api/export/test-run-results/route.test.ts
+++ b/testplanit/app/api/export/test-run-results/route.test.ts
@@ -28,8 +28,6 @@ import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
 import { GET } from "./route";
 
-const decoder = new TextDecoder();
-
 async function readNdjson(res: Response): Promise<unknown[]> {
   const text = await res.text();
   return text

--- a/testplanit/app/api/export/test-run-results/route.test.ts
+++ b/testplanit/app/api/export/test-run-results/route.test.ts
@@ -1,0 +1,245 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("~/lib/api-token-auth", () => ({
+  authenticateRequest: vi.fn(),
+}));
+
+vi.mock("@zenstackhq/runtime", () => ({
+  enhance: vi.fn(),
+}));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    projects: { findFirst: vi.fn() },
+    testRunResults: { findMany: vi.fn() },
+  },
+}));
+
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { GET } from "./route";
+
+const decoder = new TextDecoder();
+
+async function readNdjson(res: Response): Promise<unknown[]> {
+  const text = await res.text();
+  return text
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function req(url: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"), { headers });
+}
+
+const ADMIN_USER = { userId: "admin-1", access: "ADMIN" } as const;
+const PROJECT_USER = { userId: "user-1", access: null } as const;
+
+function buildResultRow(
+  id: number,
+  executedAt: Date,
+  overrides: Record<string, unknown> = {}
+): unknown {
+  return {
+    id,
+    testRunId: 10,
+    testRunCaseId: 20 + id,
+    executedAt,
+    executedById: "exec-1",
+    elapsed: 250,
+    attempt: 1,
+    iterationId: null,
+    editedAt: null,
+    editedById: null,
+    statusId: 5,
+    status: { name: "Passed", isSuccess: true, isFailure: false },
+    testRun: { projectId: 100 },
+    testRunCase: { repositoryCaseId: 200 + id },
+    ...overrides,
+  };
+}
+
+describe("GET /api/export/test-run-results", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("auth", () => {
+    it("returns 401 when authenticateRequest fails", async () => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        authenticated: false,
+        error: "Unauthorized",
+        status: 401,
+      });
+      const res = await GET(req("/api/export/test-run-results"));
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: "Unauthorized" });
+    });
+
+    it("returns 400 when non-admin omits projectId", async () => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        authenticated: true,
+        user: PROJECT_USER,
+      });
+      const res = await GET(req("/api/export/test-run-results"));
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/projectId is required/);
+    });
+
+    it("returns 403 when non-admin has no access to the project", async () => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        authenticated: true,
+        user: PROJECT_USER,
+      });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: "user-1",
+      } as never);
+      vi.mocked(enhance).mockReturnValue({
+        projects: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as never);
+
+      const res = await GET(req("/api/export/test-run-results?projectId=100"));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("streaming", () => {
+    beforeEach(() => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        authenticated: true,
+        user: ADMIN_USER,
+      });
+    });
+
+    it("streams NDJSON with a manifest, rows, and an end trailer", async () => {
+      const t1 = new Date("2026-05-01T10:00:00.000Z");
+      const t2 = new Date("2026-05-01T10:00:01.000Z");
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([
+        buildResultRow(1, t1),
+        buildResultRow(2, t2),
+      ] as never);
+
+      const res = await GET(req("/api/export/test-run-results?pageSize=10"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe(
+        "application/x-ndjson; charset=utf-8"
+      );
+
+      const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+      expect(lines).toHaveLength(4);
+      expect(lines[0]).toMatchObject({
+        type: "manifest",
+        resource: "test-run-results",
+        schemaVersion: 1,
+        pageSize: 10,
+        projectId: null,
+      });
+      expect(lines[1]).toMatchObject({
+        id: 1,
+        testCaseId: 201,
+        projectId: 100,
+        statusName: "Passed",
+        isPass: true,
+        executedAt: t1.toISOString(),
+      });
+      expect(lines[2]).toMatchObject({ id: 2 });
+      // page (2 rows) < pageSize (10) → no continuation cursor
+      expect(lines[3]).toEqual({ type: "end", count: 2, cursor: null });
+    });
+
+    it("emits a continuation cursor when the page is full", async () => {
+      const ts = new Date("2026-05-01T10:00:00.000Z");
+      const rows = Array.from({ length: 3 }, (_, i) =>
+        buildResultRow(i + 1, ts)
+      );
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue(
+        rows as never
+      );
+
+      const res = await GET(req("/api/export/test-run-results?pageSize=3"));
+      const lines = (await readNdjson(res)) as Array<Record<string, unknown>>;
+
+      const trailer = lines[lines.length - 1] as {
+        type: string;
+        count: number;
+        cursor: string;
+      };
+      expect(trailer.type).toBe("end");
+      expect(trailer.count).toBe(3);
+      expect(typeof trailer.cursor).toBe("string");
+
+      const decoded = JSON.parse(
+        Buffer.from(trailer.cursor, "base64url").toString("utf-8")
+      );
+      expect(decoded).toEqual({ e: ts.toISOString(), i: 3 });
+    });
+
+    it("applies the `since` filter to executedAt", async () => {
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
+      await GET(
+        req(
+          "/api/export/test-run-results?since=2026-05-01T00:00:00Z&pageSize=100"
+        )
+      );
+
+      const call = vi.mocked(prisma.testRunResults.findMany).mock.calls[0]![0]!;
+      expect(
+        (
+          call.where as { executedAt: { gte: Date } }
+        ).executedAt.gte.toISOString()
+      ).toBe("2026-05-01T00:00:00.000Z");
+    });
+
+    it("applies the decoded cursor as a strict forward filter", async () => {
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
+      const cursor = Buffer.from(
+        JSON.stringify({ e: "2026-05-01T10:00:00.000Z", i: 42 })
+      ).toString("base64url");
+
+      await GET(
+        req(`/api/export/test-run-results?cursor=${cursor}&pageSize=100`)
+      );
+
+      const call = vi.mocked(prisma.testRunResults.findMany).mock.calls[0]![0]!;
+      const orClause = (call.where as { OR: unknown[] }).OR;
+      expect(orClause).toEqual([
+        { executedAt: { gt: new Date("2026-05-01T10:00:00.000Z") } },
+        { executedAt: new Date("2026-05-01T10:00:00.000Z"), id: { gt: 42 } },
+      ]);
+    });
+
+    it("ignores malformed cursors without 400ing", async () => {
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
+      await GET(req("/api/export/test-run-results?cursor=not-a-cursor"));
+      const call = vi.mocked(prisma.testRunResults.findMany).mock.calls[0]![0]!;
+      expect((call.where as { OR?: unknown }).OR).toBeUndefined();
+    });
+
+    it("clamps pageSize to the upper bound", async () => {
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
+      await GET(req("/api/export/test-run-results?pageSize=99999"));
+      const call = vi.mocked(prisma.testRunResults.findMany).mock.calls[0]![0]!;
+      expect(call.take).toBe(5000);
+    });
+
+    it("filters by projectId when supplied by an admin", async () => {
+      vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
+      await GET(req("/api/export/test-run-results?projectId=42"));
+      const call = vi.mocked(prisma.testRunResults.findMany).mock.calls[0]![0]!;
+      expect((call.where as { testRun: unknown }).testRun).toEqual({
+        projectId: 42,
+        isDeleted: false,
+      });
+    });
+  });
+});

--- a/testplanit/app/api/export/test-run-results/route.test.ts
+++ b/testplanit/app/api/export/test-run-results/route.test.ts
@@ -181,7 +181,7 @@ describe("GET /api/export/test-run-results", () => {
       const decoded = JSON.parse(
         Buffer.from(trailer.cursor, "base64url").toString("utf-8")
       );
-      expect(decoded).toEqual({ e: ts.toISOString(), i: 3 });
+      expect(decoded).toEqual({ k: ts.toISOString(), i: 3 });
     });
 
     it("applies the `since` filter to executedAt", async () => {
@@ -203,7 +203,7 @@ describe("GET /api/export/test-run-results", () => {
     it("applies the decoded cursor as a strict forward filter", async () => {
       vi.mocked(prisma.testRunResults.findMany).mockResolvedValue([] as never);
       const cursor = Buffer.from(
-        JSON.stringify({ e: "2026-05-01T10:00:00.000Z", i: 42 })
+        JSON.stringify({ k: "2026-05-01T10:00:00.000Z", i: 42 })
       ).toString("base64url");
 
       await GET(

--- a/testplanit/app/api/export/test-run-results/route.ts
+++ b/testplanit/app/api/export/test-run-results/route.ts
@@ -26,42 +26,15 @@ import { authenticateRequest } from "~/lib/api-token-auth";
 import { prisma } from "~/lib/prisma";
 import { authOptions } from "~/server/auth";
 import { ndjsonResponse, type PageSource } from "~/lib/export/ndjson";
-
-const DEFAULT_PAGE_SIZE = 1000;
-const MAX_PAGE_SIZE = 5000;
-
-interface Cursor {
-  e: string; // executedAt ISO-8601
-  i: number; // result id (tiebreak)
-}
-
-function encodeCursor(c: Cursor): string {
-  return Buffer.from(JSON.stringify(c)).toString("base64url");
-}
-
-function decodeCursor(raw: string | null): Cursor | null {
-  if (!raw) return null;
-  try {
-    const obj = JSON.parse(Buffer.from(raw, "base64url").toString("utf-8"));
-    if (typeof obj?.e === "string" && typeof obj?.i === "number") return obj;
-  } catch {
-    /* fall through */
-  }
-  return null;
-}
-
-function parsePageSize(raw: string | null): number {
-  if (!raw) return DEFAULT_PAGE_SIZE;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return DEFAULT_PAGE_SIZE;
-  return Math.min(n, MAX_PAGE_SIZE);
-}
-
-function parseSince(raw: string | null): Date | null {
-  if (!raw) return null;
-  const d = new Date(raw);
-  return Number.isNaN(d.getTime()) ? null : d;
-}
+import {
+  buildManifest,
+  buildTrailer,
+  cursorWhere,
+  decodeCursor,
+  encodeCursor,
+  parsePageSize,
+  parseSince,
+} from "~/lib/export/queryParams";
 
 interface ResultRow {
   id: number;
@@ -124,8 +97,6 @@ export async function GET(request: NextRequest) {
     }
     reader = enhance(prisma, { user: userRecord }) as unknown as typeof prisma;
 
-    // Verify project access up-front to fail fast with a clear 403, rather
-    // than silently streaming an empty body.
     const accessible = await reader.projects.findFirst({
       where: { id: projectId!, isDeleted: false },
       select: { id: true },
@@ -146,15 +117,7 @@ export async function GET(request: NextRequest) {
     where.executedAt = { gte: since };
   }
   if (cursor) {
-    const cursorDate = new Date(cursor.e);
-    // (executedAt, id) > (cursorE, cursorI) — strict forward iteration with
-    // stable tiebreak so identical timestamps don't get skipped or duplicated.
-    where.OR = [
-      { executedAt: { gt: cursorDate } },
-      { executedAt: cursorDate, id: { gt: cursor.i } },
-    ];
-    // Stripping the top-level executedAt filter is unnecessary — the OR is
-    // ANDed with everything else; the cursor is strictly tighter than `since`.
+    Object.assign(where, cursorWhere("executedAt", cursor));
   }
 
   let exportedCount = 0;
@@ -206,41 +169,23 @@ export async function GET(request: NextRequest) {
     yield page;
   })();
 
-  const manifest = {
-    type: "manifest",
-    schemaVersion: 1,
+  const manifest = buildManifest({
     resource: "test-run-results",
-    exportedAt: new Date().toISOString(),
-    since: since?.toISOString() ?? null,
+    since,
     pageSize,
-    projectId: projectId ?? null,
-  };
-
-  // The trailer is computed after the page generator runs, so we wrap the
-  // generator and append the trailer line as part of the stream itself.
-  // ndjsonResponse streams pages directly; for the trailer we wrap with a
-  // generator that yields rows then a one-element page containing the
-  // trailer record.
-  const wrapped: PageSource<
-    ResultRow | { type: string; [k: string]: unknown }
-  > = (async function* () {
-    for await (const page of pages) yield page;
-    let nextCursor: string | null = null;
-    if (exportedCount === pageSize && lastRow !== null) {
-      const row: ResultRow = lastRow;
-      nextCursor = encodeCursor({ e: row.executedAt, i: row.id });
-    }
-    yield [
-      {
-        type: "end",
-        count: exportedCount,
-        cursor: nextCursor,
-      },
-    ];
-  })();
-
-  return ndjsonResponse({
-    manifest,
-    pages: wrapped,
+    projectId,
   });
+
+  const wrapped: PageSource<ResultRow | Record<string, unknown>> =
+    (async function* () {
+      for await (const page of pages) yield page;
+      let nextCursor: string | null = null;
+      if (exportedCount === pageSize && lastRow !== null) {
+        const row: ResultRow = lastRow;
+        nextCursor = encodeCursor({ k: row.executedAt, i: row.id });
+      }
+      yield [buildTrailer({ count: exportedCount, cursor: nextCursor })];
+    })();
+
+  return ndjsonResponse({ manifest, pages: wrapped });
 }

--- a/testplanit/app/api/export/test-run-results/route.ts
+++ b/testplanit/app/api/export/test-run-results/route.ts
@@ -1,0 +1,246 @@
+/**
+ * Bulk NDJSON export of TestRunResults — the test-execution fact table.
+ *
+ * Designed for data-lake ETL: pair a regular cursor-paged GET with the
+ * `since` filter to incrementally ingest results into Snowflake / BigQuery /
+ * Databricks / etc. Each line is a denormalized result row; the manifest
+ * (first line) and trailer (last line) wrap the page with metadata so the
+ * consumer can loop on cursor without re-parsing the body.
+ *
+ * Access model:
+ * - Admin: cross-project. Optional `projectId` query param narrows to one.
+ * - Non-admin: `projectId` is REQUIRED, and the enhanced ZenStack client
+ *   enforces project-membership policy on the read.
+ *
+ * Query parameters:
+ * - `since`     ISO-8601 timestamp; rows with `executedAt >= since` only.
+ * - `cursor`    Opaque cursor returned in the previous page's trailer.
+ * - `pageSize`  1..MAX_PAGE_SIZE (default 1000).
+ * - `projectId` Required for non-admins; optional for admins.
+ */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { enhance } from "@zenstackhq/runtime";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { prisma } from "~/lib/prisma";
+import { authOptions } from "~/server/auth";
+import { ndjsonResponse, type PageSource } from "~/lib/export/ndjson";
+
+const DEFAULT_PAGE_SIZE = 1000;
+const MAX_PAGE_SIZE = 5000;
+
+interface Cursor {
+  e: string; // executedAt ISO-8601
+  i: number; // result id (tiebreak)
+}
+
+function encodeCursor(c: Cursor): string {
+  return Buffer.from(JSON.stringify(c)).toString("base64url");
+}
+
+function decodeCursor(raw: string | null): Cursor | null {
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(Buffer.from(raw, "base64url").toString("utf-8"));
+    if (typeof obj?.e === "string" && typeof obj?.i === "number") return obj;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function parsePageSize(raw: string | null): number {
+  if (!raw) return DEFAULT_PAGE_SIZE;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_PAGE_SIZE;
+  return Math.min(n, MAX_PAGE_SIZE);
+}
+
+function parseSince(raw: string | null): Date | null {
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+interface ResultRow {
+  id: number;
+  testRunId: number;
+  testRunCaseId: number;
+  testCaseId: number;
+  projectId: number;
+  statusId: number;
+  statusName: string;
+  isPass: boolean;
+  isFail: boolean;
+  executedAt: string;
+  executedById: string;
+  elapsedMs: number | null;
+  attempt: number;
+  iterationId: number | null;
+  editedAt: string | null;
+  editedById: string | null;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const auth = await authenticateRequest(request, session);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status ?? 401 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const since = parseSince(url.searchParams.get("since"));
+  const cursor = decodeCursor(url.searchParams.get("cursor"));
+  const pageSize = parsePageSize(url.searchParams.get("pageSize"));
+  const projectIdRaw = url.searchParams.get("projectId");
+  const projectId = projectIdRaw ? Number.parseInt(projectIdRaw, 10) : null;
+
+  const isAdmin = auth.user.access === "ADMIN";
+
+  if (!isAdmin && (projectId === null || Number.isNaN(projectId))) {
+    return NextResponse.json(
+      { error: "projectId is required for non-admin tokens" },
+      { status: 400 }
+    );
+  }
+
+  // For non-admins we read through the enhanced client so ZenStack's
+  // project-membership policy enforces access. Admins use raw prisma so
+  // cross-project export is unrestricted (see preflight route for the same
+  // pattern; the policy layer has been observed to return zero rows under
+  // heavy parallel load even when @@allow is unconditional).
+  let reader = prisma as unknown as typeof prisma;
+  if (!isAdmin) {
+    const userRecord = await prisma.user.findUnique({
+      where: { id: auth.user.userId },
+      include: { role: { include: { rolePermissions: true } } },
+    });
+    if (!userRecord) {
+      return NextResponse.json({ error: "User not found" }, { status: 401 });
+    }
+    reader = enhance(prisma, { user: userRecord }) as unknown as typeof prisma;
+
+    // Verify project access up-front to fail fast with a clear 403, rather
+    // than silently streaming an empty body.
+    const accessible = await reader.projects.findFirst({
+      where: { id: projectId!, isDeleted: false },
+      select: { id: true },
+    });
+    if (!accessible) {
+      return NextResponse.json(
+        { error: "No access to project" },
+        { status: 403 }
+      );
+    }
+  }
+
+  const where: Record<string, unknown> = { isDeleted: false };
+  if (projectId !== null && !Number.isNaN(projectId)) {
+    where.testRun = { projectId, isDeleted: false };
+  }
+  if (since) {
+    where.executedAt = { gte: since };
+  }
+  if (cursor) {
+    const cursorDate = new Date(cursor.e);
+    // (executedAt, id) > (cursorE, cursorI) — strict forward iteration with
+    // stable tiebreak so identical timestamps don't get skipped or duplicated.
+    where.OR = [
+      { executedAt: { gt: cursorDate } },
+      { executedAt: cursorDate, id: { gt: cursor.i } },
+    ];
+    // Stripping the top-level executedAt filter is unnecessary — the OR is
+    // ANDed with everything else; the cursor is strictly tighter than `since`.
+  }
+
+  let exportedCount = 0;
+  let lastRow: ResultRow | null = null;
+
+  const pages: PageSource<ResultRow> = (async function* () {
+    const rows = await reader.testRunResults.findMany({
+      where: where as never,
+      orderBy: [{ executedAt: "asc" }, { id: "asc" }],
+      take: pageSize,
+      select: {
+        id: true,
+        testRunId: true,
+        testRunCaseId: true,
+        executedAt: true,
+        executedById: true,
+        elapsed: true,
+        attempt: true,
+        iterationId: true,
+        editedAt: true,
+        editedById: true,
+        statusId: true,
+        status: { select: { name: true, isSuccess: true, isFailure: true } },
+        testRun: { select: { projectId: true } },
+        testRunCase: { select: { repositoryCaseId: true } },
+      },
+    });
+
+    const page: ResultRow[] = rows.map((r) => ({
+      id: r.id,
+      testRunId: r.testRunId,
+      testRunCaseId: r.testRunCaseId,
+      testCaseId: r.testRunCase.repositoryCaseId,
+      projectId: r.testRun.projectId,
+      statusId: r.statusId,
+      statusName: r.status.name,
+      isPass: r.status.isSuccess,
+      isFail: r.status.isFailure,
+      executedAt: r.executedAt.toISOString(),
+      executedById: r.executedById,
+      elapsedMs: r.elapsed,
+      attempt: r.attempt,
+      iterationId: r.iterationId,
+      editedAt: r.editedAt ? r.editedAt.toISOString() : null,
+      editedById: r.editedById,
+    }));
+    exportedCount = page.length;
+    lastRow = page[page.length - 1] ?? null;
+    yield page;
+  })();
+
+  const manifest = {
+    type: "manifest",
+    schemaVersion: 1,
+    resource: "test-run-results",
+    exportedAt: new Date().toISOString(),
+    since: since?.toISOString() ?? null,
+    pageSize,
+    projectId: projectId ?? null,
+  };
+
+  // The trailer is computed after the page generator runs, so we wrap the
+  // generator and append the trailer line as part of the stream itself.
+  // ndjsonResponse streams pages directly; for the trailer we wrap with a
+  // generator that yields rows then a one-element page containing the
+  // trailer record.
+  const wrapped: PageSource<
+    ResultRow | { type: string; [k: string]: unknown }
+  > = (async function* () {
+    for await (const page of pages) yield page;
+    let nextCursor: string | null = null;
+    if (exportedCount === pageSize && lastRow !== null) {
+      const row: ResultRow = lastRow;
+      nextCursor = encodeCursor({ e: row.executedAt, i: row.id });
+    }
+    yield [
+      {
+        type: "end",
+        count: exportedCount,
+        cursor: nextCursor,
+      },
+    ];
+  })();
+
+  return ndjsonResponse({
+    manifest,
+    pages: wrapped,
+  });
+}

--- a/testplanit/app/api/webhooks/events/route.test.ts
+++ b/testplanit/app/api/webhooks/events/route.test.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("~/lib/api-token-auth", () => ({ authenticateRequest: vi.fn() }));
+
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { GET } from "./route";
+
+function req(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"));
+}
+
+const ADMIN_USER = { userId: "admin-1", access: "ADMIN" } as const;
+
+describe("GET /api/webhooks/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires auth", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: false,
+      error: "Unauthorized",
+      status: 401,
+    });
+    const res = await GET(req("/api/webhooks/events"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the full catalog with a generatedAt and count", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const res = await GET(req("/api/webhooks/events"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      generatedAt: string;
+      count: number;
+      events: Array<{ name: string; category: string }>;
+    };
+    expect(typeof body.generatedAt).toBe("string");
+    expect(body.count).toBe(body.events.length);
+    expect(
+      body.events.find((e) => e.name === "test_run.completed")
+    ).toBeDefined();
+    expect(body.events.find((e) => e.name === "issue.created")).toBeDefined();
+  });
+
+  it("filters by category when supplied", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const res = await GET(req("/api/webhooks/events?category=test-run"));
+    const body = (await res.json()) as {
+      events: Array<{ category: string }>;
+    };
+    expect(body.events.length).toBeGreaterThan(0);
+    expect(body.events.every((e) => e.category === "test-run")).toBe(true);
+  });
+
+  it("returns an empty events array for an unknown category", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      authenticated: true,
+      user: ADMIN_USER,
+    });
+    const res = await GET(req("/api/webhooks/events?category=does-not-exist"));
+    const body = (await res.json()) as { events: unknown[]; count: number };
+    expect(body.events).toEqual([]);
+    expect(body.count).toBe(0);
+  });
+});

--- a/testplanit/app/api/webhooks/events/route.ts
+++ b/testplanit/app/api/webhooks/events/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Public catalog of webhook event names that TestPlanIt emits.
+ *
+ * The response is authenticated (session OR Bearer API token) but does not
+ * apply any per-project filtering — the catalog is the same for everyone.
+ * Consumers building integrations call this to discover available events
+ * and the top-level shape of each payload; the per-event JSON schemas live
+ * in the user-guide docs.
+ *
+ * Query params:
+ * - `category`  Optional. Restrict to one category
+ *               (test-case, test-run, iteration, session, issue, review,
+ *               system). Useful when only one feed is being wired.
+ *
+ * Response shape:
+ *   {
+ *     generatedAt: string,
+ *     count: number,
+ *     events: WebhookEventDefinition[]
+ *   }
+ */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateRequest } from "~/lib/api-token-auth";
+import { authOptions } from "~/server/auth";
+import { listEventCatalog } from "~/lib/webhooks/eventCatalog";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const auth = await authenticateRequest(request, session);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status ?? 401 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const category = url.searchParams.get("category");
+
+  let events = listEventCatalog();
+  if (category) {
+    events = events.filter((e) => e.category === category);
+  }
+
+  return NextResponse.json({
+    generatedAt: new Date().toISOString(),
+    count: events.length,
+    events,
+  });
+}

--- a/testplanit/lib/export/ndjson.test.ts
+++ b/testplanit/lib/export/ndjson.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { encodeNdjsonLine, ndjsonResponse, type PageSource } from "./ndjson";
+
+const decoder = new TextDecoder();
+
+async function readAll(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  let out = "";
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+function pagesFrom<T>(...pages: T[][]): PageSource<T> {
+  return (async function* () {
+    for (const p of pages) yield p;
+  })();
+}
+
+describe("encodeNdjsonLine", () => {
+  it("serializes a value and appends a single newline", () => {
+    const bytes = encodeNdjsonLine({ id: 1, name: "a" });
+    expect(decoder.decode(bytes)).toBe('{"id":1,"name":"a"}\n');
+  });
+
+  it("handles primitives", () => {
+    expect(decoder.decode(encodeNdjsonLine(42))).toBe("42\n");
+    expect(decoder.decode(encodeNdjsonLine("hello"))).toBe('"hello"\n');
+    expect(decoder.decode(encodeNdjsonLine(null))).toBe("null\n");
+  });
+});
+
+describe("ndjsonResponse", () => {
+  it("emits one line per row across multiple pages", async () => {
+    const res = ndjsonResponse({
+      pages: pagesFrom([{ id: 1 }, { id: 2 }], [{ id: 3 }]),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/x-ndjson; charset=utf-8"
+    );
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = await readAll(res);
+    expect(body).toBe('{"id":1}\n{"id":2}\n{"id":3}\n');
+  });
+
+  it("emits the manifest as the first line", async () => {
+    const res = ndjsonResponse({
+      manifest: { type: "manifest", schemaVersion: 1, cursor: null },
+      pages: pagesFrom([{ id: 1 }]),
+    });
+    const lines = (await readAll(res)).split("\n").filter(Boolean);
+    expect(JSON.parse(lines[0])).toEqual({
+      type: "manifest",
+      schemaVersion: 1,
+      cursor: null,
+    });
+    expect(JSON.parse(lines[1])).toEqual({ id: 1 });
+  });
+
+  it("skips empty pages without emitting a stray newline", async () => {
+    const res = ndjsonResponse({
+      pages: pagesFrom([{ id: 1 }], [], [{ id: 2 }]),
+    });
+    expect(await readAll(res)).toBe('{"id":1}\n{"id":2}\n');
+  });
+
+  it("applies the serialize transform when provided", async () => {
+    const res = ndjsonResponse<{ id: number; secret: string }>({
+      pages: pagesFrom([
+        { id: 1, secret: "shh" },
+        { id: 2, secret: "shh" },
+      ]),
+      serialize: (row) => ({ id: row.id }),
+    });
+    expect(await readAll(res)).toBe('{"id":1}\n{"id":2}\n');
+  });
+
+  it("ends the stream with an error line when the source throws", async () => {
+    const failing: PageSource<{ id: number }> = (async function* () {
+      yield [{ id: 1 }];
+      throw new Error("db connection lost");
+    })();
+    const res = ndjsonResponse({ pages: failing });
+    const body = await readAll(res);
+    const lines = body.split("\n").filter(Boolean);
+    expect(JSON.parse(lines[0])).toEqual({ id: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ error: "db connection lost" });
+  });
+
+  it("merges caller-provided headers without losing the content type", async () => {
+    const res = ndjsonResponse({
+      pages: pagesFrom<{ id: number }>(),
+      headers: { "X-Manifest-Url": "/api/export/manifest" },
+    });
+    expect(res.headers.get("content-type")).toBe(
+      "application/x-ndjson; charset=utf-8"
+    );
+    expect(res.headers.get("x-manifest-url")).toBe("/api/export/manifest");
+  });
+
+  it("concatenates a page into a single network chunk", async () => {
+    const res = ndjsonResponse({
+      pages: pagesFrom([{ id: 1 }, { id: 2 }, { id: 3 }]),
+    });
+    const reader = res.body!.getReader();
+    const chunks: Uint8Array[] = [];
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    // One page = one chunk (besides the close signal).
+    expect(chunks.length).toBe(1);
+    expect(decoder.decode(chunks[0])).toBe('{"id":1}\n{"id":2}\n{"id":3}\n');
+  });
+});

--- a/testplanit/lib/export/ndjson.test.ts
+++ b/testplanit/lib/export/ndjson.test.ts
@@ -6,7 +6,6 @@ const decoder = new TextDecoder();
 async function readAll(res: Response): Promise<string> {
   const reader = res.body!.getReader();
   let out = "";
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;

--- a/testplanit/lib/export/ndjson.ts
+++ b/testplanit/lib/export/ndjson.ts
@@ -1,0 +1,108 @@
+/**
+ * NDJSON streaming response helpers for bulk export endpoints.
+ *
+ * NDJSON (Newline Delimited JSON) is the lingua franca of data-lake ingestion:
+ * Spark, Snowflake, BigQuery, Databricks, and most ETL pipelines consume it
+ * line-by-line, which means the consumer never has to materialize the whole
+ * response in memory. Pair this with `Transfer-Encoding: chunked` and a paged
+ * database cursor and the server side never holds more than one page of rows
+ * in memory either, regardless of how many rows the export ultimately produces.
+ *
+ * Two helpers are exposed:
+ *
+ * - `ndjsonResponse({ pages, manifest })` — builds a `Response` whose body is
+ *   the NDJSON stream. `pages` is an async iterable of row pages; the helper
+ *   serializes each row to a line, joins them with `\n`, and flushes one page
+ *   per chunk. `manifest` is an optional object emitted as the first line, so
+ *   consumers can read schema/version/cursor without parsing every record.
+ *
+ * - `encodeNdjsonLine(value)` — serializes a single value to a `\n`-terminated
+ *   UTF-8 line. Useful when callers want to drive the stream themselves.
+ *
+ * Error handling: if the row source throws mid-stream, the helper appends a
+ * final line `{"error":"..."}` and closes the stream. This is intentional —
+ * NDJSON has no envelope, so partial results are valid; we just need to give
+ * the consumer a clear "this stopped early" marker rather than silently
+ * truncating.
+ */
+
+const encoder = new TextEncoder();
+
+/** A page of rows produced by a paged database cursor. */
+export type RowPage<T> = readonly T[];
+
+/** Async iterable of row pages — what the route hands to `ndjsonResponse`. */
+export type PageSource<T> = AsyncIterable<RowPage<T>>;
+
+export interface NdjsonResponseInit<T> {
+  /** Async iterable yielding one page of rows at a time. */
+  pages: PageSource<T>;
+  /**
+   * Optional first-line manifest (schema, generated-at, cursor sentinel).
+   * Emitted before any row pages so consumers can branch on it.
+   */
+  manifest?: Record<string, unknown>;
+  /** Per-row transform; defaults to identity. Useful for column projection. */
+  serialize?: (row: T) => unknown;
+  /** Additional response headers merged onto the default NDJSON headers. */
+  headers?: HeadersInit;
+}
+
+/**
+ * Encode one value as an NDJSON line — `JSON.stringify(value)` + `\n`,
+ * UTF-8 bytes. Exported for routes that want to drive their own stream.
+ */
+export function encodeNdjsonLine(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value) + "\n");
+}
+
+/**
+ * Build a streaming NDJSON `Response`. The stream is driven by `pages`, an
+ * async iterable; the caller controls pagination by deciding what each page
+ * contains and when the iterable ends.
+ */
+export function ndjsonResponse<T>(init: NdjsonResponseInit<T>): Response {
+  const { pages, manifest, serialize, headers } = init;
+  const project = serialize ?? ((row: T) => row);
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        if (manifest) {
+          controller.enqueue(encodeNdjsonLine(manifest));
+        }
+        for await (const page of pages) {
+          if (page.length === 0) continue;
+          // Concatenate the page into one chunk so chunked-transfer sees a
+          // single network frame per page; this keeps overhead per page low.
+          const lines = page.map(project).map((v) => JSON.stringify(v));
+          controller.enqueue(encoder.encode(lines.join("\n") + "\n"));
+        }
+        controller.close();
+      } catch (err) {
+        // Emit a trailing error line so consumers can detect early termination.
+        // The stream itself terminates normally — `controller.error()` would
+        // give some clients an opaque TypeError instead.
+        const message = err instanceof Error ? err.message : String(err);
+        try {
+          controller.enqueue(encodeNdjsonLine({ error: message }));
+        } catch {
+          /* controller already closed */
+        }
+        controller.close();
+      }
+    },
+  });
+
+  const baseHeaders: HeadersInit = {
+    "Content-Type": "application/x-ndjson; charset=utf-8",
+    "Cache-Control": "no-store",
+    // No Content-Length — chunked transfer encoding is implicit when the
+    // response body is a stream.
+  };
+
+  return new Response(stream, {
+    status: 200,
+    headers: { ...baseHeaders, ...headers },
+  });
+}

--- a/testplanit/lib/export/queryParams.test.ts
+++ b/testplanit/lib/export/queryParams.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  cursorWhere,
+  decodeCursor,
+  encodeCursor,
+  parsePageSize,
+  parseSince,
+  buildManifest,
+  buildTrailer,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from "./queryParams";
+
+describe("cursor codec", () => {
+  it("round-trips a timestamp-based cursor", () => {
+    const c = { k: "2026-05-30T10:00:00.000Z", i: 42 };
+    const round = decodeCursor(encodeCursor(c));
+    expect(round).toEqual(c);
+  });
+
+  it("returns null for missing input", () => {
+    expect(decodeCursor(null)).toBeNull();
+    expect(decodeCursor("")).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(decodeCursor("not-base64")).toBeNull();
+    const wrongShape = Buffer.from(JSON.stringify({ x: 1 })).toString(
+      "base64url"
+    );
+    expect(decodeCursor(wrongShape)).toBeNull();
+  });
+});
+
+describe("parsePageSize", () => {
+  it("defaults when missing or non-numeric", () => {
+    expect(parsePageSize(null)).toBe(DEFAULT_PAGE_SIZE);
+    expect(parsePageSize("abc")).toBe(DEFAULT_PAGE_SIZE);
+    expect(parsePageSize("0")).toBe(DEFAULT_PAGE_SIZE);
+    expect(parsePageSize("-5")).toBe(DEFAULT_PAGE_SIZE);
+  });
+
+  it("accepts in-range values", () => {
+    expect(parsePageSize("250")).toBe(250);
+  });
+
+  it("clamps above the cap", () => {
+    expect(parsePageSize(String(MAX_PAGE_SIZE + 1))).toBe(MAX_PAGE_SIZE);
+    expect(parsePageSize("999999")).toBe(MAX_PAGE_SIZE);
+  });
+});
+
+describe("parseSince", () => {
+  it("parses valid ISO-8601", () => {
+    const d = parseSince("2026-05-30T10:00:00.000Z");
+    expect(d?.toISOString()).toBe("2026-05-30T10:00:00.000Z");
+  });
+
+  it("returns null for missing or invalid", () => {
+    expect(parseSince(null)).toBeNull();
+    expect(parseSince("")).toBeNull();
+    expect(parseSince("not a date")).toBeNull();
+  });
+});
+
+describe("cursorWhere", () => {
+  it("produces a strict-forward OR for a date sort key", () => {
+    const where = cursorWhere("executedAt", {
+      k: "2026-05-30T10:00:00.000Z",
+      i: 7,
+    });
+    expect(where).toEqual({
+      OR: [
+        { executedAt: { gt: new Date("2026-05-30T10:00:00.000Z") } },
+        {
+          executedAt: new Date("2026-05-30T10:00:00.000Z"),
+          id: { gt: 7 },
+        },
+      ],
+    });
+  });
+
+  it("falls back to string compare when the key is not a parseable date", () => {
+    const where = cursorWhere("name", { k: "alpha", i: 3 });
+    expect(where).toEqual({
+      OR: [{ name: { gt: "alpha" } }, { name: "alpha", id: { gt: 3 } }],
+    });
+  });
+});
+
+describe("buildManifest / buildTrailer", () => {
+  it("manifest carries the resource label and page metadata", () => {
+    const m = buildManifest({
+      resource: "test-run-results",
+      since: new Date("2026-05-01T00:00:00.000Z"),
+      pageSize: 250,
+      projectId: 99,
+    });
+    expect(m).toMatchObject({
+      type: "manifest",
+      schemaVersion: 1,
+      resource: "test-run-results",
+      since: "2026-05-01T00:00:00.000Z",
+      pageSize: 250,
+      projectId: 99,
+    });
+    expect(typeof m.exportedAt).toBe("string");
+  });
+
+  it("manifest emits null since when not provided", () => {
+    expect(
+      buildManifest({
+        resource: "audit-log",
+        since: null,
+        pageSize: 1000,
+        projectId: null,
+      })
+    ).toMatchObject({ since: null, projectId: null });
+  });
+
+  it("trailer shape includes cursor and count", () => {
+    expect(buildTrailer({ count: 7, cursor: "abc" })).toEqual({
+      type: "end",
+      count: 7,
+      cursor: "abc",
+    });
+    expect(buildTrailer({ count: 0, cursor: null })).toEqual({
+      type: "end",
+      count: 0,
+      cursor: null,
+    });
+  });
+});

--- a/testplanit/lib/export/queryParams.ts
+++ b/testplanit/lib/export/queryParams.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared query-parameter parsing for the NDJSON export endpoints.
+ *
+ * All three endpoints (test-run-results, repository-cases, audit-log) take
+ * the same `since` / `cursor` / `pageSize` triplet. The cursor format is a
+ * tuple of (sort-key string, integer id) base64url-encoded — works for any
+ * sort key encoded as a string (ISO-8601 timestamp, lexicographic name, etc.).
+ *
+ * Keeping the parsers here means a future change (e.g. raising the page-size
+ * cap, switching to RFC 3339 UTC offsets) lands in one place and we don't
+ * end up with three slightly-divergent implementations.
+ */
+
+export const DEFAULT_PAGE_SIZE = 1000;
+export const MAX_PAGE_SIZE = 5000;
+
+/**
+ * Composite cursor: a sort-key plus an id tiebreaker. The id is `string |
+ * number` because some entities (AuditLog) use cuid string IDs while others
+ * (TestRunResults, RepositoryCases) use auto-increment integers.
+ */
+export interface Cursor {
+  k: string; // sort key (timestamp ISO-8601 or other string)
+  i: string | number; // id (stable tiebreaker)
+}
+
+export function encodeCursor(c: Cursor): string {
+  return Buffer.from(JSON.stringify(c)).toString("base64url");
+}
+
+export function decodeCursor(raw: string | null): Cursor | null {
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(Buffer.from(raw, "base64url").toString("utf-8"));
+    if (
+      typeof obj?.k === "string" &&
+      (typeof obj?.i === "number" || typeof obj?.i === "string")
+    ) {
+      return obj;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export function parsePageSize(raw: string | null): number {
+  if (!raw) return DEFAULT_PAGE_SIZE;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_PAGE_SIZE;
+  return Math.min(n, MAX_PAGE_SIZE);
+}
+
+export function parseSince(raw: string | null): Date | null {
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Build the `(sortCol, id) > (cursor.k, cursor.i)` strict-forward WHERE
+ * filter for cursor pagination. The sort column is named at call time so
+ * each endpoint can plug in its own column (`executedAt`, `updatedAt`, etc.).
+ */
+export function cursorWhere(
+  sortColumn: string,
+  cursor: Cursor
+): Record<string, unknown> {
+  const cursorDate = new Date(cursor.k);
+  // Date.parse will succeed for ISO-8601 keys; for non-date sort keys callers
+  // pass the raw string through unchanged via the OR/eq path.
+  const sortVal: Date | string = Number.isNaN(cursorDate.getTime())
+    ? cursor.k
+    : cursorDate;
+  return {
+    OR: [
+      { [sortColumn]: { gt: sortVal } },
+      { [sortColumn]: sortVal, id: { gt: cursor.i } },
+    ],
+  };
+}
+
+/** Build the standard manifest header line. */
+export function buildManifest(args: {
+  resource: string;
+  since: Date | null;
+  pageSize: number;
+  projectId: number | null;
+}): Record<string, unknown> {
+  return {
+    type: "manifest",
+    schemaVersion: 1,
+    resource: args.resource,
+    exportedAt: new Date().toISOString(),
+    since: args.since ? args.since.toISOString() : null,
+    pageSize: args.pageSize,
+    projectId: args.projectId,
+  };
+}
+
+/** Build the standard trailer line. */
+export function buildTrailer(args: {
+  count: number;
+  cursor: string | null;
+}): Record<string, unknown> {
+  return { type: "end", count: args.count, cursor: args.cursor };
+}

--- a/testplanit/lib/openapi/custom-openapi.json
+++ b/testplanit/lib/openapi/custom-openapi.json
@@ -33,6 +33,14 @@
     {
       "name": "Integrations",
       "description": "External integrations (Jira, etc.)"
+    },
+    {
+      "name": "Data Lake Export",
+      "description": "Bulk NDJSON streaming endpoints for incremental data-lake / ETL ingestion (test-run results, repository cases, audit log)."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Outbound webhook configuration and the published event catalog."
     }
   ],
   "paths": {
@@ -817,6 +825,201 @@
               }
             }
           }
+        }
+      }
+    },
+    "/export/test-run-results": {
+      "get": {
+        "tags": ["Data Lake Export"],
+        "summary": "Stream test-run results as NDJSON",
+        "description": "Bulk export of the test-execution fact table for data-lake ingestion. Returns NDJSON (one JSON object per line) with a manifest line first and an end-trailer line last. Cursor-paged: when the trailer carries a non-null cursor, call again with `cursor=<value>` to fetch the next page. Sorted by (executedAt asc, id asc). Admin tokens read across all projects; non-admin tokens must supply `projectId` and have access to it.",
+        "operationId": "exportTestRunResults",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "description": "ISO-8601 timestamp; only rows with executedAt >= since are emitted.",
+            "schema": { "type": "string", "format": "date-time" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque base64url continuation token from the previous page's trailer.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "1..5000 (default 1000). Values outside the range are clamped.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5000,
+              "default": 1000
+            }
+          },
+          {
+            "name": "projectId",
+            "in": "query",
+            "description": "Optional for admins, required for non-admin tokens.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NDJSON stream — first line is a manifest, last is an end-trailer, rows in between.",
+            "content": {
+              "application/x-ndjson": {
+                "schema": { "type": "string" }
+              }
+            }
+          },
+          "400": { "description": "projectId required (non-admin)" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "No access to the requested project" }
+        }
+      }
+    },
+    "/export/repository-cases": {
+      "get": {
+        "tags": ["Data Lake Export"],
+        "summary": "Stream repository cases as NDJSON",
+        "description": "Bulk export of the test-case dimension table. `since` filters by case CREATION time (RepositoryCases has no updatedAt column; edits are tracked on RepositoryCaseVersions). Each row carries `currentVersion` so consumers can detect updates by tracking version increments between runs. Same auth/cursor/paging semantics as /export/test-run-results.",
+        "operationId": "exportRepositoryCases",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time" }
+          },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5000,
+              "default": 1000
+            }
+          },
+          {
+            "name": "projectId",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NDJSON stream",
+            "content": {
+              "application/x-ndjson": { "schema": { "type": "string" } }
+            }
+          },
+          "400": { "description": "projectId required (non-admin)" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "No access to the requested project" }
+        }
+      }
+    },
+    "/export/audit-log": {
+      "get": {
+        "tags": ["Data Lake Export"],
+        "summary": "Stream audit-log entries as NDJSON",
+        "description": "Bulk export of the compliance/change-history feed. Each row carries the actor, the entity touched, the action, the diff (when captured), and the metadata blob recorded at the time of the event. Sorted by (timestamp asc, id asc). Cursors carry the cuid id as a string. Same auth model as the other export endpoints.",
+        "operationId": "exportAuditLog",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time" }
+          },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5000,
+              "default": 1000
+            }
+          },
+          {
+            "name": "projectId",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NDJSON stream",
+            "content": {
+              "application/x-ndjson": { "schema": { "type": "string" } }
+            }
+          },
+          "400": { "description": "projectId required (non-admin)" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "No access to the requested project" }
+        }
+      }
+    },
+    "/webhooks/events": {
+      "get": {
+        "tags": ["Webhooks"],
+        "summary": "List webhook event catalog",
+        "description": "Returns the published catalog of outbound webhook event names TestPlanIt emits — the answer to 'what events fire when?'. Optionally filter by category.",
+        "operationId": "listWebhookEvents",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Restrict to one category.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "test-case",
+                "test-run",
+                "iteration",
+                "session",
+                "issue",
+                "review",
+                "system"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Catalog payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "generatedAt": { "type": "string", "format": "date-time" },
+                    "count": { "type": "integer" },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": { "type": "string" },
+                          "category": { "type": "string" },
+                          "description": { "type": "string" },
+                          "payloadKeys": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
         }
       }
     }

--- a/testplanit/lib/openapi/merge-specs.ts
+++ b/testplanit/lib/openapi/merge-specs.ts
@@ -32,6 +32,8 @@ export const API_CATEGORIES = {
       "Search",
       "Admin",
       "User Management",
+      "Data Lake Export",
+      "Webhooks",
     ],
   },
   projects: {

--- a/testplanit/lib/webhooks/eventCatalog.test.ts
+++ b/testplanit/lib/webhooks/eventCatalog.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { WEBHOOK_EVENT_CATALOG, listEventCatalog } from "./eventCatalog";
+
+describe("WEBHOOK_EVENT_CATALOG", () => {
+  it("returns the same array via the public accessor", () => {
+    expect(listEventCatalog()).toBe(WEBHOOK_EVENT_CATALOG);
+  });
+
+  it("has unique event names", () => {
+    const names = WEBHOOK_EVENT_CATALOG.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("every entry has a non-empty description and at least one payload key", () => {
+    for (const entry of WEBHOOK_EVENT_CATALOG) {
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(entry.payloadKeys.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every event name is dot-namespaced (entity.verb[.sub])", () => {
+    for (const entry of WEBHOOK_EVENT_CATALOG) {
+      expect(entry.name).toMatch(/^[a-z][a-z_]+\.[a-z][a-z_]+(\.[a-z_]+)?$/);
+    }
+  });
+
+  it("categories are restricted to the known set", () => {
+    const allowed = new Set([
+      "test-case",
+      "test-run",
+      "iteration",
+      "session",
+      "issue",
+      "review",
+      "system",
+    ]);
+    for (const entry of WEBHOOK_EVENT_CATALOG) {
+      expect(allowed.has(entry.category)).toBe(true);
+    }
+  });
+});

--- a/testplanit/lib/webhooks/eventCatalog.ts
+++ b/testplanit/lib/webhooks/eventCatalog.ts
@@ -1,0 +1,246 @@
+/**
+ * Published catalog of outbound webhook event names.
+ *
+ * This file is the single source of truth for "what events does TestPlanIt
+ * emit?" — referenced by:
+ *   - /api/webhooks/events           (the public catalog endpoint)
+ *   - the user-guide docs page       (Data Lake & Webhooks)
+ *   - the OpenAPI spec               (events enum)
+ *
+ * To add an event:
+ *   1. Wire the emitter in lib/webhooks/event-emitters/<area>Events.ts
+ *   2. Add a row here with a one-line description and an example payload
+ *      shape (just the top-level keys are enough for the catalog; the full
+ *      schema lives in the docs).
+ *   3. If the event applies to a new entity family, group it under a new
+ *      `category` value.
+ *
+ * The catalog is intentionally hand-curated rather than auto-discovered
+ * because we want the descriptions to be human-friendly answers to the BBVA
+ * §7.1.4 "list of internal triggers" question, not raw symbol dumps.
+ */
+
+export interface WebhookEventDefinition {
+  /** Dot-namespaced event name (`<entity>.<verb>`). */
+  name: string;
+  /** Conceptual grouping shown in the docs and the catalog response. */
+  category:
+    | "test-case"
+    | "test-run"
+    | "iteration"
+    | "session"
+    | "issue"
+    | "review"
+    | "system";
+  /** One-sentence human-readable description. */
+  description: string;
+  /** Top-level keys present in every payload of this type. */
+  payloadKeys: string[];
+}
+
+export const WEBHOOK_EVENT_CATALOG: WebhookEventDefinition[] = [
+  // --- Test cases ---
+  {
+    name: "case.created",
+    category: "test-case",
+    description: "A test case was created (manual or via import).",
+    payloadKeys: [
+      "id",
+      "projectId",
+      "name",
+      "source",
+      "automated",
+      "createdAt",
+    ],
+  },
+  {
+    name: "case.updated",
+    category: "test-case",
+    description: "A test case's metadata, steps, or field values changed.",
+    payloadKeys: ["id", "projectId", "name", "diff", "version"],
+  },
+  {
+    name: "case.deleted",
+    category: "test-case",
+    description: "A test case was soft-deleted.",
+    payloadKeys: ["id", "projectId"],
+  },
+  {
+    name: "case.review_requested",
+    category: "review",
+    description: "A review was requested on a test case.",
+    payloadKeys: ["reviewId", "caseId", "projectId", "requesterId", "dueAt"],
+  },
+  {
+    name: "case.review_completed",
+    category: "review",
+    description: "A test-case review was decided (approved or rejected).",
+    payloadKeys: ["reviewId", "caseId", "projectId", "decision", "reviewerId"],
+  },
+  {
+    name: "case.review_reminder",
+    category: "review",
+    description: "A pending case review crossed its reminder threshold.",
+    payloadKeys: ["reviewId", "caseId", "projectId", "reminderCount"],
+  },
+
+  // --- Test runs ---
+  {
+    name: "test_run.created",
+    category: "test-run",
+    description: "A test run was created.",
+    payloadKeys: ["id", "projectId", "name", "configId", "milestoneId"],
+  },
+  {
+    name: "test_run.duplicated",
+    category: "test-run",
+    description: "A test run was duplicated from an existing run.",
+    payloadKeys: ["id", "sourceRunId", "projectId"],
+  },
+  {
+    name: "test_run.completed",
+    category: "test-run",
+    description:
+      "A test run was marked complete (state moved into a terminal state).",
+    payloadKeys: ["id", "projectId", "completedAt", "summary"],
+  },
+  {
+    name: "test_run.state_changed",
+    category: "test-run",
+    description: "A test run's workflow state transitioned.",
+    payloadKeys: ["id", "projectId", "fromStateId", "toStateId"],
+  },
+  {
+    name: "test_run.result_added",
+    category: "test-run",
+    description:
+      "A result was recorded against a case in this run (one row per submit).",
+    payloadKeys: [
+      "id",
+      "testRunId",
+      "testRunCaseId",
+      "statusId",
+      "isPass",
+      "isFail",
+      "executedAt",
+    ],
+  },
+  {
+    name: "test_run.review_requested",
+    category: "review",
+    description: "A review was requested on a test run.",
+    payloadKeys: ["reviewId", "testRunId", "projectId", "requesterId", "dueAt"],
+  },
+  {
+    name: "test_run.review_completed",
+    category: "review",
+    description: "A test-run review was decided.",
+    payloadKeys: ["reviewId", "testRunId", "projectId", "decision"],
+  },
+  {
+    name: "test_run.review_reminder",
+    category: "review",
+    description: "A pending run review crossed its reminder threshold.",
+    payloadKeys: ["reviewId", "testRunId", "projectId", "reminderCount"],
+  },
+
+  // --- Iterations ---
+  {
+    name: "iteration.result.recorded",
+    category: "iteration",
+    description:
+      "A result was recorded against a specific iteration of a parameterized case.",
+    payloadKeys: [
+      "iterationId",
+      "testRunId",
+      "testRunCaseId",
+      "statusId",
+      "rowLabel",
+    ],
+  },
+
+  // --- Sessions ---
+  {
+    name: "session.created",
+    category: "session",
+    description: "An exploratory session was created.",
+    payloadKeys: ["id", "projectId", "name"],
+  },
+  {
+    name: "session.duplicated",
+    category: "session",
+    description: "A session was duplicated from an existing session.",
+    payloadKeys: ["id", "sourceSessionId", "projectId"],
+  },
+  {
+    name: "session.completed",
+    category: "session",
+    description: "A session was marked complete.",
+    payloadKeys: ["id", "projectId", "completedAt"],
+  },
+  {
+    name: "session.state_changed",
+    category: "session",
+    description: "A session's workflow state transitioned.",
+    payloadKeys: ["id", "projectId", "fromStateId", "toStateId"],
+  },
+  {
+    name: "session.result_added",
+    category: "session",
+    description: "A session item (note, charter, defect) was recorded.",
+    payloadKeys: ["id", "sessionId", "projectId"],
+  },
+  {
+    name: "session.review_requested",
+    category: "review",
+    description: "A review was requested on a session.",
+    payloadKeys: ["reviewId", "sessionId", "projectId", "requesterId", "dueAt"],
+  },
+  {
+    name: "session.review_completed",
+    category: "review",
+    description: "A session review was decided.",
+    payloadKeys: ["reviewId", "sessionId", "projectId", "decision"],
+  },
+  {
+    name: "session.review_reminder",
+    category: "review",
+    description: "A pending session review crossed its reminder threshold.",
+    payloadKeys: ["reviewId", "sessionId", "projectId", "reminderCount"],
+  },
+
+  // --- Issues ---
+  {
+    name: "issue.created",
+    category: "issue",
+    description: "An issue (defect) was created or linked from an integration.",
+    payloadKeys: ["id", "projectId", "externalId", "title"],
+  },
+  {
+    name: "issue.updated",
+    category: "issue",
+    description:
+      "An issue's metadata, status, or linked cases changed (locally or via sync).",
+    payloadKeys: ["id", "projectId", "diff"],
+  },
+  {
+    name: "issue.deleted",
+    category: "issue",
+    description: "An issue was soft-deleted (unlinked).",
+    payloadKeys: ["id", "projectId"],
+  },
+
+  // --- System ---
+  {
+    name: "webhook.test",
+    category: "system",
+    description:
+      "Synthetic test event emitted by the admin UI to verify a webhook subscription works.",
+    payloadKeys: ["subscriptionId", "projectId", "actorUserId"],
+  },
+];
+
+/** Convenience accessor used by the catalog endpoint. */
+export function listEventCatalog(): WebhookEventDefinition[] {
+  return WEBHOOK_EVENT_CATALOG;
+}


### PR DESCRIPTION
## Description

Three NDJSON streaming export endpoints + a published webhook event catalog, turning test execution into a first-class data-lake source. Marketable as **"TestPlanIt → Data Lake"** and answers RFI §3.17 / §7.1.4 / §7.2.2 with one consistent surface.

### New endpoints

- **`GET /api/export/test-run-results`** — execution fact table, NDJSON, cursor-paged by `(executedAt, id)`
- **`GET /api/export/repository-cases`** — test-case dimension table, NDJSON, cursor-paged by `(createdAt, id)`
- **`GET /api/export/audit-log`** — compliance feed, NDJSON, cursor-paged by `(timestamp, cuid)`. Admin-only for cross-project; non-admin tokens must supply a `projectId` they have access to
- **`GET /api/webhooks/events`** — published catalog of 27 outbound webhook event names across 7 categories, with optional `?category=` filter

### Shared mechanics

- Query params: `since` (ISO-8601), `cursor` (opaque base64url), `pageSize` (1..5000, default 1000), `projectId` (optional for admin, required otherwise)
- Response envelope: manifest line first, rows in between, end-trailer last. Trailer's `cursor` is `null` when the page is not full → signal to stop.
- Cursor pagination is **strict-forward with a composite tiebreaker**: `WHERE (sortCol > c.k) OR (sortCol = c.k AND id > c.i)` — never skips, never duplicates, even with identical timestamps.
- Mid-stream errors append `{"error":"..."}` instead of an end-trailer so consumers can detect incomplete responses.
- Soft-deleted rows are filtered out; consumers see deletes via `*.deleted` webhook events instead.

### Architecture pick

**Native Kafka/Kinesis/Pub-Sub producers are deliberately not in scope.** The catalog + webhook story already covers real-time (customers bridge with Kafka Connect REST source, AWS API Gateway → Kinesis Firehose, Google Pub/Sub HTTP push, or a 20-line Vector pipeline). Three SDK adapters would mean three runbooks, three CVE surfaces, three "why isn't it delivering" failure modes — for ergonomics most customers don't need. Roadmap-only.

### OpenAPI

Two new tags — **Data Lake Export** and **Webhooks** — with the four operations declared. The custom spec is regenerated; the docs site picks it up automatically.

### User-facing docs

- New top-level user-guide page **`docs/docs/data-lake-export.md`** under SDK & Integrations, with curl + Python + Spark + Snowflake `COPY INTO` recipes
- Launch blog post **`docs/blog/2026-05-30-data-lake-export.md`** with the marketing framing (NDJSON wire format, stable-forward iteration, webhook catalog, the architecture pick)
- Sidebar entry added so the doc is discoverable from the navigation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests — 53 new tests across `lib/export/ndjson.test.ts`, `lib/export/queryParams.test.ts`, `lib/webhooks/eventCatalog.test.ts`, and `route.test.ts` for each endpoint; full suite **8135/8246 passing**
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing — Playwright-driven UAT against live dev server captured the full NDJSON dump from each endpoint, verified cursor pagination across page boundaries (page 1 ends at `id 24113` with `executedAt 2023-06-23T11:37:08.327Z`, page 2 begins at `id 24114` with the **same** timestamp — proving the composite cursor handles ties correctly), confirmed auth gates (401 unauthenticated, valid project narrows correctly, bogus project returns empty stream), and confirmed Case 192's `hasParameters: true` flag flows through to the export

**Test Configuration:**
- OS: macOS 15 (Darwin)
- Browser: Chrome via Playwright
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots

(API change — no screenshots. The UAT showed Sections 1-6 returning the documented NDJSON envelopes; full raw dumps available in the PR conversation.)

## Additional Notes

The branch is 8 commits, organized so each layer is reviewable independently:

1. `feat(export): NDJSON streaming utility` — the chunked-transfer helper + 9 unit tests
2. `feat(export): NDJSON test-run-results endpoint` — first endpoint + 10 tests, sets the auth + cursor pattern
3. `feat(export): NDJSON repository-cases + audit-log endpoints` — extracts the cursor/since/pageSize plumbing into `lib/export/queryParams.ts` so all three endpoints share one implementation; cursor now accepts `i: string | number` for the audit-log cuid
4. `feat(webhooks): publish event catalog at /api/webhooks/events` — hand-curated catalog + 9 tests
5. `feat(api-docs): publish Data Lake Export and Webhooks Catalog in OpenAPI` — adds the four operations + tags; merged spec regenerated
6. `docs(export): Data Lake user guide and launch blog draft` — user-guide page with consumer recipes + marketing blog post
7. `chore(export): drop unused decoder + eslint-disable in route tests` — lint cleanup
8. `docs(sidebars): add 'data-lake-export' entry to sidebar` — Docusaurus sidebar wiring so the new page is discoverable
