### PR TITLE
enhancement(ui): full profile preferences in view mode + date/time hover tooltips

### DIFF
--- a/testplanit/app/[locale]/users/profile/[userId]/page.tsx
+++ b/testplanit/app/[locale]/users/profile/[userId]/page.tsx
@@ -811,6 +811,46 @@ const UserProfile: React.FC<UserProfileProps> = ({
                               <div className="space-y-3">
                                 <div className="flex items-center justify-between">
                                   <span className="text-sm">
+                                    {tGlobal(
+                                      "home.initialPreferences.dateFormat"
+                                    )}
+                                  </span>
+                                  <Badge variant="secondary">
+                                    <DateFormatter
+                                      date={sampleDate}
+                                      formatString={
+                                        user.userPreferences.dateFormat
+                                      }
+                                      timezone={user.userPreferences.timezone}
+                                      tooltip={false}
+                                    />
+                                  </Badge>
+                                </div>
+
+                                <Separator className="opacity-50" />
+
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm">
+                                    {tGlobal(
+                                      "home.initialPreferences.timeFormat"
+                                    )}
+                                  </span>
+                                  <Badge variant="secondary">
+                                    <DateFormatter
+                                      date={sampleDate}
+                                      formatString={
+                                        user.userPreferences.timeFormat
+                                      }
+                                      timezone={user.userPreferences.timezone}
+                                      tooltip={false}
+                                    />
+                                  </Badge>
+                                </div>
+
+                                <Separator className="opacity-50" />
+
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm">
                                     {tCommon("fields.timezone")}
                                   </span>
                                   <span className="text-sm text-muted-foreground">
@@ -847,7 +887,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                           </div>
                         ) : (
                           <Form {...form}>
-                            <div className="grid gap-4 sm:grid-cols-2 px-0.5">
+                            <div className="grid gap-4 sm:grid-cols-2 px-4">
                               <FormField
                                 control={form.control}
                                 name="theme"
@@ -1036,6 +1076,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                                                     session?.user?.preferences
                                                       ?.timezone
                                                   }
+                                                  tooltip={false}
                                                 />
                                               </SelectItem>
                                             )
@@ -1091,6 +1132,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                                                     session?.user?.preferences
                                                       ?.timezone
                                                   }
+                                                  tooltip={false}
                                                 />
                                               </SelectItem>
                                             )

--- a/testplanit/components/DateFormatter.tsx
+++ b/testplanit/components/DateFormatter.tsx
@@ -1,5 +1,13 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { format } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
+import { useSession } from "next-auth/react";
 import { useLocale } from "next-intl";
 import React from "react";
 import { getDateFnsLocale } from "~/utils/locales";
@@ -9,15 +17,27 @@ type DateFormatterProps = {
   date: Date | string | null;
   formatString?: string;
   timezone?: string | null;
+  /**
+   * When true (default), the formatted value is wrapped in a tooltip that
+   * reveals the full date and time in the viewer's preferred date/time format.
+   * Useful when the visible value shows only the date (or only the time), or
+   * is truncated. Set to false for format previews/samples or when the
+   * formatter is already rendered inside another tooltip/popover.
+   */
+  tooltip?: boolean;
 };
+
+const DEFAULT_TOOLTIP_FORMAT = "MM/dd/yyyy hh:mm a";
 
 export const DateFormatter: React.FC<DateFormatterProps> = ({
   date,
   formatString = "MM-dd-yyyy",
   timezone,
+  tooltip = true,
 }) => {
   const locale = useLocale();
   const dateLocale = getDateFnsLocale(locale);
+  const { data: session } = useSession();
 
   const dateObject = typeof date === "string" ? new Date(date) : date;
   if (
@@ -28,54 +48,69 @@ export const DateFormatter: React.FC<DateFormatterProps> = ({
     return null;
   }
 
-  const finalFormatString = mapDateTimeFormatString(formatString);
-
-  let formattedDate: string;
-  let suffix = "";
-
-  try {
-    if (timezone) {
-      const ianaTimezone = timezone.replace(/_/g, "/");
-      formattedDate = formatInTimeZone(
-        dateObject,
-        ianaTimezone,
-        finalFormatString,
-        { locale: dateLocale }
-      );
-    } else {
-      formattedDate = format(dateObject, finalFormatString, {
-        locale: dateLocale,
-      });
-    }
-  } catch (error) {
-    console.warn(
-      `Error formatting date with timezone "${timezone}" (IANA: "${timezone?.replace(/_/g, "/")}"):`,
-      error
-    );
+  // Format the date with the given format/timezone, falling back to UTC and
+  // then local time if the timezone is invalid (mirrors prior behavior).
+  const formatValue = (rawFormatString: string, tz?: string | null): string => {
+    const finalFormatString = mapDateTimeFormatString(rawFormatString);
     try {
-      formattedDate = formatInTimeZone(
-        dateObject,
-        "Etc/UTC",
-        finalFormatString,
-        { locale: dateLocale }
+      if (tz) {
+        return formatInTimeZone(
+          dateObject,
+          tz.replace(/_/g, "/"),
+          finalFormatString,
+          { locale: dateLocale }
+        );
+      }
+      return format(dateObject, finalFormatString, { locale: dateLocale });
+    } catch (error) {
+      console.warn(
+        `Error formatting date with timezone "${tz}" (IANA: "${tz?.replace(/_/g, "/")}"):`,
+        error
       );
-      suffix = " (UTC)";
-    } catch (utcError) {
-      console.error(
-        "Error formatting date with fallback UTC timezone:",
-        utcError
-      );
-      formattedDate = format(dateObject, finalFormatString, {
-        locale: dateLocale,
-      });
-      suffix = " (Local)";
+      try {
+        return (
+          formatInTimeZone(dateObject, "Etc/UTC", finalFormatString, {
+            locale: dateLocale,
+          }) + " (UTC)"
+        );
+      } catch (utcError) {
+        console.error(
+          "Error formatting date with fallback UTC timezone:",
+          utcError
+        );
+        return (
+          format(dateObject, finalFormatString, { locale: dateLocale }) +
+          " (Local)"
+        );
+      }
     }
+  };
+
+  const formattedDate = formatValue(formatString, timezone);
+
+  if (!tooltip) {
+    return <>{formattedDate}</>;
   }
 
+  // Tooltip shows the full date + time in the viewer's preferred format.
+  const preferredDateFormat = session?.user?.preferences?.dateFormat;
+  const preferredTimeFormat = session?.user?.preferences?.timeFormat;
+  const preferredTimezone = session?.user?.preferences?.timezone;
+  const tooltipFormatString =
+    preferredDateFormat && preferredTimeFormat
+      ? `${preferredDateFormat} ${preferredTimeFormat}`
+      : DEFAULT_TOOLTIP_FORMAT;
+  const tooltipText = formatValue(
+    tooltipFormatString,
+    timezone ?? preferredTimezone
+  );
+
   return (
-    <>
-      {formattedDate}
-      {suffix}
-    </>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{formattedDate}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
   );
 };

--- a/testplanit/components/LastActiveDisplay.tsx
+++ b/testplanit/components/LastActiveDisplay.tsx
@@ -56,6 +56,7 @@ export const LastActiveDisplay: React.FC<LastActiveDisplayProps> = ({
           date={dateObj}
           formatString={formatString}
           timezone={preferredTimezone}
+          tooltip={false}
         />
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Description

Two small visual enhancements:

1. **User Profile — all preferences visible in both modes.** The read-only profile view was missing **Date Format** and **Time Format**; they only appeared while editing. Both are now shown in the read-only view (rendered as samples in the user's chosen format), so the Preferences card lists the same set in view and edit modes. The edit-mode grid also gains horizontal padding (`px-4`) to match the read-only layout and the rest of the profile sections.

2. **`DateFormatter` — full date/time on hover.** `DateFormatter` now wraps its value in a tooltip (on by default) that reveals the full **date and time** in the viewer's preferred date/time format and timezone. This helps when a cell shows only the date (or only the time), or when the value is truncated. Because the **Admin > Users** *Email Verified* and *Created At* columns already use `DateFormatter`, they pick up the hover automatically. The tooltip is opt-out via a `tooltip={false}` prop and is disabled on format-preview samples and where the formatter is already rendered inside another tooltip (e.g. `LastActiveDisplay`).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

- Full unit suite passes locally (8,171 passed) — confirms the app-wide `DateFormatter` change is compatible with all of its existing usages.
- Manually verified the profile preferences (view + edit modes) and the date/time hover tooltips on the Admin > Users table.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The `DateFormatter` tooltip is enabled by default, so it applies to every date displayed across the app, not just the Users table. It can be turned off per-usage with `tooltip={false}`.
