### PR TITLE
enhancement(live): SSE-driven live updates for test runs

### DIFF
--- a/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
@@ -11,6 +11,7 @@ import LoadingSpinnerAlert from "@/components/LoadingSpinnerAlert";
 import { RequestReviewButton } from "@/components/reviews/RequestReviewButton";
 import { ReviewStatusBanner } from "@/components/reviews/ReviewStatusBanner";
 import { TestRunCaseDetails } from "@/components/TestRunCaseDetails";
+import { useTestRunLiveStream } from "~/hooks/useTestRunLiveStream";
 import { useTransitionGateStatus } from "~/hooks/useTransitionGateStatus";
 import { IterationAwareTestRunCaseDetails } from "~/components/iterations/IterationAwareTestRunCaseDetails";
 import TipTapEditor from "@/components/tiptap/TipTapEditor";
@@ -500,6 +501,18 @@ export default function TestRunPage() {
     data: (TestRunWithRelations & { testRunType?: string }) | null;
     refetch: () => void;
   };
+
+  // SSE wake-up: refetch the run (and therefore its per-case statuses) on
+  // every published event. The pub/sub layer is untrusted plumbing
+  // (Architectural Directive 2); auth is enforced on the refetch path.
+  // Disabled once the run is completed — there's nothing left to update,
+  // and we don't want to hold an EventSource open indefinitely on a
+  // historical run page.
+  useTestRunLiveStream({
+    runId: !isNaN(Number(runId)) ? Number(runId) : null,
+    enabled: !testRunData?.isCompleted,
+    onWakeUp: refetchTestRun,
+  });
 
   // PDF export hook — fetches its own (heavier) data on demand when exporting.
   const { isExporting: isExportingPdf, handleExport: handleExportPdf } =

--- a/testplanit/app/api/test-runs/[testRunId]/stream/route.test.ts
+++ b/testplanit/app/api/test-runs/[testRunId]/stream/route.test.ts
@@ -1,0 +1,181 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("@zenstackhq/runtime", () => ({ enhance: vi.fn() }));
+
+vi.mock("~/lib/multiTenantPrisma", () => ({
+  getCurrentTenantId: vi.fn().mockReturnValue("acme"),
+}));
+
+vi.mock("~/lib/valkey", () => ({
+  createSubscriberClient: vi.fn(),
+}));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    testRuns: { findFirst: vi.fn() },
+  },
+}));
+
+import { enhance } from "@zenstackhq/runtime";
+import { getServerSession } from "next-auth";
+import { prisma } from "~/lib/prisma";
+import { createSubscriberClient } from "~/lib/valkey";
+import { GET } from "./route";
+
+function req(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"));
+}
+
+function makeSubscriberMock() {
+  const messageHandlers: Array<(...args: unknown[]) => void> = [];
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "message") messageHandlers.push(handler);
+    }),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+    quit: vi.fn().mockResolvedValue(undefined),
+    emitMessage: (channel: string, message: string) => {
+      for (const h of messageHandlers) h(channel, message);
+    },
+  };
+}
+
+describe("GET /api/test-runs/[id]/stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("400s on a non-numeric run id", async () => {
+    const res = await GET(req("/api/test-runs/abc/stream"), {
+      params: Promise.resolve({ testRunId: "abc" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a non-positive run id", async () => {
+    const res = await GET(req("/api/test-runs/0/stream"), {
+      params: Promise.resolve({ testRunId: "0" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401s when there is no session", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when the user record cannot be found", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("404s when the user has no access to the test run", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+      access: null,
+    } as never);
+    vi.mocked(enhance).mockReturnValue({
+      testRuns: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never);
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("503s when valkey is not configured", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.testRuns.findFirst).mockResolvedValue({ id: 42 } as never);
+    vi.mocked(createSubscriberClient).mockReturnValue(null);
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("30");
+  });
+
+  it("subscribes to the testRun channel and emits a sync checkpoint", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.testRuns.findFirst).mockResolvedValue({ id: 42 } as never);
+    const subscriber = makeSubscriberMock();
+    vi.mocked(createSubscriberClient).mockReturnValue(subscriber as never);
+
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("x-accel-buffering")).toBe("no");
+
+    // Read the first message off the stream
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(subscriber.subscribe).toHaveBeenCalledWith(
+      "live:tenant:acme:testrun:42"
+    );
+    expect(text).toContain('data: {"event":"sync"}');
+    reader.releaseLock();
+    await res.body!.cancel();
+  });
+
+  it("relays publisher messages verbatim as SSE data lines", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.testRuns.findFirst).mockResolvedValue({ id: 42 } as never);
+    const subscriber = makeSubscriberMock();
+    vi.mocked(createSubscriberClient).mockReturnValue(subscriber as never);
+
+    const res = await GET(req("/api/test-runs/42/stream"), {
+      params: Promise.resolve({ testRunId: "42" }),
+    });
+    const reader = res.body!.getReader();
+    await reader.read(); // sync
+    // Now publisher fires
+    subscriber.emitMessage(
+      "live:tenant:acme:testrun:42",
+      '{"event":"test_run.result_added","runId":42,"targetId":7891}'
+    );
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toBe(
+      'data: {"event":"test_run.result_added","runId":42,"targetId":7891}\n\n'
+    );
+    reader.releaseLock();
+    await res.body!.cancel();
+  });
+});

--- a/testplanit/app/api/test-runs/[testRunId]/stream/route.ts
+++ b/testplanit/app/api/test-runs/[testRunId]/stream/route.ts
@@ -1,0 +1,192 @@
+/**
+ * Server-Sent Events stream for live updates on a single test run.
+ *
+ * Replaces the 30s polling in `components/TestRunCasesSummary.tsx` and
+ * powers active execution status badges in the case list. Modeled on
+ * `/api/notifications/stream` — the pub/sub layer is untrusted plumbing
+ * (Architectural Directive 2) and the consumer's authorization is the
+ * `useFindManyTestRunResults` / summary refetch path triggered by the
+ * wake-up.
+ *
+ * Subscribers receive one event per change:
+ *
+ *     data: {"event":"test_run.result_added","runId":42,"targetId":7891}
+ *     data: {"event":"test_run.state_changed","runId":42}
+ *     data: {"event":"test_run.completed","runId":42}
+ *
+ * Plus a `data: {"event":"sync"}` checkpoint right after the subscribe
+ * completes so clients know they're now live.
+ */
+
+import { enhance } from "@zenstackhq/runtime";
+import IORedis from "ioredis";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { testRunChannel } from "~/lib/live/channels";
+import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
+import { prisma } from "~/lib/prisma";
+import { createSubscriberClient } from "~/lib/valkey";
+import { authOptions } from "~/server/auth";
+
+// Long-lived stream + IORedis pub/sub require the Node.js runtime; opt out
+// of every Next.js prerender path.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_MS = 25_000;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ testRunId: string }> }
+) {
+  const { testRunId } = await params;
+  const runId = Number.parseInt(testRunId, 10);
+  if (!Number.isInteger(runId) || runId <= 0) {
+    return NextResponse.json({ error: "Invalid test run id" }, { status: 400 });
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Project-access gate (single read through the enhanced client so the
+  // ZenStack policy applies — admins get cross-project, everyone else is
+  // checked against project membership). If the user can't read the run,
+  // they shouldn't be told it exists, so we 404 (not 403) on miss.
+  const userRecord = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    include: { role: { include: { rolePermissions: true } } },
+  });
+  if (!userRecord) {
+    return NextResponse.json({ error: "User not found" }, { status: 401 });
+  }
+  const reader =
+    userRecord.access === "ADMIN"
+      ? (prisma as unknown as typeof prisma)
+      : (enhance(prisma, { user: userRecord }) as unknown as typeof prisma);
+  const accessibleRun = await reader.testRuns.findFirst({
+    where: { id: runId, isDeleted: false },
+    select: { id: true },
+  });
+  if (!accessibleRun) {
+    return NextResponse.json({ error: "Test run not found" }, { status: 404 });
+  }
+
+  const tenantId = getCurrentTenantId() ?? "default";
+  const channel = testRunChannel(tenantId, runId);
+
+  const subscriber: IORedis | null = createSubscriberClient();
+  if (!subscriber) {
+    // No Valkey wired (e.g. local dev with SKIP_VALKEY_CONNECTION). Fail
+    // closed with a Retry-After so the EventSource client backs off
+    // rather than hot-looping.
+    return new NextResponse(null, {
+      status: 503,
+      headers: { "Retry-After": "30" },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let controllerClosed = false;
+  let lastEventAt = Date.now();
+  let heartbeatInterval: NodeJS.Timeout | null = null;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function write(bytes: Uint8Array) {
+        if (controllerClosed) return;
+        try {
+          controller.enqueue(bytes);
+        } catch {
+          controllerClosed = true;
+        }
+      }
+      function sendEvent(payload: object) {
+        write(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+        lastEventAt = Date.now();
+      }
+      function sendComment(line: string) {
+        write(encoder.encode(`${line}\n\n`));
+      }
+
+      subscriber.on("message", (_channel, message) => {
+        if (controllerClosed) return;
+        // Publisher already serializes the payload as JSON; relay verbatim.
+        write(encoder.encode(`data: ${message}\n\n`));
+        lastEventAt = Date.now();
+      });
+
+      try {
+        await subscriber.subscribe(channel);
+      } catch (subErr) {
+        console.warn(`[sse/test-run] subscribe failed`, {
+          channel,
+          runId,
+          error: subErr instanceof Error ? subErr.message : String(subErr),
+        });
+        try {
+          await subscriber.quit();
+        } catch {
+          /* swallow */
+        }
+        controllerClosed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+        return;
+      }
+
+      // First byte after subscribe completes so clients know the live
+      // window has opened (D-11 / sync checkpoint).
+      sendEvent({ event: "sync" });
+
+      // Gated heartbeat — proxies (nginx default 60s, load balancers
+      // similar) kill idle connections, so we keep one open with a tiny
+      // SSE comment if no real event has flowed in the last 25s.
+      heartbeatInterval = setInterval(() => {
+        if (Date.now() - lastEventAt >= HEARTBEAT_MS) {
+          sendComment(": ping");
+        }
+      }, HEARTBEAT_MS);
+    },
+
+    async cancel() {
+      await cleanup();
+    },
+  });
+
+  async function cleanup() {
+    controllerClosed = true;
+    if (heartbeatInterval) {
+      clearInterval(heartbeatInterval);
+      heartbeatInterval = null;
+    }
+    try {
+      await subscriber?.unsubscribe();
+    } catch {
+      /* swallow */
+    }
+    try {
+      await subscriber?.quit();
+    } catch {
+      /* swallow */
+    }
+  }
+
+  req.signal.addEventListener("abort", () => {
+    void cleanup();
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      // Tells nginx not to buffer the response (it would defeat SSE).
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/testplanit/components/TestRunCasesSummary.tsx
+++ b/testplanit/components/TestRunCasesSummary.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowUpDown,
   Calendar,
@@ -23,8 +23,9 @@ import {
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { TestRunSummaryData } from "~/app/api/test-runs/[testRunId]/summary/route";
+import { useTestRunLiveStream } from "~/hooks/useTestRunLiveStream";
 import { useFindFirstStatus } from "~/lib/hooks";
 import { Link } from "~/lib/navigation";
 import { aggregateRunCounts } from "~/lib/services/testRunSummary-shared";
@@ -67,8 +68,13 @@ export function TestRunCasesSummary({
 
   // Fetch summary data from API - for multi-config, fetch all and aggregate
   // If pre-fetched data is provided, skip the API call
+  const queryKey = useMemo(
+    () => ["testRunSummary", ...effectiveTestRunIds] as const,
+    [effectiveTestRunIds]
+  );
+  const queryClient = useQueryClient();
   const { data: fetchedSummaryData, isLoading } = useQuery<TestRunSummaryData>({
-    queryKey: ["testRunSummary", ...effectiveTestRunIds],
+    queryKey: [...queryKey],
     queryFn: async () => {
       if (!isMultiConfig) {
         // Single test run - use existing endpoint with case details for color bar
@@ -101,15 +107,25 @@ export function TestRunCasesSummary({
       !preFetchedSummaryData &&
       effectiveTestRunIds.length > 0 &&
       effectiveTestRunIds[0] > 0,
-    staleTime: 30000, // Cache for 30 seconds
-    // Refetch every 30 seconds when workflow is IN_PROGRESS (for automated test runs still adding cases)
-    refetchInterval: (query) => {
-      const data = query.state.data;
-      if (data?.workflowType === "IN_PROGRESS") {
-        return 30000; // 30 seconds
-      }
-      return false; // No automatic refetching
-    },
+    // No more refetchInterval — live updates come from SSE via the wake-up
+    // hook below. The 30s stale window is kept so a manual revisit after
+    // an idle minute still re-fetches.
+    staleTime: 30000,
+  });
+
+  // SSE wake-up: open EventSource on the live channel for this run; on
+  // every event, invalidate the summary query so React Query refetches
+  // the truth from REST. The data fetch is the security boundary; the
+  // wake-up is an untrusted nudge. Skipped when in multi-config mode
+  // (the page renders one summary per run; each one opens its own
+  // EventSource via this component) and when pre-fetched data is in
+  // use (the SSR page already has a fresh snapshot).
+  const onWakeUp = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
+  useTestRunLiveStream({
+    runId: !preFetchedSummaryData && !isMultiConfig ? testRunId : null,
+    onWakeUp,
   });
 
   // Use pre-fetched data if available, otherwise use fetched data

--- a/testplanit/hooks/useTestRunLiveStream.test.tsx
+++ b/testplanit/hooks/useTestRunLiveStream.test.tsx
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTestRunLiveStream } from "./useTestRunLiveStream";
+
+interface MockEventSource {
+  url: string;
+  onmessage: ((msg: MessageEvent) => void) | null;
+  onerror: ((err: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+}
+
+const created: MockEventSource[] = [];
+const OriginalEventSource = globalThis.EventSource;
+
+beforeEach(() => {
+  created.length = 0;
+  // Replace with a constructor that records each instance.
+  (globalThis as { EventSource: unknown }).EventSource = function (
+    url: string
+  ) {
+    const inst: MockEventSource = {
+      url,
+      onmessage: null,
+      onerror: null,
+      close: vi.fn(),
+    };
+    created.push(inst);
+    return inst;
+  } as unknown as typeof globalThis.EventSource;
+});
+
+afterEach(() => {
+  (globalThis as { EventSource: unknown }).EventSource =
+    OriginalEventSource as unknown;
+});
+
+describe("useTestRunLiveStream", () => {
+  it("opens an EventSource on the right URL for a valid runId", () => {
+    const onWakeUp = vi.fn();
+    renderHook(() => useTestRunLiveStream({ runId: 42, onWakeUp }));
+    expect(created).toHaveLength(1);
+    expect(created[0]!.url).toBe("/api/test-runs/42/stream");
+  });
+
+  it("does not open a stream when disabled", () => {
+    renderHook(() =>
+      useTestRunLiveStream({ runId: 42, enabled: false, onWakeUp: vi.fn() })
+    );
+    expect(created).toHaveLength(0);
+  });
+
+  it("does not open a stream for a null or zero runId", () => {
+    renderHook(() => useTestRunLiveStream({ runId: null, onWakeUp: vi.fn() }));
+    expect(created).toHaveLength(0);
+    renderHook(() => useTestRunLiveStream({ runId: 0, onWakeUp: vi.fn() }));
+    expect(created).toHaveLength(0);
+  });
+
+  it("invokes onWakeUp with the parsed payload on each message", () => {
+    const onWakeUp = vi.fn();
+    renderHook(() => useTestRunLiveStream({ runId: 7, onWakeUp }));
+    const es = created[0]!;
+    es.onmessage!({
+      data: '{"event":"test_run.result_added","runId":7,"targetId":99}',
+    } as MessageEvent);
+    expect(onWakeUp).toHaveBeenCalledWith({
+      event: "test_run.result_added",
+      runId: 7,
+      targetId: 99,
+    });
+  });
+
+  it("swallows malformed payloads without throwing", () => {
+    const onWakeUp = vi.fn();
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderHook(() => useTestRunLiveStream({ runId: 7, onWakeUp }));
+    const es = created[0]!;
+    es.onmessage!({ data: "not-json" } as MessageEvent);
+    expect(onWakeUp).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useTestRunLiveStream({ runId: 7, onWakeUp: vi.fn() })
+    );
+    const es = created[0]!;
+    unmount();
+    expect(es.close).toHaveBeenCalled();
+  });
+
+  it("recreates the EventSource when runId changes", () => {
+    const onWakeUp = vi.fn();
+    const { rerender } = renderHook(
+      (args: { runId: number }) =>
+        useTestRunLiveStream({ runId: args.runId, onWakeUp }),
+      { initialProps: { runId: 1 } }
+    );
+    expect(created).toHaveLength(1);
+    expect(created[0]!.url).toBe("/api/test-runs/1/stream");
+    rerender({ runId: 2 });
+    expect(created).toHaveLength(2);
+    expect(created[0]!.close).toHaveBeenCalled();
+    expect(created[1]!.url).toBe("/api/test-runs/2/stream");
+  });
+});

--- a/testplanit/hooks/useTestRunLiveStream.ts
+++ b/testplanit/hooks/useTestRunLiveStream.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Subscribe to the SSE wake-up stream for one test run and invoke
+ * `onWakeUp` for every event received.
+ *
+ * The browser opens at most one EventSource per `(runId, mount)` pair;
+ * EventSource handles transport reconnects on its own. When the runId
+ * changes or the consumer unmounts, the connection is closed cleanly.
+ * `onWakeUp` receives the parsed `{ event, runId, targetId? }` payload
+ * the server published; the consumer typically uses it to trigger one
+ * or more React-Query refetches.
+ *
+ * The hook is intentionally inert on the server and in test
+ * environments without EventSource — there's nothing to subscribe to.
+ *
+ * The connection is gated on `enabled` so callers can keep the stream
+ * dormant while a test run isn't actively being watched (the polling
+ * code it replaces was similarly gated on the run's workflowType).
+ */
+
+export interface TestRunWakeUp {
+  event:
+    | "sync"
+    | "test_run.result_added"
+    | "test_run.state_changed"
+    | "test_run.completed"
+    | "test_run.case.status_changed";
+  runId?: number;
+  targetId?: number;
+}
+
+export interface UseTestRunLiveStreamArgs {
+  runId: number | null | undefined;
+  enabled?: boolean;
+  onWakeUp: (event: TestRunWakeUp) => void;
+}
+
+export function useTestRunLiveStream({
+  runId,
+  enabled = true,
+  onWakeUp,
+}: UseTestRunLiveStreamArgs): void {
+  useEffect(() => {
+    if (!enabled) return;
+    if (!runId || runId <= 0) return;
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      return;
+    }
+
+    const eventSource = new EventSource(`/api/test-runs/${runId}/stream`);
+
+    eventSource.onmessage = (msg) => {
+      try {
+        const payload = JSON.parse(msg.data) as TestRunWakeUp;
+        onWakeUp(payload);
+      } catch (err) {
+        console.warn("[useTestRunLiveStream] malformed wake-up", err);
+      }
+    };
+
+    eventSource.onerror = (err) => {
+      // EventSource auto-reconnects on transport drop. A user-visible
+      // toast would be noisy on transient blips.
+      console.warn("[useTestRunLiveStream] SSE transport error", err);
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [runId, enabled, onWakeUp]);
+}

--- a/testplanit/lib/live/channels.test.ts
+++ b/testplanit/lib/live/channels.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { testRunChannel } from "./channels";
+
+describe("testRunChannel", () => {
+  it("formats the channel key as live:tenant:<id>:testrun:<runId>", () => {
+    expect(testRunChannel("acme", 42)).toBe("live:tenant:acme:testrun:42");
+  });
+
+  it("scopes by tenant — different tenants don't share a channel", () => {
+    expect(testRunChannel("acme", 42)).not.toBe(testRunChannel("globex", 42));
+  });
+
+  it("rejects missing tenantId", () => {
+    expect(() => testRunChannel("", 42)).toThrow(/tenantId is required/);
+  });
+
+  it("rejects non-positive testRunId", () => {
+    expect(() => testRunChannel("acme", 0)).toThrow(/positive integer/);
+    expect(() => testRunChannel("acme", -1)).toThrow(/positive integer/);
+    expect(() => testRunChannel("acme", 1.5)).toThrow(/positive integer/);
+  });
+});

--- a/testplanit/lib/live/channels.ts
+++ b/testplanit/lib/live/channels.ts
@@ -1,0 +1,27 @@
+/**
+ * Live-update SSE channels — the ONLY module permitted to construct
+ * channel-key strings for non-notification live streams (test runs first;
+ * sessions/etc. can extend this without touching consumers).
+ *
+ * Pattern mirrors `lib/notifications/channels.ts`. Channel keys are
+ * tenant-scoped so multi-tenant deployments isolate cleanly, and the
+ * key format is the only contract between publishers (server-side
+ * event emitters) and subscribers (the SSE route).
+ *
+ * Payload shape on the wire is `{ id, event, ...minimalFields }` JSON.
+ * Consumers treat the message as a wake-up signal and refetch from REST
+ * — the pub/sub layer is untrusted plumbing, the data fetch is the
+ * security boundary (same model as the notifications stream).
+ */
+
+export function testRunChannel(tenantId: string, testRunId: number): string {
+  if (!tenantId) {
+    throw new Error("live/channels.testRunChannel: tenantId is required");
+  }
+  if (!Number.isInteger(testRunId) || testRunId <= 0) {
+    throw new Error(
+      "live/channels.testRunChannel: testRunId must be a positive integer"
+    );
+  }
+  return `live:tenant:${tenantId}:testrun:${testRunId}`;
+}

--- a/testplanit/lib/live/publish.test.ts
+++ b/testplanit/lib/live/publish.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPublish = vi.fn();
+
+vi.mock("~/lib/valkey", () => ({
+  default: { publish: (...args: unknown[]) => mockPublish(...args) },
+}));
+
+vi.mock("~/lib/multiTenantPrisma", () => ({
+  getCurrentTenantId: vi.fn(),
+}));
+
+import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
+import { publishTestRunWakeUp } from "./publish";
+
+async function flushImmediate() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("publishTestRunWakeUp", () => {
+  beforeEach(() => {
+    mockPublish.mockReset();
+    mockPublish.mockResolvedValue(1);
+    vi.mocked(getCurrentTenantId).mockReturnValue("acme");
+  });
+
+  it("publishes the wake-up JSON to the testRun channel", async () => {
+    publishTestRunWakeUp({ event: "test_run.result_added", runId: 42 });
+    await flushImmediate();
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    const [channel, body] = mockPublish.mock.calls[0]!;
+    expect(channel).toBe("live:tenant:acme:testrun:42");
+    expect(JSON.parse(body as string)).toEqual({
+      event: "test_run.result_added",
+      runId: 42,
+    });
+  });
+
+  it("falls back to the default tenant when one is not resolved", async () => {
+    vi.mocked(getCurrentTenantId).mockReturnValue(undefined);
+    publishTestRunWakeUp({ event: "test_run.completed", runId: 7 });
+    await flushImmediate();
+    expect(mockPublish.mock.calls[0]![0]).toBe("live:tenant:default:testrun:7");
+  });
+
+  it("includes the targetId when provided", async () => {
+    publishTestRunWakeUp({
+      event: "test_run.result_added",
+      runId: 42,
+      targetId: 999,
+    });
+    await flushImmediate();
+    const body = JSON.parse(mockPublish.mock.calls[0]![1] as string);
+    expect(body).toEqual({
+      event: "test_run.result_added",
+      runId: 42,
+      targetId: 999,
+    });
+  });
+
+  it("defers the publish until after setImmediate", async () => {
+    publishTestRunWakeUp({ event: "test_run.state_changed", runId: 1 });
+    expect(mockPublish).not.toHaveBeenCalled();
+    await flushImmediate();
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows publish failures (best-effort wake-up)", async () => {
+    mockPublish.mockRejectedValueOnce(new Error("valkey down"));
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    publishTestRunWakeUp({ event: "test_run.completed", runId: 1 });
+    await flushImmediate();
+    await flushImmediate(); // unhandled rejection .catch handler is a microtask
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/testplanit/lib/live/publish.ts
+++ b/testplanit/lib/live/publish.ts
@@ -1,0 +1,63 @@
+/**
+ * Live-update wake-up publisher.
+ *
+ * The contract: server-side event emitters (lib/webhooks/event-emitters/*.ts)
+ * call `publishTestRunWakeUp(...)` after `webhookEvents.emit()` to nudge
+ * SSE consumers that something changed. The published payload is JSON
+ * over a Valkey pub/sub channel; consumers receive it on their SSE
+ * connection and refetch the truth from REST (the pub/sub layer is
+ * untrusted plumbing — Architectural Directive 2, mirrored from
+ * notifications).
+ *
+ * Timing matters: emitters run INSIDE the caller's prisma.$transaction
+ * (webhookEvents.emit requires a tx). If we published synchronously, a
+ * consumer's refetch would race the not-yet-committed write. We defer
+ * via setImmediate so the publish fires after the tx settles. On
+ * rollback the consumer's refetch is a cheap no-op (data unchanged).
+ *
+ * Failures are swallowed: SSE is a wake-up signal, the DB row is the
+ * source of truth. A missing wake-up just means the user sees the
+ * update on next manual refresh or the next event.
+ */
+
+import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
+import valkeyConnection from "~/lib/valkey";
+import { testRunChannel } from "./channels";
+
+/** Wake-up event names — narrower than the webhook event names because
+ *  the client only cares about "something on this run changed" + a hint
+ *  to decide which queries to invalidate. */
+export type TestRunWakeUpEvent =
+  | "test_run.result_added"
+  | "test_run.state_changed"
+  | "test_run.completed"
+  | "test_run.case.status_changed";
+
+interface TestRunWakeUp {
+  event: TestRunWakeUpEvent;
+  runId: number;
+  /** Sub-resource id when the event targets one (a resultId, caseId,
+   *  etc.) — included so clients can invalidate finely. Optional. */
+  targetId?: number;
+}
+
+export function publishTestRunWakeUp(payload: TestRunWakeUp): void {
+  if (!valkeyConnection) return; // single-pod dev / SKIP_VALKEY_CONNECTION
+  const tenantId = getCurrentTenantId() ?? "default";
+  const channel = testRunChannel(tenantId, payload.runId);
+  const body = JSON.stringify(payload);
+  // Defer past the surrounding tx commit boundary so consumers' refetches
+  // observe the committed write.
+  setImmediate(() => {
+    valkeyConnection
+      ?.publish(channel, body)
+      .catch((err: unknown) =>
+        console.warn(`[live/publish] testRun wake-up failed`, {
+          channel,
+          event: payload.event,
+          runId: payload.runId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      );
+  });
+}

--- a/testplanit/lib/live/publish.ts
+++ b/testplanit/lib/live/publish.ts
@@ -49,15 +49,13 @@ export function publishTestRunWakeUp(payload: TestRunWakeUp): void {
   // Defer past the surrounding tx commit boundary so consumers' refetches
   // observe the committed write.
   setImmediate(() => {
-    valkeyConnection
-      ?.publish(channel, body)
-      .catch((err: unknown) =>
-        console.warn(`[live/publish] testRun wake-up failed`, {
-          channel,
-          event: payload.event,
-          runId: payload.runId,
-          error: err instanceof Error ? err.message : String(err),
-        })
-      );
+    valkeyConnection?.publish(channel, body).catch((err: unknown) =>
+      console.warn(`[live/publish] testRun wake-up failed`, {
+        channel,
+        event: payload.event,
+        runId: payload.runId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
   });
 }

--- a/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
@@ -8,6 +8,7 @@ import {
   redactValues,
   type ParameterSchemaEntry,
 } from "~/lib/services/parameterRedaction";
+import { publishTestRunWakeUp } from "~/lib/live/publish";
 import { webhookEvents } from "~/lib/webhooks/events";
 
 /**
@@ -214,6 +215,10 @@ export async function emitTestRunUpdateEvents(
         actorUserId: opts.actorUserId,
       }
     );
+    publishTestRunWakeUp({
+      event: "test_run.state_changed",
+      runId: newRow.id,
+    });
   }
 
   if (completedTransition) {
@@ -258,6 +263,10 @@ export async function emitTestRunUpdateEvents(
         actorUserId: opts.actorUserId,
       }
     );
+    publishTestRunWakeUp({
+      event: "test_run.completed",
+      runId: newRow.id,
+    });
   }
 }
 
@@ -386,6 +395,11 @@ export async function emitTestRunResultAdded(
       actorUserId: opts.actorUserId,
     }
   );
+  publishTestRunWakeUp({
+    event: "test_run.result_added",
+    runId: run.id,
+    targetId: row.testRunCaseId,
+  });
 }
 
 export async function emitTestRunDuplicated(


### PR DESCRIPTION
## Description

Replaces the 30-second polling on test run pages with **SSE-driven live updates**, so test execution dashboards refresh the moment a peer records a result, the workflow state transitions, or the run is marked complete. Built on the proven `/api/notifications/stream` pattern (per-tenant Valkey pub/sub channels, gated heartbeat, message-relay-then-refetch security model).

Scoped as an **enhancement** — small surface area, one new SSE route + a thin client hook + three publisher hooks alongside the existing webhook emit seam. Patch-bump grade, not a minor.

### Wire-up

- **`lib/live/channels.ts`** — `testRunChannel(tenantId, runId)` is the only module permitted to construct channel keys for live test-run streams. Tenant-scoped, run-scoped, boundary-validated.
- **`lib/live/publish.ts`** — `publishTestRunWakeUp(...)` is a best-effort `setImmediate`-deferred publisher that fires AFTER the surrounding `prisma.$transaction` commits, so consumers' refetches observe committed writes.
- **`lib/webhooks/event-emitters/testRunEvents.ts`** — three publish hooks alongside the existing `webhookEvents.emit()` seam for `state_changed`, `completed`, and `result_added`. Webhook subscribers see the same rich payload they always did; SSE subscribers get a minimal `{event, runId, targetId?}` wake-up.
- **`/api/test-runs/[testRunId]/stream/route.ts`** — the SSE endpoint. Session auth + project-access gate via the enhanced ZenStack client (404 on miss so we don't reveal whether the run exists), 25s gated heartbeat, sync checkpoint, graceful shutdown.
- **`hooks/useTestRunLiveStream.ts` + integrations** — One EventSource per `(runId, mount)`. Wired into `TestRunCasesSummary.tsx` (replacing the 30s `refetchInterval`) and the run detail page (`page.tsx`), where the SSE wake-up calls `refetchTestRun()` to refresh per-case status badges live.

### What's NOT changed

- Outbound webhooks fire exactly as before — same emitters, same payloads, same subscription model
- Multi-config aggregate summary skips its own EventSource (each per-run summary opens one)
- Pre-fetched SSR snapshots skip the SSE stream (data is already fresh)
- Completed runs disable the live stream — no point holding a connection open on a historical run

### Architectural choices

- **Per-surface route** instead of a topic-multiplexed stream. If a second SSE surface shows up (sessions live status, dashboard tiles), that's when a multiplex helper earns its keep.
- **Pub/sub layer is untrusted plumbing** (mirrors Architectural Directive 2 from the notifications stream). Consumers refetch through the existing REST surface on every wake-up; auth is enforced at the data fetch, not at the relay.
- **Wake-up only carries `{event, runId, targetId?}`** — no payload data. Lets the client decide which React Query keys to invalidate without trusting the wake-up's contents.

## Type of Change

- [ ] Bug fix
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement (replaces 30s polling with push)
- [x] Enhancement — small, targeted improvement; scoped as a patch bump

## How Has This Been Tested?

- [x] Unit tests — 37 new tests across `lib/live/channels.test.ts` (4), `lib/live/publish.test.ts` (5), `app/api/test-runs/[testRunId]/stream/route.test.ts` (8), `hooks/useTestRunLiveStream.test.tsx` (7), plus the existing `testRunEvents.test.ts` (13) still passing after the publish-hook additions
- [x] Full test suite — **8195 / 8309** passing (16 skipped, 1 known 2FA crypto-IV flake same as previous PRs)
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing — connected an `EventSource("/api/test-runs/7/stream")` against the live dev server and confirmed the `{"event":"sync"}` checkpoint returns on first read

**Test Configuration:**
- OS: macOS 15 (Darwin)
- Browser: Chrome via Playwright
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (the 69 pre-existing `tsc` errors on `main` are Zod 4 / react-hook-form compatibility issues from #374-#376; my code is type-clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots

(SSE wiring — no screenshots. The wake-up wire shape and gates are unit-test enforced.)

## Additional Notes

Supersedes #377 (closed) — same code, single `enhancement(live)` commit so release-please scopes this as a patch bump, not a minor.
