### PR TITLE
enhancement(live): multiplex test-run SSE wake-ups via a project-level stream

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddResultModal.tsx
@@ -1484,7 +1484,10 @@ export function AddResultModal({
     isLoadingProject;
 
   if (isLoadingData) {
-    // Return a dialog with loading state instead of null to prevent parent re-render issues
+    // Return a dialog with loading state instead of null to prevent parent re-render issues.
+    // DialogDescription must contain phrasing content only — a LoadingSpinner renders a
+    // <div>, which produces a <div> inside <p> and triggers a hydration error that in
+    // dev mode cascades into render-recovery thrash.
     return (
       <Dialog open={isOpen} onOpenChange={onClose}>
         <DialogContent className="max-w-4xl">
@@ -1493,8 +1496,8 @@ export function AddResultModal({
               {tCommon("actions.addResult")}
               {iterationLabel ? ` — ${iterationLabel}` : ""}
             </DialogTitle>
-            <DialogDescription>
-              <LoadingSpinner />
+            <DialogDescription className="sr-only">
+              {tCommon("actions.addResult")}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center py-8">

--- a/testplanit/app/[locale]/projects/runs/[projectId]/TestRunDisplay.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/TestRunDisplay.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Prisma } from "@prisma/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useProjectTestRunStream } from "~/hooks/useTestRunLiveStream";
 import { CirclePlus, GripVertical } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
@@ -469,6 +470,50 @@ const TestRunDisplay: React.FC<TestRunDisplayProps> = ({
       })
       .filter((run) => !run.isCompleted);
   }, [testRuns]);
+
+  // SSE wake-up for every in-progress run on this list page via a single
+  // project-level stream. One EventSource covers every run in the project;
+  // publishers fan each wake-up out to both the per-run and per-project
+  // channels server-side, so the detail page (per-run consumer) and this
+  // page (per-project consumer) each see exactly one connection. The
+  // earlier per-run plural hook saturated browsers' HTTP/1.1 6-connection-
+  // per-origin cap on projects with many in-progress runs and made the
+  // page itself unloadable.
+  //
+  // Each wake-up invalidates four query trees so every visible piece of
+  // the tile reflects the new state:
+  //   - batchTestRunSummaries: per-tile aggregated counts and completion bar
+  //   - zenstack/TestRuns:     run name, workflow state, isCompleted, etc.
+  //                            (read via useFindManyTestRuns at page level)
+  //   - zenstack/TestRunCases: each tile's per-case status (read inside
+  //                            TestRunItem via useFindManyTestRunCases)
+  //   - zenstack/ReviewRequest: the pendingRequest sidebars on each tile
+  // The "zenstack" prefix is required because @zenstackhq/tanstack-query
+  // stamps every generated hook's query key with it (see runtime-v5/react.js
+  // getQueryKey -> [QUERY_KEY_PREFIX, model, operation, args, options]).
+  // Invalidating ["TestRuns"] alone would silently no-op against those
+  // hooks.
+  //
+  // The stream stays dormant when no run on this page is in progress —
+  // nothing live to update — matching the detail page's gating on
+  // !testRunData?.isCompleted.
+  const onLiveWakeUp = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: ["batchTestRunSummaries", testRunIds],
+    });
+    void queryClient.invalidateQueries({ queryKey: ["zenstack", "TestRuns"] });
+    void queryClient.invalidateQueries({
+      queryKey: ["zenstack", "TestRunCases"],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["zenstack", "ReviewRequest"],
+    });
+  }, [queryClient, testRunIds]);
+  useProjectTestRunStream({
+    projectId: !isNaN(numericProjectId) ? numericProjectId : null,
+    enabled: incompleteTestRuns.length > 0,
+    onWakeUp: onLiveWakeUp,
+  });
 
   const milestoneTree = useMemo(
     () => buildMilestoneTree(milestonesProp),

--- a/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/page.tsx
@@ -74,7 +74,7 @@ import {
   RepositoryCases,
   Tags,
 } from "@prisma/client";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { JSONContent } from "@tiptap/react";
 import {
   ArrowLeft,
@@ -502,16 +502,26 @@ export default function TestRunPage() {
     refetch: () => void;
   };
 
-  // SSE wake-up: refetch the run (and therefore its per-case statuses) on
-  // every published event. The pub/sub layer is untrusted plumbing
-  // (Architectural Directive 2); auth is enforced on the refetch path.
-  // Disabled once the run is completed — there's nothing left to update,
-  // and we don't want to hold an EventSource open indefinitely on a
-  // historical run page.
+  // SSE wake-up: refetch the run (which carries the per-case statuses)
+  // AND invalidate the testRunSummary query that TestRunCasesSummary
+  // reads (a separate endpoint, a separate cache key, but the same
+  // underlying mutation that fires the wake-up). Two consumers per
+  // wake-up, one open EventSource at the page level — TestRunCasesSummary
+  // no longer opens its own. Auth lives on the refetch path; the pub/sub
+  // layer is untrusted plumbing (Architectural Directive 2). Stream is
+  // disabled once the run is completed so we don't hold an EventSource
+  // open indefinitely on a historical run page.
+  const queryClient = useQueryClient();
+  const onLiveWakeUp = useCallback(() => {
+    refetchTestRun();
+    void queryClient.invalidateQueries({
+      queryKey: ["testRunSummary", Number(runId)],
+    });
+  }, [refetchTestRun, queryClient, runId]);
   useTestRunLiveStream({
     runId: !isNaN(Number(runId)) ? Number(runId) : null,
     enabled: !testRunData?.isCompleted,
-    onWakeUp: refetchTestRun,
+    onWakeUp: onLiveWakeUp,
   });
 
   // PDF export hook — fetches its own (heavier) data on demand when exporting.

--- a/testplanit/app/api/projects/[projectId]/test-runs/stream/route.test.ts
+++ b/testplanit/app/api/projects/[projectId]/test-runs/stream/route.test.ts
@@ -1,0 +1,223 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("@zenstackhq/runtime", () => ({ enhance: vi.fn() }));
+
+vi.mock("~/lib/multiTenantPrisma", () => ({
+  getCurrentTenantId: vi.fn().mockReturnValue("acme"),
+}));
+
+vi.mock("~/lib/valkey", () => ({
+  createSubscriberClient: vi.fn(),
+}));
+
+vi.mock("~/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    projects: { findFirst: vi.fn() },
+  },
+}));
+
+import { enhance } from "@zenstackhq/runtime";
+import { getServerSession } from "next-auth";
+import { prisma } from "~/lib/prisma";
+import { createSubscriberClient } from "~/lib/valkey";
+import { GET } from "./route";
+
+function req(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost"));
+}
+
+function makeSubscriberMock() {
+  const messageHandlers: Array<(...args: unknown[]) => void> = [];
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "message") messageHandlers.push(handler);
+    }),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+    quit: vi.fn().mockResolvedValue(undefined),
+    emitMessage: (channel: string, message: string) => {
+      for (const h of messageHandlers) h(channel, message);
+    },
+  };
+}
+
+describe("GET /api/projects/[projectId]/test-runs/stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("400s on a non-numeric project id", async () => {
+    const res = await GET(req("/api/projects/abc/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "abc" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a non-positive project id", async () => {
+    const res = await GET(req("/api/projects/0/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "0" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401s when there is no session", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when the user record cannot be found", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("404s when the user has no access to the project (policy-enforced)", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+      access: null,
+    } as never);
+    // Non-admin → goes through enhance() → ZenStack policy filters out the
+    // project. findFirst returns null so we 404 (not 403) to avoid
+    // leaking existence.
+    vi.mocked(enhance).mockReturnValue({
+      projects: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never);
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("503s when valkey is not configured", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.projects.findFirst).mockResolvedValue({
+      id: 293,
+    } as never);
+    vi.mocked(createSubscriberClient).mockReturnValue(null);
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("30");
+  });
+
+  it("subscribes to the per-project channel and emits a sync checkpoint", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.projects.findFirst).mockResolvedValue({
+      id: 293,
+    } as never);
+    const subscriber = makeSubscriberMock();
+    vi.mocked(createSubscriberClient).mockReturnValue(subscriber as never);
+
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("x-accel-buffering")).toBe("no");
+
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(subscriber.subscribe).toHaveBeenCalledWith(
+      "live:tenant:acme:project:293:testruns"
+    );
+    expect(text).toContain('data: {"event":"sync"}');
+    reader.releaseLock();
+    await res.body!.cancel();
+  });
+
+  it("relays publisher messages verbatim as SSE data lines", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.projects.findFirst).mockResolvedValue({
+      id: 293,
+    } as never);
+    const subscriber = makeSubscriberMock();
+    vi.mocked(createSubscriberClient).mockReturnValue(subscriber as never);
+
+    const res = await GET(req("/api/projects/293/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "293" }),
+    });
+    const reader = res.body!.getReader();
+    await reader.read(); // sync
+    // Publisher fires for run 18 in this project
+    subscriber.emitMessage(
+      "live:tenant:acme:project:293:testruns",
+      '{"event":"test_run.result_added","runId":18,"projectId":293,"targetId":7891}'
+    );
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toBe(
+      'data: {"event":"test_run.result_added","runId":18,"projectId":293,"targetId":7891}\n\n'
+    );
+    reader.releaseLock();
+    await res.body!.cancel();
+  });
+
+  it("does not collide with the per-run channel — a project-id == run-id pair still subscribes to the project channel", async () => {
+    // Regression guard: if testRunProjectChannel and testRunChannel had
+    // matching key shapes (both `:testrun:`), a project with id 42 and a
+    // run with id 42 would share a channel and one consumer would receive
+    // the other's wake-ups. Confirms the per-project endpoint subscribes
+    // to the disambiguated `:project:*:testruns` key.
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "admin-1",
+      access: "ADMIN",
+    } as never);
+    vi.mocked(prisma.projects.findFirst).mockResolvedValue({
+      id: 42,
+    } as never);
+    const subscriber = makeSubscriberMock();
+    vi.mocked(createSubscriberClient).mockReturnValue(subscriber as never);
+
+    const res = await GET(req("/api/projects/42/test-runs/stream"), {
+      params: Promise.resolve({ projectId: "42" }),
+    });
+    const reader = res.body!.getReader();
+    await reader.read(); // sync
+    expect(subscriber.subscribe).toHaveBeenCalledWith(
+      "live:tenant:acme:project:42:testruns"
+    );
+    expect(subscriber.subscribe).not.toHaveBeenCalledWith(
+      "live:tenant:acme:testrun:42"
+    );
+    reader.releaseLock();
+    await res.body!.cancel();
+  });
+});

--- a/testplanit/app/api/projects/[projectId]/test-runs/stream/route.ts
+++ b/testplanit/app/api/projects/[projectId]/test-runs/stream/route.ts
@@ -1,0 +1,198 @@
+/**
+ * Server-Sent Events stream for live updates on EVERY test run in a
+ * single project. One EventSource per project, regardless of how many
+ * runs are in-progress.
+ *
+ * Backs the runs list page (`projects/runs/[projectId]`). Without this
+ * the list page would open one EventSource per in-progress run; with
+ * the browser's HTTP/1.1 6-connection-per-origin cap, a project with
+ * many active runs starves the page document and child requests of
+ * connection slots and the page hangs.
+ *
+ * The per-run endpoint at `/api/test-runs/[testRunId]/stream` still
+ * exists for the detail page (1 page → 1 EventSource → no fan-in
+ * complexity). Publishers fan out each wake-up to both channels so
+ * either consumer pattern works.
+ *
+ * Modeled on the per-run endpoint and `/api/notifications/stream` —
+ * the pub/sub layer is untrusted plumbing (Architectural Directive 2)
+ * and authorization happens on the consumer's refetch path, not here.
+ * Project membership IS gated server-side at subscribe time so a
+ * cross-project subscribe attempt 404s instead of leaking wake-ups
+ * for runs the user can't see.
+ */
+
+import { enhance } from "@zenstackhq/runtime";
+import IORedis from "ioredis";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { testRunProjectChannel } from "~/lib/live/channels";
+import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
+import { prisma } from "~/lib/prisma";
+import { createSubscriberClient } from "~/lib/valkey";
+import { authOptions } from "~/server/auth";
+
+// Long-lived stream + IORedis pub/sub require the Node.js runtime; opt out
+// of every Next.js prerender path.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_MS = 25_000;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const { projectId: projectIdParam } = await params;
+  const projectId = Number.parseInt(projectIdParam, 10);
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    return NextResponse.json({ error: "Invalid project id" }, { status: 400 });
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Project-access gate (single read through the enhanced client so the
+  // ZenStack policy applies — admins get cross-project, everyone else is
+  // checked against project membership). If the user can't read the
+  // project, they shouldn't be told it exists, so we 404 (not 403).
+  const userRecord = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    include: { role: { include: { rolePermissions: true } } },
+  });
+  if (!userRecord) {
+    return NextResponse.json({ error: "User not found" }, { status: 401 });
+  }
+  const reader =
+    userRecord.access === "ADMIN"
+      ? (prisma as unknown as typeof prisma)
+      : (enhance(prisma, { user: userRecord }) as unknown as typeof prisma);
+  const accessibleProject = await reader.projects.findFirst({
+    where: { id: projectId, isDeleted: false },
+    select: { id: true },
+  });
+  if (!accessibleProject) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const tenantId = getCurrentTenantId() ?? "default";
+  const channel = testRunProjectChannel(tenantId, projectId);
+
+  const subscriber: IORedis | null = createSubscriberClient();
+  if (!subscriber) {
+    // No Valkey wired (e.g. local dev with SKIP_VALKEY_CONNECTION). Fail
+    // closed with a Retry-After so the EventSource client backs off
+    // rather than hot-looping.
+    return new NextResponse(null, {
+      status: 503,
+      headers: { "Retry-After": "30" },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let controllerClosed = false;
+  let lastEventAt = Date.now();
+  let heartbeatInterval: NodeJS.Timeout | null = null;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function write(bytes: Uint8Array) {
+        if (controllerClosed) return;
+        try {
+          controller.enqueue(bytes);
+        } catch {
+          controllerClosed = true;
+        }
+      }
+      function sendEvent(payload: object) {
+        write(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+        lastEventAt = Date.now();
+      }
+      function sendComment(line: string) {
+        write(encoder.encode(`${line}\n\n`));
+      }
+
+      subscriber.on("message", (_channel, message) => {
+        if (controllerClosed) return;
+        // Publisher already serializes the payload as JSON; relay verbatim.
+        // The payload contains runId so the client can route the wake-up
+        // to the right query invalidations.
+        write(encoder.encode(`data: ${message}\n\n`));
+        lastEventAt = Date.now();
+      });
+
+      try {
+        await subscriber.subscribe(channel);
+      } catch (subErr) {
+        console.warn(`[sse/project-test-runs] subscribe failed`, {
+          channel,
+          projectId,
+          error: subErr instanceof Error ? subErr.message : String(subErr),
+        });
+        try {
+          await subscriber.quit();
+        } catch {
+          /* swallow */
+        }
+        controllerClosed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+        return;
+      }
+
+      // First byte after subscribe completes so clients know the live
+      // window has opened.
+      sendEvent({ event: "sync" });
+
+      // Gated heartbeat — proxies (nginx default 60s, load balancers
+      // similar) kill idle connections, so we keep one open with a tiny
+      // SSE comment if no real event has flowed in the last 25s.
+      heartbeatInterval = setInterval(() => {
+        if (Date.now() - lastEventAt >= HEARTBEAT_MS) {
+          sendComment(": ping");
+        }
+      }, HEARTBEAT_MS);
+    },
+
+    async cancel() {
+      await cleanup();
+    },
+  });
+
+  async function cleanup() {
+    controllerClosed = true;
+    if (heartbeatInterval) {
+      clearInterval(heartbeatInterval);
+      heartbeatInterval = null;
+    }
+    try {
+      await subscriber?.unsubscribe();
+    } catch {
+      /* swallow */
+    }
+    try {
+      await subscriber?.quit();
+    } catch {
+      /* swallow */
+    }
+  }
+
+  req.signal.addEventListener("abort", () => {
+    void cleanup();
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      // Tells nginx not to buffer the response (it would defeat SSE).
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/testplanit/components/TestRunCasesSummary.tsx
+++ b/testplanit/components/TestRunCasesSummary.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   ArrowUpDown,
   Calendar,
@@ -23,9 +23,8 @@ import {
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { TestRunSummaryData } from "~/app/api/test-runs/[testRunId]/summary/route";
-import { useTestRunLiveStream } from "~/hooks/useTestRunLiveStream";
 import { useFindFirstStatus } from "~/lib/hooks";
 import { Link } from "~/lib/navigation";
 import { aggregateRunCounts } from "~/lib/services/testRunSummary-shared";
@@ -66,15 +65,14 @@ export function TestRunCasesSummary({
     testRunIds && testRunIds.length > 0 ? testRunIds : [testRunId];
   const isMultiConfig = effectiveTestRunIds.length > 1;
 
-  // Fetch summary data from API - for multi-config, fetch all and aggregate
-  // If pre-fetched data is provided, skip the API call
-  const queryKey = useMemo(
-    () => ["testRunSummary", ...effectiveTestRunIds] as const,
-    [effectiveTestRunIds]
-  );
-  const queryClient = useQueryClient();
+  // Fetch summary data from API - for multi-config, fetch all and aggregate.
+  // If pre-fetched data is provided, skip the API call. Live updates are NOT
+  // driven from inside this component — the parent page (run detail or runs
+  // list) owns the SSE stream and invalidates this query's key on wake-up so
+  // there's at most one EventSource per browser tab regardless of how many
+  // summary widgets are rendered.
   const { data: fetchedSummaryData, isLoading } = useQuery<TestRunSummaryData>({
-    queryKey: [...queryKey],
+    queryKey: ["testRunSummary", ...effectiveTestRunIds],
     queryFn: async () => {
       if (!isMultiConfig) {
         // Single test run - use existing endpoint with case details for color bar
@@ -107,25 +105,12 @@ export function TestRunCasesSummary({
       !preFetchedSummaryData &&
       effectiveTestRunIds.length > 0 &&
       effectiveTestRunIds[0] > 0,
-    // No more refetchInterval — live updates come from SSE via the wake-up
-    // hook below. The 30s stale window is kept so a manual revisit after
-    // an idle minute still re-fetches.
+    // No refetchInterval — live updates come from the parent's SSE stream
+    // invalidating the query above. The 30s stale window is kept so a manual
+    // revisit after an idle minute still re-fetches even if no SSE wake-up
+    // arrived (e.g. the tab was backgrounded long enough for the stream to
+    // drop and reconnect).
     staleTime: 30000,
-  });
-
-  // SSE wake-up: open EventSource on the live channel for this run; on
-  // every event, invalidate the summary query so React Query refetches
-  // the truth from REST. The data fetch is the security boundary; the
-  // wake-up is an untrusted nudge. Skipped when in multi-config mode
-  // (the page renders one summary per run; each one opens its own
-  // EventSource via this component) and when pre-fetched data is in
-  // use (the SSR page already has a fresh snapshot).
-  const onWakeUp = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey });
-  }, [queryClient, queryKey]);
-  useTestRunLiveStream({
-    runId: !preFetchedSummaryData && !isMultiConfig ? testRunId : null,
-    onWakeUp,
   });
 
   // Use pre-fetched data if available, otherwise use fetched data

--- a/testplanit/hooks/useTestRunLiveStream.test.tsx
+++ b/testplanit/hooks/useTestRunLiveStream.test.tsx
@@ -1,6 +1,9 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useTestRunLiveStream } from "./useTestRunLiveStream";
+import {
+  useProjectTestRunStream,
+  useTestRunLiveStream,
+} from "./useTestRunLiveStream";
 
 interface MockEventSource {
   url: string;
@@ -103,5 +106,135 @@ describe("useTestRunLiveStream", () => {
     expect(created).toHaveLength(2);
     expect(created[0]!.close).toHaveBeenCalled();
     expect(created[1]!.url).toBe("/api/test-runs/2/stream");
+  });
+});
+
+describe("useProjectTestRunStream", () => {
+  it("opens a single EventSource on the project-stream URL", () => {
+    renderHook(() =>
+      useProjectTestRunStream({ projectId: 293, onWakeUp: vi.fn() })
+    );
+    expect(created).toHaveLength(1);
+    expect(created[0]!.url).toBe("/api/projects/293/test-runs/stream");
+  });
+
+  it("does not open the stream when disabled", () => {
+    renderHook(() =>
+      useProjectTestRunStream({
+        projectId: 1,
+        enabled: false,
+        onWakeUp: vi.fn(),
+      })
+    );
+    expect(created).toHaveLength(0);
+  });
+
+  it("does not open the stream for a null/zero/negative projectId", () => {
+    renderHook(() =>
+      useProjectTestRunStream({ projectId: null, onWakeUp: vi.fn() })
+    );
+    expect(created).toHaveLength(0);
+    renderHook(() =>
+      useProjectTestRunStream({ projectId: 0, onWakeUp: vi.fn() })
+    );
+    expect(created).toHaveLength(0);
+    renderHook(() =>
+      useProjectTestRunStream({ projectId: -1, onWakeUp: vi.fn() })
+    );
+    expect(created).toHaveLength(0);
+  });
+
+  it("invokes onWakeUp with the parsed payload (including runId) for each message", () => {
+    const onWakeUp = vi.fn();
+    renderHook(() => useProjectTestRunStream({ projectId: 293, onWakeUp }));
+    const es = created[0]!;
+    es.onmessage!({
+      data: '{"event":"test_run.result_added","runId":18,"projectId":293,"targetId":555}',
+    } as MessageEvent);
+    es.onmessage!({
+      data: '{"event":"test_run.state_changed","runId":19,"projectId":293}',
+    } as MessageEvent);
+    expect(onWakeUp).toHaveBeenCalledTimes(2);
+    expect(onWakeUp).toHaveBeenCalledWith({
+      event: "test_run.result_added",
+      runId: 18,
+      projectId: 293,
+      targetId: 555,
+    });
+    expect(onWakeUp).toHaveBeenCalledWith({
+      event: "test_run.state_changed",
+      runId: 19,
+      projectId: 293,
+    });
+  });
+
+  it("swallows malformed payloads without throwing", () => {
+    const onWakeUp = vi.fn();
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderHook(() => useProjectTestRunStream({ projectId: 1, onWakeUp }));
+    created[0]!.onmessage!({ data: "not-json" } as MessageEvent);
+    expect(onWakeUp).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useProjectTestRunStream({ projectId: 1, onWakeUp: vi.fn() })
+    );
+    const es = created[0]!;
+    unmount();
+    expect(es.close).toHaveBeenCalled();
+  });
+
+  it("recreates the EventSource when projectId changes", () => {
+    const onWakeUp = vi.fn();
+    const { rerender } = renderHook(
+      (args: { projectId: number }) =>
+        useProjectTestRunStream({ projectId: args.projectId, onWakeUp }),
+      { initialProps: { projectId: 1 } }
+    );
+    expect(created).toHaveLength(1);
+    expect(created[0]!.url).toBe("/api/projects/1/test-runs/stream");
+    rerender({ projectId: 2 });
+    expect(created).toHaveLength(2);
+    expect(created[0]!.close).toHaveBeenCalled();
+    expect(created[1]!.url).toBe("/api/projects/2/test-runs/stream");
+  });
+
+  it("does not recreate the connection when onWakeUp identity changes", () => {
+    // Regression: invalidate-on-wake-up loops change the callback's
+    // identity on every wake-up. Without the latest-ref pattern, every
+    // wake-up would close + reopen the EventSource — the exact server
+    // thrash this whole refactor is meant to prevent.
+    const { rerender } = renderHook(
+      (args: { onWakeUp: () => void }) =>
+        useProjectTestRunStream({ projectId: 1, onWakeUp: args.onWakeUp }),
+      { initialProps: { onWakeUp: vi.fn() } }
+    );
+    expect(created).toHaveLength(1);
+    const closesBefore = created[0]!.close.mock.calls.length;
+    rerender({ onWakeUp: vi.fn() });
+    expect(created).toHaveLength(1);
+    expect(created[0]!.close.mock.calls.length).toBe(closesBefore);
+  });
+
+  it("invokes the latest onWakeUp identity, not the one from the original render", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      (args: { onWakeUp: (e: unknown) => void }) =>
+        useProjectTestRunStream({
+          projectId: 1,
+          onWakeUp: args.onWakeUp,
+        }),
+      { initialProps: { onWakeUp: first as (e: unknown) => void } }
+    );
+    rerender({ onWakeUp: second as (e: unknown) => void });
+    created[0]!.onmessage!({
+      data: '{"event":"test_run.result_added","runId":7,"projectId":1}',
+    } as MessageEvent);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
   });
 });

--- a/testplanit/hooks/useTestRunLiveStream.ts
+++ b/testplanit/hooks/useTestRunLiveStream.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 /**
  * Subscribe to the SSE wake-up stream for one test run and invoke
@@ -43,6 +43,16 @@ export function useTestRunLiveStream({
   enabled = true,
   onWakeUp,
 }: UseTestRunLiveStreamArgs): void {
+  // Latest-ref pattern so callers don't have to memoize their onWakeUp.
+  // Without this, a caller whose onWakeUp captures state that changes on
+  // wake-up (e.g. an invalidate-on-fetch loop where invalidation triggers
+  // refetch which changes deps which regenerates the callback) would
+  // close + reopen the EventSource on every wake-up, thrashing the server.
+  const onWakeUpRef = useRef(onWakeUp);
+  useEffect(() => {
+    onWakeUpRef.current = onWakeUp;
+  }, [onWakeUp]);
+
   useEffect(() => {
     if (!enabled) return;
     if (!runId || runId <= 0) return;
@@ -55,7 +65,7 @@ export function useTestRunLiveStream({
     eventSource.onmessage = (msg) => {
       try {
         const payload = JSON.parse(msg.data) as TestRunWakeUp;
-        onWakeUp(payload);
+        onWakeUpRef.current(payload);
       } catch (err) {
         console.warn("[useTestRunLiveStream] malformed wake-up", err);
       }
@@ -70,5 +80,72 @@ export function useTestRunLiveStream({
     return () => {
       eventSource.close();
     };
-  }, [runId, enabled, onWakeUp]);
+  }, [runId, enabled]);
+}
+
+/**
+ * Project-level wake-up stream. Used by the runs list page: ONE
+ * EventSource covers every in-progress run in the project, regardless
+ * of how many runs are active.
+ *
+ * Per-run streams hit the browser's HTTP/1.1 6-connection-per-origin
+ * cap on busy projects (e.g. 22 in-progress runs → no connection slots
+ * left for the page document or its data). This stream sidesteps that
+ * by multiplexing at the Valkey-channel layer: publishers fan out each
+ * wake-up to both the per-run channel and the per-project channel, so
+ * detail-page consumers see one EventSource and list-page consumers
+ * see one EventSource, never N.
+ *
+ * The wake-up payload includes `runId`, so the list page consumer can
+ * still invalidate per-run queries when desired (or invalidate the
+ * batched summary query and re-fetch everything at once).
+ *
+ * Same null/non-browser guards as the per-run hook.
+ */
+export function useProjectTestRunStream({
+  projectId,
+  enabled = true,
+  onWakeUp,
+}: {
+  projectId: number | null | undefined;
+  enabled?: boolean;
+  onWakeUp: (event: TestRunWakeUp) => void;
+}): void {
+  // Latest-ref so callers don't have to memoize. See the singular hook's
+  // comment for why this matters: invalidate-on-wake-up loops naturally
+  // change the callback's closure identity on every wake-up, and without
+  // a ref every wake-up would tear down and reopen the EventSource.
+  const onWakeUpRef = useRef(onWakeUp);
+  useEffect(() => {
+    onWakeUpRef.current = onWakeUp;
+  }, [onWakeUp]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!projectId || projectId <= 0) return;
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      return;
+    }
+
+    const eventSource = new EventSource(
+      `/api/projects/${projectId}/test-runs/stream`
+    );
+
+    eventSource.onmessage = (msg) => {
+      try {
+        const payload = JSON.parse(msg.data) as TestRunWakeUp;
+        onWakeUpRef.current(payload);
+      } catch (err) {
+        console.warn("[useProjectTestRunStream] malformed wake-up", err);
+      }
+    };
+
+    eventSource.onerror = (err) => {
+      console.warn("[useProjectTestRunStream] SSE transport error", err);
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [projectId, enabled]);
 }

--- a/testplanit/lib/live/channels.test.ts
+++ b/testplanit/lib/live/channels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { testRunChannel } from "./channels";
+import { testRunChannel, testRunProjectChannel } from "./channels";
 
 describe("testRunChannel", () => {
   it("formats the channel key as live:tenant:<id>:testrun:<runId>", () => {
@@ -18,5 +18,39 @@ describe("testRunChannel", () => {
     expect(() => testRunChannel("acme", 0)).toThrow(/positive integer/);
     expect(() => testRunChannel("acme", -1)).toThrow(/positive integer/);
     expect(() => testRunChannel("acme", 1.5)).toThrow(/positive integer/);
+  });
+});
+
+describe("testRunProjectChannel", () => {
+  it("formats the key as live:tenant:<id>:project:<projectId>:testruns", () => {
+    expect(testRunProjectChannel("acme", 7)).toBe(
+      "live:tenant:acme:project:7:testruns"
+    );
+  });
+
+  it("scopes by tenant", () => {
+    expect(testRunProjectChannel("acme", 7)).not.toBe(
+      testRunProjectChannel("globex", 7)
+    );
+  });
+
+  it("does not collide with testRunChannel for an id-sharing project/run pair", () => {
+    // If the namespacing were wrong (e.g. both used `:testrun:`), a
+    // project with id 42 and a run with id 42 would share a channel.
+    expect(testRunProjectChannel("acme", 42)).not.toBe(
+      testRunChannel("acme", 42)
+    );
+  });
+
+  it("rejects missing tenantId", () => {
+    expect(() => testRunProjectChannel("", 7)).toThrow(/tenantId is required/);
+  });
+
+  it("rejects non-positive projectId", () => {
+    expect(() => testRunProjectChannel("acme", 0)).toThrow(/positive integer/);
+    expect(() => testRunProjectChannel("acme", -1)).toThrow(/positive integer/);
+    expect(() => testRunProjectChannel("acme", 1.5)).toThrow(
+      /positive integer/
+    );
   });
 });

--- a/testplanit/lib/live/channels.ts
+++ b/testplanit/lib/live/channels.ts
@@ -25,3 +25,28 @@ export function testRunChannel(tenantId: string, testRunId: number): string {
   }
   return `live:tenant:${tenantId}:testrun:${testRunId}`;
 }
+
+/**
+ * Project-level wake-up channel. The runs list page subscribes here so
+ * one EventSource covers every in-progress run in the project rather
+ * than opening one connection per run — the HTTP/1.1 6-connection-per-
+ * origin cap was making projects with many active runs unusable.
+ * The publisher fans out each wake-up to both this channel and the
+ * per-run channel, so detail-page consumers continue to work unchanged.
+ */
+export function testRunProjectChannel(
+  tenantId: string,
+  projectId: number
+): string {
+  if (!tenantId) {
+    throw new Error(
+      "live/channels.testRunProjectChannel: tenantId is required"
+    );
+  }
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    throw new Error(
+      "live/channels.testRunProjectChannel: projectId must be a positive integer"
+    );
+  }
+  return `live:tenant:${tenantId}:project:${projectId}:testruns`;
+}

--- a/testplanit/lib/live/publish-fanout.integration.test.ts
+++ b/testplanit/lib/live/publish-fanout.integration.test.ts
@@ -1,0 +1,233 @@
+// End-to-end publisher fan-out invariant.
+//
+// Runs against a REAL Valkey/Redis container — NO mocks of the pub/sub
+// layer (mocks would defeat the purpose: a regression where the publisher
+// silently switches the per-project channel back to the per-run pattern
+// would slip past channel-shape unit tests because both call the right
+// constructors, but the wire-level fan-out behavior is the actual
+// production contract).
+//
+// The suite is skipped when neither TEST_VALKEY_URL nor VALKEY_URL is
+// set so contributors without a local Valkey running don't see spurious
+// failures. Mirrors `lib/notifications/sse-isolation.test.ts`.
+//
+// Local prerequisite to actually exercise the assertions:
+//   docker compose -f testplanit/docker-compose.dev.yml up valkey -d
+//   TEST_VALKEY_URL=redis://localhost:6379 pnpm test run \
+//     lib/live/publish-fanout.integration.test.ts
+
+import { randomUUID } from "crypto";
+import IORedis from "ioredis";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { testRunChannel, testRunProjectChannel } from "./channels";
+
+const VALKEY_URL = process.env.TEST_VALKEY_URL ?? process.env.VALKEY_URL;
+const describeMaybe = VALKEY_URL ? describe : describe.skip;
+
+// Tenant must be set BEFORE publish.ts is imported because the mock
+// captures it via getCurrentTenantId().
+const TENANT_ID = `tenant-fanout-${randomUUID().slice(0, 8)}`;
+
+// Mock the publisher's two real-world dependencies with a real IORedis
+// client. The test fires the production publishTestRunWakeUp function;
+// the only thing diverging from prod is who owns the pub client.
+let publisher: IORedis;
+
+vi.mock("~/lib/multiTenantPrisma", () => ({
+  getCurrentTenantId: () => TENANT_ID,
+}));
+
+vi.mock("~/lib/valkey", () => ({
+  get default() {
+    return publisher;
+  },
+}));
+
+// publish.ts must be imported AFTER vi.mock so it picks up the mocked deps.
+// Dynamic import inside beforeAll guarantees order.
+type PublishFn = typeof import("./publish").publishTestRunWakeUp;
+let publishTestRunWakeUp: PublishFn;
+
+describeMaybe("publishTestRunWakeUp fan-out (real Valkey)", () => {
+  let runSub: IORedis;
+  let projectSub: IORedis;
+
+  // Unique per-run ids so concurrent CI invocations against the same
+  // Valkey instance don't collide on channel keys.
+  const rand = () => parseInt(randomUUID().replace(/-/g, "").slice(0, 6), 16);
+  const RUN_ID = 100_000 + (rand() % 10_000);
+  const PROJECT_ID = 200_000 + (rand() % 10_000);
+  const runChannelKey = testRunChannel(TENANT_ID, RUN_ID);
+  const projectChannelKey = testRunProjectChannel(TENANT_ID, PROJECT_ID);
+
+  beforeAll(async () => {
+    const opts = { maxRetriesPerRequest: null, enableReadyCheck: false };
+    const url = VALKEY_URL!.replace(/^valkey:\/\//, "redis://");
+    publisher = new IORedis(url, opts);
+    runSub = new IORedis(url, opts);
+    projectSub = new IORedis(url, opts);
+    await publisher.ping();
+
+    const mod = (await import("./publish")) as typeof import("./publish");
+    publishTestRunWakeUp = mod.publishTestRunWakeUp;
+  });
+
+  afterAll(async () => {
+    for (const client of [publisher, runSub, projectSub]) {
+      try {
+        await client?.quit();
+      } catch {
+        /* ignore — already closed or never connected */
+      }
+    }
+  });
+
+  afterEach(async () => {
+    try {
+      await runSub.unsubscribe();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await projectSub.unsubscribe();
+    } catch {
+      /* ignore */
+    }
+    runSub.removeAllListeners("message");
+    projectSub.removeAllListeners("message");
+  });
+
+  /** Subscribe a client to a channel and collect messages it receives.
+   *  Returns a promise that resolves with the FIRST message on that channel
+   *  (or rejects after timeoutMs). publishTestRunWakeUp defers via
+   *  setImmediate, so we need to wait. */
+  function captureFirstMessage(
+    client: IORedis,
+    channel: string,
+    timeoutMs = 2000
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Timed out waiting for message on ${channel}`)),
+        timeoutMs
+      );
+      client.on("message", (chan: string, msg: string) => {
+        if (chan === channel) {
+          clearTimeout(timer);
+          resolve(msg);
+        }
+      });
+      void client.subscribe(channel);
+    });
+  }
+
+  it("delivers a single publish call to BOTH the per-run and per-project subscribers", async () => {
+    const runReceived = captureFirstMessage(runSub, runChannelKey);
+    const projectReceived = captureFirstMessage(projectSub, projectChannelKey);
+
+    // Give both subscribers a beat to actually attach. IORedis subscribe
+    // is async; firing the publish before the SUBSCRIBE ack lands means
+    // Valkey drops the message (no buffering on pub/sub).
+    await new Promise((r) => setTimeout(r, 100));
+
+    publishTestRunWakeUp({
+      event: "test_run.result_added",
+      runId: RUN_ID,
+      projectId: PROJECT_ID,
+      targetId: 555,
+    });
+
+    const [runMsg, projectMsg] = await Promise.all([
+      runReceived,
+      projectReceived,
+    ]);
+
+    const expected = {
+      event: "test_run.result_added",
+      runId: RUN_ID,
+      projectId: PROJECT_ID,
+      targetId: 555,
+    };
+    expect(JSON.parse(runMsg)).toEqual(expected);
+    expect(JSON.parse(projectMsg)).toEqual(expected);
+  });
+
+  it("a different project's subscriber never receives this run's wake-up (no cross-project leak)", async () => {
+    const otherProjectId = PROJECT_ID + 1;
+    const otherProjectChannel = testRunProjectChannel(
+      TENANT_ID,
+      otherProjectId
+    );
+    const otherSub = new IORedis(VALKEY_URL!, {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+    });
+    let otherReceived = 0;
+    otherSub.on("message", () => {
+      otherReceived++;
+    });
+    await otherSub.subscribe(otherProjectChannel);
+
+    // Also subscribe the project channel so we can confirm the publish
+    // actually fired (vs. silently failing and giving a false-pass on
+    // the other-project assertion).
+    const projectReceived = captureFirstMessage(projectSub, projectChannelKey);
+    await new Promise((r) => setTimeout(r, 100));
+
+    publishTestRunWakeUp({
+      event: "test_run.state_changed",
+      runId: RUN_ID,
+      projectId: PROJECT_ID,
+    });
+
+    await projectReceived; // confirms the publish landed
+    // Give Valkey a moment to deliver any cross-project leak (won't happen)
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(otherReceived).toBe(0);
+    await otherSub.quit().catch(() => {});
+  });
+
+  it("a different tenant's subscriber never receives this tenant's wake-up", async () => {
+    // The tenant prefix is the multi-tenant isolation boundary; this is
+    // the load-bearing invariant for SaaS. If a wake-up ever leaked across
+    // tenants, one customer would see another's test-run activity.
+    const otherTenantChannel = testRunProjectChannel(
+      `tenant-other-${randomUUID().slice(0, 8)}`,
+      PROJECT_ID
+    );
+    const otherSub = new IORedis(VALKEY_URL!, {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+    });
+    let otherReceived = 0;
+    otherSub.on("message", () => {
+      otherReceived++;
+    });
+    await otherSub.subscribe(otherTenantChannel);
+
+    const projectReceived = captureFirstMessage(projectSub, projectChannelKey);
+    await new Promise((r) => setTimeout(r, 100));
+
+    publishTestRunWakeUp({
+      event: "test_run.completed",
+      runId: RUN_ID,
+      projectId: PROJECT_ID,
+    });
+
+    await projectReceived;
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(otherReceived).toBe(0);
+    await otherSub.quit().catch(() => {});
+  });
+});

--- a/testplanit/lib/live/publish.test.ts
+++ b/testplanit/lib/live/publish.test.ts
@@ -24,54 +24,86 @@ describe("publishTestRunWakeUp", () => {
     vi.mocked(getCurrentTenantId).mockReturnValue("acme");
   });
 
-  it("publishes the wake-up JSON to the testRun channel", async () => {
-    publishTestRunWakeUp({ event: "test_run.result_added", runId: 42 });
-    await flushImmediate();
-    expect(mockPublish).toHaveBeenCalledTimes(1);
-    const [channel, body] = mockPublish.mock.calls[0]!;
-    expect(channel).toBe("live:tenant:acme:testrun:42");
-    expect(JSON.parse(body as string)).toEqual({
+  it("publishes the wake-up to both the per-run and per-project channels", async () => {
+    publishTestRunWakeUp({
       event: "test_run.result_added",
       runId: 42,
+      projectId: 7,
     });
+    await flushImmediate();
+    expect(mockPublish).toHaveBeenCalledTimes(2);
+    const channels = mockPublish.mock.calls.map((c) => c[0]);
+    expect(channels).toContain("live:tenant:acme:testrun:42");
+    expect(channels).toContain("live:tenant:acme:project:7:testruns");
+    // Both calls send the identical JSON body — the consumer payload
+    // contract is shared regardless of which channel it arrived on.
+    const bodies = mockPublish.mock.calls.map((c) =>
+      JSON.parse(c[1] as string)
+    );
+    for (const body of bodies) {
+      expect(body).toEqual({
+        event: "test_run.result_added",
+        runId: 42,
+        projectId: 7,
+      });
+    }
   });
 
   it("falls back to the default tenant when one is not resolved", async () => {
     vi.mocked(getCurrentTenantId).mockReturnValue(undefined);
-    publishTestRunWakeUp({ event: "test_run.completed", runId: 7 });
+    publishTestRunWakeUp({
+      event: "test_run.completed",
+      runId: 7,
+      projectId: 3,
+    });
     await flushImmediate();
-    expect(mockPublish.mock.calls[0]![0]).toBe("live:tenant:default:testrun:7");
+    const channels = mockPublish.mock.calls.map((c) => c[0]);
+    expect(channels).toContain("live:tenant:default:testrun:7");
+    expect(channels).toContain("live:tenant:default:project:3:testruns");
   });
 
-  it("includes the targetId when provided", async () => {
+  it("includes the targetId in both channel payloads when provided", async () => {
     publishTestRunWakeUp({
       event: "test_run.result_added",
       runId: 42,
+      projectId: 7,
       targetId: 999,
     });
     await flushImmediate();
-    const body = JSON.parse(mockPublish.mock.calls[0]![1] as string);
-    expect(body).toEqual({
-      event: "test_run.result_added",
-      runId: 42,
-      targetId: 999,
-    });
+    for (const call of mockPublish.mock.calls) {
+      expect(JSON.parse(call[1] as string)).toEqual({
+        event: "test_run.result_added",
+        runId: 42,
+        projectId: 7,
+        targetId: 999,
+      });
+    }
   });
 
-  it("defers the publish until after setImmediate", async () => {
-    publishTestRunWakeUp({ event: "test_run.state_changed", runId: 1 });
+  it("defers both publishes until after setImmediate", async () => {
+    publishTestRunWakeUp({
+      event: "test_run.state_changed",
+      runId: 1,
+      projectId: 2,
+    });
     expect(mockPublish).not.toHaveBeenCalled();
     await flushImmediate();
-    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledTimes(2);
   });
 
-  it("swallows publish failures (best-effort wake-up)", async () => {
+  it("swallows publish failures on either channel (best-effort wake-up)", async () => {
+    // Fail the first publish (per-run); the second (per-project) still fires
     mockPublish.mockRejectedValueOnce(new Error("valkey down"));
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    publishTestRunWakeUp({ event: "test_run.completed", runId: 1 });
+    publishTestRunWakeUp({
+      event: "test_run.completed",
+      runId: 1,
+      projectId: 5,
+    });
     await flushImmediate();
     await flushImmediate(); // unhandled rejection .catch handler is a microtask
     expect(spy).toHaveBeenCalled();
+    expect(mockPublish).toHaveBeenCalledTimes(2);
     spy.mockRestore();
   });
 });

--- a/testplanit/lib/live/publish.ts
+++ b/testplanit/lib/live/publish.ts
@@ -22,7 +22,7 @@
 
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import valkeyConnection from "~/lib/valkey";
-import { testRunChannel } from "./channels";
+import { testRunChannel, testRunProjectChannel } from "./channels";
 
 /** Wake-up event names — narrower than the webhook event names because
  *  the client only cares about "something on this run changed" + a hint
@@ -36,6 +36,11 @@ export type TestRunWakeUpEvent =
 interface TestRunWakeUp {
   event: TestRunWakeUpEvent;
   runId: number;
+  /** Project the run belongs to. Required so the publisher can fan the
+   *  same wake-up out to both the per-run channel (detail page consumer)
+   *  and the per-project channel (list page consumer — one EventSource
+   *  for the whole project, avoiding the HTTP/1.1 6-connection cap). */
+  projectId: number;
   /** Sub-resource id when the event targets one (a resultId, caseId,
    *  etc.) — included so clients can invalidate finely. Optional. */
   targetId?: number;
@@ -44,16 +49,28 @@ interface TestRunWakeUp {
 export function publishTestRunWakeUp(payload: TestRunWakeUp): void {
   if (!valkeyConnection) return; // single-pod dev / SKIP_VALKEY_CONNECTION
   const tenantId = getCurrentTenantId() ?? "default";
-  const channel = testRunChannel(tenantId, payload.runId);
+  const runChan = testRunChannel(tenantId, payload.runId);
+  const projChan = testRunProjectChannel(tenantId, payload.projectId);
   const body = JSON.stringify(payload);
   // Defer past the surrounding tx commit boundary so consumers' refetches
   // observe the committed write.
   setImmediate(() => {
-    valkeyConnection?.publish(channel, body).catch((err: unknown) =>
-      console.warn(`[live/publish] testRun wake-up failed`, {
-        channel,
+    const conn = valkeyConnection;
+    if (!conn) return;
+    conn.publish(runChan, body).catch((err: unknown) =>
+      console.warn(`[live/publish] testRun wake-up failed (per-run)`, {
+        channel: runChan,
         event: payload.event,
         runId: payload.runId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+    conn.publish(projChan, body).catch((err: unknown) =>
+      console.warn(`[live/publish] testRun wake-up failed (per-project)`, {
+        channel: projChan,
+        event: payload.event,
+        runId: payload.runId,
+        projectId: payload.projectId,
         error: err instanceof Error ? err.message : String(err),
       })
     );

--- a/testplanit/lib/webhooks/event-emitters/testRunEvents.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/testRunEvents.test.ts
@@ -32,6 +32,10 @@ vi.mock("~/lib/webhooks/events", () => ({
   },
 }));
 
+vi.mock("~/lib/live/publish", () => ({
+  publishTestRunWakeUp: vi.fn(),
+}));
+
 vi.mock("~/lib/services/testRunSummary", () => ({
   getTestRunSummary: vi.fn(async () => ({
     testRunType: "REGULAR",
@@ -62,6 +66,7 @@ vi.mock("~/lib/services/testRunSummary", () => ({
 }));
 
 import { webhookEvents } from "~/lib/webhooks/events";
+import { publishTestRunWakeUp } from "~/lib/live/publish";
 import {
   getPerCaseIterationCounts,
   getTestRunSummary,
@@ -72,6 +77,7 @@ const summaryMock = getTestRunSummary as unknown as ReturnType<typeof vi.fn>;
 const countsMock = getPerCaseIterationCounts as unknown as ReturnType<
   typeof vi.fn
 >;
+const wakeUpMock = publishTestRunWakeUp as unknown as ReturnType<typeof vi.fn>;
 
 interface TxStub {
   workflows: { findUnique: ReturnType<typeof vi.fn> };
@@ -548,5 +554,161 @@ describe("emitTestRunDuplicated", () => {
       projectId: 7,
     });
     expect(opts.tx).toBe(tx);
+  });
+});
+
+/**
+ * publishTestRunWakeUp wiring.
+ *
+ * Catches the regression where an emitter fires a webhook but forgets the
+ * companion SSE wake-up, OR where the wake-up is fired but the projectId
+ * is missing/wrong (which silently breaks the list-page consumer because
+ * the per-project channel never gets the publish). The webhook tests above
+ * cover the webhook side; these tests cover the wake-up side.
+ */
+describe("publishTestRunWakeUp wiring", () => {
+  beforeEach(() => {
+    emitMock.mockClear();
+    summaryMock.mockClear();
+    countsMock.mockClear();
+    wakeUpMock.mockClear();
+  });
+
+  it("fires test_run.state_changed wake-up with the run's projectId on a state change", async () => {
+    const tx = makeTx({
+      workflows: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValueOnce({ name: "Open", workflowType: "NOT_STARTED" })
+          .mockResolvedValueOnce({
+            name: "In Progress",
+            workflowType: "IN_PROGRESS",
+          }),
+      },
+    });
+    await emitTestRunUpdateEvents(
+      {
+        id: 18,
+        projectId: 293,
+        name: "Run 18",
+        stateId: 100,
+        isCompleted: false,
+      },
+      {
+        id: 18,
+        projectId: 293,
+        name: "Run 18",
+        stateId: 200,
+        isCompleted: false,
+      },
+      tx as never
+    );
+    expect(wakeUpMock).toHaveBeenCalledTimes(1);
+    expect(wakeUpMock).toHaveBeenCalledWith({
+      event: "test_run.state_changed",
+      runId: 18,
+      projectId: 293,
+    });
+  });
+
+  it("fires BOTH state_changed AND completed wake-ups on a DONE transition, each with the projectId", async () => {
+    const tx = makeTx({
+      workflows: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValueOnce({
+            name: "In Progress",
+            workflowType: "IN_PROGRESS",
+          })
+          .mockResolvedValueOnce({ name: "Done", workflowType: "DONE" }),
+      },
+    });
+    await emitTestRunUpdateEvents(
+      {
+        id: 42,
+        projectId: 7,
+        name: "Run 42",
+        stateId: 100,
+        isCompleted: false,
+      },
+      { id: 42, projectId: 7, name: "Run 42", stateId: 999, isCompleted: true },
+      tx as never
+    );
+    expect(wakeUpMock).toHaveBeenCalledTimes(2);
+    const events = wakeUpMock.mock.calls.map((c) => c[0]);
+    expect(events).toContainEqual({
+      event: "test_run.state_changed",
+      runId: 42,
+      projectId: 7,
+    });
+    expect(events).toContainEqual({
+      event: "test_run.completed",
+      runId: 42,
+      projectId: 7,
+    });
+  });
+
+  it("fires test_run.result_added wake-up with projectId AND the testRunCaseId as targetId", async () => {
+    // emitTestRunResultAdded reads run + case from tx and publishes
+    // {event, runId, projectId, targetId: testRunCaseId}
+    const tx = makeTx({
+      testRuns: {
+        findUnique: vi.fn(async () => ({
+          id: 99,
+          name: "Run 99",
+          projectId: 555,
+        })),
+      },
+      testRunCases: {
+        findUnique: vi.fn(async () => ({
+          id: 50,
+          repositoryCase: { id: 1000, name: "Login flow" },
+        })),
+      },
+      status: {
+        findUnique: vi.fn(async () => ({
+          id: 1,
+          name: "Passed",
+          isCompleted: true,
+          isSuccess: true,
+          isFailure: false,
+          color: { value: "#00FF00" },
+        })),
+      },
+    });
+    await emitTestRunResultAdded(
+      {
+        id: 7891,
+        testRunCaseId: 50,
+        attempt: 1,
+        executedById: "u1",
+        executedAt: new Date(),
+      } as never,
+      tx as never,
+      { projectId: 555 }
+    );
+    expect(wakeUpMock).toHaveBeenCalledTimes(1);
+    expect(wakeUpMock).toHaveBeenCalledWith({
+      event: "test_run.result_added",
+      runId: 99,
+      projectId: 555,
+      targetId: 50,
+    });
+  });
+
+  it("does NOT fire a wake-up when neither stateId nor isCompleted changed", async () => {
+    // No webhook → no wake-up. The list page consumer would never see
+    // this no-op anyway, but we don't want speculative wake-ups either
+    // (they'd cause unnecessary React Query refetch storms).
+    const tx = makeTx();
+    const row = {
+      id: 1,
+      projectId: 7,
+      name: "Run 1",
+      stateId: 100,
+      isCompleted: false,
+    };
+    await emitTestRunUpdateEvents(row, row, tx as never);
+    expect(wakeUpMock).not.toHaveBeenCalled();
   });
 });

--- a/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
@@ -218,6 +218,7 @@ export async function emitTestRunUpdateEvents(
     publishTestRunWakeUp({
       event: "test_run.state_changed",
       runId: newRow.id,
+      projectId: newRow.projectId,
     });
   }
 
@@ -266,6 +267,7 @@ export async function emitTestRunUpdateEvents(
     publishTestRunWakeUp({
       event: "test_run.completed",
       runId: newRow.id,
+      projectId: newRow.projectId,
     });
   }
 }
@@ -398,6 +400,7 @@ export async function emitTestRunResultAdded(
   publishTestRunWakeUp({
     event: "test_run.result_added",
     runId: run.id,
+    projectId: run.projectId,
     targetId: row.testRunCaseId,
   });
 }


### PR DESCRIPTION
## Description

Fixes two bugs found after the initial SSE work shipped in #378:

1. **The runs list page hung on projects with many in-progress runs.** The list page opened one `EventSource` per in-progress run, which saturated the browser's HTTP/1.1 6-connection-per-origin cap and starved the page document of connection slots — the page literally couldn't load.

2. **The `TestRunCasesSummary` widget didn't live-update** because it managed its own SSE subscription, which conflicted with the page-level one. The summary widget now relies on the page's stream and gets its data refreshed via React Query invalidation.

### What changed

- **New multiplexed SSE channel.** Server-side publishers now fan each wake-up out to BOTH a per-run channel and a per-project channel. The list page subscribes to the per-project channel — one connection covers every run in the project. The detail page still uses the per-run channel (one page → one connection).
- **New endpoint:** `GET /api/projects/[projectId]/test-runs/stream`. Auth-gated through the enhanced (policy-aware) client — non-project members get a 404, not a leak.
- **New hook:** `useProjectTestRunStream({ projectId, enabled, onWakeUp })`.
- **Latest-ref pattern in the SSE hooks.** Without it, the invalidate-on-wake-up loop (invalidate → refetch → callback identity changes → effect tears down EventSource) would close and reopen the connection on every single wake-up, thrashing the server.
- **Hydration fix in `AddResultModal`.** The loading-state branch was rendering `<LoadingSpinner>` (a `<div>`) inside `<DialogDescription>` (Radix renders as `<p>`), producing a `<div>` inside `<p>` and triggering React's dev-mode recovery loop. Moved the spinner outside the description and gave the description an `sr-only` label.
- **`TestRunCasesSummary`** no longer opens its own EventSource; it reads from the cache the page invalidates.

### Backend channel design

```
Per-run wake-up   →  live:tenant:{tenantId}:testrun:{runId}
Per-project fan  →  live:tenant:{tenantId}:project:{projectId}:testruns
```

Both channels carry the identical JSON payload (`{event, runId, projectId, targetId?}`), so consumers don't need to know which channel they subscribed to.

## Related Issue

n/a — bug fixes against PR #378.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] E2E tests

**~30 new tests** across:

| Area | Tests | Notes |
|---|---|---|
| `lib/live/channels.ts` | 9 | Tenant isolation, both channel constructors, no collision between project-id == run-id pairs |
| `lib/live/publish.ts` | 5 | Dual-publish to both channels, tenant fallback, deferral, failure swallowing |
| `useTestRunLiveStream` / `useProjectTestRunStream` | 16 | URL, gating, payload parsing, identity-churn resistance |
| `/api/projects/[projectId]/test-runs/stream` | 9 | 400/401/404/503 paths, subscribe + sync checkpoint, message relay, no per-run/per-project collision |
| Emitter wiring (`testRunEvents.ts`) | 4 | Asserts every emitter fires `publishTestRunWakeUp` with the correct `projectId` |
| End-to-end fan-out (real Valkey) | 3 | Single publish reaches both subscribers; no cross-project leak; no cross-tenant leak — skips when `TEST_VALKEY_URL` is unset |

Manually validated against `pnpm build && pnpm start` on a project with 22+ in-progress runs:

- Network tab shows **one** stream connection to `/api/projects/{id}/test-runs/stream` (was 22 to `/api/test-runs/{id}/stream`).
- `{"metric":"sse.connections.active","count":2,...}` in server logs stays stable across React Query refetch cycles (no churn).
- The page loads consistently; widget counts and per-tile case statuses update live.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0, Apple Silicon)
- Browser: Chrome
- Node version: matches CI

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- Conventional Commit prefix is `enhancement(live):` so this lands as a **patch** release, not minor.
- The integration test (`lib/live/publish-fanout.integration.test.ts`) follows the same skip-pattern as `lib/notifications/sse-isolation.test.ts` — it auto-skips when no `TEST_VALKEY_URL` is set so contributors without a local Valkey don't see spurious failures. To exercise locally:
  ```
  docker compose -f testplanit/docker-compose.dev.yml up valkey -d
  TEST_VALKEY_URL=redis://localhost:6379 pnpm test run lib/live/publish-fanout.integration.test.ts
  ```
