### PR TITLE
enhancement(quickscript): Mobilewright templates + default-ON AI toggle + AI prompt syntax-example injection

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/QuickScriptModal.test.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/QuickScriptModal.test.tsx
@@ -434,6 +434,25 @@ describe("QuickScriptModal", () => {
     });
   });
 
+  it("defaults Generate with AI toggle to ON when AI is available", async () => {
+    // When the project has an LLM configured for QuickScript, the user
+    // shouldn't have to flip the toggle themselves on every open — the
+    // AI block is visible because availability is true, so the toggle
+    // should reflect "yes, ready to generate."
+    mockCheckAiExportAvailable.mockResolvedValue({
+      available: true,
+      hasCodeContext: true,
+    });
+
+    render(<QuickScriptModal {...defaultProps} />);
+
+    await waitFor(() => {
+      // The Switch mock renders as an <input type="checkbox" data-testid="ai-switch">.
+      const sw = screen.getByTestId("ai-switch") as HTMLInputElement;
+      expect(sw.checked).toBe(true);
+    });
+  });
+
   it("does not show AI toggle when AI is not available", async () => {
     // Default mock: available=false
     render(<QuickScriptModal {...defaultProps} />);

--- a/testplanit/app/[locale]/projects/repository/[projectId]/QuickScriptModal.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/QuickScriptModal.tsx
@@ -301,7 +301,12 @@ export function QuickScriptModal({
     });
   }, [filteredTemplates, defaultTemplate]);
 
-  // Check AI availability when modal opens (GEN-02)
+  // Check AI availability when modal opens (GEN-02). When the project
+  // has an LLM configured for QuickScript, default the Generate with AI
+  // toggle to ON — same posture as the dialog reset on close. Leaving
+  // it off when AI is wired up was a hidden affordance (the toggle
+  // section is visible but the user had to flip it themselves before
+  // every export).
   useEffect(() => {
     if (isOpen) {
       setAiCheckLoading(true);
@@ -309,6 +314,9 @@ export function QuickScriptModal({
         .then((result) => {
           setAiAvailable(result.available);
           setHasCodeContext(result.hasCodeContext ?? false);
+          if (result.available) {
+            setAiEnabled(true);
+          }
         })
         .catch(() => {
           setAiAvailable(false);

--- a/testplanit/app/actions/aiExportActions.ts
+++ b/testplanit/app/actions/aiExportActions.ts
@@ -197,6 +197,16 @@ export async function generateAiExportBatch(args: {
   if (footer) {
     userPrompt += `\n\nDEFAULT FOOTER (use as a starting point — extend or modify teardown as needed):\n\`\`\`\n${footer}\n\`\`\``;
   }
+  // FRAMEWORK SYNTAX EXAMPLE — the rendered template body shows the
+  // framework's actual API shape: fixture destructuring, locator factories,
+  // assertion calls, idiomatic helpers. Crucial when the framework is
+  // niche or new enough that the model's training data could plausibly
+  // confuse it with a closer-named neighbor (e.g. `@mobilewright/test`
+  // vs `@playwright/test`). Mirror the rendered structure, not generic
+  // assumptions from the framework name.
+  if (mustacheBodies[0]) {
+    userPrompt += `\n\nFRAMEWORK SYNTAX EXAMPLE — this is what one rendered test from the template looks like. Match this API shape (imports, fixtures, locators, action methods, assertion style) when writing the cases above. Do not substitute APIs from a similarly-named framework you happen to know better:\n\`\`\`\n${mustacheBodies[0]}\n\`\`\``;
+  }
 
   try {
     const request: LlmRequest = {
@@ -370,6 +380,14 @@ export async function generateAiExport(args: {
   }
   if (footer) {
     userPrompt += `\n\nDEFAULT FOOTER (use as a starting point — extend or modify teardown as needed):\n\`\`\`\n${footer}\n\`\`\``;
+  }
+  // FRAMEWORK SYNTAX EXAMPLE — same fix as the batch path. Without this
+  // section the model only sees framework name + a one-line import, and
+  // for niche or newer frameworks (or any framework whose package name
+  // looks like a more-popular neighbor's) it falls back to whatever
+  // similarly-named API it knows best instead.
+  if (mustacheFallback) {
+    userPrompt += `\n\nFRAMEWORK SYNTAX EXAMPLE — this is what one rendered test from the template looks like. Match this API shape (imports, fixtures, locators, action methods, assertion style) when writing the case above. Do not substitute APIs from a similarly-named framework you happen to know better:\n\`\`\`\n${mustacheFallback}\n\`\`\``;
   }
 
   // 10. Call LLM (wrapped in try/catch for GEN-05 fallback)

--- a/testplanit/app/api/export/ai-stream/route.ts
+++ b/testplanit/app/api/export/ai-stream/route.ts
@@ -72,6 +72,10 @@ export async function POST(req: NextRequest) {
   let header: string;
   let footer: string;
 
+  // One rendered case body — used both as the deterministic-fallback
+  // payload and as the FRAMEWORK SYNTAX EXAMPLE in the LLM prompt below.
+  // Keeping it hoisted so the prompt assembly later can attach it.
+  let syntaxExampleBody = "";
   if (body.mode === "single") {
     header = template.headerBody
       ? Mustache.render(template.headerBody, body.caseData)
@@ -80,6 +84,7 @@ export async function POST(req: NextRequest) {
       ? Mustache.render(template.footerBody, body.caseData)
       : "";
     const bodyCode = Mustache.render(template.templateBody, body.caseData);
+    syntaxExampleBody = bodyCode;
     mustacheFallback = [header, bodyCode, footer].filter(Boolean).join("\n\n");
   } else {
     header = template.headerBody
@@ -91,6 +96,7 @@ export async function POST(req: NextRequest) {
     const bodies = body.cases.map((c) =>
       Mustache.render(template.templateBody, c)
     );
+    syntaxExampleBody = bodies[0] ?? "";
     mustacheFallback = [header, ...bodies, footer].filter(Boolean).join("\n\n");
   }
 
@@ -254,6 +260,15 @@ export async function POST(req: NextRequest) {
         }
         if (footer) {
           userPrompt += `\n\nDEFAULT FOOTER (use as a starting point — extend or modify teardown as needed):\n\`\`\`\n${footer}\n\`\`\``;
+        }
+        // FRAMEWORK SYNTAX EXAMPLE — the rendered template body shows
+        // the actual API shape (fixture destructuring, locator helpers,
+        // assertion methods). Without it the model only sees framework
+        // name + a one-line import, and for niche or newer frameworks
+        // (or any framework whose package name resembles a more-popular
+        // neighbor's) it silently substitutes the closer neighbor's API.
+        if (syntaxExampleBody) {
+          userPrompt += `\n\nFRAMEWORK SYNTAX EXAMPLE — this is what one rendered test from the template looks like. Match this API shape (imports, fixtures, locators, action methods, assertion style) when writing the cases above. Do not substitute APIs from a similarly-named framework you happen to know better:\n\`\`\`\n${syntaxExampleBody}\n\`\`\``;
         }
 
         const request: LlmRequest = {

--- a/testplanit/prisma/seed.ts
+++ b/testplanit/prisma/seed.ts
@@ -2901,6 +2901,83 @@ void main() {
 }
 `;
 
+  // --- Mobilewright (TypeScript, @mobilewright/test fixtures) ---
+  // Playwright-style mobile testing framework for iOS + Android.
+  // Fixture-based variant uses the `@mobilewright/test` package, which
+  // exposes `device` and `screen` per test (mirrors Playwright Test's
+  // `page` fixture). Recommended for proper test suites.
+  // Docs: https://github.com/mobile-next/mobilewright
+  const mobilewrightFixtureHeader = `import { test, expect } from "@mobilewright/test";`;
+
+  const mobilewrightFixtureBody = `/**
+ * Test Case: {{{name}}}
+ * ID: {{{id}}}
+ * State: {{{state}}}
+ * Tags: {{{tags}}}
+ * Created by: {{{createdBy}}}
+ */
+test.use({ bundleId: "com.example.app" });
+
+test.describe("{{{name}}}", () => {
+{{#steps}}
+  // Step {{{order}}}: {{{step}}}
+  // Expected: {{{expectedResult}}}
+  test("Step {{order}} - {{step}}", async ({ device, screen, bundleId }) => {
+    // TODO: Implement test logic
+    // Examples:
+    //   await screen.getByRole("button", { name: "Sign In" }).tap();
+    //   await screen.getByLabel("Email").fill("user@example.com");
+    //   await expect(screen.getByText("Welcome")).toBeVisible();
+  });
+
+{{/steps}}
+});
+`;
+
+  // --- Mobilewright (TypeScript, standalone API) ---
+  // Direct `ios.launch()` / `android.launch()` entry — useful for ad-hoc
+  // automation scripts or when integrating into an existing test runner
+  // that doesn't use the `@mobilewright/test` fixtures. Each step block
+  // gets its own self-contained async IIFE so a single script file can
+  // run end-to-end without a test framework.
+  const mobilewrightStandaloneHeader = `import { ios, expect } from "mobilewright";`;
+
+  const mobilewrightStandaloneBody = `/**
+ * Test Case: {{{name}}}
+ * ID: {{{id}}}
+ * State: {{{state}}}
+ * Tags: {{{tags}}}
+ * Created by: {{{createdBy}}}
+ */
+async function run{{{id}}}() {
+  // Swap \`ios\` for \`android\` (or read platform from mobilewright.config.ts).
+  const device = await ios.launch({ bundleId: "com.example.app" });
+  const { screen } = device;
+
+  try {
+{{#steps}}
+    // Step {{{order}}}: {{{step}}}
+    // Expected: {{{expectedResult}}}
+    {
+      // TODO: Implement step logic
+      // Examples:
+      //   await screen.getByRole("button", { name: "Sign In" }).tap();
+      //   await screen.getByLabel("Email").fill("user@example.com");
+      //   await expect(screen.getByText("Welcome")).toBeVisible();
+    }
+
+{{/steps}}
+  } finally {
+    await device.close();
+  }
+}
+
+run{{{id}}}().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+`;
+
   // --- Earl Grey (Swift) ---
   const earlGreyHeader = `import XCTest`;
 
@@ -3578,6 +3655,32 @@ class Test{{{id}}}: XCTestCase {
       footerBody: null as string | null,
       fileExtension: ".swift",
       language: "swift",
+      isDefault: false,
+    },
+    {
+      name: "Mobilewright (@mobilewright/test)",
+      description:
+        "Generates Mobilewright test stubs in TypeScript using the @mobilewright/test fixtures (Playwright-style device + screen fixtures). One template drives iOS + Android against UIKit, SwiftUI, Jetpack Compose, Android Views, React Native, Expo, .NET MAUI, NativeScript, and Cordova/Capacitor apps.",
+      category: "Mobile Testing",
+      framework: "Mobilewright",
+      headerBody: mobilewrightFixtureHeader,
+      templateBody: mobilewrightFixtureBody,
+      footerBody: null as string | null,
+      fileExtension: ".test.ts",
+      language: "typescript",
+      isDefault: false,
+    },
+    {
+      name: "Mobilewright (Standalone)",
+      description:
+        "Generates Mobilewright automation scripts in TypeScript using the standalone ios/android launcher API — no test runner required. Same cross-platform reach as the fixture variant (UIKit, SwiftUI, Jetpack Compose, Android Views, React Native, Expo, .NET MAUI, NativeScript, Cordova/Capacitor). Useful for ad-hoc scripts or custom runners.",
+      category: "Mobile Testing",
+      framework: "Mobilewright",
+      headerBody: mobilewrightStandaloneHeader,
+      templateBody: mobilewrightStandaloneBody,
+      footerBody: null as string | null,
+      fileExtension: ".ts",
+      language: "typescript",
       isDefault: false,
     },
   ];


### PR DESCRIPTION
## Description

Three commits enabling QuickScript test-stub export against the [Mobilewright](https://github.com/mobile-next/mobilewright) mobile testing framework, plus two quality-of-life fixes for the AI export flow that apply to every template — not just the new ones.

### 1. Seed Mobilewright templates (commit 1)

Two new templates under the existing **Mobile Testing** category:

| Template | Idiom | Header | Ext |
| --- | --- | --- | --- |
| **Mobilewright (@mobilewright/test)** | Playwright-style fixtures (`device`, `screen`, `bundleId` per test). Recommended for proper test suites. | `import { test, expect } from "@mobilewright/test";` | `.test.ts` |
| **Mobilewright (Standalone)** | Direct `ios.launch()` launcher API, async IIFE, `device.close()` in `finally`. For ad-hoc scripts or custom runners. | `import { ios, expect } from "mobilewright";` | `.ts` |

Both templates embed inline example comments showing the locator factories (`getByRole`, `getByLabel`, `getByText`) and assertion shape so the exported stubs are easy to fill in.

Descriptions explicitly enumerate the UI frameworks/runtimes Mobilewright drives — UIKit, SwiftUI, Jetpack Compose, Android Views, React Native, Expo, .NET MAUI, NativeScript, Cordova/Capacitor — so admins searching by their stack ("SwiftUI", "React Native", "Expo", etc.) find these templates in the QuickScript admin filter. Flutter and Kotlin Multiplatform iOS are deliberately omitted because the upstream marks them in-progress.

No schema change. Templates land via the existing upsert-on-name seed pattern, idempotent across upgrades.

### 2. Default Generate-with-AI toggle to ON when project has LLM configured (commit 2)

The QuickScript dialog's "Generate with AI" toggle initialized to OFF unconditionally, even when the project had a working LLM integration. The AI block showed up (because availability resolved to true), but the user had to flip the switch on every open before clicking Export.

Now the availability-check `useEffect` flips `aiEnabled` to true when `checkAiExportAvailable` returns `available: true`. When AI is NOT available, the toggle stays false (and the AI block is hidden anyway). No behavior change for projects without an LLM.

Adds a focused unit test asserting the Switch reflects `checked: true` when availability resolves to true.

### 3. Inject rendered template body as FRAMEWORK SYNTAX EXAMPLE in AI export prompt (commit 3)

Generalized fix for AI-generated code drifting away from the chosen framework when that framework is niche, newer than the model's training data, or has a package name that resembles a more popular neighbor.

Previously the prompt only told the LLM:
- framework name + language
- DEFAULT HEADER (one line of imports)
- DEFAULT FOOTER (typically empty)

For Mobilewright specifically, the `@mobilewright/test` import shape is close enough to `@playwright/test` that the model silently fell back to writing Playwright web code (`({ page })`, `page.locator()` CSS selectors, `page.goto()`) under a Mobilewright import. Round-1 UAT against four real test cases produced **0 mobile-API calls** in the fixture variant.

The fix adds a third section, **FRAMEWORK SYNTAX EXAMPLE**, populated with the actual rendered template body. The template body is already an example of the framework's API conventions — that's what the template is for — so this surface is "free" and works for any custom template an admin adds in the future.

Applied to both AI-export entry points:
- `app/actions/aiExportActions.ts` (single + batch paths)
- `app/api/export/ai-stream/route.ts` (streaming endpoint)

The stream route hoists a `syntaxExampleBody` variable so the same rendered body that drives the mustache fallback also gets reused as the LLM example — no double rendering.

### UAT receipts

| Round | Repo context | Fixture-variant output | Standalone-variant output |
| --- | --- | --- | --- |
| 1 (direct LLM, no prompt fix) | none | 0/4 Mobilewright (all Playwright) | 4/4 partial Mobilewright |
| 2 (direct LLM, prompt fix) | none | **4/4 Mobilewright** ✅ | **4/4 Mobilewright** ✅ |
| 3 (live UI through QuickScript dialog, prompt fix) | none | **Mobilewright** ✅ | not exercised |

Round-3 live UI confirms the default-ON toggle fires (`aria-checked: "true"` on first open), the templates show up in the dropdown, and the AI export produces real Mobilewright code — `({ device, screen, bundleId })`, `device.launchApp({ bundleId })`, `screen.getByRole(...).tap()`, `screen.getByLabel(...).fill(...)`, `expect(screen.getByText(...)).toBeVisible()`.

**Worth noting for reviewers:** when a project has a code repository connected, the existing repo-context injection (`CodeContextService.assembleContext`) deliberately makes the AI follow the repo's existing test framework — even when that conflicts with the chosen template. That's intended product behavior (automation teams want their generated stubs to match their existing infrastructure). The SYNTAX EXAMPLE fix only takes precedence when there's no competing repo context.

## Related Issue

N/A — proactive enhancement.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue) — default-ON toggle was a UX bug

## How Has This Been Tested?

- [x] Unit tests — 18/18 AI export tests pass; 10/10 QuickScript modal tests pass (1 new test added for default-ON behavior); full repo suite unchanged
- [x] Manual UAT — three rounds covered above. Live UI export through QuickScript dialog produces real Mobilewright code.
- [ ] Integration tests
- [ ] E2E tests

**Test Configuration:**
- OS: macOS
- Browser: Chrome (Playwright MCP for the live-UI run)
- Node: per `.nvmrc`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- The two Mobilewright templates are added in commit 1 alone. If you want only the templates (without the AI prompt fix), commits 2 and 3 can be cherry-picked independently — each is scoped to one concern.
- The SYNTAX EXAMPLE injection (commit 3) helps **every** custom template the admin adds in the future, not just Mobilewright. It's a generalized "stop drifting to a similarly-named framework" fix.
- The default-ON commit (commit 2) only affects the first open in a session; the existing on-close handler already reset the toggle to ON for subsequent opens, so this just makes the very first open behave the same way.
