### PR TITLE
fix(tiptap): always register parameterMention node; gate suggestion popup separately

### DIFF
--- a/testplanit/components/tiptap/TipTapEditor.tsx
+++ b/testplanit/components/tiptap/TipTapEditor.tsx
@@ -317,9 +317,17 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
         TableRow,
         TableCell,
         TableHeader,
-        ...(parameters && parameters.length > 0
-          ? [createParameterMentionExtension(parameters, chipMessages)]
-          : []),
+        // Always register the parameterMention NODE so step content that
+        // contains parameter references can deserialize on every surface
+        // — even read-only previews / list cells / case views without an
+        // active iteration. The `@`-trigger Suggestion popup is opt-in
+        // (param-aware editable editors only); read-only or param-less
+        // mounts get a registered schema node that renders `@label` and
+        // never crashes. See parameterMentionExtension.tsx for the
+        // CreateParameterMentionExtensionOptions contract.
+        createParameterMentionExtension(parameters ?? [], chipMessages, {
+          withSuggestion: !readOnly && (parameters?.length ?? 0) > 0,
+        }),
       ],
       content: validateContent(content),
       onUpdate: ({ editor }) => {

--- a/testplanit/components/tiptap/__tests__/TipTapEditorParameters.test.tsx
+++ b/testplanit/components/tiptap/__tests__/TipTapEditorParameters.test.tsx
@@ -41,6 +41,34 @@ vi.mock("~/app/constants", () => ({
 // Capture the extensions array passed to useEditor.
 const capturedConfigs: Array<{ extensions: unknown[] }> = [];
 
+// Spy on the parameter-mention factory so the suggestion-gating contract
+// can be asserted directly without introspecting Tiptap output. The factory
+// is called by TipTapEditor on every mount; we record the (parameters,
+// messages, options) arguments and return a marker object the
+// extensions-array assertions can detect.
+const factoryCalls: Array<{
+  parameters: unknown;
+  messages: unknown;
+  options: { withSuggestion?: boolean } | undefined;
+}> = [];
+vi.mock("~/lib/tiptap/parameterMentionExtension", async () => {
+  const actual = await vi.importActual<
+    typeof import("~/lib/tiptap/parameterMentionExtension")
+  >("~/lib/tiptap/parameterMentionExtension");
+  return {
+    ...actual,
+    createParameterMentionExtension: (
+      parameters: unknown,
+      messages: unknown,
+      options?: { withSuggestion?: boolean }
+    ) => {
+      factoryCalls.push({ parameters, messages, options });
+      // Return a shape the existing extensions-array assertions can detect.
+      return { name: "parameterMention" };
+    },
+  };
+});
+
 vi.mock("@tiptap/react", () => ({
   useEditor: (config: { extensions: unknown[] }) => {
     capturedConfigs.push(config);
@@ -80,6 +108,7 @@ const PARAMS: ParameterChipMeta[] = [
 
 beforeEach(() => {
   capturedConfigs.length = 0;
+  factoryCalls.length = 0;
 });
 
 afterEach(() => {
@@ -87,7 +116,7 @@ afterEach(() => {
 });
 
 describe("TipTapEditor parameters wiring", () => {
-  it("does NOT mount the parameter mention extension when parameters prop is undefined", async () => {
+  it("ALWAYS mounts the parameter mention extension when parameters prop is undefined (so step content with parameter references can deserialize without 'Unknown node type')", async () => {
     const TipTapEditor = (await import("../TipTapEditor")).default;
     render(
       <TipTapEditor content={{ type: "doc", content: [] }} projectId="1" />
@@ -100,10 +129,15 @@ describe("TipTapEditor parameters wiring", () => {
         ext !== null &&
         (ext as { name?: string }).name === "parameterMention"
     );
-    expect(hasParameterMention).toBe(false);
+    expect(hasParameterMention).toBe(true);
+    // Suggestion popup must NOT be wired when there are no parameters —
+    // otherwise typing `@` in a comment / description / project doc would
+    // pop a parameter-picker.
+    expect(factoryCalls.length).toBeGreaterThan(0);
+    expect(factoryCalls[0].options?.withSuggestion).toBe(false);
   });
 
-  it("does NOT mount the parameter mention extension when parameters is empty []", async () => {
+  it("ALWAYS mounts the parameter mention extension when parameters is empty []", async () => {
     const TipTapEditor = (await import("../TipTapEditor")).default;
     render(
       <TipTapEditor
@@ -120,10 +154,12 @@ describe("TipTapEditor parameters wiring", () => {
         ext !== null &&
         (ext as { name?: string }).name === "parameterMention"
     );
-    expect(hasParameterMention).toBe(false);
+    expect(hasParameterMention).toBe(true);
+    expect(factoryCalls.length).toBeGreaterThan(0);
+    expect(factoryCalls[0].options?.withSuggestion).toBe(false);
   });
 
-  it("DOES mount the parameter mention extension when parameters is non-empty", async () => {
+  it("DOES mount the parameter mention extension AND wires the suggestion popup when parameters is non-empty and editor is editable", async () => {
     const TipTapEditor = (await import("../TipTapEditor")).default;
     render(
       <TipTapEditor
@@ -141,6 +177,22 @@ describe("TipTapEditor parameters wiring", () => {
         (ext as { name?: string }).name === "parameterMention"
     );
     expect(hasParameterMention).toBe(true);
+    expect(factoryCalls.length).toBeGreaterThan(0);
+    expect(factoryCalls[0].options?.withSuggestion).toBe(true);
+  });
+
+  it("mounts the node WITHOUT the suggestion popup when readOnly is true (read-only previews never need the `@`-picker, but must still render parameter chips)", async () => {
+    const TipTapEditor = (await import("../TipTapEditor")).default;
+    render(
+      <TipTapEditor
+        content={{ type: "doc", content: [] }}
+        projectId="1"
+        parameters={PARAMS}
+        readOnly
+      />
+    );
+    expect(factoryCalls.length).toBeGreaterThan(0);
+    expect(factoryCalls[0].options?.withSuggestion).toBe(false);
   });
 
   it("renders the InsertParameterToolbarButton when parameters is non-empty AND not readOnly", async () => {

--- a/testplanit/lib/tiptap/parameterMentionExtension.tsx
+++ b/testplanit/lib/tiptap/parameterMentionExtension.tsx
@@ -161,10 +161,34 @@ function installChipHandler() {
   );
 }
 
+export interface CreateParameterMentionExtensionOptions {
+  /**
+   * Attach the `@`-trigger suggestion popup to this editor instance.
+   *
+   * Splitting this off the node-schema registration is the whole point of
+   * the option: any read-only surface (preview, list cell, run-details
+   * without an active iteration) needs the schema NODE registered so a
+   * step document containing a parameterMention can deserialize without
+   * throwing "Unknown node type: parameterMention" — but those surfaces
+   * must NOT pop a parameter-picker on `@`, because they aren't param-
+   * aware editors (comments, descriptions, project docs).
+   *
+   * Pass true only for param-aware editable editors. The node's
+   * renderHTML degrades cleanly to `@label` when the resolved-parameter
+   * list doesn't contain a match, so registering the node with
+   * `withSuggestion: false` is always safe.
+   *
+   * Defaults to true for backward compatibility with any external caller.
+   */
+  withSuggestion?: boolean;
+}
+
 export function createParameterMentionExtension(
   parameters: ParameterChipMeta[],
-  messages: ParameterMentionMessages = DEFAULT_MESSAGES
+  messages: ParameterMentionMessages = DEFAULT_MESSAGES,
+  options: CreateParameterMentionExtensionOptions = {}
 ) {
+  const { withSuggestion = true } = options;
   installChipHandler();
   const declaredNames = new Set(parameters.map((p) => p.name));
   const paramByName = new Map(parameters.map((p) => [p.name, p]));
@@ -288,103 +312,117 @@ export function createParameterMentionExtension(
     HTMLAttributes: {
       class: "parameter-ref-chip",
     },
-    suggestion: {
-      char: "@",
-      items: ({ query }: { query: string }) => {
-        const lowered = query.toLowerCase();
-        return parameters
-          .filter((p) => p.name.toLowerCase().startsWith(lowered))
-          .slice(0, 8);
-      },
-      command: ({
-        editor,
-        range,
-        props,
-      }: {
-        editor: {
-          chain: () => {
-            focus: () => {
-              deleteRange: (range: { from: number; to: number }) => {
-                insertContent: (
-                  content:
-                    | string
-                    | { type: string; attrs: Record<string, unknown> }
-                    | Array<unknown>
-                ) => { run: () => void };
-              };
-            };
-          };
-        };
-        range: { from: number; to: number };
-        props: ParameterChipMeta;
-      }) => {
-        editor
-          .chain()
-          .focus()
-          .deleteRange(range)
-          .insertContent([
-            {
-              type: "parameterMention",
-              attrs: {
-                id: props.name,
-                label: props.name,
-                paramId: props.id,
-                paramType: props.type,
-              },
+    // Suggestion is OPT-IN: only attach the `@`-picker popup when the
+    // caller asked for it. Read-only / non-param-aware editors register
+    // the same node-schema for crash-free deserialization but omit the
+    // suggestion entirely.
+    ...(withSuggestion
+      ? {
+          suggestion: {
+            char: "@",
+            items: ({ query }: { query: string }) => {
+              const lowered = query.toLowerCase();
+              return parameters
+                .filter((p) => p.name.toLowerCase().startsWith(lowered))
+                .slice(0, 8);
             },
-            { type: "text", text: " " },
-          ] as Array<unknown>)
-          .run();
-      },
-      render: () => {
-        let component: ReactRenderer<ParameterMentionSuggestionRef> | undefined;
-        let popup: TippyInstance[] | undefined;
+            command: ({
+              editor,
+              range,
+              props,
+            }: {
+              editor: {
+                chain: () => {
+                  focus: () => {
+                    deleteRange: (range: { from: number; to: number }) => {
+                      insertContent: (
+                        content:
+                          | string
+                          | { type: string; attrs: Record<string, unknown> }
+                          | Array<unknown>
+                      ) => { run: () => void };
+                    };
+                  };
+                };
+              };
+              range: { from: number; to: number };
+              props: ParameterChipMeta;
+            }) => {
+              editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .insertContent([
+                  {
+                    type: "parameterMention",
+                    attrs: {
+                      id: props.name,
+                      label: props.name,
+                      paramId: props.id,
+                      paramType: props.type,
+                    },
+                  },
+                  { type: "text", text: " " },
+                ] as Array<unknown>)
+                .run();
+            },
+            render: () => {
+              let component:
+                | ReactRenderer<ParameterMentionSuggestionRef>
+                | undefined;
+              let popup: TippyInstance[] | undefined;
 
-        return {
-          onStart: (props: {
-            editor: unknown;
-            clientRect?: (() => DOMRect | null) | null;
-          }) => {
-            component = new ReactRenderer(ParameterMentionSuggestion, {
-              props: props as unknown as Record<string, unknown>,
-              editor: props.editor as never,
-            });
+              return {
+                onStart: (props: {
+                  editor: unknown;
+                  clientRect?: (() => DOMRect | null) | null;
+                }) => {
+                  component = new ReactRenderer(ParameterMentionSuggestion, {
+                    props: props as unknown as Record<string, unknown>,
+                    editor: props.editor as never,
+                  });
 
-            if (!props.clientRect) return;
+                  if (!props.clientRect) return;
 
-            popup = tippy("body", {
-              getReferenceClientRect: props.clientRect as () => DOMRect,
-              appendTo: () => document.body,
-              content: component.element,
-              showOnCreate: true,
-              interactive: true,
-              trigger: "manual",
-              placement: "bottom-start",
-            });
-          },
+                  popup = tippy("body", {
+                    getReferenceClientRect: props.clientRect as () => DOMRect,
+                    appendTo: () => document.body,
+                    content: component.element,
+                    showOnCreate: true,
+                    interactive: true,
+                    trigger: "manual",
+                    placement: "bottom-start",
+                  });
+                },
 
-          onUpdate(props: { clientRect?: (() => DOMRect | null) | null }) {
-            component?.updateProps(props as unknown as Record<string, unknown>);
-            if (!props.clientRect) return;
-            popup?.[0]?.setProps({
-              getReferenceClientRect: props.clientRect as () => DOMRect,
-            });
-          },
+                onUpdate(props: {
+                  clientRect?: (() => DOMRect | null) | null;
+                }) {
+                  component?.updateProps(
+                    props as unknown as Record<string, unknown>
+                  );
+                  if (!props.clientRect) return;
+                  popup?.[0]?.setProps({
+                    getReferenceClientRect: props.clientRect as () => DOMRect,
+                  });
+                },
 
-          onKeyDown(props: { event: KeyboardEvent }) {
-            if (props.event.key === "Escape") {
-              popup?.[0]?.hide();
-              return true;
-            }
-            return component?.ref?.onKeyDown(props) ?? false;
-          },
+                onKeyDown(props: { event: KeyboardEvent }) {
+                  if (props.event.key === "Escape") {
+                    popup?.[0]?.hide();
+                    return true;
+                  }
+                  return component?.ref?.onKeyDown(props) ?? false;
+                },
 
-          onExit() {
-            popup?.[0]?.destroy();
-            component?.destroy();
-          },
-        };
-      },
-    } as Partial<SuggestionOptions>,
+                onExit() {
+                  popup?.[0]?.destroy();
+                  component?.destroy();
+                },
+              };
+            },
+          } as Partial<SuggestionOptions>,
+        }
+      : {}),
   });
 }


### PR DESCRIPTION
## Description

Fixes an app crash on any render surface that loads step content containing a `parameterMention` node without threading the case's resolved parameters through to the editor.

### Symptom

```
[tiptap warn]: Invalid content. RangeError: Unknown node type: parameterMention
   at nodeFromJSON … fromJSON …
```

Steps render blank (and spam the console) on read-only previews in list/preview cells, on the case-level run view when no iteration is active, and anywhere else `TextFromJson` / `TipTapEditor` is mounted without a `parameters` prop.

### Root cause

`createParameterMentionExtension` was registered conditionally in `TipTapEditor`:

```tsx
...(parameters && parameters.length > 0
  ? [createParameterMentionExtension(parameters, chipMessages)]
  : []),
```

When step content contains a `parameterMention` node but the editor is built without parameters, ProseMirror's schema doesn't know that node type, throws `Unknown node type`, and the whole document fails to deserialize.

### Why we can't just always-register the existing factory

`createParameterMentionExtension([])` still wires the `@`-trigger Suggestion plugin, so unconditional registration would pop a parameter-picker in every editor — comments, descriptions, project docs.

### Fix

Decouples the schema NODE from the SUGGESTION:

- Adds a new `options` parameter to `createParameterMentionExtension` with a `withSuggestion` flag (defaults to true for backward compat with any external caller). When false, the returned extension still registers the node schema and its `renderHTML` (which already degrades cleanly to `@label` when no parameter metadata is available), but the `.configure({...})` block omits the suggestion entirely.
- `TipTapEditor` drops the conditional gate. The factory is now called on every mount; suggestion is opt-in via `withSuggestion: !readOnly && (parameters?.length ?? 0) > 0`. Read-only previews and param-less editors register a known schema node and never crash.

### Verification

- Unit tests: 4 specifically encode the new contract — extension is always mounted; `withSuggestion` is true only when `!readOnly && parameters.length > 0`. All 8/8 tests in the file pass. Full suite: **8302 pass / 0 fail**.
- Live UI verified

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — 4 tests encode the new always-mount + suggestion-gated contract; full suite 8302/8302 pass
- [x] Manual UI
- [ ] Integration tests
- [ ] E2E tests

**Test Configuration:**
- OS: macOS
- Browser: Chrome (Playwright MCP for the live-UI check)
- Node: per `.nvmrc`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- The third argument on `createParameterMentionExtension` defaults to `{ withSuggestion: true }` so any external caller invoking the old two-arg signature keeps its current behavior. The only in-tree caller is `TipTapEditor` itself, which now passes the flag explicitly.
- `renderHTML` was already render-safe for the no-parameters case: it falls through to `@${label}` when no resolved-parameter metadata matches. The fix just makes that render path reachable instead of crashing schema deserialization upstream.
- Optional defense-in-depth in `TextFromJson.validateContent` (downgrade unknown `parameterMention` nodes to text before handing to ProseMirror) was considered and deliberately skipped — the schema is now always known, so the crash physically cannot recur from this code path. Happy to add it as a follow-up if reviewers want a belt-and-suspenders guard against future schema regressions from a different direction.
