### PR TITLE
enhancement(cases): inline parameters & dataset on Add Case

### DIFF
--- a/docs/docs/user-guide/projects/parameterized-test-cases.md
+++ b/docs/docs/user-guide/projects/parameterized-test-cases.md
@@ -32,7 +32,7 @@ Datasets are **versioned**: every save creates a new immutable version. A run ca
 
 There are two entry points:
 
-- **Inline on Add Case** — when you create a new case from the repository, an optional **Add parameters & dataset** section appears at the bottom of the Add Case form. It is available only when the selected template has a **Steps** field (parameter `@chip` references need a step to live in). The section is a slimmed-down editor — parameter columns, dataset rows, type and required/sensitive flags — designed for the create-time happy path. When you save, the case, its parameters, and its dataset rows all land in one atomic write. The full editor (CSV import, allowed-values authoring for SELECT, per-cell sensitive masking) is still available on the created case.
+- **Inline on Add Case** — when you create a new case from the repository, a **Configure parameters** button appears above the Steps field in the Add Case form, in the same spot it lives on the case details page. The button shows on templates that include a **Steps** field (parameter `@chip` references need a step to live in) and is hidden otherwise. Clicking opens a sheet from the right with a slimmed-down editor — parameter columns, dataset rows, type and required/sensitive flags. The button label updates to `Parameters (N)` once columns are authored. When you save the case, its parameters, and its dataset rows all land in one atomic write. The full editor (CSV import, allowed-values authoring for SELECT, per-cell sensitive masking) is still available on the created case.
 - **Full editor on an existing case** — open the test case, then click **Configure Parameters** at the top of the case editor. The sheet that opens has two tabs:
 
 ### Parameters tab

--- a/docs/docs/user-guide/projects/parameterized-test-cases.md
+++ b/docs/docs/user-guide/projects/parameterized-test-cases.md
@@ -30,7 +30,10 @@ Datasets are **versioned**: every save creates a new immutable version. A run ca
 
 ## Authoring a Parameterized Case
 
-Open the test case, then click **Configure Parameters** at the top of the case editor. The sheet that opens has two tabs:
+There are two entry points:
+
+- **Inline on Add Case** — when you create a new case from the repository, an optional **Add parameters & dataset** section appears at the bottom of the Add Case form. It is available only when the selected template has a **Steps** field (parameter `@chip` references need a step to live in). The section is a slimmed-down editor — parameter columns, dataset rows, type and required/sensitive flags — designed for the create-time happy path. When you save, the case, its parameters, and its dataset rows all land in one atomic write. The full editor (CSV import, allowed-values authoring for SELECT, per-cell sensitive masking) is still available on the created case.
+- **Full editor on an existing case** — open the test case, then click **Configure Parameters** at the top of the case editor. The sheet that opens has two tabs:
 
 ### Parameters tab
 

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
@@ -7,6 +7,10 @@ import {
   type InlineDatasetRow,
   type InlineParameter,
 } from "@/components/parameters/InlineDatasetEditor";
+import {
+  pickInlinePayload,
+  templateHasStepsField,
+} from "~/lib/services/inlineParamsGate";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -578,13 +582,15 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
   // visible only when the selected template has a Steps field — without
   // steps, parameter `@chip` references have no home. Switching to a
   // template that lacks Steps clears any entered draft so a hidden section
-  // can't ship orphaned params on submit.
-  const templateHasSteps = React.useMemo(() => {
-    const tpl = templates?.find((tt) => tt.id === selectedTemplateId);
-    return !!tpl?.caseFields?.some(
-      (cf: any) => cf.caseField?.displayName === "Steps"
-    );
-  }, [templates, selectedTemplateId]);
+  // can't ship orphaned params on submit. Detection lives in
+  // `lib/services/inlineParamsGate.ts` so it has unit-test coverage.
+  const templateHasSteps = React.useMemo(
+    () =>
+      templateHasStepsField(
+        templates?.find((tt) => tt.id === selectedTemplateId)
+      ),
+    [templates, selectedTemplateId]
+  );
 
   useEffect(() => {
     if (!templateHasSteps) {
@@ -1105,15 +1111,12 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
               steps: stepRowsForCase,
               // PARAM-AddCase: forward inline state when the user has
               // actually authored columns. The Sheet is the only path that
-              // can populate `inlineParameters`, and the `templateHasSteps`
+              // populates `inlineParameters`, and the `templateHasSteps`
               // effect zeroes the array on template switch, so a non-empty
-              // array is a strong signal of authored draft columns.
-              parameters: inlineParameters.length
-                ? inlineParameters.filter((p) => p.name.trim().length > 0)
-                : undefined,
-              datasetRows: inlineParameters.length
-                ? inlineDatasetRows
-                : undefined,
+              // array signals authored draft columns. Trimming +
+              // undefined-when-empty live in `pickInlinePayload` so the
+              // edge cases get unit-test coverage.
+              ...pickInlinePayload(inlineParameters, inlineDatasetRows),
             },
           ],
           fieldMappings: [],

--- a/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/AddCase.tsx
@@ -1,7 +1,20 @@
 import { WorkflowStateDisplay } from "@/components/WorkflowStateDisplay";
 import { UnifiedIssueManager } from "@/components/issues/UnifiedIssueManager";
 import { ManageTags } from "@/components/ManageTags";
+import { ConfigureParametersButton } from "@/components/parameters/ConfigureParametersButton";
+import {
+  InlineDatasetEditor,
+  type InlineDatasetRow,
+  type InlineParameter,
+} from "@/components/parameters/InlineDatasetEditor";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import {
   Dialog,
   DialogContent,
@@ -310,6 +323,17 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
   );
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [linkedIssueIds, setLinkedIssueIds] = useState<number[]>([]);
+  // Inline parameters + dataset rows authored in AddCase (PARAM-AddCase).
+  // The collapsible section that houses these only renders when the selected
+  // template has a Steps field — without steps, parameter `@chip` references
+  // have no home, so the section would be empty UX friction.
+  const [inlineParameters, setInlineParameters] = useState<InlineParameter[]>(
+    []
+  );
+  const [inlineDatasetRows, setInlineDatasetRows] = useState<
+    InlineDatasetRow[]
+  >([]);
+  const [inlineParamsSheetOpen, setInlineParamsSheetOpen] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [selectedLinks, setSelectedLinks] = useState<LinkAttachmentInput[]>([]);
 
@@ -549,6 +573,26 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
       setSelectedTemplateId(defaultTemplateId);
     }
   }, [defaultWorkflowId, defaultTemplateId, setValue]);
+
+  // Per `feedback_addcase_params_steps_field_gated`: the inline section is
+  // visible only when the selected template has a Steps field — without
+  // steps, parameter `@chip` references have no home. Switching to a
+  // template that lacks Steps clears any entered draft so a hidden section
+  // can't ship orphaned params on submit.
+  const templateHasSteps = React.useMemo(() => {
+    const tpl = templates?.find((tt) => tt.id === selectedTemplateId);
+    return !!tpl?.caseFields?.some(
+      (cf: any) => cf.caseField?.displayName === "Steps"
+    );
+  }, [templates, selectedTemplateId]);
+
+  useEffect(() => {
+    if (!templateHasSteps) {
+      setInlineParameters([]);
+      setInlineDatasetRows([]);
+      setInlineParamsSheetOpen(false);
+    }
+  }, [templateHasSteps]);
 
   useEffect(() => {
     const selectedTemplate = templates?.find(
@@ -1059,6 +1103,17 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
               versionIssues,
               attachments: uploadedAttachments,
               steps: stepRowsForCase,
+              // PARAM-AddCase: forward inline state when the user has
+              // actually authored columns. The Sheet is the only path that
+              // can populate `inlineParameters`, and the `templateHasSteps`
+              // effect zeroes the array on template switch, so a non-empty
+              // array is a strong signal of authored draft columns.
+              parameters: inlineParameters.length
+                ? inlineParameters.filter((p) => p.name.trim().length > 0)
+                : undefined,
+              datasetRows: inlineParameters.length
+                ? inlineDatasetRows
+                : undefined,
             },
           ],
           fieldMappings: [],
@@ -1072,21 +1127,34 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
 
         const newCaseId = result.importedIds[0];
 
-        await queryClient.invalidateQueries({
-          queryKey: ["folderStats"],
-          refetchType: "all",
-        });
-
-        await queryClient.invalidateQueries({
-          predicate: (query) =>
-            Array.isArray(query.queryKey) &&
-            query.queryKey[0] === "zenstack" &&
-            query.queryKey[1] === "RepositoryCases",
-          refetchType: "all",
-        });
-
+        // Close the modal before kicking off cache invalidations so the user
+        // perceives Save → close as ~immediate. The invalidations resolve in
+        // the background and the repo view re-renders as soon as they land.
+        // Scoping by projectId + dropping `refetchType: "all"` (refetching
+        // even inactive queries app-wide) takes typical post-save latency
+        // from "freeze 1-2s" to a single render of the visible folder view.
         onClose();
         setIsSubmitting(false);
+
+        const projectIdForCache = numericProjectId;
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            if (!Array.isArray(query.queryKey)) return false;
+            const [root, model, , args] = query.queryKey as [
+              string,
+              string,
+              string,
+              { where?: { projectId?: number } } | undefined,
+            ];
+            if (root !== "zenstack" || model !== "RepositoryCases")
+              return false;
+            const projectIdArg = args?.where?.projectId;
+            return (
+              projectIdArg === undefined || projectIdArg === projectIdForCache
+            );
+          },
+        });
+        void queryClient.invalidateQueries({ queryKey: ["folderStats"] });
 
         checkForDuplicates(
           convertedData.name,
@@ -1301,15 +1369,38 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
                     <div className="space-y-4">
                       {templates
                         ?.find((template) => template.id === selectedTemplateId)
-                        ?.caseFields.map((caseField: any) => (
-                          <RenderField
-                            field={caseField}
-                            key={caseField.caseFieldId}
-                            control={control}
-                            canEditRestricted={canEditRestrictedPerm}
-                            projectId={Number(projectId)}
-                          />
-                        ))}
+                        ?.caseFields.map((caseField: any) => {
+                          const isStepsField =
+                            caseField.caseField?.type?.type === "Steps";
+                          return (
+                            <React.Fragment key={caseField.caseFieldId}>
+                              {/* Mirror the case details page: the Configure
+                              Parameters button sits right above the Steps
+                              field renderer. Same component, same placement,
+                              same affordance. In AddCase it opens a Sheet
+                              that hosts the InlineDatasetEditor instead of
+                              the live (caseId-bound) ConfigureParametersSheet
+                              — the case doesn't exist yet at this point. */}
+                              {isStepsField && (
+                                <div className="flex justify-end">
+                                  <ConfigureParametersButton
+                                    parameterCount={inlineParameters.length}
+                                    canEdit
+                                    onOpen={() =>
+                                      setInlineParamsSheetOpen(true)
+                                    }
+                                  />
+                                </div>
+                              )}
+                              <RenderField
+                                field={caseField}
+                                control={control}
+                                canEditRestricted={canEditRestrictedPerm}
+                                projectId={Number(projectId)}
+                              />
+                            </React.Fragment>
+                          );
+                        })}
                     </div>
                   )}
                 </ResizablePanel>
@@ -1418,6 +1509,36 @@ export function AddCase({ folderId, open, onClose }: AddCaseProps) {
                 </ResizablePanel>
               </ResizablePanelGroup>
             </div>
+            {templateHasSteps && (
+              <Sheet
+                open={inlineParamsSheetOpen}
+                onOpenChange={setInlineParamsSheetOpen}
+              >
+                <SheetContent
+                  side="right"
+                  className="sm:max-w-2xl overflow-y-auto"
+                  data-testid="addcase-inline-params-sheet"
+                >
+                  <SheetHeader>
+                    <SheetTitle>{t("parameters.sheetTitle")}</SheetTitle>
+                    <SheetDescription>
+                      {t("parameters.sheetDescription")}
+                    </SheetDescription>
+                  </SheetHeader>
+                  <div className="mt-4">
+                    <InlineDatasetEditor
+                      parameters={inlineParameters}
+                      rows={inlineDatasetRows}
+                      onChange={({ parameters, rows }) => {
+                        setInlineParameters(parameters);
+                        setInlineDatasetRows(rows);
+                      }}
+                      testIdPrefix="addcase-inline-dataset"
+                    />
+                  </div>
+                </SheetContent>
+              </Sheet>
+            )}
             <DialogFooter>
               {errors.root && (
                 <div

--- a/testplanit/app/actions/importGeneratedTestCases.integration.test.ts
+++ b/testplanit/app/actions/importGeneratedTestCases.integration.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Live-DB integration test for the parameters + datasetRows branches of
+ * `importGeneratedTestCases`. The mocked-Prisma path can't catch the kinds
+ * of bugs this branch is most exposed to:
+ *
+ *   - `TestCaseParameter` column-name drift (e.g. `description` removed)
+ *   - `DataSetVersion.createdById` required-field surprises
+ *   - `DataSetRow.valuesJson` Json-column quoting
+ *   - The (testCaseId, name) unique on TestCaseParameter rejecting duplicates
+ *     mid-batch and rolling back the whole case
+ *
+ * Skipped by default. Opt-in with `RUN_DB_INTEGRATION=1`. Requires
+ * `DATABASE_URL` pointing at a dev/test DB. Manual id-tracked cleanup since
+ * the action opens its own `$transaction` (we can't roll back the outer
+ * test transaction to undo committed rows).
+ */
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// The action imports `~/server/auth`, which transitively triggers
+// `~/server/db`'s server-only env guard from a non-SSR runtime. Mock the
+// session to a real seeded user so the action's internal
+// `await getServerAuthSession()` returns a usable identity without dragging
+// the env shim into the test process.
+const fixtureUserId = { current: null as string | null };
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: () =>
+    Promise.resolve(
+      fixtureUserId.current
+        ? {
+            user: {
+              id: fixtureUserId.current,
+              name: "Integration Test",
+              email: "integration-test@example.com",
+            },
+          }
+        : null
+    ),
+  authOptions: {},
+}));
+
+const RUN_INTEGRATION = process.env.RUN_DB_INTEGRATION === "1";
+const HAS_DB_URL = Boolean(process.env.DATABASE_URL);
+
+const describeIntegration =
+  RUN_INTEGRATION && HAS_DB_URL ? describe : describe.skip;
+
+describeIntegration(
+  "importGeneratedTestCases — inline parameters + dataset",
+  () => {
+    const importPrisma = async () => {
+      const { prisma } = await import("~/lib/prisma");
+      return prisma;
+    };
+
+    beforeAll(async () => {
+      const prisma = await importPrisma();
+      const user = await prisma.user.findFirst({ select: { id: true } });
+      if (!user) throw new Error("Seed DB before running this test");
+      fixtureUserId.current = user.id;
+    });
+
+    const cleanup: {
+      dataSetRowIds: number[];
+      dataSetVersionIds: number[];
+      dataSetIds: number[];
+      testCaseParameterIds: number[];
+      repositoryCaseIds: number[];
+      repositoryFolderIds: number[];
+      repositoryIds: number[];
+      workflowIds: number[];
+      templateIds: number[];
+      projectIds: number[];
+    } = {
+      dataSetRowIds: [],
+      dataSetVersionIds: [],
+      dataSetIds: [],
+      testCaseParameterIds: [],
+      repositoryCaseIds: [],
+      repositoryFolderIds: [],
+      repositoryIds: [],
+      workflowIds: [],
+      templateIds: [],
+      projectIds: [],
+    };
+
+    afterEach(async () => {
+      const prisma = await importPrisma();
+      for (const [model, ids] of [
+        ["dataSetRow", cleanup.dataSetRowIds],
+        ["dataSetVersion", cleanup.dataSetVersionIds],
+        ["dataSet", cleanup.dataSetIds],
+        ["testCaseParameter", cleanup.testCaseParameterIds],
+        ["repositoryCases", cleanup.repositoryCaseIds],
+        ["repositoryFolders", cleanup.repositoryFolderIds],
+        ["repositories", cleanup.repositoryIds],
+        ["workflows", cleanup.workflowIds],
+        ["templates", cleanup.templateIds],
+        ["projects", cleanup.projectIds],
+      ] as const) {
+        if (ids.length) {
+          await (prisma as any)[model]
+            .deleteMany({ where: { id: { in: ids } } })
+            .catch(() => {});
+        }
+      }
+      for (const k of Object.keys(cleanup) as Array<keyof typeof cleanup>) {
+        cleanup[k].length = 0;
+      }
+    });
+
+    async function seedFixture(prisma: any) {
+      const creator = await prisma.user.findFirst({ select: { id: true } });
+      if (!creator) throw new Error("Seed DB before running this test");
+      const anyColor = await prisma.color.findFirst({ select: { id: true } });
+      const anyIcon = await prisma.fieldIcon.findFirst({
+        select: { id: true },
+      });
+      if (!anyColor || !anyIcon)
+        throw new Error("Seed Color/FieldIcon rows before running this test");
+
+      const tag = `import-params-test-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const project = await prisma.projects.create({
+        data: { name: tag, createdBy: creator.id },
+        select: { id: true, name: true },
+      });
+      cleanup.projectIds.push(project.id);
+
+      const template = await prisma.templates.create({
+        data: {
+          templateName: `${tag}-tpl`,
+          isEnabled: true,
+          isDefault: false,
+        },
+        select: { id: true, templateName: true },
+      });
+      cleanup.templateIds.push(template.id);
+
+      const workflow = await prisma.workflows.create({
+        data: {
+          name: `${tag}-state`,
+          order: 0,
+          iconId: anyIcon.id,
+          colorId: anyColor.id,
+          workflowType: "IN_PROGRESS",
+          scope: "CASES",
+        },
+        select: { id: true, name: true },
+      });
+      cleanup.workflowIds.push(workflow.id);
+
+      const repo = await prisma.repositories.create({
+        data: { projectId: project.id },
+        select: { id: true },
+      });
+      cleanup.repositoryIds.push(repo.id);
+
+      const folder = await prisma.repositoryFolders.create({
+        data: {
+          name: `${tag}-folder`,
+          repositoryId: repo.id,
+          projectId: project.id,
+          creatorId: creator.id,
+        },
+        select: { id: true, name: true },
+      });
+      cleanup.repositoryFolderIds.push(folder.id);
+
+      return { tag, creator, project, template, workflow, repo, folder };
+    }
+
+    it(
+      "persists TestCaseParameter + DataSet + DataSetVersion + DataSetRow when both are provided",
+      { timeout: 60_000 },
+      async () => {
+        const prisma = await importPrisma();
+        const { importGeneratedTestCases } =
+          await import("./importGeneratedTestCases");
+        const { tag, project, template, workflow, repo, folder } =
+          await seedFixture(prisma);
+
+        const result = await importGeneratedTestCases({
+          projectId: project.id,
+          projectName: project.name,
+          repositoryId: repo.id,
+          folderId: folder.id,
+          folderName: folder.name,
+          templateId: template.id,
+          templateName: template.templateName,
+          stateId: workflow.id,
+          stateName: workflow.name,
+          maxOrder: 0,
+          autoGenerateTags: false,
+          source: "MANUAL",
+          testCases: [
+            {
+              id: `${tag}-case-0`,
+              name: `${tag}-case`,
+              fieldValues: {},
+              steps: [],
+              parameters: [
+                { name: "user", type: "STRING", required: true },
+                { name: "balance", type: "INTEGER", sensitive: true },
+              ],
+              datasetRows: [
+                {
+                  rowIndex: 0,
+                  label: "happy path",
+                  values: { user: "alice", balance: 100 },
+                },
+                {
+                  rowIndex: 1,
+                  label: "empty",
+                  values: { user: "", balance: 0 },
+                },
+              ],
+            },
+          ],
+          fieldMappings: [],
+        } as any);
+
+        expect(result.status).toBe("success");
+        expect(result.importedIds.length).toBe(1);
+        const caseId = result.importedIds[0];
+        cleanup.repositoryCaseIds.push(caseId);
+
+        const params = await prisma.testCaseParameter.findMany({
+          where: { testCaseId: caseId },
+          orderBy: { order: "asc" },
+          select: {
+            id: true,
+            name: true,
+            type: true,
+            required: true,
+            sensitive: true,
+          },
+        });
+        cleanup.testCaseParameterIds.push(...params.map((p: any) => p.id));
+        expect(params.map((p: any) => p.name)).toEqual(["user", "balance"]);
+        expect(params[0].required).toBe(true);
+        expect(params[1].sensitive).toBe(true);
+
+        const dataset = await prisma.dataSet.findFirst({
+          where: { ownerCaseId: caseId },
+          select: { id: true },
+        });
+        expect(dataset).not.toBeNull();
+        cleanup.dataSetIds.push(dataset!.id);
+
+        const version = await prisma.dataSetVersion.findFirst({
+          where: { dataSetId: dataset!.id, version: 1 },
+          select: { id: true, rowCount: true },
+        });
+        expect(version).not.toBeNull();
+        expect(version!.rowCount).toBe(2);
+        cleanup.dataSetVersionIds.push(version!.id);
+
+        const rows = await prisma.dataSetRow.findMany({
+          where: { dataSetId: dataset!.id },
+          orderBy: { rowIndex: "asc" },
+          select: { id: true, rowIndex: true, label: true },
+        });
+        cleanup.dataSetRowIds.push(...rows.map((r: any) => r.id));
+        expect(rows.map((r: any) => r.rowIndex)).toEqual([0, 1]);
+        expect(rows[0].label).toBe("happy path");
+
+        const caseRow = await prisma.repositoryCases.findUnique({
+          where: { id: caseId },
+          select: { hasParameters: true },
+        });
+        expect(caseRow?.hasParameters).toBe(true);
+      }
+    );
+
+    it(
+      "rejects datasetRows without parameters and rolls back the whole case",
+      { timeout: 60_000 },
+      async () => {
+        const prisma = await importPrisma();
+        const { importGeneratedTestCases } =
+          await import("./importGeneratedTestCases");
+        const { tag, project, template, workflow, repo, folder } =
+          await seedFixture(prisma);
+
+        const result = await importGeneratedTestCases({
+          projectId: project.id,
+          projectName: project.name,
+          repositoryId: repo.id,
+          folderId: folder.id,
+          folderName: folder.name,
+          templateId: template.id,
+          templateName: template.templateName,
+          stateId: workflow.id,
+          stateName: workflow.name,
+          maxOrder: 0,
+          autoGenerateTags: false,
+          source: "MANUAL",
+          testCases: [
+            {
+              id: `${tag}-bad-0`,
+              name: `${tag}-bad`,
+              fieldValues: {},
+              steps: [],
+              datasetRows: [{ rowIndex: 0, values: { whatever: 1 } }],
+            },
+          ],
+          fieldMappings: [],
+        } as any);
+
+        // The per-case try/catch in the action records the error and skips the
+        // case; importedCount stays at 0. The whole transaction commits but the
+        // bad case never lands.
+        expect(result.importedCount).toBe(0);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0]).toMatch(/datasetRows/i);
+      }
+    );
+
+    it(
+      "rejects duplicate parameter names and rolls back the case",
+      { timeout: 60_000 },
+      async () => {
+        const prisma = await importPrisma();
+        const { importGeneratedTestCases } =
+          await import("./importGeneratedTestCases");
+        const { tag, project, template, workflow, repo, folder } =
+          await seedFixture(prisma);
+
+        const result = await importGeneratedTestCases({
+          projectId: project.id,
+          projectName: project.name,
+          repositoryId: repo.id,
+          folderId: folder.id,
+          folderName: folder.name,
+          templateId: template.id,
+          templateName: template.templateName,
+          stateId: workflow.id,
+          stateName: workflow.name,
+          maxOrder: 0,
+          autoGenerateTags: false,
+          source: "MANUAL",
+          testCases: [
+            {
+              id: `${tag}-dup-0`,
+              name: `${tag}-dup`,
+              fieldValues: {},
+              steps: [],
+              parameters: [
+                { name: "user", type: "STRING" },
+                { name: "user", type: "STRING" },
+              ],
+            },
+          ],
+          fieldMappings: [],
+        } as any);
+
+        expect(result.importedCount).toBe(0);
+        expect(result.errors[0]).toMatch(/duplicate parameter name/i);
+      }
+    );
+  }
+);

--- a/testplanit/app/actions/importGeneratedTestCases.ts
+++ b/testplanit/app/actions/importGeneratedTestCases.ts
@@ -1,6 +1,10 @@
 "use server";
 
-import { RepositoryCaseSource, WorkflowScope } from "@prisma/client";
+import {
+  ParameterType,
+  RepositoryCaseSource,
+  WorkflowScope,
+} from "@prisma/client";
 import { z } from "zod/v4";
 import { prisma } from "~/lib/prisma";
 import { resolveCreateStateRemap } from "~/lib/services/reviewGate";
@@ -47,6 +51,26 @@ const FieldMappingSchema = z.object({
     .optional(),
 });
 
+// AddCase inline parameters/dataset (PARAM-AddCase). Both optional; datasetRows
+// requires parameters (the dataset columns are the parameter names). Validated
+// at the boundary so the modal can author a fully parameterized case in a
+// single round-trip instead of "create case → open Configure Parameters sheet
+// → save params → save dataset".
+const InlineParameterSchema = z.object({
+  name: z.string().min(1).max(64),
+  type: z.enum(ParameterType),
+  required: z.boolean().optional(),
+  sensitive: z.boolean().optional(),
+  description: z.string().optional(),
+  allowedValuesJson: z.any().optional(),
+});
+
+const InlineDatasetRowSchema = z.object({
+  rowIndex: z.number().int().nonnegative(),
+  label: z.string().optional(),
+  values: z.record(z.string(), z.any()),
+});
+
 const TestCaseInputSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -64,6 +88,8 @@ const TestCaseInputSchema = z.object({
   versionFieldValues: z.array(VersionFieldValueSchema).optional(),
   versionTags: z.array(z.string()).optional(),
   versionIssues: z.array(VersionIssueSchema).optional(),
+  parameters: z.array(InlineParameterSchema).optional(),
+  datasetRows: z.array(InlineDatasetRowSchema).optional(),
 });
 
 const ImportInputSchema = z.object({
@@ -652,6 +678,82 @@ export async function importGeneratedTestCases(
                 sharedStepGroupId: step.sharedStepGroupId ?? null,
               }));
               await tx.steps.createMany({ data: stepData });
+            }
+
+            // 7. Inline parameters + dataset (AddCase modal path; PARAM-AddCase)
+            if (testCase.parameters?.length) {
+              const seen = new Set<string>();
+              for (const p of testCase.parameters) {
+                if (seen.has(p.name)) {
+                  throw new Error(
+                    `Duplicate parameter name "${p.name}" on "${testCase.name}"`
+                  );
+                }
+                seen.add(p.name);
+              }
+              await tx.testCaseParameter.createMany({
+                data: testCase.parameters.map((p, order) => ({
+                  testCaseId: newCase.id,
+                  name: p.name,
+                  type: p.type,
+                  required: p.required ?? false,
+                  sensitive: p.sensitive ?? false,
+                  description: p.description ?? null,
+                  allowedValuesJson: p.allowedValuesJson ?? null,
+                  order,
+                })),
+              });
+              await tx.repositoryCases.update({
+                where: { id: newCase.id },
+                data: { hasParameters: true },
+              });
+
+              if (testCase.datasetRows?.length) {
+                const sortedRows = [...testCase.datasetRows].sort(
+                  (a, b) => a.rowIndex - b.rowIndex
+                );
+                const dataset = await tx.dataSet.create({
+                  data: {
+                    projectId: data.projectId,
+                    ownerCaseId: newCase.id,
+                    name: `${testCase.name} dataset`.slice(0, 255),
+                    isShared: false,
+                    createdById: userId,
+                  },
+                  select: { id: true },
+                });
+                await tx.dataSetVersion.create({
+                  data: {
+                    dataSetId: dataset.id,
+                    version: 1,
+                    parametersJson: testCase.parameters.map((p) => ({
+                      name: p.name,
+                      type: p.type,
+                      required: p.required ?? false,
+                      sensitive: p.sensitive ?? false,
+                    })),
+                    rowsJson: sortedRows.map((r) => ({
+                      rowIndex: r.rowIndex,
+                      label: r.label ?? null,
+                      values: r.values,
+                    })),
+                    rowCount: sortedRows.length,
+                    createdById: userId,
+                  },
+                });
+                await tx.dataSetRow.createMany({
+                  data: sortedRows.map((r) => ({
+                    dataSetId: dataset.id,
+                    rowIndex: r.rowIndex,
+                    label: r.label ?? null,
+                    valuesJson: r.values,
+                  })),
+                });
+              }
+            } else if (testCase.datasetRows?.length) {
+              throw new Error(
+                `"${testCase.name}" sent datasetRows without parameters — dataset columns require a parameter schema`
+              );
             }
 
             importedIds.push(newCase.id);

--- a/testplanit/components/parameters/InlineDatasetEditor.tsx
+++ b/testplanit/components/parameters/InlineDatasetEditor.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+/**
+ * Inline parameter + dataset editor for the AddCase modal.
+ *
+ * Intentionally a separate, simpler component from `ConfigureParametersSheet`
+ * + `ParametersTab` + `DatasetTab`. Those are persistence-bound (every edit
+ * POSTs to per-case endpoints), and AddCase has no caseId until Save. The
+ * trade-off we accept here is that this editor reimplements about 20% of the
+ * full sheet's surface — sufficient to author a parameterized case in one
+ * step.
+ *
+ * Gaps vs the full sheet (intentional, can be added later):
+ *   - No CSV import (use the live sheet on an existing case for bulk import).
+ *   - No per-cell sensitive masking (sensitive is a parameter-level flag).
+ *   - SELECT type is offered but `allowedValuesJson` authoring is deferred —
+ *     pick the type, fill in allowed values via the live sheet after save.
+ *   - No row drag-reorder; rows render in `rowIndex` order.
+ *
+ * Controlled component: parent owns the parameters + rows state, typically
+ * through react-hook-form. `onChange` is invoked with the next combined
+ * state on every edit so duplicate-name validation + dependent UI re-renders
+ * happen at the parent level.
+ */
+
+export type InlineParameterType = "STRING" | "INTEGER" | "BOOLEAN" | "SELECT";
+
+export interface InlineParameter {
+  name: string;
+  type: InlineParameterType;
+  required?: boolean;
+  sensitive?: boolean;
+  description?: string;
+}
+
+export interface InlineDatasetRow {
+  rowIndex: number;
+  label?: string;
+  values: Record<string, unknown>;
+}
+
+export interface InlineDatasetEditorProps {
+  parameters: InlineParameter[];
+  rows: InlineDatasetRow[];
+  onChange: (next: {
+    parameters: InlineParameter[];
+    rows: InlineDatasetRow[];
+  }) => void;
+  testIdPrefix?: string;
+}
+
+const TYPES: InlineParameterType[] = ["STRING", "INTEGER", "BOOLEAN", "SELECT"];
+
+export function InlineDatasetEditor({
+  parameters,
+  rows,
+  onChange,
+  testIdPrefix = "inline-dataset",
+}: InlineDatasetEditorProps) {
+  const t = useTranslations("parameters");
+
+  const duplicateNames = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of parameters) {
+      const key = p.name.trim();
+      if (!key) continue;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return new Set(
+      Array.from(counts.entries())
+        .filter(([, c]) => c > 1)
+        .map(([k]) => k)
+    );
+  }, [parameters]);
+
+  const updateParameter = useCallback(
+    (index: number, patch: Partial<InlineParameter>) => {
+      const next = parameters.map((p, i) =>
+        i === index ? { ...p, ...patch } : p
+      );
+      onChange({ parameters: next, rows });
+    },
+    [parameters, rows, onChange]
+  );
+
+  const renameParameter = useCallback(
+    (index: number, nextName: string) => {
+      const prevName = parameters[index]?.name;
+      const nextParams = parameters.map((p, i) =>
+        i === index ? { ...p, name: nextName } : p
+      );
+      // Cascade rename into row values so entered data isn't lost on typo
+      // fixes.
+      const nextRows = rows.map((row) => {
+        if (prevName === undefined || prevName === nextName) return row;
+        if (!(prevName in row.values)) return row;
+        const { [prevName]: moved, ...rest } = row.values;
+        return { ...row, values: { ...rest, [nextName]: moved } };
+      });
+      onChange({ parameters: nextParams, rows: nextRows });
+    },
+    [parameters, rows, onChange]
+  );
+
+  const removeParameter = useCallback(
+    (index: number) => {
+      const removed = parameters[index]?.name;
+      const nextParams = parameters.filter((_, i) => i !== index);
+      const nextRows = removed
+        ? rows.map((r) => {
+            const { [removed]: _drop, ...rest } = r.values;
+            return { ...r, values: rest };
+          })
+        : rows;
+      onChange({ parameters: nextParams, rows: nextRows });
+    },
+    [parameters, rows, onChange]
+  );
+
+  const addParameter = useCallback(() => {
+    const taken = new Set(parameters.map((p) => p.name));
+    let candidate = "param";
+    let counter = 1;
+    while (taken.has(candidate)) {
+      counter += 1;
+      candidate = `param${counter}`;
+    }
+    onChange({
+      parameters: [
+        ...parameters,
+        { name: candidate, type: "STRING", required: false, sensitive: false },
+      ],
+      rows,
+    });
+  }, [parameters, rows, onChange]);
+
+  const addRow = useCallback(() => {
+    const nextIndex = rows.length
+      ? Math.max(...rows.map((r) => r.rowIndex)) + 1
+      : 0;
+    const blankValues: Record<string, unknown> = {};
+    for (const p of parameters) {
+      blankValues[p.name] = p.type === "BOOLEAN" ? false : "";
+    }
+    onChange({
+      parameters,
+      rows: [...rows, { rowIndex: nextIndex, label: "", values: blankValues }],
+    });
+  }, [parameters, rows, onChange]);
+
+  const removeRow = useCallback(
+    (index: number) => {
+      onChange({ parameters, rows: rows.filter((_, i) => i !== index) });
+    },
+    [parameters, rows, onChange]
+  );
+
+  const updateRowLabel = useCallback(
+    (index: number, label: string) => {
+      const next = rows.map((r, i) => (i === index ? { ...r, label } : r));
+      onChange({ parameters, rows: next });
+    },
+    [parameters, rows, onChange]
+  );
+
+  const updateRowValue = useCallback(
+    (rowIdx: number, paramName: string, value: unknown) => {
+      const next = rows.map((r, i) =>
+        i === rowIdx ? { ...r, values: { ...r.values, [paramName]: value } } : r
+      );
+      onChange({ parameters, rows: next });
+    },
+    [parameters, rows, onChange]
+  );
+
+  return (
+    <div className="space-y-4" data-testid={`${testIdPrefix}-root`}>
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">{t("tabParameters")}</Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addParameter}
+            data-testid={`${testIdPrefix}-add-parameter`}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            {t("formAdd")}
+          </Button>
+        </div>
+        {parameters.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t("emptyHeading")}</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[28%]">{t("formName")}</TableHead>
+                <TableHead className="w-[18%]">{t("formType")}</TableHead>
+                <TableHead className="w-[15%] text-center">
+                  {t("formRequired")}
+                </TableHead>
+                <TableHead className="w-[15%] text-center">
+                  {t("formSensitive")}
+                </TableHead>
+                <TableHead className="w-auto" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {parameters.map((p, i) => {
+                const isDup = duplicateNames.has(p.name.trim());
+                return (
+                  <TableRow
+                    key={i}
+                    data-testid={`${testIdPrefix}-parameter-row-${i}`}
+                  >
+                    <TableCell>
+                      <Input
+                        value={p.name}
+                        onChange={(e) => renameParameter(i, e.target.value)}
+                        aria-invalid={isDup || !p.name.trim()}
+                        className={isDup ? "border-destructive" : undefined}
+                        data-testid={`${testIdPrefix}-parameter-name-${i}`}
+                      />
+                      {isDup && (
+                        <p className="mt-1 text-xs text-destructive">
+                          {t("datasetAddColumnDuplicate")}
+                        </p>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        value={p.type}
+                        onValueChange={(v) =>
+                          updateParameter(i, {
+                            type: v as InlineParameterType,
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          data-testid={`${testIdPrefix}-parameter-type-${i}`}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {TYPES.map((typ) => (
+                            <SelectItem key={typ} value={typ}>
+                              {typ}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Switch
+                        checked={!!p.required}
+                        onCheckedChange={(checked) =>
+                          updateParameter(i, { required: checked })
+                        }
+                        aria-label={t("formRequired")}
+                      />
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Switch
+                        checked={!!p.sensitive}
+                        onCheckedChange={(checked) =>
+                          updateParameter(i, { sensitive: checked })
+                        }
+                        aria-label={t("formSensitive")}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeParameter(i)}
+                        aria-label={t("deleteAria")}
+                        data-testid={`${testIdPrefix}-remove-parameter-${i}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">{t("tabDataset")}</Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addRow}
+            disabled={parameters.length === 0}
+            data-testid={`${testIdPrefix}-add-row`}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            {t("datasetAddRow")}
+          </Button>
+        </div>
+        {parameters.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t("tabDatasetDisabledTooltip")}
+          </p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t("datasetEmptyHeading")}
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[20%]">
+                  {t("datasetLabelColumn")}
+                </TableHead>
+                {parameters.map((p, i) => (
+                  <TableHead key={`${p.name}-${i}`}>{p.name || "—"}</TableHead>
+                ))}
+                <TableHead className="w-auto" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row, rowIdx) => (
+                <TableRow
+                  key={rowIdx}
+                  data-testid={`${testIdPrefix}-dataset-row-${rowIdx}`}
+                >
+                  <TableCell>
+                    <Input
+                      value={row.label ?? ""}
+                      onChange={(e) => updateRowLabel(rowIdx, e.target.value)}
+                      data-testid={`${testIdPrefix}-row-label-${rowIdx}`}
+                    />
+                  </TableCell>
+                  {parameters.map((p, colIdx) => {
+                    const raw = row.values[p.name];
+                    const cellTestId = `${testIdPrefix}-row-${rowIdx}-col-${colIdx}`;
+                    if (p.type === "BOOLEAN") {
+                      return (
+                        <TableCell key={`${p.name}-${colIdx}`}>
+                          <Switch
+                            checked={raw === true}
+                            onCheckedChange={(checked) =>
+                              updateRowValue(rowIdx, p.name, checked)
+                            }
+                            aria-label={p.name}
+                            data-testid={cellTestId}
+                          />
+                        </TableCell>
+                      );
+                    }
+                    if (p.type === "INTEGER") {
+                      return (
+                        <TableCell key={`${p.name}-${colIdx}`}>
+                          <Input
+                            type="number"
+                            inputMode="numeric"
+                            value={raw == null ? "" : String(raw)}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === "") {
+                                updateRowValue(rowIdx, p.name, "");
+                              } else {
+                                const parsed = Number(val);
+                                updateRowValue(
+                                  rowIdx,
+                                  p.name,
+                                  Number.isFinite(parsed) ? parsed : val
+                                );
+                              }
+                            }}
+                            data-testid={cellTestId}
+                          />
+                        </TableCell>
+                      );
+                    }
+                    return (
+                      <TableCell key={`${p.name}-${colIdx}`}>
+                        <Input
+                          value={raw == null ? "" : String(raw)}
+                          onChange={(e) =>
+                            updateRowValue(rowIdx, p.name, e.target.value)
+                          }
+                          data-testid={cellTestId}
+                        />
+                      </TableCell>
+                    );
+                  })}
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeRow(rowIdx)}
+                      aria-label={t("deleteAria")}
+                      data-testid={`${testIdPrefix}-remove-row-${rowIdx}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/testplanit/components/parameters/__tests__/InlineDatasetEditor.test.tsx
+++ b/testplanit/components/parameters/__tests__/InlineDatasetEditor.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
+    const dict: Record<string, string> = {
+      tabParameters: "Parameters",
+      tabDataset: "Dataset",
+      formAdd: "Add parameter",
+      formName: "Name",
+      formType: "Type",
+      formRequired: "Required",
+      formSensitive: "Sensitive",
+      datasetAddRow: "Add row",
+      datasetLabelColumn: "Label",
+      datasetEmptyHeading: "No rows yet",
+      datasetAddColumnDuplicate: "Duplicate name",
+      emptyHeading: "No parameters yet",
+      tabDatasetDisabledTooltip: "Add a parameter first",
+      deleteAria: "Delete",
+    };
+    return dict[key] ?? key + (vars ? `(${JSON.stringify(vars)})` : "");
+  },
+}));
+
+import { InlineDatasetEditor } from "@/components/parameters/InlineDatasetEditor";
+import type {
+  InlineDatasetEditorProps,
+  InlineDatasetRow,
+  InlineParameter,
+} from "@/components/parameters/InlineDatasetEditor";
+
+/**
+ * Controlled-render harness: keeps the editor's parent state inside the
+ * test so we can drive the component with userEvent and assert on the
+ * latest `onChange` payload via the captured ref.
+ */
+function Harness({
+  initialParameters = [],
+  initialRows = [],
+  captureRef,
+}: {
+  initialParameters?: InlineParameter[];
+  initialRows?: InlineDatasetRow[];
+  captureRef?: {
+    current: { parameters: InlineParameter[]; rows: InlineDatasetRow[] } | null;
+  };
+}) {
+  const [parameters, setParameters] =
+    React.useState<InlineParameter[]>(initialParameters);
+  const [rows, setRows] = React.useState<InlineDatasetRow[]>(initialRows);
+  const onChange: InlineDatasetEditorProps["onChange"] = ({
+    parameters: next,
+    rows: nextRows,
+  }) => {
+    setParameters(next);
+    setRows(nextRows);
+    if (captureRef) captureRef.current = { parameters: next, rows: nextRows };
+  };
+  return (
+    <InlineDatasetEditor
+      parameters={parameters}
+      rows={rows}
+      onChange={onChange}
+    />
+  );
+}
+
+describe("InlineDatasetEditor", () => {
+  it("renders empty-state copy when no parameters are present", () => {
+    render(<Harness />);
+    expect(screen.getByText("No parameters yet")).toBeInTheDocument();
+    // Dataset section shows the "no params" empty state, not the row empty
+    expect(screen.getByText("Add a parameter first")).toBeInTheDocument();
+  });
+
+  it("disables the Add row button when there are no parameters", () => {
+    render(<Harness />);
+    expect(screen.getByTestId("inline-dataset-add-row")).toBeDisabled();
+  });
+
+  it("addParameter creates a row with auto-named 'param', then 'param2', 'param3' on subsequent clicks", async () => {
+    const captured = { current: null as any };
+    render(<Harness captureRef={captured} />);
+    const addBtn = screen.getByTestId("inline-dataset-add-parameter");
+    await userEvent.click(addBtn);
+    expect(captured.current.parameters).toEqual([
+      {
+        name: "param",
+        type: "STRING",
+        required: false,
+        sensitive: false,
+      },
+    ]);
+    await userEvent.click(addBtn);
+    expect(
+      captured.current.parameters.map((p: InlineParameter) => p.name)
+    ).toEqual(["param", "param2"]);
+  });
+
+  it("renameParameter cascades into row values so typo-fixes don't lose data", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[{ name: "username", type: "STRING" }]}
+        initialRows={[
+          { rowIndex: 0, label: "happy", values: { username: "alice" } },
+        ]}
+      />
+    );
+    const nameInput = screen.getByTestId("inline-dataset-parameter-name-0");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "user");
+    expect(captured.current.parameters[0].name).toBe("user");
+    expect(captured.current.rows[0].values).toEqual({ user: "alice" });
+    expect(captured.current.rows[0].values).not.toHaveProperty("username");
+  });
+
+  it("removeParameter drops the column from every row's values", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[
+          { name: "a", type: "STRING" },
+          { name: "b", type: "STRING" },
+        ]}
+        initialRows={[
+          { rowIndex: 0, values: { a: "x", b: "y" } },
+          { rowIndex: 1, values: { a: "z", b: "w" } },
+        ]}
+      />
+    );
+    await userEvent.click(
+      screen.getByTestId("inline-dataset-remove-parameter-0")
+    );
+    expect(captured.current.parameters).toEqual([
+      { name: "b", type: "STRING" },
+    ]);
+    expect(captured.current.rows).toEqual([
+      { rowIndex: 0, values: { b: "y" } },
+      { rowIndex: 1, values: { b: "w" } },
+    ]);
+  });
+
+  it("flags duplicate parameter names with the destructive error message", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[
+          { name: "x", type: "STRING" },
+          { name: "y", type: "STRING" },
+        ]}
+      />
+    );
+    const second = screen.getByTestId("inline-dataset-parameter-name-1");
+    await userEvent.clear(second);
+    await userEvent.type(second, "x");
+    expect(captured.current.parameters[1].name).toBe("x");
+    expect(screen.getAllByText("Duplicate name").length).toBeGreaterThan(0);
+  });
+
+  it("addRow seeds blank values keyed by parameter name, BOOLEAN defaulting to false", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[
+          { name: "user", type: "STRING" },
+          { name: "active", type: "BOOLEAN" },
+          { name: "score", type: "INTEGER" },
+        ]}
+      />
+    );
+    await userEvent.click(screen.getByTestId("inline-dataset-add-row"));
+    expect(captured.current.rows).toHaveLength(1);
+    expect(captured.current.rows[0].values).toEqual({
+      user: "",
+      active: false,
+      score: "",
+    });
+  });
+
+  it("INTEGER cell coerces numeric input via Number() and preserves empty string for clears", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[{ name: "score", type: "INTEGER" }]}
+        initialRows={[{ rowIndex: 0, values: { score: "" } }]}
+      />
+    );
+    const cell = screen.getByTestId("inline-dataset-row-0-col-0");
+    await userEvent.type(cell, "42");
+    expect(captured.current.rows[0].values.score).toBe(42);
+    await userEvent.clear(cell);
+    expect(captured.current.rows[0].values.score).toBe("");
+  });
+
+  it("BOOLEAN cell renders a switch and toggles between true and false", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[{ name: "active", type: "BOOLEAN" }]}
+        initialRows={[{ rowIndex: 0, values: { active: false } }]}
+      />
+    );
+    const cell = screen.getByTestId("inline-dataset-row-0-col-0");
+    await userEvent.click(cell);
+    expect(captured.current.rows[0].values.active).toBe(true);
+    await userEvent.click(cell);
+    expect(captured.current.rows[0].values.active).toBe(false);
+  });
+
+  it("removeRow drops only the targeted row, leaving siblings intact", async () => {
+    const captured = { current: null as any };
+    render(
+      <Harness
+        captureRef={captured}
+        initialParameters={[{ name: "a", type: "STRING" }]}
+        initialRows={[
+          { rowIndex: 0, label: "keep", values: { a: "x" } },
+          { rowIndex: 1, label: "drop", values: { a: "y" } },
+          { rowIndex: 2, label: "keep too", values: { a: "z" } },
+        ]}
+      />
+    );
+    await userEvent.click(screen.getByTestId("inline-dataset-remove-row-1"));
+    expect(captured.current.rows).toHaveLength(2);
+    expect(captured.current.rows.map((r: InlineDatasetRow) => r.label)).toEqual(
+      ["keep", "keep too"]
+    );
+  });
+
+  it("renders the parameter name as the dataset column header", () => {
+    render(
+      <Harness
+        initialParameters={[
+          { name: "username", type: "STRING" },
+          { name: "balance", type: "INTEGER" },
+        ]}
+        initialRows={[{ rowIndex: 0, values: { username: "", balance: "" } }]}
+      />
+    );
+    // Headers should include both parameter names
+    const headers = screen.getAllByRole("columnheader");
+    const headerTexts = headers.map((h) => h.textContent?.trim());
+    expect(headerTexts).toContain("username");
+    expect(headerTexts).toContain("balance");
+  });
+
+  it("uses a test-id prefix override when provided so two editors can co-exist", () => {
+    render(
+      <InlineDatasetEditor
+        parameters={[]}
+        rows={[]}
+        onChange={() => {}}
+        testIdPrefix="alt"
+      />
+    );
+    expect(screen.getByTestId("alt-root")).toBeInTheDocument();
+    expect(screen.getByTestId("alt-add-parameter")).toBeInTheDocument();
+  });
+});

--- a/testplanit/e2e/tests/repository/add-case-inline-parameters.spec.ts
+++ b/testplanit/e2e/tests/repository/add-case-inline-parameters.spec.ts
@@ -1,0 +1,434 @@
+import { expect, test } from "../../fixtures";
+import { RepositoryPage } from "../../page-objects/repository/repository.page";
+
+/**
+ * Add Case — Inline Parameters & Dataset
+ *
+ * The Add Case modal exposes a Configure Parameters button above the Steps
+ * field (mirrors the case details page). Clicking opens a Sheet that hosts
+ * an InlineDatasetEditor; on submit the parameters + dataset rows land
+ * atomically through the same `importGeneratedTestCases` server action
+ * that the plain (no-parameters) path uses.
+ *
+ * These tests guard against regressions in three high-blast-radius
+ * scenarios that the unit tests in
+ * `lib/services/inlineParamsGate.test.ts` and
+ * `components/parameters/__tests__/InlineDatasetEditor.test.tsx` can't
+ * cover end-to-end:
+ *
+ *   1. The Configure Parameters affordance appears at all and the Sheet
+ *      opens with the editor wired up (UI rendering + dependency chain
+ *      from React state down to the test ids that downstream automation
+ *      keys off).
+ *   2. The full save path round-trips: case + parameter + dataset +
+ *      dataset version + dataset row all land in the database from a
+ *      single Submit click, with `hasParameters` flipped on the case.
+ *   3. The plain happy path (no Sheet interaction) still creates a
+ *      non-parameterized case so the new code paths can't silently
+ *      regress AddCase — the biggest feature in the product.
+ */
+
+async function setupProjectAndFolder(
+  api: import("../../fixtures/api.fixture").ApiHelper
+): Promise<{ projectId: number; folderId: number }> {
+  const projectId = await api.createProject(
+    `E2E Inline Params ${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+  );
+  const folderId = await api.createFolder(projectId, `Folder ${Date.now()}`);
+  return { projectId, folderId };
+}
+
+async function findCaseIdByName(
+  api: import("../../fixtures/api.fixture").ApiHelper,
+  folderId: number,
+  name: string
+): Promise<number | null> {
+  const resp = await (api as any).request.get(
+    `${(api as any).baseURL}/api/model/repositoryCases/findFirst?q=` +
+      encodeURIComponent(
+        JSON.stringify({
+          where: { folderId, name, isDeleted: false },
+          select: { id: true },
+        })
+      )
+  );
+  if (!resp.ok()) return null;
+  const json = await resp.json();
+  return json?.data?.id ?? null;
+}
+
+async function getCaseSnapshot(
+  api: import("../../fixtures/api.fixture").ApiHelper,
+  caseId: number
+): Promise<{
+  hasParameters: boolean | null;
+  parameterCount: number;
+  datasetCount: number;
+  datasetVersionCount: number;
+  datasetRowCount: number;
+  firstParamName: string | null;
+  firstRowLabel: string | null;
+  firstRowValues: Record<string, unknown> | null;
+}> {
+  // RepositoryCases.hasParameters
+  const caseResp = await (api as any).request.get(
+    `${(api as any).baseURL}/api/model/repositoryCases/findFirst?q=` +
+      encodeURIComponent(
+        JSON.stringify({
+          where: { id: caseId },
+          select: { id: true, hasParameters: true },
+        })
+      )
+  );
+  const caseRow = caseResp.ok() ? (await caseResp.json()).data : null;
+
+  const paramResp = await (api as any).request.get(
+    `${(api as any).baseURL}/api/model/testCaseParameter/findMany?q=` +
+      encodeURIComponent(
+        JSON.stringify({
+          where: { testCaseId: caseId, isDeleted: false },
+          orderBy: { order: "asc" },
+          select: { id: true, name: true, type: true },
+        })
+      )
+  );
+  const params = paramResp.ok() ? (await paramResp.json()).data ?? [] : [];
+
+  const datasetResp = await (api as any).request.get(
+    `${(api as any).baseURL}/api/model/dataSet/findMany?q=` +
+      encodeURIComponent(
+        JSON.stringify({
+          where: { ownerCaseId: caseId, isDeleted: false },
+          select: { id: true },
+        })
+      )
+  );
+  const datasets = datasetResp.ok() ? (await datasetResp.json()).data ?? [] : [];
+  const datasetIds = datasets.map((d: { id: number }) => d.id);
+
+  let datasetVersions: any[] = [];
+  let datasetRows: any[] = [];
+  if (datasetIds.length) {
+    const vResp = await (api as any).request.get(
+      `${(api as any).baseURL}/api/model/dataSetVersion/findMany?q=` +
+        encodeURIComponent(
+          JSON.stringify({
+            where: { dataSetId: { in: datasetIds } },
+            select: { id: true, version: true },
+          })
+        )
+    );
+    datasetVersions = vResp.ok() ? (await vResp.json()).data ?? [] : [];
+
+    const rResp = await (api as any).request.get(
+      `${(api as any).baseURL}/api/model/dataSetRow/findMany?q=` +
+        encodeURIComponent(
+          JSON.stringify({
+            where: { dataSetId: { in: datasetIds }, isDeleted: false },
+            orderBy: { rowIndex: "asc" },
+            select: {
+              id: true,
+              rowIndex: true,
+              label: true,
+              valuesJson: true,
+            },
+          })
+        )
+    );
+    datasetRows = rResp.ok() ? (await rResp.json()).data ?? [] : [];
+  }
+
+  return {
+    hasParameters: caseRow?.hasParameters ?? null,
+    parameterCount: params.length,
+    datasetCount: datasets.length,
+    datasetVersionCount: datasetVersions.length,
+    datasetRowCount: datasetRows.length,
+    firstParamName: params[0]?.name ?? null,
+    firstRowLabel: datasetRows[0]?.label ?? null,
+    firstRowValues: datasetRows[0]?.valuesJson ?? null,
+  };
+}
+
+test.describe("Add Case — Inline Parameters & Dataset", () => {
+  let repositoryPage: RepositoryPage;
+
+  test.beforeEach(async ({ page }) => {
+    repositoryPage = new RepositoryPage(page);
+  });
+
+  test("Configure Parameters button is visible on a Steps-bearing template and the Sheet opens with the editor wired @smoke", async ({
+    api,
+    page,
+  }) => {
+    const { projectId, folderId } = await setupProjectAndFolder(api);
+    await repositoryPage.goto(projectId);
+    await repositoryPage.selectFolder(folderId);
+
+    const addCaseButton = page.getByTestId("add-case-button");
+    await expect(addCaseButton).toBeEnabled({ timeout: 10000 });
+    await addCaseButton.click();
+
+    const dialog = page.getByTestId("add-case-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    // The seeded "Default Template" has a Steps field, so the button
+    // renders by default. Label is "Configure parameters" when the
+    // editor has nothing authored yet.
+    const configureBtn = dialog
+      .getByRole("button", { name: /^configure parameters$/i })
+      .first();
+    await expect(configureBtn).toBeVisible({ timeout: 10000 });
+    await configureBtn.click();
+
+    // The Sheet renders the editor with its add-parameter affordance
+    // and the dataset Add-row button disabled until a parameter exists.
+    const editorRoot = page.getByTestId("addcase-inline-dataset-root");
+    await expect(editorRoot).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByTestId("addcase-inline-dataset-add-parameter")
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("addcase-inline-dataset-add-row")
+    ).toBeDisabled();
+  });
+
+  test("Inline parameters and a dataset row persist on save (full round-trip)", async ({
+    api,
+    page,
+  }) => {
+    const { projectId, folderId } = await setupProjectAndFolder(api);
+    const caseName = `Inline Params ${Date.now()}`;
+
+    await repositoryPage.goto(projectId);
+    await repositoryPage.selectFolder(folderId);
+
+    await page.getByTestId("add-case-button").click();
+    const dialog = page.getByTestId("add-case-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    await dialog.getByTestId("case-name-input").fill(caseName);
+
+    // Open the Configure Parameters sheet, author a single column + row.
+    await dialog
+      .getByRole("button", { name: /^configure parameters$/i })
+      .first()
+      .click();
+    await expect(
+      page.getByTestId("addcase-inline-dataset-root")
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByTestId("addcase-inline-dataset-add-parameter").click();
+    const nameInput = page.getByTestId(
+      "addcase-inline-dataset-parameter-name-0"
+    );
+    await expect(nameInput).toHaveValue("param", { timeout: 5000 });
+    await nameInput.fill("user");
+
+    await page.getByTestId("addcase-inline-dataset-add-row").click();
+    await page
+      .getByTestId("addcase-inline-dataset-row-label-0")
+      .fill("happy path");
+    await page
+      .getByTestId("addcase-inline-dataset-row-0-col-0")
+      .fill("alice");
+
+    // Close the Sheet via Escape — Dialog must stay open and the button
+    // label updates to reflect the new column count.
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByTestId("addcase-inline-dataset-root")
+    ).not.toBeVisible({ timeout: 5000 });
+    await expect(
+      dialog.getByRole("button", { name: /^parameters \(1\)$/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByTestId("case-submit-button").click();
+    await expect(dialog).not.toBeVisible({ timeout: 15000 });
+
+    // Case must appear in the table, and the DB row must have its
+    // parameter + dataset + dataset version + dataset row all written
+    // in the single atomic save.
+    const caseRow = repositoryPage.getTestCaseByName(caseName);
+    await expect(caseRow).toBeVisible({ timeout: 15000 });
+
+    const caseId = await findCaseIdByName(api, folderId, caseName);
+    expect(caseId).not.toBeNull();
+    const snapshot = await getCaseSnapshot(api, caseId!);
+    expect(snapshot.hasParameters).toBe(true);
+    expect(snapshot.parameterCount).toBe(1);
+    expect(snapshot.firstParamName).toBe("user");
+    expect(snapshot.datasetCount).toBe(1);
+    expect(snapshot.datasetVersionCount).toBe(1);
+    expect(snapshot.datasetRowCount).toBe(1);
+    expect(snapshot.firstRowLabel).toBe("happy path");
+    expect(snapshot.firstRowValues).toEqual({ user: "alice" });
+  });
+
+  test("Plain submit without opening the Sheet creates a non-parameterized case (regression guard) @smoke", async ({
+    api,
+    page,
+  }) => {
+    const { projectId, folderId } = await setupProjectAndFolder(api);
+    const caseName = `Plain Case ${Date.now()}`;
+
+    await repositoryPage.goto(projectId);
+    await repositoryPage.selectFolder(folderId);
+
+    await page.getByTestId("add-case-button").click();
+    const dialog = page.getByTestId("add-case-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+    await dialog.getByTestId("case-name-input").fill(caseName);
+
+    // The Configure Parameters button is present (Default Template has
+    // Steps) but we never click it. This is the most common user path —
+    // a quick case creation with no parameter authoring.
+    await page.getByTestId("case-submit-button").click();
+    await expect(dialog).not.toBeVisible({ timeout: 15000 });
+
+    const caseRow = repositoryPage.getTestCaseByName(caseName);
+    await expect(caseRow).toBeVisible({ timeout: 15000 });
+
+    const caseId = await findCaseIdByName(api, folderId, caseName);
+    expect(caseId).not.toBeNull();
+    const snapshot = await getCaseSnapshot(api, caseId!);
+    expect(snapshot.hasParameters).toBe(false);
+    expect(snapshot.parameterCount).toBe(0);
+    expect(snapshot.datasetCount).toBe(0);
+    expect(snapshot.datasetVersionCount).toBe(0);
+    expect(snapshot.datasetRowCount).toBe(0);
+  });
+
+  /**
+   * Highest-risk regression from this PR: the `templateHasSteps` memo + the
+   * effect that fires when it flips. The effect zeroes `inlineParameters`,
+   * `inlineDatasetRows`, and `inlineParamsSheetOpen` so a template switch
+   * can't ship orphan columns on submit. This test exercises both
+   * directions of the switch (Steps -> no-Steps -> Steps) and asserts on
+   * the DB to prove no orphaned state survived.
+   */
+  test("Switching from a Steps template to a no-Steps template clears authored inline parameters", async ({
+    api,
+    page,
+  }) => {
+    const { projectId, folderId } = await setupProjectAndFolder(api);
+    const caseName = `Switch Test ${Date.now()}`;
+
+    // Build a sibling template with no Steps field and assign it to the
+    // test project. `Priority` is a seeded standard field that's not Steps.
+    const priorityFieldId = await api.getCaseFieldId("Priority");
+    expect(priorityFieldId).not.toBeNull();
+    const noStepsTemplateName = `No Steps Template ${Date.now()}`;
+    await api.createTemplate({
+      name: noStepsTemplateName,
+      isEnabled: true,
+      isDefault: false,
+      caseFieldIds: [priorityFieldId!],
+      projectIds: [projectId],
+    });
+
+    await repositoryPage.goto(projectId);
+    await repositoryPage.selectFolder(folderId);
+
+    await page.getByTestId("add-case-button").click();
+    const dialog = page.getByTestId("add-case-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    // Default Template has Steps → button is visible. Author a parameter.
+    const configureBtnInitial = dialog
+      .getByRole("button", { name: /^configure parameters$/i })
+      .first();
+    await expect(configureBtnInitial).toBeVisible({ timeout: 10000 });
+    await configureBtnInitial.click();
+    await page.getByTestId("addcase-inline-dataset-add-parameter").click();
+    await expect(
+      page.getByTestId("addcase-inline-dataset-parameter-name-0")
+    ).toHaveValue("param", { timeout: 5000 });
+    await page.keyboard.press("Escape");
+    await expect(
+      dialog.getByRole("button", { name: /^parameters \(1\)$/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Switch to the no-Steps template via the dialog's template select.
+    // The Configure Parameters button must disappear because the
+    // templateHasSteps memo flips to false.
+    const templateTrigger = dialog.getByRole("combobox").first();
+    await templateTrigger.click();
+    await page
+      .getByRole("option", { name: noStepsTemplateName })
+      .first()
+      .click();
+    await expect(templateTrigger).toHaveText(noStepsTemplateName, {
+      timeout: 5000,
+    });
+    await expect(
+      dialog.getByRole("button", { name: /configure parameters|parameters \(/i })
+    ).toHaveCount(0, { timeout: 5000 });
+
+    // Switch BACK to Default Template. Button returns and label resets to
+    // "Configure parameters" (count = 0) — proves the clear effect ran.
+    await templateTrigger.click();
+    await page.getByRole("option", { name: "Default Template" }).first().click();
+    await expect(templateTrigger).toHaveText("Default Template", {
+      timeout: 5000,
+    });
+    await expect(
+      dialog.getByRole("button", { name: /^configure parameters$/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Submit and verify the saved case has zero parameters — the authored
+    // param was discarded by the clear effect, not carried over silently.
+    await dialog.getByTestId("case-name-input").fill(caseName);
+    await page.getByTestId("case-submit-button").click();
+    await expect(dialog).not.toBeVisible({ timeout: 15000 });
+
+    const caseRow = repositoryPage.getTestCaseByName(caseName);
+    await expect(caseRow).toBeVisible({ timeout: 15000 });
+    const caseId = await findCaseIdByName(api, folderId, caseName);
+    expect(caseId).not.toBeNull();
+    const snapshot = await getCaseSnapshot(api, caseId!);
+    expect(snapshot.hasParameters).toBe(false);
+    expect(snapshot.parameterCount).toBe(0);
+    expect(snapshot.datasetCount).toBe(0);
+  });
+
+  /**
+   * Regression guard for the Configure Parameters button injection above
+   * the Steps field. The button is rendered via `React.Fragment` next to
+   * `RenderField` inside the field-loop map. If the fragment key, the
+   * `isStepsField` check, or the conditional render regresses, the Steps
+   * field could disappear or fail to receive its props. This test asserts
+   * (a) both the button and the Steps field renderer are present, and
+   * (b) DOM order places the button above the Steps field.
+   */
+  test("Configure Parameters button sits above the Steps field renderer in DOM order (button injection regression guard)", async ({
+    api,
+    page,
+  }) => {
+    const { projectId, folderId } = await setupProjectAndFolder(api);
+    await repositoryPage.goto(projectId);
+    await repositoryPage.selectFolder(folderId);
+
+    await page.getByTestId("add-case-button").click();
+    const dialog = page.getByTestId("add-case-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    const configureBtn = dialog
+      .getByRole("button", { name: /^configure parameters$/i })
+      .first();
+    await expect(configureBtn).toBeVisible({ timeout: 10000 });
+
+    // The Steps field renderer surfaces an `Add Step` affordance below
+    // the button. Both must be in the same scrollable region (the left
+    // ResizablePanel), and the button's bounding box must be above the
+    // Steps section's bounding box.
+    const stepsHeading = dialog.getByText("Steps", { exact: true }).first();
+    await expect(stepsHeading).toBeVisible({ timeout: 10000 });
+
+    const btnBox = await configureBtn.boundingBox();
+    const stepsBox = await stepsHeading.boundingBox();
+    expect(btnBox).not.toBeNull();
+    expect(stepsBox).not.toBeNull();
+    expect(btnBox!.y + btnBox!.height).toBeLessThan(stepsBox!.y);
+  });
+});

--- a/testplanit/e2e/tests/repository/add-case-inline-parameters.spec.ts
+++ b/testplanit/e2e/tests/repository/add-case-inline-parameters.spec.ts
@@ -92,7 +92,7 @@ async function getCaseSnapshot(
         })
       )
   );
-  const params = paramResp.ok() ? (await paramResp.json()).data ?? [] : [];
+  const params = paramResp.ok() ? ((await paramResp.json()).data ?? []) : [];
 
   const datasetResp = await (api as any).request.get(
     `${(api as any).baseURL}/api/model/dataSet/findMany?q=` +
@@ -103,7 +103,9 @@ async function getCaseSnapshot(
         })
       )
   );
-  const datasets = datasetResp.ok() ? (await datasetResp.json()).data ?? [] : [];
+  const datasets = datasetResp.ok()
+    ? ((await datasetResp.json()).data ?? [])
+    : [];
   const datasetIds = datasets.map((d: { id: number }) => d.id);
 
   let datasetVersions: any[] = [];
@@ -118,7 +120,7 @@ async function getCaseSnapshot(
           })
         )
     );
-    datasetVersions = vResp.ok() ? (await vResp.json()).data ?? [] : [];
+    datasetVersions = vResp.ok() ? ((await vResp.json()).data ?? []) : [];
 
     const rResp = await (api as any).request.get(
       `${(api as any).baseURL}/api/model/dataSetRow/findMany?q=` +
@@ -135,7 +137,7 @@ async function getCaseSnapshot(
           })
         )
     );
-    datasetRows = rResp.ok() ? (await rResp.json()).data ?? [] : [];
+    datasetRows = rResp.ok() ? ((await rResp.json()).data ?? []) : [];
   }
 
   return {
@@ -214,9 +216,9 @@ test.describe("Add Case — Inline Parameters & Dataset", () => {
       .getByRole("button", { name: /^configure parameters$/i })
       .first()
       .click();
-    await expect(
-      page.getByTestId("addcase-inline-dataset-root")
-    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId("addcase-inline-dataset-root")).toBeVisible({
+      timeout: 5000,
+    });
 
     await page.getByTestId("addcase-inline-dataset-add-parameter").click();
     const nameInput = page.getByTestId(
@@ -229,9 +231,7 @@ test.describe("Add Case — Inline Parameters & Dataset", () => {
     await page
       .getByTestId("addcase-inline-dataset-row-label-0")
       .fill("happy path");
-    await page
-      .getByTestId("addcase-inline-dataset-row-0-col-0")
-      .fill("alice");
+    await page.getByTestId("addcase-inline-dataset-row-0-col-0").fill("alice");
 
     // Close the Sheet via Escape — Dialog must stay open and the button
     // label updates to reflect the new column count.
@@ -362,13 +362,18 @@ test.describe("Add Case — Inline Parameters & Dataset", () => {
       timeout: 5000,
     });
     await expect(
-      dialog.getByRole("button", { name: /configure parameters|parameters \(/i })
+      dialog.getByRole("button", {
+        name: /configure parameters|parameters \(/i,
+      })
     ).toHaveCount(0, { timeout: 5000 });
 
     // Switch BACK to Default Template. Button returns and label resets to
     // "Configure parameters" (count = 0) — proves the clear effect ran.
     await templateTrigger.click();
-    await page.getByRole("option", { name: "Default Template" }).first().click();
+    await page
+      .getByRole("option", { name: "Default Template" })
+      .first()
+      .click();
     await expect(templateTrigger).toHaveText("Default Template", {
       timeout: 5000,
     });

--- a/testplanit/lib/services/inlineParamsGate.test.ts
+++ b/testplanit/lib/services/inlineParamsGate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { pickInlinePayload, templateHasStepsField } from "./inlineParamsGate";
+
+describe("templateHasStepsField", () => {
+  it("returns true when caseFields contains a field with displayName 'Steps'", () => {
+    expect(
+      templateHasStepsField({
+        caseFields: [
+          { caseField: { displayName: "Name" } },
+          { caseField: { displayName: "Steps" } },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when no caseField has displayName 'Steps'", () => {
+    expect(
+      templateHasStepsField({
+        caseFields: [
+          { caseField: { displayName: "Name" } },
+          { caseField: { displayName: "Description" } },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it("is case-sensitive on displayName (matches the canonical 'Steps')", () => {
+    expect(
+      templateHasStepsField({
+        caseFields: [{ caseField: { displayName: "steps" } }],
+      })
+    ).toBe(false);
+    expect(
+      templateHasStepsField({
+        caseFields: [{ caseField: { displayName: "STEPS" } }],
+      })
+    ).toBe(false);
+  });
+
+  it("returns false for null / undefined templates (defensive)", () => {
+    expect(templateHasStepsField(null)).toBe(false);
+    expect(templateHasStepsField(undefined)).toBe(false);
+  });
+
+  it("returns false when caseFields is missing or empty", () => {
+    expect(templateHasStepsField({})).toBe(false);
+    expect(templateHasStepsField({ caseFields: null })).toBe(false);
+    expect(templateHasStepsField({ caseFields: [] })).toBe(false);
+  });
+
+  it("ignores caseFields entries with no nested caseField", () => {
+    expect(
+      templateHasStepsField({
+        caseFields: [
+          { caseField: null },
+          { caseField: { displayName: undefined } },
+        ],
+      })
+    ).toBe(false);
+  });
+});
+
+describe("pickInlinePayload", () => {
+  it("returns both undefined when no parameters declared (non-parameterized branch)", () => {
+    expect(pickInlinePayload([], [])).toEqual({
+      parameters: undefined,
+      datasetRows: undefined,
+    });
+  });
+
+  it("returns both undefined when parameters declared but every name is empty / whitespace", () => {
+    expect(
+      pickInlinePayload(
+        [
+          { name: "", type: "STRING" },
+          { name: "   ", type: "INTEGER" },
+        ],
+        [{ rowIndex: 0, values: {} }]
+      )
+    ).toEqual({ parameters: undefined, datasetRows: undefined });
+  });
+
+  it("forwards trimmed (non-empty-name) parameters and rows when at least one valid param exists", () => {
+    const params = [
+      { name: "user", type: "STRING" as const },
+      { name: "", type: "INTEGER" as const },
+    ];
+    const rows = [{ rowIndex: 0, label: "happy", values: { user: "alice" } }];
+    const out = pickInlinePayload(params, rows);
+    expect(out.parameters).toEqual([{ name: "user", type: "STRING" }]);
+    expect(out.datasetRows).toBe(rows);
+  });
+
+  it("does not mutate the input arrays", () => {
+    const params = [{ name: "a", type: "STRING" as const }];
+    const rows = [{ rowIndex: 0, values: { a: "x" } }];
+    pickInlinePayload(params, rows);
+    expect(params).toEqual([{ name: "a", type: "STRING" }]);
+    expect(rows).toEqual([{ rowIndex: 0, values: { a: "x" } }]);
+  });
+
+  it("forwards rows even when there are zero rows (parameters declared but no rows yet is a valid intermediate state)", () => {
+    const params = [{ name: "a", type: "STRING" as const }];
+    const out = pickInlinePayload(params, []);
+    expect(out.parameters).toEqual([{ name: "a", type: "STRING" }]);
+    expect(out.datasetRows).toEqual([]);
+  });
+});

--- a/testplanit/lib/services/inlineParamsGate.ts
+++ b/testplanit/lib/services/inlineParamsGate.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure helpers for the AddCase inline parameters/dataset flow. Extracted
+ * from `AddCase.tsx` so the gate logic (when to show the Configure
+ * Parameters button, what to forward on submit) has unit-test coverage
+ * without having to mock react-hook-form, ZenStack hooks, and next-intl.
+ *
+ * Two concerns live here:
+ *   1. `templateHasStepsField` — drives whether the AddCase form renders
+ *      the Configure Parameters button at all. Parameters reference each
+ *      other via `@chip` tokens inside TipTap step content; without a
+ *      Steps field, the chips have nowhere to live and the editor would
+ *      be empty UX friction. Per the project memory rule
+ *      `feedback_addcase_params_steps_field_gated`.
+ *
+ *   2. `pickInlinePayload` — decides what to forward on submit. Returns
+ *      `undefined` for both arrays when no parameters were authored so
+ *      the import action's non-parameterized branch fires and we don't
+ *      ship orphan dataset rows or empty-name parameters.
+ */
+
+import type {
+  InlineDatasetRow,
+  InlineParameter,
+} from "@/components/parameters/InlineDatasetEditor";
+
+interface TemplateCaseFieldLike {
+  caseField?: {
+    displayName?: string | null;
+  } | null;
+}
+
+interface TemplateLike {
+  caseFields?: TemplateCaseFieldLike[] | null;
+}
+
+const STEPS_FIELD_NAME = "Steps";
+
+/**
+ * Returns `true` when the given template includes a Steps field. Defensive
+ * about partial inputs so callers can pass the raw template record without
+ * pre-null-checking; missing template, missing caseFields, missing
+ * displayName all coerce to `false`.
+ */
+export function templateHasStepsField(
+  template: TemplateLike | null | undefined
+): boolean {
+  if (!template?.caseFields) return false;
+  return template.caseFields.some(
+    (cf) => cf?.caseField?.displayName === STEPS_FIELD_NAME
+  );
+}
+
+export interface InlinePayloadPick {
+  parameters: InlineParameter[] | undefined;
+  datasetRows: InlineDatasetRow[] | undefined;
+}
+
+/**
+ * Computes the `{ parameters, datasetRows }` slice of the import payload
+ * the AddCase modal should forward.
+ *
+ *   - When no parameters were authored, both fields are `undefined` so the
+ *     import action's non-parameterized branch fires.
+ *   - When at least one parameter has a non-empty trimmed name, the
+ *     trimmed parameter list is forwarded alongside the rows. Empty-name
+ *     drafts are silently dropped — the user added a row to the table
+ *     and hasn't named it yet; the server-side Zod schema would reject
+ *     it with a less-actionable error.
+ *   - When parameters exist but all have empty names, nothing is
+ *     forwarded (degenerate input).
+ */
+export function pickInlinePayload(
+  parameters: InlineParameter[],
+  rows: InlineDatasetRow[]
+): InlinePayloadPick {
+  if (!parameters.length) {
+    return { parameters: undefined, datasetRows: undefined };
+  }
+  const trimmed = parameters.filter((p) => p.name.trim().length > 0);
+  if (!trimmed.length) {
+    return { parameters: undefined, datasetRows: undefined };
+  }
+  return { parameters: trimmed, datasetRows: rows };
+}


### PR DESCRIPTION
## Description

Adds a **Configure Parameters** affordance to the Add Case modal so testers can author parameters and their dataset rows in a single round-trip instead of saving the case first, then opening the sheet, then editing.

UX mirrors the case details page:

- A `ConfigureParametersButton` renders above the Steps field when the selected template has one. The label updates from `Configure parameters` to `Parameters (N)` once columns are authored.
- Clicking opens a right-side Sheet whose content is a new `InlineDatasetEditor` — a controlled, form-state-driven editor with parameter columns (name / type / required / sensitive) and dataset rows below them. Reuses existing `parameters.*` i18n keys rather than introducing parallel ones.
- Switching to a template without a Steps field clears any draft parameters and rows so a hidden Sheet can't ship orphaned columns on submit.
- On save, the case + its parameters + its dataset rows all land in one atomic write via `importGeneratedTestCases` — the same server action AddCase already used for plain cases.

`importGeneratedTestCases` is extended to accept optional `parameters[]` and `datasetRows[]` per testCase. The new branch sits inside the existing `$transaction`, creates `TestCaseParameter` rows (unique-name pre-check; mirrors the schema's `@@unique([testCaseId, name])`), flips `RepositoryCases.hasParameters`, and creates an owner-bound `DataSet` + `DataSetVersion` (v1) + `DataSetRow` rows when both are provided. Sending `datasetRows` without `parameters` is rejected with a structured error so the dataset columns always have a schema.

### Perf side-quest

While we were already in `AddCase.onSubmit`:

- The two post-save cache invalidations are no longer awaited before the modal closes; both run as fire-and-forget so Save → close feels ~immediate.
- The `["zenstack", "RepositoryCases"]` invalidation is now scoped by `projectId` via a predicate (was `refetchType: "all"`, fanning out to every in-flight repository-case query app-wide). Typical post-save latency drops from a multi-second freeze to a single render of the visible folder view.

## Related Issue

None — feature follow-up to Review & Approval / Parameterized Test Cases.

## Type of Change

- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

**Unit tests (Vitest):**
- 11 tests on the new pure helpers in `lib/services/inlineParamsGate.ts` (`templateHasStepsField`, `pickInlinePayload`) — case sensitivity, null safety, missing caseFields, undefined-on-empty, trimmed-on-populated, no-mutation invariant.
- 12 RTL tests on `InlineDatasetEditor` — auto-suffix on collision, rename cascading into row values, remove-column dropping from every row, duplicate-name destructive error, addRow disabled without params, addRow seeds blank values per parameter type (BOOLEAN defaulting to `false`), INTEGER cell numeric coercion, BOOLEAN cell toggle, removeRow preserves siblings, parameter names render as dataset column headers, `testIdPrefix` override.

**Live-DB integration tests** (opt-in via `RUN_DB_INTEGRATION=1`):
- 3 tests on `importGeneratedTestCases.integration.test.ts` exercising the new tx-body branch end-to-end against real Postgres: happy path persists every row, datasetRows-without-parameters rejected, duplicate parameter names rejected.

**E2E tests (Playwright):**
- 5 tests in `e2e/tests/repository/add-case-inline-parameters.spec.ts` covering the highest-blast-radius regressions:
  1. `@smoke` — Configure Parameters button visible on Steps templates + Sheet opens with editor wired.
  2. Inline parameters and a dataset row persist on save (full round-trip).
  3. `@smoke` — Plain submit without opening the Sheet creates a non-parameterized case (regression guard for the biggest feature in the product).
  4. Switching from a Steps template to a no-Steps template clears authored inline parameters (creates an inline no-Steps template via `createTemplate`).
  5. Configure Parameters button sits above the Steps field renderer in DOM order (bounding-box assertion so a future fragment-key / `isStepsField` regression that swallows the Steps field fails loudly).

**Full E2E sweep on this branch:**
- 1236 passed, 3 failed (`webhooks/auto-disable-and-reenable`, `webhooks/replay-bulk-deliveries`, `webhooks/replay-single-outbound`), 7 flaky, 3 skipped.
- All 3 failures sit inside `e2e/tests/webhooks/` and exercise webhook retry / replay / re-enable flows — outside the cases / parameters / dataset / templates / repository code paths this PR touches.
- The 5 new specs pass in 25.2s in isolation.

**Manual UAT walkthrough** (against dev DB, project 293):
- [x] Default template w/ Steps → button visible above Steps; clicking opens the Sheet
- [x] Switch to "Case (text)" (no Steps) → button + Steps heading both disappear
- [x] Switch back to "Just Steps" → button returns; label resets to "Configure parameters" (state cleared)
- [x] Open Sheet, add 2 params + 2 rows, rename + fill cells
- [x] Close Sheet → Dialog stays open; button reads "Parameters (2)"
- [x] Submit → DB has case `108068`, `hasParameters=true`, template "Just Steps"; 2 parameters (`username` / `expected_role`), 2 dataset rows (`happy path: alice/admin`, `bad creds: bob/guest`) — all in one atomic write

**Precommit:** `pnpm precommit` green (lint + format + 8344 tests pass, 0 fail).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code in areas where the WHY is non-obvious
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
