### PR TITLE
fix(packages): lower minimum Node.js engine to >=20

### DIFF
--- a/.changeset/lower-node-engine-to-20.md
+++ b/.changeset/lower-node-engine-to-20.md
@@ -1,0 +1,9 @@
+---
+"@testplanit/wdio-reporter": patch
+"@testplanit/mcp-server": patch
+"@testplanit/api": patch
+---
+
+Lower minimum Node.js requirement to 20
+
+Relaxes `engines.node` from `>=24` to `>=20` so the packages can be installed on projects that have not yet upgraded to Node 24. The client code only relies on APIs available since Node 18 (`fetch`, `FormData`, `Blob`, `AbortSignal.timeout`, and Web Streams); the previous `>=24` pin came from a workspace-wide standardization rather than an actual code requirement.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/testplanit/testplanit/tree/main/packages/api#readme",
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/testplanit/testplanit/tree/main/packages/mcp-server#readme",
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "publishConfig": {
     "provenance": true,

--- a/packages/wdio-testplanit-reporter/package.json
+++ b/packages/wdio-testplanit-reporter/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/testplanit/testplanit/tree/main/packages/wdio-testplanit-reporter#readme",
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "peerDependencies": {
     "@wdio/reporter": "^8.0.0 || ^9.0.0",


### PR DESCRIPTION
## Description

Lowers the minimum Node.js requirement for the three published npm packages from `>=24` back down to `>=20`:

- `@testplanit/api`
- `@testplanit/wdio-reporter`
- `@testplanit/mcp-server`

A user reported that `@testplanit/api` 0.3.0 pins `engines.node` to `>=24`, which forces consuming projects onto Node 24 — many can't upgrade that quickly. Version 0.2.0 only required `>=18`.

The `>=24` pin came from a workspace-wide "standardize on Node 24" change, not from any actual code requirement. Audit of all three packages:

| Package | Code APIs used | Shipped runtime deps | True floor |
|---|---|---|---|
| `@testplanit/api` | `fetch`, `FormData`, `Blob`, `AbortSignal.timeout`, Web Streams | none | Node 18.0 |
| `@testplanit/mcp-server` | `fetch` + `AbortSignal.timeout`, `node:fs`, `process.*` | `@modelcontextprotocol/sdk` (`>=18`), `zod@4` (no engines) | Node 18.0 |
| `@testplanit/wdio-reporter` | `fs`, `process.*`, `globalThis` | `@testplanit/api`; `@wdio/*` peers require `>=18.20.0` | Node 18.20.0 |

All three genuinely run on Node 18.x. We set the floor to `>=20` (rather than `>=18`) to avoid advertising support for an end-of-life runtime — Node 18 reached EOL on 2025-04-30 — while still resolving the upgrade-friction complaint.

A Changeset is included so the next release publishes a patch bump for all three.

## Related Issue

User feedback (no tracked issue).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified each package's source uses only Node 18-era APIs (`fetch`, `AbortSignal.timeout`, `node:` imports, `process.*`).
- Confirmed shipped runtime dependency floors from the registry: `@modelcontextprotocol/sdk@1.29.0` → `node >=18`, `zod@4.4.3` → no `engines`, `@wdio/reporter`/`@wdio/types@9.27.0` → `node >=18.20.0`.
- `>=20` clears every dependency floor.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] A changeset has been added for the affected packages
