### PR TITLE
chore(packages): add provenance publishConfig to api and wdio-reporter

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,6 +46,11 @@
   "engines": {
     "node": ">=20"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public",
+    "tag": "latest"
+  },
   "devDependencies": {
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.3",

--- a/packages/wdio-testplanit-reporter/package.json
+++ b/packages/wdio-testplanit-reporter/package.json
@@ -46,6 +46,11 @@
   "engines": {
     "node": ">=20"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public",
+    "tag": "latest"
+  },
   "peerDependencies": {
     "@wdio/reporter": "^8.0.0 || ^9.0.0",
     "@wdio/types": "^8.0.0 || ^9.0.0"


### PR DESCRIPTION
## Description

Adds a `publishConfig` block (`provenance: true`, `access: "public"`, `tag: "latest"`) to `@testplanit/api` and `@testplanit/wdio-reporter`, mirroring `@testplanit/mcp-server`. These two packages lacked it, so they produced no npm provenance attestation under the OIDC trusted-publishing release flow.

This also completes the recovery of the stuck release: `@testplanit/mcp-server@0.1.3` published successfully, but `@testplanit/api@0.3.1` and `@testplanit/wdio-reporter@0.4.1` failed because their npm trusted publishers weren't configured. With the trusted publishers now in place, merging this PR re-triggers `packages-release.yml` -> `changeset publish` to release the two already-versioned packages with provenance.

## Related Issue

Failed release run: https://github.com/TestPlanIt/testplanit/actions/runs/26899020477

## Type of Change

- [x] Chore (build/release configuration)

## Testing

- Both `package.json` files validated (parse cleanly)
- `publishConfig` block is identical to the working `@testplanit/mcp-server` manifest
- No changeset included intentionally - versions are already bumped (0.3.1 / 0.4.1); adding one would force an unwanted re-bump

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No new warnings generated