### PR TITLE
ci(cli): publish @testplanit/cli via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/cli-semantic-release.yml
+++ b/.github/workflows/cli-semantic-release.yml
@@ -14,6 +14,7 @@ permissions:
   issues: write
   pull-requests: write
   actions: write
+  id-token: write
 
 jobs:
   release:
@@ -47,11 +48,18 @@ jobs:
           cd cli
           pnpm add -D semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
 
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1. Node 24 ships
+      # npm 11.x, but pin to latest so the OIDC handshake can't silently fall
+      # back to anonymous auth. Mirrors packages-release.yml.
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Release
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN — @testplanit/cli publishes via OIDC trusted publishing
+          # (id-token: write above + the trusted publisher configured on npm).
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]


### PR DESCRIPTION
## Description

Migrates the `@testplanit/cli` release to npm **trusted publishing (OIDC)**, matching the package release workflow. The npm trusted publisher was configured on the npm side, so the long-lived `NPM_TOKEN` is no longer used (or needed).

Changes to `.github/workflows/cli-semantic-release.yml`:

- Grant `id-token: write` to the release job
- Add a step pinning npm to latest (OIDC trusted publishing requires npm CLI >= 11.5.1; Node 24 ships npm 11.x but pinning prevents a silent fallback to anonymous auth)
- Remove `NPM_TOKEN`; `@semantic-release/npm` performs the OIDC token exchange

`GITHUB_TOKEN` (from `secrets.RELEASE_PLEASE_TOKEN`) is unchanged — only npm authentication moved to OIDC.

## Related Issue

Follow-up to moving all packages to npm Trusted Publisher.

## Type of Change

- [x] CI / build configuration

## Testing

- Validated the workflow YAML parses and that `id-token: write` is present and `NPM_TOKEN` is no longer referenced in the release step.
- Mirrors `packages-release.yml`, which already publishes the `@testplanit/*` packages successfully via OIDC.

## Checklist

- [x] Mirrors the existing OIDC pattern in `packages-release.yml`
- [x] Requires the trusted publisher for `@testplanit/cli` to be configured on npm (done)
