### PR TITLE
enhancement(import): link JUnit/CLI results to existing cases by ID

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ Command-line interface for TestPlanIt - import test results and manage test data
 The CLI supports importing test results from 7 different formats:
 
 | Format | Description | File Extensions |
-|--------|-------------|-----------------|
+| -------- | ------------- | ----------------- |
 | `junit` | JUnit XML | `.xml` |
 | `testng` | TestNG XML | `.xml` |
 | `xunit` | xUnit XML | `.xml` |
@@ -25,7 +25,7 @@ The CLI can auto-detect the format based on file content, or you can specify it 
 Download the appropriate binary for your platform from the [CLI releases](https://github.com/testplanit/testplanit/releases?q=cli&expanded=true):
 
 | Platform | Binary |
-|----------|--------|
+| ---------- | -------- |
 | Linux (x64) | `testplanit-linux-x64` |
 | macOS (Apple Silicon) | `testplanit-macos-arm64` |
 | macOS (Intel) | `testplanit-macos-x64` |
@@ -97,8 +97,12 @@ testplanit import <files...> --project <id|name> --name <name> [options]
 - `-f, --folder <value>` - Parent folder for test cases (ID or exact name)
 - `-t, --tags <values>` - Tags (comma-separated IDs or names; use quotes for names with commas)
 - `-r, --test-run <value>` - Existing test run to append results (ID or exact name)
+- `--case-matcher <mode>` - Link results to existing cases by ID: `off`, `name`, `property`, `auto` (default: `off`)
+- `--case-id-format <preset>` - Case-ID pattern in the test name when matching by name: `brackets`, `c`, `tc` (default: `brackets`)
 
 **Note:** For project, state, config, milestone, folder, and test run options, the CLI looks up entities by exact name match. If no match is found, an error is returned. For tags, if a tag name doesn't exist, it will be created automatically.
+
+**Linking results to existing cases by ID:** By default a result is matched to a case by name and class name, so renaming a test creates a duplicate. With `--case-matcher`, a result instead links to an existing case by an ID in the test name (`--case-id-format`: `brackets` → `[123]`, `c` → `C123`, `tc` → `TC-123`) or a `test_id` / `testplanit_case_id` JUnit `<property>` (`property`/`auto`). Multiple IDs link one result to multiple cases; an ID not found in the project is skipped with a warning.
 
 **Examples:**
 
@@ -120,6 +124,12 @@ testplanit import cucumber-report.json -p 1 -n "BDD Tests" -F cucumber
 
 # Import multiple files with glob pattern
 testplanit import "./test-results/*.xml" -p 1 -n "CI Build"
+
+# Link results to existing cases by an ID in the test name (e.g. "[123] login")
+testplanit import results.xml -p 1 -n "Build 123" --case-matcher name
+
+# Link by a test_id property in the XML, falling back to the name pattern
+testplanit import results.xml -p 1 -n "Build 123" --case-matcher auto
 
 # Import with IDs
 testplanit import results.xml \

--- a/cli/src/commands/import.ts
+++ b/cli/src/commands/import.ts
@@ -18,7 +18,16 @@ import {
   formatFileSize,
   resolveTestRunAttachmentFiles,
 } from "../lib/attachments.js";
-import { TEST_RESULT_FORMATS, type TestResultFormat, type SSEProgressEvent, type ImportOptions } from "../types.js";
+import {
+  TEST_RESULT_FORMATS,
+  CASE_MATCHERS,
+  CASE_ID_FORMATS,
+  type TestResultFormat,
+  type SSEProgressEvent,
+  type ImportOptions,
+  type CaseMatcher,
+  type CaseIdFormat,
+} from "../types.js";
 
 const VALID_FORMATS = ["auto", ...Object.keys(TEST_RESULT_FORMATS)] as const;
 
@@ -42,6 +51,16 @@ export function createImportCommand(): Command {
     .option("-d, --attachments-dir <path>", "Base directory for resolving attachment paths (default: directory of test result file)")
     .option("--no-attachments", "Skip uploading attachments")
     .option("-a, --run-attachments <files...>", "Files to attach to the test run (e.g., test plans, reports)")
+    .option(
+      "--case-matcher <mode>",
+      `Link results to existing cases by ID: ${CASE_MATCHERS.join(", ")} (default: off)`,
+      "off"
+    )
+    .option(
+      "--case-id-format <preset>",
+      `Case-ID pattern in the test name when matching by name: ${CASE_ID_FORMATS.join(", ")} (default: brackets, e.g. [123])`,
+      "brackets"
+    )
     .addHelpText("after", `
 Examples:
 
@@ -82,6 +101,15 @@ Examples:
   Import without uploading attachments:
     $ testplanit import ./results.xml -p "My Project" -n "Build" --no-attachments
 
+  Link results to existing cases by an ID in the test name (e.g. "[123] login"):
+    $ testplanit import ./results.xml -p "My Project" -n "Build" --case-matcher name
+
+  Link by a test_id property in the XML, falling back to the name pattern:
+    $ testplanit import ./results.xml -p "My Project" -n "Build" --case-matcher auto
+
+  Use the TestRail-style C-prefix pattern (e.g. "C123 login"):
+    $ testplanit import ./results.xml -p "My Project" -n "Build" --case-matcher name --case-id-format c
+
   Attach files to the test run (test plans, reports, etc.):
     $ testplanit import ./results.xml -p "My Project" -n "Build" -a ./test-plan.pdf ./coverage-report.html
 `)
@@ -105,6 +133,20 @@ Examples:
       if (!VALID_FORMATS.includes(format)) {
         logger.error(`Invalid format: ${options.format}`);
         logger.info(`Valid formats: ${VALID_FORMATS.join(", ")}`);
+        process.exit(1);
+      }
+
+      // Validate case-ID matching options
+      const caseMatcher = options.caseMatcher.toLowerCase() as CaseMatcher;
+      if (!CASE_MATCHERS.includes(caseMatcher)) {
+        logger.error(`Invalid case matcher: ${options.caseMatcher}`);
+        logger.info(`Valid matchers: ${CASE_MATCHERS.join(", ")}`);
+        process.exit(1);
+      }
+      const caseIdFormat = options.caseIdFormat.toLowerCase() as CaseIdFormat;
+      if (!CASE_ID_FORMATS.includes(caseIdFormat)) {
+        logger.error(`Invalid case ID format: ${options.caseIdFormat}`);
+        logger.info(`Valid formats: ${CASE_ID_FORMATS.join(", ")}`);
         process.exit(1);
       }
 
@@ -171,6 +213,12 @@ Examples:
           format: format,
         };
 
+        // Only send case-ID matching config when enabled
+        if (caseMatcher !== "off") {
+          importOptions.caseMatcher = caseMatcher;
+          importOptions.caseIdFormat = caseIdFormat;
+        }
+
         // Resolve state
         if (options.state) {
           logger.updateSpinner("Resolving workflow state...");
@@ -226,6 +274,20 @@ Examples:
         const url = config.getUrl();
         console.log();
         logger.success(`Test run created with ID: ${logger.formatNumber(result.testRunId)}`);
+
+        // Surface any results that referenced an unknown case ID (skipped)
+        if (result.caseIdWarnings && result.caseIdWarnings.length > 0) {
+          console.log();
+          logger.warn(
+            `Skipped ${logger.formatNumber(result.caseIdWarnings.length)} result(s) referencing a case ID not found in this project:`
+          );
+          for (const warning of result.caseIdWarnings.slice(0, 10)) {
+            logger.dim(`    - C${warning.requestedCaseId} (${warning.testName})`);
+          }
+          if (result.caseIdWarnings.length > 10) {
+            logger.dim(`    ... and ${result.caseIdWarnings.length - 10} more`);
+          }
+        }
 
         // Handle attachment uploads if present and not disabled
         if (

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -143,6 +143,14 @@ export async function importTestResults(
     }
   }
 
+  if (options.caseMatcher) {
+    form.append("caseMatcher", options.caseMatcher);
+  }
+
+  if (options.caseIdFormat) {
+    form.append("caseIdFormat", options.caseIdFormat);
+  }
+
   // Add files (read as buffers for compatibility with form.getBuffer())
   for (const filePath of files) {
     const absolutePath = path.resolve(filePath);
@@ -224,6 +232,7 @@ export async function importTestResults(
             result = {
               testRunId: data.testRunId,
               attachmentMappings: data.attachmentMappings,
+              caseIdWarnings: data.caseIdWarnings,
             };
           }
         } catch (e) {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -31,6 +31,26 @@ export const TEST_RESULT_FORMATS: Record<Exclude<TestResultFormat, "auto">, { la
 };
 
 /**
+ * Case-ID matching: how (and whether) to link results to existing cases by an
+ * ID parsed from the test name or a `test_id` property, instead of matching on
+ * name + class name.
+ */
+export type CaseMatcher = "off" | "name" | "property" | "auto";
+export type CaseIdFormat = "brackets" | "c" | "tc";
+
+export const CASE_MATCHERS: readonly CaseMatcher[] = [
+  "off",
+  "name",
+  "property",
+  "auto",
+];
+export const CASE_ID_FORMATS: readonly CaseIdFormat[] = [
+  "brackets",
+  "c",
+  "tc",
+];
+
+/**
  * Import options - IDs are resolved before being passed to the API
  */
 export interface ImportOptions {
@@ -43,6 +63,8 @@ export interface ImportOptions {
   parentFolderId?: number;
   tagIds?: number[];
   testRunId?: number;
+  caseMatcher?: CaseMatcher;
+  caseIdFormat?: CaseIdFormat;
 }
 
 /**
@@ -104,10 +126,21 @@ export interface AttachmentMapping {
 }
 
 /**
- * Extended SSE progress event with attachment mappings
+ * A test whose declared case ID could not be linked (unknown id, or not in
+ * the target project). The result for this test was skipped.
+ */
+export interface CaseIdWarning {
+  testName: string;
+  className: string | null;
+  requestedCaseId: number;
+}
+
+/**
+ * Extended SSE progress event with attachment mappings and advisory warnings
  */
 export interface ImportSSEProgressEvent extends SSEProgressEvent {
   attachmentMappings?: AttachmentMapping[];
+  caseIdWarnings?: CaseIdWarning[];
 }
 
 /**
@@ -154,11 +187,12 @@ export interface BulkAttachmentUploadResponse {
 }
 
 /**
- * Import result with optional attachment mappings
+ * Import result with optional attachment mappings and advisory warnings
  */
 export interface ImportResult {
   testRunId: number;
   attachmentMappings?: AttachmentMapping[];
+  caseIdWarnings?: CaseIdWarning[];
 }
 
 /**

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -144,6 +144,8 @@ testplanit import <files...> --project <id|name> --name <name> [options]
 | `-d, --attachments-dir <path>` | Base directory for resolving attachment paths (default: directory of test result file) |
 | `--no-attachments` | Skip uploading attachments from test results |
 | `-a, --run-attachments <files...>` | Files to attach to the test run (e.g., test plans, reports) |
+| `--case-matcher <mode>` | Link results to existing cases by ID: `off`, `name`, `property`, `auto` (default: `off`) |
+| `--case-id-format <preset>` | Case-ID pattern in the test name when matching by name: `brackets`, `c`, `tc` (default: `brackets`) |
 
 :::note
 For project, state, config, milestone, folder, and test run options, the CLI looks up entities by exact name match. If no match is found, an error is returned. For tags, if a tag name doesn't exist, it will be created automatically.
@@ -171,6 +173,42 @@ Use `-d, --attachments-dir` to specify a custom base directory for resolving rel
 
 Use `--no-attachments` to skip uploading test result attachments entirely.
 
+#### Linking results to existing cases by ID
+
+By default the importer matches each result to a case by **name and class name**. If your automation renames a test, the importer no longer recognizes it and creates a duplicate case. To prevent this, assign each automated test the ID of the case it belongs to, and turn on case-ID matching with `--case-matcher`. When a result carries a recognized ID, it links to that case **regardless of the test name**, so renames stop creating duplicates.
+
+There are two ways to carry the ID, controlled by `--case-matcher`:
+
+- **`name`** — the ID is embedded in the test name; the pattern is chosen with `--case-id-format` (see below).
+- **`property`** — the ID is carried in a JUnit `<property>` named `test_id` (or `testplanit_case_id`), following the convention used by TestRail and Xray (see below).
+- **`auto`** — try the `test_id` property first, then fall back to the name pattern.
+
+Name patterns (`--case-id-format`):
+
+| Preset | Matches | Example test name |
+| -------- | --------- | ------------------- |
+| `brackets` (default) | `[123]`, `[C123]`, `[123, 456]` | `[123] user can log in` |
+| `c` | `C123` | `C123 user can log in` |
+| `tc` | `TC-123`, `TC123` | `TC-123 user can log in` |
+
+Property form (`--case-matcher property` or `auto`):
+
+```xml
+<testcase name="user can log in" classname="auth.LoginTests">
+  <properties>
+    <property name="test_id" value="123"/>
+  </properties>
+</testcase>
+```
+
+Notes:
+
+- A single test may reference multiple cases (`[123, 456]` or `value="123,456"`); each referenced case receives the same result.
+- Tests **without** an ID still import normally — they are matched/created by name and class name as before.
+- If a referenced case ID does not exist in the target project, that result is **skipped** (never auto-created under a wrong name) and reported as a warning at the end of the import.
+- The ID is the numeric TestPlanIt case ID; a leading `C` or `#` is tolerated.
+- Property matching requires a reporter that writes per-`<testcase>` properties (e.g. pytest's `record_property`, the Playwright JUnit reporter with `embedAnnotationsAsProperties`, NUnit `[Property]`). Frameworks that only emit suite-level properties (e.g. Maven Surefire) should use the name-based pattern instead.
+
 #### Examples
 
 ```bash
@@ -191,6 +229,15 @@ testplanit import cucumber-report.json -p 1 -n "BDD Tests" -F cucumber
 
 # Import multiple files with glob pattern
 testplanit import "./test-results/*.xml" -p 1 -n "CI Build"
+
+# Link results to existing cases by an ID in the test name (e.g. "[123] login")
+testplanit import results.xml -p 1 -n "Build 123" --case-matcher name
+
+# Use the TestRail-style C-prefix pattern (e.g. "C123 login")
+testplanit import results.xml -p 1 -n "Build 123" --case-matcher name --case-id-format c
+
+# Link by a test_id property in the XML, falling back to the name pattern
+testplanit import results.xml -p 1 -n "Build 123" --case-matcher auto
 
 # Import with IDs
 testplanit import results.xml \

--- a/docs/docs/import-export.md
+++ b/docs/docs/import-export.md
@@ -758,6 +758,8 @@ parentFolderId: 101
 configId: 102 (optional)
 milestoneId: 103 (optional)
 tagIds: [1, 2, 3] (optional)
+caseMatcher: "off" | "name" | "property" | "auto" (optional, default "off")
+caseIdFormat: "brackets" | "c" | "tc" (optional, default "brackets")
 ```
 
 Response is Server-Sent Events (SSE) with progress updates:
@@ -767,6 +769,8 @@ Response is Server-Sent Events (SSE) with progress updates:
 {"progress": 100, "status": "Import completed successfully!"}
 {"complete": true, "testRunId": 12345}
 ```
+
+By default each result is matched to a case by **name + class name**, so renaming an automated test creates a duplicate case. Set `caseMatcher` to instead link results to an existing case by an ID carried in the test name (`caseIdFormat` preset) or a `test_id` / `testplanit_case_id` JUnit property — see [Linking results to existing cases by ID](./cli.md#linking-results-to-existing-cases-by-id) in the CLI guide for the full behavior. Results whose referenced case ID is not found in the project are skipped and listed in the final SSE event as `caseIdWarnings`.
 
 ### Export
 

--- a/docs/docs/import-export.md
+++ b/docs/docs/import-export.md
@@ -30,10 +30,12 @@ Import test cases from CSV files with flexible field mapping.
 There are two ways to start a CSV import:
 
 **Using the Import button:**
+
 1. Navigate to **Repository** in your project
 2. Click the **Import** button in the toolbar
 
 **Using drag and drop:**
+
 1. Drag a `.csv` file from your desktop over the Repository page
 2. A full-page drop overlay will appear indicating you can drop to import
 3. Drop the file — the import wizard opens automatically with your file pre-loaded
@@ -104,7 +106,7 @@ Test steps in a single cell can be formatted in several ways:
 
 **Simple Format:**
 
-```
+```text
 1. Step one
 2. Step two
 3. Step three
@@ -112,7 +114,7 @@ Test steps in a single cell can be formatted in several ways:
 
 **Detailed Format with Expected Results** — separate the step from its expected result with a pipe (`|`):
 
-```
+```text
 1. Navigate to login page | Login page displays
 2. Enter username and password | Fields accept input
 3. Click login button | User is redirected to dashboard
@@ -122,7 +124,7 @@ Test steps in a single cell can be formatted in several ways:
 
 Steps can also contain markdown formatting:
 
-```
+```text
 1. Navigate to the **Login** page | Login page displays with _username_ and _password_ fields
 2. Enter `admin` credentials | Fields accept input
 3. Click **Submit** | User is redirected to [Dashboard](/dashboard)
@@ -297,11 +299,13 @@ TestPlanIt supports importing test results from the following formats:
 There are two ways to start a test results import:
 
 **Using the Import button:**
+
 1. Navigate to **Test Runs** in your project
 2. Click **Import Results** button
 3. The import dialog opens with format options
 
 **Using drag and drop:**
+
 1. Drag one or more test result files (`.xml`, `.trx`, or `.json`) from your desktop over the Test Runs page
 2. A full-page drop overlay will appear indicating you can drop to import
 3. Drop the files — the import dialog opens automatically with your files pre-loaded

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ allowBuilds:
   'core-js': true
   'core-js-pure': true
   'esbuild': true
+  iframe-resizer: true
   'keytar': true
   'msgpackr-extract': true
   'msw': true

--- a/testplanit/app/api/test-results/import/route.test.ts
+++ b/testplanit/app/api/test-results/import/route.test.ts
@@ -693,4 +693,288 @@ describe("Test Results Import API Route", () => {
       expect(routeToIteration).not.toHaveBeenCalled();
     });
   });
+
+  describe("case-ID linking", () => {
+    const setSingleCase = (
+      testName: string,
+      metadata?: Record<string, string>
+    ) => {
+      (parseTestResults as any).mockResolvedValueOnce({
+        result: {
+          total: 1,
+          passed: 1,
+          failed: 0,
+          errors: 0,
+          skipped: 0,
+          duration: 1,
+          suites: [
+            {
+              name: "com.example.TestSuite",
+              total: 1,
+              passed: 1,
+              failed: 0,
+              errors: 0,
+              skipped: 0,
+              duration: 1,
+              cases: [
+                {
+                  name: testName,
+                  status: "passed",
+                  duration: 1,
+                  failure: null,
+                  stack_trace: null,
+                  attachments: [],
+                  ...(metadata ? { metadata } : {}),
+                },
+              ],
+            },
+          ],
+        },
+        errors: [],
+      });
+    };
+
+    it("links to an existing case by an ID in the name without creating a case", async () => {
+      (prisma.repositoryCases.findFirst as any).mockImplementation(
+        async (args: any) =>
+          args?.where?.id === 123
+            ? { id: 123, name: "Curated name", className: null }
+            : null
+      );
+      (prisma.repositoryCases.update as any).mockResolvedValue({
+        id: 123,
+        name: "Curated name",
+        className: null,
+      });
+
+      setSingleCase("[123] login works");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "name");
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      const events = await readSseResponse(response);
+
+      expect(prisma.repositoryCases.findFirst).toHaveBeenCalledWith({
+        where: { id: 123, projectId: 1 },
+      });
+      expect(prisma.repositoryCases.create).not.toHaveBeenCalled();
+      expect(prisma.testRunCases.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            testRunId_repositoryCaseId: {
+              testRunId: 42,
+              repositoryCaseId: 123,
+            },
+          },
+        })
+      );
+      expect(events.find((e) => e.complete === true)).toBeDefined();
+    });
+
+    it("prefers the test_id property over the name in auto mode", async () => {
+      (prisma.repositoryCases.findFirst as any).mockImplementation(
+        async (args: any) =>
+          args?.where?.id === 456
+            ? { id: 456, name: "Curated", className: null }
+            : null
+      );
+      (prisma.repositoryCases.update as any).mockResolvedValue({
+        id: 456,
+        name: "Curated",
+        className: null,
+      });
+
+      setSingleCase("[123] login works", { test_id: "456" });
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "auto");
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      await readSseResponse(response);
+
+      expect(prisma.repositoryCases.findFirst).toHaveBeenCalledWith({
+        where: { id: 456, projectId: 1 },
+      });
+      expect(prisma.repositoryCases.create).not.toHaveBeenCalled();
+    });
+
+    it("warns and skips when the referenced case ID is not in the project", async () => {
+      (prisma.repositoryCases.findFirst as any).mockResolvedValue(null);
+
+      setSingleCase("[999] login works");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "name");
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      const events = await readSseResponse(response);
+
+      expect(prisma.repositoryCases.create).not.toHaveBeenCalled();
+      expect(prisma.testRunCases.upsert).not.toHaveBeenCalled();
+      const complete = events.find((e) => e.complete === true);
+      expect(complete?.caseIdWarnings).toEqual([
+        {
+          testName: "[999] login works",
+          className: "com.example.TestClass",
+          requestedCaseId: 999,
+        },
+      ]);
+    });
+
+    it("falls back to name+className matching when matching is off (default)", async () => {
+      (prisma.repositoryCases.findFirst as any).mockResolvedValue(null);
+
+      setSingleCase("[123] login works");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      // no caseMatcher → off
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      await readSseResponse(response);
+
+      expect(prisma.repositoryCases.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            name: "[123] login works",
+            className: "com.example.TestClass",
+          }),
+        })
+      );
+      expect(prisma.repositoryCases.create).toHaveBeenCalled();
+    });
+
+    it("links one result to every case when multiple IDs are present", async () => {
+      (prisma.repositoryCases.findFirst as any).mockImplementation(
+        async (args: any) => {
+          const id = args?.where?.id;
+          return id === 123 || id === 456
+            ? { id, name: `Case ${id}`, className: null }
+            : null;
+        }
+      );
+      (prisma.repositoryCases.update as any).mockImplementation(
+        async (args: any) => ({
+          id: args.where.id,
+          name: `Case ${args.where.id}`,
+          className: null,
+        })
+      );
+
+      setSingleCase("[123, 456] login works");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "name");
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      const events = await readSseResponse(response);
+
+      expect(prisma.repositoryCases.findFirst).toHaveBeenCalledWith({
+        where: { id: 123, projectId: 1 },
+      });
+      expect(prisma.repositoryCases.findFirst).toHaveBeenCalledWith({
+        where: { id: 456, projectId: 1 },
+      });
+      expect(prisma.repositoryCases.create).not.toHaveBeenCalled();
+      const linkedIds = (prisma.testRunCases.upsert as any).mock.calls.map(
+        (c: any[]) => c[0].where.testRunId_repositoryCaseId.repositoryCaseId
+      );
+      expect(linkedIds).toEqual(expect.arrayContaining([123, 456]));
+      // One result row created per matched case.
+      expect((prisma.jUnitTestResult.create as any).mock.calls.length).toBe(2);
+      expect(events.find((e) => e.complete === true)).toBeDefined();
+    });
+
+    it("links the found IDs and warns on the missing ones", async () => {
+      (prisma.repositoryCases.findFirst as any).mockImplementation(
+        async (args: any) =>
+          args?.where?.id === 123
+            ? { id: 123, name: "Found", className: null }
+            : null
+      );
+      (prisma.repositoryCases.update as any).mockResolvedValue({
+        id: 123,
+        name: "Found",
+        className: null,
+      });
+
+      setSingleCase("[123, 999] login works");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "name");
+
+      const request = createFormDataRequest(formData);
+      const response = await POST(request);
+      const events = await readSseResponse(response);
+
+      expect(prisma.repositoryCases.create).not.toHaveBeenCalled();
+      expect(prisma.testRunCases.upsert).toHaveBeenCalledTimes(1);
+      const complete = events.find((e) => e.complete === true);
+      expect(complete?.caseIdWarnings).toEqual([
+        {
+          testName: "[123, 999] login works",
+          className: "com.example.TestClass",
+          requestedCaseId: 999,
+        },
+      ]);
+    });
+
+    it("updates an ID-matched case non-destructively (preserves curated fields)", async () => {
+      (prisma.repositoryCases.findFirst as any).mockImplementation(
+        async (args: any) =>
+          args?.where?.id === 123
+            ? { id: 123, name: "Curated", className: "Curated.Class" }
+            : null
+      );
+      (prisma.repositoryCases.update as any).mockResolvedValue({
+        id: 123,
+        name: "Curated",
+        className: "Curated.Class",
+      });
+
+      setSingleCase("[123] renamed in code");
+
+      const formData = new FormData();
+      formData.append("files", createMockFile("results.xml"));
+      formData.append("name", "CI Run");
+      formData.append("projectId", "1");
+      formData.append("caseMatcher", "name");
+
+      const request = createFormDataRequest(formData);
+      await readSseResponse(await POST(request));
+
+      const updateArg = (prisma.repositoryCases.update as any).mock.calls[0][0];
+      expect(updateArg.where).toEqual({ id: 123 });
+      // Only linkability fields are touched; name/class/template/state/estimate
+      // are left to the user's curation.
+      expect(updateArg.data).toEqual({
+        automated: true,
+        isDeleted: false,
+        isArchived: false,
+      });
+    });
+  });
 });

--- a/testplanit/app/api/test-results/import/route.ts
+++ b/testplanit/app/api/test-results/import/route.ts
@@ -35,6 +35,13 @@ import {
   routeToIteration,
   validateIterationCaps,
 } from "~/lib/services/junitIterationRouter";
+import {
+  parseCaseMatcher,
+  parseCaseIdFormat,
+  resolveCaseIdRefs,
+  type CaseMatcher,
+  type CaseIdFormat,
+} from "~/lib/services/automationCaseId";
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import {
   countTotalTestCases,
@@ -195,6 +202,16 @@ export const POST = withAuditContext(async (request: NextRequest) => {
         const templateId = formData.get("templateId")
           ? parseInt(formData.get("templateId") as string)
           : undefined;
+        // Optional case-ID linking: when active, results link to an existing
+        // case by an ID parsed from the test name (preset) or a `test_id`
+        // property, instead of matching on name+className. Defaults to off,
+        // so unconfigured imports behave exactly as before.
+        const caseMatcher: CaseMatcher = parseCaseMatcher(
+          formData.get("caseMatcher") as string | null
+        );
+        const caseIdFormat: CaseIdFormat = parseCaseIdFormat(
+          formData.get("caseIdFormat") as string | null
+        );
 
         sendProgress(5, progressMessages.validating);
 
@@ -580,6 +597,14 @@ export const POST = withAuditContext(async (request: NextRequest) => {
           attachments: Array<{ name: string; path: string }>;
         }> = [];
 
+        // Track case-ID references that could not be linked (unknown id, or
+        // not in this project). Surfaced as advisory warnings; never blocks.
+        const caseIdWarnings: Array<{
+          testName: string;
+          className: string | null;
+          requestedCaseId: number;
+        }> = [];
+
         sendProgress(
           25,
           progressMessages.countingTests(totalTestCases, files.length)
@@ -810,75 +835,131 @@ export const POST = withAuditContext(async (request: NextRequest) => {
               );
               const extendedData = extendedDataMap.get(extendedDataKey);
 
-              // Find or create RepositoryCase
-              // Match by (projectId, name, className) ignoring source so that
-              // re-imports with a different detected format reuse the existing case
-              // instead of creating duplicates.
-              // When updating existing cases, we intentionally do NOT update folderId
-              // to preserve the user's folder organization.
-              let repositoryCase = await prisma.repositoryCases.findFirst({
-                where: {
-                  projectId: projectId,
-                  name: testCase.name,
-                  className: className,
-                  isDeleted: false,
-                },
-              });
+              // Resolve the target case(s) for this result.
+              //
+              // When case-ID matching is active and the test carries one or
+              // more IDs (parsed from the test name preset, or a `test_id`
+              // property), link to those existing cases by id (scoped to this
+              // project) and skip name+className matching entirely. Unknown
+              // ids are recorded as advisory warnings.
+              //
+              // Otherwise match by (projectId, name, className) ignoring
+              // source so re-imports with a different detected format reuse
+              // the existing case instead of creating duplicates, creating it
+              // when absent. Existing-case updates intentionally do NOT change
+              // folderId, preserving the user's folder organization.
+              const testCaseMetadata =
+                (testCase as { metadata?: Record<string, string> }).metadata ??
+                undefined;
+              const caseIdRefs = resolveCaseIdRefs(
+                { name: testCase.name, metadata: testCaseMetadata },
+                { matcher: caseMatcher, format: caseIdFormat }
+              );
 
-              if (repositoryCase) {
-                repositoryCase = await prisma.repositoryCases.update({
-                  where: { id: repositoryCase.id },
-                  data: {
-                    automated: true,
-                    isDeleted: false,
-                    isArchived: false,
-                    stateId: defaultCaseStateId,
-                    templateId: template.id,
-                    repositoryId: repository.id,
-                    creatorId: userId,
-                    order: caseOrder,
-                    estimate: Math.max(1, Math.round(testCaseTime)),
-                    forecastManual: Math.max(1, Math.round(testCaseTime)),
-                  },
-                });
+              const casesToProcess: Awaited<
+                ReturnType<typeof prisma.repositoryCases.create>
+              >[] = [];
+
+              if (caseIdRefs.ids.length > 0) {
+                for (const refId of caseIdRefs.ids) {
+                  const existing = await prisma.repositoryCases.findFirst({
+                    where: { id: refId, projectId: projectId },
+                  });
+                  if (!existing) {
+                    caseIdWarnings.push({
+                      testName: testCase.name,
+                      className: className,
+                      requestedCaseId: refId,
+                    });
+                    continue;
+                  }
+                  // Minimal, non-destructive update: ensure the referenced
+                  // case is linkable without overwriting the user's curated
+                  // fields (name, className, template, state, estimate,
+                  // folder, order).
+                  const linkable = await prisma.repositoryCases.update({
+                    where: { id: existing.id },
+                    data: {
+                      automated: true,
+                      isDeleted: false,
+                      isArchived: false,
+                    },
+                  });
+                  casesToProcess.push(linkable);
+                }
+                // Every referenced id was unknown to this project: skip the
+                // result rather than creating a duplicate. The warnings above
+                // explain why.
+                if (casesToProcess.length === 0) {
+                  continue;
+                }
               } else {
-                const folder = await getFolderForNewCase();
-                repositoryCase = await prisma.repositoryCases.create({
-                  data: {
+                let repositoryCase = await prisma.repositoryCases.findFirst({
+                  where: {
                     projectId: projectId,
-                    repositoryId: repository.id,
-                    folderId: folder.id,
-                    templateId: template.id,
                     name: testCase.name,
                     className: className,
-                    source: caseSource,
-                    stateId: defaultCaseStateId,
-                    automated: true,
-                    creatorId: userId,
-                    order: caseOrder,
-                    estimate: Math.max(1, Math.round(testCaseTime)),
-                    forecastManual: Math.max(1, Math.round(testCaseTime)),
+                    isDeleted: false,
                   },
                 });
+
+                if (repositoryCase) {
+                  repositoryCase = await prisma.repositoryCases.update({
+                    where: { id: repositoryCase.id },
+                    data: {
+                      automated: true,
+                      isDeleted: false,
+                      isArchived: false,
+                      stateId: defaultCaseStateId,
+                      templateId: template.id,
+                      repositoryId: repository.id,
+                      creatorId: userId,
+                      order: caseOrder,
+                      estimate: Math.max(1, Math.round(testCaseTime)),
+                      forecastManual: Math.max(1, Math.round(testCaseTime)),
+                    },
+                  });
+                } else {
+                  const folder = await getFolderForNewCase();
+                  repositoryCase = await prisma.repositoryCases.create({
+                    data: {
+                      projectId: projectId,
+                      repositoryId: repository.id,
+                      folderId: folder.id,
+                      templateId: template.id,
+                      name: testCase.name,
+                      className: className,
+                      source: caseSource,
+                      stateId: defaultCaseStateId,
+                      automated: true,
+                      creatorId: userId,
+                      order: caseOrder,
+                      estimate: Math.max(1, Math.round(testCaseTime)),
+                      forecastManual: Math.max(1, Math.round(testCaseTime)),
+                    },
+                  });
+                }
+                casesToProcess.push(repositoryCase);
               }
 
-              // Upsert TestRunCases
-              await prisma.testRunCases.upsert({
-                where: {
-                  testRunId_repositoryCaseId: {
+              for (const repositoryCase of casesToProcess) {
+                // Upsert TestRunCases
+                await prisma.testRunCases.upsert({
+                  where: {
+                    testRunId_repositoryCaseId: {
+                      testRunId: testRunId,
+                      repositoryCaseId: repositoryCase.id,
+                    },
+                  },
+                  update: {},
+                  create: {
                     testRunId: testRunId,
                     repositoryCaseId: repositoryCase.id,
+                    order: caseOrder,
                   },
-                },
-                update: {},
-                create: {
-                  testRunId: testRunId,
-                  repositoryCaseId: repositoryCase.id,
-                  order: caseOrder,
-                },
-              });
+                });
 
-              try {
+                try {
                 // Map status to result type and find matching project status
                 let resultType: JUnitResultType;
                 let matchingStatus = null;
@@ -963,9 +1044,6 @@ export const POST = withAuditContext(async (request: NextRequest) => {
                 // PARAM-07 invariant: when extractIterationIndex returns null
                 // (no property, or unparseable), the legacy path runs
                 // unchanged — bit-identical to today.
-                const testCaseMetadata =
-                  (testCase as { metadata?: Record<string, string> })
-                    .metadata ?? undefined;
                 const iterationIndex = extractIterationIndex(
                   testCaseMetadata,
                   junitIterationPropertyNames
@@ -1100,11 +1178,18 @@ export const POST = withAuditContext(async (request: NextRequest) => {
                 // Continue with next test case
               }
 
-              caseOrder++;
+                caseOrder++;
+
+                // Stop linking further matched cases for this test once the
+                // cap-exceeded error is set by routeToIteration.
+                if (iterationCapError !== null) {
+                  break;
+                }
+              }
 
               // INT-02 T-06-01-03: break the case loop when the cap-exceeded
-              // error was set by routeToIteration. The outer suite loop also
-              // breaks below; the post-loop block emits the 422 error event.
+              // error was set. The outer suite loop also breaks below; the
+              // post-loop block emits the 422 error event.
               if (iterationCapError !== null) {
                 break;
               }
@@ -1217,12 +1302,13 @@ export const POST = withAuditContext(async (request: NextRequest) => {
 
         sendProgress(100, progressMessages.completed);
 
-        // Include attachment mappings and duplicate warnings in response for CLI
+        // Include attachment mappings and advisory warnings in response for CLI
         const responseData: {
           complete: true;
           testRunId: number;
           attachmentMappings?: typeof attachmentMappings;
           duplicateWarnings?: typeof duplicateWarnings;
+          caseIdWarnings?: typeof caseIdWarnings;
         } = { complete: true, testRunId };
 
         // Only include mappings if there are attachments to upload
@@ -1231,6 +1317,9 @@ export const POST = withAuditContext(async (request: NextRequest) => {
         }
         if (duplicateWarnings.length > 0) {
           responseData.duplicateWarnings = duplicateWarnings;
+        }
+        if (caseIdWarnings.length > 0) {
+          responseData.caseIdWarnings = caseIdWarnings;
         }
 
         controller.enqueue(

--- a/testplanit/lib/services/automationCaseId.test.ts
+++ b/testplanit/lib/services/automationCaseId.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  parseCaseMatcher,
+  parseCaseIdFormat,
+  parseCaseIdsFromName,
+  parseCaseIdsFromProperty,
+  resolveCaseIdRefs,
+} from "./automationCaseId";
+
+describe("parseCaseMatcher", () => {
+  it("accepts known matchers", () => {
+    expect(parseCaseMatcher("name")).toBe("name");
+    expect(parseCaseMatcher("property")).toBe("property");
+    expect(parseCaseMatcher("auto")).toBe("auto");
+    expect(parseCaseMatcher("off")).toBe("off");
+  });
+
+  it("defaults unknown/empty values to off", () => {
+    expect(parseCaseMatcher(undefined)).toBe("off");
+    expect(parseCaseMatcher(null)).toBe("off");
+    expect(parseCaseMatcher("")).toBe("off");
+    expect(parseCaseMatcher("bogus")).toBe("off");
+  });
+});
+
+describe("parseCaseIdFormat", () => {
+  it("accepts known formats", () => {
+    expect(parseCaseIdFormat("brackets")).toBe("brackets");
+    expect(parseCaseIdFormat("c")).toBe("c");
+    expect(parseCaseIdFormat("tc")).toBe("tc");
+  });
+
+  it("defaults unknown/empty values to brackets", () => {
+    expect(parseCaseIdFormat(undefined)).toBe("brackets");
+    expect(parseCaseIdFormat("nope")).toBe("brackets");
+  });
+});
+
+describe("parseCaseIdsFromName - brackets", () => {
+  it("extracts a single id", () => {
+    expect(parseCaseIdsFromName("[123] user can log in", "brackets")).toEqual([
+      123,
+    ]);
+  });
+
+  it("tolerates a leading C (TestRail style)", () => {
+    expect(parseCaseIdsFromName("[C123] login", "brackets")).toEqual([123]);
+  });
+
+  it("extracts multiple ids inside one bracket", () => {
+    expect(parseCaseIdsFromName("[123, 456] login", "brackets")).toEqual([
+      123, 456,
+    ]);
+  });
+
+  it("extracts ids from multiple brackets", () => {
+    expect(parseCaseIdsFromName("[12][34] login", "brackets")).toEqual([
+      12, 34,
+    ]);
+  });
+
+  it("de-duplicates repeated ids", () => {
+    expect(parseCaseIdsFromName("[12, 12] login", "brackets")).toEqual([12]);
+  });
+
+  it("ignores brackets that are not pure id tokens", () => {
+    expect(parseCaseIdsFromName("[2024-01-01] nightly", "brackets")).toEqual(
+      []
+    );
+  });
+
+  it("returns empty when there is no bracket", () => {
+    expect(parseCaseIdsFromName("plain test name", "brackets")).toEqual([]);
+  });
+});
+
+describe("parseCaseIdsFromName - c", () => {
+  it("extracts a C-prefixed id", () => {
+    expect(parseCaseIdsFromName("C123 login", "c")).toEqual([123]);
+  });
+
+  it("is case-insensitive on the prefix", () => {
+    expect(parseCaseIdsFromName("c7 login", "c")).toEqual([7]);
+  });
+
+  it("ignores a C preceded by a letter (ABC123)", () => {
+    expect(parseCaseIdsFromName("ABC123 login", "c")).toEqual([]);
+  });
+
+  it("extracts underscore-separated ids (TestRail style)", () => {
+    expect(parseCaseIdsFromName("C200_C201_C202_endpoints", "c")).toEqual([
+      200, 201, 202,
+    ]);
+  });
+});
+
+describe("parseCaseIdsFromName - tc", () => {
+  it("extracts TC-123 and TC123", () => {
+    expect(parseCaseIdsFromName("TC-123 login", "tc")).toEqual([123]);
+    expect(parseCaseIdsFromName("TC456 login", "tc")).toEqual([456]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseCaseIdsFromName("tc-9 login", "tc")).toEqual([9]);
+  });
+
+  it("ignores a TC preceded by a letter", () => {
+    expect(parseCaseIdsFromName("XTC-9 login", "tc")).toEqual([]);
+  });
+});
+
+describe("parseCaseIdsFromProperty", () => {
+  it("reads the test_id property", () => {
+    expect(parseCaseIdsFromProperty({ test_id: "123" })).toEqual([123]);
+  });
+
+  it("reads the testplanit_case_id alias", () => {
+    expect(parseCaseIdsFromProperty({ testplanit_case_id: "55" })).toEqual([
+      55,
+    ]);
+  });
+
+  it("is case-insensitive on the property key", () => {
+    expect(parseCaseIdsFromProperty({ Test_ID: "8" })).toEqual([8]);
+  });
+
+  it("parses a comma-separated list with C prefixes", () => {
+    expect(parseCaseIdsFromProperty({ test_id: "C123, C456" })).toEqual([
+      123, 456,
+    ]);
+  });
+
+  it("returns empty for absent metadata or unknown keys", () => {
+    expect(parseCaseIdsFromProperty(undefined)).toEqual([]);
+    expect(parseCaseIdsFromProperty({ iteration: "3" })).toEqual([]);
+  });
+
+  it("ignores non-numeric values", () => {
+    expect(parseCaseIdsFromProperty({ test_id: "abc" })).toEqual([]);
+    expect(parseCaseIdsFromProperty({ test_id: "0" })).toEqual([]);
+  });
+
+  it("does not read inherited object properties", () => {
+    expect(parseCaseIdsFromProperty({})).toEqual([]);
+  });
+});
+
+describe("resolveCaseIdRefs", () => {
+  it("returns nothing when matcher is off", () => {
+    expect(
+      resolveCaseIdRefs(
+        { name: "[123] login", metadata: { test_id: "456" } },
+        { matcher: "off", format: "brackets" }
+      )
+    ).toEqual({ ids: [], source: null });
+  });
+
+  it("prefers the property over the name in auto mode", () => {
+    expect(
+      resolveCaseIdRefs(
+        { name: "[123] login", metadata: { test_id: "456" } },
+        { matcher: "auto", format: "brackets" }
+      )
+    ).toEqual({ ids: [456], source: "property" });
+  });
+
+  it("falls back to the name in auto mode when no property is present", () => {
+    expect(
+      resolveCaseIdRefs(
+        { name: "[123] login" },
+        { matcher: "auto", format: "brackets" }
+      )
+    ).toEqual({ ids: [123], source: "name" });
+  });
+
+  it("name mode ignores the property", () => {
+    expect(
+      resolveCaseIdRefs(
+        { name: "plain", metadata: { test_id: "456" } },
+        { matcher: "name", format: "brackets" }
+      )
+    ).toEqual({ ids: [], source: null });
+  });
+
+  it("property mode ignores the name", () => {
+    expect(
+      resolveCaseIdRefs(
+        { name: "[123] login" },
+        { matcher: "property", format: "brackets" }
+      )
+    ).toEqual({ ids: [], source: null });
+  });
+});

--- a/testplanit/lib/services/automationCaseId.ts
+++ b/testplanit/lib/services/automationCaseId.ts
@@ -1,0 +1,192 @@
+/**
+ * Automation case-ID resolution for test-results import.
+ *
+ * Lets an automated test declare which existing TestPlanIt case its result
+ * belongs to, so renaming the test no longer creates a duplicate case. Two
+ * channels are supported, mirroring the conventions used across the market
+ * (TestRail, Xray, Zephyr):
+ *
+ *   1. An ID embedded in the test name, parsed with one of a fixed set of
+ *      curated presets (no caller-supplied regex ever runs server-side).
+ *   2. An ID carried in a JUnit `<property>` (`test_id` / `testplanit_case_id`).
+ *
+ * When both are present the property wins (explicit metadata over a parsed
+ * name). Multiple IDs per test are supported; each resolved case receives the
+ * same result.
+ *
+ * All matching uses compiled constant regexes on bounded inputs, so there is
+ * no ReDoS surface.
+ */
+
+export type CaseMatcher = "off" | "name" | "property" | "auto";
+export type CaseIdFormat = "brackets" | "c" | "tc";
+
+export const CASE_MATCHERS: readonly CaseMatcher[] = [
+  "off",
+  "name",
+  "property",
+  "auto",
+];
+
+export const CASE_ID_FORMATS: readonly CaseIdFormat[] = ["brackets", "c", "tc"];
+
+/**
+ * Property names recognized for property-based matching. `test_id` is the
+ * de-facto standard (TestRail, Xray); `testplanit_case_id` is the explicit
+ * alias. Lookup is case-insensitive.
+ */
+export const CASE_ID_PROPERTY_NAMES: readonly string[] = [
+  "test_id",
+  "testplanit_case_id",
+];
+
+/** Coerce an untrusted form value to a known matcher, defaulting to `off`. */
+export function parseCaseMatcher(
+  value: string | null | undefined
+): CaseMatcher {
+  return (CASE_MATCHERS as readonly string[]).includes(value ?? "")
+    ? (value as CaseMatcher)
+    : "off";
+}
+
+/** Coerce an untrusted form value to a known format, defaulting to `brackets`. */
+export function parseCaseIdFormat(
+  value: string | null | undefined
+): CaseIdFormat {
+  return (CASE_ID_FORMATS as readonly string[]).includes(value ?? "")
+    ? (value as CaseIdFormat)
+    : "brackets";
+}
+
+export interface CaseIdResolution {
+  /** Resolved numeric case IDs, de-duplicated, in first-seen order. */
+  ids: number[];
+  /** Which channel produced the IDs, or `null` when none matched. */
+  source: "property" | "name" | null;
+}
+
+const ID_TOKEN = /^[Cc]?#?(\d+)$/;
+
+function toCaseId(token: string): number | null {
+  const match = ID_TOKEN.exec(token.trim());
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isSafeInteger(n) && n > 0 ? n : null;
+}
+
+function dedupe(ids: number[]): number[] {
+  return [...new Set(ids)];
+}
+
+/**
+ * Extract IDs from bracketed segments: `[123]`, `[C123]`, `[123, 456]`,
+ * `[C1 C2]`. Each bracket's contents must be only id tokens separated by
+ * commas/whitespace/underscores, so incidental brackets (e.g. `[2024-01-01]`)
+ * are ignored.
+ */
+function extractBrackets(name: string): number[] {
+  const ids: number[] = [];
+  const bracket = /\[([^\]]*)\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = bracket.exec(name)) !== null) {
+    for (const token of match[1].split(/[,\s_]+/).filter(Boolean)) {
+      const id = toCaseId(token);
+      if (id !== null) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/** Extract `C123`-style IDs. A preceding letter (e.g. `ABC123`) is rejected. */
+function extractCPrefix(name: string): number[] {
+  const ids: number[] = [];
+  const re = /(?<![A-Za-z])[Cc]#?(\d+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(name)) !== null) {
+    const n = Number(match[1]);
+    if (Number.isSafeInteger(n) && n > 0) ids.push(n);
+  }
+  return ids;
+}
+
+/** Extract `TC-123` / `TC123`-style IDs. A preceding letter is rejected. */
+function extractTcPrefix(name: string): number[] {
+  const ids: number[] = [];
+  const re = /(?<![A-Za-z])TC[-_]?(\d+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(name)) !== null) {
+    const n = Number(match[1]);
+    if (Number.isSafeInteger(n) && n > 0) ids.push(n);
+  }
+  return ids;
+}
+
+/** Parse case IDs out of a test name using the given preset. */
+export function parseCaseIdsFromName(
+  name: string,
+  format: CaseIdFormat
+): number[] {
+  if (!name) return [];
+  switch (format) {
+    case "c":
+      return dedupe(extractCPrefix(name));
+    case "tc":
+      return dedupe(extractTcPrefix(name));
+    case "brackets":
+    default:
+      return dedupe(extractBrackets(name));
+  }
+}
+
+/**
+ * Parse case IDs out of the parsed JUnit `<property>` map. Values may be a
+ * single id or a comma/space separated list (`"C123, C456"`).
+ */
+export function parseCaseIdsFromProperty(
+  metadata: Record<string, string> | undefined,
+  propertyNames: readonly string[] = CASE_ID_PROPERTY_NAMES
+): number[] {
+  if (!metadata) return [];
+  const lowered = propertyNames.map((n) => n.toLowerCase());
+  const ids: number[] = [];
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!lowered.includes(key.toLowerCase())) continue;
+    for (const token of String(value)
+      .split(/[,\s]+/)
+      .filter(Boolean)) {
+      const id = toCaseId(token);
+      if (id !== null) ids.push(id);
+    }
+  }
+  return dedupe(ids);
+}
+
+/**
+ * Resolve the case-ID references for a single test case, applying the
+ * configured matcher mode. Property matches take precedence over name
+ * matches. Returns an empty result (and `source: null`) when matching is
+ * off or nothing is found — the caller then falls back to name+className.
+ */
+export function resolveCaseIdRefs(
+  input: { name: string; metadata?: Record<string, string> },
+  opts: {
+    matcher: CaseMatcher;
+    format: CaseIdFormat;
+    propertyNames?: readonly string[];
+  }
+): CaseIdResolution {
+  if (opts.matcher === "off") return { ids: [], source: null };
+
+  const tryProperty = opts.matcher === "property" || opts.matcher === "auto";
+  const tryName = opts.matcher === "name" || opts.matcher === "auto";
+
+  if (tryProperty) {
+    const ids = parseCaseIdsFromProperty(input.metadata, opts.propertyNames);
+    if (ids.length > 0) return { ids, source: "property" };
+  }
+  if (tryName) {
+    const ids = parseCaseIdsFromName(input.name, opts.format);
+    if (ids.length > 0) return { ids, source: "name" };
+  }
+  return { ids: [], source: null };
+}


### PR DESCRIPTION
## Description

Lets automated tests declare which existing TestPlanIt case a result belongs to, so **renaming a test no longer creates a duplicate case** when importing JUnit/XML results via the CLI.

By default the importer matches a result to a case by **name + class name**, so a renamed test is treated as new. This adds opt-in **case-ID matching**: when a result carries an ID, it links to that case regardless of the test name.

Two ways to carry the ID (controlled by `--case-matcher`):

- **`name`** — an ID in the test name, via a fixed preset (`--case-id-format`): `brackets` (`[123]`, default), `c` (`C123`), `tc` (`TC-123`)
- **`property`** — a JUnit `<property name="test_id" value="123">` (also accepts `testplanit_case_id`), the de-facto convention used by TestRail and Xray
- **`auto`** — try the property, then the name

Behavior:

- Default is `off` — existing imports are unchanged.
- Property matches take precedence over name matches; multiple IDs link one result to multiple cases.
- ID lookups are scoped to the target project (a job can't attach to another project's case).
- An ID not found in the project is **skipped and reported as a warning** (`caseIdWarnings`), never auto-created under the wrong name.
- ID-matched cases are updated non-destructively (curated name/class/template/state/estimate preserved).

Security: name matching uses a fixed set of **compiled presets only** — no caller-supplied regex ever runs server-side (no ReDoS surface).

This branch also includes minor housekeeping: a `docs(import-export)` doc refresh and adding `iframe-resizer` to the pnpm allowed-builds list.

## Related Issue

User request: assign a case ID to automated tests so CLI/JUnit imports link to the correct case instead of duplicating on rename.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- New `automationCaseId` unit tests (presets, property parsing, precedence, multi-ID, false-positive avoidance) — 30 tests.
- New import-route tests: link-by-ID without creating, property precedence, unknown-ID skip+warn, off→legacy unchanged, multi-ID linking, partial multi-ID warn, non-destructive update.
- `automationCaseId` + route tests: 51 passing; CLI suite: 130 passing.
- `tsc --noEmit` clean (testplanit + cli); eslint clean; CLI build succeeds.

## Checklist

- [x] Default-off; no behavior change for existing imports
- [x] No caller-supplied regex executed server-side
- [x] Project-scoped case lookups
- [x] Docs updated (`docs/docs/cli.md`, `docs/docs/import-export.md`, `cli/README.md`)
- [x] Tests added
