### PR TITLE
enhancement(sessions): server-side enforcement of required Result Fields

### DIFF
--- a/testplanit/app/api/model/[...path]/route.test.ts
+++ b/testplanit/app/api/model/[...path]/route.test.ts
@@ -1505,3 +1505,203 @@ describe("ZenStack chokepoint Review & Approval gate", () => {
     expect(baseHandlerMock).toHaveBeenCalled();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionResults required-result-field guard at the auto-API chokepoint.
+// Closes the bypass that the placeholder in
+// `.planning/backlog/999.17-session-result-required-field-enforcement/`
+// documents: raw-API callers POSTing to /api/model/sessionResults could
+// previously skip a server-required Result Field. The handler-level gate
+// runs `hasMissingRequiredResultField` before the ZenStack pipeline executes,
+// so first-party and raw-API callers go through the same check.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("ZenStack chokepoint SessionResults required-field gate", () => {
+  function makeCreateRequest(body: unknown): NextRequest {
+    const headers = new Headers();
+    headers.set("content-type", "application/json");
+    headers.set("authorization", "Bearer tpi_test_token");
+    const json = JSON.stringify(body);
+    return {
+      method: "POST",
+      headers,
+      url: "http://localhost:3000/api/model/sessionResults/create",
+      clone() {
+        return this;
+      },
+      async text() {
+        return json;
+      },
+    } as unknown as NextRequest;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { getServerAuthSession } = await import("~/server/auth");
+    (getServerAuthSession as any).mockResolvedValue({
+      user: { id: "user-1", email: "u@e.com", name: "U" },
+    });
+    const { extractBearerToken } = await import("~/lib/api-token-auth");
+    (extractBearerToken as any).mockReturnValue("tpi_test_token");
+    const { authenticateApiTokenForMethod } =
+      await import("~/lib/api-token-auth");
+    (authenticateApiTokenForMethod as any).mockResolvedValue({
+      authenticated: true,
+      userId: "user-1",
+      access: "USER",
+      scopes: [],
+    });
+    const { prisma } = await import("~/lib/prisma");
+    (prisma as any).user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "u@e.com",
+      name: "U",
+    });
+    baseHandlerMock.mockClear();
+    baseHandlerMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: 7 } }), { status: 200 })
+    );
+  });
+
+  function mockSessionLookup(templateId: number) {
+    return async () => {
+      const { prisma } = await import("~/lib/prisma");
+      (prisma as any).sessions = {
+        findUnique: vi.fn().mockResolvedValue({ templateId }),
+      };
+    };
+  }
+
+  function mockRequiredFieldAssignments(
+    requiredFieldIds: number[]
+  ): () => Promise<void> {
+    return async () => {
+      const { prisma } = await import("~/lib/prisma");
+      (prisma as any).templateResultAssignment = {
+        findMany: vi
+          .fn()
+          .mockResolvedValue(
+            requiredFieldIds.map((resultFieldId) => ({ resultFieldId }))
+          ),
+      };
+    };
+  }
+
+  it("rejects with REQUIRED_FIELDS_MISSING when the body omits any required field", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([11, 12])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({
+      data: {
+        sessionId: 100,
+        statusId: 2,
+        // no resultFieldValues.create
+      },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("REQUIRED_FIELDS_MISSING");
+    expect(baseHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when only some required fields are supplied", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([11, 12])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({
+      data: {
+        sessionId: 100,
+        statusId: 2,
+        resultFieldValues: { create: [{ fieldId: 11, value: "x" }] },
+      },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("REQUIRED_FIELDS_MISSING");
+    expect(baseHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("passes through to baseHandler when every required field is supplied via nested create", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([11, 12])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({
+      data: {
+        sessionId: 100,
+        statusId: 2,
+        resultFieldValues: {
+          create: [
+            { fieldId: 11, value: "a" },
+            { fieldId: 12, value: "b" },
+          ],
+        },
+      },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(baseHandlerMock).toHaveBeenCalled();
+  });
+
+  it("passes through when the template has no required fields", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({
+      data: { sessionId: 100, statusId: 2 },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(baseHandlerMock).toHaveBeenCalled();
+  });
+
+  it("passes through when sessionId is missing (ZenStack will reject schema-wise)", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([11])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({ data: { statusId: 2 } });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(baseHandlerMock).toHaveBeenCalled();
+  });
+
+  it("accepts the `session: { connect: { id } }` body shape (treated same as sessionId)", async () => {
+    await mockSessionLookup(5)();
+    await mockRequiredFieldAssignments([11])();
+
+    const { POST } = await import("./route");
+    const req = makeCreateRequest({
+      data: {
+        session: { connect: { id: 100 } },
+        statusId: 2,
+        resultFieldValues: { create: [{ fieldId: 11, value: "x" }] },
+      },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["sessionResults", "create"] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(baseHandlerMock).toHaveBeenCalled();
+  });
+});

--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -80,6 +80,7 @@ function getCurrentApiAuth(): ApiAuthContext {
 const AUTO_INJECT_USER_FIELDS: Record<string, string[]> = {
   testRuns: ["createdBy"],
   testRunResults: ["executedBy"],
+  sessionResults: ["createdBy"],
   repositoryCases: ["creator"],
   repositoryFolders: ["creator"],
   sessions: ["createdBy"],

--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -30,6 +30,7 @@ import {
   assertResultEditWindowOpen,
   isEditWindowExpiredError,
 } from "~/lib/services/editWindow";
+import { hasMissingRequiredResultField } from "~/lib/services/resultGuards";
 import { softDeleteUnexecutedRunCasesForDraftRevert } from "~/lib/services/runCaseEligibility";
 import {
   isAlreadyPendingError,
@@ -744,6 +745,97 @@ async function innerHandler(
             );
           }
           throw err;
+        }
+      }
+    }
+
+    // Required-result-field guard for SessionResults.create. The model handler
+    // is the universal chokepoint — `lib/prisma.ts`'s `$extends` middleware is
+    // bypassed by ZenStack's `enhance()` (see the repositoryCases ES-sync shim
+    // above), so a Prisma-extension hook would silently miss raw POSTs landing
+    // here. Reading the supplied `resultFieldValues.create[]` from the
+    // request body lets the same `hasMissingRequiredResultField` helper that
+    // gates the `/api/test-runs/submit-result` path enforce parity against
+    // session results too. SessionResults must be created with the field
+    // values nested in the same call; the SessionResultForm UI is the canonical
+    // first-party caller and uses that shape.
+    if (
+      isMutation &&
+      parsedPath &&
+      parsedPath.model === "sessionResults" &&
+      parsedPath.operation === "create"
+    ) {
+      const data = (requestBody as { data?: Record<string, unknown> } | null)
+        ?.data;
+      const rawSessionId =
+        (data?.sessionId as number | string | undefined) ??
+        ((data?.session as { connect?: { id?: number | string } } | undefined)
+          ?.connect?.id as number | string | undefined);
+      const sessionId =
+        typeof rawSessionId === "number"
+          ? rawSessionId
+          : typeof rawSessionId === "string" && rawSessionId !== ""
+            ? Number(rawSessionId)
+            : NaN;
+      if (Number.isFinite(sessionId)) {
+        const session = await prisma.sessions.findUnique({
+          where: { id: sessionId },
+          select: { templateId: true },
+        });
+        if (session) {
+          const nestedCreate = (
+            data?.resultFieldValues as
+              | {
+                  create?:
+                    | Array<Record<string, unknown>>
+                    | Record<string, unknown>;
+                }
+              | undefined
+          )?.create;
+          const nestedArray = Array.isArray(nestedCreate)
+            ? nestedCreate
+            : nestedCreate
+              ? [nestedCreate]
+              : [];
+          const suppliedFieldValues = nestedArray
+            .map((fv) => {
+              const rawFieldId =
+                (fv?.fieldId as number | string | undefined) ??
+                ((
+                  fv?.field as
+                    | { connect?: { id?: number | string } }
+                    | undefined
+                )?.connect?.id as number | string | undefined);
+              const fieldId =
+                typeof rawFieldId === "number"
+                  ? rawFieldId
+                  : typeof rawFieldId === "string" && rawFieldId !== ""
+                    ? Number(rawFieldId)
+                    : NaN;
+              return Number.isFinite(fieldId)
+                ? { fieldId, value: fv?.value }
+                : null;
+            })
+            .filter(
+              (entry): entry is { fieldId: number; value: unknown } =>
+                entry !== null
+            );
+          const missing = await hasMissingRequiredResultField(
+            prisma,
+            session.templateId,
+            suppliedFieldValues
+          );
+          if (missing) {
+            return NextResponse.json(
+              {
+                error: {
+                  code: "REQUIRED_FIELDS_MISSING",
+                  message: "A required result field is missing a value",
+                },
+              },
+              { status: 400 }
+            );
+          }
         }
       }
     }

--- a/testplanit/components/SessionResultForm.test.tsx
+++ b/testplanit/components/SessionResultForm.test.tsx
@@ -24,7 +24,6 @@ vi.mock("~/lib/hooks", () => ({
     isLoading: false,
   })),
   useCreateAttachments: vi.fn(() => ({ mutateAsync: vi.fn() })),
-  useCreateResultFieldValues: vi.fn(() => ({ mutateAsync: vi.fn() })),
   useUpdateSessions: vi.fn(() => ({ mutateAsync: vi.fn() })),
 }));
 

--- a/testplanit/components/SessionResultForm.tsx
+++ b/testplanit/components/SessionResultForm.tsx
@@ -37,7 +37,6 @@ import { z } from "zod/v4";
 import { emptyEditorContent, MAX_DURATION } from "~/app/constants";
 import {
   useCreateAttachments,
-  useCreateResultFieldValues,
   useCreateSessionResults,
   useFindFirstProjects,
   useFindFirstSessions,
@@ -344,7 +343,6 @@ export function SessionResultForm({
 
   const { mutateAsync: createSessionResult } = useCreateSessionResults();
   const { mutateAsync: createAttachments } = useCreateAttachments();
-  const { mutateAsync: createResultFieldValue } = useCreateResultFieldValues();
   const { mutateAsync: updateSession } = useUpdateSessions();
 
   // Update useEffect to remove debug logging
@@ -573,7 +571,27 @@ export function SessionResultForm({
         }
       }
 
-      // Create the session result
+      // Build the nested ResultFieldValues create payload from the template
+      // fields the user filled in. Persisting them atomically with the parent
+      // SessionResult is what makes the server-side required-field guard in
+      // `app/api/model/[...path]/route.ts` enforceable on every caller — the
+      // gate reads `data.resultFieldValues.create[]` straight off this body.
+      const nestedFieldValues = templateFields.flatMap((field) => {
+        const fieldId = field.resultField.id;
+        const fieldValue = values[fieldId.toString()];
+        if (fieldValue === undefined || fieldValue === null) return [];
+        return [
+          {
+            fieldId,
+            value:
+              typeof fieldValue === "object"
+                ? JSON.stringify(fieldValue)
+                : String(fieldValue as string | number | boolean),
+          },
+        ];
+      });
+
+      // Create the session result + its field values atomically.
       const result = await createSessionResult({
         data: {
           sessionId: sessionId,
@@ -584,6 +602,9 @@ export function SessionResultForm({
           issues: {
             connect: selectedIssues.map((id) => ({ id })),
           },
+          ...(nestedFieldValues.length > 0 && {
+            resultFieldValues: { create: nestedFieldValues },
+          }),
         },
       });
 
@@ -600,31 +621,6 @@ export function SessionResultForm({
             },
           });
         }
-      }
-
-      // Now save the template field values directly to the ResultFieldValues table
-      if (result && templateFields.length > 0) {
-        const fieldValuesPromises = templateFields.map((field) => {
-          const fieldId = field.resultField.id.toString();
-          const fieldValue = values[fieldId];
-
-          // Only save if field has a value
-          if (fieldValue !== undefined && fieldValue !== null) {
-            return createResultFieldValue({
-              data: {
-                fieldId: parseInt(fieldId),
-                value:
-                  typeof fieldValue === "object"
-                    ? JSON.stringify(fieldValue)
-                    : String(fieldValue as string | number | boolean),
-                sessionResultsId: result.id,
-              },
-            });
-          }
-          return Promise.resolve();
-        });
-
-        await Promise.all(fieldValuesPromises);
       }
 
       // Upload attachments if there are any (files OR external links)

--- a/testplanit/e2e/fixtures/api.fixture.ts
+++ b/testplanit/e2e/fixtures/api.fixture.ts
@@ -3141,6 +3141,7 @@ export class ApiHelper {
     name: string,
     options?: {
       stateId?: number;
+      templateId?: number;
       milestoneId?: number;
       configId?: number;
       configurationGroupId?: string;
@@ -3153,7 +3154,9 @@ export class ApiHelper {
       options?.stateId
         ? Promise.resolve(options.stateId)
         : this.getStateId(projectId),
-      this.getTemplateId(projectId),
+      options?.templateId
+        ? Promise.resolve(options.templateId)
+        : this.getTemplateId(projectId),
     ]);
 
     const data: Record<string, unknown> = {

--- a/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
+++ b/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "../../fixtures";
+
+/**
+ * Session result required-field server-side enforcement.
+ *
+ * Covers the bypass closed by the handler-level guard added to
+ * `app/api/model/[...path]/route.ts`. The guard intercepts every
+ * `sessionResults.create` request — first-party UI and raw API alike — and
+ * rejects with `REQUIRED_FIELDS_MISSING` (HTTP 400) when the parent session's
+ * template marks any Result Field as required and the supplied nested
+ * `resultFieldValues.create[]` doesn't cover it.
+ *
+ * Each test creates its own template + required result field so we never
+ * pollute the seeded "Default Template" that other suites depend on.
+ */
+test.describe("Sessions — required result-field enforcement", () => {
+  test("raw API rejects sessionResults.create when a required field is missing", async ({
+    api,
+    request,
+    baseURL,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(`E2E Session Required RF ${ts}`);
+
+    // Fresh template scoped to this project + a required Text-String result
+    // field assigned to it. Using a fresh template avoids racing with other
+    // tests that rely on the seeded "Default Template".
+    const templateId = await api.createTemplate({
+      name: `Required RF Template ${ts}`,
+      projectIds: [projectId],
+    });
+    const requiredFieldId = await api.createResultField({
+      displayName: `Build ${ts}`,
+      systemName: `e2e_required_build_${ts}`,
+      typeName: "Text String",
+      isRequired: true,
+    });
+    await api.assignResultFieldToTemplate(templateId, requiredFieldId);
+
+    const sessionId = await api.createSession(
+      projectId,
+      `Session Required RF ${ts}`,
+      { templateId }
+    );
+
+    // Find a status enabled for the project.
+    const statusResp = await request.get(
+      `${baseURL}/api/model/status/findFirst`,
+      {
+        params: {
+          q: JSON.stringify({
+            where: {
+              isDeleted: false,
+              isEnabled: true,
+              projects: { some: { projectId } },
+            },
+          }),
+        },
+      }
+    );
+    expect(statusResp.ok()).toBe(true);
+    const statusId = (await statusResp.json()).data.id;
+
+    // Raw POST with NO resultFieldValues — the guard must reject.
+    const rejected = await request.post(
+      `${baseURL}/api/model/sessionResults/create`,
+      {
+        data: {
+          data: {
+            sessionId,
+            statusId,
+            resultData: { type: "doc", content: [{ type: "paragraph" }] },
+          },
+        },
+      }
+    );
+    expect(rejected.status()).toBe(400);
+    const rejectedBody = await rejected.json();
+    expect(rejectedBody.error?.code).toBe("REQUIRED_FIELDS_MISSING");
+  });
+
+  test("raw API accepts sessionResults.create when nested field values cover all required fields", async ({
+    api,
+    request,
+    baseURL,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(
+      `E2E Session Required RF OK ${ts}`
+    );
+
+    const templateId = await api.createTemplate({
+      name: `Required RF Template OK ${ts}`,
+      projectIds: [projectId],
+    });
+    const requiredFieldId = await api.createResultField({
+      displayName: `Build ${ts}`,
+      systemName: `e2e_required_build_ok_${ts}`,
+      typeName: "Text String",
+      isRequired: true,
+    });
+    await api.assignResultFieldToTemplate(templateId, requiredFieldId);
+
+    const sessionId = await api.createSession(
+      projectId,
+      `Session Required RF OK ${ts}`,
+      { templateId }
+    );
+
+    const statusResp = await request.get(
+      `${baseURL}/api/model/status/findFirst`,
+      {
+        params: {
+          q: JSON.stringify({
+            where: {
+              isDeleted: false,
+              isEnabled: true,
+              projects: { some: { projectId } },
+            },
+          }),
+        },
+      }
+    );
+    expect(statusResp.ok()).toBe(true);
+    const statusId = (await statusResp.json()).data.id;
+
+    // Atomic create with the required field nested in the same payload —
+    // the same shape SessionResultForm now sends.
+    const ok = await request.post(
+      `${baseURL}/api/model/sessionResults/create`,
+      {
+        data: {
+          data: {
+            sessionId,
+            statusId,
+            resultData: { type: "doc", content: [{ type: "paragraph" }] },
+            resultFieldValues: {
+              create: [{ fieldId: requiredFieldId, value: "1.2.3" }],
+            },
+          },
+        },
+      }
+    );
+    expect(ok.status()).toBe(200);
+    const body = await ok.json();
+    expect(body.data?.id).toBeGreaterThan(0);
+  });
+
+  test("raw API accepts sessionResults.create when the template has no required fields", async ({
+    api,
+    request,
+    baseURL,
+  }) => {
+    const ts = Date.now();
+    const projectId = await api.createProject(
+      `E2E Session No Required RF ${ts}`
+    );
+
+    // No required fields — the guard should be a no-op even though the
+    // payload omits `resultFieldValues` entirely.
+    const sessionId = await api.createSession(
+      projectId,
+      `Session No Required RF ${ts}`
+    );
+
+    const statusResp = await request.get(
+      `${baseURL}/api/model/status/findFirst`,
+      {
+        params: {
+          q: JSON.stringify({
+            where: {
+              isDeleted: false,
+              isEnabled: true,
+              projects: { some: { projectId } },
+            },
+          }),
+        },
+      }
+    );
+    expect(statusResp.ok()).toBe(true);
+    const statusId = (await statusResp.json()).data.id;
+
+    const ok = await request.post(
+      `${baseURL}/api/model/sessionResults/create`,
+      {
+        data: {
+          data: {
+            sessionId,
+            statusId,
+            resultData: { type: "doc", content: [{ type: "paragraph" }] },
+          },
+        },
+      }
+    );
+    expect(ok.status()).toBe(200);
+    const body = await ok.json();
+    expect(body.data?.id).toBeGreaterThan(0);
+  });
+});

--- a/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
+++ b/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
@@ -61,18 +61,16 @@ test.describe("Sessions — required result-field enforcement", () => {
     expect(statusResp.ok()).toBe(true);
     const statusId = (await statusResp.json()).data.id;
 
-    // Raw POST with NO resultFieldValues — the guard must reject. Note that
-    // `createdById` is set so the rejection isolates the required-field
-    // scenario (rather than racing the missing-FK validation).
-    const userId = await api.getCurrentUserId();
+    // Raw POST with NO resultFieldValues — the guard must reject. The handler
+    // auto-injects `createdBy` for sessionResults (AUTO_INJECT_USER_FIELDS),
+    // so the failure isolates the required-field scenario.
     const rejected = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
         data: {
           data: {
-            sessionId,
-            statusId,
-            createdById: userId,
+            session: { connect: { id: sessionId } },
+            status: { connect: { id: statusId } },
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
           },
         },
@@ -129,19 +127,15 @@ test.describe("Sessions — required result-field enforcement", () => {
     const statusId = (await statusResp.json()).data.id;
 
     // Atomic create with the required field nested in the same payload —
-    // the same shape SessionResultForm now sends. `createdById` is required
-    // explicitly here because `sessionResults` isn't in the route's
-    // AUTO_INJECT_USER_FIELDS map (route.ts:80) the way sessions / testRuns
-    // are; the UI sets it directly off `session.user.id`.
-    const userId = await api.getCurrentUserId();
+    // the same shape SessionResultForm now sends. `createdBy` is filled in
+    // server-side via AUTO_INJECT_USER_FIELDS off the authenticated user.
     const ok = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
         data: {
           data: {
-            sessionId,
-            statusId,
-            createdById: userId,
+            session: { connect: { id: sessionId } },
+            status: { connect: { id: statusId } },
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
             resultFieldValues: {
               create: [{ fieldId: requiredFieldId, value: "1.2.3" }],
@@ -189,15 +183,13 @@ test.describe("Sessions — required result-field enforcement", () => {
     expect(statusResp.ok()).toBe(true);
     const statusId = (await statusResp.json()).data.id;
 
-    const userId = await api.getCurrentUserId();
     const ok = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
         data: {
           data: {
-            sessionId,
-            statusId,
-            createdById: userId,
+            session: { connect: { id: sessionId } },
+            status: { connect: { id: statusId } },
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
           },
         },

--- a/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
+++ b/testplanit/e2e/tests/sessions/session-required-result-fields.spec.ts
@@ -61,7 +61,10 @@ test.describe("Sessions — required result-field enforcement", () => {
     expect(statusResp.ok()).toBe(true);
     const statusId = (await statusResp.json()).data.id;
 
-    // Raw POST with NO resultFieldValues — the guard must reject.
+    // Raw POST with NO resultFieldValues — the guard must reject. Note that
+    // `createdById` is set so the rejection isolates the required-field
+    // scenario (rather than racing the missing-FK validation).
+    const userId = await api.getCurrentUserId();
     const rejected = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
@@ -69,6 +72,7 @@ test.describe("Sessions — required result-field enforcement", () => {
           data: {
             sessionId,
             statusId,
+            createdById: userId,
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
           },
         },
@@ -125,7 +129,11 @@ test.describe("Sessions — required result-field enforcement", () => {
     const statusId = (await statusResp.json()).data.id;
 
     // Atomic create with the required field nested in the same payload —
-    // the same shape SessionResultForm now sends.
+    // the same shape SessionResultForm now sends. `createdById` is required
+    // explicitly here because `sessionResults` isn't in the route's
+    // AUTO_INJECT_USER_FIELDS map (route.ts:80) the way sessions / testRuns
+    // are; the UI sets it directly off `session.user.id`.
+    const userId = await api.getCurrentUserId();
     const ok = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
@@ -133,6 +141,7 @@ test.describe("Sessions — required result-field enforcement", () => {
           data: {
             sessionId,
             statusId,
+            createdById: userId,
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
             resultFieldValues: {
               create: [{ fieldId: requiredFieldId, value: "1.2.3" }],
@@ -141,7 +150,7 @@ test.describe("Sessions — required result-field enforcement", () => {
         },
       }
     );
-    expect(ok.status()).toBe(200);
+    expect(ok.status()).toBe(201);
     const body = await ok.json();
     expect(body.data?.id).toBeGreaterThan(0);
   });
@@ -180,6 +189,7 @@ test.describe("Sessions — required result-field enforcement", () => {
     expect(statusResp.ok()).toBe(true);
     const statusId = (await statusResp.json()).data.id;
 
+    const userId = await api.getCurrentUserId();
     const ok = await request.post(
       `${baseURL}/api/model/sessionResults/create`,
       {
@@ -187,12 +197,13 @@ test.describe("Sessions — required result-field enforcement", () => {
           data: {
             sessionId,
             statusId,
+            createdById: userId,
             resultData: { type: "doc", content: [{ type: "paragraph" }] },
           },
         },
       }
     );
-    expect(ok.status()).toBe(200);
+    expect(ok.status()).toBe(201);
     const body = await ok.json();
     expect(body.data?.id).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Description

The interactive UI suggests that required Result Fields on a session's template are enforced server-side, but a raw `POST /api/model/sessionResults` could create a SessionResult without supplying values for them. The bypass existed because the field values were written in separate ZenStack mutations after the parent SessionResult, so no single chokepoint saw both at once.

This PR closes the bypass at the model handler chokepoint (`app/api/model/[...path]/route.ts`). For every `sessionResults.create` operation, the handler reads the supplied `data.resultFieldValues.create[]` straight off the request body, fetches the parent session's `templateId`, and runs the existing `hasMissingRequiredResultField` helper (already used by the `/api/test-runs/submit-result` route). When any required field is missing, the handler returns HTTP 400 with `{ error: { code: "REQUIRED_FIELDS_MISSING" } }` before the ZenStack pipeline executes — first-party UI, MCP, and raw API are all gated identically.

### Why handler-level, not Prisma-extension

The `lib/prisma.ts` `$extends` middleware is bypassed by ZenStack's `enhance()` (see the existing `repositoryCases` ES-sync shim in the same file for the same observation). A Prisma-extension hook would silently miss raw POSTs landing on the auto-API. Handler-level gating is the universal layer.

### UI rewire

`SessionResultForm.tsx` switches from a multi-step `createSessionResult` + per-field `createResultFieldValue` to a single nested-create — the same shape the handler reads. The unused `useCreateResultFieldValues` hook is dropped along with its test mock.

### Bonus consistency win

`sessionResults` was the only result model missing from the route's `AUTO_INJECT_USER_FIELDS` map (`testRuns` injects `createdBy`, `testRunResults` injects `executedBy`, etc.). Adding `sessionResults: ["createdBy"]` lets raw-API callers omit `createdById` like they can on every other model.

## Related Issue

Closes the gap captured in `.planning/backlog/999.17-session-result-required-field-enforcement/` (RFI §3.10 Tier 4 honest-scope follow-up).

## Type of Change

- [x] Enhancement (server-side enforcement parity — not a new feature, closes a documented bypass)

## Testing

- **6 unit tests** in `app/api/model/[...path]/route.test.ts`: rejects with `REQUIRED_FIELDS_MISSING` when fields are omitted, rejects partial coverage, passes through with full coverage, passes through when the template has no required fields, passes through when sessionId is missing (ZenStack rejects schema-wise), accepts the `session: { connect: { id } }` body shape.
- **3 E2E tests** in `e2e/tests/sessions/session-required-result-fields.spec.ts`: raw-API rejection, nested-create success, no-required-fields no-op. Each test creates its own template + field so the seeded "Default Template" is never polluted.
- Full unit suite still green (8393 tests).
- `pnpm type-check` clean.
- `pnpm precommit` clean.

E2E run against a fresh `pnpm build` + `E2E_PROD=on pnpm test:e2e e2e/tests/sessions/session-required-result-fields.spec.ts --workers=1`: 3/3 pass (rejection 1.0s, nested-create accept 512ms, no-required-fields no-op 346ms).

## Checklist

- [x] Code follows the project style
- [x] No new warnings
- [x] Tests added (unit + E2E)
- [x] Self-reviewed
