### PR TITLE
enhancement(workers): BullMQ worker groups via configurable key prefix

### DIFF
--- a/testplanit/app/api/admin/elasticsearch/reindex/[jobId]/route.ts
+++ b/testplanit/app/api/admin/elasticsearch/reindex/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import { getCurrentTenantId, isMultiTenantMode } from "@/lib/multiTenantPrisma";
 import { prisma } from "@/lib/prisma";
 import { getElasticsearchReindexQueue } from "@/lib/queues";
+import { BULLMQ_PREFIX } from "@/lib/bullPrefix";
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateApiToken } from "~/lib/api-token-auth";
 import { getServerAuthSession } from "~/server/auth";
@@ -100,7 +101,7 @@ export async function GET(
     const progress = job.progress;
 
     // Get job logs from Redis
-    const logsKey = `bull:${elasticsearchReindexQueue.name}:${jobId}:logs`;
+    const logsKey = `${BULLMQ_PREFIX}:${elasticsearchReindexQueue.name}:${jobId}:logs`;
     const connection = await elasticsearchReindexQueue.client;
     const logs = await connection.lrange(logsKey, 0, -1);
 

--- a/testplanit/lib/bullPrefix.test.ts
+++ b/testplanit/lib/bullPrefix.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// lib/bullPrefix.ts reads process.env at module load, so each case needs a
+// fresh module instance.
+async function loadModule() {
+  vi.resetModules();
+  return import("./bullPrefix");
+}
+
+describe("BULLMQ_PREFIX", () => {
+  afterEach(() => {
+    delete process.env.BULLMQ_PREFIX;
+  });
+
+  it('defaults to "bull" when env is unset (zero-migration invariant)', async () => {
+    // "bull" is BullMQ's built-in default prefix: with the env unset, every
+    // Redis key is byte-identical to a build without prefix support. If this
+    // test ever fails, deploying the image silently strands all existing jobs.
+    delete process.env.BULLMQ_PREFIX;
+    const { BULLMQ_PREFIX } = await loadModule();
+    expect(BULLMQ_PREFIX).toBe("bull");
+  });
+
+  it('defaults to "bull" when env is empty string', async () => {
+    process.env.BULLMQ_PREFIX = "";
+    const { BULLMQ_PREFIX } = await loadModule();
+    expect(BULLMQ_PREFIX).toBe("bull");
+  });
+
+  it("uses the env value when set", async () => {
+    process.env.BULLMQ_PREFIX = "bull-heavy";
+    const { BULLMQ_PREFIX } = await loadModule();
+    expect(BULLMQ_PREFIX).toBe("bull-heavy");
+  });
+
+  it("throws on a prefix containing a colon", async () => {
+    process.env.BULLMQ_PREFIX = "bull:heavy";
+    await expect(loadModule()).rejects.toThrow(/Invalid BULLMQ_PREFIX/);
+  });
+
+  it("throws on other invalid characters", async () => {
+    process.env.BULLMQ_PREFIX = "bull heavy";
+    await expect(loadModule()).rejects.toThrow(/Invalid BULLMQ_PREFIX/);
+  });
+
+  it("allows alphanumerics, underscore and hyphen", async () => {
+    process.env.BULLMQ_PREFIX = "Bull_Group-2";
+    const { BULLMQ_PREFIX } = await loadModule();
+    expect(BULLMQ_PREFIX).toBe("Bull_Group-2");
+  });
+});

--- a/testplanit/lib/bullPrefix.ts
+++ b/testplanit/lib/bullPrefix.ts
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for the BullMQ Redis key prefix.
+ *
+ * Unset => "bull" (BullMQ's built-in default) => byte-identical Redis keys
+ * to a build without this module — existing deployments need no migration.
+ *
+ * Worker-group deployments set BULLMQ_PREFIX=bull-<group> so that a tenant's
+ * app pod (enqueue side) and its group's worker deployment (consume side)
+ * operate on a disjoint keyspace from other groups. The invariant: a tenant's
+ * app pod, its worker-group deployment, and any tooling acting on that tenant
+ * must all resolve to the same prefix (enforced by provisioning, which writes
+ * BULLMQ_PREFIX into the tenant env Secret and the group Deployment together).
+ *
+ * NOTE: BullMQ pub/sub channels used for SSE (lib/notifications/channels.ts)
+ * are deliberately NOT prefixed — they are tenant-scoped and must work
+ * across groups.
+ */
+
+// Empty string is treated like unset (a k8s env var set to "" should mean
+// "default group", not a crash).
+const rawPrefix = process.env.BULLMQ_PREFIX || undefined;
+
+if (rawPrefix !== undefined && !/^[a-zA-Z0-9_-]+$/.test(rawPrefix)) {
+  // A colon (or any other separator BullMQ uses internally) in the prefix
+  // would corrupt every key in the keyspace. Fail the process fast rather
+  // than silently splitting queues.
+  throw new Error(
+    `Invalid BULLMQ_PREFIX "${rawPrefix}": must match [a-zA-Z0-9_-]+ (no colons).`
+  );
+}
+
+export const BULLMQ_PREFIX = rawPrefix || "bull";

--- a/testplanit/lib/queues.prefix.test.ts
+++ b/testplanit/lib/queues.prefix.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Verifies every lazy Queue getter passes BULLMQ_PREFIX through to the
+// BullMQ Queue constructor — the enqueue half of worker-group isolation.
+// The Queue and the IORedis connection are both mocked; we only assert on
+// the constructor options.
+
+const constructed: Array<{ name: string; opts: Record<string, unknown> }> = [];
+
+vi.mock("bullmq", () => ({
+  Queue: class {
+    name: string;
+    constructor(name: string, opts: Record<string, unknown>) {
+      this.name = name;
+      constructed.push({ name, opts });
+    }
+    on() {
+      return this;
+    }
+  },
+}));
+
+vi.mock("./valkey", () => ({
+  // Truthy stand-in: lib/queues.ts only checks for presence before passing
+  // the connection to the Queue constructor.
+  default: { fake: "connection" },
+  createSubscriberClient: () => null,
+}));
+
+async function loadQueues() {
+  vi.resetModules();
+  constructed.length = 0;
+  return import("./queues");
+}
+
+afterEach(() => {
+  delete process.env.BULLMQ_PREFIX;
+});
+
+describe("queue getters propagate BULLMQ_PREFIX", () => {
+  it('constructs every queue with prefix "bull" when env is unset', async () => {
+    delete process.env.BULLMQ_PREFIX;
+    const queues = await loadQueues();
+    const getters = Object.entries(queues).filter(
+      ([k, v]) => k.startsWith("get") && typeof v === "function"
+    );
+
+    for (const [, getter] of getters) {
+      (getter as () => unknown)();
+    }
+
+    // getAllQueues-style helpers may construct nothing new; assert on what was
+    // constructed rather than on getter count.
+    expect(constructed.length).toBeGreaterThanOrEqual(17);
+    for (const { name, opts } of constructed) {
+      expect(opts.prefix, `queue "${name}" missing default prefix`).toBe(
+        "bull"
+      );
+    }
+  });
+
+  it("constructs every queue with the group prefix when env is set", async () => {
+    process.env.BULLMQ_PREFIX = "bull-heavy";
+    const queues = await loadQueues();
+    const getters = Object.entries(queues).filter(
+      ([k, v]) => k.startsWith("get") && typeof v === "function"
+    );
+
+    for (const [, getter] of getters) {
+      (getter as () => unknown)();
+    }
+
+    expect(constructed.length).toBeGreaterThanOrEqual(17);
+    for (const { name, opts } of constructed) {
+      expect(opts.prefix, `queue "${name}" missing group prefix`).toBe(
+        "bull-heavy"
+      );
+    }
+  });
+});

--- a/testplanit/lib/queues.ts
+++ b/testplanit/lib/queues.ts
@@ -19,6 +19,7 @@ import {
   WEBHOOK_DISPATCH_QUEUE_NAME,
 } from "./queueNames";
 import valkeyConnection from "./valkey";
+import { BULLMQ_PREFIX } from "./bullPrefix";
 
 // Re-export queue names for backward compatibility
 export {
@@ -94,6 +95,7 @@ export function getForecastQueue(): Queue | null {
 
   _forecastQueue = new Queue(FORECAST_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...STANDARD_RETRY },
   });
 
@@ -120,6 +122,7 @@ export function getNotificationQueue(): Queue | null {
 
   _notificationQueue = new Queue(NOTIFICATION_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...STANDARD_RETRY },
   });
 
@@ -146,6 +149,7 @@ export function getEmailQueue(): Queue | null {
 
   _emailQueue = new Queue(EMAIL_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       attempts: 5,
       backoff: { type: "exponential", delay: 10000 },
@@ -177,6 +181,7 @@ export function getSyncQueue(): Queue | null {
 
   _syncQueue = new Queue(SYNC_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...STANDARD_RETRY,
       removeOnComplete: { age: 3600 * 24 * 3, count: 500 },
@@ -207,6 +212,7 @@ export function getTestmoImportQueue(): Queue | null {
 
   _testmoImportQueue = new Queue(TESTMO_IMPORT_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...NO_RETRY_LIGHT_RETENTION,
       removeOnComplete: { age: 3600 * 24 * 30, count: 100 },
@@ -237,6 +243,7 @@ export function getElasticsearchReindexQueue(): Queue | null {
 
   _elasticsearchReindexQueue = new Queue(ELASTICSEARCH_REINDEX_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...NO_RETRY_LIGHT_RETENTION,
       removeOnComplete: { age: 3600 * 24 * 7, count: 50 },
@@ -275,6 +282,7 @@ export function getAuditLogQueue(): Queue | null {
 
   _auditLogQueue = new Queue(AUDIT_LOG_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...STANDARD_RETRY,
       // Long retention for audit logs - keep completed jobs for 1 year
@@ -308,6 +316,7 @@ export function getBudgetAlertQueue(): Queue | null {
 
   _budgetAlertQueue = new Queue(BUDGET_ALERT_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...STANDARD_RETRY },
   });
 
@@ -335,6 +344,7 @@ export function getAutoTagQueue(): Queue | null {
 
   _autoTagQueue = new Queue(AUTO_TAG_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...NO_RETRY_LIGHT_RETENTION },
   });
 
@@ -362,6 +372,7 @@ export function getRepoCacheQueue(): Queue | null {
 
   _repoCacheQueue = new Queue(REPO_CACHE_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...STANDARD_RETRY,
       backoff: { type: "exponential", delay: 10000 },
@@ -393,6 +404,7 @@ export function getCopyMoveQueue(): Queue | null {
   }
   _copyMoveQueue = new Queue(COPY_MOVE_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     // LOCKED: no retry — partial retry creates duplicates
     defaultJobOptions: { ...NO_RETRY_MEDIUM_RETENTION },
   });
@@ -418,6 +430,7 @@ export function getDuplicateScanQueue(): Queue | null {
 
   _duplicateScanQueue = new Queue(DUPLICATE_SCAN_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...NO_RETRY_LIGHT_RETENTION },
   });
 
@@ -446,6 +459,7 @@ export function getStepScanQueue(): Queue | null {
   }
   _stepScanQueue = new Queue(STEP_SCAN_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     // LOCKED: no retry — user retries from UI
     defaultJobOptions: { ...NO_RETRY_MEDIUM_RETENTION },
   });
@@ -470,6 +484,7 @@ export function getMagicSelectQueue(): Queue | null {
   }
   _magicSelectQueue = new Queue(MAGIC_SELECT_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: { ...NO_RETRY_LIGHT_RETENTION },
   });
   console.log(`Queue "${MAGIC_SELECT_QUEUE_NAME}" initialized.`);
@@ -493,6 +508,7 @@ export function getGenerateFromUrlQueue(): Queue | null {
   }
   _generateFromUrlQueue = new Queue(GENERATE_FROM_URL_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       ...NO_RETRY_LIGHT_RETENTION,
       removeOnFail: { age: 3600 * 24 * 3 },
@@ -521,6 +537,7 @@ export function getIterationGenerationQueue(): Queue | null {
   }
   _iterationGenerationQueue = new Queue(ITERATION_GENERATION_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       attempts: 1, // LOCKED: no retry — partial retry creates duplicate iterations
       removeOnComplete: { age: 3600 * 24 * 7, count: 500 },
@@ -559,6 +576,7 @@ export function getWebhookDispatchQueue(): Queue | null {
   }
   _webhookDispatchQueue = new Queue(WEBHOOK_DISPATCH_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
     defaultJobOptions: {
       attempts: 7, // OUT-01: 1 initial + 6 retries
       backoff: { type: "custom" }, // strategy on Worker (Pitfall 6)

--- a/testplanit/scheduler.reconcile.test.ts
+++ b/testplanit/scheduler.reconcile.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Unit tests for reconcileStaleSchedulers (scheduler.ts). The function is
+// exercised directly with fake queues; scheduler.ts's import graph is mocked
+// so the test never touches Valkey, Prisma, or the worker modules.
+
+vi.mock("./lib/queues", () => ({
+  FORECAST_QUEUE_NAME: "forecast-updates",
+  NOTIFICATION_QUEUE_NAME: "notifications",
+  REPO_CACHE_QUEUE_NAME: "repo-cache",
+  WEBHOOK_DISPATCH_QUEUE_NAME: "webhook-dispatch",
+  getForecastQueue: () => null,
+  getNotificationQueue: () => null,
+  getRepoCacheQueue: () => null,
+  getWebhookDispatchQueue: () => null,
+}));
+
+vi.mock("./lib/multiTenantPrisma", () => ({
+  getAllTenantIds: () => [],
+  isMultiTenantMode: () => true,
+}));
+
+vi.mock("./workers/forecastWorker", () => ({
+  JOB_UPDATE_ALL_CASES: "update-all-cases-forecast",
+  JOB_AUTO_COMPLETE_MILESTONES: "auto-complete-milestones",
+  JOB_MILESTONE_DUE_NOTIFICATIONS: "milestone-due-notifications",
+  JOB_REVIEW_REMINDERS: "review-reminders",
+}));
+
+vi.mock("./workers/notificationWorker", () => ({
+  JOB_SEND_DAILY_DIGEST: "send-daily-digest",
+}));
+
+vi.mock("./workers/repoCacheWorker", () => ({
+  JOB_REFRESH_EXPIRED_CACHES: "refresh-expired-caches",
+}));
+
+import { reconcileStaleSchedulers } from "./scheduler";
+
+const JOB = "update-all-cases-forecast";
+
+function fakeQueue(
+  schedulerKeys: string[],
+  opts: { listError?: Error; removeError?: Error } = {}
+) {
+  const removed: string[] = [];
+  return {
+    name: "forecast-updates",
+    removed,
+    getJobSchedulers: vi.fn(async () => {
+      if (opts.listError) throw opts.listError;
+      return schedulerKeys.map((key) => ({ key, name: JOB }));
+    }),
+    removeJobScheduler: vi.fn(async (id: string) => {
+      if (opts.removeError) throw opts.removeError;
+      removed.push(id);
+    }),
+  };
+}
+
+describe("reconcileStaleSchedulers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps schedulers for tenants still in the group config", async () => {
+    const q = fakeQueue([`${JOB}-acme`]);
+    await reconcileStaleSchedulers(
+      [{ queue: q, jobNames: [JOB] }],
+      new Set(["acme"])
+    );
+    expect(q.removed).toEqual([]);
+  });
+
+  it("removes schedulers for tenants absent from the group config", async () => {
+    const q = fakeQueue([`${JOB}-acme`, `${JOB}-gone`]);
+    await reconcileStaleSchedulers(
+      [{ queue: q, jobNames: [JOB] }],
+      new Set(["acme"])
+    );
+    expect(q.removed).toEqual([`${JOB}-gone`]);
+  });
+
+  it("parses hyphenated tenant slugs by stripping the known job-name prefix", async () => {
+    // Tenant slug "old-co" contains a hyphen — naive splitting on "-" would
+    // mis-parse it. The active set contains "old-co", so it must be kept;
+    // "other-corp-2" is stale and must be removed intact.
+    const q = fakeQueue([`${JOB}-old-co`, `${JOB}-other-corp-2`]);
+    await reconcileStaleSchedulers(
+      [{ queue: q, jobNames: [JOB] }],
+      new Set(["old-co"])
+    );
+    expect(q.removed).toEqual([`${JOB}-other-corp-2`]);
+  });
+
+  it("never touches the suffix-less single-tenant scheduler form", async () => {
+    const q = fakeQueue([JOB]);
+    await reconcileStaleSchedulers(
+      [{ queue: q, jobNames: [JOB] }],
+      new Set<string>()
+    );
+    expect(q.removed).toEqual([]);
+  });
+
+  it("never touches schedulers with unknown job names", async () => {
+    const q = fakeQueue(["some-foreign-scheduler-xyz"]);
+    await reconcileStaleSchedulers(
+      [{ queue: q, jobNames: [JOB] }],
+      new Set<string>()
+    );
+    expect(q.removed).toEqual([]);
+  });
+
+  it("matches the longest job name first (overlapping names)", async () => {
+    // "send-daily-digest-summary" is its own job; its tenant-suffixed
+    // scheduler must not be parsed as job "send-daily-digest" with tenant
+    // "summary-acme".
+    const removed: string[] = [];
+    const q = {
+      name: "notifications",
+      getJobSchedulers: vi.fn(async () => [
+        { key: "send-daily-digest-summary-acme", name: "irrelevant" },
+        { key: "send-daily-digest-acme", name: "irrelevant" },
+      ]),
+      removeJobScheduler: vi.fn(async (id: string) => {
+        removed.push(id);
+      }),
+    };
+    await reconcileStaleSchedulers(
+      [
+        {
+          queue: q,
+          jobNames: ["send-daily-digest", "send-daily-digest-summary"],
+        },
+      ],
+      new Set<string>() // nothing active -> both tenants stale
+    );
+    // Both removed, but each under its own job name with tenant "acme" —
+    // proven by both ids being removed exactly as stored.
+    expect(removed.sort()).toEqual([
+      "send-daily-digest-acme",
+      "send-daily-digest-summary-acme",
+    ]);
+  });
+
+  it("continues past a failing removeJobScheduler", async () => {
+    const q = fakeQueue([`${JOB}-gone1`, `${JOB}-gone2`], {
+      removeError: new Error("redis hiccup"),
+    });
+    await expect(
+      reconcileStaleSchedulers(
+        [{ queue: q, jobNames: [JOB] }],
+        new Set<string>()
+      )
+    ).resolves.toBeUndefined();
+    expect(q.removeJobScheduler).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues past a failing getJobSchedulers and processes later queues", async () => {
+    const broken = fakeQueue([], { listError: new Error("conn reset") });
+    const healthy = fakeQueue([`${JOB}-gone`]);
+    await reconcileStaleSchedulers(
+      [
+        { queue: broken, jobNames: [JOB] },
+        { queue: healthy, jobNames: [JOB] },
+      ],
+      new Set<string>()
+    );
+    expect(healthy.removed).toEqual([`${JOB}-gone`]);
+  });
+
+  it("skips null queues", async () => {
+    await expect(
+      reconcileStaleSchedulers(
+        [{ queue: null, jobNames: [JOB] }],
+        new Set<string>()
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/testplanit/scheduler.ts
+++ b/testplanit/scheduler.ts
@@ -28,6 +28,87 @@ const CRON_SCHEDULE_DAILY_2AM = "0 2 * * *"; // Plan 02-06 / D-04 — auto-retir
 const CRON_SCHEDULE_HOURLY = "0 * * * *"; // Top of every hour — review-reminder scan
 const JOB_RETIRE_EXPIRED_SECRETS = "retire-expired-secrets";
 
+/**
+ * Remove job schedulers for tenants that are no longer in this worker group's
+ * tenant config. Self-heals two cases:
+ *  - a tenant migrated to another worker group (its schedulers under THIS
+ *    group's BULLMQ_PREFIX must go away or its crons would run twice), and
+ *  - a deprovisioned tenant (schedulers previously persisted forever).
+ *
+ * Safety properties:
+ *  - getJobSchedulers() only sees schedulers under this process's BULLMQ_PREFIX,
+ *    so one group can never delete another group's schedulers.
+ *  - tenantId is parsed by stripping the KNOWN job-name prefix from the
+ *    scheduler key (`${jobName}-${tenantId}`), never by splitting on "-" —
+ *    tenant slugs may themselves contain hyphens.
+ *  - Scheduler keys that exactly equal a job name (the single-tenant, no-suffix
+ *    form) and keys that match no known job name are never touched.
+ *  - Failures are logged and skipped; reconciliation must never block worker
+ *    boot (the upserts above already succeeded — a stale scheduler is benign,
+ *    a crash-looping pod is not).
+ *
+ * Exported for unit tests.
+ */
+export async function reconcileStaleSchedulers(
+  queuesWithJobs: Array<{
+    queue: {
+      getJobSchedulers: (
+        start?: number,
+        end?: number,
+        asc?: boolean
+      ) => Promise<Array<{ key: string; name: string }>>;
+      removeJobScheduler: (id: string) => Promise<unknown>;
+      name: string;
+    } | null;
+    jobNames: string[];
+  }>,
+  activeTenants: Set<string>
+): Promise<void> {
+  for (const { queue, jobNames } of queuesWithJobs) {
+    if (!queue) continue;
+
+    let schedulers;
+    try {
+      schedulers = await queue.getJobSchedulers(0, -1, true);
+    } catch (err) {
+      console.warn(
+        `[scheduler] Could not list job schedulers on queue "${queue.name}" for reconciliation:`,
+        err
+      );
+      continue;
+    }
+
+    for (const scheduler of schedulers) {
+      const schedulerId = scheduler.key;
+      // Match the longest job name first so e.g. a hypothetical
+      // "send-daily-digest-summary" job is not mistaken for
+      // "send-daily-digest" with tenant "summary".
+      const jobName = [...jobNames]
+        .sort((a, b) => b.length - a.length)
+        .find((n) => schedulerId === n || schedulerId.startsWith(`${n}-`));
+
+      if (!jobName) continue; // foreign/unknown scheduler — never touch
+      if (schedulerId === jobName) continue; // single-tenant form — never touch
+
+      const tenantId = schedulerId.slice(jobName.length + 1);
+      if (!tenantId) continue;
+      if (activeTenants.has(tenantId)) continue;
+
+      try {
+        await queue.removeJobScheduler(schedulerId);
+        console.log(
+          `[scheduler] Reconciled away stale scheduler "${schedulerId}" on queue "${queue.name}" (tenant "${tenantId}" not in this worker group's config).`
+        );
+      } catch (err) {
+        console.warn(
+          `[scheduler] Failed to remove stale scheduler "${schedulerId}" on queue "${queue.name}" (will retry on next boot):`,
+          err
+        );
+      }
+    }
+  }
+}
+
 async function scheduleJobs() {
   console.log("Attempting to schedule jobs...");
 
@@ -194,6 +275,38 @@ async function scheduleJobs() {
       console.warn(
         `[scheduler] webhookDispatchQueue unavailable — auto-retire cron NOT registered`
       );
+    }
+
+    // Reconcile away schedulers for tenants no longer in this worker group's
+    // config (migrated to another group, or deprovisioned). Multi-tenant only:
+    // single-tenant deployments use suffix-less scheduler ids and have no
+    // group concept. Own try/catch — reconciliation failures must not trip
+    // the process.exit(1) below.
+    if (multiTenant) {
+      try {
+        await reconcileStaleSchedulers(
+          [
+            {
+              queue: forecastQueue,
+              jobNames: [
+                JOB_UPDATE_ALL_CASES,
+                JOB_AUTO_COMPLETE_MILESTONES,
+                JOB_MILESTONE_DUE_NOTIFICATIONS,
+                JOB_REVIEW_REMINDERS,
+              ],
+            },
+            { queue: notificationQueue, jobNames: [JOB_SEND_DAILY_DIGEST] },
+            { queue: repoCacheQueue, jobNames: [JOB_REFRESH_EXPIRED_CACHES] },
+            {
+              queue: webhookDispatchQueue,
+              jobNames: [JOB_RETIRE_EXPIRED_SECRETS],
+            },
+          ],
+          new Set(tenantIds.filter((t): t is string => Boolean(t)))
+        );
+      } catch (err) {
+        console.warn("[scheduler] Scheduler reconciliation failed:", err);
+      }
     }
   } catch (error) {
     console.error("Error scheduling jobs:", error);

--- a/testplanit/scripts/clean-queues.ts
+++ b/testplanit/scripts/clean-queues.ts
@@ -28,6 +28,7 @@ import {
   TESTMO_IMPORT_QUEUE_NAME,
 } from "../lib/queueNames";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 const ALL_QUEUES = [
   FORECAST_QUEUE_NAME,
@@ -54,6 +55,7 @@ async function main() {
   for (const name of queueNames) {
     const queue = new Queue(name, {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
     });
 
     try {
@@ -67,7 +69,7 @@ async function main() {
         (err as Error).message
       );
       try {
-        const keys = await valkeyConnection.keys(`bull:${name}:*`);
+        const keys = await valkeyConnection.keys(`${BULLMQ_PREFIX}:${name}:*`);
         if (keys.length > 0) {
           await valkeyConnection.del(...keys);
           console.log(`Deleted ${keys.length} raw keys for queue "${name}".`);

--- a/testplanit/scripts/clear-all-queues.ts
+++ b/testplanit/scripts/clear-all-queues.ts
@@ -9,6 +9,7 @@ import {
   TESTMO_IMPORT_QUEUE_NAME,
 } from "../lib/queues";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 const QUEUE_NAMES = [
   FORECAST_QUEUE_NAME,
@@ -29,6 +30,7 @@ async function clearQueue(queueName: string) {
   try {
     const queue = new Queue(queueName, {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
     });
 
     console.log(`Clearing queue "${queueName}"...`);

--- a/testplanit/scripts/clear-testmo-import-queue.ts
+++ b/testplanit/scripts/clear-testmo-import-queue.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "@prisma/client";
 import { Queue } from "bullmq";
 import { TESTMO_IMPORT_QUEUE_NAME } from "../lib/queues";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 async function main() {
   if (!valkeyConnection) {
@@ -11,6 +12,7 @@ async function main() {
 
   const queue = new Queue(TESTMO_IMPORT_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
   });
 
   console.log(`Clearing queue "${TESTMO_IMPORT_QUEUE_NAME}"...`);

--- a/testplanit/scripts/test-budget-alert.ts
+++ b/testplanit/scripts/test-budget-alert.ts
@@ -16,6 +16,7 @@ import { Queue } from "bullmq";
 import { enqueueWithAuditContext } from "../lib/auditContextEnqueue";
 import { BUDGET_ALERT_QUEUE_NAME } from "../lib/queueNames";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 const BUDGET_ALERT_JOB_CHECK = "check-budget";
 
@@ -34,6 +35,7 @@ async function main() {
 
   const queue = new Queue(BUDGET_ALERT_QUEUE_NAME, {
     connection: valkeyConnection as any,
+    prefix: BULLMQ_PREFIX,
   });
 
   const job = await enqueueWithAuditContext(

--- a/testplanit/workers/auditLogWorker.ts
+++ b/testplanit/workers/auditLogWorker.ts
@@ -10,6 +10,7 @@ import { AUDIT_LOG_QUEUE_NAME } from "../lib/queues";
 import type { AuditLogJobData } from "../lib/services/auditLog";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 /**
  * Process an audit log job.
@@ -118,6 +119,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(AUDIT_LOG_QUEUE_NAME, withTenantContext(processor), {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.AUDIT_LOG_CONCURRENCY || "10", 10), // Higher concurrency since audit logs are independent
     });
 

--- a/testplanit/workers/autoTagWorker.ts
+++ b/testplanit/workers/autoTagWorker.ts
@@ -13,6 +13,7 @@ import {
 import { AUTO_TAG_QUEUE_NAME } from "../lib/queueNames";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 // ─── Job data / result types ────────────────────────────────────────────────
 
@@ -332,6 +333,7 @@ const startWorker = async () => {
       withTenantContext(processor),
       {
         connection: valkeyConnection as any,
+        prefix: BULLMQ_PREFIX,
         concurrency: parseInt(process.env.AUTO_TAG_CONCURRENCY || "3", 10), // Process up to 3 jobs in parallel (one per entity type)
       }
     );

--- a/testplanit/workers/budgetAlertWorker.ts
+++ b/testplanit/workers/budgetAlertWorker.ts
@@ -10,6 +10,7 @@ import { BUDGET_ALERT_QUEUE_NAME } from "../lib/queues";
 import { BudgetAlertService } from "../lib/services/budgetAlertService";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 export const BUDGET_ALERT_JOB_CHECK = "check-budget";
 
@@ -50,6 +51,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(BUDGET_ALERT_QUEUE_NAME, withTenantContext(processor), {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.BUDGET_ALERT_CONCURRENCY || "2", 10),
     });
 

--- a/testplanit/workers/copyMoveWorker.ts
+++ b/testplanit/workers/copyMoveWorker.ts
@@ -14,6 +14,7 @@ import { captureAuditEvent } from "../lib/services/auditLog";
 import { resolveCreateStateRemap } from "../lib/services/reviewGate";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import { createTestCaseVersionInTransaction } from "../lib/services/testCaseVersionService";
 import { syncRepositoryCaseToElasticsearch } from "../services/repositoryCaseSync";
 
@@ -997,6 +998,7 @@ const startWorker = async () => {
       withTenantContext(processor),
       {
         connection: valkeyConnection as any,
+        prefix: BULLMQ_PREFIX,
         concurrency: 1, // LOCKED: prevent ZenStack v3 deadlocks (40P01)
       }
     );

--- a/testplanit/workers/duplicateScanWorker.ts
+++ b/testplanit/workers/duplicateScanWorker.ts
@@ -11,6 +11,7 @@ import { DUPLICATE_SCAN_QUEUE_NAME } from "../lib/queueNames";
 import { getElasticsearchClient } from "../services/elasticsearchService";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import { DuplicateAnalysisService } from "../lib/llm/services/duplicate-detection/duplicate-analysis.service";
 import { LlmManager } from "../lib/llm/services/llm-manager.service";
 import { PromptResolver } from "../lib/llm/services/prompt-resolver.service";
@@ -317,7 +318,7 @@ export function startDuplicateScanWorker() {
   worker = new Worker<DuplicateScanJobData, DuplicateScanJobResult>(
     DUPLICATE_SCAN_QUEUE_NAME,
     withTenantContext(processor),
-    { connection: valkeyConnection as any, concurrency: 1 }
+    { connection: valkeyConnection as any, prefix: BULLMQ_PREFIX, concurrency: 1 }
   );
 
   worker.on("completed", (job) =>

--- a/testplanit/workers/duplicateScanWorker.ts
+++ b/testplanit/workers/duplicateScanWorker.ts
@@ -318,7 +318,11 @@ export function startDuplicateScanWorker() {
   worker = new Worker<DuplicateScanJobData, DuplicateScanJobResult>(
     DUPLICATE_SCAN_QUEUE_NAME,
     withTenantContext(processor),
-    { connection: valkeyConnection as any, prefix: BULLMQ_PREFIX, concurrency: 1 }
+    {
+      connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
+      concurrency: 1,
+    }
   );
 
   worker.on("completed", (job) =>

--- a/testplanit/workers/elasticsearchReindexWorker.ts
+++ b/testplanit/workers/elasticsearchReindexWorker.ts
@@ -22,6 +22,7 @@ import {
 import { ELASTICSEARCH_REINDEX_QUEUE_NAME } from "../lib/queueNames";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 export interface ReindexJobData extends MultiTenantJobData {
   entityType:
@@ -384,6 +385,7 @@ const startWorker = async () => {
       withTenantContext(processor),
       {
         connection: valkeyConnection as any,
+        prefix: BULLMQ_PREFIX,
         concurrency: parseInt(
           process.env.ELASTICSEARCH_REINDEX_CONCURRENCY || "2",
           10

--- a/testplanit/workers/emailWorker.ts
+++ b/testplanit/workers/emailWorker.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/server-translations";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import { isTipTapContent, tiptapToHtml } from "../utils/tiptapToHtml";
 
 interface SendNotificationEmailJobData extends MultiTenantJobData {
@@ -763,6 +764,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(EMAIL_QUEUE_NAME, withTenantContext(processor), {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.EMAIL_CONCURRENCY || "3", 10),
     });
 

--- a/testplanit/workers/forecastWorker.ts
+++ b/testplanit/workers/forecastWorker.ts
@@ -15,6 +15,7 @@ import { getReviewReminderThresholdDays } from "../lib/services/reviewReminderCo
 import { withTenantContext } from "../lib/tenantContext";
 import { emitReviewReminderEvent } from "../lib/webhooks/event-emitters/reviewEvents";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import {
   getUniqueCaseGroupIds,
   updateRepositoryCaseForecast,
@@ -737,6 +738,7 @@ async function startWorker() {
       withTenantContext(processor),
       {
         connection: valkeyConnection as any,
+        prefix: BULLMQ_PREFIX,
         concurrency: parseInt(process.env.FORECAST_CONCURRENCY || "5", 10),
         limiter: {
           max: 100,

--- a/testplanit/workers/generateFromUrlWorker.ts
+++ b/testplanit/workers/generateFromUrlWorker.ts
@@ -8,6 +8,7 @@ import {
 import { GENERATE_FROM_URL_QUEUE_NAME } from "../lib/queueNames";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import { ssrfSafeFetch, SsrfError } from "../lib/utils/ssrf";
 import { extractContent } from "../lib/utils/contentExtractor";
 import {
@@ -315,6 +316,7 @@ export function startGenerateFromUrlWorker() {
     withTenantContext(processor),
     {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: 1,
       lockDuration: 60_000,
       maxStalledCount: 1,

--- a/testplanit/workers/iterationGenerationWorker.ts
+++ b/testplanit/workers/iterationGenerationWorker.ts
@@ -11,6 +11,7 @@ import { ITERATION_GENERATION_QUEUE_NAME } from "../lib/queueNames";
 import { materializeIterations } from "../lib/services/iterationFanOut";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 // ─── Job data / result types ────────────────────────────────────────────────
 
@@ -118,6 +119,7 @@ export function startIterationGenerationWorker() {
     withTenantContext(processor),
     {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: 1,
     }
   );

--- a/testplanit/workers/magicSelectWorker.ts
+++ b/testplanit/workers/magicSelectWorker.ts
@@ -1106,7 +1106,11 @@ export function startMagicSelectWorker() {
   worker = new Worker<MagicSelectJobData, MagicSelectJobResult>(
     MAGIC_SELECT_QUEUE_NAME,
     withTenantContext(processor),
-    { connection: valkeyConnection as any, prefix: BULLMQ_PREFIX, concurrency: 1 }
+    {
+      connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
+      concurrency: 1,
+    }
   );
 
   worker.on("completed", (job) =>

--- a/testplanit/workers/magicSelectWorker.ts
+++ b/testplanit/workers/magicSelectWorker.ts
@@ -18,6 +18,7 @@ import {
 import { MAGIC_SELECT_QUEUE_NAME } from "../lib/queueNames";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import {
   getElasticsearchClient,
   getRepositoryCaseIndexName,
@@ -1105,7 +1106,7 @@ export function startMagicSelectWorker() {
   worker = new Worker<MagicSelectJobData, MagicSelectJobResult>(
     MAGIC_SELECT_QUEUE_NAME,
     withTenantContext(processor),
-    { connection: valkeyConnection as any, concurrency: 1 }
+    { connection: valkeyConnection as any, prefix: BULLMQ_PREFIX, concurrency: 1 }
   );
 
   worker.on("completed", (job) =>

--- a/testplanit/workers/notificationWorker.ts
+++ b/testplanit/workers/notificationWorker.ts
@@ -13,6 +13,7 @@ import {
 import { getEmailQueue, NOTIFICATION_QUEUE_NAME } from "../lib/queues";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 // Define job data structures with multi-tenant support
 interface CreateNotificationJobData extends MultiTenantJobData {
@@ -261,6 +262,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(NOTIFICATION_QUEUE_NAME, withTenantContext(processor), {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.NOTIFICATION_CONCURRENCY || "5", 10),
     });
 

--- a/testplanit/workers/repoCacheWorker.ts
+++ b/testplanit/workers/repoCacheWorker.ts
@@ -10,6 +10,7 @@ import { REPO_CACHE_QUEUE_NAME } from "../lib/queueNames";
 import { refreshRepoCache } from "../lib/services/repoCacheRefreshService";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 export const JOB_REFRESH_EXPIRED_CACHES = "refresh-expired-repo-caches";
 
@@ -127,6 +128,7 @@ async function startWorker() {
       withTenantContext(processor),
       {
         connection: valkeyConnection as any,
+        prefix: BULLMQ_PREFIX,
         concurrency: 1, // Serial processing — avoid hammering git APIs
       }
     );

--- a/testplanit/workers/stepSequenceScanWorker.ts
+++ b/testplanit/workers/stepSequenceScanWorker.ts
@@ -11,6 +11,7 @@ import { StepSequenceScanService } from "../lib/services/stepSequenceScanService
 import { resolveSharedSteps } from "../lib/utils/resolveSharedSteps";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 // ─── Job data / result types ────────────────────────────────────────────────
 
@@ -192,6 +193,7 @@ export function startStepSequenceScanWorker() {
     }),
     {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: 1, // LOCKED: prevent ZenStack v3 deadlocks (40P01)
     }
   );

--- a/testplanit/workers/syncWorker.ts
+++ b/testplanit/workers/syncWorker.ts
@@ -16,6 +16,7 @@ import { SYNC_QUEUE_NAME } from "../lib/queueNames";
 import { captureAuditEvent } from "../lib/services/auditLog";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 
 // Extend SyncJobData with multi-tenant + actor-context support
 interface MultiTenantSyncJobData
@@ -220,6 +221,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(SYNC_QUEUE_NAME, withTenantContext(processor), {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.SYNC_CONCURRENCY || "2", 10),
       lockDuration: 21600000,
       maxStalledCount: 3,

--- a/testplanit/workers/testmoImportWorker.ts
+++ b/testplanit/workers/testmoImportWorker.ts
@@ -37,6 +37,7 @@ import { resolveCreateStateRemap } from "../lib/services/reviewGate";
 import { createTestCaseVersionInTransaction } from "../lib/services/testCaseVersionService.js";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import {
   normalizeMappingConfiguration,
   serializeMappingConfiguration,
@@ -7996,6 +7997,7 @@ async function startWorker() {
     withTenantContext(processor),
     {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(process.env.TESTMO_IMPORT_CONCURRENCY || "1", 10),
     }
   );

--- a/testplanit/workers/webhookDispatchWorker.ts
+++ b/testplanit/workers/webhookDispatchWorker.ts
@@ -9,6 +9,7 @@ import {
 import { WEBHOOK_DISPATCH_QUEUE_NAME } from "../lib/queues";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
+import { BULLMQ_PREFIX } from "../lib/bullPrefix";
 import {
   dispatchWebhook,
   type DispatchJobData,
@@ -159,6 +160,7 @@ const startWorker = async () => {
   if (valkeyConnection) {
     worker = new Worker(WEBHOOK_DISPATCH_QUEUE_NAME, dispatch, {
       connection: valkeyConnection as any,
+      prefix: BULLMQ_PREFIX,
       concurrency: parseInt(
         process.env.WEBHOOK_DISPATCH_CONCURRENCY || "5",
         10

--- a/testplanit/workers/workerPrefix.test.ts
+++ b/testplanit/workers/workerPrefix.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard for the consume half of worker-group isolation: a Worker
+// constructed without the group prefix would watch an empty keyspace while
+// the tenant's jobs pile up under the prefixed one. budgetAlertWorker is the
+// representative — all 17 BullMQ workers share the same constructor pattern.
+
+const constructed: Array<{ name: string; opts: Record<string, unknown> }> = [];
+
+vi.mock("bullmq", () => ({
+  Worker: class {
+    constructor(
+      name: string,
+      _processor: unknown,
+      opts: Record<string, unknown>
+    ) {
+      constructed.push({ name, opts });
+    }
+    on() {
+      return this;
+    }
+    close() {
+      return Promise.resolve();
+    }
+  },
+  Queue: class {
+    on() {
+      return this;
+    }
+  },
+}));
+
+vi.mock("../lib/valkey", () => ({
+  default: { fake: "connection" },
+  createSubscriberClient: () => null,
+}));
+
+vi.mock("../lib/multiTenantPrisma", () => ({
+  isMultiTenantMode: () => true,
+  validateMultiTenantJobData: () => undefined,
+  getPrismaClientForJob: () => null,
+  getAllTenantIds: () => [],
+}));
+
+afterEach(() => {
+  delete process.env.BULLMQ_PREFIX;
+});
+
+describe("worker constructors propagate BULLMQ_PREFIX", () => {
+  it("passes the group prefix to the BullMQ Worker", async () => {
+    process.env.BULLMQ_PREFIX = "bull-heavy";
+    vi.resetModules();
+    constructed.length = 0;
+
+    const { startWorker } = await import("./budgetAlertWorker");
+    await startWorker();
+
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0].name).toBe("budget-alerts");
+    expect(constructed[0].opts.prefix).toBe("bull-heavy");
+  });
+
+  it('defaults to prefix "bull" when env is unset', async () => {
+    delete process.env.BULLMQ_PREFIX;
+    vi.resetModules();
+    constructed.length = 0;
+
+    const { startWorker } = await import("./budgetAlertWorker");
+    await startWorker();
+
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0].opts.prefix).toBe("bull");
+  });
+});


### PR DESCRIPTION
## Description

Adds optional tenant→worker-group partitioning for BullMQ via a configurable Redis key prefix, so a subset of tenants can be served by a dedicated, independently-scalable worker deployment without affecting the rest.

A new single source of truth, `lib/bullPrefix.ts`, reads `BULLMQ_PREFIX` (validated `[a-zA-Z0-9_-]+`, colons rejected to avoid corrupting the keyspace). The prefix is applied to **all 17 queue getters and all 17 worker constructors**, plus the raw-`bull:` maintenance scripts and the admin Elasticsearch-reindex enqueue path.

**Default behaviour is unchanged:** when `BULLMQ_PREFIX` is unset it resolves to `"bull"` — BullMQ's built-in default — producing byte-identical Redis keys to a build without this change. Existing deployments need no migration; merging is a no-op until a group is actually assigned.

The scheduler gains a boot-time reconciliation pass that removes job schedulers for tenants no longer in the current group's config — self-healing both group migrations (so a moved tenant's crons don't run in two groups) and deprovisioned-tenant orphans. Tenant ids are parsed by stripping the known job-name prefix (longest match first), never by splitting on `-`, so hyphenated tenant slugs are safe; foreign and single-tenant (suffix-less) schedulers are never touched; and reconciliation failures are logged and skipped so they can never block worker boot.

SSE pub/sub channels are intentionally **not** prefixed — they are tenant-scoped and must work across groups.

## Related Issue

_No linked issue — internal infrastructure work._

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing (staging cluster)

19 new tests across 4 suites (`bullPrefix`, `queues.prefix`, `workerPrefix`, `scheduler.reconcile`) covering prefix validation/defaulting, queue/worker wiring, and the reconciliation edge cases (hyphenated slugs, longest-match, foreign/suffix-less keys, failure-soft). Full suite green: **8,412 passing**, lint + type-check clean.

Validated end-to-end on a staging cluster running two worker groups (a default group and a dedicated group):

- **Keyspace isolation** — each group's schedulers/jobs live only under its own prefix; zero cross-leakage in either direction.
- **Routing isolation** — each group's jobs (incl. a ~16.8k-doc reindex) processed only by that group's workers, verified per-job.
- **Failure isolation** — scaling the dedicated group to 0 left its jobs queued and untouched; the default group did **not** steal them, and drained the backlog on scale-up.
- **Migration drill (both directions)** — moving a tenant between groups and back; reconciliation removed all of the departed prefix's schedulers and their delayed jobs each time, with no duplicates; final topology identical to start.
- **Zero-migration regression** — the default-prefix image wrote byte-identical `bull:` keys, confirming a prod no-op.

**Test Configuration:**
- OS: macOS (local), Linux (CI + staging)
- Node version: 20.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Default-off and additive — no schema changes, no migration. Activating a worker group is a deployment-side concern (setting `BULLMQ_PREFIX=bull-<group>` on a tenant's app pod and its group's worker deployment together); the orchestration for that lives in the ops tooling, outside this repo.
