### PR TITLE
fix(scheduler): skip legacy keyless entries in reconciliation

### DIFF
--- a/testplanit/scheduler.reconcile.test.ts
+++ b/testplanit/scheduler.reconcile.test.ts
@@ -177,4 +177,47 @@ describe("reconcileStaleSchedulers", () => {
       )
     ).resolves.toBeUndefined();
   });
+
+  it("skips undefined/keyless entries from legacy repeat-zset members", async () => {
+    // Pre-BullMQ-5 repeat members (MD5-style, no scheduler hash) make
+    // getJobSchedulers() yield undefined or keyless entries. Prod incident
+    // 2026-06-05: one undefined entry TypeError'd the whole reconciliation
+    // pass. Stale entries AFTER the bad ones must still be processed.
+    const removed: string[] = [];
+    const q = {
+      name: "forecast-updates",
+      getJobSchedulers: vi.fn(async () => [
+        undefined,
+        null,
+        { name: JOB }, // keyless
+        { key: null, name: JOB },
+        { key: `${JOB}-gone`, name: JOB }, // real stale entry after the junk
+      ]),
+      removeJobScheduler: vi.fn(async (id: string) => {
+        removed.push(id);
+      }),
+    };
+    await expect(
+      reconcileStaleSchedulers(
+        [{ queue: q as never, jobNames: [JOB] }],
+        new Set<string>()
+      )
+    ).resolves.toBeUndefined();
+    expect(removed).toEqual([`${JOB}-gone`]);
+  });
+
+  it("tolerates getJobSchedulers resolving to null", async () => {
+    const q = {
+      name: "forecast-updates",
+      getJobSchedulers: vi.fn(async () => null),
+      removeJobScheduler: vi.fn(),
+    };
+    await expect(
+      reconcileStaleSchedulers(
+        [{ queue: q as never, jobNames: [JOB] }],
+        new Set<string>()
+      )
+    ).resolves.toBeUndefined();
+    expect(q.removeJobScheduler).not.toHaveBeenCalled();
+  });
 });

--- a/testplanit/scheduler.ts
+++ b/testplanit/scheduler.ts
@@ -56,7 +56,9 @@ export async function reconcileStaleSchedulers(
         start?: number,
         end?: number,
         asc?: boolean
-      ) => Promise<Array<{ key: string; name: string }>>;
+      ) => Promise<
+        Array<{ key?: string | null; name?: string } | undefined | null>
+      >;
       removeJobScheduler: (id: string) => Promise<unknown>;
       name: string;
     } | null;
@@ -78,8 +80,15 @@ export async function reconcileStaleSchedulers(
       continue;
     }
 
-    for (const scheduler of schedulers) {
-      const schedulerId = scheduler.key;
+    for (const scheduler of schedulers ?? []) {
+      // Legacy (pre-BullMQ-5) repeat zset members have no scheduler hash, so
+      // getJobSchedulers() yields undefined/keyless entries for them — seen
+      // in prod 2026-06-05 (95 MD5-style members), where one such entry
+      // TypeError'd the whole reconciliation pass. Skip them; they are
+      // exactly the "foreign — never touch" case.
+      const schedulerId = scheduler?.key;
+      if (typeof schedulerId !== "string" || schedulerId.length === 0)
+        continue;
       // Match the longest job name first so e.g. a hypothetical
       // "send-daily-digest-summary" job is not mistaken for
       // "send-daily-digest" with tenant "summary".

--- a/testplanit/scheduler.ts
+++ b/testplanit/scheduler.ts
@@ -87,8 +87,7 @@ export async function reconcileStaleSchedulers(
       // TypeError'd the whole reconciliation pass. Skip them; they are
       // exactly the "foreign — never touch" case.
       const schedulerId = scheduler?.key;
-      if (typeof schedulerId !== "string" || schedulerId.length === 0)
-        continue;
+      if (typeof schedulerId !== "string" || schedulerId.length === 0) continue;
       // Match the longest job name first so e.g. a hypothetical
       // "send-daily-digest-summary" job is not mistaken for
       // "send-daily-digest" with tenant "summary".


### PR DESCRIPTION
## Why
First v0.34.11 prod boot (2026-06-05): the new scheduler reconciliation TypeError'd on `scheduler.key` and aborted. Root cause: prod's repeat zsets contain ~95 legacy pre-BullMQ-5 members (MD5-style, no scheduler hash), so `getJobSchedulers()` yields `undefined`/keyless entries. Staging had none, which is why validation missed it.

Boot was unaffected (the outer guard caught it as designed) and no schedulers were touched, but reconciliation is **inert in prod** until this merges — group migrations and deprovision scheduler-cleanup depend on it.

## What
- Skip `undefined`/keyless entries in the reconciliation loop (they're exactly the "foreign — never touch" case) and keep processing entries after them
- Loosen the accepted `getJobSchedulers` return type to match reality
- Regression tests: junk entries mixed with a real stale entry (must still be removed), and a `null` return

## Verification
- CI green (run 26993973958 lineage; prettier'd)
- Prod evidence in the boot log of `multitenant-workers-85db5545-5l79p`: `[scheduler] Scheduler reconciliation failed: TypeError: Cannot read properties of undefined (reading 'key')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)