### PR TITLE
enhancement(auth): support IdP-initiated SAML and harden the SSO completion flow

### DIFF
--- a/testplanit/app/api/auth/callback/saml/route.test.ts
+++ b/testplanit/app/api/auth/callback/saml/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("~/lib/valkey", () => ({ default: null })); // RelayState via signed tok
 
 vi.mock("~/server/db", () => ({
   db: {
-    samlConfiguration: { findUnique: vi.fn() },
+    samlConfiguration: { findUnique: vi.fn(), findMany: vi.fn() },
     user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
     account: { upsert: vi.fn() },
     roles: { findFirst: vi.fn() },
@@ -59,9 +59,10 @@ function relayFor(providerId: string, callbackUrl = "/dash") {
 describe("POST /api/auth/callback/saml — ACS validator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (db.samlConfiguration.findMany as any).mockResolvedValue([]);
   });
 
-  it("returns 400 when RelayState is missing or invalid (Bug 4 regression)", async () => {
+  it("returns 400 when there is no RelayState and no enabled config validates it", async () => {
     const res = await POST(makeReq(null));
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -114,5 +115,47 @@ describe("POST /api/auth/callback/saml — ACS validator", () => {
     (db.samlConfiguration.findUnique as any).mockResolvedValue(null);
     const res = await POST(makeReq(relayFor("nope")));
     expect(res.status).toBe(404);
+  });
+
+  it("supports IdP-initiated login (no RelayState) via the config that validates", async () => {
+    (db.samlConfiguration.findMany as any).mockResolvedValue([
+      {
+        id: "cfg",
+        entryPoint: "e",
+        cert: "c",
+        issuer: "i",
+        attributeMapping: {},
+        autoProvisionUsers: false,
+        provider: { name: "okta", enabled: true },
+      },
+    ]);
+    validateSAMLResponse.mockResolvedValue({
+      email: "carol@example.com",
+      nameID: "carol",
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_8",
+      email: "carol@example.com",
+      name: "Carol",
+      authMethod: "SSO",
+      externalId: "carol",
+    });
+    (db.account.upsert as any).mockResolvedValue({});
+
+    const res = await POST(makeReq(null)); // no RelayState = IdP-initiated
+
+    // Picked the config by validating the assertion (findMany over enabled
+    // providers), not by a RelayState-carried id.
+    expect(db.samlConfiguration.findMany).toHaveBeenCalled();
+    expect(db.samlConfiguration.findUnique).not.toHaveBeenCalled();
+
+    const location = res.headers.get("location")!;
+    expect(
+      location.startsWith(
+        "https://app.example.com/api/auth/saml/complete?token="
+      )
+    ).toBe(true);
+    // Post-login destination defaults to /.
+    expect(location).toContain("callbackUrl=%2F");
   });
 });

--- a/testplanit/app/api/auth/callback/saml/route.ts
+++ b/testplanit/app/api/auth/callback/saml/route.ts
@@ -15,6 +15,43 @@ import { db } from "~/server/db";
 import { createSAMLClient, validateSAMLResponse } from "~/server/saml-provider";
 
 /**
+ * Resolve an IdP-initiated SAMLResponse (no RelayState — e.g. an Okta dashboard
+ * tile) to the enabled SAML config whose IdP signed it. The stored issuer field
+ * is the SP entity id, not a reliable IdP identifier, so we let cryptographic
+ * validation pick the config: the assertion only validates against the cert of
+ * the IdP that actually issued it. Returns null if none validate it.
+ */
+async function resolveIdpInitiatedConfig(samlResponse: FormDataEntryValue) {
+  const configs = await db.samlConfiguration.findMany({
+    where: { provider: { enabled: true } },
+    include: { provider: true },
+  });
+
+  for (const samlConfig of configs) {
+    try {
+      const samlClient = await createSAMLClient({
+        name: samlConfig.provider.name,
+        entryPoint: samlConfig.entryPoint,
+        cert: samlConfig.cert,
+        issuer: samlConfig.issuer,
+      });
+      const profile = await validateSAMLResponse(samlClient, {
+        SAMLResponse: samlResponse,
+      });
+      return { samlConfig, profile };
+    } catch {
+      // Not this IdP (or the assertion is invalid) — try the next config.
+    }
+  }
+
+  return null;
+}
+
+type ResolvedSaml = NonNullable<
+  Awaited<ReturnType<typeof resolveIdpInitiatedConfig>>
+>;
+
+/**
  * SAML Assertion Consumer Service (ACS).
  *
  * The IdP POSTs the SAMLResponse here. This path matches the ACS URL embedded
@@ -54,48 +91,57 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Recover the provider and destination from RelayState (the IdP echoes it
-    // back here; same-site cookies are not sent on this cross-site POST). The
-    // token is single-use and short-lived, which is what guards this endpoint.
+    // Recover the provider and destination from RelayState. The IdP echoes it
+    // back on this cross-site POST (where same-site cookies are not sent); the
+    // token is single-use and short-lived, which guards SP-initiated logins.
     const relay = await consumeSamlRelayState(
       typeof relayState === "string" ? relayState : null
     );
 
-    if (!relay) {
-      return NextResponse.json(
-        { error: "Invalid or expired SAML request" },
-        { status: 400 }
-      );
+    let samlConfig: ResolvedSaml["samlConfig"];
+    let profile: ResolvedSaml["profile"];
+    let callbackUrl = "/";
+
+    if (relay) {
+      // SP-initiated: RelayState carries the SsoProvider id, which is the unique
+      // foreign key on SamlConfiguration (not its own id).
+      callbackUrl = sanitizeCallbackUrl(relay.callbackUrl);
+      const found = await db.samlConfiguration.findUnique({
+        where: { providerId: relay.providerId },
+        include: { provider: true },
+      });
+
+      if (!found || !found.provider.enabled) {
+        return NextResponse.json(
+          { error: "SAML provider not found or disabled" },
+          { status: 404 }
+        );
+      }
+
+      const samlClient = await createSAMLClient({
+        name: found.provider.name,
+        entryPoint: found.entryPoint,
+        cert: found.cert,
+        issuer: found.issuer,
+      });
+
+      samlConfig = found;
+      profile = await validateSAMLResponse(samlClient, {
+        SAMLResponse: samlResponse,
+      });
+    } else {
+      // IdP-initiated (no RelayState — e.g. an Okta dashboard tile): pick the
+      // enabled config whose cert validates this assertion's signature.
+      const resolved = await resolveIdpInitiatedConfig(samlResponse);
+      if (!resolved) {
+        return NextResponse.json(
+          { error: "Invalid or expired SAML request" },
+          { status: 400 }
+        );
+      }
+      samlConfig = resolved.samlConfig;
+      profile = resolved.profile;
     }
-
-    const providerId = relay.providerId;
-    const callbackUrl = sanitizeCallbackUrl(relay.callbackUrl);
-
-    // Fetch SAML configuration. RelayState carries the SsoProvider id, which is
-    // the unique foreign key on SamlConfiguration (not its own id).
-    const samlConfig = await db.samlConfiguration.findUnique({
-      where: { providerId },
-      include: { provider: true },
-    });
-
-    if (!samlConfig || !samlConfig.provider.enabled) {
-      return NextResponse.json(
-        { error: "SAML provider not found or disabled" },
-        { status: 404 }
-      );
-    }
-
-    // Create SAML client and validate response
-    const samlClient = await createSAMLClient({
-      name: samlConfig.provider.name,
-      entryPoint: samlConfig.entryPoint,
-      cert: samlConfig.cert,
-      issuer: samlConfig.issuer,
-    });
-
-    const profile = await validateSAMLResponse(samlClient, {
-      SAMLResponse: samlResponse,
-    });
 
     // Validate SAML response timestamps if available
     if (profile.notBefore || profile.notOnOrAfter) {
@@ -269,8 +315,8 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Create a temporary session token for secure user info transfer
-    const tempToken = createTempSessionToken({
+    // Create a one-time session token for secure user info transfer.
+    const tempToken = await createTempSessionToken({
       userId: user.id,
       provider: `saml-${samlConfig.provider.name}`,
       email: user.email,

--- a/testplanit/app/api/auth/saml/complete/route.test.ts
+++ b/testplanit/app/api/auth/saml/complete/route.test.ts
@@ -21,7 +21,10 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("~/server/db", () => ({
-  db: { user: { findUnique: vi.fn() } },
+  db: {
+    user: { findUnique: vi.fn() },
+    registrationSettings: { findFirst: vi.fn() },
+  },
 }));
 
 import { db } from "~/server/db";
@@ -35,6 +38,7 @@ const user = {
   isApi: false,
   passwordChangedAt: null,
   mustChangePassword: false,
+  twoFactorEnabled: false,
 };
 
 function makeReq(token: string, callbackUrl = "/dashboard") {
@@ -58,6 +62,7 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
     cookieJar.clear();
     vi.clearAllMocks();
     (db.user.findUnique as any).mockResolvedValue(user);
+    (db.registrationSettings.findFirst as any).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -97,6 +102,40 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
     expect(
       cookieJar.get("__Secure-next-auth.session-token")?.value
     ).toBeTruthy();
+  });
+
+  it("stamps 2FA-required when force2FAAllLogins is on and the user has 2FA", async () => {
+    (db.registrationSettings.findFirst as any).mockResolvedValue({
+      force2FAAllLogins: true,
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      ...user,
+      twoFactorEnabled: true,
+    });
+
+    await GET(makeReq(tempToken()));
+
+    const decoded = await decode({
+      token: cookieJar.get("next-auth.session-token")!.value,
+      secret: SECRET,
+    });
+    expect(decoded?.twoFactorRequired).toBe(true);
+    expect(decoded?.twoFactorVerified).toBe(false);
+  });
+
+  it("stamps 2FA-setup-required when force2FA is on but the user has no 2FA", async () => {
+    (db.registrationSettings.findFirst as any).mockResolvedValue({
+      force2FAAllLogins: true,
+    });
+    // user.twoFactorEnabled is false by default
+
+    await GET(makeReq(tempToken()));
+
+    const decoded = await decode({
+      token: cookieJar.get("next-auth.session-token")!.value,
+      secret: SECRET,
+    });
+    expect(decoded?.twoFactorSetupRequired).toBe(true);
   });
 
   it("rejects an invalid/expired token with 401", async () => {

--- a/testplanit/app/api/auth/saml/complete/route.ts
+++ b/testplanit/app/api/auth/saml/complete/route.ts
@@ -1,8 +1,7 @@
-import jwt from "jsonwebtoken";
 import { encode } from "next-auth/jwt";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
-import { getAppBaseUrl } from "~/lib/auth-security";
+import { consumeTempSessionToken, getAppBaseUrl } from "~/lib/auth-security";
 import { db } from "~/server/db";
 
 // SAML completion handler - creates NextAuth session
@@ -16,14 +15,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Token is required" }, { status: 400 });
     }
 
-    // Verify the JWT token
-    let tokenData: any;
-    try {
-      tokenData = jwt.verify(
-        token,
-        process.env.NEXTAUTH_SECRET || "development-secret"
-      );
-    } catch {
+    // Verify and consume the one-time token (single-use via Valkey when
+    // present, so the token in the redirect URL can't be replayed).
+    const tokenData = await consumeTempSessionToken(token);
+    if (!tokenData) {
       return NextResponse.json(
         { error: "Invalid or expired token" },
         { status: 401 }
@@ -41,11 +36,32 @@ export async function GET(request: NextRequest) {
         isApi: true,
         passwordChangedAt: true,
         mustChangePassword: true,
+        twoFactorEnabled: true,
       },
     });
 
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Mirror NextAuth's force-2FA-for-SSO gate (the jwt callback in server/auth):
+    // this flow mints the session directly, so without stamping the same flags
+    // here a SAML login would bypass an enforced 2FA policy.
+    const twoFactorClaims: {
+      twoFactorRequired?: boolean;
+      twoFactorVerified?: boolean;
+      twoFactorSetupRequired?: boolean;
+    } = {};
+    const registrationSettings = await db.registrationSettings.findFirst({
+      select: { force2FAAllLogins: true },
+    });
+    if (registrationSettings?.force2FAAllLogins) {
+      if (user.twoFactorEnabled) {
+        twoFactorClaims.twoFactorRequired = true;
+        twoFactorClaims.twoFactorVerified = false;
+      } else {
+        twoFactorClaims.twoFactorSetupRequired = true;
+      }
     }
 
     // Create NextAuth JWT session token. Seed the same fields the NextAuth `jwt`
@@ -61,6 +77,7 @@ export async function GET(request: NextRequest) {
         isApi: user.isApi,
         passwordChangedAt: user.passwordChangedAt?.toISOString() ?? null,
         mustChangePassword: user.mustChangePassword ?? false,
+        ...twoFactorClaims,
       },
       secret: process.env.NEXTAUTH_SECRET || "development-secret",
     });

--- a/testplanit/lib/auth-security.test.ts
+++ b/testplanit/lib/auth-security.test.ts
@@ -193,7 +193,7 @@ describe("createTempSessionToken and verifyTempSessionToken", () => {
     const { createTempSessionToken: createToken } =
       await import("./auth-security");
 
-    const token = createToken(testData);
+    const token = await createToken(testData);
     expect(typeof token).toBe("string");
     expect(token.split(".")).toHaveLength(3); // JWT has 3 parts
 
@@ -210,7 +210,7 @@ describe("createTempSessionToken and verifyTempSessionToken", () => {
       verifyTempSessionToken: verifyToken,
     } = await import("./auth-security");
 
-    const token = createToken(testData);
+    const token = await createToken(testData);
     const verified = verifyToken(token);
 
     expect(verified).not.toBeNull();
@@ -236,12 +236,61 @@ describe("createTempSessionToken and verifyTempSessionToken", () => {
       verifyTempSessionToken: verifyToken,
     } = await import("./auth-security");
 
-    const token = createToken(testData);
+    const token = await createToken(testData);
     const tamperedToken = token.slice(0, -5) + "xxxxx";
     const result = verifyToken(tamperedToken);
     expect(result).toBeNull();
 
     process.env.NEXTAUTH_SECRET = originalSecret;
+  });
+});
+
+describe("consumeTempSessionToken (single-use)", () => {
+  const testData = {
+    userId: "user-9",
+    provider: "saml-okta",
+    email: "u@example.com",
+  };
+  const SECRET = "test-secret-key-at-least-32-chars-long";
+
+  it("Valkey-backed: a token consumes once; replay returns null", async () => {
+    const store = new Map<string, string>();
+    const fakeRedis = {
+      set: vi.fn(async (k: string, v: string) => {
+        store.set(k, v);
+        return "OK";
+      }),
+      get: vi.fn(async (k: string) => store.get(k) ?? null),
+      del: vi.fn(async (k: string) => (store.delete(k) ? 1 : 0)),
+    };
+
+    vi.resetModules();
+    process.env.NEXTAUTH_SECRET = SECRET;
+    vi.doMock("./valkey", () => ({ default: fakeRedis }));
+    const { createTempSessionToken, consumeTempSessionToken } =
+      await import("./auth-security");
+
+    const token = await createTempSessionToken(testData);
+    expect(fakeRedis.set).toHaveBeenCalledTimes(1);
+
+    const first = await consumeTempSessionToken(token);
+    expect(first).toEqual(testData);
+
+    const replay = await consumeTempSessionToken(token);
+    expect(replay).toBeNull();
+
+    vi.doUnmock("./valkey");
+  });
+
+  it("returns null for an invalid token", async () => {
+    vi.resetModules();
+    process.env.NEXTAUTH_SECRET = SECRET;
+    vi.doMock("./valkey", () => ({ default: null }));
+    const { consumeTempSessionToken } = await import("./auth-security");
+
+    expect(await consumeTempSessionToken("not-a-jwt")).toBeNull();
+
+    vi.doUnmock("./valkey");
   });
 });
 

--- a/testplanit/lib/auth-security.ts
+++ b/testplanit/lib/auth-security.ts
@@ -78,7 +78,9 @@ export function getAppBaseUrl(request?: Request): string {
 
 // JWT token configuration for temporary session data
 const JWT_SECRET = process.env.NEXTAUTH_SECRET || "";
-const JWT_EXPIRY = "5m"; // 5 minutes for temporary tokens
+const JWT_EXPIRY = "2m"; // short-lived: the completion redirect is immediate
+const SAML_COMPLETE_PREFIX = "saml:complete:";
+const SAML_COMPLETE_TTL_SECONDS = 120; // mirrors JWT_EXPIRY
 
 export interface TempSessionData {
   userId: string;
@@ -86,8 +88,25 @@ export interface TempSessionData {
   email: string;
 }
 
-export function createTempSessionToken(data: TempSessionData): string {
-  return jwt.sign(data, JWT_SECRET, { expiresIn: JWT_EXPIRY });
+/**
+ * Mint the short-lived token handed to /api/auth/saml/complete. When Valkey is
+ * available the token's jti is registered so it can be consumed exactly once —
+ * the token rides in a redirect URL (logs, Referer, history), so single-use
+ * closes the replay window that a bare expiry leaves open.
+ */
+export async function createTempSessionToken(
+  data: TempSessionData
+): Promise<string> {
+  const jti = randomBytes(16).toString("hex");
+  if (valkeyConnection) {
+    await valkeyConnection.set(
+      `${SAML_COMPLETE_PREFIX}${jti}`,
+      "1",
+      "EX",
+      SAML_COMPLETE_TTL_SECONDS
+    );
+  }
+  return jwt.sign(data, JWT_SECRET, { expiresIn: JWT_EXPIRY, jwtid: jti });
 }
 
 export function verifyTempSessionToken(token: string): TempSessionData | null {
@@ -96,6 +115,39 @@ export function verifyTempSessionToken(token: string): TempSessionData | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Verify and consume a completion token. With Valkey the jti is single-use
+ * (deleted on first read, so a replay finds nothing and is rejected); without
+ * it, the short JWT expiry bounds the window. Returns null if the token is
+ * invalid, expired, or already consumed.
+ */
+export async function consumeTempSessionToken(
+  token: string
+): Promise<TempSessionData | null> {
+  let decoded: TempSessionData & { jti?: string };
+  try {
+    decoded = jwt.verify(token, JWT_SECRET) as TempSessionData & {
+      jti?: string;
+    };
+  } catch {
+    return null;
+  }
+
+  if (valkeyConnection) {
+    if (!decoded.jti) return null;
+    const removed = await valkeyConnection.del(
+      `${SAML_COMPLETE_PREFIX}${decoded.jti}`
+    );
+    if (removed === 0) return null; // already consumed or expired
+  }
+
+  return {
+    userId: decoded.userId,
+    provider: decoded.provider,
+    email: decoded.email,
+  };
 }
 
 // SAML relay state — carries the provider id and post-login destination across


### PR DESCRIPTION
## Description

Follow-up to #405 (SP-initiated SAML). Three changes to the SAML SSO flow:

### IdP-initiated SSO (new capability)
An Okta dashboard-tile launch posts an assertion to the ACS with no `RelayState`, which #405 rejected with a 400. The ACS now handles it: with no `RelayState` it selects the enabled SAML config whose certificate validates the assertion's signature (the stored `issuer` is the SP entity id, not a reliable IdP identifier, so matching is by cryptographic validation, not a field compare) and defaults the post-login destination to `/`.

### Enforce 2FA for SAML logins (security)
`force2FAAllLogins` was bypassed for SAML, because that gate only fires inside NextAuth's `jwt` callback (which needs an `account`) and this flow mints the session directly. `/api/auth/saml/complete` now reads the setting and stamps the same `twoFactorRequired` / `twoFactorSetupRequired` claims, so SAML sessions hit the existing middleware 2FA gate.

### Single-use completion token (security)
The token handed to `/api/auth/saml/complete` rides in a redirect URL (Referer, logs, history), so it now registers a single-use `jti` in Valkey (deleted on consume) with a signed-JWT fallback, and its lifetime is cut from 5 minutes to 2. A replayed link is rejected.

## Related Issue

Follow-up to #405; addresses review observations on IdP-initiated launches, 2FA bypass, and token replay.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix / hardening

## Testing

- 66 SAML unit tests pass, including: single-use replay rejection, force-2FA claims stamped into the session token (decoded via NextAuth's `decode`), and IdP-initiated config selection by signature.
- `tsc` clean for the changed files; prettier clean.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added tests that prove the changes are effective
- [x] New and existing unit tests pass locally
