### PR TITLE
fix(auth): reject replayed SAML assertions

### DIFF
--- a/testplanit/app/api/auth/callback/saml/route.test.ts
+++ b/testplanit/app/api/auth/callback/saml/route.test.ts
@@ -34,6 +34,15 @@ vi.mock("~/lib/utils/email-domain-validation", () => ({
   isEmailDomainAllowed: vi.fn(async () => true),
 }));
 
+// Override only the assertion replay guard; everything else stays real.
+const { registerSamlAssertion } = vi.hoisted(() => ({
+  registerSamlAssertion: vi.fn(async () => true),
+}));
+vi.mock("~/lib/auth-security", async (importActual) => {
+  const actual = await importActual<typeof import("~/lib/auth-security")>();
+  return { ...actual, registerSamlAssertion };
+});
+
 import { db } from "~/server/db";
 import { POST } from "./route";
 
@@ -109,6 +118,29 @@ describe("POST /api/auth/callback/saml — ACS validator", () => {
       )
     ).toBe(true);
     expect(location).not.toContain("/api/auth/callback/saml?token=");
+  });
+
+  it("rejects a replayed assertion with 400 (single-use)", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue({
+      id: "cfg",
+      entryPoint: "e",
+      cert: "c",
+      issuer: "i",
+      attributeMapping: {},
+      autoProvisionUsers: false,
+      provider: { name: "okta", enabled: true },
+    });
+    validateSAMLResponse.mockResolvedValue({
+      email: "bob@example.com",
+      nameID: "bob",
+    });
+    registerSamlAssertion.mockResolvedValueOnce(false); // already seen
+
+    const res = await POST(makeReq(relayFor("ssoprovider_9")));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/already been used/i);
   });
 
   it("returns 404 when the provider in RelayState is unknown", async () => {

--- a/testplanit/app/api/auth/callback/saml/route.ts
+++ b/testplanit/app/api/auth/callback/saml/route.ts
@@ -6,6 +6,7 @@ import {
   createTempSessionToken,
   getAppBaseUrl,
   getSecurityHeaders,
+  registerSamlAssertion,
   sanitizeCallbackUrl,
   validateSAMLTimestamp,
 } from "~/lib/auth-security";
@@ -156,6 +157,41 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
+    }
+
+    // Reject replayed assertions: a validated assertion is single-use within its
+    // validity window. This closes the replay vector opened by accepting
+    // IdP-initiated (no-RelayState) POSTs — without it any captured assertion
+    // could be re-POSTed until it expires.
+    const notOnOrAfterMs = profile.notOnOrAfter
+      ? new Date(profile.notOnOrAfter as string).getTime()
+      : 0;
+    const assertionTtlSeconds =
+      notOnOrAfterMs > Date.now()
+        ? (notOnOrAfterMs - Date.now()) / 1000 + 60
+        : 300;
+    // Dedup on the signed assertion ID — the replay-stable anchor (it's inside
+    // the signed element, unlike the surrounding bytes). Fall back to the
+    // validated assertion XML, then the raw response, only if the ID is absent.
+    const getAssertionXml = (
+      profile as unknown as { getAssertionXml?: () => string }
+    ).getAssertionXml;
+    const assertionXml = getAssertionXml ? getAssertionXml() : "";
+    const assertionId =
+      assertionXml.match(
+        /<(?:\w+:)?Assertion\b[^>]*\bID=["']([^"']+)["']/
+      )?.[1] ||
+      assertionXml ||
+      (samlResponse as string);
+    const isFreshAssertion = await registerSamlAssertion(
+      assertionId,
+      assertionTtlSeconds
+    );
+    if (!isFreshAssertion) {
+      return NextResponse.json(
+        { error: "SAML response has already been used" },
+        { status: 400 }
+      );
     }
 
     // Extract user attributes based on mapping

--- a/testplanit/lib/auth-security.test.ts
+++ b/testplanit/lib/auth-security.test.ts
@@ -458,6 +458,53 @@ describe("createSamlRelayState / consumeSamlRelayState", () => {
   });
 });
 
+describe("registerSamlAssertion (single-use)", () => {
+  const SECRET = "test-secret-key-at-least-32-chars-long";
+
+  it("Valkey-backed: first use returns true, replay returns false", async () => {
+    const store = new Map<string, string>();
+    const fakeRedis = {
+      set: vi.fn(
+        async (
+          k: string,
+          _v: string,
+          _ex: string,
+          _ttl: number,
+          nx?: string
+        ) => {
+          if (nx === "NX" && store.has(k)) return null;
+          store.set(k, "1");
+          return "OK";
+        }
+      ),
+    };
+
+    vi.resetModules();
+    process.env.NEXTAUTH_SECRET = SECRET;
+    vi.doMock("./valkey", () => ({ default: fakeRedis }));
+    const { registerSamlAssertion } = await import("./auth-security");
+
+    expect(await registerSamlAssertion("_assertion-id-1", 300)).toBe(true);
+    expect(await registerSamlAssertion("_assertion-id-1", 300)).toBe(false);
+    // A different assertion is tracked independently.
+    expect(await registerSamlAssertion("_assertion-id-2", 300)).toBe(true);
+
+    vi.doUnmock("./valkey");
+  });
+
+  it("without Valkey: returns true (no cross-pod dedup)", async () => {
+    vi.resetModules();
+    process.env.NEXTAUTH_SECRET = SECRET;
+    vi.doMock("./valkey", () => ({ default: null }));
+    const { registerSamlAssertion } = await import("./auth-security");
+
+    expect(await registerSamlAssertion("_assertion-id-3", 300)).toBe(true);
+    expect(await registerSamlAssertion("_assertion-id-3", 300)).toBe(true);
+
+    vi.doUnmock("./valkey");
+  });
+});
+
 describe("getSecureCookieOptions", () => {
   it("should return httpOnly as true", () => {
     const options = getSecureCookieOptions();

--- a/testplanit/lib/auth-security.ts
+++ b/testplanit/lib/auth-security.ts
@@ -222,6 +222,37 @@ export async function consumeSamlRelayState(
   }
 }
 
+const SAML_ASSERTION_PREFIX = "saml:assertion:";
+
+/**
+ * Enforce one-time use of a validated SAML assertion. The IdP-initiated ACS
+ * accepts assertions with no RelayState, so without this an attacker could
+ * replay a captured assertion (SP- or IdP-issued) within its validity window.
+ *
+ * The caller passes the signed assertion's ID — the replay-stable anchor. The
+ * ID lives inside the signed element, so an attacker can't change it without
+ * the IdP's key; the surrounding bytes can be mutated (re-canonicalization,
+ * namespace/attribute reordering, the unsigned Response wrapper) while keeping
+ * a valid signature, which is why a byte hash is not a safe dedup key. The ID
+ * is hashed here only to bound the Valkey key length/charset. Returns true on
+ * first use, false if already seen; needs Valkey for the cross-pod check
+ * (without it the assertion's expiry window is the only bound).
+ */
+export async function registerSamlAssertion(
+  assertionId: string,
+  ttlSeconds: number
+): Promise<boolean> {
+  if (!valkeyConnection) return true;
+  const result = await valkeyConnection.set(
+    `${SAML_ASSERTION_PREFIX}${hashData(assertionId)}`,
+    "1",
+    "EX",
+    Math.max(1, Math.ceil(ttlSeconds)),
+    "NX"
+  );
+  return result !== null;
+}
+
 // Rate limiting configuration
 export interface RateLimitConfig {
   windowMs: number;


### PR DESCRIPTION
## Description

Fast-follow to #406. Accepting IdP-initiated (no-`RelayState`) POSTs opened an assertion-replay vector: any captured `SAMLResponse` — including an SP-initiated one with its `RelayState` stripped — could be re-POSTed to the ACS and accepted until it expired, because the only remaining bound was the assertion's `notBefore`/`notOnOrAfter` window.

The ACS now records each validated assertion by its **signed assertion ID** in Valkey for the remainder of its validity window and rejects a second use — the same single-use pattern as the relay state (#405) and the completion token (#406). The ID is the dedup key (rather than a byte hash of the response) because it lives inside the signed element: an attacker can't change it without the IdP's key, whereas the surrounding bytes can be mutated (re-canonicalization, namespace/attribute reordering, the unsigned Response wrapper) while keeping a valid signature. Without Valkey the assertion's expiry window remains the only bound (consistent with the relay-state fallback).

## Related Issue

Fast-follow to #406; closes the assertion-replay gap raised in review.

## Type of Change

- [x] Bug fix / hardening (non-breaking)

## Testing

- Unit: `registerSamlAssertion` returns true on first use, false on replay (Valkey-backed); returns true without Valkey.
- Validator: a replayed assertion returns 400 "SAML response has already been used".
- Full SAML suite green; `tsc` + prettier clean for the changed files.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added tests that prove the change is effective
- [x] New and existing unit tests pass locally
