### PR TITLE
fix(attachments): syntax-highlight markdown code blocks (QuickScript-style)

### DIFF
--- a/testplanit/components/AttachmentPreview.tsx
+++ b/testplanit/components/AttachmentPreview.tsx
@@ -7,7 +7,16 @@ import { useEffect, useState } from "react";
 import type { Components } from "react-markdown";
 import Markdown from "react-markdown";
 import { Link } from "~/lib/navigation";
+import { highlightCode, mapLanguageToPrism } from "~/lib/utils/codeHighlight";
 import { getStorageUrlClient } from "~/utils/storageUrl";
+import "prismjs/themes/prism-tomorrow.css";
+
+/** Flatten react-markdown code children into a raw string for highlighting. */
+function codeToText(children: unknown): string {
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) return children.map(codeToText).join("");
+  return children == null ? "" : String(children);
+}
 
 interface AttachmentPreviewProps {
   attachment: Attachments;
@@ -205,24 +214,41 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
             {children}
           </a>
         ),
+        // Block fences render like QuickScript: PrismJS highlighting on a dark
+        // background (prism-tomorrow). Inline code stays a small muted chip.
         code: ({ node, className, children, ...props }: any) => {
+          const text = codeToText(children).replace(/\n$/, "");
           const match = /language-(\w+)/.exec(className || "");
-          const isInline = props.inline || false;
-          return !isInline ? (
-            <pre className="block bg-muted p-4 rounded text-sm font-mono overflow-x-auto my-3">
-              <code className={match ? className : ""} {...props}>
+          const isBlock = !!match || text.includes("\n");
+          if (!isBlock) {
+            return (
+              <code
+                className="bg-muted text-foreground px-1 py-0.5 rounded text-sm font-mono"
+                {...props}
+              >
                 {children}
               </code>
+            );
+          }
+          const lang = match ? mapLanguageToPrism(match[1]) : null;
+          return (
+            <pre className="bg-stone-800 rounded-md overflow-auto p-4 text-sm my-3 max-w-full">
+              {lang ? (
+                <code
+                  className={`language-${lang}`}
+                  // Prism HTML-escapes the source, so this cannot inject markup.
+                  dangerouslySetInnerHTML={{
+                    __html: highlightCode(text, lang),
+                  }}
+                />
+              ) : (
+                <code className="text-stone-100">{text}</code>
+              )}
             </pre>
-          ) : (
-            <code
-              className="bg-muted px-1 py-0.5 rounded text-sm font-mono"
-              {...props}
-            >
-              {children}
-            </code>
           );
         },
+        // Unwrap react-markdown's default <pre>; the code component renders its own.
+        pre: ({ children }: any) => <>{children}</>,
         blockquote: ({ node, ...props }) => (
           <blockquote
             className="border-l-4 border-border pl-4 italic my-3"


### PR DESCRIPTION
## Description

Markdown attachment previews (e.g. Playwright's `error-context.md`) rendered fenced code as faint, low-contrast text: language-tagged fences inherited the global Prism theme's light base color on a light `bg-muted`, so a section like **Test source** was nearly unreadable while plain fences (**Error details**) were fine.

Now fenced code renders the way **QuickScript** does — PrismJS highlighting on the `prism-tomorrow` dark theme:
- Block code shows on a dark `bg-stone-800` with proper token colors (language-less fences fall back to plain light text on the same dark background).
- Inline code stays a small muted chip.
- react-markdown's default `<pre>` is unwrapped so there's no nested/double code block.

**Security:** Prism HTML-escapes the source before producing token markup, so rendering it via `dangerouslySetInnerHTML` can't inject HTML (verified). The markdown renderer has no `rehype-raw`, the language is mapped through an allowlist, and code is displayed, not executed — the same safe pattern QuickScript already uses on user-supplied code.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

`pnpm precommit` passes (8,436 unit tests). Verified live against a failed Playwright result's `error-context.md`: the "Test source" fence now renders as a syntax-highlighted dark code block (readable), and "Error details" is readable on the same dark background — in both light and dark mode.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): chromium
- Node version: 20+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)
