### PR TITLE
fix(saml): normalize IdP certificates whose PEM newlines were collapsed to spaces

### DIFF
--- a/testplanit/app/api/model/[...path]/route.test.ts
+++ b/testplanit/app/api/model/[...path]/route.test.ts
@@ -1743,7 +1743,9 @@ describe("ZenStack chokepoint SamlConfiguration cert normalization", () => {
 
   async function forwardedBody(): Promise<any> {
     expect(baseHandlerMock).toHaveBeenCalled();
-    const forwardedReq = baseHandlerMock.mock.calls[0][0] as Request;
+    const forwardedReq = (
+      baseHandlerMock.mock.calls[0] as unknown[]
+    )[0] as Request;
     return JSON.parse(await forwardedReq.text());
   }
 

--- a/testplanit/app/api/model/[...path]/route.test.ts
+++ b/testplanit/app/api/model/[...path]/route.test.ts
@@ -1705,3 +1705,120 @@ describe("ZenStack chokepoint SessionResults required-field gate", () => {
     expect(baseHandlerMock).toHaveBeenCalled();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SamlConfiguration cert normalization (defense-in-depth normalize-on-save).
+// The admin SSO form writes the IdP cert through the generated RPC hooks, so
+// this route is the universal mutation seam. A cert whose PEM newlines were
+// collapsed to spaces must be re-emitted as canonical PEM before it reaches
+// the ZenStack handler (and the DB), matching the normalize-on-use path in
+// createSAMLClient.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("ZenStack chokepoint SamlConfiguration cert normalization", () => {
+  // 48 raw bytes → exactly 64 base64 chars (one PEM line).
+  const CERT_BODY = Buffer.from("x".repeat(48)).toString("base64");
+  const CANONICAL_PEM = `-----BEGIN CERTIFICATE-----\n${CERT_BODY}\n-----END CERTIFICATE-----\n`;
+  const MANGLED = `-----BEGIN CERTIFICATE----- ${CERT_BODY} -----END CERTIFICATE-----`;
+
+  function makeRequest(
+    method: string,
+    operation: string,
+    body: unknown
+  ): NextRequest {
+    const headers = new Headers();
+    headers.set("content-type", "application/json");
+    const json = JSON.stringify(body);
+    return {
+      method,
+      headers,
+      url: `http://localhost:3000/api/model/samlConfiguration/${operation}`,
+      clone() {
+        return this;
+      },
+      async text() {
+        return json;
+      },
+    } as unknown as NextRequest;
+  }
+
+  async function forwardedBody(): Promise<any> {
+    expect(baseHandlerMock).toHaveBeenCalled();
+    const forwardedReq = baseHandlerMock.mock.calls[0][0] as Request;
+    return JSON.parse(await forwardedReq.text());
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { getServerAuthSession } = await import("~/server/auth");
+    (getServerAuthSession as any).mockResolvedValue({
+      user: { id: "user-1", email: "u@e.com", name: "U", access: "ADMIN" },
+    });
+    const { extractBearerToken } = await import("~/lib/api-token-auth");
+    (extractBearerToken as any).mockReturnValue(null);
+    const { prisma } = await import("~/lib/prisma");
+    (prisma as any).user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "u@e.com",
+      name: "U",
+      access: "ADMIN",
+    });
+    // The audited-update path takes a best-effort before/after snapshot of the
+    // row; stub it so the test output stays clean (the value is irrelevant to
+    // the cert-normalization assertions).
+    (prisma as any).samlConfiguration = {
+      findUnique: vi.fn().mockResolvedValue(null),
+    };
+    baseHandlerMock.mockClear();
+    baseHandlerMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: 7 } }), { status: 200 })
+    );
+  });
+
+  it("normalizes the space-mangled cert on create before forwarding", async () => {
+    const { POST } = await import("./route");
+    const req = makeRequest("POST", "create", {
+      data: { providerId: "p1", entryPoint: "https://idp", cert: MANGLED },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["samlConfiguration", "create"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await forwardedBody();
+    expect(body.data.cert).toBe(CANONICAL_PEM);
+    // Untouched fields are preserved.
+    expect(body.data.providerId).toBe("p1");
+  });
+
+  it("normalizes the cert in both branches of an upsert", async () => {
+    const { POST } = await import("./route");
+    const req = makeRequest("POST", "upsert", {
+      where: { providerId: "p1" },
+      create: { providerId: "p1", cert: MANGLED },
+      update: { cert: MANGLED },
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ["samlConfiguration", "upsert"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await forwardedBody();
+    expect(body.create.cert).toBe(CANONICAL_PEM);
+    expect(body.update.cert).toBe(CANONICAL_PEM);
+  });
+
+  it("passes through unchanged when the write carries no cert", async () => {
+    const { PATCH } = await import("./route");
+    const req = makeRequest("PATCH", "update", {
+      where: { id: 7 },
+      data: { entryPoint: "https://idp/new" },
+    });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ path: ["samlConfiguration", "update"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await forwardedBody();
+    expect(body.data).toEqual({ entryPoint: "https://idp/new" });
+  });
+});

--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -58,6 +58,7 @@ import {
   emitTestRunUpdateEvents,
 } from "~/lib/webhooks/event-emitters/testRunEvents";
 import { getServerAuthSession } from "~/server/auth";
+import { normalizeSamlCert } from "~/server/saml-cert";
 import { syncIssueToElasticsearch } from "~/services/issueSearch";
 import { syncMilestoneToElasticsearch } from "~/services/milestoneSearch";
 import { syncProjectToElasticsearch } from "~/services/projectSearch";
@@ -410,6 +411,38 @@ function injectUserFields(
   return newBody;
 }
 
+// The RPC operation shapes that carry a SamlConfiguration write payload:
+//   create / update / updateMany: body.data (object)
+//   createMany:                   body.data (array of objects)
+//   upsert:                       body.create and body.update (objects)
+function collectSamlCertTargets(operation: string, body: any): any[] {
+  if (!body) return [];
+  if (operation === "upsert") {
+    return [body.create, body.update].filter(Boolean);
+  }
+  const data = body.data;
+  if (Array.isArray(data)) return data.filter(Boolean);
+  return data ? [data] : [];
+}
+
+// Normalize the IdP signing certificate on every SamlConfiguration write.
+// Returns a new request body with canonical-PEM cert(s), or null when there's
+// no cert string to touch (so the caller skips rebuilding the request).
+function normalizeSamlConfigCertBody(operation: string, body: any): any | null {
+  const hasCert = collectSamlCertTargets(operation, body).some(
+    (target) => typeof target?.cert === "string" && target.cert.length > 0
+  );
+  if (!hasCert) return null;
+
+  const next = JSON.parse(JSON.stringify(body));
+  for (const target of collectSamlCertTargets(operation, next)) {
+    if (typeof target?.cert === "string" && target.cert.length > 0) {
+      target.cert = normalizeSamlCert(target.cert);
+    }
+  }
+  return next;
+}
+
 // Inner handler. Exports below wrap this with `withAuditContext` per HTTP
 // verb so each export carries its own ALS frame for audit correlation (D-01).
 async function innerHandler(
@@ -497,6 +530,39 @@ async function innerHandler(
         }
       } catch {
         // Ignore body parsing errors
+      }
+    }
+
+    // Normalize the IdP signing certificate on SamlConfiguration writes.
+    // Admins paste certs through the generic SSO config form, where a
+    // copy/paste or JSON round-trip can collapse the PEM newlines to spaces —
+    // leaving a value node-saml later rejects as "not in PEM format or in
+    // base64 format". This chokepoint re-emits canonical PEM before the row is
+    // persisted (defense in depth alongside the normalize-on-use path in
+    // createSAMLClient). The model route is the universal mutation seam for
+    // SamlConfiguration (the admin UI writes via the generated RPC hooks), and
+    // the lib/prisma.ts $extends middleware is bypassed by ZenStack's enhance()
+    // on this path — same reason the ES-sync shims below live here — so the
+    // guard belongs here rather than in a Prisma extension.
+    if (
+      isMutation &&
+      parsedPath &&
+      parsedPath.model === "samlConfiguration" &&
+      ["create", "createMany", "update", "updateMany", "upsert"].includes(
+        parsedPath.operation
+      )
+    ) {
+      const normalizedBody = normalizeSamlConfigCertBody(
+        parsedPath.operation,
+        requestBody
+      );
+      if (normalizedBody) {
+        requestBody = normalizedBody;
+        modifiedReq = new NextRequest(req.url, {
+          method: req.method,
+          headers: req.headers,
+          body: JSON.stringify(normalizedBody),
+        });
       }
     }
 

--- a/testplanit/server/saml-cert.test.ts
+++ b/testplanit/server/saml-cert.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { SAML } from "@node-saml/node-saml";
+import { describe, expect, it, vi } from "vitest";
+
+import { normalizeSamlCert, normalizeSamlCertForClient } from "./saml-cert";
+import { createSAMLClient } from "./saml-provider";
+
+vi.hoisted(() => {
+  process.env.NEXTAUTH_URL = "https://app.example.com";
+});
+
+// A valid base64 body of realistic length. node-saml only checks that the
+// body is decodeable base64 when wrapping it as PEM, so this need not be a
+// real DER certificate — the failure mode under test is purely about
+// whitespace, not certificate content.
+const CERT_BODY = Buffer.from("a".repeat(900)).toString("base64");
+const CERT_BODY_2 = Buffer.from("b".repeat(900)).toString("base64");
+
+function pem(body: string): string {
+  const wrapped = body.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----\n`;
+}
+
+// The whitespace-mangled form: a PEM whose newlines were all collapsed to
+// single spaces (markers and body on one line). This is exactly what broke
+// the customer's Okta login.
+function singleLineWithSpaces(body: string): string {
+  const spacedBody = body.match(/.{1,64}/g)!.join(" ");
+  return `-----BEGIN CERTIFICATE----- ${spacedBody} -----END CERTIFICATE-----`;
+}
+
+describe("normalizeSamlCert", () => {
+  it("(a) recovers canonical PEM from a single-line PEM with spaces", () => {
+    expect(normalizeSamlCert(singleLineWithSpaces(CERT_BODY))).toBe(
+      pem(CERT_BODY)
+    );
+  });
+
+  it("(b) leaves an already-canonical PEM unchanged and is idempotent", () => {
+    const canonical = pem(CERT_BODY);
+    expect(normalizeSamlCert(canonical)).toBe(canonical);
+
+    const once = normalizeSamlCert(singleLineWithSpaces(CERT_BODY));
+    expect(normalizeSamlCert(once)).toBe(once);
+  });
+
+  it("(c) wraps a raw base64 body (no headers) into canonical PEM", () => {
+    expect(normalizeSamlCert(CERT_BODY)).toBe(pem(CERT_BODY));
+  });
+
+  it("(d) collapses a base64 body with embedded newlines into canonical PEM", () => {
+    const withNewlines = CERT_BODY.match(/.{1,64}/g)!.join("\n");
+    expect(normalizeSamlCert(withNewlines)).toBe(pem(CERT_BODY));
+  });
+
+  it("(e) returns genuinely non-base64 input unchanged (no throw)", () => {
+    const garbage = "this is definitely not a certificate!!!";
+    expect(normalizeSamlCert(garbage)).toBe(garbage);
+    expect(normalizeSamlCert("")).toBe("");
+  });
+
+  it("normalizes each certificate in a concatenated chain", () => {
+    const chain = pem(CERT_BODY) + pem(CERT_BODY_2);
+    expect(normalizeSamlCert(chain)).toBe(pem(CERT_BODY) + pem(CERT_BODY_2));
+    // Idempotent across the chain too.
+    expect(normalizeSamlCert(normalizeSamlCert(chain))).toBe(
+      normalizeSamlCert(chain)
+    );
+  });
+});
+
+describe("normalizeSamlCertForClient", () => {
+  it("returns a single PEM string for one certificate", () => {
+    expect(normalizeSamlCertForClient(singleLineWithSpaces(CERT_BODY))).toBe(
+      pem(CERT_BODY)
+    );
+  });
+
+  it("returns an array of PEM strings for a chain", () => {
+    const chain = pem(CERT_BODY) + pem(CERT_BODY_2);
+    expect(normalizeSamlCertForClient(chain)).toEqual([
+      pem(CERT_BODY),
+      pem(CERT_BODY_2),
+    ]);
+  });
+
+  it("returns non-base64 input unchanged", () => {
+    const garbage = "not a cert";
+    expect(normalizeSamlCertForClient(garbage)).toBe(garbage);
+  });
+});
+
+describe("createSAMLClient cert handling", () => {
+  it("builds a client whose cert node-saml accepts, from the space-mangled form", async () => {
+    const mangled = singleLineWithSpaces(CERT_BODY);
+
+    const client = await createSAMLClient({
+      name: "test",
+      entryPoint: "https://idp.example.com/sso",
+      issuer: "https://app.example.com",
+      cert: mangled,
+    });
+
+    // getKeyInfosAsPem() runs the same node-saml code path
+    // (keyInfoToPem) that threw "not in PEM format or in base64 format" on the
+    // mangled input. It now resolves to a single canonical PEM.
+    const pems = await (client as unknown as {
+      getKeyInfosAsPem: () => Promise<string[]>;
+    }).getKeyInfosAsPem();
+    expect(pems).toHaveLength(1);
+    expect(pems[0]).toContain("-----BEGIN CERTIFICATE-----");
+    expect(pems[0]).toContain("-----END CERTIFICATE-----");
+
+    // Negative control: node-saml rejects the un-normalized mangled cert,
+    // confirming the normalization is what makes the client work.
+    const raw = new SAML({
+      callbackUrl: "https://app.example.com/api/auth/callback/saml",
+      issuer: "https://app.example.com",
+      idpCert: mangled,
+    });
+    await expect(
+      (raw as unknown as {
+        getKeyInfosAsPem: () => Promise<string[]>;
+      }).getKeyInfosAsPem()
+    ).rejects.toThrow(/PEM format or in base64 format/);
+  });
+});

--- a/testplanit/server/saml-cert.test.ts
+++ b/testplanit/server/saml-cert.test.ts
@@ -85,7 +85,7 @@ describe("normalizeSamlCertForClient", () => {
   });
 
   it("returns non-base64 input unchanged", () => {
-    const garbage = "not a cert";
+    const garbage = "this is definitely not a certificate!!!";
     expect(normalizeSamlCertForClient(garbage)).toBe(garbage);
   });
 });
@@ -104,9 +104,11 @@ describe("createSAMLClient cert handling", () => {
     // getKeyInfosAsPem() runs the same node-saml code path
     // (keyInfoToPem) that threw "not in PEM format or in base64 format" on the
     // mangled input. It now resolves to a single canonical PEM.
-    const pems = await (client as unknown as {
-      getKeyInfosAsPem: () => Promise<string[]>;
-    }).getKeyInfosAsPem();
+    const pems = await (
+      client as unknown as {
+        getKeyInfosAsPem: () => Promise<string[]>;
+      }
+    ).getKeyInfosAsPem();
     expect(pems).toHaveLength(1);
     expect(pems[0]).toContain("-----BEGIN CERTIFICATE-----");
     expect(pems[0]).toContain("-----END CERTIFICATE-----");
@@ -119,9 +121,11 @@ describe("createSAMLClient cert handling", () => {
       idpCert: mangled,
     });
     await expect(
-      (raw as unknown as {
-        getKeyInfosAsPem: () => Promise<string[]>;
-      }).getKeyInfosAsPem()
+      (
+        raw as unknown as {
+          getKeyInfosAsPem: () => Promise<string[]>;
+        }
+      ).getKeyInfosAsPem()
     ).rejects.toThrow(/PEM format or in base64 format/);
   });
 });

--- a/testplanit/server/saml-cert.ts
+++ b/testplanit/server/saml-cert.ts
@@ -1,0 +1,94 @@
+// IdP signing-certificate normalization.
+//
+// Admins paste the IdP certificate into the generic SSO config form, which
+// stores whatever they paste verbatim. A copy/paste or JSON round-trip can
+// collapse the PEM line breaks into spaces, leaving the
+// `-----BEGIN/END CERTIFICATE-----` markers and the base64 body all on one
+// line. That value is neither valid PEM (node-saml's PEM regex requires
+// newlines) nor valid base64 (spaces and the marker dashes aren't base64
+// characters), so node-saml rejects it at validation time with
+// "idpCert is not in PEM format or in base64 format".
+//
+// These helpers recover the base64 body regardless of whitespace mangling and
+// re-emit canonical PEM (markers + base64 wrapped at 64 chars). They are
+// deliberately defensive: anything that doesn't decode as base64 is returned
+// untouched, so a genuinely different or future format is never silently
+// corrupted.
+
+const PEM_LABEL = "CERTIFICATE";
+
+// Certificate markers carry a single space between the verb and the label
+// ("BEGIN CERTIFICATE"), and labels never contain a dash, so `[^-]+` matches
+// the label without swallowing the trailing dashes. The body capture is
+// non-greedy so each BEGIN pairs with its nearest END (a chain stays split).
+const BEGIN_MARKER = /-----BEGIN [^-]+-----/;
+const CERT_BLOCK = /-----BEGIN [^-]+-----([\s\S]*?)-----END [^-]+-----/g;
+
+function isBase64Body(body: string): boolean {
+  if (body.length === 0 || body.length % 4 !== 0) return false;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(body)) return false;
+  try {
+    return Buffer.from(body, "base64").length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function wrapAsPem(body: string): string {
+  const wrapped = body.match(/.{1,64}/g)?.join("\n") ?? body;
+  return `-----BEGIN ${PEM_LABEL}-----\n${wrapped}\n-----END ${PEM_LABEL}-----\n`;
+}
+
+/**
+ * Pull the base64 body out of every certificate in `cert` and return them as
+ * canonical PEM blocks. Returns `null` when nothing in the input decodes as
+ * base64 (the signal for callers to leave the original value untouched).
+ */
+function canonicalizeCertBlocks(cert: string): string[] | null {
+  // When markers are present, take the content between each BEGIN/END pair so
+  // a concatenated chain splits cleanly. With no markers the whole value is
+  // treated as a single bare base64 body. Either way the candidate bodies have
+  // all whitespace stripped before being validated as base64.
+  const rawBodies = BEGIN_MARKER.test(cert)
+    ? [...cert.matchAll(CERT_BLOCK)].map((match) => match[1])
+    : [cert];
+
+  const bodies = rawBodies
+    .map((body) => body.replace(/\s+/g, ""))
+    .filter((body) => body.length > 0);
+
+  if (bodies.length === 0) return null;
+  if (!bodies.every(isBase64Body)) return null;
+
+  return bodies.map(wrapAsPem);
+}
+
+/**
+ * Normalize a stored certificate value to canonical PEM for persistence.
+ *
+ * Idempotent: re-normalizing an already-canonical value yields the same
+ * string. A multi-certificate chain is returned as the canonical blocks
+ * concatenated. Non-base64 input is returned unchanged.
+ */
+export function normalizeSamlCert(cert: string): string {
+  if (typeof cert !== "string") return cert;
+  const blocks = canonicalizeCertBlocks(cert);
+  return blocks ? blocks.join("") : cert;
+}
+
+/**
+ * Normalize a certificate for handoff to node-saml's `idpCert` option.
+ *
+ * A single certificate is returned as a PEM string; a chain is returned as an
+ * array of PEM strings (node-saml accepts `string | string[]`). Passing a
+ * chain as one concatenated string would let node-saml's PEM normalizer
+ * re-wrap across the internal markers and corrupt the boundary, so the array
+ * form is used whenever more than one certificate is present. Non-base64
+ * input is returned unchanged.
+ */
+export function normalizeSamlCertForClient(cert: string): string | string[] {
+  if (typeof cert !== "string") return cert;
+  const blocks = canonicalizeCertBlocks(cert);
+  if (!blocks) return cert;
+  return blocks.length === 1 ? blocks[0] : blocks;
+}

--- a/testplanit/server/saml-provider.ts
+++ b/testplanit/server/saml-provider.ts
@@ -1,6 +1,7 @@
 import { SAML } from "@node-saml/node-saml";
 import { Profile as SAML2Profile } from "@node-saml/passport-saml";
 import { OAuthConfig, OAuthUserConfig } from "next-auth/providers/oauth";
+import { normalizeSamlCertForClient } from "./saml-cert";
 
 export interface SAMLProfile extends Record<string, any> {
   id: string;
@@ -134,7 +135,11 @@ export function SAMLProvider(options: SAMLConfig): OAuthConfig<SAMLProfile> {
 export async function createSAMLClient(config: SAMLConfig) {
   const samlOptions = {
     entryPoint: config.entryPoint,
-    idpCert: config.cert, // node-saml expects idpCert not cert
+    // node-saml expects `idpCert`, not `cert`. Normalize first so a cert whose
+    // PEM newlines were collapsed to spaces on save (see ./saml-cert) is
+    // re-emitted as canonical PEM instead of being rejected as
+    // "not in PEM format or in base64 format" during response validation.
+    idpCert: normalizeSamlCertForClient(config.cert),
     issuer: config.issuer,
     privateKey: config.privateKey,
     decryptionPvk: config.decryptionPvk,


### PR DESCRIPTION
## Description

Adds certificate normalization for SAML configurations so an IdP signing certificate whose PEM line breaks were collapsed into spaces (a common result of copy/paste or a JSON round-trip) is recovered into canonical PEM instead of being rejected.

Previously, pasting such a certificate into the SSO config form stored it verbatim. At login, node-saml rejected the value with `idpCert is not in PEM format or in base64 format`, breaking SAML sign-in (observed with an Okta IdP).

The fix is defense-in-depth across two seams:

- **Normalize on use** — `createSAMLClient` now passes the cert through `normalizeSamlCertForClient` before handing it to node-saml, so existing stored certs work without re-saving. A single cert is returned as a PEM string and a chain as an array of PEM strings (`string | string[]`), avoiding boundary corruption when node-saml re-wraps a concatenated chain.
- **Normalize on save** — the `/api/model/[...path]` route (the universal mutation seam for `SamlConfiguration`, since the admin UI writes via the generated RPC hooks) re-emits canonical PEM before the row is persisted. This guard lives in the route because ZenStack's `enhance()` bypasses the `lib/prisma.ts` `$extends` middleware on this path, the same reason the Elasticsearch-sync shims live there.

The new `server/saml-cert.ts` helpers are deliberately conservative: input that doesn't decode as base64 is returned untouched, so unknown or future formats are never silently corrupted. Normalization is idempotent and handles raw base64 bodies, embedded newlines, space-mangled markers, and multi-cert chains.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

New coverage:

- `server/saml-cert.test.ts` — normalization of space-mangled PEM, already-canonical (idempotent), raw base64, embedded newlines, non-base64 passthrough, and multi-cert chains; plus a `createSAMLClient` test that builds a client node-saml accepts from the mangled form, with a negative control proving un-normalized input still throws.
- `app/api/model/[...path]/route.test.ts` — the normalize-on-save chokepoint for create, both branches of upsert, and passthrough when a write carries no cert.

**Test Configuration:**
- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

`fix(saml):` commit type keeps this a patch release.
