### PR TITLE
fix: attachment preview sizing, SAML response handling, and share-link URLs

### DIFF
--- a/docs/blog/2026-01-24-v0.11.0-release.md
+++ b/docs/blog/2026-01-24-v0.11.0-release.md
@@ -97,7 +97,7 @@ Available actions:
 4. Set title, description, expiration, and other options
 5. Click **Create Share** and copy the link
 
-Share URL format: `https://app.testplanit.io/share/{shareKey}`
+Share URL format: `https://app.testplanit.com/share/{shareKey}`
 
 ## Common Use Cases
 
@@ -128,7 +128,7 @@ docker pull ghcr.io/testplanit/testplanit:latest
 
 Comprehensive documentation is available in the user guide:
 
-- [Share Links User Guide](https://docs.testplanit.io/user-guide/share-links) - Complete feature documentation
+- [Share Links User Guide](https://docs.testplanit.com/user-guide/share-links) - Complete feature documentation
 - Security best practices and recommendations
 - Troubleshooting guide for common issues
 - API reference for ShareLink models

--- a/docs/blog/2026-02-20-v0.12.0-release.md
+++ b/docs/blog/2026-02-20-v0.12.0-release.md
@@ -30,7 +30,7 @@ TestPlanIt now supports **Microsoft / Azure Active Directory** as a sign-in prov
 4. Enter your Client ID, Client Secret, and optionally a Tenant ID
 5. Toggle the switch to enable Microsoft sign-in
 
-For full setup instructions, see the [SSO documentation](https://docs.testplanit.io/user-guide/sso).
+For full setup instructions, see the [SSO documentation](https://docs.testplanit.com/user-guide/sso).
 
 ## Demo Project
 
@@ -84,8 +84,8 @@ docker pull ghcr.io/testplanit/testplanit:latest
 
 ## Documentation
 
-- [SSO / Authentication Guide](https://docs.testplanit.io/user-guide/sso) — updated with Microsoft setup instructions
-- [Getting Started](https://docs.testplanit.io/getting-started) — updated with Demo Project walkthrough
+- [SSO / Authentication Guide](https://docs.testplanit.com/user-guide/sso) — updated with Microsoft setup instructions
+- [Getting Started](https://docs.testplanit.com/getting-started) — updated with Demo Project walkthrough
 
 ## Get Involved
 

--- a/docs/docs/user-guide/share-links.md
+++ b/docs/docs/user-guide/share-links.md
@@ -145,7 +145,7 @@ Public access with password requirement.
 ### Share Link Format
 
 ```text
-https://app.testplanit.io/share/A8j2KmPqR5vWxYz7BnC3DfG9HkL4MtN6
+https://app.testplanit.com/share/A8j2KmPqR5vWxYz7BnC3DfG9HkL4MtN6
 ```
 
 - 43-character random share key

--- a/testplanit/app/api/auth/callback/saml/route.ts
+++ b/testplanit/app/api/auth/callback/saml/route.ts
@@ -22,7 +22,7 @@ import { createSAMLClient, validateSAMLResponse } from "~/server/saml-provider";
  * validation pick the config: the assertion only validates against the cert of
  * the IdP that actually issued it. Returns null if none validate it.
  */
-async function resolveIdpInitiatedConfig(samlResponse: FormDataEntryValue) {
+async function resolveIdpInitiatedConfig(samlResponse: string) {
   const configs = await db.samlConfiguration.findMany({
     where: { provider: { enabled: true } },
     include: { provider: true },
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
     const samlResponse = formData.get("SAMLResponse");
     const relayState = formData.get("RelayState");
 
-    if (!samlResponse) {
+    if (!samlResponse || typeof samlResponse !== "string") {
       return NextResponse.json(
         { error: "SAML response is required" },
         { status: 400 }

--- a/testplanit/components/AttachmentPreview.tsx
+++ b/testplanit/components/AttachmentPreview.tsx
@@ -278,7 +278,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
 
       return (
         <div
-          className={`w-fit border-2 border-primary/50 rounded-lg p-4 max-h-[650px] max-w-[${width}px] overflow-auto prose prose-sm dark:prose-invert bg-background`}
+          className="w-fit border-2 border-primary/50 rounded-lg p-4 max-h-[650px] overflow-auto prose prose-sm dark:prose-invert bg-background"
+          style={{ maxWidth: `${width}px` }}
         >
           <Markdown components={markdownComponents}>{textContent}</Markdown>
         </div>
@@ -287,7 +288,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
 
     return (
       <pre
-        className={`w-fit border-2 border-primary/50 rounded-lg p-2 max-h-[650px] max-w-[${width}px] overflow-auto`}
+        className="w-fit border-2 border-primary/50 rounded-lg p-2 max-h-[650px] overflow-auto"
+        style={{ maxWidth: `${width}px` }}
       >
         {textContent || attachment.name}
       </pre>
@@ -298,7 +300,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
       <video
         src={fileURL}
         controls
-        className={`w-full h-${height} max-h-full rounded-lg`}
+        className="w-full max-h-full rounded-lg"
+        style={{ height: `${height}px` }}
       />
     );
   } else if (fileType.startsWith("audio/")) {
@@ -307,7 +310,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
       <audio
         src={fileURL}
         controls
-        className={`min-h-[50px] w-${width} rounded-lg`}
+        className="min-h-[50px] rounded-lg"
+        style={{ width: `${width}px` }}
       />
     );
   } else {

--- a/testplanit/lib/upgrade-notifications.ts
+++ b/testplanit/lib/upgrade-notifications.ts
@@ -141,7 +141,7 @@ export const upgradeNotifications: Record<string, UpgradeNotification> = {
         <li>Access analytics with view tracking and detailed logs</li>
         <li>Notifications when links are accessed</li>
       </ul>
-      <p>Click the <strong>Share</strong> button in Report Builder to create your first share link. See the <a href="https://docs.testplanit.io/user-guide/share-links" target="_blank">documentation</a> for details.</p>
+      <p>Click the <strong>Share</strong> button in Report Builder to create your first share link. See the <a href="https://docs.testplanit.com/user-guide/share-links" target="_blank">documentation</a> for details.</p>
     `,
   },
   "0.12.0": {
@@ -154,7 +154,7 @@ export const upgradeNotifications: Record<string, UpgradeNotification> = {
         <li>Supports single-tenant and multi-tenant configurations</li>
         <li>Configure via the Admin UI at <strong>Admin → SSO</strong> or environment variables</li>
       </ul>
-      <p>See the <a href="https://docs.testplanit.io/user-guide/sso" target="_blank">SSO documentation</a> for Microsoft setup instructions.</p>
+      <p>See the <a href="https://docs.testplanit.com/user-guide/sso" target="_blank">SSO documentation</a> for Microsoft setup instructions.</p>
       <h4>Demo Project</h4>
       <ul>
         <li>A pre-populated Demo Project showcasing all major features</li>

--- a/testplanit/server/saml-provider.ts
+++ b/testplanit/server/saml-provider.ts
@@ -173,13 +173,15 @@ export async function createSAMLClient(config: SAMLConfig) {
 // Helper to validate SAML response
 export async function validateSAMLResponse(
   samlClient: SAML,
-  body: any
+  body: Record<string, string>
 ): Promise<SAML2Profile> {
   try {
     const profile = await samlClient.validatePostResponseAsync(body);
     return profile.profile as SAML2Profile;
   } catch (error) {
     console.error("SAML validation error:", error);
-    throw new Error("Invalid SAML response");
+    throw new Error("Invalid SAML response", {
+      cause: error instanceof Error ? error : new Error(String(error)),
+    });
   }
 }


### PR DESCRIPTION
## Description

Three small, independent bug fixes:

- **attachments** — The markdown/text/video/audio attachment previews built their size constraints with interpolated Tailwind classes (`max-w-[${width}px]`, `h-${height}`, `w-${width}`). Tailwind can only extract complete literal class strings at build time, so these were silently dropped and the size constraints never applied. Moved the dynamic dimensions to the `style` prop, matching the existing inline-style pattern already used elsewhere in the component.
- **saml** — Tightened the `samlResponse` type to `string` and improved error handling in `validateSAMLResponse`.
- **docs** — Corrected share-link URLs to use the proper domain across the user guide, two release blog posts, and the upgrade-notifications catalog.

## Related Issue

N/A — surfaced via AI code review of recently merged changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `pnpm precommit` (ESLint + `tsc --noEmit` + format check) passes clean — no new warnings from the changed files.
- Full unit suite green (8449 passed / 125 skipped).
- Attachment sizing fix is style-only and mirrors the established `style={{ ... }}` pattern in the same file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] Self-review completed
- [x] No new lint/type errors introduced
- [x] Changes generate no new warnings
