### PR TITLE
fix(saml): support standard IdP configurations and harden the SSO completion flow

### DIFF
--- a/testplanit/app/[locale]/admin/sso/page.tsx
+++ b/testplanit/app/[locale]/admin/sso/page.tsx
@@ -93,6 +93,13 @@ export default function SSOAdminPage() {
   const [samlCert, setSamlCert] = useState("");
   const [samlCallbackUrl, setSamlCallbackUrl] = useState("");
   const [samlLogoutUrl, setSamlLogoutUrl] = useState("");
+  // Signature-validation toggles; defaults match the schema (assertions must
+  // be signed; outer response signature optional). Admins can re-tighten the
+  // outer response check here OR via the per-provider edit page later.
+  const [samlWantAssertionsSigned, setSamlWantAssertionsSigned] =
+    useState(true);
+  const [samlWantAuthnResponseSigned, setSamlWantAuthnResponseSigned] =
+    useState(false);
   const [isSavingSamlConfig, setIsSavingSamlConfig] = useState(false);
   const [samlConfigured, setSamlConfigured] = useState(false);
 
@@ -321,6 +328,8 @@ export default function SSOAdminPage() {
         attributeMapping: {},
         autoProvisionUsers: false,
         defaultAccess: "USER" as const,
+        wantAssertionsSigned: samlWantAssertionsSigned,
+        wantAuthnResponseSigned: samlWantAuthnResponseSigned,
       };
 
       const existingProvider = ssoProviders?.find(
@@ -1640,6 +1649,47 @@ export default function SSOAdminPage() {
                 placeholder={t("admin.sso.dialogs.saml.logoutUrlPlaceholder")}
               />
             </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="samlWantAssertionsSigned"
+                  checked={samlWantAssertionsSigned}
+                  onCheckedChange={setSamlWantAssertionsSigned}
+                />
+                <Label htmlFor="samlWantAssertionsSigned">
+                  {t(
+                    "admin.sso.samlConfiguration.samlSettings.wantAssertionsSigned"
+                  )}
+                </Label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t(
+                  "admin.sso.samlConfiguration.samlSettings.wantAssertionsSignedDescription"
+                )}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="samlWantAuthnResponseSigned"
+                  checked={samlWantAuthnResponseSigned}
+                  onCheckedChange={setSamlWantAuthnResponseSigned}
+                />
+                <Label htmlFor="samlWantAuthnResponseSigned">
+                  {t(
+                    "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSigned"
+                  )}
+                </Label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t(
+                  "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSignedDescription"
+                )}
+              </p>
+            </div>
+
             <div className="text-sm text-muted-foreground">
               <p>{t("admin.sso.dialogs.saml.instructions.title")}</p>
               <ol className="list-decimal ml-4 space-y-1">

--- a/testplanit/app/[locale]/admin/sso/page.tsx
+++ b/testplanit/app/[locale]/admin/sso/page.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { Access, SsoProviderType } from "@prisma/client";
 import {
   Edit,
@@ -1582,14 +1583,14 @@ export default function SSOAdminPage() {
 
       {/* SAML Configuration Dialog */}
       <Dialog open={isSamlConfigOpen} onOpenChange={setIsSamlConfigOpen}>
-        <DialogContent className="sm:max-w-[600px]">
+        <DialogContent className="sm:max-w-[900px]">
           <DialogHeader>
             <DialogTitle>{t("admin.sso.samlConfiguration.title")}</DialogTitle>
             <DialogDescription>
               {t("admin.sso.dialogs.saml.description")}
             </DialogDescription>
           </DialogHeader>
-          <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 py-4">
             <div className="grid gap-2">
               <Label htmlFor="entryPoint">
                 {t("admin.sso.dialogs.saml.entryPoint")}
@@ -1610,17 +1611,6 @@ export default function SSOAdminPage() {
                 value={samlIssuer}
                 onChange={(e) => setSamlIssuer(e.target.value)}
                 placeholder={t("admin.sso.dialogs.saml.issuerPlaceholder")}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="cert">
-                {t("admin.sso.samlConfiguration.samlSettings.certificate")}
-              </Label>
-              <Input
-                id="cert"
-                value={samlCert}
-                onChange={(e) => setSamlCert(e.target.value)}
-                placeholder={t("admin.sso.dialogs.saml.certPlaceholder")}
               />
             </div>
             <div className="grid gap-2">
@@ -1649,48 +1639,62 @@ export default function SSOAdminPage() {
                 placeholder={t("admin.sso.dialogs.saml.logoutUrlPlaceholder")}
               />
             </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="samlWantAssertionsSigned"
-                  checked={samlWantAssertionsSigned}
-                  onCheckedChange={setSamlWantAssertionsSigned}
-                />
-                <Label htmlFor="samlWantAssertionsSigned">
+            <div className="grid gap-2">
+              <Label htmlFor="cert">
+                {t("admin.sso.samlConfiguration.samlSettings.certificate")}
+              </Label>
+              <Textarea
+                id="cert"
+                value={samlCert}
+                onChange={(e) => setSamlCert(e.target.value)}
+                placeholder={t("admin.sso.dialogs.saml.certPlaceholder")}
+                rows={10}
+                className="font-mono text-xs"
+              />
+            </div>
+            <div className="grid gap-4 content-start">
+              <div className="space-y-2">
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="samlWantAssertionsSigned"
+                    checked={samlWantAssertionsSigned}
+                    onCheckedChange={setSamlWantAssertionsSigned}
+                  />
+                  <Label htmlFor="samlWantAssertionsSigned">
+                    {t(
+                      "admin.sso.samlConfiguration.samlSettings.wantAssertionsSigned"
+                    )}
+                  </Label>
+                </div>
+                <p className="text-sm text-muted-foreground">
                   {t(
-                    "admin.sso.samlConfiguration.samlSettings.wantAssertionsSigned"
+                    "admin.sso.samlConfiguration.samlSettings.wantAssertionsSignedDescription"
                   )}
-                </Label>
+                </p>
               </div>
-              <p className="text-sm text-muted-foreground">
-                {t(
-                  "admin.sso.samlConfiguration.samlSettings.wantAssertionsSignedDescription"
-                )}
-              </p>
+
+              <div className="space-y-2">
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="samlWantAuthnResponseSigned"
+                    checked={samlWantAuthnResponseSigned}
+                    onCheckedChange={setSamlWantAuthnResponseSigned}
+                  />
+                  <Label htmlFor="samlWantAuthnResponseSigned">
+                    {t(
+                      "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSigned"
+                    )}
+                  </Label>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {t(
+                    "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSignedDescription"
+                  )}
+                </p>
+              </div>
             </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="samlWantAuthnResponseSigned"
-                  checked={samlWantAuthnResponseSigned}
-                  onCheckedChange={setSamlWantAuthnResponseSigned}
-                />
-                <Label htmlFor="samlWantAuthnResponseSigned">
-                  {t(
-                    "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSigned"
-                  )}
-                </Label>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                {t(
-                  "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSignedDescription"
-                )}
-              </p>
-            </div>
-
-            <div className="text-sm text-muted-foreground">
+            <div className="md:col-span-2 text-sm text-muted-foreground">
               <p>{t("admin.sso.dialogs.saml.instructions.title")}</p>
               <ol className="list-decimal ml-4 space-y-1">
                 <li>{t("admin.sso.dialogs.saml.instructions.step1")}</li>

--- a/testplanit/app/[locale]/admin/sso/saml/[providerId]/page.tsx
+++ b/testplanit/app/[locale]/admin/sso/saml/[providerId]/page.tsx
@@ -42,6 +42,8 @@ interface SamlFormData {
   cert: string;
   callbackUrl: string;
   logoutUrl: string;
+  wantAssertionsSigned: boolean;
+  wantAuthnResponseSigned: boolean;
   autoProvisionUsers: boolean;
   defaultAccess: Access;
   attributeMapping: {
@@ -79,6 +81,8 @@ export default function SAMLConfigurationPage() {
     cert: "",
     callbackUrl: "",
     logoutUrl: "",
+    wantAssertionsSigned: true,
+    wantAuthnResponseSigned: false,
     autoProvisionUsers: true,
     defaultAccess: Access.USER,
     attributeMapping: {
@@ -100,6 +104,8 @@ export default function SAMLConfigurationPage() {
         cert: samlConfig.cert,
         callbackUrl: samlConfig.callbackUrl,
         logoutUrl: samlConfig.logoutUrl || "",
+        wantAssertionsSigned: samlConfig.wantAssertionsSigned ?? true,
+        wantAuthnResponseSigned: samlConfig.wantAuthnResponseSigned ?? false,
         autoProvisionUsers: samlConfig.autoProvisionUsers,
         defaultAccess: samlConfig.defaultAccess || Access.USER,
         attributeMapping: {
@@ -156,6 +162,8 @@ export default function SAMLConfigurationPage() {
         cert: formData.cert,
         callbackUrl: formData.callbackUrl,
         logoutUrl: formData.logoutUrl || null,
+        wantAssertionsSigned: formData.wantAssertionsSigned,
+        wantAuthnResponseSigned: formData.wantAuthnResponseSigned,
         autoProvisionUsers: formData.autoProvisionUsers,
         defaultAccess: formData.defaultAccess,
         attributeMapping: formData.attributeMapping,
@@ -285,6 +293,53 @@ export default function SAMLConfigurationPage() {
                 }
                 placeholder="https://idp.example.com/logout"
               />
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="wantAssertionsSigned"
+                  checked={formData.wantAssertionsSigned}
+                  onCheckedChange={(checked) =>
+                    setFormData({ ...formData, wantAssertionsSigned: checked })
+                  }
+                />
+                <Label htmlFor="wantAssertionsSigned">
+                  {t(
+                    "admin.sso.samlConfiguration.samlSettings.wantAssertionsSigned"
+                  )}
+                </Label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t(
+                  "admin.sso.samlConfiguration.samlSettings.wantAssertionsSignedDescription"
+                )}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="wantAuthnResponseSigned"
+                  checked={formData.wantAuthnResponseSigned}
+                  onCheckedChange={(checked) =>
+                    setFormData({
+                      ...formData,
+                      wantAuthnResponseSigned: checked,
+                    })
+                  }
+                />
+                <Label htmlFor="wantAuthnResponseSigned">
+                  {t(
+                    "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSigned"
+                  )}
+                </Label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t(
+                  "admin.sso.samlConfiguration.samlSettings.wantAuthnResponseSignedDescription"
+                )}
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/testplanit/app/api/auth/callback/saml/route.test.ts
+++ b/testplanit/app/api/auth/callback/saml/route.test.ts
@@ -118,6 +118,12 @@ describe("POST /api/auth/callback/saml — ACS validator", () => {
       )
     ).toBe(true);
     expect(location).not.toContain("/api/auth/callback/saml?token=");
+
+    // Bug 5: status MUST be 303 (See Other), not the NextResponse.redirect()
+    // default of 307. The IdP POSTs the assertion here; 307 preserves the
+    // method, so the browser would re-POST to /complete (which only exports
+    // GET) and get 405. 303 forces the follow-up to be a GET.
+    expect(res.status).toBe(303);
   });
 
   it("rejects a replayed assertion with 400 (single-use)", async () => {
@@ -189,5 +195,205 @@ describe("POST /api/auth/callback/saml — ACS validator", () => {
     ).toBe(true);
     // Post-login destination defaults to /.
     expect(location).toContain("callbackUrl=%2F");
+  });
+
+  it("Bug 6: stamps emailVerified on existing users so they bypass the verify-email gate", async () => {
+    // A pre-existing user whose emailVerified is null was getting trapped in
+    // the verify-email flow even after a successful SAML assertion. The IdP
+    // already proved control of the email, so the gate is redundant.
+    (db.samlConfiguration.findUnique as any).mockResolvedValue({
+      id: "cfg",
+      entryPoint: "e",
+      cert: "c",
+      issuer: "i",
+      attributeMapping: {},
+      autoProvisionUsers: false,
+      provider: { name: "okta", enabled: true },
+    });
+    validateSAMLResponse.mockResolvedValue({
+      email: "dave@example.com",
+      nameID: "dave",
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_unverified",
+      email: "dave@example.com",
+      name: "Dave",
+      authMethod: "SSO",
+      externalId: "dave",
+      emailVerified: null,
+    });
+    (db.user.update as any).mockResolvedValue({});
+    (db.account.upsert as any).mockResolvedValue({});
+
+    await POST(makeReq(relayFor("ssoprovider_x")));
+
+    expect(db.user.update).toHaveBeenCalled();
+    const updateArgs = (db.user.update as any).mock.calls[0][0];
+    expect(updateArgs.data.emailVerified).toBeInstanceOf(Date);
+  });
+
+  it("Bug 6: leaves emailVerified alone for already-verified users", async () => {
+    const verifiedAt = new Date("2024-01-01");
+    (db.samlConfiguration.findUnique as any).mockResolvedValue({
+      id: "cfg",
+      entryPoint: "e",
+      cert: "c",
+      issuer: "i",
+      attributeMapping: {},
+      autoProvisionUsers: false,
+      provider: { name: "okta", enabled: true },
+    });
+    validateSAMLResponse.mockResolvedValue({
+      email: "eve@example.com",
+      nameID: "eve",
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_verified",
+      email: "eve@example.com",
+      name: "Eve",
+      authMethod: "SSO",
+      externalId: "eve",
+      emailVerified: verifiedAt,
+    });
+    (db.account.upsert as any).mockResolvedValue({});
+
+    await POST(makeReq(relayFor("ssoprovider_y")));
+
+    // No update call (or, if there is one for other reasons, emailVerified
+    // must not be in it).
+    const updateCalls = (db.user.update as any).mock.calls;
+    for (const [args] of updateCalls) {
+      expect(args.data.emailVerified).toBeUndefined();
+    }
+  });
+});
+
+describe("POST /api/auth/callback/saml — email resolution & guard ordering", () => {
+  const cfg = (attributeMapping: any, autoProvisionUsers = false) => ({
+    id: "cfg",
+    entryPoint: "e",
+    cert: "c",
+    issuer: "i",
+    attributeMapping,
+    autoProvisionUsers,
+    defaultAccess: "USER",
+    provider: { name: "okta", enabled: true },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db.samlConfiguration.findMany as any).mockResolvedValue([]);
+  });
+
+  it("resolves the email from the NameID when there is no email attribute (empty mapping)", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue(cfg({}));
+    // IdP sends the email in the NameID, no email attribute statement.
+    validateSAMLResponse.mockResolvedValue({ nameID: "dave@example.com" });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_d",
+      email: "dave@example.com",
+      name: "Dave",
+      authMethod: "SSO",
+      externalId: "dave@example.com",
+    });
+    (db.user.update as any).mockResolvedValue({});
+    (db.account.upsert as any).mockResolvedValue({});
+
+    const res = await POST(makeReq(relayFor("ssoprovider_d")));
+
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "dave@example.com" },
+    });
+    // No 500/TypeError: it proceeds to the session-minting handoff.
+    expect(res.status).not.toBe(500);
+    expect(res.headers.get("location")).toContain(
+      "/api/auth/saml/complete?token="
+    );
+  });
+
+  it("returns a clean 400 (not a 500) when no email is present anywhere", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue(cfg({}));
+    // No email attribute and a non-email NameID.
+    validateSAMLResponse.mockResolvedValue({ nameID: "not-an-email" });
+
+    const res = await POST(makeReq(relayFor("ssoprovider_x")));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/email not found/i);
+    // The guard runs before any use of email (no lookup, no name .split crash).
+    expect(db.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("prefers an explicit email attribute over the NameID", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue(cfg({}));
+    validateSAMLResponse.mockResolvedValue({
+      email: "erin@example.com",
+      nameID: "other@example.com",
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_e",
+      email: "erin@example.com",
+      name: "Erin",
+      authMethod: "SSO",
+      externalId: "other@example.com",
+    });
+    (db.user.update as any).mockResolvedValue({});
+    (db.account.upsert as any).mockResolvedValue({});
+
+    await POST(makeReq(relayFor("ssoprovider_e")));
+
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "erin@example.com" },
+    });
+  });
+
+  it("honors a custom attributeMapping.email key", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue(
+      cfg({ email: "mail" })
+    );
+    validateSAMLResponse.mockResolvedValue({
+      mail: "frank@example.com",
+      nameID: "frank",
+    });
+    (db.user.findUnique as any).mockResolvedValue({
+      id: "user_f",
+      email: "frank@example.com",
+      name: "Frank",
+      authMethod: "SSO",
+      externalId: "frank",
+    });
+    (db.user.update as any).mockResolvedValue({});
+    (db.account.upsert as any).mockResolvedValue({});
+
+    await POST(makeReq(relayFor("ssoprovider_f")));
+
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "frank@example.com" },
+    });
+  });
+
+  it("derives the name from the email local-part when no name attributes are present", async () => {
+    (db.samlConfiguration.findUnique as any).mockResolvedValue(cfg({}, true));
+    validateSAMLResponse.mockResolvedValue({ nameID: "gina@example.com" });
+    (db.user.findUnique as any).mockResolvedValue(null); // new user → provision
+    (db.roles.findFirst as any).mockResolvedValue({ id: "role_1" });
+    (db.user.create as any).mockResolvedValue({
+      id: "user_g",
+      email: "gina@example.com",
+    });
+    (db.account.upsert as any).mockResolvedValue({});
+
+    const res = await POST(makeReq(relayFor("ssoprovider_g")));
+
+    expect(db.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          email: "gina@example.com",
+          name: "gina",
+        }),
+      })
+    );
+    expect(res.status).not.toBe(500);
   });
 });

--- a/testplanit/app/api/auth/callback/saml/route.ts
+++ b/testplanit/app/api/auth/callback/saml/route.ts
@@ -35,6 +35,8 @@ async function resolveIdpInitiatedConfig(samlResponse: string) {
         entryPoint: samlConfig.entryPoint,
         cert: samlConfig.cert,
         issuer: samlConfig.issuer,
+        wantAssertionsSigned: samlConfig.wantAssertionsSigned,
+        wantAuthnResponseSigned: samlConfig.wantAuthnResponseSigned,
       });
       const profile = await validateSAMLResponse(samlClient, {
         SAMLResponse: samlResponse,
@@ -124,6 +126,8 @@ export async function POST(request: NextRequest) {
         entryPoint: found.entryPoint,
         cert: found.cert,
         issuer: found.issuer,
+        wantAssertionsSigned: found.wantAssertionsSigned,
+        wantAuthnResponseSigned: found.wantAuthnResponseSigned,
       });
 
       samlConfig = found;

--- a/testplanit/app/api/auth/callback/saml/route.ts
+++ b/testplanit/app/api/auth/callback/saml/route.ts
@@ -198,9 +198,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Extract user attributes based on mapping
-    const attributeMapping = samlConfig.attributeMapping as any;
-    const email = profile[attributeMapping.email || "email"] as string;
+    // Extract user attributes based on mapping. attributeMapping can be {} or
+    // null (some IdPs send none), so default it and read keys null-safely.
+    const attributeMapping = (samlConfig.attributeMapping as any) ?? {};
+    const nameId = profile.nameID as string | undefined;
+    const mappedEmail = profile[attributeMapping.email || "email"] as
+      | string
+      | undefined;
+    // Accept the email carried in the NameID (Name ID format EmailAddress) when
+    // there is no email attribute statement — a common IdP setup (e.g. Okta's
+    // default). Only treat the NameID as an email when it actually looks like
+    // one, since NameID is non-email in other configurations.
+    const email =
+      mappedEmail || (nameId && nameId.includes("@") ? nameId : undefined);
     const externalId = (profile[attributeMapping.id || "nameID"] ||
       profile.nameID) as string;
 
@@ -215,20 +225,22 @@ export async function POST(request: NextRequest) {
       | string
       | undefined;
 
-    // Construct full name from available fields
+    // Guard before any use of email (name fallback, user lookup, provisioning).
+    if (!email) {
+      return NextResponse.json(
+        { error: "Email not found in SAML response" },
+        { status: 400 }
+      );
+    }
+
+    // Construct full name from available fields, falling back to the email
+    // local-part only once we know an email is present.
     let name = displayName;
     if (!name && (firstName || lastName)) {
       name = [firstName, lastName].filter(Boolean).join(" ");
     }
     if (!name) {
       name = email.split("@")[0];
-    }
-
-    if (!email) {
-      return NextResponse.json(
-        { error: "Email not found in SAML response" },
-        { status: 400 }
-      );
     }
 
     // Check if user exists
@@ -328,6 +340,14 @@ export async function POST(request: NextRequest) {
         updates.authMethod = "BOTH";
       }
 
+      // Authentication through SAML satisfies email verification — the IdP
+      // already asserted control of the address. Without this, an existing
+      // user whose emailVerified is null gets trapped in the verify-email
+      // gate even though they just proved control via the IdP.
+      if (!user.emailVerified) {
+        updates.emailVerified = new Date();
+      }
+
       if (Object.keys(updates).length > 0) {
         await db.user.update({
           where: { id: user.id },
@@ -364,11 +384,15 @@ export async function POST(request: NextRequest) {
 
     // Hand off to the completion route, which verifies the token and mints the
     // NextAuth session cookie before redirecting to the final destination.
+    // Use 303 See Other so the IdP's POST does not get re-POSTed to /complete
+    // (which only exports GET) — without this the browser would re-POST and
+    // hit 405. NextResponse.redirect() defaults to 307, preserving method.
     const response = NextResponse.redirect(
       new URL(
         `/api/auth/saml/complete?token=${tempToken}&callbackUrl=${encodeURIComponent(callbackUrl)}`,
         getAppBaseUrl(request)
-      )
+      ),
+      303
     );
 
     // Set security headers

--- a/testplanit/app/api/auth/logout/route.ts
+++ b/testplanit/app/api/auth/logout/route.ts
@@ -93,6 +93,9 @@ export const POST = withAuditContext(async (request: NextRequest) => {
             entryPoint: samlProvider.samlConfig.entryPoint,
             cert: samlProvider.samlConfig.cert,
             issuer: samlProvider.samlConfig.issuer,
+            wantAssertionsSigned: samlProvider.samlConfig.wantAssertionsSigned,
+            wantAuthnResponseSigned:
+              samlProvider.samlConfig.wantAuthnResponseSigned,
           });
 
           // Generate SAML logout request

--- a/testplanit/app/api/auth/saml/complete/route.test.ts
+++ b/testplanit/app/api/auth/saml/complete/route.test.ts
@@ -10,16 +10,6 @@ vi.hoisted(() => {
 
 const SECRET = "test-secret-key-at-least-32-chars-long";
 
-// Capture every cookie the route sets so we can decode the session token.
-const cookieJar = new Map<string, { value: string }>();
-vi.mock("next/headers", () => ({
-  cookies: vi.fn(async () => ({
-    set: (name: string, value: string) => cookieJar.set(name, { value }),
-    get: (name: string) => cookieJar.get(name),
-    delete: (name: string) => cookieJar.delete(name),
-  })),
-}));
-
 vi.mock("~/server/db", () => ({
   db: {
     user: { findUnique: vi.fn() },
@@ -59,7 +49,6 @@ function tempToken() {
 
 describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
   beforeEach(() => {
-    cookieJar.clear();
     vi.clearAllMocks();
     (db.user.findUnique as any).mockResolvedValue(user);
     (db.registrationSettings.findFirst as any).mockResolvedValue(null);
@@ -80,7 +69,7 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
 
     // The session cookie it set must be a valid NextAuth v4 JWT — decode it the
     // exact way NextAuth would on the next request.
-    const sessionCookie = cookieJar.get("next-auth.session-token");
+    const sessionCookie = res.cookies.get("next-auth.session-token");
     expect(sessionCookie?.value).toBeTruthy();
 
     const decoded = await decode({
@@ -97,10 +86,10 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
   it("sets the __Secure- cookie name in production (matches NextAuth on https)", async () => {
     vi.stubEnv("NODE_ENV", "production");
 
-    await GET(makeReq(tempToken()));
+    const res = await GET(makeReq(tempToken()));
 
     expect(
-      cookieJar.get("__Secure-next-auth.session-token")?.value
+      res.cookies.get("__Secure-next-auth.session-token")?.value
     ).toBeTruthy();
   });
 
@@ -113,10 +102,10 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
       twoFactorEnabled: true,
     });
 
-    await GET(makeReq(tempToken()));
+    const res = await GET(makeReq(tempToken()));
 
     const decoded = await decode({
-      token: cookieJar.get("next-auth.session-token")!.value,
+      token: res.cookies.get("next-auth.session-token")!.value,
       secret: SECRET,
     });
     expect(decoded?.twoFactorRequired).toBe(true);
@@ -129,10 +118,10 @@ describe("GET /api/auth/saml/complete — post-Okta session handoff", () => {
     });
     // user.twoFactorEnabled is false by default
 
-    await GET(makeReq(tempToken()));
+    const res = await GET(makeReq(tempToken()));
 
     const decoded = await decode({
-      token: cookieJar.get("next-auth.session-token")!.value,
+      token: res.cookies.get("next-auth.session-token")!.value,
       secret: SECRET,
     });
     expect(decoded?.twoFactorSetupRequired).toBe(true);

--- a/testplanit/app/api/auth/saml/complete/route.ts
+++ b/testplanit/app/api/auth/saml/complete/route.ts
@@ -1,5 +1,4 @@
 import { encode } from "next-auth/jwt";
-import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { consumeTempSessionToken, getAppBaseUrl } from "~/lib/auth-security";
 import { db } from "~/server/db";
@@ -82,9 +81,16 @@ export async function GET(request: NextRequest) {
       secret: process.env.NEXTAUTH_SECRET || "development-secret",
     });
 
-    // Set the session cookie
-    const cookieStore = await cookies();
-    cookieStore.set("next-auth.session-token", sessionToken, {
+    // Build the redirect first, then attach the session cookie to the response
+    // object directly. Mutating `cookies()` from `next/headers` does not
+    // reliably propagate to a separately-constructed NextResponse.redirect()
+    // — Set-Cookie ends up missing from the wire and the user lands back on
+    // the sign-in page after Okta.
+    const response = NextResponse.redirect(
+      new URL(callbackUrl, getAppBaseUrl(request))
+    );
+
+    response.cookies.set("next-auth.session-token", sessionToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
@@ -94,7 +100,7 @@ export async function GET(request: NextRequest) {
 
     // For production, use secure cookie name
     if (process.env.NODE_ENV === "production") {
-      cookieStore.set("__Secure-next-auth.session-token", sessionToken, {
+      response.cookies.set("__Secure-next-auth.session-token", sessionToken, {
         httpOnly: true,
         secure: true,
         sameSite: "lax",
@@ -103,8 +109,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Redirect to callback URL
-    return NextResponse.redirect(new URL(callbackUrl, getAppBaseUrl(request)));
+    return response;
   } catch (error) {
     console.error("SAML completion error:", error);
     return NextResponse.json(

--- a/testplanit/app/api/auth/saml/route.ts
+++ b/testplanit/app/api/auth/saml/route.ts
@@ -59,6 +59,8 @@ export async function GET(request: NextRequest) {
       entryPoint: samlConfig.entryPoint,
       cert: samlConfig.cert,
       issuer: samlConfig.issuer,
+      wantAssertionsSigned: samlConfig.wantAssertionsSigned,
+      wantAuthnResponseSigned: samlConfig.wantAuthnResponseSigned,
     });
 
     // Carry the provider and post-login destination in RelayState. The IdP

--- a/testplanit/lib/hooks/__model_meta.ts
+++ b/testplanit/lib/hooks/__model_meta.ts
@@ -9037,6 +9037,14 @@ const metadata: ModelMeta = {
                     name: "logoutUrl",
                     type: "String",
                     isOptional: true,
+                }, wantAssertionsSigned: {
+                    name: "wantAssertionsSigned",
+                    type: "Boolean",
+                    attributes: [{ "name": "@default", "args": [{ "name": "value", "value": true }] }],
+                }, wantAuthnResponseSigned: {
+                    name: "wantAuthnResponseSigned",
+                    type: "Boolean",
+                    attributes: [{ "name": "@default", "args": [{ "name": "value", "value": false }] }],
                 }, attributeMapping: {
                     name: "attributeMapping",
                     type: "Json",

--- a/testplanit/lib/hooks/saml-configuration.ts
+++ b/testplanit/lib/hooks/saml-configuration.ts
@@ -328,7 +328,7 @@ export function useSuspenseCountSamlConfiguration<TArgs extends Prisma.SamlConfi
 }
 import type { Access } from '@prisma/client';
 
-export function useCheckSamlConfiguration<TError = DefaultError>(args: { operation: PolicyCrudKind; where?: { id?: string; providerId?: string; entryPoint?: string; issuer?: string; cert?: string; callbackUrl?: string; logoutUrl?: string; autoProvisionUsers?: boolean; defaultAccess?: Access }; }, options?: (Omit<UseQueryOptions<boolean, TError, boolean>, 'queryKey'> & ExtraQueryOptions)) {
+export function useCheckSamlConfiguration<TError = DefaultError>(args: { operation: PolicyCrudKind; where?: { id?: string; providerId?: string; entryPoint?: string; issuer?: string; cert?: string; callbackUrl?: string; logoutUrl?: string; wantAssertionsSigned?: boolean; wantAuthnResponseSigned?: boolean; autoProvisionUsers?: boolean; defaultAccess?: Access }; }, options?: (Omit<UseQueryOptions<boolean, TError, boolean>, 'queryKey'> & ExtraQueryOptions)) {
     const { endpoint, fetch } = getHooksContext();
     return useModelQuery<boolean, boolean, TError>('SamlConfiguration', `${endpoint}/samlConfiguration/check`, args, options, fetch);
 }

--- a/testplanit/lib/session-cache.ts
+++ b/testplanit/lib/session-cache.ts
@@ -79,11 +79,17 @@ export async function getCachedSessionUser(
 
   if (!user) return null;
 
-  // 3. Ensure preferences exist. This is a one-time-per-user cost at most.
+  // 3. Ensure preferences exist. Upsert (not create-after-check) because
+  // NextAuth fires multiple concurrent session() calls during sign-in; the
+  // check-then-create above raced and threw P2002 on the second concurrent
+  // call, which NextAuth surfaced as JWT_SESSION_ERROR and aborted the
+  // session.
   let preferences = (user as SelectedUser).userPreferences;
   if (!preferences) {
-    preferences = await prisma.userPreferences.create({
-      data: { userId },
+    preferences = await prisma.userPreferences.upsert({
+      where: { userId },
+      create: { userId },
+      update: {},
     });
   }
 

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -3838,7 +3838,11 @@
           "entityId": "Entity ID (Issuer)",
           "certificate": "X.509 Certificate",
           "callbackUrl": "Callback URL",
-          "logoutUrl": "Logout URL (Optional)"
+          "logoutUrl": "Logout URL (Optional)",
+          "wantAssertionsSigned": "Require signed assertions",
+          "wantAssertionsSignedDescription": "Reject responses whose SAML assertion is not signed. This protects the authenticated identity and should stay enabled.",
+          "wantAuthnResponseSigned": "Require signed response",
+          "wantAuthnResponseSignedDescription": "Also require the outer SAML response to be signed. Most identity providers sign only the assertion, so leave this off unless your IdP signs the response."
         },
         "userProvisioning": {
           "title": "User Provisioning",

--- a/testplanit/prisma/schema.prisma
+++ b/testplanit/prisma/schema.prisma
@@ -2550,19 +2550,21 @@ model RegistrationSettings {
 }
 
 model SamlConfiguration {
-  id                 String      @id() @default(cuid())
-  providerId         String      @unique()
-  provider           SsoProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
-  entryPoint         String
-  issuer             String
-  cert               String      @db.Text()
-  callbackUrl        String
-  logoutUrl          String?
-  attributeMapping   Json
-  autoProvisionUsers Boolean     @default(false)
-  defaultAccess      Access      @default(USER)
-  createdAt          DateTime    @default(now())
-  updatedAt          DateTime    @updatedAt()
+  id                      String      @id() @default(cuid())
+  providerId              String      @unique()
+  provider                SsoProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  entryPoint              String
+  issuer                  String
+  cert                    String      @db.Text()
+  callbackUrl             String
+  logoutUrl               String?
+  wantAssertionsSigned    Boolean     @default(true)
+  wantAuthnResponseSigned Boolean     @default(false)
+  attributeMapping        Json
+  autoProvisionUsers      Boolean     @default(false)
+  defaultAccess           Access      @default(USER)
+  createdAt               DateTime    @default(now())
+  updatedAt               DateTime    @updatedAt()
 }
 
 model TestmoImportJob {

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -5011,21 +5011,21 @@ enum SsoProviderType {
 }
 
 model SamlConfiguration {
-    id                 String      @id @default(cuid())
-    providerId         String      @unique
-    provider           SsoProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
-    entryPoint         String      // SSO login URL
-    issuer             String      // SP entity ID
-    cert               String      @db.Text // IdP certificate
-    callbackUrl        String      // ACS URL
-    logoutUrl          String?     // SLO URL
-    wantAssertionsSigned    Boolean @default(true)  // Require the SAML assertion to be signed
-    wantAuthnResponseSigned Boolean @default(false) // Require the outer SAML response to be signed
-    attributeMapping   Json        // Map SAML attributes to user fields
-    autoProvisionUsers Boolean     @default(false)
-    defaultAccess      Access      @default(USER) // Default system access for auto-provisioned users
-    createdAt          DateTime    @default(now())
-    updatedAt          DateTime    @updatedAt
+    id                      String      @id @default(cuid())
+    providerId              String      @unique
+    provider                SsoProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+    entryPoint              String      // SSO login URL
+    issuer                  String      // SP entity ID
+    cert                    String      @db.Text // IdP certificate
+    callbackUrl             String      // ACS URL
+    logoutUrl               String?     // SLO URL
+    wantAssertionsSigned    Boolean     @default(true)  // Require the SAML assertion to be signed
+    wantAuthnResponseSigned Boolean     @default(false) // Require the outer SAML response to be signed
+    attributeMapping        Json        // Map SAML attributes to user fields
+    autoProvisionUsers      Boolean     @default(false)
+    defaultAccess           Access      @default(USER) // Default system access for auto-provisioned users
+    createdAt               DateTime    @default(now())
+    updatedAt               DateTime    @updatedAt
 
     // Allow everyone to read SAML configuration (needed for sign-in page)
     @@allow('read', true)

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -5019,6 +5019,8 @@ model SamlConfiguration {
     cert               String      @db.Text // IdP certificate
     callbackUrl        String      // ACS URL
     logoutUrl          String?     // SLO URL
+    wantAssertionsSigned    Boolean @default(true)  // Require the SAML assertion to be signed
+    wantAuthnResponseSigned Boolean @default(false) // Require the outer SAML response to be signed
     attributeMapping   Json        // Map SAML attributes to user fields
     autoProvisionUsers Boolean     @default(false)
     defaultAccess      Access      @default(USER) // Default system access for auto-provisioned users

--- a/testplanit/server/saml-provider.test.ts
+++ b/testplanit/server/saml-provider.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { SAML } from "@node-saml/node-saml";
+import { describe, expect, it, vi } from "vitest";
+
+import { createSAMLClient, type SAMLConfig } from "./saml-provider";
+
+vi.hoisted(() => {
+  process.env.NEXTAUTH_URL = "https://app.example.com";
+});
+
+// node-saml only needs a decodeable base64 PEM body to construct a client; the
+// signature-validation behavior under test does not depend on the cert content.
+const CERT_BODY = Buffer.from("a".repeat(900)).toString("base64");
+
+function pem(body: string): string {
+  const wrapped = body.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----\n`;
+}
+
+const baseConfig: SAMLConfig = {
+  name: "test",
+  entryPoint: "https://idp.example.com/sso",
+  issuer: "https://app.example.com",
+  cert: pem(CERT_BODY),
+};
+
+// node-saml stores the resolved options (ctor value ?? library default) on
+// `client.options`, which is what an SP-side validation actually enforces.
+function resolvedOptions(client: SAML) {
+  return (
+    client as unknown as {
+      options: {
+        wantAssertionsSigned: boolean;
+        wantAuthnResponseSigned: boolean;
+      };
+    }
+  ).options;
+}
+
+describe("createSAMLClient signature-validation defaults", () => {
+  it("requires a signed assertion but not a signed response when the config omits both", async () => {
+    const client = await createSAMLClient(baseConfig);
+    const options = resolvedOptions(client);
+
+    expect(options.wantAssertionsSigned).toBe(true);
+    expect(options.wantAuthnResponseSigned).toBe(false);
+  });
+
+  it("relaxes the response-signature requirement that node-saml enables by default", async () => {
+    // node-saml defaults wantAuthnResponseSigned to true, which rejects the
+    // common assertion-only-signed IdP configuration ("Invalid signature").
+    const nodeSamlDefault = new SAML({
+      callbackUrl: "https://app.example.com/api/auth/callback/saml",
+      issuer: "https://app.example.com",
+      idpCert: pem(CERT_BODY),
+    });
+    expect(resolvedOptions(nodeSamlDefault).wantAuthnResponseSigned).toBe(true);
+
+    // Our client flips that default to false so the standard setup works.
+    const client = await createSAMLClient(baseConfig);
+    expect(resolvedOptions(client).wantAuthnResponseSigned).toBe(false);
+  });
+
+  it("honors explicit config values over the defaults", async () => {
+    const client = await createSAMLClient({
+      ...baseConfig,
+      wantAssertionsSigned: false,
+      wantAuthnResponseSigned: true,
+    });
+    const options = resolvedOptions(client);
+
+    expect(options.wantAssertionsSigned).toBe(false);
+    expect(options.wantAuthnResponseSigned).toBe(true);
+  });
+});

--- a/testplanit/server/saml-provider.ts
+++ b/testplanit/server/saml-provider.ts
@@ -145,8 +145,12 @@ export async function createSAMLClient(config: SAMLConfig) {
     decryptionPvk: config.decryptionPvk,
     signatureAlgorithm: config.signatureAlgorithm,
     digestAlgorithm: config.digestAlgorithm,
-    wantAssertionsSigned: config.wantAssertionsSigned,
-    wantAuthnResponseSigned: config.wantAuthnResponseSigned,
+    // node-saml defaults both of these to true. We keep the assertion signature
+    // mandatory but relax the outer response signature, since most IdPs (Okta's
+    // default included) sign only the assertion; a response signature is still
+    // validated when present. Either can be overridden per-provider.
+    wantAssertionsSigned: config.wantAssertionsSigned ?? true,
+    wantAuthnResponseSigned: config.wantAuthnResponseSigned ?? false,
     allowCreate: config.allowCreate,
     identifierFormat: config.identifierFormat,
     acceptedClockSkewMs: config.acceptedClockSkewMs,


### PR DESCRIPTION
## Description

Makes TestPlanIt's SAML sign-in work with standard identity-provider configurations and fixes several failures seen in production with Okta. Three areas:

**1. Signature-validation posture.** `@node-saml/node-saml` v5 defaults to requiring *both* the assertion and the outer response to be signed, and `createSAMLClient` passed these through unset. Most IdPs (including Okta's default) sign only the assertion, so those responses were rejected with `Invalid signature`. The assertion signature stays mandatory (it carries the authenticated identity); the outer response signature is now optional by default and is still validated when present. Both flags are now stored on `SamlConfiguration` and surfaced as admin toggles, so an operator can tighten to "both required" without a code change.

**2. Email resolution + a 500 crash (ACS handler).** The handler read the email only from an attribute statement, so an IdP that carries the email in the NameID (Name ID format `EmailAddress`, with no separate email attribute — a common setup) produced `undefined`. Worse, the name fallback called `email.split("@")` *before* the "email not found" guard, so a missing email threw `TypeError: Cannot read properties of undefined (reading 'split')` → a 500 instead of a clean 400. Now the email falls back to the NameID when it looks like an email, the attribute mapping is read null-safely (an empty `{}` mapping no longer throws), and the guard runs before any use of the email.

**3. SSO completion-flow hardening.**
- Redirect to `/api/auth/saml/complete` with **303 See Other** instead of the framework default 307, so the IdP's POST isn't re-POSTed to the GET-only completion route (which returned 405).
- Attach the session cookie to the redirect response directly instead of mutating `cookies()` from `next/headers`, which didn't reliably emit `Set-Cookie` — users were bounced back to the sign-in page after authenticating.
- `upsert` `UserPreferences` instead of check-then-create, fixing a `P2002` race from NextAuth's concurrent `session()` calls during sign-in.
- Stamp `emailVerified` on existing SSO users so a successful SAML login bypasses the verify-email gate the IdP has already satisfied.

## Related Issue

N/A — production incident (Okta SAML login).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality) — per-provider signature toggles
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

New/updated specs:
- `server/saml-provider.test.ts` — signature defaults (assertion required, response optional) and explicit overrides.
- `app/api/auth/callback/saml/route.test.ts` — email-in-NameID, clean-400-not-500 when no email, explicit/custom-mapping email precedence, name-from-local-part, plus the 303 redirect and `emailVerified` behaviors.

All 20 SAML-area unit tests pass locally.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): n/a
- Node version: 24.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

n/a

## Additional Notes

**Security posture:** the assertion remains mandatorily signed by default — only the *outer response* signature becomes optional-by-default, matching standard SP behaviour. A response signature is still verified when the IdP sends one, and admins can require it per provider via the new toggle.

**Deploy note:** adds two columns to `SamlConfiguration` (`wantAssertionsSigned` default `true`, `wantAuthnResponseSigned` default `false`). This repo is `prisma db push`-based (no migration files), so deploy must push the schema; existing rows pick up the defaults.

**Reviewer note:** locally, `tsc` may report `TS2554` on the four new admin-toggle `t()` keys — that's next-intl's `createMessagesDeclaration` type being stale until a Next build regenerates it; CI builds and passes clean.
