### PR TITLE
ci(release): fix Semantic Release trigger and version detection

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,6 +8,10 @@ on:
       - 'testplanit/**'
       - '!testplanit/CHANGELOG.md'
       - '.github/workflows/semantic-release.yml'
+  # Manual trigger: runs against the current main HEAD, so a release can be cut
+  # when a push-triggered run was skipped (e.g. raced "behind remote" by a
+  # concurrent [skip ci] commit).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -19,8 +23,8 @@ jobs:
   release:
     name: Release
     runs-on: [self-hosted]
-    # Skip release commits
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    # Skip release commits on push; manual dispatch always runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
     env:
       NODE_OPTIONS: "--max-old-space-size=6144"
     steps:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -57,49 +57,22 @@ jobs:
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
           cd testplanit
-          npx semantic-release 2>&1 | tee release-output.txt
-          # Extract the version if a release was made
-          # Try multiple patterns to handle different semantic-release output formats
-          VERSION=""
-          # Early exit: if semantic-release explicitly says no release, skip version extraction
-          if grep -q "no relevant changes, so no new version is released" release-output.txt; then
-            echo "No release detected (semantic-release found no relevant changes)"
-            echo "released=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          # Pattern 1: "Published release X.Y.Z" (semantic-release <v24)
-          if grep -q "Published release" release-output.txt; then
-            VERSION=$(grep "Published release" release-output.txt | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
-          fi
-          # Pattern 2: "Created release X.Y.Z" or "Published GitHub release: X.Y.Z"
-          if [ -z "$VERSION" ] && grep -qE "(Created release|Published GitHub release)" release-output.txt; then
-            VERSION=$(grep -E "(Created release|Published GitHub release)" release-output.txt | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
-          fi
-          # Pattern 3: Look for "next release version is X.Y.Z" from semantic-release
-          if [ -z "$VERSION" ] && grep -qE "next release version is [0-9]+\.[0-9]+\.[0-9]+" release-output.txt; then
-            VERSION=$(grep -oE "next release version is [0-9]+\.[0-9]+\.[0-9]+" release-output.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          fi
-          # Pattern 4: Check the git tag that was just created
-          if [ -z "$VERSION" ]; then
-            LATEST_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-            PREV_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
-            if [ "$LATEST_TAG" != "$PREV_TAG" ] && [ -n "$LATEST_TAG" ]; then
-              # A new tag was created during this run
-              TAG_COMMIT=$(git rev-list -n 1 "$LATEST_TAG" 2>/dev/null)
-              HEAD_COMMIT=$(git rev-parse HEAD 2>/dev/null)
-              if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
-                VERSION="${LATEST_TAG#v}"
-                echo "Detected new release tag: $LATEST_TAG"
-              fi
-            fi
-          fi
+          # Detect a genuinely new release by comparing the latest release tag
+          # before and after the run. Keying off a new tag — not parsing
+          # semantic-release's log — means a skipped publish ("no relevant
+          # changes", or "behind the remote one") leaves the tag unchanged and
+          # does NOT trigger a Docker build of an already-released version.
+          PREV_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
-          if [ -n "$VERSION" ] && [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected release version: $VERSION"
-            echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+          npx semantic-release
+
+          NEW_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -n "$NEW_TAG" ] && [ "$NEW_TAG" != "$PREV_TAG" ]; then
+            echo "Released new version: $NEW_TAG"
+            echo "version=$NEW_TAG" >> $GITHUB_OUTPUT
             echo "released=true" >> $GITHUB_OUTPUT
           else
-            echo "No release detected (version extraction result: '$VERSION')"
+            echo "No new release (latest tag unchanged: ${PREV_TAG:-none}); skipping Docker build"
             echo "released=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Description

Fixes the release pipeline so a production release (`v0.36.4`, carrying the SAML login fix already on `main`) can be cut reliably, and stops spurious Docker builds. Two fixes to `.github/workflows/semantic-release.yml`:

1. **Add a `workflow_dispatch` trigger.** The release was push-only. When a push-triggered run is skipped — e.g. semantic-release reports the checkout is *"behind the remote one"* because a concurrent `[skip ci]` Crowdin commit landed right behind it — there was no way to re-run it against the current `main` HEAD. A manual dispatch runs on the live HEAD, so that race can't block a release; manual runs also bypass the `[skip ci]` guard.

2. **Trigger the Docker build only on a genuinely new release.** The old version-extraction fell back to reading the latest *existing* tag whenever semantic-release ran but didn't publish, set `released=true` with the already-shipped version, and fired `release.yml -f tag=<existing>` — rebuilding an already-released image (observed: a duplicate `v0.36.3` build). It now compares the latest release tag before/after the run: `released=true` only when a new tag was created this run; a skip leaves the tag unchanged → no build. Dropping the `tee` pipe also lets a real semantic-release error fail the step instead of being masked by the pipe's exit code.

## Related Issue

N/A — release-pipeline reliability (unblocks the `v0.36.4` production hotfix).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Manual testing

- Both shell snippets pass `bash -n`.
- Logic dry-run: tag unchanged ⇒ `released=false` (no Docker build); `v0.36.3 → v0.36.4` ⇒ `released=true`, builds `v0.36.4`.
- Workflow YAML structure validated.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Merging this is itself the `main` push that triggers the release; the `v0.36.4` bump is carried by the SAML `fix:` already on `main` since `v0.36.3`. Titled `ci(...)` so the `0.36.4` changelog shows just the user-facing SAML fix.
