### PR TITLE
enhancement(llm): show feature-override projects in AI Models connections

### DIFF
--- a/testplanit/app/[locale]/admin/llm/columns.tsx
+++ b/testplanit/app/[locale]/admin/llm/columns.tsx
@@ -15,6 +15,7 @@ export interface ExtendedLlmIntegration extends LlmIntegration {
   llmProviderConfig?: LlmProviderConfig | null;
   isConnected?: boolean;
   projectLlmIntegrations?: { projectId: number }[];
+  llmFeatureConfigs?: { projectId: number }[];
 }
 
 export const useColumns = (
@@ -98,11 +99,25 @@ export const useColumns = (
         enableResizing: true,
         size: 75,
         cell: ({ row }) => {
-          const projects = row.original.projectLlmIntegrations || [];
+          // A project connects to this LLM either by setting it as the project
+          // default (projectLlmIntegrations) or by overriding a feature to use
+          // it (llmFeatureConfigs). Merge and dedupe so a project counts once.
+          const projectIds = new Set<number>();
+          for (const { projectId } of row.original.projectLlmIntegrations ||
+            []) {
+            projectIds.add(projectId);
+          }
+          for (const { projectId } of row.original.llmFeatureConfigs || []) {
+            projectIds.add(projectId);
+          }
 
-          if (projects.length === 0) {
+          if (projectIds.size === 0) {
             return null;
           }
+
+          const projects = Array.from(projectIds, (projectId) => ({
+            projectId,
+          }));
 
           return <ProjectListDisplay projects={projects} usePopover={true} />;
         },

--- a/testplanit/app/[locale]/admin/llm/page.tsx
+++ b/testplanit/app/[locale]/admin/llm/page.tsx
@@ -147,6 +147,15 @@ function LlmIntegrationList() {
           },
           select: { projectId: true },
         },
+        llmFeatureConfigs: {
+          where: {
+            enabled: true,
+            project: {
+              isDeleted: false,
+            },
+          },
+          select: { projectId: true },
+        },
       },
       where: {
         AND: [
@@ -189,6 +198,10 @@ function LlmIntegrationList() {
         llmProviderConfig: true,
         projectLlmIntegrations: {
           where: { isActive: true, project: { isDeleted: false } },
+          select: { projectId: true },
+        },
+        llmFeatureConfigs: {
+          where: { enabled: true, project: { isDeleted: false } },
           select: { projectId: true },
         },
       },

--- a/testplanit/components/tables/ProjectListDisplay.tsx
+++ b/testplanit/components/tables/ProjectListDisplay.tsx
@@ -247,7 +247,7 @@ export const ProjectListDisplay: React.FC<ProjectListProps> = ({
       renderOption={(option) => (
         <Link
           href={`/projects/overview/${option.id}`}
-          className="flex items-center gap-1"
+          className="flex items-center gap-1 no-underline text-inherit hover:text-accent-foreground"
         >
           <div className="max-w-5 max-h-5">
             <ProjectIcon iconUrl={option.iconUrl} height={20} width={20} />


### PR DESCRIPTION
## Description

Two related improvements to how project–LLM connections are surfaced.

**1. AI Models admin — show feature-override connections (enhancement)**

The Admin > AI Models **Projects** column previously counted only projects that set an LLM as their *project default* (`ProjectLlmIntegration`, `isActive = true`). A project can also connect to an LLM by overriding a specific feature to use it (`LlmFeatureConfig`, `enabled = true`) without changing its project default — those connections were invisible on this page.

Both list queries now also include enabled feature-override connections, and the Projects cell merges and de-duplicates project IDs across both sources, so a project that both defaults to and overrides the same LLM is counted once. Disabled "No LLM" overrides (null integration) are naturally excluded by the relation, and soft-deleted projects are filtered out to match the existing default-connection query.

**2. Project link hover styling in the project combobox (fix)**

The global `body a` rule underlines anchors and mutes them to `text-muted-foreground` on hover, which fought the command item's selected background (`bg-accent` / `text-accent-foreground`) — the hovered project row showed underlined, washed-out text. The project option link now suppresses the underline and follows the selected-row color.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

ESLint, Prettier, and `tsc --noEmit` pass cleanly for the changed files. No unit test exercises the admin LLM columns, this query, or `ProjectListDisplay`; the full suite runs in CI.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chromium
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

The two changes are independent and kept as separate commits. The PR title is scoped to the primary enhancement (patch-level); the combobox hover fix is also patch-level, so the bundled release bump is unaffected.
