### PR TITLE
enhancement(quickscript): resilient repo scans with rate-limit backoff

### DIFF
--- a/testplanit/app/[locale]/projects/settings/[projectId]/quickscript/page.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/quickscript/page.tsx
@@ -136,6 +136,7 @@ export default function QuickScriptPage() {
     filesFound?: number;
     scope?: string;
     totalFiles?: number;
+    waitSeconds?: number;
   } | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshStep, setRefreshStep] = useState<string>("");
@@ -342,6 +343,7 @@ export default function QuickScriptPage() {
                 filesFound: event.filesFound,
                 scope: event.scope,
                 totalFiles: event.totalFiles,
+                waitSeconds: event.waitSeconds,
               });
             } else if (event.type === "complete") {
               setPreview(event);
@@ -800,6 +802,10 @@ export default function QuickScriptPage() {
                           {previewProgress.step === "filtering" &&
                             t("preview.filtering", {
                               count: previewProgress.totalFiles ?? 0,
+                            })}
+                          {previewProgress.step === "rate-limited" &&
+                            t("preview.rateLimited", {
+                              seconds: previewProgress.waitSeconds ?? 0,
                             })}
                         </span>
                       )}

--- a/testplanit/app/api/code-repositories/[id]/preview-files/route.ts
+++ b/testplanit/app/api/code-repositories/[id]/preview-files/route.ts
@@ -1,53 +1,15 @@
 import { prisma } from "@/lib/prisma";
-import micromatch from "micromatch";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
+import { createGitRepoAdapter } from "~/lib/integrations/adapters/GitRepoAdapter";
 import {
-  createGitRepoAdapter,
-  RepoFileEntry,
-} from "~/lib/integrations/adapters/GitRepoAdapter";
+  applyPathPatterns,
+  extractBasePaths,
+  type PathPattern,
+} from "~/lib/integrations/repoPathPatterns";
 import { authOptions } from "~/server/auth";
 
 const MAX_CONTEXT_BYTES = 500_000;
-
-interface PathPattern {
-  path: string;
-  pattern: string;
-}
-
-function applyPathPatterns(
-  allFiles: RepoFileEntry[],
-  pathPatterns: PathPattern[]
-): RepoFileEntry[] {
-  if (!pathPatterns.length) return allFiles;
-
-  const matched = new Set<string>();
-  for (const { path: basePath, pattern } of pathPatterns) {
-    // Combine basePath + pattern into a single glob
-    const trimmedBase = basePath.replace(/\/$/, "");
-    const globPattern = trimmedBase ? `${trimmedBase}/${pattern}` : pattern;
-    const matchedPaths = micromatch(
-      allFiles.map((f) => f.path),
-      globPattern
-    );
-    matchedPaths.forEach((p: string) => matched.add(p));
-  }
-
-  return allFiles
-    .filter((f) => matched.has(f.path))
-    .sort((a, b) => a.path.localeCompare(b.path));
-}
-
-/** Extract unique base directory paths from PathPattern[] for scoped listing. */
-function extractBasePaths(pathPatterns: PathPattern[]): string[] {
-  if (!pathPatterns.length) return [];
-  const paths = new Set<string>();
-  for (const { path: basePath } of pathPatterns) {
-    const trimmed = basePath.replace(/\/$/, "");
-    if (trimmed) paths.add(trimmed);
-  }
-  return paths.size > 0 ? [...paths] : [];
-}
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -111,6 +73,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
           repo.settings as Record<string, string> | null
         );
 
+        // Surface rate-limit waits as progress so the user sees we're backing
+        // off and retrying rather than staring at a frozen spinner.
+        adapter.onRateLimitWait = (waitSeconds) => {
+          send({ type: "progress", step: "rate-limited", waitSeconds });
+        };
+
         // Step 1: Resolve branch
         send({ type: "progress", step: "branch" });
         const resolvedBranch = branch || (await adapter.getDefaultBranch());
@@ -118,7 +86,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         // Step 2: Fetch files — use path-scoped listing when paths are available
         const basePaths = extractBasePaths(pathPatterns);
         const scopeLabel =
-          basePaths.length > 0 ? basePaths.join(", ") : "repository root";
+          basePaths.length > 0
+            ? basePaths.map((p) => p || "repository root").join(", ")
+            : "repository root";
         send({ type: "progress", step: "listing", scope: scopeLabel });
 
         const { files: allFiles, truncated } = await adapter.listFilesInPaths(
@@ -140,7 +110,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
           step: "filtering",
           totalFiles: allFiles.length,
         });
-        const filteredFiles = applyPathPatterns(allFiles, pathPatterns);
+        const filteredFiles = applyPathPatterns(allFiles, pathPatterns).sort(
+          (a, b) => a.path.localeCompare(b.path)
+        );
 
         const totalSize = filteredFiles.reduce(
           (sum, f) => sum + (f.size ?? 0),

--- a/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.test.ts
@@ -4,6 +4,15 @@ import { BitbucketRepoAdapter } from "./BitbucketRepoAdapter";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// Mock DNS resolution to avoid real lookups in tests
+vi.mock("~/utils/ssrf", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/ssrf")>();
+  return {
+    ...actual,
+    assertSsrfSafeResolved: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 function makeResponse(data: any, status = 200) {
   return {
     ok: status >= 200 && status < 300,
@@ -167,6 +176,95 @@ describe("BitbucketRepoAdapter", () => {
 
       const result = await adapter.listAllFiles("main");
       expect(result.files).toHaveLength(2);
+    });
+  });
+
+  describe("listFilesInPaths root handling", () => {
+    it("lists the repo root as /src/<branch>/ (no '.' segment) for an empty base path", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [{ path: "CLAUDE.md", type: "commit_file", size: 100 }],
+          next: null,
+        })
+      );
+
+      const result = await adapter.listFilesInPaths("main", [""]);
+
+      expect(result.files.map((f) => f.path)).toEqual(["CLAUDE.md"]);
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/src/main/?");
+      expect(calledUrl).not.toContain("/src/main/.");
+    });
+
+    it("normalizes a literal '.' base path to the repo root URL", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [{ path: "CLAUDE.md", type: "commit_file", size: 100 }],
+          next: null,
+        })
+      );
+
+      await adapter.listFilesInPaths("main", ["."]);
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/src/main/?");
+      expect(calledUrl).not.toContain("/src/main/.");
+    });
+
+    it("lists mixed root + scoped base paths correctly", async () => {
+      // First seed "" (root)
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [
+            { path: "CLAUDE.md", type: "commit_file", size: 100 },
+            { path: "src/index.ts", type: "commit_file", size: 50 },
+          ],
+          next: null,
+        })
+      );
+      // Second seed "src"
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [
+            { path: "src/index.ts", type: "commit_file", size: 50 }, // dup
+            { path: "src/util.ts", type: "commit_file", size: 60 },
+          ],
+          next: null,
+        })
+      );
+
+      const result = await adapter.listFilesInPaths("main", ["", "src"]);
+
+      expect(result.files.map((f) => f.path)).toEqual([
+        "CLAUDE.md",
+        "src/index.ts",
+        "src/util.ts",
+      ]);
+      const rootUrl = mockFetch.mock.calls[0][0] as string;
+      const srcUrl = mockFetch.mock.calls[1][0] as string;
+      expect(rootUrl).toContain("/src/main/?");
+      expect(srcUrl).toContain("/src/main/src?");
+    });
+  });
+
+  describe("non-JSON listing response", () => {
+    it("throws a friendly error (not a raw SyntaxError) when a path resolves to a file body", async () => {
+      // Bitbucket resolves a bad path to a FILE and returns its raw markdown body.
+      (adapter as any).maxRetries = 0;
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "text/markdown" }),
+        json: () =>
+          Promise.reject(new SyntaxError("Unexpected token '#' in JSON")),
+        text: () => Promise.resolve("# CLAUDE.md\n\nProject docs go here."),
+      });
+
+      const promise = adapter.listFilesInPaths("main", ["docs"]);
+
+      await expect(promise).rejects.toThrow(/non-JSON content/i);
+      await expect(promise).rejects.not.toThrow(SyntaxError);
     });
   });
 

--- a/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.ts
@@ -61,7 +61,12 @@ export class BitbucketRepoAdapter extends GitRepoAdapter {
     const queue: string[] = [...seeds];
 
     while (queue.length > 0 && files.length < MAX_FILES) {
-      const path = queue.shift()!;
+      const rawPath = queue.shift()!;
+      // Treat ".", "./" and "" all as repository root. Bitbucket resolves a
+      // literal "." path segment to a FILE and returns its raw body instead of
+      // a JSON directory listing, which would blow up JSON parsing downstream.
+      const path =
+        rawPath === "." || rawPath === "./" || rawPath === "/" ? "" : rawPath;
       let url: string | null =
         `https://api.bitbucket.org/2.0/repositories/${this.workspace}/${this.repoSlug}/src/${encodeURIComponent(branch)}/${path}?pagelen=100&max_depth=${MAX_DEPTH}`;
 

--- a/testplanit/lib/integrations/adapters/GitRepoAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/GitRepoAdapter.test.ts
@@ -195,3 +195,76 @@ describe("GitRepoAdapter redirect protection", () => {
     );
   });
 });
+
+describe("GitRepoAdapter rate-limit retry", () => {
+  let adapter: GitHubRepoAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new GitHubRepoAdapter(
+      { personalAccessToken: "test-token" },
+      { owner: "testorg", repo: "testrepo" }
+    );
+    // Keep the test fast — no baseline throttle, tiny backoff.
+    (adapter as any).rateLimitDelay = 0;
+    (adapter as any).lastRequestTime = 0;
+    (adapter as any).retryDelay = 1;
+    (adapter as any).maxRateLimitWaitMs = 5_000;
+  });
+
+  it("waits and retries when the reset window is within the cap", async () => {
+    const onWait = vi.fn();
+    adapter.onRateLimitWait = onWait;
+
+    // 429 with an immediate reset, then success on retry.
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({ message: "rate limited" }, 429, { "Retry-After": "0" })
+    );
+    mockFetch.mockResolvedValueOnce(makeResponse({ default_branch: "main" }));
+
+    const branch = await adapter.getDefaultBranch();
+
+    expect(branch).toBe("main");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(onWait).toHaveBeenCalled();
+  });
+
+  it("fails fast (no retry storm) when the reset window exceeds the cap", async () => {
+    const onWait = vi.fn();
+    adapter.onRateLimitWait = onWait;
+
+    // Reset is 10 minutes out — far beyond the 5s cap.
+    mockFetch.mockResolvedValue(
+      makeResponse({ message: "rate limited" }, 429, { "Retry-After": "600" })
+    );
+
+    await expect(adapter.getDefaultBranch()).rejects.toThrow(
+      "Rate limit exceeded"
+    );
+    // No retries burned — the actionable error surfaces immediately.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(onWait).not.toHaveBeenCalled();
+  });
+
+  it("still retries transient 5xx errors with backoff", async () => {
+    const onWait = vi.fn();
+    adapter.onRateLimitWait = onWait;
+
+    mockFetch.mockResolvedValueOnce(makeResponse({ message: "boom" }, 500));
+    mockFetch.mockResolvedValueOnce(makeResponse({ default_branch: "main" }));
+
+    const branch = await adapter.getDefaultBranch();
+
+    expect(branch).toBe("main");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // 5xx is not a rate limit, so the rate-limit hook never fires.
+    expect(onWait).not.toHaveBeenCalled();
+  });
+
+  it("does not retry non-rate-limit 4xx errors", async () => {
+    mockFetch.mockResolvedValue(makeResponse({ message: "not found" }, 404));
+
+    await expect(adapter.getDefaultBranch()).rejects.toThrow("HTTP 404");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
@@ -30,10 +30,22 @@ export abstract class GitRepoAdapter {
   protected maxRetries: number = 3;
   protected retryDelay: number = 1000;
   protected requestTimeout: number = 30000; // 30 seconds
+  // Longest a single request will block waiting out a rate-limit window before
+  // giving up. Brief/secondary limits (short reset) are absorbed transparently;
+  // primary limits (reset minutes away) fail fast with an actionable message
+  // rather than hanging an interactive request for minutes.
+  protected maxRateLimitWaitMs: number = 15_000;
 
   // Populated from response headers to drive adaptive throttling
   private rateLimitRemaining: number | null = null;
   private rateLimitResetAt: number | null = null; // Unix seconds
+
+  /**
+   * Optional hook fired just before sleeping to wait out a rate limit. Lets a
+   * caller (e.g. the preview SSE stream) surface "retrying in Ns" progress to
+   * the user instead of leaving them on a silent spinner.
+   */
+  onRateLimitWait?: (waitSeconds: number, attempt: number) => void;
 
   /**
    * Seconds until the rate-limit window resets (from server headers).
@@ -168,7 +180,25 @@ export abstract class GitRepoAdapter {
           );
         }
 
-        return (await response.json()) as T;
+        // Read as text and parse ourselves so a non-JSON body (e.g. a path that
+        // resolves to a file instead of a directory listing) surfaces a clear,
+        // actionable error rather than a raw JSON.parse SyntaxError.
+        const rawBody = await response.text();
+        try {
+          return JSON.parse(rawBody) as T;
+        } catch {
+          const contentType = response.headers.get("content-type") ?? "";
+          const preview = rawBody.trim().slice(0, 80);
+          throw new Error(
+            `Expected a JSON response but received non-JSON content` +
+              (contentType ? ` (content-type: ${contentType})` : "") +
+              `. This usually means the requested path points to a file ` +
+              `rather than a directory listing.` +
+              (preview
+                ? ` Response began with: ${JSON.stringify(preview)}`
+                : "")
+          );
+        }
       } finally {
         clearTimeout(timeoutId);
       }
@@ -332,11 +362,17 @@ export abstract class GitRepoAdapter {
     let delay = this.rateLimitDelay;
     if (this.rateLimitRemaining !== null) {
       if (this.rateLimitRemaining < 10) {
-        // Nearly exhausted — wait until the window resets
+        // Nearly exhausted — wait until the window resets, but never block
+        // longer than maxRateLimitWaitMs. If the reset is further out than
+        // that, let the request proceed and surface a fast rate-limit error
+        // (handled by executeWithRetry) instead of hanging for minutes.
         const waitMs = this.rateLimitResetAt
           ? this.rateLimitResetAt * 1000 - now
           : 30_000;
-        delay = Math.max(delay, waitMs > 0 ? waitMs : 0);
+        delay = Math.max(
+          delay,
+          Math.min(waitMs > 0 ? waitMs : 0, this.maxRateLimitWaitMs)
+        );
       } else if (this.rateLimitRemaining < 50) {
         delay = Math.max(delay, 8_000);
       } else if (this.rateLimitRemaining < 100) {
@@ -373,9 +409,24 @@ export abstract class GitRepoAdapter {
       ) {
         throw err;
       }
-      // Rate limits: applyRateLimit() in the next makeRequest call will
-      // handle the long pause; just wait a short backoff here.
-      const backoff = this.retryDelay * Math.pow(2, attempt);
+
+      let backoff: number;
+      if (isRateLimit) {
+        // Honor the server's reset window (parsed from Retry-After /
+        // X-RateLimit-Reset). The plain exponential backoff is far too short
+        // for a real rate limit — retrying after a few seconds just hits the
+        // wall again. If the window is further out than we're willing to block
+        // this request, don't burn retries: let the actionable "try again in N
+        // minutes" error propagate now.
+        const resetMs = this.retryAfterSeconds * 1000;
+        if (resetMs > this.maxRateLimitWaitMs) throw err;
+        backoff = Math.max(resetMs, this.retryDelay * Math.pow(2, attempt));
+        this.onRateLimitWait?.(Math.ceil(backoff / 1000), attempt);
+      } else {
+        backoff = this.retryDelay * Math.pow(2, attempt);
+      }
+      // Small additive jitter so batched retries don't fire in lockstep
+      backoff += Math.floor(Math.random() * 250);
       await new Promise((r) => setTimeout(r, backoff));
       return this.executeWithRetry(fn, retriesLeft - 1, attempt + 1);
     }

--- a/testplanit/lib/integrations/repoPathPatterns.test.ts
+++ b/testplanit/lib/integrations/repoPathPatterns.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPathPatterns,
+  extractBasePaths,
+  normalizeBasePath,
+  type PathPattern,
+} from "./repoPathPatterns";
+
+function file(path: string, size = 0) {
+  return { path, size, type: "file" as const };
+}
+
+describe("normalizeBasePath", () => {
+  it("treats '.', './', and '' all as repository root ('')", () => {
+    expect(normalizeBasePath(".")).toBe("");
+    expect(normalizeBasePath("./")).toBe("");
+    expect(normalizeBasePath("")).toBe("");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeBasePath("src/")).toBe("src");
+    expect(normalizeBasePath("src/utils//")).toBe("src/utils");
+  });
+
+  it("strips a leading './' prefix", () => {
+    expect(normalizeBasePath("./src")).toBe("src");
+  });
+
+  it("leaves a normal path untouched", () => {
+    expect(normalizeBasePath("src/utils")).toBe("src/utils");
+  });
+});
+
+describe("extractBasePaths", () => {
+  it("returns [] when there are no patterns", () => {
+    expect(extractBasePaths([])).toEqual([]);
+  });
+
+  it("maps '.', './', and '' to root ('') so root is explicitly seeded", () => {
+    for (const path of [".", "./", ""]) {
+      const result = extractBasePaths([{ path, pattern: "CLAUDE.md" }]);
+      expect(result).toEqual([""]);
+    }
+  });
+
+  it("keeps non-root base paths and dedupes them", () => {
+    const patterns: PathPattern[] = [
+      { path: "src/", pattern: "**/*.ts" },
+      { path: "src", pattern: "*.js" },
+    ];
+    expect(extractBasePaths(patterns)).toEqual(["src"]);
+  });
+
+  it("includes root ('') alongside non-root paths for mixed patterns", () => {
+    const patterns: PathPattern[] = [
+      { path: ".", pattern: "CLAUDE.md" },
+      { path: "src", pattern: "**/*.ts" },
+    ];
+    expect(extractBasePaths(patterns)).toEqual(["", "src"]);
+  });
+});
+
+describe("applyPathPatterns", () => {
+  it("matches a root-level file when the base path is root", () => {
+    const files = [file("CLAUDE.md"), file("src/index.ts"), file("README.md")];
+    for (const path of [".", "./", ""]) {
+      const result = applyPathPatterns(files, [{ path, pattern: "CLAUDE.md" }]);
+      expect(result.map((f) => f.path)).toEqual(["CLAUDE.md"]);
+    }
+  });
+
+  it("does not prefix a root glob with './'", () => {
+    // A "./CLAUDE.md" glob would fail to match the bare "CLAUDE.md" path.
+    const files = [file("CLAUDE.md")];
+    const result = applyPathPatterns(files, [
+      { path: ".", pattern: "CLAUDE.md" },
+    ]);
+    expect(result.map((f) => f.path)).toEqual(["CLAUDE.md"]);
+  });
+
+  it("scopes a glob under a non-root base path", () => {
+    const files = [
+      file("src/a.ts"),
+      file("src/nested/b.ts"),
+      file("other/c.ts"),
+    ];
+    const result = applyPathPatterns(files, [
+      { path: "src", pattern: "**/*.ts" },
+    ]);
+    expect(result.map((f) => f.path)).toEqual(["src/a.ts", "src/nested/b.ts"]);
+  });
+
+  it("matches mixed root + scoped patterns together", () => {
+    const files = [
+      file("CLAUDE.md"),
+      file("README.md"),
+      file("src/index.ts"),
+      file("src/util.ts"),
+      file("docs/guide.md"),
+    ];
+    const result = applyPathPatterns(files, [
+      { path: ".", pattern: "CLAUDE.md" },
+      { path: "src", pattern: "**/*.ts" },
+    ]);
+    expect(result.map((f) => f.path).sort()).toEqual([
+      "CLAUDE.md",
+      "src/index.ts",
+      "src/util.ts",
+    ]);
+  });
+
+  it("returns all files unchanged when there are no patterns", () => {
+    const files = [file("a.ts"), file("b.ts")];
+    expect(applyPathPatterns(files, [])).toBe(files);
+  });
+});

--- a/testplanit/lib/integrations/repoPathPatterns.ts
+++ b/testplanit/lib/integrations/repoPathPatterns.ts
@@ -12,10 +12,16 @@ export interface PathPattern {
  * JSON directory listing, whereas `/src/<branch>/.` resolves to a file body).
  */
 export function normalizeBasePath(basePath: string): string {
-  const trimmed = (basePath ?? "").trim().replace(/\/+$/, "");
+  // Strip trailing slashes with a linear scan rather than a `/\/+$/` regex:
+  // the end-anchored `+` backtracks O(n^2) on a long run of slashes, and
+  // basePath is user-supplied (ReDoS — flagged by CodeQL).
+  const start = (basePath ?? "").trim();
+  let end = start.length;
+  while (end > 0 && start.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  const trimmed = start.slice(0, end);
   if (trimmed === "" || trimmed === ".") return "";
   // Strip a leading "./" so "./src" behaves the same as "src".
-  return trimmed.replace(/^\.\//, "");
+  return trimmed.startsWith("./") ? trimmed.slice(2) : trimmed;
 }
 
 /**

--- a/testplanit/lib/integrations/repoPathPatterns.ts
+++ b/testplanit/lib/integrations/repoPathPatterns.ts
@@ -1,0 +1,58 @@
+import micromatch from "micromatch";
+
+export interface PathPattern {
+  path: string;
+  pattern: string;
+}
+
+/**
+ * Normalize a base directory path so that ".", "./", and "" all mean the
+ * repository root. Root is represented as the empty string "" — the form the
+ * listing adapters expect (e.g. Bitbucket's `/src/<branch>/` returns a proper
+ * JSON directory listing, whereas `/src/<branch>/.` resolves to a file body).
+ */
+export function normalizeBasePath(basePath: string): string {
+  const trimmed = (basePath ?? "").trim().replace(/\/+$/, "");
+  if (trimmed === "" || trimmed === ".") return "";
+  // Strip a leading "./" so "./src" behaves the same as "src".
+  return trimmed.replace(/^\.\//, "");
+}
+
+/**
+ * Extract unique base directory paths from PathPattern[] for scoped listing.
+ *
+ * Root ("") is included as an explicit seed whenever any pattern targets root,
+ * so root-level files (e.g. CLAUDE.md) are actually scanned. Without this, a
+ * naive "drop empty strings" guard would silently skip the repository root.
+ */
+export function extractBasePaths(pathPatterns: PathPattern[]): string[] {
+  if (!pathPatterns.length) return [];
+  const paths = new Set<string>();
+  for (const { path: basePath } of pathPatterns) {
+    paths.add(normalizeBasePath(basePath));
+  }
+  return [...paths];
+}
+
+/**
+ * Filter a flat file list down to those matching the combined base + glob
+ * patterns. A root pattern uses the glob as-is (e.g. "CLAUDE.md", with no "./"
+ * prefix) so micromatch matches root-level paths.
+ */
+export function applyPathPatterns<T extends { path: string }>(
+  allFiles: T[],
+  pathPatterns: PathPattern[]
+): T[] {
+  if (!pathPatterns.length) return allFiles;
+
+  const matched = new Set<string>();
+  const filePaths = allFiles.map((f) => f.path);
+  for (const { path: basePath, pattern } of pathPatterns) {
+    const base = normalizeBasePath(basePath);
+    const globPattern = base ? `${base}/${pattern}` : pattern;
+    const matchedPaths = micromatch(filePaths, globPattern);
+    matchedPaths.forEach((p: string) => matched.add(p));
+  }
+
+  return allFiles.filter((f) => matched.has(f.path));
+}

--- a/testplanit/lib/llm/services/code-context.service.ts
+++ b/testplanit/lib/llm/services/code-context.service.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@/lib/prisma";
-import micromatch from "micromatch";
 import {
   createGitRepoAdapter,
   type GitRepoAdapter,
@@ -8,7 +7,14 @@ import {
   repoFileCache,
   type RepoFileEntry,
 } from "~/lib/integrations/cache/RepoFileCache";
+import {
+  applyPathPatterns,
+  type PathPattern,
+} from "~/lib/integrations/repoPathPatterns";
 import { bfsRank, buildImportGraph, isBarrelFile } from "./import-analyzer";
+
+// Re-exported for backwards compatibility with existing importers/tests.
+export { applyPathPatterns };
 
 // Same heuristic as LlmManager.chatStream (line 261): ~4 chars per token
 const CHARS_PER_TOKEN = 4;
@@ -85,31 +91,6 @@ export interface AssembledContext {
   filesUsed: string[]; // Paths of files included
   tokenEstimate: number; // Estimated tokens used
   truncated: boolean; // true if some files were skipped due to budget
-}
-
-interface PathPattern {
-  path: string;
-  pattern: string;
-}
-
-export function applyPathPatterns(
-  allFiles: RepoFileEntry[],
-  pathPatterns: PathPattern[]
-): RepoFileEntry[] {
-  if (!pathPatterns.length) return allFiles;
-
-  const matched = new Set<string>();
-  for (const { path: basePath, pattern } of pathPatterns) {
-    const trimmedBase = basePath.replace(/\/$/, "");
-    const globPattern = trimmedBase ? `${trimmedBase}/${pattern}` : pattern;
-    const matchedPaths = micromatch(
-      allFiles.map((f) => f.path),
-      globPattern
-    );
-    matchedPaths.forEach((p: string) => matched.add(p));
-  }
-
-  return allFiles.filter((f) => matched.has(f.path));
 }
 
 /**

--- a/testplanit/lib/services/repoCacheRefreshService.ts
+++ b/testplanit/lib/services/repoCacheRefreshService.ts
@@ -1,46 +1,14 @@
 import type { PrismaClient } from "@prisma/client";
-import micromatch from "micromatch";
 import { createGitRepoAdapter } from "~/lib/integrations/adapters/GitRepoAdapter";
 import {
   repoFileCache,
   type RepoFileEntry,
 } from "~/lib/integrations/cache/RepoFileCache";
-
-interface PathPattern {
-  path: string;
-  pattern: string;
-}
-
-function applyPathPatterns(
-  allFiles: RepoFileEntry[],
-  pathPatterns: PathPattern[]
-): RepoFileEntry[] {
-  if (!pathPatterns.length) return allFiles;
-
-  const matched = new Set<string>();
-  for (const { path: basePath, pattern } of pathPatterns) {
-    const trimmedBase = basePath.replace(/\/$/, "");
-    const globPattern = trimmedBase ? `${trimmedBase}/${pattern}` : pattern;
-    const matchedPaths = micromatch(
-      allFiles.map((f) => f.path),
-      globPattern
-    );
-    matchedPaths.forEach((p: string) => matched.add(p));
-  }
-
-  return allFiles.filter((f) => matched.has(f.path));
-}
-
-/** Extract unique base directory paths from PathPattern[] for scoped listing. */
-function extractBasePaths(pathPatterns: PathPattern[]): string[] {
-  if (!pathPatterns.length) return [];
-  const paths = new Set<string>();
-  for (const { path: basePath } of pathPatterns) {
-    const trimmed = basePath.replace(/\/$/, "");
-    if (trimmed) paths.add(trimmed);
-  }
-  return paths.size > 0 ? [...paths] : [];
-}
+import {
+  applyPathPatterns,
+  extractBasePaths,
+  type PathPattern,
+} from "~/lib/integrations/repoPathPatterns";
 
 function isRateLimitError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Auflösen des Zweigs…",
           "scanningFiles": "Dateien werden gescannt in {scope}…",
           "scanningFilesCount": "Dateien in {scope}… werden durchsucht ({count, number} gefunden)",
-          "filtering": "Anwenden von Filtern auf {count, number} Dateien…"
+          "filtering": "Anwenden von Filtern auf {count, number} Dateien…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Cache-Einstellungen",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Resolving branch…",
           "scanningFiles": "Scanning files in {scope}…",
           "scanningFilesCount": "Scanning files in {scope}… ({count, number} found)",
-          "filtering": "Applying filters to {count, number} files…"
+          "filtering": "Applying filters to {count, number} files…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Cache Settings",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Resolviendo la rama…",
           "scanningFiles": "Escaneando archivos en {scope}…",
           "scanningFilesCount": "Escaneando archivos en {scope}… ({count, number} encontrados)",
-          "filtering": "Aplicando filtros a los archivos {count, number}…"
+          "filtering": "Aplicando filtros a los archivos {count, number}…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Configuración de caché",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Résolution de la branche…",
           "scanningFiles": "Analyse des fichiers dans {scope}…",
           "scanningFilesCount": "Analyse des fichiers dans {scope}… ({count, number} trouvé)",
-          "filtering": "Application des filtres aux fichiers {count, number}…"
+          "filtering": "Application des filtres aux fichiers {count, number}…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Paramètres du cache",

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Risoluzione del ramo…",
           "scanningFiles": "Scansione dei file in {scope}…",
           "scanningFilesCount": "Scansione dei file in {scope}… ({count, number} trovato)",
-          "filtering": "Applicazione dei filtri ai file {count, number}…"
+          "filtering": "Applicazione dei filtri ai file {count, number}…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Impostazioni della cache",

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "ブランチ… を解決しています",
           "scanningFiles": "{scope}… のファイルをスキャンしています。",
           "scanningFilesCount": "{scope}… 内のファイルをスキャンしています ({count, number} が見つかりました)",
-          "filtering": "{count, number} ファイル… にフィルタを適用しています。"
+          "filtering": "{count, number} ファイル… にフィルタを適用しています。",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "キャッシュ設定",

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "분기…를 해결 중",
           "scanningFiles": "{scope}…에서 파일을 스캔합니다.",
           "scanningFilesCount": "{scope}… 에서 파일을 스캔하는 중입니다 ({count, number} 발견됨)",
-          "filtering": "{count, number} 파일…에 필터를 적용합니다."
+          "filtering": "{count, number} 파일…에 필터를 적용합니다.",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "캐시 설정",

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Oplossende tak…",
           "scanningFiles": "Bestanden scannen in {scope}…",
           "scanningFilesCount": "Bestanden scannen in {scope}… ({count, number} gevonden)",
-          "filtering": "Filters toepassen op {count, number} bestanden…"
+          "filtering": "Filters toepassen op {count, number} bestanden…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Cache-instellingen",

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Rozwiązywanie gałęzi…",
           "scanningFiles": "Skanowanie plików w {scope}…",
           "scanningFilesCount": "Skanowanie plików w {scope}… (znaleziono{count, number})",
-          "filtering": "Stosowanie filtrów do plików {count, number}…"
+          "filtering": "Stosowanie filtrów do plików {count, number}…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Ustawienia pamięci podręcznej",

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Resolvendo ramificação…",
           "scanningFiles": "Analisando arquivos em {scope}…",
           "scanningFilesCount": "Analisando arquivos em {scope}… ({count, number} encontrado)",
-          "filtering": "Aplicando filtros a {count, number} arquivos…"
+          "filtering": "Aplicando filtros a {count, number} arquivos…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Configurações de cache",

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Разрешение ветви…",
           "scanningFiles": "Сканирование файлов в {scope}…",
           "scanningFilesCount": "Сканирование файлов в {scope}… ({count, number} найдено)",
-          "filtering": "Применение фильтров к {count, number} файлам…"
+          "filtering": "Применение фильтров к {count, number} файлам…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Настройки кэша",

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "… dalının çözümlenmesi",
           "scanningFiles": "{scope}… içindeki dosyalar taranıyor.",
           "scanningFilesCount": "{scope}… içindeki dosyalar taranıyor ({count, number} bulundu)",
-          "filtering": "{count, number} dosyalarına filtreler uygulanıyor…"
+          "filtering": "{count, number} dosyalarına filtreler uygulanıyor…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Önbellek Ayarları",

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "Đang giải quyết nhánh…",
           "scanningFiles": "Đang quét các tập tin trong {scope}…",
           "scanningFilesCount": "Đang quét các tập tin trong {scope}… ({count, number} đã tìm thấy)",
-          "filtering": "Áp dụng bộ lọc cho các tệp {count, number}…"
+          "filtering": "Áp dụng bộ lọc cho các tệp {count, number}…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "Cài đặt bộ nhớ đệm",

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "正在解析分支…",
           "scanningFiles": "正在扫描 {scope}… 中的文件",
           "scanningFilesCount": "正在扫描 {scope}… 中的文件（已找到{count, number}）",
-          "filtering": "对 {count, number} 个文件应用过滤器…"
+          "filtering": "对 {count, number} 个文件应用过滤器…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "缓存设置",

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -1831,7 +1831,8 @@
           "resolvingBranch": "正在解析分支…",
           "scanningFiles": "正在掃描 {scope}… 中的文件",
           "scanningFilesCount": "正在掃描 {scope}… 中的檔案（已找到{count, number}）",
-          "filtering": "對 {count, number} 個檔案套用篩選器…"
+          "filtering": "對 {count, number} 個檔案套用篩選器…",
+          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
         },
         "cache": {
           "title": "快取設定",


### PR DESCRIPTION
## Description

Hardens QuickScript repository scanning (Project Settings → QuickScript: file **preview** and **refresh cache**) so external git-provider rate limits are handled gracefully instead of failing within seconds.

The core issue: every scan request funnels through `GitRepoAdapter.makeRequest()` → `executeWithRetry()`, and on a `429` that loop waited a fixed `1s → 2s → 4s` and retried the *same* request, **ignoring** the `Retry-After` / `X-RateLimit-Reset` window the adapter already parses. Against a real rate limit that just re-hits the wall and throws after ~7s.

**Rate limits (`GitRepoAdapter`)**
- `executeWithRetry` now honors the provider's reset window. Brief/secondary limits are waited out (capped at `maxRateLimitWaitMs`, jittered) and retried; primary limits (reset minutes away) **fail fast** with the actionable *"Try again in N minutes"* message instead of burning retries on doomed calls.
- `applyRateLimit` caps its proactive "nearly exhausted" pause so a multi-request listing can't silently hang for minutes.
- New `onRateLimitWait` hook — the preview SSE stream emits a `rate-limited` progress event so the user sees *"Rate limited — retrying in Ns…"* rather than a frozen spinner. Added `preview.rateLimited` string (synced across locales).

Both the preview and refresh-cache flows benefit, since they share the adapter.

**Path matching (repo scans)** — bundled in from parallel work on the same files
- Extracted path-pattern helpers into `repoPathPatterns.ts` with corrected base-path normalization so root-level files (e.g. `CLAUDE.md`) are actually scanned and Bitbucket directory paths resolve to listings rather than file bodies.
- `makeRequest` parses JSON itself so a non-JSON body surfaces a clear, actionable error instead of a raw `JSON.parse` `SyntaxError`.

## Related Issue

N/A — internal enhancement (no tracking issue).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Added focused `GitRepoAdapter` retry tests: within-cap retry succeeds, fail-fast beyond cap (no retry storm), 5xx still retries, non-rate-limit 4xx does not. Full gate run locally — production build succeeded and `pnpm precommit` passed (**9148 passed / 145 skipped / 0 failures**, eslint 0 errors, prettier + tsc clean).

The preview "retrying in Ns…" SSE progress UI has not yet been exercised against a live rate-limited provider — recommend a manual smoke before merge.

**Test Configuration:**
- OS: macOS (Darwin 25.4.0)
- Browser (if applicable): N/A
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Single commit because the rate-limit and path-matching changes interleave within shared files (`GitRepoAdapter.ts`, `preview-files/route.ts`) and can't be cleanly bisected by file. Both halves are patch-level (`enhancement` / `fix`), so the PR title is `enhancement(...)` to keep release-please on a patch bump under squash-merge.
