### PR TITLE
enhancement(webhooks): rich Slack formatting for all webhook events

### DIFF
--- a/testplanit/app/api/model/[...path]/route.ts
+++ b/testplanit/app/api/model/[...path]/route.ts
@@ -40,6 +40,7 @@ import {
 import {
   emitCaseCreated,
   emitCaseDeleted,
+  emitCaseFieldValueChanged,
   emitCaseUpdated,
 } from "~/lib/webhooks/event-emitters/caseEvents";
 import {
@@ -97,6 +98,7 @@ const WEBHOOK_EMIT_MODELS = new Set([
   "sessions",
   "issue",
   "repositoryCases",
+  "caseFieldValues",
   "testRunResults",
   "sessionResults",
 ]);
@@ -1439,6 +1441,30 @@ async function innerHandler(
                   webhookPreSnapshot
                 ) {
                   await emitCaseDeleted(webhookPreSnapshot, tx);
+                }
+                break;
+              }
+              case "caseFieldValues": {
+                // Custom field value edits (dropdown / multi-select / text)
+                // are the only path that surfaces a field change on a case;
+                // resolve happens inside the emitter. Create has no
+                // pre-snapshot (new value); delete clears it.
+                if (
+                  ["create", "update", "upsert"].includes(
+                    parsedPath.operation
+                  ) &&
+                  postRow
+                ) {
+                  await emitCaseFieldValueChanged(
+                    webhookPreSnapshot,
+                    postRow,
+                    tx
+                  );
+                } else if (
+                  parsedPath.operation === "delete" &&
+                  webhookPreSnapshot
+                ) {
+                  await emitCaseFieldValueChanged(webhookPreSnapshot, null, tx);
                 }
                 break;
               }

--- a/testplanit/lib/webhooks/adapters/slack/formatters/_shared.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/_shared.ts
@@ -30,11 +30,28 @@ export const url = {
     `${baseUrl()}/projects/sessions/${projectId}/${sessionId}`,
   case: (projectId: number, caseId: number): string =>
     `${baseUrl()}/projects/repository/${projectId}/${caseId}`,
+  issue: (projectId: number, issueId: number): string =>
+    `${baseUrl()}/projects/issues/${projectId}?issueId=${issueId}`,
 };
 
 /** Slack mrkdwn link `<url|text>`, or plain bold text when url is omitted. */
 export function boldLink(text: string, href?: string): string {
   return href ? `*<${href}|${text}>*` : `*${text}*`;
+}
+
+/**
+ * "Tracked in <key>" line linking to the external issue tracker (Jira /
+ * GitHub) when the issue carries one. Used by issue.created and issue.updated
+ * so both keep the tracker reachable while the title links into TestPlanIt.
+ */
+export function trackerLine(
+  externalKey?: string | null,
+  externalUrl?: string | null
+): string | null {
+  if (!externalKey) return null;
+  return externalUrl
+    ? `Tracked in <${externalUrl}|${externalKey}>`
+    : `Tracked in *${externalKey}*`;
 }
 
 /** "Title (linked) \n in Project" — the standard 2-line entity header. */

--- a/testplanit/lib/webhooks/adapters/slack/formatters/case-deleted.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/case-deleted.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { OutboundEnvelope } from "../../types";
+import { formatCaseDeletedBlocks } from "./case-deleted";
+
+function envelope(data: Record<string, unknown>): OutboundEnvelope {
+  return {
+    eventId: "evt_test",
+    eventName: "case.deleted",
+    eventTimestamp: "2026-06-10T12:00:00.000Z",
+    tenantId: null,
+    projectId: 1,
+    projectName: "Demo Project",
+    actorUserId: null,
+    data,
+  };
+}
+
+describe("formatCaseDeletedBlocks", () => {
+  it("renders a red card with the case name and project", () => {
+    const { body } = formatCaseDeletedBlocks(
+      envelope({ id: 50, name: "Login case", projectId: 1 })
+    );
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Case deleted: Login case");
+    expect(payload.attachments[0].color).toBe("#ef4444");
+    const rendered = JSON.stringify(payload);
+    expect(rendered).toContain("Case deleted");
+    expect(rendered).toContain("*Login case*");
+    expect(rendered).toContain("in Demo Project");
+  });
+
+  it("falls back to the id when no name is present", () => {
+    const { body } = formatCaseDeletedBlocks(
+      envelope({ id: 50, projectId: 1 })
+    );
+    expect(JSON.parse(body).text).toBe("Case deleted: Case #50");
+  });
+});

--- a/testplanit/lib/webhooks/adapters/slack/formatters/case-deleted.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/case-deleted.ts
@@ -1,0 +1,39 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, COLOR_RED, projectNameOf } from "./_shared";
+
+/**
+ * `case.deleted` payload (see lib/webhooks/event-emitters/caseEvents.ts):
+ *   { id, name, projectId }
+ * The case row is gone, so the title is plain bold text (no deep link — it
+ * would 404). Red bar signals the destructive action.
+ */
+interface CaseDeletedData {
+  id: number;
+  name?: string;
+  projectId: number;
+}
+
+export function formatCaseDeletedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as CaseDeletedData;
+  const title = data.name ?? `Case #${data.id}`;
+
+  return buildBody({
+    text: `Case deleted: ${title}`,
+    color: COLOR_RED,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Case deleted", emoji: false },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*${title}*\nin ${projectNameOf(envelope)}`,
+        },
+      },
+    ],
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/case-updated.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/case-updated.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { OutboundEnvelope } from "../../types";
+import { formatCaseUpdatedBlocks } from "./case-updated";
+
+function envelope(data: Record<string, unknown>): OutboundEnvelope {
+  return {
+    eventId: "evt_test",
+    eventName: "case.updated",
+    eventTimestamp: "2026-06-09T12:00:00.000Z",
+    tenantId: null,
+    projectId: 1,
+    projectName: "Demo Project",
+    actorUserId: null,
+    data,
+  };
+}
+
+describe("formatCaseUpdatedBlocks", () => {
+  it("renders resolved change rows with before → after values", () => {
+    const { body } = formatCaseUpdatedBlocks(
+      envelope({
+        id: 50,
+        projectId: 1,
+        name: "Login case",
+        changes: [
+          { label: "State", from: "Active", to: "Draft", color: "#FFAA00" },
+          { label: "Type", from: "Functional", to: "Security" },
+        ],
+      })
+    );
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Case updated: Login case");
+    // Color bar comes from the change carrying a color (the state).
+    expect(payload.attachments[0].color).toBe("#FFAA00");
+    const rendered = JSON.stringify(payload);
+    expect(rendered).toContain("*State:* `Active` → `Draft`");
+    expect(rendered).toContain("*Type:* `Functional` → `Security`");
+  });
+
+  it("omits the color bar when no change carries a color", () => {
+    const { body } = formatCaseUpdatedBlocks(
+      envelope({
+        id: 50,
+        projectId: 1,
+        name: "Login case",
+        changes: [{ label: "Name", from: "old", to: "new" }],
+      })
+    );
+    const payload = JSON.parse(body);
+    expect(payload.attachments).toBeUndefined();
+    expect(payload.blocks).toBeDefined();
+  });
+
+  it("caps at 8 rows with an overflow note", () => {
+    const changes = Array.from({ length: 10 }, (_, i) => ({
+      label: `F${i}`,
+      from: "a",
+      to: "b",
+    }));
+    const { body } = formatCaseUpdatedBlocks(
+      envelope({ id: 1, projectId: 1, name: "C", changes })
+    );
+    expect(body).toContain("and 2 more changes");
+  });
+});

--- a/testplanit/lib/webhooks/adapters/slack/formatters/case-updated.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/case-updated.ts
@@ -1,0 +1,75 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `case.updated` payload (see lib/webhooks/event-emitters/caseEvents.ts):
+ *   { id, projectId, name, changes: ResolvedChange[], diff }
+ * The emitter resolves every foreign-key id and option-backed custom field to
+ * a display name, so this formatter just renders the `changes` rows. The raw
+ * `diff` is still on the payload for generic-HMAC consumers.
+ */
+interface ResolvedChange {
+  label: string;
+  from: string | null;
+  to: string | null;
+  color?: string | null;
+}
+
+interface CaseUpdatedData {
+  id: number;
+  projectId: number;
+  name: string;
+  changes?: ResolvedChange[];
+}
+
+const SLACK_MAX_ROWS = 8;
+
+function row(c: ResolvedChange): string {
+  return `*${c.label}:* \`${c.from ?? "—"}\` → \`${c.to ?? "—"}\``;
+}
+
+export function formatCaseUpdatedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as CaseUpdatedData;
+  const changes = data.changes ?? [];
+  const title = data.name ?? "(unnamed case)";
+  // Color bar = the workflow state's color when a state change is present.
+  const color = changes.find((c) => c.color)?.color ?? undefined;
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Case updated", emoji: false },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: titleAndProject(
+          title,
+          projectNameOf(envelope),
+          url.case(data.projectId, data.id)
+        ),
+      },
+    },
+  ];
+
+  if (changes.length > 0) {
+    const rows = changes.slice(0, SLACK_MAX_ROWS).map(row);
+    if (changes.length > SLACK_MAX_ROWS) {
+      rows.push(`_…and ${changes.length - SLACK_MAX_ROWS} more changes_`);
+    }
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: rows.join("\n") },
+    });
+  }
+
+  return buildBody({
+    text: `Case updated: ${title}`,
+    color: color ?? undefined,
+    blocks,
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
@@ -8,6 +8,7 @@ import { formatIssueCreatedBlocks } from "./issue-created";
 import { formatIssueUpdatedBlocks } from "./issue-updated";
 import { formatCaseCreatedBlocks } from "./case-created";
 import { formatCaseUpdatedBlocks } from "./case-updated";
+import { formatCaseDeletedBlocks } from "./case-deleted";
 import { formatReviewRequestedBlocks } from "./review-requested";
 import { formatReviewCompletedBlocks } from "./review-completed";
 import { formatReviewReminderBlocks } from "./review-reminder";
@@ -33,6 +34,7 @@ export const SLACK_FORMATTERS: Record<string, SlackFormatter> = {
   "issue.updated": formatIssueUpdatedBlocks,
   "case.created": formatCaseCreatedBlocks,
   "case.updated": formatCaseUpdatedBlocks,
+  "case.deleted": formatCaseDeletedBlocks,
   "case.review_requested": formatReviewRequestedBlocks,
   "case.review_completed": formatReviewCompletedBlocks,
   "test_run.review_requested": formatReviewRequestedBlocks,

--- a/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
@@ -1,11 +1,18 @@
 import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
 import { formatTestRunCompletedBlocks } from "./test-run-completed";
+import { formatTestRunCreatedBlocks } from "./test-run-created";
 import { formatTestRunStateChangedBlocks } from "./test-run-state-changed";
 import { formatTestRunResultAddedBlocks } from "./test-run-result-added";
 import { formatTestRunDuplicatedBlocks } from "./test-run-duplicated";
 import { formatSessionCompletedBlocks } from "./session-completed";
+import { formatSessionCreatedBlocks } from "./session-created";
+import { formatSessionDuplicatedBlocks } from "./session-duplicated";
+import { formatSessionStateChangedBlocks } from "./session-state-changed";
+import { formatSessionResultAddedBlocks } from "./session-result-added";
+import { formatIterationResultRecordedBlocks } from "./iteration-result-recorded";
 import { formatIssueCreatedBlocks } from "./issue-created";
 import { formatIssueUpdatedBlocks } from "./issue-updated";
+import { formatIssueDeletedBlocks } from "./issue-deleted";
 import { formatCaseCreatedBlocks } from "./case-created";
 import { formatCaseUpdatedBlocks } from "./case-updated";
 import { formatCaseDeletedBlocks } from "./case-deleted";
@@ -26,12 +33,19 @@ export type SlackFormatter = (
  */
 export const SLACK_FORMATTERS: Record<string, SlackFormatter> = {
   "test_run.completed": formatTestRunCompletedBlocks,
+  "test_run.created": formatTestRunCreatedBlocks,
   "test_run.state_changed": formatTestRunStateChangedBlocks,
   "test_run.result_added": formatTestRunResultAddedBlocks,
   "test_run.duplicated": formatTestRunDuplicatedBlocks,
   "session.completed": formatSessionCompletedBlocks,
+  "session.created": formatSessionCreatedBlocks,
+  "session.duplicated": formatSessionDuplicatedBlocks,
+  "session.state_changed": formatSessionStateChangedBlocks,
+  "session.result_added": formatSessionResultAddedBlocks,
+  "iteration.result.recorded": formatIterationResultRecordedBlocks,
   "issue.created": formatIssueCreatedBlocks,
   "issue.updated": formatIssueUpdatedBlocks,
+  "issue.deleted": formatIssueDeletedBlocks,
   "case.created": formatCaseCreatedBlocks,
   "case.updated": formatCaseUpdatedBlocks,
   "case.deleted": formatCaseDeletedBlocks,

--- a/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/index.ts
@@ -7,6 +7,7 @@ import { formatSessionCompletedBlocks } from "./session-completed";
 import { formatIssueCreatedBlocks } from "./issue-created";
 import { formatIssueUpdatedBlocks } from "./issue-updated";
 import { formatCaseCreatedBlocks } from "./case-created";
+import { formatCaseUpdatedBlocks } from "./case-updated";
 import { formatReviewRequestedBlocks } from "./review-requested";
 import { formatReviewCompletedBlocks } from "./review-completed";
 import { formatReviewReminderBlocks } from "./review-reminder";
@@ -31,6 +32,7 @@ export const SLACK_FORMATTERS: Record<string, SlackFormatter> = {
   "issue.created": formatIssueCreatedBlocks,
   "issue.updated": formatIssueUpdatedBlocks,
   "case.created": formatCaseCreatedBlocks,
+  "case.updated": formatCaseUpdatedBlocks,
   "case.review_requested": formatReviewRequestedBlocks,
   "case.review_completed": formatReviewCompletedBlocks,
   "test_run.review_requested": formatReviewRequestedBlocks,

--- a/testplanit/lib/webhooks/adapters/slack/formatters/issue-created.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/issue-created.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { OutboundEnvelope } from "../../types";
+import { formatIssueCreatedBlocks } from "./issue-created";
+
+function env(data: Record<string, unknown>): OutboundEnvelope {
+  return {
+    eventId: "evt_test",
+    eventName: "issue.created",
+    eventTimestamp: "2026-06-10T12:00:00.000Z",
+    tenantId: null,
+    projectId: 293,
+    projectName: "Demo Project",
+    actorUserId: null,
+    data,
+  };
+}
+
+describe("formatIssueCreatedBlocks", () => {
+  it("links the title to the TestPlanIt issue and the tracker as a secondary link", () => {
+    const { body } = formatIssueCreatedBlocks(
+      env({
+        id: 81,
+        title: "Checkout bug",
+        status: "Open",
+        externalKey: "TPIWEB-37",
+        externalUrl: "https://x.atlassian.net/browse/TPIWEB-37",
+      })
+    );
+    // Title links INTERNALLY (consistent with issue.updated).
+    expect(body).toContain("/projects/issues/293?issueId=81");
+    // External tracker is a secondary "Tracked in" link, not the title.
+    expect(body).toContain(
+      "Tracked in <https://x.atlassian.net/browse/TPIWEB-37|TPIWEB-37>"
+    );
+    expect(body).toContain("*Status:* Open");
+  });
+
+  it("omits the tracker line for a local issue with no external key", () => {
+    const { body } = formatIssueCreatedBlocks(
+      env({ id: 81, title: "Local only", status: "Open" })
+    );
+    expect(body).toContain("/projects/issues/293?issueId=81");
+    expect(body).not.toContain("Tracked in");
+  });
+});

--- a/testplanit/lib/webhooks/adapters/slack/formatters/issue-created.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/issue-created.ts
@@ -1,5 +1,5 @@
 import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
-import { buildBody, projectNameOf } from "./_shared";
+import { buildBody, projectNameOf, trackerLine, url } from "./_shared";
 
 interface IssueCreatedData {
   id: number;
@@ -27,16 +27,15 @@ export function formatIssueCreatedBlocks(
   envelope: OutboundEnvelope
 ): FormattedHttpRequest {
   const data = envelope.data as unknown as IssueCreatedData;
-  const titleLink = data.externalUrl
-    ? `*<${data.externalUrl}|${data.title}>*`
-    : `*${data.title}*`;
+  // Title links into the issue in TestPlanIt (consistent with issue.updated).
+  const titleLink = `*<${url.issue(envelope.projectId, data.id)}|${data.title}>*`;
+  const tracker = trackerLine(data.externalKey, data.externalUrl);
 
-  // Inline meta-line: severity · status · externalKey, with separators
-  // only between present values.
+  // Inline meta-line: severity · status, with separators only between
+  // present values. The external tracker key moves to its own line.
   const metaParts: string[] = [];
   if (data.severity) metaParts.push(`*Severity:* ${data.severity}`);
   if (data.status) metaParts.push(`*Status:* ${data.status}`);
-  if (data.externalKey) metaParts.push(`*${data.externalKey}*`);
   const metaLine = metaParts.length > 0 ? metaParts.join(" · ") : null;
 
   const blocks: Array<Record<string, unknown>> = [
@@ -52,6 +51,10 @@ export function formatIssueCreatedBlocks(
       },
     },
   ];
+
+  if (tracker) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: tracker } });
+  }
 
   if (metaLine) {
     blocks.push({

--- a/testplanit/lib/webhooks/adapters/slack/formatters/issue-deleted.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/issue-deleted.ts
@@ -1,0 +1,40 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, COLOR_RED, projectNameOf } from "./_shared";
+
+/**
+ * `issue.deleted` payload (see event-emitters/issueEvents.ts):
+ *   { id, name, title, projectId }
+ * The issue row is gone, so the title is plain bold text (no deep link).
+ * Red bar signals the destructive action. Mirrors case.deleted.
+ */
+interface IssueDeletedData {
+  id: number;
+  title?: string;
+  name?: string;
+  projectId: number;
+}
+
+export function formatIssueDeletedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as IssueDeletedData;
+  const title = data.title ?? data.name ?? `Issue #${data.id}`;
+
+  return buildBody({
+    text: `Issue deleted: ${title}`,
+    color: COLOR_RED,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Issue deleted", emoji: false },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*${title}*\nin ${projectNameOf(envelope)}`,
+        },
+      },
+    ],
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/issue-updated.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/issue-updated.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { OutboundEnvelope } from "../../types";
+import { formatIssueUpdatedBlocks } from "./issue-updated";
+
+function env(data: Record<string, unknown>): OutboundEnvelope {
+  return {
+    eventId: "evt_test",
+    eventName: "issue.updated",
+    eventTimestamp: "2026-06-10T12:00:00.000Z",
+    tenantId: null,
+    projectId: 293,
+    projectName: "Demo Project",
+    actorUserId: null,
+    data,
+  };
+}
+
+describe("formatIssueUpdatedBlocks", () => {
+  it("links the title back to the issue in TestPlanIt", () => {
+    const { body } = formatIssueUpdatedBlocks(
+      env({
+        id: 654,
+        title: "Checkout bug",
+        diff: {
+          changedFields: ["status"],
+          before: { status: "Open" },
+          after: { status: "In Progress" },
+        },
+      })
+    );
+    expect(body).toContain("/projects/issues/293?issueId=654");
+    expect(body).toContain("Checkout bug");
+    expect(body).toContain("*status:* `Open` → `In Progress`");
+  });
+
+  it("adds a Tracked in link to the external tracker when present", () => {
+    const { body } = formatIssueUpdatedBlocks(
+      env({
+        id: 654,
+        title: "Checkout bug",
+        externalKey: "TPIWEB-37",
+        externalUrl: "https://x.atlassian.net/browse/TPIWEB-37",
+        diff: { changedFields: [], before: {}, after: {} },
+      })
+    );
+    // Title still links internally; tracker is a secondary link.
+    expect(body).toContain("/projects/issues/293?issueId=654");
+    expect(body).toContain(
+      "Tracked in <https://x.atlassian.net/browse/TPIWEB-37|TPIWEB-37>"
+    );
+  });
+});

--- a/testplanit/lib/webhooks/adapters/slack/formatters/issue-updated.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/issue-updated.ts
@@ -1,9 +1,10 @@
 import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
-import { buildBody, projectNameOf } from "./_shared";
+import { buildBody, projectNameOf, trackerLine, url } from "./_shared";
 
 interface IssueUpdatedData {
   id: number;
   title: string;
+  externalKey?: string | null;
   externalUrl?: string | null;
   diff?: {
     changedFields: string[];
@@ -37,9 +38,8 @@ export function formatIssueUpdatedBlocks(
   const changed = data.diff?.changedFields ?? [];
   const before = data.diff?.before ?? {};
   const after = data.diff?.after ?? {};
-  const titleLink = data.externalUrl
-    ? `*<${data.externalUrl}|${data.title}>*`
-    : `*${data.title}*`;
+  // Link back to the issue in TestPlanIt (the issues page deep-links by id).
+  const titleLink = `*<${url.issue(envelope.projectId, data.id)}|${data.title}>*`;
 
   const blocks: Array<Record<string, unknown>> = [
     {
@@ -54,6 +54,11 @@ export function formatIssueUpdatedBlocks(
       },
     },
   ];
+
+  const tracker = trackerLine(data.externalKey, data.externalUrl);
+  if (tracker) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: tracker } });
+  }
 
   if (changed.length > 0) {
     const rows = changed.slice(0, SLACK_MAX_DIFF_ROWS).map((field) => {

--- a/testplanit/lib/webhooks/adapters/slack/formatters/iteration-result-recorded.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/iteration-result-recorded.ts
@@ -1,0 +1,80 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `iteration.result.recorded` payload (see event-emitters/iterationEvents.ts):
+ *   { iterationId, testRunCaseId, testRunId, statusId, statusName, runTitle,
+ *     projectId, rowIndex, redactedValues }
+ * `redactedValues` is the parameter map with sensitive values already
+ * replaced by the caller (D-13). statusName / runTitle are resolved at emit.
+ */
+interface IterationResultRecordedData {
+  testRunId: number;
+  projectId: number;
+  statusName?: string | null;
+  runTitle?: string | null;
+  rowIndex?: number;
+  redactedValues?: Record<string, unknown>;
+}
+
+const MAX_PARAMS = 6;
+const VALUE_MAX_LEN = 40;
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}
+
+export function formatIterationResultRecordedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as IterationResultRecordedData;
+  const statusName = data.statusName ?? "—";
+  const runLabel = data.runTitle ?? `Run #${data.testRunId}`;
+  const rowLabel =
+    typeof data.rowIndex === "number" ? `Row ${data.rowIndex + 1}` : null;
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Iteration result recorded",
+        emoji: false,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: titleAndProject(
+          runLabel,
+          projectNameOf(envelope),
+          url.testRun(data.projectId, data.testRunId)
+        ),
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: rowLabel
+          ? `*Status:* ${statusName} · ${rowLabel}`
+          : `*Status:* ${statusName}`,
+      },
+    },
+  ];
+
+  const entries = Object.entries(data.redactedValues ?? {});
+  if (entries.length > 0) {
+    const params = entries
+      .slice(0, MAX_PARAMS)
+      .map(([k, v]) => `${k}=${truncate(String(v), VALUE_MAX_LEN)}`)
+      .join(" · ");
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: params },
+    });
+  }
+
+  return buildBody({ text: `Iteration result: ${statusName}`, blocks });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/lifecycle-formatters.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/lifecycle-formatters.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import type { OutboundEnvelope } from "../../types";
+import { formatTestRunCreatedBlocks } from "./test-run-created";
+import { formatSessionCreatedBlocks } from "./session-created";
+import { formatSessionDuplicatedBlocks } from "./session-duplicated";
+import { formatSessionStateChangedBlocks } from "./session-state-changed";
+import { formatSessionResultAddedBlocks } from "./session-result-added";
+import { formatIterationResultRecordedBlocks } from "./iteration-result-recorded";
+import { formatIssueDeletedBlocks } from "./issue-deleted";
+
+/**
+ * Lifecycle / informational formatters that previously fell through to the
+ * raw-JSON generic fallback. Each consumes the resolved-name payload its
+ * emitter produces.
+ */
+
+function env(data: Record<string, unknown>): OutboundEnvelope {
+  return {
+    eventId: "evt_test",
+    eventName: "x",
+    eventTimestamp: "2026-06-10T12:00:00.000Z",
+    tenantId: null,
+    projectId: 1,
+    projectName: "Demo Project",
+    actorUserId: null,
+    data,
+  };
+}
+
+describe("test_run.created", () => {
+  it("links the run and shows the resolved state", () => {
+    const { body } = formatTestRunCreatedBlocks(
+      env({
+        runId: 9,
+        runTitle: "Smoke",
+        projectId: 1,
+        stateName: "In Progress",
+      })
+    );
+    expect(JSON.parse(body).text).toBe("Test run created: Smoke");
+    expect(body).toContain("/projects/runs/1/9");
+    expect(body).toContain("*State:* In Progress");
+  });
+});
+
+describe("session.created", () => {
+  it("links the session and shows the resolved state", () => {
+    const { body } = formatSessionCreatedBlocks(
+      env({
+        sessionId: 7,
+        sessionName: "Explore",
+        projectId: 1,
+        stateName: "New",
+      })
+    );
+    expect(JSON.parse(body).text).toBe("Session created: Explore");
+    expect(body).toContain("/projects/sessions/1/7");
+    expect(body).toContain("*State:* New");
+  });
+});
+
+describe("session.duplicated", () => {
+  it("links the new session and references the source", () => {
+    const { body } = formatSessionDuplicatedBlocks(
+      env({
+        newSessionId: 8,
+        sourceSessionId: 7,
+        sessionName: "Explore (copy)",
+        projectId: 1,
+      })
+    );
+    expect(JSON.parse(body).text).toBe("Session duplicated: Explore (copy)");
+    expect(body).toContain("/projects/sessions/1/8");
+    expect(body).toContain("Duplicated from <");
+  });
+});
+
+describe("session.state_changed", () => {
+  it("renders from → to using resolved state names", () => {
+    const { body } = formatSessionStateChangedBlocks(
+      env({
+        sessionId: 7,
+        sessionName: "Explore",
+        projectId: 1,
+        from: { stateName: "In Progress" },
+        to: { stateName: "Done" },
+      })
+    );
+    expect(body).toContain("*In Progress*  →  *Done*");
+  });
+});
+
+describe("session.result_added", () => {
+  it("shows the resolved status and links via the envelope projectId", () => {
+    const { body } = formatSessionResultAddedBlocks(
+      env({ sessionId: 7, sessionName: "Explore", statusName: "Failed" })
+    );
+    expect(JSON.parse(body).text).toBe("Session result added: Failed");
+    expect(body).toContain("/projects/sessions/1/7");
+    expect(body).toContain("*Status:* Failed");
+  });
+});
+
+describe("iteration.result.recorded", () => {
+  it("shows status, 1-based row, and parameter values", () => {
+    const { body } = formatIterationResultRecordedBlocks(
+      env({
+        testRunId: 5,
+        projectId: 1,
+        statusName: "Passed",
+        runTitle: "Regression",
+        rowIndex: 2,
+        redactedValues: { currency: "EUR", region: "[REDACTED]" },
+      })
+    );
+    expect(body).toContain("/projects/runs/1/5");
+    expect(body).toContain("*Status:* Passed · Row 3");
+    expect(body).toContain("currency=EUR");
+    expect(body).toContain("region=[REDACTED]");
+  });
+});
+
+describe("issue.deleted", () => {
+  it("renders a red card with the title", () => {
+    const { body } = formatIssueDeletedBlocks(
+      env({ id: 4, title: "Checkout bug", projectId: 1 })
+    );
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Issue deleted: Checkout bug");
+    expect(payload.attachments[0].color).toBe("#ef4444");
+  });
+
+  it("falls back to name then id when no title", () => {
+    expect(
+      JSON.parse(formatIssueDeletedBlocks(env({ id: 4, projectId: 1 })).body)
+        .text
+    ).toBe("Issue deleted: Issue #4");
+  });
+});

--- a/testplanit/lib/webhooks/adapters/slack/formatters/lifecycle-formatters.test.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/lifecycle-formatters.test.ts
@@ -29,32 +29,38 @@ function env(data: Record<string, unknown>): OutboundEnvelope {
 }
 
 describe("test_run.created", () => {
-  it("links the run and shows the resolved state", () => {
+  it("links the run, shows the resolved state, and uses the state color bar", () => {
     const { body } = formatTestRunCreatedBlocks(
       env({
         runId: 9,
         runTitle: "Smoke",
         projectId: 1,
         stateName: "In Progress",
+        stateColor: "#3b82f6",
       })
     );
-    expect(JSON.parse(body).text).toBe("Test run created: Smoke");
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Test run created: Smoke");
+    expect(payload.attachments[0].color).toBe("#3b82f6");
     expect(body).toContain("/projects/runs/1/9");
     expect(body).toContain("*State:* In Progress");
   });
 });
 
 describe("session.created", () => {
-  it("links the session and shows the resolved state", () => {
+  it("links the session, shows the resolved state, and uses the state color bar", () => {
     const { body } = formatSessionCreatedBlocks(
       env({
         sessionId: 7,
         sessionName: "Explore",
         projectId: 1,
         stateName: "New",
+        stateColor: "#FFAA00",
       })
     );
-    expect(JSON.parse(body).text).toBe("Session created: Explore");
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Session created: Explore");
+    expect(payload.attachments[0].color).toBe("#FFAA00");
     expect(body).toContain("/projects/sessions/1/7");
     expect(body).toContain("*State:* New");
   });
@@ -77,28 +83,50 @@ describe("session.duplicated", () => {
 });
 
 describe("session.state_changed", () => {
-  it("renders from → to using resolved state names", () => {
+  it("renders from → to and uses the destination state color bar", () => {
     const { body } = formatSessionStateChangedBlocks(
       env({
         sessionId: 7,
         sessionName: "Explore",
         projectId: 1,
         from: { stateName: "In Progress" },
-        to: { stateName: "Done" },
+        to: { stateName: "Done", stateColor: "#22c55e" },
       })
     );
+    const payload = JSON.parse(body);
+    expect(payload.attachments[0].color).toBe("#22c55e");
     expect(body).toContain("*In Progress*  →  *Done*");
   });
 });
 
 describe("session.result_added", () => {
-  it("shows the resolved status and links via the envelope projectId", () => {
+  it("uses the status color bar, a status emoji, and links via envelope projectId", () => {
     const { body } = formatSessionResultAddedBlocks(
-      env({ sessionId: 7, sessionName: "Explore", statusName: "Failed" })
+      env({
+        sessionId: 7,
+        sessionName: "Explore",
+        statusName: "Failed",
+        statusColor: "#ef4444",
+        isFailure: true,
+      })
     );
-    expect(JSON.parse(body).text).toBe("Session result added: Failed");
+    const payload = JSON.parse(body);
+    expect(payload.text).toBe("Session result added: Failed");
+    expect(payload.attachments[0].color).toBe("#ef4444");
     expect(body).toContain("/projects/sessions/1/7");
-    expect(body).toContain("*Status:* Failed");
+    expect(body).toContain(":x: *Failed*");
+  });
+
+  it("falls back to green/red/yellow from flags when no status color", () => {
+    const { body } = formatSessionResultAddedBlocks(
+      env({
+        sessionId: 7,
+        sessionName: "Explore",
+        statusName: "Passed",
+        isSuccess: true,
+      })
+    );
+    expect(JSON.parse(body).attachments[0].color).toBe("#22c55e");
   });
 });
 

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-created.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-created.ts
@@ -1,0 +1,44 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `session.created` payload (see event-emitters/sessionEvents.ts):
+ *   { sessionId, sessionName, stateId, stateName, isCompleted, projectId }
+ * Informational event — no color bar. The emitter already resolves stateName.
+ */
+interface SessionCreatedData {
+  sessionId: number;
+  sessionName: string;
+  projectId: number;
+  stateName?: string | null;
+}
+
+export function formatSessionCreatedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as SessionCreatedData;
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Session created", emoji: false },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: titleAndProject(
+          data.sessionName,
+          projectNameOf(envelope),
+          url.session(data.projectId, data.sessionId)
+        ),
+      },
+    },
+  ];
+  if (data.stateName) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*State:* ${data.stateName}` },
+    });
+  }
+  return buildBody({ text: `Session created: ${data.sessionName}`, blocks });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-created.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-created.ts
@@ -11,6 +11,7 @@ interface SessionCreatedData {
   sessionName: string;
   projectId: number;
   stateName?: string | null;
+  stateColor?: string | null;
 }
 
 export function formatSessionCreatedBlocks(
@@ -40,5 +41,10 @@ export function formatSessionCreatedBlocks(
       text: { type: "mrkdwn", text: `*State:* ${data.stateName}` },
     });
   }
-  return buildBody({ text: `Session created: ${data.sessionName}`, blocks });
+  return buildBody({
+    text: `Session created: ${data.sessionName}`,
+    // Color bar = the session's workflow state color, mirroring case.created.
+    color: data.stateColor ?? undefined,
+    blocks,
+  });
 }

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-duplicated.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-duplicated.ts
@@ -1,0 +1,50 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `session.duplicated` payload (see event-emitters/sessionEvents.ts):
+ *   { newSessionId, sourceSessionId, sessionName, projectId }
+ * Informational event — no color bar.
+ */
+interface SessionDuplicatedData {
+  newSessionId: number;
+  sourceSessionId: number;
+  sessionName?: string | null;
+  projectId: number;
+}
+
+export function formatSessionDuplicatedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as SessionDuplicatedData;
+  const title = data.sessionName ?? `Session #${data.newSessionId}`;
+  const sourceUrl = url.session(data.projectId, data.sourceSessionId);
+
+  return buildBody({
+    text: `Session duplicated: ${title}`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Session duplicated", emoji: false },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: titleAndProject(
+            title,
+            projectNameOf(envelope),
+            url.session(data.projectId, data.newSessionId)
+          ),
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Duplicated from <${sourceUrl}|#${data.sourceSessionId}>`,
+        },
+      },
+    ],
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-result-added.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-result-added.ts
@@ -1,0 +1,50 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `session.result_added` payload (see event-emitters/sessionEvents.ts):
+ *   { sessionId, sessionName, resultId, statusId, statusName, isCompleted, ... }
+ * The payload carries no projectId, so the deep link uses envelope.projectId.
+ * The emitter already resolves statusName.
+ */
+interface SessionResultAddedData {
+  sessionId: number;
+  sessionName: string;
+  statusName?: string | null;
+}
+
+export function formatSessionResultAddedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as SessionResultAddedData;
+  const statusName = data.statusName ?? "—";
+
+  return buildBody({
+    text: `Session result added: ${statusName}`,
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "Session result added",
+          emoji: false,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: titleAndProject(
+            data.sessionName,
+            projectNameOf(envelope),
+            url.session(envelope.projectId, data.sessionId)
+          ),
+        },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Status:* ${statusName}` },
+      },
+    ],
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-result-added.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-result-added.ts
@@ -1,16 +1,31 @@
 import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
-import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+import {
+  buildBody,
+  COLOR_GREEN,
+  COLOR_RED,
+  COLOR_YELLOW,
+  emojiForStatus,
+  projectNameOf,
+  titleAndProject,
+  url,
+} from "./_shared";
 
 /**
  * `session.result_added` payload (see event-emitters/sessionEvents.ts):
- *   { sessionId, sessionName, resultId, statusId, statusName, isCompleted, ... }
+ *   { sessionId, sessionName, resultId, statusId, statusName, statusColor,
+ *     isCompleted, isSuccess, isFailure, ... }
  * The payload carries no projectId, so the deep link uses envelope.projectId.
- * The emitter already resolves statusName.
+ * Color bar = the result Status's own color, falling back to the canonical
+ * green/red/yellow rule from the status flags. Mirrors test_run.result_added.
  */
 interface SessionResultAddedData {
   sessionId: number;
   sessionName: string;
   statusName?: string | null;
+  statusColor?: string | null;
+  isCompleted?: boolean;
+  isSuccess?: boolean;
+  isFailure?: boolean;
 }
 
 export function formatSessionResultAddedBlocks(
@@ -18,9 +33,13 @@ export function formatSessionResultAddedBlocks(
 ): FormattedHttpRequest {
   const data = envelope.data as unknown as SessionResultAddedData;
   const statusName = data.statusName ?? "—";
+  const color =
+    data.statusColor ??
+    (data.isSuccess ? COLOR_GREEN : data.isFailure ? COLOR_RED : COLOR_YELLOW);
 
   return buildBody({
     text: `Session result added: ${statusName}`,
+    color,
     blocks: [
       {
         type: "header",
@@ -43,7 +62,10 @@ export function formatSessionResultAddedBlocks(
       },
       {
         type: "section",
-        text: { type: "mrkdwn", text: `*Status:* ${statusName}` },
+        text: {
+          type: "mrkdwn",
+          text: `${emojiForStatus(data)} *${statusName}*`,
+        },
       },
     ],
   });

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-state-changed.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-state-changed.ts
@@ -12,7 +12,7 @@ interface SessionStateChangedData {
   sessionName: string;
   projectId: number;
   from?: { stateName?: string | null };
-  to?: { stateName?: string | null };
+  to?: { stateName?: string | null; stateColor?: string | null };
 }
 
 export function formatSessionStateChangedBlocks(
@@ -24,6 +24,8 @@ export function formatSessionStateChangedBlocks(
 
   return buildBody({
     text: `Session state changed: ${data.sessionName}`,
+    // Color bar = the workflow color of the state being transitioned TO.
+    color: data.to?.stateColor ?? undefined,
     blocks: [
       {
         type: "header",

--- a/testplanit/lib/webhooks/adapters/slack/formatters/session-state-changed.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/session-state-changed.ts
@@ -1,0 +1,53 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `session.state_changed` payload (see event-emitters/sessionEvents.ts):
+ *   { sessionId, sessionName, projectId, from:{stateName}, to:{stateName}, ... }
+ * Compact transition log — no color bar (the emitter resolves stateName but
+ * not a color). Mirrors test_run.state_changed.
+ */
+interface SessionStateChangedData {
+  sessionId: number;
+  sessionName: string;
+  projectId: number;
+  from?: { stateName?: string | null };
+  to?: { stateName?: string | null };
+}
+
+export function formatSessionStateChangedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as SessionStateChangedData;
+  const fromName = data.from?.stateName ?? "—";
+  const toName = data.to?.stateName ?? "—";
+
+  return buildBody({
+    text: `Session state changed: ${data.sessionName}`,
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "Session state changed",
+          emoji: false,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: titleAndProject(
+            data.sessionName,
+            projectNameOf(envelope),
+            url.session(data.projectId, data.sessionId)
+          ),
+        },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*${fromName}*  →  *${toName}*` },
+      },
+    ],
+  });
+}

--- a/testplanit/lib/webhooks/adapters/slack/formatters/test-run-created.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/test-run-created.ts
@@ -11,6 +11,7 @@ interface TestRunCreatedData {
   runTitle: string;
   projectId: number;
   stateName?: string | null;
+  stateColor?: string | null;
 }
 
 export function formatTestRunCreatedBlocks(
@@ -40,5 +41,10 @@ export function formatTestRunCreatedBlocks(
       text: { type: "mrkdwn", text: `*State:* ${data.stateName}` },
     });
   }
-  return buildBody({ text: `Test run created: ${data.runTitle}`, blocks });
+  return buildBody({
+    text: `Test run created: ${data.runTitle}`,
+    // Color bar = the run's workflow state color, mirroring case/session.created.
+    color: data.stateColor ?? undefined,
+    blocks,
+  });
 }

--- a/testplanit/lib/webhooks/adapters/slack/formatters/test-run-created.ts
+++ b/testplanit/lib/webhooks/adapters/slack/formatters/test-run-created.ts
@@ -1,0 +1,44 @@
+import type { FormattedHttpRequest, OutboundEnvelope } from "../../types";
+import { buildBody, projectNameOf, titleAndProject, url } from "./_shared";
+
+/**
+ * `test_run.created` payload (see event-emitters/testRunEvents.ts):
+ *   { runId, runTitle, stateId, stateName, isCompleted, projectId }
+ * Informational event — no color bar. The emitter already resolves stateName.
+ */
+interface TestRunCreatedData {
+  runId: number;
+  runTitle: string;
+  projectId: number;
+  stateName?: string | null;
+}
+
+export function formatTestRunCreatedBlocks(
+  envelope: OutboundEnvelope
+): FormattedHttpRequest {
+  const data = envelope.data as unknown as TestRunCreatedData;
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Test run created", emoji: false },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: titleAndProject(
+          data.runTitle,
+          projectNameOf(envelope),
+          url.testRun(data.projectId, data.runId)
+        ),
+      },
+    },
+  ];
+  if (data.stateName) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*State:* ${data.stateName}` },
+    });
+  }
+  return buildBody({ text: `Test run created: ${data.runTitle}`, blocks });
+}

--- a/testplanit/lib/webhooks/event-emitters/caseChangeResolve.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/caseChangeResolve.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatFieldValue,
+  resolveCaseScalarChanges,
+  type OptionFieldMeta,
+} from "./caseChangeResolve";
+
+/**
+ * Resolver contract: foreign-key ids -> display names, option ids -> labels,
+ * bookkeeping columns hidden, scalar values formatted (bool, duration).
+ */
+
+// Fake transaction client — only the readers the resolvers touch.
+const tx = {
+  workflows: {
+    findUnique: async ({ where: { id } }: any) => ({
+      name: id === 14 ? "Active" : "Draft",
+      color: { value: "#FFAA00" },
+    }),
+  },
+  repositoryFolders: {
+    findUnique: async () => ({ name: "Regression" }),
+  },
+  templates: {
+    findUnique: async () => ({ templateName: "Default template" }),
+  },
+  user: {
+    findUnique: async () => ({ name: "Dana Lee" }),
+  },
+  projects: {
+    findUnique: async () => ({ name: "Demo Project" }),
+  },
+};
+
+describe("resolveCaseScalarChanges", () => {
+  it("resolves stateId to the workflow name + color", async () => {
+    const changes = await resolveCaseScalarChanges(tx, {
+      changedFields: ["stateId"],
+      before: { stateId: 14 },
+      after: { stateId: 11 },
+    });
+    expect(changes).toEqual([
+      { label: "State", from: "Active", to: "Draft", color: "#FFAA00" },
+    ]);
+  });
+
+  it("hides bookkeeping columns (currentVersion) but keeps real changes", async () => {
+    const changes = await resolveCaseScalarChanges(tx, {
+      changedFields: ["stateId", "currentVersion"],
+      before: { stateId: 14, currentVersion: 2 },
+      after: { stateId: 11, currentVersion: 3 },
+    });
+    expect(changes.map((c) => c.label)).toEqual(["State"]);
+  });
+
+  it("returns an empty set when only bookkeeping columns changed", async () => {
+    const changes = await resolveCaseScalarChanges(tx, {
+      changedFields: ["currentVersion", "order"],
+      before: { currentVersion: 1, order: 5 },
+      after: { currentVersion: 2, order: 6 },
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("formats durations and booleans", async () => {
+    const changes = await resolveCaseScalarChanges(tx, {
+      changedFields: ["estimate", "automated"],
+      before: { estimate: 300, automated: false },
+      after: { estimate: 600, automated: true },
+    });
+    expect(changes).toEqual([
+      { label: "Estimate", from: "5 minutes", to: "10 minutes" },
+      { label: "Automated", from: "No", to: "Yes" },
+    ]);
+  });
+
+  it("resolves folder / template / creator foreign keys to names", async () => {
+    const changes = await resolveCaseScalarChanges(tx, {
+      changedFields: ["folderId", "templateId", "creatorId"],
+      before: { folderId: 1, templateId: 1, creatorId: "u1" },
+      after: { folderId: 2, templateId: 2, creatorId: "u2" },
+    });
+    expect(changes.map((c) => `${c.label}:${c.to}`)).toEqual([
+      "Folder:Regression",
+      "Template:Default template",
+      "Created by:Dana Lee",
+    ]);
+  });
+
+  it("falls back to #id when a foreign key can't be resolved", async () => {
+    const emptyTx = { workflows: { findUnique: async () => null } };
+    const changes = await resolveCaseScalarChanges(emptyTx, {
+      changedFields: ["stateId"],
+      before: { stateId: 14 },
+      after: { stateId: 11 },
+    });
+    expect(changes[0]).toMatchObject({ from: "#14", to: "#11" });
+  });
+});
+
+describe("formatFieldValue", () => {
+  const dropdown: OptionFieldMeta = {
+    displayName: "Type",
+    type: { type: "Dropdown" },
+    fieldOptions: [
+      { fieldOption: { id: 157, name: "Functional" } },
+      { fieldOption: { id: 161, name: "Security" } },
+    ],
+  };
+  const multiSelect: OptionFieldMeta = {
+    displayName: "access_required",
+    type: { type: "Multi-Select" },
+    fieldOptions: [
+      { fieldOption: { id: 169, name: "Admin Tool" } },
+      { fieldOption: { id: 170, name: "DB" } },
+      { fieldOption: { id: 175, name: "DataDog" } },
+    ],
+  };
+
+  it("resolves a dropdown option id to its label", () => {
+    expect(formatFieldValue(157, dropdown)).toBe("Functional");
+    expect(formatFieldValue(161, dropdown)).toBe("Security");
+  });
+
+  it("resolves a multi-select array of ids to a joined label list", () => {
+    expect(formatFieldValue([170, 169, 175], multiSelect)).toBe(
+      "DB, Admin Tool, DataDog"
+    );
+  });
+
+  it("falls back to the raw id when an option was removed", () => {
+    expect(formatFieldValue(999, dropdown)).toBe("999");
+  });
+
+  it("passes non-option field values through unchanged", () => {
+    const text: OptionFieldMeta = {
+      displayName: "Notes",
+      type: { type: "Text String" },
+      fieldOptions: [],
+    };
+    expect(formatFieldValue("hello world", text)).toBe("hello world");
+  });
+
+  it("renders null / empty as an em dash", () => {
+    expect(formatFieldValue(null, dropdown)).toBe("—");
+    expect(formatFieldValue([], multiSelect)).toBe("—");
+  });
+});

--- a/testplanit/lib/webhooks/event-emitters/caseChangeResolve.ts
+++ b/testplanit/lib/webhooks/event-emitters/caseChangeResolve.ts
@@ -1,0 +1,234 @@
+import { toHumanReadable } from "~/utils/duration";
+
+/**
+ * Resolve a test case's raw diff into display-ready change rows for the
+ * `case.updated` webhook.
+ *
+ * All resolution happens at EMIT time (where DB access exists) so the Slack
+ * formatter can stay a pure renderer. Every foreign-key column is resolved to
+ * the referenced record's display name ("stateId: 14 → 11" becomes
+ * "State: Active → Draft"); option-backed custom fields resolve their stored
+ * option ids to labels; internal/bookkeeping columns are hidden.
+ */
+
+export interface ResolvedChange {
+  /** Human label, e.g. "State", "Folder", "Priority". */
+  label: string;
+  /** Display value before the change (null = unset). */
+  from: string | null;
+  /** Display value after the change (null = unset). */
+  to: string | null;
+  /** Optional hex color carried by the change (state color → Slack bar). */
+  color?: string | null;
+}
+
+/**
+ * Foreign-key columns on RepositoryCases and how to resolve each id to a
+ * display name. `repositoryId` is intentionally absent — the Repositories
+ * model has no name column (it's the per-project container). `tx` is the
+ * Prisma transaction client (typed `any`, as the webhook hooks are).
+ */
+const FK_RESOLVERS: Record<
+  string,
+  {
+    label: string;
+    resolve: (
+      tx: any,
+      id: number | string
+    ) => Promise<{ name: string | null; color?: string | null } | null>;
+  }
+> = {
+  stateId: {
+    label: "State",
+    resolve: async (tx, id) => {
+      const r = await tx.workflows.findUnique({
+        where: { id },
+        select: { name: true, color: { select: { value: true } } },
+      });
+      return r ? { name: r.name, color: r.color?.value ?? null } : null;
+    },
+  },
+  folderId: {
+    label: "Folder",
+    resolve: async (tx, id) => {
+      const r = await tx.repositoryFolders.findUnique({
+        where: { id },
+        select: { name: true },
+      });
+      return r ? { name: r.name } : null;
+    },
+  },
+  templateId: {
+    label: "Template",
+    resolve: async (tx, id) => {
+      const r = await tx.templates.findUnique({
+        where: { id },
+        select: { templateName: true },
+      });
+      return r ? { name: r.templateName } : null;
+    },
+  },
+  creatorId: {
+    label: "Created by",
+    resolve: async (tx, id) => {
+      const r = await tx.user.findUnique({
+        where: { id },
+        select: { name: true },
+      });
+      return r ? { name: r.name } : null;
+    },
+  },
+  projectId: {
+    label: "Project",
+    resolve: async (tx, id) => {
+      const r = await tx.projects.findUnique({
+        where: { id },
+        select: { name: true },
+      });
+      return r ? { name: r.name } : null;
+    },
+  },
+};
+
+/** Bookkeeping columns that carry no meaning to a webhook reader. */
+const HIDDEN_FIELDS = new Set([
+  "id",
+  "order",
+  "createdAt",
+  "updatedAt",
+  "currentVersion",
+  "hasParameters",
+  "repositoryId",
+  "forecastManual",
+  "forecastAutomated",
+]);
+
+const SCALAR_LABELS: Record<string, string> = {
+  name: "Name",
+  className: "Class",
+  source: "Source",
+  estimate: "Estimate",
+  automated: "Automated",
+  isArchived: "Archived",
+  isDeleted: "Deleted",
+};
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}
+
+/** camelCase column → "Title case" label, dropping a trailing "Id". */
+function prettyLabel(field: string): string {
+  const spaced = field
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\bId\b/g, "")
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function formatScalar(field: string, v: unknown): string {
+  if (v === undefined || v === null) return "—";
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (field === "estimate" && typeof v === "number") {
+    return v > 0 ? toHumanReadable(v, { isSeconds: true }) : "0";
+  }
+  if (typeof v === "string") return truncate(v, 80) || "—";
+  return truncate(String(v), 80);
+}
+
+/**
+ * Turn a top-level scalar diff (`{changedFields, before, after}`) into
+ * display-ready rows, resolving every foreign-key column to a name and
+ * dropping bookkeeping columns.
+ */
+export async function resolveCaseScalarChanges(
+  tx: any,
+  diff: {
+    changedFields: string[];
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+  }
+): Promise<ResolvedChange[]> {
+  const changes: ResolvedChange[] = [];
+  for (const field of diff.changedFields) {
+    if (HIDDEN_FIELDS.has(field)) continue;
+    const before = diff.before[field] ?? null;
+    const after = diff.after[field] ?? null;
+
+    const fk = FK_RESOLVERS[field];
+    if (fk) {
+      const [fromR, toR] = await Promise.all([
+        before != null
+          ? fk.resolve(tx, before as number | string).catch(() => null)
+          : null,
+        after != null
+          ? fk.resolve(tx, after as number | string).catch(() => null)
+          : null,
+      ]);
+      changes.push({
+        label: fk.label,
+        from: fromR?.name ?? (before != null ? `#${before}` : null),
+        to: toR?.name ?? (after != null ? `#${after}` : null),
+        color: toR?.color ?? null,
+      });
+      continue;
+    }
+
+    changes.push({
+      label: SCALAR_LABELS[field] ?? prettyLabel(field),
+      from: formatScalar(field, before),
+      to: formatScalar(field, after),
+    });
+  }
+  return changes;
+}
+
+/** Field metadata needed to resolve option ids to labels. */
+export interface OptionFieldMeta {
+  displayName: string;
+  type: { type: string } | null;
+  fieldOptions: Array<{ fieldOption: { id: number; name: string } }>;
+}
+
+/**
+ * For option-backed field types (Dropdown / Multi-Select / Checkbox) the
+ * stored value is a FieldOption id (or array of ids). Resolve to the
+ * option's display name(s). Other types pass through unchanged. Mirrors
+ * lib/services/reports/automationCandidatesContext.ts::resolveFieldValue so
+ * the LLM context and the webhook never disagree on how a value reads.
+ */
+function resolveOptionIds(value: unknown, field: OptionFieldMeta): unknown {
+  const typeName = field.type?.type;
+  const isOptionType =
+    typeName === "Dropdown" ||
+    typeName === "Multi-Select" ||
+    typeName === "Checkbox";
+  if (!isOptionType || field.fieldOptions.length === 0) return value;
+
+  const optionNameById = new Map<number, string>();
+  for (const a of field.fieldOptions) {
+    optionNameById.set(a.fieldOption.id, a.fieldOption.name);
+  }
+  const resolveOne = (raw: unknown): unknown => {
+    if (typeof raw === "number") return optionNameById.get(raw) ?? raw;
+    if (typeof raw === "string" && /^\d+$/.test(raw)) {
+      return optionNameById.get(Number(raw)) ?? raw;
+    }
+    return raw;
+  };
+  return Array.isArray(value) ? value.map(resolveOne) : resolveOne(value);
+}
+
+/** Resolve a stored field value to a single display string. */
+export function formatFieldValue(
+  value: unknown,
+  field: OptionFieldMeta
+): string {
+  const resolved = resolveOptionIds(value, field);
+  if (resolved === undefined || resolved === null) return "—";
+  if (Array.isArray(resolved)) {
+    return resolved.length ? resolved.map((v) => String(v)).join(", ") : "—";
+  }
+  const s = String(resolved);
+  return s.trim() === "" ? "—" : truncate(s, 120);
+}

--- a/testplanit/lib/webhooks/event-emitters/caseEvents.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/caseEvents.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitCaseCreated,
   emitCaseDeleted,
+  emitCaseFieldValueChanged,
   emitCaseUpdated,
 } from "./caseEvents";
 
@@ -120,6 +121,90 @@ describe("emitCaseUpdated", () => {
   it("returns silently when oldRow is null", async () => {
     const tx = makeTx();
     await emitCaseUpdated(null, baseCase, tx as never);
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("emitCaseUpdated — resolved changes", () => {
+  beforeEach(() => emitMock.mockClear());
+
+  const fkTx = {
+    repositoryCases: { findUnique: vi.fn(async () => null) },
+    workflows: {
+      findUnique: vi.fn(async ({ where: { id } }: any) => ({
+        name: id === 14 ? "Active" : "Draft",
+        color: { value: "#FFAA00" },
+      })),
+    },
+  };
+
+  it("resolves stateId to a State row with the workflow color", async () => {
+    await emitCaseUpdated(
+      { ...baseCase, stateId: 14 },
+      { ...baseCase, stateId: 11 },
+      fkTx as never
+    );
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    const [, payload] = emitMock.mock.calls[0];
+    expect((payload as { changes: unknown }).changes).toEqual([
+      { label: "State", from: "Active", to: "Draft", color: "#FFAA00" },
+    ]);
+  });
+
+  it("does NOT emit when only bookkeeping columns changed", async () => {
+    await emitCaseUpdated(
+      { ...baseCase, currentVersion: 1 } as never,
+      { ...baseCase, currentVersion: 2 } as never,
+      fkTx as never
+    );
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("emitCaseFieldValueChanged", () => {
+  beforeEach(() => emitMock.mockClear());
+
+  const fieldTx = {
+    repositoryCases: {
+      findUnique: vi.fn(async () => ({
+        id: 11,
+        name: "Case 11",
+        projectId: 7,
+        isDeleted: false,
+      })),
+    },
+    caseFields: {
+      findUnique: vi.fn(async () => ({
+        displayName: "Priority",
+        type: { type: "Dropdown" },
+        fieldOptions: [
+          { fieldOption: { id: 1, name: "Low" } },
+          { fieldOption: { id: 2, name: "High" } },
+        ],
+      })),
+    },
+  };
+
+  it("emits case.updated with the resolved option label change", async () => {
+    await emitCaseFieldValueChanged(
+      { id: 5, testCaseId: 11, fieldId: 9, value: 1 },
+      { id: 5, testCaseId: 11, fieldId: 9, value: 2 },
+      fieldTx as never
+    );
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = emitMock.mock.calls[0];
+    expect(eventName).toBe("case.updated");
+    expect((payload as { changes: unknown }).changes).toEqual([
+      { label: "Priority", from: "Low", to: "High" },
+    ]);
+  });
+
+  it("does NOT emit when the field value is unchanged", async () => {
+    await emitCaseFieldValueChanged(
+      { id: 5, testCaseId: 11, fieldId: 9, value: 2 },
+      { id: 5, testCaseId: 11, fieldId: 9, value: 2 },
+      fieldTx as never
+    );
     expect(emitMock).not.toHaveBeenCalled();
   });
 });

--- a/testplanit/lib/webhooks/event-emitters/caseEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/caseEvents.ts
@@ -2,6 +2,11 @@ import type { Prisma } from "@prisma/client";
 
 import { computeObjectDiff } from "~/lib/webhooks/diff";
 import { webhookEvents } from "~/lib/webhooks/events";
+import {
+  formatFieldValue,
+  resolveCaseScalarChanges,
+  type OptionFieldMeta,
+} from "~/lib/webhooks/event-emitters/caseChangeResolve";
 
 /**
  * Emit per-mutation outbound webhook events for the RepositoryCases (test
@@ -109,6 +114,14 @@ export async function emitCaseUpdated(
   );
   if (diff.changedFields.length === 0) return;
 
+  // Resolve every changed column to a display-ready row: foreign keys
+  // (stateId, folderId, ...) become names, bookkeeping columns
+  // (currentVersion, order, ...) are dropped. When nothing user-meaningful
+  // changed (e.g. a bare currentVersion bump from a field-value save), the
+  // resolved set is empty and we skip the emit so destinations aren't spammed.
+  const changes = await resolveCaseScalarChanges(tx, diff);
+  if (changes.length === 0) return;
+
   await webhookEvents.emit(
     "case.updated",
     {
@@ -117,9 +130,89 @@ export async function emitCaseUpdated(
       name: newRow.name,
       after: newRow,
       diff,
+      changes,
     },
     {
       projectId: opts.projectId ?? newRow.projectId,
+      tx,
+      actorUserId: opts.actorUserId,
+    }
+  );
+}
+
+/** Bare CaseFieldValues row as captured by the webhook pre/post snapshots. */
+export interface CaseFieldValueRow {
+  id: number;
+  testCaseId: number;
+  fieldId: number;
+  value: unknown;
+}
+
+/**
+ * Emit `case.updated` for a custom field value change. Custom field values
+ * live in a separate table (CaseFieldValues) and are saved through their own
+ * mutations, so they never appear in the scalar case diff — this is the only
+ * path that surfaces a dropdown / multi-select / text field edit on a case.
+ *
+ * Option-backed values (Dropdown / Multi-Select / Checkbox) are resolved from
+ * stored option ids to their labels before emit. A no-op (same display value)
+ * is skipped so a re-save that rewrites the same value doesn't fire.
+ */
+export async function emitCaseFieldValueChanged(
+  oldRow: CaseFieldValueRow | null,
+  newRow: CaseFieldValueRow | null,
+  tx: Prisma.TransactionClient,
+  opts: EmitOptions = {}
+): Promise<void> {
+  const row = newRow ?? oldRow;
+  if (!row || row.testCaseId == null || row.fieldId == null) return;
+
+  const oldValue = oldRow ? oldRow.value : null;
+  const newValue = newRow ? newRow.value : null;
+  if (JSON.stringify(oldValue ?? null) === JSON.stringify(newValue ?? null)) {
+    return;
+  }
+
+  const [caseRow, field] = await Promise.all([
+    tx.repositoryCases.findUnique({
+      where: { id: row.testCaseId },
+      select: { id: true, name: true, projectId: true, isDeleted: true },
+    }),
+    tx.caseFields.findUnique({
+      where: { id: row.fieldId },
+      select: {
+        displayName: true,
+        type: { select: { type: true } },
+        fieldOptions: {
+          where: { fieldOption: { isDeleted: false } },
+          select: { fieldOption: { select: { id: true, name: true } } },
+        },
+      },
+    }),
+  ]);
+  if (!caseRow || caseRow.isDeleted || !field) return;
+
+  const meta = field as unknown as OptionFieldMeta;
+  const from = formatFieldValue(oldValue, meta);
+  const to = formatFieldValue(newValue, meta);
+  if (from === to) return;
+
+  await webhookEvents.emit(
+    "case.updated",
+    {
+      id: caseRow.id,
+      projectId: caseRow.projectId,
+      name: caseRow.name,
+      fieldChange: {
+        fieldId: row.fieldId,
+        fieldName: field.displayName,
+        before: oldValue,
+        after: newValue,
+      },
+      changes: [{ label: field.displayName, from, to }],
+    },
+    {
+      projectId: opts.projectId ?? caseRow.projectId,
       tx,
       actorUserId: opts.actorUserId,
     }

--- a/testplanit/lib/webhooks/event-emitters/issueEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/issueEvents.ts
@@ -129,6 +129,8 @@ export async function emitIssueUpdated(
       title: newRow.title,
       status: newRow.status,
       priority: newRow.priority ?? null,
+      externalKey: newRow.externalKey ?? null,
+      externalUrl: newRow.externalUrl ?? null,
       projectId: newRow.projectId,
       integrationId: newRow.integrationId ?? null,
       after: newRow,

--- a/testplanit/lib/webhooks/event-emitters/iterationEvents.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/iterationEvents.test.ts
@@ -32,7 +32,12 @@ import { webhookEvents } from "~/lib/webhooks/events";
 const emitMock = webhookEvents.emit as unknown as ReturnType<typeof vi.fn>;
 
 function makeTx() {
-  return {} as any; // emitter never reaches into tx — it only forwards.
+  // The emitter resolves statusName (Status) and runTitle (TestRuns) before
+  // forwarding; the readers return fixed names regardless of id.
+  return {
+    status: { findUnique: vi.fn(async () => ({ name: "Passed" })) },
+    testRuns: { findUnique: vi.fn(async () => ({ name: "Run 7" })) },
+  } as any;
 }
 
 describe("emitIterationResultRecorded — Wave 2 INT-04 contract", () => {
@@ -72,6 +77,8 @@ describe("emitIterationResultRecorded — Wave 2 INT-04 contract", () => {
         username: "alice",
         password: "[REDACTED]",
       },
+      statusName: "Passed",
+      runTitle: "Run 7",
     });
     expect(opts.tx).toBe(tx);
     expect(opts.projectId).toBe(42);

--- a/testplanit/lib/webhooks/event-emitters/iterationEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/iterationEvents.ts
@@ -125,9 +125,31 @@ export async function emitIterationResultRecorded(
     ...payload,
     redactedValues: capValueBytes(payload.redactedValues),
   };
-  await webhookEvents.emit("iteration.result.recorded", safePayload, {
-    projectId: opts.projectId ?? payload.projectId,
-    tx,
-    actorUserId: opts.actorUserId,
-  });
+  // Resolve display names so the Slack formatter renders "Status — Run title"
+  // instead of raw ids (read-only lookups; redaction boundary untouched).
+  const [status, run] = await Promise.all([
+    payload.statusId != null
+      ? tx.status.findUnique({
+          where: { id: payload.statusId },
+          select: { name: true },
+        })
+      : Promise.resolve(null),
+    tx.testRuns.findUnique({
+      where: { id: payload.testRunId },
+      select: { name: true },
+    }),
+  ]);
+  await webhookEvents.emit(
+    "iteration.result.recorded",
+    {
+      ...safePayload,
+      statusName: status?.name ?? null,
+      runTitle: run?.name ?? null,
+    },
+    {
+      projectId: opts.projectId ?? payload.projectId,
+      tx,
+      actorUserId: opts.actorUserId,
+    }
+  );
 }

--- a/testplanit/lib/webhooks/event-emitters/sessionEvents.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/sessionEvents.test.ts
@@ -84,6 +84,7 @@ describe("emitSessionCreated", () => {
         findUnique: vi.fn(async () => ({
           name: "Open",
           workflowType: "NOT_STARTED",
+          color: { value: "#FFAA00" },
         })),
       },
     });
@@ -106,6 +107,7 @@ describe("emitSessionCreated", () => {
       projectId: 7,
       stateId: 100,
       stateName: "Open",
+      stateColor: "#FFAA00",
       isCompleted: false,
     });
     expect(opts.tx).toBe(tx);
@@ -197,8 +199,13 @@ describe("emitSessionUpdateEvents — lifecycle policy", () => {
           .mockResolvedValueOnce({
             name: "In Progress",
             workflowType: "IN_PROGRESS",
+            color: { value: "#3b82f6" },
           })
-          .mockResolvedValueOnce({ name: "Done", workflowType: "DONE" }),
+          .mockResolvedValueOnce({
+            name: "Done",
+            workflowType: "DONE",
+            color: { value: "#22c55e" },
+          }),
       },
       sessionResults: {
         count: vi.fn(),
@@ -250,6 +257,10 @@ describe("emitSessionUpdateEvents — lifecycle policy", () => {
     );
     expect(emitMock).toHaveBeenCalledTimes(2);
     expect(emitMock.mock.calls[0][0]).toBe("session.state_changed");
+    expect(emitMock.mock.calls[0][1]).toMatchObject({
+      from: { stateName: "In Progress", stateColor: "#3b82f6" },
+      to: { stateName: "Done", stateColor: "#22c55e" },
+    });
     expect(emitMock.mock.calls[1][0]).toBe("session.completed");
     expect(emitMock.mock.calls[1][1]).toMatchObject({
       sessionId: 1,
@@ -286,6 +297,9 @@ describe("emitSessionResultAdded", () => {
           id: 5,
           name: "Passed",
           isCompleted: true,
+          isSuccess: true,
+          isFailure: false,
+          color: { value: "#22c55e" },
         })),
       },
     });
@@ -302,7 +316,10 @@ describe("emitSessionResultAdded", () => {
       resultId: 88,
       statusId: 5,
       statusName: "Passed",
+      statusColor: "#22c55e",
       isCompleted: true,
+      isSuccess: true,
+      isFailure: false,
       executedById: "user-1",
       executedAt: createdAt.toISOString(),
     });

--- a/testplanit/lib/webhooks/event-emitters/sessionEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/sessionEvents.ts
@@ -30,13 +30,19 @@ export async function emitSessionCreated(
   opts: EmitOptions = {}
 ): Promise<void> {
   let stateName: string | null = null;
+  let stateColor: string | null = null;
   let stateIsCompleted = false;
   if (row.stateId != null) {
     const state = await tx.workflows.findUnique({
       where: { id: row.stateId },
-      select: { name: true, workflowType: true },
+      select: {
+        name: true,
+        workflowType: true,
+        color: { select: { value: true } },
+      },
     });
     stateName = state?.name ?? null;
+    stateColor = state?.color?.value ?? null;
     stateIsCompleted = state?.workflowType === "DONE";
   }
   await webhookEvents.emit(
@@ -47,6 +53,7 @@ export async function emitSessionCreated(
       projectId: row.projectId,
       stateId: row.stateId,
       stateName,
+      stateColor,
       isCompleted: stateIsCompleted,
     },
     {
@@ -75,17 +82,22 @@ export async function emitSessionUpdateEvents(
   if (!stateChanged && !completedTransition) return;
 
   if (stateChanged) {
+    const stateSelect = {
+      name: true,
+      workflowType: true,
+      color: { select: { value: true } },
+    } as const;
     const [fromState, toState] = await Promise.all([
       oldRow.stateId != null
         ? tx.workflows.findUnique({
             where: { id: oldRow.stateId },
-            select: { name: true, workflowType: true },
+            select: stateSelect,
           })
         : Promise.resolve(null),
       newRow.stateId != null
         ? tx.workflows.findUnique({
             where: { id: newRow.stateId },
-            select: { name: true, workflowType: true },
+            select: stateSelect,
           })
         : Promise.resolve(null),
     ]);
@@ -99,11 +111,13 @@ export async function emitSessionUpdateEvents(
         from: {
           stateId: oldRow.stateId,
           stateName: fromState?.name ?? null,
+          stateColor: fromState?.color?.value ?? null,
           isCompleted: oldRow.isCompleted === true,
         },
         to: {
           stateId: newRow.stateId,
           stateName: toState?.name ?? null,
+          stateColor: toState?.color?.value ?? null,
           isCompleted: newRow.isCompleted === true,
         },
         isCompletedTransition: completedTransition,
@@ -213,7 +227,14 @@ export async function emitSessionResultAdded(
     row.statusId != null
       ? tx.status.findUnique({
           where: { id: row.statusId },
-          select: { id: true, name: true, isCompleted: true },
+          select: {
+            id: true,
+            name: true,
+            isCompleted: true,
+            isSuccess: true,
+            isFailure: true,
+            color: { select: { value: true } },
+          },
         })
       : Promise.resolve(null),
   ]);
@@ -226,7 +247,10 @@ export async function emitSessionResultAdded(
       resultId: row.id,
       statusId: status?.id ?? null,
       statusName: status?.name ?? null,
+      statusColor: status?.color?.value ?? null,
       isCompleted: status?.isCompleted ?? false,
+      isSuccess: status?.isSuccess ?? false,
+      isFailure: status?.isFailure ?? false,
       executedById: row.createdById ?? null,
       executedAt: row.createdAt?.toISOString() ?? null,
     },

--- a/testplanit/lib/webhooks/event-emitters/testRunEvents.test.ts
+++ b/testplanit/lib/webhooks/event-emitters/testRunEvents.test.ts
@@ -137,6 +137,7 @@ describe("emitTestRunCreated", () => {
         findUnique: vi.fn(async () => ({
           name: "Open",
           workflowType: "NOT_STARTED",
+          color: { value: "#3b82f6" },
         })),
       },
     });
@@ -153,6 +154,7 @@ describe("emitTestRunCreated", () => {
       projectId: 7,
       stateId: 100,
       stateName: "Open",
+      stateColor: "#3b82f6",
       isCompleted: false,
     });
     expect(opts.tx).toBe(tx);

--- a/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
+++ b/testplanit/lib/webhooks/event-emitters/testRunEvents.ts
@@ -116,13 +116,19 @@ export async function emitTestRunCreated(
   opts: EmitOptions = {}
 ): Promise<void> {
   let stateName: string | null = null;
+  let stateColor: string | null = null;
   let stateIsCompleted = false;
   if (row.stateId != null) {
     const state = await tx.workflows.findUnique({
       where: { id: row.stateId },
-      select: { name: true, workflowType: true },
+      select: {
+        name: true,
+        workflowType: true,
+        color: { select: { value: true } },
+      },
     });
     stateName = state?.name ?? null;
+    stateColor = state?.color?.value ?? null;
     stateIsCompleted = state?.workflowType === "DONE";
   }
   await webhookEvents.emit(
@@ -133,6 +139,7 @@ export async function emitTestRunCreated(
       projectId: row.projectId,
       stateId: row.stateId,
       stateName,
+      stateColor,
       isCompleted: stateIsCompleted,
     },
     {


### PR DESCRIPTION
## Description

Every Project > Webhooks event now renders as a proper Slack card. Previously 9 of the 27 events fell through to a raw-JSON dump, and several others showed raw foreign-key IDs (e.g. `stateId: 14 -> 11`) instead of names.

**What changed**

- **`case.updated` — IDs resolved to display names.** Foreign-key columns (`stateId`, `folderId`, `templateId`, `creatorId`, `projectId`) now resolve to the referenced record's name at emit time; bookkeeping columns (`currentVersion`, `order`, forecasts, ...) are hidden, and the emit is skipped when only noise changed. A new `caseFieldValues` hook in the model RPC route surfaces dropdown / multi-select / text custom-field edits (option IDs resolved to labels) — these never appeared in the webhook before. All resolution happens at emit time so the Slack formatters stay pure (no I/O).
- **Formatters for the remaining raw-JSON events:** `case.deleted`, `test_run.created`, `session.created`, `session.duplicated`, `session.state_changed`, `session.result_added`, `iteration.result.recorded`, `issue.deleted`.
- **Workflow state / result status color bars** on `case.created`, `session.created`, `test_run.created`, `session.state_changed`, and `session.result_added` (mirrors the existing `test_run`/`case` cards; `session.result_added` also gets a status emoji).
- **Consistent issue links:** `issue.created` and `issue.updated` both link the title to the issue in TestPlanIt (`/projects/issues/<project>?issueId=<id>`) with the external tracker key (Jira/GitHub) as a secondary "Tracked in" link.

The raw `diff` payload is retained for generic-HMAC consumers; only the Slack rendering changes.

## Related Issue

N/A — surfaced while reviewing the Project > Webhooks Slack output.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Each event's **real stored payload** was pulled from the webhook outbox table and rendered through the new formatters to a live Slack channel, confirming real names, IDs, links, and colors (not synthetic data). `pnpm precommit` passes: 8,501 unit tests pass, ESLint 0 errors, prettier + zenstack format clean, full `tsc` clean.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A (backend / Slack rendering)
- Node version: 20.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- **Known follow-up (not in this PR):** soft-deletes arrive as `case.updated` / `issue.updated` with `isDeleted: true` rather than as `*.deleted`, so the dedicated `case.deleted` / `issue.deleted` cards rarely fire in practice. Rerouting soft-deletes to the `*.deleted` events is a separate behavioral change.
- Custom field-value webhooks are emitted only on the single-case edit path (the model RPC route), intentionally not on bulk-edit / import server paths, to avoid per-field webhook storms.
