### PR TITLE
enhancement(db): route startup schema sync to a direct connection for pgbouncer

### DIFF
--- a/docs/docs/external-database-deployment.md
+++ b/docs/docs/external-database-deployment.md
@@ -261,6 +261,11 @@ docker compose -f docker-compose.prod.yml run --rm \
   prod sh -c "pnpm prisma db push --accept-data-loss && pnpm tsx prisma/seed.ts"
 ```
 
+If your database sits behind a transaction-mode pooler (e.g. pgbouncer), point this
+command at a connection that bypasses the pooler — `prisma db push` and the index
+setup require a real (non-pooled) session. See [Configure connection pooling](#best-practices)
+below for the matching `DIRECT_DATABASE_URL` setup the running container uses.
+
 Or use your existing database if it's already initialized.
 
 ### Step 4: Monitor Deployment
@@ -371,6 +376,26 @@ To run multiple TestPlanIt instances against different databases:
    ```text
    DATABASE_URL="postgresql://user:pass@host:5432/db?schema=public&connection_limit=10&pool_timeout=20"
    ```
+
+   **Transaction-mode poolers (pgbouncer, RDS Proxy, Supabase pooler):** when a
+   transaction-mode pooler fronts Postgres, two extra steps are required:
+
+   - Append `&pgbouncer=true` to `DATABASE_URL` so Prisma disables named prepared
+     statements (which transaction pooling cannot keep alive across requests).
+     Optionally add `&connection_limit=<n>` to cap each process's client-side pool.
+
+     ```text
+     DATABASE_URL="postgresql://user:pass@pgbouncer:6432/db?schema=public&pgbouncer=true&connection_limit=5"
+     ```
+
+   - Set `DIRECT_DATABASE_URL` to a connection that **bypasses the pooler** (straight
+     to Postgres). Startup schema sync (`prisma db push`) and extension/index setup
+     (`CREATE INDEX CONCURRENTLY`) use it, since those need a real session. Leave it
+     unset when no pooler is used — it falls back to `DATABASE_URL`.
+
+     ```text
+     DIRECT_DATABASE_URL="postgresql://user:pass@postgres:5432/db?schema=public"
+     ```
 
 ## Troubleshooting Commands
 

--- a/testplanit/.env.example
+++ b/testplanit/.env.example
@@ -10,6 +10,18 @@
 # Default connects to the database service defined in docker-compose.yml via the host-mapped port (5432)
 DATABASE_URL="postgresql://user:password@postgres:5432/testplanit?schema=public"
 
+# Connection pooler (pgbouncer) support — OPTIONAL
+# When a transaction-mode pooler (e.g. pgbouncer) sits in front of Postgres:
+#   1. Append "&pgbouncer=true" to DATABASE_URL above so Prisma disables named
+#      prepared statements (required under transaction pooling). Optionally add
+#      "&connection_limit=<n>" to cap each process's client-side pool.
+#      e.g. DATABASE_URL="postgresql://user:password@pgbouncer:6432/testplanit?schema=public&pgbouncer=true&connection_limit=5"
+#   2. Set DIRECT_DATABASE_URL to a connection that BYPASSES the pooler (straight
+#      to Postgres). Startup schema sync (`prisma db push`) and extension/index
+#      setup (CREATE INDEX CONCURRENTLY) use it, since those need a real session.
+#      Leave it unset when no pooler is used — it falls back to DATABASE_URL.
+# DIRECT_DATABASE_URL="postgresql://user:password@postgres:5432/testplanit?schema=public"
+
 # PostgreSQL connection details (used by db-init service)
 # Only needed when using Docker's included PostgreSQL service
 # POSTGRES_HOST=postgres

--- a/testplanit/docker-compose.prod.yml
+++ b/testplanit/docker-compose.prod.yml
@@ -41,7 +41,9 @@ services:
     env_file:
       - .env.production
     working_dir: /app/testplanit
-    # Push schema and seed database (no migrations)
+    # Push schema and seed database (no migrations).
+    # If Postgres is fronted by a transaction-mode pooler (pgbouncer), point this
+    # service at the direct DB — `prisma db push` needs a real (non-pooled) session.
     command:
       [
         "sh",

--- a/testplanit/docker-entrypoint.sh
+++ b/testplanit/docker-entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 set -e
 
+# Schema sync + extension setup run on the direct (non-pooled) connection;
+# falls back to DATABASE_URL when DIRECT_DATABASE_URL is unset (no pooler).
+INIT_DATABASE_URL="${DIRECT_DATABASE_URL:-$DATABASE_URL}"
+
 echo "Running database migrations..."
-prisma db push --skip-generate --accept-data-loss
+DATABASE_URL="$INIT_DATABASE_URL" prisma db push --skip-generate --accept-data-loss
 
 echo "Setting up PostgreSQL extensions..."
-npx tsx prisma/setup-extensions.ts
+DATABASE_URL="$INIT_DATABASE_URL" npx tsx prisma/setup-extensions.ts
 
 echo "Starting application..."
 exec "$@"


### PR DESCRIPTION
## Description

Routes the production container's startup schema sync to a **direct (non-pooled)** Postgres connection so TestPlanIt can run behind a transaction-mode connection pooler such as **pgbouncer**.

At container start, `docker-entrypoint.sh` runs `prisma db push` followed by `prisma/setup-extensions.ts` (which ensures the `pg_trgm` extension and a `CREATE INDEX CONCURRENTLY`). Those operations need a real, session-pinned connection — `db push` takes session-level advisory locks and `CREATE INDEX CONCURRENTLY` cannot run through a transaction-mode pooler. The entrypoint now resolves an init connection from `DIRECT_DATABASE_URL` (falling back to `DATABASE_URL` when unset) and scopes it to just those two startup commands. The running application and workers continue to use `DATABASE_URL`.

**Opt-in and fully backward compatible:** when `DIRECT_DATABASE_URL` is unset (no pooler in use), behavior is identical to before. No schema change and no new required configuration.

`.env.example` now documents the pooler setup: append `&pgbouncer=true` (and optionally `&connection_limit=<n>`) to `DATABASE_URL`, and set `DIRECT_DATABASE_URL` to a connection that bypasses the pooler.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Manual testing

Describe the tests you ran to verify your changes:

- Validated `docker-entrypoint.sh` parses as POSIX `sh` (`sh -n`).
- Verified the inline `DATABASE_URL=...` overrides apply only to the two startup commands; `exec "$@"` (the app) keeps the container's original `DATABASE_URL`.
- Confirmed by grep that `DIRECT_DATABASE_URL` is consumed only by the entrypoint — the app runtime, workers, and `env.js` do not read it, so leaving it unset is identical to current behavior.

> This change touches only a shell script, a compose comment, and `.env.example` — no TypeScript/build-affecting source — so the unit/integration/E2E suites are not exercised by it.

**Test Configuration:**
- OS: macOS (darwin)
- Browser (if applicable): N/A
- Node version: N/A (no application code changed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (shell/docs only; no testable application code path)
- [x] New and existing unit tests pass locally with my changes — unaffected (no application source changed)
- [x] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

These are **deployment/operator follow-ups**, intentionally kept out of this code change (they are configuration, not app code):

- **Runtime pooling flag:** append `&pgbouncer=true` to the `DATABASE_URL` the app/workers/scheduler use so Prisma disables named prepared statements under transaction pooling. For multi-tenant, each `TENANT_<ID>_DATABASE_URL` needs the same suffix.
- **Pool sizing:** set a small `connection_limit` per process and size pgbouncer (`pool_mode=transaction`, `default_pool_size`, `max_client_conn`) against the worker fleet's summed concurrency (~24 processes, each with its own Prisma pool).
- **Long-running workers:** the testmo import and iteration-generation workers hold a server connection for the duration of their transaction (minutes). Consider a dedicated pgbouncer pool so they cannot starve the web tier.
- **Backup/restore:** `scripts/db-backup.sh` (`pg_dump`) and `scripts/db-restore.sh` (`psql`, `DROP/CREATE DATABASE`) must target the direct DB, never the pooler.
