### PR TITLE
fix(quickscript): make repo scans and cache refresh resilient to provider rate limits

### DIFF
--- a/testplanit/app/[locale]/projects/settings/[projectId]/quickscript/page.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/quickscript/page.tsx
@@ -295,6 +295,7 @@ export default function QuickScriptPage() {
           body: JSON.stringify({
             branch: values.branch || undefined,
             pathPatterns: values.pathPatterns,
+            cacheEnabled: values.cacheEnabled,
           }),
         }
       );
@@ -384,55 +385,63 @@ export default function QuickScriptPage() {
   const handleRefreshCache = async () => {
     if (!existingConfig) return;
     setIsRefreshing(true);
+    setRefreshError(null);
+    setRefreshStep(t("cache.statusPending"));
 
-    const post = (step: string) =>
-      fetch(
+    try {
+      // Enqueue a background refresh. The list+content fetch runs in the
+      // repo-cache worker so a rate-limited provider can't time out the
+      // request; we poll the config's cacheStatus for completion.
+      const res = await fetch(
         `/api/code-repositories/${existingConfig.repositoryId}/refresh-cache`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ projectConfigId: existingConfig.id, step }),
+          body: JSON.stringify({ projectConfigId: existingConfig.id }),
         }
-      ).then((r) => r.json());
+      );
+      const data = await res.json().catch(() => ({}));
 
-    setRefreshError(null);
-
-    try {
-      // Step 1: fetch file list (fast — single git tree API call)
-      setRefreshStep(t("cache.listingFiles"));
-      const listData = await post("list-only");
-      if (!listData.success) {
-        setRefreshError(listData.error ?? t("listError"));
+      if (!res.ok || data.error) {
+        setRefreshError(data.error ?? t("networkError"));
         void refetchConfig();
         return;
       }
 
-      // Step 2: fetch and cache file contents (slow — one call per file)
-      setRefreshStep(t("cache.cachingFiles", { count: listData.fileCount }));
-      const contentData = await post("contents-only");
+      // Poll until the worker finishes (cacheStatus leaves "pending").
+      const POLL_MS = 2500;
+      const MAX_POLLS = 144; // ~6 minutes
+      for (let polls = 0; polls < MAX_POLLS; polls++) {
+        await new Promise((r) => setTimeout(r, POLL_MS));
+        const { data: fresh } = await refetchConfig();
+        const status = (fresh as { cacheStatus?: string } | null)?.cacheStatus;
+        const fileCount = (fresh as { cacheFileCount?: number } | null)
+          ?.cacheFileCount;
 
-      if (!contentData.success) {
-        setRefreshError(contentData.error ?? t("contentsError"));
-        void refetchConfig();
+        if (status == null || status === "pending") {
+          setRefreshStep(
+            fileCount != null
+              ? t("cache.cachingFiles", { count: String(fileCount) })
+              : t("cache.listingFiles")
+          );
+          continue;
+        }
+
+        if (status === "error") {
+          setRefreshError(
+            (fresh as { cacheError?: string } | null)?.cacheError ??
+              t("contentsError")
+          );
+        } else {
+          toast.success(
+            t("refreshComplete", { fileCount: String(fileCount ?? 0) })
+          );
+        }
         return;
       }
 
-      if (contentData.contentRateLimited) {
-        toast.warning(
-          t("refreshRateLimited", {
-            fileCount: listData.fileCount,
-            contentCached: contentData.contentCached,
-          })
-        );
-      } else {
-        toast.success(
-          t("refreshSuccess", {
-            fileCount: listData.fileCount,
-            contentCached: contentData.contentCached,
-          })
-        );
-      }
-      void refetchConfig();
+      // Still running after the poll window — it continues in the background.
+      toast.info(t("refreshInProgress"));
     } catch (err) {
       setRefreshError(err instanceof Error ? err.message : t("networkError"));
     } finally {

--- a/testplanit/app/api/code-repositories/[id]/preview-files/route.ts
+++ b/testplanit/app/api/code-repositories/[id]/preview-files/route.ts
@@ -1,10 +1,14 @@
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
-import { createGitRepoAdapter } from "~/lib/integrations/adapters/GitRepoAdapter";
+import {
+  createGitRepoAdapter,
+  type RepoFileEntry,
+} from "~/lib/integrations/adapters/GitRepoAdapter";
+import { repoFileCache } from "~/lib/integrations/cache/RepoFileCache";
 import {
   applyPathPatterns,
-  extractBasePaths,
+  extractBasePathScopes,
   type PathPattern,
 } from "~/lib/integrations/repoPathPatterns";
 import { authOptions } from "~/server/auth";
@@ -36,7 +40,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const {
     branch,
     pathPatterns = [],
-  }: { branch?: string; pathPatterns?: PathPattern[] } = body;
+    cacheEnabled = true,
+  }: {
+    branch?: string;
+    pathPatterns?: PathPattern[];
+    cacheEnabled?: boolean;
+  } = body;
 
   const repo = await prisma.codeRepository.findUnique({
     where: { id: parseInt(id) },
@@ -83,26 +92,76 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         send({ type: "progress", step: "branch" });
         const resolvedBranch = branch || (await adapter.getDefaultBranch());
 
-        // Step 2: Fetch files — use path-scoped listing when paths are available
-        const basePaths = extractBasePaths(pathPatterns);
+        // Step 2: Fetch files — use path-scoped listing when paths are
+        // available, bounding each base's scan depth to what its glob needs so
+        // a non-recursive root pattern (e.g. "." + "*.md") doesn't crawl the
+        // whole repo.
+        const scopes = extractBasePathScopes(pathPatterns);
+        const basePaths = scopes.map((s) => s.path);
+        const maxDepthByPath = Object.fromEntries(
+          scopes.map((s) => [s.path, s.maxDepth])
+        );
+        // Depth-aware cache key: tuning a glob from "*.md" to "**/*.md" changes
+        // the scan depth, so the cached listing must not be reused across them.
+        const scopeKeys = scopes.map((s) => `${s.path}@${s.maxDepth}`);
         const scopeLabel =
           basePaths.length > 0
             ? basePaths.map((p) => p || "repository root").join(", ")
             : "repository root";
         send({ type: "progress", step: "listing", scope: scopeLabel });
 
-        const { files: allFiles, truncated } = await adapter.listFilesInPaths(
-          resolvedBranch,
-          basePaths,
-          (filesFound) => {
-            send({
-              type: "progress",
-              step: "listing",
-              filesFound,
-              scope: scopeLabel,
-            });
+        // The listing (paths + sizes) is independent of the glob patterns, so a
+        // short-lived cache lets re-previews while tuning patterns reuse one
+        // provider call instead of re-listing (and risking rate limits) each
+        // time. Skipped in privacy mode (caching disabled).
+        const repoId = parseInt(id);
+        let allFiles: RepoFileEntry[];
+        let truncated: boolean | undefined;
+
+        const cachedList = cacheEnabled
+          ? await repoFileCache.getPreviewList(
+              repoId,
+              resolvedBranch,
+              scopeKeys
+            )
+          : null;
+
+        if (cachedList) {
+          allFiles = cachedList.files;
+          truncated = cachedList.truncated;
+          send({
+            type: "progress",
+            step: "listing",
+            filesFound: allFiles.length,
+            scope: scopeLabel,
+            cached: true,
+          });
+        } else {
+          const listed = await adapter.listFilesInPaths(
+            resolvedBranch,
+            basePaths,
+            (filesFound) => {
+              send({
+                type: "progress",
+                step: "listing",
+                filesFound,
+                scope: scopeLabel,
+              });
+            },
+            maxDepthByPath
+          );
+          allFiles = listed.files;
+          truncated = listed.truncated;
+
+          if (cacheEnabled) {
+            await repoFileCache.setPreviewList(
+              repoId,
+              resolvedBranch,
+              scopeKeys,
+              { files: allFiles, truncated: truncated ?? false }
+            );
           }
-        );
+        }
 
         // Step 3: Apply glob pattern filtering
         send({

--- a/testplanit/app/api/code-repositories/[id]/refresh-cache/route.ts
+++ b/testplanit/app/api/code-repositories/[id]/refresh-cache/route.ts
@@ -1,10 +1,9 @@
+import { getCurrentTenantId } from "@/lib/multiTenantPrisma";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  refreshRepoCache,
-  refreshRepoCacheContentsOnly,
-} from "~/lib/services/repoCacheRefreshService";
+import { JOB_REFRESH_SINGLE_REPO_CACHE } from "~/lib/queueNames";
+import { getRepoCacheQueue } from "~/lib/queues";
 import { authOptions } from "~/server/auth";
 
 interface RouteParams {
@@ -12,11 +11,11 @@ interface RouteParams {
 }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
-  // This endpoint refreshes the code-repository metadata cache (file
-  // listings, branch state) — cache hygiene with no business-object
-  // state mutation. Admin/project-admin surface. Matches the lastActiveAt
-  // session-keep-alive precedent at lib/prisma.ts:693-701: cache-refresh
-  // operations do not produce audit-relevant events.
+  // This endpoint kicks off a code-repository cache refresh (file listings +
+  // contents). Admin/project-admin surface, cache hygiene with no business
+  // object mutation. The actual fetch runs in the repo-cache worker so a
+  // rate-limited provider can't time out (or HTML-error) the HTTP request —
+  // the UI polls the config's cacheStatus for completion.
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
@@ -36,7 +35,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     await params; // consume params to avoid Next.js warning
 
     const body = await req.json();
-    const { projectConfigId, step = "all" } = body;
+    const { projectConfigId } = body;
 
     if (!projectConfigId) {
       return NextResponse.json(
@@ -47,39 +46,62 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
     const configId = parseInt(projectConfigId);
 
-    if (step === "contents-only") {
-      const result = await refreshRepoCacheContentsOnly(
-        configId,
-        prisma as any
-      );
-      if (!result.success) {
-        return NextResponse.json(
-          { success: false, error: result.error },
-          { status: 400 }
-        );
+    const config = await (prisma as any).projectCodeRepositoryConfig.findUnique(
+      {
+        where: { id: configId },
+        select: { id: true, cacheEnabled: true },
       }
-      return NextResponse.json(result);
-    }
+    );
 
-    // step === "list-only" is no longer a separate code path — we always do a
-    // full refresh via the shared service.  The "list-only" step was only used
-    // by the UI as an intermediate preview, and the shared service always
-    // fetches both list + contents in one pass (matching step=all behavior).
-    const result = await refreshRepoCache(configId, prisma as any);
-
-    if (!result.success) {
+    if (!config) {
       return NextResponse.json(
-        { success: false, error: result.error },
-        {
-          status:
-            result.error === "File caching is disabled for this project"
-              ? 400
-              : 500,
-        }
+        { error: "Configuration not found" },
+        { status: 404 }
       );
     }
 
-    return NextResponse.json(result);
+    if (!config.cacheEnabled) {
+      return NextResponse.json(
+        { error: "File caching is disabled for this project" },
+        { status: 400 }
+      );
+    }
+
+    const queue = getRepoCacheQueue();
+    if (!queue) {
+      return NextResponse.json(
+        {
+          error:
+            "Background job queue is not available. Ensure the repo-cache worker is running.",
+        },
+        { status: 503 }
+      );
+    }
+
+    const tenantId = getCurrentTenantId();
+
+    // Reuse an in-flight refresh for the same config+tenant rather than piling
+    // up duplicate jobs if the user clicks Refresh repeatedly.
+    const existingJobs = await queue.getJobs(["active", "waiting", "delayed"]);
+    const existing = existingJobs.find(
+      (j) =>
+        j.name === JOB_REFRESH_SINGLE_REPO_CACHE &&
+        Number(j.data?.configId) === configId &&
+        j.data?.tenantId === tenantId
+    );
+
+    // Mark pending immediately so the UI reflects "in progress" before the
+    // worker picks the job up.
+    await (prisma as any).projectCodeRepositoryConfig.update({
+      where: { id: configId },
+      data: { cacheStatus: "pending", cacheError: null },
+    });
+
+    const job =
+      existing ??
+      (await queue.add(JOB_REFRESH_SINGLE_REPO_CACHE, { configId, tenantId }));
+
+    return NextResponse.json({ queued: true, jobId: job.id });
   } catch (err: unknown) {
     console.error("[POST refresh-cache]:", err);
     const message =

--- a/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.test.ts
@@ -247,6 +247,96 @@ describe("BitbucketRepoAdapter", () => {
     });
   });
 
+  describe("depth-bounded listing", () => {
+    it("scans the root seed shallow (max_depth=1) and does not descend subdirs for a bounded glob", async () => {
+      // Root listing at depth 1 returns top-level files plus subdirectories.
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [
+            { path: "README.md", type: "commit_file", size: 100 },
+            { path: "src", type: "commit_directory" },
+            { path: "docs", type: "commit_directory" },
+          ],
+          next: null,
+        })
+      );
+
+      const result = await adapter.listFilesInPaths("main", [""], undefined, {
+        "": 1,
+      });
+
+      // Only the top-level file — subdirectories were NOT followed.
+      expect(result.files.map((f) => f.path)).toEqual(["README.md"]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("max_depth=1");
+    });
+
+    it("still recurses subdirectories for a deep glob (default depth)", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [
+            { path: "src/index.ts", type: "commit_file", size: 10 },
+            { path: "src/deep", type: "commit_directory" },
+          ],
+          next: null,
+        })
+      );
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [
+            { path: "src/deep/nested.ts", type: "commit_file", size: 20 },
+          ],
+          next: null,
+        })
+      );
+
+      const result = await adapter.listFilesInPaths(
+        "main",
+        ["src"],
+        undefined,
+        {
+          src: 10,
+        }
+      );
+
+      expect(result.files.map((f) => f.path)).toEqual([
+        "src/index.ts",
+        "src/deep/nested.ts",
+      ]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("rate-limited partial listing", () => {
+    it("returns the files collected so far (truncated) instead of throwing", async () => {
+      (adapter as any).maxRetries = 0;
+      // First page succeeds...
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          values: [{ path: "a.ts", type: "commit_file", size: 10 }],
+          next: "https://api.bitbucket.org/page2",
+        })
+      );
+      // ...second page is rate limited.
+      mockFetch.mockResolvedValue(makeResponse({}, 429));
+
+      const result = await adapter.listFilesInPaths("main", [""]);
+
+      expect(result.truncated).toBe(true);
+      expect(result.files.map((f) => f.path)).toEqual(["a.ts"]);
+    });
+
+    it("rethrows when rate limited before any files are collected", async () => {
+      (adapter as any).maxRetries = 0;
+      mockFetch.mockResolvedValue(makeResponse({}, 429));
+
+      await expect(adapter.listFilesInPaths("main", [""])).rejects.toThrow(
+        /rate limit/i
+      );
+    });
+  });
+
   describe("non-JSON listing response", () => {
     it("throws a friendly error (not a raw SyntaxError) when a path resolves to a file body", async () => {
       // Bitbucket resolves a bad path to a FILE and returns its raw markdown body.

--- a/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/BitbucketRepoAdapter.ts
@@ -7,6 +7,10 @@ import {
 
 const MAX_FILES = 10000;
 
+function isRateLimitError(err: unknown): boolean {
+  return err instanceof Error && /rate limit/i.test(err.message);
+}
+
 export class BitbucketRepoAdapter extends GitRepoAdapter {
   private email: string;
   private apiToken: string;
@@ -51,48 +55,70 @@ export class BitbucketRepoAdapter extends GitRepoAdapter {
   async listFilesInPaths(
     branch: string,
     basePaths: string[],
-    onProgress?: (filesFound: number) => void
+    onProgress?: (filesFound: number) => void,
+    maxDepthByPath?: Record<string, number>
   ): Promise<ListFilesResult> {
     const files: RepoFileEntry[] = [];
     const seen = new Set<string>();
     const MAX_DEPTH = 10;
-    // Deduplicate and normalise paths; empty string = repo root
+    // Deduplicate and normalise paths; empty string = repo root. Each seed
+    // carries the depth its glob needs, so a non-recursive root pattern
+    // (e.g. "." + "*.md") scans only the top level instead of the whole repo.
     const seeds = basePaths.length > 0 ? basePaths : [""];
-    const queue: string[] = [...seeds];
+    const queue: { path: string; depth: number }[] = seeds.map((p) => ({
+      path: p,
+      depth: maxDepthByPath?.[p] ?? MAX_DEPTH,
+    }));
 
-    while (queue.length > 0 && files.length < MAX_FILES) {
-      const rawPath = queue.shift()!;
-      // Treat ".", "./" and "" all as repository root. Bitbucket resolves a
-      // literal "." path segment to a FILE and returns its raw body instead of
-      // a JSON directory listing, which would blow up JSON parsing downstream.
-      const path =
-        rawPath === "." || rawPath === "./" || rawPath === "/" ? "" : rawPath;
-      let url: string | null =
-        `https://api.bitbucket.org/2.0/repositories/${this.workspace}/${this.repoSlug}/src/${encodeURIComponent(branch)}/${path}?pagelen=100&max_depth=${MAX_DEPTH}`;
+    try {
+      while (queue.length > 0 && files.length < MAX_FILES) {
+        const { path: rawPath, depth } = queue.shift()!;
+        // Treat ".", "./" and "" all as repository root. Bitbucket resolves a
+        // literal "." path segment to a FILE and returns its raw body instead
+        // of a JSON directory listing, which would blow up JSON parsing.
+        const path =
+          rawPath === "." || rawPath === "./" || rawPath === "/" ? "" : rawPath;
+        let url: string | null =
+          `https://api.bitbucket.org/2.0/repositories/${this.workspace}/${this.repoSlug}/src/${encodeURIComponent(branch)}/${path}?pagelen=100&max_depth=${depth}`;
 
-      while (url && files.length < MAX_FILES) {
-        const data: any = await this.makeRequest<any>(url, {
-          headers: this.authHeaders,
-        });
-        for (const item of data.values ?? []) {
-          if (item.type === "commit_file") {
-            const filePath = item.path as string;
-            if (!seen.has(filePath)) {
-              seen.add(filePath);
-              files.push({
-                path: filePath,
-                size: (item.size as number) ?? 0,
-                type: "file",
-              });
+        while (url && files.length < MAX_FILES) {
+          const data: any = await this.makeRequest<any>(url, {
+            headers: this.authHeaders,
+          });
+          for (const item of data.values ?? []) {
+            if (item.type === "commit_file") {
+              const filePath = item.path as string;
+              if (!seen.has(filePath)) {
+                seen.add(filePath);
+                files.push({
+                  path: filePath,
+                  size: (item.size as number) ?? 0,
+                  type: "file",
+                });
+              }
+            } else if (item.type === "commit_directory") {
+              // A directory still surfacing means it's deeper than max_depth.
+              // Only follow it for recursive globs (depth at the deep cap);
+              // a shallow/bounded glob doesn't want anything deeper.
+              if (depth >= MAX_DEPTH) {
+                queue.push({ path: item.path as string, depth: MAX_DEPTH });
+              }
             }
-          } else if (item.type === "commit_directory") {
-            // Directories still appearing means they're deeper than max_depth
-            queue.push(item.path as string);
           }
+          url = data.next ?? null; // Bitbucket provides full next URL
+          onProgress?.(files.length);
         }
-        url = data.next ?? null; // Bitbucket provides full next URL
-        onProgress?.(files.length);
       }
+    } catch (err) {
+      // A large repo can exhaust the provider rate limit mid-listing. Rather
+      // than discard a long-running scan, return what we collected so far and
+      // flag it truncated — same graceful-partial behavior the content fetcher
+      // uses. With nothing collected yet, surface the error so the caller can
+      // report it (and we don't cache an empty "complete" listing).
+      if (files.length > 0 && isRateLimitError(err)) {
+        return { files: files.slice(0, MAX_FILES), truncated: true };
+      }
+      throw err;
     }
 
     return { files: files.slice(0, MAX_FILES) };

--- a/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
@@ -70,7 +70,8 @@ export abstract class GitRepoAdapter {
   async listFilesInPaths(
     branch: string,
     _basePaths: string[],
-    _onProgress?: (filesFound: number) => void
+    _onProgress?: (filesFound: number) => void,
+    _maxDepthByPath?: Record<string, number>
   ): Promise<ListFilesResult> {
     // Default: ignore basePaths and list everything.
     // Subclasses (e.g. Bitbucket) override for path-scoped listing.

--- a/testplanit/lib/integrations/cache/RepoFileCache.test.ts
+++ b/testplanit/lib/integrations/cache/RepoFileCache.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock valkey connection (mirrors IssueCache.test.ts).
+vi.mock("../../valkey", () => {
+  const mockValkey = {
+    get: vi.fn(),
+    setex: vi.fn().mockResolvedValue("OK"),
+    del: vi.fn().mockResolvedValue(1),
+    pipeline: vi.fn().mockImplementation(() => ({
+      setex: vi.fn().mockReturnThis(),
+      del: vi.fn().mockReturnThis(),
+      hset: vi.fn().mockReturnThis(),
+      expire: vi.fn().mockReturnThis(),
+      exec: vi.fn().mockResolvedValue([]),
+    })),
+    hgetall: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  return {
+    default: { duplicate: () => mockValkey },
+    __mockValkey: mockValkey,
+  };
+});
+
+import { RepoFileCache, type PreviewListCacheEntry } from "./RepoFileCache";
+
+let mockValkey: any;
+
+const entry: PreviewListCacheEntry = {
+  files: [{ path: "src/a.ts", size: 10, type: "file" }],
+  truncated: false,
+};
+
+describe("RepoFileCache preview listing", () => {
+  let cache: RepoFileCache;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const valkeyModule = await import("../../valkey");
+    mockValkey = (valkeyModule as any).__mockValkey;
+    cache = new RepoFileCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null on a miss", async () => {
+    mockValkey.get.mockResolvedValue(null);
+    const result = await cache.getPreviewList(7, "main", ["src"]);
+    expect(result).toBeNull();
+  });
+
+  it("returns the parsed entry on a hit", async () => {
+    mockValkey.get.mockResolvedValue(JSON.stringify(entry));
+    const result = await cache.getPreviewList(7, "main", ["src"]);
+    expect(result).toEqual(entry);
+  });
+
+  it("stores with a 5-minute TTL and a repo-scoped key", async () => {
+    await cache.setPreviewList(7, "main", ["src"], entry);
+    expect(mockValkey.setex).toHaveBeenCalledWith(
+      expect.stringContaining("repo-preview-list:repo:7:"),
+      300,
+      JSON.stringify(entry)
+    );
+  });
+
+  it("uses an order-independent key for base paths", async () => {
+    await cache.setPreviewList(7, "main", ["src", "tests"], entry);
+    await cache.setPreviewList(7, "main", ["tests", "src"], entry);
+    expect(mockValkey.setex.mock.calls[0][0]).toBe(
+      mockValkey.setex.mock.calls[1][0]
+    );
+  });
+
+  it("uses a different key per branch and per base path", async () => {
+    await cache.setPreviewList(7, "main", ["src"], entry);
+    await cache.setPreviewList(7, "dev", ["src"], entry);
+    await cache.setPreviewList(7, "main", ["lib"], entry);
+    const [k1, k2, k3] = mockValkey.setex.mock.calls.map((c: any[]) => c[0]);
+    expect(k1).not.toBe(k2);
+    expect(k1).not.toBe(k3);
+  });
+
+  it("drops a corrupted entry and returns null", async () => {
+    mockValkey.get.mockResolvedValue("{not json");
+    const result = await cache.getPreviewList(7, "main", ["src"]);
+    expect(result).toBeNull();
+    expect(mockValkey.del).toHaveBeenCalled();
+  });
+});

--- a/testplanit/lib/integrations/cache/RepoFileCache.ts
+++ b/testplanit/lib/integrations/cache/RepoFileCache.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { Redis } from "ioredis";
 import { getCurrentTenantId } from "~/lib/multiTenantPrisma";
 import valkeyConnection from "../../valkey";
@@ -8,6 +9,17 @@ export interface RepoFileEntry {
   path: string;
   size: number; // bytes
   type: "file";
+}
+
+// Short-lived cache for the QuickScript "Preview" listing. The raw file list
+// for a repo+branch+base-paths rarely changes while a user tunes glob patterns,
+// so caching it briefly turns N previews into a single provider listing call —
+// the main lever against hitting provider rate limits during pattern tuning.
+const PREVIEW_LIST_TTL_SECONDS = 300; // 5 minutes
+
+export interface PreviewListCacheEntry {
+  files: RepoFileEntry[];
+  truncated: boolean;
 }
 
 export type RepoCacheStatus = "success" | "error" | "pending";
@@ -225,6 +237,76 @@ export class RepoFileCache {
     } catch (err) {
       console.error(
         `[RepoFileCache] Failed to set file contents for config ${projectConfigId}:`,
+        err
+      );
+    }
+  }
+
+  /**
+   * Key for a preview listing, scoped by tenant + repo + branch + base paths.
+   * Base paths are order-normalized so {"src","tests"} and {"tests","src"} hit
+   * the same entry; the (branch, paths) tuple is hashed to keep keys bounded.
+   */
+  private getPreviewListKey(
+    repoId: number,
+    branch: string,
+    scopeKeys: string[]
+  ): string {
+    const tenantId = getCurrentTenantId();
+    const prefix = tenantId ? `${tenantId}:` : "";
+    const sortedPaths = [...scopeKeys].sort().join("\n");
+    const hash = createHash("sha1")
+      .update(`${branch}\n${sortedPaths}`)
+      .digest("hex")
+      .slice(0, 16);
+    return `repo-preview-list:${prefix}repo:${repoId}:${hash}`;
+  }
+
+  /**
+   * Retrieve a cached preview listing. Returns null on miss/Valkey unavailable.
+   */
+  async getPreviewList(
+    repoId: number,
+    branch: string,
+    scopeKeys: string[]
+  ): Promise<PreviewListCacheEntry | null> {
+    if (!this.valkey) return null;
+
+    const key = this.getPreviewListKey(repoId, branch, scopeKeys);
+    try {
+      const cached = await this.valkey.get(key);
+      if (!cached) return null;
+      return JSON.parse(cached) as PreviewListCacheEntry;
+    } catch (err) {
+      console.error(
+        `[RepoFileCache] Failed to parse preview list for repo ${repoId}:`,
+        err
+      );
+      await this.valkey.del(key).catch(() => {}); // Remove corrupted entry
+      return null;
+    }
+  }
+
+  /**
+   * Store a preview listing with a short TTL. Failures are logged but not
+   * re-thrown — this is a best-effort optimization; callers fall back to a
+   * live listing on miss.
+   */
+  async setPreviewList(
+    repoId: number,
+    branch: string,
+    scopeKeys: string[],
+    entry: PreviewListCacheEntry,
+    ttlSeconds: number = PREVIEW_LIST_TTL_SECONDS
+  ): Promise<void> {
+    if (!this.valkey) return;
+
+    const key = this.getPreviewListKey(repoId, branch, scopeKeys);
+    try {
+      await this.valkey.setex(key, ttlSeconds, JSON.stringify(entry));
+    } catch (err) {
+      console.error(
+        `[RepoFileCache] Failed to cache preview list for repo ${repoId}:`,
         err
       );
     }

--- a/testplanit/lib/integrations/repoPathPatterns.test.ts
+++ b/testplanit/lib/integrations/repoPathPatterns.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   applyPathPatterns,
+  DEEP_SCAN_DEPTH,
   extractBasePaths,
+  extractBasePathScopes,
+  globScanDepth,
   normalizeBasePath,
   type PathPattern,
 } from "./repoPathPatterns";
@@ -112,5 +115,66 @@ describe("applyPathPatterns", () => {
   it("returns all files unchanged when there are no patterns", () => {
     const files = [file("a.ts"), file("b.ts")];
     expect(applyPathPatterns(files, [])).toBe(files);
+  });
+});
+
+describe("globScanDepth", () => {
+  it("returns 1 for a non-recursive top-level glob", () => {
+    expect(globScanDepth("*.md")).toBe(1);
+    expect(globScanDepth("CLAUDE.md")).toBe(1);
+    expect(globScanDepth("*")).toBe(1);
+  });
+
+  it("counts segments for a bounded nested glob", () => {
+    expect(globScanDepth("sub/*.ts")).toBe(2);
+    expect(globScanDepth("a/b/file.ts")).toBe(3);
+  });
+
+  it("returns the deep cap for any recursive '**' glob", () => {
+    expect(globScanDepth("**/*.ts")).toBe(DEEP_SCAN_DEPTH);
+    expect(globScanDepth("**")).toBe(DEEP_SCAN_DEPTH);
+    expect(globScanDepth("src/**/test/*.ts")).toBe(DEEP_SCAN_DEPTH);
+  });
+
+  it("tolerates a leading './' on the glob", () => {
+    expect(globScanDepth("./*.md")).toBe(1);
+  });
+});
+
+describe("extractBasePathScopes", () => {
+  it("bounds a non-recursive root pattern to depth 1", () => {
+    const scopes = extractBasePathScopes([{ path: ".", pattern: "*.md" }]);
+    expect(scopes).toEqual([{ path: "", maxDepth: 1 }]);
+  });
+
+  it("gives a recursive pattern the deep cap", () => {
+    const scopes = extractBasePathScopes([{ path: "src", pattern: "**/*.ts" }]);
+    expect(scopes).toEqual([{ path: "src", maxDepth: DEEP_SCAN_DEPTH }]);
+  });
+
+  it("takes the max depth across globs sharing a base", () => {
+    const scopes = extractBasePathScopes([
+      { path: "src", pattern: "*.ts" },
+      { path: "src", pattern: "**/*.spec.ts" },
+    ]);
+    expect(scopes).toEqual([{ path: "src", maxDepth: DEEP_SCAN_DEPTH }]);
+  });
+
+  it("mirrors the real-world mixed config (scoped recursive + shallow root)", () => {
+    const scopes = extractBasePathScopes([
+      { path: "src/sharedpageobjects", pattern: "**/*.ts" },
+      { path: ".claude/skills", pattern: "**/*.md" },
+      { path: "./", pattern: "*.md" },
+    ]);
+    expect(scopes).toContainEqual({
+      path: "src/sharedpageobjects",
+      maxDepth: DEEP_SCAN_DEPTH,
+    });
+    expect(scopes).toContainEqual({
+      path: ".claude/skills",
+      maxDepth: DEEP_SCAN_DEPTH,
+    });
+    // The root pattern stays shallow — no full-repo crawl.
+    expect(scopes).toContainEqual({ path: "", maxDepth: 1 });
   });
 });

--- a/testplanit/lib/integrations/repoPathPatterns.ts
+++ b/testplanit/lib/integrations/repoPathPatterns.ts
@@ -40,6 +40,56 @@ export function extractBasePaths(pathPatterns: PathPattern[]): string[] {
   return [...paths];
 }
 
+// Deepest directory level we'll recurse for a recursive ("**") glob. Matches
+// the provider listers' historical default and bounds runaway scans.
+export const DEEP_SCAN_DEPTH = 10;
+
+export interface BasePathScope {
+  path: string; // normalized base ("" = repository root)
+  maxDepth: number; // directory levels to scan below the base
+}
+
+/**
+ * How many directory levels below the base a glob can match. A non-recursive
+ * glob like "*.md" matches only files directly in the base (depth 1), so the
+ * lister can scan shallow instead of crawling the whole subtree. Any
+ * double-star segment means unbounded — use the deep cap.
+ *
+ * Examples: "*.md" is depth 1; "sub/*.ts" is depth 2; a recursive
+ * double-star glob is DEEP_SCAN_DEPTH.
+ */
+export function globScanDepth(pattern: string): number {
+  // Tolerate a leading "./" or "/" on the glob.
+  const segments = pattern
+    .replace(/^\.?\//, "")
+    .split("/")
+    .filter((s) => s.length > 0);
+  if (segments.length === 0) return 1;
+  if (segments.some((s) => s.includes("**"))) return DEEP_SCAN_DEPTH;
+  return Math.min(segments.length, DEEP_SCAN_DEPTH);
+}
+
+/**
+ * Like extractBasePaths, but also derives the shallowest scan depth that still
+ * satisfies every glob targeting each base. Lets the lister avoid a full-repo
+ * crawl when a root pattern only wants top-level files (e.g. "." + "*.md").
+ */
+export function extractBasePathScopes(
+  pathPatterns: PathPattern[]
+): BasePathScope[] {
+  if (!pathPatterns.length) return [];
+  const depthByBase = new Map<string, number>();
+  for (const { path: basePath, pattern } of pathPatterns) {
+    const base = normalizeBasePath(basePath);
+    const depth = globScanDepth(pattern);
+    depthByBase.set(base, Math.max(depthByBase.get(base) ?? 0, depth));
+  }
+  return [...depthByBase.entries()].map(([path, maxDepth]) => ({
+    path,
+    maxDepth,
+  }));
+}
+
 /**
  * Filter a flat file list down to those matching the combined base + glob
  * patterns. A root pattern uses the glob as-is (e.g. "CLAUDE.md", with no "./"

--- a/testplanit/lib/queueNames.ts
+++ b/testplanit/lib/queueNames.ts
@@ -9,6 +9,10 @@ export const AUDIT_LOG_QUEUE_NAME = "audit-logs";
 export const BUDGET_ALERT_QUEUE_NAME = "budget-alerts";
 export const AUTO_TAG_QUEUE_NAME = "auto-tag";
 export const REPO_CACHE_QUEUE_NAME = "repo-cache";
+// Job name for an on-demand, single-config cache refresh (manual "Refresh"
+// button). Runs the full list+content fetch off-request in the worker so a
+// rate-limited provider can't time out the HTTP request.
+export const JOB_REFRESH_SINGLE_REPO_CACHE = "refresh-single-repo-cache";
 export const COPY_MOVE_QUEUE_NAME = "copy-move";
 export const DUPLICATE_SCAN_QUEUE_NAME = "duplicate-scan";
 export const STEP_SCAN_QUEUE_NAME = "step-scan";

--- a/testplanit/lib/services/repoCacheRefreshService.ts
+++ b/testplanit/lib/services/repoCacheRefreshService.ts
@@ -6,7 +6,7 @@ import {
 } from "~/lib/integrations/cache/RepoFileCache";
 import {
   applyPathPatterns,
-  extractBasePaths,
+  extractBasePathScopes,
   type PathPattern,
 } from "~/lib/integrations/repoPathPatterns";
 
@@ -165,11 +165,19 @@ export async function refreshRepoCache(
   try {
     const pathPatterns =
       (config.pathPatterns as unknown as PathPattern[]) ?? [];
-    const basePaths = extractBasePaths(pathPatterns);
+    // Bound each base's scan depth to its glob so a non-recursive root pattern
+    // (e.g. "." + "*.md") doesn't crawl the whole repo.
+    const scopes = extractBasePathScopes(pathPatterns);
+    const basePaths = scopes.map((s) => s.path);
+    const maxDepthByPath = Object.fromEntries(
+      scopes.map((s) => [s.path, s.maxDepth])
+    );
 
     const { files: allFiles, truncated } = await adapter.listFilesInPaths(
       branch,
-      basePaths
+      basePaths,
+      undefined,
+      maxDepthByPath
     );
 
     // Apply glob pattern filtering
@@ -245,75 +253,4 @@ export async function refreshRepoCache(
       error: errorMessage,
     };
   }
-}
-
-/**
- * Refresh only file contents for a config that already has a cached file list.
- * Used by the "contents-only" step in the API route.
- */
-export async function refreshRepoCacheContentsOnly(
-  configId: number,
-  prismaClient: PrismaClient
-): Promise<{
-  success: boolean;
-  contentCached: number;
-  contentTotal: number;
-  contentRateLimited: boolean;
-  error?: string;
-}> {
-  const config = await (
-    prismaClient as any
-  ).projectCodeRepositoryConfig.findUnique({
-    where: { id: configId },
-    include: {
-      repository: {
-        select: { credentials: true, settings: true, provider: true },
-      },
-    },
-  });
-
-  if (!config) {
-    throw new Error(`ProjectCodeRepositoryConfig ${configId} not found`);
-  }
-
-  const cachedFiles = await repoFileCache.getFiles(config.id);
-  if (!cachedFiles || cachedFiles.length === 0) {
-    return {
-      success: false,
-      contentCached: 0,
-      contentTotal: 0,
-      contentRateLimited: false,
-      error: "No cached file list — run list step first",
-    };
-  }
-
-  const credentials = config.repository.credentials as Record<string, string>;
-  const adapter = createGitRepoAdapter(
-    config.repository.provider,
-    credentials,
-    config.repository.settings as Record<string, string> | null
-  );
-  const branch = config.branch || (await adapter.getDefaultBranch());
-
-  const { contentMap, contentRateLimited } = await fetchContentsBatched(
-    cachedFiles,
-    adapter,
-    branch,
-    10
-  );
-
-  if (contentMap.size > 0) {
-    await repoFileCache.setFileContents(
-      config.id,
-      contentMap,
-      config.cacheTtlDays
-    );
-  }
-
-  return {
-    success: true,
-    contentCached: contentMap.size,
-    contentTotal: cachedFiles.length,
-    contentRateLimited,
-  };
 }

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -1858,6 +1858,8 @@
         "networkError": "Netzwerkfehler während der Cache-Aktualisierung",
         "refreshSuccess": "Cache aktualisiert: {fileCount} Dateien ({contentCached} Inhalt zwischengespeichert)",
         "refreshRateLimited": "Cache aktualisiert: {fileCount} Dateien aufgelistet, {contentCached}/{fileCount} Inhalte zwischengespeichert (Rate begrenzt – erneut aktualisieren, um den Vorgang abzuschließen)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Pfad erforderlich",
           "patternRequired": "Ein Schnittmuster ist erforderlich.",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1858,6 +1858,8 @@
         "networkError": "Network error during cache refresh",
         "refreshSuccess": "Cache refreshed: {fileCount} files ({contentCached} contents cached)",
         "refreshRateLimited": "Cache refreshed: {fileCount} files listed, {contentCached}/{fileCount} contents cached (rate limited — refresh again to complete)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Path is required",
           "patternRequired": "Pattern is required",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -1858,6 +1858,8 @@
         "networkError": "Error de red durante la actualización de caché",
         "refreshSuccess": "Caché actualizada: {fileCount} archivos ({contentCached} contenidos almacenados en caché)",
         "refreshRateLimited": "Caché actualizada: {fileCount} archivos listados, {contentCached}/{fileCount} contenidos almacenados en caché (velocidad limitada; actualice nuevamente para completar)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "La ruta es obligatoria",
           "patternRequired": "Se requiere patrón",

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -1858,6 +1858,8 @@
         "networkError": "Erreur réseau lors de l'actualisation du cache",
         "refreshSuccess": "Cache actualisé : {fileCount} fichiers ({contentCached} contenus mis en cache)",
         "refreshRateLimited": "Cache actualisé : {fileCount} fichiers listés, {contentCached}/{fileCount} contenus mis en cache (limite de débit — actualisez à nouveau pour terminer)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Le chemin d'accès est requis.",
           "patternRequired": "Un modèle est requis.",

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -1858,6 +1858,8 @@
         "networkError": "Errore di rete durante l'aggiornamento della cache",
         "refreshSuccess": "Cache aggiornata: {fileCount} file ({contentCached} contenuto memorizzato nella cache)",
         "refreshRateLimited": "Cache aggiornata: {fileCount} file elencati, {contentCached}/{fileCount} contenuti memorizzati nella cache (frequenza limitata: aggiorna di nuovo per completare)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Il percorso è richiesto",
           "patternRequired": "È richiesto un modello",

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -1858,6 +1858,8 @@
         "networkError": "キャッシュ更新中にネットワークエラーが発生しました",
         "refreshSuccess": "キャッシュが更新されました: {fileCount} 個のファイル ({contentCached} 個のコンテンツがキャッシュされました)",
         "refreshRateLimited": "キャッシュが更新されました: {fileCount} 個のファイルが一覧表示され、 {contentCached}/{fileCount} 個のコンテンツがキャッシュされました (レート制限あり - 完了するには再度更新してください)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "パスが必要です",
           "patternRequired": "型紙が必要です",

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -1858,6 +1858,8 @@
         "networkError": "캐시 새로 고침 중 네트워크 오류 발생",
         "refreshSuccess": "캐시 새로 고침됨: {fileCount} 개 파일 ({contentCached} 개 콘텐츠 캐시됨)",
         "refreshRateLimited": "캐시 새로 고침됨: {fileCount} 개의 파일이 나열되었고, {contentCached}/{fileCount} 개의 콘텐츠가 캐시되었습니다(호출 속도 제한됨 - 완료하려면 다시 새로 고침하세요).",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "경로가 필요합니다",
           "patternRequired": "패턴이 필요합니다",

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -1858,6 +1858,8 @@
         "networkError": "Netwerkfout tijdens het vernieuwen van de cache.",
         "refreshSuccess": "Cache vernieuwd: {fileCount} bestanden ({contentCached} inhoud in cache opgeslagen)",
         "refreshRateLimited": "Cache vernieuwd: {fileCount} bestanden weergegeven, {contentCached}/{fileCount} inhoud in cache opgeslagen (snelheid beperkt — vernieuw opnieuw om te voltooien)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Pad is vereist",
           "patternRequired": "Een patroon is vereist.",

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -1858,6 +1858,8 @@
         "networkError": "Błąd sieciowy podczas odświeżania pamięci podręcznej",
         "refreshSuccess": "Odświeżono pamięć podręczną: {fileCount} plików (zawartość w pamięci podręcznej:{contentCached})",
         "refreshRateLimited": "Odświeżono pamięć podręczną: {fileCount} plików na liście, {contentCached}/{fileCount} zawartości w pamięci podręcznej (ograniczona szybkość — w celu dokończenia należy odświeżyć ponownie)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Ścieżka jest wymagana",
           "patternRequired": "Wzór jest wymagany",

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -1858,6 +1858,8 @@
         "networkError": "Erro de rede durante a atualização do cache",
         "refreshSuccess": "Cache atualizado: {fileCount} arquivos ({contentCached} conteúdo em cache)",
         "refreshRateLimited": "Cache atualizado: {fileCount} arquivos listados, {contentCached}/{fileCount} conteúdo em cache (taxa limitada — atualize novamente para concluir)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "O caminho é obrigatório",
           "patternRequired": "É necessário um padrão.",

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -1858,6 +1858,8 @@
         "networkError": "Сетевая ошибка во время обновления кэша.",
         "refreshSuccess": "Кэш обновлен: {fileCount} файлов ({contentCached} содержимое кэшировано)",
         "refreshRateLimited": "Кэш обновлен: {fileCount} файлов в списке, содержимое {contentCached}/{fileCount} кэшировано (ограничение скорости — обновите еще раз для завершения)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Требуется указать путь.",
           "patternRequired": "Требуется шаблон",

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -1858,6 +1858,8 @@
         "networkError": "Önbellek yenileme sırasında ağ hatası",
         "refreshSuccess": "Önbellek yenilendi: {fileCount} dosya ({contentCached} içerik önbelleğe alındı)",
         "refreshRateLimited": "Önbellek yenilendi: {fileCount} dosya listelendi, {contentCached}/{fileCount} içerik önbelleğe alındı (oran sınırlı — tamamlamak için tekrar yenileyin)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Yol gereklidir.",
           "patternRequired": "Desen gereklidir.",

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -1858,6 +1858,8 @@
         "networkError": "Lỗi mạng trong quá trình làm mới bộ nhớ cache",
         "refreshSuccess": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin ({contentCached} nội dung đã được lưu vào bộ nhớ cache)",
         "refreshRateLimited": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin đã được liệt kê, {contentCached}/{fileCount} nội dung đã được lưu vào bộ nhớ cache (tốc độ truy cập bị giới hạn — hãy làm mới lại để hoàn tất)",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "Cần có đường dẫn.",
           "patternRequired": "Cần có mẫu.",

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -1858,6 +1858,8 @@
         "networkError": "缓存刷新期间出现网络错误",
         "refreshSuccess": "缓存已刷新： {fileCount} 个文件（已缓存{contentCached} 个内容）",
         "refreshRateLimited": "缓存已刷新：列出了 {fileCount} 个文件，缓存了 {contentCached}/{fileCount} 个内容（速率受限——请再次刷新以完成）",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "路径是必需的",
           "patternRequired": "需要图案",

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -1858,6 +1858,8 @@
         "networkError": "快取刷新期間出現網路錯誤",
         "refreshSuccess": "快取已刷新： {fileCount} 個檔案（已快取{contentCached} 個內容）",
         "refreshRateLimited": "快取已刷新：列出了 {fileCount} 個文件，快取了 {contentCached}/{fileCount} 個內容（速率受限——請再次刷新以完成）",
+        "refreshComplete": "Cache refreshed: {fileCount} files",
+        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
         "validation": {
           "pathRequired": "路徑是必需的",
           "patternRequired": "需要圖案",

--- a/testplanit/workers/repoCacheWorker.test.ts
+++ b/testplanit/workers/repoCacheWorker.test.ts
@@ -1,5 +1,6 @@
 import { Job } from "bullmq";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JOB_REFRESH_SINGLE_REPO_CACHE } from "../lib/queueNames";
 import { JOB_REFRESH_EXPIRED_CACHES } from "./repoCacheWorker";
 
 // Create mock prisma instance
@@ -40,6 +41,7 @@ vi.mock("../lib/services/repoCacheRefreshService", () => ({
 // Mock queue names
 vi.mock("../lib/queueNames", () => ({
   REPO_CACHE_QUEUE_NAME: "test-repo-cache-queue",
+  JOB_REFRESH_SINGLE_REPO_CACHE: "refresh-single-repo-cache",
 }));
 
 const mockConfigs = [
@@ -301,6 +303,67 @@ describe("RepoCacheWorker", () => {
 
       // INSTANCE_TENANT_ID should be restored even after error
       expect(process.env.INSTANCE_TENANT_ID).toBe("original-tenant");
+    });
+  });
+
+  describe(`${JOB_REFRESH_SINGLE_REPO_CACHE} job`, () => {
+    it("refreshes the single config from job.data.configId", async () => {
+      mockRefreshRepoCache.mockResolvedValue({
+        success: true,
+        fileCount: 12,
+        contentCached: 12,
+        contentRateLimited: false,
+      });
+
+      const { processor } = await import("./repoCacheWorker");
+
+      const mockJob = {
+        id: "job-single-1",
+        name: JOB_REFRESH_SINGLE_REPO_CACHE,
+        data: { configId: 101, tenantId: "tenant-a" },
+      } as Job;
+
+      const result = await processor(mockJob);
+
+      expect(mockRefreshRepoCache).toHaveBeenCalledWith(101, mockPrisma);
+      expect(result).toMatchObject({ successCount: 1, failCount: 0 });
+      // It must NOT scan all configs like the expired-cache job does.
+      expect(
+        mockPrisma.projectCodeRepositoryConfig.findMany
+      ).not.toHaveBeenCalled();
+    });
+
+    it("counts a failed refresh without throwing", async () => {
+      mockRefreshRepoCache.mockResolvedValue({
+        success: false,
+        error: "Rate limit exceeded. Try again in 5 minutes.",
+      });
+
+      const { processor } = await import("./repoCacheWorker");
+
+      const mockJob = {
+        id: "job-single-2",
+        name: JOB_REFRESH_SINGLE_REPO_CACHE,
+        data: { configId: 102 },
+      } as Job;
+
+      const result = await processor(mockJob);
+
+      expect(mockRefreshRepoCache).toHaveBeenCalledWith(102, mockPrisma);
+      expect(result).toMatchObject({ successCount: 0, failCount: 1 });
+    });
+
+    it("throws when configId is missing/non-numeric", async () => {
+      const { processor } = await import("./repoCacheWorker");
+
+      const mockJob = {
+        id: "job-single-3",
+        name: JOB_REFRESH_SINGLE_REPO_CACHE,
+        data: {},
+      } as Job;
+
+      await expect(processor(mockJob)).rejects.toThrow(/configId/);
+      expect(mockRefreshRepoCache).not.toHaveBeenCalled();
     });
   });
 

--- a/testplanit/workers/repoCacheWorker.ts
+++ b/testplanit/workers/repoCacheWorker.ts
@@ -6,7 +6,10 @@ import {
   isMultiTenantMode,
   validateMultiTenantJobData,
 } from "../lib/multiTenantPrisma";
-import { REPO_CACHE_QUEUE_NAME } from "../lib/queueNames";
+import {
+  JOB_REFRESH_SINGLE_REPO_CACHE,
+  REPO_CACHE_QUEUE_NAME,
+} from "../lib/queueNames";
 import { refreshRepoCache } from "../lib/services/repoCacheRefreshService";
 import { withTenantContext } from "../lib/tenantContext";
 import valkeyConnection from "../lib/valkey";
@@ -97,6 +100,37 @@ const processor = async (job: Job) => {
         console.log(
           `Job ${job.id} completed: ${successCount} refreshed, ${skippedCount} still valid, ${failCount} failed (of ${configs.length} total)`
         );
+        break;
+      }
+
+      case JOB_REFRESH_SINGLE_REPO_CACHE: {
+        // On-demand refresh for one config (manual "Refresh" button). Runs the
+        // full list+content fetch here so the request that enqueued it returned
+        // immediately and can't time out while we wait out provider rate limits.
+        const configId = Number(job.data.configId);
+        if (!Number.isFinite(configId)) {
+          throw new Error(
+            `${JOB_REFRESH_SINGLE_REPO_CACHE} job requires a numeric configId`
+          );
+        }
+
+        console.log(`Job ${job.id}: Manual refresh for config ${configId}`);
+
+        // refreshRepoCache persists cacheStatus (pending → success/error),
+        // cacheFileCount, cacheError, etc., which the UI polls for completion.
+        const result = await refreshRepoCache(configId, prisma);
+
+        if (result.success) {
+          successCount++;
+          console.log(
+            `Job ${job.id}: Refreshed config ${configId} — ${result.fileCount} files, ${result.contentCached} contents cached${result.contentRateLimited ? " (rate limited — partial)" : ""}`
+          );
+        } else {
+          failCount++;
+          console.warn(
+            `Job ${job.id}: Manual refresh failed for config ${configId}: ${result.error}`
+          );
+        }
         break;
       }
 


### PR DESCRIPTION
## Description

Hardens QuickScript's code-repository scanning so large repos and provider rate
limits no longer break **Preview Files** or **Refresh Cache**.

Three root causes are addressed:

1. **A root path pattern crawled the whole repo.** A pattern like `.` + `*.md`
   normalized to the repository root and triggered a full `max_depth=10` crawl
   on Bitbucket, exhausting the rate limit even though the glob only wanted
   top-level files. Scan depth is now derived from each glob
   (`globScanDepth` / `extractBasePathScopes`), so a non-recursive root pattern
   scans only the top level. Base-path normalization (`.`, `./`, `""` → repo
   root) and a non-JSON-listing guard are included so a literal `.` path no
   longer returns a file body that crashes JSON parsing.

2. **Manual cache refresh ran synchronously in the request.** For a rate-limited
   repo the full list + per-file content fetch blew past the HTTP timeout and
   returned an HTML error page. Refresh now enqueues a `refresh-single-repo-cache`
   job on the existing repo-cache worker and returns immediately; the UI polls
   `cacheStatus` to completion.

3. **Repeated previews re-hit the provider.** The preview file listing is now
   cached in Valkey with a depth-aware key (5-minute TTL), so re-previewing while
   tuning glob patterns reuses a single provider call. A rate-limited listing
   returns a partial (truncated) result instead of discarding the whole scan.

## Related Issue

N/A — internal reliability hardening.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

New/extended unit tests cover depth derivation, depth-bounded and rate-limited
partial Bitbucket listings, base-path normalization, the preview listing cache,
and the new worker job. The full `pnpm precommit` suite passes (9169 tests;
lint, types, and formatting clean).

Manually verified live against a real Bitbucket repository on a project whose
patterns include a root `*.md` pattern plus scoped recursive patterns:

- **Preview Files**: 164 files listed (incl. root `CLAUDE.md` / `README.md`) with
  no rate-limit error — the root pattern scanned depth-1 instead of crawling.
- **Refresh Cache**: completed via the worker — Status **Success**, 164 files
  cached.

**Test Configuration:**
- OS: macOS (darwin)
- Browser (if applicable): Chrome
- Node version: 24.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- Manual **Refresh Cache** requires the `repo-cache` worker to be running
  (`pnpm workers`); without it the route returns a clear 503. The refresh runs
  off-request so provider rate-limit waits can't time out the HTTP request.
- Adds two `en-US` keys (`refreshComplete`, `refreshInProgress`); placeholders
  synced to the other locales for Crowdin to translate.
- A pre-existing flaky unhandled error in `two-factor-setup.test.tsx`
  (an `input-otp` timer firing after unmount) surfaces only under the full
  concurrent suite and passes clean in isolation. It is unrelated to this change
  and will be fixed in a separate PR.
