### PR TITLE
enhancement(search): virtual scrolling + infinite list for unified search

### DIFF
--- a/docs/docs/user-guide/advanced-search.md
+++ b/docs/docs/user-guide/advanced-search.md
@@ -122,7 +122,7 @@ When searching multiple entity types, results are organized into tabs:
 ### Navigation
 
 - Click on any result to navigate directly to that item
-- Use pagination controls at the bottom for large result sets
+- Results load continuously as you scroll — there are no pages to click through. More results are fetched automatically as you near the bottom of the list, and a "Showing X of Y" count above the list tracks how many of the total matches have loaded so far
 - Results are sorted by relevance by default
 
 ## Search Tips

--- a/testplanit/components/UnifiedSearch.test.tsx
+++ b/testplanit/components/UnifiedSearch.test.tsx
@@ -1,8 +1,51 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "~/test/test-utils";
+import { act, fireEvent, render, screen, waitFor } from "~/test/test-utils";
 import { SearchableEntityType } from "~/types/search";
 import { UnifiedSearch } from "./UnifiedSearch";
+
+// The real hook owns TanStack Virtual + an IntersectionObserver, neither of
+// which produces layout (or fires) under jsdom. Replace it with a pass-through
+// that renders every loaded hit and exposes the latest `onLoadMore` so a test
+// can simulate the sentinel firing. The hook has its own focused unit test
+// (hooks/useVirtualizedInfiniteList.test.tsx) for the observer wiring.
+const virtualListMock = vi.hoisted(() => ({
+  lastOnLoadMore: null as null | (() => void),
+  lastOptions: null as Record<string, unknown> | null,
+}));
+
+vi.mock("~/hooks/useVirtualizedInfiniteList", () => ({
+  useVirtualizedInfiniteList: (opts: {
+    count: number;
+    onLoadMore: () => void;
+  }) => {
+    virtualListMock.lastOnLoadMore = opts.onLoadMore;
+    virtualListMock.lastOptions = opts as unknown as Record<string, unknown>;
+    return {
+      scrollRef: { current: null },
+      sentinelRef: { current: null },
+      virtualizer: {},
+      virtualItems: Array.from({ length: opts.count }, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 120,
+        size: 120,
+        end: (i + 1) * 120,
+        lane: 0,
+      })),
+      totalSize: opts.count * 120,
+      measureElement: () => {},
+      maxHeight: 600,
+    };
+  },
+}));
+
+// Simulate the infinite-scroll sentinel coming into view.
+function triggerLoadMore() {
+  act(() => {
+    virtualListMock.lastOnLoadMore?.();
+  });
+}
 
 // Mock next-intl
 vi.mock("next-intl", () => ({
@@ -229,6 +272,8 @@ describe("UnifiedSearch Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (global.fetch as any).mockReset();
+    virtualListMock.lastOnLoadMore = null;
+    virtualListMock.lastOptions = null;
   });
 
   it("should render search input with placeholder", () => {
@@ -498,83 +543,151 @@ describe("UnifiedSearch Component", () => {
     expect(searchInput).toBeInTheDocument();
   });
 
-  it("should handle pagination", async () => {
-    (global.fetch as any).mockResolvedValueOnce({
+  it("appends the next page when the infinite-scroll sentinel fires", async () => {
+    const page = (offset: number) => ({
       ok: true,
       json: async () => ({
         total: 100,
         hits: Array(50)
           .fill(null)
           .map((_, i) => ({
-            id: i + 1,
+            id: offset + i + 1,
             entityType: SearchableEntityType.REPOSITORY_CASE,
             score: 1.0,
             source: {
-              id: i + 1,
-              name: `Test Case ${i + 1}`,
+              id: offset + i + 1,
+              name: `Test Case ${offset + i + 1}`,
               projectName: "Test Project",
               projectId: 1,
             },
           })),
-        took: 100,
+        took: 1,
+      }),
+    });
+
+    (global.fetch as any).mockResolvedValueOnce(page(0));
+
+    render(<UnifiedSearch />);
+    fireEvent.change(screen.getByPlaceholderText(/search/i), {
+      target: { value: "test" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Case 1")).toBeInTheDocument();
+      expect(screen.getByText("Test Case 50")).toBeInTheDocument();
+    });
+    // Page 2 hasn't loaded yet.
+    expect(screen.queryByText("Test Case 51")).not.toBeInTheDocument();
+
+    // Simulate the sentinel reaching the viewport.
+    (global.fetch as any).mockResolvedValueOnce(page(50));
+    triggerLoadMore();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Test Case 51")).toBeInTheDocument();
+    });
+
+    // Both pages are now accumulated in one continuous list (no page seam).
+    expect(screen.getByText("Test Case 1")).toBeInTheDocument();
+    expect(screen.getByText("Test Case 100")).toBeInTheDocument();
+
+    // The next-page request carried the incremented page cursor.
+    const secondBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+    expect(secondBody.pagination.page).toBe(2);
+  });
+
+  it("does not fetch more once every result is loaded", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        total: 2,
+        hits: [
+          {
+            id: 1,
+            entityType: SearchableEntityType.REPOSITORY_CASE,
+            score: 1.0,
+            source: { id: 1, name: "Only One", projectName: "P", projectId: 1 },
+          },
+          {
+            id: 2,
+            entityType: SearchableEntityType.REPOSITORY_CASE,
+            score: 1.0,
+            source: { id: 2, name: "Only Two", projectName: "P", projectId: 1 },
+          },
+        ],
+        took: 1,
       }),
     });
 
     render(<UnifiedSearch />);
-
-    const searchInput = screen.getByPlaceholderText(/search/i);
-    fireEvent.change(searchInput, { target: { value: "test" } });
-
-    await waitFor(() => {
-      // First check if we have results
-      expect(screen.getByText("Test Case 1")).toBeInTheDocument();
-
-      // Check pagination text (rendered at top and bottom)
-      const paginationTexts = screen.getAllByText((content, element) => {
-        return (
-          element?.textContent ===
-          "common.pagination.showing 1-50 common.of 100 common.results"
-        );
-      });
-      expect(paginationTexts.length).toBeGreaterThanOrEqual(1);
+    fireEvent.change(screen.getByPlaceholderText(/search/i), {
+      target: { value: "test" },
     });
 
-    // Mock the second page response
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Only One")).toBeInTheDocument();
+    });
+
+    // All results are already loaded — the sentinel firing must be a no-op.
+    triggerLoadMore();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the accumulated list when the query changes", async () => {
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        total: 100,
-        hits: Array(50)
-          .fill(null)
-          .map((_, i) => ({
-            id: i + 51,
+        total: 1,
+        hits: [
+          {
+            id: 1,
             entityType: SearchableEntityType.REPOSITORY_CASE,
             score: 1.0,
             source: {
-              id: i + 51,
-              name: `Test Case ${i + 51}`,
-              projectName: "Test Project",
+              id: 1,
+              name: "Alpha One",
+              projectName: "P",
               projectId: 1,
             },
-          })),
-        took: 100,
+          },
+        ],
+        took: 1,
       }),
     });
 
-    // Find and click the next page button
-    const buttons = screen.getAllByRole("button");
-    const nextButton = buttons.find((btn) => {
-      const svg = btn.querySelector("svg");
-      return svg && svg.classList.contains("lucide-chevron-right");
+    render(<UnifiedSearch />);
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(searchInput, { target: { value: "alpha" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha One")).toBeInTheDocument();
     });
 
-    if (nextButton) {
-      fireEvent.click(nextButton);
+    // A new query replaces (does not append to) the prior results.
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        total: 1,
+        hits: [
+          {
+            id: 2,
+            entityType: SearchableEntityType.REPOSITORY_CASE,
+            score: 1.0,
+            source: { id: 2, name: "Beta One", projectName: "P", projectId: 1 },
+          },
+        ],
+        took: 1,
+      }),
+    });
+    fireEvent.change(searchInput, { target: { value: "beta" } });
 
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledTimes(2);
-      });
-    }
+    await waitFor(() => {
+      expect(screen.getByText("Beta One")).toBeInTheDocument();
+      expect(screen.queryByText("Alpha One")).not.toBeInTheDocument();
+    });
   });
 
   it("should display deleted items with destructive styling", async () => {
@@ -1304,6 +1417,62 @@ describe("UnifiedSearch Component", () => {
           screen.queryByTestId("bulk-action-toolbar")
         ).not.toBeInTheDocument();
       });
+    });
+
+    it("retains a selection made on an earlier page after more pages load", async () => {
+      // Page 1: cases 1 & 2 of a 4-result set, all in project 100.
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          total: 4,
+          hits: [caseHit(1, 100), caseHit(2, 100)],
+          took: 1,
+        }),
+      });
+      render(<UnifiedSearch />);
+      fireEvent.change(screen.getByPlaceholderText(/search/i), {
+        target: { value: "anything" },
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("bulk-select-repository_case-1")
+        ).toBeInTheDocument();
+      });
+
+      // Select a case on page 1.
+      fireEvent.click(screen.getByTestId("bulk-select-repository_case-1"));
+      expect(screen.getByTestId("bulk-action-toolbar")).toBeInTheDocument();
+
+      // Scroll past the seam — page 2 appends cases 3 & 4.
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          total: 4,
+          hits: [caseHit(3, 100), caseHit(4, 100)],
+          took: 1,
+        }),
+      });
+      triggerLoadMore();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("bulk-select-repository_case-4")
+        ).toBeInTheDocument();
+      });
+
+      // The page-1 selection survived the append, and we can add a page-2 case.
+      fireEvent.click(screen.getByTestId("bulk-select-repository_case-4"));
+      await waitFor(() => {
+        expect(screen.getByTestId("bulk-action-toolbar").textContent).toContain(
+          "2"
+        );
+      });
+
+      // Both ids reach the bulk editor — selection genuinely spans the pages.
+      fireEvent.click(screen.getByTestId("bulk-edit-button"));
+      await waitFor(() => {
+        expect(screen.getByTestId("bulk-edit-modal-mock")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("bulk-edit-ids").textContent).toBe("1,4");
     });
   });
 });

--- a/testplanit/components/UnifiedSearch.tsx
+++ b/testplanit/components/UnifiedSearch.tsx
@@ -47,10 +47,6 @@ import {
 import { WorkflowStateDisplay } from "@/components/WorkflowStateDisplay";
 import { BulkEditModal } from "@/projects/repository/[projectId]/BulkEditModal";
 import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
   Filter,
   Folder,
   Pencil,
@@ -67,6 +63,7 @@ import {
   getEntityLabel,
   useSearchContext,
 } from "~/hooks/useSearchContext";
+import { useVirtualizedInfiniteList } from "~/hooks/useVirtualizedInfiniteList";
 import { useSearchState } from "~/lib/contexts/SearchStateContext";
 import { IconName } from "~/types/globals";
 import {
@@ -140,9 +137,22 @@ export function UnifiedSearch({
   const [results, setResults] = useState<UnifiedSearchResult | null>(
     searchState?.results || null
   );
+  // Accumulated hits across every loaded page for the current tab/query. The
+  // virtualized list renders from this rather than a single page, so the user
+  // scrolls one continuous list with no page seam.
+  const [loadedHits, setLoadedHits] = useState<SearchHit[]>(
+    searchState?.results?.hits ?? []
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A failed "load more" stops the auto-fetch from looping on the still-visible
+  // sentinel; cleared on every reset (query/scope/tab change).
+  const [loadMoreError, setLoadMoreError] = useState(false);
+  // Guards against an inconsistent `total` (more reported than returnable, e.g.
+  // count drift) wedging the sentinel into fetching empty pages forever.
+  const [reachedEnd, setReachedEnd] = useState(false);
   const [isFirstSearch, setIsFirstSearch] = useState(!searchState?.results);
+  // Highest page loaded for the current tab/query (the infinite-scroll cursor).
   const [currentPage, setCurrentPage] = useState(searchState?.currentPage || 1);
   const [pageSize] = useState(compactMode ? 10 : 50);
   const [showFilters, setShowFilters] = useState(false);
@@ -191,17 +201,24 @@ export function UnifiedSearch({
     return t("search.placeholder.allProjects");
   }, [placeholder, currentProjectOnly, searchContext.projectId, t]);
 
-  // Search function
+  // Search function. `append` distinguishes the next-page fetch (results are
+  // appended to the accumulated list) from a fresh search (results replace it).
   const performSearch = useCallback(
-    async (page: number = 1, forSpecificTab?: SearchableEntityType | "all") => {
+    async (
+      page: number = 1,
+      forSpecificTab?: SearchableEntityType | "all",
+      { append = false }: { append?: boolean } = {}
+    ) => {
       // Don't search if query is empty
       if (!debouncedQuery.trim()) {
         setResults(null);
+        setLoadedHits([]);
         return;
       }
 
       setLoading(true);
-      setError(null);
+      if (append) setLoadMoreError(false);
+      else setError(null);
 
       try {
         // Build filters based on selected scope and entities
@@ -263,13 +280,37 @@ export function UnifiedSearch({
           data.entityTypeCounts = allEntityTypeCountsRef.current;
         }
 
-        setResults(data);
+        if (append) {
+          // An empty page means we've reached the end regardless of what the
+          // reported total claims — stop the sentinel from refetching it.
+          if (data.hits.length === 0) setReachedEnd(true);
+          // Keep the first-page metadata (total, counts, facets) and grow the
+          // rendered list. De-dupe by entity+id in case a page boundary
+          // overlaps so the virtualizer never gets duplicate keys.
+          setLoadedHits((prev) => {
+            const seen = new Set(prev.map((h) => `${h.entityType}-${h.id}`));
+            const next = data.hits.filter(
+              (h) => !seen.has(`${h.entityType}-${h.id}`)
+            );
+            return next.length ? [...prev, ...next] : prev;
+          });
+        } else {
+          setResults(data);
+          setLoadedHits(data.hits);
+          setReachedEnd(false);
+        }
         setCurrentPage(page);
         setIsFirstSearch(false);
         onResultsChange?.(data);
       } catch (err) {
         console.error("Search error:", err);
-        setError(t("search.errors.searchFailed"));
+        if (append) {
+          // Don't wipe the already-rendered list on a next-page failure; surface
+          // an inline retry and pause the auto-fetch loop instead.
+          setLoadMoreError(true);
+        } else {
+          setError(t("search.errors.searchFailed"));
+        }
       } finally {
         setLoading(false);
       }
@@ -288,22 +329,28 @@ export function UnifiedSearch({
   // Track if parameters have changed (not tab/page)
   const [searchTrigger, setSearchTrigger] = useState(0);
 
-  // Trigger search when query or filters change
+  // Reset to the first page + "all" tab whenever the query/filters/scope
+  // change, then trigger a fresh search.
   useEffect(() => {
-    setCurrentPage(1); // Reset pagination
-    setSelectedTab("all"); // Reset to all tab
-    setSearchTrigger((prev) => prev + 1); // Trigger search
+    setCurrentPage(1);
+    setSelectedTab("all");
+    setLoadMoreError(false);
+    setReachedEnd(false);
+    setSearchTrigger((prev) => prev + 1);
   }, [debouncedQuery, filters, selectedEntities, currentProjectOnly]);
 
-  // Perform search when triggered or when tab/page changes
+  // Run the fresh (page 1) search when triggered. Subsequent pages are
+  // appended by the infinite-scroll sentinel; tab switches load their own
+  // page 1 (see the Tabs onValueChange handler).
   useEffect(() => {
     if (debouncedQuery.trim() && searchTrigger > 0) {
-      void performSearch(currentPage, selectedTab);
+      void performSearch(1, "all", { append: false });
     } else if (!debouncedQuery.trim()) {
       setResults(null);
+      setLoadedHits([]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTrigger, currentPage, selectedTab]);
+  }, [searchTrigger]);
 
   // Save search state whenever it changes
   useEffect(() => {
@@ -432,7 +479,10 @@ export function UnifiedSearch({
   const clearSearch = () => {
     setQuery("");
     setResults(null);
+    setLoadedHits([]);
     setError(null);
+    setLoadMoreError(false);
+    setReachedEnd(false);
     setIsFirstSearch(true);
     setCurrentPage(1);
     setSelectedCaseRows(new Map());
@@ -563,38 +613,122 @@ export function UnifiedSearch({
     return count;
   };
 
-  // Pagination calculations based on selected tab
-  const { totalForTab, totalPagesForTab, showingFromForTab, showingToForTab } =
-    useMemo(() => {
-      if (!results)
-        return {
-          totalForTab: 0,
-          totalPagesForTab: 0,
-          showingFromForTab: 0,
-          showingToForTab: 0,
-        };
+  // Total available for the active tab — drives the "showing X of Y" summary
+  // and whether the infinite-scroll sentinel may fetch another page.
+  const totalForTab = useMemo(() => {
+    if (!results) return 0;
+    return selectedTab === "all"
+      ? results.total
+      : results.entityTypeCounts?.[selectedTab as SearchableEntityType] || 0;
+  }, [results, selectedTab]);
 
-      // Calculate totals based on selected tab
-      const total =
-        selectedTab === "all"
-          ? results.total
-          : results.entityTypeCounts?.[selectedTab as SearchableEntityType] ||
-            0;
+  const hasMore =
+    loadedHits.length < totalForTab && !loadMoreError && !reachedEnd;
 
-      const totalPages = Math.ceil(total / pageSize);
-      const showingFrom = total === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-      const showingTo =
-        total === 0 ? 0 : Math.min(currentPage * pageSize, total);
+  // Fetch the next page and append it. The cursor is the highest page loaded
+  // for the current tab/query. Guard on `hasMore` so a stray trigger can't
+  // fetch past the end of the result set.
+  const handleLoadMore = useCallback(() => {
+    if (!hasMore) return;
+    void performSearch(currentPage + 1, selectedTab, { append: true });
+  }, [hasMore, performSearch, currentPage, selectedTab]);
 
-      return {
-        totalForTab: total,
-        totalPagesForTab: totalPages,
-        showingFromForTab: showingFrom,
-        showingToForTab: showingTo,
-      };
-    }, [results, selectedTab, currentPage, pageSize]);
+  // Full skeleton only on the first fetch; later fetches keep the list visible
+  // and show an inline indicator at the bottom.
+  const isInitialLoading = loading && loadedHits.length === 0;
+  const isLoadingMore = loading && loadedHits.length > 0;
 
-  // Default result renderer with proper tab support
+  const {
+    scrollRef,
+    sentinelRef,
+    virtualItems,
+    totalSize,
+    measureElement,
+    maxHeight,
+  } = useVirtualizedInfiniteList({
+    count: loadedHits.length,
+    estimateSize: 140,
+    overscan: 6,
+    hasMore,
+    isLoading: loading,
+    onLoadMore: handleLoadMore,
+    // Leave room for the fixed bulk-action toolbar so the last rows stay clear.
+    bottomMargin: selectedCaseRows.size > 0 ? 96 : 16,
+    resetKey: `${searchTrigger}:${selectedTab}`,
+  });
+
+  // Virtualized, infinite-scrolling list of the accumulated hits for the
+  // active tab. One continuous scroll container — no page seam — so a bulk
+  // selection can span the entire result set.
+  const renderVirtualizedHits = () => (
+    <div
+      ref={scrollRef}
+      className="relative overflow-auto"
+      style={{ height: maxHeight ?? undefined }}
+      data-testid="search-results-scroll"
+    >
+      <div className="relative w-full" style={{ height: totalSize }}>
+        {virtualItems.map((vItem) => {
+          const hit = loadedHits[vItem.index];
+          if (!hit) return null;
+          return (
+            <div
+              key={vItem.key}
+              data-index={vItem.index}
+              ref={measureElement}
+              className="absolute left-0 top-0 w-full pb-2"
+              style={{ transform: `translateY(${vItem.start}px)` }}
+            >
+              <SearchResultCard
+                hit={hit}
+                onClick={() => onResultClick?.(hit)}
+                searchQuery={query}
+                isSelected={selectedCaseRows.has(Number(hit.id))}
+                onSelectToggle={
+                  hit.entityType === SearchableEntityType.REPOSITORY_CASE
+                    ? () => toggleCaseSelection(hit)
+                    : undefined
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Sentinel — when it nears the viewport the hook fetches the next page. */}
+      <div
+        ref={sentinelRef}
+        aria-hidden
+        className="h-px w-full"
+        data-testid="search-results-sentinel"
+      />
+
+      {isLoadingMore && (
+        <div
+          className="space-y-2 py-3"
+          aria-label={t("common.loading")}
+          data-testid="search-results-loading-more"
+        >
+          <Skeleton className="h-20 w-full" />
+        </div>
+      )}
+
+      {loadMoreError && (
+        <div className="py-4 text-center">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleLoadMore}
+            data-testid="search-results-load-more-retry"
+          >
+            {t("search.errors.tryAgain")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+
+  // Default result renderer with tab support over the virtualized list.
   const defaultResultRenderer = (results: UnifiedSearchResult) => {
     if (!results.hits.length && results.total === 0) {
       return (
@@ -620,23 +754,20 @@ export function UnifiedSearch({
       Object.keys(results.entityTypeCounts).length > 0;
     const hasMultipleTypes = selectedEntities.length > 1;
 
-    if (hasMultipleTypes && hasEntityTypeCounts) {
-      // Filter results for the selected tab
-      const filteredHits =
-        selectedTab === "all"
-          ? results.hits
-          : results.hits.filter((hit) => hit.entityType === selectedTab);
-
-      return (
-        <div>
+    return (
+      <div>
+        {hasMultipleTypes && hasEntityTypeCounts && (
           <Tabs
             value={selectedTab}
             onValueChange={(value) => {
               const newTab = value as SearchableEntityType | "all";
               setSelectedTab(newTab);
-              setCurrentPage(1); // Reset to first page when changing tabs
-              // Perform search for the specific tab
-              void performSearch(1, newTab);
+              setCurrentPage(1);
+              setLoadMoreError(false);
+              setReachedEnd(false);
+              // Each tab loads its own page 1; the accumulated list resets as
+              // the new results arrive.
+              void performSearch(1, newTab, { append: false });
             }}
             className="w-full"
           >
@@ -683,119 +814,19 @@ export function UnifiedSearch({
               })}
             </TabsList>
           </Tabs>
+        )}
 
-          {/* Results for selected tab */}
-          <div className="mt-4 space-y-2">
-            {filteredHits.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <p>{t("common.labels.noResults")}</p>
-              </div>
-            ) : (
-              filteredHits.map((hit) => (
-                <SearchResultCard
-                  key={`${hit.entityType}-${hit.id}`}
-                  hit={hit}
-                  onClick={() => onResultClick?.(hit)}
-                  searchQuery={query}
-                  isSelected={selectedCaseRows.has(Number(hit.id))}
-                  onSelectToggle={
-                    hit.entityType === SearchableEntityType.REPOSITORY_CASE
-                      ? () => toggleCaseSelection(hit)
-                      : undefined
-                  }
-                />
-              ))
-            )}
+        {totalForTab > 0 && (
+          <div className="mt-4 text-sm text-muted-foreground">
+            {t("common.pagination.showing")} {loadedHits.length}{" "}
+            {t("common.of")} {totalForTab} {t("common.results")}
           </div>
-        </div>
-      );
-    } else {
-      // Single entity type or no counts - show results directly
-      return (
-        <div className="space-y-2">
-          {results.hits.map((hit) => (
-            <SearchResultCard
-              key={`${hit.entityType}-${hit.id}`}
-              hit={hit}
-              onClick={() => onResultClick?.(hit)}
-              searchQuery={query}
-              isSelected={selectedCaseRows.has(Number(hit.id))}
-              onSelectToggle={
-                hit.entityType === SearchableEntityType.REPOSITORY_CASE
-                  ? () => toggleCaseSelection(hit)
-                  : undefined
-              }
-            />
-          ))}
-        </div>
-      );
-    }
+        )}
+
+        <div className="mt-2">{renderVirtualizedHits()}</div>
+      </div>
+    );
   };
-
-  const paginationControls = (
-    <div className="my-4 flex items-center justify-between">
-      <div className="text-sm text-muted-foreground">
-        {t("common.pagination.showing")} {showingFromForTab}-{showingToForTab}{" "}
-        {t("common.of")} {totalForTab} {t("common.results")}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => performSearch(1, selectedTab)}
-          disabled={currentPage === 1}
-        >
-          <ChevronsLeft className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => performSearch(currentPage - 1, selectedTab)}
-          disabled={currentPage === 1}
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </Button>
-
-        <div className="flex items-center gap-1">
-          <span className="text-sm">{t("search.results.page")}</span>
-          <Input
-            type="number"
-            min={1}
-            max={totalPagesForTab}
-            value={currentPage}
-            onChange={(e) => {
-              const page = parseInt(e.target.value) || 1;
-              if (page >= 1 && page <= totalPagesForTab) {
-                void performSearch(page, selectedTab);
-              }
-            }}
-            className="w-16 h-9 text-center"
-          />
-          <span className="text-sm">
-            {t("common.of")} {totalPagesForTab}
-          </span>
-        </div>
-
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => performSearch(currentPage + 1, selectedTab)}
-          disabled={currentPage === totalPagesForTab}
-        >
-          <ChevronRight className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => performSearch(totalPagesForTab, selectedTab)}
-          disabled={currentPage === totalPagesForTab}
-        >
-          <ChevronsRight className="h-4 w-4" />
-        </Button>
-      </div>
-    </div>
-  );
 
   return (
     <div className={cn("space-y-4", compactMode && "space-y-2")}>
@@ -942,7 +973,7 @@ export function UnifiedSearch({
           selectedCaseRows.size > 0 && "pb-20"
         )}
       >
-        {loading && (
+        {isInitialLoading && (
           <div className="space-y-2">
             <Skeleton className="h-20 w-full" />
             <Skeleton className="h-20 w-full" />
@@ -956,22 +987,18 @@ export function UnifiedSearch({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => performSearch(currentPage, selectedTab)}
+              onClick={() => performSearch(1, selectedTab, { append: false })}
             >
               {t("search.errors.tryAgain")}
             </Button>
           </div>
         )}
 
-        {!loading && !error && results && (
+        {!isInitialLoading && !error && results && (
           <>
-            {totalPagesForTab > 1 && paginationControls}
-
             {renderResults
               ? renderResults(results)
               : defaultResultRenderer(results)}
-
-            {totalPagesForTab > 1 && paginationControls}
           </>
         )}
 

--- a/testplanit/hooks/useVirtualizedInfiniteList.test.tsx
+++ b/testplanit/hooks/useVirtualizedInfiniteList.test.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "~/test/test-utils";
+import {
+  useVirtualizedInfiniteList,
+  type UseVirtualizedInfiniteListOptions,
+} from "./useVirtualizedInfiniteList";
+
+// jsdom has no IntersectionObserver. Provide a controllable stand-in that lets
+// each test drive the sentinel's intersection state by hand. Disconnected
+// instances drop out of the registry so `fireAll` only hits live observers.
+let observers: MockIntersectionObserver[] = [];
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  elements = new Set<Element>();
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit
+  ) {
+    this.callback = callback;
+    this.options = options;
+    observers.push(this);
+  }
+  observe(el: Element) {
+    this.elements.add(el);
+  }
+  unobserve(el: Element) {
+    this.elements.delete(el);
+  }
+  disconnect() {
+    this.elements.clear();
+    observers = observers.filter((o) => o !== this);
+  }
+  takeRecords() {
+    return [];
+  }
+  fire(isIntersecting: boolean) {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+function fireAll(isIntersecting: boolean) {
+  act(() => {
+    observers.forEach((o) => o.fire(isIntersecting));
+  });
+}
+
+type HarnessProps = Omit<UseVirtualizedInfiniteListOptions, "estimateSize"> & {
+  estimateSize?: number;
+};
+
+function Harness(props: HarnessProps) {
+  const { scrollRef, sentinelRef } = useVirtualizedInfiniteList({
+    estimateSize: 40,
+    ...props,
+  });
+  return (
+    <div ref={scrollRef} data-testid="scroll" style={{ height: 400 }}>
+      <div style={{ height: 1 }} />
+      <div ref={sentinelRef} data-testid="sentinel" />
+    </div>
+  );
+}
+
+describe("useVirtualizedInfiniteList", () => {
+  beforeEach(() => {
+    observers = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers an intersection observer on the sentinel once bounded", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <Harness count={5} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(observers.length).toBe(1);
+    expect(observers[0].elements.size).toBe(1);
+  });
+
+  it("calls onLoadMore when the sentinel intersects and more is available", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <Harness count={5} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).not.toHaveBeenCalled();
+    fireAll(true);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onLoadMore while a fetch is in flight", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <Harness count={5} hasMore isLoading={true} onLoadMore={onLoadMore} />
+    );
+    fireAll(true);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("does not call onLoadMore when there is nothing more to load", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <Harness
+        count={5}
+        hasMore={false}
+        isLoading={false}
+        onLoadMore={onLoadMore}
+      />
+    );
+    fireAll(true);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("retries once a fetch settles while the sentinel stays in view", () => {
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <Harness count={5} hasMore isLoading={true} onLoadMore={onLoadMore} />
+    );
+    // Sentinel is visible, but a fetch is in flight — no load yet.
+    fireAll(true);
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    // Fetch settles; the sentinel is still in view, so the next page is pulled
+    // without waiting for another scroll event.
+    rerender(
+      <Harness count={5} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the observer when the scroll container mounts after the hook", () => {
+    // Mirrors UnifiedSearch, where the scroll container only renders once
+    // results arrive — long after the hook itself first ran.
+    function LateHarness({
+      show,
+      onLoadMore,
+    }: {
+      show: boolean;
+      onLoadMore: () => void;
+    }) {
+      const { scrollRef, sentinelRef } = useVirtualizedInfiniteList({
+        count: 5,
+        hasMore: true,
+        isLoading: false,
+        onLoadMore,
+        estimateSize: 40,
+      });
+      if (!show) return <div data-testid="placeholder" />;
+      return (
+        <div ref={scrollRef} data-testid="scroll" style={{ height: 400 }}>
+          <div ref={sentinelRef} data-testid="sentinel" />
+        </div>
+      );
+    }
+
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <LateHarness show={false} onLoadMore={onLoadMore} />
+    );
+    // No scroll element yet → nothing observed.
+    expect(observers.length).toBe(0);
+
+    // Container mounts later → the observer must still get wired.
+    rerender(<LateHarness show={true} onLoadMore={onLoadMore} />);
+    expect(observers.length).toBe(1);
+
+    fireAll(true);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/testplanit/hooks/useVirtualizedInfiniteList.ts
+++ b/testplanit/hooks/useVirtualizedInfiniteList.ts
@@ -1,0 +1,172 @@
+"use client";
+/* eslint-disable react-hooks/incompatible-library -- TanStack Virtual's useVirtualizer() returns unstable function references by design; React Compiler auto-skips memoization here and the lint rule reports it (same as components/matrix/MatrixGrid.tsx). */
+
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+/**
+ * Shared wiring for a virtualized, infinite-scrolling list.
+ *
+ * Combines three concerns that a paginated surface needs to drop the
+ * page-seam scroll reset:
+ *
+ *   1. A row virtualizer (TanStack Virtual) so an accumulated hit/row array
+ *      of arbitrary length renders only the visible window.
+ *   2. A bounded scroll-container height computed from the live bounding rect
+ *      to the viewport bottom — without it the virtualizer treats the parent
+ *      as infinitely tall and renders every row (see MatrixGrid for the same
+ *      reasoning).
+ *   3. An IntersectionObserver sentinel near the bottom that fetches the next
+ *      page as the user nears it and the result set is appended in place.
+ *
+ * Attach `scrollRef` to the scroll container, render the virtual items inside
+ * a spacer sized to `totalSize`, and place a zero-height element with
+ * `sentinelRef` after the spacer. Wire each row's `ref` to `measureElement`
+ * and give it a `data-index` so variable-height rows measure themselves.
+ *
+ * Designed to be consumed by more than one surface (UnifiedSearch results and
+ * the reports table) so both converge on the same scroll model.
+ */
+
+export interface UseVirtualizedInfiniteListOptions {
+  /** Number of items currently loaded (the accumulated array length). */
+  count: number;
+  /** Estimated row height in px, used before dynamic measurement settles. */
+  estimateSize?: number;
+  /** Rows rendered beyond the visible window on each side. */
+  overscan?: number;
+  /** Whether another page can be fetched. */
+  hasMore: boolean;
+  /** Whether a fetch is currently in flight. */
+  isLoading: boolean;
+  /** Called when the sentinel nears the viewport and another page is available. */
+  onLoadMore: () => void;
+  /** Distance (px) below the viewport at which to prefetch the next page. */
+  loadMoreMargin?: number;
+  /** Space (px) to leave below the list when filling the viewport. */
+  bottomMargin?: number;
+  /** When this value changes, the list scrolls to the top and re-measures. */
+  resetKey?: unknown;
+}
+
+// useLayoutEffect warns when run during SSR; consumers are client components,
+// but guard anyway so the hook is safe to import anywhere.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export function useVirtualizedInfiniteList({
+  count,
+  estimateSize = 140,
+  overscan = 6,
+  hasMore,
+  isLoading,
+  onLoadMore,
+  loadMoreMargin = 300,
+  bottomMargin = 16,
+  resetKey,
+}: UseVirtualizedInfiniteListOptions) {
+  // A callback ref (rather than a plain useRef) so the effects re-run when the
+  // scroll container actually mounts. The container is often rendered *after*
+  // this hook (e.g. only once search results arrive), so a one-shot mount
+  // effect would measure a null element and leave `maxHeight` null forever —
+  // unbounding the list and disabling the load-more sentinel.
+  const scrollElRef = useRef<HTMLDivElement | null>(null);
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const scrollRef = useCallback((node: HTMLDivElement | null) => {
+    scrollElRef.current = node;
+    setScrollEl(node);
+  }, []);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [maxHeight, setMaxHeight] = useState<number | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!scrollEl) return;
+    const compute = () => {
+      const top = scrollEl.getBoundingClientRect().top;
+      setMaxHeight(Math.max(200, window.innerHeight - top - bottomMargin));
+    };
+    compute();
+    window.addEventListener("resize", compute);
+    return () => window.removeEventListener("resize", compute);
+  }, [scrollEl, bottomMargin]);
+
+  const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+    count,
+    getScrollElement: () => scrollElRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+  });
+
+  // Latest values for the observer callback without re-subscribing each
+  // render. `isIntersecting` is tracked so a settled fetch can re-attempt a
+  // load while the sentinel is still in view (result set shorter than the
+  // viewport).
+  const stateRef = useRef({
+    hasMore,
+    isLoading,
+    onLoadMore,
+    isIntersecting: false,
+  });
+  stateRef.current.hasMore = hasMore;
+  stateRef.current.isLoading = isLoading;
+  stateRef.current.onLoadMore = onLoadMore;
+
+  const maybeLoadMore = useCallback(() => {
+    const s = stateRef.current;
+    if (s.isIntersecting && s.hasMore && !s.isLoading) s.onLoadMore();
+  }, []);
+
+  // Only wire the sentinel once the container is mounted and bounded, so an
+  // unbounded first paint can't fire a burst of page loads before the height
+  // settles. Re-runs when the scroll element mounts (`scrollEl`).
+  useEffect(() => {
+    if (maxHeight == null) return;
+    const root = scrollElRef.current;
+    const sentinel = sentinelRef.current;
+    if (!root || !sentinel || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        stateRef.current.isIntersecting = entry.isIntersecting;
+        if (entry.isIntersecting) maybeLoadMore();
+      },
+      { root, rootMargin: `0px 0px ${loadMoreMargin}px 0px`, threshold: 0 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [scrollEl, maxHeight, loadMoreMargin, maybeLoadMore]);
+
+  // After a page settles (or hasMore flips), pull again if the sentinel is
+  // still visible — fills the viewport without waiting for a scroll event.
+  useEffect(() => {
+    maybeLoadMore();
+  }, [count, hasMore, isLoading, maybeLoadMore]);
+
+  // Reset scroll position and drop cached measurements when the query/scope
+  // changes so the new result set starts from the top.
+  useEffect(() => {
+    const el = scrollElRef.current;
+    if (el) el.scrollTop = 0;
+    virtualizer.scrollToOffset(0);
+    virtualizer.measure();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey]);
+
+  return {
+    scrollRef,
+    sentinelRef,
+    virtualizer,
+    virtualItems: virtualizer.getVirtualItems(),
+    totalSize: virtualizer.getTotalSize(),
+    measureElement: virtualizer.measureElement,
+    maxHeight,
+  };
+}


### PR DESCRIPTION
## Description

Unified/global search results now render as a single virtualized, infinite-scrolling list instead of paged results. Additional pages load automatically as you approach the bottom, so there's no page-seam scroll reset, and a "Showing X of Y results" count tracks how much of the total has loaded. Because every loaded result stays in the list, the per-row bulk selection added in #400 can now span the **entire** result set rather than being trapped on a single page.

The virtualizer + bounded-height + intersection-observer wiring is extracted into a reusable `useVirtualizedInfiniteList` hook (mirroring the existing Iteration Matrix virtualization) so other paginated surfaces — e.g. the reports table — can converge on the same scroll model.

### What changed

- **`components/UnifiedSearch.tsx`** — paged controls replaced with accumulated hits + a virtualized list and a load-more sentinel. Tabs, the bulk-action toolbar, and cross-project guards are preserved. Defensive `hasMore` / `reachedEnd` guards prevent runaway fetches if the reported total ever over-counts what's returnable.
- **`hooks/useVirtualizedInfiniteList.ts`** — new shared hook (TanStack Virtual + viewport-bounded height + `IntersectionObserver`). The scroll container is attached via a callback ref so the observer wires correctly even though the list mounts *after* the hook runs — the cause of an early "only the first 50 results show" bug.
- **Docs** — `advanced-search.md` Navigation section updated from "pagination controls" to continuous scrolling.

The `/api/search` contract is unchanged; the UI still requests pages under the hood.

## Related Issue

N/A — follows on from #400 (search-results bulk actions).

## Type of Change

- [x] Enhancement (non-breaking improvement to existing functionality)

## Testing

- New **`hooks/useVirtualizedInfiniteList.test.tsx`** (6 tests): observer fires on intersect; respects `hasMore` / `isLoading`; retries when a fetch settles with the sentinel still in view; and wires correctly when the scroll container mounts after the hook (regression for the "first 50 only" bug).
- **`components/UnifiedSearch.test.tsx`**: replaced the next-page test with an infinite-scroll append test (asserts `pagination.page` increments and pages accumulate), plus cross-page bulk-selection retention and reset-on-query-change.
- Full gate green locally: production build, ESLint, `tsc --noEmit`, `format:check`, and the full Vitest suite (**9220 passed / 145 skipped**).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally
- [x] I have made corresponding changes to the documentation
