### PR TITLE
enhancement(reports): virtual scrolling + infinite list for report tables

### DIFF
--- a/testplanit/components/matrix/MatrixGrid.tsx
+++ b/testplanit/components/matrix/MatrixGrid.tsx
@@ -255,7 +255,12 @@ export function MatrixGrid({
                 }
               >
                 {isCaseRow ? (
-                  <div className="min-w-0 flex-1 overflow-hidden [&_*]:min-w-0 [&_span]:block [&_span]:overflow-hidden [&_span]:truncate [&_span]:whitespace-nowrap">
+                  // `[&_*]:min-w-0` lets the name truncate inside the nested
+                  // flex layout. We deliberately do NOT blanket-force spans to
+                  // `block` — that broke CaseDisplay's inline-flex type icon
+                  // onto its own line. The name already truncates via the
+                  // CaseDisplay `maxLines={1}` below.
+                  <div className="min-w-0 flex-1 overflow-hidden [&_*]:min-w-0">
                     <CaseDisplay
                       id={sr.caseId}
                       name={sr.caseName}

--- a/testplanit/components/reports/ReportBuilder.tsx
+++ b/testplanit/components/reports/ReportBuilder.tsx
@@ -77,10 +77,6 @@ import {
   getCrossProjectReportTypes,
   getProjectReportTypes,
 } from "~/lib/config/reportTypes";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
 import { usePathname, useRouter } from "~/lib/navigation";
 import { reportRequestSchema } from "~/lib/schemas/reportRequestSchema";
 import type {
@@ -163,7 +159,11 @@ const dateRangeSchema = z.object({
 
 type DateRangeFormData = z.infer<typeof dateRangeSchema>;
 
-// Inner component that uses pagination context
+// Rows fetched per execution-log scroll page. Kept within the server's
+// per-request clamp (1–200) so `loaded < total` math stays accurate.
+const EXECUTION_LOG_PAGE_SIZE = 100;
+
+// Inner component
 function ReportBuilderContent({
   mode,
   projectId,
@@ -190,15 +190,12 @@ function ReportBuilderContent({
       : getProjectReportTypes(tReports);
   }, [mode, tReports]);
 
-  // Use pagination context
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems: totalCount,
-    setTotalItems: setTotalCount,
-  } = usePagination();
+  // Results count for the "Showing X of Y" summary. The table is virtualized
+  // and infinite-scrolling now, so there is no page/pageSize state — full-set
+  // reports render their whole array and execution-log fetches more on scroll.
+  const [totalCount, setTotalCount] = useState(0);
+  // A load-more fetch is in flight (execution-log only).
+  const [loadingMore, setLoadingMore] = useState(false);
 
   // Form for date range
   const form = useForm<DateRangeFormData>({
@@ -925,9 +922,6 @@ function ReportBuilderContent({
     const newParams = new URLSearchParams();
     newParams.set("reportType", safeReportType);
     newParams.set("tab", newTab);
-    // Reset pagination when changing reports
-    newParams.set("page", "1");
-    newParams.set("pageSize", String(pageSize !== "All" ? pageSize : 10));
     router.replace(`${pathname}?${newParams.toString()}`);
   };
 
@@ -1199,7 +1193,8 @@ function ReportBuilderContent({
     async (
       selectedDimensions: any[],
       selectedMetrics: any[],
-      updateUrl: boolean = false
+      updateUrl: boolean = false,
+      { append = false, page = 1 }: { append?: boolean; page?: number } = {}
     ) => {
       try {
         // Don't attempt to run report if metrics are empty (except for pre-built reports)
@@ -1221,12 +1216,16 @@ function ReportBuilderContent({
           return;
         }
 
+        // Only execution-log is truly server-paginated (real DB skip/take); it
+        // fetches a window per scroll. Every other report returns its full set,
+        // so we ask for everything in one request and virtualize it client-side.
+        const isExecLog = matchesReportType(reportType, "execution-log");
         const dateRange = form.getValues("dateRange");
         const body: any = {
           dimensions: selectedDimensions.map((d) => d.value),
           metrics: selectedMetrics.map((m) => m.value),
-          page: currentPage,
-          pageSize: pageSize,
+          page: isExecLog ? page : 1,
+          pageSize: isExecLog ? EXECUTION_LOG_PAGE_SIZE : "All",
         };
 
         if (mode === "project" && projectId) {
@@ -1395,14 +1394,21 @@ function ReportBuilderContent({
 
         // Handle client-side pagination for pre-built reports
         if (currentReport?.isPreBuilt) {
-          // Execution log uses server-side pagination
-          if (matchesReportType(reportType, "execution-log")) {
+          // Execution log uses true server-side pagination — accumulate pages
+          // as the user scrolls instead of replacing the visible page.
+          if (isExecLog) {
             const tableData = data.data || data.results || [];
-            setResults(tableData);
+            setResults((prev) => {
+              if (!append || !prev) return tableData;
+              // De-dupe by row id in case a page boundary overlaps.
+              const seen = new Set(prev.map((r: any) => r.id));
+              const fresh = tableData.filter((r: any) => !seen.has(r.id));
+              return fresh.length ? [...prev, ...fresh] : prev;
+            });
             setTotalCount(data.total ?? tableData.length);
-            if (updateUrl) {
-              // Store status breakdown in allResults for the chart;
-              // don't replace it on pagination so the chart stays stable.
+            // Only on a fresh run (never on append): store the status breakdown
+            // for the chart so scrolling doesn't disturb it.
+            if (updateUrl && !append) {
               setAllResults(data.statusBreakdown || []);
               setLastUsedDimensions(selectedDimensions);
             }
@@ -1480,21 +1486,14 @@ function ReportBuilderContent({
             });
           }
 
-          // Slice data for current page
-          if (pageSize === "All") {
-            // Show all data when pageSize is "All"
-            setResults(sortedData);
-          } else {
-            const startIndex = (currentPage - 1) * (pageSize as number);
-            const endIndex = startIndex + (pageSize as number);
-            setResults(sortedData.slice(startIndex, endIndex));
-          }
+          // Render the full sorted set; the table virtualizes it (no paging).
+          setResults(sortedData);
         } else {
-          // Standard server-side pagination for other reports
-          const tableData = data.data || data.results;
-          const chartData = data.allResults || data.data || data.results;
+          // Custom reports return the entire result set in `allResults` on the
+          // first POST — render that full set and virtualize it (no paging).
+          const fullData = data.allResults || data.data || data.results || [];
 
-          setResults(tableData); // Support both formats
+          setResults(fullData);
 
           // Store projects for automation trends report
           if (
@@ -1504,19 +1503,12 @@ function ReportBuilderContent({
             setAutomationTrendsProjects(data.projects);
           }
 
-          // Update allResults and chartDataRef with the full dataset
-          // For pagination/sorting changes, we still need the full dataset for the chart
-          const newAllResults = chartData;
-
-          // Only update chart data when running a new report (not pagination)
-          // Chart should always show the full dataset, not update on pagination
+          // Chart shows the full dataset; only refresh it on a new run.
           if (updateUrl) {
-            setAllResults(newAllResults);
+            setAllResults(fullData);
           }
 
-          setTotalCount(
-            data.total || data.totalCount || (data.data || data.results).length
-          );
+          setTotalCount(data.total || data.totalCount || fullData.length);
         }
 
         // Only update these when running a new report (not just sorting/paginating)
@@ -1590,8 +1582,6 @@ function ReportBuilderContent({
     },
     [
       form,
-      currentPage,
-      pageSize,
       mode,
       projectId,
       sortConfig,
@@ -1629,6 +1619,32 @@ function ReportBuilderContent({
     },
     [fetchReportData]
   );
+
+  // Infinite scroll only applies to execution-log (the one truly server-paged
+  // report). Every other report has its full set loaded, so hasMore stays false.
+  const isExecutionLog = matchesReportType(reportType, "execution-log");
+  const loadedCount = results?.length ?? 0;
+  const hasMore = isExecutionLog && loadedCount < totalCount;
+
+  const handleLoadMore = useCallback(() => {
+    if (!isExecutionLog || loadingMore) return;
+    const loaded = results?.length ?? 0;
+    if (loaded >= totalCount) return;
+    const nextPage = Math.floor(loaded / EXECUTION_LOG_PAGE_SIZE) + 1;
+    setLoadingMore(true);
+    void fetchReportData(lastUsedDimensions, lastUsedMetrics, false, {
+      append: true,
+      page: nextPage,
+    }).finally(() => setLoadingMore(false));
+  }, [
+    isExecutionLog,
+    loadingMore,
+    results,
+    totalCount,
+    fetchReportData,
+    lastUsedDimensions,
+    lastUsedMetrics,
+  ]);
 
   // Auto-run report if we have stored selections
   useEffect(() => {
@@ -1670,77 +1686,57 @@ function ReportBuilderContent({
     currentReport,
   ]);
 
-  // Re-fetch data when pagination changes (without full loading state)
+  // Pre-built (non-execution-log) reports hold their full set client-side and
+  // re-sort it in place — no server round-trip, no paging.
   useEffect(() => {
-    // Execution log uses server-side pagination — refetch like a custom report
-    if (
-      matchesReportType(reportType, "execution-log") &&
-      currentReport?.isPreBuilt &&
-      results
-    ) {
-      void fetchReportData(lastUsedDimensions, lastUsedMetrics, false);
-      return;
-    }
+    if (!currentReport?.isPreBuilt) return;
+    if (matchesReportType(reportType, "execution-log")) return;
+    if (!allResults || allResults.length === 0) return;
 
-    // For pre-built reports, handle client-side pagination
-    if (currentReport?.isPreBuilt && allResults && allResults.length > 0) {
-      // Apply client-side sorting first
-      let sortedResults = [...allResults];
-      if (sortConfig) {
-        sortedResults.sort((a, b) => {
-          let aVal = a[sortConfig.column];
-          let bVal = b[sortConfig.column];
+    let sortedResults = [...allResults];
+    if (sortConfig) {
+      sortedResults.sort((a, b) => {
+        let aVal = a[sortConfig.column];
+        let bVal = b[sortConfig.column];
 
-          // Handle project column - extract name from object
-          if (sortConfig.column === "project") {
-            aVal = aVal?.name || "";
-            bVal = bVal?.name || "";
-          }
+        // Handle project column - extract name from object
+        if (sortConfig.column === "project") {
+          aVal = aVal?.name || "";
+          bVal = bVal?.name || "";
+        }
 
-          if (aVal === bVal) return 0;
-          if (aVal === null || aVal === undefined) return 1;
-          if (bVal === null || bVal === undefined) return -1;
+        if (aVal === bVal) return 0;
+        if (aVal === null || aVal === undefined) return 1;
+        if (bVal === null || bVal === undefined) return -1;
 
-          // For strings, use localeCompare for proper alphabetical sorting
-          if (typeof aVal === "string" && typeof bVal === "string") {
-            const comparison = aVal.localeCompare(bVal);
-            return sortConfig.direction === "asc" ? comparison : -comparison;
-          }
-
-          // For numbers or other types, use standard comparison
-          const comparison = aVal < bVal ? -1 : 1;
+        // For strings, use localeCompare for proper alphabetical sorting
+        if (typeof aVal === "string" && typeof bVal === "string") {
+          const comparison = aVal.localeCompare(bVal);
           return sortConfig.direction === "asc" ? comparison : -comparison;
-        });
-      }
+        }
 
-      // Then apply pagination
-      if (pageSize === "All") {
-        setResults(sortedResults);
-      } else {
-        const startIdx = (currentPage - 1) * pageSize;
-        const endIdx = startIdx + pageSize;
-        setResults(sortedResults.slice(startIdx, endIdx));
-      }
-    } else if (
-      lastUsedDimensions.length > 0 &&
-      lastUsedMetrics.length > 0 &&
-      results &&
-      !currentReport?.isPreBuilt
-    ) {
-      // Standard server-side pagination for other reports
-      void fetchReportData(lastUsedDimensions, lastUsedMetrics, false);
+        // For numbers or other types, use standard comparison
+        const comparison = aVal < bVal ? -1 : 1;
+        return sortConfig.direction === "asc" ? comparison : -comparison;
+      });
     }
+    setResults(sortedResults);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage, pageSize, sortConfig, reportType, allResults]);
+  }, [sortConfig, reportType, allResults]);
 
-  // Re-fetch data when sort changes for non-prebuilt reports (without full loading state)
+  // Server-sorted reports (custom + execution-log) refetch the full sorted set
+  // when sort changes. Execution-log restarts its accumulation from page 1
+  // (append:false replaces the rows) since the whole list reorders.
   useEffect(() => {
     if (
       (!currentReport?.isPreBuilt ||
         matchesReportType(reportType, "execution-log")) &&
       results
     ) {
-      void fetchReportData(lastUsedDimensions, lastUsedMetrics, false);
+      void fetchReportData(lastUsedDimensions, lastUsedMetrics, false, {
+        append: false,
+        page: 1,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortConfig]);
@@ -1810,18 +1806,15 @@ function ReportBuilderContent({
       );
       return;
     }
-    setCurrentPage(1); // Reset to first page when running new report
     void runReport(dimensions, metrics);
   };
 
   const handleDimensionsChange = (newDimensions: any[]) => {
     setDimensions(newDimensions);
-    setCurrentPage(1); // Reset to first page when dimensions change
   };
 
   const handleMetricsChange = (newMetrics: any[]) => {
     setMetrics(newMetrics);
-    setCurrentPage(1); // Reset to first page when metrics change
   };
 
   // Note: Sorting is now done server-side, so we use results directly
@@ -2920,11 +2913,11 @@ function ReportBuilderContent({
                 ? allResults.length
                 : undefined
             }
-            currentPage={currentPage}
-            pageSize={pageSize}
+            loadedCount={loadedCount}
             totalCount={totalCount}
-            onPageChange={setCurrentPage}
-            onPageSizeChange={setPageSize}
+            hasMore={hasMore}
+            isLoading={loadingMore}
+            onLoadMore={handleLoadMore}
             sortConfig={sortConfig}
             onSortChange={(columnId: string) => {
               setSortConfig((prev) => ({
@@ -3009,11 +3002,6 @@ function ReportBuilderContent({
   );
 }
 
-// Wrapper component with PaginationProvider
 export function ReportBuilder(props: ReportBuilderProps) {
-  return (
-    <PaginationProvider defaultPageSize={50}>
-      <ReportBuilderContent {...props} />
-    </PaginationProvider>
-  );
+  return <ReportBuilderContent {...props} />;
 }

--- a/testplanit/components/reports/ReportRenderer.test.tsx
+++ b/testplanit/components/reports/ReportRenderer.test.tsx
@@ -56,21 +56,26 @@ vi.mock("~/hooks/useExecutionLogColumns", () => ({
   useExecutionLogColumns: () => mockExecutionLogColumns,
 }));
 
-// Mock DataTable to render data rows for inspection
-vi.mock("~/components/tables/DataTable", () => ({
-  DataTable: ({ data, columns }: { data: any[]; columns: any[] }) => (
-    <div data-testid="data-table">
-      {data.map((row, i) => (
-        <div key={i} data-testid="data-table-row">
-          {columns.map((col: any) => (
-            <span key={col.id || col.accessorKey}>
-              {row[col.accessorKey] ?? ""}
-            </span>
-          ))}
-        </div>
-      ))}
-    </div>
-  ),
+// Mock VirtualizedReportTable to render data rows for inspection and capture
+// the props ReportRenderer forwards (incl. the infinite-scroll wiring).
+const tableMock = vi.hoisted(() => ({ lastProps: null as any }));
+vi.mock("~/components/reports/VirtualizedReportTable", () => ({
+  VirtualizedReportTable: (props: any) => {
+    tableMock.lastProps = props;
+    return (
+      <div data-testid="data-table">
+        {props.data.map((row: any, i: number) => (
+          <div key={i} data-testid="data-table-row">
+            {props.columns.map((col: any) => (
+              <span key={col.id || col.accessorKey}>
+                {row[col.accessorKey] ?? ""}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  },
 }));
 
 // Mock ReportChart to avoid D3 complexity
@@ -78,16 +83,6 @@ vi.mock("@/components/dataVisualizations/ReportChart", () => ({
   ReportChart: ({ results }: { results: any[] }) => (
     <div data-testid="report-chart">chart-data-length:{results.length}</div>
   ),
-}));
-
-// Mock PaginationComponent
-vi.mock("~/components/tables/Pagination", () => ({
-  PaginationComponent: () => <div data-testid="pagination" />,
-}));
-
-// Mock PaginationControls
-vi.mock("~/components/tables/PaginationControls", () => ({
-  PaginationInfo: () => <div data-testid="pagination-info" />,
 }));
 
 // Mock DateFormatter
@@ -106,21 +101,16 @@ vi.mock("@/components/ui/resizable", () => ({
   ResizableHandle: () => <div data-testid="resizable-handle" />,
 }));
 
-// Mock PaginationContext
-vi.mock("~/lib/contexts/PaginationContext", () => ({
-  defaultPageSizeOptions: [10, 25, 50, 100, "All"],
-}));
-
 import { ReportRenderer } from "./ReportRenderer";
 
 const defaultProps = {
   results: [],
   reportType: "repository-stats",
-  currentPage: 1,
-  pageSize: 10 as number | "All",
+  loadedCount: 0,
   totalCount: 0,
-  onPageChange: vi.fn(),
-  onPageSizeChange: vi.fn(),
+  hasMore: false,
+  isLoading: false,
+  onLoadMore: vi.fn(),
   onSortChange: vi.fn(),
   columnVisibility: {},
   onColumnVisibilityChange: vi.fn(),
@@ -243,5 +233,60 @@ describe("ReportRenderer", () => {
       />
     );
     expect(screen.getByText("Summary text")).toBeInTheDocument();
+  });
+
+  it("renders every row it is given (no pagination slicing)", () => {
+    const many = Array.from({ length: 120 }, (_, i) => ({
+      name: `Test ${i + 1}`,
+      value: String(i),
+    }));
+    render(
+      <ReportRenderer
+        {...defaultProps}
+        results={many}
+        loadedCount={120}
+        totalCount={120}
+        reportType="repository-stats"
+      />
+    );
+    expect(screen.getAllByTestId("data-table-row")).toHaveLength(120);
+  });
+
+  it("shows a 'Showing X of Y' summary instead of pagination controls", () => {
+    render(
+      <ReportRenderer
+        {...defaultProps}
+        results={sampleResults}
+        loadedCount={2}
+        totalCount={50}
+        reportType="repository-stats"
+      />
+    );
+    expect(
+      screen.getByText(
+        (_content, el) => el?.textContent === "showing 2 of 50 results"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("forwards the infinite-scroll wiring to the virtualized table", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ReportRenderer
+        {...defaultProps}
+        results={sampleResults}
+        loadedCount={2}
+        totalCount={100}
+        hasMore={true}
+        isLoading={true}
+        onLoadMore={onLoadMore}
+        reportType="cross-project-execution-log"
+      />
+    );
+    expect(tableMock.lastProps.hasMore).toBe(true);
+    expect(tableMock.lastProps.isLoading).toBe(true);
+    expect(tableMock.lastProps.onLoadMore).toBe(onLoadMore);
+    // Execution-log wires sub-rows (steps) for expansion.
+    expect(typeof tableMock.lastProps.getSubRows).toBe("function");
   });
 });

--- a/testplanit/components/reports/ReportRenderer.tsx
+++ b/testplanit/components/reports/ReportRenderer.tsx
@@ -4,7 +4,7 @@ import { AutomationCandidatesReportPreset } from "@/components/automationCandida
 import { ReportChart } from "@/components/dataVisualizations/ReportChart";
 import { DateFormatter } from "@/components/DateFormatter";
 import { MatrixReportPreset } from "@/components/matrix/MatrixReportPreset";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedReportTable } from "@/components/reports/VirtualizedReportTable";
 import {
   Card,
   CardContent,
@@ -25,15 +25,12 @@ import {
 } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
-import { PaginationComponent } from "~/components/tables/Pagination";
-import { PaginationInfo } from "~/components/tables/PaginationControls";
 import { useAutomationTrendsColumns } from "~/hooks/useAutomationTrendsColumns";
 import { useExecutionLogColumns } from "~/hooks/useExecutionLogColumns";
 import { useFlakyTestsColumns } from "~/hooks/useFlakyTestsColumns";
 import { useIssueTestCoverageSummaryColumns } from "~/hooks/useIssueTestCoverageColumns";
 import { useReportColumns } from "~/hooks/useReportColumns";
 import { useTestCaseHealthColumns } from "~/hooks/useTestCaseHealthColumns";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 
 // Helper functions for report type matching
 // These helpers allow us to write code that works with both project-level and cross-project variants
@@ -105,12 +102,17 @@ interface ReportRendererProps {
   // "regenerate this for a public viewer" interaction.
   automationCandidatesSnapshot?: any;
 
-  // Pagination
-  currentPage: number;
-  pageSize: number | "All";
+  // Results count + infinite scroll. `loadedCount` is how many rows are
+  // currently in `results` (the "X" in "Showing X of Y"); `totalCount` is the
+  // full match count. For full-set reports loadedCount === totalCount and
+  // hasMore is false; execution-log fetches more on scroll.
+  loadedCount: number;
   totalCount: number;
-  onPageChange: (page: number) => void;
-  onPageSizeChange: (size: number | "All") => void;
+  hasMore?: boolean;
+  isLoading?: boolean;
+  onLoadMore?: () => void;
+  loadMoreError?: boolean;
+  onRetryLoadMore?: () => void;
 
   // Sorting
   sortConfig?: { column: string; direction: "asc" | "desc" } | null;
@@ -156,11 +158,13 @@ export function ReportRenderer({
   totalFlakyTests,
   matrixAxes,
   automationCandidatesSnapshot,
-  currentPage,
-  pageSize,
+  loadedCount,
   totalCount,
-  onPageChange,
-  onPageSizeChange,
+  hasMore = false,
+  isLoading = false,
+  onLoadMore,
+  loadMoreError = false,
+  onRetryLoadMore,
   sortConfig,
   onSortChange,
   columnVisibility,
@@ -254,14 +258,6 @@ export function ReportRenderer({
     reportType,
     "automation-candidates"
   );
-
-  // Calculate pagination
-  const startIndex = pageSize === "All" ? 1 : (currentPage - 1) * pageSize + 1;
-  const endIndex =
-    pageSize === "All"
-      ? totalCount
-      : Math.min(currentPage * pageSize, totalCount);
-  const pageSizeOptions = usePageSizeOptions(totalCount);
 
   // Maximum number of data points to render in charts
   const MAX_CHART_DATA_POINTS = 50;
@@ -490,35 +486,15 @@ export function ReportRenderer({
             <div className="flex flex-row items-end justify-between">
               <CardTitle>{tCommon("results")}</CardTitle>
               {totalCount > 0 && (
-                <div className="flex flex-col items-end">
-                  <div className="justify-end">
-                    <PaginationInfo
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalCount}
-                      searchString=""
-                      pageSize={pageSize}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={onPageSizeChange}
-                    />
-                  </div>
-                  {pageSize !== "All" && totalCount > (pageSize as number) && (
-                    <div className="justify-end -mx-4">
-                      <PaginationComponent
-                        currentPage={currentPage}
-                        totalPages={Math.ceil(
-                          totalCount / (pageSize as number)
-                        )}
-                        onPageChange={onPageChange}
-                      />
-                    </div>
-                  )}
+                <div className="text-sm text-muted-foreground">
+                  {tCommon("pagination.showing")} {loadedCount} {tCommon("of")}{" "}
+                  {totalCount} {tCommon("results")}
                 </div>
               )}
             </div>
           </CardHeader>
-          <CardContent className="h-[calc(100%-4rem)] overflow-y-auto p-6 pt-0">
-            <DataTable
+          <CardContent className="h-[calc(100%-4rem)] p-6 pt-0">
+            <VirtualizedReportTable
               columns={columns as ColumnDef<any>[]}
               data={results}
               columnVisibility={columnVisibility}
@@ -539,6 +515,11 @@ export function ReportRenderer({
                   ? tCommon("fields.steps").toLowerCase()
                   : undefined
               }
+              hasMore={hasMore}
+              isLoading={isLoading}
+              onLoadMore={onLoadMore}
+              loadMoreError={loadMoreError}
+              onRetryLoadMore={onRetryLoadMore}
             />
           </CardContent>
         </Card>

--- a/testplanit/components/reports/VirtualizedReportTable.test.tsx
+++ b/testplanit/components/reports/VirtualizedReportTable.test.tsx
@@ -1,0 +1,160 @@
+import { ColumnDef } from "@tanstack/react-table";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "~/test/test-utils";
+import { VirtualizedReportTable } from "./VirtualizedReportTable";
+
+// The real hook owns TanStack Virtual + an IntersectionObserver, neither of
+// which produces layout (or fires) under jsdom. Replace it with a pass-through
+// that renders every flattened row and captures the latest `onLoadMore` so a
+// test can simulate the sentinel firing. The hook has its own unit test for the
+// observer wiring (hooks/useVirtualizedInfiniteList.test.tsx).
+const hookMock = vi.hoisted(() => ({
+  lastOnLoadMore: null as null | (() => void),
+  lastOpts: null as Record<string, unknown> | null,
+}));
+
+vi.mock("~/hooks/useVirtualizedInfiniteList", () => ({
+  useVirtualizedInfiniteList: (opts: {
+    count: number;
+    onLoadMore: () => void;
+  }) => {
+    hookMock.lastOnLoadMore = opts.onLoadMore;
+    hookMock.lastOpts = opts as unknown as Record<string, unknown>;
+    return {
+      scrollRef: () => {},
+      sentinelRef: { current: null },
+      virtualizer: {},
+      virtualItems: Array.from({ length: opts.count }, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 44,
+        size: 44,
+        end: (i + 1) * 44,
+        lane: 0,
+      })),
+      totalSize: opts.count * 44,
+      measureElement: () => {},
+      maxHeight: null,
+    };
+  },
+}));
+
+// Bare-key i18n mock (namespace-agnostic) — matches the pattern used by other
+// component tests so we can assert on stable label keys.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+interface RowShape {
+  id: number;
+  name: string;
+  count: number;
+  subRows?: RowShape[];
+}
+
+const baseColumns: ColumnDef<RowShape, any>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ getValue }) => String(getValue()),
+    enableGrouping: true,
+  },
+  {
+    id: "count",
+    accessorKey: "count",
+    header: "Count",
+    cell: ({ getValue }) => String(getValue()),
+  },
+];
+
+function renderTable(
+  overrides: Partial<React.ComponentProps<typeof VirtualizedReportTable>> = {}
+) {
+  const props: React.ComponentProps<typeof VirtualizedReportTable> = {
+    columns: baseColumns as ColumnDef<any, any>[],
+    data: [
+      { id: 1, name: "Alpha", count: 10 },
+      { id: 2, name: "Beta", count: 20 },
+    ],
+    columnVisibility: {},
+    onColumnVisibilityChange: vi.fn(),
+    onSortChange: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<VirtualizedReportTable {...props} />) };
+}
+
+describe("VirtualizedReportTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hookMock.lastOnLoadMore = null;
+    hookMock.lastOpts = null;
+  });
+
+  it("renders the header and every row (no pagination slicing)", () => {
+    renderTable();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    // The whole result set is handed to the virtualizer.
+    expect(hookMock.lastOpts?.count).toBe(2);
+  });
+
+  it("calls onSortChange with the column id when a sort control is clicked", () => {
+    const onSortChange = vi.fn();
+    renderTable({ onSortChange });
+    // First sortable column is "name".
+    const sortButtons = screen.getAllByLabelText("sort");
+    fireEvent.click(sortButtons[0]);
+    expect(onSortChange).toHaveBeenCalledWith("name");
+  });
+
+  it("renders an empty state when there are no rows", () => {
+    renderTable({ data: [] });
+    expect(screen.getByText("noResults")).toBeInTheDocument();
+  });
+
+  it("passes onLoadMore through to the infinite-scroll hook (server-paged mode)", () => {
+    const onLoadMore = vi.fn();
+    renderTable({ hasMore: true, isLoading: false, onLoadMore });
+    expect(typeof hookMock.lastOnLoadMore).toBe("function");
+    act(() => hookMock.lastOnLoadMore?.());
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the load-more indicator while appending a page", () => {
+    renderTable({ hasMore: true, isLoading: true });
+    expect(screen.getByTestId("report-table-loading-more")).toBeInTheDocument();
+  });
+
+  it("surfaces a retry control when a load-more fetch failed", () => {
+    const onRetryLoadMore = vi.fn();
+    renderTable({ loadMoreError: true, onRetryLoadMore });
+    const retry = screen.getByTestId("report-table-load-more-retry");
+    fireEvent.click(retry);
+    expect(onRetryLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an expander for rows that have sub-rows (execution-log shape)", () => {
+    renderTable({
+      data: [
+        {
+          id: 1,
+          name: "Parent",
+          count: 1,
+          subRows: [{ id: 11, name: "Step", count: 0 }],
+        },
+      ],
+      getSubRows: (row: RowShape) => row.subRows,
+      subRowsLabel: "steps",
+    });
+    // The expander column renders an expand control for the expandable parent.
+    expect(screen.getByText("Parent")).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/expand/).length).toBeGreaterThan(0);
+  });
+});

--- a/testplanit/components/reports/VirtualizedReportTable.tsx
+++ b/testplanit/components/reports/VirtualizedReportTable.tsx
@@ -258,7 +258,10 @@ export function VirtualizedReportTable({
       >
         {/* Header — stays put vertically (lives above the scroll body) and
             scrolls horizontally with the body via the outer container. */}
-        <div className="flex shrink-0 border-b bg-accent" role="row">
+        <div
+          className="flex shrink-0 border-b bg-muted text-foreground"
+          role="row"
+        >
           {headers
             .filter((header) => header.column.getIsVisible())
             .map((header) => {
@@ -343,7 +346,11 @@ export function VirtualizedReportTable({
                 const isSubRow = row.depth > 0;
                 return (
                   <div
-                    key={row.id}
+                    // Key by the virtual item (index), not the data id, so React
+                    // reuses DOM nodes by position to match TanStack Virtual's
+                    // index-based dynamic measurement — otherwise some rows stick
+                    // at estimateSize and the row heights come out uneven.
+                    key={vItem.key}
                     data-index={vItem.index}
                     ref={measureElement}
                     role="row"
@@ -352,7 +359,7 @@ export function VirtualizedReportTable({
                     className={cn(
                       "absolute left-0 top-0 flex border-b",
                       isGrouped
-                        ? "bg-accent font-semibold"
+                        ? "bg-muted font-semibold text-foreground"
                         : isSubRow
                           ? "bg-muted/5 hover:bg-muted/20"
                           : "hover:bg-muted/50"

--- a/testplanit/components/reports/VirtualizedReportTable.tsx
+++ b/testplanit/components/reports/VirtualizedReportTable.tsx
@@ -1,0 +1,464 @@
+"use client";
+/* eslint-disable react-hooks/incompatible-library -- This file consumes TanStack Table / TanStack Virtual APIs that return unstable function references by design; React Compiler auto-skips memoization here and the lint rule reports it (same as components/matrix/MatrixGrid.tsx and hooks/useVirtualizedInfiniteList.ts). */
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ColumnDef,
+  ExpandedState,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getGroupedRowModel,
+  getSortedRowModel,
+  OnChangeFn,
+  Row,
+  SortingState,
+  Updater,
+  useReactTable,
+  VisibilityState,
+} from "@tanstack/react-table";
+import {
+  ArrowDownAZ,
+  ArrowDownUp,
+  ArrowUpZA,
+  Group,
+  UnfoldVertical,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type ReactNode, useCallback, useMemo } from "react";
+import { useVirtualizedInfiniteList } from "~/hooks/useVirtualizedInfiniteList";
+import { cn } from "~/utils";
+
+/**
+ * Virtualized, infinite-scrolling table for the reports results panel.
+ *
+ * A reports-specific alternative to the shared `DataTable` — it deliberately
+ * does NOT replicate that component's look or its column resize/pinning (no
+ * report column opts into either). It keeps the table features reports rely on
+ * (sorting, grouping, expansion, sub-rows, column visibility) by driving a
+ * TanStack `useReactTable` instance and rendering its flattened row model
+ * (`getRowModel().rows`) through `useVirtualizedInfiniteList`, so an arbitrarily
+ * large result set scrolls as one continuous list with no page seam.
+ *
+ * Layout: an outer horizontal-scroll container holds a flex column whose width
+ * is the summed column width; a non-scrolling header row sits on top and a
+ * vertical-scroll body (the virtualizer's scroll element) holds the rows. Both
+ * header and body size every cell from `column.getSize()`, so they stay aligned
+ * while the whole table scrolls horizontally as a unit.
+ *
+ * Pagination modes:
+ *   - Full-set (most reports): caller passes the entire array with
+ *     `hasMore=false`; the list virtualizes it.
+ *   - Fetch-on-scroll (execution-log): caller supplies `hasMore`/`isLoading`/
+ *     `onLoadMore`; the sentinel pulls and the caller appends.
+ */
+
+const EXPANDER_WIDTH = 24;
+const ESTIMATED_ROW_HEIGHT = 44;
+
+interface VirtualizedReportTableProps {
+  columns: ColumnDef<any, any>[];
+  data: any[];
+
+  columnVisibility: VisibilityState;
+  onColumnVisibilityChange: (visibility: VisibilityState) => void;
+
+  sortConfig?: { column: string; direction: "asc" | "desc" } | null;
+  onSortChange?: (columnId: string) => void;
+
+  grouping?: string[];
+  onGroupingChange?: OnChangeFn<string[]>;
+  expanded?: ExpandedState;
+  onExpandedChange?: OnChangeFn<ExpandedState>;
+
+  getSubRows?: (row: any, index: number) => any[] | undefined;
+  subRowsLabel?: string;
+
+  // Infinite scroll (defaults keep the table in full-set / client mode).
+  hasMore?: boolean;
+  isLoading?: boolean;
+  onLoadMore?: () => void;
+  loadMoreError?: boolean;
+  onRetryLoadMore?: () => void;
+
+  rowTestIdPrefix?: string;
+}
+
+export function VirtualizedReportTable({
+  columns,
+  data,
+  columnVisibility,
+  onColumnVisibilityChange,
+  sortConfig,
+  onSortChange,
+  grouping,
+  onGroupingChange,
+  expanded,
+  onExpandedChange,
+  getSubRows,
+  subRowsLabel,
+  hasMore = false,
+  isLoading = false,
+  onLoadMore,
+  loadMoreError = false,
+  onRetryLoadMore,
+  rowTestIdPrefix = "report-row",
+}: VirtualizedReportTableProps) {
+  const t = useTranslations("common.table");
+  const tActions = useTranslations("common.actions");
+  const tLabels = useTranslations("common.labels");
+  const tAria = useTranslations("common.aria");
+  const tErrors = useTranslations("search.errors");
+
+  // Convert the report's sortConfig into TanStack's controlled sorting state,
+  // ignoring a stale sort that points at a column the current report lacks
+  // (mirrors DataTable's guard).
+  const sorting: SortingState = useMemo(() => {
+    if (!sortConfig) return [];
+    if (!columns.some((c) => c.id === sortConfig.column)) return [];
+    return [{ id: sortConfig.column, desc: sortConfig.direction === "desc" }];
+  }, [sortConfig, columns]);
+
+  const handleSortingChange = useCallback(
+    (updaterOrValue: Updater<SortingState>) => {
+      if (!onSortChange) return;
+      const next =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(sorting)
+          : updaterOrValue;
+      if (next.length > 0) onSortChange(next[0].id);
+    },
+    [onSortChange, sorting]
+  );
+
+  const handleVisibilityChange = useCallback(
+    (updaterOrValue: Updater<VisibilityState>) => {
+      const next =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(columnVisibility)
+          : updaterOrValue;
+      onColumnVisibilityChange(next);
+    },
+    [columnVisibility, onColumnVisibilityChange]
+  );
+
+  // Prepend an expander column when rows can nest (grouping or sub-rows).
+  const expanderColumn: ColumnDef<any, any> = useMemo(
+    () => ({
+      id: "expander",
+      header: () => null,
+      cell: ({ row }: { row: Row<any> }) => {
+        if (!row.getCanExpand()) return null;
+        const isExpanded = row.getIsExpanded();
+        const subRowsCount = row.subRows?.length ?? 0;
+        const label = isExpanded
+          ? tActions("collapse")
+          : `${tActions("expand")}${
+              subRowsLabel && subRowsCount > 0
+                ? ` • ${subRowsCount} ${subRowsLabel}`
+                : ""
+            }`;
+        return (
+          <button
+            onClick={row.getToggleExpandedHandler()}
+            className="inline-flex w-4 items-center justify-center"
+            aria-label={label}
+            title={label}
+          >
+            <span
+              className="inline-block transition-transform duration-200"
+              style={{
+                transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
+              }}
+            >
+              {"▶"}
+            </span>
+          </button>
+        );
+      },
+      size: EXPANDER_WIDTH,
+      minSize: EXPANDER_WIDTH,
+      maxSize: EXPANDER_WIDTH,
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    [tActions, subRowsLabel]
+  );
+
+  const groupingActive = !!(grouping && grouping.length > 0);
+  const finalColumns = useMemo(
+    () =>
+      groupingActive || getSubRows ? [expanderColumn, ...columns] : columns,
+    [groupingActive, getSubRows, expanderColumn, columns]
+  );
+
+  const table = useReactTable({
+    data,
+    columns: finalColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getGroupedRowModel: groupingActive ? getGroupedRowModel() : undefined,
+    getExpandedRowModel:
+      groupingActive || getSubRows ? getExpandedRowModel() : undefined,
+    getSubRows,
+    enableSorting: true,
+    state: {
+      columnVisibility,
+      sorting,
+      ...(grouping !== undefined && { grouping }),
+      ...(expanded !== undefined && { expanded }),
+    },
+    ...(onGroupingChange !== undefined && { onGroupingChange }),
+    ...(onExpandedChange !== undefined && { onExpandedChange }),
+    onSortingChange: handleSortingChange,
+    onColumnVisibilityChange: handleVisibilityChange,
+    defaultColumn: { minSize: 50, maxSize: 1500, size: 150 },
+  });
+
+  const rows = table.getRowModel().rows;
+  const leafColumns = table.getVisibleLeafColumns();
+  const totalWidth = leafColumns.reduce((sum, c) => sum + c.getSize(), 0);
+
+  // Reset scroll + measurements when the *result set identity* changes (sort,
+  // grouping, or report type via the column set) — but NOT when a page is
+  // appended (that would defeat infinite scroll).
+  const resetKey = useMemo(
+    () =>
+      JSON.stringify({
+        sort: sortConfig ?? null,
+        grouping: grouping ?? null,
+        cols: columns.map((c) => c.id),
+      }),
+    [sortConfig, grouping, columns]
+  );
+
+  const { scrollRef, sentinelRef, virtualItems, totalSize, measureElement } =
+    useVirtualizedInfiniteList({
+      count: rows.length,
+      estimateSize: ESTIMATED_ROW_HEIGHT,
+      overscan: 8,
+      hasMore,
+      isLoading,
+      onLoadMore: onLoadMore ?? (() => {}),
+      boundToViewport: false,
+      resetKey,
+    });
+
+  const headers = table.getHeaderGroups().at(-1)?.headers ?? [];
+
+  return (
+    <div
+      className="h-full overflow-x-auto rounded-lg border-2 border-primary/10"
+      data-testid="report-table"
+    >
+      <div
+        className="flex h-full min-h-0 flex-col"
+        style={{ width: totalWidth, minWidth: "100%" }}
+      >
+        {/* Header — stays put vertically (lives above the scroll body) and
+            scrolls horizontally with the body via the outer container. */}
+        <div className="flex shrink-0 border-b bg-accent" role="row">
+          {headers
+            .filter((header) => header.column.getIsVisible())
+            .map((header) => {
+              const { column } = header;
+              const isSortable = column.columnDef.enableSorting !== false;
+              const isActiveSort = sortConfig?.column === column.id;
+              const direction = isActiveSort
+                ? sortConfig?.direction
+                : undefined;
+              return (
+                <div
+                  key={header.id}
+                  role="columnheader"
+                  className="flex shrink-0 select-none items-center gap-1 border-r px-3 py-2 text-xs font-medium last:border-r-0"
+                  style={{ width: column.getSize() }}
+                >
+                  {column.getCanGroup() && onGroupingChange ? (
+                    <button
+                      onClick={column.getToggleGroupingHandler()}
+                      className="mr-1"
+                      aria-label={
+                        column.getIsGrouped()
+                          ? tAria("grouped")
+                          : tAria("group")
+                      }
+                      title={
+                        column.getIsGrouped()
+                          ? tAria("grouped")
+                          : tAria("group")
+                      }
+                    >
+                      {column.getIsGrouped() ? (
+                        <UnfoldVertical className="h-4 w-4" />
+                      ) : (
+                        <Group className="h-4 w-4" />
+                      )}
+                    </button>
+                  ) : null}
+                  <span className="min-w-0 truncate">
+                    {flexRender(column.columnDef.header, header.getContext())}
+                  </span>
+                  {isSortable && column.id !== "expander" && (
+                    <button
+                      onClick={() => onSortChange?.(column.id)}
+                      className="ml-1 shrink-0"
+                      aria-label={t("sort")}
+                    >
+                      {isActiveSort && direction === "asc" ? (
+                        <ArrowDownAZ className="h-4 w-4" />
+                      ) : isActiveSort && direction === "desc" ? (
+                        <ArrowUpZA className="h-4 w-4" />
+                      ) : (
+                        <ArrowDownUp className="h-4 w-4 opacity-50" />
+                      )}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Body — the virtualizer's scroll element. CSS-bounded height
+            (flex-1) so it works inside the resizable report panel. */}
+        <div
+          ref={scrollRef}
+          className="relative min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+          data-testid="report-table-scroll"
+        >
+          {rows.length === 0 && !isLoading ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              {tLabels("noResults")}
+            </div>
+          ) : (
+            <div
+              className="relative"
+              style={{ height: totalSize, width: totalWidth }}
+            >
+              {virtualItems.map((vItem) => {
+                const row = rows[vItem.index];
+                if (!row) return null;
+                const isGrouped = row.getIsGrouped();
+                const isSubRow = row.depth > 0;
+                return (
+                  <div
+                    key={row.id}
+                    data-index={vItem.index}
+                    ref={measureElement}
+                    role="row"
+                    data-row-id={row.original?.id}
+                    data-testid={`${rowTestIdPrefix}-${row.original?.id ?? vItem.index}`}
+                    className={cn(
+                      "absolute left-0 top-0 flex border-b",
+                      isGrouped
+                        ? "bg-accent font-semibold"
+                        : isSubRow
+                          ? "bg-muted/5 hover:bg-muted/20"
+                          : "hover:bg-muted/50"
+                    )}
+                    style={{
+                      width: totalWidth,
+                      transform: `translateY(${vItem.start}px)`,
+                    }}
+                  >
+                    {row.getVisibleCells().map((cell) => {
+                      const { column } = cell;
+                      let content: ReactNode;
+                      if (groupingActive && cell.getIsGrouped()) {
+                        const showCount = !column.columnDef.aggregatedCell;
+                        content = (
+                          <div className="flex items-center gap-1">
+                            <button
+                              onClick={row.getToggleExpandedHandler()}
+                              className="mr-1 p-1"
+                              aria-label={
+                                row.getIsExpanded()
+                                  ? tActions("collapse")
+                                  : tActions("expand")
+                              }
+                            >
+                              <span
+                                className="inline-block transition-transform duration-200"
+                                style={{
+                                  transform: row.getIsExpanded()
+                                    ? "rotate(90deg)"
+                                    : "rotate(0deg)",
+                                }}
+                              >
+                                {"▶"}
+                              </span>
+                            </button>
+                            {flexRender(
+                              column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                            {showCount ? ` (${row.subRows.length})` : null}
+                          </div>
+                        );
+                      } else if (groupingActive && cell.getIsAggregated()) {
+                        content = flexRender(
+                          column.columnDef.aggregatedCell ??
+                            column.columnDef.cell,
+                          cell.getContext()
+                        );
+                      } else if (groupingActive && cell.getIsPlaceholder()) {
+                        content = null;
+                      } else {
+                        content = flexRender(
+                          column.columnDef.cell,
+                          cell.getContext()
+                        );
+                      }
+                      return (
+                        <div
+                          key={column.id}
+                          role="cell"
+                          className="flex min-w-0 shrink-0 items-center overflow-hidden border-r px-3 py-2 text-sm last:border-r-0"
+                          style={{ width: column.getSize() }}
+                        >
+                          {content}
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Sentinel — when it nears the viewport and there's more, the hook
+              fetches the next page (execution-log only). */}
+          <div
+            ref={sentinelRef}
+            aria-hidden
+            className="h-px w-full"
+            data-testid="report-table-sentinel"
+          />
+
+          {isLoading && data.length > 0 && (
+            <div
+              className="space-y-2 px-3 py-3"
+              data-testid="report-table-loading-more"
+            >
+              <Skeleton className="h-8 w-full" />
+            </div>
+          )}
+
+          {loadMoreError && (
+            <div className="py-4 text-center">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRetryLoadMore}
+                data-testid="report-table-load-more-retry"
+              >
+                {tErrors("tryAgain")}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/testplanit/components/share/StaticReportViewer.tsx
+++ b/testplanit/components/share/StaticReportViewer.tsx
@@ -30,8 +30,6 @@ export function StaticReportViewer({
     column: string;
     direction: "asc" | "desc";
   } | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState<number | "All">(10);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [grouping, setGrouping] = useState<string[]>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -63,19 +61,16 @@ export function StaticReportViewer({
           ? config.metrics.join(",")
           : config.metrics
       );
-    if (config.page) params.set("page", config.page.toString());
-    if (config.pageSize) params.set("pageSize", config.pageSize.toString());
-
     return `/projects/reports/${shareData.projectId}?${params.toString()}`;
   }, [shareData.projectId, config]);
 
-  // Client-side pagination and sorting
-  const paginatedResults = useMemo(() => {
+  // Client-side sorting only — the whole shared result set is in memory and the
+  // table virtualizes it (no paging).
+  const sortedResults = useMemo(() => {
     if (!reportData?.results) return [];
 
-    let processed = [...reportData.results];
+    const processed = [...reportData.results];
 
-    // Apply sorting if configured
     if (sortConfig) {
       processed.sort((a, b) => {
         const aValue = a[sortConfig.column];
@@ -90,15 +85,8 @@ export function StaticReportViewer({
       });
     }
 
-    // Apply pagination
-    if (pageSize === "All") {
-      return processed;
-    }
-
-    const startIndex = (currentPage - 1) * pageSize;
-    const endIndex = startIndex + pageSize;
-    return processed.slice(startIndex, endIndex);
-  }, [reportData?.results, sortConfig, currentPage, pageSize]);
+    return processed;
+  }, [reportData?.results, sortConfig]);
 
   // Handle sort changes
   const handleSortChange = useCallback((columnId: string) => {
@@ -107,13 +95,6 @@ export function StaticReportViewer({
       direction:
         prev?.column === columnId && prev.direction === "asc" ? "desc" : "asc",
     }));
-    setCurrentPage(1);
-  }, []);
-
-  // Handle page size changes
-  const handlePageSizeChange = useCallback((newPageSize: number | "All") => {
-    setPageSize(newPageSize);
-    setCurrentPage(1);
   }, []);
 
   const fetchReportData = useCallback(async () => {
@@ -260,7 +241,7 @@ export function StaticReportViewer({
       {/* Report content */}
       <div className="container mx-auto px-4 py-6">
         <ReportRenderer
-          results={paginatedResults}
+          results={sortedResults}
           chartData={reportData.chartData || reportData.results}
           reportType={config.reportType}
           dimensions={reportData.dimensions || []}
@@ -280,13 +261,12 @@ export function StaticReportViewer({
           totalFlakyTests={reportData.totalFlakyTests}
           matrixAxes={reportData.matrixAxes}
           automationCandidatesSnapshot={reportData.automationCandidatesSnapshot}
-          currentPage={currentPage}
-          pageSize={pageSize}
+          loadedCount={sortedResults.length}
           totalCount={
             reportData.pagination?.totalCount || reportData.results?.length || 0
           }
-          onPageChange={setCurrentPage}
-          onPageSizeChange={handlePageSizeChange}
+          hasMore={false}
+          isLoading={false}
           sortConfig={sortConfig}
           onSortChange={handleSortChange}
           columnVisibility={columnVisibility}

--- a/testplanit/hooks/useVirtualizedInfiniteList.test.tsx
+++ b/testplanit/hooks/useVirtualizedInfiniteList.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render } from "~/test/test-utils";
+import { act, render, screen } from "~/test/test-utils";
 import {
   useVirtualizedInfiniteList,
   type UseVirtualizedInfiniteListOptions,
@@ -173,6 +173,37 @@ describe("useVirtualizedInfiniteList", () => {
     rerender(<LateHarness show={true} onLoadMore={onLoadMore} />);
     expect(observers.length).toBe(1);
 
+    fireAll(true);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the observer in CSS-bound mode (boundToViewport=false) without a viewport height", () => {
+    // The container is sized by its own layout (here a fixed height), so the
+    // hook must not depend on the viewport-bottom maxHeight to wire the
+    // sentinel — used by the reports panel.
+    function CssBoundHarness({ onLoadMore }: { onLoadMore: () => void }) {
+      const { scrollRef, sentinelRef, maxHeight } = useVirtualizedInfiniteList({
+        count: 5,
+        hasMore: true,
+        isLoading: false,
+        onLoadMore,
+        estimateSize: 40,
+        boundToViewport: false,
+      });
+      return (
+        <div ref={scrollRef} data-testid="scroll" style={{ height: "100%" }}>
+          <span data-testid="max-height">{String(maxHeight)}</span>
+          <div ref={sentinelRef} data-testid="sentinel" />
+        </div>
+      );
+    }
+
+    const onLoadMore = vi.fn();
+    render(<CssBoundHarness onLoadMore={onLoadMore} />);
+    // No viewport-derived height is computed in this mode.
+    expect(screen.getByTestId("max-height").textContent).toBe("null");
+    // ...but the sentinel is still observed and can trigger a load.
+    expect(observers.length).toBe(1);
     fireAll(true);
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });

--- a/testplanit/hooks/useVirtualizedInfiniteList.ts
+++ b/testplanit/hooks/useVirtualizedInfiniteList.ts
@@ -51,6 +51,15 @@ export interface UseVirtualizedInfiniteListOptions {
   loadMoreMargin?: number;
   /** Space (px) to leave below the list when filling the viewport. */
   bottomMargin?: number;
+  /**
+   * When true (default), the scroll container is sized to fill from its top
+   * edge to the viewport bottom. Set false when the container is bounded by
+   * its own layout instead (e.g. a fixed-height panel) — the consumer sizes it
+   * via CSS (`h-full`) and the returned `maxHeight` stays null. In that mode
+   * the load-more sentinel wires as soon as the scroll element mounts, and
+   * container resizes are picked up by the virtualizer's own ResizeObserver.
+   */
+  boundToViewport?: boolean;
   /** When this value changes, the list scrolls to the top and re-measures. */
   resetKey?: unknown;
 }
@@ -69,6 +78,7 @@ export function useVirtualizedInfiniteList({
   onLoadMore,
   loadMoreMargin = 300,
   bottomMargin = 16,
+  boundToViewport = true,
   resetKey,
 }: UseVirtualizedInfiniteListOptions) {
   // A callback ref (rather than a plain useRef) so the effects re-run when the
@@ -86,7 +96,7 @@ export function useVirtualizedInfiniteList({
   const [maxHeight, setMaxHeight] = useState<number | null>(null);
 
   useIsomorphicLayoutEffect(() => {
-    if (!scrollEl) return;
+    if (!boundToViewport || !scrollEl) return;
     const compute = () => {
       const top = scrollEl.getBoundingClientRect().top;
       setMaxHeight(Math.max(200, window.innerHeight - top - bottomMargin));
@@ -94,7 +104,7 @@ export function useVirtualizedInfiniteList({
     compute();
     window.addEventListener("resize", compute);
     return () => window.removeEventListener("resize", compute);
-  }, [scrollEl, bottomMargin]);
+  }, [boundToViewport, scrollEl, bottomMargin]);
 
   const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
     count,
@@ -124,9 +134,11 @@ export function useVirtualizedInfiniteList({
 
   // Only wire the sentinel once the container is mounted and bounded, so an
   // unbounded first paint can't fire a burst of page loads before the height
-  // settles. Re-runs when the scroll element mounts (`scrollEl`).
+  // settles. In viewport-bound mode that means waiting for `maxHeight`; in
+  // CSS-bound mode the container is already sized, so wire as soon as the
+  // scroll element mounts. Re-runs when the scroll element mounts (`scrollEl`).
   useEffect(() => {
-    if (maxHeight == null) return;
+    if (boundToViewport && maxHeight == null) return;
     const root = scrollElRef.current;
     const sentinel = sentinelRef.current;
     if (!root || !sentinel || typeof IntersectionObserver === "undefined") {
@@ -142,7 +154,7 @@ export function useVirtualizedInfiniteList({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [scrollEl, maxHeight, loadMoreMargin, maybeLoadMore]);
+  }, [scrollEl, maxHeight, boundToViewport, loadMoreMargin, maybeLoadMore]);
 
   // After a page settles (or hasMore flips), pull again if the sentinel is
   // still visible — fills the viewport without waiting for a scroll event.

--- a/testplanit/utils/executionLogUtils.ts
+++ b/testplanit/utils/executionLogUtils.ts
@@ -99,7 +99,14 @@ export async function handleExecutionLogPOST(
       testCaseName: { testRunCase: { repositoryCase: { name: dir } } },
       project: { testRun: { project: { name: dir } } },
     };
-    const orderBy: any = orderByMap[sortColumn] ?? { executedAt: dir };
+    // A stable secondary key (id) makes skip/take pagination deterministic.
+    // Without it, ties on the primary key (e.g. many executions sharing an
+    // executedAt) let rows shift between pages, so the infinite-scroll loader
+    // sees overlaps/gaps and never reaches the true total.
+    const orderBy: any = [
+      orderByMap[sortColumn] ?? { executedAt: dir },
+      { id: dir },
+    ];
 
     const [rawResults, total, rawStatusBreakdown] = await Promise.all([
       prisma.testRunResults.findMany({


### PR DESCRIPTION
## Description

The report results panel now uses a virtualized, infinite-scrolling table instead of page-based pagination — across project reports, cross-project admin reports, and shared report links. This is the reports-side sibling of the unified-search infinite scroll (#424): no page-seam scroll reset, and no "All" page-size foot-gun that lays out 10k+ rows at once.

Reports that already hold their full result set in memory (every report except the execution log) now render their whole array as one continuous virtualized list. The **execution log** — the one report that is truly paginated at the database (`skip`/`take`) — fetches further pages as you near the bottom and appends them, resetting to page one when you change the sort.

### What changed

- **`components/reports/VirtualizedReportTable.tsx`** (new) — a reports-specific virtualized table. It drives a TanStack `useReactTable` instance (so sorting, grouping, expansion, sub-rows, and column visibility all keep working) and renders the flattened row model through the shared `useVirtualizedInfiniteList` hook: a sticky flex header above a vertically-scrolling, virtualized flex-row body. It deliberately does **not** copy the shared `DataTable`'s look, column resize, or column pinning — no report column uses those, and a leaner table keeps the focus on the data.
- **`hooks/useVirtualizedInfiniteList.ts`** — added a backward-compatible `boundToViewport` option. Search keeps filling to the viewport bottom; reports set it to `false` so the list is bounded by its resizable panel via CSS (`h-full`), which also makes panel-resize work through react-virtual's own ResizeObserver.
- **`components/reports/ReportRenderer.tsx`** — swapped `DataTable` for `VirtualizedReportTable`, replaced the pagination controls with a "Showing X of Y" summary, and let the inner container own scrolling.
- **`components/reports/ReportBuilder.tsx`** — full-set reports stop slicing and render the whole sorted array (`hasMore=false`); the execution log accumulates fetched pages (de-duped) with fetch-on-scroll and resets on sort. Dropped this surface's `usePagination`/`PaginationProvider` usage and the now-dead `page`/`pageSize` URL params. The shared `PaginationContext` is untouched (40+ other tables still use it).
- **`components/share/StaticReportViewer.tsx`** — shared links render the full result set with client-side sort; no slicing.

Iteration Matrix and Automation Candidates already bypass this table and are unchanged.

## Related Issue

N/A — sibling of #424 (unified-search virtual scrolling).

## Type of Change

- [x] Enhancement (non-breaking improvement to existing functionality)

## Testing

- New **`components/reports/VirtualizedReportTable.test.tsx`** (7): renders all rows (no slicing); sort-header click → `onSortChange`; empty state; `onLoadMore` pass-through; load-more indicator; load-more retry; expander for sub-rows.
- New **`hooks/useVirtualizedInfiniteList.test.tsx`** case: observer wires in `boundToViewport=false` mode without a viewport height (existing search cases still pass).
- **`components/reports/ReportRenderer.test.tsx`** updated: dropped pagination assertions; added full-set render, "Showing X of Y" summary, and infinite-scroll prop forwarding.
- Full gate green locally: production build, ESLint, `tsc --noEmit`, `format:check`, and the full Vitest suite (**9231 passed / 145 skipped**).
- Manual: project reports (`/projects/reports/[projectId]`), admin cross-project reports (`/admin/reports`), and a shared report link — continuous scroll on full-set reports; incremental page fetches on the execution log; sort resets to top.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally
- [x] My changes generate no new warnings
