### PR TITLE
enhancement(reports): CSV export of report results

### DIFF
--- a/docs/docs/user-guide/cross-project-reports.md
+++ b/docs/docs/user-guide/cross-project-reports.md
@@ -34,6 +34,10 @@ The [Report Builder](./projects/reports/report-builder.md) is available in cross
 
 Drill-down works the same way as in per-project mode (it just shows records from any of the selected projects).
 
+## Exporting Results
+
+The **Export CSV** button above the results table downloads the full result set, with a **Project** column added so rows stay attributable across the portfolio. See [Exporting Results](./projects/reports/index.md#exporting-results) for details.
+
 ## Not Available Cross-Project
 
 Two pre-built reports are project-only and do not appear in **Administration → Reports**:

--- a/docs/docs/user-guide/projects/reports/index.md
+++ b/docs/docs/user-guide/projects/reports/index.md
@@ -27,6 +27,16 @@ Pre-built reports have fixed configurations and don't require dimension or metri
 
 The [Report Builder](./report-builder.md) lets you compose a report by picking a data source (Test Execution, Repository Stats, User Engagement, Project Health, Session Analysis, Issue Tracking), then choosing dimensions, metrics, and a chart type. The builder also supports interactive **drill-down** — click any metric cell to open a drawer showing the underlying records.
 
+## Exporting Results
+
+Tabular reports — every pre-built report except the [Iteration Matrix](./iteration-matrix.md) and [Automation Candidates](./automation-candidates.md) (which have their own dedicated views), plus any custom report — show an **Export CSV** button above the results table.
+
+- It exports the columns you see, with their displayed values (status and priority names, pass-rate percentages, durations, dates), for the **entire** result set — not just the rows currently scrolled into view.
+- The [Execution Log](./execution-log.md), which loads incrementally as you scroll, fetches all of its pages first so the file is complete.
+- Export is also available on read-only [Share Links](../../share-links.md) and works the same in [cross-project reports](../../cross-project-reports.md) (where it adds a Project column).
+
+This is separate from the drill-down **Export to CSV** in the [Report Builder](./report-builder.md#drill-down), which exports the underlying records behind a single metric cell rather than the report's summary rows.
+
 ## Sharing
 
 Any report — pre-built or custom — can be shared with team members, clients, and stakeholders using a Share Link. See [Share Links](../../share-links.md) for the three share modes (Public, Password-Protected, Authenticated), password rate limiting, view notifications, and access analytics.

--- a/docs/docs/user-guide/projects/reports/report-builder.md
+++ b/docs/docs/user-guide/projects/reports/report-builder.md
@@ -29,7 +29,7 @@ The Report Builder lets you compose a custom report by picking a data source, th
 7. Pick a **Chart Type** — bar, line, pie, or table.
 8. Click **Run Report**.
 
-Results are paginated and the columns are sortable.
+Results render as a single, continuously-scrolling list (no page controls) and the columns are sortable. Use **Export CSV** above the table to download the full result set — see [Exporting Results](./index.md#exporting-results).
 
 ## Drill-Down
 

--- a/testplanit/components/reports/ReportBuilder.tsx
+++ b/testplanit/components/reports/ReportBuilder.tsx
@@ -72,6 +72,7 @@ import { useExecutionLogColumns } from "~/hooks/useExecutionLogColumns";
 import { useFlakyTestsColumns } from "~/hooks/useFlakyTestsColumns";
 import { useIssueTestCoverageSummaryColumns } from "~/hooks/useIssueTestCoverageColumns";
 import { useReportColumns } from "~/hooks/useReportColumns";
+import { useReportCsvExport } from "~/hooks/useReportCsvExport";
 import { useTestCaseHealthColumns } from "~/hooks/useTestCaseHealthColumns";
 import {
   getCrossProjectReportTypes,
@@ -1646,6 +1647,70 @@ function ReportBuilderContent({
     lastUsedMetrics,
   ]);
 
+  // CSV export. Full-set reports serialize the in-memory `allResults`;
+  // execution-log (truly server-paged) fetches every page first so the export
+  // is complete.
+  const { isExporting: isExportingCsv, exportCsv } = useReportCsvExport();
+  const handleExportCsv = useCallback(() => {
+    const getRows = async (): Promise<any[]> => {
+      if (!isExecutionLog) return allResults ?? results ?? [];
+      const all: any[] = [];
+      const seen = new Set<number | string>();
+      let page = 1;
+      // Loop the report endpoint until every row is fetched (no truncation).
+      while (currentReport?.endpoint) {
+        const response = await fetch(currentReport.endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...(lastRequestBody || {}),
+            page,
+            pageSize: EXECUTION_LOG_PAGE_SIZE,
+          }),
+        });
+        if (!response.ok) throw new Error("Failed to fetch report for export");
+        const data = await response.json();
+        const batch: any[] = data.data || data.results || [];
+        for (const r of batch) {
+          if (!seen.has(r.id)) {
+            seen.add(r.id);
+            all.push(r);
+          }
+        }
+        const total = data.total ?? all.length;
+        if (batch.length < EXECUTION_LOG_PAGE_SIZE || all.length >= total)
+          break;
+        page += 1;
+      }
+      return all;
+    };
+
+    void exportCsv({
+      reportType,
+      isCrossProject: mode === "cross-project",
+      getRows,
+      dimensions: lastUsedDimensions,
+      metrics: lastUsedMetrics,
+      projects: automationTrendsProjects,
+      consecutiveRuns: lastUsedConsecutiveRuns,
+      projectId: mode === "project" ? projectId : undefined,
+    });
+  }, [
+    exportCsv,
+    isExecutionLog,
+    allResults,
+    results,
+    currentReport,
+    lastRequestBody,
+    reportType,
+    mode,
+    lastUsedDimensions,
+    lastUsedMetrics,
+    automationTrendsProjects,
+    lastUsedConsecutiveRuns,
+    projectId,
+  ]);
+
   // Auto-run report if we have stored selections
   useEffect(() => {
     // Check if we need to run report for current reportType
@@ -2918,6 +2983,8 @@ function ReportBuilderContent({
             hasMore={hasMore}
             isLoading={loadingMore}
             onLoadMore={handleLoadMore}
+            onExportCsv={handleExportCsv}
+            isExportingCsv={isExportingCsv}
             sortConfig={sortConfig}
             onSortChange={(columnId: string) => {
               setSortConfig((prev) => ({

--- a/testplanit/components/reports/ReportRenderer.test.tsx
+++ b/testplanit/components/reports/ReportRenderer.test.tsx
@@ -262,11 +262,9 @@ describe("ReportRenderer", () => {
         reportType="repository-stats"
       />
     );
-    expect(
-      screen.getByText(
-        (_content, el) => el?.textContent === "showing 2 of 50 results"
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("report-results-summary").textContent).toBe(
+      "showing 2 of 50 results"
+    );
   });
 
   it("forwards the infinite-scroll wiring to the virtualized table", () => {

--- a/testplanit/components/reports/ReportRenderer.tsx
+++ b/testplanit/components/reports/ReportRenderer.tsx
@@ -5,6 +5,7 @@ import { ReportChart } from "@/components/dataVisualizations/ReportChart";
 import { DateFormatter } from "@/components/DateFormatter";
 import { MatrixReportPreset } from "@/components/matrix/MatrixReportPreset";
 import { VirtualizedReportTable } from "@/components/reports/VirtualizedReportTable";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -23,6 +24,7 @@ import {
   OnChangeFn,
   VisibilityState,
 } from "@tanstack/react-table";
+import { Download } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { useAutomationTrendsColumns } from "~/hooks/useAutomationTrendsColumns";
@@ -114,6 +116,10 @@ interface ReportRendererProps {
   loadMoreError?: boolean;
   onRetryLoadMore?: () => void;
 
+  // CSV export (rendered in the results header when provided)
+  onExportCsv?: () => void;
+  isExportingCsv?: boolean;
+
   // Sorting
   sortConfig?: { column: string; direction: "asc" | "desc" } | null;
   onSortChange: (columnId: string) => void;
@@ -165,6 +171,8 @@ export function ReportRenderer({
   onLoadMore,
   loadMoreError = false,
   onRetryLoadMore,
+  onExportCsv,
+  isExportingCsv = false,
   sortConfig,
   onSortChange,
   columnVisibility,
@@ -483,14 +491,31 @@ export function ReportRenderer({
       >
         <Card className="h-full rounded-none border-0 overflow-hidden">
           <CardHeader className="pt-2 pb-2">
-            <div className="flex flex-row items-end justify-between">
+            <div className="flex flex-row items-end justify-between gap-4">
               <CardTitle>{tCommon("results")}</CardTitle>
-              {totalCount > 0 && (
-                <div className="text-sm text-muted-foreground">
-                  {tCommon("pagination.showing")} {loadedCount} {tCommon("of")}{" "}
-                  {totalCount} {tCommon("results")}
-                </div>
-              )}
+              <div className="flex items-center gap-3">
+                {totalCount > 0 && (
+                  <div
+                    className="text-sm text-muted-foreground"
+                    data-testid="report-results-summary"
+                  >
+                    {tCommon("pagination.showing")} {loadedCount}{" "}
+                    {tCommon("of")} {totalCount} {tCommon("results")}
+                  </div>
+                )}
+                {onExportCsv && totalCount > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onExportCsv}
+                    disabled={isExportingCsv}
+                    data-testid="report-export-csv-button"
+                  >
+                    <Download className="h-4 w-4" />
+                    {tReports("exportCsv")}
+                  </Button>
+                )}
+              </div>
             </div>
           </CardHeader>
           <CardContent className="h-[calc(100%-4rem)] p-6 pt-0">

--- a/testplanit/components/share/StaticReportViewer.tsx
+++ b/testplanit/components/share/StaticReportViewer.tsx
@@ -8,6 +8,7 @@ import { ExpandedState, VisibilityState } from "@tanstack/react-table";
 import { AlertCircle, BarChart3, ExternalLink, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useReportCsvExport } from "~/hooks/useReportCsvExport";
 import { Link } from "~/lib/navigation";
 
 interface StaticReportViewerProps {
@@ -96,6 +97,20 @@ export function StaticReportViewer({
         prev?.column === columnId && prev.direction === "asc" ? "desc" : "asc",
     }));
   }, []);
+
+  // CSV export — the shared payload holds the full result set in memory.
+  const { isExporting: isExportingCsv, exportCsv } = useReportCsvExport();
+  const handleExportCsv = useCallback(() => {
+    void exportCsv({
+      reportType: config?.reportType ?? "report",
+      isCrossProject: config?.mode === "cross-project",
+      getRows: () => reportData?.results ?? [],
+      dimensions: reportData?.dimensions ?? [],
+      metrics: reportData?.metrics ?? [],
+      projects: reportData?.projects ?? [],
+      projectId: shareData?.projectId,
+    });
+  }, [exportCsv, config, reportData, shareData]);
 
   const fetchReportData = useCallback(async () => {
     if (shareData.entityType !== "REPORT") {
@@ -267,6 +282,8 @@ export function StaticReportViewer({
           }
           hasMore={false}
           isLoading={false}
+          onExportCsv={handleExportCsv}
+          isExportingCsv={isExportingCsv}
           sortConfig={sortConfig}
           onSortChange={handleSortChange}
           columnVisibility={columnVisibility}

--- a/testplanit/hooks/useReportCsvExport.test.ts
+++ b/testplanit/hooks/useReportCsvExport.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useReportCsvExport } from "./useReportCsvExport";
+
+const { mockUnparse } = vi.hoisted(() => ({
+  mockUnparse: vi.fn((_rows: unknown) => "header\nvalue"),
+}));
+const { mockLogDataExport } = vi.hoisted(() => ({
+  mockLogDataExport: vi.fn(),
+}));
+
+vi.mock("papaparse", () => ({
+  default: { unparse: mockUnparse },
+  unparse: mockUnparse,
+}));
+vi.mock("~/lib/services/auditClient", () => ({
+  logDataExport: mockLogDataExport,
+}));
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+describe("useReportCsvExport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.URL.createObjectURL = vi.fn(() => "blob:test-url");
+    global.URL.revokeObjectURL = vi.fn();
+    vi.spyOn(document.body, "appendChild").mockImplementation((el) => el);
+    vi.spyOn(document.body, "removeChild").mockImplementation((el) => el);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("awaits getRows, serializes, downloads, and logs the export", async () => {
+    const linkEl = document.createElement("a");
+    const clickSpy = vi.spyOn(linkEl, "click").mockImplementation(() => {});
+    vi.spyOn(document, "createElement").mockReturnValue(linkEl as any);
+
+    const getRows = vi.fn(async () => [
+      { testCaseName: "A", flipCount: 1, executions: [] },
+      { testCaseName: "B", flipCount: 2, executions: [] },
+    ]);
+
+    const { result } = renderHook(() => useReportCsvExport());
+
+    await act(async () => {
+      await result.current.exportCsv({
+        reportType: "flaky-tests",
+        isCrossProject: false,
+        getRows,
+        consecutiveRuns: 5,
+        projectId: 1,
+      });
+    });
+
+    expect(getRows).toHaveBeenCalledTimes(1);
+    expect(mockUnparse).toHaveBeenCalledTimes(1);
+    // Two rows handed to the serializer.
+    expect(mockUnparse.mock.calls[0][0]).toHaveLength(2);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+    expect(mockLogDataExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exportType: "Report-CSV",
+        entityType: "flaky-tests",
+        recordCount: 2,
+        projectId: 1,
+      })
+    );
+    expect(result.current.isExporting).toBe(false);
+  });
+
+  it("resets isExporting even if getRows throws", async () => {
+    const getRows = vi.fn(async () => {
+      throw new Error("fetch failed");
+    });
+    const { result } = renderHook(() => useReportCsvExport());
+
+    await act(async () => {
+      await expect(
+        result.current.exportCsv({
+          reportType: "execution-log",
+          isCrossProject: false,
+          getRows,
+        })
+      ).rejects.toThrow("fetch failed");
+    });
+
+    expect(mockUnparse).not.toHaveBeenCalled();
+    expect(result.current.isExporting).toBe(false);
+  });
+});

--- a/testplanit/hooks/useReportCsvExport.ts
+++ b/testplanit/hooks/useReportCsvExport.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Export a report's results to CSV. The full result set now lives client-side
+ * (no paging), so for most reports this just serializes what's already in
+ * memory; the caller supplies `getRows` so the execution log (the one
+ * server-paged report) can fetch all pages first.
+ *
+ * Mirrors `hooks/useDrillDownExport.ts`: Papa.unparse with `escapeFormulae`
+ * (CSV-injection safe) + a BOM for Excel, and a `logDataExport` audit entry.
+ */
+
+import { useLocale, useTranslations } from "next-intl";
+import Papa from "papaparse";
+import { useCallback, useState } from "react";
+import { logDataExport } from "~/lib/services/auditClient";
+import {
+  buildReportCsvRows,
+  getBaseReportType,
+  reportCsvFileName,
+} from "~/utils/reportCsvUtils";
+
+export interface ReportCsvExportParams {
+  reportType: string;
+  isCrossProject: boolean;
+  /** Resolves the full row set to export (in-memory or fetch-all). */
+  getRows: () => Promise<any[]> | any[];
+  dimensions?: Array<{ value: string; label: string }>;
+  metrics?: Array<{ value: string; label: string; apiLabel?: string }>;
+  projects?: Array<{ id: number; name: string }>;
+  consecutiveRuns?: number;
+  projectId?: number | string;
+}
+
+export function useReportCsvExport() {
+  const t = useTranslations();
+  const locale = useLocale();
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportCsv = useCallback(
+    async (params: ReportCsvExportParams) => {
+      setIsExporting(true);
+      try {
+        const rows = await params.getRows();
+        const csvRows = buildReportCsvRows({
+          reportType: params.reportType,
+          rows: rows ?? [],
+          dimensions: params.dimensions,
+          metrics: params.metrics,
+          projects: params.projects,
+          isCrossProject: params.isCrossProject,
+          consecutiveRuns: params.consecutiveRuns,
+          locale,
+          // next-intl types `t` with a strict key union; the CSV builder takes
+          // dynamic string keys, so adapt at the boundary.
+          t: (key, values) => t(key as never, values as never),
+        });
+
+        const csvString = Papa.unparse(csvRows, {
+          delimiter: ",",
+          header: true,
+          quotes: true,
+          escapeFormulae: true,
+        });
+
+        const blob = new Blob(["﻿" + csvString], {
+          type: "text/csv;charset=utf-8;",
+        });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = reportCsvFileName(params.reportType, new Date());
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(link.href);
+
+        void logDataExport({
+          exportType: "Report-CSV",
+          entityType: getBaseReportType(params.reportType),
+          recordCount: csvRows.length,
+          filters: { reportType: params.reportType },
+          projectId:
+            params.projectId != null ? Number(params.projectId) : undefined,
+        });
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [t, locale]
+  );
+
+  return { isExporting, exportCsv };
+}

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -6569,6 +6569,7 @@
       "addDimension": "Add dimension...",
       "addMetric": "Add metric...",
       "runReport": "Run Report",
+      "exportCsv": "Export CSV",
       "noResultsFound": "No results found.",
       "selectAtLeastOneDimensionAndMetric": "Select at least one dimension and one metric.",
       "noDataMatchingCriteria": "No data found matching the selected dimensions and metrics.",

--- a/testplanit/utils/reportCsvUtils.test.ts
+++ b/testplanit/utils/reportCsvUtils.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReportCsvRows,
+  getBaseReportType,
+  reportCsvFileName,
+} from "./reportCsvUtils";
+
+// Bare-key translator: returns the key (with {count} interpolated) so tests
+// assert on stable header keys instead of localized strings.
+const t = (key: string, values?: Record<string, unknown>) =>
+  values && "count" in values ? `${key}:${values.count}` : key;
+
+const base = {
+  isCrossProject: false,
+  locale: "en",
+  t,
+};
+
+describe("getBaseReportType", () => {
+  it("strips the cross-project- prefix", () => {
+    expect(getBaseReportType("cross-project-flaky-tests")).toBe("flaky-tests");
+    expect(getBaseReportType("flaky-tests")).toBe("flaky-tests");
+  });
+});
+
+describe("reportCsvFileName", () => {
+  it("builds a timestamped filename", () => {
+    const name = reportCsvFileName(
+      "flaky-tests",
+      new Date("2026-06-11T14:15:30")
+    );
+    expect(name).toBe("flaky-tests-2026-06-11-141530.csv");
+  });
+});
+
+describe("buildReportCsvRows", () => {
+  it("returns [] for empty input", () => {
+    expect(
+      buildReportCsvRows({ ...base, reportType: "flaky-tests", rows: [] })
+    ).toEqual([]);
+  });
+
+  it("flaky-tests: name, flips, and joined last-N statuses", () => {
+    const rows = [
+      {
+        testCaseName: "Login",
+        flipCount: 3,
+        executions: [
+          { statusName: "Passed" },
+          { statusName: "Failed" },
+          { statusName: "Passed" },
+        ],
+      },
+    ];
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "flaky-tests",
+      rows,
+      consecutiveRuns: 2,
+    });
+    expect(row["reports.dimensions.testCase"]).toBe("Login");
+    expect(row["reports.ui.flakyTests.flips"]).toBe(3);
+    // Only `consecutiveRuns` (2) statuses, joined.
+    expect(row["reports.ui.flakyTests.lastNResults:2"]).toBe("Passed Failed");
+  });
+
+  it("flaky-tests cross-project: adds a Project column", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      isCrossProject: true,
+      reportType: "cross-project-flaky-tests",
+      rows: [{ testCaseName: "X", flipCount: 1, project: { name: "Proj A" } }],
+    });
+    expect(row["reports.dimensions.project"]).toBe("Proj A");
+  });
+
+  it("test-case-health: translates status, formats stale/pass-rate", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-case-health",
+      rows: [
+        {
+          testCaseName: "Case 1",
+          healthStatus: "never_executed",
+          isStale: false,
+          healthScore: 80,
+          lastExecutedAt: null,
+          totalExecutions: 0,
+          passRate: 0,
+        },
+      ],
+    });
+    expect(row["reports.ui.testCaseHealth.status"]).toBe(
+      "reports.ui.testCaseHealth.healthStatus.neverExecuted"
+    );
+    expect(row["reports.ui.testCaseHealth.healthStatus.stale"]).toBe(
+      "common.no"
+    );
+    expect(row["reports.ui.testCaseHealth.lastExecuted"]).toBe(
+      "reports.ui.testCaseHealth.never"
+    );
+    // No executions → pass rate blank.
+    expect(row["reports.ui.testCaseHealth.passRate"]).toBe("");
+  });
+
+  it("test-case-health: pass rate shown as % when executed", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-case-health",
+      rows: [
+        {
+          testCaseName: "Case 2",
+          healthStatus: "healthy",
+          isStale: true,
+          healthScore: 90,
+          lastExecutedAt: "2026-06-01T10:00:00Z",
+          totalExecutions: 10,
+          passRate: 50,
+        },
+      ],
+    });
+    expect(row["reports.ui.testCaseHealth.passRate"]).toBe("50%");
+    expect(row["reports.ui.testCaseHealth.healthStatus.stale"]).toBe(
+      "common.yes"
+    );
+  });
+
+  it("issue-test-coverage: combines key + title, falls back to Not Tested", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "issue-test-coverage",
+      rows: [
+        {
+          externalKey: "TPI-12",
+          issueTitle: "Test Issue",
+          testCaseName: "Login case",
+          issueStatus: "To Do",
+          issuePriority: "Medium",
+          lastStatusName: null,
+          lastExecutedAt: null,
+        },
+      ],
+    });
+    expect(row["reports.ui.issueTestCoverage.issue"]).toBe(
+      "TPI-12: Test Issue"
+    );
+    expect(row["reports.ui.issueTestCoverage.lastStatus"]).toBe(
+      "reports.ui.issueTestCoverage.notTested"
+    );
+  });
+
+  it("execution-log: maps top-level execution fields", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "execution-log",
+      rows: [
+        {
+          testCaseName: "Case",
+          testRunName: "Run 1",
+          status: { name: "Passed" },
+          executedBy: { name: "Alice" },
+          executedAt: "2026-06-01T10:00:00Z",
+          elapsed: 0,
+        },
+      ],
+    });
+    expect(row["reports.dimensions.testRun"]).toBe("Run 1");
+    expect(row["common.actions.status"]).toBe("Passed");
+    expect(row["common.fields.executedBy"]).toBe("Alice");
+    expect(row["common.fields.duration"]).toBe(""); // 0 → blank
+  });
+
+  it("custom report: dimension values + formatted metric values", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-execution",
+      rows: [
+        {
+          user: { id: 1, name: "Bob" },
+          "Test Results Count": 42,
+          "Pass Rate (%)": 87.5,
+        },
+      ],
+      dimensions: [{ value: "user", label: "User" }],
+      metrics: [
+        { value: "testResults", label: "Test Results" },
+        { value: "passRate", label: "Pass Rate" },
+      ],
+    });
+    expect(row["User"]).toBe("Bob");
+    expect(row["Test Results"]).toBe(42);
+    expect(row["Pass Rate"]).toBe("87.5%");
+  });
+
+  it("custom report: date dimension uses UTC (no off-by-one) and elapsed is ms", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-execution",
+      rows: [
+        {
+          // UTC midnight — must stay 03-28 regardless of the runner's timezone.
+          date: { executedAt: "2025-03-28T00:00:00.000Z" },
+          "Avg. Elapsed Time": 60000, // milliseconds
+        },
+      ],
+      dimensions: [{ value: "date", label: "Date" }],
+      metrics: [{ value: "avgElapsedTime", label: "Avg. Elapsed Time" }],
+    });
+    expect(row["Date"]).toBe("2025-03-28");
+    expect(row["Avg. Elapsed Time"]).toBe("1 minute");
+  });
+
+  it("custom report: null dimension object yields empty string", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-execution",
+      rows: [{ status: null, "Test Results Count": 0 }],
+      dimensions: [{ value: "status", label: "Status" }],
+      metrics: [{ value: "testResults", label: "Test Results" }],
+    });
+    expect(row["Status"]).toBe("");
+    expect(row["Test Results"]).toBe(0);
+  });
+});

--- a/testplanit/utils/reportCsvUtils.test.ts
+++ b/testplanit/utils/reportCsvUtils.test.ts
@@ -210,6 +210,21 @@ describe("buildReportCsvRows", () => {
     expect(row["Avg. Elapsed Time"]).toBe("1 minute");
   });
 
+  it("custom report: zero-duration metric is a blank cell, not a hyphen", () => {
+    const [row] = buildReportCsvRows({
+      ...base,
+      reportType: "test-execution",
+      rows: [{ "Avg. Elapsed Time": 0, "Total Elapsed Time": 0 }],
+      metrics: [
+        { value: "avgElapsedTime", label: "Avg. Elapsed Time" },
+        { value: "totalElapsedTime", label: "Total Elapsed Time" },
+      ],
+    });
+    // A "-" here would get a leading apostrophe from papaparse escapeFormulae.
+    expect(row["Avg. Elapsed Time"]).toBe("");
+    expect(row["Total Elapsed Time"]).toBe("");
+  });
+
   it("custom report: null dimension object yields empty string", () => {
     const [row] = buildReportCsvRows({
       ...base,

--- a/testplanit/utils/reportCsvUtils.ts
+++ b/testplanit/utils/reportCsvUtils.ts
@@ -1,0 +1,336 @@
+/**
+ * Pure CSV-row builders for the report results table.
+ *
+ * Report columns render composite React cells (links, badges, the P/F/U
+ * widget) and JSX headers, so values can't be pulled generically off the
+ * column defs — each report type gets an explicit transform here, mirroring
+ * the per-type approach in `hooks/useDrillDownExport.ts`. Each builder returns
+ * an array of `{ "Header Label": value }` objects ready for `Papa.unparse`.
+ *
+ * Translation lookups go through an injected `t` (an unscoped next-intl
+ * translator) so this module stays pure and unit-testable.
+ */
+
+import { format } from "date-fns";
+import { toHumanReadable } from "~/utils/duration";
+
+export type Translate = (
+  key: string,
+  values?: Record<string, unknown>
+) => string;
+export type CsvRow = Record<string, string | number>;
+
+export interface BuildReportCsvParams {
+  /** Report type id, possibly prefixed with "cross-project-". */
+  reportType: string;
+  /** The full result set (already in memory / fetched). */
+  rows: any[];
+  /** Selected dimensions (custom reports) — `{ value, label }`. */
+  dimensions?: Array<{ value: string; label: string }>;
+  /** Selected metrics (custom reports) — `{ value, label, apiLabel? }`. */
+  metrics?: Array<{ value: string; label: string; apiLabel?: string }>;
+  /** Whether this is a cross-project report (adds a Project column). */
+  isCrossProject: boolean;
+  /** Flaky-tests "last N results" window. */
+  consecutiveRuns?: number;
+  /** Automation-trends projects (drives per-project columns). */
+  projects?: Array<{ id: number; name: string }>;
+  locale: string;
+  t: Translate;
+}
+
+/** Strip the "cross-project-" prefix to get the base report type. */
+export function getBaseReportType(reportType: string): string {
+  return reportType.replace(/^cross-project-/, "");
+}
+
+// ---- formatting helpers -------------------------------------------------
+
+function fmtDateTime(value: string | null | undefined): string {
+  if (!value) return "";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "" : format(d, "yyyy-MM-dd HH:mm:ss");
+}
+
+/** Date in UTC components — for grouping dates the backend stores at UTC midnight. */
+function fmtDateUtc(value: string | null | undefined): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "";
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function fmtDuration(
+  value: number | null | undefined,
+  isSeconds: boolean,
+  locale: string
+): string {
+  if (!value || value <= 0) return "";
+  return toHumanReadable(value, { isSeconds, locale, largest: 2, round: true });
+}
+
+function fmtPercent(value: number | null | undefined): string {
+  if (typeof value !== "number" || isNaN(value)) return "";
+  return `${Math.round(value)}%`;
+}
+
+const HEALTH_STATUS_KEY: Record<string, string> = {
+  healthy: "reports.ui.testCaseHealth.healthStatus.healthy",
+  never_executed: "reports.ui.testCaseHealth.healthStatus.neverExecuted",
+  always_passing: "reports.ui.testCaseHealth.healthStatus.alwaysPassing",
+  always_failing: "reports.ui.testCaseHealth.healthStatus.alwaysFailing",
+};
+
+// ---- per-type builders --------------------------------------------------
+
+function buildFlakyTests(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, t, isCrossProject, consecutiveRuns = 5 } = p;
+  const hProject = t("reports.dimensions.project");
+  const hCase = t("reports.dimensions.testCase");
+  const hFlips = t("reports.ui.flakyTests.flips");
+  const hResults = t("reports.ui.flakyTests.lastNResults", {
+    count: consecutiveRuns,
+  });
+  return rows.map((r: any) => {
+    const row: CsvRow = {};
+    if (isCrossProject) row[hProject] = r.project?.name ?? "";
+    row[hCase] = r.testCaseName ?? "";
+    row[hFlips] = r.flipCount ?? 0;
+    row[hResults] = (r.executions ?? [])
+      .slice(0, consecutiveRuns)
+      .map((e: any) => e.statusName)
+      .filter(Boolean)
+      .join(" ");
+    return row;
+  });
+}
+
+function buildTestCaseHealth(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, t, isCrossProject } = p;
+  const h = {
+    project: t("reports.dimensions.project"),
+    testCase: t("reports.dimensions.testCase"),
+    status: t("reports.ui.testCaseHealth.status"),
+    stale: t("reports.ui.testCaseHealth.healthStatus.stale"),
+    score: t("reports.ui.testCaseHealth.healthScore"),
+    lastExecuted: t("reports.ui.testCaseHealth.lastExecuted"),
+    executions: t("reports.ui.testCaseHealth.executions"),
+    passRate: t("reports.ui.testCaseHealth.passRate"),
+  };
+  const never = t("reports.ui.testCaseHealth.never");
+  return rows.map((r: any) => {
+    const row: CsvRow = {};
+    if (isCrossProject) row[h.project] = r.project?.name ?? "";
+    row[h.testCase] = r.testCaseName ?? "";
+    row[h.status] = HEALTH_STATUS_KEY[r.healthStatus]
+      ? t(HEALTH_STATUS_KEY[r.healthStatus])
+      : (r.healthStatus ?? "");
+    row[h.stale] = r.isStale ? t("common.yes") : t("common.no");
+    row[h.score] = r.healthScore ?? 0;
+    row[h.lastExecuted] = r.lastExecutedAt
+      ? fmtDateTime(r.lastExecutedAt)
+      : never;
+    row[h.executions] = r.totalExecutions ?? 0;
+    row[h.passRate] = r.totalExecutions > 0 ? fmtPercent(r.passRate) : "";
+    return row;
+  });
+}
+
+function buildIssueTestCoverage(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, t, isCrossProject } = p;
+  const h = {
+    project: t("reports.dimensions.project"),
+    issue: t("reports.ui.issueTestCoverage.issue"),
+    testCase: t("reports.ui.issueTestCoverage.testCase"),
+    status: t("reports.ui.issueTestCoverage.issueStatus"),
+    priority: t("reports.ui.issueTestCoverage.priority"),
+    lastStatus: t("reports.ui.issueTestCoverage.lastStatus"),
+    lastExecuted: t("reports.ui.issueTestCoverage.lastExecuted"),
+  };
+  const notTested = t("reports.ui.issueTestCoverage.notTested");
+  // One row per issue × test case (the underlying flat shape), so the export
+  // is data-complete; the grouped P/F/U aggregates are a view convenience.
+  return rows.map((r: any) => {
+    const key = r.externalKey || r.externalId || r.issueName || "";
+    const row: CsvRow = {};
+    if (isCrossProject) row[h.project] = r.project?.name ?? "";
+    row[h.issue] = r.issueTitle ? `${key}: ${r.issueTitle}` : String(key);
+    row[h.testCase] = r.testCaseName ?? "";
+    row[h.status] = r.issueStatus ?? r.issueExternalStatus ?? "";
+    row[h.priority] = r.issuePriority ?? "";
+    row[h.lastStatus] = r.lastStatusName ?? notTested;
+    row[h.lastExecuted] = fmtDateTime(r.lastExecutedAt);
+    return row;
+  });
+}
+
+function buildExecutionLog(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, t, isCrossProject, locale } = p;
+  const h = {
+    project: t("reports.dimensions.project"),
+    testCase: t("reports.dimensions.testCase"),
+    testRun: t("reports.dimensions.testRun"),
+    status: t("common.actions.status"),
+    executedBy: t("common.fields.executedBy"),
+    executedAt: t("common.fields.executedAt"),
+    duration: t("common.fields.duration"),
+  };
+  // Export the top-level execution rows (steps are nested sub-rows in the UI).
+  return rows.map((r: any) => {
+    const row: CsvRow = {};
+    if (isCrossProject) row[h.project] = r.project?.name ?? "";
+    row[h.testCase] = r.testCaseName ?? "";
+    row[h.testRun] = r.testRunName ?? "";
+    row[h.status] = r.status?.name ?? "";
+    row[h.executedBy] = r.executedBy?.name ?? "";
+    row[h.executedAt] = fmtDateTime(r.executedAt);
+    row[h.duration] = fmtDuration(r.elapsed, true, locale);
+    return row;
+  });
+}
+
+function buildAutomationTrends(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, t, projects = [] } = p;
+  const hPeriod = t("reports.dimensions.period");
+  const single = projects.length <= 1;
+  return rows.map((r: any) => {
+    const row: CsvRow = {};
+    row[hPeriod] =
+      r.periodStart && r.periodEnd
+        ? `${fmtDateUtc(r.periodStart)} – ${fmtDateUtc(r.periodEnd)}`
+        : fmtDateUtc(r.periodStart);
+    for (const project of projects) {
+      const prefix = project.name.replace(/\s+/g, "");
+      const tag = single ? "" : `${project.name} `;
+      row[`${tag}${t("reports.metrics.automatedCount")}`] =
+        r[`${prefix}_automated`] ?? 0;
+      row[`${tag}${t("reports.metrics.manualCount")}`] =
+        r[`${prefix}_manual`] ?? 0;
+      row[`${tag}${t("reports.metrics.totalCount")}`] =
+        r[`${prefix}_total`] ?? 0;
+      row[`${tag}% ${t("common.fields.automated")}`] = fmtPercent(
+        r[`${prefix}_percentAutomated`]
+      );
+    }
+    return row;
+  });
+}
+
+// custom / standard reports (dynamic dimensions + metrics) -----------------
+
+function metricAccessor(metric: {
+  value: string;
+  label: string;
+  apiLabel?: string;
+}): string {
+  if (metric.apiLabel) return metric.apiLabel;
+  switch (metric.value) {
+    case "testResults":
+      return "Test Results Count";
+    case "passRate":
+      return "Pass Rate (%)";
+    case "avgElapsedTime":
+      return "Avg. Elapsed Time";
+    case "totalElapsedTime":
+      return "Total Elapsed Time";
+    case "testRuns":
+      return "Test Runs Count";
+    case "testCases":
+      return "Test Cases Count";
+    default:
+      return metric.label;
+  }
+}
+
+function isRateMetric(m: { value: string; label: string }): boolean {
+  return /rate|percentage|%/i.test(m.value) || /rate|%/i.test(m.label);
+}
+
+function isTimeMetric(m: { value: string; label: string }): boolean {
+  return (
+    /time|duration|elapsed/i.test(m.value) ||
+    /time|duration|elapsed/i.test(m.label)
+  );
+}
+
+function dimensionValue(row: any, dimId: string): string {
+  const v = row[dimId];
+  if (v == null) return "";
+  if (dimId === "date") {
+    const d = typeof v === "object" ? (v.executedAt ?? v.createdAt ?? null) : v;
+    // The backend normalizes grouping dates to UTC midnight; the on-screen
+    // column reads UTC components. Use UTC here too, otherwise users behind
+    // UTC see every date shifted back a day.
+    return fmtDateUtc(d);
+  }
+  if (typeof v === "object") {
+    return v.name ?? v.title ?? v.templateName ?? v.email ?? "";
+  }
+  return String(v);
+}
+
+function buildCustom(p: BuildReportCsvParams): CsvRow[] {
+  const { rows, dimensions = [], metrics = [], locale } = p;
+  return rows.map((r: any) => {
+    const row: CsvRow = {};
+    for (const dim of dimensions) {
+      row[dim.label] = dimensionValue(r, dim.value);
+    }
+    for (const metric of metrics) {
+      const raw = r[metricAccessor(metric)];
+      const num = typeof raw === "number" ? raw : Number(raw);
+      let value: string | number;
+      if (raw == null || isNaN(num)) {
+        value = "";
+      } else if (isRateMetric(metric)) {
+        value = `${num.toFixed(1)}%`;
+      } else if (isTimeMetric(metric)) {
+        // Custom-report elapsed metrics (avg/total) are in milliseconds, matching
+        // the on-screen leaf cell (`isSeconds: false`).
+        value =
+          num === 0
+            ? "-"
+            : toHumanReadable(num, {
+                isSeconds: false,
+                locale,
+                largest: 2,
+                round: true,
+              });
+      } else {
+        value = num;
+      }
+      row[metric.label] = value;
+    }
+    return row;
+  });
+}
+
+/**
+ * Build the CSV rows for a report. Dispatches to a per-type transform; falls
+ * back to the dimension/metric-driven custom builder.
+ */
+export function buildReportCsvRows(p: BuildReportCsvParams): CsvRow[] {
+  if (!p.rows || p.rows.length === 0) return [];
+  switch (getBaseReportType(p.reportType)) {
+    case "flaky-tests":
+      return buildFlakyTests(p);
+    case "test-case-health":
+      return buildTestCaseHealth(p);
+    case "issue-test-coverage":
+      return buildIssueTestCoverage(p);
+    case "execution-log":
+      return buildExecutionLog(p);
+    case "automation-trends":
+      return buildAutomationTrends(p);
+    default:
+      return buildCustom(p);
+  }
+}
+
+/** Filename like `flaky-tests-2026-06-11-141530.csv`. */
+export function reportCsvFileName(reportType: string, now: Date): string {
+  return `${reportType}-${format(now, "yyyy-MM-dd-HHmmss")}.csv`;
+}

--- a/testplanit/utils/reportCsvUtils.ts
+++ b/testplanit/utils/reportCsvUtils.ts
@@ -289,10 +289,13 @@ function buildCustom(p: BuildReportCsvParams): CsvRow[] {
         value = `${num.toFixed(1)}%`;
       } else if (isTimeMetric(metric)) {
         // Custom-report elapsed metrics (avg/total) are in milliseconds, matching
-        // the on-screen leaf cell (`isSeconds: false`).
+        // the on-screen leaf cell (`isSeconds: false`). Empty value → blank cell
+        // (the screen's "-" placeholder would get a leading apostrophe from
+        // papaparse's formula-injection escaping, and blank is the right CSV
+        // representation of "no data" anyway).
         value =
           num === 0
-            ? "-"
+            ? ""
             : toHumanReadable(num, {
                 isSeconds: false,
                 locale,


### PR DESCRIPTION
## Description

Adds an **Export CSV** button to the report results panel, on both the report builder (project + cross-project admin reports) and read-only shared report links. Now that report tables hold their full result set in memory (no paging), export just serializes what's already loaded — except the execution log (the one truly server-paged report), which fetches every page first so the file is complete.

Per-report-type transforms produce the columns you see on screen with proper labels (e.g. Issue = "TPI-12: Test Issue", Pass Rate = "50%"), mirroring the existing drill-down CSV. The report columns render composite React cells / JSX headers, so values can't be pulled generically off the column defs — hence an explicit transform per type.

### What's included

- **`utils/reportCsvUtils.ts`** (new) — pure, unit-tested per-type row builders: flaky-tests, test-case-health, issue-test-coverage, automation-trends, execution-log, and dynamic custom/standard reports (dimension + metric driven). Cross-project variants add a Project column.
- **`hooks/useReportCsvExport.ts`** (new) — `Papa.unparse` with `escapeFormulae` (CSV-injection safe) + a BOM for Excel, anchor download, and a `logDataExport` audit entry. Takes a caller-supplied `getRows` so execution-log can fetch all pages.
- **ReportRenderer / ReportBuilder / StaticReportViewer** — Export button in the results header; full-set reports serialize in-memory `allResults`, execution-log loops the endpoint until complete.
- One i18n key (`reports.ui.exportCsv`).

### Correctness notes

- **Grouping dates use UTC components** — the backend stores grouping dates at UTC midnight and the on-screen column renders them in UTC, so the CSV does too (otherwise users behind UTC saw every date shifted back a day).
- **Custom-report elapsed metrics are milliseconds** — matched to the on-screen leaf cell (`isSeconds: false`); execution-log `elapsed` is seconds (`DurationDisplay`), handled separately.

## Related Issue

N/A — follows the reports virtual-scrolling work (#425, this PR's base branch).

## Type of Change

- [x] Enhancement (non-breaking new functionality)

## Testing

- **`utils/reportCsvUtils.test.ts`** (12): per-type transforms produce expected headers/values; cross-project Project column; UTC date (verified under `America/Los_Angeles`); custom-report elapsed in ms; empty input.
- **`hooks/useReportCsvExport.test.ts`** (2): awaits `getRows`, serializes, downloads, logs the audit entry; resets state on error.
- **`ReportRenderer.test.tsx`**: export button forwarding + "Showing X of Y" summary.
- Full gate green locally: production build, ESLint, `tsc --noEmit`, `format:check`, full Vitest suite (**9245 passed / 145 skipped**).
- Manual: exported each report type from the builder and a shared link; opened in Excel; columns/labels match the table; execution-log exports every row.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally
- [x] My changes generate no new warnings
