### PR TITLE
fix(issues): persist external ID for in-app Simple URL issues

### DIFF
--- a/docs/docs/user-guide/projects/issues.md
+++ b/docs/docs/user-guide/projects/issues.md
@@ -11,6 +11,8 @@ This page, accessible from within a specific project's navigation menu (under "I
 
 Unlike the global Issues List, this view is filtered to show only the issues relevant to the currently selected project. It helps in understanding which known issues might impact testing activities or are associated with test failures specifically within this project context.
 
+This page is **read-only** — it lists issues that already exist. You do not add or link issues from here. Issues appear in this list once they are linked to a Test Case, Test Run, Result, or Session, or when an inbound webhook imports them. To add or link an issue (including with a Simple URL integration), open the relevant test artifact and use the **Link Issue** / **Add** controls in its Issues panel. See [Issue Integrations](../integrations.md) for the full add/link flow.
+
 ## Features
 
 ### Project Context Header

--- a/testplanit/components/issues/UnifiedIssueManager.test.tsx
+++ b/testplanit/components/issues/UnifiedIssueManager.test.tsx
@@ -75,7 +75,10 @@ vi.mock("@/components/ui/button", () => ({
     ),
 }));
 
-import { UnifiedIssueManager } from "./UnifiedIssueManager";
+import {
+  SimpleUnifiedIssueManager,
+  UnifiedIssueManager,
+} from "./UnifiedIssueManager";
 
 const defaultProps = {
   projectId: 1,
@@ -270,5 +273,108 @@ describe("UnifiedIssueManager", () => {
     render(<UnifiedIssueManager {...defaultProps} />);
 
     expect(screen.getByRole("alert")).toBeTruthy();
+  });
+});
+
+describe("SimpleUnifiedIssueManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const simpleUrlProjectData = {
+    projectIntegrations: [
+      {
+        id: 10,
+        isActive: true,
+        integration: {
+          id: 5,
+          name: "Simple Links",
+          provider: "SIMPLE_URL",
+          settings: { baseUrl: "https://tracker/issues/{issueId}" },
+        },
+      },
+    ],
+  };
+
+  const jiraProjectData = {
+    projectIntegrations: [
+      {
+        id: 20,
+        isActive: true,
+        integration: { id: 7, name: "My Jira", provider: "JIRA" },
+      },
+    ],
+  };
+
+  const baseProps = {
+    projectId: 1,
+    linkedIssueIds: [],
+    setLinkedIssueIds: vi.fn(),
+    entityType: "testCase" as const,
+  };
+
+  it("renders ManageSimpleUrlIssues for SIMPLE_URL when entityId > 0", () => {
+    render(
+      <SimpleUnifiedIssueManager
+        {...baseProps}
+        projectData={simpleUrlProjectData as any}
+        entityId={42}
+      />
+    );
+
+    expect(screen.getByTestId("manage-simple-url-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
+  });
+
+  it("renders ManageSimpleUrlIssues (not DeferredIssueManager) for SIMPLE_URL when entityId is 0", () => {
+    render(
+      <SimpleUnifiedIssueManager
+        {...baseProps}
+        projectData={simpleUrlProjectData as any}
+        entityId={0}
+      />
+    );
+
+    expect(screen.getByTestId("manage-simple-url-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
+  });
+
+  it("renders ManageSimpleUrlIssues (not DeferredIssueManager) for SIMPLE_URL when entityId is undefined", () => {
+    render(
+      <SimpleUnifiedIssueManager
+        {...baseProps}
+        projectData={simpleUrlProjectData as any}
+        entityId={undefined}
+      />
+    );
+
+    expect(screen.getByTestId("manage-simple-url-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
+  });
+
+  it("still defers external providers (JIRA) when entityId is 0", () => {
+    render(
+      <SimpleUnifiedIssueManager
+        {...baseProps}
+        projectData={jiraProjectData as any}
+        entityId={0}
+      />
+    );
+
+    expect(screen.getByTestId("deferred-issue-manager")).toBeTruthy();
+    expect(screen.queryByTestId("manage-simple-url-issues")).toBeNull();
+  });
+
+  it("renders ManageExternalIssues for JIRA when entityId > 0", () => {
+    render(
+      <SimpleUnifiedIssueManager
+        {...baseProps}
+        projectData={jiraProjectData as any}
+        entityId={42}
+      />
+    );
+
+    expect(screen.getByTestId("manage-external-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
   });
 });

--- a/testplanit/components/issues/UnifiedIssueManager.test.tsx
+++ b/testplanit/components/issues/UnifiedIssueManager.test.tsx
@@ -192,6 +192,58 @@ describe("UnifiedIssueManager", () => {
     expect(screen.getByTestId("deferred-issue-manager")).toBeTruthy();
   });
 
+  it("renders ManageSimpleUrlIssues (not DeferredIssueManager) for SIMPLE_URL when entityId is 0", () => {
+    mockUseFindFirstProjects.mockReturnValue({
+      data: {
+        projectIntegrations: [
+          {
+            id: 10,
+            isActive: true,
+            config: {},
+            integration: {
+              id: 5,
+              name: "Simple Links",
+              provider: "SIMPLE_URL",
+              settings: { baseUrl: "https://tracker/issues/{issueId}" },
+            },
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<UnifiedIssueManager {...defaultProps} entityId={0} />);
+
+    expect(screen.getByTestId("manage-simple-url-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
+  });
+
+  it("renders ManageSimpleUrlIssues (not DeferredIssueManager) for SIMPLE_URL when entityId is undefined", () => {
+    mockUseFindFirstProjects.mockReturnValue({
+      data: {
+        projectIntegrations: [
+          {
+            id: 10,
+            isActive: true,
+            config: {},
+            integration: {
+              id: 5,
+              name: "Simple Links",
+              provider: "SIMPLE_URL",
+              settings: { baseUrl: "https://tracker/issues/{issueId}" },
+            },
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<UnifiedIssueManager {...defaultProps} entityId={undefined} />);
+
+    expect(screen.getByTestId("manage-simple-url-issues")).toBeTruthy();
+    expect(screen.queryByTestId("deferred-issue-manager")).toBeNull();
+  });
+
   it("renders alert with configure integration link when project has no active integrations", () => {
     mockUseFindFirstProjects.mockReturnValue({
       data: {

--- a/testplanit/components/issues/UnifiedIssueManager.tsx
+++ b/testplanit/components/issues/UnifiedIssueManager.tsx
@@ -69,22 +69,6 @@ export function UnifiedIssueManager({
   // Check for new integration system first
   const activeIntegration = project?.projectIntegrations?.[0];
 
-  // If entity doesn't exist yet (entityId is 0 or undefined), use deferred linking
-  if (activeIntegration?.integration && (!entityId || entityId === 0)) {
-    return (
-      <DeferredIssueManager
-        projectId={projectId}
-        selectedIssues={[]} // Not used anymore
-        linkedIssueIds={linkedIssueIds}
-        onIssuesChange={(issueIds) => {
-          setLinkedIssueIds(issueIds);
-        }}
-        maxBadgeWidth={maxBadgeWidth}
-        iterationContext={iterationContext}
-      />
-    );
-  }
-
   if (activeIntegration?.integration) {
     const integrationId =
       typeof activeIntegration.integration.id === "string"
@@ -95,7 +79,9 @@ export function UnifiedIssueManager({
         ? parseInt(activeIntegration.id)
         : activeIntegration.id;
 
-    // Handle SIMPLE_URL provider
+    // Handle SIMPLE_URL before the deferred branch — these issues carry a
+    // manually entered externalId that the deferred create flow can't set,
+    // and ManageSimpleUrlIssues already works for unsaved entities.
     if (
       activeIntegration.integration.provider === IntegrationProvider.SIMPLE_URL
     ) {
@@ -113,6 +99,22 @@ export function UnifiedIssueManager({
           config={{
             baseUrl: integrationSettings.baseUrl as string | undefined,
           }}
+        />
+      );
+    }
+
+    // If entity doesn't exist yet (entityId is 0 or undefined), use deferred linking
+    if (!entityId || entityId === 0) {
+      return (
+        <DeferredIssueManager
+          projectId={projectId}
+          selectedIssues={[]} // Not used anymore
+          linkedIssueIds={linkedIssueIds}
+          onIssuesChange={(issueIds) => {
+            setLinkedIssueIds(issueIds);
+          }}
+          maxBadgeWidth={maxBadgeWidth}
+          iterationContext={iterationContext}
         />
       );
     }
@@ -186,20 +188,6 @@ export function SimpleUnifiedIssueManager({
     (pi) => pi.isActive
   );
 
-  // If entity doesn't exist yet (entityId is 0 or undefined), use deferred linking
-  if (activeIntegration && (!entityId || entityId === 0)) {
-    return (
-      <DeferredIssueManager
-        projectId={projectId}
-        selectedIssues={[]} // Not used anymore
-        linkedIssueIds={linkedIssueIds}
-        onIssuesChange={(issueIds) => {
-          setLinkedIssueIds(issueIds);
-        }}
-      />
-    );
-  }
-
   if (activeIntegration) {
     const integrationId =
       typeof activeIntegration.integration.id === "string"
@@ -210,7 +198,9 @@ export function SimpleUnifiedIssueManager({
         ? parseInt(activeIntegration.id)
         : activeIntegration.id;
 
-    // Handle SIMPLE_URL provider
+    // Handle SIMPLE_URL before the deferred branch — these issues carry a
+    // manually entered externalId that the deferred create flow can't set,
+    // and ManageSimpleUrlIssues already works for unsaved entities.
     if (
       activeIntegration.integration.provider === IntegrationProvider.SIMPLE_URL
     ) {
@@ -229,6 +219,20 @@ export function SimpleUnifiedIssueManager({
           entityType={entityType}
           config={{
             baseUrl: integrationSettings.baseUrl as string | undefined,
+          }}
+        />
+      );
+    }
+
+    // If entity doesn't exist yet (entityId is 0 or undefined), use deferred linking
+    if (!entityId || entityId === 0) {
+      return (
+        <DeferredIssueManager
+          projectId={projectId}
+          selectedIssues={[]} // Not used anymore
+          linkedIssueIds={linkedIssueIds}
+          onIssuesChange={(issueIds) => {
+            setLinkedIssueIds(issueIds);
           }}
         />
       );

--- a/testplanit/components/issues/create-issue-dialog.test.tsx
+++ b/testplanit/components/issues/create-issue-dialog.test.tsx
@@ -298,6 +298,96 @@ describe("CreateIssueDialog", () => {
     expect(selects.length).toBeGreaterThan(0);
   });
 
+  describe("SIMPLE_URL", () => {
+    const simpleUrlIntegration = {
+      data: [
+        {
+          id: 10,
+          integrationId: 5,
+          isActive: true,
+          integration: { id: 5, name: "Redmine", provider: "SIMPLE_URL" },
+        },
+      ],
+    };
+
+    it("renders the Issue ID field for SIMPLE_URL integrations", () => {
+      mockUseFindManyProjectIntegration.mockReturnValue(simpleUrlIntegration);
+
+      render(<CreateIssueDialog {...defaultProps} />);
+
+      // common.fields.id → mock returns last segment "id"
+      expect(screen.getAllByText("id").length).toBeGreaterThan(0);
+    });
+
+    it("does not render the Issue ID field for non-SIMPLE_URL integrations", () => {
+      mockUseFindManyProjectIntegration.mockReturnValue({
+        data: [
+          {
+            id: 10,
+            integrationId: 5,
+            isActive: true,
+            integration: { id: 5, name: "My Jira", provider: "JIRA" },
+          },
+        ],
+      });
+
+      render(<CreateIssueDialog {...defaultProps} />);
+
+      expect(screen.queryByText("id")).toBeNull();
+    });
+
+    it("creates the issue with the entered ID as externalId", async () => {
+      mockUseFindManyProjectIntegration.mockReturnValue(simpleUrlIntegration);
+      mockMutateAsync.mockResolvedValue({
+        id: 99,
+        name: "ISSUE-77",
+        externalId: "ISSUE-77",
+      });
+
+      render(
+        <CreateIssueDialog
+          {...defaultProps}
+          defaultValues={{ externalId: "ISSUE-77", title: "Login broken" }}
+        />
+      );
+
+      const form = document.querySelector("form");
+      if (form) {
+        fireEvent.submit(form);
+      }
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              externalId: "ISSUE-77",
+              name: "ISSUE-77",
+              title: "Login broken",
+            }),
+          })
+        );
+      });
+    });
+
+    it("does not create the issue when the Issue ID is empty", async () => {
+      mockUseFindManyProjectIntegration.mockReturnValue(simpleUrlIntegration);
+
+      render(
+        <CreateIssueDialog
+          {...defaultProps}
+          defaultValues={{ title: "No ID provided" }}
+        />
+      );
+
+      const form = document.querySelector("form");
+      if (form) {
+        fireEvent.submit(form);
+      }
+
+      await waitFor(() => expect(mockMutateAsync).not.toHaveBeenCalled());
+    });
+  });
+
   describe("INT-05: TipTap doc prefill", () => {
     const tiptapDoc = {
       type: "doc" as const,

--- a/testplanit/components/issues/create-issue-dialog.tsx
+++ b/testplanit/components/issues/create-issue-dialog.tsx
@@ -59,6 +59,9 @@ const createIssueSchema = z.object({
   description: z.string().optional(),
   priority: z.string().optional().default("medium"),
   issueType: z.string().optional(),
+  // Only used for Simple URL integrations, where the issue ID becomes the
+  // externalId substituted into the Base URL template.
+  externalId: z.string().optional(),
   customFields: z.record(z.string(), z.any()).optional(),
 });
 
@@ -150,6 +153,7 @@ export function CreateIssueDialog({
       description: initialMarkdownPreview,
       priority: defaultValues?.priority || "medium",
       issueType: defaultValues?.issueType || undefined,
+      externalId: defaultValues?.externalId || "",
       customFields: {},
     },
   });
@@ -404,10 +408,20 @@ export function CreateIssueDialog({
           throw new Error("Authentication required");
         }
 
-        // Use ZenStack hook for Simple URL integrations to create internal issues
+        // Simple URL link-outs require the issue ID as externalId
+        const externalId = values.externalId?.trim();
+        if (!externalId) {
+          form.setError("externalId", {
+            message: t("common.errors.fieldRequired"),
+          });
+          setIsCreating(false);
+          return;
+        }
+
         const createData: any = {
-          name: values.title, // Both name and title are required
+          name: externalId,
           title: values.title,
+          externalId,
           description: values.description || "",
           status: "open",
           priority: values.priority || "medium",
@@ -851,6 +865,30 @@ export function CreateIssueDialog({
                   />
                 </div>
               )}
+
+            {isSimpleUrlIntegration && (
+              <FormField
+                control={form.control as any}
+                name="externalId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="inline-flex items-center gap-0.5">
+                      {t("common.fields.id")}
+                      <sup>
+                        <Asterisk className="w-3 h-3 text-destructive" />
+                      </sup>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={t("common.placeholders.issueIdExample")}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
 
             <FormField
               control={form.control as any}


### PR DESCRIPTION
## Description

Simple URL issue integrations (e.g. Redmine) could create issues with a **null external ID**, leaving them unusable: the link-out URL can't be built from the Base URL template, and the issue can't be matched on its `externalId_integrationId` unique key (so it can't be edited or de-duplicated). This happened on two paths:

1. **Adding an issue against an unsaved entity** (e.g. a new test-run result). `UnifiedIssueManager`/`SimpleUnifiedIssueManager` checked the "deferred linking" branch *before* the SIMPLE_URL branch, so SIMPLE_URL fell through to the generic create dialog, which has no issue-ID field.
2. **The test-case generation wizard**, which renders `SearchIssuesDialog` → `CreateIssueDialog` directly. Its SIMPLE_URL create path never set `externalId`.

Fixes:

- Route SIMPLE_URL to `ManageSimpleUrlIssues` **before** the deferred branch in both `UnifiedIssueManager` and `SimpleUnifiedIssueManager`, so unsaved entities still capture the issue ID. `ManageSimpleUrlIssues` is entity-agnostic (it buffers via `linkedIssueIds`), so this is safe for both saved and unsaved entities.
- Add a required **Issue ID** field to `CreateIssueDialog` for SIMPLE_URL integrations and persist it as `externalId` (reusing existing i18n keys), blocking submit when empty. This fixes every surface that reaches the dialog, including the generation wizard.
- Clarify in the docs that the project **Issues** page is read-only — issues are added/linked from a test artifact, not from that list.

## Related Issue

Reported via customer support (Redmine via the Simple URL integration). No tracking issue number.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Added 6 unit tests (2 routing guards in `UnifiedIssueManager`, 4 in `CreateIssueDialog`). Full gate run locally: `pnpm build` (clean) and `pnpm precommit` — eslint 0 errors, prettier clean, **9252 tests passed / 145 skipped / 0 failed**.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Existing SIMPLE_URL issues that were already created with a null `externalId` are not repaired by this change (their original IDs aren't recoverable); they should be removed and re-added with the correct issue ID.
