### PR TITLE
enhancement(tables): remember column selection per view

### DIFF
--- a/docs/docs/user-guide/admin-issues.md
+++ b/docs/docs/user-guide/admin-issues.md
@@ -19,7 +19,7 @@ Only system administrators can open this page. To view or manage issues for a si
 
 ## Viewing issues
 
-Issues are listed in a sortable, filterable table. Use the **Filter issues...** box to search by name, title, or description (matching is case-insensitive). The **Columns** control lets you show or hide optional columns.
+Issues are listed in a sortable, filterable table. Use the **Filter issues...** box to search by name, title, or description (matching is case-insensitive). The **Columns** control lets you show or hide optional columns; your choice is remembered in this browser for this table.
 
 | Column | Description |
 | --- | --- |

--- a/docs/docs/user-guide/projects/repository.md
+++ b/docs/docs/user-guide/projects/repository.md
@@ -64,7 +64,7 @@ The page features a resizable two-panel layout:
     * **Generate Test Cases Button**: Opens the AI generation wizard (sparkles icon, requires [LLM Integration](../llm-integrations.md)).
     * **Import Cases Button**: Opens the CSV import wizard for bulk test case creation.
     * **Filter Input**: Search for test cases by name within the current view/filter.
-    * **Column Selection**: Choose which columns are visible in the table.
+    * **Column Selection**: Choose which columns are visible in the table using the **Columns** control. Your selection is remembered automatically — it is saved in your browser and scoped to this project's repository, so the columns you pick are still there the next time you open it.
     * **Pagination**: Controls for navigating through pages of test cases.
     * **Test Case Table (`DataTable`)**: Displays the list of test cases based on the current selection/filters. Supports:
         * Sorting by clicking column headers (Name, State, etc.).
@@ -110,6 +110,10 @@ The main table displays the following information for each test case:
     * **Delete**: Initiates the soft delete process for the test case, requiring confirmation.
 
 Additional dynamic columns appear based on the fields defined in the templates used by the displayed cases.
+
+### Remembered column choices
+
+Your column selections are saved per project and restored each time you return. Because the available columns change with the templates in view, choices are matched by column: a column you hid or showed is restored whenever that column is present, and any saved choice for a column that is not in the current view — for example a removed template field, or a field that belongs to a template you are not currently looking at — is simply ignored. Switching between templates therefore keeps each template's columns the way you left them. If you open the repository from a shared link whose URL specifies columns, those columns take precedence for that visit.
 
 ## Drag and Drop
 

--- a/docs/docs/user-guide/tags.md
+++ b/docs/docs/user-guide/tags.md
@@ -20,7 +20,7 @@ The Tags page displays a table listing all defined tags (excluding those marked 
 - **Filtering**: Use the filter input above the table to search for tags by name.
 - **Pagination**: If there are many tags, use the pagination controls at the top-right to navigate through pages and adjust the number of tags shown per page.
 - **Sorting**: Click on the "Name" column header to sort the tags alphabetically in ascending or descending order.
-- **Column Selection**: Use the "View" dropdown to show or hide specific columns.
+- **Column Selection**: Use the **Columns** control to show or hide specific columns. Your choice is remembered in this browser for this table, so it persists across visits.
 - **Columns**: The table includes columns for:
   - **Name**: The unique name of the Tag.
   - **Test Cases**: Displays the number of Test Cases associated with this Tag. Clicking the number may show a list or link to the relevant cases (depending on component implementation).

--- a/docs/docs/user-guide/users-list.md
+++ b/docs/docs/user-guide/users-list.md
@@ -14,7 +14,7 @@ Users with the `NONE` access level cannot view this page and will be redirected.
 ## Features
 
 - **Filtering**: Use the filter input above the table to search for users by name. The search is case-insensitive.
-- **Column Selection**: Use the "View" dropdown (usually represented by an eye icon or similar) to show or hide specific columns in the table.
+- **Column Selection**: Use the **Columns** control above the table to show or hide specific columns. Your choice is remembered in this browser for this table, so it persists across visits.
 - **Pagination**: If there are many users, use the pagination controls at the top-right to navigate through pages and adjust the number of users shown per page.
 - **Sorting**: Click on the column headers for "Name" or "Email" to sort the user list accordingly (ascending/descending).
 

--- a/testplanit/app/[locale]/admin/api-tokens/page.tsx
+++ b/testplanit/app/[locale]/admin/api-tokens/page.tsx
@@ -379,6 +379,7 @@ function ApiTokensList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="api-tokens-column-selection"
+                      storageKey="admin-api-tokens"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/audit-logs/page.tsx
+++ b/testplanit/app/[locale]/admin/audit-logs/page.tsx
@@ -567,6 +567,7 @@ function AuditLogsContent({ session }: { session: Session }) {
               <div>
                 <ColumnSelection
                   key="audit-logs-column-selection"
+                  storageKey="admin-audit-logs"
                   columns={columns}
                   onVisibilityChange={setColumnVisibility}
                 />

--- a/testplanit/app/[locale]/admin/code-repositories/page.tsx
+++ b/testplanit/app/[locale]/admin/code-repositories/page.tsx
@@ -318,6 +318,7 @@ function CodeRepositoryList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="code-repo-column-selection"
+                      storageKey="admin-code-repositories"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/integrations/page.tsx
+++ b/testplanit/app/[locale]/admin/integrations/page.tsx
@@ -344,6 +344,7 @@ function IntegrationList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="integration-column-selection"
+                      storageKey="admin-integrations"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/issues/page.tsx
+++ b/testplanit/app/[locale]/admin/issues/page.tsx
@@ -409,6 +409,7 @@ function IssueList() {
           <div className="mt-4 flex justify-between">
             <ColumnSelection
               key="issue-column-selection"
+              storageKey="admin-issues"
               columns={columns}
               onVisibilityChange={setColumnVisibility}
             />

--- a/testplanit/app/[locale]/admin/llm/page.tsx
+++ b/testplanit/app/[locale]/admin/llm/page.tsx
@@ -406,6 +406,7 @@ function LlmIntegrationList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="llm-column-selection"
+                      storageKey="admin-llm"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/milestones/page.tsx
+++ b/testplanit/app/[locale]/admin/milestones/page.tsx
@@ -345,6 +345,7 @@ function MilestoneTypes() {
           <div className="mt-4 flex justify-between">
             <ColumnSelection
               key="milestone-column-selection"
+              storageKey="admin-milestones"
               columns={columns}
               onVisibilityChange={setColumnVisibility}
             />

--- a/testplanit/app/[locale]/admin/projects/page.tsx
+++ b/testplanit/app/[locale]/admin/projects/page.tsx
@@ -482,6 +482,7 @@ function ProjectAdmin() {
                 <div className="m-2">
                   <ColumnSelection
                     key="project-column-selection"
+                    storageKey="admin-projects"
                     columns={columns}
                     onVisibilityChange={setColumnVisibility}
                   />

--- a/testplanit/app/[locale]/admin/prompts/page.tsx
+++ b/testplanit/app/[locale]/admin/prompts/page.tsx
@@ -279,6 +279,7 @@ function PromptConfigList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="prompts-column-selection"
+                      storageKey="admin-prompts"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/scim/page.tsx
+++ b/testplanit/app/[locale]/admin/scim/page.tsx
@@ -470,6 +470,7 @@ function ScimTokensList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="scim-tokens-column-selection"
+                      storageKey="admin-scim-tokens"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/admin/statuses/page.tsx
+++ b/testplanit/app/[locale]/admin/statuses/page.tsx
@@ -201,6 +201,7 @@ function Status() {
             <div className="flex flex-col w-full sm:w-1/3 min-w-[150px]">
               <ColumnSelection
                 key="status-column-selection"
+                storageKey="admin-statuses"
                 columns={columns}
                 onVisibilityChange={setColumnVisibility}
               />

--- a/testplanit/app/[locale]/admin/tags/page.tsx
+++ b/testplanit/app/[locale]/admin/tags/page.tsx
@@ -354,6 +354,7 @@ function TagList() {
           <div className="mt-4 flex justify-between">
             <ColumnSelection
               key="tag-column-selection"
+              storageKey="admin-tags"
               columns={columns}
               onVisibilityChange={setColumnVisibility}
             />

--- a/testplanit/app/[locale]/admin/users/page.tsx
+++ b/testplanit/app/[locale]/admin/users/page.tsx
@@ -349,6 +349,7 @@ function UserList() {
                   <div className="m-2">
                     <ColumnSelection
                       key="project-column-selection"
+                      storageKey="admin-users"
                       columns={columns}
                       onVisibilityChange={setColumnVisibility}
                     />

--- a/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/Cases.tsx
@@ -3636,6 +3636,7 @@ export default function Cases({
             <div className="mt-4">
               <ColumnSelection
                 key="repository-cases-column-selection"
+                storageKey={`repository-cases:${projectId}`}
                 columns={columns}
                 columnMetadata={columnMetadata}
                 onVisibilityChange={(newVisibility) => {

--- a/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/JunitTableSection.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/[runId]/JunitTableSection.tsx
@@ -546,6 +546,7 @@ function JunitTableSection({
                         />
                         <div className="mt-4">
                           <ColumnSelection<any>
+                            storageKey={`junit-results:${projectId}:${runId}`}
                             columns={junitColumns as any}
                             onVisibilityChange={setJunitColumnVisibility}
                           />

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
@@ -751,6 +751,7 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
           <div className="m-2">
             <ColumnSelection
               key="webhook-deliveries-column-selection"
+              storageKey={`webhook-deliveries:${projectId}`}
               columns={
                 columns as ColumnDef<DeliveryRow & { name: string }, unknown>[]
               }

--- a/testplanit/app/[locale]/users/page.tsx
+++ b/testplanit/app/[locale]/users/page.tsx
@@ -203,6 +203,7 @@ function Users() {
                 <div className="mt-4">
                   <ColumnSelection
                     key="user-column-selection"
+                    storageKey="users-directory"
                     columns={columns}
                     onVisibilityChange={setColumnVisibility}
                   />

--- a/testplanit/components/tables/ColumnSelection.test.tsx
+++ b/testplanit/components/tables/ColumnSelection.test.tsx
@@ -1,0 +1,442 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the `?columns=` query param per test.
+const mockSearchParams = { current: "" };
+
+// Stable router spies so we can assert URL pushes — e.g. that restoring stored
+// columns does NOT write `?columns=` to the URL on mount.
+const navMocks = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mockSearchParams.current),
+}));
+
+vi.mock("~/lib/navigation", () => ({
+  useRouter: () => ({ push: navMocks.push, replace: navMocks.replace }),
+  usePathname: () => "/test",
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import {
+  ColumnSelection,
+  CustomColumnDef,
+  readStoredColumnVisibility,
+  writeStoredColumnVisibility,
+} from "./ColumnSelection";
+
+const STORAGE_PREFIX = "testplanit:columnVisibility:";
+
+interface Row {
+  id: number;
+}
+
+// name (first, cannot hide) | description | customField | actions (last, cannot hide)
+const columns: CustomColumnDef<Row>[] = [
+  { id: "name", header: "Name", enableHiding: false },
+  { id: "description", header: "Description" },
+  { id: "customField", header: "Custom Field" },
+  { id: "actions", header: "Actions", enableHiding: false },
+];
+
+function lastVisibility(spy: ReturnType<typeof vi.fn>) {
+  return spy.mock.calls.at(-1)?.[0] as Record<string, boolean>;
+}
+
+// Radix popover/checkbox use pointer-capture + scrollIntoView APIs jsdom
+// doesn't implement; stub them so the selector can be opened and toggled.
+beforeAll(() => {
+  const proto = window.HTMLElement.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  proto.hasPointerCapture ||= () => false;
+  proto.setPointerCapture ||= () => {};
+  proto.releasePointerCapture ||= () => {};
+  proto.scrollIntoView ||= () => {};
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  mockSearchParams.current = "";
+  navMocks.push.mockClear();
+  navMocks.replace.mockClear();
+});
+
+describe("column visibility storage helpers", () => {
+  it("returns null when nothing is stored", () => {
+    expect(readStoredColumnVisibility("view-a")).toBeNull();
+  });
+
+  it("returns null when no storage key is provided", () => {
+    expect(readStoredColumnVisibility(undefined)).toBeNull();
+  });
+
+  it("round-trips a boolean map", () => {
+    writeStoredColumnVisibility("view-a", { description: false, tags: true });
+    expect(readStoredColumnVisibility("view-a")).toEqual({
+      description: false,
+      tags: true,
+    });
+  });
+
+  it("ignores non-boolean and malformed stored values", () => {
+    window.localStorage.setItem(
+      `${STORAGE_PREFIX}view-a`,
+      JSON.stringify({ description: false, bogus: "yes", count: 3 })
+    );
+    expect(readStoredColumnVisibility("view-a")).toEqual({
+      description: false,
+    });
+
+    window.localStorage.setItem(`${STORAGE_PREFIX}view-b`, "not json");
+    expect(readStoredColumnVisibility("view-b")).toBeNull();
+
+    window.localStorage.setItem(
+      `${STORAGE_PREFIX}view-c`,
+      JSON.stringify([1, 2])
+    );
+    expect(readStoredColumnVisibility("view-c")).toBeNull();
+  });
+
+  it("merges on write so choices for columns from other views are preserved", () => {
+    // e.g. columns from template A
+    writeStoredColumnVisibility("repository-cases:1", { fieldA: false });
+    // later, columns from template B under the same view key
+    writeStoredColumnVisibility("repository-cases:1", { fieldB: true });
+
+    expect(readStoredColumnVisibility("repository-cases:1")).toEqual({
+      fieldA: false,
+      fieldB: true,
+    });
+  });
+});
+
+describe("ColumnSelection restore", () => {
+  it("restores a remembered hidden column on mount", () => {
+    writeStoredColumnVisibility("view-a", { description: false });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    expect(lastVisibility(onVisibilityChange)).toEqual({
+      name: true,
+      description: false,
+      customField: true,
+      actions: true,
+    });
+  });
+
+  it("ignores stored columns that do not exist in the current view", () => {
+    // `ghost` is not one of this view's columns; `customField` is.
+    writeStoredColumnVisibility("view-a", {
+      ghost: false,
+      customField: false,
+    });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    const result = lastVisibility(onVisibilityChange);
+    expect(result).not.toHaveProperty("ghost");
+    expect(result.customField).toBe(false);
+    expect(result.description).toBe(true);
+  });
+
+  it("never lets storage hide always-visible (first/last/non-hideable) columns", () => {
+    writeStoredColumnVisibility("view-a", {
+      name: false,
+      actions: false,
+    });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    const result = lastVisibility(onVisibilityChange);
+    expect(result.name).toBe(true);
+    expect(result.actions).toBe(true);
+  });
+
+  it("lets an explicit ?columns= link override the remembered preference", () => {
+    writeStoredColumnVisibility("view-a", { description: false });
+    mockSearchParams.current = "columns=description"; // URL says: show description, hide the rest
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    const result = lastVisibility(onVisibilityChange);
+    expect(result.description).toBe(true); // URL wins over stored `false`
+    expect(result.customField).toBe(false); // not in URL list
+  });
+
+  it("does not persist the computed defaults on mount", () => {
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="fresh-view"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    // Nothing should be written until the user actually changes a column.
+    expect(readStoredColumnVisibility("fresh-view")).toBeNull();
+  });
+
+  it("does not touch storage when no storageKey is provided", () => {
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    // Defaults still propagate, storage stays empty.
+    expect(lastVisibility(onVisibilityChange)).toEqual({
+      name: true,
+      description: true,
+      customField: true,
+      actions: true,
+    });
+    expect(window.localStorage.length).toBe(0);
+  });
+});
+
+// Three hideable columns (colB can be hidden while colA stays visible, so the
+// "always keep one visible" guard doesn't fight a single deliberate toggle).
+const wideColumns: CustomColumnDef<Row>[] = [
+  { id: "name", header: "Name", enableHiding: false },
+  { id: "colA", header: "Col A" },
+  { id: "colB", header: "Col B" },
+  { id: "colC", header: "Col C" },
+  { id: "actions", header: "Actions", enableHiding: false },
+];
+
+// (1) SSR / hydration safety.
+describe("SSR / hydration safety", () => {
+  it("read + write are safe no-ops with no window, and don't mutate client storage", () => {
+    const stored = { description: false };
+    writeStoredColumnVisibility("view-a", stored);
+    expect(readStoredColumnVisibility("view-a")).toEqual(stored);
+
+    // Simulate the server render: `window` is undefined.
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(readStoredColumnVisibility("view-a")).toBeNull();
+      expect(() =>
+        writeStoredColumnVisibility("view-a", { description: true })
+      ).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    // The server-side no-op must not have touched what the client stored.
+    expect(readStoredColumnVisibility("view-a")).toEqual(stored);
+  });
+
+  it("emits the stored visibility on the very first render (no defaults-then-correction flash)", () => {
+    writeStoredColumnVisibility("view-a", { description: false });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    // First emitted value already reflects storage, so there is no visible
+    // flip from computed defaults to stored state after mount.
+    expect(onVisibilityChange.mock.calls[0]?.[0]).toEqual({
+      name: true,
+      description: false,
+      customField: true,
+      actions: true,
+    });
+  });
+});
+
+// (2) A shared ?columns= link updates the remembered view once the user changes
+// a column. Confirmed-intended behavior.
+describe("URL columns persist to storage on change", () => {
+  it("persists URL-derived visibility (incl. URL-hidden columns) after a user toggle", async () => {
+    const user = userEvent.setup();
+    mockSearchParams.current = "columns=colA,colB"; // colC hidden purely by the URL
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="url-view"
+        columns={wideColumns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    // Loading the URL alone does not write storage (first render is skipped).
+    expect(readStoredColumnVisibility("url-view")).toBeNull();
+
+    // User opens the selector and hides Col B.
+    await user.click(screen.getByTestId("column-selection-trigger"));
+    await user.click(await screen.findByRole("checkbox", { name: /Col B/ }));
+
+    const stored = readStoredColumnVisibility("url-view");
+    expect(stored).not.toBeNull();
+    expect(stored?.colB).toBe(false); // the explicit change
+    expect(stored?.colA).toBe(true);
+    // colC was hidden only because of the URL, yet it is now persisted —
+    // i.e. opening a shared ?columns= link rewrote the remembered view.
+    expect(stored?.colC).toBe(false);
+  });
+});
+
+// (3) Restoring stored prefs must not leak into the shareable URL on load; only
+// an explicit change should update it.
+describe("restore vs. URL", () => {
+  it("does not push a ?columns= URL when restoring stored columns on mount", () => {
+    writeStoredColumnVisibility("view-a", { description: false });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="view-a"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    expect(onVisibilityChange).toHaveBeenCalled(); // mounted + computed state
+    expect(navMocks.push).not.toHaveBeenCalled(); // but no URL written
+  });
+
+  it("updates the ?columns= URL on an explicit change when column memory is OFF", async () => {
+    const user = userEvent.setup();
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        columns={wideColumns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    ); // no storageKey
+    expect(navMocks.push).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("column-selection-trigger"));
+    await user.click(await screen.findByRole("checkbox", { name: /Col B/ }));
+
+    await waitFor(() => expect(navMocks.push).toHaveBeenCalled());
+    const url = navMocks.push.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain("columns=");
+  });
+
+  it("KNOWN INTERACTION: with column memory ON, a change is saved to storage but the ?columns= URL is NOT updated", async () => {
+    // The persist effect runs before the URL effect and writes the new state
+    // to storage; the URL effect then recomputes getInitialVisibility(), which
+    // overlays that fresh storage and so equals the new state — making the
+    // change look like "no change from initial", which suppresses the URL push.
+    const user = userEvent.setup();
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="mem-view"
+        columns={wideColumns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    await user.click(screen.getByTestId("column-selection-trigger"));
+    await user.click(await screen.findByRole("checkbox", { name: /Col B/ }));
+
+    // The change is remembered in storage...
+    await waitFor(() =>
+      expect(readStoredColumnVisibility("mem-view")?.colB).toBe(false)
+    );
+    // ...but the shareable URL is never updated.
+    expect(navMocks.push).not.toHaveBeenCalled();
+  });
+});
+
+// (4) Columns that load after mount (e.g. repository custom fields fetched
+// async) — the initial state is computed once.
+describe("columns that load after mount", () => {
+  it("restores stored prefs for columns present at first render", () => {
+    writeStoredColumnVisibility("late-view", { customField: false });
+    const onVisibilityChange = vi.fn();
+
+    render(
+      <ColumnSelection
+        storageKey="late-view"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    expect(lastVisibility(onVisibilityChange).customField).toBe(false);
+  });
+
+  it("does NOT retroactively apply stored prefs to columns that appear only after mount", () => {
+    writeStoredColumnVisibility("late-view", { customField: false });
+    const onVisibilityChange = vi.fn();
+    const initialColumns = columns.filter((c) => c.id !== "customField");
+
+    const { rerender } = render(
+      <ColumnSelection
+        storageKey="late-view"
+        columns={initialColumns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+    expect(lastVisibility(onVisibilityChange)).not.toHaveProperty(
+      "customField"
+    );
+
+    // customField arrives later (async custom-field columns).
+    rerender(
+      <ColumnSelection
+        storageKey="late-view"
+        columns={columns}
+        onVisibilityChange={onVisibilityChange}
+      />
+    );
+
+    // Known limitation: initial visibility is computed once, so the stored
+    // `false` is not applied to the late-arriving column — it isn't added to
+    // the visibility map by this in-place update. A fresh mount restores it
+    // (covered by the test above).
+    expect(lastVisibility(onVisibilityChange)).not.toHaveProperty(
+      "customField"
+    );
+  });
+});

--- a/testplanit/components/tables/ColumnSelection.test.tsx
+++ b/testplanit/components/tables/ColumnSelection.test.tsx
@@ -360,11 +360,10 @@ describe("restore vs. URL", () => {
     expect(url).toContain("columns=");
   });
 
-  it("KNOWN INTERACTION: with column memory ON, a change is saved to storage but the ?columns= URL is NOT updated", async () => {
-    // The persist effect runs before the URL effect and writes the new state
-    // to storage; the URL effect then recomputes getInitialVisibility(), which
-    // overlays that fresh storage and so equals the new state — making the
-    // change look like "no change from initial", which suppresses the URL push.
+  it("with column memory ON, a change updates both storage and the ?columns= URL", async () => {
+    // The persist effect writes the change to storage; change-detection in the
+    // URL effect compares against a stable mount-time snapshot (not re-read
+    // storage), so the shareable ?columns= URL stays in sync with the change.
     const user = userEvent.setup();
     const onVisibilityChange = vi.fn();
 
@@ -383,8 +382,11 @@ describe("restore vs. URL", () => {
     await waitFor(() =>
       expect(readStoredColumnVisibility("mem-view")?.colB).toBe(false)
     );
-    // ...but the shareable URL is never updated.
-    expect(navMocks.push).not.toHaveBeenCalled();
+    // ...and the shareable URL is kept in sync.
+    await waitFor(() => expect(navMocks.push).toHaveBeenCalled());
+    expect(navMocks.push.mock.calls.at(-1)?.[0] as string).toContain(
+      "columns="
+    );
   });
 });
 

--- a/testplanit/components/tables/ColumnSelection.tsx
+++ b/testplanit/components/tables/ColumnSelection.tsx
@@ -10,8 +10,61 @@ import { ColumnDef } from "@tanstack/react-table";
 import { CircleMinus, CirclePlus, Columns3 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "~/lib/navigation";
+
+const COLUMN_VISIBILITY_STORAGE_PREFIX = "testplanit:columnVisibility:";
+
+/**
+ * Read the remembered column visibility map for a view. Returns null when
+ * nothing is stored, when running on the server, or when the stored value is
+ * unusable. Callers only apply keys for columns that exist in the current
+ * view, so stale keys for columns that no longer exist are ignored.
+ */
+export function readStoredColumnVisibility(
+  storageKey?: string
+): Record<string, boolean> | null {
+  if (!storageKey || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(
+      `${COLUMN_VISIBILITY_STORAGE_PREFIX}${storageKey}`
+    );
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const result: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "boolean") result[key] = value;
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist column visibility for a view, merging with any previously-saved map
+ * so choices for columns not currently present (e.g. fields from a different
+ * template) are preserved across views that share a storage key.
+ */
+export function writeStoredColumnVisibility(
+  storageKey: string,
+  visibility: Record<string, boolean>
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing = readStoredColumnVisibility(storageKey) ?? {};
+    const merged = { ...existing, ...visibility };
+    window.localStorage.setItem(
+      `${COLUMN_VISIBILITY_STORAGE_PREFIX}${storageKey}`,
+      JSON.stringify(merged)
+    );
+  } catch {
+    // ignore storage errors (quota exceeded, private browsing, etc.)
+  }
+}
 
 export interface CustomColumnMeta {
   isVisible?: boolean;
@@ -44,12 +97,20 @@ interface ColumnSelectionProps<TData> {
   columns: CustomColumnDef<TData>[];
   columnMetadata?: ColumnMetadata[];
   onVisibilityChange: (visibility: Record<string, boolean>) => void;
+  /**
+   * Stable identifier for this table view. When provided, the user's column
+   * choices are remembered in localStorage and restored on return. Must be
+   * unique per view and stable across renders (e.g. include the projectId so
+   * each project's repository remembers its own columns).
+   */
+  storageKey?: string;
 }
 
 export function ColumnSelection<TData>({
   columns,
   columnMetadata,
   onVisibilityChange,
+  storageKey,
 }: ColumnSelectionProps<TData>) {
   const router = useRouter();
   const pathname = usePathname();
@@ -92,6 +153,31 @@ export function ColumnSelection<TData>({
       }
     });
 
+    // Overlay remembered choices from localStorage. Lower precedence than the
+    // URL param below (an explicit shared link wins). Only keys for columns
+    // present in this view are applied, so a stored column that no longer
+    // exists in the view is ignored.
+    const storedVisibility = readStoredColumnVisibility(storageKey);
+    if (storedVisibility) {
+      metadataSource.forEach((item, index) => {
+        const columnId = (
+          "id" in item ? item.id : (item as CustomColumnDef<TData>).id
+        ) as string;
+        const enableHiding =
+          "enableHiding" in item
+            ? item.enableHiding
+            : (item as CustomColumnDef<TData>).enableHiding;
+
+        if (!columnId) return;
+        // Never let storage hide always-visible or first/last columns
+        if (enableHiding === false) return;
+        if (index === 0 || index === metadataSource.length - 1) return;
+        if (typeof storedVisibility[columnId] === "boolean") {
+          initialVisibility[columnId] = storedVisibility[columnId];
+        }
+      });
+    }
+
     if (columnVisibilityQuery) {
       const visibleColumns = columnVisibilityQuery.split(",");
       metadataSource.forEach((item, index) => {
@@ -117,10 +203,24 @@ export function ColumnSelection<TData>({
     }
 
     return initialVisibility;
-  }, [metadataSource, columnVisibilityQuery]);
+  }, [metadataSource, columnVisibilityQuery, storageKey]);
 
   const [columnVisibility, setColumnVisibility] =
     useState<Record<string, boolean>>(getInitialVisibility);
+
+  // Remember the user's choices for this view. Skip the first render so we only
+  // persist deliberate changes (not the computed defaults or a shared-link URL
+  // state), then write on every subsequent change. Merging happens in the
+  // writer so choices for columns from other views/templates are preserved.
+  const hasPersistedRef = useRef(false);
+  useEffect(() => {
+    if (!storageKey) return;
+    if (!hasPersistedRef.current) {
+      hasPersistedRef.current = true;
+      return;
+    }
+    writeStoredColumnVisibility(storageKey, columnVisibility);
+  }, [storageKey, columnVisibility]);
 
   useEffect(() => {
     onVisibilityChange(columnVisibility);

--- a/testplanit/components/tables/ColumnSelection.tsx
+++ b/testplanit/components/tables/ColumnSelection.tsx
@@ -208,6 +208,16 @@ export function ColumnSelection<TData>({
   const [columnVisibility, setColumnVisibility] =
     useState<Record<string, boolean>>(getInitialVisibility);
 
+  // Snapshot the mount-time initial visibility once, as a stable baseline for
+  // URL change-detection. Recomputing getInitialVisibility() in the URL effect
+  // would re-read localStorage *after* the persist effect writes it, so every
+  // change would look like "no change" and the shareable ?columns= URL would
+  // stop updating once a storageKey is set.
+  const initialVisibilityRef = useRef<Record<string, boolean> | null>(null);
+  if (initialVisibilityRef.current === null) {
+    initialVisibilityRef.current = columnVisibility;
+  }
+
   // Remember the user's choices for this view. Skip the first render so we only
   // persist deliberate changes (not the computed defaults or a shared-link URL
   // state), then write on every subsequent change. Merging happens in the
@@ -224,9 +234,13 @@ export function ColumnSelection<TData>({
 
   useEffect(() => {
     onVisibilityChange(columnVisibility);
-    // Skip URL update if no columns have changed from initial state
+    // Skip URL update if no columns have changed from the mount-time initial
+    // state. Compare against the stable snapshot (not getInitialVisibility(),
+    // which would re-read storage written by the persist effect and mask the
+    // change), so the ?columns= URL stays in sync with the selection.
+    const initialVisibility = initialVisibilityRef.current ?? {};
     const hasChanges = Object.entries(columnVisibility).some(
-      ([key, value]) => value !== getInitialVisibility()[key]
+      ([key, value]) => value !== initialVisibility[key]
     );
     if (!hasChanges) return;
 
@@ -269,7 +283,6 @@ export function ColumnSelection<TData>({
     router,
     columnVisibilityQuery,
     metadataSource,
-    getInitialVisibility,
     pathname,
   ]);
 


### PR DESCRIPTION
## Description

Tables now remember which columns you've shown or hidden. Each table persists its column visibility to the browser's `localStorage` under a per-view key and restores it on return, so your layout survives navigation and reloads.

- A shared `?columns=` link still takes precedence on load, and the URL stays in sync as you change columns.
- Always-visible columns and the first/last columns can never be hidden.
- Stored entries for columns that no longer exist are ignored.
- Wired into the admin tables, the repository cases table, JUnit results, webhook deliveries, and the users lists.

Also includes a fix so the `?columns=` URL stays in sync with the current selection when column memory is on: change-detection compares against a stable mount-time snapshot instead of re-reading the `localStorage` value the persist step just wrote (which had been masking changes and silently disabling shareable column links).

## Related Issue

N/A — no tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Added unit + interaction tests for the column selector covering SSR/hydration safety, restore-on-mount, `?columns=` URL precedence, persistence on change, URL sync, and columns that load after mount.

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chromium (jsdom for unit tests)
- Node version: 24.14.0

Full local gate passed: production build + the complete unit suite (9341 passed, 149 skipped, 0 failures).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- Storage is per-browser / per-origin — it is not synced across devices and is not cleared on logout, which is appropriate for a view preference.
- Known limitation: columns that load asynchronously after mount (e.g. repository custom fields) are restored on a fresh visit but are not retroactively applied within a single in-place update. This is covered by a characterization test.
