### PR TITLE
enhancement(integrations): add Redmine issue tracker support

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -10,7 +10,7 @@ slug: /faq
 
 ### What is TestPlanIt?
 
-TestPlanIt is an open-source test management platform for creating, managing, and executing test plans. It supports manual testing, automated test result integration, exploratory testing sessions, and integrates with popular issue trackers like Jira, GitHub, and Azure DevOps.
+TestPlanIt is an open-source test management platform for creating, managing, and executing test plans. It supports manual testing, automated test result integration, exploratory testing sessions, and integrates with popular issue trackers like Jira, GitHub, GitLab, Azure DevOps, and Redmine.
 
 ### Is TestPlanIt free?
 
@@ -69,7 +69,10 @@ Yes, TestPlanIt has built-in integrations with:
 
 - **Jira** - Link test cases to Jira issues and create issues from failed tests
 - **GitHub** - Connect with GitHub Issues for defect tracking
+- **GitLab** - Link to GitLab.com or self-hosted GitLab issues
+- **Gitea / Forgejo / Gogs** - Connect to self-hosted Gitea-family issue trackers
 - **Azure DevOps** - Sync with Azure Boards work items
+- **Redmine** - Connect to a self-hosted Redmine instance for issue tracking
 
 See the [integrations documentation](/docs/user-guide/integrations) for setup instructions.
 

--- a/docs/docs/features.md
+++ b/docs/docs/features.md
@@ -105,6 +105,7 @@ TestPlanIt is a comprehensive test management platform designed to help teams pl
 - **GitLab integration** - Link to GitLab.com or self-hosted GitLab issues
 - **Gitea / Forgejo / Gogs integration** - Connect to self-hosted Gitea-family issue trackers
 - **Azure DevOps integration** - Sync with Azure Boards work items
+- **Redmine integration** - Connect to a self-hosted Redmine instance for issue tracking
 - **OAuth 2.0 authentication** - Use OAuth for GitHub, GitLab, and Gitea/Forgejo connections (no personal access token required)
 - **Two-way sync** - Optional outbound notifications and inbound webhook updates between TestPlanIt and the issue tracker
 - **Linked-issue context for AI** - Auto-tag and test case generation pull labels, components, and metadata from linked issues
@@ -224,7 +225,7 @@ TestPlanIt is a comprehensive test management platform designed to help teams pl
 
 ### Inbound Webhooks
 
-- **Issue-tracker sync** - Configure inbound webhooks from Jira / GitHub / GitLab / Gitea so issue updates flow back into TestPlanIt
+- **Issue-tracker sync** - Configure inbound webhooks from Jira / GitHub / GitLab / Gitea / Azure DevOps / Redmine so issue updates flow back into TestPlanIt
 - **Adapter-aware** - The inbound config is keyed to the issue integration so swapping providers cleanly resets the webhook
 
 ### Agent Integrations

--- a/docs/docs/user-guide/admin-issues.md
+++ b/docs/docs/user-guide/admin-issues.md
@@ -6,7 +6,7 @@ description: Manage every external issue linked into TestPlanIt from one cross-p
 
 # Issues
 
-The **Administration → Issues** page is a global, cross-project table of every issue that has been linked into TestPlanIt from an external tracker — Jira, GitHub, GitLab, Azure DevOps, Gitea, or a Simple URL link. Use it to review, re-sync, edit, or delete issue records that appear across your test cases, runs, and sessions.
+The **Administration → Issues** page is a global, cross-project table of every issue that has been linked into TestPlanIt from an external tracker — Jira, GitHub, GitLab, Azure DevOps, Gitea, Redmine, or a Simple URL link. Use it to review, re-sync, edit, or delete issue records that appear across your test cases, runs, and sessions.
 
 :::note
 Only system administrators can open this page. To view or manage issues for a single project, use the project's own **Issues** page instead.
@@ -61,7 +61,7 @@ Opens the **Edit Issue** dialog with these fields:
 - **Title**
 - **Description**
 
-Saving recalculates the external URL from the integration's base URL and the provider's link format (for example Jira `/browse/KEY`, GitHub `/issues/NUMBER`, Azure DevOps `/_workitems/edit/ID`).
+Saving recalculates the external URL from the integration's base URL and the provider's link format (for example Jira `/browse/KEY`, GitHub `/issues/NUMBER`, Azure DevOps `/_workitems/edit/ID`, Redmine `/issues/ID`).
 
 ### Delete
 

--- a/docs/docs/user-guide/integrations.md
+++ b/docs/docs/user-guide/integrations.md
@@ -5,7 +5,7 @@ title: 'Issue Tracking and External Integrations'
 
 # Issue Tracking and External Integrations
 
-TestPlanIt provides comprehensive issue tracking capabilities, allowing you to track bugs, tasks, and other issues directly within the platform or integrate with external issue tracking systems like Jira, GitHub Issues, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, and more.
+TestPlanIt provides comprehensive issue tracking capabilities, allowing you to track bugs, tasks, and other issues directly within the platform or integrate with external issue tracking systems like Jira, GitHub Issues, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, Redmine, and more.
 
 ## Internal Issue Management
 
@@ -129,7 +129,21 @@ Connect to Azure DevOps Boards for work item tracking.
 - Inbound webhook support for real-time status sync
 - Works with both Azure DevOps Services (cloud) and Azure DevOps Server (on-premises)
 
-### 6. **Simple URL Integration**
+### 6. **Redmine Integration**
+
+Connect to a self-hosted Redmine instance for issue tracking.
+
+**Features:**
+
+- Create Redmine issues directly from TestPlanIt, choosing the tracker and priority
+- Search issues by text (subject) or by exact reference (e.g., `#42`)
+- Maps Redmine **trackers** to issue types; statuses and priorities are discovered from your instance
+- Custom field and linked-issue (relations) support
+- API key authentication (Redmine has no OAuth)
+- Inbound webhook support for status sync via the `redmine_webhook` plugin
+- Configurable instance URL — works with any self-hosted Redmine deployment
+
+### 7. **Simple URL Integration**
 
 A flexible integration for any issue tracking system that uses URL-based linking.
 
@@ -152,7 +166,7 @@ A flexible integration for any issue tracking system that uses URL-based linking
 
 1. Navigate to **Administration** → **Integrations**
 2. Click **Add Integration**
-3. Select your integration type (Jira, GitHub, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, or Simple URL)
+3. Select your integration type (Jira, GitHub, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, Redmine, or Simple URL)
 4. Fill in the integration details:
 
 ```yaml
@@ -333,6 +347,25 @@ Organization URL: https://dev.azure.com/your-organization
 - Priority values (1–4) map directly to Azure DevOps priority field values
 - Work items are always created as the account that owns the personal access token, regardless of which TestPlanIt user created them — Azure DevOps populates `System.CreatedBy` from the authenticating identity and does not allow setting it on another user's behalf
 
+#### Redmine
+
+1. Enable the REST API in Redmine: **Administration → Settings → API → Enable REST web service**
+2. Copy your API key from **My account → API access key**
+3. Configure in TestPlanIt:
+
+```text
+Redmine API Key: Your API access key
+Redmine URL: https://your-redmine-instance.com
+```
+
+**Notes:**
+
+- The Redmine URL is required — TestPlanIt uses it for all API calls.
+- The API key inherits the permissions of the user it belongs to. Use a dedicated **service account** for shared integrations so issue creation and reads are not tied to one person's account.
+- Redmine **trackers** (Bug, Feature, Support, …) are used as the issue type; statuses and priorities are read from your instance. Custom fields are supported.
+- Redmine has no OAuth — issues are always created as the account that owns the API key.
+- The linked Redmine project must have **trackers enabled** and the **Issue tracking** module active, or issue creation will fail with a "Tracker cannot be blank" error.
+
 #### Simple URL
 
 ```text
@@ -491,7 +524,7 @@ When enabled, TestPlanIt can:
 
 ### Real-time updates via inbound webhooks
 
-For Jira, GitHub, GitLab, Gitea/Forgejo/Gogs, and Azure DevOps integrations, TestPlanIt can also subscribe to events emitted by the external tracker so issue changes appear in TestPlanIt without waiting for a manual refresh. When an inbound webhook is configured for a project:
+For Jira, GitHub, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, and Redmine integrations, TestPlanIt can also subscribe to events emitted by the external tracker so issue changes appear in TestPlanIt without waiting for a manual refresh. When an inbound webhook is configured for a project:
 
 - Status, assignee, and other supported fields on linked issues update within seconds of the change in the external tracker.
 - New issues filed directly in the external tracker are imported into TestPlanIt's Issues list automatically the first time they are referenced by a webhook event.
@@ -510,6 +543,7 @@ field support varies by provider:
   are fetched per-project and per-issue-type from the create metadata API
 - **Azure DevOps**: Work item types are discovered per-project; fields are fixed per type
 - **GitHub / GitLab / Gitea**: Fixed field set (title, description, labels); no custom fields
+- **Redmine**: Trackers are discovered as issue types; statuses, priorities, and custom fields are read from the instance
 
 ### Custom Field Support
 
@@ -541,7 +575,7 @@ TestPlanIt preserves rich text formatting when creating external issues:
 TestPlanIt automatically converts between:
 
 - TipTap Editor JSON → Atlassian Document Format (Jira)
-- TipTap Editor JSON → Markdown (GitHub, GitLab, Gitea/Forgejo/Gogs)
+- TipTap Editor JSON → Markdown (GitHub, GitLab, Gitea/Forgejo/Gogs, Redmine)
 - TipTap Editor JSON → HTML (Azure DevOps)
 - User references → Account IDs
 - Dates → ISO 8601 format
@@ -621,6 +655,7 @@ Respect external API limits:
 - GitLab: 600 requests/minute (GitLab.com); self-managed instances vary
 - Gitea / Forgejo / Gogs: Configured per-instance (no default limit)
 - Azure DevOps: No published hard limit
+- Redmine: Configured per-instance (no default limit)
 
 ## Security Considerations
 
@@ -658,6 +693,10 @@ curl -H "Authorization: token YOUR_PAT" \
 # Test Azure DevOps connection
 curl -u ":YOUR_PAT" \
   "https://dev.azure.com/your-org/_apis/projects?api-version=7.0"
+
+# Test Redmine connection
+curl -H "X-Redmine-API-Key: YOUR_API_KEY" \
+  https://your-redmine-instance.com/users/current.json
 ```
 
 ### Common Issues
@@ -769,6 +808,11 @@ curl -u ":YOUR_PAT" \
 
 - `Work Items (Read & Write)` — Create and update work items
 - `Project and Team (Read)` — List projects and teams
+
+**Redmine:**
+
+- REST API enabled on the instance (**Administration → Settings → API**)
+- An API key belonging to a user with permission to view and add issues in the linked project(s)
 
 ## API Reference
 

--- a/docs/docs/user-guide/projects/settings/integrations.md
+++ b/docs/docs/user-guide/projects/settings/integrations.md
@@ -25,7 +25,7 @@ Only system administrators and project administrators can open this page.
 | | The **linked external projects** and which one is the **default** |
 | | The **default issue type** (Jira) for each linked project |
 
-Only integrations a system administrator has created and activated appear here. Supported providers are Jira, GitHub, GitLab, Gitea, Azure DevOps, and Simple URL. If none exist, the page shows a **No issue integration assigned** empty state and an admin must configure one first.
+Only integrations a system administrator has created and activated appear here. Supported providers are Jira, GitHub, GitLab, Gitea, Azure DevOps, Redmine, and Simple URL. If none exist, the page shows a **No issue integration assigned** empty state and an admin must configure one first.
 
 ## Assigning an integration
 

--- a/docs/docs/user-guide/webhooks.md
+++ b/docs/docs/user-guide/webhooks.md
@@ -8,7 +8,7 @@ description: Configure inbound and outbound webhooks for real-time integration w
 
 Webhooks let TestPlanIt exchange events with external systems in near-real time. They are configured per project from **Project Settings** → **Webhooks** and come in two flavors:
 
-- **Inbound webhooks** receive events from your issue tracker (Jira, GitHub, or Azure DevOps) so issues linked in TestPlanIt stay in sync without manual refreshes.
+- **Inbound webhooks** receive events from your issue tracker (Jira, GitHub, GitLab, Gitea/Forgejo/Gogs, Azure DevOps, or Redmine) so issues linked in TestPlanIt stay in sync without manual refreshes.
 - **Outbound webhooks** push TestPlanIt events (test runs, sessions, cases, issues) to a destination URL — typically a Slack channel, an automation tool, or a custom service that consumes a generic HMAC-signed payload.
 
 ## Overview
@@ -32,9 +32,10 @@ When no integration is configured, the empty state reads "An Issue Integration i
 
 1. Navigate to **Project Settings** → **Webhooks**.
 2. Click **Add Webhook** in the Inbound section.
-3. For Jira and GitHub, the webhook is created immediately — TestPlanIt mints a random HMAC secret on the server.
+3. For Jira, GitHub, GitLab, and Gitea/Forgejo/Gogs, the webhook is created immediately — TestPlanIt mints a random HMAC secret on the server.
 4. For Azure DevOps, a credentials form appears. Type the username and password (typically a Personal Access Token used as the password) that the ADO Service Hook will send via Basic authentication.
-5. After creation, the webhook URL and secret are revealed once. Copy both before dismissing the panel — neither value is shown again.
+5. For Redmine, the webhook is created immediately with **no secret** — the `redmine_webhook` plugin cannot sign requests, so the unguessable webhook URL itself is the credential. Treat the URL as a secret and rotate it (delete + recreate) if it leaks.
+6. After creation, the webhook URL (and, for the HMAC providers, the secret) is revealed once. Copy it before dismissing the panel — it is not shown again.
 
 ### Configuring the external tracker
 
@@ -42,7 +43,10 @@ The reveal panel includes per-provider setup steps. The general flow is:
 
 - **Jira** — In your Jira project's webhook settings, paste the URL, paste the secret as the HMAC signing secret, and subscribe the webhook to issue-created and issue-updated events.
 - **GitHub** — In your repository's **Settings** → **Webhooks** page, paste the URL, paste the secret, set Content type to `application/json`, and subscribe to **Issues** events.
+- **GitLab** — In your project's **Settings → Webhooks**, paste the URL, paste the secret into the **Secret token** field, and enable the **Issues events** trigger.
+- **Gitea / Forgejo / Gogs** — In your repository's **Settings → Webhooks**, add a webhook, paste the URL, paste the secret, set the content type to `application/json`, and enable **Issue** events.
 - **Azure DevOps** — Create a Service Hook of type **Web Hooks** for the **Work item updated** (and optionally **Work item created**) events. Paste the URL, then paste the username and password you typed into TestPlanIt as the Basic-Auth credentials.
+- **Redmine** — Redmine has no built-in webhooks, so install the [`redmine_webhook`](https://github.com/suer/redmine_webhook) plugin and enable the **Webhooks** module on the project. Then under **Project → Settings → WebHook**, paste the URL. Requests are unsigned, so the URL is the credential — no secret is configured on either side.
 
 ### One webhook per project
 
@@ -147,7 +151,7 @@ Inbound Jira and GitHub webhooks and outbound generic-HMAC webhooks all expose a
 - **Inbound (Jira / GitHub)** — Rotation is a hard cutover: a new token and a new HMAC secret are minted, the URL changes (because it embeds the token), and the previous values stop accepting traffic. Update the external tracker's webhook configuration with the new URL and secret immediately after rotating.
 - **Outbound (generic HMAC)** — Rotation opens a brief two-secret window. The newly minted secret becomes active immediately, and the previous secret enters a retiring state. Both are accepted by signing logic during the window so receivers have time to re-key. The retiring secret has an auto-retire deadline shown on the card; you can shorten it by clicking **Retire now**, or extend it once if your receiver needs more time.
 
-Inbound Azure DevOps webhooks do not have a separate secret to rotate (the credentials are typed by the admin and stored encrypted). To change ADO credentials, delete the webhook and recreate it.
+Inbound Azure DevOps webhooks do not have a separate secret to rotate (the credentials are typed by the admin and stored encrypted). To change ADO credentials, delete the webhook and recreate it. Inbound **Redmine** webhooks likewise have no secret — the unguessable URL token is the credential. To rotate it, delete the webhook and recreate it, then update the URL in Redmine.
 
 Plaintext secrets are never read back from the database. They are returned only in the response to the create or rotate action and held in memory until you dismiss the reveal panel.
 
@@ -163,11 +167,17 @@ Plaintext secrets are never read back from the database. They are returned only 
 
 When an inbound webhook arrives, TestPlanIt syncs the affected issue and pushes a project-scoped update event over a Server-Sent Events stream. Issue badges, lists, popovers, and detail views in any open browser tab update in near-real time without a manual refresh.
 
+:::note Redmine status timing
+
+TestPlanIt re-fetches the issue from the tracker on each inbound event. The `redmine_webhook` plugin sends its event from within Redmine's save hook (before the change commits), so an immediate re-fetch can briefly read the previous status; it self-corrects on the next event or sync. This is a limitation of the plugin's timing, not of the integration — other trackers send events after their change commits.
+
+:::
+
 The SSE stream is project-scoped (`/api/issues/stream?projectId=<id>`) and shares the long-lived-stream ingress requirements documented for in-app notifications. Operators deploying behind a load balancer should review [SSE Notifications and Live Updates](../sse-notifications.md) to make sure both streams are configured correctly.
 
 ## Reference
 
-- **Inbound URL pattern** — `https://<your-testplanit-host>/api/webhooks/<token>`. The token is the only identifier the receiver needs; the URL itself authenticates the request alongside the HMAC signature (Jira / GitHub) or Basic-Auth credentials (ADO).
+- **Inbound URL pattern** — `https://<your-testplanit-host>/api/webhooks/<token>`. The token is the only identifier the receiver needs; the URL itself authenticates the request alongside the provider's signature (HMAC for Jira / GitHub / Gitea, secret token for GitLab) or Basic-Auth credentials (ADO). For **Redmine**, the URL token is the sole credential — the `redmine_webhook` plugin sends no signature.
 - **Outbound payload signing** — Generic HMAC endpoints receive the JSON envelope and an HMAC-SHA256 signature header derived from the body and the active secret.
 - **Bulk replay cap** — 100 deliveries per batch.
 - **Auto-disable threshold** — 10 consecutive failures.

--- a/testplanit/app/[locale]/admin/integrations/columns.tsx
+++ b/testplanit/app/[locale]/admin/integrations/columns.tsx
@@ -7,7 +7,7 @@ import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 import { Link, Plug } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
-import { siGithub, siGitlab, siJira } from "simple-icons";
+import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { DeleteIntegrationButton } from "./DeleteIntegrationButton";
 import { EditIntegrationButton } from "./EditIntegrationButton";
 import { SyncIntegrationButton } from "./SyncIntegrationButton";
@@ -34,6 +34,11 @@ const providerIcons: Record<string, React.ReactNode> = {
   GITLAB: (
     <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor">
       <path d={siGitlab.path} />
+    </svg>
+  ),
+  REDMINE: (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor">
+      <path d={siRedmine.path} />
     </svg>
   ),
   SIMPLE_URL: <Link className="h-4 w-4" />,

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -2213,6 +2213,8 @@ export function GenerateTestCasesWizard({
         return "GitLab";
       case "GITEA":
         return "Gitea / Forgejo / Gogs";
+      case "REDMINE":
+        return "Redmine";
       case "SIMPLE_URL":
         return externalSystem;
       default:

--- a/testplanit/app/[locale]/projects/settings/[projectId]/integrations/page.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/integrations/page.tsx
@@ -89,6 +89,7 @@ export default function ProjectIntegrationsPage() {
             "AZURE_DEVOPS",
             "GITLAB",
             "GITEA",
+            "REDMINE",
             "SIMPLE_URL",
           ],
         },
@@ -108,6 +109,7 @@ export default function ProjectIntegrationsPage() {
         "AZURE_DEVOPS",
         "GITLAB",
         "GITEA",
+        "REDMINE",
         "SIMPLE_URL",
       ].includes(pi.integration.provider)
   );

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-config-form.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-config-form.tsx
@@ -74,7 +74,8 @@ type InboundAdapterType =
   | "GITHUB"
   | "AZURE_DEVOPS"
   | "GITLAB"
-  | "GITEA";
+  | "GITEA"
+  | "REDMINE";
 
 // Inbound webhooks today are 1:1 with the project's active issue integration:
 // the only inbound consumer is `applyInboundIssueUpdate`, and a project has
@@ -89,6 +90,7 @@ function inboundAdapterForProvider(
   if (provider === "AZURE_DEVOPS") return "AZURE_DEVOPS";
   if (provider === "GITLAB") return "GITLAB";
   if (provider === "GITEA") return "GITEA";
+  if (provider === "REDMINE") return "REDMINE";
   return null;
 }
 
@@ -136,7 +138,8 @@ const ADAPTER_OPTIONS: ReadonlyArray<{
     | "inboundChooserGithub"
     | "inboundChooserAdo"
     | "inboundChooserGitlab"
-    | "inboundChooserGitea";
+    | "inboundChooserGitea"
+    | "inboundChooserRedmine";
   testid: string;
 }> = [
   {
@@ -164,15 +167,21 @@ const ADAPTER_OPTIONS: ReadonlyArray<{
     labelKey: "inboundChooserGitea",
     testid: "webhook-inbound-chooser-gitea",
   },
+  {
+    value: "REDMINE",
+    labelKey: "inboundChooserRedmine",
+    testid: "webhook-inbound-chooser-redmine",
+  },
 ];
 
 function adapterSlug(
   adapterType: InboundAdapterType
-): "jira" | "github" | "ado" | "gitlab" | "gitea" {
+): "jira" | "github" | "ado" | "gitlab" | "gitea" | "redmine" {
   if (adapterType === "JIRA") return "jira";
   if (adapterType === "GITHUB") return "github";
   if (adapterType === "GITLAB") return "gitlab";
   if (adapterType === "GITEA") return "gitea";
+  if (adapterType === "REDMINE") return "redmine";
   return "ado";
 }
 
@@ -183,11 +192,13 @@ function adapterTitleKey(
   | "inboundGithubTitle"
   | "inboundAdoTitle"
   | "inboundGitlabTitle"
-  | "inboundGiteaTitle" {
+  | "inboundGiteaTitle"
+  | "inboundRedmineTitle" {
   if (adapterType === "JIRA") return "inboundJiraTitle";
   if (adapterType === "GITHUB") return "inboundGithubTitle";
   if (adapterType === "GITLAB") return "inboundGitlabTitle";
   if (adapterType === "GITEA") return "inboundGiteaTitle";
+  if (adapterType === "REDMINE") return "inboundRedmineTitle";
   return "inboundAdoTitle";
 }
 
@@ -689,6 +700,12 @@ export function WebhookConfigForm({ projectId }: WebhookConfigFormProps) {
         "setupStepsGiteaStep4",
         "setupStepsGiteaStep5",
       ],
+      REDMINE: [
+        "setupStepsRedmineStep1",
+        "setupStepsRedmineStep2",
+        "setupStepsRedmineStep3",
+        "setupStepsRedmineStep4",
+      ],
     };
     return (
       <div
@@ -952,6 +969,11 @@ export function WebhookConfigForm({ projectId }: WebhookConfigFormProps) {
                   </code>
                 ),
               })}
+            </p>
+          )}
+          {config.adapterType === "REDMINE" && (
+            <p className="text-xs text-muted-foreground">
+              {t("inboundRedmineScopeHint")}
             </p>
           )}
 

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
@@ -84,6 +84,7 @@ function adapterLabelKey(
   | "inboundChooserAdo"
   | "inboundChooserGitlab"
   | "inboundChooserGitea"
+  | "inboundChooserRedmine"
   | "adapterLabelSlack"
   | "adapterLabelGenericHmac"
   | null {
@@ -98,6 +99,8 @@ function adapterLabelKey(
       return "inboundChooserGitlab";
     case "GITEA":
       return "inboundChooserGitea";
+    case "REDMINE":
+      return "inboundChooserRedmine";
     case "SLACK":
       return "adapterLabelSlack";
     case "GENERIC_HMAC":

--- a/testplanit/app/actions/webhook-config.ts
+++ b/testplanit/app/actions/webhook-config.ts
@@ -91,6 +91,17 @@ const SYNTHETIC_GITEA_PAYLOAD = JSON.stringify({
   repository: { full_name: "__synthetic__/__synthetic__" },
 });
 
+// Redmine: the redmine_webhook plugin sends no signature, so the synthetic
+// self-test posts unsigned (the URL token is the credential). issue.id === 0
+// is the non-forgeable synthetic sentinel — real Redmine issue ids are >= 1.
+const SYNTHETIC_REDMINE_PAYLOAD = JSON.stringify({
+  payload: {
+    action: "updated",
+    issue: { id: 0, status: { name: "New" } },
+    url: "__synthetic__",
+  },
+});
+
 function generateToken(): string {
   // 32 random bytes → 64 hex chars with "whk_" prefix.
   return `whk_${randomBytes(32).toString("hex")}`;
@@ -513,6 +524,8 @@ export interface SendTestWebhookResult {
  *     + `x-gitea-event: issues` headers.
  *   - AZURE_DEVOPS: Basic Auth from JSON-decoded {username, password};
  *     `authorization: Basic <base64>` header; SYNTHETIC_ADO_PAYLOAD body.
+ *   - REDMINE: unsigned (the redmine_webhook plugin cannot sign); the URL token
+ *     is the credential. SYNTHETIC_REDMINE_PAYLOAD body.
  *
  * Determinism invariant: each adapter's synthetic payload is a module-level
  * `const` (declared once, JSON.stringify'd once). Two consecutive calls
@@ -683,6 +696,14 @@ export async function sendTestWebhook(
         authorization: auth,
       },
       body: SYNTHETIC_ADO_PAYLOAD,
+    };
+  } else if (config.adapterType === "REDMINE") {
+    // redmine_webhook sends no signature; the URL token is the credential, so
+    // the synthetic request is posted unsigned.
+    requestInit = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: SYNTHETIC_REDMINE_PAYLOAD,
     };
   } else {
     // SLACK / GENERIC_HMAC are OUTBOUND-only adapters; reaching this code

--- a/testplanit/app/actions/webhook-config.ts
+++ b/testplanit/app/actions/webhook-config.ts
@@ -180,6 +180,13 @@ export async function createOrRotateInboundWebhook(input: {
   ) {
     plaintextToEncrypt = generateSecret();
     returnSecretToAdmin = true;
+  } else if (adapterType === "REDMINE") {
+    // The redmine_webhook plugin cannot sign payloads or send a secret; the
+    // unguessable URL token is the credential. Mint and store an (unused)
+    // secret to satisfy the schema, and reveal only the URL — there is
+    // nothing for the admin to copy into Redmine.
+    plaintextToEncrypt = generateSecret();
+    returnSecretToAdmin = false;
   } else if (adapterType === "AZURE_DEVOPS") {
     if (
       !secretInput ||

--- a/testplanit/app/api/integrations/test-connection/route.ts
+++ b/testplanit/app/api/integrations/test-connection/route.ts
@@ -506,6 +506,59 @@ async function testGiteaConnection(
   };
 }
 
+async function testRedmineConnection(
+  credentials: Record<string, string>,
+  settings: Record<string, string>
+): Promise<TestConnectionResult> {
+  const apiKey = credentials.apiToken || credentials.personalAccessToken;
+  const { baseUrl } = settings;
+
+  if (!apiKey || !baseUrl) {
+    return {
+      success: false,
+      error: "Missing required Redmine configuration (API key, URL)",
+    };
+  }
+
+  const root = baseUrl.replace(/\/$/, "");
+  const headers = {
+    "X-Redmine-API-Key": apiKey,
+    Accept: "application/json",
+  };
+
+  // Auth probe — /users/current.json returns the authenticated user.
+  const connection = await probe(`${root}/users/current.json`, { headers });
+  if (!connection.ok) {
+    return {
+      success: false,
+      error: summarizeProbeFailures("Redmine", { connection }),
+      capabilities: { connection },
+    };
+  }
+
+  // Search probe — listing issues proves issue read scope.
+  const searchIssues = await probe(`${root}/issues.json?limit=1&status_id=*`, {
+    headers,
+  });
+
+  // Read probe — listing projects proves project read scope (needed to pick a
+  // project when creating or linking issues).
+  const readIssue = await probe(`${root}/projects.json?limit=1`, { headers });
+
+  const success = connection.ok && searchIssues.ok && readIssue.ok;
+  return {
+    success,
+    error: success
+      ? undefined
+      : summarizeProbeFailures("Redmine", {
+          connection,
+          searchIssues,
+          readIssue,
+        }),
+    capabilities: { connection, searchIssues, readIssue },
+  };
+}
+
 async function testSimpleUrlConnection(
   credentials: Record<string, string>,
   settings: Record<string, string>
@@ -669,6 +722,9 @@ export const POST = withAuditContext(async (req: NextRequest) => {
           authType === "OAUTH2"
             ? checkOAuthClientConfig(testCredentials)
             : await testGiteaConnection(testCredentials, testSettings);
+        break;
+      case IntegrationProvider.REDMINE:
+        result = await testRedmineConnection(testCredentials, testSettings);
         break;
       case IntegrationProvider.SIMPLE_URL:
         result = await testSimpleUrlConnection(testCredentials, testSettings);

--- a/testplanit/components/admin/integrations/IntegrationConfigForm.tsx
+++ b/testplanit/components/admin/integrations/IntegrationConfigForm.tsx
@@ -256,6 +256,27 @@ const providerFields: Record<IntegrationProvider, FieldConfig[]> = {
       required: true,
     },
   ],
+  [IntegrationProvider.REDMINE]: [
+    {
+      // Redmine REST API key. Stored under `apiToken` so IntegrationManager
+      // plumbs it into the adapter's API-key auth path.
+      name: "apiToken",
+      label: "config.redmineApiKey",
+      placeholder: "config.redmineApiKeyPlaceholder",
+      help: "config.redmineApiKeyHelp",
+      type: "password",
+      isCredential: true,
+      required: true,
+    },
+    {
+      name: "baseUrl",
+      label: "config.redmineUrl",
+      placeholder: "config.redmineUrlPlaceholder",
+      help: "config.redmineUrlHelp",
+      isCredential: false,
+      required: true,
+    },
+  ],
 };
 
 function generateApiKey(): string {

--- a/testplanit/components/admin/integrations/IntegrationModal.tsx
+++ b/testplanit/components/admin/integrations/IntegrationModal.tsx
@@ -77,6 +77,7 @@ const providerAuthTypes: Record<IntegrationProvider, IntegrationAuthType[]> = {
     IntegrationAuthType.PERSONAL_ACCESS_TOKEN,
     IntegrationAuthType.OAUTH2,
   ],
+  [IntegrationProvider.REDMINE]: [IntegrationAuthType.API_KEY],
 };
 
 export function IntegrationModal({

--- a/testplanit/components/admin/integrations/IntegrationModal.tsx
+++ b/testplanit/components/admin/integrations/IntegrationModal.tsx
@@ -262,7 +262,7 @@ export function IntegrationModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl min-h-[34rem] content-start">
         <DialogHeader>
           <DialogTitle>
             {integration

--- a/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
+++ b/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
@@ -9,7 +9,7 @@ import {
 import { IntegrationProvider } from "@prisma/client";
 import { Check, Link } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { siGithub, siGitlab, siJira } from "simple-icons";
+import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { GiteaFamilyIcon } from "@/components/shared/gitea-family-icon";
 import { cn } from "~/utils";
 
@@ -68,6 +68,15 @@ const integrationTypes = [
       </svg>
     ),
     color: "text-blue-700",
+  },
+  {
+    type: IntegrationProvider.REDMINE,
+    icon: () => (
+      <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
+        <path d={siRedmine.path} />
+      </svg>
+    ),
+    color: "text-[#B32024]",
   },
 ];
 

--- a/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
+++ b/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { IntegrationProvider } from "@prisma/client";
-import { Check, Link } from "lucide-react";
+import { Link } from "lucide-react";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
-import { GiteaFamilyIcon } from "@/components/shared/gitea-family-icon";
+import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 import { cn } from "~/utils";
 
 interface IntegrationTypeSelectorProps {
@@ -18,116 +20,99 @@ interface IntegrationTypeSelectorProps {
   onSelectType: (type: IntegrationProvider) => void;
 }
 
-const JiraIcon = () => (
-  <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
-    <path d={siJira.path} />
-  </svg>
-);
+function BrandIcon({ path, className }: { path: string; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={cn("h-4 w-4 shrink-0", className)}
+      fill="currentColor"
+    >
+      <path d={path} />
+    </svg>
+  );
+}
 
-const integrationTypes = [
+// Compact (h-4) icons for the dropdown rows — one per provider.
+const integrationTypes: { type: IntegrationProvider; icon: ReactNode }[] = [
   {
     type: IntegrationProvider.SIMPLE_URL,
-    icon: Link,
-    color: "text-purple-600",
+    icon: <Link className="h-4 w-4 shrink-0 text-purple-600" />,
   },
   {
     type: IntegrationProvider.JIRA,
-    icon: JiraIcon,
-    color: "text-blue-600",
+    icon: <BrandIcon path={siJira.path} className="text-blue-600" />,
   },
   {
     type: IntegrationProvider.GITHUB,
-    icon: () => (
-      <div className="h-8 w-8 rounded bg-gray-900 dark:bg-gray-700 flex items-center justify-center">
-        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="white">
-          <path d={siGithub.path} />
-        </svg>
-      </div>
-    ),
-    color: "",
+    icon: <BrandIcon path={siGithub.path} />,
   },
   {
     type: IntegrationProvider.GITLAB,
-    icon: () => (
-      <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
-        <path d={siGitlab.path} />
-      </svg>
-    ),
-    color: "text-[#FC6D26]",
+    icon: <BrandIcon path={siGitlab.path} className="text-[#FC6D26]" />,
   },
   {
     type: IntegrationProvider.GITEA,
-    icon: () => <GiteaFamilyIcon className="h-8 w-24" />,
-    color: "w-24",
+    icon: <GiteaPlatformIcon className="h-4 w-4 shrink-0" />,
   },
   {
     type: IntegrationProvider.AZURE_DEVOPS,
-    icon: () => (
-      <svg viewBox="0 0 18 18" className="h-8 w-8" fill="currentColor">
+    icon: (
+      <svg
+        viewBox="0 0 18 18"
+        className="h-4 w-4 shrink-0 text-blue-700"
+        fill="currentColor"
+      >
         <path d="M17,4v9.74l-4,3.28-6.2-2.26V17L3.29,12.41l10.23.8V4.44Zm-3.41.49L7.85,1V3.29L2.58,4.84,1,6.87v4.61l2.26,1V6.57Z" />
       </svg>
     ),
-    color: "text-blue-700",
   },
   {
     type: IntegrationProvider.REDMINE,
-    icon: () => (
-      <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
-        <path d={siRedmine.path} />
-      </svg>
-    ),
-    color: "text-[#B32024]",
+    icon: <BrandIcon path={siRedmine.path} className="text-[#B32024]" />,
   },
 ];
+
+function typeKeyFor(type: IntegrationProvider): string {
+  return type === IntegrationProvider.AZURE_DEVOPS
+    ? "azureDevops"
+    : type.toLowerCase();
+}
 
 export function IntegrationTypeSelector({
   selectedType,
   onSelectType,
 }: IntegrationTypeSelectorProps) {
   const t = useTranslations("admin.integrations.add");
+  const selected = integrationTypes.find((i) => i.type === selectedType);
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h3 className="text-lg font-medium">{t("selectType")}</h3>
-        <p className="text-sm text-muted-foreground">{t("typeDescription")}</p>
-      </div>
+    <div className="space-y-2">
+      <h3 className="text-lg font-medium">{t("selectType")}</h3>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        {integrationTypes.map(({ type, icon: Icon, color }) => {
-          const isSelected = selectedType === type;
-          const typeKey =
-            type === IntegrationProvider.AZURE_DEVOPS
-              ? "azureDevops"
-              : type.toLowerCase();
+      <Select
+        value={selectedType ?? undefined}
+        onValueChange={(value) => onSelectType(value as IntegrationProvider)}
+      >
+        <SelectTrigger className="w-full" data-testid="integration-type-select">
+          <SelectValue placeholder={t("typeDescription")} />
+        </SelectTrigger>
+        <SelectContent>
+          {integrationTypes.map(({ type, icon }) => (
+            <SelectItem key={type} value={type}>
+              <span className="flex items-center gap-2">
+                {icon}
+                <span>{t(`${typeKeyFor(type)}.name` as any)}</span>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
 
-          return (
-            <Card
-              key={type}
-              className={cn(
-                "cursor-pointer transition-colors hover:border-primary",
-                isSelected && "border-primary"
-              )}
-              onClick={() => onSelectType(type)}
-            >
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div className={cn("h-8 w-8", color)}>
-                    <Icon />
-                  </div>
-                  {isSelected && <Check className="h-5 w-5 text-primary" />}
-                </div>
-                <CardTitle className="text-base">
-                  {t(`${typeKey}.name` as any)}
-                </CardTitle>
-                <CardDescription>
-                  {t(`${typeKey}.description` as any)}
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          );
-        })}
-      </div>
+      {selected && (
+        <p className="text-sm text-muted-foreground">
+          {t(`${typeKeyFor(selected.type)}.description` as any)}
+        </p>
+      )}
     </div>
   );
 }

--- a/testplanit/components/admin/integrations/integration-icon.tsx
+++ b/testplanit/components/admin/integrations/integration-icon.tsx
@@ -1,6 +1,6 @@
 import { IntegrationProvider } from "@prisma/client";
 import { Bug } from "lucide-react";
-import { siGithub, siGitlab, siJira } from "simple-icons";
+import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 import { cn } from "~/utils";
 
@@ -56,6 +56,14 @@ export function IntegrationIcon({
       return (
         <div className={cn(baseClass, "bg-white dark:bg-gray-800 p-0.5")}>
           <GiteaPlatformIcon platform={platform} className="h-full w-full" />
+        </div>
+      );
+    case "REDMINE":
+      return (
+        <div className={cn(baseClass, "bg-[#B32024] text-white")}>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
+            <path d={siRedmine.path} />
+          </svg>
         </div>
       );
     default:

--- a/testplanit/components/issues/create-issue-dialog.test.tsx
+++ b/testplanit/components/issues/create-issue-dialog.test.tsx
@@ -281,6 +281,29 @@ describe("CreateIssueDialog", () => {
     );
   });
 
+  it("does not submit an enclosing form when the create form is submitted (nested-form guard)", () => {
+    // Repro of the case-details edit bug: the dialog is portaled but stays a
+    // React descendant of the page's edit <form>, so the inner submit must not
+    // bubble to the outer form's onSubmit. See the stopPropagation in the
+    // dialog's <form onSubmit>.
+    const outerSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    mockUseFindManyProjectIntegration.mockReturnValue({ data: [] });
+
+    render(
+      <form onSubmit={outerSubmit} data-testid="outer-form">
+        <CreateIssueDialog {...defaultProps} />
+      </form>
+    );
+
+    // The create dialog renders its own <form> nested inside the outer one.
+    const forms = document.querySelectorAll("form");
+    expect(forms.length).toBe(2);
+    const innerForm = forms[forms.length - 1];
+    fireEvent.submit(innerForm);
+
+    expect(outerSubmit).not.toHaveBeenCalled();
+  });
+
   it("renders priority select field for Jira integrations", () => {
     mockUseFindManyProjectIntegration.mockReturnValue({
       data: [

--- a/testplanit/components/issues/create-issue-dialog.tsx
+++ b/testplanit/components/issues/create-issue-dialog.tsx
@@ -771,7 +771,15 @@ export function CreateIssueDialog({
 
         <Form {...form}>
           <form
-            onSubmit={form.handleSubmit(onSubmit as any)}
+            onSubmit={(e) => {
+              // This dialog is portaled but remains a React descendant of the
+              // page's edit form (e.g. repository case details). React events
+              // bubble through the portal up the React tree, so without this the
+              // inner submit also triggers the outer form's onSubmit. Stop it
+              // here so "Create" only creates the issue.
+              e.stopPropagation();
+              void form.handleSubmit(onSubmit as any)(e);
+            }}
             className="space-y-4"
           >
             {/* Removed integration status display - was causing rendering issues */}

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -475,9 +475,11 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
             ? "Gitea"
             : integrationProvider === "AZURE_DEVOPS"
               ? "Azure DevOps"
-              : integrationProvider === "SIMPLE_URL"
-                ? "External"
-                : integrationProvider;
+              : integrationProvider === "REDMINE"
+                ? "Redmine"
+                : integrationProvider === "SIMPLE_URL"
+                  ? "External"
+                  : integrationProvider;
 
     return (
       <div

--- a/testplanit/components/webhooks/webhook-adapter-icon.tsx
+++ b/testplanit/components/webhooks/webhook-adapter-icon.tsx
@@ -1,5 +1,5 @@
 import { MessagesSquare, Webhook } from "lucide-react";
-import { siGithub, siGitlab, siJira } from "simple-icons";
+import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 
 import { cn } from "~/utils";
@@ -59,6 +59,14 @@ export function WebhookAdapterIcon({
       return (
         <div className={cn(baseClass, "bg-white dark:bg-gray-800 p-0.5")}>
           <GiteaPlatformIcon platform={platform} className="h-full w-full" />
+        </div>
+      );
+    case "REDMINE":
+      return (
+        <div className={cn(baseClass, "bg-[#B32024] text-white")}>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
+            <path d={siRedmine.path} />
+          </svg>
         </div>
       );
     case "SLACK":

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -73,7 +73,8 @@ describe("IntegrationManager", () => {
       expect(types).toContain("SIMPLE_URL");
       expect(types).toContain("GITLAB");
       expect(types).toContain("GITEA");
-      expect(types).toHaveLength(6);
+      expect(types).toContain("REDMINE");
+      expect(types).toHaveLength(7);
     });
   });
 

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -8,6 +8,7 @@ import { GitHubAdapter } from "./adapters/GitHubAdapter";
 import { GitLabAdapter } from "./adapters/GitLabAdapter";
 import { IssueAdapter } from "./adapters/IssueAdapter";
 import { JiraAdapter } from "./adapters/JiraAdapter";
+import { RedmineAdapter } from "./adapters/RedmineAdapter";
 import { SimpleUrlAdapter } from "./adapters/SimpleUrlAdapter";
 
 /**
@@ -46,6 +47,7 @@ export class IntegrationManager {
     this.registerAdapter("SIMPLE_URL", SimpleUrlAdapter);
     this.registerAdapter("GITLAB", GitLabAdapter);
     this.registerAdapter("GITEA", GiteaAdapter);
+    this.registerAdapter("REDMINE", RedmineAdapter);
   }
 
   /**

--- a/testplanit/lib/integrations/adapters/BaseAdapter.ts
+++ b/testplanit/lib/integrations/adapters/BaseAdapter.ts
@@ -243,6 +243,9 @@ export abstract class BaseAdapter implements IssueAdapter {
           } else if (this.config.provider === "GITEA") {
             // Gitea: Authorization: token <pat>
             headers["Authorization"] = `token ${this.authData.apiKey}`;
+          } else if (this.config.provider === "REDMINE") {
+            // Redmine authenticates the REST API with the user's API key
+            headers["X-Redmine-API-Key"] = this.authData.apiKey;
           } else {
             // Default to X-API-Key header
             headers["X-API-Key"] = this.authData.apiKey;
@@ -278,6 +281,13 @@ export abstract class BaseAdapter implements IssueAdapter {
       if (!response.ok) {
         const errorText = await response.text();
         throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      // Some APIs answer successful mutations with an empty body (e.g. Redmine
+      // returns 204 No Content on issue update). Calling response.json() on an
+      // empty body throws, so short-circuit those to undefined.
+      if (response.status === 204) {
+        return undefined as T;
       }
 
       return response.json();

--- a/testplanit/lib/integrations/adapters/RedmineAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/RedmineAdapter.test.ts
@@ -1,0 +1,462 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RedmineAdapter } from "./RedmineAdapter";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const BASE_URL = "https://redmine.example.com";
+
+function okJson(data: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(data) };
+}
+
+function noContent() {
+  return { ok: true, status: 204 };
+}
+
+function httpError(status: number, body = "error") {
+  return { ok: false, status, text: () => Promise.resolve(body) };
+}
+
+describe("RedmineAdapter", () => {
+  let adapter: RedmineAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    adapter = new RedmineAdapter({ provider: "REDMINE", baseUrl: BASE_URL });
+    // Strip the inter-request throttle/backoff so multi-request methods don't sleep.
+    (adapter as any).rateLimitDelay = 0;
+    (adapter as any).maxRetries = 0;
+  });
+
+  /** Authenticate the adapter, consuming one mocked /users/current.json call. */
+  async function authenticate() {
+    mockFetch.mockResolvedValueOnce(
+      okJson({ user: { id: 1, login: "admin" } })
+    );
+    await adapter.authenticate({ type: "api_key", apiKey: "test-key" });
+    mockFetch.mockClear();
+  }
+
+  describe("getCapabilities", () => {
+    it("reports the supported capabilities", () => {
+      expect(adapter.getCapabilities()).toEqual({
+        createIssue: true,
+        updateIssue: true,
+        linkIssue: true,
+        syncIssue: true,
+        searchIssues: true,
+        webhooks: true,
+        customFields: true,
+        attachments: false,
+        linkedIssues: true,
+        comments: true,
+      });
+    });
+  });
+
+  describe("authenticate", () => {
+    it("validates the key against /users/current.json and sends X-Redmine-API-Key", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ user: { id: 1 } }));
+
+      await expect(
+        adapter.authenticate({ type: "api_key", apiKey: "abc123" })
+      ).resolves.not.toThrow();
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/users/current.json`);
+      expect(opts.headers["X-Redmine-API-Key"]).toBe("abc123");
+    });
+
+    it("accepts the key supplied as apiToken", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ user: { id: 1 } }));
+
+      await adapter.authenticate({ type: "api_key", apiToken: "tok-456" });
+
+      expect(mockFetch.mock.calls[0][1].headers["X-Redmine-API-Key"]).toBe(
+        "tok-456"
+      );
+    });
+
+    it("uses baseUrl from authData when not configured", async () => {
+      const noUrlAdapter = new RedmineAdapter({ provider: "REDMINE" });
+      (noUrlAdapter as any).maxRetries = 0;
+      mockFetch.mockResolvedValueOnce(okJson({ user: { id: 1 } }));
+
+      await noUrlAdapter.authenticate({
+        type: "api_key",
+        apiKey: "k",
+        baseUrl: "https://rm.internal/",
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://rm.internal/users/current.json"
+      );
+    });
+
+    it("throws a friendly error on a rejected key", async () => {
+      mockFetch.mockResolvedValueOnce(httpError(401, "Unauthorized"));
+
+      await expect(
+        adapter.authenticate({ type: "api_key", apiKey: "bad" })
+      ).rejects.toThrow("Invalid Redmine API key or instance URL");
+    });
+
+    it("rejects non-api_key auth types", async () => {
+      await expect(
+        adapter.authenticate({ type: "oauth", accessToken: "x" })
+      ).rejects.toThrow("only supports API key authentication");
+    });
+
+    it("requires an API key", async () => {
+      await expect(adapter.authenticate({ type: "api_key" })).rejects.toThrow(
+        "Redmine API key is required"
+      );
+    });
+  });
+
+  describe("getIssue", () => {
+    it("fetches an issue with journals + relations and maps the fields", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issue: {
+            id: 42,
+            subject: "Login fails",
+            description: "Steps to reproduce",
+            status: { id: 2, name: "In Progress" },
+            priority: { id: 4, name: "High" },
+            tracker: { id: 1, name: "Bug" },
+            category: { id: 9, name: "Auth" },
+            assigned_to: { id: 7, name: "Dev One" },
+            author: { id: 3, name: "Reporter" },
+            custom_fields: [{ id: 11, name: "Severity", value: "Critical" }],
+            created_on: "2024-01-15T10:00:00Z",
+            updated_on: "2024-01-16T12:00:00Z",
+          },
+        })
+      );
+
+      const issue = await adapter.getIssue("#42");
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        `${BASE_URL}/issues/42.json?include=journals,relations`
+      );
+      expect(issue).toMatchObject({
+        id: "42",
+        key: "#42",
+        title: "Login fails",
+        status: "In Progress",
+        priority: "High",
+        issueType: { id: "1", name: "Bug" },
+        assignee: { id: "7", name: "Dev One" },
+        reporter: { id: "3", name: "Reporter" },
+        labels: ["Auth"],
+        customFields: { Severity: "Critical" },
+        url: `${BASE_URL}/issues/42`,
+      });
+      expect(issue.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("searchIssues", () => {
+    it("fetches directly by id for a numeric query", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue: { id: 7, subject: "Found" } })
+      );
+
+      const res = await adapter.searchIssues({ query: "7" });
+
+      expect(mockFetch.mock.calls[0][0]).toContain("/issues/7.json");
+      expect(res).toMatchObject({ total: 1, hasMore: false });
+      expect(res.issues[0].key).toBe("#7");
+    });
+
+    it("returns empty when a direct id lookup 404s", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(httpError(404, "Not Found"));
+
+      const res = await adapter.searchIssues({ query: "#999" });
+
+      expect(res).toEqual({ issues: [], total: 0, hasMore: false });
+    });
+
+    it("uses a subject contains filter for a text query", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issues: [{ id: 1, subject: "login bug" }],
+          total_count: 1,
+        })
+      );
+
+      const res = await adapter.searchIssues({
+        query: "login",
+        projectId: "3",
+        limit: 10,
+      });
+
+      const url = new URL(mockFetch.mock.calls[0][0]);
+      expect(url.pathname).toBe("/issues.json");
+      expect(url.searchParams.get("subject")).toBe("~login");
+      expect(url.searchParams.get("project_id")).toBe("3");
+      expect(url.searchParams.get("status_id")).toBe("*");
+      expect(url.searchParams.get("limit")).toBe("10");
+      expect(res.total).toBe(1);
+      expect(res.issues[0].id).toBe("1");
+    });
+
+    it("computes hasMore from total_count and offset", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issues: [{ id: 1 }, { id: 2 }],
+          total_count: 10,
+        })
+      );
+
+      const res = await adapter.searchIssues({ limit: 2, offset: 0 });
+
+      expect(res.hasMore).toBe(true);
+      expect(res.total).toBe(10);
+    });
+  });
+
+  describe("createIssue", () => {
+    it("POSTs an issue with mapped fields", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue: { id: 100, subject: "New bug" } })
+      );
+
+      const result = await adapter.createIssue({
+        title: "New bug",
+        description: "details",
+        projectId: "5",
+        issueType: "2",
+        priority: "4",
+        assigneeId: "8",
+      });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/issues.json`);
+      expect(opts.method).toBe("POST");
+      expect(JSON.parse(opts.body)).toEqual({
+        issue: {
+          project_id: "5",
+          subject: "New bug",
+          description: "details",
+          tracker_id: 2,
+          priority_id: 4,
+          assigned_to_id: 8,
+        },
+      });
+      expect(result.id).toBe("100");
+    });
+  });
+
+  describe("updateIssue", () => {
+    it("PUTs changed fields then re-fetches the issue", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(noContent()); // PUT
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue: { id: 42, subject: "Updated" } })
+      ); // GET
+
+      const result = await adapter.updateIssue("#42", { title: "Updated" });
+
+      const [putUrl, putOpts] = mockFetch.mock.calls[0];
+      expect(putUrl).toBe(`${BASE_URL}/issues/42.json`);
+      expect(putOpts.method).toBe("PUT");
+      expect(JSON.parse(putOpts.body)).toEqual({
+        issue: { subject: "Updated" },
+      });
+      expect(result.title).toBe("Updated");
+    });
+
+    it("resolves a status name to a status id", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issue_statuses: [
+            { id: 1, name: "New" },
+            { id: 3, name: "Closed" },
+          ],
+        })
+      ); // getStatuses
+      mockFetch.mockResolvedValueOnce(noContent()); // PUT
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue: { id: 42, status: { id: 3, name: "Closed" } } })
+      ); // GET
+
+      await adapter.updateIssue("42", { status: "Closed" });
+
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+        issue: { status_id: 3 },
+      });
+    });
+  });
+
+  describe("getIssueComments", () => {
+    it("returns journal notes, skipping empty entries", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issue: {
+            id: 5,
+            journals: [
+              {
+                id: 1,
+                notes: "first note",
+                user: { id: 2, name: "Bob" },
+                created_on: "2024-01-01",
+              },
+              { id: 2, notes: "", user: { id: 3, name: "Quiet" } },
+            ],
+          },
+        })
+      );
+
+      const comments = await adapter.getIssueComments("5");
+
+      expect(mockFetch.mock.calls[0][0]).toContain("include=journals");
+      expect(comments).toEqual([
+        { id: "1", author: "Bob", body: "first note", created: "2024-01-01" },
+      ]);
+    });
+
+    it("fails soft to an empty array on error", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(httpError(500, "boom"));
+
+      await expect(adapter.getIssueComments("5")).resolves.toEqual([]);
+    });
+  });
+
+  describe("getLinkedIssues", () => {
+    it("maps relations with direction relative to the source issue", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          issue: {
+            id: 10,
+            relations: [
+              {
+                id: 1,
+                issue_id: 10,
+                issue_to_id: 20,
+                relation_type: "relates",
+              },
+              { id: 2, issue_id: 5, issue_to_id: 10, relation_type: "blocks" },
+            ],
+          },
+        })
+      );
+
+      const links = await adapter.getLinkedIssues("10");
+
+      expect(links).toEqual([
+        { id: "20", key: "#20", linkType: "relates", direction: "outward" },
+        { id: "5", key: "#5", linkType: "blocks", direction: "inward" },
+      ]);
+    });
+  });
+
+  describe("metadata lookups", () => {
+    it("getProjects maps id/identifier/name", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          projects: [{ id: 1, identifier: "web", name: "Website" }],
+        })
+      );
+
+      expect(await adapter.getProjects()).toEqual([
+        { id: "1", key: "web", name: "Website" },
+      ]);
+    });
+
+    it("getIssueTypes maps trackers", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          trackers: [
+            { id: 1, name: "Bug" },
+            { id: 2, name: "Feature" },
+          ],
+        })
+      );
+
+      expect(await adapter.getIssueTypes("any")).toEqual([
+        { id: "1", name: "Bug" },
+        { id: "2", name: "Feature" },
+      ]);
+    });
+
+    it("getStatuses maps issue_statuses", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue_statuses: [{ id: 1, name: "New" }] })
+      );
+
+      expect(await adapter.getStatuses()).toEqual([{ id: "1", name: "New" }]);
+    });
+
+    it("getPriorities maps issue_priorities", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({ issue_priorities: [{ id: 4, name: "High" }] })
+      );
+
+      expect(await adapter.getPriorities()).toEqual([
+        { id: "4", name: "High" },
+      ]);
+    });
+  });
+
+  describe("user lookups", () => {
+    it("searchUsers fails soft on 403 (non-admin key)", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(httpError(403, "Forbidden"));
+
+      await expect(adapter.searchUsers("bob")).resolves.toEqual([]);
+    });
+
+    it("getCurrentUser returns the authenticated user", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          user: {
+            id: 1,
+            firstname: "Ada",
+            lastname: "Lovelace",
+            mail: "ada@x.io",
+          },
+        })
+      );
+
+      expect(await adapter.getCurrentUser()).toEqual({
+        accountId: "1",
+        displayName: "Ada Lovelace",
+        emailAddress: "ada@x.io",
+      });
+    });
+  });
+
+  describe("linkToTestCase", () => {
+    it("adds a note via PUT and swallows failures", async () => {
+      await authenticate();
+      mockFetch.mockResolvedValueOnce(noContent());
+
+      await adapter.linkToTestCase("#42", "TC-1");
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/issues/42.json`);
+      expect(opts.method).toBe("PUT");
+      expect(JSON.parse(opts.body).issue.notes).toContain("TC-1");
+    });
+  });
+});

--- a/testplanit/lib/integrations/adapters/RedmineAdapter.ts
+++ b/testplanit/lib/integrations/adapters/RedmineAdapter.ts
@@ -1,0 +1,478 @@
+import { BaseAdapter } from "./BaseAdapter";
+import {
+  AuthenticationData,
+  CreateIssueData,
+  IssueAdapterCapabilities,
+  IssueComment,
+  IssueData,
+  IssueSearchOptions,
+  LinkedIssueRef,
+  UpdateIssueData,
+} from "./IssueAdapter";
+
+interface RedmineNamed {
+  id: number;
+  name: string;
+}
+
+interface RedmineUser {
+  id: number;
+  login?: string;
+  firstname?: string;
+  lastname?: string;
+  mail?: string;
+}
+
+interface RedmineCustomField {
+  id: number;
+  name: string;
+  value: unknown;
+}
+
+interface RedmineJournal {
+  id?: number;
+  notes?: string;
+  created_on?: string;
+  user?: RedmineNamed;
+}
+
+interface RedmineRelation {
+  id: number;
+  issue_id: number;
+  issue_to_id: number;
+  relation_type: string;
+}
+
+interface RedmineIssue {
+  id: number;
+  subject?: string;
+  description?: string;
+  status?: RedmineNamed;
+  priority?: RedmineNamed;
+  tracker?: RedmineNamed;
+  category?: RedmineNamed;
+  assigned_to?: RedmineNamed;
+  author?: RedmineNamed;
+  custom_fields?: RedmineCustomField[];
+  created_on?: string;
+  updated_on?: string;
+  journals?: RedmineJournal[];
+  relations?: RedmineRelation[];
+}
+
+interface RedmineProject {
+  id: number;
+  identifier: string;
+  name: string;
+}
+
+/**
+ * Adapter for Redmine (https://www.redmine.org) via its REST API.
+ *
+ * Auth is an API key sent as `X-Redmine-API-Key` (handled by BaseAdapter). Redmine
+ * has no OAuth, so this adapter is API-key only. Issue mutations (PUT) return 204
+ * with no body — BaseAdapter.makeRequest returns undefined for those, and we re-GET
+ * the issue to return the updated representation.
+ *
+ * Redmine concepts map onto the IssueAdapter contract as: trackers → issue types,
+ * issue_statuses → statuses, issue_priorities → priorities, journals → comments,
+ * relations → linked issues.
+ */
+export class RedmineAdapter extends BaseAdapter {
+  private baseUrl: string = "";
+
+  constructor(config: any) {
+    super(config);
+    // The config form stores the instance URL as `baseUrl`; accept `instanceUrl`
+    // too for symmetry with the other self-hosted adapters.
+    const base = config.baseUrl || config.instanceUrl;
+    if (base) this.baseUrl = String(base).replace(/\/$/, "");
+  }
+
+  getCapabilities(): IssueAdapterCapabilities {
+    return {
+      createIssue: true,
+      updateIssue: true,
+      linkIssue: true,
+      syncIssue: true,
+      searchIssues: true,
+      webhooks: true,
+      customFields: true,
+      attachments: false,
+      linkedIssues: true,
+      comments: true,
+    };
+  }
+
+  protected async performAuthentication(
+    authData: AuthenticationData
+  ): Promise<void> {
+    if (authData.baseUrl) {
+      this.baseUrl = authData.baseUrl.replace(/\/$/, "");
+    }
+    if (!this.baseUrl) {
+      throw new Error(
+        "Redmine instance URL is required (e.g. https://redmine.example.com)"
+      );
+    }
+    if (authData.type !== "api_key") {
+      throw new Error("Redmine adapter only supports API key authentication");
+    }
+    // The admin form may store the key under either credential field; normalise
+    // onto `apiKey` so BaseAdapter emits the X-Redmine-API-Key header.
+    const apiKey = authData.apiKey ?? authData.apiToken;
+    if (!apiKey) {
+      throw new Error("Redmine API key is required");
+    }
+    this.authData!.apiKey = apiKey;
+
+    try {
+      await this.makeRequest(`${this.baseUrl}/users/current.json`);
+    } catch {
+      throw new Error("Invalid Redmine API key or instance URL");
+    }
+  }
+
+  async searchIssues(options: IssueSearchOptions): Promise<{
+    issues: IssueData[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const limit = options.limit || 25;
+    const offset = options.offset || 0;
+
+    // Direct reference lookup: "#123" or "123" fetches that issue directly.
+    if (options.query) {
+      const idMatch = options.query.trim().match(/^#?(\d+)$/);
+      if (idMatch) {
+        try {
+          const issue = await this.getIssue(idMatch[1]);
+          return { issues: [issue], total: 1, hasMore: false };
+        } catch {
+          return { issues: [], total: 0, hasMore: false };
+        }
+      }
+    }
+
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      // `*` returns both open and closed issues; without it Redmine defaults to open.
+      status_id: "*",
+    });
+    if (options.projectId) params.set("project_id", options.projectId);
+    if (options.query) {
+      // Redmine's "contains" operator for text fields is the `~` value prefix.
+      params.set("subject", `~${options.query}`);
+    }
+
+    const resp = await this.makeRequest<{
+      issues?: RedmineIssue[];
+      total_count?: number;
+    }>(`${this.baseUrl}/issues.json?${params.toString()}`);
+
+    const issues = (resp.issues ?? []).map((i) => this.mapIssue(i));
+    const total = resp.total_count ?? issues.length;
+    return { issues, total, hasMore: offset + issues.length < total };
+  }
+
+  async getIssue(issueId: string): Promise<IssueData> {
+    const id = this.parseId(issueId);
+    const resp = await this.makeRequest<{ issue: RedmineIssue }>(
+      `${this.baseUrl}/issues/${id}.json?include=journals,relations`
+    );
+    return this.mapIssue(resp.issue);
+  }
+
+  async createIssue(data: CreateIssueData): Promise<IssueData> {
+    const issue: Record<string, unknown> = {
+      project_id: data.projectId,
+      subject: data.title,
+    };
+    if (data.description !== undefined) {
+      issue.description =
+        typeof data.description === "string" ? data.description : "";
+    }
+    const trackerId = Number(data.issueType);
+    if (data.issueType && !Number.isNaN(trackerId))
+      issue.tracker_id = trackerId;
+    const priorityId = Number(data.priority);
+    if (data.priority && !Number.isNaN(priorityId)) {
+      issue.priority_id = priorityId;
+    }
+    const assigneeId = Number(data.assigneeId);
+    if (data.assigneeId && !Number.isNaN(assigneeId)) {
+      issue.assigned_to_id = assigneeId;
+    }
+    if (data.customFields) {
+      issue.custom_fields = Object.entries(data.customFields).map(
+        ([id, value]) => ({ id: Number(id), value })
+      );
+    }
+
+    const resp = await this.makeRequest<{ issue: RedmineIssue }>(
+      `${this.baseUrl}/issues.json`,
+      { method: "POST", body: JSON.stringify({ issue }) }
+    );
+    return this.mapIssue(resp.issue);
+  }
+
+  async updateIssue(
+    issueId: string,
+    data: UpdateIssueData
+  ): Promise<IssueData> {
+    const id = this.parseId(issueId);
+    const issue: Record<string, unknown> = {};
+    if (data.title !== undefined) issue.subject = data.title;
+    if (data.description !== undefined) {
+      issue.description =
+        typeof data.description === "string" ? data.description : "";
+    }
+    if (data.status !== undefined) {
+      const statusId = await this.resolveStatusId(data.status);
+      if (statusId !== null) issue.status_id = statusId;
+    }
+    if (data.priority !== undefined) {
+      const priorityId = Number(data.priority);
+      if (!Number.isNaN(priorityId)) issue.priority_id = priorityId;
+    }
+    if (data.assigneeId !== undefined) {
+      const assigneeId = Number(data.assigneeId);
+      if (!Number.isNaN(assigneeId)) issue.assigned_to_id = assigneeId;
+    }
+
+    // Redmine answers a successful PUT with 204 No Content.
+    await this.makeRequest(`${this.baseUrl}/issues/${id}.json`, {
+      method: "PUT",
+      body: JSON.stringify({ issue }),
+    });
+    return this.getIssue(id);
+  }
+
+  async getIssueComments(issueId: string): Promise<IssueComment[]> {
+    try {
+      const id = this.parseId(issueId);
+      const resp = await this.makeRequest<{ issue: RedmineIssue }>(
+        `${this.baseUrl}/issues/${id}.json?include=journals`
+      );
+      const journals = resp.issue?.journals ?? [];
+      return journals
+        .filter((j) => j.notes && j.notes.trim().length > 0)
+        .map((j) => ({
+          id: j.id != null ? String(j.id) : undefined,
+          author: j.user?.name ?? "Unknown",
+          body: j.notes ?? "",
+          created: j.created_on ?? "",
+        }));
+    } catch (error) {
+      const status = this.parseStatusFromError(error);
+      const level = status === null || status >= 500 ? "error" : "warn";
+      console[level](
+        `[RedmineAdapter] getIssueComments failed for %s:`,
+        issueId,
+        error
+      );
+      return [];
+    }
+  }
+
+  async getLinkedIssues(issueId: string): Promise<LinkedIssueRef[]> {
+    try {
+      const id = this.parseId(issueId);
+      const numId = Number(id);
+      const resp = await this.makeRequest<{ issue: RedmineIssue }>(
+        `${this.baseUrl}/issues/${id}.json?include=relations`
+      );
+      const relations = resp.issue?.relations ?? [];
+      return relations.map((r) => {
+        const outward = r.issue_id === numId;
+        const otherId = outward ? r.issue_to_id : r.issue_id;
+        return {
+          id: String(otherId),
+          key: `#${otherId}`,
+          linkType: r.relation_type,
+          direction: outward ? "outward" : "inward",
+        };
+      });
+    } catch (error) {
+      console.warn("[RedmineAdapter] getLinkedIssues failed:", error);
+      return [];
+    }
+  }
+
+  async getProjects(): Promise<
+    Array<{ id: string; key: string; name: string }>
+  > {
+    const resp = await this.makeRequest<{ projects?: RedmineProject[] }>(
+      `${this.baseUrl}/projects.json?limit=100`
+    );
+    return (resp.projects ?? []).map((p) => ({
+      id: String(p.id),
+      key: p.identifier,
+      name: p.name,
+    }));
+  }
+
+  async getIssueTypes(
+    _projectId: string
+  ): Promise<Array<{ id: string; name: string }>> {
+    // Redmine trackers are defined globally, not per project.
+    const resp = await this.makeRequest<{ trackers?: RedmineNamed[] }>(
+      `${this.baseUrl}/trackers.json`
+    );
+    return (resp.trackers ?? []).map((t) => ({
+      id: String(t.id),
+      name: t.name,
+    }));
+  }
+
+  async getStatuses(): Promise<Array<{ id: string; name: string }>> {
+    const resp = await this.makeRequest<{ issue_statuses?: RedmineNamed[] }>(
+      `${this.baseUrl}/issue_statuses.json`
+    );
+    return (resp.issue_statuses ?? []).map((s) => ({
+      id: String(s.id),
+      name: s.name,
+    }));
+  }
+
+  async getPriorities(): Promise<Array<{ id: string; name: string }>> {
+    const resp = await this.makeRequest<{ issue_priorities?: RedmineNamed[] }>(
+      `${this.baseUrl}/enumerations/issue_priorities.json`
+    );
+    return (resp.issue_priorities ?? []).map((p) => ({
+      id: String(p.id),
+      name: p.name,
+    }));
+  }
+
+  async searchUsers(query: string): Promise<
+    Array<{
+      accountId: string;
+      displayName: string;
+      emailAddress?: string;
+    }>
+  > {
+    try {
+      const params = new URLSearchParams({ name: query, limit: "20" });
+      const resp = await this.makeRequest<{ users?: RedmineUser[] }>(
+        `${this.baseUrl}/users.json?${params.toString()}`
+      );
+      return (resp.users ?? []).map((u) => ({
+        accountId: String(u.id),
+        displayName: this.userDisplayName(u),
+        emailAddress: u.mail,
+      }));
+    } catch (error) {
+      // /users.json requires admin privileges; non-admin keys get 403. Fail soft
+      // so issue linking still works without user-assignment lookups.
+      console.warn("[RedmineAdapter] searchUsers failed:", error);
+      return [];
+    }
+  }
+
+  async getCurrentUser(): Promise<{
+    accountId: string;
+    displayName: string;
+    emailAddress?: string;
+  } | null> {
+    try {
+      const resp = await this.makeRequest<{ user: RedmineUser }>(
+        `${this.baseUrl}/users/current.json`
+      );
+      const u = resp.user;
+      return {
+        accountId: String(u.id),
+        displayName: this.userDisplayName(u),
+        emailAddress: u.mail,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async linkToTestCase(
+    issueId: string,
+    testCaseId: string,
+    metadata?: any
+  ): Promise<void> {
+    try {
+      const id = this.parseId(issueId);
+      const notes = `Linked to TestPlanIt test case: ${testCaseId}${
+        metadata ? `\n\n${JSON.stringify(metadata, null, 2)}` : ""
+      }`;
+      await this.makeRequest(`${this.baseUrl}/issues/${id}.json`, {
+        method: "PUT",
+        body: JSON.stringify({ issue: { notes } }),
+      });
+    } catch (error) {
+      console.warn("[RedmineAdapter] linkToTestCase failed:", error);
+    }
+  }
+
+  async syncIssue(issueId: string): Promise<IssueData> {
+    return this.getIssue(issueId);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private parseId(issueId: string): string {
+    return issueId.replace(/^#/, "").trim();
+  }
+
+  private userDisplayName(u: RedmineUser): string {
+    const full = `${u.firstname ?? ""} ${u.lastname ?? ""}`.trim();
+    return full || u.login || String(u.id);
+  }
+
+  /**
+   * Resolve a status name (or numeric id) to a Redmine status id for updates.
+   * Accepts a numeric string verbatim; otherwise looks it up by name.
+   */
+  private async resolveStatusId(status: string): Promise<number | null> {
+    const numeric = Number(status);
+    if (status.trim() !== "" && !Number.isNaN(numeric)) return numeric;
+    try {
+      const statuses = await this.getStatuses();
+      const match = statuses.find(
+        (s) => s.name.toLowerCase() === status.toLowerCase()
+      );
+      return match ? Number(match.id) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private mapIssue(issue: RedmineIssue): IssueData {
+    const customFields =
+      Array.isArray(issue.custom_fields) && issue.custom_fields.length > 0
+        ? Object.fromEntries(
+            issue.custom_fields.map((cf) => [cf.name, cf.value])
+          )
+        : undefined;
+
+    return {
+      id: String(issue.id),
+      key: `#${issue.id}`,
+      title: issue.subject ?? "",
+      description: issue.description ?? undefined,
+      status: issue.status?.name ?? "",
+      priority: issue.priority?.name,
+      issueType: issue.tracker
+        ? { id: String(issue.tracker.id), name: issue.tracker.name }
+        : undefined,
+      assignee: issue.assigned_to
+        ? { id: String(issue.assigned_to.id), name: issue.assigned_to.name }
+        : undefined,
+      reporter: issue.author
+        ? { id: String(issue.author.id), name: issue.author.name }
+        : undefined,
+      // Redmine has no labels; its nearest equivalent is the issue category.
+      labels: issue.category ? [issue.category.name] : [],
+      customFields,
+      createdAt: issue.created_on ? new Date(issue.created_on) : new Date(),
+      updatedAt: issue.updated_on ? new Date(issue.updated_on) : new Date(),
+      url: `${this.baseUrl}/issues/${issue.id}`,
+    };
+  }
+}

--- a/testplanit/lib/services/jira-link-service.test.ts
+++ b/testplanit/lib/services/jira-link-service.test.ts
@@ -29,6 +29,10 @@ vi.mock("@prisma/client", () => ({
   IntegrationProvider: {
     JIRA: "JIRA",
     GITHUB: "GITHUB",
+    AZURE_DEVOPS: "AZURE_DEVOPS",
+    GITLAB: "GITLAB",
+    GITEA: "GITEA",
+    REDMINE: "REDMINE",
   },
 }));
 
@@ -766,7 +770,16 @@ describe("JiraLinkService", () => {
         where: {
           externalId: "jira-id-123",
           integration: {
-            provider: { in: ["JIRA", "GITHUB"] },
+            provider: {
+              in: [
+                "JIRA",
+                "GITHUB",
+                "AZURE_DEVOPS",
+                "GITLAB",
+                "GITEA",
+                "REDMINE",
+              ],
+            },
           },
         },
         data: {

--- a/testplanit/lib/services/jira-link-service.ts
+++ b/testplanit/lib/services/jira-link-service.ts
@@ -1,10 +1,16 @@
 import { prisma } from "@/lib/prisma";
 import { IntegrationProvider } from "@prisma/client";
 
-// Supported issue tracking providers
+// Supported issue tracking providers (every provider routed through
+// ManageExternalIssues — i.e. all issue trackers except SIMPLE_URL, which has
+// its own ManageSimpleUrlIssues path).
 const ISSUE_TRACKING_PROVIDERS = [
   IntegrationProvider.JIRA,
   IntegrationProvider.GITHUB,
+  IntegrationProvider.AZURE_DEVOPS,
+  IntegrationProvider.GITLAB,
+  IntegrationProvider.GITEA,
+  IntegrationProvider.REDMINE,
 ];
 
 export class JiraLinkService {

--- a/testplanit/lib/upgrade-notifications.ts
+++ b/testplanit/lib/upgrade-notifications.ts
@@ -354,6 +354,19 @@ export const upgradeNotifications: Record<string, UpgradeNotification> = {
     `,
     access: [Access.ADMIN],
   },
+  "0.37.13": {
+    title: "New Feature: Redmine Integration",
+    message: `
+      <p>Connect TestPlanIt to a self-hosted <strong>Redmine</strong> instance to link, create, and sync issues — alongside the existing Jira, GitHub, GitLab, Gitea, and Azure DevOps integrations.</p>
+      <ul>
+        <li>Create and link Redmine issues from test cases, runs, results, and sessions</li>
+        <li>Search by text or by issue reference (e.g. <strong>#42</strong>); Redmine trackers map to issue types, with statuses and priorities read from your instance</li>
+        <li>Inbound status sync via the <code>redmine_webhook</code> plugin</li>
+      </ul>
+      <p>Configure it at <strong>Admin → Integrations</strong> with your Redmine URL and API key (enable the REST API in Redmine first). See the <a href="https://docs.testplanit.com/docs/user-guide/integrations" target="_blank">documentation</a>.</p>
+    `,
+    access: [Access.ADMIN],
+  },
 };
 
 /**

--- a/testplanit/lib/webhooks/adapters/index.ts
+++ b/testplanit/lib/webhooks/adapters/index.ts
@@ -5,6 +5,7 @@ import { giteaAdapter } from "./gitea";
 import { gitlabAdapter } from "./gitlab";
 import { githubAdapter } from "./github";
 import { jiraAdapter } from "./jira";
+import { redmineAdapter } from "./redmine";
 import { slackAdapter } from "./slack";
 import type { OutboundWebhookAdapter, WebhookAdapter } from "./types";
 
@@ -29,6 +30,7 @@ export const ADAPTER_REGISTRY: Record<AdapterType, WebhookAdapter | null> = {
   AZURE_DEVOPS: azureDevopsAdapter,
   GITLAB: gitlabAdapter,
   GITEA: giteaAdapter,
+  REDMINE: redmineAdapter,
   SLACK: null,
   GENERIC_HMAC: null,
 };
@@ -68,6 +70,7 @@ export const OUTBOUND_ADAPTER_REGISTRY: Record<
   AZURE_DEVOPS: null,
   GITLAB: null,
   GITEA: null,
+  REDMINE: null,
   SLACK: slackAdapter,
   GENERIC_HMAC: genericHmacAdapter,
 };
@@ -87,7 +90,8 @@ export function getOutboundAdapter(
       adapterType === "GITHUB" ||
       adapterType === "AZURE_DEVOPS" ||
       adapterType === "GITLAB" ||
-      adapterType === "GITEA"
+      adapterType === "GITEA" ||
+      adapterType === "REDMINE"
     ) {
       throw new Error(
         `Adapter ${adapterType} is INBOUND-only — call getAdapter() instead`

--- a/testplanit/lib/webhooks/adapters/redmine.test.ts
+++ b/testplanit/lib/webhooks/adapters/redmine.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { redmineAdapter } from "./redmine";
+import type { ParsedWebhookPayload } from "./types";
+
+// Shapes captured from the redmine_webhook plugin against Redmine 6.1.2.
+const OPENED = {
+  payload: {
+    action: "opened",
+    issue: {
+      id: 5,
+      subject: "[hook] capture create",
+      status: { id: 1, name: "New" },
+      tracker: { id: 1, name: "Bug" },
+      priority: { id: 3, name: "High" },
+    },
+    url: "http://redmine.example.com/issues/5",
+  },
+};
+
+const UPDATED = {
+  payload: {
+    action: "updated",
+    issue: {
+      id: 5,
+      status: { id: 3, name: "Resolved" },
+    },
+    journal: {
+      id: 6,
+      notes: "resolving",
+      details: [{ prop_key: "status_id", old_value: "1", value: "3" }],
+    },
+    url: "http://redmine.example.com/issues/5",
+  },
+};
+
+const buf = (o: unknown) => Buffer.from(JSON.stringify(o), "utf8");
+const headers = new Headers();
+const SECRET = "unused-for-redmine";
+
+describe("redmineAdapter (inbound webhook)", () => {
+  it("declares the REDMINE adapter type", () => {
+    expect(redmineAdapter.adapterType).toBe("REDMINE");
+  });
+
+  describe("verify", () => {
+    it("parses an 'opened' delivery (no signature required)", () => {
+      const r = redmineAdapter.verify(buf(OPENED), headers, SECRET);
+      expect(r.valid).toBe(true);
+      if (!r.valid) return;
+      expect(r.payload.eventType).toBe("redmine:issue_opened");
+      expect(r.payload.issueKey).toBe("#5");
+      expect(r.payload.externalStatus).toBe("New");
+      expect(r.payload.synthetic).toBe(false);
+      expect(r.payload.data).toEqual(OPENED);
+    });
+
+    it("parses an 'updated' delivery with the changed status", () => {
+      const r = redmineAdapter.verify(buf(UPDATED), headers, SECRET);
+      expect(r.valid).toBe(true);
+      if (!r.valid) return;
+      expect(r.payload.eventType).toBe("redmine:issue_updated");
+      expect(r.payload.issueKey).toBe("#5");
+      expect(r.payload.externalStatus).toBe("Resolved");
+    });
+
+    it("rejects an unparseable body", () => {
+      const r = redmineAdapter.verify(Buffer.from("not json"), headers, SECRET);
+      expect(r).toEqual({ valid: false, reason: "unparseable-body" });
+    });
+
+    it("rejects a payload missing issue.id", () => {
+      const r = redmineAdapter.verify(
+        buf({ payload: { action: "opened", issue: { subject: "x" } } }),
+        headers,
+        SECRET
+      );
+      expect(r).toEqual({ valid: false, reason: "missing-required-field" });
+    });
+
+    it("rejects a payload missing the action", () => {
+      const r = redmineAdapter.verify(
+        buf({ payload: { issue: { id: 5 } } }),
+        headers,
+        SECRET
+      );
+      expect(r).toEqual({ valid: false, reason: "missing-required-field" });
+    });
+
+    it("tolerates a missing status (externalStatus empty)", () => {
+      const r = redmineAdapter.verify(
+        buf({ payload: { action: "opened", issue: { id: 9 } } }),
+        headers,
+        SECRET
+      );
+      expect(r.valid).toBe(true);
+      if (!r.valid) return;
+      expect(r.payload.externalStatus).toBe("");
+    });
+
+    it("flags the synthetic sentinel id", () => {
+      const r = redmineAdapter.verify(
+        buf({ payload: { action: "opened", issue: { id: 0 } } }),
+        headers,
+        SECRET
+      );
+      expect(r.valid).toBe(true);
+      if (!r.valid) return;
+      expect(r.payload.synthetic).toBe(true);
+    });
+  });
+
+  describe("extractLinkedIssueRef", () => {
+    it("returns #id keyed to REDMINE from a parsed payload", () => {
+      const parsed: ParsedWebhookPayload = {
+        eventType: "redmine:issue_updated",
+        issueKey: "#5",
+        externalStatus: "Resolved",
+        synthetic: false,
+        data: UPDATED,
+      };
+      expect(redmineAdapter.extractLinkedIssueRef(parsed)).toEqual({
+        externalKey: "#5",
+        externalSystem: "REDMINE",
+      });
+    });
+
+    it("reads the raw body shape directly too", () => {
+      expect(redmineAdapter.extractLinkedIssueRef(OPENED)).toEqual({
+        externalKey: "#5",
+        externalSystem: "REDMINE",
+      });
+    });
+
+    it("returns null when there is no issue id", () => {
+      expect(
+        redmineAdapter.extractLinkedIssueRef({ payload: { action: "opened" } })
+      ).toBeNull();
+    });
+  });
+
+  describe("extractExternalStatus", () => {
+    it("returns the status name for opened/updated events", () => {
+      expect(
+        redmineAdapter.extractExternalStatus(OPENED, "redmine:issue_opened")
+      ).toBe("New");
+      expect(
+        redmineAdapter.extractExternalStatus(UPDATED, "redmine:issue_updated")
+      ).toBe("Resolved");
+    });
+
+    it("returns null for unrelated event types", () => {
+      expect(
+        redmineAdapter.extractExternalStatus(OPENED, "redmine:issue_deleted")
+      ).toBeNull();
+    });
+  });
+});

--- a/testplanit/lib/webhooks/adapters/redmine.ts
+++ b/testplanit/lib/webhooks/adapters/redmine.ts
@@ -1,0 +1,101 @@
+import type { AdapterType } from "@prisma/client";
+import type {
+  ParsedWebhookPayload,
+  VerifyResult,
+  WebhookAdapter,
+} from "./types";
+
+/**
+ * Inbound webhook adapter for the `redmine_webhook` plugin.
+ *
+ * Auth model — URL token, NOT a signature. Redmine core emits no webhooks; the
+ * `redmine_webhook` plugin posts JSON but cannot sign it or send custom headers
+ * (the captured deliveries carry only Faraday/content-type headers). The
+ * unguessable per-config token in the receiver URL (`/api/webhooks/<token>`) is
+ * therefore the credential — the receiver authenticates by resolving the
+ * WebhookConfig from that token before this adapter runs. `verify()` does no
+ * HMAC; it only parses and shape-checks the body. The encrypted
+ * WebhookConfig.secret is unused for Redmine.
+ *
+ * Payload shape (captured from redmine_webhook against Redmine 6.1.2):
+ *   { payload: { action: "opened" | "updated",
+ *                issue: { id, status: { name }, ... },
+ *                journal?: { ... },   // present on "updated"
+ *                url } }
+ *
+ * issueKey is `#<id>` to match RedmineAdapter.mapIssue's `key`, which is what
+ * gets stored as Issue.externalKey and what applyInboundIssueUpdate matches on.
+ */
+
+// Sentinel issue id for self-test pings — real Redmine issue ids are >= 1.
+const SYNTHETIC_ISSUE_ID = 0;
+
+interface RedmineWebhookBody {
+  payload?: {
+    action?: string;
+    issue?: {
+      id?: number;
+      status?: { name?: string };
+    };
+    url?: string;
+  };
+}
+
+function issueKeyFor(id: number): string {
+  return `#${id}`;
+}
+
+export const redmineAdapter: WebhookAdapter = {
+  adapterType: "REDMINE" satisfies AdapterType,
+
+  verify(rawBody: Buffer, _headers: Headers, _secret: string): VerifyResult {
+    // No signature to verify — the URL token (already validated by the receiver)
+    // is the credential. Parse and shape-check only.
+    let parsed: RedmineWebhookBody;
+    try {
+      parsed = JSON.parse(rawBody.toString("utf8")) as RedmineWebhookBody;
+    } catch {
+      return { valid: false, reason: "unparseable-body" };
+    }
+
+    const p = parsed.payload;
+    const id = p?.issue?.id;
+    const action = p?.action;
+    if (typeof id !== "number" || typeof action !== "string" || !action) {
+      return { valid: false, reason: "missing-required-field" };
+    }
+
+    const status = p?.issue?.status?.name;
+    const payload: ParsedWebhookPayload = {
+      eventType: `redmine:issue_${action}`,
+      issueKey: issueKeyFor(id),
+      externalStatus: typeof status === "string" ? status : "",
+      synthetic: id === SYNTHETIC_ISSUE_ID,
+      data: parsed,
+    };
+    return { valid: true, payload };
+  },
+
+  extractLinkedIssueRef(payload) {
+    const raw = (payload as ParsedWebhookPayload).data ?? payload;
+    const id = (raw as RedmineWebhookBody).payload?.issue?.id;
+    if (typeof id !== "number") return null;
+    return {
+      externalKey: issueKeyFor(id),
+      externalSystem: "REDMINE" satisfies AdapterType,
+    };
+  },
+
+  extractExternalStatus(payload, eventType) {
+    // Both "opened" and "updated" carry the full issue with status.name.
+    if (
+      eventType !== "redmine:issue_opened" &&
+      eventType !== "redmine:issue_updated"
+    ) {
+      return null;
+    }
+    const raw = (payload as ParsedWebhookPayload).data ?? payload;
+    const name = (raw as RedmineWebhookBody).payload?.issue?.status?.name;
+    return typeof name === "string" ? name : null;
+  },
+};

--- a/testplanit/lib/webhooks/services/applyInboundIssueUpdate.ts
+++ b/testplanit/lib/webhooks/services/applyInboundIssueUpdate.ts
@@ -31,7 +31,7 @@ const WEBHOOK_SYNC_FRESHNESS_SECONDS = 15;
  */
 function inboundProviderForAdapter(
   adapterType: AdapterType
-): "JIRA" | "GITHUB" | "AZURE_DEVOPS" | "GITLAB" | "GITEA" | null {
+): "JIRA" | "GITHUB" | "AZURE_DEVOPS" | "GITLAB" | "GITEA" | "REDMINE" | null {
   switch (adapterType) {
     case "JIRA":
       return "JIRA";
@@ -43,6 +43,8 @@ function inboundProviderForAdapter(
       return "GITLAB";
     case "GITEA":
       return "GITEA";
+    case "REDMINE":
+      return "REDMINE";
     default:
       return null;
   }

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -5083,6 +5083,10 @@
         "azureDevops": {
           "name": "Azure DevOps",
           "description": "Connect to Azure DevOps for work item tracking"
+        },
+        "redmine": {
+          "name": "Redmine",
+          "description": "Connect to a self-hosted Redmine instance for issue tracking"
         }
       },
       "filterPlaceholder": "Filter integrations...",
@@ -5173,7 +5177,13 @@
         "platformPlaceholder": "Select platform...",
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
-        "platformGogs": "Gogs"
+        "platformGogs": "Gogs",
+        "redmineApiKey": "Redmine API Key",
+        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
+        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
+        "redmineUrl": "Redmine URL",
+        "redmineUrlPlaceholder": "https://redmine.example.com",
+        "redmineUrlHelp": "The base URL of your Redmine instance"
       },
       "authType": {
         "api_key": "API Key",
@@ -6096,7 +6106,9 @@
       "repo": "## Repository Name\nThe name of the repository to link issues from.\n\n- Exact repository name (not the full URL)\n- Example: my-project\n- Must be accessible with the provided credentials",
       "instanceUrl": "## Instance URL\nThe base URL of your self-hosted instance.\n\n- Format: https://git.example.com\n- Do not include trailing slashes or paths\n- Must be accessible from this server",
       "projectPath": "## Project Path\nThe full path to your GitLab project.\n\n- Format: namespace/project or group/subgroup/project\n- Example: my-org/my-project\n- Found in the project URL: gitlab.com/namespace/project",
-      "platform": "## Platform\nThe self-hosted Git platform you are connecting to.\n\n- **Gitea**: gitea.io-based instances\n- **Forgejo**: forgejo.org-based instances (Gitea fork)\n- **Gogs**: gogs.io-based instances\n\nThis controls which icon is shown and may affect API compatibility."
+      "platform": "## Platform\nThe self-hosted Git platform you are connecting to.\n\n- **Gitea**: gitea.io-based instances\n- **Forgejo**: forgejo.org-based instances (Gitea fork)\n- **Gogs**: gogs.io-based instances\n\nThis controls which icon is shown and may affect API compatibility.",
+      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
+      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server"
     },
     "config": {
       "name": "## Configuration Name\nA clear, descriptive name for this configuration.\n\n- Helps describe the variant cominations that make up the Configuration (e.g. \"Chrome, Windows 10\",  \"Safari/macOS 15.5\", \"Edge/Windows 11\", etc.).",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1365,6 +1365,9 @@
           },
           "azure_devops": {
             "description": "Connect to Azure DevOps for work item tracking."
+          },
+          "redmine": {
+            "description": "Connect to a self-hosted Redmine instance for issue tracking."
           }
         }
       },
@@ -6115,7 +6118,8 @@
       "projectPath": "## Project Path\nThe full path to your GitLab project.\n\n- Format: namespace/project or group/subgroup/project\n- Example: my-org/my-project\n- Found in the project URL: gitlab.com/namespace/project",
       "platform": "## Platform\nThe self-hosted Git platform you are connecting to.\n\n- **Gitea**: gitea.io-based instances\n- **Forgejo**: forgejo.org-based instances (Gitea fork)\n- **Gogs**: gogs.io-based instances\n\nThis controls which icon is shown and may affect API compatibility.",
       "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server"
+      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
+      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
     },
     "config": {
       "name": "## Configuration Name\nA clear, descriptive name for this configuration.\n\n- Helps describe the variant cominations that make up the Configuration (e.g. \"Chrome, Windows 10\",  \"Safari/macOS 15.5\", \"Edge/Windows 11\", etc.).",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1642,7 +1642,14 @@
         "toastBulkReplaySuccess": "Bulk replay started · batch {batchId}",
         "toastBulkReplayFailed": "Bulk replay failed: {error}",
         "toastReEnableSuccess": "Webhook re-enabled",
-        "toastReEnableFailed": "Failed to re-enable: {error}"
+        "toastReEnableFailed": "Failed to re-enable: {error}",
+        "inboundChooserRedmine": "Redmine",
+        "inboundRedmineTitle": "Redmine inbound webhook",
+        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
+        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
+        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
+        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
+        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here."
       },
       "aiModels": {
         "description": "Configure AI models for intelligent test case generation and analysis",

--- a/testplanit/prisma/schema.prisma
+++ b/testplanit/prisma/schema.prisma
@@ -179,6 +179,7 @@ enum IntegrationProvider {
   SIMPLE_URL
   GITLAB
   GITEA
+  REDMINE
 }
 
 enum AdapterType {
@@ -189,6 +190,7 @@ enum AdapterType {
   GENERIC_HMAC
   GITLAB
   GITEA
+  REDMINE
 }
 
 enum WebhookDirection {

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -3161,6 +3161,7 @@ enum IntegrationProvider {
     SIMPLE_URL
     GITLAB
     GITEA
+    REDMINE
 
     @@deny('all', !auth())
     @@allow('update', auth().access == 'ADMIN')
@@ -3175,6 +3176,7 @@ enum AdapterType {
     GENERIC_HMAC
     GITLAB
     GITEA
+    REDMINE
 
     @@deny('all', !auth())
     @@allow('update', auth().access == 'ADMIN')


### PR DESCRIPTION
## Description

Adds first-class support for **Redmine** as an issue tracker, alongside the existing Jira, GitHub, GitLab, Gitea, and Azure DevOps integrations. You can link, create, search, and sync Redmine issues from test cases, runs, results, and sessions, and receive inbound status updates via Redmine's webhook plugin.

What's included:

- **Redmine adapter** — API-key auth (`X-Redmine-API-Key`), issue search (text and `#id` reference), create/update, comments (journals), linked issues (relations), trackers→issue types, statuses, and priorities, all read from your instance.
- **Admin integration UI** — Redmine provider option, config form (base URL + API key), and a real **Test Connection** that probes the Redmine REST API.
- **Project settings** — assign Redmine as a project's active integration and link external Redmine projects.
- **Inbound webhooks** — receiver, config UI, and **Send test** support for the `redmine_webhook` plugin (URL-token credential; the plugin posts unsigned), with near-real-time status sync over the existing SSE channel.
- **Upgrade notification** — system-admin-only notice announcing the integration after upgrade.
- **Docs** — provider setup, configuration, webhooks, and troubleshooting.

### Bug fixes surfaced while building this

- **Cross-provider issue linking was broken for GitLab, Gitea, and Azure DevOps.** The link service's allowlist was hardcoded to `[JIRA, GITHUB]`, so linking an issue to a test run failed with *"Invalid or inactive integration"* for every other provider. Now allows all six issue-tracking providers.
- **The create-issue dialog submitted its enclosing form.** When opened inside the repository-case details edit form, clicking **Create** also submitted the outer form. Added the missing `stopPropagation` guard (matching the sibling issue forms) plus a regression test.

## Related Issue

Closes #429

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Manual testing

Manual UAT was run end-to-end against a live Redmine 6.1.2 instance: admin integration setup + Test Connection, project assignment, issue link/create from a test case, and the full inbound webhook loop (a Redmine status change reflected in TestPlanIt over SSE without a page refresh).

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chrome
- Node version: 22.x

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

**Webhook timing caveat (documented):** Redmine's `redmine_webhook` plugin fires from an `after_save` callback, which runs *before* the transaction commits. TestPlanIt re-fetches on receipt, so a rapid status change can briefly read the pre-commit value. This is a limitation of the third-party plugin, not the integration; Redmine 7.0's planned native webhooks are expected to resolve it. Captured in the webhooks docs.
