### PR TITLE
fix(ci): re-trigger Semantic Release after Crowdin sync so raced releases still publish

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -49,6 +49,7 @@ jobs:
         run: crowdin download
 
       - name: Commit updated locale files
+        id: commit
         working-directory: testplanit
         run: |
           git config user.name "github-actions[bot]"
@@ -56,8 +57,21 @@ jobs:
           git add messages/*.json
           if git diff --cached --quiet; then
             echo "Locale files already up to date, nothing to commit"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore(i18n): sync locale files [skip ci]"
             git pull --rebase origin main
             git push
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # The locale commit carries [skip ci], and it advances main after the
+      # merge that triggered Semantic Release — which then aborts as "behind the
+      # remote". Re-dispatch the release against the now-current main so it ships
+      # with the freshly synced translations. Must use the PAT: the default
+      # GITHUB_TOKEN is barred from triggering workflow_dispatch.
+      - name: Trigger release with synced translations
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: gh workflow run semantic-release.yml --ref main --repo "${{ github.repository }}"


### PR DESCRIPTION
## Description

Fixes an automation race where a release is silently skipped when a merged PR also changes translations.

**The race** (observed with PR #432 → v0.37.13, which had to be released manually):

1. A PR that touches `testplanit/messages/en-US.json` is merged to `main`. The push triggers **Semantic Release**.
2. The same push triggers **Crowdin Sync**, which machine-translates and pushes a `chore(i18n): sync locale files [skip ci]` commit to `main` — advancing `main` a minute or two later.
3. The (often queued) Semantic Release job, checked out at the original merge SHA, now finds its branch **behind the remote** and aborts:
   > *The local branch `main` is behind the remote one, therefore a new version won't be published.*
4. The locale commit carries `[skip ci]`, so it does **not** trigger its own release run — and the release never happens automatically.

**The fix:** after Crowdin Sync commits translations, it re-dispatches Semantic Release against the now-current `main`, so the release publishes automatically **and includes the freshly synced translations**.

Safeguards:

- The re-dispatch only runs when a locale commit was actually made (new `committed` step output); a no-op sync changes nothing and triggers nothing.
- If the original release already succeeded before the sync landed, the re-triggered run finds only `chore` commits since the last tag and no-ops — so at most one release results.
- The release commit (`[skip ci]`, doesn't touch `en-US.json`) does not re-trigger Crowdin Sync, so there is no loop.
- The dispatch uses the `RELEASE_PLEASE_TOKEN` PAT, because GitHub deliberately bars the default `GITHUB_TOKEN` from triggering `workflow_dispatch`.

## Related Issue

N/A — infrastructure fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Workflow YAML validated locally (parses; step graph and `if` condition verified). End-to-end behavior will be confirmed on the next merge that changes `en-US.json`.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: N/A (CI workflow change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

**Action required to verify:** the dispatch step depends on `RELEASE_PLEASE_TOKEN` having workflow-dispatch rights — `actions: write` (fine-grained) or classic `repo`/`workflow` scope. That token already performs the authenticated push in this same workflow, so it is very likely scoped correctly; if the *Trigger release with synced translations* step ever returns 403, an insufficient token scope is the cause.
