### PR TITLE
fix(workers): raise scim-access-recompute-worker memory ceiling

### DIFF
--- a/docs/docs/background-processes.md
+++ b/docs/docs/background-processes.md
@@ -231,6 +231,7 @@ Most workers run with a 512 MB `max_memory_restart` ceiling and a 384 MB old-spa
 | --- | --- | --- | --- |
 | Sync Worker | 1G | 768M | Loads integration adapters + Elasticsearch sync extensions |
 | Forecast Worker | 2G | 1536M | Recomputes run/case forecasts over large historical result sets; the default 512 MB tier was OOM-killed under production data volumes |
+| SCIM Access Recompute Worker | 2G | 1536M | Loads the full ZenStack runtime to recompute `User.access` tiers from IdP group mappings; boots to ~1.4 GB RSS at idle, so the default 512 MB tier triggered a tight PM2 SIGINT/restart loop rather than a real OOM |
 | Webhook Dispatch Worker | 3G | 2304M | Loads ZenStack runtime + ES sync services + audit log service; carries full `test_run.completed` payloads under concurrency=5; observed steady-state RSS in multi-tenant clusters sits near 1.9 GB |
 | Webhook Outbox Worker | 3G | 2304M | Same heavy dependency tree as dispatch; caches one Prisma client per tenant in multi-tenant mode |
 | Webhook Retention Worker | 3G | 2304M | Iterates every tenant's database per pass; headroom protects against batched-delete loops on tenants with large retention backlogs. Tenant Prisma clients are disconnected after each pass to release Rust query engine buffers, so steady-state should drop substantially after the first few passes — these ceilings can be lowered once production telemetry confirms it. |
@@ -297,7 +298,7 @@ You can monitor worker health and performance using:
 
 ### Memory issues
 
-- Most workers run with a 512 MB ceiling; the sync worker runs with a 1 GB ceiling; the forecast worker runs with a 2 GB ceiling; the three webhook workers (dispatch, outbox, retention) run with a 3 GB ceiling. See the **Worker memory tiers** table above for the rationale on each elevated tier.
+- Most workers run with a 512 MB ceiling; the sync worker runs with a 1 GB ceiling; the forecast and SCIM access recompute workers run with a 2 GB ceiling; the three webhook workers (dispatch, outbox, retention) run with a 3 GB ceiling. See the **Worker memory tiers** table above for the rationale on each elevated tier.
 - If a worker is being killed and restarted by PM2 in a tight loop (visible as repeated `restart` events in `pm2 status`), raise `max_memory_restart` and `--max-old-space-size` in `ecosystem.config.js` for that worker before assuming there is a real leak.
 - Monitor with `pm2 monit`
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -10,7 +10,7 @@ This guide outlines the steps to deploy TestPlanIt to production using the compr
 ## Prerequisites
 
 - A server with Docker and Docker Compose installed
-- For all services, at least 8GB RAM (12GB recommended for production worker headroom) and 4 CPU cores; building requires 24GB RAM
+- For all services, at least 8GB RAM (14GB recommended for production worker headroom) and 4 CPU cores; building requires 24GB RAM
 - Storage for persistent data volumes
 - A domain name and SSL certificate (for HTTPS)
 

--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -32,23 +32,23 @@ The Docker Compose setup starts these containerized services:
   | Phase                    | Minimum | Recommended | Notes                                      |
   | -------------------------- | --------- | ------------- | -------------------------------------------- |
   | **Building**             | 24GB    | 24GB+       | Required during initial build and updates  |
-  | **Running (Full Stack)** | 7GB     | 11GB        | All services combined                      |
+  | **Running (Full Stack)** | 8GB     | 14GB        | All services combined                      |
 
-  **Memory-constrained systems:** Allocate 24GB to Docker for building, then reduce to 7-12GB for running after build completes.
+  **Memory-constrained systems:** Allocate 24GB to Docker for building, then reduce to 8-14GB for running after build completes.
 
   **Per-service breakdown (running):**
 
   | Service                | Minimum  | Recommended |
   | ------------------------ | ---------- | ------------- |
   | TestPlanIt Application | 3GB      | 4GB         |
-  | Background Workers     | 512MB    | 2GB         |
+  | Background Workers     | 2GB      | 4GB         |
   | PostgreSQL             | 1GB      | 2GB         |
   | Elasticsearch          | 2GB      | 3GB         |
   | MinIO                  | 512MB    | 1GB         |
   | Valkey (Redis)         | 32MB     | 64MB        |
-  | **Total**              | **~7GB** | **~12GB**   |
+  | **Total**              | **~8GB** | **~14GB**   |
 
-  The Background Workers figure is steady-state for the whole fleet; individual workers restart at higher ceilings under load (the forecast worker at 2GB, the webhook workers at 3GB each). See the [worker memory tiers](./background-processes.md) for the per-worker breakdown.
+  The Background Workers figure is steady-state for a typical single-tenant install. One always-on worker (SCIM access recompute) idles near 1.4GB on its own regardless of whether SCIM is configured, which is why the fleet no longer fits in the old 512MB floor. Individual workers also restart at higher ceilings under load (forecast and SCIM access recompute at 2GB, the webhook workers at 3GB each — whose steady-state RSS can approach 1.9GB each in busy multi-tenant clusters). Multi-tenant operators should size the worker fleet well above the recommended figure; see the [worker memory tiers](./background-processes.md) for the per-worker breakdown.
 
 - 25GB+ disk space for data and images
 

--- a/testplanit/ecosystem.config.js
+++ b/testplanit/ecosystem.config.js
@@ -261,8 +261,8 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: "512M",
-      node_args: "--max-old-space-size=384",
+      max_memory_restart: "2G",
+      node_args: "--max-old-space-size=1536",
       env: {
         NODE_ENV: "production",
       },


### PR DESCRIPTION
## What

Raises the PM2 memory ceiling for the SCIM access recompute worker from `512M` / `--max-old-space-size=384` to `2G` / `--max-old-space-size=1536`, matching the forecast worker.

## Why

The worker boots to ~1.4 GB RSS — it loads the full ZenStack runtime to recompute `User.access` tiers from IdP group mappings. On the old 512M ceiling, PM2 SIGINT-killed it within seconds of every boot and autorestarted it in a tight loop (observed hundreds of restarts per pod). The restart churn, not the work, was the CPU cost. It was the only heavy ZenStack worker still on the 512M default.

This isn't a leak — it's a fixed startup footprint that never fit the ceiling, so the fix is headroom, not investigation.

## Docs

Because this is an **always-on** worker that idles near 1.4 GB regardless of whether SCIM is configured, the worker fleet no longer fits the old 512 MB floor. Updated the deployment sizing docs accordingly:

- Added the worker to the **Worker memory tiers** table and the memory-issues troubleshooting note in `background-processes.md`.
- Bumped the **Background Workers** per-service allocation to 2 GB min / 4 GB recommended, full-stack running guidance to 8–14 GB, and the production RAM recommendation to 14 GB.
- Added a note that multi-tenant operators should size the worker fleet above the recommended figure.