### PR TITLE
fix(runs): stop test run list rows from overflowing and overlapping

### DIFF
--- a/testplanit/app/[locale]/projects/runs/[projectId]/TestRunDisplay.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/TestRunDisplay.tsx
@@ -635,6 +635,10 @@ const TestRunDisplay: React.FC<TestRunDisplayProps> = ({
               onDuplicate={onDuplicateTestRun}
               summaryData={batchSummaries?.summaries[testRun.id]}
               pendingRequest={pendingByTestRunId.get(testRun.id)}
+              // Completed runs render as a flat list (not grouped by
+              // milestone), so the milestone is shown here — unlike the
+              // active tab's grouped view, where it would be redundant.
+              showMilestone={true}
             />
           ))}
         </div>
@@ -831,6 +835,7 @@ const TestRunDisplay: React.FC<TestRunDisplayProps> = ({
                         onDuplicate={onDuplicateTestRunParam}
                         summaryData={summariesData?.summaries[testRun.id]}
                         pendingRequest={pendingByTestRunId.get(testRun.id)}
+                        showMilestone={false}
                       />
                     </DraggableTestRunWrapper>
                   </div>

--- a/testplanit/app/[locale]/projects/runs/[projectId]/TestRunItem.tsx
+++ b/testplanit/app/[locale]/projects/runs/[projectId]/TestRunItem.tsx
@@ -97,12 +97,7 @@ export interface TestRunItemProps {
   onDuplicate?: (run: { id: number; name: string }) => void;
   onComplete?: (testRun: any) => void;
   isAdmin?: boolean;
-  summaryData?: TestRunSummaryData; // Pre-fetched summary data for batch mode
-  /**
-   * Pre-fetched PENDING ReviewRequest for this row's entity (bulk-loaded by
-   * the parent TestRunDisplay; see RESEARCH §"Pitfall 6"). `undefined` means
-   * no pending review for this row.
-   */
+  summaryData?: TestRunSummaryData;
   pendingRequest?: PendingReviewSummary;
 }
 
@@ -232,9 +227,12 @@ const TestRunItem: React.FC<TestRunItemProps> = ({
     }));
   }, [testRun.createdBy, testRunCases, tCommon]);
 
-  // Using consistent grid layout for all items
+  // Using consistent grid layout for all items. Every track is minmax(0,fr)
+  // so columns shrink to fit the row instead of overflowing into each other,
+  // and resolve to the same width on every row for clean column alignment.
+  // Content inside each cell truncates rather than widening its track.
   const gridLayout =
-    "grid-cols-[minmax(0,1.5fr)_minmax(auto,0.75fr)_minmax(auto,0.5fr)_minmax(auto,1fr)_minmax(auto,1.5fr)_minmax(0,0.75fr)]";
+    "grid-cols-[minmax(0,1.5fr)_minmax(0,0.75fr)_minmax(0,0.7fr)_minmax(0,1.1fr)_minmax(0,1.5fr)_minmax(0,0.75fr)]";
 
   return (
     <>
@@ -352,12 +350,15 @@ const TestRunItem: React.FC<TestRunItemProps> = ({
         </div>
 
         {/* Middle Column 1 - Status */}
-        <div className="flex min-w-12 whitespace-nowrap justify-start">
+        {/* `[&>span]:!shrink [&>span]:!min-w-0` overrides WorkflowStateDisplay's
+            outer `shrink-0` span so it shrinks within the cell and its inner
+            `truncate` on the name engages (ellipsis instead of a hard clip). */}
+        <div className="flex min-w-0 justify-start overflow-hidden [&>span]:!shrink [&>span]:!min-w-0">
           <WorkflowStateDisplay {...workflowState} />
         </div>
 
         {/* Middle Column 2 - Forecast */}
-        <div className="min-w-48 truncate">
+        <div className="flex flex-col min-w-0 overflow-hidden">
           <ForecastDisplay seconds={testRun.forecastManual} type="manual" />
           <ForecastDisplay
             seconds={testRun.forecastAutomated}

--- a/testplanit/components/ForecastDisplay.tsx
+++ b/testplanit/components/ForecastDisplay.tsx
@@ -35,21 +35,23 @@ export const ForecastDisplay: React.FC<ForecastDisplayProps> = ({
   return (
     <Tooltip>
       <TooltipTrigger
-        className={`cursor-default flex items-center gap-1 ${className || ""}`}
+        className={`cursor-default flex items-center gap-1 min-w-0 ${className || ""}`}
       >
         {type === "manual" && (
-          <CloudSunRain className="h-4 w-4 text-muted-foreground" />
+          <CloudSunRain className="h-4 w-4 shrink-0 text-muted-foreground" />
         )}
         {type === "automated" && (
-          <Bot className="h-4 w-4 text-muted-foreground" />
+          <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
         )}
         {type === "mixed" && (
           <>
-            <CloudSunRain className="h-4 w-4 text-muted-foreground" />
-            <Bot className="h-4 w-4 text-muted-foreground" />
+            <CloudSunRain className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
           </>
         )}
-        <DurationDisplay seconds={seconds} round={round} />
+        <span className="truncate min-w-0">
+          <DurationDisplay seconds={seconds} round={round} />
+        </span>
       </TooltipTrigger>
       <TooltipContent>
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Problem

On the project Test Runs page, the list rows rendered their columns with a CSS grid that used `minmax(auto, …)` tracks plus hard min-width floors (`min-w-48` on the forecast column, `min-w-12` on the status column). Those minimums refused to shrink, so on a narrower row the columns pushed past the row's `overflow-hidden` container and clipped or crammed into each other — the status, forecast, and summary text visibly ran together and got cut off. Because each row is its own grid, the content-based `auto` minimums also made columns land at slightly different widths from row to row.

## Changes

- **Grid sizing:** every column track is now `minmax(0, fr)`, so columns shrink to fit the row instead of overflowing, and resolve to the same width on every row for consistent alignment.
- **Status & forecast cells:** given `min-w-0` / `overflow-hidden` and dropped the hard floors, so their content truncates within the column rather than widening the track.
- **Forecast text** now truncates with an ellipsis (the existing hover tooltip still shows the full value); the leading icons are `shrink-0`.
- **Workflow state name** now truncates with an ellipsis instead of a hard mid-word clip, reusing the existing `[&>span]:!shrink [&>span]:!min-w-0` override so the shared `WorkflowStateDisplay` doesn't need to change.
- **Milestone visibility:** completed runs (shown as a flat list) display their milestone, while active runs (already grouped under milestone headers, where it's redundant) no longer repeat it. The milestone detail page keeps its own behavior.

## Testing

- `tsc --noEmit` clean
- Full precommit suite passed (zenstack format, lint, format check, 9419 unit tests)

Visual layout change — best confirmed by loading the Test Runs page (Active and Completed tabs) and a milestone detail page.
