### PR TITLE
fix(llm): generate test case names in the configured prompt language

### DIFF
--- a/testplanit/app/api/llm/generate-test-cases/outline/route.ts
+++ b/testplanit/app/api/llm/generate-test-cases/outline/route.ts
@@ -114,7 +114,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const systemPrompt = buildOutlineSystemPrompt(quantity);
+    // Forward the project's resolved generation prompt so language/tone
+    // preferences also apply to the titles (which become the test case names).
+    const styleGuidance =
+      resolvedPrompt.source !== "fallback"
+        ? resolvedPrompt.systemPrompt
+        : undefined;
+    const systemPrompt = buildOutlineSystemPrompt(quantity, styleGuidance);
 
     let maxTokens = resolvedPrompt.maxOutputTokens ?? 2048;
     const providerConfig = await (prisma as any).llmProviderConfig.findFirst({

--- a/testplanit/app/api/llm/generate-test-cases/shared.test.ts
+++ b/testplanit/app/api/llm/generate-test-cases/shared.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "~/lib/integrations/adapters/IssueAdapter";
 import { parameterCreateSchema } from "~/lib/schemas/parameterSchema";
 import {
+  buildOutlineSystemPrompt,
   buildOutlineUserPrompt,
   buildSystemPrompt,
   fetchLinkedIssuesContext,
@@ -473,6 +474,81 @@ describe("buildSystemPrompt — INT-06 includeParameters extension", () => {
         lookupDataSetId: 2,
       })
     ).toThrow();
+  });
+});
+
+describe("buildSystemPrompt — name field language consistency", () => {
+  it("fallback (inline) prompt instructs that the name match the fieldValues language", () => {
+    const prompt = buildSystemPrompt(
+      sampleTemplate,
+      { folderContext: 0 },
+      "few",
+      false,
+      undefined,
+      false
+    );
+
+    expect(prompt).toContain("LANGUAGE CONSISTENCY");
+    expect(prompt).toMatch(/name[\s\S]*same language[\s\S]*fieldValues/i);
+  });
+
+  it("custom/DB template (baseTemplate) path injects the language instruction when missing", () => {
+    const customTemplate =
+      "Responde SIEMPRE en español.\n\n{{EXAMPLE_STRUCTURE}}\n\nREQUIRED:\n{{REQUIRED_FIELDS_LIST}}\n\nReturn ONLY the JSON.";
+
+    const prompt = buildSystemPrompt(
+      sampleTemplate,
+      { folderContext: 0 },
+      "few",
+      false,
+      customTemplate,
+      false
+    );
+
+    // The admin's custom instruction is preserved...
+    expect(prompt).toContain("Responde SIEMPRE en español.");
+    // ...and the name-language guardrail reaches custom prompts too.
+    expect(prompt).toContain("LANGUAGE CONSISTENCY");
+    expect(prompt).toMatch(/name[\s\S]*same language[\s\S]*fieldValues/i);
+  });
+
+  it("does not duplicate the instruction when the base template already carries it", () => {
+    const seededTemplate =
+      "{{EXAMPLE_STRUCTURE}}\n\nREQUIREMENTS:\n- LANGUAGE CONSISTENCY: Write the name in the same language as fieldValues.\n\nReturn ONLY the JSON.";
+
+    const prompt = buildSystemPrompt(
+      sampleTemplate,
+      { folderContext: 0 },
+      "few",
+      false,
+      seededTemplate,
+      false
+    );
+
+    const occurrences = prompt.split("LANGUAGE CONSISTENCY").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe("buildOutlineSystemPrompt — title language follows project prompt", () => {
+  it("without style guidance, leaves the outline prompt language-neutral", () => {
+    const prompt = buildOutlineSystemPrompt("few");
+    expect(prompt).toContain('"outlines"');
+    expect(prompt).not.toContain("PROJECT GENERATION INSTRUCTIONS");
+  });
+
+  it("forwards the resolved prompt so titles follow its language directive", () => {
+    const prompt = buildOutlineSystemPrompt(
+      "few",
+      "You are a generator. Responde SIEMPRE en español."
+    );
+
+    // The project's prompt (carrying the language directive) is forwarded...
+    expect(prompt).toContain("Responde SIEMPRE en español.");
+    expect(prompt).toContain("PROJECT GENERATION INSTRUCTIONS");
+    // ...and the outline still owns the authoritative output format.
+    expect(prompt).toContain('"outlines"');
+    expect(prompt).toMatch(/language[\s\S]*project instructions/i);
   });
 });
 

--- a/testplanit/app/api/llm/generate-test-cases/shared.ts
+++ b/testplanit/app/api/llm/generate-test-cases/shared.ts
@@ -743,6 +743,12 @@ export function buildSystemPrompt(
     ? buildParameterInstructionBlock(STARTER_DATASET_ROW_CAP)
     : "";
 
+  // Keep each test case's top-level `name` in the same language as its
+  // fieldValues. Injected for every prompt source (the marker check below
+  // avoids duplicating it when a customized prompt already carries the line).
+  const languageConsistencyInstruction =
+    "- LANGUAGE CONSISTENCY: Write the top-level `name` of every test case in the SAME language you use for the values inside `fieldValues`. The `name` is human-readable content — never leave it in English (or reuse the English wording from this prompt) when the field values are generated in another language.";
+
   if (baseTemplate) {
     const rendered = baseTemplate
       .replace("{{EXAMPLE_STRUCTURE}}", exampleStructure)
@@ -752,9 +758,12 @@ export function buildSystemPrompt(
       .replace("{{STEPS_INSTRUCTION}}", stepsInstruction)
       .replace("{{PRIORITY_INSTRUCTION}}", priorityInstruction)
       .replace("{{TAG_INSTRUCTIONS}}", tagInstructions);
-    return parameterInstructions
-      ? `${rendered}\n\n${parameterInstructions}`
-      : rendered;
+    const languageTail = rendered.includes("LANGUAGE CONSISTENCY")
+      ? ""
+      : languageConsistencyInstruction;
+    return [rendered, parameterInstructions, languageTail]
+      .filter(Boolean)
+      .join("\n\n");
   }
 
   return `You are an expert test case generator. Analyze the provided issue and create specific, targeted test cases that validate the exact requirements and functionality described in that issue.
@@ -779,6 +788,7 @@ REQUIREMENTS:
 - Each test case object must contain ONLY: id, name, fieldValues${autoGenerateTags ? ", tags" : ""}. Do NOT include priority, automated, steps, or any other top-level keys.
 - ALL data belongs inside fieldValues using the exact field names shown above
 - Each test case name should reference the actual feature/functionality being tested${stepsInstruction}${priorityInstruction}
+${languageConsistencyInstruction}
 - CRITICAL: ALL REQUIRED FIELDS must be included in fieldValues with meaningful content
 - IMPORTANT: Include ALL optional fields in fieldValues
 - For text/textarea fields (Description, Preconditions, Post Conditions, etc.):
@@ -981,9 +991,27 @@ export interface TestCaseOutline {
   summary: string;
 }
 
-export function buildOutlineSystemPrompt(quantity?: string): string {
+export function buildOutlineSystemPrompt(
+  quantity?: string,
+  styleGuidance?: string
+): string {
   const quantityGuidance = quantity ? getQuantityGuidance(quantity) : "3-5";
-  return `You are a test case planning assistant. Given a software issue, generate a concise list of test case titles and one-sentence summaries.
+  // The outline title becomes the test case `name`. Forward the project's
+  // resolved generation prompt so any language/tone/terminology preferences
+  // (e.g. "respond in Spanish") also shape the titles — the structure-specific
+  // parts are explicitly out of scope here.
+  const guidanceBlock = styleGuidance?.trim()
+    ? `PROJECT GENERATION INSTRUCTIONS — apply ONLY their language, tone, and domain terminology when writing the titles and summaries. Ignore anything below about JSON shape, output format, or field values; the required output format is defined further down.
+---
+${styleGuidance.trim()}
+---
+
+`
+    : "";
+  const languageRequirement = styleGuidance?.trim()
+    ? "\n- Write the titles and summaries in the language and terminology called for by the project instructions above"
+    : "";
+  return `${guidanceBlock}You are a test case planning assistant. Given a software issue, generate a concise list of test case titles and one-sentence summaries.
 
 CRITICAL: Respond with ONLY valid JSON. No explanations, no text before or after.
 
@@ -999,7 +1027,7 @@ REQUIREMENTS:
 - Each title must be specific to the issue — no generic names
 - Each summary must be a single sentence explaining what the test validates
 - Titles and summaries must be distinct — no duplicates or overlapping coverage
-- Do NOT include field values, steps, or any other detail — only title and summary
+- Do NOT include field values, steps, or any other detail — only title and summary${languageRequirement}
 
 Return ONLY the JSON.`;
 }

--- a/testplanit/lib/llm/services/fallback-prompts.ts
+++ b/testplanit/lib/llm/services/fallback-prompts.ts
@@ -75,6 +75,7 @@ ADDITIONAL FIELDS (include ALL of these in fieldValues):
 REQUIREMENTS:
 - Generate {{QUANTITY_GUIDANCE}} that are SPECIFIC to the provided issue
 - Each test case name should reference the actual feature/functionality being tested
+- LANGUAGE CONSISTENCY: Write the top-level \`name\` of every test case in the SAME language you use for the values inside \`fieldValues\`. The \`name\` is human-readable content — never leave it in English (or reuse the English wording from this prompt) when the field values are generated in another language.
 {{STEPS_INSTRUCTION}}
 {{PRIORITY_INSTRUCTION}}
 - CRITICAL: ALL REQUIRED FIELDS must be included in fieldValues with meaningful content

--- a/testplanit/prisma/seedPromptConfig.ts
+++ b/testplanit/prisma/seedPromptConfig.ts
@@ -93,6 +93,7 @@ ADDITIONAL FIELDS (include ALL of these in fieldValues):
 REQUIREMENTS:
 - Generate {{QUANTITY_GUIDANCE}} that are SPECIFIC to the provided issue
 - Each test case name should reference the actual feature/functionality being tested
+- LANGUAGE CONSISTENCY: Write the top-level \`name\` of every test case in the SAME language you use for the values inside \`fieldValues\`. The \`name\` is human-readable content — never leave it in English (or reuse the English wording from this prompt) when the field values are generated in another language.
 {{STEPS_INSTRUCTION}}
 {{PRIORITY_INSTRUCTION}}
 - CRITICAL: ALL REQUIRED FIELDS must be included in fieldValues with meaningful content


### PR DESCRIPTION
Fixes #439

## The bug

When a custom system prompt instructs the model to respond in another language (the report used Spanish, on v0.38.2 with Claude `claude-sonnet-4-5-20250929`), the AI **Generate Test Cases** wizard produced every field in that language **except the test case `name`, which always came out in English**.

## Root cause

The wizard generates each case in two LLM phases:

1. **Outline phase** produces the titles that become the case names. Its system prompt was fully hardcoded in English and never received the project's resolved/custom prompt, so the titles ignored any language instruction.
2. **Expand phase** generates the fields *using* the custom prompt (so those came out correctly translated), but then force-set the case `name` back to the English outline title.

Net result: translated fields, English name.

## The fix

- **Outline phase** now forwards the project's resolved generation prompt as language/tone/terminology guidance, while keeping the outline JSON format authoritative. Titles — and therefore names — follow the requested language.
- **Single-shot path** (`route.ts` / `stream/route.ts`, used by the issue-tracker panel): added a `LANGUAGE CONSISTENCY` requirement to the generation prompt tying the top-level `name` to the language of the field values. It's injected for every prompt source and guarded so it never duplicates.
- Mirrored that instruction in the seeded default prompt and the hardcoded fallback so it's visible/editable in the Default config and stays consistent. The seed upserts the Default config, so existing installs pick it up on the next seed; user-customized configs are left untouched.

## Testing

- Added unit tests for the name-language instruction (fallback + custom-template paths, the no-duplication guard) and for the outline prompt forwarding the language directive.
- Full suite passes (`pnpm test run`: 9458 passed).