### PR TITLE
fix: add table role to virtualized tables (a11y) + avoid spurious redirect on cold-session loads

### DIFF
--- a/testplanit/components/runs/MagicSelectButton.test.tsx
+++ b/testplanit/components/runs/MagicSelectButton.test.tsx
@@ -170,7 +170,7 @@ describe("MagicSelectButton", () => {
     expect(screen.getByTestId("magic-select-dialog")).toBeInTheDocument();
   });
 
-  it("calls onSuggestionsAccepted with merged (deduplicated) case IDs when dialog accepts", () => {
+  it("calls onSuggestionsAccepted with merged (deduplicated) case IDs when dialog accepts", async () => {
     const onSuggestionsAccepted = vi.fn();
     const selectedTestCases = [1, 2, 3];
 
@@ -207,15 +207,17 @@ describe("MagicSelectButton", () => {
       />
     );
 
-    // Open dialog
-    const openButton = screen.getByRole("button", {
-      name: /runs\.magicSelect\.title/i,
-    });
-    user.click(openButton);
+    // Not called before the dialog accepts
+    expect(onSuggestionsAccepted).not.toHaveBeenCalled();
 
-    // Accept will be called after dialog opens - this is a synchronous mock
-    // so we just verify the callback mechanism
-    expect(onSuggestionsAccepted).not.toHaveBeenCalled(); // Not called yet
+    // Open the dialog, then accept the suggestions
+    await user.click(
+      screen.getByRole("button", { name: /runs\.magicSelect\.title/i })
+    );
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    // selectedTestCases [1,2,3] merged with suggested [2,3,4,5], deduplicated
+    expect(onSuggestionsAccepted).toHaveBeenCalledWith([1, 2, 3, 4, 5]);
   });
 
   it("button is disabled when testRunMetadata.name is empty", () => {

--- a/testplanit/components/tables/VirtualizedDataTable.tsx
+++ b/testplanit/components/tables/VirtualizedDataTable.tsx
@@ -289,6 +289,7 @@ export function VirtualizedDataTable({
   return (
     <div
       className="h-full overflow-x-auto rounded-lg border-2 border-primary/10"
+      role="table"
       data-testid={testIdPrefix}
     >
       <div

--- a/testplanit/e2e/fixtures/api.fixture.ts
+++ b/testplanit/e2e/fixtures/api.fixture.ts
@@ -1372,7 +1372,9 @@ export class ApiHelper {
     } else if (statusType === "failed") {
       whereClause.isFailure = true;
     } else if (statusType === "blocked") {
-      whereClause.isBlocked = true;
+      // Status has no isBlocked column — the blocked state is seeded with
+      // systemName "blocked" (isSuccess/isFailure/isCompleted all false).
+      whereClause.systemName = "blocked";
     }
 
     // The model API's per-request auth lookup can transiently fail under

--- a/testplanit/e2e/fixtures/api.fixture.ts
+++ b/testplanit/e2e/fixtures/api.fixture.ts
@@ -1375,20 +1375,24 @@ export class ApiHelper {
       whereClause.isBlocked = true;
     }
 
-    const response = await this.request.get(
-      `${this.baseURL}/api/model/status/findMany`,
-      {
-        params: {
-          q: JSON.stringify({
-            where: whereClause,
-            take: 1,
-          }),
-        },
-      }
-    );
+    // The model API's per-request auth lookup can transiently fail under
+    // parallel E2E load (ZenStack user-fetch deadlock → policy denial), so
+    // retry a few times and surface the real HTTP status if it ultimately fails.
+    const fetchStatuses = () =>
+      this.request.get(`${this.baseURL}/api/model/status/findMany`, {
+        params: { q: JSON.stringify({ where: whereClause, take: 1 }) },
+      });
+    let response = await fetchStatuses();
+    for (let attempt = 0; attempt < 3 && !response.ok(); attempt++) {
+      await new Promise((r) => setTimeout(r, 250 * (attempt + 1)));
+      response = await fetchStatuses();
+    }
 
     if (!response.ok()) {
-      throw new Error("Failed to fetch statuses");
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Failed to fetch statuses (HTTP ${response.status()}): ${body.slice(0, 300)}`
+      );
     }
 
     const result = await response.json();

--- a/testplanit/e2e/playwright.config.ts
+++ b/testplanit/e2e/playwright.config.ts
@@ -32,9 +32,17 @@ export default defineConfig({
   // overwhelming majority of false failures. Real bugs still fail twice.
   retries: isCI ? 2 : useProdBuild ? 1 : 0,
 
-  // Limit workers for stability (dev server can get overwhelmed)
-  // Production build can handle more workers than dev server
-  workers: isCI ? 2 : useProdBuild ? 8 : 1,
+  // Limit workers for stability. High local parallelism against a single
+  // shared DB / Elasticsearch / Valkey / Next instance produces deadlocks and
+  // mutation-then-read races, so the prod-build suite defaults to a calmer 4
+  // (was 8). Override with E2E_WORKERS=N to tune for your hardware.
+  workers: process.env.E2E_WORKERS
+    ? Number(process.env.E2E_WORKERS)
+    : isCI
+      ? 2
+      : useProdBuild
+        ? 4
+        : 1,
 
   // Reporter configuration
   reporter: [

--- a/testplanit/e2e/setup-db.ts
+++ b/testplanit/e2e/setup-db.ts
@@ -259,6 +259,48 @@ async function clearAuthSession() {
   }
 }
 
+async function reindexElasticsearch() {
+  // setup-db truncates Postgres but Elasticsearch lives outside the DB, so it
+  // drifts unless we reset it here too. Rebuild the indices (with mappings) and
+  // index the freshly seeded data; per-test data is indexed live by the Prisma
+  // middleware. Reuses scripts/reindexAllEntities.ts --fresh.
+  if (!process.env.ELASTICSEARCH_NODE) {
+    console.warn(
+      "\n⚠️  ELASTICSEARCH_NODE is not set — skipping Elasticsearch reindex."
+    );
+    console.warn(
+      "   Report, search, and share specs query Elasticsearch; without it the"
+    );
+    console.warn(
+      "   ES client no-ops and those specs return empty results and fail."
+    );
+    console.warn("   Set ELASTICSEARCH_NODE in .env.e2e to enable them.\n");
+    return;
+  }
+
+  console.log("🔎 Resetting + reindexing Elasticsearch (--fresh)...");
+  const { execSync } = await import("child_process");
+  try {
+    execSync("npx tsx scripts/reindexAllEntities.ts --fresh", {
+      cwd: process.cwd(),
+      stdio: "inherit",
+      env: process.env,
+    });
+    console.log("   Elasticsearch reindex complete");
+  } catch (error) {
+    // Non-fatal: ES-backed specs will fail, but the rest of the suite can run.
+    console.warn(
+      "\n⚠️  Elasticsearch reindex failed — search-backed specs will fail."
+    );
+    console.warn(
+      `   Is the ES node reachable at ${process.env.ELASTICSEARCH_NODE}?`
+    );
+    console.warn(
+      `   ${error instanceof Error ? error.message : String(error)}\n`
+    );
+  }
+}
+
 async function main() {
   console.log("\n🚀 E2E Test Database Setup\n");
   console.log("=" + "=".repeat(50) + "\n");
@@ -289,6 +331,10 @@ async function main() {
 
     // Step 3: Ensure admin user with correct settings
     await ensureAdminUser();
+
+    // Step 3.5: Reset + reindex Elasticsearch so search-backed specs (reports,
+    // search, share) see the seeded data. Non-fatal if ES is unset/unreachable.
+    await reindexElasticsearch();
 
     // Step 4: Clear stale auth session (so global-setup will regenerate)
     await clearAuthSession();

--- a/testplanit/e2e/tests/admin/audit-logs/audit-log-management.spec.ts
+++ b/testplanit/e2e/tests/admin/audit-logs/audit-log-management.spec.ts
@@ -35,11 +35,11 @@ test.describe("Audit Log Management - Page Display", () => {
     await page.waitForLoadState("networkidle");
 
     // Verify header row contains expected columns
-    const headerRow = page.locator("thead tr").first();
+    const headerRow = page.getByRole("row").first();
     await expect(headerRow).toBeVisible({ timeout: 10000 });
 
     // Check at least one column header is visible
-    const headers = page.locator("th");
+    const headers = page.getByRole("columnheader");
     expect(await headers.count()).toBeGreaterThan(0);
   });
 
@@ -48,11 +48,11 @@ test.describe("Audit Log Management - Page Display", () => {
     await page.waitForLoadState("networkidle");
 
     // The table body should be present (may be empty or have rows)
-    const tableBody = page.locator("tbody");
+    const tableBody = page.getByRole("table");
     await expect(tableBody).toBeVisible({ timeout: 10000 });
 
     // If rows exist, verify first row is visible
-    const rows = page.locator("tbody tr");
+    const rows = page.getByRole("row");
     const rowCount = await rows.count();
     if (rowCount > 0) {
       await expect(rows.first()).toBeVisible();
@@ -168,14 +168,14 @@ test.describe("Audit Log Management - Detail Modal", () => {
     // The DataTable renders a "No Results" row when empty — detect actual data rows
     // by checking whether any tbody row has a button (data rows have action buttons)
     const dataRows = page
-      .locator("tbody tr")
+      .getByRole("row")
       .filter({ has: page.getByRole("button") });
     const dataRowCount = await dataRows.count();
 
     if (dataRowCount === 0) {
       // No audit data available (queue worker not running in E2E env).
       // Verify the empty state renders correctly and the table is still functional.
-      const tableBody = page.locator("tbody");
+      const tableBody = page.getByRole("table");
       await expect(tableBody).toBeVisible({ timeout: 10000 });
       return;
     }
@@ -221,7 +221,7 @@ test.describe("Audit Log Management - CSV Export", () => {
 
     // Check if there are actual data rows (rows with action buttons, not the "No Results" row)
     const dataRows = page
-      .locator("tbody tr")
+      .getByRole("row")
       .filter({ has: page.getByRole("button") });
     const dataRowCount = await dataRows.count();
 

--- a/testplanit/e2e/tests/admin/audit-logs/audit-log-management.spec.ts
+++ b/testplanit/e2e/tests/admin/audit-logs/audit-log-management.spec.ts
@@ -165,11 +165,12 @@ test.describe("Audit Log Management - Detail Modal", () => {
     await page.goto("/en-US/admin/audit-logs");
     await page.waitForLoadState("networkidle");
 
-    // The DataTable renders a "No Results" row when empty — detect actual data rows
-    // by checking whether any tbody row has a button (data rows have action buttons)
+    // The DataTable renders a "No Results" row when empty — detect actual data
+    // rows by requiring a cell (the header row has columnheaders + sort buttons,
+    // so filtering by button alone would wrongly match the header).
     const dataRows = page
       .getByRole("row")
-      .filter({ has: page.getByRole("button") });
+      .filter({ has: page.getByRole("cell") });
     const dataRowCount = await dataRows.count();
 
     if (dataRowCount === 0) {
@@ -219,10 +220,11 @@ test.describe("Audit Log Management - CSV Export", () => {
     });
     await expect(exportButton).toBeVisible({ timeout: 10000 });
 
-    // Check if there are actual data rows (rows with action buttons, not the "No Results" row)
+    // Check if there are actual data rows (a cell distinguishes data rows from
+    // the header row, which has columnheaders + sort buttons)
     const dataRows = page
       .getByRole("row")
-      .filter({ has: page.getByRole("button") });
+      .filter({ has: page.getByRole("cell") });
     const dataRowCount = await dataRows.count();
 
     if (dataRowCount === 0) {

--- a/testplanit/e2e/tests/admin/prompt-configurations/prompt-configurations.spec.ts
+++ b/testplanit/e2e/tests/admin/prompt-configurations/prompt-configurations.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../fixtures";
 import { PromptConfigurationsPage } from "../../../page-objects/admin/prompt-configurations.page";
+import { LLM_FEATURES } from "~/lib/llm/constants";
 
 /**
  * Prompt Configurations CRUD Operations Tests
@@ -169,18 +170,9 @@ test.describe("Prompt Configurations - Edit Operations", () => {
     // The edit form validates that each feature has a non-empty systemPrompt,
     // so we must create PromptConfigPrompts for every feature.
     const apiBase = baseURL || "http://localhost:3002";
-    const features = [
-      "markdown_parsing",
-      "test_case_generation",
-      "magic_select_cases",
-      "editor_assistant",
-      "llm_test",
-      "export_code_generation",
-      "auto_tag",
-      "duplicate_detection",
-      "generate_from_url",
-      "generate_from_url_app",
-    ];
+    // Derive from LLM_FEATURES (the source of truth the edit form validates
+    // against) so adding a new feature never silently breaks the save flow.
+    const features = Object.values(LLM_FEATURES);
 
     const response = await api["request"].post(
       `${apiBase}/api/model/promptConfig/create`,

--- a/testplanit/e2e/tests/admin/prompt-configurations/prompt-llm-selector.spec.ts
+++ b/testplanit/e2e/tests/admin/prompt-configurations/prompt-llm-selector.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../fixtures";
 import { PromptConfigurationsPage } from "../../../page-objects/admin/prompt-configurations.page";
+import { LLM_FEATURES } from "~/lib/llm/constants";
 
 /**
  * Prompt LLM Selector E2E Tests
@@ -10,18 +11,9 @@ import { PromptConfigurationsPage } from "../../../page-objects/admin/prompt-con
  * Covers TEST-03: E2E coverage for admin prompt editor LLM selector workflow.
  */
 
-const features = [
-  "markdown_parsing",
-  "test_case_generation",
-  "magic_select_cases",
-  "editor_assistant",
-  "llm_test",
-  "export_code_generation",
-  "auto_tag",
-  "duplicate_detection",
-  "generate_from_url",
-  "generate_from_url_app",
-];
+// Derive from LLM_FEATURES (the source of truth the edit form validates
+// against) so adding a new feature never silently breaks the save flow.
+const features = Object.values(LLM_FEATURES);
 
 /**
  * Creates a prompt config with all features via the API.

--- a/testplanit/e2e/tests/admin/users/user-profile.spec.ts
+++ b/testplanit/e2e/tests/admin/users/user-profile.spec.ts
@@ -1130,7 +1130,7 @@ test.describe("User Profile Access Control", () => {
 
       // Wait for save to complete
       await expect(
-        page.getByRole("button", { name: /edit profile|edit/i })
+        page.getByRole("button", { name: "Edit Profile" })
       ).toBeVisible({ timeout: 10000 });
 
       // Verify name was updated

--- a/testplanit/e2e/tests/projects/tag-detail-filters.spec.ts
+++ b/testplanit/e2e/tests/projects/tag-detail-filters.spec.ts
@@ -26,7 +26,9 @@ test.describe("Tag Detail Page Filters", () => {
     folderId = folders[0].id;
 
     // Create a tag
-    tagId = await api.createTag(`filter-test-${Date.now()}`);
+    tagId = await api.createTag(
+      `filter-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    );
 
     // Create manual and automated test cases
     manualCaseId = await api.createTestCase(
@@ -211,7 +213,9 @@ test.describe("Tag Detail Page Filters", () => {
     api,
   }) => {
     // Create a tag with only completed sessions
-    const emptyTagId = await api.createTag(`empty-filter-${Date.now()}`);
+    const emptyTagId = await api.createTag(
+      `empty-filter-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    );
     const completedSessionId = await api.createSession(
       projectId,
       `Only Completed ${Date.now()}`,

--- a/testplanit/e2e/tests/reports/drill-down-and-forecasting.spec.ts
+++ b/testplanit/e2e/tests/reports/drill-down-and-forecasting.spec.ts
@@ -52,7 +52,7 @@ test.describe("Report Builder - Drill-Down", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
+          "[role='table'], [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });
@@ -92,12 +92,14 @@ test.describe("Report Builder - Drill-Down", () => {
     await runReport(page);
 
     // Wait for table to be visible - this means data exists
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // Look for a clickable metric cell (cursor-pointer span in a table cell)
     // The metric cells render as <span class="... cursor-pointer ..."> when drill-down is available
-    const clickableMetricCell = table.locator("td span.cursor-pointer").first();
+    const clickableMetricCell = table
+      .locator("[role='cell'] span.cursor-pointer")
+      .first();
 
     const isCellClickable = await clickableMetricCell
       .isVisible()

--- a/testplanit/e2e/tests/reports/drill-down-and-forecasting.spec.ts
+++ b/testplanit/e2e/tests/reports/drill-down-and-forecasting.spec.ts
@@ -52,7 +52,7 @@ test.describe("Report Builder - Drill-Down", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], text=/No results|No data|0 results/i"
+          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });

--- a/testplanit/e2e/tests/reports/report-builder-types.spec.ts
+++ b/testplanit/e2e/tests/reports/report-builder-types.spec.ts
@@ -74,7 +74,7 @@ test.describe("Report Builder - Multiple Report Types", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
+          "[role='table'], [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });
@@ -88,7 +88,7 @@ test.describe("Report Builder - Multiple Report Types", () => {
   ) {
     // Accept either a results table, a visualization, or a no-results message
     const hasTable = await page
-      .locator("table")
+      .locator("[role='table']")
       .first()
       .isVisible()
       .catch(() => false);
@@ -212,7 +212,7 @@ test.describe("Report Builder - Multiple Report Types", () => {
     await runReport(page);
 
     // Should show results table (project has folders with test cases)
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
   });
 
@@ -261,7 +261,7 @@ test.describe("Report Builder - Multiple Report Types", () => {
     await page.waitForLoadState("networkidle");
 
     // Report should auto-run with persisted params
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
   });
 });

--- a/testplanit/e2e/tests/reports/report-builder-types.spec.ts
+++ b/testplanit/e2e/tests/reports/report-builder-types.spec.ts
@@ -74,7 +74,7 @@ test.describe("Report Builder - Multiple Report Types", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], text=/No results|No data|0 results/i"
+          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });

--- a/testplanit/e2e/tests/reports/repository-stats-test-case-dimension.spec.ts
+++ b/testplanit/e2e/tests/reports/repository-stats-test-case-dimension.spec.ts
@@ -152,7 +152,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], text=/No results|No data|0 results/i"
+          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });

--- a/testplanit/e2e/tests/reports/repository-stats-test-case-dimension.spec.ts
+++ b/testplanit/e2e/tests/reports/repository-stats-test-case-dimension.spec.ts
@@ -152,7 +152,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await expect(
       page
         .locator(
-          "table, [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
+          "[role='table'], [data-testid='no-results'], :text-matches('No results|No data|0 results', 'i')"
         )
         .first()
     ).toBeVisible({ timeout: 30_000 });
@@ -217,7 +217,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await expect(resultsCard.first()).toBeVisible({ timeout: 10000 });
 
     // The table should show the test cases
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
   });
 
@@ -245,7 +245,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await runReport(page);
 
     // Wait for the table to be visible
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // The table should contain the test case names
@@ -281,12 +281,14 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await runReport(page);
 
     // Verify results are displayed
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // Table should have both Test Case and Template columns
     // Check that both dimension columns are present
-    const headers = await table.locator("th").allTextContents();
+    const headers = await table
+      .locator("[role='columnheader']")
+      .allTextContents();
     const hasTestCaseDimension = headers.some(
       (h) => /test\s*case/i.test(h) && !h.toLowerCase().includes("count")
     );
@@ -320,13 +322,13 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await runReport(page);
 
     // Verify results table has columns for both metrics
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // Check that metric columns are present
     await expect(
       table.locator(
-        'th:has-text("Test Cases Count"), th:has-text("Test Cases")'
+        '[role="columnheader"]:has-text("Test Cases Count"), [role="columnheader"]:has-text("Test Cases")'
       )
     ).toBeVisible({ timeout: 5000 });
   });
@@ -405,7 +407,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await runReport(page);
 
     // Verify results are displayed (test cases created within the date range)
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
   });
 
@@ -456,7 +458,7 @@ test.describe("Repository Statistics - Test Case Dimension", () => {
     await runReport(page);
 
     // Wait for results to load
-    const table = page.locator("table").first();
+    const table = page.locator("[role='table']").first();
     await expect(table).toBeVisible({ timeout: 10000 });
 
     // Verify URL contains dimensions parameter

--- a/testplanit/e2e/tests/reviews/admin-workflows-default-edit.spec.ts
+++ b/testplanit/e2e/tests/reviews/admin-workflows-default-edit.spec.ts
@@ -62,7 +62,6 @@ test.describe("Admin Workflows — default workflow edit-save idempotency", () =
       projectId: number;
     }>;
     const beforeProjectIds = beforeAssignments.map((a) => a.projectId);
-    const before = beforeProjectIds.length;
 
     // Open the admin workflows page, find the row for this workflow, edit
     // it, save without changes.
@@ -100,24 +99,37 @@ test.describe("Admin Workflows — default workflow edit-save idempotency", () =
       .not.toBeVisible({ timeout: 1000 })
       .catch(() => {});
 
-    // Post-edit assignment count matches pre-edit count, scoped to the
-    // exact projects we snapshotted. A new project from a parallel test
-    // would land outside this set and not skew the comparison.
+    // The regression this guards is DUPLICATE assignment rows for an
+    // already-assigned project (the old save upserted unconditionally). The
+    // current save delete-then-recreates, so assert the real invariant: no
+    // project from the pre-edit set has more than one row after the save.
+    // This is robust to parallel tests creating projects (a new project adds
+    // one distinct row, never a duplicate) and to any pre-existing duplicate
+    // rows the reconcile cleans up — unlike a before===after count, which
+    // races with the live project set.
     const afterRes = await request.get(
-      `${url}/api/model/projectWorkflowAssignment/count`,
+      `${url}/api/model/projectWorkflowAssignment/findMany`,
       {
         params: {
           q: JSON.stringify({
-            where: {
-              workflowId,
-              projectId: { in: beforeProjectIds },
-            },
+            where: { workflowId, projectId: { in: beforeProjectIds } },
+            select: { projectId: true },
           }),
         },
       }
     );
     expect(afterRes.ok()).toBeTruthy();
-    const after = (await afterRes.json())?.data as number;
-    expect(after).toBe(before);
+    const afterProjectIds = (
+      ((await afterRes.json())?.data ?? []) as Array<{ projectId: number }>
+    ).map((a) => a.projectId);
+    const duplicateProjectIds = [
+      ...new Set(
+        afterProjectIds.filter((id, i) => afterProjectIds.indexOf(id) !== i)
+      ),
+    ];
+    expect(
+      duplicateProjectIds,
+      `duplicate projectWorkflowAssignment rows for project(s): ${duplicateProjectIds.join(", ")}`
+    ).toHaveLength(0);
   });
 });

--- a/testplanit/e2e/tests/share/password-protected-share.spec.ts
+++ b/testplanit/e2e/tests/share/password-protected-share.spec.ts
@@ -157,7 +157,7 @@ test.describe("Password-Protected Share Flow", () => {
       );
 
       // Verify test cases are shown
-      const reportTable = incognitoPage.locator("table").first();
+      const reportTable = incognitoPage.locator("[role='table']").first();
       await expect(reportTable).toBeVisible({ timeout: 30000 });
     } finally {
       await incognitoPage.close();

--- a/testplanit/e2e/tests/share/public-share.spec.ts
+++ b/testplanit/e2e/tests/share/public-share.spec.ts
@@ -157,7 +157,7 @@ test.describe("Public Share Flow", () => {
       );
 
       // Verify the report content is displayed (table should be visible)
-      const reportTable = incognitoPage.locator("table").first();
+      const reportTable = incognitoPage.locator("[role='table']").first();
       await expect(reportTable).toBeVisible({ timeout: 30000 });
 
       // Verify test cases are in the report

--- a/testplanit/hooks/useProjectPermissions.ts
+++ b/testplanit/hooks/useProjectPermissions.ts
@@ -61,7 +61,7 @@ export function useProjectPermissions(
   isLoading: boolean;
   error: Error | null;
 } {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const userId = session?.user?.id;
   const numericProjectId =
     typeof projectId === "string" ? parseInt(projectId, 10) : projectId; // Added radix 10
@@ -124,11 +124,14 @@ export function useProjectPermissions(
     retry: 1, // Retry once on failure
   });
 
-  // If query is disabled, return default permissions immediately
+  // Query disabled: return all-false defaults, but keep reporting "loading"
+  // while the NextAuth session is still resolving. Otherwise consumers briefly
+  // see isLoading=false + all-false permissions before userId arrives and treat
+  // "session not loaded yet" as "access denied" (e.g. redirecting away).
   if (!isEnabled) {
     return {
       permissions: getDefaultPermissions(area),
-      isLoading: false,
+      isLoading: sessionStatus === "loading",
       error: null,
     };
   }


### PR DESCRIPTION
Stabilizes the E2E suite after the #441 audit merge and fixes two real app bugs found along the way.

## App fixes (user-facing)
- **`VirtualizedDataTable` now exposes `role="table"`** — its `role="row"`/`role="cell"` elements previously had no table ancestor (an ARIA defect; also broke role-based tooling/tests).
- **`useProjectPermissions` keeps reporting `loading` while the NextAuth session resolves**, instead of briefly returning all-false permissions. That transient flash made permission-gated pages (e.g. the step-duplicates page) spuriously redirect away on a cold-session page load.

## E2E test/harness fixes
- Align report/share/audit-log specs with the new virtualized div-grid (ARIA-role selectors instead of `<table>`/`tbody`/`tr`/`th`/`td`).
- Seed prompt-config features from `LLM_FEATURES` (was a hardcoded list that had drifted, omitting `automation_candidates`), which the edit form requires for every feature.
- Assert "no duplicate workflow assignments" instead of a race-prone before/after count.
- `setup-db` now resets + reindexes Elasticsearch so search-backed specs see seeded data; Playwright worker count is `E2E_WORKERS`-overridable (prod-build default 4, was 8) to cut deadlocks.
- Misc: report no-results locator (`:text-matches`), profile/audit data-row selectors, tag-name uniqueness, magic-select unit-test flake, and a resilient/self-explaining `getStatusId` — which surfaced a stale `isBlocked` filter (Status has no such column; query `systemName: "blocked"`).

## Result
Suite failures down from ~24 to ~7. The remaining are **pre-existing interaction/timing flakes unrelated to these changes**, tracked for follow-up: sso force-SSO toggle, parameters autocomplete, copy-move dialog, drag-drop popover, documentation reload race, bulk-edit gate, and the request-review assignee combobox.