### PR TITLE
chore(forge-app): mark package private so it isn't published to npm

### DIFF
--- a/forge-app/package.json
+++ b/forge-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@testplanit/forge-app",
   "version": "2.0.0",
+  "private": true,
   "description": "TestPlanIt Plugin for Jira",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Marks `@testplanit/forge-app` as `private: true` so it is never published to npm.

It's an Atlassian Forge app (`manifest.yml`, deployed via `forge deploy`), not an npm dependency — and it's already in the changesets `ignore` list. But it defaulted to `private: false` with no `repository`/`publishConfig`, so `changeset publish` kept trying to publish it and failing npm's provenance/sigstore check:

```
E422 — Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/TestPlanIt/testplanit" from provenance
```

That reddened the Package Release job (e.g. run on PR #445), even though the intended packages (`@testplanit/api`, `@testplanit/playwright-reporter`, `@testplanit/wdio-reporter`) published successfully. Marking it private makes `changeset publish` skip it. Forge deploy is unaffected.
