### PR TITLE
fix(access): honor project default access on project-scoped child models

### DIFF
--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa59732246fdb1e32 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
+ };
+ 
+ /**

--- a/patches/read-yaml-file@1.1.0.patch
+++ b/patches/read-yaml-file@1.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index bcb70193b4bf60c5a1d021a6756adf5f81d67ac6..aebe7d24cf2fb19f9aa483261126a3f3f46f51c6 100644
+--- a/index.js
++++ b/index.js
+@@ -5,7 +5,7 @@ const pify = require('pify')
+ const stripBom = require('strip-bom')
+ const yaml = require('js-yaml')
+ 
+-const parse = data => yaml.safeLoad(stripBom(data))
++const parse = data => yaml.load(stripBom(data))
+ 
+ const readYamlFile = fp => pify(fs.readFile)(fp, 'utf8').then(data => parse(data))
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,6 @@ overrides:
   form-data: ^4.0.6
   validator: ^13.15.22
   js-yaml: ^4.2.0
-  gray-matter>js-yaml: ^3.14.1
-  read-yaml-file>js-yaml: ^3.14.1
   tmp: ^0.2.6
   mdast-util-to-hast: ^13.2.1
   content-security-policy-parser: ^0.6.0
@@ -79,6 +77,10 @@ overrides:
   yaml@2: '>=2.8.3'
   defu: '>=6.1.5'
   joi: ^17.13.4
+
+patchedDependencies:
+  gray-matter@4.0.3: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
+  read-yaml-file@1.1.0: 488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6
 
 importers:
 
@@ -13718,10 +13720,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -28764,7 +28762,7 @@ snapshots:
       fs-extra: 11.3.5
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       jiti: 1.21.7
       js-yaml: 4.2.0
       lodash: 4.18.1
@@ -28796,7 +28794,7 @@ snapshots:
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       jiti: 1.21.7
       js-yaml: 4.2.0
       lodash: 4.18.1
@@ -30026,7 +30024,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 1.1.0(patch_hash=488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6)
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -37986,9 +37984,9 @@ snapshots:
 
   graphql@16.14.2: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -38961,11 +38959,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -42630,10 +42623,10 @@ snapshots:
       type-fest: 4.41.0
       unicorn-magic: 0.1.0
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@1.1.0(patch_hash=488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6):
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,8 +45,6 @@ overrides:
   'form-data': '^4.0.6'
   'validator': '^13.15.22'
   'js-yaml': '^4.2.0'
-  'gray-matter>js-yaml': '^3.14.1'
-  'read-yaml-file>js-yaml': '^3.14.1'
   'tmp': '^0.2.6'
   'mdast-util-to-hast': '^13.2.1'
   'content-security-policy-parser': '^0.6.0'
@@ -113,3 +111,7 @@ overrides:
   'yaml@2': '>=2.8.3'
   'defu': '>=6.1.5'
   'joi': '^17.13.4'
+
+patchedDependencies:
+  gray-matter@4.0.3: patches/gray-matter@4.0.3.patch
+  read-yaml-file@1.1.0: patches/read-yaml-file@1.1.0.patch

--- a/testplanit/__tests__/integration/testrun-group-permission-update.test.ts
+++ b/testplanit/__tests__/integration/testrun-group-permission-update.test.ts
@@ -86,6 +86,8 @@ async function setupFixture(): Promise<Fixture> {
   });
 
   // Negative control: not in the group, not the creator, no direct perms.
+  // The project below also grants no blanket default access (see defaultRoleId:
+  // null), so this user has NO path to the project at all.
   const outsiderCreated = await prisma.user.create({
     data: {
       email: `${RUN_TAG}-outsider@example.test`,
@@ -98,12 +100,17 @@ async function setupFixture(): Promise<Fixture> {
   const groupMember = await fetchAuthUser(groupMemberCreated.id);
   const outsider = await fetchAuthUser(outsiderCreated.id);
 
+  // defaultRoleId is null on purpose: a project whose default *is* a granting
+  // role (e.g. the seeded "user" role) confers that role's access on every
+  // authenticated user, so the "outsider" below would no longer be an outsider.
+  // A null default role grants nothing by default — access must come from the
+  // explicit group permission, which is exactly what these tests exercise.
   const project = await prisma.projects.create({
     data: {
       name: `${RUN_TAG}-project`,
       createdBy: creatorCreated.id,
       defaultAccessType: "SPECIFIC_ROLE",
-      defaultRoleId: userRole.id,
+      defaultRoleId: null,
     },
   });
 

--- a/testplanit/lib/auth/projectDefaultAccess.integration.test.ts
+++ b/testplanit/lib/auth/projectDefaultAccess.integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Live-DB integration test for project *default access* propagation to
+ * project-scoped child models (RepositoryCases here as the representative).
+ *
+ * Background: the `Projects` model grants read to any non-NONE user when the
+ * project sets a default access type ("default access for all users, not just
+ * assigned"). That same path must hold on the child models — otherwise a user
+ * who can SEE a project (via its default access) cannot open its test-case
+ * repository. A customer hit exactly this with a project whose default access
+ * was a "Read-only" role (defaultAccessType = SPECIFIC_ROLE, defaultRole set)
+ * and a user with no explicit/group permission and no assignment.
+ *
+ * These ACL rules compile to SQL and are only truly enforced at runtime by the
+ * enhanced (policy-applying) client — a mocked Prisma cannot catch a regression
+ * here. So this test drives the REAL `getEnhancedDb` client against the test DB.
+ *
+ * Execution model:
+ *   - Skipped by default. Opt-in with `RUN_DB_INTEGRATION=1`.
+ *   - Requires DATABASE_URL pointing at a development/test database that has
+ *     been seeded (needs at least one Workflows + Templates row).
+ *   - Creates committed fixtures in `beforeAll` and removes them in `afterAll`.
+ *     The rollback-in-a-transaction trick does NOT work here: `getEnhancedDb`
+ *     resolves the acting user via the OUTER prisma client, which cannot see an
+ *     uncommitted transactional user.
+ *
+ * The "fix" cases (allowed reads/writes via SPECIFIC_ROLE/DEFAULT defaults) fail
+ * before the schema fix and pass after it. The "guard" cases (NONE tier,
+ * explicit NO_ACCESS, null default role, read-only role) must hold either way.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const RUN_INTEGRATION = process.env.RUN_DB_INTEGRATION === "1";
+const HAS_DB_URL = Boolean(process.env.DATABASE_URL);
+
+const describeIntegration =
+  RUN_INTEGRATION && HAS_DB_URL ? describe : describe.skip;
+
+describeIntegration(
+  "project default access → RepositoryCases (live DB)",
+  () => {
+    const importDeps = async () => {
+      const { prisma } = await import("~/lib/prisma");
+      const { getEnhancedDb } = await import("~/lib/auth/utils");
+      return { prisma, getEnhancedDb };
+    };
+
+    interface SeedCtx {
+      // Projects keyed by the default-access scenario they exercise.
+      pReadOnly: number; // SPECIFIC_ROLE, defaultRole has NO canAddEdit
+      pEditor: number; // SPECIFIC_ROLE, defaultRole HAS canAddEdit
+      pDefault: number; // DEFAULT access type, no default role
+      pNullRole: number; // SPECIFIC_ROLE but defaultRole is null
+      pNoAccess: number; // like pReadOnly, but uUser has explicit NO_ACCESS
+      caseReadOnly: number;
+      caseEditor: number;
+      caseDefault: number;
+      caseNullRole: number;
+      caseNoAccess: number;
+      uUser: string; // access USER, no project grant, not a creator
+      uNone: string; // access NONE
+      // cleanup bookkeeping
+      projectIds: number[];
+      roleIds: number[];
+      userIds: string[];
+    }
+
+    let ctx: SeedCtx;
+
+    async function seed(prisma: any): Promise<SeedCtx> {
+      const wf = await prisma.workflows.findFirst({ select: { id: true } });
+      if (!wf) throw new Error("Seed the DB first (no Workflows row)");
+      const tpl = await prisma.templates.findFirst({ select: { id: true } });
+      if (!tpl) throw new Error("Seed the DB first (no Templates row)");
+
+      const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      // Role WITHOUT repository edit permission ("Read-only"-style default).
+      const roleReadOnly = await prisma.roles.create({
+        data: {
+          name: `PDA-ReadOnly-${stamp}`,
+          rolePermissions: {
+            create: { area: "TestCaseRepository", canAddEdit: false },
+          },
+        },
+        select: { id: true },
+      });
+      // Role WITH repository edit permission ("Editor"-style default).
+      const roleEditor = await prisma.roles.create({
+        data: {
+          name: `PDA-Editor-${stamp}`,
+          rolePermissions: {
+            create: { area: "TestCaseRepository", canAddEdit: true },
+          },
+        },
+        select: { id: true },
+      });
+
+      // Project owner — distinct from the test users so they are never creators
+      // (which would grant access independently of default-access rules).
+      const owner = await prisma.user.create({
+        data: {
+          name: `PDA-Owner-${stamp}`,
+          email: `pda-owner-${stamp}@example.com`,
+          access: "USER",
+          roleId: roleReadOnly.id,
+        },
+        select: { id: true },
+      });
+      // The user under test: USER tier, a global role that has NO bearing on
+      // SPECIFIC_ROLE/DEFAULT default access, no assignment, no explicit grant.
+      const uUser = await prisma.user.create({
+        data: {
+          name: `PDA-User-${stamp}`,
+          email: `pda-user-${stamp}@example.com`,
+          access: "USER",
+          roleId: roleReadOnly.id,
+        },
+        select: { id: true },
+      });
+      // NONE-tier user — must be denied everywhere.
+      const uNone = await prisma.user.create({
+        data: {
+          name: `PDA-None-${stamp}`,
+          email: `pda-none-${stamp}@example.com`,
+          access: "NONE",
+          roleId: roleReadOnly.id,
+        },
+        select: { id: true },
+      });
+
+      async function setupProject(
+        prefix: string,
+        defaultAccessType: string,
+        defaultRoleId: number | null
+      ): Promise<{ projectId: number; caseId: number }> {
+        const project = await prisma.projects.create({
+          data: {
+            name: `${prefix}-${stamp}`,
+            createdBy: owner.id,
+            defaultAccessType,
+            defaultRoleId,
+          },
+          select: { id: true },
+        });
+        const repo = await prisma.repositories.create({
+          data: { projectId: project.id },
+          select: { id: true },
+        });
+        const folder = await prisma.repositoryFolders.create({
+          data: {
+            name: `f-${stamp}`,
+            repositoryId: repo.id,
+            projectId: project.id,
+            creatorId: owner.id,
+          },
+          select: { id: true },
+        });
+        const c = await prisma.repositoryCases.create({
+          data: {
+            projectId: project.id,
+            repositoryId: repo.id,
+            folderId: folder.id,
+            templateId: tpl.id,
+            name: `${prefix}-Case`,
+            stateId: wf.id,
+            creatorId: owner.id,
+            hasParameters: false,
+          },
+          select: { id: true },
+        });
+        return { projectId: project.id, caseId: c.id };
+      }
+
+      const pReadOnly = await setupProject(
+        "PDA-ReadOnly",
+        "SPECIFIC_ROLE",
+        roleReadOnly.id
+      );
+      const pEditor = await setupProject(
+        "PDA-Editor",
+        "SPECIFIC_ROLE",
+        roleEditor.id
+      );
+      const pDefault = await setupProject("PDA-Default", "DEFAULT", null);
+      const pNullRole = await setupProject(
+        "PDA-NullRole",
+        "SPECIFIC_ROLE",
+        null
+      );
+      const pNoAccess = await setupProject(
+        "PDA-NoAccess",
+        "SPECIFIC_ROLE",
+        roleReadOnly.id
+      );
+
+      // Explicit NO_ACCESS for uUser on pNoAccess — must override default access.
+      await prisma.userProjectPermission.create({
+        data: {
+          projectId: pNoAccess.projectId,
+          userId: uUser.id,
+          accessType: "NO_ACCESS",
+        },
+      });
+
+      return {
+        pReadOnly: pReadOnly.projectId,
+        pEditor: pEditor.projectId,
+        pDefault: pDefault.projectId,
+        pNullRole: pNullRole.projectId,
+        pNoAccess: pNoAccess.projectId,
+        caseReadOnly: pReadOnly.caseId,
+        caseEditor: pEditor.caseId,
+        caseDefault: pDefault.caseId,
+        caseNullRole: pNullRole.caseId,
+        caseNoAccess: pNoAccess.caseId,
+        uUser: uUser.id,
+        uNone: uNone.id,
+        projectIds: [
+          pReadOnly.projectId,
+          pEditor.projectId,
+          pDefault.projectId,
+          pNullRole.projectId,
+          pNoAccess.projectId,
+        ],
+        roleIds: [roleReadOnly.id, roleEditor.id],
+        userIds: [owner.id, uUser.id, uNone.id],
+      };
+    }
+
+    async function cleanup(prisma: any, c: SeedCtx) {
+      try {
+        await prisma.repositoryCases.deleteMany({
+          where: { projectId: { in: c.projectIds } },
+        });
+        await prisma.repositoryFolders.deleteMany({
+          where: { projectId: { in: c.projectIds } },
+        });
+        await prisma.repositories.deleteMany({
+          where: { projectId: { in: c.projectIds } },
+        });
+        await prisma.userProjectPermission.deleteMany({
+          where: { projectId: { in: c.projectIds } },
+        });
+        await prisma.projects.deleteMany({
+          where: { id: { in: c.projectIds } },
+        });
+        // Users (FK from Projects.createdBy) and RolePermission/Roles last.
+        await prisma.user.deleteMany({ where: { id: { in: c.userIds } } });
+        await prisma.rolePermission.deleteMany({
+          where: { roleId: { in: c.roleIds } },
+        });
+        await prisma.roles.deleteMany({ where: { id: { in: c.roleIds } } });
+      } catch (err) {
+        console.warn("[project default access integration cleanup]", err);
+      }
+    }
+
+    // Build the real, policy-applying client for a given acting user.
+    let edbUser: any;
+    let edbNone: any;
+
+    beforeAll(async () => {
+      const { prisma, getEnhancedDb } = await importDeps();
+      ctx = await seed(prisma);
+      edbUser = await getEnhancedDb({ user: { id: ctx.uUser } } as any);
+      edbNone = await getEnhancedDb({ user: { id: ctx.uNone } } as any);
+    });
+
+    afterAll(async () => {
+      if (RUN_INTEGRATION && HAS_DB_URL) {
+        const { prisma } = await import("~/lib/prisma");
+        if (ctx) await cleanup(prisma, ctx);
+        await prisma.$disconnect();
+      }
+    });
+
+    // ---- The fix: default access reaches the repository ----
+
+    it("[fix] SPECIFIC_ROLE default + non-assigned USER → CAN read the case", async () => {
+      const found = await edbUser.repositoryCases.findUnique({
+        where: { id: ctx.caseReadOnly },
+        select: { id: true },
+      });
+      expect(found?.id).toBe(ctx.caseReadOnly);
+    });
+
+    it("[fix] DEFAULT access type + non-assigned USER → CAN read the case", async () => {
+      const found = await edbUser.repositoryCases.findUnique({
+        where: { id: ctx.caseDefault },
+        select: { id: true },
+      });
+      expect(found?.id).toBe(ctx.caseDefault);
+    });
+
+    it("[fix] SPECIFIC_ROLE default whose role grants edit → CAN update the case", async () => {
+      const updated = await edbUser.repositoryCases.update({
+        where: { id: ctx.caseEditor },
+        data: { name: `PDA-Editor-Case-upd-${Date.now()}` },
+        select: { id: true, name: true },
+      });
+      expect(updated.id).toBe(ctx.caseEditor);
+      expect(updated.name).toContain("upd");
+    });
+
+    // ---- Guards: behavior that must not regress ----
+
+    it("[guard] NONE-tier user → CANNOT read even with SPECIFIC_ROLE default", async () => {
+      const found = await edbNone.repositoryCases.findUnique({
+        where: { id: ctx.caseReadOnly },
+        select: { id: true },
+      });
+      expect(found).toBeNull();
+    });
+
+    it("[guard] explicit NO_ACCESS overrides default access → CANNOT read", async () => {
+      const found = await edbUser.repositoryCases.findUnique({
+        where: { id: ctx.caseNoAccess },
+        select: { id: true },
+      });
+      expect(found).toBeNull();
+    });
+
+    it("[guard] SPECIFIC_ROLE default with a NULL default role → CANNOT read", async () => {
+      const found = await edbUser.repositoryCases.findUnique({
+        where: { id: ctx.caseNullRole },
+        select: { id: true },
+      });
+      expect(found).toBeNull();
+    });
+
+    it("[guard] read-only default role → CAN read but CANNOT update", async () => {
+      const found = await edbUser.repositoryCases.findUnique({
+        where: { id: ctx.caseReadOnly },
+        select: { id: true },
+      });
+      expect(found?.id).toBe(ctx.caseReadOnly);
+
+      await expect(
+        edbUser.repositoryCases.update({
+          where: { id: ctx.caseReadOnly },
+          data: { name: "should-be-denied" },
+        })
+      ).rejects.toThrow();
+    });
+  }
+);

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -745,7 +745,10 @@ model Milestones {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access for users with milestone permissions
@@ -1242,7 +1245,10 @@ model Repositories {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Update/delete access for project admins
@@ -1277,6 +1283,9 @@ model Repositories {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1326,7 +1335,10 @@ model RepositoryFolders {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access for users with repository permissions
@@ -1398,7 +1410,10 @@ model RepositoryCaseLink {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (caseA.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (caseA.project.assignedUsers?[user == auth()] &&
-         caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null)
+         caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null && auth().access != 'NONE') ||
+        (caseA.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on repository permissions
@@ -1425,6 +1440,9 @@ model RepositoryCaseLink {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (caseA.project.assignedUsers?[user == auth()] &&
          caseA.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         caseA.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          caseA.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1474,7 +1492,10 @@ model DuplicateScanResult {
         ] ||
         (caseA.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (caseA.project.assignedUsers?[user == auth()] &&
-         caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null)
+         caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && caseA.project.defaultRole != null && auth().access != 'NONE') ||
+        (caseA.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update,delete',
@@ -1500,6 +1521,9 @@ model DuplicateScanResult {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (caseA.project.assignedUsers?[user == auth()] &&
          caseA.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         caseA.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (caseA.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          caseA.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1544,7 +1568,10 @@ model StepSequenceMatch {
         ] ||
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update,delete',
@@ -1592,7 +1619,10 @@ model StepSequenceMatchCase {
         ] ||
         (match.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (match.project.assignedUsers?[user == auth()] &&
-         match.project.defaultAccessType == 'SPECIFIC_ROLE' && match.project.defaultRole != null)
+         match.project.defaultAccessType == 'SPECIFIC_ROLE' && match.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (match.project.defaultAccessType == 'SPECIFIC_ROLE' && match.project.defaultRole != null && auth().access != 'NONE') ||
+        (match.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update,delete',
@@ -1618,6 +1648,9 @@ model StepSequenceMatchCase {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (match.project.assignedUsers?[user == auth()] &&
          match.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         match.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (match.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          match.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1699,7 +1732,10 @@ model RepositoryCases {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on role permissions
@@ -1728,6 +1764,9 @@ model RepositoryCases {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1797,7 +1836,10 @@ model RepositoryCaseVersions {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on role permissions
@@ -1826,6 +1868,9 @@ model RepositoryCaseVersions {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1860,7 +1905,10 @@ model CaseFieldValues {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testCase.project.assignedUsers?[user == auth()] &&
-         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null)
+         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (testCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on repository permissions
@@ -1887,6 +1935,9 @@ model CaseFieldValues {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testCase.project.assignedUsers?[user == auth()] &&
          testCase.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -1918,7 +1969,10 @@ model CaseFieldVersionValues {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (version.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (version.project.assignedUsers?[user == auth()] &&
-         version.project.defaultAccessType == 'SPECIFIC_ROLE' && version.project.defaultRole != null)
+         version.project.defaultAccessType == 'SPECIFIC_ROLE' && version.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (version.project.defaultAccessType == 'SPECIFIC_ROLE' && version.project.defaultRole != null && auth().access != 'NONE') ||
+        (version.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on repository permissions
@@ -1945,6 +1999,9 @@ model CaseFieldVersionValues {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (version.project.assignedUsers?[user == auth()] &&
          version.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         version.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (version.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          version.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -2037,7 +2094,10 @@ model Steps {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testCase.project.assignedUsers?[user == auth()] &&
-         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null)
+         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (testCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on repository permissions
@@ -2064,6 +2124,9 @@ model Steps {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testCase.project.assignedUsers?[user == auth()] &&
          testCase.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -2117,7 +2180,10 @@ model TestCaseParameter {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testCase.project.assignedUsers?[user == auth()] &&
-         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null)
+         testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && testCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (testCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on repository permissions
@@ -2144,6 +2210,9 @@ model TestCaseParameter {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testCase.project.assignedUsers?[user == auth()] &&
          testCase.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testCase.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testCase.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -2219,7 +2288,10 @@ model Sessions {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access for users with session permissions
@@ -2261,6 +2333,9 @@ model Sessions {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'Sessions' && (canAddEdit || canDelete)])
     )
 
@@ -2313,7 +2388,10 @@ model SessionResults {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (session.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (session.project.assignedUsers?[user == auth()] &&
-         session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null)
+         session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null && auth().access != 'NONE') ||
+        (session.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access for users with session result permissions
@@ -2342,6 +2420,9 @@ model SessionResults {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (session.project.assignedUsers?[user == auth()] &&
          session.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         session.project.defaultRole.rolePermissions?[area == 'SessionResults' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (session.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          session.project.defaultRole.rolePermissions?[area == 'SessionResults' && canAddEdit])
     )
 
@@ -2372,6 +2453,9 @@ model SessionResults {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (session.project.assignedUsers?[user == auth()] &&
          session.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         session.project.defaultRole.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)]) ||
+    // Default access for all users (not just assigned)
+        (session.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          session.project.defaultRole.rolePermissions?[area == 'SessionResults' && (canAddEdit || canDelete)])
     )
 
@@ -2433,7 +2517,10 @@ model SessionVersions {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access (for versioning)
@@ -2462,6 +2549,9 @@ model SessionVersions {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'Sessions' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'Sessions' && canAddEdit])
     )
 
@@ -2495,7 +2585,10 @@ model SessionFieldValues {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (session.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (session.project.assignedUsers?[user == auth()] &&
-         session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null)
+         session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (session.project.defaultAccessType == 'SPECIFIC_ROLE' && session.project.defaultRole != null && auth().access != 'NONE') ||
+        (session.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access inherits from session permissions
@@ -2524,6 +2617,9 @@ model SessionFieldValues {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (session.project.assignedUsers?[user == auth()] &&
          session.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         session.project.defaultRole.rolePermissions?[area == 'Sessions' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (session.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          session.project.defaultRole.rolePermissions?[area == 'Sessions' && canAddEdit])
     )
 
@@ -2587,7 +2683,10 @@ model TestRuns {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access for users with test run permissions
@@ -2629,6 +2728,9 @@ model TestRuns {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (project.assignedUsers?[user == auth()] &&
          project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         project.defaultRole.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)]) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          project.defaultRole.rolePermissions?[area == 'TestRuns' && (canAddEdit || canDelete)])
     )
 
@@ -2715,7 +2817,10 @@ model TestRunCases {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRun.project.assignedUsers?[user == auth()] &&
-         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null)
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access - creator or users with test run permissions
@@ -2745,6 +2850,9 @@ model TestRunCases {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testRun.project.assignedUsers?[user == auth()] &&
          testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit])
     )
 
@@ -2776,6 +2884,9 @@ model TestRunCases {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testRun.project.assignedUsers?[user == auth()] &&
          testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRun.project.defaultRole.rolePermissions?[area == 'TestRuns' && canAddEdit])
     )
 
@@ -2837,7 +2948,10 @@ model TestRunResults {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRun.project.assignedUsers?[user == auth()] &&
-         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null)
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update access - executor or users with result permissions
@@ -2867,6 +2981,9 @@ model TestRunResults {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testRun.project.assignedUsers?[user == auth()] &&
          testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
@@ -2914,7 +3031,10 @@ model TestRunStepResults {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testRunResult.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRunResult.testRun.project.assignedUsers?[user == auth()] &&
-         testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunResult.testRun.project.defaultRole != null)
+         testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunResult.testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunResult.testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRunResult.testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update access - executor or users with result permissions
@@ -2944,6 +3064,9 @@ model TestRunStepResults {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testRunResult.testRun.project.assignedUsers?[user == auth()] &&
          testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRunResult.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRunResult.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRunResult.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
@@ -2995,7 +3118,10 @@ model TestRunCaseIteration {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testRunCase.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRunCase.testRun.project.assignedUsers?[user == auth()] &&
-         testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null)
+         testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRunCase.testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create access - users with test run result permissions
@@ -3017,6 +3143,9 @@ model TestRunCaseIteration {
          auth().role.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
         (testRunCase.testRun.project.assignedUsers?[user == auth()] &&
          testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRunCase.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRunCase.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
@@ -3047,6 +3176,9 @@ model TestRunCaseIteration {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (testRunCase.testRun.project.assignedUsers?[user == auth()] &&
          testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         testRunCase.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          testRunCase.testRun.project.defaultRole.rolePermissions?[area == 'TestRunResults' && canAddEdit])
     )
 
@@ -3102,7 +3234,10 @@ model TestRunCaseDataSetSnapshot {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (testRunCase.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRunCase.testRun.project.assignedUsers?[user == auth()] &&
-         testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null)
+         testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRunCase.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRunCase.testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRunCase.testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Mutations are ADMIN-only via the enhanced client; Phase 3 server actions
@@ -3565,7 +3700,10 @@ model JUnitTestSuite {
         ] ||
         (testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testRun.project.assignedUsers?[user == auth()] &&
-         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null)
+         testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
     @@allow('create,update', auth().id == createdById)
     @@allow('all', auth().access == 'PROJECTADMIN' || auth().access == 'ADMIN')
@@ -3614,7 +3752,10 @@ model JUnitTestResult {
         ] ||
         (testSuite.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (testSuite.testRun.project.assignedUsers?[user == auth()] &&
-         testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null)
+         testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testSuite.testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update', auth().id == createdById)
@@ -3655,7 +3796,10 @@ model JUnitProperty {
             ] ||
             (testSuite.testRun.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
             (testSuite.testRun.project.assignedUsers?[user == auth()] &&
-             testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null)
+             testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (testSuite.testRun.project.defaultAccessType == 'SPECIFIC_ROLE' && testSuite.testRun.project.defaultRole != null && auth().access != 'NONE') ||
+        (testSuite.testRun.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
         )) ||
     // Through repository case
         (repositoryCase != null && (
@@ -3668,7 +3812,10 @@ model JUnitProperty {
             ] ||
             (repositoryCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
             (repositoryCase.project.assignedUsers?[user == auth()] &&
-             repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null)
+             repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (repositoryCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
         ))
     )
 
@@ -3704,7 +3851,10 @@ model JUnitAttachment {
         ] ||
         (repositoryCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (repositoryCase.project.assignedUsers?[user == auth()] &&
-         repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null)
+         repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (repositoryCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update', auth().id == createdById)
@@ -3740,7 +3890,10 @@ model JUnitTestStep {
         ] ||
         (repositoryCase.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (repositoryCase.project.assignedUsers?[user == auth()] &&
-         repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null)
+         repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (repositoryCase.project.defaultAccessType == 'SPECIFIC_ROLE' && repositoryCase.project.defaultRole != null && auth().access != 'NONE') ||
+        (repositoryCase.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     @@allow('create,update', auth().id == createdById)
@@ -3802,7 +3955,10 @@ model SharedStepGroup {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on shared steps permissions
@@ -3850,7 +4006,10 @@ model SharedStepItem {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (sharedStepGroup.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (sharedStepGroup.project.assignedUsers?[user == auth()] &&
-         sharedStepGroup.project.defaultAccessType == 'SPECIFIC_ROLE' && sharedStepGroup.project.defaultRole != null)
+         sharedStepGroup.project.defaultAccessType == 'SPECIFIC_ROLE' && sharedStepGroup.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (sharedStepGroup.project.defaultAccessType == 'SPECIFIC_ROLE' && sharedStepGroup.project.defaultRole != null && auth().access != 'NONE') ||
+        (sharedStepGroup.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on shared steps permissions
@@ -3917,7 +4076,10 @@ model DataSet {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on shared steps permissions
@@ -3964,7 +4126,10 @@ model DataSetRow {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (dataSet.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (dataSet.project.assignedUsers?[user == auth()] &&
-         dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null)
+         dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null && auth().access != 'NONE') ||
+        (dataSet.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on shared steps permissions
@@ -4022,7 +4187,10 @@ model DataSetVersion {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (dataSet.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (dataSet.project.assignedUsers?[user == auth()] &&
-         dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null)
+         dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (dataSet.project.defaultAccessType == 'SPECIFIC_ROLE' && dataSet.project.defaultRole != null && auth().access != 'NONE') ||
+        (dataSet.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on shared steps permissions (mirrors DataSet).
@@ -4086,7 +4254,10 @@ model CaseSharedDataSetAssignment {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (case.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (case.project.assignedUsers?[user == auth()] &&
-         case.project.defaultAccessType == 'SPECIFIC_ROLE' && case.project.defaultRole != null)
+         case.project.defaultAccessType == 'SPECIFIC_ROLE' && case.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (case.project.defaultAccessType == 'SPECIFIC_ROLE' && case.project.defaultRole != null && auth().access != 'NONE') ||
+        (case.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update/delete access based on TestCaseRepository permissions
@@ -4114,6 +4285,9 @@ model CaseSharedDataSetAssignment {
     // Project default SPECIFIC_ROLE - project's default role has permission
         (case.project.assignedUsers?[user == auth()] &&
          case.project.defaultAccessType == 'SPECIFIC_ROLE' &&
+         case.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit]) ||
+    // Default access for all users (not just assigned)
+        (case.project.defaultAccessType == 'SPECIFIC_ROLE' && auth().access != 'NONE' &&
          case.project.defaultRole.rolePermissions?[area == 'TestCaseRepository' && canAddEdit])
     )
 
@@ -4450,7 +4624,10 @@ model ProjectIntegration {
     // Allow access if project uses GLOBAL_ROLE and user has a valid role
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Only project admins can manage integrations
@@ -4498,7 +4675,10 @@ model IntegrationProject {
         ] ||
         (projectIntegration.project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (projectIntegration.project.assignedUsers?[user == auth()] &&
-         projectIntegration.project.defaultAccessType == 'SPECIFIC_ROLE' && projectIntegration.project.defaultRole != null)
+         projectIntegration.project.defaultAccessType == 'SPECIFIC_ROLE' && projectIntegration.project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (projectIntegration.project.defaultAccessType == 'SPECIFIC_ROLE' && projectIntegration.project.defaultRole != null && auth().access != 'NONE') ||
+        (projectIntegration.project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
     @@allow('create,update,delete',
         projectIntegration.project.creator == auth() ||
@@ -4984,7 +5164,10 @@ model LlmReportSnapshot {
         ] ||
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create/update gated on Reporting.canAddEdit (server flips status/output on completion)
@@ -5316,7 +5499,10 @@ model Comment {
         ] ||
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Create - same as read access
@@ -5331,7 +5517,10 @@ model Comment {
         ] ||
         (project.defaultAccessType == 'GLOBAL_ROLE' && auth().role != null && auth().access != 'NONE') ||
         (project.assignedUsers?[user == auth()] &&
-         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null)
+         project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null) ||
+    // Default access for all users (not just assigned)
+        (project.defaultAccessType == 'SPECIFIC_ROLE' && project.defaultRole != null && auth().access != 'NONE') ||
+        (project.defaultAccessType == 'DEFAULT' && auth().access != 'NONE')
     )
 
     // Update - creator can edit their own comments (with time limit handled in app logic)


### PR DESCRIPTION
## Summary

Fixes a default-access bug reported by a customer: with a project's **Default access** set to a role (e.g. "Read-only") and a user who has no explicit user- or group-level grant and isn't directly assigned, the user could open the project but its **test case repository — and runs, sessions, milestones, etc. — were inaccessible**.

**Root cause:** the `Projects` model grants read to any non-`NONE` user when a project sets a default access type ("default access for all users, not just assigned"). That same path was never propagated to the project's child models — they only honored the default for *assigned* users on the `SPECIFIC_ROLE` path and didn't handle the `DEFAULT` type at all.

**Fix:** propagate the "default access for all users" clauses to the **read and write** rules across every project-scoped child model (test cases, versions, field values, steps, parameters, milestones, test runs, run cases/results, sessions, session results, shared steps, datasets, integrations, …). A Read-only default now grants read-only everywhere; an Editor default grants edit — matching the `Projects` model's own behavior. The change is purely additive (it only widens access, as intended).

## Test coverage

- New live-DB policy integration test (`lib/auth/projectDefaultAccess.integration.test.ts`, opt-in via `RUN_DB_INTEGRATION=1`) that drives the real access-controlled client. It covers the fix (`SPECIFIC_ROLE` and `DEFAULT` reads; `SPECIFIC_ROLE` write via an editor default role) and the must-not-regress guards (`NONE` tier denied, explicit `NO_ACCESS` overrides default, null default role denied, read-only default can read but not write). Verified red→green: 4 of these fail without the fix and all pass with it.
- Corrected the negative control in `testrun-group-permission-update.test.ts`. Its project used a permissive `SPECIFIC_ROLE → "user"` default, so under the corrected semantics the "outsider" legitimately gains that default access. The fixture now uses a non-granting default (`defaultRoleId: null`) so the negative control stays meaningful; the positive group-permission case is unaffected (it relies on an explicit group grant). **This is an intended behavior change worth a look during review.**
- Full precommit passes (lint + typecheck + 9,705 unit tests), as does the existing cross-project denial integration test.

## Also included: dependency security fix

Bundles a fix for a dev/build-only `js-yaml` DoS (CVE-2026-53550 / GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in merge-key handling). `js-yaml@3.14.2` was pinned for `gray-matter` and `read-yaml-file` via scoped overrides, because both call the v3 `safeLoad`/`safeDump` API that js-yaml 4.x removed. Dropped those scoped overrides so both pick up the already-present patched `js-yaml@4.2.0`, and patched both packages to the v4 `load`/`dump` API. Verified the docs (`docusaurus`) build and `changeset status` still work, and `pnpm install --frozen-lockfile` is consistent.
