### PR TITLE
fix(docker): copy pnpm patches into image build context

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,6 +15,10 @@ COPY docs/package.json ./docs/
 COPY package.json ./
 COPY pnpm-workspace.yaml ./
 
+# Dependency patches referenced by pnpm-workspace.yaml#patchedDependencies; the
+# frozen install reads these, so they must be present before it runs.
+COPY patches ./patches/
+
 # Copy the source code for the docs workspace
 COPY ./docs/ ./docs/
 

--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -26,6 +26,10 @@ COPY packages/api/package.json ./packages/api/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
 COPY packages/wdio-testplanit-reporter/package.json ./packages/wdio-testplanit-reporter/
 
+# Dependency patches referenced by pnpm-workspace.yaml#patchedDependencies; the
+# frozen install reads these, so they must be present before it runs.
+COPY patches ./patches/
+
 # Install only the testplanit project's dependencies (it has no workspace deps).
 RUN pnpm install --frozen-lockfile --filter testplanit --ignore-scripts
 
@@ -68,6 +72,9 @@ COPY cli/package.json ./cli/
 COPY packages/api/package.json ./packages/api/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
 COPY packages/wdio-testplanit-reporter/package.json ./packages/wdio-testplanit-reporter/
+# Dependency patches referenced by pnpm-workspace.yaml#patchedDependencies; the
+# frozen install reads these, so they must be present before it runs.
+COPY patches ./patches/
 RUN pnpm install --frozen-lockfile --filter testplanit --ignore-scripts
 # Produce a self-contained production node_modules for testplanit (no symlinks
 # pointing outside the deploy dir), suitable for copying into the final images.


### PR DESCRIPTION
## Summary

The recent js-yaml security fix introduced pnpm `patchedDependencies` (for `gray-matter` and `read-yaml-file`) referenced by `pnpm-workspace.yaml`. The Docker image builds run `pnpm install --frozen-lockfile` from the repo-root context but never copied the `patches/` directory, so the install failed with `ENOENT: no such file or directory, open '/app/patches/gray-matter@4.0.3.patch'` — which broke the release Docker build.

## Fix

Add `COPY patches ./patches/` before each frozen install so the patch files are present when pnpm applies them:

- `testplanit/Dockerfile` — `base` and `deps` stages
- `docs/Dockerfile`

## Verification

Built the `deps` stage locally (the exact stage that failed in the release). The previously failing `pnpm install --frozen-lockfile` now completes and the image exports successfully.
