### PR TITLE
fix(docker): include @testplanit/api dist in image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,9 @@ docs/.docusaurus
 forge-app/dist
 cli/dist
 packages/*/dist
+# Exception: @testplanit/api ships its built dist (committed, not regenerated
+# in-image) and the app imports it, so the image build needs it.
+!packages/api/dist
 
 # Large local data & prebuilt binaries — never needed in the image.
 testplanit/backups

--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -30,11 +30,14 @@ COPY packages/wdio-testplanit-reporter/package.json ./packages/wdio-testplanit-r
 # frozen install reads these, so they must be present before it runs.
 COPY patches ./patches/
 
-# Install only the testplanit project's dependencies (it has no workspace deps).
+# Install testplanit's dependencies (includes the @testplanit/api workspace pkg).
 RUN pnpm install --frozen-lockfile --filter testplanit --ignore-scripts
 
-# App source.
+# App source, plus the @testplanit/api workspace package it imports. Its built
+# dist is committed (and un-ignored in .dockerignore); without it the workspace
+# symlink resolves to an empty dir and `next build` cannot resolve @testplanit/api.
 COPY testplanit/ ./testplanit/
+COPY packages/api ./packages/api/
 
 WORKDIR /app/testplanit
 # Version info: use the pre-generated file if present, else derive it.
@@ -79,6 +82,9 @@ RUN pnpm install --frozen-lockfile --filter testplanit --ignore-scripts
 # Produce a self-contained production node_modules for testplanit (no symlinks
 # pointing outside the deploy dir), suitable for copying into the final images.
 COPY testplanit/ ./testplanit/
+# @testplanit/api workspace dependency, so `pnpm deploy` bundles it into the
+# self-contained production node_modules.
+COPY packages/api ./packages/api/
 RUN pnpm --filter=testplanit deploy --prod --legacy --ignore-scripts /app/deploy
 # Rebuild native modules in the deployed tree.
 RUN cd /app/deploy && npm rebuild bcrypt sharp 2>/dev/null || true


### PR DESCRIPTION
## Summary

The release Docker build's `next build` failed with `module-not-found` for `@testplanit/api` (imported by `app/api/test-results/import/route.ts`). PR #448 added the dependency on the `@testplanit/api` workspace package — it's declared (`workspace:*`) and symlinked — but the image build never made the package's files available:

- `.dockerignore` excluded `packages/api/dist` via the generic `packages/*/dist` glob, even though that dist is committed and not regenerated in-image.
- The Dockerfile only copied `packages/api/package.json`, never the package source/dist (the base stage was written assuming the app "has no workspace deps").

So the workspace symlink resolved to a directory with no `dist/`, and `next build` couldn't resolve the module.

## Fix

- `.dockerignore`: add a `!packages/api/dist` exception so the committed dist reaches the build context.
- `testplanit/Dockerfile`: `COPY packages/api ./packages/api/` in both the build stage (for `next build`) and the deps stage (so `pnpm deploy` bundles it into the self-contained production `node_modules`).

No package.json/lockfile change — the dependency is already declared.

## Verification

Built the full `production` target locally — the exact target the release builds. `next build` compiled and type-checked successfully (it previously failed at compile), and the production image exported cleanly.
