### PR TITLE
fix(repository): prevent test case edit crash from null dropdown option colors

### DIFF
--- a/testplanit/app/[locale]/error.tsx
+++ b/testplanit/app/[locale]/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex justify-center py-16">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <div className="flex items-center space-x-2">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            <CardTitle>{t("common.errors.error")}</CardTitle>
+          </div>
+          <CardDescription>
+            {t("common.errors.somethingWentWrong")}
+          </CardDescription>
+        </CardHeader>
+        {error.digest && (
+          <CardContent>
+            <p className="text-xs text-muted-foreground">{error.digest}</p>
+          </CardContent>
+        )}
+        <CardFooter>
+          <Button onClick={() => reset()}>{t("search.errors.tryAgain")}</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.test.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.test.tsx
@@ -354,6 +354,55 @@ describe("FieldValueRenderer", () => {
     });
   });
 
+  describe("Dropdown/Multi-Select options without an icon color", () => {
+    // Regression: FieldOptions.iconColorId and iconId are both nullable, so an
+    // option can legitimately have icon === null / iconColor === null. The
+    // edit-mode option renderers must guard these the same way view mode does,
+    // otherwise mapping over the options throws at render time and the page
+    // fails to load.
+    it("renders Dropdown in edit mode when an option has no icon or color", () => {
+      const template = makeTemplate(3, "Dropdown", [
+        { id: 10, name: "Option A", icon: null, iconColor: null },
+        { id: 11, name: "Option B", icon: { name: "circle" }, iconColor: null },
+      ]);
+
+      const { container } = render(
+        <FieldValueRenderer
+          {...defaultProps}
+          fieldValue={10}
+          fieldType="Dropdown"
+          template={template}
+          fieldId={3}
+          isEditMode={true}
+        />
+      );
+
+      expect(
+        container.querySelector('[data-testid="field-value-field-3"]')
+      ).toBeInTheDocument();
+    });
+
+    it("renders Multi-Select in edit mode when a selected option has no icon or color", () => {
+      const template = makeTemplate(4, "Multi-Select", [
+        { id: 20, name: "Tag Alpha", icon: null, iconColor: null },
+        { id: 21, name: "Tag Beta", icon: { name: "circle" }, iconColor: null },
+      ]);
+
+      render(
+        <FieldValueRenderer
+          {...defaultProps}
+          fieldValue={[20]}
+          fieldType="Multi-Select"
+          template={template}
+          fieldId={4}
+          isEditMode={true}
+        />
+      );
+
+      expect(screen.getByText("Tag Alpha")).toBeInTheDocument();
+    });
+  });
+
   describe("Date field", () => {
     it("renders DateFormatter in view mode", () => {
       const template = makeTemplate(5, "Date");

--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/FieldValueRenderer.tsx
@@ -229,8 +229,8 @@ const FieldValueRenderer: React.FC<FieldValueRendererProps> = ({
                         <div className="flex items-center">
                           <DynamicIcon
                             className="h-4 w-4 mr-1"
-                            name={option.fieldOption.icon.name}
-                            color={option.fieldOption.iconColor.value}
+                            name={option.fieldOption.icon?.name as IconName}
+                            color={option.fieldOption.iconColor?.value}
                           />
                           {option.fieldOption.name}
                         </div>
@@ -253,8 +253,8 @@ const FieldValueRenderer: React.FC<FieldValueRendererProps> = ({
                         <div className="flex items-center">
                           <DynamicIcon
                             className="h-4 w-4 mr-1"
-                            name={option.fieldOption.icon.name}
-                            color={option.fieldOption.iconColor.value}
+                            name={option.fieldOption.icon?.name as IconName}
+                            color={option.fieldOption.iconColor?.value}
                           />
                           {option.fieldOption.name}
                         </div>
@@ -322,8 +322,8 @@ const FieldValueRenderer: React.FC<FieldValueRendererProps> = ({
                         <div className="flex items-center">
                           <DynamicIcon
                             className="shrink-0 mr-1"
-                            name={option.fieldOption.icon.name}
-                            color={option.fieldOption.iconColor.value}
+                            name={option.fieldOption.icon?.name as IconName}
+                            color={option.fieldOption.iconColor?.value}
                           />
                           {option.fieldOption.name}
                         </div>

--- a/testplanit/components/FieldIconPicker.test.tsx
+++ b/testplanit/components/FieldIconPicker.test.tsx
@@ -1,0 +1,103 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseFindManyFieldIcon = vi.fn();
+const mockUseFindManyColor = vi.fn();
+
+vi.mock("~/lib/hooks", () => ({
+  useFindManyFieldIcon: (...args: any[]) => mockUseFindManyFieldIcon(...args),
+  useFindManyColor: (...args: any[]) => mockUseFindManyColor(...args),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("./DynamicIcon", () => ({
+  default: () => <span data-testid="dynamic-icon" />,
+}));
+
+vi.mock("@/components/ColorPicker", () => ({
+  ColorPicker: () => <div data-testid="color-picker" />,
+}));
+
+import { FieldIconPicker } from "./FieldIconPicker";
+
+const icons = [
+  { id: 1, name: "layout-list" },
+  { id: 2, name: "circle" },
+];
+
+// Deliberately unsorted to prove the darkest shade (order 0) is chosen, not
+// the first array entry.
+const colors = [
+  {
+    id: 30,
+    order: 2,
+    value: "#838485",
+    colorFamily: { id: 1, name: "Black", order: 1 },
+  },
+  {
+    id: 31,
+    order: 0,
+    value: "#333435",
+    colorFamily: { id: 1, name: "Black", order: 1 },
+  },
+  {
+    id: 40,
+    order: 0,
+    value: "#8D2007",
+    colorFamily: { id: 2, name: "Red", order: 2 },
+  },
+];
+
+describe("FieldIconPicker color default", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFindManyFieldIcon.mockReturnValue({
+      data: icons,
+      isLoading: false,
+    });
+    mockUseFindManyColor.mockReturnValue({ data: colors, isLoading: false });
+  });
+
+  it("defaults to the darkest black color when none is selected", async () => {
+    const onColorSelect = vi.fn();
+
+    render(
+      <FieldIconPicker onIconSelect={vi.fn()} onColorSelect={onColorSelect} />
+    );
+
+    await waitFor(() => expect(onColorSelect).toHaveBeenCalledWith(31));
+  });
+
+  it("does not override an explicitly selected color", async () => {
+    const onColorSelect = vi.fn();
+    const onIconSelect = vi.fn();
+
+    render(
+      <FieldIconPicker
+        onIconSelect={onIconSelect}
+        onColorSelect={onColorSelect}
+        initialColorId={40}
+        initialIconId={2}
+      />
+    );
+
+    // Let any effects flush.
+    await waitFor(() => expect(onIconSelect).not.toHaveBeenCalled());
+    expect(onColorSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt a color default when no color handler is provided", async () => {
+    const onIconSelect = vi.fn();
+
+    expect(() =>
+      render(<FieldIconPicker onIconSelect={onIconSelect} />)
+    ).not.toThrow();
+
+    // Icon still auto-defaults to layout-list; no color handler to call.
+    await waitFor(() => expect(onIconSelect).toHaveBeenCalledWith(1));
+  });
+});

--- a/testplanit/components/FieldIconPicker.tsx
+++ b/testplanit/components/FieldIconPicker.tsx
@@ -67,6 +67,21 @@ export const FieldIconPicker: React.FC<FieldIconPickerProps> = ({
     }
   }, [allIcons, selectedIconId, initialIconId, onIconSelect]);
 
+  useEffect(() => {
+    if (colors && onColorSelect && !selectedColorId && !initialColorId) {
+      const darkestBlackId =
+        [...colors]
+          .filter((color) => color.colorFamily?.name === "Black")
+          .sort((a, b) => a.order - b.order)[0]?.id ??
+        colors[0]?.id ??
+        null;
+      if (darkestBlackId != null) {
+        setSelectedColorId(darkestBlackId);
+        onColorSelect(darkestBlackId);
+      }
+    }
+  }, [colors, onColorSelect, selectedColorId, initialColorId]);
+
   const filteredIcons = allIcons?.filter((icon) =>
     icon.name.toLowerCase().includes(searchQuery.toLowerCase())
   );


### PR DESCRIPTION
## Description

Opening a repository test case in **edit mode** crashed to the opaque "this page couldn't load" screen when any of the case's Dropdown / Multi-Select field options had no icon color.

`FieldOptions.iconColorId` is nullable, so an option can legitimately have `iconColor == null`. The view-mode renderer guards this with optional chaining, but the edit-mode option renderers read `option.fieldOption.iconColor.value` (and `icon.name`) unguarded — so a single null-colored option threw during render. With no error boundary anywhere in the app, Next.js fell back to its default error page. The case viewed and bulk-edited fine; only inline edit crashed, which is why it was hard to reproduce.

This PR fixes the crash, prevents the bad data going forward, and adds a recovery boundary:

- **Guard the render** — edit-mode Dropdown/Multi-Select option renderers now use optional chaining for `icon`/`iconColor`, matching the existing view-mode pattern.
- **Prevent null colors** — new option colors now default to the darkest black instead of being saved as `null`, mirroring the existing icon default in the field icon picker. (Editing and saving an existing option that already has a null color also heals it.)
- **Add an error boundary** — a render exception now shows a recoverable message with a "Try again" action instead of an opaque failure. This class of client-side render crash was previously invisible to server logs.

## Related Issue

N/A — reported via customer support.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Added regression tests for both the crash and the null-color default. Each was verified to **fail without the fix** (reproducing the exact `TypeError: Cannot read properties of null`) and pass with it. Full local suite green via `pnpm precommit` (9775 passing).

**Test Configuration:**
- OS: macOS (darwin 25.4.0)
- Browser (if applicable): N/A
- Node version: v24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The component fix is the root-cause fix; the color default prevents new null-colored options; the error boundary is defense-in-depth for this class of otherwise-silent client render crash.
