### PR TITLE
fix(tags): persist tag selections in the case and session editors

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/[caseId]/page.tsx
@@ -914,7 +914,11 @@ export default function TestCaseDetails() {
       folderId: testcase.folderId,
       estimate: testcase.estimate ? formatSeconds(testcase.estimate) : "",
       automated: testcase.automated,
-      tags: testcase.tags?.map((tag: any) => tag.id) || [],
+      // Preserve the in-progress tag selection across re-runs of this effect (e.g. creating a tag
+      // invalidates the Tags query and refetches the case, re-firing this reset). Without this the
+      // user's edits to tags are silently reverted to the case's saved tags, like issues below.
+      tags:
+        currentValues.tags || testcase.tags?.map((tag: any) => tag.id) || [],
       // Preserve existing issues value if it's already set (from external issues)
       issues:
         currentValues.issues ||

--- a/testplanit/app/[locale]/projects/sessions/[projectId]/[sessionId]/page.tsx
+++ b/testplanit/app/[locale]/projects/sessions/[projectId]/[sessionId]/page.tsx
@@ -804,6 +804,10 @@ export default function SessionPage() {
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  // Initialize selectedTags from the loaded session ONCE. Creating a tag invalidates parent queries
+  // (the session includes its tags), refetching sessionData; without this guard the re-sync effect
+  // below would revert the user's in-progress tag edits on that refetch.
+  const hasInitializedTagsRef = useRef(false);
   const [missionContent, setMissionContent] =
     useState<JSONContent>(emptyEditorContent);
   const [noteContent, setNoteContent] =
@@ -1251,7 +1255,6 @@ export default function SessionPage() {
         keepDefaultValues: true,
       });
       setInitialValues(formValues);
-      setSelectedTags(sessionData.tags.map((tag) => tag.id));
 
       // Delay setting form as initialized
       requestAnimationFrame(() => {
@@ -1402,10 +1405,12 @@ export default function SessionPage() {
     }
   }, [sessionData, sessionData?.note, sessionData?.mission]);
 
-  // Add useEffect for initial tags
+  // Initialize the tag selection from the loaded session, once (see hasInitializedTagsRef) so a
+  // tag-create refetch of sessionData does not revert in-progress edits.
   useEffect(() => {
-    if (sessionData) {
+    if (sessionData && !hasInitializedTagsRef.current) {
       setSelectedTags(sessionData.tags.map((tag) => tag.id));
+      hasInitializedTagsRef.current = true;
     }
   }, [sessionData]);
 


### PR DESCRIPTION
## Problem

Adding a tag in the **case** or **session** editor created the Tag but never linked it — the new tag (and any existing tag selected alongside it) was silently dropped on save. The **run** editor was unaffected.

## Root cause

Creating a tag invalidates the parent queries: the tanstack-query plugin invalidates the `RepositoryCases` / `Sessions` queries because they *include* `tags`. That refetches the case/session, which re-fires a reset/re-sync effect that reverts the user's in-progress tag selection back to the saved tags **before the form submits** — so `tags: { set: [] }` / `connect: []` persists nothing. The chips also visibly disappear a moment after selection (the refetch window).

The run editor was immune because it keeps tags in plain `useState`, with no such re-sync.

## Fix

- **Case editor** — the defaults-restore effect now preserves the current tags value (`currentValues.tags`), exactly mirroring how `issues` was already preserved one line below.
- **Session editor** — `selectedTags` is initialized from the loaded session **once** (guarded by a ref) instead of re-syncing on every `sessionData` change.

## Verification

Built the branch and ran it against a real database. Adding both an existing tag and a newly created tag to a case and a session now persists the join after save and survives the create-tag refetch window:

- Case → 2 tags (existing + new)
- Session → 1 tag (new)

Both were 0 before the fix.
