### PR TITLE
fix(integrations): unblock Jira OAuth authorize + align admin action icons

### DIFF
--- a/testplanit/app/[locale]/admin/integrations/AuthorizeIntegrationButton.tsx
+++ b/testplanit/app/[locale]/admin/integrations/AuthorizeIntegrationButton.tsx
@@ -12,6 +12,12 @@ import { useTranslations } from "next-intl";
 
 interface AuthorizeIntegrationButtonProps {
   integration: Integration;
+  /**
+   * When true, render an invisible, non-interactive button that occupies the
+   * exact same footprint as the real one, so the remaining action icons stay
+   * aligned on rows where authorization doesn't apply.
+   */
+  placeholder?: boolean;
 }
 
 /**
@@ -22,6 +28,7 @@ interface AuthorizeIntegrationButtonProps {
  */
 export function AuthorizeIntegrationButton({
   integration,
+  placeholder = false,
 }: AuthorizeIntegrationButtonProps) {
   const t = useTranslations("admin.integrations");
 
@@ -31,6 +38,21 @@ export function AuthorizeIntegrationButton({
     });
     window.location.href = `/api/integrations/oauth/${integration.provider.toLowerCase()}/auth?${params.toString()}`;
   };
+
+  // Reserve the slot with the same Button + icon (identical size) but hidden
+  // and inert, so action icons line up across rows that don't show Authorize.
+  if (placeholder) {
+    return (
+      <Button
+        variant="ghost"
+        className="px-2 py-1 h-auto invisible pointer-events-none"
+        aria-hidden="true"
+        tabIndex={-1}
+      >
+        <ShieldCheck className="h-4 w-4" />
+      </Button>
+    );
+  }
 
   return (
     <Tooltip>

--- a/testplanit/app/[locale]/admin/integrations/columns.tsx
+++ b/testplanit/app/[locale]/admin/integrations/columns.tsx
@@ -249,13 +249,19 @@ export const useColumns = (
         meta: { isPinned: "right" },
         cell: ({ row }) => (
           <div className="bg-primary-foreground whitespace-nowrap flex justify-center gap-1">
-            {row.original.authType === "OAUTH2" &&
-              row.original.status === "INACTIVE" && (
-                <AuthorizeIntegrationButton
-                  key={`authorize-${row.original.id}`}
-                  integration={row.original}
-                />
-              )}
+            {/* Always render the Authorize slot. Rows that aren't an
+                unauthorized OAuth integration get an invisible, same-size
+                placeholder so the remaining action icons stay aligned. */}
+            <AuthorizeIntegrationButton
+              key={`authorize-${row.original.id}`}
+              integration={row.original}
+              placeholder={
+                !(
+                  row.original.authType === "OAUTH2" &&
+                  row.original.status === "INACTIVE"
+                )
+              }
+            />
             <SyncIntegrationButton
               key={`sync-${row.original.id}`}
               integration={row.original}

--- a/testplanit/app/api/integrations/oauth/[type]/auth/route.test.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/auth/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// Shared mock fns (hoisted so the vi.mock factories can reference them).
+const {
+  getServerSessionMock,
+  getEnhancedDbMock,
+  integrationFindUniqueMock,
+  generateStateMock,
+  storeOAuthStateMock,
+  getAdapterMock,
+  getAuthorizationUrlMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  getEnhancedDbMock: vi.fn(),
+  integrationFindUniqueMock: vi.fn(),
+  generateStateMock: vi.fn(),
+  storeOAuthStateMock: vi.fn(),
+  getAdapterMock: vi.fn(),
+  getAuthorizationUrlMock: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: getServerSessionMock,
+}));
+vi.mock("~/server/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/auth/utils", () => ({ getEnhancedDb: getEnhancedDbMock }));
+vi.mock("~/lib/integrations/AuthenticationService", () => ({
+  AuthenticationService: {
+    generateState: generateStateMock,
+    storeOAuthState: storeOAuthStateMock,
+  },
+}));
+vi.mock("~/lib/integrations/IntegrationManager", () => ({
+  IntegrationManager: {
+    getInstance: () => ({ getAdapter: getAdapterMock }),
+  },
+}));
+
+import { GET } from "./route";
+
+const buildGet = (query: string) =>
+  new NextRequest(
+    `http://localhost:3000/api/integrations/oauth/jira/auth${query}`
+  );
+const params = { params: Promise.resolve({ type: "jira" }) };
+
+describe("GET /api/integrations/oauth/[type]/auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    getEnhancedDbMock.mockResolvedValue({
+      integration: { findUnique: integrationFindUniqueMock },
+    });
+    // The integration is INACTIVE — the exact state an OAuth integration is in
+    // before its first authorization, and the state that previously made
+    // getAdapter throw "Integration is not active" → a 500 on this route.
+    integrationFindUniqueMock.mockResolvedValue({
+      id: 2,
+      provider: "JIRA",
+      status: "INACTIVE",
+      authType: "OAUTH2",
+    });
+    generateStateMock.mockReturnValue("state-123");
+    storeOAuthStateMock.mockResolvedValue(undefined);
+    getAuthorizationUrlMock.mockReturnValue(
+      "https://auth.atlassian.com/authorize?client_id=abc&redirect_uri=https%3A%2F%2Fapp%2Fapi%2Fintegrations%2Foauth%2Fjira%2Fcallback&state=state-123&response_type=code"
+    );
+    getAdapterMock.mockResolvedValue({
+      supportsOAuth: true,
+      getAuthorizationUrl: getAuthorizationUrlMock,
+    });
+  });
+
+  it("redirects an INACTIVE OAuth integration to the provider authorize URL (no 500 deadlock)", async () => {
+    const response = await GET(buildGet("?integrationId=2"), params);
+
+    // Must be a redirect to the provider, never a 500. Before the fix,
+    // getAdapter threw on the inactive integration and this route 500'd.
+    expect([302, 307]).toContain(response.status);
+    expect(response.headers.get("location") ?? "").toContain(
+      "https://auth.atlassian.com/authorize"
+    );
+  });
+
+  it("builds the adapter with allowInactive so the active-check doesn't block setup", async () => {
+    await GET(buildGet("?integrationId=2"), params);
+
+    // The wiring that breaks the deadlock: the route must ask getAdapter to
+    // allow an inactive integration during the authorization handshake.
+    expect(getAdapterMock).toHaveBeenCalledWith(
+      "2",
+      undefined,
+      undefined,
+      expect.objectContaining({ allowInactive: true })
+    );
+    expect(storeOAuthStateMock).toHaveBeenCalledWith("user-1", 2, "state-123");
+  });
+
+  it("returns 400 when integrationId is missing", async () => {
+    const response = await GET(buildGet(""), params);
+    expect(response.status).toBe(400);
+  });
+});

--- a/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
@@ -54,9 +54,14 @@ export async function GET(
     const manager = IntegrationManager.getInstance();
     // The integration is intentionally inactive until this authorization
     // completes, so allow building the adapter to generate the authorize URL.
-    const adapter = await manager.getAdapter(integrationId, undefined, undefined, {
-      allowInactive: true,
-    });
+    const adapter = await manager.getAdapter(
+      integrationId,
+      undefined,
+      undefined,
+      {
+        allowInactive: true,
+      }
+    );
 
     if (!adapter) {
       return NextResponse.json(

--- a/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
@@ -52,7 +52,11 @@ export async function GET(
 
     // Get the appropriate adapter based on the integration
     const manager = IntegrationManager.getInstance();
-    const adapter = await manager.getAdapter(integrationId);
+    // The integration is intentionally inactive until this authorization
+    // completes, so allow building the adapter to generate the authorize URL.
+    const adapter = await manager.getAdapter(integrationId, undefined, undefined, {
+      allowInactive: true,
+    });
 
     if (!adapter) {
       return NextResponse.json(

--- a/testplanit/app/api/integrations/oauth/[type]/callback/route.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/callback/route.ts
@@ -78,7 +78,15 @@ export async function GET(
 
     // Get the appropriate adapter
     const manager = IntegrationManager.getInstance();
-    const adapter = await manager.getAdapter(integrationId!.toString());
+    // The integration is still inactive at callback time (it's flipped to
+    // ACTIVE below, once a token is stored), so allow building the adapter to
+    // exchange the authorization code for tokens.
+    const adapter = await manager.getAdapter(
+      integrationId!.toString(),
+      undefined,
+      undefined,
+      { allowInactive: true }
+    );
 
     if (!adapter || !adapter.exchangeCodeForTokens) {
       return NextResponse.redirect(

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -287,6 +287,28 @@ describe("IntegrationManager", () => {
       );
     });
 
+    it("builds an adapter for an inactive integration when allowInactive is set (OAuth authorization flow)", async () => {
+      // OAuth integrations are inactive until authorized; the authorize and
+      // callback routes must still be able to build the adapter to run the
+      // handshake. Without allowInactive this would throw and deadlock setup.
+      mockPrisma.integration.findUnique.mockResolvedValue({
+        id: 2,
+        name: "Jira OAuth",
+        provider: "JIRA",
+        status: "INACTIVE",
+        authType: "OAUTH2",
+        credentials: { clientId: "abc", clientSecret: "shh" },
+        settings: { baseUrl: "https://test.atlassian.net" },
+        userIntegrationAuths: [],
+      });
+
+      const adapter = await manager.getAdapter("2", undefined, undefined, {
+        allowInactive: true,
+      });
+
+      expect(adapter).toBeTruthy();
+    });
+
     it("should throw error when no adapter registered for provider", async () => {
       mockPrisma.integration.findUnique.mockResolvedValue({
         id: 1,

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -68,7 +68,8 @@ export class IntegrationManager {
   async getAdapter(
     integrationId: string,
     prismaClient?: typeof prisma,
-    userId?: string
+    userId?: string,
+    options?: { allowInactive?: boolean }
   ): Promise<IssueAdapter | null> {
     // OAuth adapters carry a per-user token, so they must be cached per user
     const cacheKey = userId ? `${integrationId}:${userId}` : integrationId;
@@ -95,7 +96,13 @@ export class IntegrationManager {
       throw new Error(`Integration not found: ${integrationId}`);
     }
 
-    if (integration.status !== "ACTIVE") {
+    // OAuth 2.0 (3LO) integrations are intentionally inactive until a user
+    // completes authorization — and the authorization flow itself needs the
+    // adapter to build the authorize URL and to exchange the code for tokens.
+    // Those two routes pass allowInactive so the setup handshake isn't blocked
+    // by the very state it exists to resolve (otherwise an OAuth integration
+    // can never become active). Every other caller still requires ACTIVE.
+    if (integration.status !== "ACTIVE" && !options?.allowInactive) {
       throw new Error(`Integration is not active: ${integrationId}`);
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups to #462 (per-integration Jira OAuth) that make the OAuth flow actually complete from the admin UI.

### 1. Fix the OAuth authorize deadlock (the blocker)
A new OAuth 2.0 (3LO) integration is intentionally **inactive** until a user authorizes — but `IntegrationManager.getAdapter` threw `Integration is not active` for any non-ACTIVE integration. Both the authorize **and** callback routes go through `getAdapter`, so the very flow that *activates* an integration could never run: clicking **Authorize** returned a 500 and the integration stayed stuck at "Awaiting authorization".

- Add an `allowInactive` option to `getAdapter`; the OAuth `auth` + `callback` routes pass it. The ACTIVE guard still applies to every normal issue operation.
- Root-caused from the live failure: `Error: Integration is not active: 2 at getAdapter`.

### 2. Align admin action icons
The Authorize (shield) action only renders for unauthorized OAuth integrations, so on other rows the remaining icons shifted left. The previous `w-8` spacer only approximated the button width. Now non-applicable rows render the real button in an invisible, inert placeholder mode (`visibility:hidden`, `pointer-events-none`, `aria-hidden`) — a pixel-identical slot — so Sync/Test/Edit/Delete line up across all rows.

## Testing
- New regression coverage at both layers: the `getAdapter` test builds an inactive adapter only with `allowInactive`, and a new auth-route test asserts an inactive integration **redirects to the provider** instead of 500ing. The `getAdapter` test **fails if the guard fix is reverted** — closing the gap that let the original deadlock ship green.
- `pnpm test` (affected suites, 128 passing), `pnpm type-check`, and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)