### PR TITLE
fix: Jira OAuth callback/adapter fixes + single-use magic-link notice

### DIFF
--- a/testplanit/app/api/integrations/oauth/[type]/callback/route.test.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/callback/route.test.ts
@@ -123,4 +123,24 @@ describe("GET /api/integrations/oauth/[type]/callback", () => {
     expect(location.startsWith("http")).toBe(true);
     expect(location).toContain("oauth_callback_failed");
   });
+
+  it("builds the redirect from NEXTAUTH_URL, not the (internal) request host", async () => {
+    // Behind the k8s ingress the request arrives with the pod hostname; the
+    // post-auth redirect must use the public app URL or the browser lands on
+    // a connection error after a successful authorization.
+    vi.stubEnv("NEXTAUTH_URL", "https://demo.testplanit.com");
+    const req = new NextRequest(
+      "http://demo-prod-abc123/api/integrations/oauth/gitea/callback?code=abc&state=xyz"
+    );
+
+    const response = await GET(req, params);
+
+    expect([302, 307]).toContain(response.status);
+    const location = response.headers.get("location") ?? "";
+    expect(location.startsWith("https://demo.testplanit.com/")).toBe(true);
+    expect(location).not.toContain("demo-prod-abc123");
+    expect(location).toContain("success=connected");
+
+    vi.unstubAllEnvs();
+  });
 });

--- a/testplanit/app/api/integrations/oauth/[type]/callback/route.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/callback/route.ts
@@ -9,13 +9,21 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ type: string }> }
 ) {
+  // Build post-OAuth redirects from the app's public URL, NOT request.url.
+  // Behind the k8s ingress, request.url resolves to the internal pod hostname
+  // (e.g. http://demo-prod-xxxx/...), so a Location built from it is
+  // unreachable — the user lands on a connection error right after a
+  // successful authorization. NEXTAUTH_URL is the public origin; fall back to
+  // the request origin only if it's somehow unset.
+  const baseUrl = process.env.NEXTAUTH_URL || new URL(request.url).origin;
+  const redirectTo = (path: string) =>
+    NextResponse.redirect(new URL(path, baseUrl));
+
   try {
     // Check if user is authenticated
     const session = await getServerSession(authOptions);
     if (!session?.user) {
-      return NextResponse.redirect(
-        new URL("/signin?error=unauthorized", request.url)
-      );
+      return redirectTo("/signin?error=unauthorized");
     }
 
     // Get OAuth parameters
@@ -30,18 +38,13 @@ export async function GET(
         "OAuth authorization failed";
       const { type } = await params;
       console.error(`OAuth error for ${type}:`, error, errorDescription);
-      return NextResponse.redirect(
-        new URL(
-          `/projects/settings?error=${encodeURIComponent(errorDescription)}`,
-          request.url
-        )
+      return redirectTo(
+        `/projects/settings?error=${encodeURIComponent(errorDescription)}`
       );
     }
 
     if (!code || !state) {
-      return NextResponse.redirect(
-        new URL("/projects/settings?error=missing_oauth_params", request.url)
-      );
+      return redirectTo("/projects/settings?error=missing_oauth_params");
     }
 
     // Get enhanced Prisma client for the user
@@ -71,9 +74,7 @@ export async function GET(
     }
 
     if (!validIntegration) {
-      return NextResponse.redirect(
-        new URL("/projects/settings?error=invalid_state", request.url)
-      );
+      return redirectTo("/projects/settings?error=invalid_state");
     }
 
     // Get the appropriate adapter
@@ -89,9 +90,7 @@ export async function GET(
     );
 
     if (!adapter || !adapter.exchangeCodeForTokens) {
-      return NextResponse.redirect(
-        new URL("/projects/settings?error=adapter_init_failed", request.url)
-      );
+      return redirectTo("/projects/settings?error=adapter_init_failed");
     }
 
     // Exchange code for tokens
@@ -130,22 +129,15 @@ export async function GET(
     const projectId = (validIntegration as any).issueConfigs?.[0]?.projects?.[0]
       ?.id;
     if (projectId) {
-      return NextResponse.redirect(
-        new URL(
-          `/projects/settings/${projectId}/integrations?success=connected`,
-          request.url
-        )
+      return redirectTo(
+        `/projects/settings/${projectId}/integrations?success=connected`
       );
     } else {
-      return NextResponse.redirect(
-        new URL("/admin/integrations?success=connected", request.url)
-      );
+      return redirectTo("/admin/integrations?success=connected");
     }
   } catch (error) {
     const { type } = await params;
     console.error(`Error in OAuth callback endpoint for ${type}:`, error);
-    return NextResponse.redirect(
-      new URL("/projects/settings?error=oauth_callback_failed", request.url)
-    );
+    return redirectTo("/projects/settings?error=oauth_callback_failed");
   }
 }

--- a/testplanit/lib/email/magicLink.ts
+++ b/testplanit/lib/email/magicLink.ts
@@ -45,6 +45,7 @@ export async function sendMagicLinkEmail(
     "email.magicLink.intro",
     "email.magicLink.signInButton",
     "email.magicLink.copyPasteIntro",
+    "email.magicLink.singleUseNotice",
     "email.magicLink.disclaimer",
     "email.magicLink.textBody",
   ]);
@@ -71,6 +72,7 @@ export async function sendMagicLinkEmail(
       <a href="${args.url}" style="display: inline-block; background-color: ${PURPLE}; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 16px 0;">${t["email.magicLink.signInButton"]}</a>
       <p style="color: #666; font-size: 14px;">${t["email.magicLink.copyPasteIntro"]}</p>
       <p style="color: #666; font-size: 14px; word-break: break-all;">${args.url}</p>
+      <p style="color: #666; font-size: 14px; background-color: #f3f0ff; border-left: 3px solid ${PURPLE}; padding: 12px 16px; border-radius: 4px; margin: 24px 0;">${t["email.magicLink.singleUseNotice"]}</p>
       <p style="color: #999; font-size: 12px; margin-top: 32px;">${t["email.magicLink.disclaimer"]}</p>
     </div>
   `;

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -309,6 +309,31 @@ describe("IntegrationManager", () => {
       expect(adapter).toBeTruthy();
     });
 
+    it("does NOT cache adapters built with allowInactive (avoids poisoning a pod with an unauthenticated, cloud-id-less adapter)", async () => {
+      mockPrisma.integration.findUnique.mockResolvedValue({
+        id: 2,
+        name: "Jira OAuth",
+        provider: "JIRA",
+        status: "INACTIVE",
+        authType: "OAUTH2",
+        credentials: { clientId: "abc", clientSecret: "shh" },
+        settings: { baseUrl: "https://test.atlassian.net" },
+        userIntegrationAuths: [],
+      });
+
+      // First call builds the transient setup adapter…
+      await manager.getAdapter("2", undefined, undefined, {
+        allowInactive: true,
+      });
+      // …a second call must rebuild from the DB rather than return a cached
+      // (unauthenticated, no cloud ID) instance.
+      await manager.getAdapter("2", undefined, undefined, {
+        allowInactive: true,
+      });
+
+      expect(mockPrisma.integration.findUnique).toHaveBeenCalledTimes(2);
+    });
+
     it("should throw error when no adapter registered for provider", async () => {
       mockPrisma.integration.findUnique.mockResolvedValue({
         id: 1,

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -200,8 +200,18 @@ export class IntegrationManager {
       await adapter.authenticate(authData);
     }
 
-    // Cache the adapter
-    this.adapterCache.set(cacheKey, adapter);
+    // Cache the adapter — but never the transient ones built for the OAuth
+    // setup handshake (allowInactive). Those are constructed before a user
+    // token exists, so they are unauthenticated and have no cloud ID. Caching
+    // one under the shared integration key poisons later real requests on this
+    // pod with "Cloud ID not set" until it restarts — and because each pod has
+    // its own cache (and the callback's clearAdapter only clears the pod it
+    // runs on), other replicas would keep serving the stale adapter. The auth
+    // and callback routes each use their adapter once, so skipping the cache
+    // costs nothing.
+    if (!options?.allowInactive) {
+      this.adapterCache.set(cacheKey, adapter);
+    }
 
     return adapter;
   }

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1095,7 +1095,7 @@
     "errors": {
       "accessDenied": "Access denied. Your account may be inactive or you don't have permission to sign in.",
       "configuration": "There is a problem with the server configuration.",
-      "verification": "The verification token has expired or has already been used.",
+      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
       "invalid2FACode": "Invalid verification code. Please try again.",
       "twoFactorTokenRequired": "Token is required",
       "verificationCodeRequired": "Verification code is required"
@@ -7643,8 +7643,9 @@
       "intro": "Click the button below to sign in:",
       "signInButton": "Sign In",
       "copyPasteIntro": "Or copy and paste this link into your browser:",
+      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
       "disclaimer": "If you did not request this email, you can safely ignore it.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
     }
   },
   "comments": {


### PR DESCRIPTION
## Summary

Patch-release follow-up to #462/#463. Three changes that should ship together in the next patch:

### 1. Build OAuth callback redirects from `NEXTAUTH_URL`
After a successful authorization, the callback built its redirect from `request.url`. Behind the k8s ingress that resolves to the internal **pod hostname** (e.g. `demo-prod-xxxx`), so the browser landed on a "site cannot be reached" page even though the token was stored and the integration activated. All callback redirects now use `NEXTAUTH_URL` (the public origin), falling back to the request origin only if unset.

### 2. Do not cache the OAuth setup adapter (fixes intermittent `Cloud ID not set`)
`getAdapter` cached the transient, unauthenticated adapter built during the authorize/callback handshake (`allowInactive`) under the shared `integrationId` cache key. That adapter has no user token and no Jira cloud ID, so later issue searches routed to the same pod failed with `HTTP 500: failed to search external issues` (`JiraAdapter: Cloud ID not set`). Across replicas it was intermittent — `clearAdapter` only clears the pod it runs on. `allowInactive` builds are now never cached.

### 3. Magic-link single-use notice (sign-in email + error)
Add a single-use notice to the magic-link email (HTML + text body) and reword the verification error so users understand an expired/already-used link must be re-requested. `en-US` only — Crowdin manages the other locales.

## Testing
- Regression tests for the OAuth fixes (cache test fails if reverted; callback test asserts a pod-host request still redirects to the public URL).
- `pnpm test` (affected suites), `type-check`, `lint`, `prettier` all pass.
- OAuth flow verified live on the demo: Authorize → consent → callback → **Active**, and issue search returns results consistently.

No changeset — the `testplanit` app is in the changeset ignore list (same as #462/#463); the app patch version is cut from `main` by release automation on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
