### PR TITLE
fix(integrations): keep Jira reads working past token expiry and persist created issues

### DIFF
--- a/testplanit/app/api/integrations/[id]/create-issue/route.test.ts
+++ b/testplanit/app/api/integrations/[id]/create-issue/route.test.ts
@@ -295,6 +295,53 @@ describe("POST /api/integrations/[id]/create-issue", () => {
       expect(prisma.issue.upsert).toHaveBeenCalledOnce();
       expect(data.internalId).toBe(99);
     });
+
+    it("persists tracker columns (key in name, externalKey/Url/Status, issue type) so it renders like a synced issue", async () => {
+      mockAdapter.createIssue.mockResolvedValue({
+        id: "ext-123",
+        key: "PROJ-7",
+        title: "Render Me",
+        description: "<p>body</p>",
+        status: "To Do",
+        priority: "High",
+        url: "https://example.com/browse/PROJ-7",
+        issueType: {
+          id: "10001",
+          name: "Bug",
+          iconUrl: "https://example.com/bug.png",
+        },
+        labels: ["x"],
+      });
+
+      const response = await POST(
+        createRequest({
+          title: "Render Me",
+          projectId: "PROJ",
+          testCaseId: "42",
+        }),
+        params
+      );
+      expect(response.status).toBe(200);
+
+      const upsertArg = (prisma.issue.upsert as any).mock.calls[0][0];
+      // Regression: the issue key — not the title — must land in `name`, and the
+      // first-class columns the UI reads must be populated (were empty before).
+      expect(upsertArg.create.name).toBe("PROJ-7");
+      expect(upsertArg.create.externalKey).toBe("PROJ-7");
+      expect(upsertArg.create.externalUrl).toBe(
+        "https://example.com/browse/PROJ-7"
+      );
+      expect(upsertArg.create.externalStatus).toBe("To Do");
+      expect(upsertArg.create.status).toBe("To Do");
+      expect(upsertArg.create.issueTypeId).toBe("10001");
+      expect(upsertArg.create.issueTypeName).toBe("Bug");
+      expect(upsertArg.create.issueTypeIconUrl).toBe(
+        "https://example.com/bug.png"
+      );
+      // The update branch refreshes the same columns.
+      expect(upsertArg.update.name).toBe("PROJ-7");
+      expect(upsertArg.update.externalKey).toBe("PROJ-7");
+    });
   });
 
   describe("Error handling", () => {

--- a/testplanit/app/api/integrations/[id]/create-issue/route.ts
+++ b/testplanit/app/api/integrations/[id]/create-issue/route.ts
@@ -359,6 +359,66 @@ export async function POST(
       validatedData.testRunResultId ||
       validatedData.testRunStepResultId
     ) {
+      // Entity links to (re)connect on both create and update.
+      const linkConnects = {
+        ...(validatedData.testCaseId && {
+          repositoryCases: {
+            connect: { id: parseInt(validatedData.testCaseId) },
+          },
+        }),
+        ...(validatedData.testRunId && {
+          testRuns: {
+            connect: { id: parseInt(validatedData.testRunId) },
+          },
+        }),
+        ...(validatedData.sessionId && {
+          sessions: {
+            connect: { id: parseInt(validatedData.sessionId) },
+          },
+        }),
+        ...(validatedData.testRunResultId && {
+          testRunResults: {
+            connect: { id: parseInt(validatedData.testRunResultId) },
+          },
+        }),
+        ...(validatedData.testRunStepResultId && {
+          testRunStepResults: {
+            connect: { id: parseInt(validatedData.testRunStepResultId) },
+          },
+        }),
+      };
+
+      // Populate the same first-class columns a synced/webhooked issue gets
+      // (mirrors SyncService's issueFields) so a created issue renders with its
+      // key, Jira link, status, and hover details everywhere — not just as a
+      // title with the key buried in the data blob.
+      const trackerFields = {
+        name: createdIssue.key || createdIssue.id,
+        title: createdIssue.title,
+        description: createdIssue.description ?? "",
+        status: createdIssue.status,
+        priority: createdIssue.priority || "medium",
+        externalKey: createdIssue.key || createdIssue.id,
+        externalUrl: createdIssue.url,
+        externalStatus: createdIssue.status,
+        externalData: createdIssue.customFields || {},
+        issueTypeId: createdIssue.issueType?.id,
+        issueTypeName: createdIssue.issueType?.name,
+        issueTypeIconUrl: createdIssue.issueType?.iconUrl,
+        lastSyncedAt: new Date(),
+        data: {
+          id: createdIssue.id,
+          key: createdIssue.key,
+          url: createdIssue.url,
+          status: createdIssue.status,
+          priority: createdIssue.priority,
+          assignee: createdIssue.assignee,
+          reporter: createdIssue.reporter,
+          labels: createdIssue.labels,
+          customFields: createdIssue.customFields,
+        },
+      };
+
       // Use upsert to handle cases where the issue already exists
       const issue = await prisma.issue.upsert({
         where: {
@@ -368,91 +428,17 @@ export async function POST(
           },
         },
         create: {
-          name: createdIssue.title,
-          title: createdIssue.title, // Use the same value for title
+          ...trackerFields,
           externalId: createdIssue.key || createdIssue.id,
-          data: {
-            id: createdIssue.id,
-            key: createdIssue.key,
-            url: createdIssue.url,
-            status: createdIssue.status,
-            priority: createdIssue.priority,
-            assignee: createdIssue.assignee,
-            reporter: createdIssue.reporter,
-            labels: createdIssue.labels,
-            customFields: createdIssue.customFields,
-          },
           integrationId: parseInt(integrationId),
           // Use the internal TestPlanIt project ID (from request or derived from linked entities)
           projectId: internalProjectId,
           createdById: session.user.id,
-          // Link to the appropriate entities
-          ...(validatedData.testCaseId && {
-            repositoryCases: {
-              connect: { id: parseInt(validatedData.testCaseId) },
-            },
-          }),
-          ...(validatedData.testRunId && {
-            testRuns: {
-              connect: { id: parseInt(validatedData.testRunId) },
-            },
-          }),
-          ...(validatedData.sessionId && {
-            sessions: {
-              connect: { id: parseInt(validatedData.sessionId) },
-            },
-          }),
-          ...(validatedData.testRunResultId && {
-            testRunResults: {
-              connect: { id: parseInt(validatedData.testRunResultId) },
-            },
-          }),
-          ...(validatedData.testRunStepResultId && {
-            testRunStepResults: {
-              connect: { id: parseInt(validatedData.testRunStepResultId) },
-            },
-          }),
+          ...linkConnects,
         },
         update: {
-          // Update fields that might have changed
-          title: createdIssue.title,
-          data: {
-            id: createdIssue.id,
-            key: createdIssue.key,
-            url: createdIssue.url,
-            status: createdIssue.status,
-            priority: createdIssue.priority,
-            assignee: createdIssue.assignee,
-            reporter: createdIssue.reporter,
-            labels: createdIssue.labels,
-            customFields: createdIssue.customFields,
-          },
-          // Also connect any new relationships
-          ...(validatedData.testCaseId && {
-            repositoryCases: {
-              connect: { id: parseInt(validatedData.testCaseId) },
-            },
-          }),
-          ...(validatedData.testRunId && {
-            testRuns: {
-              connect: { id: parseInt(validatedData.testRunId) },
-            },
-          }),
-          ...(validatedData.sessionId && {
-            sessions: {
-              connect: { id: parseInt(validatedData.sessionId) },
-            },
-          }),
-          ...(validatedData.testRunResultId && {
-            testRunResults: {
-              connect: { id: parseInt(validatedData.testRunResultId) },
-            },
-          }),
-          ...(validatedData.testRunStepResultId && {
-            testRunStepResults: {
-              connect: { id: parseInt(validatedData.testRunStepResultId) },
-            },
-          }),
+          ...trackerFields,
+          ...linkConnects,
         },
       });
 

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -263,6 +263,149 @@ describe("IntegrationManager", () => {
 
       vi.unstubAllEnvs();
     });
+
+    it("refreshes a borrowed (no caller userId) token on the token owner's behalf", async () => {
+      // Read paths (issue hover/details) borrow a token via getAdapter without
+      // passing a userId. Such a read must still refresh an expired token —
+      // using the owner recorded on the auth row — otherwise reads start failing
+      // one hour after the admin connects.
+      vi.stubEnv("NEXTAUTH_URL", "https://app.example.com");
+      vi.mocked(EncryptionService.decrypt).mockImplementation(
+        (value: string) => value
+      );
+
+      const integration = {
+        id: 60,
+        name: "GitLab OAuth",
+        provider: "GITLAB",
+        status: "ACTIVE",
+        authType: "OAUTH2",
+        credentials: {
+          encrypted: JSON.stringify({
+            clientId: "gl-client",
+            clientSecret: "gl-secret",
+          }),
+        },
+        settings: { instanceUrl: "https://gitlab.com" },
+        userIntegrationAuths: [
+          {
+            userId: "owner-9",
+            isActive: true,
+            accessToken: "old-access",
+            refreshToken: "the-refresh-token",
+            tokenExpiresAt: new Date(Date.now() - 1000),
+            updatedAt: new Date(),
+          },
+        ],
+      };
+      mockPrisma.integration.findUnique.mockResolvedValue(integration);
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: "fresh-access",
+              refresh_token: "fresh-refresh",
+              expires_in: 7200,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: 1, username: "u" }),
+        });
+      global.fetch = mockFetch;
+
+      // Borrowed read: NO userId argument.
+      await manager.getAdapter("60");
+
+      // The refresh fired even without a caller userId…
+      expect(mockFetch.mock.calls[0][0]).toBe("https://gitlab.com/oauth/token");
+      // …and the new token was persisted for the token's OWNER, not skipped.
+      expect(AuthenticationService.storeUserAuth).toHaveBeenCalledWith(
+        "owner-9",
+        60,
+        expect.objectContaining({
+          accessToken: "fresh-access",
+          refreshToken: "fresh-refresh",
+        })
+      );
+
+      vi.unstubAllEnvs();
+    });
+
+    it("evicts a cached OAuth adapter once its access token expires", async () => {
+      // A cached OAuth adapter holds a 1-hour token. Once it lapses, the next
+      // getAdapter must rebuild (and refresh) rather than serve the stale token.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      vi.stubEnv("NEXTAUTH_URL", "https://app.example.com");
+      vi.mocked(EncryptionService.decrypt).mockImplementation(
+        (value: string) => value
+      );
+
+      const integration = {
+        id: 61,
+        name: "GitLab OAuth",
+        provider: "GITLAB",
+        status: "ACTIVE",
+        authType: "OAUTH2",
+        credentials: {
+          encrypted: JSON.stringify({
+            clientId: "gl-client",
+            clientSecret: "gl-secret",
+          }),
+        },
+        settings: { instanceUrl: "https://gitlab.com" },
+        userIntegrationAuths: [
+          {
+            userId: "owner-x",
+            isActive: true,
+            accessToken: "access",
+            refreshToken: "refresh",
+            tokenExpiresAt: new Date(Date.now() + 3600_000),
+            updatedAt: new Date(),
+          },
+        ],
+      };
+      mockPrisma.integration.findUnique.mockResolvedValue(integration);
+
+      // Token endpoint returns fresh tokens; everything else is the validation
+      // call. Keyed off the URL so both the first build and the post-expiry
+      // rebuild (which refreshes) are satisfied.
+      global.fetch = vi.fn().mockImplementation((url: string) =>
+        String(url).includes("oauth/token")
+          ? Promise.resolve({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  access_token: "fresh-access",
+                  refresh_token: "fresh-refresh",
+                  expires_in: 3600,
+                }),
+            })
+          : Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ id: 1, username: "u" }),
+            })
+      );
+
+      const first = await manager.getAdapter("61");
+      const stillCached = await manager.getAdapter("61");
+      expect(stillCached).toBe(first); // cache hit while token valid
+      expect(mockPrisma.integration.findUnique).toHaveBeenCalledTimes(1);
+
+      // An hour passes — the cached adapter's token is now expired.
+      vi.advanceTimersByTime(3600_000 + 1000);
+
+      const afterExpiry = await manager.getAdapter("61");
+      expect(afterExpiry).not.toBe(first); // evicted + rebuilt
+      expect(mockPrisma.integration.findUnique).toHaveBeenCalledTimes(2);
+
+      vi.unstubAllEnvs();
+      vi.useRealTimers();
+    });
   });
 
   describe("getAdapter", () => {

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -22,6 +22,10 @@ export class IntegrationManager {
     new (config: any) => IssueAdapter
   > = new Map();
   private adapterCache: Map<string, IssueAdapter> = new Map();
+  // Access-token expiry (epoch ms) for cached OAuth adapters. A cached adapter
+  // holding an expired token must be rebuilt (so its token can refresh) rather
+  // than served stale — otherwise reads start failing one hour after connect.
+  private adapterCacheExpiry: Map<string, number> = new Map();
 
   private constructor() {
     // Initialize with built-in adapters
@@ -74,9 +78,16 @@ export class IntegrationManager {
     // OAuth adapters carry a per-user token, so they must be cached per user
     const cacheKey = userId ? `${integrationId}:${userId}` : integrationId;
 
-    // Check cache first
+    // Check cache first — but never serve an OAuth adapter whose access token
+    // has expired. Evict it so the rebuild below refreshes the token; otherwise
+    // borrowed reads keep using the stale token and fail with a 401.
     if (this.adapterCache.has(cacheKey)) {
-      return this.adapterCache.get(cacheKey)!;
+      const expiry = this.adapterCacheExpiry.get(cacheKey);
+      if (expiry === undefined || expiry > Date.now()) {
+        return this.adapterCache.get(cacheKey)!;
+      }
+      this.adapterCache.delete(cacheKey);
+      this.adapterCacheExpiry.delete(cacheKey);
     }
 
     // Fetch integration from database (use provided client for multi-tenant support)
@@ -168,18 +179,22 @@ export class IntegrationManager {
         ? EncryptionService.decrypt(auth.refreshToken, masterKey)
         : undefined;
 
-      // Transparently refresh an expired access token when the adapter
-      // supports it and we have both a refresh token and the owning user.
-      // The new token is persisted so subsequent requests skip the refresh.
+      // Transparently refresh an expired access token. Refresh on behalf of the
+      // token's owner: read paths (issue hover/details) borrow a token without
+      // passing a userId, so fall back to the owning user recorded on the auth
+      // row. Without this, borrowed reads can never refresh and start failing an
+      // hour after the admin connects. The new token is persisted so subsequent
+      // requests skip the refresh.
       const isExpired =
         !!auth.tokenExpiresAt && auth.tokenExpiresAt < new Date();
-      if (isExpired && refreshToken && userId && adapter.refreshTokens) {
+      const ownerId = userId ?? auth.userId;
+      if (isExpired && refreshToken && ownerId && adapter.refreshTokens) {
         try {
           const refreshed = await adapter.refreshTokens(refreshToken);
           accessToken = refreshed.accessToken;
           refreshToken = refreshed.refreshToken || refreshToken;
           authData.expiresAt = refreshed.expiresAt;
-          await AuthenticationService.storeUserAuth(userId, integration.id, {
+          await AuthenticationService.storeUserAuth(ownerId, integration.id, {
             accessToken: refreshed.accessToken,
             refreshToken,
             expiresAt: refreshed.expiresAt,
@@ -211,6 +226,14 @@ export class IntegrationManager {
     // costs nothing.
     if (!options?.allowInactive) {
       this.adapterCache.set(cacheKey, adapter);
+      // Track the access-token expiry so the cache hit above can evict and
+      // rebuild once it lapses (OAuth only; API-key adapters have no expiry).
+      if (authData.expiresAt) {
+        this.adapterCacheExpiry.set(
+          cacheKey,
+          new Date(authData.expiresAt).getTime()
+        );
+      }
     }
 
     return adapter;
@@ -276,6 +299,7 @@ export class IntegrationManager {
     for (const key of this.adapterCache.keys()) {
       if (key === integrationId || key.startsWith(`${integrationId}:`)) {
         this.adapterCache.delete(key);
+        this.adapterCacheExpiry.delete(key);
       }
     }
   }
@@ -285,6 +309,7 @@ export class IntegrationManager {
    */
   clearAllAdapters(): void {
     this.adapterCache.clear();
+    this.adapterCacheExpiry.clear();
   }
 
   /**

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -1072,7 +1072,7 @@
         "apple": "Weiter mit Apple",
         "microsoft": "Mit Microsoft fortfahren",
         "samlProvider": "Melden Sie sich mit {name}an.",
-        "magicLink": "Mit Magic Link anmelden",
+        "magicLink": "Mit einmaligem Magic Link anmelden",
         "emailLogin": "Mit der E-Mail fortfahren"
       },
       "magicLink": {

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1072,7 +1072,7 @@
         "apple": "Continue with Apple",
         "microsoft": "Continue with Microsoft",
         "samlProvider": "Sign in with {name}",
-        "magicLink": "Sign in with Magic Link",
+        "magicLink": "Sign in with single-use Magic Link",
         "emailLogin": "Continue with email"
       },
       "magicLink": {

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -1072,7 +1072,7 @@
         "apple": "Continuar con Apple",
         "microsoft": "Continuar con Microsoft",
         "samlProvider": "Iniciar sesión con {name}",
-        "magicLink": "Inicia sesión con Magic Link",
+        "magicLink": "Iniciar sesión con Magic Link de un solo uso",
         "emailLogin": "Continuar con el email"
       },
       "magicLink": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -1072,7 +1072,7 @@
         "apple": "Continuez avec Apple",
         "microsoft": "Continuez avec Microsoft",
         "samlProvider": "Connectez-vous avec {name}",
-        "magicLink": "Se connecter avec Magic Link",
+        "magicLink": "Se connecter avec un Magic Link à usage unique",
         "emailLogin": "Poursuivre par courriel"
       },
       "magicLink": {

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -1072,7 +1072,7 @@
         "apple": "Continua con Apple",
         "microsoft": "Continua con Microsoft",
         "samlProvider": "Accedi con {name}",
-        "magicLink": "Accedi con Magic Link",
+        "magicLink": "Accedi con Magic Link monouso",
         "emailLogin": "Continua con l'email"
       },
       "magicLink": {

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -1072,7 +1072,7 @@
         "apple": "Appleで続ける",
         "microsoft": "Microsoft で続行",
         "samlProvider": "{name}でサインイン",
-        "magicLink": "マジックリンクでサインイン",
+        "magicLink": "1回限り有効なマジックリンクでサインイン",
         "emailLogin": "メールで続行"
       },
       "magicLink": {

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -1072,7 +1072,7 @@
         "apple": "Apple에서 계속 진행하세요",
         "microsoft": "Microsoft에서 계속 진행하세요",
         "samlProvider": "{name}로 로그인하세요",
-        "magicLink": "매직링크로 로그인",
+        "magicLink": "일회용 매직 링크로 로그인",
         "emailLogin": "이메일로 계속 진행"
       },
       "magicLink": {

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -1072,7 +1072,7 @@
         "apple": "Doorgaan met Apple",
         "microsoft": "Ga verder met Microsoft",
         "samlProvider": "Meld je aan met {name}",
-        "magicLink": "Aanmelden met Magic Link",
+        "magicLink": "Inloggen met eenmalige Magic Link",
         "emailLogin": "Doorgaan met e-mail"
       },
       "magicLink": {

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -1072,7 +1072,7 @@
         "apple": "Kontynuuj z Apple",
         "microsoft": "Kontynuuj z Microsoft",
         "samlProvider": "Zaloguj się za pomocą {name}",
-        "magicLink": "Zaloguj się za pomocą Magic Link",
+        "magicLink": "Zaloguj się jednorazowym Magic Linkiem",
         "emailLogin": "Kontynuuj z e-mailem"
       },
       "magicLink": {

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -1072,7 +1072,7 @@
         "apple": "Continue com a Apple",
         "microsoft": "Continue com a Microsoft",
         "samlProvider": "Faça login com {name}",
-        "magicLink": "Faça login com o Magic Link",
+        "magicLink": "Entrar com Magic Link de uso único",
         "emailLogin": "Continuar com o e-mail"
       },
       "magicLink": {

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -1072,7 +1072,7 @@
         "apple": "Продолжить с Apple",
         "microsoft": "Продолжить работу с Microsoft",
         "samlProvider": "Войдите с помощью {name}",
-        "magicLink": "Войдите с помощью Magic Link",
+        "magicLink": "Войти с помощью одноразовой Magic Link",
         "emailLogin": "Продолжить отправку электронного письма"
       },
       "magicLink": {

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -1072,7 +1072,7 @@
         "apple": "Apple ile devam edin",
         "microsoft": "Microsoft ile devam edin",
         "samlProvider": "{name} ile giriş yapın",
-        "magicLink": "Magic Link ile giriş yapın",
+        "magicLink": "Tek kullanımlık Magic Link ile oturum aç",
         "emailLogin": "E-posta ile devam edin"
       },
       "magicLink": {

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -1072,7 +1072,7 @@
         "apple": "Tiếp tục với Apple",
         "microsoft": "Tiếp tục với Microsoft",
         "samlProvider": "Đăng nhập bằng {name}",
-        "magicLink": "Đăng nhập bằng Magic Link",
+        "magicLink": "Đăng nhập bằng Magic Link dùng một lần",
         "emailLogin": "Tiếp tục với email"
       },
       "magicLink": {

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -1072,7 +1072,7 @@
         "apple": "继续使用 Apple",
         "microsoft": "继续使用 Microsoft",
         "samlProvider": "使用 {name}登录",
-        "magicLink": "使用 Magic Link 登录",
+        "magicLink": "使用一次性魔法链接登录",
         "emailLogin": "继续通过电子邮件"
       },
       "magicLink": {

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -1072,7 +1072,7 @@
         "apple": "繼續使用 Apple",
         "microsoft": "繼續使用 Microsoft",
         "samlProvider": "使用 {name} 登入",
-        "magicLink": "使用 Magic Link 登入",
+        "magicLink": "使用一次性魔法連結登入",
         "emailLogin": "繼續透過電子郵件"
       },
       "magicLink": {


### PR DESCRIPTION
## Description

Three fixes to the Jira OAuth integration, surfaced while UAT-ing the per-user OAuth flow on a local dev build against a real Atlassian app + Jira Cloud:

1. **Reads no longer break ~1 hour after the admin connects.** Issue reads (hover / details) borrow any connected user's OAuth token via `getAdapter` without passing a `userId`. Token refresh was gated on that (absent) caller `userId`, and the adapter cache returned the expired-token adapter before any refresh check — so read-without-login worked for an hour, then started failing with `Failed to get accessible resources` until some user-scoped request refreshed the token. Now the borrowed token refreshes on the **token owner's** behalf (`auth.userId`), and cached OAuth adapters are **evicted once their access token expires** so the next read rebuilds and refreshes.

2. **Issues created through the create flow now render correctly.** `create-issue` wrote the issue **title** into the `name` column and left the columns the UI actually reads — `externalKey`, `externalUrl`, `externalStatus`, `status`, `priority`, and issue-type fields — empty, populating only the `data` JSON blob. Created issues therefore appeared with no key, no Jira link, no status, and no hover badge across lists, the Issues page, and the case editor. They now get the same first-class columns a synced/webhooked issue gets (mirrors `SyncService.issueFields`).

3. **i18n:** the "single-use Magic Link" sign-in button label is translated across all locales (a Crowdin sync had reverted it to English).

## Related Issue

N/A — found during local UAT of the per-user Jira OAuth flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Details:

- **Unit / regression tests** — added coverage for the borrowed-token refresh and cache eviction-on-expiry (`IntegrationManager.test.ts`), and for the created-issue column persistence (`create-issue/route.test.ts`).
- **Manual UAT** (local dev build, real Atlassian OAuth app + Jira Cloud): admin connects the integration; a second user who never connected Jira can read issue details (works); create is blocked until that user connects their own Jira and is then attributed to that user; the post-1h read failure was reproduced (expired stored token → borrowed read refreshes + persists a new token).
- Full `pnpm precommit` is green — **9788 unit tests passing**, lint + format clean.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): n/a (Playwright-driven local dev server)
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

Two operational notes for production OAuth (not code in this PR), also surfaced during UAT:

- A **development-mode** Atlassian OAuth app can only be authorized by its owner — every other user gets "you don't have access to this app." For multi-user OAuth the app must be set to **Distributed / Sharing**.
- Per-user attribution depends on each user connecting **their own** Atlassian account; with a single shared Atlassian login every created issue is reported as that one account.
