### PR TITLE
fix(audit): stop silent audit-capture loss — self-heal triggers on every boot

### DIFF
--- a/docs/docs/background-processes.md
+++ b/docs/docs/background-processes.md
@@ -142,7 +142,7 @@ The application uses the following background processes:
 ### DataChangeLog Retention Worker
 
 - Wakes once per day and batch-deletes processed `DataChangeLog` rows (the audit change-capture substrate) older than 30 days
-- Never deletes unprocessed rows — the audit log worker must correlate them into `AuditLog` first; the append-only `datachangelog_append_only` trigger enforces this at the database level too
+- Never deletes unprocessed rows — the audit log worker must correlate them into `AuditLog` first; the append-only enforcement triggers (`tpl_dcl_no_delete` / `tpl_dcl_no_update`) enforce this at the database level too
 - Batched `LIMIT 1000` deletes to avoid lock contention with the capture path; emits one `DCL_RETENTION_PURGED` audit event per run
 - Multi-tenant aware: runs the purge against every configured tenant database per cycle and emits one audit row per (tenant, run)
 - Standalone daily loop (no BullMQ queue) — self-schedules internally rather than via the scheduler

--- a/docs/docs/external-database-deployment.md
+++ b/docs/docs/external-database-deployment.md
@@ -266,6 +266,20 @@ command at a connection that bypasses the pooler — `prisma db push` and the in
 setup require a real (non-pooled) session. See [Configure connection pooling](#best-practices)
 below for the matching `DIRECT_DATABASE_URL` setup the running container uses.
 
+You do **not** need a separate step to install the audit-capture database triggers.
+`prisma db push` silently drops them, but the application re-installs them
+automatically on every boot (idempotent, advisory-locked across replicas), so a plain
+`db push` followed by starting the app leaves audit capture intact. Two optional
+environment variables tune this self-install:
+
+- `AUDIT_TRIGGER_BOOTSTRAP=off` — skip the install entirely. Use this only when the
+  app's database role cannot run DDL (e.g. a read-only role); you must then apply the
+  triggers out-of-band.
+- `AUDIT_TRIGGER_BOOTSTRAP_FATAL=1` — abort startup if the install fails instead of
+  logging and continuing. The default is fail-open so an unrelated database hiccup
+  can't take the web tier down; set this to `1` on the **worker tier**, where audit
+  integrity is load-bearing.
+
 Or use your existing database if it's already initialized.
 
 ### Step 4: Monitor Deployment

--- a/testplanit/instrumentation.ts
+++ b/testplanit/instrumentation.ts
@@ -1,6 +1,9 @@
 /**
  * Next.js server instrumentation hook. Runs once when the server starts
- * (nodejs runtime only, not edge), before any request is served.
+ * (nodejs runtime only, not edge), before any request is served — and on
+ * EVERY launcher: docker entrypoint, `next start`, standalone `node server.js`,
+ * pm2, or a k8s `command:` override. That makes it the one launch-agnostic
+ * place to guarantee runtime invariants.
  *
  * Use this to fail fast on missing security-critical configuration. A
  * production deployment without ENCRYPTION_KEY would silently fall back
@@ -22,4 +25,12 @@ export async function register() {
     console.error("[startup] encryption misconfiguration:", error);
     throw error;
   }
+
+  // Re-attach the audit-trigger substrate on every boot. `prisma db push` silently drops these
+  // triggers and not every launch path runs apply-triggers, so doing it here is what keeps audit
+  // capture alive no matter how the app is installed/updated/launched. Idempotent, advisory-locked,
+  // and fail-open by default (see ensureAuditTriggers); never blocks startup unless explicitly made
+  // fatal via AUDIT_TRIGGER_BOOTSTRAP_FATAL=1.
+  const { ensureAuditTriggers } = await import("~/lib/audit/ensureAuditTriggers");
+  await ensureAuditTriggers();
 }

--- a/testplanit/instrumentation.ts
+++ b/testplanit/instrumentation.ts
@@ -31,6 +31,7 @@ export async function register() {
   // capture alive no matter how the app is installed/updated/launched. Idempotent, advisory-locked,
   // and fail-open by default (see ensureAuditTriggers); never blocks startup unless explicitly made
   // fatal via AUDIT_TRIGGER_BOOTSTRAP_FATAL=1.
-  const { ensureAuditTriggers } = await import("~/lib/audit/ensureAuditTriggers");
+  const { ensureAuditTriggers } =
+    await import("~/lib/audit/ensureAuditTriggers");
   await ensureAuditTriggers();
 }

--- a/testplanit/lib/audit/ensureAuditTriggers.ts
+++ b/testplanit/lib/audit/ensureAuditTriggers.ts
@@ -1,0 +1,50 @@
+/**
+ * Runtime guarantee that the audit-trigger substrate exists — applied from the application's own
+ * boot, independent of HOW the process was launched.
+ *
+ * The audit pipeline depends on per-table DB triggers that write "DataChangeLog" (capture) plus the
+ * append-only enforcement triggers and grants. Those are installed by scripts/apply-triggers.ts.
+ * The catch: `prisma db push` SILENTLY DROPS triggers, and the various launch paths don't all run
+ * apply-triggers — the docker entrypoint does, but a bare `node server.js`, `next start`, pm2, or a
+ * k8s `command:` override that runs `prisma db push` alone does not. The result is silent audit
+ * data loss with no error.
+ *
+ * Calling this from instrumentation.ts (Next's server boot hook) closes that gap: every server
+ * start re-attaches the triggers, so capture survives no matter how the app is installed, updated,
+ * or relaunched. It is idempotent and serialized across replicas by an advisory lock in
+ * applyAuditTriggers.
+ *
+ * Behavior:
+ *  - Runs at most once per process (memoized).
+ *  - Uses DIRECT_DATABASE_URL (pooler-bypass) when set, else DATABASE_URL — DDL must not go through
+ *    a transaction-pooled PgBouncer.
+ *  - Fail-open: a failure is logged loudly but does NOT block startup, so an unrelated DB hiccup
+ *    can't take the web tier down. Set AUDIT_TRIGGER_BOOTSTRAP_FATAL=1 to abort startup instead
+ *    (recommended for the worker tier, where audit integrity is load-bearing).
+ *  - Set AUDIT_TRIGGER_BOOTSTRAP=off to skip entirely (e.g. a read-only role that cannot run DDL).
+ */
+import { applyAuditTriggers } from "~/scripts/apply-triggers";
+
+let inFlight: Promise<void> | null = null;
+
+export function ensureAuditTriggers(): Promise<void> {
+  if (process.env.AUDIT_TRIGGER_BOOTSTRAP === "off") return Promise.resolve();
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      await applyAuditTriggers({ lock: true });
+      console.info("[startup] audit triggers ensured ✓");
+    } catch (error) {
+      console.error(
+        "[startup] audit trigger bootstrap failed — audit capture may be incomplete until this is resolved:",
+        error
+      );
+      if (process.env.AUDIT_TRIGGER_BOOTSTRAP_FATAL === "1") throw error;
+      // Fail-open: clear the memo so a later explicit call can retry.
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}

--- a/testplanit/next.config.ts
+++ b/testplanit/next.config.ts
@@ -131,8 +131,16 @@ const nextConfig: NextConfig = {
     "test-results-parser",
     "jspdf",
     "fflate",
+    // The instrumentation boot hook imports apply-triggers, which uses `pg` for raw DDL.
+    // Keep it external so the native driver isn't bundled into the server runtime.
+    "pg",
   ],
   outputFileTracingRoot: path.join(__dirname, "../"),
+  // The instrumentation boot hook reads prisma/audit_row_change.sql at runtime to (re)install the
+  // audit triggers. Trace it into the standalone output so it exists wherever the server runs.
+  outputFileTracingIncludes: {
+    "/**": ["./prisma/audit_row_change.sql"],
+  },
   experimental: {
     // Limit number of workers to reduce memory usage during build
     workerThreads: false,

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -9,6 +9,8 @@
     "generate:dev": "zenstack format && NODE_OPTIONS='--max-old-space-size=12288' zenstack generate && node scripts/fix-zenstack-symlink.js && dotenv -e .env.development -- prisma db push && dotenv -e .env.development -- tsx scripts/apply-triggers.ts",
     "triggers:apply": "tsx scripts/apply-triggers.ts",
     "triggers:apply:dev": "dotenv -e .env.development -- tsx scripts/apply-triggers.ts",
+    "db:push": "prisma db push --skip-generate && tsx scripts/apply-triggers.ts",
+    "db:push:dev": "dotenv -e .env.development -- prisma db push --skip-generate && dotenv -e .env.development -- tsx scripts/apply-triggers.ts",
     "build": "node scripts/generate-version.js && node scripts/fix-zenstack-symlink.js && pnpm build:workers && NODE_OPTIONS='--max-old-space-size=24576' next build",
     "build:workers": "node scripts/build-workers.js",
     "build:docs": "pnpm --filter docs build",

--- a/testplanit/scripts/apply-triggers.ts
+++ b/testplanit/scripts/apply-triggers.ts
@@ -1,10 +1,15 @@
 /**
  * Idempotent trigger DDL applier — the SOLE source of audit trigger DDL (CAP-02).
  *
- * Generalizes the proven Phase 12 spike applier (prisma/spike/apply-spike-trigger.ts) from a
- * single hard-coded table to the full TRIGGER_REGISTRY. Run on every `pnpm generate` and from
- * the deploy entrypoint AFTER `prisma db push` (which silently drops triggers), so the audit
- * substrate is re-attached on every schema sync.
+ * Attaches one capture trigger per TRIGGER_REGISTRY entry (each writes "DataChangeLog") plus the
+ * DataChangeLog append-only enforcement triggers and grants. `prisma db push` silently DROPS these
+ * triggers, and not every launch path re-runs the applier, so the substrate is re-attached from
+ * three places — losing it means silent audit-capture loss with no error:
+ *   - `pnpm generate` / `pnpm db:push`, immediately AFTER `prisma db push` (every schema sync),
+ *   - the deploy entrypoint (docker-entrypoint.sh), after db push,
+ *   - the application's own boot, launch-agnostic, via the exported applyAuditTriggers() — called by
+ *     lib/audit/ensureAuditTriggers from instrumentation.ts (web tier) and the audit-log worker
+ *     (worker tier), so capture survives however the app is installed, updated, or relaunched.
  *
  * In order, against a DIRECT (pooler-bypassing) connection, it:
  *   1. resolves DIRECT_DATABASE_URL ?? DATABASE_URL,
@@ -21,8 +26,10 @@
  *   7. self-checks: count(DISTINCT trigger_name) over tpl_audit_% against the registry length, and
  *      asserts the connecting role holds INSERT/SELECT/UPDATE/DELETE on DataChangeLog.
  *
- * Run:  cd testplanit && tsx scripts/apply-triggers.ts
- * Safe to run repeatedly — every function/trigger is CREATE OR REPLACE / DROP IF EXISTS first.
+ * Run as a CLI:  cd testplanit && tsx scripts/apply-triggers.ts
+ * Or import applyAuditTriggers() to apply from the running app. Safe to run repeatedly — every
+ * function/trigger is CREATE OR REPLACE / DROP IF EXISTS first, and concurrent runners serialize on
+ * a session advisory lock so parallel replica boots can't deadlock on the catalogs.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/testplanit/scripts/apply-triggers.ts
+++ b/testplanit/scripts/apply-triggers.ts
@@ -11,12 +11,15 @@
  *   2. asserts the registry is safe (no prohibited table),
  *   3. executes prisma/audit_row_change.sql (CREATE OR REPLACE FUNCTION — idempotent),
  *   4. attaches one tpl_audit_<table> trigger per registry entry (DROP IF EXISTS + CREATE),
- *   5. installs the ownership-independent append-only ENFORCEMENT triggers on DataChangeLog
+ *   5. installs the append-only ENFORCEMENT triggers on DataChangeLog regardless of ownership
  *      (the REAL SAF-03 guarantee — a BEFORE DELETE and a BEFORE UPDATE trigger that RAISE a
  *      42501 privilege error; the BEFORE UPDATE trigger allows worker-cursor-only updates),
- *   6. applies the INSERT-only GRANT/REVOKE as documented defense-in-depth (a no-op for the
- *      table owner — the enforcement triggers above are the real guard),
- *   7. self-checks via count(DISTINCT trigger_name) over tpl_audit_% against the registry length.
+ *   6. converges the GRANT/REVOKE as defense-in-depth — the connecting role keeps
+ *      INSERT/SELECT/UPDATE/DELETE (the worker advances the processed cursor and the retention job
+ *      purges rows), UPDATE/DELETE are revoked from PUBLIC, and the enforcement triggers above
+ *      remain the real guard,
+ *   7. self-checks: count(DISTINCT trigger_name) over tpl_audit_% against the registry length, and
+ *      asserts the connecting role holds INSERT/SELECT/UPDATE/DELETE on DataChangeLog.
  *
  * Run:  cd testplanit && tsx scripts/apply-triggers.ts
  * Safe to run repeatedly — every function/trigger is CREATE OR REPLACE / DROP IF EXISTS first.
@@ -42,12 +45,13 @@ function triggerNameFor(table: string): string {
 }
 
 /**
- * Append-only ENFORCEMENT for DataChangeLog. Ownership-independent: `prisma db push` makes the
- * app role the table owner, and an owner keeps every privilege, so GRANT/REVOKE cannot revoke
- * the owner's UPDATE/DELETE. These BEFORE triggers RAISE a 42501 privilege error regardless of
- * ownership — they are the real SAF-03 guarantee. The BEFORE UPDATE path allows worker-cursor-
- * only updates (processed/processedAt): subtracting a not-yet-existent key from jsonb is a
- * harmless no-op, future-proofing the Phase 14 worker cursor.
+ * Append-only ENFORCEMENT for DataChangeLog. These BEFORE triggers RAISE a 42501 privilege error
+ * regardless of table ownership or grant state — they are the real SAF-03 guarantee, not the
+ * GRANT/REVOKE below. Because the triggers enforce integrity, the grant layer is free to leave the
+ * connecting role holding UPDATE/DELETE: the worker needs UPDATE to advance the processed cursor
+ * and DELETE to run the retention purge, and these triggers still reject every other mutation. The
+ * BEFORE UPDATE path allows worker-cursor-only updates (processed/processedAt): subtracting a
+ * not-yet-existent key from jsonb is a harmless no-op, future-proofing the Phase 14 worker cursor.
  *
  * DELETE carve-out: unprocessed rows (processed = false) are immutable and cannot be deleted;
  * processed rows (processed = true) may be pruned by the retention job. This is DB-enforced,
@@ -81,13 +85,22 @@ CREATE TRIGGER tpl_dcl_no_update BEFORE UPDATE ON "DataChangeLog"
 `;
 
 /**
- * Defense-in-depth ONLY — NOT the append-only guarantee. The app role OWNS the table (db push
- * creates it), and an owner retains all privileges, so this REVOKE is a documented no-op for the
- * owner. The tpl_dcl_* enforcement triggers above are the real guard.
+ * Defense-in-depth ONLY — NOT the append-only guarantee; the tpl_dcl_* enforcement triggers above
+ * are the real guard. Converges on a working grant set on every run: the connecting role keeps the
+ * full INSERT/SELECT/UPDATE/DELETE it needs (the worker sets processed = true and the retention job
+ * DELETEs pruned rows), while UPDATE/DELETE are revoked from PUBLIC so no unprivileged role can
+ * touch the log.
+ *
+ * Earlier revisions revoked UPDATE/DELETE from CURRENT_USER on the false premise that the
+ * connecting role always owns the table, so the REVOKE would be a no-op (an owner's implicit rights
+ * survive a REVOKE). In prod the runtime role is NOT the table owner, so that REVOKE actually
+ * stripped the worker's UPDATE/DELETE and silently stalled the CDC cursor and the retention purge.
+ * Integrity is unaffected either way: the enforcement triggers reject every non-cursor mutation
+ * regardless of grant state, so granting these privileges back is safe.
  */
 const APPEND_ONLY_GRANT_SQL = `
-GRANT INSERT ON "DataChangeLog" TO CURRENT_USER;
-REVOKE UPDATE, DELETE ON "DataChangeLog" FROM CURRENT_USER; -- no-op for the table owner; the tpl_dcl_* enforcement triggers are the real guarantee
+GRANT INSERT, SELECT, UPDATE, DELETE ON "DataChangeLog" TO CURRENT_USER;
+REVOKE UPDATE, DELETE ON "DataChangeLog" FROM PUBLIC; -- defense-in-depth without touching the owner/worker; the tpl_dcl_* enforcement triggers are the real guarantee
 `;
 
 /**
@@ -185,7 +198,9 @@ async function main() {
     // 3. Append-only ENFORCEMENT triggers on DataChangeLog (the real SAF-03 guarantee).
     await client.query(APPEND_ONLY_ENFORCEMENT_SQL);
 
-    // 4. INSERT-only GRANT/REVOKE as documented defense-in-depth (no-op for the table owner).
+    // 4. GRANT/REVOKE defense-in-depth: the connecting role keeps INSERT/SELECT/UPDATE/DELETE (the
+    //    worker cursor + retention purge need UPDATE/DELETE); UPDATE/DELETE revoked from PUBLIC. The
+    //    tpl_dcl_* enforcement triggers guard integrity regardless of grant state.
     await client.query(APPEND_ONLY_GRANT_SQL);
 
     // 5. CDC idempotency partial unique index on AuditLog (CREATE ... IF NOT EXISTS — idempotent).
@@ -222,9 +237,43 @@ async function main() {
       );
     }
 
+    // 6b. Grant self-check: assert the connecting role can actually INSERT/SELECT/UPDATE/DELETE on
+    //     DataChangeLog. The worker needs UPDATE (advance the processed cursor) and DELETE (retention
+    //     purge); a regression that revokes either from this role would silently stall CDC, so fail
+    //     loudly here instead. has_table_privilege reflects effective rights (owner-implicit OR an
+    //     explicit GRANT), so this passes whether or not the connecting role owns the table.
+    const { rows: grantRows } = await client.query<{
+      ins: boolean;
+      sel: boolean;
+      upd: boolean;
+      del: boolean;
+    }>(
+      `SELECT has_table_privilege('"DataChangeLog"', 'INSERT') AS ins,
+              has_table_privilege('"DataChangeLog"', 'SELECT') AS sel,
+              has_table_privilege('"DataChangeLog"', 'UPDATE') AS upd,
+              has_table_privilege('"DataChangeLog"', 'DELETE') AS del`
+    );
+    const grant = grantRows[0];
+    const missingPrivs = (
+      [
+        ["INSERT", grant?.ins],
+        ["SELECT", grant?.sel],
+        ["UPDATE", grant?.upd],
+        ["DELETE", grant?.del],
+      ] as const
+    )
+      .filter(([, held]) => !held)
+      .map(([priv]) => priv);
+    if (missingPrivs.length) {
+      throw new Error(
+        `[apply-triggers] GRANT regression: the connecting role lacks ${missingPrivs.join(", ")} ` +
+          `on DataChangeLog (the audit worker needs UPDATE for the processed cursor and DELETE for retention).`
+      );
+    }
+
     console.log(
       `[apply-triggers] applied audit_row_change() + ${TRIGGER_REGISTRY.length} tpl_audit_* triggers ` +
-        `+ DataChangeLog append-only enforcement (tpl_dcl_no_delete/tpl_dcl_no_update) + INSERT-only GRANT ` +
+        `+ DataChangeLog append-only enforcement (tpl_dcl_no_delete/tpl_dcl_no_update) + GRANT/REVOKE defense-in-depth ` +
         `+ AuditLog CDC idempotency index (audit_log_cdc_idempotency) ` +
         `(idempotent, via ${usingDirect ? "DIRECT_DATABASE_URL" : "DATABASE_URL"}).`
     );

--- a/testplanit/scripts/apply-triggers.ts
+++ b/testplanit/scripts/apply-triggers.ts
@@ -24,7 +24,7 @@
  * Run:  cd testplanit && tsx scripts/apply-triggers.ts
  * Safe to run repeatedly — every function/trigger is CREATE OR REPLACE / DROP IF EXISTS first.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { Client } from "pg";
@@ -36,8 +36,37 @@ import {
 } from "./trigger-registry";
 import { ROLLUP_MAP } from "../lib/audit/rollupMap";
 
-const PRISMA_DIR = join(__dirname, "..", "prisma");
-const AUDIT_FN_SQL = join(PRISMA_DIR, "audit_row_change.sql");
+/**
+ * Locate prisma/audit_row_change.sql robustly. `__dirname` is correct under tsx (scripts/), but when
+ * this module is imported from the running app (the instrumentation boot hook) it may be bundled and
+ * `__dirname` repointed, so we also try the process working directory and the monorepo layout. First
+ * existing candidate wins; otherwise fall back to the original path so readFileSync raises a clear
+ * ENOENT.
+ */
+function resolveAuditFnSqlPath(): string {
+  const candidates = [
+    join(process.cwd(), "prisma", "audit_row_change.sql"),
+    join(__dirname, "..", "prisma", "audit_row_change.sql"),
+    join(process.cwd(), "testplanit", "prisma", "audit_row_change.sql"),
+  ];
+  return candidates.find((p) => existsSync(p)) ?? candidates[0];
+}
+
+/**
+ * Session-level advisory-lock key for the apply critical section. Concurrent runners — e.g. two app
+ * replicas hitting the instrumentation boot hook at once — serialize on this so their parallel
+ * DROP/CREATE TRIGGER churn cannot deadlock on the system catalogs. Auto-released on disconnect.
+ */
+const APPLY_TRIGGERS_LOCK_KEY = 798_113_001;
+
+export interface ApplyAuditTriggersOptions {
+  /** Connection string override. Defaults to DIRECT_DATABASE_URL ?? DATABASE_URL. */
+  connectionString?: string;
+  /** Serialize concurrent runners with a session advisory lock. Default true. */
+  lock?: boolean;
+  /** Log sink. Defaults to console.log; pass () => {} to silence. */
+  log?: (message: string) => void;
+}
 
 /** tpl_audit_<lowercased table, non-alphanumeric → _>. Must match the drift test transform. */
 function triggerNameFor(table: string): string {
@@ -117,24 +146,48 @@ CREATE UNIQUE INDEX IF NOT EXISTS audit_log_cdc_idempotency
   WHERE "operationId" IS NOT NULL;
 `;
 
-async function main() {
-  const usingDirect = Boolean(process.env.DIRECT_DATABASE_URL);
+/**
+ * Apply the full audit-trigger substrate to one database, idempotently. Importable so the app can
+ * self-install on boot (see lib/audit/ensureAuditTriggers + instrumentation.ts) in addition to the
+ * CLI / deploy-entrypoint paths — `prisma db push` silently drops these triggers, so they must be
+ * re-attached on every schema sync AND on every app start, regardless of how the app is launched.
+ */
+export async function applyAuditTriggers(
+  opts: ApplyAuditTriggersOptions = {}
+): Promise<void> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const useLock = opts.lock ?? true;
   const connectionString =
-    process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+    opts.connectionString ??
+    process.env.DIRECT_DATABASE_URL ??
+    process.env.DATABASE_URL;
   if (!connectionString) {
     throw new Error(
-      "Set DIRECT_DATABASE_URL (preferred — bypasses pgbouncer for DDL) or DATABASE_URL before running apply-triggers."
+      "Set DIRECT_DATABASE_URL (preferred — bypasses pgbouncer for DDL) or DATABASE_URL before applying audit triggers."
     );
   }
+  const usingDirect = Boolean(
+    opts.connectionString ?? process.env.DIRECT_DATABASE_URL
+  );
 
   // Fail fast before connecting if a prohibited table slipped into the registry.
   assertRegistrySafe();
 
-  const auditFnSql = readFileSync(AUDIT_FN_SQL, "utf8");
+  const auditFnSql = readFileSync(resolveAuditFnSqlPath(), "utf8");
 
   const client = new Client({ connectionString });
   await client.connect();
+  let locked = false;
   try {
+    // 0. Serialize concurrent appliers (multiple booting replicas) so their DROP/CREATE TRIGGER
+    //    churn can't deadlock. Session-level lock; auto-released on disconnect, unlocked in finally.
+    if (useLock) {
+      await client.query("SELECT pg_advisory_lock($1::bigint)", [
+        APPLY_TRIGGERS_LOCK_KEY,
+      ]);
+      locked = true;
+    }
+
     // 1. Generic trigger function (CREATE OR REPLACE — idempotent).
     await client.query(auditFnSql);
 
@@ -189,7 +242,7 @@ async function main() {
         await client.query(
           `DROP TRIGGER IF EXISTS ${t.trigger_name} ON "${t.event_object_table}";`
         );
-        console.log(
+        log(
           `[apply-triggers] dropped orphaned trigger ${t.trigger_name} on "${t.event_object_table}"`
         );
       }
@@ -271,18 +324,35 @@ async function main() {
       );
     }
 
-    console.log(
+    log(
       `[apply-triggers] applied audit_row_change() + ${TRIGGER_REGISTRY.length} tpl_audit_* triggers ` +
         `+ DataChangeLog append-only enforcement (tpl_dcl_no_delete/tpl_dcl_no_update) + GRANT/REVOKE defense-in-depth ` +
         `+ AuditLog CDC idempotency index (audit_log_cdc_idempotency) ` +
         `(idempotent, via ${usingDirect ? "DIRECT_DATABASE_URL" : "DATABASE_URL"}).`
     );
   } finally {
+    if (locked) {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1::bigint)", [
+          APPLY_TRIGGERS_LOCK_KEY,
+        ]);
+      } catch {
+        // Best-effort: the session advisory lock is released on disconnect anyway.
+      }
+    }
     await client.end();
   }
 }
 
-main().catch((err) => {
-  console.error("[apply-triggers] apply failed:", err);
-  process.exit(1);
-});
+async function main() {
+  await applyAuditTriggers();
+}
+
+// CLI entry only — guarded so importing applyAuditTriggers() (e.g. the instrumentation boot hook)
+// never auto-runs the apply or calls process.exit. `require.main` is undefined when bundled.
+if (typeof require !== "undefined" && require.main === module) {
+  main().catch((err) => {
+    console.error("[apply-triggers] apply failed:", err);
+    process.exit(1);
+  });
+}

--- a/testplanit/workers/auditLogWorker.ts
+++ b/testplanit/workers/auditLogWorker.ts
@@ -22,6 +22,7 @@ import {
   pollDataChangeLogsAcrossTenants,
   type TenantPollClient,
 } from "../lib/audit/correlation";
+import { ensureAuditTriggers } from "../lib/audit/ensureAuditTriggers";
 
 /**
  * Process an audit log job.
@@ -316,10 +317,21 @@ const startWorker = async () => {
 // Run the worker only when this file is executed directly (not on require)
 if (require.main === module) {
   console.log("[AuditLogWorker] Running as standalone process...");
-  startWorker().catch((err) => {
-    console.error("[AuditLogWorker] Failed to start:", err);
-    process.exit(1);
-  });
+  // Re-attach the audit-trigger substrate before draining DataChangeLog. The web tier's
+  // instrumentation hook does this too, but workers can boot first (or the web pod can fail its
+  // startup asserts), and this worker is the direct consumer of the capture triggers — if they were
+  // dropped (by `prisma db push`, or a launch path that skips apply-triggers) it would silently
+  // drain nothing. Idempotent and advisory-locked; fail-open by default so a DDL hiccup can't
+  // crash-loop the worker — set AUDIT_TRIGGER_BOOTSTRAP_FATAL=1 to refuse to start without it.
+  void (async () => {
+    try {
+      await ensureAuditTriggers();
+      await startWorker();
+    } catch (err) {
+      console.error("[AuditLogWorker] Failed to start:", err);
+      process.exit(1);
+    }
+  })();
 }
 
 export default worker;

--- a/testplanit/workers/auditLogWorker.ts
+++ b/testplanit/workers/auditLogWorker.ts
@@ -317,15 +317,24 @@ const startWorker = async () => {
 // Run the worker only when this file is executed directly (not on require)
 if (require.main === module) {
   console.log("[AuditLogWorker] Running as standalone process...");
-  // Re-attach the audit-trigger substrate before draining DataChangeLog. The web tier's
-  // instrumentation hook does this too, but workers can boot first (or the web pod can fail its
-  // startup asserts), and this worker is the direct consumer of the capture triggers — if they were
-  // dropped (by `prisma db push`, or a launch path that skips apply-triggers) it would silently
-  // drain nothing. Idempotent and advisory-locked; fail-open by default so a DDL hiccup can't
-  // crash-loop the worker — set AUDIT_TRIGGER_BOOTSTRAP_FATAL=1 to refuse to start without it.
+  // Re-attach the audit-trigger substrate before draining DataChangeLog — but ONLY in single-tenant
+  // mode, where this worker owns its one database and is the direct consumer of the capture triggers
+  // (if they were dropped by `prisma db push` or a launch path that skips apply-triggers it would
+  // silently drain nothing). In multi-tenant mode this process has no single database to apply to —
+  // its DATABASE_URL is a placeholder and tenant connections are resolved per-cycle — so each
+  // tenant's web app owns trigger install via the instrumentation boot hook, and we skip here rather
+  // than uselessly connect to the placeholder. Idempotent and advisory-locked; fail-open by default
+  // so a DDL hiccup can't crash-loop the worker — set AUDIT_TRIGGER_BOOTSTRAP_FATAL=1 to refuse to
+  // start without it.
   void (async () => {
     try {
-      await ensureAuditTriggers();
+      if (isMultiTenantMode()) {
+        console.log(
+          "[AuditLogWorker] multi-tenant mode — skipping trigger bootstrap (each tenant's web tier owns it)"
+        );
+      } else {
+        await ensureAuditTriggers();
+      }
       await startWorker();
     } catch (err) {
       console.error("[AuditLogWorker] Failed to start:", err);


### PR DESCRIPTION
## Problem

Audit capture depends on per-table Postgres triggers that write `DataChangeLog`, plus append-only enforcement triggers and grants on that table. Two things were silently breaking that substrate in production, with **no error** — audit events just stopped being recorded:

1. **Self-revoking grant.** `apply-triggers.ts` revoked `UPDATE, DELETE` on `DataChangeLog` from `CURRENT_USER`, on the assumption that the connecting role always owns the table (where the revoke would be a harmless no-op). In production the runtime role is **not** the owner, so the revoke actually stripped the audit worker's privileges — stalling the CDC cursor advance and the retention purge.

2. **Triggers dropped on schema sync, not always re-applied.** `prisma db push` silently drops these triggers. The Docker entrypoint re-runs `apply-triggers` afterward, but other launch paths don't — a bare `node server.js`, `next start`, pm2, or a Kubernetes `command:` override that runs `prisma db push` alone. Any of those leaves the app running without capture.

## Fix

- **Grant convergence.** Grant the connecting role `INSERT/SELECT/UPDATE/DELETE` and revoke `UPDATE/DELETE` from `PUBLIC` instead of from the role. The append-only invariant is unchanged — the `BEFORE UPDATE/DELETE` enforcement triggers reject every non-cursor mutation regardless of grant state, so they remain the real guarantee. Added an end-of-run self-check that fails loudly if the role cannot `INSERT/SELECT/UPDATE/DELETE`, so a future regression breaks the deploy instead of stalling silently.

- **Launch-agnostic self-install.** The trigger substrate now re-attaches from the application's own boot, so it survives no matter how the app is installed, updated, or relaunched:
  - **Web tier** — the server instrumentation hook (`instrumentation.ts`), which Next runs on every launcher.
  - **Worker tier** — the audit-log worker, the direct consumer of the capture triggers, re-attaches them at its own boot.
  - The apply logic is extracted into an importable `applyAuditTriggers()`: idempotent, serialized across replicas by a session advisory lock, and **fail-open by default** so a transient DB hiccup at boot never takes a process down. Set `AUDIT_TRIGGER_BOOTSTRAP_FATAL=1` to fail closed (e.g. for the worker tier); `AUDIT_TRIGGER_BOOTSTRAP=off` to skip entirely.

- **Belt-and-suspenders.** The Docker entrypoint and prod compose still run `apply-triggers` directly, and new `db:push` / `db:push:dev` scripts give a single command that cannot run `prisma db push` without re-attaching triggers.

## Notes / scope

- The boot-time install targets the connecting database (`DIRECT_DATABASE_URL ?? DATABASE_URL`). In the per-customer isolated-DB model each deployment self-heals its own database on boot.
- Standalone build wiring: `pg` is externalized and `prisma/audit_row_change.sql` is traced into the standalone output so the boot hook can read it at runtime.

## Testing

- Full unit suite green (9745 passed), lint clean, Prettier clean, docs build.
- Typecheck clean across all changed files.
- Local Docker build (production + workers images) to validate the standalone tracing and worker bundling end-to-end.
