### PR TITLE
fix: bundling-safe CLI guard in apply-triggers (stop audit-worker crash-loop)

### DIFF
--- a/testplanit/scripts/apply-triggers.ts
+++ b/testplanit/scripts/apply-triggers.ts
@@ -355,9 +355,14 @@ async function main() {
   await applyAuditTriggers();
 }
 
-// CLI entry only — guarded so importing applyAuditTriggers() (e.g. the instrumentation boot hook)
-// never auto-runs the apply or calls process.exit. `require.main` is undefined when bundled.
-if (typeof require !== "undefined" && require.main === module) {
+// CLI entry only. `require.main === module` is NOT safe here: esbuild inlines this file into the
+// worker bundle (dist/workers/auditLogWorker.js), where `require.main === module` is TRUE for the
+// bundle entry — so it would wrongly run the CLI, connect to the worker's placeholder DB, and crash
+// it on a loop. Gate on the actual process entry-script path instead: argv[1] only contains
+// "apply-triggers" when this is invoked directly as the CLI (tsx scripts/apply-triggers.ts), and
+// never when bundled into auditLogWorker.js or the Next server.
+const isCliEntry = /apply-triggers/.test(process.argv[1] ?? "");
+if (isCliEntry) {
   main().catch((err) => {
     console.error("[apply-triggers] apply failed:", err);
     process.exit(1);


### PR DESCRIPTION
## Problem
After the audit self-heal change (#467) rolled to `:latest-workers`, the **audit-log worker crash-looped** in production: the `audit-logs` BullMQ queue stopped draining (~298 jobs stuck in `wait`) and Loop B (`DataChangeLog → AuditLog`) materialization stalled for ~2h. No data lost — `DataChangeLog` is append-only and jobs sat in `wait` (not `failed`).

## Root cause
`scripts/apply-triggers.ts` guarded its CLI entry with `require.main === module`. That is **unreliable under esbuild bundling**: esbuild inlines apply-triggers into `dist/workers/auditLogWorker.js`, where `require.main === module` is `true` for the bundle entry. So the apply-triggers **CLI `main()` ran inside the worker**, connected to the worker's placeholder `DATABASE_URL` (`localhost:5432`), hit `ECONNREFUSED`, and `process.exit(1)` → PM2 crash-loop. The Next/webpack web build resolves `require.main` differently, so the web boot hook (and the demo canary) were unaffected — which is why this slipped through.

## Fix
Gate the CLI on the process **entry-script path** instead: `process.argv[1]` contains `"apply-triggers"` only when invoked directly (`tsx scripts/apply-triggers.ts`), never when bundled into `auditLogWorker.js` or the Next server. `applyAuditTriggers()` stays a side-effect-free import for the instrumentation/worker boot hooks.

## Note
A temporary prod stopgap is live (worker `DIRECT_DATABASE_URL` pointed at an idle tenant DB so the bundled `main()` succeeds idempotently instead of crashing). It will be removed once this ships in `:latest-workers` and the workers are re-rolled.

## Follow-up
Add a worker smoke-test that boots a worker and asserts it stays up + drains a test job — a web-only canary can't catch an esbuild-worker-specific regression.