### PR TITLE
fix(imports): resolve created field types by name, not source typeId

### DIFF
--- a/testplanit/workers/testmoImport/templateImports.ts
+++ b/testplanit/workers/testmoImport/templateImports.ts
@@ -435,6 +435,29 @@ export async function importTemplateFields(
     details.assignmentsCreated += 1;
   };
 
+  // Build a lookup from field-type NAME to this instance's CaseFieldTypes id.
+  // The mapping config carries source (Testmo) typeIds that live in a
+  // DIFFERENT id space than the local CaseFieldTypes, so a created field must
+  // be typed by NAME — trusting the source typeId silently mis-types it (e.g.
+  // source typeId 3 "Text (Long)" collides with local id 3 "Dropdown", which
+  // routes rich text through dropdown normalization and drops the value).
+  // Result fields share the CaseFieldTypes table.
+  const normalizeTypeName = (name: unknown): string =>
+    String(name ?? "")
+      .toLowerCase()
+      .replace(/[()]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  const fieldTypeIdByName = new Map<string, number>();
+  {
+    const allFieldTypes = await tx.caseFieldTypes.findMany({
+      select: { id: true, type: true },
+    });
+    for (const ft of allFieldTypes) {
+      fieldTypeIdByName.set(normalizeTypeName(ft.type), ft.id);
+    }
+  }
+
   for (const [key, config] of Object.entries(
     configuration.templateFields ?? {}
   )) {
@@ -513,15 +536,31 @@ export async function importTemplateFields(
       );
     }
 
-    const typeId = config.typeId ?? null;
-    if (typeId === null) {
+    const sourceTypeId = config.typeId ?? null;
+    if (sourceTypeId === null) {
       throw new Error(
         `Template field "${displayName}" requires a field type before it can be created.`
       );
     }
 
+    // Translate the source field type to this instance's CaseFieldTypes id by
+    // NAME. The source typeId is in Testmo's id space and must not be used
+    // directly (see fieldTypeIdByName above). Fall back to the source id only
+    // when the name cannot be resolved, and warn loudly.
+    const normalizedTypeName = normalizeTypeName(config.typeName);
+    const resolvedTypeId =
+      fieldTypeIdByName.get(normalizedTypeName) ?? sourceTypeId;
+    if (!fieldTypeIdByName.has(normalizedTypeName)) {
+      console.warn(
+        `[templateFields] Could not resolve field type by name for "${displayName}" ` +
+          `(typeName="${config.typeName ?? ""}", sourceTypeId=${sourceTypeId}); ` +
+          `falling back to source typeId, which may mis-type the field.`
+      );
+    }
+    const typeId = resolvedTypeId;
+
     console.log(
-      `[DEBUG] Processing field "${displayName}" (${systemName}) with typeId ${typeId}, action: ${config.action}`
+      `[DEBUG] Processing field "${displayName}" (${systemName}) typeName="${config.typeName ?? ""}" -> typeId ${typeId} (source ${sourceTypeId}), action: ${config.action}`
     );
     await ensureFieldTypeExists(typeId);
 


### PR DESCRIPTION
## Problem
When the Testmo importer **creates** a custom field, it wrote the source (Testmo) `typeId` directly as this instance's `CaseFieldTypes.id`. The two id spaces are unrelated, so created fields were silently mis-typed — e.g. a `"Text (Long)"` field (Testmo typeId 3) became local type 3 = **Dropdown**. `normalizeCaseFieldValue` then routed rich text through dropdown normalization, matched no option, and **dropped every value** (logging `"Unrecognized dropdown option"` per row — 61k times on a real import, which also bloated the job's `activityLog` and stalled progress writes).

Mapped fields were unaffected because they reuse the existing field.

## Fix
Resolve the destination `CaseFieldTypes.id` by matching the config's **`typeName`** (normalized for `"(Long)"` / `"Long"` style variants) against the local field types, falling back to the source id with a warning only when the name can't be resolved. Result fields share the `CaseFieldTypes` table, so the same lookup applies.

## Verification
Re-ran a real import after the fix: every created field now gets the correct type (`preconditions`/`scope`/`post_conditions` → Text Long, `type`/`automation` → Dropdown, `access_required` → Multi-Select, `brads_float` → Number, etc.) and **0** `"Unrecognized dropdown option"` warnings. `tsc --noEmit` clean.