### PR TITLE
perf(db): index foreign-key columns missing an index

### DIFF
--- a/testplanit/migrations/20260629010000_add_missing_fk_indexes/migration.sql
+++ b/testplanit/migrations/20260629010000_add_missing_fk_indexes/migration.sql
@@ -1,0 +1,23 @@
+-- Index the foreign-key columns that were missing an index.
+--
+-- Postgres does not auto-create an index on the referencing (child) column of
+-- a foreign key. All of the columns below are `onDelete: Cascade`, so without
+-- an index every parent-row delete triggers a full sequential scan of the
+-- child table to find rows to cascade. On large data this is catastrophic
+-- (e.g. deleting projects cascaded into a per-row seq-scan of Attachments,
+-- turning a bulk delete into an O(parents x rows) operation). These indexes
+-- also speed ordinary parent->child joins and FK-filtered lookups.
+
+CREATE INDEX IF NOT EXISTS "Attachments_testCaseId_idx" ON "Attachments"("testCaseId");
+CREATE INDEX IF NOT EXISTS "Attachments_sessionId_idx" ON "Attachments"("sessionId");
+CREATE INDEX IF NOT EXISTS "Attachments_sessionResultsId_idx" ON "Attachments"("sessionResultsId");
+CREATE INDEX IF NOT EXISTS "Attachments_testRunsId_idx" ON "Attachments"("testRunsId");
+CREATE INDEX IF NOT EXISTS "Attachments_testRunResultsId_idx" ON "Attachments"("testRunResultsId");
+CREATE INDEX IF NOT EXISTS "Attachments_testRunStepResultId_idx" ON "Attachments"("testRunStepResultId");
+CREATE INDEX IF NOT EXISTS "Attachments_junitTestResultId_idx" ON "Attachments"("junitTestResultId");
+CREATE INDEX IF NOT EXISTS "JUnitProperty_testSuiteId_idx" ON "JUnitProperty"("testSuiteId");
+CREATE INDEX IF NOT EXISTS "JUnitProperty_repositoryCaseId_idx" ON "JUnitProperty"("repositoryCaseId");
+CREATE INDEX IF NOT EXISTS "JUnitAttachment_repositoryCaseId_idx" ON "JUnitAttachment"("repositoryCaseId");
+CREATE INDEX IF NOT EXISTS "JUnitTestStep_repositoryCaseId_idx" ON "JUnitTestStep"("repositoryCaseId");
+CREATE INDEX IF NOT EXISTS "ResultFieldValues_testCaseId_idx" ON "ResultFieldValues"("testCaseId");
+CREATE INDEX IF NOT EXISTS "TestRunResults_testRunId_idx" ON "TestRunResults"("testRunId");

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -2120,6 +2120,7 @@ model ResultFieldValues {
     @@allow('all', auth().access == 'ADMIN')
     @@allow('read', auth().access != null)
     @@allow('create', auth() != null)
+    @@index([testCaseId])
 }
 
 model Attachments {
@@ -2152,6 +2153,13 @@ model Attachments {
     @@deny('all', auth().access == 'NONE')
     @@allow('all', auth().access == 'ADMIN')
     @@allow('create, read, update', auth().access != null)
+    @@index([testCaseId])
+    @@index([sessionId])
+    @@index([sessionResultsId])
+    @@index([testRunsId])
+    @@index([testRunResultsId])
+    @@index([testRunStepResultId])
+    @@index([junitTestResultId])
 }
 
 model Steps {
@@ -3081,6 +3089,7 @@ model TestRunResults {
     )
 
     @@allow('all', auth().access == 'ADMIN')
+    @@index([testRunId])
 }
 
 model TestRunStepResults {
@@ -3914,6 +3923,8 @@ model JUnitProperty {
 
     @@allow('create,update', auth().id == createdById)
     @@allow('all', auth().access == 'ADMIN')
+    @@index([testSuiteId])
+    @@index([repositoryCaseId])
 }
 
 model JUnitAttachment {
@@ -3952,6 +3963,7 @@ model JUnitAttachment {
 
     @@allow('create,update', auth().id == createdById)
     @@allow('all', auth().access == 'ADMIN')
+    @@index([repositoryCaseId])
 }
 
 model JUnitTestStep {
@@ -3991,6 +4003,7 @@ model JUnitTestStep {
 
     @@allow('create,update', auth().id == createdById)
     @@allow('all', auth().access == 'ADMIN')
+    @@index([repositoryCaseId])
 }
 
 enum JUnitResultType {


### PR DESCRIPTION
## Problem
Postgres does not auto-create an index on the referencing (child) column of a foreign key, and the columns below are all `onDelete: Cascade`. Without an index, every parent-row delete triggers a **full sequential scan of the child table** to find rows to cascade — O(parents × child-rows). Deleting a set of projects cascaded into a per-row seq-scan of the ~380k-row `Attachments` table and ran for **~8 hours**; with these indexes the same delete completed in minutes. The missing indexes also slow ordinary parent→child joins and FK-filtered lookups in the app.

## Change
Adds `@@index` for the previously-unindexed cascade FKs, plus the matching migration (idempotent `CREATE INDEX IF NOT EXISTS`):
- **Attachments**: testCaseId, sessionId, sessionResultsId, testRunsId, testRunResultsId, testRunStepResultId, junitTestResultId
- **JUnitProperty**: testSuiteId, repositoryCaseId
- **JUnitAttachment**: repositoryCaseId
- **JUnitTestStep**: repositoryCaseId
- **ResultFieldValues**: testCaseId
- **TestRunResults**: testRunId