### PR TITLE
fix(forecast): ignore soft-deleted test cases in forecast calculations

### DIFF
--- a/testplanit/services/forecastService.test.ts
+++ b/testplanit/services/forecastService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prisma client used by forecastService.
+const repoFindUnique = vi.fn();
+const repoFindMany = vi.fn();
+const repoUpdate = vi.fn();
+const trcFindMany = vi.fn();
+const trrFindMany = vi.fn();
+const junitFindMany = vi.fn();
+const runsFindUnique = vi.fn();
+const runsUpdate = vi.fn();
+
+vi.mock("../lib/prismaBase", () => ({
+  prisma: {
+    repositoryCases: {
+      findUnique: (...a: any[]) => repoFindUnique(...a),
+      findMany: (...a: any[]) => repoFindMany(...a),
+      update: (...a: any[]) => repoUpdate(...a),
+    },
+    testRunCases: { findMany: (...a: any[]) => trcFindMany(...a) },
+    testRunResults: { findMany: (...a: any[]) => trrFindMany(...a) },
+    jUnitTestResult: { findMany: (...a: any[]) => junitFindMany(...a) },
+    testRuns: {
+      findUnique: (...a: any[]) => runsFindUnique(...a),
+      update: (...a: any[]) => runsUpdate(...a),
+    },
+  },
+}));
+
+import {
+  updateRepositoryCaseForecast,
+  updateTestRunForecast,
+} from "./forecastService";
+
+describe("forecastService — soft-deleted cases are ignored", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("updateRepositoryCaseForecast", () => {
+    it("filters soft-deleted cases out of the group and never writes their forecasts", async () => {
+      // Seed case 1 is linked to case 2 (which is soft-deleted in the DB).
+      repoFindUnique.mockResolvedValue({
+        id: 1,
+        source: "MANUAL",
+        linksFrom: [{ caseBId: 2 }],
+        linksTo: [],
+      });
+
+      // repositoryCases.findMany is used twice: (a) the group fetch with a
+      // `source` selection, (b) the current-forecasts fetch keyed by id.
+      repoFindMany.mockImplementation((arg: any) => {
+        if (arg?.select?.source) {
+          // allCases: the DB returns only the live case (2 is soft-deleted).
+          return Promise.resolve([{ id: 1, source: "MANUAL" }]);
+        }
+        // currentForecasts (keyed off liveCaseIds).
+        return Promise.resolve([
+          { id: 1, forecastManual: null, forecastAutomated: null },
+        ]);
+      });
+
+      trcFindMany.mockResolvedValue([]); // no manual results, no affected runs
+      repoUpdate.mockResolvedValue({});
+
+      await updateRepositoryCaseForecast(1, { skipTestRunUpdate: true });
+
+      // The group query must exclude soft-deleted cases.
+      const allCasesCall = repoFindMany.mock.calls.find(
+        (c) => c[0]?.select?.source
+      );
+      expect(allCasesCall?.[0].where).toEqual({
+        id: { in: [1, 2] },
+        isDeleted: false,
+      });
+
+      // Forecast writes are scoped to the live case ids only — case 2 is gone.
+      const currentForecastsCall = repoFindMany.mock.calls.find(
+        (c) => c[0]?.select?.forecastManual && c[0]?.select?.id
+      );
+      expect(currentForecastsCall?.[0].where).toEqual({ id: { in: [1] } });
+
+      // The soft-deleted case 2 must never be updated.
+      const updatedIds = repoUpdate.mock.calls.map((c) => c[0]?.where?.id);
+      expect(updatedIds).not.toContain(2);
+    });
+  });
+
+  describe("updateTestRunForecast", () => {
+    it("excludes soft-deleted memberships and soft-deleted repository cases from the run total", async () => {
+      // Two untested cases in the run; the DB will only return the live one
+      // from the forecast-sum query (case 2's repository case is deleted).
+      trcFindMany.mockResolvedValue([
+        { repositoryCaseId: 1, status: null },
+        { repositoryCaseId: 2, status: null },
+      ]);
+      repoFindMany.mockResolvedValue([
+        { forecastManual: 100, forecastAutomated: 50 },
+      ]);
+      runsFindUnique.mockResolvedValue({
+        forecastManual: null,
+        forecastAutomated: null,
+      });
+      runsUpdate.mockResolvedValue({});
+
+      // Pre-seed alreadyRefreshedCaseIds so the function skips the per-case
+      // refresh recursion and goes straight to the run-sum logic.
+      await updateTestRunForecast(7, {
+        alreadyRefreshedCaseIds: new Set([1, 2]),
+      });
+
+      // The run-membership query must exclude soft-deleted memberships.
+      expect(trcFindMany.mock.calls[0][0].where).toEqual({
+        testRunId: 7,
+        isDeleted: false,
+      });
+
+      // The forecast-sum query must exclude soft-deleted repository cases.
+      const sumCall = repoFindMany.mock.calls.find(
+        (c) => c[0]?.select?.forecastManual && !c[0]?.select?.id
+      );
+      expect(sumCall?.[0].where).toEqual({
+        id: { in: [1, 2] },
+        isDeleted: false,
+      });
+
+      // Only the live case's forecast (100/50) lands on the run.
+      expect(runsUpdate).toHaveBeenCalledWith({
+        where: { id: 7 },
+        data: { forecastManual: 100, forecastAutomated: 50 },
+      });
+    });
+  });
+});

--- a/testplanit/services/forecastService.ts
+++ b/testplanit/services/forecastService.ts
@@ -69,11 +69,19 @@ export async function updateRepositoryCaseForecast(
     if (process.env.DEBUG_FORECAST)
       console.log("[Forecast] Group case IDs:", uniqueCaseIds);
 
-    // 2. Fetch all cases in the group with their source
+    // 2. Fetch all NON-DELETED cases in the group with their source.
+    // Soft-deleted cases must not pool their historical results into the
+    // group average, nor have their own forecast columns recalculated. We
+    // still keep `uniqueCaseIds` (which may include a just-deleted member)
+    // for affected-test-run discovery below, so a run that contained the
+    // deleted case still gets refreshed to drop its contribution.
     const allCases = await prisma.repositoryCases.findMany({
-      where: { id: { in: uniqueCaseIds } },
+      where: { id: { in: uniqueCaseIds }, isDeleted: false },
       select: { id: true, source: true },
     });
+    // The live (non-deleted) group members — the only cases whose forecast
+    // columns we write back below.
+    const liveCaseIds = allCases.map((c) => c.id);
     if (process.env.DEBUG_FORECAST)
       console.log("[Forecast] allCases:", allCases);
 
@@ -154,9 +162,9 @@ export async function updateRepositoryCaseForecast(
     if (process.env.DEBUG_FORECAST)
       console.log("[Forecast] avgManual:", avgManual, "avgJunit:", avgJunit);
 
-    // 5. Update only cases whose forecast values have actually changed
+    // 5. Update only live cases whose forecast values have actually changed
     const currentForecasts = await prisma.repositoryCases.findMany({
-      where: { id: { in: uniqueCaseIds } },
+      where: { id: { in: liveCaseIds } },
       select: { id: true, forecastManual: true, forecastAutomated: true },
     });
     for (const current of currentForecasts) {
@@ -234,7 +242,8 @@ export async function updateTestRunForecast(
   try {
     // 1. Fetch all TestRunCases for this TestRun, including their status system name
     let testRunCasesWithDetails = await prisma.testRunCases.findMany({
-      where: { testRunId: testRunId },
+      // Exclude soft-deleted run memberships (cases removed from the run).
+      where: { testRunId: testRunId, isDeleted: false },
       select: {
         repositoryCaseId: true,
         status: {
@@ -327,9 +336,11 @@ export async function updateTestRunForecast(
       return;
     }
 
-    // 3. Fetch the RepositoryCases for these filtered IDs
+    // 3. Fetch the live RepositoryCases for these filtered IDs. A case that
+    // is soft-deleted from the repository must not contribute its forecast
+    // to the run total, even if a stale run membership still references it.
     const repositoryCases = await prisma.repositoryCases.findMany({
-      where: { id: { in: repositoryCaseIdsToForecast } },
+      where: { id: { in: repositoryCaseIdsToForecast }, isDeleted: false },
       select: { forecastManual: true, forecastAutomated: true },
     });
 

--- a/testplanit/services/testRunService.test.ts
+++ b/testplanit/services/testRunService.test.ts
@@ -52,10 +52,11 @@ describe("testRunService", () => {
       await updateTestRunForecast(1);
 
       expect(mockFindMany).toHaveBeenCalledWith({
-        where: { testRunId: 1 },
+        where: { testRunId: 1, isDeleted: false },
         include: {
           repositoryCase: {
             select: {
+              isDeleted: true,
               forecastManual: true,
               forecastAutomated: true,
             },
@@ -133,6 +134,44 @@ describe("testRunService", () => {
         where: { id: 1 },
         data: {
           forecastManual: 100,
+          forecastAutomated: 50,
+        },
+      });
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should exclude soft-deleted repository cases from the forecast", async () => {
+      mockFindMany.mockResolvedValue([
+        {
+          id: 1,
+          testRunId: 1,
+          repositoryCase: {
+            isDeleted: false,
+            forecastManual: 100,
+            forecastAutomated: 50,
+          },
+        },
+        {
+          id: 2,
+          testRunId: 1,
+          // Soft-deleted repository case — must not contribute to the total.
+          repositoryCase: {
+            isDeleted: true,
+            forecastManual: 999,
+            forecastAutomated: 999,
+          },
+        },
+      ]);
+      mockUpdate.mockResolvedValue({});
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await updateTestRunForecast(1);
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: {
+          forecastManual: 100, // only the live case counts
           forecastAutomated: 50,
         },
       });

--- a/testplanit/services/testRunService.ts
+++ b/testplanit/services/testRunService.ts
@@ -5,6 +5,7 @@ import { prisma } from "~/lib/prismaBase";
 // Define a type for the structure returned by the findMany query
 type TestRunCaseWithForecast = TestRunCases & {
   repositoryCase: {
+    isDeleted: boolean;
     forecastManual: number | null;
     forecastAutomated: number | null;
   } | null;
@@ -18,13 +19,16 @@ type TestRunCaseWithForecast = TestRunCases & {
  */
 export async function updateTestRunForecast(testRunId: number): Promise<void> {
   try {
-    // Fetch the TestRunCases and their associated RepositoryCase forecasts
+    // Fetch the TestRunCases and their associated RepositoryCase forecasts.
+    // Exclude soft-deleted run memberships (cases removed from the run) so
+    // their forecast never counts toward the run total.
     const testRunCases: TestRunCaseWithForecast[] =
       await prisma.testRunCases.findMany({
-        where: { testRunId: testRunId },
+        where: { testRunId: testRunId, isDeleted: false },
         include: {
           repositoryCase: {
             select: {
+              isDeleted: true,
               forecastManual: true,
               forecastAutomated: true,
             },
@@ -32,15 +36,21 @@ export async function updateTestRunForecast(testRunId: number): Promise<void> {
         },
       });
 
+    // Drop cases whose repository case has been soft-deleted from the
+    // repository (a stale membership may still reference it).
+    const liveTestRunCases = testRunCases.filter(
+      (trc) => trc.repositoryCase && !trc.repositoryCase.isDeleted
+    );
+
     // Calculate the total forecasts, treating null as 0
-    const totalForecastManual = testRunCases.reduce(
+    const totalForecastManual = liveTestRunCases.reduce(
       (sum: number, testRunCase: any) => {
         const forecast = testRunCase.repositoryCase?.forecastManual ?? 0;
         return sum + forecast;
       },
       0
     );
-    const totalForecastAutomated = testRunCases.reduce(
+    const totalForecastAutomated = liveTestRunCases.reduce(
       (sum: number, testRunCase: any) => {
         const forecast = testRunCase.repositoryCase?.forecastAutomated ?? 0;
         return sum + forecast;


### PR DESCRIPTION
## Description

Forecast calculations never filtered `isDeleted`, so soft-deleted test cases were still factored into forecasts. A soft-deleted repository case (or a case removed from a run) still:

- had its historical durations averaged into its link-group's forecast,
- had its own `forecastManual` / `forecastAutomated` columns rewritten, and
- contributed its forecast to any test run that still referenced it.

This scopes every forecast read to **live** cases only:

- **`forecastService.updateRepositoryCaseForecast`** — group fetch now excludes `isDeleted`, so deleted members don't pool their results into the group average; forecast writes are scoped to live members only. (`uniqueCaseIds` is still used for affected-run discovery, so a run that contained a just-deleted case is still refreshed to drop its contribution.)
- **`forecastService.updateTestRunForecast`** (worker path) — run-membership query excludes soft-deleted memberships; the run-forecast sum excludes globally soft-deleted repository cases.
- **`testRunService.updateTestRunForecast`** (UI path: AddTestRunModal + run page) — same exclusions, so the UI can't rewrite the same stale numbers into the same columns.

This is a missing-filter logic bug that predates the ZenStack v3 work; the equivalent fix is also being applied on the `zenstack-v3-upgrade` branch.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

New `forecastService.test.ts` proves the `isDeleted: false` filters are applied and that a soft-deleted group member is never written. `testRunService.test.ts` gains a regression test asserting a soft-deleted repository case is excluded from the run total.

- Full unit suite: **9748 passed / 184 skipped / 0 failed**
- Full type-check (`tsc --noEmit`): **0 errors**
- `eslint` + `prettier --check` on changed files: clean

**Test Configuration:**
- OS: macOS
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes