### PR TITLE
fix(integrations): test edited/new config instead of stale state

### DIFF
--- a/testplanit/app/api/integrations/test-connection/route.ts
+++ b/testplanit/app/api/integrations/test-connection/route.ts
@@ -680,9 +680,17 @@ export const POST = withAuditContext(async (req: NextRequest) => {
       }
 
       testProvider = integration.provider;
-      authType = integration.authType;
+      // The admin may be testing values edited in the form (including a
+      // changed auth type). Prefer what the request supplies and fall back to
+      // the stored integration only for fields the form didn't provide (e.g.
+      // an unchanged, still-encrypted secret). Previously the stored values
+      // unconditionally overrode the request, so editing an existing
+      // integration — or switching its auth type — could never be tested and
+      // always failed against the originally-saved config.
+      authType = body.authType ?? integration.authType;
 
-      // Decrypt stored credentials for testing
+      // Decrypt stored credentials as a base; request-provided (form) values win.
+      const storedCredentials: Record<string, string> = {};
       if (
         integration.credentials &&
         typeof integration.credentials === "object"
@@ -694,7 +702,7 @@ export const POST = withAuditContext(async (req: NextRequest) => {
         ) {
           try {
             const decrypted = await decrypt(integration.credentials.encrypted);
-            Object.assign(testCredentials, JSON.parse(decrypted));
+            Object.assign(storedCredentials, JSON.parse(decrypted));
           } catch (e) {
             console.error("Failed to decrypt credentials:", e);
           }
@@ -708,26 +716,33 @@ export const POST = withAuditContext(async (req: NextRequest) => {
             if (value && typeof value === "string") {
               try {
                 // Check if the value is encrypted using the utility function
-                if (isEncrypted(value)) {
-                  testCredentials[key] = await decrypt(value);
-                } else {
-                  // If not encrypted, use as-is
-                  testCredentials[key] = value;
-                }
+                storedCredentials[key] = isEncrypted(value)
+                  ? await decrypt(value)
+                  : value;
               } catch {
                 // If decryption fails, use the value as-is
                 console.warn(
                   `Failed to decrypt credential ${key}, using as-is`
                 );
-                testCredentials[key] = value;
+                storedCredentials[key] = value;
               }
             }
           }
         }
       }
+      // Fill only the credentials the form did not supply (request wins).
+      for (const [key, value] of Object.entries(storedCredentials)) {
+        if (testCredentials[key] === undefined || testCredentials[key] === "") {
+          testCredentials[key] = value;
+        }
+      }
 
       if (integration.settings && typeof integration.settings === "object") {
-        testSettings = integration.settings as Record<string, string>;
+        // Stored settings as a base; request-provided settings override them.
+        testSettings = {
+          ...(integration.settings as Record<string, string>),
+          ...testSettings,
+        };
       }
     }
 

--- a/testplanit/components/admin/integrations/IntegrationModal.tsx
+++ b/testplanit/components/admin/integrations/IntegrationModal.tsx
@@ -121,6 +121,9 @@ export function IntegrationModal({
   });
 
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
     if (integration) {
       form.reset({
         name: integration.name,
@@ -135,8 +138,23 @@ export function IntegrationModal({
             : {},
       });
       setSelectedType(integration.provider);
+    } else {
+      // Opening for a NEW integration: clear any state left over from a
+      // prior edit session in this (persistent) modal. Without this, stale
+      // credentials/settings/authType leak into the create flow and produce
+      // a misleading "missing required configuration" error on Test
+      // Connection even though the visible fields look filled in.
+      form.reset({
+        name: "",
+        provider: undefined,
+        authType: undefined,
+        credentials: {},
+        settings: {},
+      });
+      setSelectedType(null);
     }
-  }, [integration, form]);
+    setTestPassed(false);
+  }, [isOpen, integration, form]);
 
   const handleTestConnection = async () => {
     setIsTesting(true);


### PR DESCRIPTION
## Problem
Setting up or editing a Jira (or any multi-field) issue integration failed `Test Connection` with **"Missing required Jira API key configuration (email, apiToken, baseUrl)"** even with all fields filled. Two compounding bugs:

### 1. Backend — `app/api/integrations/test-connection/route.ts`
When an `integrationId` was supplied (editing an existing integration), the stored integration's `authType`, `settings`, and `credentials` **unconditionally overrode** the values submitted in the form. So editing an existing integration — or switching its auth type — always tested the originally-saved config and reported the missing-config error. The imported Jira integration had been stored with empty API-key fields, so it could never be corrected.

**Fix:** request (form) values take precedence; the stored integration only fills fields the form didn't supply (e.g. an unchanged, still-encrypted secret). `authType` uses the request value when present. Row-level "Test" on the list (which sends only `integrationId`) still uses the stored config.

### 2. Frontend — `components/admin/integrations/IntegrationModal.tsx`
The form was only reset when opening to **edit** an existing integration, never when opening to **add** a new one. In the persistent (`isOpen`-toggled) modal, a prior edit session's `authType`/`credentials`/`settings` leaked into the create flow — producing the same misleading error on a "brand new" integration even though the visible fields looked filled in. (A page reload cleared it, which is what made it intermittent.)

**Fix:** reset the form on every open — clean defaults for a new integration, the integration's values for edit — and clear the prior `testPassed` state.

## Testing
- `app/api/integrations/test-connection/route.test.ts`: **23/23 pass**; `tsc --noEmit` clean.
- Verified live: editing the imported Jira integration and a fresh integration both now reach the real Jira probe instead of the missing-config error.