### PR TITLE
perf(db): drive issue/tag count queries from the small side (v3 EXISTS scans)

### DIFF
--- a/testplanit/app/api/issues/counts/route.ts
+++ b/testplanit/app/api/issues/counts/route.ts
@@ -80,151 +80,105 @@ export async function POST(request: Request) {
     // If projectId is provided, scope counts to that project only
     const projectFilter = projectId !== undefined ? { projectId } : {};
 
-    // Fetch counts for each issue using individual queries
-    const counts = await Promise.all(
-      issueIds.map(async (issueId) => {
-        const [
-          repositoryCasesCount,
-          directSessionsCount,
-          sessionResultsCount,
-          directTestRunsCount,
-          testRunResultsCount,
-          testRunStepResultsCount,
-        ] = await Promise.all([
-          // Repository cases
-          baseDb.repositoryCases.count({
-            where: {
+    // Fetch all requested issues with their linked entities in ONE
+    // issue-driven query. Driving from the issue side (a small set of ids)
+    // makes the m2m relation loads compile to `... WHERE "A" IN (issueIds)`
+    // join lookups instead of the correlated EXISTS subqueries that ZenStack
+    // v3 generates for `issues: { some: { id } }` filters — those scanned the
+    // large TestRunResults / TestRunStepResults tables once per issue and
+    // pegged the database. Counts are then derived in memory with the same
+    // additive semantics as before.
+    const issues = await baseDb.issue.findMany({
+      where: { id: { in: issueIds } },
+      select: {
+        id: true,
+        caseIssues: {
+          where: {
+            case: { isDeleted: false, ...projectFilter, ...projectAccessWhere },
+          },
+          select: { caseId: true },
+        },
+        sessions: {
+          where: { isDeleted: false, ...projectFilter, ...projectAccessWhere },
+          select: { id: true },
+        },
+        sessionResults: {
+          where: {
+            session: {
               isDeleted: false,
-              caseIssues: { some: { issue: { id: issueId } } },
               ...projectFilter,
               ...projectAccessWhere,
             },
-          }),
-          // Sessions - direct
-          baseDb.sessions.count({
-            where: {
+          },
+          select: { sessionId: true },
+        },
+        testRuns: {
+          where: { isDeleted: false, ...projectFilter, ...projectAccessWhere },
+          select: { id: true },
+        },
+        testRunResults: {
+          where: {
+            testRun: {
               isDeleted: false,
-              issues: { some: { id: issueId } },
               ...projectFilter,
               ...projectAccessWhere,
             },
-          }),
-          // Sessions - from session results
-          baseDb.sessionResults
-            .groupBy({
-              by: ["sessionId"],
-              where: {
-                issues: {
-                  some: {
-                    id: issueId,
-                  },
-                },
-                session: {
-                  isDeleted: false,
-                  ...projectFilter,
-                  ...projectAccessWhere,
-                },
-              },
-            })
-            .then((results) => results.length),
-          // Test runs - direct
-          baseDb.testRuns.count({
-            where: {
-              isDeleted: false,
-              issues: { some: { id: issueId } },
-              ...projectFilter,
-              ...projectAccessWhere,
-            },
-          }),
-          // Test runs - from test run results
-          baseDb.testRunResults
-            .groupBy({
-              by: ["testRunId"],
-              where: {
-                issues: {
-                  some: {
-                    id: issueId,
-                  },
-                },
-                testRun: {
-                  isDeleted: false,
-                  ...projectFilter,
-                  ...projectAccessWhere,
-                },
-              },
-            })
-            .then((results) => results.length),
-          // Test runs - from test run step results
-          baseDb.testRunStepResults.findMany({
-            where: {
-              issues: {
-                some: {
-                  id: issueId,
-                },
-              },
-              testRunResult: {
-                testRun: {
-                  isDeleted: false,
-                  ...projectFilter,
-                  ...projectAccessWhere,
-                },
+          },
+          select: { testRunId: true },
+        },
+        testRunStepResults: {
+          where: {
+            testRunResult: {
+              testRun: {
+                isDeleted: false,
+                ...projectFilter,
+                ...projectAccessWhere,
               },
             },
-            select: {
-              testRunResultId: true,
-            },
-            distinct: ["testRunResultId"],
-          }),
-        ]);
-
-        // Combine unique sessions
-        const totalSessionsCount = directSessionsCount + sessionResultsCount;
-
-        // To get test run IDs from step results, we need to fetch the test run results
-        const uniqueTestRunResultIds = testRunStepResultsCount.map(
-          (r) => r.testRunResultId
-        );
-        let stepResultsTestRunsCount = 0;
-        if (uniqueTestRunResultIds.length > 0) {
-          // Fetch the test runs for these results
-          const testRunResults = await baseDb.testRunResults.findMany({
-            where: {
-              id: { in: uniqueTestRunResultIds },
-            },
-            select: { testRunId: true },
-            distinct: ["testRunId"],
-          });
-          stepResultsTestRunsCount = testRunResults.length;
-        }
-
-        // Total unique test runs
-        const totalTestRunsCount =
-          directTestRunsCount + testRunResultsCount + stepResultsTestRunsCount;
-
-        return {
-          issueId,
-          repositoryCasesCount,
-          sessionsCount: totalSessionsCount,
-          testRunsCount: totalTestRunsCount,
-        };
-      })
-    );
-
-    // Convert to map for easy lookup
-    const countsMap = counts.reduce(
-      (acc, item) => {
-        acc[item.issueId] = {
-          repositoryCases: item.repositoryCasesCount,
-          sessions: item.sessionsCount,
-          testRuns: item.testRunsCount,
-        };
-        return acc;
+          },
+          select: { testRunResult: { select: { testRunId: true } } },
+        },
       },
-      {} as Record<
-        number,
-        { repositoryCases: number; sessions: number; testRuns: number }
-      >
-    );
+    });
+
+    const countsMap: Record<
+      number,
+      { repositoryCases: number; sessions: number; testRuns: number }
+    > = {};
+
+    for (const issue of issues) {
+      // Sessions: directly-linked + sessions reached via linked session
+      // results (kept additive to preserve the previous totals exactly).
+      const directSessions = issue.sessions.length;
+      const viaResultSessions = new Set(
+        issue.sessionResults.map((r) => r.sessionId)
+      ).size;
+
+      // Test runs: directly-linked + via test run results + via test run
+      // step results (same additive semantics as before).
+      const directTestRuns = issue.testRuns.length;
+      const viaResultTestRuns = new Set(
+        issue.testRunResults.map((r) => r.testRunId)
+      ).size;
+      const viaStepTestRuns = new Set(
+        issue.testRunStepResults
+          .map((s) => s.testRunResult?.testRunId)
+          .filter((id): id is number => id != null)
+      ).size;
+
+      countsMap[issue.id] = {
+        repositoryCases: issue.caseIssues.length,
+        sessions: directSessions + viaResultSessions,
+        testRuns: directTestRuns + viaResultTestRuns + viaStepTestRuns,
+      };
+    }
+
+    // Ensure every requested id has an entry (issue not found / no links).
+    for (const id of issueIds) {
+      if (!countsMap[id]) {
+        countsMap[id] = { repositoryCases: 0, sessions: 0, testRuns: 0 };
+      }
+    }
 
     return NextResponse.json({ counts: countsMap });
   } catch (error) {

--- a/testplanit/app/api/tags/counts/route.ts
+++ b/testplanit/app/api/tags/counts/route.ts
@@ -74,59 +74,52 @@ export async function POST(request: Request) {
           },
         };
 
-    // Fetch counts for each tag using individual queries
-    // This avoids the bind variable explosion from complex joins
-    const counts = await Promise.all(
-      tagIds.map(async (tagId) => {
-        const [repositoryCasesCount, sessionsCount, testRunsCount] =
-          await Promise.all([
-            baseDb.repositoryCases.count({
-              where: {
-                isDeleted: false,
-                caseTags: { some: { tag: { id: tagId } } },
-                ...projectAccessWhere,
-              },
-            }),
-            baseDb.sessions.count({
-              where: {
-                isDeleted: false,
-                tags: { some: { id: tagId } },
-                ...projectAccessWhere,
-              },
-            }),
-            baseDb.testRuns.count({
-              where: {
-                isDeleted: false,
-                tags: { some: { id: tagId } },
-                ...projectAccessWhere,
-              },
-            }),
-          ]);
-
-        return {
-          tagId,
-          repositoryCasesCount,
-          sessionsCount,
-          testRunsCount,
-        };
-      })
-    );
-
-    // Convert to map for easy lookup
-    const countsMap = counts.reduce(
-      (acc, item) => {
-        acc[item.tagId] = {
-          repositoryCases: item.repositoryCasesCount,
-          sessions: item.sessionsCount,
-          testRuns: item.testRunsCount,
-        };
-        return acc;
+    // Fetch all requested tags with their linked entities in ONE tag-driven
+    // query. Driving from the tag side (a small set of ids) makes the m2m
+    // relation loads compile to join lookups keyed by the tag ids, instead of
+    // the correlated EXISTS subqueries ZenStack v3 generates for
+    // `tags: { some: { id } }` filters — those scanned the large
+    // RepositoryCases / TestRuns tables once per tag. Counts are derived in
+    // memory; each linked row is distinct per (entity, tag) so a plain
+    // length is the distinct count.
+    const tags = await baseDb.tags.findMany({
+      where: { id: { in: tagIds } },
+      select: {
+        id: true,
+        caseTags: {
+          where: { case: { isDeleted: false, ...projectAccessWhere } },
+          select: { caseId: true },
+        },
+        sessions: {
+          where: { isDeleted: false, ...projectAccessWhere },
+          select: { id: true },
+        },
+        testRuns: {
+          where: { isDeleted: false, ...projectAccessWhere },
+          select: { id: true },
+        },
       },
-      {} as Record<
-        number,
-        { repositoryCases: number; sessions: number; testRuns: number }
-      >
-    );
+    });
+
+    const countsMap: Record<
+      number,
+      { repositoryCases: number; sessions: number; testRuns: number }
+    > = {};
+
+    for (const tag of tags) {
+      countsMap[tag.id] = {
+        repositoryCases: tag.caseTags.length,
+        sessions: tag.sessions.length,
+        testRuns: tag.testRuns.length,
+      };
+    }
+
+    // Ensure every requested id has an entry (tag not found / no links).
+    for (const id of tagIds) {
+      if (!countsMap[id]) {
+        countsMap[id] = { repositoryCases: 0, sessions: 0, testRuns: 0 };
+      }
+    }
 
     return NextResponse.json({ counts: countsMap });
   } catch (error) {

--- a/testplanit/app/api/tags/projects/route.ts
+++ b/testplanit/app/api/tags/projects/route.ts
@@ -72,81 +72,78 @@ export async function POST(request: Request) {
           ],
         };
 
-    // For each tag, fetch a small sample of projects from different sources
-    const projectsData = await Promise.all(
-      tagIds.map(async (tagId) => {
-        // Fetch all distinct project IDs from each relation type
-        // No need to limit since we're using direct Prisma queries (no bind variable issues)
-        const [caseProjectIds, sessionProjectIds, runProjectIds] =
-          await Promise.all([
-            baseDb.repositoryCases.findMany({
-              where: {
-                isDeleted: false,
-                caseTags: { some: { tag: { id: tagId } } },
-              },
-              select: { projectId: true },
-              distinct: ["projectId"],
-            }),
-            baseDb.sessions.findMany({
-              where: {
-                isDeleted: false,
-                tags: { some: { id: tagId } },
-              },
-              select: { projectId: true },
-              distinct: ["projectId"],
-            }),
-            baseDb.testRuns.findMany({
-              where: {
-                isDeleted: false,
-                tags: { some: { id: tagId } },
-              },
-              select: { projectId: true },
-              distinct: ["projectId"],
-            }),
-          ]);
-
-        // Combine and deduplicate project IDs
-        const uniqueProjectIds = [
-          ...new Set([
-            ...caseProjectIds.map((c) => c.projectId),
-            ...sessionProjectIds.map((s) => s.projectId),
-            ...runProjectIds.map((r) => r.projectId),
-          ]),
-        ];
-
-        // Fetch actual project data with access control
-        if (uniqueProjectIds.length === 0) {
-          return { tagId, projects: [] };
-        }
-
-        const projects = await baseDb.projects.findMany({
-          where: {
-            id: { in: uniqueProjectIds },
-            isDeleted: false,
-            ...projectAccessWhere,
-          },
-          select: {
-            id: true,
-            name: true,
-            iconUrl: true,
-          },
-        });
-
-        return { tagId, projects };
-      })
-    );
-
-    // Convert to map for easy lookup
-    const projectsMap = projectsData.reduce(
-      (acc, item) => {
-        acc[item.tagId] = item.projects;
-        return acc;
+    // Fetch all requested tags with the project ids they touch, driven from
+    // the tag side so the m2m relation loads are join lookups keyed by the tag
+    // ids rather than ZenStack v3 correlated-EXISTS scans of the large
+    // RepositoryCases / TestRuns tables (which previously ran once per tag).
+    const tags = await baseDb.tags.findMany({
+      where: { id: { in: tagIds } },
+      select: {
+        id: true,
+        caseTags: {
+          where: { case: { isDeleted: false } },
+          select: { case: { select: { projectId: true } } },
+        },
+        sessions: {
+          where: { isDeleted: false },
+          select: { projectId: true },
+        },
+        testRuns: {
+          where: { isDeleted: false },
+          select: { projectId: true },
+        },
       },
-      {} as Record<
-        number,
-        Array<{ id: number; name: string; iconUrl: string | null }>
-      >
-    );
+    });
+
+    // Collect the distinct project ids each tag touches, plus the union.
+    const projectIdsByTag = new Map<number, Set<number>>();
+    const allProjectIds = new Set<number>();
+    for (const tag of tags) {
+      const ids = new Set<number>();
+      for (const ct of tag.caseTags) {
+        const pid = ct.case?.projectId;
+        if (pid != null) ids.add(pid);
+      }
+      for (const s of tag.sessions) {
+        if (s.projectId != null) ids.add(s.projectId);
+      }
+      for (const r of tag.testRuns) {
+        if (r.projectId != null) ids.add(r.projectId);
+      }
+      projectIdsByTag.set(tag.id, ids);
+      ids.forEach((id) => allProjectIds.add(id));
+    }
+
+    // Fetch the accessible projects once (access control applied here).
+    const accessibleProjects =
+      allProjectIds.size > 0
+        ? await baseDb.projects.findMany({
+            where: {
+              id: { in: Array.from(allProjectIds) },
+              isDeleted: false,
+              ...projectAccessWhere,
+            },
+            select: { id: true, name: true, iconUrl: true },
+          })
+        : [];
+    const projectById = new Map(accessibleProjects.map((p) => [p.id, p]));
+
+    // Build per-tag project lists (only accessible projects).
+    const projectsMap: Record<
+      number,
+      Array<{ id: number; name: string; iconUrl: string | null }>
+    > = {};
+    for (const tagId of tagIds) {
+      const ids = projectIdsByTag.get(tagId);
+      projectsMap[tagId] = ids
+        ? Array.from(ids)
+            .map((id) => projectById.get(id))
+            .filter(
+              (p): p is { id: number; name: string; iconUrl: string | null } =>
+                p != null
+            )
+        : [];
+    }
 
     return NextResponse.json({ projects: projectsMap });
   } catch (error) {


### PR DESCRIPTION
## Problem
ZenStack v3 compiles a `{ relation: { some: { id } } }` filter into a **correlated `EXISTS`** subquery that references the outer row. Filtering a large table by a relation therefore forces a full table scan, and the issue/tag count endpoints did this **once per id in a `Promise.all` loop** — scanning the large imported tables (TestRunResults ~464k, TestRunStepResults ~714k, RepositoryCases ~130k, TestRuns ~89k) dozens of times per page load. This pegged the database CPU. (Did not occur under v2/Prisma, which compiled an efficient plan.)

## Fix
Rewrite each endpoint to **drive from the small side**: a single `findMany({ where: { id: { in: ids } }, select: { <relations> } })` on the issue/tag, whose m2m relation loads compile to indexed join lookups keyed by the ids. Counts are derived in memory with identical (additive) semantics, and the per-id loops collapse into one batched query.

Endpoints: `/api/issues/counts` (global, **Project > Issues**, admin issue lists), `/api/tags/counts`, `/api/tags/projects`.

## Verification (EXPLAIN on production-scale data)
| Query | plan cost before → after |
|---|---|
| issues/counts — TestRunStepResults relation | **6,894,817 → 108** |
| tags/counts — TestRuns relation | **365,160 → 30** |

`_IssueToTestRunStepResults` is empty, so the old query scanned all 714k step-result rows just to return nothing. Typecheck clean.

## Follow-up (not in this PR)
An audit found the same v3 pattern in other spots, to be handled separately with the same drive-from-small-side approach + EXPLAIN verification:
- **Project > Issues page** `issue.useGroupBy/useFindMany` filtered by 6 large-table relations (`~1.3M` plan cost; client-side, needs a careful refactor)
- `repository-cases/view-options` `count({ steps: { some } })`
- `report-builder/project-health` issue relation filters
- `Cases.tsx` `steps`/`caseFieldValues` `some`/`none` filters