### PR TITLE
perf(db): make DataChangeLog poll index partial (WHERE processed = false)

### DIFF
--- a/testplanit/migrations/20260629020000_datachangelog_partial_poll_index/migration.sql
+++ b/testplanit/migrations/20260629020000_datachangelog_partial_poll_index/migration.sql
@@ -1,0 +1,14 @@
+-- CDC worker poll hot path: `WHERE "processed" = false ORDER BY "seq"`.
+--
+-- The init migration created `dcl_unprocessed_seq` as a PLAIN btree("seq")
+-- because Prisma/ZenStack `@@index` cannot express a partial-index predicate
+-- (the schema comment already notes the intended `WHERE processed = false`
+-- clause). Once DataChangeLog grew to millions of rows, every poll scanned
+-- the whole index + heap to confirm there was no unprocessed backlog,
+-- pinning a CPU core continuously.
+--
+-- Recreate it as the intended PARTIAL index. When there is no backlog the
+-- index is empty, so the poll returns instantly instead of scanning the
+-- entire table.
+DROP INDEX IF EXISTS "dcl_unprocessed_seq";
+CREATE INDEX "dcl_unprocessed_seq" ON "DataChangeLog"("seq") WHERE "processed" = false;


### PR DESCRIPTION
## Problem
The CDC/audit worker continuously polls:
```sql
SELECT * FROM "DataChangeLog" WHERE processed = false ORDER BY seq ASC LIMIT n FOR UPDATE SKIP LOCKED
```
Its supporting index `dcl_unprocessed_seq` was created as a **plain** `btree("seq")` — Prisma/ZenStack `@@index` can't express the partial `WHERE processed = false` predicate the schema comment already documents as the intent. Once `DataChangeLog` grew to millions of rows, every poll scanned the full index + heap to confirm there was no unprocessed backlog, pinning a CPU core continuously (showed up as a sustained ~83% Postgres backend from the workers container).

## Fix
Recreate `dcl_unprocessed_seq` as a **partial index** `("seq") WHERE "processed" = false`. With no backlog the index is empty, so the poll returns instantly.

## Verification (production-scale data: 4.37M rows, 0 unprocessed)
Poll plan cost **379,637 → 5** after the partial index + ANALYZE. Host load dropped accordingly.

## Note
Prisma/ZenStack can't express partial-index predicates in `@@index`, so this is a raw-SQL migration; the `@@index([seq], map: "dcl_unprocessed_seq")` in the schema stays (same name/columns) and this migration refines it to partial. `migrate deploy` applies it as-is.