### PR TITLE
perf(db): compute project-relevant issue ids from the small side

### DIFF
--- a/testplanit/app/[locale]/projects/issues/[projectId]/page.tsx
+++ b/testplanit/app/[locale]/projects/issues/[projectId]/page.tsx
@@ -116,25 +116,43 @@ function ProjectIssues() {
     typeof pageSize === "number" ? pageSize : totalItems;
   const skip = (currentPage - 1) * effectivePageSize;
 
-  // Build project filter for groupBy queries
-  const projectFilterForGroupBy = useMemo(() => {
-    if (projectId === null) return {};
-    return {
-      OR: [
-        { projectId },
-        { repositoryCases: { some: { projectId } } },
-        { sessions: { some: { projectId } } },
-        { testRuns: { some: { projectId } } },
-        { sessionResults: { some: { session: { projectId } } } },
-        { testRunResults: { some: { testRun: { projectId } } } },
-        {
-          testRunStepResults: {
-            some: { testRunResult: { testRun: { projectId } } },
-          },
-        },
-      ],
+  // The set of issue ids relevant to this project (filed under it, or linked
+  // to any of its cases / sessions / runs / results). Computed server-side
+  // from the small issue<->entity join tables; see /api/projects/[id]/issue-ids
+  // and getProjectRelevantIssueIds. We filter issues by `id: { in: ... }`
+  // instead of `{ relation: { some } }`, which ZenStack v3 compiles into
+  // correlated EXISTS subqueries that scan the large tables. `null` = not yet
+  // loaded (issue queries stay disabled until it resolves).
+  const [relevantIssueIds, setRelevantIssueIds] = useState<number[] | null>(
+    null
+  );
+  useEffect(() => {
+    if (projectId === null) {
+      setRelevantIssueIds(null);
+      return;
+    }
+    let cancelled = false;
+    setRelevantIssueIds(null);
+    fetch(`/api/projects/${projectId}/issue-ids`)
+      .then((r) => (r.ok ? r.json() : { issueIds: [] }))
+      .then((d) => {
+        if (!cancelled) {
+          setRelevantIssueIds(Array.isArray(d.issueIds) ? d.issueIds : []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRelevantIssueIds([]);
+      });
+    return () => {
+      cancelled = true;
     };
   }, [projectId]);
+
+  // Build project filter for groupBy queries
+  const projectFilterForGroupBy = useMemo(() => {
+    if (projectId === null || relevantIssueIds === null) return {};
+    return { id: { in: relevantIssueIds } };
+  }, [projectId, relevantIssueIds]);
 
   // Fetch distinct status values for the filter dropdown (scoped to this project)
   const { data: statusOptions } = useClientQueries(schema).issue.useGroupBy(
@@ -144,7 +162,8 @@ function ProjectIssues() {
       orderBy: { status: "asc" },
     },
     {
-      enabled: !!session?.user && projectId !== null,
+      enabled:
+        !!session?.user && projectId !== null && relevantIssueIds !== null,
     }
   );
 
@@ -156,7 +175,8 @@ function ProjectIssues() {
       orderBy: { priority: "asc" },
     },
     {
-      enabled: !!session?.user && projectId !== null,
+      enabled:
+        !!session?.user && projectId !== null && relevantIssueIds !== null,
     }
   );
 
@@ -228,35 +248,14 @@ function ProjectIssues() {
 
   // Build the where clause for issues in this project
   const issuesWhere = useMemo(() => {
-    if (projectId === null) {
+    if (projectId === null || relevantIssueIds === null) {
       return null;
     }
 
-    const projectFilter = {
-      OR: [
-        { projectId },
-        { repositoryCases: { some: { projectId } } },
-        { sessions: { some: { projectId } } },
-        { testRuns: { some: { projectId } } },
-        {
-          sessionResults: {
-            some: { session: { projectId } },
-          },
-        },
-        {
-          testRunResults: {
-            some: { testRun: { projectId } },
-          },
-        },
-        {
-          testRunStepResults: {
-            some: {
-              testRunResult: { testRun: { projectId } },
-            },
-          },
-        },
-      ],
-    };
+    // Filter by the precomputed set of project-relevant issue ids (see
+    // relevantIssueIds above) instead of `{ relation: { some } }`, which
+    // ZenStack v3 compiles into correlated EXISTS scans of the large tables.
+    const projectFilter = { id: { in: relevantIssueIds } };
 
     // Combine search filter and project filter using AND
     const conditions: Array<Record<string, unknown>> = [
@@ -286,7 +285,7 @@ function ProjectIssues() {
     return {
       AND: conditions,
     };
-  }, [projectId, searchFilter, statusFilter, priorityFilter]);
+  }, [projectId, relevantIssueIds, searchFilter, statusFilter, priorityFilter]);
 
   const orderBy = useMemo(() => {
     // Only apply server-side sorting for database columns

--- a/testplanit/app/api/projects/[projectId]/issue-ids/route.ts
+++ b/testplanit/app/api/projects/[projectId]/issue-ids/route.ts
@@ -1,0 +1,42 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { getProjectRelevantIssueIds } from "~/lib/projectIssueIds";
+import { authOptions } from "~/server/auth";
+
+/**
+ * Returns the IDs of issues relevant to a project (filed under it, or linked
+ * to any of its cases / sessions / runs / results). Computed efficiently from
+ * the small issue<->entity join tables so the client can filter issues with
+ * `id: { in: [...] }` instead of a `{ relation: { some } }` filter that
+ * ZenStack v3 compiles to correlated EXISTS scans of the large tables.
+ *
+ * Access policy is still enforced when the client subsequently queries the
+ * issues themselves via the policy-enabled client; this endpoint only narrows
+ * the candidate set to the project.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+  const projectIdNum = Number(projectId);
+  if (!Number.isInteger(projectIdNum)) {
+    return NextResponse.json({ error: "Invalid projectId" }, { status: 400 });
+  }
+
+  try {
+    const issueIds = await getProjectRelevantIssueIds(projectIdNum);
+    return NextResponse.json({ issueIds });
+  } catch (error) {
+    console.error("Error fetching project issue ids:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch issue ids" },
+      { status: 500 }
+    );
+  }
+}

--- a/testplanit/app/api/report-builder/project-health/route.ts
+++ b/testplanit/app/api/report-builder/project-health/route.ts
@@ -1,4 +1,5 @@
 import { baseDb } from "@/lib/db";
+import { getProjectRelevantIssueIds } from "@/lib/projectIssueIds";
 import { NextRequest } from "next/server";
 
 // Note: Project health uses custom milestone and issue-based logic
@@ -77,30 +78,23 @@ const DIMENSION_REGISTRY: Record<
         distinct: ["createdBy"],
       });
 
-      const issueCreators = await baseDb.issue.findMany({
-        where: {
-          OR: [
-            { repositoryCases: { some: { projectId: Number(projectId) } } },
-            {
-              sessions: {
-                some: { projectId: Number(projectId), isDeleted: false },
+      // Drive from the small issue<->entity join tables (see helper) rather
+      // than filtering the issue table by `{ relation: { some } }`, which
+      // ZenStack v3 compiles to correlated EXISTS scans of the large tables.
+      const relevantIssueIds = await getProjectRelevantIssueIds(
+        Number(projectId)
+      );
+      const issueCreators = relevantIssueIds.length
+        ? await baseDb.issue.findMany({
+            where: { id: { in: relevantIssueIds }, isDeleted: false },
+            select: {
+              createdBy: {
+                select: { id: true, name: true, email: true },
               },
             },
-            {
-              testRuns: {
-                some: { projectId: Number(projectId), isDeleted: false },
-              },
-            },
-          ],
-          isDeleted: false,
-        },
-        select: {
-          createdBy: {
-            select: { id: true, name: true, email: true },
-          },
-        },
-        distinct: ["createdById"],
-      });
+            distinct: ["createdById"],
+          })
+        : [];
 
       const allCreators = [
         ...milestoneCreators.map((m: any) => m.creator),
@@ -140,27 +134,17 @@ const DIMENSION_REGISTRY: Record<
         orderBy: { createdAt: "asc" },
       });
 
-      const issueDates = await baseDb.issue.findMany({
-        where: {
-          OR: [
-            { repositoryCases: { some: { projectId: Number(projectId) } } },
-            {
-              sessions: {
-                some: { projectId: Number(projectId), isDeleted: false },
-              },
-            },
-            {
-              testRuns: {
-                some: { projectId: Number(projectId), isDeleted: false },
-              },
-            },
-          ],
-          isDeleted: false,
-        },
-        select: { createdAt: true },
-        distinct: ["createdAt"],
-        orderBy: { createdAt: "asc" },
-      });
+      const relevantIssueIds = await getProjectRelevantIssueIds(
+        Number(projectId)
+      );
+      const issueDates = relevantIssueIds.length
+        ? await baseDb.issue.findMany({
+            where: { id: { in: relevantIssueIds }, isDeleted: false },
+            select: { createdAt: true },
+            distinct: ["createdAt"],
+            orderBy: { createdAt: "asc" },
+          })
+        : [];
 
       const allDates = [...milestoneDates, ...issueDates];
 

--- a/testplanit/lib/projectIssueIds.ts
+++ b/testplanit/lib/projectIssueIds.ts
@@ -1,0 +1,52 @@
+import { baseDb } from "~/lib/db";
+
+/**
+ * Returns the IDs of issues relevant to a project: filed under the project
+ * directly, or linked to any of its repository cases, sessions, session
+ * results, test runs, test run results, or test run step results.
+ *
+ * This is driven from the small issue<->entity join tables (a few thousand
+ * rows total) and joined up to the parent entity to filter by project, rather
+ * than filtering the large entity tables by `{ relation: { some: { id } } }`.
+ * Under ZenStack v3 the latter compiles to a correlated EXISTS subquery that
+ * scans the large tables — ~1.1 s per query on production-scale data, vs ~3 ms
+ * for this union. Callers then re-query issues by `id: { in: ids }` (which
+ * still applies access policies), or filter further as needed.
+ */
+export async function getProjectRelevantIssueIds(
+  projectId: number
+): Promise<number[]> {
+  const rows = await baseDb.$queryRaw<Array<{ id: number }>>`
+    SELECT i."id" AS id FROM "Issue" i
+      WHERE i."isDeleted" = false AND i."projectId" = ${projectId}
+    UNION
+    SELECT ci."issueId" AS id FROM "RepositoryCaseIssue" ci
+      JOIN "RepositoryCases" rc ON rc."id" = ci."caseId"
+      WHERE rc."projectId" = ${projectId} AND rc."isDeleted" = false
+    UNION
+    SELECT j."A" AS id FROM "_IssueToSessions" j
+      JOIN "Sessions" s ON s."id" = j."B"
+      WHERE s."projectId" = ${projectId} AND s."isDeleted" = false
+    UNION
+    SELECT j."A" AS id FROM "_IssueToSessionResults" j
+      JOIN "SessionResults" sr ON sr."id" = j."B"
+      JOIN "Sessions" s ON s."id" = sr."sessionId"
+      WHERE s."projectId" = ${projectId} AND s."isDeleted" = false
+    UNION
+    SELECT j."A" AS id FROM "_IssueToTestRuns" j
+      JOIN "TestRuns" r ON r."id" = j."B"
+      WHERE r."projectId" = ${projectId} AND r."isDeleted" = false
+    UNION
+    SELECT j."A" AS id FROM "_IssueToTestRunResults" j
+      JOIN "TestRunResults" rr ON rr."id" = j."B"
+      JOIN "TestRuns" r ON r."id" = rr."testRunId"
+      WHERE r."projectId" = ${projectId} AND r."isDeleted" = false
+    UNION
+    SELECT j."A" AS id FROM "_IssueToTestRunStepResults" j
+      JOIN "TestRunStepResults" trsr ON trsr."id" = j."B"
+      JOIN "TestRunResults" rr ON rr."id" = trsr."testRunResultId"
+      JOIN "TestRuns" r ON r."id" = rr."testRunId"
+      WHERE r."projectId" = ${projectId} AND r."isDeleted" = false
+  `;
+  return rows.map((r) => Number(r.id));
+}


### PR DESCRIPTION
Follow-up to #480. Two more queries filtered the `issue` table by `{ relation: { some: { projectId } } }` across up to six large-table relations — the same ZenStack v3 anti-pattern (correlated EXISTS scans):

- **Project > Issues page** (`issue.useGroupBy` ×2 + `useFindMany`): **~1,153 ms per query, ×3 per page load**.
- **Report Builder → project-health** (issue creators/dates dimensions).

## Fix
New shared helper `getProjectRelevantIssueIds(projectId)` computes the relevant issue set by driving from the small `issue↔entity` join tables (a few thousand rows) and joining up to filter by project — **~3 ms** vs ~1.15 s.
- `project-health` calls it directly (server).
- The Project > Issues page fetches the ids via a new `GET /api/projects/[projectId]/issue-ids` and filters issues with `id: { in: ... }`; access policy is still enforced when the issues are queried, and issue queries stay disabled until the ids resolve. Behavior is preserved (the full relation-relevance set, which is ~2–10% larger than `projectId` alone, is kept).

## Scope note
`repository-cases/view-options` and `Cases.tsx` use the same relation-filter shape but are **project-scoped** (`baseWhere`), so they measure **31–77 ms** even on the largest project (42k cases) — left unchanged (no benefit, only risk).