### PR TITLE
fix(issues): multiplex issue-update SSE and speed up the cross-project list

### DIFF
--- a/testplanit/app/api/issues/projects/route.ts
+++ b/testplanit/app/api/issues/projects/route.ts
@@ -72,184 +72,107 @@ export async function POST(request: Request) {
           ],
         };
 
-    // For each issue, fetch all associated projects from different sources
-    const projectsData = await Promise.all(
-      issueIds.map(async (issueId) => {
-        // Fetch all distinct project IDs from each relation type
-        const [
-          caseProjectIds,
-          sessionProjectIds,
-          sessionResultProjectIds,
-          runProjectIds,
-          runResultProjectIds,
-          stepResultProjectIds,
-        ] = await Promise.all([
-          // From repository cases
-          baseDb.repositoryCases.findMany({
-            where: {
-              isDeleted: false,
-              caseIssues: { some: { issue: { id: issueId } } },
-            },
-            select: { projectId: true },
-            distinct: ["projectId"],
-          }),
-          // From sessions
-          baseDb.sessions.findMany({
-            where: {
-              isDeleted: false,
-              issues: { some: { id: issueId } },
-            },
-            select: { projectId: true },
-            distinct: ["projectId"],
-          }),
-          // From session results
-          baseDb.sessionResults.findMany({
-            where: {
-              issues: {
-                some: {
-                  id: issueId,
-                },
-              },
-              session: { isDeleted: false },
-            },
-            select: {
-              sessionId: true,
-            },
-          }),
-          // From test runs
-          baseDb.testRuns.findMany({
-            where: {
-              isDeleted: false,
-              issues: { some: { id: issueId } },
-            },
-            select: { projectId: true },
-            distinct: ["projectId"],
-          }),
-          // From test run results
-          baseDb.testRunResults.findMany({
-            where: {
-              issues: {
-                some: {
-                  id: issueId,
-                },
-              },
-              testRun: { isDeleted: false },
-            },
-            select: {
-              testRunId: true,
-            },
-          }),
-          // From test run step results
-          baseDb.testRunStepResults.findMany({
-            where: {
-              issues: {
-                some: {
-                  id: issueId,
-                },
-              },
-              testRunResult: {
-                testRun: { isDeleted: false },
-              },
-            },
-            select: {
-              testRunResultId: true,
-            },
-          }),
-        ]);
-
-        // Fetch project IDs from session IDs and test run IDs
-        const sessionIdsFromResults = sessionResultProjectIds.map(
-          (sr) => sr.sessionId
-        );
-        const testRunIdsFromResults = runResultProjectIds.map(
-          (rr) => rr.testRunId
-        );
-        const testRunResultIdsFromStepResults = stepResultProjectIds.map(
-          (srr) => srr.testRunResultId
-        );
-
-        // Fetch sessions to get their project IDs
-        const sessionsFromResults =
-          sessionIdsFromResults.length > 0
-            ? await baseDb.sessions.findMany({
-                where: { id: { in: sessionIdsFromResults } },
-                select: { projectId: true },
-              })
-            : [];
-
-        // Fetch test runs to get their project IDs
-        const testRunsFromResults =
-          testRunIdsFromResults.length > 0
-            ? await baseDb.testRuns.findMany({
-                where: { id: { in: testRunIdsFromResults } },
-                select: { projectId: true },
-              })
-            : [];
-
-        // Fetch test run results to get test run IDs, then get their project IDs
-        const testRunsFromStepResults =
-          testRunResultIdsFromStepResults.length > 0
-            ? await baseDb.testRunResults
-                .findMany({
-                  where: { id: { in: testRunResultIdsFromStepResults } },
-                  select: { testRunId: true },
-                })
-                .then(async (results) => {
-                  const testRunIds = results.map((r) => r.testRunId);
-                  return testRunIds.length > 0
-                    ? await baseDb.testRuns.findMany({
-                        where: { id: { in: testRunIds } },
-                        select: { projectId: true },
-                      })
-                    : [];
-                })
-            : [];
-
-        // Combine and deduplicate project IDs
-        const uniqueProjectIds = [
-          ...new Set([
-            ...caseProjectIds.map((c) => c.projectId),
-            ...sessionProjectIds.map((s) => s.projectId),
-            ...sessionsFromResults.map((s) => s.projectId),
-            ...runProjectIds.map((r) => r.projectId),
-            ...testRunsFromResults.map((r) => r.projectId),
-            ...testRunsFromStepResults.map((r) => r.projectId),
-          ]),
-        ];
-
-        // Fetch actual project data with access control
-        if (uniqueProjectIds.length === 0) {
-          return { issueId, projects: [] };
-        }
-
-        const projects = await baseDb.projects.findMany({
-          where: {
-            id: { in: uniqueProjectIds },
-            isDeleted: false,
-            ...projectAccessWhere,
-          },
+    // Pull every issue's associated project IDs in ONE issue-driven query.
+    // Driving from the issue side (a small set of ids) makes each relation load
+    // compile to a `WHERE "A" IN (issueIds)` join lookup, so the whole page
+    // costs ~7 queries total regardless of page size. The previous shape ran
+    // ~10 correlated queries PER issue (≈500 for a 50-row page) — same result,
+    // orders of magnitude more round-trips. Project IDs are collected in memory
+    // and resolved to project rows (with access control) in a single follow-up.
+    const issues = await baseDb.issue.findMany({
+      where: { id: { in: issueIds } },
+      select: {
+        id: true,
+        caseIssues: {
+          where: { case: { isDeleted: false } },
+          select: { case: { select: { projectId: true } } },
+        },
+        sessions: {
+          where: { isDeleted: false },
+          select: { projectId: true },
+        },
+        sessionResults: {
+          where: { session: { isDeleted: false } },
+          select: { session: { select: { projectId: true } } },
+        },
+        testRuns: {
+          where: { isDeleted: false },
+          select: { projectId: true },
+        },
+        testRunResults: {
+          where: { testRun: { isDeleted: false } },
+          select: { testRun: { select: { projectId: true } } },
+        },
+        testRunStepResults: {
+          where: { testRunResult: { testRun: { isDeleted: false } } },
           select: {
-            id: true,
-            name: true,
-            iconUrl: true,
+            testRunResult: {
+              select: { testRun: { select: { projectId: true } } },
+            },
           },
-        });
-
-        return { issueId, projects };
-      })
-    );
-
-    // Convert to map for easy lookup
-    const projectsMap = projectsData.reduce(
-      (acc, item) => {
-        acc[item.issueId] = item.projects;
-        return acc;
+        },
       },
-      {} as Record<
-        number,
-        Array<{ id: number; name: string; iconUrl: string | null }>
-      >
-    );
+    });
+
+    // Per-issue set of referenced project IDs, plus the union across all issues
+    // (so the access-controlled project fetch below runs exactly once).
+    const projectIdsByIssue = new Map<number, Set<number>>();
+    const allProjectIds = new Set<number>();
+
+    for (const issue of issues) {
+      const ids = new Set<number>();
+      const add = (projectId: number | null | undefined) => {
+        if (typeof projectId === "number") {
+          ids.add(projectId);
+          allProjectIds.add(projectId);
+        }
+      };
+
+      for (const ci of issue.caseIssues) add(ci.case?.projectId);
+      for (const s of issue.sessions) add(s.projectId);
+      for (const sr of issue.sessionResults) add(sr.session?.projectId);
+      for (const tr of issue.testRuns) add(tr.projectId);
+      for (const trr of issue.testRunResults) add(trr.testRun?.projectId);
+      for (const tsr of issue.testRunStepResults) {
+        add(tsr.testRunResult?.testRun?.projectId);
+      }
+
+      projectIdsByIssue.set(issue.id, ids);
+    }
+
+    // One access-controlled fetch for every referenced project. A project that
+    // the caller can't access simply won't appear here, so it's dropped from
+    // each issue's list below — matching the previous per-issue behavior.
+    const projects =
+      allProjectIds.size > 0
+        ? await baseDb.projects.findMany({
+            where: {
+              id: { in: Array.from(allProjectIds) },
+              isDeleted: false,
+              ...projectAccessWhere,
+            },
+            select: { id: true, name: true, iconUrl: true },
+          })
+        : [];
+
+    const projectById = new Map(projects.map((p) => [p.id, p]));
+
+    const projectsMap: Record<
+      number,
+      Array<{ id: number; name: string; iconUrl: string | null }>
+    > = {};
+
+    for (const id of issueIds) {
+      const ids = projectIdsByIssue.get(id);
+      projectsMap[id] = ids
+        ? Array.from(ids)
+            .map((pid) => projectById.get(pid))
+            .filter(
+              (p): p is { id: number; name: string; iconUrl: string | null } =>
+                p != null
+            )
+        : [];
+    }
 
     return NextResponse.json({ projects: projectsMap });
   } catch (error) {

--- a/testplanit/app/api/issues/stream/route.ts
+++ b/testplanit/app/api/issues/stream/route.ts
@@ -25,7 +25,7 @@ const METRICS_INTERVAL_MS = 30_000;
 interface ActiveConnection {
   tenantId: string;
   userId: string;
-  projectId: number;
+  projectIds: number[];
   cleanup: () => Promise<void>;
   writeShutdown: () => void;
   openedAt: number;
@@ -85,28 +85,47 @@ export async function GET(req: NextRequest) {
   }
   const userId = session.user.id;
 
-  // 2. Project param. The channel is project-scoped; clients pass
-  //    `?projectId=<int>`.
-  const rawProjectId = req.nextUrl.searchParams.get("projectId");
-  const projectId = rawProjectId ? parseInt(rawProjectId, 10) : NaN;
-  if (!Number.isInteger(projectId) || projectId <= 0) {
+  // 2. Project params. The channel is project-scoped, but a single client
+  //    connection multiplexes ALL the projects it's watching so a cross-project
+  //    list (global /issues, /admin/issues) opens ONE stream instead of one per
+  //    project. Clients pass `?projectIds=<csv of ints>` (legacy single
+  //    `?projectId=<int>` still accepted). Capped so a pathological request
+  //    can't ask the subscriber to fan out over an unbounded channel set.
+  const MAX_PROJECTS = 500;
+  const rawIds =
+    req.nextUrl.searchParams.get("projectIds") ??
+    req.nextUrl.searchParams.get("projectId") ??
+    "";
+  const requestedProjectIds = [
+    ...new Set(
+      rawIds
+        .split(",")
+        .map((s) => parseInt(s.trim(), 10))
+        .filter((n) => Number.isInteger(n) && n > 0)
+    ),
+  ].slice(0, MAX_PROJECTS);
+  if (requestedProjectIds.length === 0) {
     return NextResponse.json(
-      { error: "projectId query param required (positive integer)" },
+      {
+        error:
+          "projectIds query param required (comma-separated positive ints)",
+      },
       { status: 400 }
     );
   }
 
-  // 3. Project access gate. Re-fetch through the ZenStack-enhanced
-  //    client so the project's `@@allow('read', ...)` policy decides
-  //    whether this user can subscribe. If the policy returns null,
-  //    the user has no access — same response as if the project
-  //    didn't exist (do not leak existence).
+  // 3. Project access gate. Filter to the projects this user can actually read
+  //    through the ZenStack-enhanced client so the `@@allow('read', ...)`
+  //    policy decides which channels the subscription may join. Inaccessible
+  //    (or non-existent) ids are silently dropped — same as before, we don't
+  //    leak existence — and if none survive we 404.
   const db = await getEnhancedDb(session);
-  const project = await db.projects.findUnique({
-    where: { id: projectId },
+  const accessibleProjects = await db.projects.findMany({
+    where: { id: { in: requestedProjectIds } },
     select: { id: true },
   });
-  if (!project) {
+  const projectIds = accessibleProjects.map((p) => p.id);
+  if (projectIds.length === 0) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
@@ -185,13 +204,13 @@ export async function GET(req: NextRequest) {
 
       try {
         await subscriber.subscribe(
-          projectIssueUpdateChannel(tenantId, projectId)
+          ...projectIds.map((pid) => projectIssueUpdateChannel(tenantId, pid))
         );
       } catch (subErr) {
         console.warn(`[sse/issues] subscribe failed`, {
           tenantId,
           userId,
-          projectId,
+          projectIds,
           error: subErr instanceof Error ? subErr.message : String(subErr),
         });
         try {
@@ -223,7 +242,7 @@ export async function GET(req: NextRequest) {
       connection = {
         tenantId,
         userId,
-        projectId,
+        projectIds,
         openedAt: Date.now(),
         writeShutdown,
         cleanup: async () => {

--- a/testplanit/hooks/issueUpdateStreamManager.test.ts
+++ b/testplanit/hooks/issueUpdateStreamManager.test.ts
@@ -2,17 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __resetIssueUpdateStreamsForTests,
-  subscribeToProjectIssueUpdates,
+  subscribeToIssueUpdates,
 } from "./issueUpdateStreamManager";
 
 /**
- * Verifies the refcounted singleton contract. Multiple subscribers for
- * the same project must share a single EventSource; subscribers for
- * different projects must each get their own; releasing the last
- * subscriber for a project must close the connection.
+ * Verifies the multiplexed singleton contract: ONE EventSource carries the
+ * union of every watched project (so a cross-project list opens one stream,
+ * not one per project); the connection reconnects when the union changes and
+ * closes when the last subscriber leaves; messages route to the listeners for
+ * the event's projectId.
  *
- * Uses a fake EventSource constructor installed on globalThis so we can
- * inspect call counts and trigger onmessage manually.
+ * Reconciliation is debounced, so tests use fake timers and flush after each
+ * (un)subscribe. A fake EventSource on globalThis lets us inspect connections
+ * and fire messages manually.
  */
 
 interface FakeES {
@@ -21,7 +23,6 @@ interface FakeES {
   onmessage: ((ev: MessageEvent) => void) | null;
   onerror: ((ev: Event) => void) | null;
   close: () => void;
-  // Test helpers — fire onmessage from outside.
   __fire: (data: string) => void;
 }
 
@@ -45,10 +46,14 @@ class FakeEventSource implements Pick<EventSource, "close"> {
   }
 }
 
+// Flush the debounced reconcile.
+function flush() {
+  vi.runOnlyPendingTimers();
+}
+
 beforeEach(() => {
+  vi.useFakeTimers();
   constructed.length = 0;
-  // Install fake. globalThis.EventSource normally only exists in browsers;
-  // we attach it for the duration of the test.
   (globalThis as any).EventSource =
     FakeEventSource as unknown as typeof EventSource;
 });
@@ -56,128 +61,165 @@ beforeEach(() => {
 afterEach(() => {
   __resetIssueUpdateStreamsForTests();
   delete (globalThis as any).EventSource;
+  vi.useRealTimers();
 });
 
-describe("subscribeToProjectIssueUpdates", () => {
-  it("opens exactly ONE EventSource per project regardless of subscriber count", () => {
-    const a = vi.fn();
-    const b = vi.fn();
-    const c = vi.fn();
+const openStreams = () => constructed.filter((es) => !es.closed);
+const latestOpen = () => openStreams().at(-1)!;
 
-    subscribeToProjectIssueUpdates(7, a);
-    subscribeToProjectIssueUpdates(7, b);
-    subscribeToProjectIssueUpdates(7, c);
+describe("subscribeToIssueUpdates (multiplexed)", () => {
+  it("opens ONE EventSource for many subscribers in the same project", () => {
+    subscribeToIssueUpdates(7, vi.fn());
+    subscribeToIssueUpdates(7, vi.fn());
+    subscribeToIssueUpdates(7, vi.fn());
+    flush();
+
+    expect(openStreams().length).toBe(1);
+    expect(latestOpen().url).toBe("/api/issues/stream?projectIds=7");
+  });
+
+  it("multiplexes distinct projects into ONE connection over their union", () => {
+    subscribeToIssueUpdates(7, vi.fn());
+    subscribeToIssueUpdates(8, vi.fn());
+    subscribeToIssueUpdates([9, 8], vi.fn());
+    flush();
+
+    expect(openStreams().length).toBe(1);
+    // Sorted, deduped union.
+    expect(latestOpen().url).toBe("/api/issues/stream?projectIds=7,8,9");
+  });
+
+  it("batches a single commit's subscribes into one connection (no per-project storm)", () => {
+    // 15 badges across 15 projects mounting together.
+    for (let p = 1; p <= 15; p++) subscribeToIssueUpdates(p, vi.fn());
+    flush();
 
     expect(constructed.length).toBe(1);
-    expect(constructed[0]!.url).toBe("/api/issues/stream?projectId=7");
+    expect(latestOpen().url).toBe(
+      "/api/issues/stream?projectIds=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"
+    );
   });
 
-  it("opens distinct EventSources for distinct projectIds", () => {
-    subscribeToProjectIssueUpdates(7, vi.fn());
-    subscribeToProjectIssueUpdates(8, vi.fn());
+  it("reconnects with the new union when a fresh project is added", () => {
+    subscribeToIssueUpdates(7, vi.fn());
+    flush();
+    expect(latestOpen().url).toBe("/api/issues/stream?projectIds=7");
 
+    subscribeToIssueUpdates(8, vi.fn());
+    flush();
+
+    // Old connection closed, new one covers the union.
     expect(constructed.length).toBe(2);
-    expect(constructed[0]!.url).toBe("/api/issues/stream?projectId=7");
-    expect(constructed[1]!.url).toBe("/api/issues/stream?projectId=8");
+    expect(constructed[0]!.closed).toBe(true);
+    expect(latestOpen().url).toBe("/api/issues/stream?projectIds=7,8");
   });
 
-  it("fans an SSE message out to every subscriber for that project", () => {
-    const a = vi.fn();
-    const b = vi.fn();
-    subscribeToProjectIssueUpdates(7, a);
-    subscribeToProjectIssueUpdates(7, b);
+  it("routes a message to the listeners for its projectId only", () => {
+    const sevenA = vi.fn();
+    const sevenB = vi.fn();
+    const eight = vi.fn();
+    subscribeToIssueUpdates(7, sevenA);
+    subscribeToIssueUpdates(7, sevenB);
+    subscribeToIssueUpdates(8, eight);
+    flush();
 
-    constructed[0]!.__fire(
-      '{"event":"issue-updated","issueId":1,"projectId":7}'
-    );
+    latestOpen().__fire('{"event":"issue-updated","issueId":1,"projectId":7}');
 
-    expect(a).toHaveBeenCalledTimes(1);
-    expect(b).toHaveBeenCalledTimes(1);
+    expect(sevenA).toHaveBeenCalledTimes(1);
+    expect(sevenB).toHaveBeenCalledTimes(1);
+    expect(eight).not.toHaveBeenCalled();
   });
 
-  it("does NOT fan messages from project 7 out to subscribers of project 8", () => {
-    const sevenSub = vi.fn();
-    const eightSub = vi.fn();
-    subscribeToProjectIssueUpdates(7, sevenSub);
-    subscribeToProjectIssueUpdates(8, eightSub);
+  it("does not reconnect when the union is unchanged (extra subscriber same project)", () => {
+    subscribeToIssueUpdates(7, vi.fn());
+    flush();
+    const first = latestOpen();
 
-    constructed[0]!.__fire(
-      '{"event":"issue-updated","issueId":1,"projectId":7}'
-    );
+    subscribeToIssueUpdates(7, vi.fn());
+    flush();
 
-    expect(sevenSub).toHaveBeenCalledTimes(1);
-    expect(eightSub).not.toHaveBeenCalled();
+    expect(openStreams().length).toBe(1);
+    expect(latestOpen()).toBe(first);
+    expect(first.closed).toBe(false);
   });
 
-  it("closes the EventSource only when the LAST subscriber unmounts", () => {
-    const a = vi.fn();
-    const b = vi.fn();
-    const unsubA = subscribeToProjectIssueUpdates(7, a);
-    const unsubB = subscribeToProjectIssueUpdates(7, b);
+  it("closes the connection when the last subscriber for every project leaves", () => {
+    const unsubA = subscribeToIssueUpdates(7, vi.fn());
+    const unsubB = subscribeToIssueUpdates(7, vi.fn());
+    flush();
+    const es = latestOpen();
 
     unsubA();
-    expect(constructed[0]!.closed).toBe(false);
+    flush();
+    expect(es.closed).toBe(false); // one subscriber remains
 
     unsubB();
-    expect(constructed[0]!.closed).toBe(true);
+    flush();
+    expect(es.closed).toBe(true);
+    expect(openStreams().length).toBe(0);
   });
 
-  it("starts a fresh EventSource when a new subscriber arrives after the previous one was released", () => {
-    const a = vi.fn();
-    const unsubA = subscribeToProjectIssueUpdates(7, a);
-    unsubA();
-    expect(constructed[0]!.closed).toBe(true);
+  it("returns a no-op unsubscribe for invalid ids (no connection opened)", () => {
+    const unsub = subscribeToIssueUpdates(0, vi.fn());
+    const unsubNeg = subscribeToIssueUpdates(-3, vi.fn());
+    const unsubEmpty = subscribeToIssueUpdates([], vi.fn());
+    flush();
 
-    subscribeToProjectIssueUpdates(7, vi.fn());
-    expect(constructed.length).toBe(2);
-    expect(constructed[1]!.closed).toBe(false);
-  });
-
-  it("returns a no-op unsubscribe for invalid projectIds (no EventSource opened)", () => {
-    const unsub = subscribeToProjectIssueUpdates(0, vi.fn());
     expect(constructed.length).toBe(0);
-    expect(() => unsub()).not.toThrow();
-
-    const unsubNeg = subscribeToProjectIssueUpdates(-3, vi.fn());
-    expect(constructed.length).toBe(0);
-    expect(() => unsubNeg()).not.toThrow();
+    expect(() => {
+      unsub();
+      unsubNeg();
+      unsubEmpty();
+    }).not.toThrow();
   });
 
-  it("a listener throwing does NOT prevent other listeners from being called", () => {
+  it("a throwing listener does not prevent others from being called", () => {
     const bad = vi.fn(() => {
       throw new Error("listener crashed");
     });
     const good = vi.fn();
-    subscribeToProjectIssueUpdates(7, bad);
-    subscribeToProjectIssueUpdates(7, good);
+    subscribeToIssueUpdates(7, bad);
+    subscribeToIssueUpdates(7, good);
+    flush();
 
-    constructed[0]!.__fire('{"event":"issue-updated","issueId":42}');
+    latestOpen().__fire('{"event":"issue-updated","issueId":42,"projectId":7}');
 
     expect(bad).toHaveBeenCalledTimes(1);
     expect(good).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores the server's `{event:'sync'}` connection handshake (no issueId) — prevents thundering-herd loops", async () => {
+  it("ignores the `{event:'sync'}` handshake (no issueId) — prevents herd loops", () => {
     const listener = vi.fn();
-    subscribeToProjectIssueUpdates(7, listener);
+    subscribeToIssueUpdates(7, listener);
+    flush();
 
-    // Server's first-byte sync envelope after subscribe completes.
-    constructed[0]!.__fire('{"event":"sync"}');
-
+    latestOpen().__fire('{"event":"sync"}');
     expect(listener).not.toHaveBeenCalled();
 
-    // Real update with issueId still fans out.
-    constructed[0]!.__fire(
-      '{"event":"issue-updated","issueId":1,"projectId":7}'
-    );
+    latestOpen().__fire('{"event":"issue-updated","issueId":1,"projectId":7}');
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
   it("ignores malformed JSON without throwing", () => {
     const listener = vi.fn();
-    subscribeToProjectIssueUpdates(7, listener);
+    subscribeToIssueUpdates(7, listener);
+    flush();
 
-    expect(() => constructed[0]!.__fire("not json {[")).not.toThrow();
+    expect(() => latestOpen().__fire("not json {[")).not.toThrow();
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("idempotent unsubscribe does not double-decrement the refcount", () => {
+    const unsubA = subscribeToIssueUpdates(7, vi.fn());
+    subscribeToIssueUpdates(7, vi.fn());
+    flush();
+    const es = latestOpen();
+
+    unsubA();
+    unsubA(); // second call must be a no-op
+    flush();
+
+    // The other subscriber still holds project 7 open.
+    expect(es.closed).toBe(false);
   });
 });

--- a/testplanit/hooks/issueUpdateStreamManager.ts
+++ b/testplanit/hooks/issueUpdateStreamManager.ts
@@ -1,119 +1,203 @@
 "use client";
 
 /**
- * Refcounted singleton EventSource manager for the project-scoped
- * issue-update SSE stream.
+ * Single multiplexed EventSource for issue-update SSE across ALL watched
+ * projects.
  *
- * Components anywhere in the tree (issue badges, lists, popovers,
- * detail views) call `subscribeToProjectIssueUpdates(projectId, fn)`
- * to register interest in updates for a project. Multiple subscribers
- * for the same projectId share a single EventSource — the SSE route's
- * per-user connection cap (default 8) bounds simultaneously-watched
- * PROJECTS, not number of subscribers.
+ * Every subscriber registers the set of project ids it cares about; the
+ * manager keeps ONE connection subscribed to the union of those ids
+ * (`/api/issues/stream?projectIds=<csv>`) and reconnects only when that union
+ * changes. Reconciliation is debounced so a page whose badges mount in a
+ * single commit (e.g. a 25-row issues list spanning 15 projects) collapses to
+ * ONE connection rather than one per project.
  *
- * Lifecycle:
- *   - First subscriber for a project → opens the EventSource.
- *   - Each subsequent subscriber → registered as a listener; no new
- *     network connection.
- *   - Last subscriber unmounts → closes the EventSource and forgets
- *     the entry so the next subscriber starts fresh.
+ * This replaces the previous one-EventSource-per-project model. That model
+ * stormed on cross-project list pages (global `/issues`, `/admin/issues`):
+ * the client opened more connections than the SSE route's per-user cap (8),
+ * the server LRU-closed the overflow, `EventSource` auto-reconnected on the
+ * drop, the server closed another to make room, and the cycle span up a fresh
+ * IORedis subscriber on every reconnect — ballooning server memory until the
+ * whole dev process wedged.
+ *
+ * Messages carry `{event, issueId, projectId}`; the manager routes each to the
+ * listeners that registered interest in that `projectId`.
  *
  * SSR-safe: returns a no-op unsubscribe when window/EventSource are
- * unavailable (server-render, jsdom test envs without polyfill, etc.).
+ * unavailable (server render, jsdom without polyfill).
  */
 
 type IssueUpdateListener = () => void;
 
-interface StreamEntry {
-  es: EventSource;
-  listeners: Set<IssueUpdateListener>;
+// How many active subscribers currently watch each project id.
+const projectRefCounts: Map<number, number> = new Map();
+// Listeners registered per project id (a subscriber appears under each id it
+// passed). Message routing keys on the event's projectId.
+const listenersByProject: Map<number, Set<IssueUpdateListener>> = new Map();
+
+let es: EventSource | null = null;
+// Sorted csv of the project ids the current `es` is subscribed to ("" = none).
+let connectedKey = "";
+let reconcileHandle: ReturnType<typeof setTimeout> | null = null;
+
+// Debounce window. Long enough to batch a page's worth of badge mounts (and to
+// coalesce the mount/unmount churn of a future virtualized list) into a single
+// reconnect; short enough that live updates start flowing promptly.
+const RECONCILE_DEBOUNCE_MS = 250;
+
+function unionKey(): string {
+  const ids: number[] = [];
+  for (const [id, rc] of projectRefCounts) {
+    if (rc > 0) ids.push(id);
+  }
+  ids.sort((a, b) => a - b);
+  return ids.join(",");
 }
 
-const streams: Map<number, StreamEntry> = new Map();
+function callListener(listener: IssueUpdateListener) {
+  try {
+    listener();
+  } catch (err) {
+    console.warn("[issueUpdateStreamManager] listener threw", err);
+  }
+}
 
-export function subscribeToProjectIssueUpdates(
-  projectId: number,
+function notify(projectId: number | undefined) {
+  // Snapshot each listener set — a listener may trigger a subscribe/unsubscribe
+  // (re-mounting badges) that mutates the set mid-iteration.
+  if (typeof projectId === "number") {
+    const set = listenersByProject.get(projectId);
+    if (set) {
+      for (const listener of [...set]) callListener(listener);
+    }
+    return;
+  }
+  // Event without a projectId — notify everyone (defensive; keeps parity with
+  // the previous per-project manager, which fanned any message to that stream's
+  // listeners regardless of payload shape).
+  for (const set of listenersByProject.values()) {
+    for (const listener of [...set]) callListener(listener);
+  }
+}
+
+function reconcile() {
+  reconcileHandle = null;
+  const key = unionKey();
+  if (key === connectedKey) return;
+
+  // Drop the old connection before opening the new one so we never hold two.
+  if (es) {
+    es.close();
+    es = null;
+    connectedKey = "";
+  }
+  if (!key) return;
+
+  const next = new EventSource(`/api/issues/stream?projectIds=${key}`);
+  next.onmessage = (ev) => {
+    // The route emits `{event:"sync"}` as its first byte (a ready handshake);
+    // it carries no issueId, so it's skipped here — broad invalidation on sync
+    // would thrash (invalidate → refetch → badges remount → reconnect → sync…).
+    let parsed: {
+      event?: string;
+      issueId?: number;
+      projectId?: number;
+    } | null = null;
+    try {
+      parsed = JSON.parse(ev.data);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed.issueId !== "number") return;
+    notify(parsed.projectId);
+  };
+  next.onerror = (err) => {
+    // EventSource auto-reconnects on transport drops; the route's post-subscribe
+    // sync byte makes listeners refetch on reconnect, so just log.
+    console.warn("[issueUpdateStreamManager] SSE transport error", err);
+  };
+  es = next;
+  connectedKey = key;
+}
+
+function scheduleReconcile() {
+  if (reconcileHandle != null) return; // already pending — coalesce
+  reconcileHandle = setTimeout(reconcile, RECONCILE_DEBOUNCE_MS);
+}
+
+/**
+ * Register interest in issue updates for a set of projects. Returns an
+ * idempotent unsubscribe. Multiple subscribers share the single multiplexed
+ * EventSource; the connection reconnects (debounced) when the union of watched
+ * projects changes and closes when the last subscriber for every project goes
+ * away.
+ */
+export function subscribeToIssueUpdates(
+  projectIds: number | number[] | null | undefined,
   onUpdate: IssueUpdateListener
 ): () => void {
   if (typeof window === "undefined" || typeof EventSource === "undefined") {
     return () => undefined;
   }
-  if (!Number.isInteger(projectId) || projectId <= 0) {
-    return () => undefined;
-  }
 
-  let entry = streams.get(projectId);
-  if (!entry) {
-    const es = new EventSource(`/api/issues/stream?projectId=${projectId}`);
-    const created: StreamEntry = { es, listeners: new Set() };
-    es.onmessage = (ev) => {
-      // The SSE route emits a `{event:"sync"}` envelope as its first byte
-      // after subscribe completes — a connection-ready handshake the
-      // notifications bell uses to coalesce refetch on reconnect. For
-      // issue updates, broad cache invalidation on the sync handshake
-      // creates a thundering herd: invalidate → refetch → parent
-      // rerender flips children to skeleton → IssuesDisplay unmounts →
-      // last subscriber leaves → EventSource closes → next render
-      // re-mounts → reconnects → sync → loop. Skip the sync envelope
-      // here; real update events carry `issueId` and pass through.
-      let parsed: { event?: string; issueId?: number } | null = null;
-      try {
-        parsed = JSON.parse(ev.data);
-      } catch {
-        return;
-      }
-      if (!parsed || typeof parsed.issueId !== "number") {
-        return;
-      }
-      // Snapshot the listener set so a listener that triggers another
-      // subscribe/unsubscribe (e.g., re-renders that re-mount badges)
-      // doesn't mutate what we're iterating.
-      for (const listener of [...created.listeners]) {
-        try {
-          listener();
-        } catch (err) {
-          console.warn("[issueUpdateStreamManager] listener threw", err);
-        }
-      }
-    };
-    es.onerror = (err) => {
-      // EventSource auto-reconnects on transport drops. Log for
-      // visibility but don't surface — the server's `{event:"sync"}`
-      // first byte after subscribe ensures listeners refetch on
-      // reconnect and catch anything missed.
-      console.warn(
-        `[issueUpdateStreamManager] SSE transport error for project ${projectId}`,
-        err
-      );
-    };
-    streams.set(projectId, created);
-    entry = created;
-  }
-  entry.listeners.add(onUpdate);
+  const raw = Array.isArray(projectIds)
+    ? projectIds
+    : projectIds != null
+      ? [projectIds]
+      : [];
+  const ids = [
+    ...new Set(
+      raw.filter((id): id is number => Number.isInteger(id) && id > 0)
+    ),
+  ];
+  if (ids.length === 0) return () => undefined;
 
-  return () => {
-    const current = streams.get(projectId);
-    if (!current) return;
-    current.listeners.delete(onUpdate);
-    if (current.listeners.size === 0) {
-      current.es.close();
-      streams.delete(projectId);
+  for (const id of ids) {
+    projectRefCounts.set(id, (projectRefCounts.get(id) ?? 0) + 1);
+    let set = listenersByProject.get(id);
+    if (!set) {
+      set = new Set();
+      listenersByProject.set(id, set);
     }
+    set.add(onUpdate);
+  }
+  scheduleReconcile();
+
+  let released = false;
+  return () => {
+    if (released) return; // idempotent
+    released = true;
+    for (const id of ids) {
+      const rc = (projectRefCounts.get(id) ?? 1) - 1;
+      if (rc <= 0) projectRefCounts.delete(id);
+      else projectRefCounts.set(id, rc);
+      const set = listenersByProject.get(id);
+      if (set) {
+        set.delete(onUpdate);
+        if (set.size === 0) listenersByProject.delete(id);
+      }
+    }
+    scheduleReconcile();
   };
 }
 
 /**
- * Test-only: drop all active subscriptions and connections. Used by
- * the unit suite's `beforeEach` so each test starts with an empty
- * registry. Production code never calls this.
+ * Test-only: drop all state + the active connection so each test starts clean.
+ * Production code never calls this.
  */
 export function __resetIssueUpdateStreamsForTests(): void {
-  for (const entry of streams.values()) {
+  if (reconcileHandle != null) {
+    clearTimeout(reconcileHandle);
+    reconcileHandle = null;
+  }
+  if (es) {
     try {
-      entry.es.close();
+      es.close();
     } catch {
       /* swallow */
     }
+    es = null;
   }
-  streams.clear();
+  connectedKey = "";
+  projectRefCounts.clear();
+  listenersByProject.clear();
 }

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -3,7 +3,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 
-import { subscribeToProjectIssueUpdates } from "./issueUpdateStreamManager";
+import { subscribeToIssueUpdates } from "./issueUpdateStreamManager";
 
 /**
  * Subscribe an issue display component to live updates from the inbound
@@ -13,17 +13,17 @@ import { subscribeToProjectIssueUpdates } from "./issueUpdateStreamManager";
  * event lands on the relevant project's SSE channel.
  *
  * Connection management is handled by the singleton
- * `issueUpdateStreamManager`: every component asking for the same
- * projectId shares ONE EventSource (refcounted), and the connection
- * auto-closes when the last subscriber unmounts. So putting this hook
- * in `IssuesDisplay` (the per-issue badge) is correct — a page with
- * 50 issue badges all in project 7 still opens just one stream.
+ * `issueUpdateStreamManager`, which keeps ONE multiplexed EventSource
+ * subscribed to the union of every project any mounted subscriber is
+ * watching. So a page with 50 badges in project 7 opens one stream —
+ * and, crucially, a cross-project list (global `/issues`,
+ * `/admin/issues`) spanning many projects ALSO opens just one stream,
+ * instead of one per project (which stormed past the server's per-user
+ * connection cap).
  *
  * `projectIds` accepts an array because some Issue rows surface in
- * multi-project contexts (`IssuesDisplay.projectIds: number[]`). The
- * hook subscribes to every distinct project id in the array. For the
- * common single-project case, callers can pass `issue.projectId` and
- * the array machinery degenerates to one subscription.
+ * multi-project contexts (`IssuesDisplay.projectIds: number[]`). All of
+ * the caller's ids fold into the shared connection's project union.
  *
  * Auth + read-policy enforcement happens at refetch time via
  * `useFindManyIssue` / `useFindUniqueIssue` going through
@@ -76,13 +76,7 @@ export function useIssueUpdateStream(
       });
     };
 
-    const unsubs = depKey
-      .split(",")
-      .map((s) => Number(s))
-      .map((id) => subscribeToProjectIssueUpdates(id, onUpdate));
-
-    return () => {
-      unsubs.forEach((u) => u());
-    };
+    const ids = depKey.split(",").map((s) => Number(s));
+    return subscribeToIssueUpdates(ids, onUpdate);
   }, [depKey, queryClient]);
 }

--- a/testplanit/migrations/20260703000000_issue_list_name_index/migration.sql
+++ b/testplanit/migrations/20260703000000_issue_list_name_index/migration.sql
@@ -1,0 +1,17 @@
+-- Index the issue-list page's default ordering.
+--
+-- The issues list orders non-deleted issues by name while filtering to those
+-- linked to at least one non-deleted case/session/run/result (a 6-branch
+-- OR-EXISTS). With no index on `name`, Postgres hashed the entire
+-- RepositoryCases (100k+) and TestRuns (67k+) tables, seq-scanned every Issue,
+-- and full-sorted the result — the same ~510ms cost on EVERY page of infinite
+-- scroll, regardless of offset (verified via EXPLAIN ANALYZE on production
+-- data). This showed up as a "loading forever" skeleton at the bottom of the
+-- list, especially under a slower dev server.
+--
+-- This composite index lets the planner walk issues in (isDeleted, name, id)
+-- order and evaluate the linked-entity OR-EXISTS as index-driven correlated
+-- subqueries per row, short-circuiting once a page's worth of matches is found
+-- (~510ms -> ~70ms). Leading with `isDeleted` keeps it an index-only scan for
+-- the always-present `isDeleted = false` filter; `id` is the sort tiebreaker.
+CREATE INDEX IF NOT EXISTS "Issue_isDeleted_name_id_idx" ON "Issue"("isDeleted", "name", "id");

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -3385,6 +3385,12 @@ model Issue {
     @@index([createdById])
     @@index([projectId])
     @@index([integrationId])
+    // Serves the issue-list page: ordering by name over non-deleted issues.
+    // Lets Postgres walk issues in name order and short-circuit the linked-
+    // entity OR-EXISTS filter per row (O(pageSize)) instead of hashing the
+    // whole RepositoryCases/TestRuns tables and full-sorting every page
+    // (~510ms -> ~70ms; verified via EXPLAIN on production data).
+    @@index([isDeleted, name, id])
     @@deny('all', auth() == null)
     @@deny('all', auth().access == 'NONE')
     @@allow('all', auth().access == 'ADMIN')


### PR DESCRIPTION
## Description

Two fixes for the issues list, both scoped to `/issues` (global + admin) and the project issues page.

### 1. Multiplex the issue-update SSE (the main fix)

Issue-update SSE opened **one `EventSource` per project**. On the cross-project list pages a page's issues span many projects, so the client opened more connections than the SSE route's per-user cap (8): the server LRU-closed the overflow, `EventSource` auto-reconnected on the drop, the server closed another to make room, and each reconnect spun up a fresh IORedis subscriber. The resulting reconnect storm ballooned server memory until the process wedged — which is why, after visiting `/issues`, navigating to any other page hung.

- `issueUpdateStreamManager` now keeps **one** multiplexed `EventSource` subscribed to the union of every watched project (`?projectIds=<csv>`), reconnecting only when that union changes and debounced so a page's badges collapse into a single connection.
- `/api/issues/stream` accepts `projectIds` (legacy `projectId` still works), access-gates them through the enhanced client, and subscribes one IORedis client to all accessible channels. The per-user cap now bounds **tabs**, not projects, so the storm is structurally impossible.

### 2. Speed up the cross-project list queries

Both verified with `EXPLAIN ANALYZE` on production data:

- **`/api/issues/projects`**: issue-driven batching (one `findMany` + one access-controlled projects fetch) instead of ~10 correlated queries per issue — **~500 queries per 50-row page down to ~7**.
- **`Issue @@index([isDeleted, name, id])`**: the list orders non-deleted issues by name; with no index Postgres hashed the whole `RepositoryCases`/`TestRuns` tables and full-sorted every page (~510ms, O(total rows)). The index lets it walk name order and short-circuit the linked-entity `OR`-`EXISTS` per row — **~510ms → ~70ms**. Migration `20260703000000_issue_list_name_index` is included and already applied to the `ew` database.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Rewrote the `issueUpdateStreamManager` test suite (12 tests) for the multiplexed contract: union batching, no per-project storm, reconnect-on-union-change, `projectId` routing, idempotent unsubscribe. Full `precommit` is green (eslint 0 errors, formatting clean, 9,786 tests pass, docs build).

Manual verification against a production build + real data:
- `/api/issues/stream?projectIds=370,368,365` → `200 text/event-stream` streaming the sync handshake (one connection over three projects).
- Loading `/issues` then navigating to `/tags` works (the reported hang is gone); server RSS held flat instead of ballooning.
- `EXPLAIN ANALYZE` timings above measured on the live dataset.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- Heads-up: `pnpm precommit`'s `zenstack format` step (zenstack 3.8) strips regular `//` comments from `schema.zmodel` — it wiped several unrelated doc comments (including the `DataChangeLog` "load-bearing column reconciliation" block) on this run. I restored all of them, so this PR's `schema.zmodel` change is only the new index. Worth converting the important ones to `///` doc comments in a follow-up so the formatter stops eating them.
