### PR TITLE
enhancement(tables): virtualized infinite-scroll tables across the app

### DIFF
--- a/testplanit/app/[locale]/admin/api-tokens/page.tsx
+++ b/testplanit/app/[locale]/admin/api-tokens/page.tsx
@@ -5,22 +5,15 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedApiToken, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -46,11 +39,7 @@ import { AlertTriangle, Ban, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 export default function ApiTokensPage() {
-  return (
-    <PaginationProvider>
-      <ApiTokensList />
-    </PaginationProvider>
-  );
+  return <ApiTokensList />;
 }
 
 function ApiTokensList() {
@@ -59,17 +48,6 @@ function ApiTokensList() {
   const tCommon = useTranslations("common");
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -99,10 +77,6 @@ function ApiTokensList() {
     status: "isActive",
   };
 
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
   const sortField = sortConfig
     ? columnToFieldMap[sortConfig.column] || sortConfig.column
     : "createdAt";
@@ -115,66 +89,6 @@ function ApiTokensList() {
   useEffect(() => {
     updateApiTokenRef.current = updateApiToken;
   });
-
-  const { data: totalFilteredTokens } = useClientQueries(
-    schema
-  ).apiToken.useFindMany(
-    {
-      orderBy: { [sortField]: sortConfig?.direction || "desc" },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            image: true,
-          },
-        },
-      },
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                name: {
-                  contains: debouncedSearchString,
-                  mode: "insensitive",
-                },
-              },
-              {
-                user: {
-                  name: {
-                    contains: debouncedSearchString,
-                    mode: "insensitive",
-                  },
-                },
-              },
-              {
-                user: {
-                  email: {
-                    contains: debouncedSearchString,
-                    mode: "insensitive",
-                  },
-                },
-              },
-            ],
-          },
-          showRevokedTokens ? {} : { isActive: true },
-        ],
-      },
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredTokens) {
-      setTotalItems(totalFilteredTokens.length);
-    }
-  }, [totalFilteredTokens, setTotalItems]);
 
   const {
     data: tokens,
@@ -224,8 +138,6 @@ function ApiTokensList() {
           showRevokedTokens ? {} : { isActive: true },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -233,17 +145,10 @@ function ApiTokensList() {
     }
   );
 
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const tokenRows = useMemo(
+    () => (tokens ?? []) as unknown as ExtendedApiToken[],
+    [tokens]
+  );
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -282,10 +187,9 @@ function ApiTokensList() {
     setIsRevokingAll(true);
     try {
       // Get all active token IDs
-      const activeTokenIds =
-        totalFilteredTokens
-          ?.filter((token) => token.isActive)
-          .map((token) => token.id) || [];
+      const activeTokenIds = tokenRows
+        .filter((token) => token.isActive)
+        .map((token) => token.id);
 
       // Revoke each token
       await Promise.all(
@@ -306,7 +210,7 @@ function ApiTokensList() {
     } finally {
       setIsRevokingAll(false);
     }
-  }, [revokeAllConfirmText, totalFilteredTokens, t, refetchTokens]);
+  }, [revokeAllConfirmText, tokenRows, t, refetchTokens]);
 
   // Extract stable primitives from session to avoid column remounts when session object changes
   const dateFormat = session?.user?.preferences?.dateFormat;
@@ -336,11 +240,9 @@ function ApiTokensList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
-  const activeTokenCount =
-    totalFilteredTokens?.filter((t) => t.isActive).length || 0;
+  const activeTokenCount = tokenRows.filter((t) => t.isActive).length;
 
   return (
     <main>
@@ -370,7 +272,7 @@ function ApiTokensList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -407,50 +309,30 @@ function ApiTokensList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="api-tokens-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {tokenRows.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: tokenRows.length.toLocaleString(),
+                  total: tokenRows.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between">
-            {tokens && tokens.length > 0 ? (
-              <DataTable<ExtendedApiToken, unknown>
-                columns={columns}
-                data={tokens}
-                onSortChange={handleSortChange}
-                sortConfig={sortConfig}
-                columnVisibility={columnVisibility}
-                onColumnVisibilityChange={setColumnVisibility}
-                pageSize={typeof pageSize === "number" ? pageSize : totalItems}
-                isLoading={isLoading}
-              />
-            ) : !isLoading ? (
-              <div className="w-full text-center py-12 text-muted-foreground">
-                {t("noTokens")}
-              </div>
-            ) : null}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={tokenRows}
+              onSortChange={handleSortChange}
+              sortConfig={sortConfig}
+              columnVisibility={columnVisibility}
+              onColumnVisibilityChange={setColumnVisibility}
+              isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${showRevokedTokens}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-api-tokens-table"
+              rowTestIdPrefix="admin-api-token-row"
+            />
           </div>
         </CardContent>
       </Card>

--- a/testplanit/app/[locale]/admin/app-config/page.spec.tsx
+++ b/testplanit/app/[locale]/admin/app-config/page.spec.tsx
@@ -94,19 +94,20 @@ vi.mock("@/components/Debounce", () => ({
   useDebounce: (value: any) => value, // Return value immediately
 }));
 
-// Mock the DataTable component
-vi.mock("@/components/tables/DataTable", () => ({
-  DataTable: vi.fn(({ data, isLoading, columns: _columns }) => {
+// Mock the VirtualizedDataTable component (the page renders the table through it
+// since the pagination → infinite-scroll conversion).
+vi.mock("@/components/tables/VirtualizedDataTable", () => ({
+  VirtualizedDataTable: vi.fn(({ data, isLoading, columns: _columns }) => {
     if (isLoading) {
-      return <div>{"DataTable Loading..."}</div>;
+      return <div>{"Table Loading..."}</div>;
     }
     if (!data || data.length === 0) {
-      return <div>{"DataTable No Data"}</div>;
+      return <div>{"Table No Data"}</div>;
     }
     // Render confirmation and the mocked Edit Modals based on data
     return (
       <div>
-        <div>{`DataTable Received ${data.length} items`}</div>
+        <div>{`Table Received ${data.length} items`}</div>
         {/* Render mocked Edit Modals to verify data prop */}
         {data.map((item: any) => (
           <EditAppConfig
@@ -182,12 +183,12 @@ test("renders initial layout, title, and add button", async () => {
     screen.getByPlaceholderText("admin.appConfig.filterPlaceholder")
   ).toBeInTheDocument();
 
-  // Wait for the DataTable mock to render the correct state based on the mock implementation
+  // Wait for the table mock to render the correct state based on the mock implementation
   await waitFor(() => {
-    expect(screen.getByText("DataTable No Data")).toBeInTheDocument();
+    expect(screen.getByText("Table No Data")).toBeInTheDocument();
   });
   // Ensure loading state is NOT present finally
-  expect(screen.queryByText("DataTable Loading...")).not.toBeInTheDocument();
+  expect(screen.queryByText("Table Loading...")).not.toBeInTheDocument();
 });
 
 test("renders table indication and edit buttons when data exists", async () => {
@@ -204,13 +205,13 @@ test("renders table indication and edit buttons when data exists", async () => {
 
   renderPage(AppConfigs);
 
-  // Wait for the DataTable mock to render the correct state
+  // Wait for the table mock to render the correct state
   await waitFor(() => {
-    expect(screen.getByText("DataTable Received 2 items")).toBeVisible();
+    expect(screen.getByText("Table Received 2 items")).toBeVisible();
   });
 
   // Ensure loading state is NOT present finally
-  expect(screen.queryByText("DataTable Loading...")).not.toBeInTheDocument();
+  expect(screen.queryByText("Table Loading...")).not.toBeInTheDocument();
 
   // Check that the Edit Modals were rendered by the DataTable mock
   expect(screen.getByText("Mock Edit key1")).toBeVisible(); // Can use getBy now
@@ -265,10 +266,11 @@ test("sorts ascending on first click", async () => {
   }));
   renderPage(AppConfigs);
 
-  const dataTableMock = (await vi.importMock("@/components/tables/DataTable"))
-    .DataTable as any;
-  await waitFor(() => expect(dataTableMock).toHaveBeenCalled());
-  const onSortChange = dataTableMock.mock.lastCall![0].onSortChange;
+  const tableMock = (
+    await vi.importMock("@/components/tables/VirtualizedDataTable")
+  ).VirtualizedDataTable as any;
+  await waitFor(() => expect(tableMock).toHaveBeenCalled());
+  const onSortChange = tableMock.mock.lastCall![0].onSortChange;
 
   // Set implementation for the *next* call (after sort)
   mockUseFindManyAppConfig.mockImplementation(() => ({
@@ -286,9 +288,6 @@ test("sorts ascending on first click", async () => {
       2,
       expect.objectContaining({ orderBy: { value: "asc" } })
     );
-  });
-  await waitFor(() => {
-    expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
   });
 });
 

--- a/testplanit/app/[locale]/admin/app-config/page.tsx
+++ b/testplanit/app/[locale]/admin/app-config/page.tsx
@@ -3,20 +3,13 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CirclePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { AddAppConfig } from "./AddAppConfig";
 import { getColumns } from "./columns";
 import { DeleteAppConfig } from "./DeleteAppConfig";
@@ -24,19 +17,13 @@ import { EditAppConfig } from "./EditAppConfig";
 import { AppConfigRow } from "./types";
 
 export default function AppConfigsPage() {
-  return (
-    <PaginationProvider>
-      <AppConfigs />
-    </PaginationProvider>
-  );
+  return <AppConfigs />;
 }
 
 function AppConfigs() {
   const t = useTranslations("admin.appConfig");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-  const { currentPage, setCurrentPage, pageSize, setPageSize, totalItems } =
-    usePagination();
   const [searchString, setSearchString] = useState("");
   const [valueSearchString, setValueSearchString] = useState("");
   const [sortConfig, setSortConfig] = useState<{
@@ -58,6 +45,9 @@ function AppConfigs() {
   const debouncedSearchString = useDebounce(searchString, 300);
   const debouncedValueSearchString = useDebounce(valueSearchString, 300);
 
+  // Full-set fetch: the value filter below runs client-side over every config,
+  // and the virtualized table renders only the visible window, so there's no
+  // pagination and value-search covers the whole set (not just one page).
   const { data: appConfigs, isLoading } = useClientQueries(
     schema
   ).appConfig.useFindMany({
@@ -70,8 +60,6 @@ function AppConfigs() {
     orderBy: {
       [sortConfig.column]: sortConfig.direction,
     },
-    skip: (currentPage - 1) * (typeof pageSize === "number" ? pageSize : 0),
-    take: typeof pageSize === "number" ? pageSize : undefined,
   });
 
   // Transform AppConfig to AppConfigRow and filter by value
@@ -98,25 +86,12 @@ function AppConfigs() {
     }));
   }, [appConfigs, debouncedValueSearchString]);
 
-  const totalPages = Math.ceil(
-    totalItems / (typeof pageSize === "number" ? pageSize : totalItems)
-  );
-  const startIndex =
-    (currentPage - 1) * (typeof pageSize === "number" ? pageSize : 0) + 1;
-  const endIndex = Math.min(
-    startIndex + (typeof pageSize === "number" ? pageSize : totalItems) - 1,
-    totalItems
-  );
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
   const handleSortChange = (column: string) => {
     const direction =
       sortConfig.column === column && sortConfig.direction === "asc"
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   const columns = useMemo(
@@ -144,7 +119,7 @@ function AppConfigs() {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="flex flex-row items-start">
+        <div className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px] space-y-2">
             <div className="text-muted-foreground w-full text-nowrap">
               <Filter
@@ -166,42 +141,28 @@ function AppConfigs() {
             </div>
           </div>
 
-          <div className="flex flex-col w-full sm:w-2/3 items-end">
-            {totalItems > 0 && (
-              <>
-                <div className="justify-end">
-                  <PaginationInfo
-                    key="app-config-pagination-info"
-                    startIndex={startIndex}
-                    endIndex={endIndex}
-                    totalRows={totalItems}
-                    searchString={searchString}
-                    pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                    pageSizeOptions={pageSizeOptions}
-                    handlePageSizeChange={(size) => setPageSize(size)}
-                  />
-                </div>
-                <div className="justify-end -mx-4">
-                  <PaginationComponent
-                    currentPage={currentPage}
-                    totalPages={totalPages}
-                    onPageChange={setCurrentPage}
-                  />
-                </div>
-              </>
-            )}
-          </div>
+          {tableData.length > 0 && (
+            <p className="text-sm text-muted-foreground shrink-0">
+              {tGlobal("admin.auditLogs.showing", {
+                loaded: tableData.length.toLocaleString(),
+                total: tableData.length.toLocaleString(),
+              })}
+            </p>
+          )}
         </div>
-        <div className="mt-4 flex justify-between">
-          <DataTable<AppConfigRow, unknown>
-            columns={columns}
+        <div className="mt-4 w-full">
+          <VirtualizedDataTable
+            fillViewport
+            columns={columns as any}
             data={tableData}
             onSortChange={handleSortChange}
             sortConfig={sortConfig}
             columnVisibility={columnVisibility}
             onColumnVisibilityChange={setColumnVisibility}
-            pageSize={typeof pageSize === "number" ? pageSize : totalItems}
             isLoading={isLoading}
+            resetKey={`${debouncedSearchString}|${debouncedValueSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+            testIdPrefix="admin-app-config-table"
+            rowTestIdPrefix="admin-app-config-row"
           />
         </div>
       </CardContent>

--- a/testplanit/app/[locale]/admin/code-repositories/page.tsx
+++ b/testplanit/app/[locale]/admin/code-repositories/page.tsx
@@ -5,10 +5,8 @@ import { schema } from "~/zenstack/schema";
 import { CodeRepositoryModal } from "@/components/admin/code-repositories/CodeRepositoryModal";
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,20 +31,11 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { CodeRepositoryRow, getColumns } from "./columns";
 
 export default function CodeRepositoriesPage() {
-  return (
-    <PaginationProvider>
-      <CodeRepositoryList />
-    </PaginationProvider>
-  );
+  return <CodeRepositoryList />;
 }
 
 function CodeRepositoryList() {
@@ -55,17 +44,7 @@ function CodeRepositoryList() {
   const queryClient = useQueryClient();
   const tCommon = useTranslations("common");
   const t = useTranslations("admin.codeRepositories");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
+  const tGlobal = useTranslations();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -83,11 +62,6 @@ function CodeRepositoryList() {
   const [repoToDelete, setRepoToDelete] = useState<CodeRepositoryRow | null>(
     null
   );
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const queryWhere = useMemo(
     () => ({
@@ -112,28 +86,9 @@ function CodeRepositoryList() {
     [sortConfig]
   );
 
-  // Query for total filtered repositories (for pagination)
-  const { data: totalFilteredRepos } = useClientQueries(
-    schema
-  ).codeRepository.useFindMany(
-    {
-      orderBy: queryOrderBy,
-      where: queryWhere,
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredRepos) {
-      setTotalItems(totalFilteredRepos.length);
-    }
-  }, [totalFilteredRepos, setTotalItems]);
-
-  // Query for paginated repositories
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window so there's no page seam and no need for a
+  // separate count query (the loaded array length IS the total).
   const {
     data: repositories,
     isLoading,
@@ -142,8 +97,6 @@ function CodeRepositoryList() {
     {
       orderBy: queryOrderBy,
       where: queryWhere,
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -151,17 +104,10 @@ function CodeRepositoryList() {
     }
   );
 
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const repoRows = useMemo(
+    () => (repositories as unknown as CodeRepositoryRow[]) || [],
+    [repositories]
+  );
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -279,7 +225,6 @@ function CodeRepositoryList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -306,7 +251,7 @@ function CodeRepositoryList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -328,34 +273,17 @@ function CodeRepositoryList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="code-repo-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {repoRows.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: repoRows.length.toLocaleString(),
+                  total: repoRows.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          {!isLoading && totalItems === 0 && !debouncedSearchString ? (
+          {!isLoading && repoRows.length === 0 && !debouncedSearchString ? (
             <div className="mt-8 flex flex-col items-center justify-center gap-4 py-16 text-center">
               <GitBranch className="h-12 w-12 text-muted-foreground/40" />
               <div>
@@ -370,16 +298,19 @@ function CodeRepositoryList() {
               </Button>
             </div>
           ) : (
-            <div className="mt-4 flex justify-between">
-              <DataTable<CodeRepositoryRow, unknown>
-                columns={columns}
-                data={(repositories as unknown as CodeRepositoryRow[]) || []}
+            <div className="mt-4 w-full">
+              <VirtualizedDataTable
+                fillViewport
+                columns={columns as any}
+                data={repoRows}
                 onSortChange={handleSortChange}
                 sortConfig={sortConfig}
                 columnVisibility={columnVisibility}
                 onColumnVisibilityChange={setColumnVisibility}
-                pageSize={typeof pageSize === "number" ? pageSize : totalItems}
                 isLoading={isLoading}
+                resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+                testIdPrefix="admin-code-repositories-table"
+                rowTestIdPrefix="admin-code-repository-row"
               />
             </div>
           )}

--- a/testplanit/app/[locale]/admin/configurations/Configurations.tsx
+++ b/testplanit/app/[locale]/admin/configurations/Configurations.tsx
@@ -2,10 +2,8 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
 import { CustomColumnMeta } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { ProjectIcon } from "@/components/ProjectIcon";
 import { AsyncCombobox } from "@/components/ui/async-combobox";
 import { Button } from "@/components/ui/button";
@@ -16,8 +14,6 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { searchProjects } from "~/app/actions/searchProjects";
 import { useRequireAuth } from "~/hooks/useRequireAuth";
-import { usePagination } from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import AddConfigurationWizard from "./AddConfigurationWizard";
 import { BulkEditConfigurations } from "./BulkEditConfigurations";
 import { ConfigWithVariants, useColumns } from "./configColumns";
@@ -37,17 +33,6 @@ function Configurations(): React.ReactElement | null {
   const t = useTranslations("admin.configurations");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<
     | {
         column: string;
@@ -65,11 +50,6 @@ function Configurations(): React.ReactElement | null {
     name: string;
     iconUrl: string | null;
   } | null>(null);
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   // Fetch ALL configurations (no pagination, no search filter in query)
   const { data: allConfigurations, isLoading } = useClientQueries(
@@ -122,15 +102,9 @@ function Configurations(): React.ReactElement | null {
     return result;
   }, [allConfigurations, debouncedSearchString, projectFilter]);
 
-  // Update total items based on filtered configurations count
-  useEffect(() => {
-    setTotalItems(filteredConfigurations.length);
-  }, [filteredConfigurations, setTotalItems]);
-
-  // Apply client-side pagination
-  const configurations = useMemo(() => {
-    return filteredConfigurations.slice(skip, skip + effectivePageSize);
-  }, [filteredConfigurations, skip, effectivePageSize]);
+  // The virtualized table renders the entire filtered set (windowing the DOM),
+  // so there's no page slice; row-selection indices below key into this array.
+  const configurations = filteredConfigurations;
 
   const { mutate: updateConfiguration } =
     useClientQueries(schema).configurations.useUpdate();
@@ -248,24 +222,16 @@ function Configurations(): React.ReactElement | null {
     return initialVisibility;
   });
 
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search or project filter changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, projectFilter, setCurrentPage]);
-
   // Clear selection when the filtered set changes meaningfully (search or
-  // project filter). Pagination and sort leave the set intact, so we keep
-  // selection across those.
+  // project filter). Sort leaves the set intact, so we keep selection across it.
   useEffect(() => {
     setSelectedConfigurationIds([]);
     setLastSelectedIndex(null);
   }, [searchString, projectFilter]);
 
-  // Derive the DataTable's per-row selection from the ID set for the visible
-  // page slice. tanstack-table keys selection by row index, which we map back
-  // to the configuration ID via `configurations[index]`.
+  // Derive the table's per-row selection from the ID set. tanstack-table keys
+  // selection by row index, which we map back to the configuration ID via
+  // `configurations[index]` (the full filtered set the table renders).
   const rowSelection: RowSelectionState = useMemo(() => {
     const sel: RowSelectionState = {};
     const selSet = new Set(selectedConfigurationIds);
@@ -274,11 +240,6 @@ function Configurations(): React.ReactElement | null {
     });
     return sel;
   }, [configurations, selectedConfigurationIds]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   if (isAuthLoading) {
     return null;
@@ -292,7 +253,6 @@ function Configurations(): React.ReactElement | null {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   if (isAuthenticated && session?.user.access === "ADMIN") {
@@ -362,45 +322,29 @@ function Configurations(): React.ReactElement | null {
                 )}
               </div>
 
-              <div className="flex flex-col items-end shrink-0">
-                {totalItems > 0 && (
-                  <>
-                    <div className="justify-end">
-                      <PaginationInfo
-                        key="configuration-pagination-info"
-                        startIndex={startIndex}
-                        endIndex={endIndex}
-                        totalRows={totalItems}
-                        searchString={searchString}
-                        pageSize={
-                          typeof pageSize === "number" ? pageSize : "All"
-                        }
-                        pageSizeOptions={pageSizeOptions}
-                        handlePageSizeChange={(size) => setPageSize(size)}
-                      />
-                    </div>
-                    <div className="justify-end -mx-4">
-                      <PaginationComponent
-                        currentPage={currentPage}
-                        totalPages={totalPages}
-                        onPageChange={setCurrentPage}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
+              {filteredConfigurations.length > 0 && (
+                <p className="text-sm text-muted-foreground shrink-0">
+                  {tGlobal("admin.auditLogs.showing", {
+                    loaded: filteredConfigurations.length.toLocaleString(),
+                    total: filteredConfigurations.length.toLocaleString(),
+                  })}
+                </p>
+              )}
             </div>
-            <div className="mt-4 flex justify-between">
-              <DataTable<ConfigWithVariants, unknown>
-                columns={columns}
+            <div className="mt-4 w-full">
+              <VirtualizedDataTable
+                columns={columns as any}
                 data={configurations || []}
                 onSortChange={handleSortChange}
                 sortConfig={sortConfig}
                 columnVisibility={columnVisibility}
                 onColumnVisibilityChange={setColumnVisibility}
-                pageSize={typeof pageSize === "number" ? pageSize : totalItems}
                 isLoading={isLoading}
                 rowSelection={rowSelection}
+                fillViewport
+                resetKey={`${debouncedSearchString}|${projectFilter?.id ?? ""}|${sortConfig?.column}|${sortConfig?.direction}`}
+                testIdPrefix="admin-configurations-table"
+                rowTestIdPrefix="admin-configuration-row"
               />
             </div>
           </CardContent>

--- a/testplanit/app/[locale]/admin/groups/page.tsx
+++ b/testplanit/app/[locale]/admin/groups/page.tsx
@@ -4,22 +4,15 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { CustomColumnDef } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedGroups, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -34,11 +27,7 @@ import { DeleteGroup } from "./DeleteGroup";
 import { EditGroup } from "./EditGroup";
 
 export default function GroupListPage() {
-  return (
-    <PaginationProvider>
-      <GroupList />
-    </PaginationProvider>
-  );
+  return <GroupList />;
 }
 
 function GroupList() {
@@ -47,17 +36,6 @@ function GroupList() {
   const t = useTranslations("admin.groups");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -73,44 +51,9 @@ function GroupList() {
     null
   );
 
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
-  const { data: totalFilteredGroups } = useClientQueries(
-    schema
-  ).groups.useFindMany(
-    {
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredGroups) {
-      setTotalItems(totalFilteredGroups.length);
-    }
-  }, [totalFilteredGroups, setTotalItems]);
-
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window, so there's no page seam and no separate
+  // count query (the loaded array length IS the total).
   const { data, isLoading } = useClientQueries(schema).groups.useFindMany(
     {
       orderBy: sortConfig
@@ -129,8 +72,6 @@ function GroupList() {
           },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
       include: {
         assignedUsers: {
           where: {
@@ -160,19 +101,7 @@ function GroupList() {
     }
   );
 
-  const groups = data as ExtendedGroups[];
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const groups = useMemo(() => (data ?? []) as ExtendedGroups[], [data]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -188,7 +117,6 @@ function GroupList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   const columns: CustomColumnDef<ExtendedGroups>[] = useColumns(
@@ -236,7 +164,7 @@ function GroupList() {
             <CardDescription>{t("description.groupInfo")}</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex flex-row items-start">
+            <div className="flex flex-row items-start justify-between gap-4">
               <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
                 <div className="text-muted-foreground w-full text-nowrap">
                   <Filter
@@ -248,44 +176,28 @@ function GroupList() {
                 </div>
               </div>
 
-              <div className="flex flex-col w-full sm:w-2/3 items-end">
-                {totalItems > 0 && (
-                  <>
-                    <div className="justify-end">
-                      <PaginationInfo
-                        key="group-pagination-info"
-                        startIndex={startIndex}
-                        endIndex={endIndex}
-                        totalRows={totalItems}
-                        searchString={searchString}
-                        pageSize={
-                          typeof pageSize === "number" ? pageSize : "All"
-                        }
-                        pageSizeOptions={pageSizeOptions}
-                        handlePageSizeChange={(size) => setPageSize(size)}
-                      />
-                    </div>
-                    <div className="justify-end -mx-4">
-                      <PaginationComponent
-                        currentPage={currentPage}
-                        totalPages={totalPages}
-                        onPageChange={setCurrentPage}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
+              {groups.length > 0 && (
+                <p className="text-sm text-muted-foreground shrink-0">
+                  {tGlobal("admin.auditLogs.showing", {
+                    loaded: groups.length.toLocaleString(),
+                    total: groups.length.toLocaleString(),
+                  })}
+                </p>
+              )}
             </div>
-            <div className="mt-4 flex justify-between">
-              <DataTable<ExtendedGroups, unknown>
-                columns={columns}
-                data={groups || []}
+            <div className="mt-4 w-full">
+              <VirtualizedDataTable
+                fillViewport
+                columns={columns as any}
+                data={groups}
                 onSortChange={handleSortChange}
                 sortConfig={sortConfig}
                 columnVisibility={columnVisibility}
                 onColumnVisibilityChange={setColumnVisibility}
-                pageSize={typeof pageSize === "number" ? pageSize : totalItems}
                 isLoading={isLoading}
+                resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+                testIdPrefix="admin-groups-table"
+                rowTestIdPrefix="admin-group-row"
               />
             </div>
           </CardContent>

--- a/testplanit/app/[locale]/admin/integrations/page.tsx
+++ b/testplanit/app/[locale]/admin/integrations/page.tsx
@@ -5,10 +5,8 @@ import { schema } from "~/zenstack/schema";
 import { IntegrationModal } from "@/components/admin/integrations/IntegrationModal";
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,20 +31,11 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
-import { type ExtendedIntegration, useColumns } from "./columns";
+import { useColumns } from "./columns";
 
 export default function IntegrationsPage() {
-  return (
-    <PaginationProvider>
-      <IntegrationList />
-    </PaginationProvider>
-  );
+  return <IntegrationList />;
 }
 
 function IntegrationList() {
@@ -54,19 +43,9 @@ function IntegrationList() {
   const tCommon = useTranslations("common");
   const tApiTokens = useTranslations("admin.apiTokens");
   const tAdminMenu = useTranslations("admin.menu");
+  const tGlobal = useTranslations();
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -83,53 +62,9 @@ function IntegrationList() {
   const [integrationToDelete, setIntegrationToDelete] =
     useState<Integration | null>(null);
 
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
-  // Query for total filtered integrations (for pagination)
-  const { data: totalFilteredIntegrations } = useClientQueries(
-    schema
-  ).integration.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      include: {
-        projectIntegrations: {
-          where: { isActive: true, project: { isDeleted: false } },
-          select: { projectId: true },
-        },
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredIntegrations) {
-      setTotalItems(totalFilteredIntegrations.length);
-    }
-  }, [totalFilteredIntegrations, setTotalItems]);
-
-  // Query for paginated integrations
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window, so there's no page seam and no separate
+  // count query (the loaded array length IS the total).
   const {
     data: integrations,
     isLoading,
@@ -158,8 +93,6 @@ function IntegrationList() {
           },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -167,17 +100,7 @@ function IntegrationList() {
     }
   );
 
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const integrationRows = useMemo(() => integrations ?? [], [integrations]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -305,7 +228,6 @@ function IntegrationList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -332,7 +254,7 @@ function IntegrationList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -354,43 +276,29 @@ function IntegrationList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="integration-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {integrationRows.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: integrationRows.length.toLocaleString(),
+                  total: integrationRows.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between">
-            <DataTable<ExtendedIntegration, unknown>
-              columns={columns}
-              data={integrations || []}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={integrationRows}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
               isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-integrations-table"
+              rowTestIdPrefix="admin-integration-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/issues/page.tsx
+++ b/testplanit/app/[locale]/admin/issues/page.tsx
@@ -5,19 +5,12 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import {
   Card,
   CardContent,
@@ -29,28 +22,15 @@ import { ExtendedIssue, useIssueColumns } from "./columns";
 import { DeleteIssue } from "./DeleteIssue";
 import { EditIssue } from "./EditIssue";
 
+const PAGE_SIZE = 50;
+
 export default function IssueListPage() {
-  return (
-    <PaginationProvider>
-      <IssueList />
-    </PaginationProvider>
-  );
+  return <IssueList />;
 }
 
 function IssueList() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -63,11 +43,6 @@ function IssueList() {
   const t = useTranslations("admin.issues");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const searchFilter = useMemo(() => {
     if (!debouncedSearchString.trim()) {
@@ -160,43 +135,56 @@ function IssueList() {
     };
   }, [sortConfig]);
 
-  const shouldPaginate = typeof effectivePageSize === "number";
-  const paginationArgs = {
-    skip: shouldPaginate ? skip : undefined,
-    take: shouldPaginate ? effectivePageSize : undefined,
-  };
+  const include = useMemo(
+    () => ({
+      project: {
+        select: {
+          id: true,
+          name: true,
+          iconUrl: true,
+        },
+      },
+      integration: {
+        select: {
+          id: true,
+          name: true,
+          provider: true,
+        },
+      },
+    }),
+    []
+  );
 
-  // Fetch ONLY basic issue data - no includes at all
-  // Projects and counts are fetched separately via direct Prisma queries
-  const { data: issues, isLoading: isLoadingIssues } = useClientQueries(
-    schema
-  ).issue.useFindMany(
-    issuesWhere
-      ? {
-          where: issuesWhere,
-          orderBy,
-          ...paginationArgs,
-          include: {
-            project: {
-              select: {
-                id: true,
-                name: true,
-                iconUrl: true,
-              },
-            },
-            integration: {
-              select: {
-                id: true,
-                name: true,
-                provider: true,
-              },
-            },
-          },
-        }
-      : undefined,
-    {
-      enabled: !!issuesWhere && status === "authenticated",
-    }
+  // Infinite scroll accumulates pages of PAGE_SIZE; the virtualized table
+  // renders only the visible window. Projects and counts are fetched separately
+  // (see below) to avoid bind-variable explosion on access-controlled includes.
+  const infiniteBaseArgs = useMemo(
+    () => ({
+      where: issuesWhere ?? undefined,
+      orderBy,
+      include,
+      take: PAGE_SIZE,
+    }),
+    [issuesWhere, orderBy, include]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingIssues,
+  } = useClientQueries(schema).issue.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled: !!issuesWhere && status === "authenticated",
+  });
+
+  const issues = useMemo(
+    () => infinitePages?.pages.flat() ?? [],
+    [infinitePages]
   );
 
   const { data: issuesCount } = useClientQueries(schema).issue.useCount(
@@ -227,16 +215,24 @@ function IssueList() {
   >({});
 
   const [isLoadingCounts, setIsLoadingCounts] = useState(false);
+  // Counts/projects are cached per issue id for the life of the page, so once
+  // fetched they never need re-requesting as the infinite list appends new ids.
+  const fetchedIssueIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (!issues || issues.length === 0) {
       setIssueCounts({});
       setIssueProjects({});
       setIsLoadingCounts(false);
+      fetchedIssueIdsRef.current = new Set();
       return;
     }
 
-    const issueIds = issues.map((i) => i.id);
+    const newIds = issues
+      .map((i) => i.id)
+      .filter((id) => !fetchedIssueIdsRef.current.has(id));
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => fetchedIssueIdsRef.current.add(id));
 
     const fetchCountsAndProjects = async () => {
       setIsLoadingCounts(true);
@@ -246,23 +242,23 @@ function IssueList() {
           fetch("/api/issues/counts", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ issueIds }),
+            body: JSON.stringify({ issueIds: newIds }),
           }),
           fetch("/api/issues/projects", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ issueIds }),
+            body: JSON.stringify({ issueIds: newIds }),
           }),
         ]);
 
         if (countsResponse.ok) {
           const data = await countsResponse.json();
-          setIssueCounts(data.counts || {});
+          setIssueCounts((prev) => ({ ...prev, ...(data.counts || {}) }));
         }
 
         if (projectsResponse.ok) {
           const data = await projectsResponse.json();
-          setIssueProjects(data.projects || {});
+          setIssueProjects((prev) => ({ ...prev, ...(data.projects || {}) }));
         }
       } catch (error) {
         console.error("Failed to fetch issue data:", error);
@@ -298,29 +294,6 @@ function IssueList() {
   }, [issues, issueCounts, issueProjects]);
 
   useEffect(() => {
-    setTotalItems(issuesCount ?? 0);
-  }, [issuesCount, setTotalItems]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
-
-  useEffect(() => {
     if (status !== "loading" && !session) {
       router.push("/");
     }
@@ -354,7 +327,6 @@ function IssueList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -371,7 +343,7 @@ function IssueList() {
           <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -383,31 +355,14 @@ function IssueList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="issue-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {mappedIssues.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: mappedIssues.length.toLocaleString(),
+                  total: (issuesCount ?? mappedIssues.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
           <div className="mt-4 flex justify-between">
             <ColumnSelection
@@ -417,16 +372,22 @@ function IssueList() {
               onVisibilityChange={setColumnVisibility}
             />
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
-              columns={columns}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
               data={mappedIssues}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              isLoading={isLoadingIssues || !issuesWhere}
-              pageSize={effectivePageSize}
+              isLoading={isLoadingIssues || isFetchingNextPage}
+              hasMore={!!hasNextPage}
+              onLoadMore={fetchNextPage}
+              estimateSize={60}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-issues-table"
+              rowTestIdPrefix="admin-issue-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/llm/page.tsx
+++ b/testplanit/app/[locale]/admin/llm/page.tsx
@@ -5,19 +5,12 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CirclePlus, RefreshCw, Sparkles } from "lucide-react";
@@ -29,11 +22,7 @@ import { EditLlmIntegration } from "./EditLlmIntegration";
 import { ExtendedLlmIntegration, useColumns } from "./columns";
 
 export default function LlmAdminPage() {
-  return (
-    <PaginationProvider>
-      <LlmIntegrationList />
-    </PaginationProvider>
-  );
+  return <LlmIntegrationList />;
 }
 
 function LlmIntegrationList() {
@@ -42,17 +31,6 @@ function LlmIntegrationList() {
   const tCommon = useTranslations("common");
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -64,11 +42,6 @@ function LlmIntegrationList() {
   const debouncedSearchString = useDebounce(searchString, 500);
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const { mutateAsync: updateLlmIntegration } =
     useClientQueries(schema).llmIntegration.useUpdate();
@@ -125,10 +98,14 @@ function LlmIntegrationList() {
     []
   );
 
-  // Query for total filtered integrations (for pagination)
-  const { data: totalFilteredIntegrations } = useClientQueries(
-    schema
-  ).llmIntegration.useFindMany(
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window so there's no page seam and no need for a
+  // separate count query (the loaded array length IS the total).
+  const {
+    data: integrations,
+    isLoading,
+    refetch,
+  } = useClientQueries(schema).llmIntegration.useFindMany(
     {
       orderBy: sortConfig
         ? { [sortConfig.column]: sortConfig.direction }
@@ -174,68 +151,6 @@ function LlmIntegrationList() {
     }
   );
 
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredIntegrations) {
-      setTotalItems(totalFilteredIntegrations.length);
-    }
-  }, [totalFilteredIntegrations, setTotalItems]);
-
-  // Query for paginated integrations
-  const {
-    data: integrations,
-    isLoading,
-    refetch,
-  } = useClientQueries(schema).llmIntegration.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      include: {
-        llmProviderConfig: true,
-        projectLlmIntegrations: {
-          where: { isActive: true, project: { isDeleted: false } },
-          select: { projectId: true },
-        },
-        llmFeatureConfigs: {
-          where: { enabled: true, project: { isDeleted: false } },
-          select: { projectId: true },
-        },
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-      take: effectivePageSize,
-      skip: skip,
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
-
   useEffect(() => {
     if (status !== "loading" && !session) {
       router.push("/");
@@ -258,14 +173,14 @@ function LlmIntegrationList() {
   // (gap is bounded by max-min-day-of-month). Acceptable for this 10s-refresh
   // display column; alerting/reset paths use the integration-specific period.
   const earliestPeriodStart = useMemo(() => {
-    const days = (totalFilteredIntegrations ?? []).map(
+    const days = (integrations ?? []).map(
       (i: any) => i.llmProviderConfig?.billingPeriodStartDay ?? 1
     );
     if (days.length === 0) return getBillingPeriodStart(1);
     return days
       .map((d: number) => getBillingPeriodStart(d))
       .reduce((a: Date, b: Date) => (a < b ? a : b));
-  }, [totalFilteredIntegrations]);
+  }, [integrations]);
 
   const { data: monthlyUsageGroups } = useClientQueries(
     schema
@@ -369,7 +284,6 @@ function LlmIntegrationList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   return (
@@ -392,7 +306,7 @@ function LlmIntegrationList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -427,43 +341,29 @@ function LlmIntegrationList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="llm-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {(integrations?.length ?? 0) > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: (integrations?.length ?? 0).toLocaleString(),
+                  total: (integrations?.length ?? 0).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between">
-            <DataTable<ExtendedLlmIntegration, unknown>
-              columns={columns}
-              data={integrations || []}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={integrations ?? []}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
               isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-llm-table"
+              rowTestIdPrefix="admin-llm-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/milestones/page.tsx
+++ b/testplanit/app/[locale]/admin/milestones/page.tsx
@@ -5,11 +5,6 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
@@ -17,10 +12,8 @@ import {
   ColumnSelection,
   CustomColumnDef,
 } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -47,14 +40,6 @@ import { DeleteMilestoneType } from "./DeleteMilestoneTypes";
 import { EditMilestoneType } from "./EditMilestoneTypes";
 
 export default function MilestoneTypesListPage() {
-  return (
-    <PaginationProvider>
-      <MilestoneTypesList />
-    </PaginationProvider>
-  );
-}
-
-function MilestoneTypesList() {
   return <MilestoneTypes />;
 }
 
@@ -64,17 +49,6 @@ function MilestoneTypes() {
   const tCommon = useTranslations("common");
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -89,47 +63,6 @@ function MilestoneTypes() {
     useState<ExtendedMilestoneTypes | null>(null);
   const [deletingMilestoneType, setDeletingMilestoneType] =
     useState<ExtendedMilestoneTypes | null>(null);
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
-  const { data: totalFilteredMilestoneTypes } = useClientQueries(
-    schema
-  ).milestoneTypes.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredMilestoneTypes) {
-      setTotalItems(totalFilteredMilestoneTypes.length);
-    }
-  }, [totalFilteredMilestoneTypes, setTotalItems]);
 
   const { data, isLoading } = useClientQueries(
     schema
@@ -161,8 +94,6 @@ function MilestoneTypes() {
         },
         icon: true,
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled:
@@ -172,23 +103,11 @@ function MilestoneTypes() {
     }
   );
 
-  const milestoneTypes = data as ExtendedMilestoneTypes[];
+  const milestoneTypes = (data ?? []) as ExtendedMilestoneTypes[];
 
   const { data: projects } = useClientQueries(schema).projects.useFindMany({
     where: { isDeleted: false },
   });
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -273,7 +192,6 @@ function MilestoneTypes() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   return (
@@ -303,7 +221,7 @@ function MilestoneTypes() {
           <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -315,31 +233,14 @@ function MilestoneTypes() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="milestone-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {milestoneTypes.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: milestoneTypes.length.toLocaleString(),
+                  total: milestoneTypes.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
           <div className="mt-4 flex justify-between">
             <ColumnSelection
@@ -349,16 +250,19 @@ function MilestoneTypes() {
               onVisibilityChange={setColumnVisibility}
             />
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
-              columns={columns}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
               data={milestoneTypes}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
               isLoading={isLoading}
-              pageSize={effectivePageSize}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-milestones-table"
+              rowTestIdPrefix="admin-milestone-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/notifications/page.tsx
+++ b/testplanit/app/[locale]/admin/notifications/page.tsx
@@ -3,9 +3,7 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { Loading } from "@/components/Loading";
-import { DataTable } from "@/components/tables/DataTable";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import TipTapEditor from "@/components/tiptap/TipTapEditor";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,21 +28,17 @@ import {
   getSystemNotificationHistory,
 } from "~/app/actions/admin-system-notifications";
 import { emptyEditorContent } from "~/app/constants";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { extractTextFromNode } from "~/utils/extractTextFromJson";
 import { useColumns, NotificationHistoryItem } from "./columns";
 
+// System-notification history is fetched from a server action a page at a time
+// and accumulated into one list; the virtualized table renders only the visible
+// window and pulls the next page as the admin scrolls near the bottom.
+const PAGE_SIZE = 50;
+
 export default function NotificationSettingsPage() {
-  return (
-    <PaginationProvider>
-      <NotificationSettingsContent />
-    </PaginationProvider>
-  );
+  return <NotificationSettingsContent />;
 }
 
 function NotificationSettingsContent() {
@@ -53,18 +47,7 @@ function NotificationSettingsContent() {
   const tGlobal = useTranslations();
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
-  const pageSizeOptions = usePageSizeOptions(totalItems);
+  const [totalCount, setTotalCount] = useState(0);
 
   const [defaultMode, setDefaultMode] = useState<NotificationMode>("IN_APP");
   const [systemNotificationTitle, setSystemNotificationTitle] = useState("");
@@ -162,16 +145,18 @@ function NotificationSettingsContent() {
   }, [defaultMode]);
 
   const loadNotificationHistory = useCallback(
-    async (page: number, size: number) => {
+    async (page: number, append: boolean) => {
       setIsLoadingHistory(true);
       try {
         const result = await getSystemNotificationHistory({
           page,
-          pageSize: size,
+          pageSize: PAGE_SIZE,
         });
         if (result.success) {
-          setNotificationHistory(result.notifications);
-          setTotalItems(result.totalCount || 0);
+          setNotificationHistory((prev) =>
+            append ? [...prev, ...result.notifications] : result.notifications
+          );
+          setTotalCount(result.totalCount || 0);
         }
       } catch (error) {
         console.error("Failed to load notification history:", error);
@@ -179,14 +164,19 @@ function NotificationSettingsContent() {
         setIsLoadingHistory(false);
       }
     },
-    [setTotalItems]
+    []
   );
 
-  // Load notification history when page or pageSize changes
+  // Load the first page on mount.
   useEffect(() => {
-    const effectivePageSize = typeof pageSize === "number" ? pageSize : 10;
-    void loadNotificationHistory(currentPage, effectivePageSize);
-  }, [currentPage, pageSize, loadNotificationHistory]);
+    void loadNotificationHistory(1, false);
+  }, [loadNotificationHistory]);
+
+  // Pull the next page and append as the table nears the bottom.
+  const handleLoadMore = useCallback(() => {
+    const nextPage = Math.floor(notificationHistory.length / PAGE_SIZE) + 1;
+    void loadNotificationHistory(nextPage, true);
+  }, [notificationHistory.length, loadNotificationHistory]);
 
   const handleSendSystemNotification = async () => {
     const messageText = extractTextFromNode(systemNotificationMessage);
@@ -210,10 +200,8 @@ function NotificationSettingsContent() {
         });
         setSystemNotificationTitle("");
         setSystemNotificationMessage(emptyEditorContent);
-        // Reload the first page after sending
-        setCurrentPage(1);
-        const effectivePageSize = typeof pageSize === "number" ? pageSize : 10;
-        void loadNotificationHistory(1, effectivePageSize);
+        // Reload from the first page after sending (replaces the accumulated list)
+        void loadNotificationHistory(1, false);
       } else {
         toast.error(tGlobal("common.errors.error"), {
           description:
@@ -449,43 +437,32 @@ function NotificationSettingsContent() {
               >
                 {t("systemNotification.history.title")}
               </h3>
-              {totalItems > 0 && (
-                <div className="flex flex-col items-end">
-                  <PaginationInfo
-                    startIndex={startIndex}
-                    endIndex={endIndex}
-                    totalRows={totalItems}
-                    searchString=""
-                    pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                    pageSizeOptions={pageSizeOptions}
-                    handlePageSizeChange={(size) => setPageSize(size)}
-                  />
-                  <PaginationComponent
-                    currentPage={currentPage}
-                    totalPages={totalPages}
-                    onPageChange={setCurrentPage}
-                  />
-                </div>
+              {tableData.length > 0 && (
+                <p className="text-sm text-muted-foreground shrink-0">
+                  {tGlobal("admin.auditLogs.showing", {
+                    loaded: tableData.length.toLocaleString(),
+                    total: (totalCount || tableData.length).toLocaleString(),
+                  })}
+                </p>
               )}
             </div>
-            {notificationHistory.length > 0 || isLoadingHistory ? (
-              <div data-testid="notification-history-table">
-                <DataTable
-                  columns={columns as any}
-                  data={tableData}
-                  columnVisibility={columnVisibility}
-                  onColumnVisibilityChange={setColumnVisibility}
-                  isLoading={isLoadingHistory}
-                  pageSize={
-                    typeof pageSize === "number" ? pageSize : totalItems
-                  }
-                />
-              </div>
-            ) : (
-              <p className="text-muted-foreground">
-                {t("systemNotification.history.empty")}
-              </p>
-            )}
+            <div
+              className="h-[500px] min-h-[300px] w-full"
+              data-testid="notification-history-table"
+            >
+              <VirtualizedDataTable
+                columns={columns as any}
+                data={tableData}
+                columnVisibility={columnVisibility}
+                onColumnVisibilityChange={setColumnVisibility}
+                isLoading={isLoadingHistory}
+                hasMore={notificationHistory.length < totalCount}
+                onLoadMore={handleLoadMore}
+                emptyMessage={t("systemNotification.history.empty")}
+                testIdPrefix="notification-history-vtable"
+                rowTestIdPrefix="notification-history-row"
+              />
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/testplanit/app/[locale]/admin/projects/page.tsx
+++ b/testplanit/app/[locale]/admin/projects/page.tsx
@@ -5,11 +5,6 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
@@ -17,13 +12,11 @@ import {
   ColumnSelection,
   CustomColumnDef,
 } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedProjects, useColumns } from "./columns";
 
 import { CreateProjectWizard } from "@/admin/projects/CreateProjectWizard";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DeleteProject } from "./DeleteProject";
 import { EditProjectModal } from "./EditProject";
@@ -71,12 +64,10 @@ interface FormData {
 }
 
 export default function ProjectAdminPage() {
-  return (
-    <PaginationProvider>
-      <ProjectAdmin />
-    </PaginationProvider>
-  );
+  return <ProjectAdmin />;
 }
+
+const PAGE_SIZE = 50;
 
 function ProjectAdmin() {
   const { data: session, status } = useSession();
@@ -84,18 +75,6 @@ function ProjectAdmin() {
   const t = useTranslations("admin.projects");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
-  const pageSizeOptions = usePageSizeOptions(totalItems);
 
   const [sortConfig, setSortConfig] = useState<{
     column: string;
@@ -179,163 +158,166 @@ function ProjectAdmin() {
     setIsAddModalOpen(false);
   }, []);
 
-  // Columns that require client-side sorting (relation counts, not scalar DB fields)
+  // Columns that require client-side sorting (relation counts, not scalar DB
+  // fields). Sorting one fetches the full set and sorts it in memory; every
+  // other column drives a genuine infinite fetch.
   const clientSortColumns = new Set([
     "users",
     "milestoneTypes",
     "milestones",
     "integration",
   ]);
-  const needsClientSideSorting = clientSortColumns.has(sortConfig.column);
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
+  const isCountSort = clientSortColumns.has(sortConfig.column);
   const debouncedSearchString = useDebounce(searchString, 500);
 
-  const { data: totalFilteredProjects } = useClientQueries(
-    schema
-  ).projects.useFindMany(
-    {
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-            isDeleted: false,
+  const projectsWhere = useMemo(
+    () => ({
+      AND: [
+        {
+          name: {
+            contains: debouncedSearchString,
+            mode: "insensitive" as const,
           },
-        ],
-      },
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
+          isDeleted: false,
+        },
+      ],
+    }),
+    [debouncedSearchString]
   );
 
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredProjects) {
-      setTotalItems(totalFilteredProjects.length);
-    }
-  }, [totalFilteredProjects, setTotalItems]);
+  const { data: totalCount } = useClientQueries(schema).projects.useCount(
+    { where: projectsWhere },
+    { enabled: !!session?.user, refetchOnWindowFocus: true }
+  );
 
-  // 1. Fetch Projects with refined include for direct/group users
-  const { data: projectsRaw, isLoading: isLoadingProjects } = useClientQueries(
-    schema
-  ).projects.useFindMany(
-    {
-      orderBy:
-        !needsClientSideSorting && sortConfig
-          ? { [sortConfig.column]: sortConfig.direction }
-          : { name: "asc" },
-      include: {
-        creator: true,
-        milestones: {
-          include: { milestoneType: { include: { icon: true } } },
-          where: { isDeleted: false },
-          orderBy: [
-            { isStarted: "desc" },
-            { startedAt: "asc" },
-            { isCompleted: "asc" },
-            { completedAt: "desc" },
-          ],
+  // Heavy include shared by both fetch modes: hydrates the members / milestones
+  // / integrations each row's columns render.
+  const include = useMemo(
+    () => ({
+      creator: true,
+      milestones: {
+        include: { milestoneType: { include: { icon: true } } },
+        where: { isDeleted: false },
+        orderBy: [
+          { isStarted: "desc" as const },
+          { startedAt: "asc" as const },
+          { isCompleted: "asc" as const },
+          { completedAt: "desc" as const },
+        ],
+      },
+      milestoneTypes: true,
+      projectIntegrations: {
+        include: {
+          integration: true,
         },
-        milestoneTypes: true,
-        projectIntegrations: {
-          include: {
-            integration: true,
+      },
+
+      // Refined includes for user IDs with filtering
+      assignedUsers: {
+        // Direct assignments
+        where: {
+          // Filter ProjectAssignment records
+          user: {
+            // Based on the related User's status
+            isActive: true,
+            isDeleted: false,
           },
         },
-
-        // Refined includes for user IDs with filtering
-        assignedUsers: {
-          // Direct assignments
-          where: {
-            // Filter ProjectAssignment records
-            user: {
-              // Based on the related User's status
-              isActive: true,
-              isDeleted: false,
-            },
-          },
-          select: { userId: true }, // Select only the ID of active/not-deleted users
-        },
-        groupPermissions: {
-          // Group permissions link for the project
-          select: {
-            groupId: true, // Expose groupId for GroupListDisplay column
-            accessType: true, // Include accessType to filter later if needed
-            // Select only the group relation from the permission
-            group: {
-              // The actual group
-              select: {
-                // Select only the user assignments from the group
-                assignedUsers: {
-                  // The GroupAssignment records linking users to this group
-                  where: {
-                    // Filter GroupAssignment records
-                    user: {
-                      // Based on the related User's status
-                      isActive: true,
-                      isDeleted: false,
-                    },
+        select: { userId: true }, // Select only the ID of active/not-deleted users
+      },
+      groupPermissions: {
+        // Group permissions link for the project
+        select: {
+          groupId: true, // Expose groupId for GroupListDisplay column
+          accessType: true, // Include accessType to filter later if needed
+          // Select only the group relation from the permission
+          group: {
+            // The actual group
+            select: {
+              // Select only the user assignments from the group
+              assignedUsers: {
+                // The GroupAssignment records linking users to this group
+                where: {
+                  // Filter GroupAssignment records
+                  user: {
+                    // Based on the related User's status
+                    isActive: true,
+                    isDeleted: false,
                   },
-                  select: { userId: true }, // Select the userId from the filtered assignments
                 },
+                select: { userId: true }, // Select the userId from the filtered assignments
               },
             },
           },
         },
-        codeRepositoryConfig: {
-          select: {
-            id: true,
-            repository: {
-              select: { name: true },
-            },
-          },
-        },
-        projectLlmIntegrations: {
-          select: {
-            isActive: true,
-            llmIntegration: {
-              select: { name: true, provider: true },
-            },
-          },
-        },
-        defaultRole: {
-          select: {
-            id: true,
-            name: true,
+      },
+      codeRepositoryConfig: {
+        select: {
+          id: true,
+          repository: {
+            select: { name: true },
           },
         },
       },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-            isDeleted: false,
+      projectLlmIntegrations: {
+        select: {
+          isActive: true,
+          llmIntegration: {
+            select: { name: true, provider: true },
           },
-        ],
+        },
       },
-      take: needsClientSideSorting ? undefined : effectivePageSize,
-      skip: needsClientSideSorting ? undefined : skip,
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
+      defaultRole: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    }),
+    []
   );
+
+  const orderBy = useMemo(
+    () =>
+      isCountSort
+        ? { name: "asc" as const }
+        : { [sortConfig.column]: sortConfig.direction },
+    [isCountSort, sortConfig]
+  );
+
+  const infiniteBaseArgs = useMemo(
+    () => ({ orderBy, include, where: projectsWhere, take: PAGE_SIZE }),
+    [orderBy, include, projectsWhere]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingInfinite,
+  } = useClientQueries(schema).projects.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled: !!session?.user && !isCountSort,
+    refetchOnWindowFocus: true,
+  });
+
+  const { data: allProjectsRaw, isLoading: isLoadingAll } = useClientQueries(
+    schema
+  ).projects.useFindMany(
+    { orderBy: { name: "asc" }, include, where: projectsWhere },
+    { enabled: !!session?.user && isCountSort, refetchOnWindowFocus: true }
+  );
+
+  const projectsRaw = useMemo(() => {
+    if (isCountSort) return allProjectsRaw;
+    return infinitePages?.pages.flat();
+  }, [isCountSort, allProjectsRaw, infinitePages]);
+
+  const isLoading = isCountSort ? isLoadingAll : isLoadingInfinite;
 
   // Use the utility function (potentially within useMemo for optimization)
   const projects: ProcessedProject[] = useMemo(
@@ -343,11 +325,11 @@ function ProjectAdmin() {
     [projectsRaw, allUsers]
   );
 
-  // Client-side sort by relation count, then paginate
+  // Client-side sort by relation count over the full set (count columns only).
   const displayedProjects = useMemo(() => {
-    if (!needsClientSideSorting || !projects.length) return projects;
+    if (!isCountSort || !projects.length) return projects;
 
-    const sorted = [...projects].sort((a, b) => {
+    return [...projects].sort((a, b) => {
       let aValue = 0;
       let bValue = 0;
       switch (sortConfig.column) {
@@ -372,12 +354,9 @@ function ProjectAdmin() {
       }
       return sortConfig.direction === "asc" ? aValue - bValue : bValue - aValue;
     });
+  }, [projects, isCountSort, sortConfig]);
 
-    return sorted.slice(skip, skip + effectivePageSize);
-  }, [projects, needsClientSideSorting, sortConfig, skip, effectivePageSize]);
-
-  // Use only the project loading state now
-  const isLoading = isLoadingProjects;
+  const tableData = isCountSort ? displayedProjects : projects;
 
   const handleSortChange = (column: string) => {
     const direction =
@@ -387,25 +366,7 @@ function ProjectAdmin() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
     if (data.completedAt) {
@@ -471,7 +432,7 @@ function ProjectAdmin() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/3 min-w-[150px]">
               <div className="">
                 <Filter
@@ -490,44 +451,30 @@ function ProjectAdmin() {
                 </div>
               </div>
             </div>
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="project-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {tableData.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: tableData.length.toLocaleString(),
+                  total: (totalCount ?? tableData.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
               columns={columns}
-              data={
-                (needsClientSideSorting ? displayedProjects : projects) || []
-              }
+              data={tableData || []}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
-              isLoading={isLoading}
+              isLoading={isLoading || isFetchingNextPage}
+              hasMore={isCountSort ? false : !!hasNextPage}
+              onLoadMore={fetchNextPage}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-projects-table"
+              rowTestIdPrefix="admin-project-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/prompts/page.tsx
+++ b/testplanit/app/[locale]/admin/prompts/page.tsx
@@ -5,19 +5,12 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CirclePlus, MessageSquareCode } from "lucide-react";
@@ -28,11 +21,7 @@ import { DeletePromptConfig } from "./DeletePromptConfig";
 import { EditPromptConfig } from "./EditPromptConfig";
 
 export default function PromptsAdminPage() {
-  return (
-    <PaginationProvider>
-      <PromptConfigList />
-    </PaginationProvider>
-  );
+  return <PromptConfigList />;
 }
 
 function PromptConfigList() {
@@ -41,17 +30,6 @@ function PromptConfigList() {
   const tCommon = useTranslations("common");
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -63,10 +41,6 @@ function PromptConfigList() {
   const debouncedSearchString = useDebounce(searchString, 500);
   const [showAddDialog, setShowAddDialog] = useState(false);
 
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
   const { mutateAsync: updatePromptConfig } =
     useClientQueries(schema).promptConfig.useUpdate();
 
@@ -75,48 +49,9 @@ function PromptConfigList() {
     updatePromptConfigRef.current = updatePromptConfig;
   });
 
-  // Query for total filtered configs (for pagination)
-  const { data: totalFilteredConfigs } = useClientQueries(
-    schema
-  ).promptConfig.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      include: {
-        prompts: {
-          include: {
-            llmIntegration: {
-              select: { id: true, name: true },
-            },
-          },
-        },
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive" as const,
-            },
-          },
-          { isDeleted: false },
-        ],
-      },
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  useEffect(() => {
-    if (totalFilteredConfigs) {
-      setTotalItems(totalFilteredConfigs.length);
-    }
-  }, [totalFilteredConfigs, setTotalItems]);
-
-  // Paginated query
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window so there's no page seam and no need for a
+  // separate count query (the loaded array length IS the total).
   const {
     data: configs,
     isLoading,
@@ -147,8 +82,6 @@ function PromptConfigList() {
           { isDeleted: false },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -187,16 +120,6 @@ function PromptConfigList() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [configs]
   );
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -244,7 +167,6 @@ function PromptConfigList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -267,7 +189,7 @@ function PromptConfigList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -289,43 +211,29 @@ function PromptConfigList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="prompts-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {(configs?.length ?? 0) > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: (configs?.length ?? 0).toLocaleString(),
+                  total: (configs?.length ?? 0).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between">
-            <DataTable<ExtendedPromptConfig, unknown>
-              columns={columns}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
               data={(configs as ExtendedPromptConfig[]) || []}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
               isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-prompts-table"
+              rowTestIdPrefix="admin-prompt-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/roles/page.tsx
+++ b/testplanit/app/[locale]/admin/roles/page.tsx
@@ -5,20 +5,13 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedRoles, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -33,11 +26,7 @@ import { DeleteRole } from "./DeleteRoles";
 import { EditRole } from "./EditRoles";
 
 export default function RoleListPage() {
-  return (
-    <PaginationProvider>
-      <RoleList />
-    </PaginationProvider>
-  );
+  return <RoleList />;
 }
 
 function RoleList() {
@@ -46,17 +35,6 @@ function RoleList() {
   const t = useTranslations("admin.roles");
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -70,14 +48,7 @@ function RoleList() {
   const [deletingRole, setDeletingRole] = useState<ExtendedRoles | null>(null);
   const debouncedSearchString = useDebounce(searchString, 500);
 
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
-  const { data: totalFilteredRoles } = useClientQueries(
-    schema
-  ).roles.useFindMany(
+  const { data: roles, isLoading } = useClientQueries(schema).roles.useFindMany(
     {
       orderBy: sortConfig
         ? { [sortConfig.column]: sortConfig.direction }
@@ -107,63 +78,7 @@ function RoleList() {
     }
   );
 
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredRoles) {
-      setTotalItems(totalFilteredRoles.length);
-    }
-  }, [totalFilteredRoles, setTotalItems]);
-
-  const { data: roles, isLoading } = useClientQueries(schema).roles.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      include: {
-        users: {
-          where: {
-            isDeleted: false,
-            isActive: true,
-          },
-        },
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-      take: effectivePageSize,
-      skip: skip,
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  const rolesData = roles as ExtendedRoles[];
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const rolesData = (roles ?? []) as ExtendedRoles[];
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -225,7 +140,6 @@ function RoleList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   if (!session || session.user.access !== "ADMIN") {
@@ -256,7 +170,7 @@ function RoleList() {
           <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -268,42 +182,28 @@ function RoleList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="role-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {rolesData.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: rolesData.length.toLocaleString(),
+                  total: rolesData.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable<ExtendedRoles, unknown>
-              columns={columns}
-              data={rolesData || []}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={rolesData}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
               isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-roles-table"
+              rowTestIdPrefix="admin-role-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/scim/page.tsx
+++ b/testplanit/app/[locale]/admin/scim/page.tsx
@@ -5,22 +5,15 @@ import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedScimToken, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { UserNameCell } from "@/components/tables/UserNameCell";
 import {
   AlertDialog,
@@ -65,11 +58,7 @@ import { ConflictLogTable } from "./ConflictLogTable";
 import { MintDialog } from "./MintDialog";
 
 export default function ScimTokensPage() {
-  return (
-    <PaginationProvider>
-      <ScimTokensList />
-    </PaginationProvider>
-  );
+  return <ScimTokensList />;
 }
 
 function FallbackDefaultCard() {
@@ -211,17 +200,6 @@ function ScimTokensList() {
   const tCommon = useTranslations("common");
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -250,9 +228,6 @@ function ScimTokensList() {
     status: "isActive",
   };
 
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
   const sortField = sortConfig
     ? columnToFieldMap[sortConfig.column] || sortConfig.column
     : "lastUsedAt";
@@ -265,47 +240,6 @@ function ScimTokensList() {
   useEffect(() => {
     updateScimTokenRef.current = updateScimToken;
   });
-
-  const { data: totalFilteredTokens } = useClientQueries(
-    schema
-  ).scimToken.useFindMany(
-    {
-      orderBy: { [sortField]: sortConfig?.direction || "desc" },
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                name: {
-                  contains: debouncedSearchString,
-                  mode: "insensitive",
-                },
-              },
-              {
-                idpName: debouncedSearchString
-                  ? {
-                      equals: debouncedSearchString.toUpperCase() as any,
-                    }
-                  : undefined,
-              },
-            ],
-          },
-          showRevokedTokens ? {} : { isActive: true, revokedAt: null },
-        ],
-      },
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredTokens) {
-      setTotalItems(totalFilteredTokens.length);
-    }
-  }, [totalFilteredTokens, setTotalItems]);
 
   const {
     data: tokens,
@@ -336,24 +270,12 @@ function ScimTokensList() {
           showRevokedTokens ? {} : { isActive: true, revokedAt: null },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
       refetchOnWindowFocus: true,
     }
   );
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -427,7 +349,6 @@ function ScimTokensList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -456,7 +377,7 @@ function ScimTokensList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -493,50 +414,30 @@ function ScimTokensList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="scim-tokens-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {tokens && tokens.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: tokens.length.toLocaleString(),
+                  total: tokens.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between" data-testid="scim-table">
-            {tokens && tokens.length > 0 ? (
-              <DataTable<ExtendedScimToken, unknown>
-                columns={columns}
-                data={tokens as ExtendedScimToken[]}
-                onSortChange={handleSortChange}
-                sortConfig={sortConfig}
-                columnVisibility={columnVisibility}
-                onColumnVisibilityChange={setColumnVisibility}
-                pageSize={typeof pageSize === "number" ? pageSize : totalItems}
-                isLoading={isLoading}
-              />
-            ) : !isLoading ? (
-              <div className="w-full text-center py-12 text-muted-foreground">
-                {t("noTokens")}
-              </div>
-            ) : null}
+          <div className="mt-4 w-full" data-testid="scim-table">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={(tokens ?? []) as ExtendedScimToken[]}
+              onSortChange={handleSortChange}
+              sortConfig={sortConfig}
+              columnVisibility={columnVisibility}
+              onColumnVisibilityChange={setColumnVisibility}
+              isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${showRevokedTokens}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-scim-table"
+              rowTestIdPrefix="admin-scim-row"
+            />
           </div>
         </CardContent>
       </Card>

--- a/testplanit/app/[locale]/admin/tags/page.tsx
+++ b/testplanit/app/[locale]/admin/tags/page.tsx
@@ -4,20 +4,13 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -32,28 +25,15 @@ import { ExtendedTags, useColumns } from "./columns";
 import { DeleteTag } from "./DeleteTag";
 import { EditTag } from "./EditTag";
 
+const PAGE_SIZE = 50;
+
 export default function TagListPage() {
-  return (
-    <PaginationProvider>
-      <TagList />
-    </PaginationProvider>
-  );
+  return <TagList />;
 }
 
 function TagList() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -68,11 +48,6 @@ function TagList() {
   const [deletingTag, setDeletingTag] = useState<ExtendedTags | null>(null);
   const tGlobal = useTranslations();
   const tCommon = useTranslations("common");
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const nameFilter = useMemo(() => {
     if (!debouncedSearchString.trim()) {
@@ -110,28 +85,37 @@ function TagList() {
     };
   }, [sortConfig]);
 
-  const shouldPaginate = typeof effectivePageSize === "number";
-  const paginationArgs = {
-    skip: shouldPaginate ? skip : undefined,
-    take: shouldPaginate ? effectivePageSize : undefined,
-  };
-
   // Fetch ONLY basic tag data - no includes at all
-  // ZenStack's access control on includes causes bind variable explosion (even with limits)
-  // Projects and counts are fetched separately via direct Prisma queries
-  const { data: tags, isLoading: isLoadingTags } = useClientQueries(
-    schema
-  ).tags.useFindMany(
-    tagsWhere
-      ? {
-          where: tagsWhere,
-          orderBy,
-          ...paginationArgs,
-        }
-      : undefined,
-    {
-      enabled: !!tagsWhere && status === "authenticated",
-    }
+  // ZenStack's access control on includes causes bind variable explosion (even
+  // with limits). Projects and counts are fetched separately (see below).
+  // Infinite scroll accumulates pages of PAGE_SIZE; the virtualized table
+  // renders only the visible window.
+  const infiniteBaseArgs = useMemo(
+    () => ({
+      where: tagsWhere ?? undefined,
+      orderBy,
+      take: PAGE_SIZE,
+    }),
+    [tagsWhere, orderBy]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingTags,
+  } = useClientQueries(schema).tags.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled: !!tagsWhere && status === "authenticated",
+  });
+
+  const tags = useMemo(
+    () => infinitePages?.pages.flat() ?? [],
+    [infinitePages]
   );
 
   const { data: tagsCount } = useClientQueries(schema).tags.useCount(
@@ -169,16 +153,24 @@ function TagList() {
   >({});
 
   const [isLoadingCounts, setIsLoadingCounts] = useState(false);
+  // Counts/projects are cached per tag id for the life of the page, so once
+  // fetched they never need re-requesting as the infinite list appends new ids.
+  const fetchedTagIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (!tags || tags.length === 0) {
       setTagCounts({});
       setTagProjects({});
       setIsLoadingCounts(false);
+      fetchedTagIdsRef.current = new Set();
       return;
     }
 
-    const tagIds = tags.map((t) => t.id);
+    const newIds = tags
+      .map((t) => t.id)
+      .filter((id) => !fetchedTagIdsRef.current.has(id));
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => fetchedTagIdsRef.current.add(id));
 
     const fetchCountsAndProjects = async () => {
       setIsLoadingCounts(true);
@@ -188,23 +180,23 @@ function TagList() {
           fetch("/api/tags/counts", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ tagIds }),
+            body: JSON.stringify({ tagIds: newIds }),
           }),
           fetch("/api/tags/projects", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ tagIds }),
+            body: JSON.stringify({ tagIds: newIds }),
           }),
         ]);
 
         if (countsResponse.ok) {
           const data = await countsResponse.json();
-          setTagCounts(data.counts || {});
+          setTagCounts((prev) => ({ ...prev, ...(data.counts || {}) }));
         }
 
         if (projectsResponse.ok) {
           const data = await projectsResponse.json();
-          setTagProjects(data.projects || {});
+          setTagProjects((prev) => ({ ...prev, ...(data.projects || {}) }));
         }
       } catch (error) {
         console.error("Failed to fetch tag data:", error);
@@ -240,22 +232,6 @@ function TagList() {
   }, [tags, tagCounts, tagProjects]);
 
   useEffect(() => {
-    setTotalItems(tagsCount ?? 0);
-  }, [tagsCount, setTotalItems]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
-
-  useEffect(() => {
     if (status !== "loading" && !session) {
       router.push("/");
     }
@@ -285,7 +261,6 @@ function TagList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -316,7 +291,7 @@ function TagList() {
           <CardDescription>{tGlobal("tags.description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -328,31 +303,14 @@ function TagList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="tag-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {mappedTags.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: mappedTags.length.toLocaleString(),
+                  total: (tagsCount ?? mappedTags.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
           <div className="mt-4 flex justify-between">
             <ColumnSelection
@@ -362,16 +320,21 @@ function TagList() {
               onVisibilityChange={setColumnVisibility}
             />
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
-              columns={columns}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
               data={mappedTags}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              isLoading={isLoadingTags || !tagsWhere}
-              pageSize={effectivePageSize}
+              isLoading={isLoadingTags || isFetchingNextPage}
+              hasMore={!!hasNextPage}
+              onLoadMore={fetchNextPage}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-tags-table"
+              rowTestIdPrefix="admin-tag-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/users/page.tsx
+++ b/testplanit/app/[locale]/admin/users/page.tsx
@@ -5,24 +5,17 @@ import { schema } from "~/zenstack/schema";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import type { UserFindManyArgs } from "~/zenstack/input";
 import { ExtendedUser, useColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
 
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -42,11 +35,7 @@ import { DeleteUser } from "./DeleteUser";
 import { EditUser } from "./EditUser";
 
 export default function UserListPage() {
-  return (
-    <PaginationProvider>
-      <UserList />
-    </PaginationProvider>
-  );
+  return <UserList />;
 }
 
 function UserList() {
@@ -57,17 +46,6 @@ function UserList() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -85,11 +63,6 @@ function UserList() {
   const [revokingUser, setRevokingUser] = useState<ExtendedUser | null>(null);
   const [isForceLoading, setIsForceLoading] = useState(false);
   const [isRevokeLoading, setIsRevokeLoading] = useState(false);
-
-  // Calculate skip and take based on pageSize
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const handleToggle = useCallback(
     async (id: string, key: keyof ExtendedUser, value: boolean) => {
@@ -177,45 +150,9 @@ function UserList() {
         ? { [sortConfig.column]: sortConfig.direction }
         : { name: "asc" };
 
-  const { data: totalFilteredUsers } = useClientQueries(
-    schema
-  ).user.useFindMany(
-    {
-      orderBy,
-      include: {
-        role: true,
-        groups: true,
-        projects: true,
-        createdBy: true,
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          showInactiveUsers ? {} : { isActive: true },
-          {
-            isDeleted: false,
-          },
-        ],
-      },
-    },
-    {
-      enabled: !!session?.user,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredUsers) {
-      setTotalItems(totalFilteredUsers.length);
-    }
-  }, [totalFilteredUsers, setTotalItems]);
-
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window so there's no page seam and no need for a
+  // separate count query (the loaded array length IS the total).
   const { data: users, isLoading } = useClientQueries(schema).user.useFindMany(
     {
       orderBy,
@@ -239,8 +176,6 @@ function UserList() {
           },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -248,24 +183,10 @@ function UserList() {
     }
   );
 
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const userRows = useMemo(
+    () => (users ?? []) as unknown as ExtendedUser[],
+    [users]
+  );
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -311,7 +232,6 @@ function UserList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   return (
@@ -339,7 +259,7 @@ function UserList() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -376,43 +296,29 @@ function UserList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="users-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {userRows.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {tGlobal("admin.auditLogs.showing", {
+                  loaded: userRows.length.toLocaleString(),
+                  total: userRows.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
 
-          <div className="mt-4 flex justify-between">
-            <DataTable<ExtendedUser, unknown>
-              columns={columns}
-              data={(users ?? []) as unknown as ExtendedUser[]}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={userRows}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={typeof pageSize === "number" ? pageSize : totalItems}
               isLoading={isLoading}
+              resetKey={`${debouncedSearchString}|${showInactiveUsers}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="admin-users-table"
+              rowTestIdPrefix="admin-user-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/admin/workflows/ProjectReviewToggleList.test.tsx
+++ b/testplanit/app/[locale]/admin/workflows/ProjectReviewToggleList.test.tsx
@@ -9,13 +9,16 @@ vi.mock("~/hooks/useReviewFeatureEnabled", () => ({
     mockUseReviewFeatureEnabled(...args),
 }));
 
+// The list moved from paged useFindMany to infinite scroll; `useInfiniteFindMany`
+// records the (where/orderBy) args the assertions below check.
 const mockUseFindManyProjects = vi.fn();
 const mockUseCountProjects = vi.fn();
 const mockUseUpdateProjects = vi.fn();
 vi.mock("@zenstackhq/tanstack-query/react", () => ({
   useClientQueries: () => ({
     projects: {
-      useFindMany: (...args: unknown[]) => mockUseFindManyProjects(...args),
+      useInfiniteFindMany: (...args: unknown[]) =>
+        mockUseFindManyProjects(...args),
       useCount: (...args: unknown[]) => mockUseCountProjects(...args),
       useUpdate: (...args: unknown[]) => mockUseUpdateProjects(...args),
     },
@@ -58,8 +61,8 @@ vi.mock("~/lib/contexts/PaginationContext", () => ({
 // effects firing. Also exposes a sort-header proxy so tests can trigger the
 // onSortChange callback the real DataTable invokes on header click.
 const dataTableLastProps: { current: any } = { current: null };
-vi.mock("@/components/tables/DataTable", () => ({
-  DataTable: (props: any) => {
+vi.mock("@/components/tables/VirtualizedDataTable", () => ({
+  VirtualizedDataTable: (props: any) => {
     dataTableLastProps.current = props;
     const { columns, data, onSortChange } = props;
     return (
@@ -143,7 +146,10 @@ beforeEach(() => {
   mutateAsync.mockResolvedValue({});
 
   mockUseFindManyProjects.mockReturnValue({
-    data: sampleProjects,
+    data: { pages: [sampleProjects], pageParams: [undefined] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
     isLoading: false,
   });
   mockUseCountProjects.mockReturnValue({ data: sampleProjects.length });

--- a/testplanit/app/[locale]/admin/workflows/ProjectReviewToggleList.tsx
+++ b/testplanit/app/[locale]/admin/workflows/ProjectReviewToggleList.tsx
@@ -4,19 +4,17 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
 import { ProjectIcon } from "@/components/ProjectIcon";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { ProjectNameCell } from "@/components/tables/ProjectNameCell";
 import { Switch } from "@/components/ui/switch";
 import { ColumnDef } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useReviewFeatureEnabled } from "~/hooks/useReviewFeatureEnabled";
-import { usePagination } from "~/lib/contexts/PaginationContext";
+
+const PAGE_SIZE = 50;
 
 type ProjectRow = {
   id: number;
@@ -28,22 +26,10 @@ type ProjectRow = {
 export function ProjectReviewToggleList() {
   const t = useTranslations("admin.workflows.projectReviewToggleList");
   const tCommon = useTranslations("common");
+  const tGlobal = useTranslations();
 
   const { systemEnabled, isLoading: featureLoading } =
     useReviewFeatureEnabled();
-
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
-  const pageSizeOptions = usePageSizeOptions(totalItems);
 
   const [searchString, setSearchString] = useState("");
   const debouncedSearch = useDebounce(searchString, 300);
@@ -59,14 +45,9 @@ export function ProjectReviewToggleList() {
           ? "desc"
           : "asc";
       setSortConfig({ column, direction });
-      setCurrentPage(1);
     },
-    [sortConfig, setCurrentPage]
+    [sortConfig]
   );
-
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const where = useMemo(
     () => ({
@@ -81,14 +62,9 @@ export function ProjectReviewToggleList() {
     { enabled: systemEnabled === true }
   );
 
-  useEffect(() => {
-    if (typeof count === "number") setTotalItems(count);
-  }, [count, setTotalItems]);
-
-  const { data: projects, isLoading } = useClientQueries(
-    schema
-  ).projects.useFindMany(
-    {
+  // Infinite scroll accumulates pages; the virtualized table windows the DOM.
+  const infiniteBaseArgs = useMemo(
+    () => ({
       where,
       select: {
         id: true,
@@ -97,10 +73,28 @@ export function ProjectReviewToggleList() {
         reviewWorkflowEnabled: true,
       },
       orderBy: { [sortConfig.column]: sortConfig.direction },
-      take: effectivePageSize > 0 ? effectivePageSize : undefined,
-      skip,
-    },
-    { enabled: systemEnabled === true }
+      take: PAGE_SIZE,
+    }),
+    [where, sortConfig]
+  );
+
+  const {
+    data: projectsPages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useClientQueries(schema).projects.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) =>
+      !lastPage || lastPage.length < PAGE_SIZE
+        ? undefined
+        : { ...infiniteBaseArgs, skip: allPages.flat().length },
+    enabled: systemEnabled === true,
+  });
+
+  const projects = useMemo(
+    () => (projectsPages?.pages.flat() ?? []) as ProjectRow[],
+    [projectsPages]
   );
 
   const { mutateAsync: updateProjects } =
@@ -126,19 +120,6 @@ export function ProjectReviewToggleList() {
     },
     [t]
   );
-
-  const prevSearchRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-  useEffect(() => {
-    if (searchString === prevSearchRef.current) return;
-    prevSearchRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
 
   const columns: ColumnDef<ProjectRow>[] = useMemo(
     () => [
@@ -193,12 +174,11 @@ export function ProjectReviewToggleList() {
   if (featureLoading) return null;
   if (systemEnabled !== true) return null;
 
-  const showEmptyState =
-    !isLoading && (projects?.length ?? 0) === 0 && totalItems === 0;
+  const showEmptyState = !isLoading && projects.length === 0;
 
   return (
     <div data-testid="project-review-toggle-list-card">
-      <div className="flex flex-row items-start">
+      <div className="flex flex-row items-start justify-between gap-4">
         <div className="flex flex-col grow w-full sm:w-1/3 min-w-[150px]">
           <Filter
             key="project-review-filter"
@@ -208,30 +188,14 @@ export function ProjectReviewToggleList() {
             dataTestId="project-review-toggle-search"
           />
         </div>
-        <div className="flex flex-col w-full sm:w-2/3 items-end">
-          {totalItems > 0 && (
-            <>
-              <div className="justify-end">
-                <PaginationInfo
-                  startIndex={startIndex}
-                  endIndex={endIndex}
-                  totalRows={totalItems}
-                  searchString={searchString}
-                  pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                  pageSizeOptions={pageSizeOptions}
-                  handlePageSizeChange={setPageSize}
-                />
-              </div>
-              <div className="justify-end -mx-4">
-                <PaginationComponent
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  onPageChange={setCurrentPage}
-                />
-              </div>
-            </>
-          )}
-        </div>
+        {projects.length > 0 && (
+          <p className="text-sm text-muted-foreground shrink-0">
+            {tGlobal("admin.auditLogs.showing", {
+              loaded: projects.length.toLocaleString(),
+              total: (count ?? projects.length).toLocaleString(),
+            })}
+          </p>
+        )}
       </div>
       {showEmptyState && (
         <p
@@ -241,16 +205,20 @@ export function ProjectReviewToggleList() {
           {t("emptyState")}
         </p>
       )}
-      <div className="mt-4">
-        <DataTable
-          columns={columns}
-          data={(projects as ProjectRow[]) ?? []}
+      <div className="mt-4 h-[500px] min-h-[300px] w-full">
+        <VirtualizedDataTable
+          columns={columns as ColumnDef<any, any>[]}
+          data={projects}
           onSortChange={handleSortChange}
           sortConfig={sortConfig}
           columnVisibility={columnVisibility}
           onColumnVisibilityChange={setColumnVisibility}
-          isLoading={isLoading}
-          pageSize={typeof pageSize === "number" ? pageSize : 10}
+          isLoading={isLoading || isFetchingNextPage}
+          hasMore={!!hasNextPage}
+          onLoadMore={fetchNextPage}
+          resetKey={`${debouncedSearch}|${sortConfig.column}|${sortConfig.direction}`}
+          testIdPrefix="project-review-toggle-table"
+          rowTestIdPrefix="project-review-toggle-row"
         />
       </div>
     </div>

--- a/testplanit/app/[locale]/admin/workflows/SystemFeatureCard.tsx
+++ b/testplanit/app/[locale]/admin/workflows/SystemFeatureCard.tsx
@@ -19,7 +19,6 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useReviewFeatureEnabled } from "~/hooks/useReviewFeatureEnabled";
 import { Label } from "~/components/ui/label";
-import { PaginationProvider } from "~/lib/contexts/PaginationContext";
 import { ProjectReviewToggleList } from "./ProjectReviewToggleList";
 
 const REMINDER_THRESHOLD_KEY = "review_reminder_threshold_days";
@@ -204,9 +203,7 @@ export function SystemFeatureCard() {
               </>
             )}
           </div>
-          <PaginationProvider defaultPageSize={10}>
-            <ProjectReviewToggleList />
-          </PaginationProvider>
+          <ProjectReviewToggleList />
         </CardContent>
       )}
     </Card>

--- a/testplanit/app/[locale]/issues/page.tsx
+++ b/testplanit/app/[locale]/issues/page.tsx
@@ -3,10 +3,8 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import {
   Card,
   CardContent,
@@ -25,37 +23,25 @@ import type { VisibilityState } from "@tanstack/react-table";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { ExtendedIssues, useIssueColumns } from "./columns";
 
+const PAGE_SIZE = 50;
+
+// Count columns are computed via a separate join call and can't be sorted
+// across pages without the full set in hand. Sorting by one fetches everything
+// once and renders it through the same virtualized table in full-set mode;
+// every other column is a real DB column and drives a genuine infinite fetch.
+const COUNT_SORT_COLUMNS = ["cases", "testRuns", "sessions", "projects"];
+
 export default function IssueList() {
-  return (
-    <PaginationProvider>
-      <Issues />
-    </PaginationProvider>
-  );
+  return <Issues />;
 }
 
 function Issues() {
   const t = useTranslations();
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -69,40 +55,28 @@ function Issues() {
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [priorityFilter, setPriorityFilter] = useState<string>("");
 
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-  const prevStatusFilterRef = useRef(statusFilter);
-  const prevPriorityFilterRef = useRef(priorityFilter);
-
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   const accessFilterReady = !!session?.user?.id;
 
-  // Fetch distinct status values for the filter dropdown
+  // Distinct status/priority values for the filter dropdowns.
   const { data: statusOptions } = useClientQueries(schema).issue.useGroupBy(
     {
       by: ["status"],
       where: { isDeleted: false },
       orderBy: { status: "asc" },
     },
-    {
-      enabled: status === "authenticated",
-    }
+    { enabled: status === "authenticated" }
   );
-
-  // Fetch distinct priority values for the filter dropdown
   const { data: priorityOptions } = useClientQueries(schema).issue.useGroupBy(
     {
       by: ["priority"],
       where: { isDeleted: false },
       orderBy: { priority: "asc" },
     },
-    {
-      enabled: status === "authenticated",
-    }
+    { enabled: status === "authenticated" }
   );
 
-  // Extract unique non-null values, combining options with mismatched casing
   const statuses = useMemo(() => {
     if (!statusOptions) return [];
     const seen = new Map<string, string>();
@@ -111,9 +85,7 @@ function Issues() {
       .filter((s): s is string => s !== null && s.trim() !== "")
       .forEach((s) => {
         const lower = s.toLowerCase();
-        if (!seen.has(lower)) {
-          seen.set(lower, s);
-        }
+        if (!seen.has(lower)) seen.set(lower, s);
       });
     return Array.from(seen.values()).sort((a, b) =>
       a.toLowerCase().localeCompare(b.toLowerCase())
@@ -128,302 +100,184 @@ function Issues() {
       .filter((p): p is string => p !== null && p.trim() !== "")
       .forEach((p) => {
         const lower = p.toLowerCase();
-        if (!seen.has(lower)) {
-          seen.set(lower, p);
-        }
+        if (!seen.has(lower)) seen.set(lower, p);
       });
     return Array.from(seen.values()).sort((a, b) =>
       a.toLowerCase().localeCompare(b.toLowerCase())
     );
   }, [priorityOptions]);
 
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
-  // Build search filter for name, title, and description
   const searchFilter = useMemo(() => {
     if (!debouncedSearchString.trim()) {
       return {};
     }
-
     const searchTerm = debouncedSearchString.trim();
     return {
       OR: [
-        {
-          name: {
-            contains: searchTerm,
-            mode: "insensitive" as const,
-          },
-        },
-        {
-          title: {
-            contains: searchTerm,
-            mode: "insensitive" as const,
-          },
-        },
-        {
-          description: {
-            contains: searchTerm,
-            mode: "insensitive" as const,
-          },
-        },
+        { name: { contains: searchTerm, mode: "insensitive" as const } },
+        { title: { contains: searchTerm, mode: "insensitive" as const } },
+        { description: { contains: searchTerm, mode: "insensitive" as const } },
       ],
     };
   }, [debouncedSearchString]);
 
-  // Note: We don't need a manual project filter here anymore.
-  // ZenStack's access policies on RepositoryCases, Sessions, TestRuns, etc.
-  // will automatically filter out data the user doesn't have access to.
-  // This handles all access types: assignedUsers, userPermissions,
-  // groupPermissions, and project defaultAccessType (GLOBAL_ROLE/SPECIFIC_ROLE).
-
-  // Build the where clause for issues
+  // Issue is visible if associated with any accessible project relation.
+  // ZenStack's access policies handle the permission filtering automatically.
   const issuesWhere = useMemo(() => {
     if (!accessFilterReady) {
       return null;
     }
 
-    // Issue is visible if associated with any accessible project relation.
-    // ZenStack's access policies handle the permission filtering automatically.
     const relations = [
       {
-        // `Issue.repositoryCases` does not exist in the v3 schema; the case
-        // link is the explicit `caseIssues` join (RepositoryCaseIssue ->
-        // case). Using the old relation name made ZenStack reject the whole
-        // findMany (422), which is why the issues list came back empty.
-        caseIssues: {
-          some: {
-            case: {
-              isDeleted: false,
-            },
-          },
-        },
+        // `Issue.repositoryCases` does not exist in v3; the case link is the
+        // explicit `caseIssues` join (RepositoryCaseIssue -> case).
+        caseIssues: { some: { case: { isDeleted: false } } },
       },
-      {
-        sessions: {
-          some: {
-            isDeleted: false,
-          },
-        },
-      },
-      {
-        sessionResults: {
-          some: {
-            session: {
-              isDeleted: false,
-            },
-          },
-        },
-      },
-      {
-        testRuns: {
-          some: {
-            isDeleted: false,
-          },
-        },
-      },
-      {
-        testRunResults: {
-          some: {
-            testRun: {
-              isDeleted: false,
-            },
-          },
-        },
-      },
+      { sessions: { some: { isDeleted: false } } },
+      { sessionResults: { some: { session: { isDeleted: false } } } },
+      { testRuns: { some: { isDeleted: false } } },
+      { testRunResults: { some: { testRun: { isDeleted: false } } } },
       {
         testRunStepResults: {
-          some: {
-            testRunResult: {
-              testRun: {
-                isDeleted: false,
-              },
-            },
-          },
+          some: { testRunResult: { testRun: { isDeleted: false } } },
         },
       },
     ];
 
-    // Combine search filter and project relations using AND
     const conditions: Array<Record<string, unknown>> = [
       { isDeleted: false },
       { OR: relations },
     ];
-
-    // Add search filter if present
-    if (searchFilter.OR) {
-      conditions.push(searchFilter);
-    }
-
-    // Add status filter if selected (case-insensitive)
+    if (searchFilter.OR) conditions.push(searchFilter);
     if (statusFilter) {
       conditions.push({
         status: { equals: statusFilter, mode: "insensitive" as const },
       });
     }
-
-    // Add priority filter if selected (case-insensitive)
     if (priorityFilter) {
       conditions.push({
         priority: { equals: priorityFilter, mode: "insensitive" as const },
       });
     }
 
-    return {
-      AND: conditions,
-    };
+    return { AND: conditions };
   }, [accessFilterReady, searchFilter, statusFilter, priorityFilter]);
 
+  const isCountSort = COUNT_SORT_COLUMNS.includes(sortConfig.column);
   const orderBy = useMemo(() => {
-    // Only apply server-side sorting for database columns
-    // Count columns (cases, testRuns, sessions, projects) will be sorted client-side
-    if (!sortConfig?.column) {
-      return {
-        name: "asc" as const,
-      };
+    if (
+      ["name", "title", "status", "priority", "lastSyncedAt"].includes(
+        sortConfig.column
+      )
+    ) {
+      return { [sortConfig.column]: sortConfig.direction } as const;
     }
-
-    if (sortConfig.column === "name") {
-      return {
-        name: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "title") {
-      return {
-        title: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "status") {
-      return {
-        status: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "priority") {
-      return {
-        priority: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "lastSyncedAt") {
-      return {
-        lastSyncedAt: sortConfig.direction,
-      } as const;
-    }
-
-    // For count columns, return default sort (will sort client-side)
-    return {
-      name: "asc" as const,
-    };
+    return { name: "asc" as const };
   }, [sortConfig]);
 
-  // When sorting by count columns, we need to fetch ALL issues to sort properly
-  const needsClientSideSorting = [
-    "cases",
-    "testRuns",
-    "sessions",
-    "projects",
-  ].includes(sortConfig.column);
-  const shouldPaginate =
-    !needsClientSideSorting && typeof effectivePageSize === "number";
-  const paginationArgs = {
-    skip: shouldPaginate ? skip : undefined,
-    take: shouldPaginate ? effectivePageSize : undefined,
-  };
+  const include = useMemo(
+    () => ({
+      integration: { select: { id: true, name: true, provider: true } },
+    }),
+    []
+  );
 
-  // Fetch basic issue data - only include integration to avoid bind variable issues
-  const { data: issues, isLoading: isLoadingIssues } = useClientQueries(
+  const infiniteBaseArgs = useMemo(
+    () => ({
+      where: issuesWhere ?? undefined,
+      orderBy,
+      include,
+      take: PAGE_SIZE,
+    }),
+    [issuesWhere, orderBy, include]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingInfinite,
+  } = useClientQueries(schema).issue.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled: !!issuesWhere && status === "authenticated" && !isCountSort,
+  });
+
+  const { data: allIssues, isLoading: isLoadingAll } = useClientQueries(
     schema
   ).issue.useFindMany(
-    issuesWhere
-      ? {
-          where: issuesWhere,
-          orderBy,
-          ...paginationArgs,
-          include: {
-            integration: {
-              select: {
-                id: true,
-                name: true,
-                provider: true,
-              },
-            },
-          },
-        }
-      : undefined,
-    {
-      enabled: !!issuesWhere && status === "authenticated",
-    }
+    issuesWhere ? { where: issuesWhere, include } : undefined,
+    { enabled: !!issuesWhere && status === "authenticated" && isCountSort }
   );
 
-  // Get total count of issues
+  const issues = useMemo(() => {
+    if (isCountSort) return allIssues ?? [];
+    return infinitePages?.pages.flat() ?? [];
+  }, [isCountSort, infinitePages, allIssues]);
+
+  const isLoadingIssues = isCountSort ? isLoadingAll : isLoadingInfinite;
+
   const { data: issuesCount } = useClientQueries(schema).issue.useCount(
-    issuesWhere
-      ? {
-          where: issuesWhere,
-        }
-      : undefined,
-    {
-      enabled: !!issuesWhere && status === "authenticated",
-    }
+    issuesWhere ? { where: issuesWhere } : undefined,
+    { enabled: !!issuesWhere && status === "authenticated" }
   );
 
-  // Fetch counts and projects separately to avoid bind variable explosion
+  // Counts + projects fetched separately, cached per issue id for the life of
+  // the page (not scoped to the current search/sort, so once fetched they never
+  // need re-requesting as the infinite list appends new ids).
   const [issueCounts, setIssueCounts] = useState<
     Record<
       number,
-      {
-        repositoryCases: number;
-        sessions: number;
-        testRuns: number;
-      }
+      { repositoryCases: number; sessions: number; testRuns: number }
     >
   >({});
-
   const [issueProjects, setIssueProjects] = useState<
     Record<number, Array<{ id: number; name: string; iconUrl: string | null }>>
   >({});
-
   const [isLoadingCounts, setIsLoadingCounts] = useState(false);
+  const fetchedIssueIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (!issues || issues.length === 0) {
       setIssueCounts({});
       setIssueProjects({});
       setIsLoadingCounts(false);
+      fetchedIssueIdsRef.current = new Set();
       return;
     }
 
-    const issueIds = issues.map((i) => i.id);
+    const newIds = issues
+      .map((i) => i.id)
+      .filter((id) => !fetchedIssueIdsRef.current.has(id));
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => fetchedIssueIdsRef.current.add(id));
 
     const fetchCountsAndProjects = async () => {
       setIsLoadingCounts(true);
       try {
-        // Fetch counts and projects in parallel
         const [countsResponse, projectsResponse] = await Promise.all([
           fetch("/api/issues/counts", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ issueIds }),
+            body: JSON.stringify({ issueIds: newIds }),
           }),
           fetch("/api/issues/projects", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ issueIds }),
+            body: JSON.stringify({ issueIds: newIds }),
           }),
         ]);
-
         if (countsResponse.ok) {
           const data = await countsResponse.json();
-          setIssueCounts(data.counts || {});
+          setIssueCounts((prev) => ({ ...prev, ...(data.counts || {}) }));
         }
-
         if (projectsResponse.ok) {
           const data = await projectsResponse.json();
-          setIssueProjects(data.projects || {});
+          setIssueProjects((prev) => ({ ...prev, ...(data.projects || {}) }));
         }
       } catch (error) {
         console.error("Failed to fetch issue data:", error);
@@ -435,7 +289,6 @@ function Issues() {
     void fetchCountsAndProjects();
   }, [issues]);
 
-  // Map issues with counts and projects
   const mappedIssues = useMemo(() => {
     if (!issues) {
       return [];
@@ -445,18 +298,13 @@ function Issues() {
       const counts = issueCounts[issue.id];
       const projects = issueProjects[issue.id] || [];
       const projectIds = projects.map((p) => p.id);
-
-      // For aggregatedTestRunIds, we'll use the count
-      // This is a simplification - if exact IDs are needed, we'd need to fetch them
-      const aggregatedTestRunIds: number[] = [];
-
       return {
         ...issue,
         repositoryCases: [],
         sessions: [],
         testRuns: [],
         projects,
-        aggregatedTestRunIds,
+        aggregatedTestRunIds: [],
         projectIds,
         repositoryCasesCount: counts?.repositoryCases,
         sessionsCount: counts?.sessions,
@@ -464,12 +312,10 @@ function Issues() {
       };
     });
 
-    // Apply client-side sorting for count columns (since these aren't in the DB)
-    if (needsClientSideSorting) {
+    if (isCountSort) {
       return mapped.sort((a, b) => {
         let aValue: number;
         let bValue: number;
-
         switch (sortConfig.column) {
           case "cases":
             aValue = a.repositoryCasesCount ?? 0;
@@ -490,7 +336,6 @@ function Issues() {
           default:
             return 0;
         }
-
         return sortConfig.direction === "asc"
           ? aValue - bValue
           : bValue - aValue;
@@ -498,44 +343,7 @@ function Issues() {
     }
 
     return mapped;
-  }, [issues, issueCounts, issueProjects, sortConfig, needsClientSideSorting]);
-
-  useEffect(() => {
-    setTotalItems(issuesCount ?? 0);
-  }, [issuesCount, setTotalItems]);
-
-  // When sorting by count columns, apply pagination client-side
-  const displayedIssues = useMemo(() => {
-    if (needsClientSideSorting) {
-      return mappedIssues.slice(skip, skip + effectivePageSize);
-    }
-    return mappedIssues;
-  }, [mappedIssues, needsClientSideSorting, skip, effectivePageSize]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
-
-  useEffect(() => {
-    if (
-      statusFilter === prevStatusFilterRef.current &&
-      priorityFilter === prevPriorityFilterRef.current
-    )
-      return;
-    prevStatusFilterRef.current = statusFilter;
-    prevPriorityFilterRef.current = priorityFilter;
-    setCurrentPage(1);
-  }, [statusFilter, priorityFilter, setCurrentPage]);
+  }, [issues, issueCounts, issueProjects, sortConfig, isCountSort]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -570,7 +378,6 @@ function Issues() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -585,7 +392,7 @@ function Issues() {
           <CardDescription>{t("Pages.Issues.description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="flex items-center gap-2 text-muted-foreground w-full flex-wrap">
                 <Filter
@@ -607,9 +414,9 @@ function Issues() {
                     <SelectItem value="all">
                       {t("common.filters.allStatuses")}
                     </SelectItem>
-                    {statuses.map((status) => (
-                      <SelectItem key={status} value={status}>
-                        {status}
+                    {statuses.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -627,9 +434,9 @@ function Issues() {
                     <SelectItem value="all">
                       {t("common.filters.allPriorities")}
                     </SelectItem>
-                    {priorities.map((priority) => (
-                      <SelectItem key={priority} value={priority}>
-                        {priority}
+                    {priorities.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {p}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -637,42 +444,31 @@ function Issues() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="issue-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {mappedIssues.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {t("admin.auditLogs.showing", {
+                  loaded: mappedIssues.length.toLocaleString(),
+                  total: (issuesCount ?? mappedIssues.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
-              columns={columns}
-              data={displayedIssues}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
+              columns={columns as any}
+              data={mappedIssues as any}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
-              isLoading={isLoadingIssues || !issuesWhere}
-              pageSize={effectivePageSize}
+              isLoading={isLoadingIssues || isFetchingNextPage}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
+              hasMore={isCountSort ? false : !!hasNextPage}
+              onLoadMore={fetchNextPage}
+              estimateSize={60}
+              resetKey={`${debouncedSearchString}|${statusFilter}|${priorityFilter}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="issues-table"
+              rowTestIdPrefix="issue-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/projects/issues/[projectId]/page.tsx
+++ b/testplanit/app/[locale]/projects/issues/[projectId]/page.tsx
@@ -4,10 +4,8 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
 import { ProjectIcon } from "@/components/ProjectIcon";
-import { DataTable } from "@/components/tables/DataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import {
   Card,
   CardContent,
@@ -28,20 +26,19 @@ import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Loading } from "~/components/Loading";
 import { useRequireAuth } from "~/hooks/useRequireAuth";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { ExtendedIssues, useIssueColumns } from "./columns";
 
+const PAGE_SIZE = 50;
+
+// Count columns are computed via a separate join call and can't be sorted
+// across pages without the full set in hand. Sorting by one fetches everything
+// once and renders it through the same virtualized table in full-set mode;
+// every other column is a real DB column and drives a genuine infinite fetch.
+const COUNT_SORT_COLUMNS = ["cases", "testRuns", "sessions"];
+
 export default function ProjectIssueList() {
-  return (
-    <PaginationProvider>
-      <ProjectIssues />
-    </PaginationProvider>
-  );
+  return <ProjectIssues />;
 }
 
 function ProjectIssues() {
@@ -52,13 +49,10 @@ function ProjectIssues() {
   const searchParams = useSearchParams();
   const projectId = params.projectId ? Number(params.projectId) : null;
   const targetIssueId = searchParams.get("issueId");
-  // Live issue updates are subscribed at the IssuesDisplay component
-  // level — every issue badge on this page registers a refcounted
-  // listener via the singleton SSE manager, so every page that renders
-  // issues gets live refresh "for free."
-  const scrollAttempts = useRef(0);
-  const maxScrollAttempts = 10;
-  const scrollInterval = useRef<NodeJS.Timeout | null>(null);
+  // Live issue updates are subscribed at the IssuesDisplay component level —
+  // every issue badge on this page registers a refcounted listener via the
+  // singleton SSE manager, so every page that renders issues gets live refresh
+  // "for free."
 
   const { data: project } = useClientQueries(schema).projects.useFindFirst(
     {
@@ -77,18 +71,6 @@ function ProjectIssues() {
     }
   );
 
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
-
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -103,18 +85,6 @@ function ProjectIssues() {
   const [priorityFilter, setPriorityFilter] = useState<string>("");
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
-  const hasInitializedRef = useRef(false);
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-  const prevStatusFilterRef = useRef(statusFilter);
-  const prevPriorityFilterRef = useRef(priorityFilter);
-  const [shouldPreventPageReset, setShouldPreventPageReset] =
-    useState(!!targetIssueId);
-  const [isTableReady, setIsTableReady] = useState(false);
-
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   // Build project filter for groupBy queries
   const projectFilterForGroupBy = useMemo(() => {
@@ -292,109 +262,80 @@ function ProjectIssues() {
     };
   }, [projectId, searchFilter, statusFilter, priorityFilter]);
 
+  const isCountSort = COUNT_SORT_COLUMNS.includes(sortConfig.column);
+  // A deep link (?issueId=) also fetches the full set so the target row is
+  // present to scroll to and highlight — otherwise it might live beyond the
+  // pages loaded so far.
+  const isFullSet = isCountSort || !!targetIssueId;
+
   const orderBy = useMemo(() => {
-    // Only apply server-side sorting for database columns
-    // Count columns (cases, testRuns, sessions) will be sorted client-side
-    if (!sortConfig?.column) {
-      return {
-        name: "asc" as const,
-      };
+    // Only apply server-side sorting for database columns; count columns
+    // (cases, testRuns, sessions) sort client-side over the full set.
+    if (
+      ["name", "title", "status", "priority", "lastSyncedAt"].includes(
+        sortConfig.column
+      )
+    ) {
+      return { [sortConfig.column]: sortConfig.direction } as const;
     }
-
-    if (sortConfig.column === "name") {
-      return {
-        name: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "title") {
-      return {
-        title: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "status") {
-      return {
-        status: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "priority") {
-      return {
-        priority: sortConfig.direction,
-      } as const;
-    }
-
-    if (sortConfig.column === "lastSyncedAt") {
-      return {
-        lastSyncedAt: sortConfig.direction,
-      } as const;
-    }
-
-    // For count columns, return default sort (will sort client-side)
-    return {
-      name: "asc" as const,
-    };
+    return { name: "asc" as const };
   }, [sortConfig]);
 
-  // When sorting by count columns, we need to fetch ALL issues to sort properly
-  const needsClientSideSorting = ["cases", "testRuns", "sessions"].includes(
-    sortConfig.column
-  );
-  const shouldPaginate =
-    !needsClientSideSorting && typeof effectivePageSize === "number";
-  const paginationArgs = {
-    skip: shouldPaginate ? skip : undefined,
-    take: shouldPaginate ? effectivePageSize : undefined,
-  };
-
-  // When we have a targetIssueId, fetch all issues to find which page it's on
-  const { data: allIssues } = useClientQueries(schema).issue.useFindMany(
-    targetIssueId && issuesWhere && shouldPreventPageReset
-      ? {
-          where: issuesWhere,
-          orderBy,
-          select: {
-            id: true,
-          },
-        }
-      : undefined,
-    {
-      enabled:
-        !!targetIssueId &&
-        !!issuesWhere &&
-        !!session?.user &&
-        projectId !== null &&
-        shouldPreventPageReset,
-    }
+  const include = useMemo(
+    () => ({
+      integration: {
+        select: {
+          id: true,
+          provider: true,
+          name: true,
+          settings: true,
+        },
+      },
+    }),
+    []
   );
 
-  // Fetch basic issue data
-  const { data: issues, isLoading: isLoadingIssues } = useClientQueries(
+  const infiniteBaseArgs = useMemo(
+    () => ({
+      where: issuesWhere ?? undefined,
+      orderBy,
+      include,
+      take: PAGE_SIZE,
+    }),
+    [issuesWhere, orderBy, include]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingInfinite,
+  } = useClientQueries(schema).issue.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled:
+      !!issuesWhere && !!session?.user && projectId !== null && !isFullSet,
+  });
+
+  const { data: allIssues, isLoading: isLoadingAll } = useClientQueries(
     schema
   ).issue.useFindMany(
-    issuesWhere
-      ? {
-          where: issuesWhere,
-          orderBy,
-          ...paginationArgs,
-          include: {
-            integration: {
-              select: {
-                id: true,
-                provider: true,
-                name: true,
-                settings: true,
-              },
-            },
-          },
-        }
-      : undefined,
+    issuesWhere ? { where: issuesWhere, orderBy, include } : undefined,
     {
-      enabled: !!issuesWhere && !!session?.user && projectId !== null,
-      refetchOnWindowFocus: true,
+      enabled:
+        !!issuesWhere && !!session?.user && projectId !== null && isFullSet,
     }
   );
+
+  const issues = useMemo(() => {
+    if (isFullSet) return allIssues ?? [];
+    return infinitePages?.pages.flat() ?? [];
+  }, [isFullSet, infinitePages, allIssues]);
+
+  const isLoadingIssues = isFullSet ? isLoadingAll : isLoadingInfinite;
 
   // Get total count of issues
   const { data: issuesCount } = useClientQueries(schema).issue.useCount(
@@ -408,7 +349,9 @@ function ProjectIssues() {
     }
   );
 
-  // Fetch counts for project-scoped issues
+  // Counts fetched separately and cached per issue id for the life of the page
+  // (project-scoped, so once fetched they never need re-requesting as the
+  // infinite list appends new ids).
   const [issueCounts, setIssueCounts] = useState<
     Record<
       number,
@@ -419,17 +362,22 @@ function ProjectIssues() {
       }
     >
   >({});
-
   const [isLoadingCounts, setIsLoadingCounts] = useState(false);
+  const fetchedIssueIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (!issues || issues.length === 0 || projectId === null) {
       setIssueCounts({});
       setIsLoadingCounts(false);
+      fetchedIssueIdsRef.current = new Set();
       return;
     }
 
-    const issueIds = issues.map((i) => i.id);
+    const newIds = issues
+      .map((i) => i.id)
+      .filter((id) => !fetchedIssueIdsRef.current.has(id));
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => fetchedIssueIdsRef.current.add(id));
 
     const fetchCounts = async () => {
       setIsLoadingCounts(true);
@@ -438,12 +386,12 @@ function ProjectIssues() {
         const response = await fetch("/api/issues/counts", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ issueIds, projectId }),
+          body: JSON.stringify({ issueIds: newIds, projectId }),
         });
 
         if (response.ok) {
           const data = await response.json();
-          setIssueCounts(data.counts || {});
+          setIssueCounts((prev) => ({ ...prev, ...(data.counts || {}) }));
         }
       } catch (error) {
         console.error("Failed to fetch issue counts:", error);
@@ -478,7 +426,7 @@ function ProjectIssues() {
     });
 
     // Apply client-side sorting for count columns (since these aren't in the DB)
-    if (needsClientSideSorting) {
+    if (isCountSort) {
       return mapped.sort((a, b) => {
         let aValue: number;
         let bValue: number;
@@ -507,228 +455,7 @@ function ProjectIssues() {
     }
 
     return mapped;
-  }, [issues, issueCounts, projectId, sortConfig, needsClientSideSorting]);
-
-  useEffect(() => {
-    setTotalItems(issuesCount ?? 0);
-  }, [issuesCount, setTotalItems]);
-
-  // When sorting by count columns, apply pagination client-side
-  const displayedIssues = useMemo(() => {
-    if (needsClientSideSorting) {
-      return mappedIssues.slice(skip, skip + effectivePageSize);
-    }
-    return mappedIssues;
-  }, [mappedIssues, needsClientSideSorting, skip, effectivePageSize]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  // Calculate and set the correct page IMMEDIATELY when allIssues load and we have a target
-  useEffect(() => {
-    if (
-      targetIssueId &&
-      allIssues &&
-      allIssues.length > 0 &&
-      shouldPreventPageReset
-    ) {
-      const targetIndex = allIssues.findIndex(
-        (issue) => issue.id.toString() === targetIssueId
-      );
-
-      if (targetIndex !== -1) {
-        // Get page size from URL params first, then user preferences, then default
-        let pageSizeValue = 10; // default
-
-        const urlPageSize = searchParams.get("pageSize");
-        if (urlPageSize) {
-          if (urlPageSize === "All") {
-            pageSizeValue = allIssues.length;
-          } else {
-            const size = parseInt(urlPageSize, 10);
-            if (!isNaN(size) && size > 0) {
-              pageSizeValue = size;
-            }
-          }
-        } else if (session?.user?.preferences?.itemsPerPage) {
-          const preferredSize = parseInt(
-            session.user.preferences.itemsPerPage.replace("P", ""),
-            10
-          );
-          if (!isNaN(preferredSize) && preferredSize > 0) {
-            pageSizeValue = preferredSize;
-          }
-        }
-
-        const targetPage = Math.floor(targetIndex / pageSizeValue) + 1;
-
-        // Immediately set the page
-        if (targetPage !== currentPage) {
-          setCurrentPage(targetPage);
-        }
-
-        // Prevent further resets
-        setShouldPreventPageReset(false);
-      }
-    }
-  }, [
-    targetIssueId,
-    allIssues,
-    shouldPreventPageReset,
-    currentPage,
-    setCurrentPage,
-    searchParams,
-    session,
-  ]);
-
-  // Set table ready state after issues load
-  useEffect(() => {
-    if (issues && issues.length > 0) {
-      // Wait for DataTable to render
-      const timer = setTimeout(() => {
-        setIsTableReady(true);
-      }, 500);
-
-      return () => clearTimeout(timer);
-    }
-  }, [issues]);
-
-  // Handle scrolling and highlighting for specific issue
-  useEffect(() => {
-    if (targetIssueId && !hasInitializedRef.current && isTableReady) {
-      hasInitializedRef.current = true;
-      let scrollCancelled = false;
-
-      // Detect user scroll to cancel auto-scroll
-      const handleUserScroll = () => {
-        scrollCancelled = true;
-        if (scrollInterval.current) {
-          clearInterval(scrollInterval.current);
-          scrollInterval.current = null;
-        }
-        window.removeEventListener("wheel", handleUserScroll);
-        window.removeEventListener("touchmove", handleUserScroll);
-      };
-
-      // Add scroll listeners to detect user interaction
-      window.addEventListener("wheel", handleUserScroll, { passive: true });
-      window.addEventListener("touchmove", handleUserScroll, { passive: true });
-
-      // Start scrolling attempts after a short delay
-      const timeoutId = setTimeout(() => {
-        if (scrollCancelled) return;
-
-        scrollInterval.current = setInterval(() => {
-          if (scrollCancelled) {
-            if (scrollInterval.current) {
-              clearInterval(scrollInterval.current);
-              scrollInterval.current = null;
-            }
-            return;
-          }
-
-          const targetRow = document.querySelector(
-            `[data-row-id="${targetIssueId}"]`
-          );
-
-          if (targetRow) {
-            targetRow.scrollIntoView({ behavior: "smooth", block: "center" });
-
-            // Get all cells in the row
-            const cells = targetRow.querySelectorAll("td");
-
-            // Apply highlight to row with outline (doesn't affect layout)
-            (targetRow as HTMLElement).style.setProperty(
-              "outline",
-              "4px solid hsl(var(--primary))",
-              "important"
-            );
-            (targetRow as HTMLElement).style.setProperty(
-              "outline-offset",
-              "-2px",
-              "important"
-            );
-
-            // Apply background to each cell
-            cells.forEach((cell) => {
-              const htmlCell = cell as HTMLElement;
-              // Apply highlight background
-              htmlCell.style.setProperty(
-                "background-color",
-                "hsl(var(--primary) / 0.15)",
-                "important"
-              );
-            });
-
-            // Clear interval and remove listeners after successful scroll
-            if (scrollInterval.current) {
-              clearInterval(scrollInterval.current);
-              scrollInterval.current = null;
-            }
-            window.removeEventListener("wheel", handleUserScroll);
-            window.removeEventListener("touchmove", handleUserScroll);
-          } else {
-            scrollAttempts.current += 1;
-            if (scrollAttempts.current >= maxScrollAttempts) {
-              if (scrollInterval.current) {
-                clearInterval(scrollInterval.current);
-                scrollInterval.current = null;
-              }
-              window.removeEventListener("wheel", handleUserScroll);
-              window.removeEventListener("touchmove", handleUserScroll);
-            }
-          }
-        }, 100);
-      }, 1000);
-
-      return () => {
-        scrollCancelled = true;
-        clearTimeout(timeoutId);
-        if (scrollInterval.current) {
-          clearInterval(scrollInterval.current);
-          scrollInterval.current = null;
-        }
-        window.removeEventListener("wheel", handleUserScroll);
-        window.removeEventListener("touchmove", handleUserScroll);
-      };
-    }
-  }, [targetIssueId, isTableReady]);
-
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-    setIsTableReady(false);
-    hasInitializedRef.current = false;
-  }, [searchString, setCurrentPage]);
-
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-    setIsTableReady(false);
-    hasInitializedRef.current = false;
-  }, [pageSize, setCurrentPage]);
-
-  useEffect(() => {
-    if (
-      statusFilter === prevStatusFilterRef.current &&
-      priorityFilter === prevPriorityFilterRef.current
-    )
-      return;
-    prevStatusFilterRef.current = statusFilter;
-    prevPriorityFilterRef.current = priorityFilter;
-    setCurrentPage(1);
-    setIsTableReady(false);
-    hasInitializedRef.current = false;
-  }, [statusFilter, priorityFilter, setCurrentPage]);
-
-  // Reset table ready state when page changes
-  useEffect(() => {
-    setIsTableReady(false);
-    if (!targetIssueId) {
-      hasInitializedRef.current = false; // Only reset if no target issue
-    }
-  }, [currentPage, targetIssueId]);
+  }, [issues, issueCounts, projectId, sortConfig, isCountSort]);
 
   useEffect(() => {
     if (!isAuthLoading && !session) {
@@ -792,7 +519,6 @@ function ProjectIssues() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -810,7 +536,7 @@ function ProjectIssues() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="flex items-center gap-2 text-muted-foreground w-full flex-wrap">
                 <Filter
@@ -862,42 +588,33 @@ function ProjectIssues() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="issue-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {mappedIssues.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {t("admin.auditLogs.showing", {
+                  loaded: mappedIssues.length.toLocaleString(),
+                  total: (issuesCount ?? mappedIssues.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
-              columns={columns}
-              data={displayedIssues}
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              columns={columns as any}
+              data={mappedIssues as any}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
-              isLoading={isLoadingIssues}
-              pageSize={effectivePageSize}
+              isLoading={isLoadingIssues || isFetchingNextPage}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
+              hasMore={isFullSet ? false : !!hasNextPage}
+              onLoadMore={fetchNextPage}
+              estimateSize={60}
+              fillViewport
+              scrollToRowId={targetIssueId}
+              highlightRowId={targetIssueId}
+              resetKey={`${debouncedSearchString}|${statusFilter}|${priorityFilter}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="issues-table"
+              rowTestIdPrefix="issue-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.test.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ─── Hoisted mock refs ───────────────────────────────────────────────────
 const {
   mockFindManyWebhookDelivery,
+  mockInfiniteWebhookDelivery,
   mockFindManyWebhookConfig,
   mockCountWebhookDelivery,
   mockFindUniqueWebhookDelivery,
@@ -16,6 +17,7 @@ const {
   mockRouterReplace,
 } = vi.hoisted(() => ({
   mockFindManyWebhookDelivery: vi.fn(),
+  mockInfiniteWebhookDelivery: vi.fn(),
   mockFindManyWebhookConfig: vi.fn(),
   mockCountWebhookDelivery: vi.fn(),
   mockFindUniqueWebhookDelivery: vi.fn(),
@@ -31,6 +33,8 @@ vi.mock("@zenstackhq/tanstack-query/react", () => ({
   useClientQueries: () => ({
     webhookDelivery: {
       useFindMany: (...args: any[]) => mockFindManyWebhookDelivery(...args),
+      useInfiniteFindMany: (...args: any[]) =>
+        mockInfiniteWebhookDelivery(...args),
       useCount: (...args: any[]) => mockCountWebhookDelivery(...args),
       useFindUnique: (...args: any[]) => mockFindUniqueWebhookDelivery(...args),
     },
@@ -179,20 +183,14 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogFooter: ({ children }: any) => <div>{children}</div>,
 }));
 
-// DataTable stub: emits row testids + invokes each column's cell renderer
-// so the new "actions" Eye-icon column is exercisable in tests.
-vi.mock("@/components/tables/DataTable", () => ({
-  DataTable: ({ data, columns, onTestCaseClick }: any) => (
+// VirtualizedDataTable stub: emits row testids + invokes each column's cell
+// renderer so the "actions" Eye-icon column is exercisable in tests.
+vi.mock("@/components/tables/VirtualizedDataTable", () => ({
+  VirtualizedDataTable: ({ data, columns }: any) => (
     <table data-testid="webhook-deliveries-datatable">
       <tbody>
         {data.map((row: any) => (
-          <tr
-            key={row.id}
-            data-testid={`webhook-delivery-row-${row.id}`}
-            onClick={
-              onTestCaseClick ? () => onTestCaseClick(row.id) : undefined
-            }
-          >
+          <tr key={row.id} data-testid={`webhook-delivery-row-${row.id}`}>
             {columns.map((col: any, idx: number) => {
               const content = col.cell
                 ? col.cell({ row: { original: row } })
@@ -436,6 +434,15 @@ const inboundDelivery = {
 function setDeliveries(rows: any[]) {
   mockFindManyWebhookDelivery.mockReturnValue({
     data: rows,
+    isLoading: false,
+    refetch: vi.fn().mockResolvedValue({ data: rows }),
+  });
+  // Infinite-scroll shape: one page holding all seeded rows, nothing more to load.
+  mockInfiniteWebhookDelivery.mockReturnValue({
+    data: { pages: [rows], pageParams: [undefined] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
     isLoading: false,
     refetch: vi.fn().mockResolvedValue({ data: rows }),
   });
@@ -699,17 +706,20 @@ describe("WebhookDeliveriesTab", () => {
     });
   });
 
-  it("Test 15: paginator visible when there are rows (replaces old load-more)", () => {
+  it("Test 15: renders rows via the virtualized table with no paginator (infinite scroll)", () => {
     const fifty = Array.from({ length: 50 }, (_, i) => ({
       ...outboundFailedDelivery,
       id: `d_${i}`,
     }));
     setDeliveries(fifty);
     render(<WebhookDeliveriesTab projectId={42} />);
-    // Cursor "load more" was replaced by server-side paginator (D-35 follow-up).
+    // The server-side paginator was replaced by a virtualized infinite-scroll
+    // table: rows render, and there is no paginator control.
+    expect(screen.getByTestId("webhook-deliveries-table")).toBeInTheDocument();
+    expect(screen.getByTestId("webhook-delivery-row-d_0")).toBeInTheDocument();
     expect(
-      screen.getByTestId("webhook-deliveries-paginator")
-    ).toBeInTheDocument();
+      screen.queryByTestId("webhook-deliveries-paginator")
+    ).not.toBeInTheDocument();
   });
 
   it("Test 16: filter URL state survives initial render (status=failed pre-selected)", () => {

--- a/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/webhooks/webhook-deliveries-tab.tsx
@@ -17,17 +17,10 @@ import { Button } from "@/components/ui/button";
 import { DateFormatter } from "@/components/DateFormatter";
 import { DateRangePicker } from "@/components/forms/DateRangePicker";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useSession } from "next-auth/react";
 
-import {
-  PaginationProvider,
-  usePagination,
-  type PageSizeOption,
-} from "~/lib/contexts/PaginationContext";
 import {
   Select,
   SelectContent,
@@ -38,7 +31,7 @@ import {
 import { Eye, Inbox, Send } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { bulkReplayFailedDeliveries } from "~/app/actions/webhook-config";
@@ -195,17 +188,16 @@ function parseFilterFromSearchParams(
  *   - if all visible failures are inbound, the button is hidden and a
  *     helper line invites re-triggering upstream instead.
  */
+const PAGE_SIZE = 50;
+
 export function WebhookDeliveriesTab({ projectId }: WebhookDeliveriesTabProps) {
-  return (
-    <PaginationProvider defaultPageSize={50}>
-      <WebhookDeliveriesTabContent projectId={projectId} />
-    </PaginationProvider>
-  );
+  return <WebhookDeliveriesTabContent projectId={projectId} />;
 }
 
 function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
   const t = useTranslations("projects.settings.webhooks");
   const tCommon = useTranslations("common");
+  const tGlobal = useTranslations();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -215,36 +207,6 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
     [searchParams]
   );
 
-  // ─── Server-side pagination via PaginationProvider context ─────────
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
-
-  const pageSizeOptions: PageSizeOption[] = useMemo(() => {
-    if (totalItems <= 10) {
-      return ["All"];
-    }
-    const options: PageSizeOption[] = [10, 25, 50, 100, 250].filter(
-      (size) => size < totalItems || totalItems === 0
-    );
-    options.push("All");
-    return options;
-  }, [totalItems]);
-
-  const handlePageSizeChange = (value: string | number) => {
-    const newSize =
-      value === "All" ? totalItems : parseInt(value.toString(), 10);
-    setPageSize(newSize);
-    setCurrentPage(1);
-  };
   // ─── DataTable sort + visibility state ──────────────────────────────
   const [sortConfig, setSortConfig] = useState<{
     column: string;
@@ -260,7 +222,6 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
       direction:
         prev.column === columnId && prev.direction === "asc" ? "desc" : "asc",
     }));
-    setCurrentPage(1);
   };
 
   const { data: session } = useSession();
@@ -282,20 +243,23 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
   }>;
 
   // ─── Fetch deliveries with filter applied ───────────────────────────
-  const where: Record<string, unknown> = {
-    webhookConfig: { projectId },
-  };
-  if (filter.since || filter.until) {
-    const receivedAt: Record<string, Date> = {};
-    if (filter.since) receivedAt.gte = filter.since;
-    if (filter.until) receivedAt.lte = filter.until;
-    where.receivedAt = receivedAt;
-  }
-  if (filter.status === "failed") where.error = { not: null };
-  if (filter.status === "success") where.error = null;
-  if (filter.configIds.length > 0) {
-    where.webhookConfigId = { in: filter.configIds };
-  }
+  const where = useMemo(() => {
+    const w: Record<string, unknown> = {
+      webhookConfig: { projectId },
+    };
+    if (filter.since || filter.until) {
+      const receivedAt: Record<string, Date> = {};
+      if (filter.since) receivedAt.gte = filter.since;
+      if (filter.until) receivedAt.lte = filter.until;
+      w.receivedAt = receivedAt;
+    }
+    if (filter.status === "failed") w.error = { not: null };
+    if (filter.status === "success") w.error = null;
+    if (filter.configIds.length > 0) {
+      w.webhookConfigId = { in: filter.configIds };
+    }
+    return w;
+  }, [projectId, filter]);
 
   const orderBy = useMemo(() => {
     const dir: "asc" | "desc" = sortConfig.direction;
@@ -319,49 +283,59 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
     }
   }, [sortConfig]);
 
-  const effectivePageSize = typeof pageSize === "number" ? pageSize : 250;
-  const skip = (currentPage - 1) * effectivePageSize;
-
   const { data: totalCount } = useClientQueries(
     schema
   ).webhookDelivery.useCount({ where });
 
-  useEffect(() => {
-    if (typeof totalCount === "number") {
-      setTotalItems(totalCount);
-    }
-  }, [totalCount, setTotalItems]);
-
-  const { data: deliveriesData, refetch: refetchDeliveries } = useClientQueries(
-    schema
-  ).webhookDelivery.useFindMany({
-    where,
-    orderBy,
-    take: effectivePageSize,
-    skip,
-    select: {
-      id: true,
-      webhookConfigId: true,
-      webhookConfig: {
-        select: { name: true, adapterType: true, direction: true },
+  // Deliveries load a page at a time and accumulate; the virtualized table
+  // renders only the visible window and pulls the next page as the user scrolls.
+  const deliveriesInfiniteArgs = useMemo(
+    () => ({
+      where,
+      orderBy,
+      take: PAGE_SIZE,
+      select: {
+        id: true,
+        webhookConfigId: true,
+        webhookConfig: {
+          select: { name: true, adapterType: true, direction: true },
+        },
+        direction: true,
+        adapterType: true,
+        eventType: true,
+        eventId: true,
+        payloadDigest: true,
+        statusCode: true,
+        error: true,
+        latencyMs: true,
+        attempt: true,
+        receivedAt: true,
+        replayedFromDeliveryId: true,
       },
-      direction: true,
-      adapterType: true,
-      eventType: true,
-      eventId: true,
-      payloadDigest: true,
-      statusCode: true,
-      error: true,
-      latencyMs: true,
-      attempt: true,
-      receivedAt: true,
-      replayedFromDeliveryId: true,
-    },
-  });
+    }),
+    [where, orderBy]
+  );
+
+  const {
+    data: deliveriesPages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingDeliveries,
+    refetch: refetchDeliveries,
+  } = useClientQueries(schema).webhookDelivery.useInfiniteFindMany(
+    deliveriesInfiniteArgs,
+    {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...deliveriesInfiniteArgs, skip: allPages.flat().length },
+    }
+  );
 
   const deliveries = useMemo(
-    () => (deliveriesData ?? []) as DeliveryListItem[],
-    [deliveriesData]
+    () => (deliveriesPages?.pages.flat() ?? []) as DeliveryListItem[],
+    [deliveriesPages]
   );
 
   // ─── Drawer + bulk-replay local state ───────────────────────────────
@@ -398,19 +372,12 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
     // Preserve the current tab so updates from the deliveries tab don't
     // unwittingly send the user back to the inbound default.
     if (!params.has("tab")) params.set("tab", "deliveries");
-    setCurrentPage(1);
     router.replace(`${pathname}?${params.toString()}`);
   }
 
   function resetFilters() {
     const params = new URLSearchParams();
     params.set("tab", "deliveries");
-    // Preserve pagination params on the same write so PaginationProvider's
-    // URL-sync effect doesn't fire a follow-up replace() against a stale
-    // searchParams snapshot — that race could leave filter params behind.
-    params.set("page", "1");
-    params.set("pageSize", String(pageSize));
-    setCurrentPage(1);
     router.replace(`${pathname}?${params.toString()}`);
   }
 
@@ -727,16 +694,22 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
 
   function renderTable() {
     return (
-      <div data-testid="webhook-deliveries-table">
-        <DataTable
-          columns={
-            columns as ColumnDef<DeliveryRow & { name: string }, unknown>[]
-          }
+      <div
+        className="h-[calc(100vh-24rem)] min-h-[400px] w-full"
+        data-testid="webhook-deliveries-table"
+      >
+        <VirtualizedDataTable
+          columns={columns as ColumnDef<any, any>[]}
           data={tableData}
           sortConfig={sortConfig}
           onSortChange={handleSortChange}
           columnVisibility={columnVisibility}
           onColumnVisibilityChange={setColumnVisibility}
+          isLoading={isLoadingDeliveries || isFetchingNextPage}
+          hasMore={!!hasNextPage}
+          onLoadMore={fetchNextPage}
+          resetKey={`${filter.configIds.join(",")}|${filter.status}|${filter.since?.toISOString() ?? ""}|${filter.until?.toISOString() ?? ""}|${sortConfig.column}|${sortConfig.direction}`}
+          testIdPrefix="webhook-deliveries-vtable"
           rowTestIdPrefix="webhook-delivery-row"
         />
       </div>
@@ -752,7 +725,7 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
     <div className="space-y-4" data-testid="webhook-deliveries-tab">
       {renderFilterBar()}
 
-      <div className="flex flex-row items-start">
+      <div className="flex flex-row items-start justify-between gap-4">
         <div className="flex flex-col grow w-full sm:w-1/3 min-w-[150px]">
           <div className="m-2">
             <ColumnSelection
@@ -765,34 +738,19 @@ function WebhookDeliveriesTabContent({ projectId }: WebhookDeliveriesTabProps) {
             />
           </div>
         </div>
-        <div className="flex flex-col w-full sm:w-2/3 items-end">
-          {totalItems > 0 && (
-            <>
-              <div className="justify-end">
-                <PaginationInfo
-                  key="webhook-deliveries-pagination-info"
-                  startIndex={startIndex}
-                  endIndex={endIndex}
-                  totalRows={totalItems}
-                  searchString=""
-                  pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                  pageSizeOptions={pageSizeOptions}
-                  handlePageSizeChange={handlePageSizeChange}
-                />
-              </div>
-              <div className="justify-end -mx-4">
-                <PaginationComponent
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  onPageChange={setCurrentPage}
-                />
-              </div>
-            </>
-          )}
-        </div>
+        {deliveries.length > 0 && (
+          <p className="text-sm text-muted-foreground shrink-0">
+            {tGlobal("admin.auditLogs.showing", {
+              loaded: deliveries.length.toLocaleString(),
+              total: (totalCount ?? deliveries.length).toLocaleString(),
+            })}
+          </p>
+        )}
       </div>
 
-      {deliveries.length === 0 ? renderEmpty() : renderTable()}
+      {deliveries.length === 0 && !isLoadingDeliveries
+        ? renderEmpty()
+        : renderTable()}
 
       <WebhookDeliveryDrawer
         deliveryId={openDrawerDeliveryId}

--- a/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/page.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/[tagId]/page.tsx
@@ -3,10 +3,8 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { TagsDisplay } from "@/components/tables/TagDisplay";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,13 +23,14 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import {
   useCaseColumns,
   useSessionColumns,
   useTestRunColumns,
 } from "./columns";
+
+const PAGE_SIZE = 50;
 
 type TabType = "cases" | "sessions" | "testRuns";
 type CaseTypeFilter = "all" | "manual" | "automated";
@@ -118,22 +117,6 @@ function TagDetail() {
     if (filters.caseType !== "all") count++;
     return count;
   }, [filters]);
-
-  // Pagination state for each tab
-  const [casesPage, setCasesPage] = useState(1);
-  const [casesPageSize, setCasesPageSize] = useState<number | "All">(25);
-  const [sessionsPage, setSessionsPage] = useState(1);
-  const [sessionsPageSize, setSessionsPageSize] = useState<number | "All">(25);
-  const [testRunsPage, setTestRunsPage] = useState(1);
-  const [testRunsPageSize, setTestRunsPageSize] = useState<number | "All">(25);
-
-  // Convert page size to number for calculations
-  const effectiveCasesPageSize =
-    typeof casesPageSize === "number" ? casesPageSize : 999999;
-  const effectiveSessionsPageSize =
-    typeof sessionsPageSize === "number" ? sessionsPageSize : 999999;
-  const effectiveTestRunsPageSize =
-    typeof testRunsPageSize === "number" ? testRunsPageSize : 999999;
 
   // Fetch the tag metadata only
   const { data: tags, isLoading: isLoadingTag } = useClientQueries(
@@ -237,11 +220,9 @@ function TagDetail() {
     return where;
   }, [baseWhere, debouncedSearchString, filters.hideCompletedTestRuns]);
 
-  // Fetch paginated test cases
-  const { data: repositoryCases, isLoading: isLoadingCases } = useClientQueries(
-    schema
-  ).repositoryCases.useFindMany(
-    {
+  // Fetch test cases (infinite scroll)
+  const casesInfiniteArgs = useMemo(
+    () => ({
       where: casesWhere,
       select: {
         id: true,
@@ -251,12 +232,29 @@ function TagDetail() {
         hasParameters: true,
       },
       orderBy: { name: "asc" as const },
-      skip: (casesPage - 1) * effectiveCasesPageSize,
-      take: effectiveCasesPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [casesWhere]
+  );
+  const {
+    data: casesPages,
+    fetchNextPage: fetchMoreCases,
+    hasNextPage: hasMoreCases,
+    isFetchingNextPage: isFetchingMoreCases,
+    isLoading: isLoadingCases,
+  } = useClientQueries(schema).repositoryCases.useInfiniteFindMany(
+    casesInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...casesInfiniteArgs, skip: allPages.flat().length },
       enabled: !!tagId && status === "authenticated" && activeTab === "cases",
     }
+  );
+  const repositoryCases = useMemo(
+    () => casesPages?.pages.flat() ?? [],
+    [casesPages]
   );
 
   const { data: casesCount } = useClientQueries(
@@ -270,11 +268,9 @@ function TagDetail() {
     }
   );
 
-  // Fetch paginated sessions
-  const { data: sessions, isLoading: isLoadingSessions } = useClientQueries(
-    schema
-  ).sessions.useFindMany(
-    {
+  // Fetch sessions (infinite scroll)
+  const sessionsInfiniteArgs = useMemo(
+    () => ({
       where: sessionsWhere,
       select: {
         id: true,
@@ -282,13 +278,30 @@ function TagDetail() {
         isCompleted: true,
       },
       orderBy: { createdAt: "desc" as const },
-      skip: (sessionsPage - 1) * effectiveSessionsPageSize,
-      take: effectiveSessionsPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [sessionsWhere]
+  );
+  const {
+    data: sessionsPages,
+    fetchNextPage: fetchMoreSessions,
+    hasNextPage: hasMoreSessions,
+    isFetchingNextPage: isFetchingMoreSessions,
+    isLoading: isLoadingSessions,
+  } = useClientQueries(schema).sessions.useInfiniteFindMany(
+    sessionsInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...sessionsInfiniteArgs, skip: allPages.flat().length },
       enabled:
         !!tagId && status === "authenticated" && activeTab === "sessions",
     }
+  );
+  const sessions = useMemo(
+    () => sessionsPages?.pages.flat() ?? [],
+    [sessionsPages]
   );
 
   const { data: sessionsCount } = useClientQueries(schema).sessions.useCount(
@@ -300,11 +313,9 @@ function TagDetail() {
     }
   );
 
-  // Fetch paginated test runs
-  const { data: testRuns, isLoading: isLoadingTestRuns } = useClientQueries(
-    schema
-  ).testRuns.useFindMany(
-    {
+  // Fetch test runs (infinite scroll)
+  const testRunsInfiniteArgs = useMemo(
+    () => ({
       where: testRunsWhere,
       select: {
         id: true,
@@ -312,13 +323,30 @@ function TagDetail() {
         isCompleted: true,
       },
       orderBy: { createdAt: "desc" as const },
-      skip: (testRunsPage - 1) * effectiveTestRunsPageSize,
-      take: effectiveTestRunsPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [testRunsWhere]
+  );
+  const {
+    data: testRunsPages,
+    fetchNextPage: fetchMoreTestRuns,
+    hasNextPage: hasMoreTestRuns,
+    isFetchingNextPage: isFetchingMoreTestRuns,
+    isLoading: isLoadingTestRuns,
+  } = useClientQueries(schema).testRuns.useInfiniteFindMany(
+    testRunsInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...testRunsInfiniteArgs, skip: allPages.flat().length },
       enabled:
         !!tagId && status === "authenticated" && activeTab === "testRuns",
     }
+  );
+  const testRuns = useMemo(
+    () => testRunsPages?.pages.flat() ?? [],
+    [testRunsPages]
   );
 
   const { data: testRunsCount } = useClientQueries(schema).testRuns.useCount(
@@ -387,44 +415,6 @@ function TagDetail() {
     completed: t("common.fields.completed"),
     inProgress: t("milestones.statusLabels.IN_PROGRESS"),
   });
-
-  // Pagination calculations
-  const casesTotalPages = Math.ceil((casesCount ?? 0) / effectiveCasesPageSize);
-  const sessionsTotalPages = Math.ceil(
-    (sessionsCount ?? 0) / effectiveSessionsPageSize
-  );
-  const testRunsTotalPages = Math.ceil(
-    (testRunsCount ?? 0) / effectiveTestRunsPageSize
-  );
-
-  const casesStartIndex = (casesPage - 1) * effectiveCasesPageSize + 1;
-  const casesEndIndex = Math.min(
-    casesPage * effectiveCasesPageSize,
-    casesCount ?? 0
-  );
-
-  const sessionsStartIndex = (sessionsPage - 1) * effectiveSessionsPageSize + 1;
-  const sessionsEndIndex = Math.min(
-    sessionsPage * effectiveSessionsPageSize,
-    sessionsCount ?? 0
-  );
-
-  const testRunsStartIndex = (testRunsPage - 1) * effectiveTestRunsPageSize + 1;
-  const testRunsEndIndex = Math.min(
-    testRunsPage * effectiveTestRunsPageSize,
-    testRunsCount ?? 0
-  );
-
-  const casesPageSizeOptions = usePageSizeOptions(casesCount ?? 0);
-  const testRunsPageSizeOptions = usePageSizeOptions(testRunsCount ?? 0);
-  const sessionsPageSizeOptions = usePageSizeOptions(sessionsCount ?? 0);
-
-  // Reset page when search or filters change
-  useEffect(() => {
-    setCasesPage(1);
-    setSessionsPage(1);
-    setTestRunsPage(1);
-  }, [debouncedSearchString, filters]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -584,116 +574,96 @@ function TagDetail() {
 
             <TabsContent value="cases" className="max-w-full overflow-hidden">
               {(casesCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={casesStartIndex}
-                    endIndex={casesEndIndex}
-                    totalRows={casesCount ?? 0}
-                    searchString={searchString}
-                    pageSize={casesPageSize}
-                    pageSizeOptions={casesPageSizeOptions}
-                    handlePageSizeChange={setCasesPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={casesPage}
-                    totalPages={casesTotalPages}
-                    onPageChange={setCasesPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedCases.length.toLocaleString(),
+                    total: (casesCount ?? mappedCases.length).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={caseColumns}
-                data={mappedCases}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingCases}
-                pageSize={effectiveCasesPageSize}
-              />
-              {(casesCount ?? 0) === 0 && !isLoadingCases && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.caseType !== "all"
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={caseColumns as any}
+                  data={mappedCases}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingCases || isFetchingMoreCases}
+                  hasMore={!!hasMoreCases}
+                  onLoadMore={fetchMoreCases}
+                  resetKey={`cases|${debouncedSearchString}|${filters.caseType}`}
+                  emptyMessage={
+                    filters.caseType !== "all"
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-cases-table"
+                  rowTestIdPrefix="tag-detail-case-row"
+                />
+              </div>
             </TabsContent>
 
             <TabsContent value="testRuns">
               {(testRunsCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={testRunsStartIndex}
-                    endIndex={testRunsEndIndex}
-                    totalRows={testRunsCount ?? 0}
-                    searchString={searchString}
-                    pageSize={testRunsPageSize}
-                    pageSizeOptions={testRunsPageSizeOptions}
-                    handlePageSizeChange={setTestRunsPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={testRunsPage}
-                    totalPages={testRunsTotalPages}
-                    onPageChange={setTestRunsPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedTestRuns.length.toLocaleString(),
+                    total: (
+                      testRunsCount ?? mappedTestRuns.length
+                    ).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={testRunColumns}
-                data={mappedTestRuns}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingTestRuns}
-                pageSize={effectiveTestRunsPageSize}
-              />
-              {(testRunsCount ?? 0) === 0 && !isLoadingTestRuns && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.hideCompletedTestRuns
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={testRunColumns as any}
+                  data={mappedTestRuns}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingTestRuns || isFetchingMoreTestRuns}
+                  hasMore={!!hasMoreTestRuns}
+                  onLoadMore={fetchMoreTestRuns}
+                  resetKey={`testRuns|${debouncedSearchString}|${filters.hideCompletedTestRuns}`}
+                  emptyMessage={
+                    filters.hideCompletedTestRuns
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-runs-table"
+                  rowTestIdPrefix="tag-detail-run-row"
+                />
+              </div>
             </TabsContent>
 
             <TabsContent value="sessions">
               {(sessionsCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={sessionsStartIndex}
-                    endIndex={sessionsEndIndex}
-                    totalRows={sessionsCount ?? 0}
-                    searchString={searchString}
-                    pageSize={sessionsPageSize}
-                    pageSizeOptions={sessionsPageSizeOptions}
-                    handlePageSizeChange={setSessionsPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={sessionsPage}
-                    totalPages={sessionsTotalPages}
-                    onPageChange={setSessionsPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedSessions.length.toLocaleString(),
+                    total: (
+                      sessionsCount ?? mappedSessions.length
+                    ).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={sessionColumns}
-                data={mappedSessions}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingSessions}
-                pageSize={effectiveSessionsPageSize}
-              />
-              {(sessionsCount ?? 0) === 0 && !isLoadingSessions && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.hideCompletedSessions
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={sessionColumns as any}
+                  data={mappedSessions}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingSessions || isFetchingMoreSessions}
+                  hasMore={!!hasMoreSessions}
+                  onLoadMore={fetchMoreSessions}
+                  resetKey={`sessions|${debouncedSearchString}|${filters.hideCompletedSessions}`}
+                  emptyMessage={
+                    filters.hideCompletedSessions
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-sessions-table"
+                  rowTestIdPrefix="tag-detail-session-row"
+                />
+              </div>
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/testplanit/app/[locale]/projects/tags/[projectId]/page.tsx
+++ b/testplanit/app/[locale]/projects/tags/[projectId]/page.tsx
@@ -5,10 +5,8 @@ import { schema } from "~/zenstack/schema";
 import { AutoTagWizardDialog } from "@/components/auto-tag/AutoTagWizardDialog";
 import { useDebounce } from "@/components/Debounce";
 import { ProjectIcon } from "@/components/ProjectIcon";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -20,22 +18,13 @@ import {
 import { Tags } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useParams, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRequireAuth } from "~/hooks/useRequireAuth";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { useColumns } from "./columns";
 
 export default function ProjectTagListPage() {
-  return (
-    <PaginationProvider>
-      <TagList />
-    </PaginationProvider>
-  );
+  return <TagList />;
 }
 
 function TagList() {
@@ -47,17 +36,6 @@ function TagList() {
   const router = useRouter();
   const { projectId } = useParams<{ projectId: string }>();
   const t = useTranslations();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -86,11 +64,6 @@ function TagList() {
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>
   >({});
-
-  // Calculate effective page size and skip
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
 
   const { data: project } = useClientQueries(schema).projects.useFindFirst(
     {
@@ -448,36 +421,6 @@ function TagList() {
     activeRunMap,
   ]);
 
-  // Update total items in pagination context
-  useEffect(() => {
-    if (filteredTags) {
-      setTotalItems(filteredTags.length);
-    }
-  }, [filteredTags, setTotalItems]);
-
-  const displayedTags = useMemo(() => {
-    return filteredTags.slice(skip, skip + effectivePageSize);
-  }, [filteredTags, skip, effectivePageSize]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
-
   useEffect(() => {
     if (!isAuthLoading && !session) {
       router.push("/");
@@ -492,7 +435,6 @@ function TagList() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   const isLoadingCounts = isLoadingCases || isLoadingSessions || isLoadingRuns;
@@ -564,7 +506,7 @@ function TagList() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -576,41 +518,27 @@ function TagList() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="tag-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {filteredTags.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {t("admin.auditLogs.showing", {
+                  loaded: filteredTags.length.toLocaleString(),
+                  total: filteredTags.length.toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
               columns={columns as any}
-              data={displayedTags as any}
+              data={filteredTags as any}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              pageSize={effectivePageSize}
+              fillViewport
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="project-tags-table"
+              rowTestIdPrefix="project-tag-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/tags/[tagId]/page.tsx
+++ b/testplanit/app/[locale]/tags/[tagId]/page.tsx
@@ -3,10 +3,8 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { TagsDisplay } from "@/components/tables/TagDisplay";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,13 +23,14 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import {
   useCaseColumns,
   useSessionColumns,
   useTestRunColumns,
 } from "./columns";
+
+const PAGE_SIZE = 50;
 
 type TabType = "cases" | "sessions" | "testRuns";
 type CaseTypeFilter = "all" | "manual" | "automated";
@@ -110,24 +109,8 @@ function TagDetail() {
     return count;
   }, [filters]);
 
-  // Pagination state for each tab
-  const [casesPage, setCasesPage] = useState(1);
-  const [casesPageSize, setCasesPageSize] = useState<number | "All">(25);
-  const [sessionsPage, setSessionsPage] = useState(1);
-  const [sessionsPageSize, setSessionsPageSize] = useState<number | "All">(25);
-  const [testRunsPage, setTestRunsPage] = useState(1);
-  const [testRunsPageSize, setTestRunsPageSize] = useState<number | "All">(25);
-
   const isAdmin = session?.user?.access === "ADMIN";
   const userId = session?.user?.id;
-
-  // Convert page size to number for calculations
-  const effectiveCasesPageSize =
-    typeof casesPageSize === "number" ? casesPageSize : 999999;
-  const effectiveSessionsPageSize =
-    typeof sessionsPageSize === "number" ? sessionsPageSize : 999999;
-  const effectiveTestRunsPageSize =
-    typeof testRunsPageSize === "number" ? testRunsPageSize : 999999;
 
   // Fetch the tag metadata only
   const { data: tags, isLoading: isLoadingTag } = useClientQueries(
@@ -256,11 +239,9 @@ function TagDetail() {
     return where;
   }, [baseWhere, tagId, debouncedSearchString, filters.hideCompletedTestRuns]);
 
-  // Fetch paginated test cases
-  const { data: repositoryCases, isLoading: isLoadingCases } = useClientQueries(
-    schema
-  ).repositoryCases.useFindMany(
-    {
+  // Fetch test cases (infinite scroll)
+  const casesInfiniteArgs = useMemo(
+    () => ({
       where: casesWhere,
       select: {
         id: true,
@@ -278,12 +259,29 @@ function TagDetail() {
         },
       },
       orderBy: { name: "asc" as const },
-      skip: (casesPage - 1) * effectiveCasesPageSize,
-      take: effectiveCasesPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [casesWhere]
+  );
+  const {
+    data: casesPages,
+    fetchNextPage: fetchMoreCases,
+    hasNextPage: hasMoreCases,
+    isFetchingNextPage: isFetchingMoreCases,
+    isLoading: isLoadingCases,
+  } = useClientQueries(schema).repositoryCases.useInfiniteFindMany(
+    casesInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...casesInfiniteArgs, skip: allPages.flat().length },
       enabled: !!tagId && status === "authenticated" && activeTab === "cases",
     }
+  );
+  const repositoryCases = useMemo(
+    () => casesPages?.pages.flat() ?? [],
+    [casesPages]
   );
 
   const { data: casesCount } = useClientQueries(
@@ -297,11 +295,9 @@ function TagDetail() {
     }
   );
 
-  // Fetch paginated sessions
-  const { data: sessions, isLoading: isLoadingSessions } = useClientQueries(
-    schema
-  ).sessions.useFindMany(
-    {
+  // Fetch sessions (infinite scroll)
+  const sessionsInfiniteArgs = useMemo(
+    () => ({
       where: sessionsWhere,
       select: {
         id: true,
@@ -317,13 +313,30 @@ function TagDetail() {
         },
       },
       orderBy: { createdAt: "desc" as const },
-      skip: (sessionsPage - 1) * effectiveSessionsPageSize,
-      take: effectiveSessionsPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [sessionsWhere]
+  );
+  const {
+    data: sessionsPages,
+    fetchNextPage: fetchMoreSessions,
+    hasNextPage: hasMoreSessions,
+    isFetchingNextPage: isFetchingMoreSessions,
+    isLoading: isLoadingSessions,
+  } = useClientQueries(schema).sessions.useInfiniteFindMany(
+    sessionsInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...sessionsInfiniteArgs, skip: allPages.flat().length },
       enabled:
         !!tagId && status === "authenticated" && activeTab === "sessions",
     }
+  );
+  const sessions = useMemo(
+    () => sessionsPages?.pages.flat() ?? [],
+    [sessionsPages]
   );
 
   const { data: sessionsCount } = useClientQueries(schema).sessions.useCount(
@@ -335,11 +348,9 @@ function TagDetail() {
     }
   );
 
-  // Fetch paginated test runs
-  const { data: testRuns, isLoading: isLoadingTestRuns } = useClientQueries(
-    schema
-  ).testRuns.useFindMany(
-    {
+  // Fetch test runs (infinite scroll)
+  const testRunsInfiniteArgs = useMemo(
+    () => ({
       where: testRunsWhere,
       select: {
         id: true,
@@ -355,13 +366,30 @@ function TagDetail() {
         },
       },
       orderBy: { createdAt: "desc" as const },
-      skip: (testRunsPage - 1) * effectiveTestRunsPageSize,
-      take: effectiveTestRunsPageSize,
-    },
+      take: PAGE_SIZE,
+    }),
+    [testRunsWhere]
+  );
+  const {
+    data: testRunsPages,
+    fetchNextPage: fetchMoreTestRuns,
+    hasNextPage: hasMoreTestRuns,
+    isFetchingNextPage: isFetchingMoreTestRuns,
+    isLoading: isLoadingTestRuns,
+  } = useClientQueries(schema).testRuns.useInfiniteFindMany(
+    testRunsInfiniteArgs,
     {
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < PAGE_SIZE
+          ? undefined
+          : { ...testRunsInfiniteArgs, skip: allPages.flat().length },
       enabled:
         !!tagId && status === "authenticated" && activeTab === "testRuns",
     }
+  );
+  const testRuns = useMemo(
+    () => testRunsPages?.pages.flat() ?? [],
+    [testRunsPages]
   );
 
   const { data: testRunsCount } = useClientQueries(schema).testRuns.useCount(
@@ -442,44 +470,6 @@ function TagDetail() {
     project: t("common.fields.project"),
     noProject: t("tags.noProject"),
   });
-
-  // Pagination calculations
-  const casesTotalPages = Math.ceil((casesCount ?? 0) / effectiveCasesPageSize);
-  const sessionsTotalPages = Math.ceil(
-    (sessionsCount ?? 0) / effectiveSessionsPageSize
-  );
-  const testRunsTotalPages = Math.ceil(
-    (testRunsCount ?? 0) / effectiveTestRunsPageSize
-  );
-
-  const casesStartIndex = (casesPage - 1) * effectiveCasesPageSize + 1;
-  const casesEndIndex = Math.min(
-    casesPage * effectiveCasesPageSize,
-    casesCount ?? 0
-  );
-
-  const sessionsStartIndex = (sessionsPage - 1) * effectiveSessionsPageSize + 1;
-  const sessionsEndIndex = Math.min(
-    sessionsPage * effectiveSessionsPageSize,
-    sessionsCount ?? 0
-  );
-
-  const testRunsStartIndex = (testRunsPage - 1) * effectiveTestRunsPageSize + 1;
-  const testRunsEndIndex = Math.min(
-    testRunsPage * effectiveTestRunsPageSize,
-    testRunsCount ?? 0
-  );
-
-  const casesPageSizeOptions = usePageSizeOptions(casesCount ?? 0);
-  const testRunsPageSizeOptions = usePageSizeOptions(testRunsCount ?? 0);
-  const sessionsPageSizeOptions = usePageSizeOptions(sessionsCount ?? 0);
-
-  // Reset page when search or filters change
-  useEffect(() => {
-    setCasesPage(1);
-    setSessionsPage(1);
-    setTestRunsPage(1);
-  }, [debouncedSearchString, filters]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -635,116 +625,96 @@ function TagDetail() {
 
             <TabsContent value="cases" className="max-w-full overflow-hidden">
               {(casesCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={casesStartIndex}
-                    endIndex={casesEndIndex}
-                    totalRows={casesCount ?? 0}
-                    searchString={searchString}
-                    pageSize={casesPageSize}
-                    pageSizeOptions={casesPageSizeOptions}
-                    handlePageSizeChange={setCasesPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={casesPage}
-                    totalPages={casesTotalPages}
-                    onPageChange={setCasesPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedCases.length.toLocaleString(),
+                    total: (casesCount ?? mappedCases.length).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={caseColumns}
-                data={mappedCases}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingCases}
-                pageSize={effectiveCasesPageSize}
-              />
-              {(casesCount ?? 0) === 0 && !isLoadingCases && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.caseType !== "all"
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={caseColumns as any}
+                  data={mappedCases}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingCases || isFetchingMoreCases}
+                  hasMore={!!hasMoreCases}
+                  onLoadMore={fetchMoreCases}
+                  resetKey={`cases|${debouncedSearchString}|${filters.caseType}`}
+                  emptyMessage={
+                    filters.caseType !== "all"
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-cases-table"
+                  rowTestIdPrefix="tag-detail-case-row"
+                />
+              </div>
             </TabsContent>
 
             <TabsContent value="testRuns">
               {(testRunsCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={testRunsStartIndex}
-                    endIndex={testRunsEndIndex}
-                    totalRows={testRunsCount ?? 0}
-                    searchString={searchString}
-                    pageSize={testRunsPageSize}
-                    pageSizeOptions={testRunsPageSizeOptions}
-                    handlePageSizeChange={setTestRunsPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={testRunsPage}
-                    totalPages={testRunsTotalPages}
-                    onPageChange={setTestRunsPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedTestRuns.length.toLocaleString(),
+                    total: (
+                      testRunsCount ?? mappedTestRuns.length
+                    ).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={testRunColumns}
-                data={mappedTestRuns}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingTestRuns}
-                pageSize={effectiveTestRunsPageSize}
-              />
-              {(testRunsCount ?? 0) === 0 && !isLoadingTestRuns && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.hideCompletedTestRuns
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={testRunColumns as any}
+                  data={mappedTestRuns}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingTestRuns || isFetchingMoreTestRuns}
+                  hasMore={!!hasMoreTestRuns}
+                  onLoadMore={fetchMoreTestRuns}
+                  resetKey={`testRuns|${debouncedSearchString}|${filters.hideCompletedTestRuns}`}
+                  emptyMessage={
+                    filters.hideCompletedTestRuns
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-runs-table"
+                  rowTestIdPrefix="tag-detail-run-row"
+                />
+              </div>
             </TabsContent>
 
             <TabsContent value="sessions">
               {(sessionsCount ?? 0) > 0 && (
-                <div className="mb-4 flex justify-end items-center gap-4">
-                  <PaginationInfo
-                    startIndex={sessionsStartIndex}
-                    endIndex={sessionsEndIndex}
-                    totalRows={sessionsCount ?? 0}
-                    searchString={searchString}
-                    pageSize={sessionsPageSize}
-                    pageSizeOptions={sessionsPageSizeOptions}
-                    handlePageSizeChange={setSessionsPageSize}
-                  />
-                  <PaginationComponent
-                    currentPage={sessionsPage}
-                    totalPages={sessionsTotalPages}
-                    onPageChange={setSessionsPage}
-                  />
-                </div>
+                <p className="mb-2 text-right text-sm text-muted-foreground">
+                  {t("admin.auditLogs.showing", {
+                    loaded: mappedSessions.length.toLocaleString(),
+                    total: (
+                      sessionsCount ?? mappedSessions.length
+                    ).toLocaleString(),
+                  })}
+                </p>
               )}
-              <DataTable
-                columns={sessionColumns}
-                data={mappedSessions}
-                onSortChange={() => {}}
-                sortConfig={{ column: "name", direction: "asc" }}
-                columnVisibility={{}}
-                onColumnVisibilityChange={() => {}}
-                isLoading={isLoadingSessions}
-                pageSize={effectiveSessionsPageSize}
-              />
-              {(sessionsCount ?? 0) === 0 && !isLoadingSessions && (
-                <div className="text-center text-muted-foreground py-8">
-                  {filters.hideCompletedSessions
-                    ? t("tags.detail.noFilterResults")
-                    : t("tags.detail.noResults")}
-                </div>
-              )}
+              <div className="h-[calc(100vh-24rem)] min-h-[400px] w-full">
+                <VirtualizedDataTable
+                  columns={sessionColumns as any}
+                  data={mappedSessions}
+                  columnVisibility={{}}
+                  onColumnVisibilityChange={() => {}}
+                  isLoading={isLoadingSessions || isFetchingMoreSessions}
+                  hasMore={!!hasMoreSessions}
+                  onLoadMore={fetchMoreSessions}
+                  resetKey={`sessions|${debouncedSearchString}|${filters.hideCompletedSessions}`}
+                  emptyMessage={
+                    filters.hideCompletedSessions
+                      ? t("tags.detail.noFilterResults")
+                      : t("tags.detail.noResults")
+                  }
+                  testIdPrefix="tag-detail-sessions-table"
+                  rowTestIdPrefix="tag-detail-session-row"
+                />
+              </div>
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/testplanit/app/[locale]/tags/page.tsx
+++ b/testplanit/app/[locale]/tags/page.tsx
@@ -3,10 +3,8 @@
 import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useDebounce } from "@/components/Debounce";
-import { DataTable } from "@/components/tables/DataTable";
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -32,38 +30,26 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
-import { usePageSizeOptions } from "~/hooks/usePageSizeOptions";
 import { useRouter } from "~/lib/navigation";
 import { cn } from "~/utils";
 import { useTagColumns } from "./columns";
 
+const PAGE_SIZE = 50;
+
+// Count columns are derived from a separate join call, so they can't be sorted
+// across pages without the full set in hand. Sorting by one fetches everything
+// once and renders it through the same virtualized table in full-set mode
+// (hasMore=false); every other column drives a genuine infinite fetch.
+const COUNT_SORT_COLUMNS = ["cases", "testRuns", "sessions", "projects"];
+
 export default function TagList() {
-  return (
-    <PaginationProvider>
-      <Tags />
-    </PaginationProvider>
-  );
+  return <Tags />;
 }
 
 function Tags() {
   const t = useTranslations();
   const { data: session, status } = useSession();
   const router = useRouter();
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
   const [sortConfig, setSortConfig] = useState<{
     column: string;
     direction: "asc" | "desc";
@@ -86,35 +72,15 @@ function Tags() {
     orderBy: [{ isCompleted: "asc" }, { name: "asc" }],
   });
 
-  // Valid column IDs for sorting
-  const validColumnIds = useMemo(
-    () => ["name", "cases", "testRuns", "sessions", "projects"],
-    []
-  );
-
-  // Validate and fix sortConfig if it references a non-existent column
-  useEffect(() => {
-    if (!validColumnIds.includes(sortConfig.column)) {
-      console.warn(
-        `Invalid sort column "${sortConfig.column}", resetting to "name"`
-      );
-      setSortConfig({ column: "name", direction: "asc" });
-    }
-  }, [sortConfig.column, validColumnIds]);
   const [searchString, setSearchString] = useState("");
   const debouncedSearchString = useDebounce(searchString, 500);
 
   const accessFilterReady = !!session?.user?.id;
 
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
-
   const nameFilter = useMemo(() => {
     if (!debouncedSearchString.trim()) {
       return {};
     }
-
     return {
       name: {
         contains: debouncedSearchString.trim(),
@@ -123,12 +89,8 @@ function Tags() {
     };
   }, [debouncedSearchString]);
 
-  // Note: We don't need a manual project filter here anymore.
-  // ZenStack's access policies on RepositoryCases, Sessions, and TestRuns
-  // will automatically filter out data the user doesn't have access to.
-  // This handles all access types: assignedUsers, userPermissions,
-  // groupPermissions, and project defaultAccessType (GLOBAL_ROLE).
-
+  // Note: ZenStack's access policies on RepositoryCases, Sessions, and TestRuns
+  // filter out data the user doesn't have access to automatically.
   const tagsWhere = useMemo(() => {
     if (!accessFilterReady) {
       return null;
@@ -171,120 +133,110 @@ function Tags() {
     };
   }, [accessFilterReady, nameFilter]);
 
-  const orderBy = useMemo(() => {
-    // Only apply server-side sorting for name column
-    // Other columns will be sorted client-side after counts are fetched
-    if (sortConfig?.column === "name") {
-      return {
-        name: sortConfig.direction,
-      } as const;
-    }
-
-    // For count columns, fetch all tags unsorted (will sort client-side)
-    return {
-      name: "asc" as const,
-    };
-  }, [sortConfig]);
-
-  // When sorting by count columns, we need to fetch ALL tags to sort properly
-  // Otherwise we can paginate server-side
-  const needsClientSideSorting = sortConfig.column !== "name";
-  const shouldPaginate =
-    !needsClientSideSorting && typeof effectivePageSize === "number";
-  const paginationArgs = {
-    skip: shouldPaginate ? skip : undefined,
-    take: shouldPaginate ? effectivePageSize : undefined,
-  };
-
-  // Fetch ONLY basic tag data - no includes at all
-  // ZenStack's access control on includes causes bind variable explosion (even with limits)
-  // Projects and counts are fetched separately via direct Prisma queries
-  const { data: tags, isLoading: isLoadingTags } = useClientQueries(
-    schema
-  ).tags.useFindMany(
-    tagsWhere
-      ? {
-          where: tagsWhere,
-          orderBy,
-          ...paginationArgs,
-        }
-      : undefined,
-    {
-      enabled: !!tagsWhere && status === "authenticated",
-    }
+  const isCountSort = COUNT_SORT_COLUMNS.includes(sortConfig.column);
+  const orderBy = useMemo(
+    () =>
+      sortConfig.column === "name"
+        ? ({ name: sortConfig.direction } as const)
+        : { name: "asc" as const },
+    [sortConfig]
   );
+
+  const infiniteBaseArgs = useMemo(
+    () => ({
+      where: tagsWhere ?? undefined,
+      orderBy,
+      take: PAGE_SIZE,
+    }),
+    [tagsWhere, orderBy]
+  );
+
+  const {
+    data: infinitePages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingInfinite,
+  } = useClientQueries(schema).tags.useInfiniteFindMany(infiniteBaseArgs, {
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return { ...infiniteBaseArgs, skip: allPages.flat().length };
+    },
+    enabled: !!tagsWhere && status === "authenticated" && !isCountSort,
+  });
+
+  const { data: allTags, isLoading: isLoadingAll } = useClientQueries(
+    schema
+  ).tags.useFindMany(tagsWhere ? { where: tagsWhere } : undefined, {
+    enabled: !!tagsWhere && status === "authenticated" && isCountSort,
+  });
+
+  const tags = useMemo(() => {
+    if (isCountSort) return allTags ?? [];
+    return infinitePages?.pages.flat() ?? [];
+  }, [isCountSort, infinitePages, allTags]);
+
+  const isLoadingTags = isCountSort ? isLoadingAll : isLoadingInfinite;
 
   const { data: tagsCount } = useClientQueries(schema).tags.useCount(
-    tagsWhere
-      ? {
-          where: tagsWhere,
-        }
-      : undefined,
-    {
-      enabled: !!tagsWhere && status === "authenticated",
-    }
+    tagsWhere ? { where: tagsWhere } : undefined,
+    { enabled: !!tagsWhere && status === "authenticated" }
   );
 
-  // Fetch counts and projects separately to avoid bind variable explosion
+  // Counts + projects are fetched separately (join queries too heavy to include)
+  // and cached per tag id for the life of the page — a tag's counts/projects
+  // aren't scoped to the current search/sort, so once fetched they never need
+  // re-requesting as the infinite list appends new ids.
   const [tagCounts, setTagCounts] = useState<
     Record<
       number,
-      {
-        repositoryCases: number;
-        sessions: number;
-        testRuns: number;
-      }
+      { repositoryCases: number; sessions: number; testRuns: number }
     >
   >({});
-
   const [tagProjects, setTagProjects] = useState<
-    Record<
-      number,
-      Array<{
-        id: number;
-        name: string;
-        iconUrl: string | null;
-      }>
-    >
+    Record<number, Array<{ id: number; name: string; iconUrl: string | null }>>
   >({});
-
   const [isLoadingCounts, setIsLoadingCounts] = useState(false);
+  const fetchedTagIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (!tags || tags.length === 0) {
       setTagCounts({});
       setTagProjects({});
       setIsLoadingCounts(false);
+      fetchedTagIdsRef.current = new Set();
       return;
     }
 
-    const tagIds = tags.map((t) => t.id);
+    const newIds = tags
+      .map((tag) => tag.id)
+      .filter((id) => !fetchedTagIdsRef.current.has(id));
+    if (newIds.length === 0) return;
+    newIds.forEach((id) => fetchedTagIdsRef.current.add(id));
 
     const fetchCountsAndProjects = async () => {
       setIsLoadingCounts(true);
       try {
-        // Fetch counts and projects in parallel
         const [countsResponse, projectsResponse] = await Promise.all([
           fetch("/api/tags/counts", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ tagIds }),
+            body: JSON.stringify({ tagIds: newIds }),
           }),
           fetch("/api/tags/projects", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ tagIds }),
+            body: JSON.stringify({ tagIds: newIds }),
           }),
         ]);
 
         if (countsResponse.ok) {
           const data = await countsResponse.json();
-          setTagCounts(data.counts || {});
+          setTagCounts((prev) => ({ ...prev, ...(data.counts || {}) }));
         }
-
         if (projectsResponse.ok) {
           const data = await projectsResponse.json();
-          setTagProjects(data.projects || {});
+          setTagProjects((prev) => ({ ...prev, ...(data.projects || {}) }));
         }
       } catch (error) {
         console.error("Failed to fetch tag data:", error);
@@ -301,11 +253,9 @@ function Tags() {
       return [];
     }
 
-    // Map counts and projects from the separate API calls
     const mapped = tags.map((tag) => {
       const counts = tagCounts[tag.id];
       const projects = tagProjects[tag.id] || [];
-
       return {
         ...tag,
         repositoryCases: [],
@@ -318,13 +268,11 @@ function Tags() {
       };
     });
 
-    // Apply client-side sorting for count columns (since these aren't in the DB)
-    // Name sorting is already handled server-side via orderBy
-    if (sortConfig.column !== "name") {
+    // Count columns aren't in the DB — sort them client-side over the full set.
+    if (isCountSort) {
       return mapped.sort((a, b) => {
         let aValue: number;
         let bValue: number;
-
         switch (sortConfig.column) {
           case "cases":
             aValue = a.repositoryCasesCount ?? 0;
@@ -345,7 +293,6 @@ function Tags() {
           default:
             return 0;
         }
-
         return sortConfig.direction === "asc"
           ? aValue - bValue
           : bValue - aValue;
@@ -353,39 +300,7 @@ function Tags() {
     }
 
     return mapped;
-  }, [tags, tagCounts, tagProjects, sortConfig]);
-
-  useEffect(() => {
-    setTotalItems(tagsCount ?? 0);
-  }, [tagsCount, setTotalItems]);
-
-  // When sorting by count columns, apply pagination client-side
-  // Otherwise the data is already paginated from the server
-  const displayedTags = useMemo(() => {
-    if (sortConfig.column !== "name") {
-      // Client-side pagination for count column sorting
-      return mappedTags.slice(skip, skip + effectivePageSize);
-    }
-    // Server-side pagination (already applied)
-    return mappedTags;
-  }, [mappedTags, sortConfig.column, skip, effectivePageSize]);
-
-  const pageSizeOptions = usePageSizeOptions(totalItems);
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  }, [tags, tagCounts, tagProjects, sortConfig, isCountSort]);
 
   useEffect(() => {
     if (status !== "loading" && !session) {
@@ -417,7 +332,6 @@ function Tags() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1);
   };
 
   return (
@@ -500,7 +414,7 @@ function Tags() {
           <CardDescription>{t("tags.description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row items-start justify-between gap-4">
             <div className="flex flex-col grow w-full sm:w-1/2 min-w-[250px]">
               <div className="text-muted-foreground w-full text-nowrap">
                 <Filter
@@ -512,42 +426,30 @@ function Tags() {
               </div>
             </div>
 
-            <div className="flex flex-col w-full sm:w-2/3 items-end">
-              {totalItems > 0 && (
-                <>
-                  <div className="justify-end">
-                    <PaginationInfo
-                      key="tag-pagination-info"
-                      startIndex={startIndex}
-                      endIndex={endIndex}
-                      totalRows={totalItems}
-                      searchString={searchString}
-                      pageSize={typeof pageSize === "number" ? pageSize : "All"}
-                      pageSizeOptions={pageSizeOptions}
-                      handlePageSizeChange={(size) => setPageSize(size)}
-                    />
-                  </div>
-                  <div className="justify-end -mx-4">
-                    <PaginationComponent
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={setCurrentPage}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
+            {mappedTags.length > 0 && (
+              <p className="text-sm text-muted-foreground shrink-0">
+                {t("admin.auditLogs.showing", {
+                  loaded: mappedTags.length.toLocaleString(),
+                  total: (tagsCount ?? mappedTags.length).toLocaleString(),
+                })}
+              </p>
+            )}
           </div>
-          <div className="mt-4 flex justify-between">
-            <DataTable
+          <div className="mt-4 w-full">
+            <VirtualizedDataTable
+              fillViewport
               columns={columns as any}
-              data={displayedTags as any}
+              data={mappedTags as any}
               onSortChange={handleSortChange}
               sortConfig={sortConfig}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
-              isLoading={isLoadingTags || !tagsWhere}
-              pageSize={effectivePageSize}
+              isLoading={isLoadingTags || isFetchingNextPage || !tagsWhere}
+              hasMore={isCountSort ? false : !!hasNextPage}
+              onLoadMore={fetchNextPage}
+              resetKey={`${debouncedSearchString}|${sortConfig.column}|${sortConfig.direction}`}
+              testIdPrefix="tags-table"
+              rowTestIdPrefix="tag-row"
             />
           </div>
         </CardContent>

--- a/testplanit/app/[locale]/users/page.tsx
+++ b/testplanit/app/[locale]/users/page.tsx
@@ -4,48 +4,26 @@ import { useClientQueries } from "@zenstackhq/tanstack-query/react";
 import { schema } from "~/zenstack/schema";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  PaginationProvider,
-  usePagination,
-} from "~/lib/contexts/PaginationContext";
+import { useMemo, useState } from "react";
 import { useRouter } from "~/lib/navigation";
 
 import { useDebounce } from "@/components/Debounce";
 import { ColumnSelection } from "@/components/tables/ColumnSelection";
-import { DataTable } from "@/components/tables/DataTable";
+import { VirtualizedDataTable } from "@/components/tables/VirtualizedDataTable";
 import { ExtendedUser, useUserColumns } from "./columns";
 
 import { Filter } from "@/components/tables/Filter";
-import { PaginationComponent } from "@/components/tables/Pagination";
-import { PaginationInfo } from "@/components/tables/PaginationControls";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-type PageSizeOption = number | "All";
-
 export default function UserList() {
-  return (
-    <PaginationProvider>
-      <Users />
-    </PaginationProvider>
-  );
+  return <Users />;
 }
 
 function Users() {
   const { data: session, status } = useSession();
   const t = useTranslations("users");
   const tCommon = useTranslations("common");
-  const {
-    currentPage,
-    setCurrentPage,
-    pageSize,
-    setPageSize,
-    totalItems,
-    setTotalItems,
-    startIndex,
-    endIndex,
-    totalPages,
-  } = usePagination();
+  const tGlobal = useTranslations();
   const [sortConfig, setSortConfig] = useState<
     | {
         column: string;
@@ -62,50 +40,11 @@ function Users() {
   >({});
 
   const router = useRouter();
-  // Calculate effective page size and skip
-  const effectivePageSize =
-    typeof pageSize === "number" ? pageSize : totalItems;
-  const skip = (currentPage - 1) * effectivePageSize;
   const debouncedSearchString = useDebounce(searchString, 500);
 
-  const { data: totalFilteredUsers } = useClientQueries(
-    schema
-  ).user.useFindMany(
-    {
-      orderBy: sortConfig
-        ? { [sortConfig.column]: sortConfig.direction }
-        : { name: "asc" },
-      include: {
-        projects: true,
-      },
-      where: {
-        AND: [
-          {
-            name: {
-              contains: debouncedSearchString,
-              mode: "insensitive",
-            },
-          },
-          { isActive: true },
-          { isDeleted: false },
-        ],
-      },
-    },
-    {
-      enabled:
-        (!!session?.user && debouncedSearchString.length === 0) ||
-        debouncedSearchString.length > 0,
-      refetchOnWindowFocus: true,
-    }
-  );
-
-  // Update total items in pagination context
-  useEffect(() => {
-    if (totalFilteredUsers) {
-      setTotalItems(totalFilteredUsers.length);
-    }
-  }, [totalFilteredUsers, setTotalItems]);
-
+  // Single full-set fetch feeds the virtualized table directly; the table
+  // renders only the visible window, so there's no page seam and no separate
+  // count query (the loaded array length IS the total).
   const { data, isLoading } = useClientQueries(schema).user.useFindMany(
     {
       orderBy: sortConfig
@@ -128,8 +67,6 @@ function Users() {
           { isDeleted: false },
         ],
       },
-      take: effectivePageSize,
-      skip: skip,
     },
     {
       enabled: !!session?.user,
@@ -137,35 +74,7 @@ function Users() {
     }
   );
 
-  const users = data as ExtendedUser[];
-
-  const pageSizeOptions: PageSizeOption[] = useMemo(() => {
-    if (totalItems <= 10) {
-      return ["All"];
-    }
-    const options: PageSizeOption[] = [10, 25, 50, 100, 250].filter(
-      (size) => size < totalItems || totalItems === 0
-    );
-    options.push("All");
-    return options;
-  }, [totalItems]);
-
-  const prevSearchStringRef = useRef(searchString);
-  const prevPageSizeRef = useRef(pageSize);
-
-  // Reset to first page when search changes
-  useEffect(() => {
-    if (searchString === prevSearchStringRef.current) return;
-    prevSearchStringRef.current = searchString;
-    setCurrentPage(1);
-  }, [searchString, setCurrentPage]);
-
-  // Reset to first page when page size changes
-  useEffect(() => {
-    if (pageSize === prevPageSizeRef.current) return;
-    prevPageSizeRef.current = pageSize;
-    setCurrentPage(1);
-  }, [pageSize, setCurrentPage]);
+  const users = useMemo(() => (data ?? []) as ExtendedUser[], [data]);
 
   const columns = useUserColumns(tCommon);
 
@@ -179,7 +88,6 @@ function Users() {
         ? "desc"
         : "asc";
     setSortConfig({ column, direction });
-    setCurrentPage(1); // Reset to first page when sorting changes
   };
 
   if (session && session.user.access !== "NONE") {
@@ -195,7 +103,7 @@ function Users() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="flex flex-row items-start">
+            <div className="flex flex-row items-start justify-between gap-4">
               <div className="flex flex-col grow w-full sm:w-1/3 min-w-[150px]">
                 <Filter
                   key="user-filter"
@@ -213,39 +121,17 @@ function Users() {
                 </div>
               </div>
 
-              <div
-                id="pagination"
-                className="flex flex-col w-full sm:w-2/3 items-end"
-              >
-                {totalItems > 0 && (
-                  <>
-                    <div className="justify-end">
-                      <PaginationInfo
-                        key="user-pagination-info"
-                        startIndex={startIndex}
-                        endIndex={endIndex}
-                        totalRows={totalItems}
-                        searchString={searchString}
-                        pageSize={
-                          typeof pageSize === "number" ? pageSize : "All"
-                        }
-                        pageSizeOptions={pageSizeOptions}
-                        handlePageSizeChange={(size) => setPageSize(size)}
-                      />
-                    </div>
-                    <div className="justify-end -mx-4">
-                      <PaginationComponent
-                        currentPage={currentPage}
-                        totalPages={totalPages}
-                        onPageChange={setCurrentPage}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
+              {users.length > 0 && (
+                <p className="text-sm text-muted-foreground shrink-0">
+                  {tGlobal("admin.auditLogs.showing", {
+                    loaded: users.length.toLocaleString(),
+                    total: users.length.toLocaleString(),
+                  })}
+                </p>
+              )}
             </div>
-            <div id="users-list" className="mt-4 flex justify-between">
-              <DataTable
+            <div id="users-list" className="mt-4 w-full">
+              <VirtualizedDataTable
                 columns={columns as any}
                 data={users as any}
                 onSortChange={handleSortChange}
@@ -253,7 +139,10 @@ function Users() {
                 columnVisibility={columnVisibility}
                 onColumnVisibilityChange={setColumnVisibility}
                 isLoading={isLoading}
-                pageSize={effectivePageSize}
+                fillViewport
+                resetKey={`${debouncedSearchString}|${sortConfig?.column}|${sortConfig?.direction}`}
+                testIdPrefix="users-directory-table"
+                rowTestIdPrefix="users-directory-row"
               />
             </div>
           </CardContent>

--- a/testplanit/components/tables/VirtualizedDataTable.test.tsx
+++ b/testplanit/components/tables/VirtualizedDataTable.test.tsx
@@ -12,6 +12,7 @@ import { VirtualizedDataTable } from "./VirtualizedDataTable";
 const hookMock = vi.hoisted(() => ({
   lastOnLoadMore: null as null | (() => void),
   lastOpts: null as Record<string, unknown> | null,
+  scrollToIndex: vi.fn(),
 }));
 
 vi.mock("~/hooks/useVirtualizedInfiniteList", () => ({
@@ -24,7 +25,7 @@ vi.mock("~/hooks/useVirtualizedInfiniteList", () => ({
     return {
       scrollRef: () => {},
       sentinelRef: { current: null },
-      virtualizer: {},
+      virtualizer: { scrollToIndex: hookMock.scrollToIndex },
       virtualItems: Array.from({ length: opts.count }, (_, i) => ({
         key: i,
         index: i,
@@ -93,6 +94,7 @@ describe("VirtualizedDataTable", () => {
     vi.clearAllMocks();
     hookMock.lastOnLoadMore = null;
     hookMock.lastOpts = null;
+    hookMock.scrollToIndex.mockClear();
   });
 
   it("renders the header and every row (no pagination slicing)", () => {
@@ -103,6 +105,42 @@ describe("VirtualizedDataTable", () => {
     expect(screen.getByText("Beta")).toBeInTheDocument();
     // The whole result set is handed to the virtualizer.
     expect(hookMock.lastOpts?.count).toBe(2);
+  });
+
+  it("adds a title tooltip to a header only when its label is clipped", () => {
+    // jsdom reports 0 for layout, so fake a header whose content (scrollWidth)
+    // overflows its box (clientWidth); the label should expose its full text as
+    // a native tooltip.
+    const scrollWidth = vi
+      .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+      .mockReturnValue(500);
+    const clientWidth = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(100);
+    try {
+      renderTable();
+      expect(screen.getByText("Name")).toHaveAttribute("title", "Name");
+    } finally {
+      scrollWidth.mockRestore();
+      clientWidth.mockRestore();
+    }
+  });
+
+  it("omits the header tooltip when the label fits within its column", () => {
+    // Content fits its box (scrollWidth === clientWidth) — no tooltip needed.
+    const scrollWidth = vi
+      .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+      .mockReturnValue(100);
+    const clientWidth = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(100);
+    try {
+      renderTable();
+      expect(screen.getByText("Name")).not.toHaveAttribute("title");
+    } finally {
+      scrollWidth.mockRestore();
+      clientWidth.mockRestore();
+    }
   });
 
   it("calls onSortChange with the column id when a sort control is clicked", () => {
@@ -176,6 +214,30 @@ describe("VirtualizedDataTable", () => {
     expect(
       screen.queryByTestId("virtualized-table-resize-expander")
     ).not.toBeInTheDocument();
+  });
+
+  it("scrolls the virtualizer to a deep-linked row once it's in the set", () => {
+    renderTable({ scrollToRowId: 2 });
+    // "Beta" (id 2) is the second row → index 1.
+    expect(hookMock.scrollToIndex).toHaveBeenCalledWith(1, { align: "center" });
+  });
+
+  it("does not scroll when the deep-linked row isn't present", () => {
+    renderTable({ scrollToRowId: 999 });
+    expect(hookMock.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("draws a highlight ring on the deep-linked row", () => {
+    renderTable({ highlightRowId: 1 });
+    const highlighted = screen
+      .getByText("Alpha")
+      .closest('[role="row"]') as HTMLElement;
+    expect(highlighted.className).toContain("outline-primary");
+    // The other row is not highlighted.
+    const other = screen
+      .getByText("Beta")
+      .closest('[role="row"]') as HTMLElement;
+    expect(other.className).not.toContain("outline-primary");
   });
 
   it("seeds column widths from localStorage when a storage key is set", () => {

--- a/testplanit/components/tables/VirtualizedDataTable.tsx
+++ b/testplanit/components/tables/VirtualizedDataTable.tsx
@@ -14,6 +14,7 @@ import {
   getSortedRowModel,
   OnChangeFn,
   Row,
+  RowSelectionState,
   SortingState,
   Updater,
   useReactTable,
@@ -70,6 +71,38 @@ import { cn } from "~/utils";
 const EXPANDER_WIDTH = 24;
 const ESTIMATED_ROW_HEIGHT = 44;
 
+/**
+ * Header label that surfaces a native tooltip with the column's full text, but
+ * only while that text is actually clipped by the column's width. Works for any
+ * header content (a plain string or a render function with icons) by reading the
+ * rendered `textContent`, and re-measures on column resize via a ResizeObserver
+ * so the tooltip appears/disappears live as the user drags the column narrower
+ * or wider.
+ */
+function TruncatedHeaderLabel({ children }: { children: ReactNode }) {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const [title, setTitle] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const el = spanRef.current;
+    if (!el) return;
+    const measure = () => {
+      const isClipped = el.scrollWidth > el.clientWidth;
+      setTitle(isClipped ? el.textContent?.trim() || undefined : undefined);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
+
+  return (
+    <span ref={spanRef} title={title} className="min-w-0 truncate">
+      {children}
+    </span>
+  );
+}
+
 interface VirtualizedDataTableProps {
   columns: ColumnDef<any, any>[];
   data: any[];
@@ -87,6 +120,17 @@ interface VirtualizedDataTableProps {
 
   getSubRows?: (row: any, index: number) => any[] | undefined;
   subRowsLabel?: string;
+
+  /**
+   * Controlled row-selection state (keyed by row index, TanStack's default), for
+   * surfaces with a checkbox column that reads `row.getIsSelected()`. When
+   * provided, row selection is enabled and driven by the caller; omit it and the
+   * table has no selection behavior. Note the keys are row indices into `data`,
+   * so the caller must pass the full (unpaged) set — which a virtualized table
+   * already does.
+   */
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
 
   /**
    * Id of a column that should flex to absorb any horizontal space left over
@@ -123,6 +167,41 @@ interface VirtualizedDataTableProps {
    * filters) so the scroll returns to the top on those changes too.
    */
   resetKey?: unknown;
+  /**
+   * Estimated row height in px. The virtualizer measures real heights once rows
+   * render, but a close estimate keeps the pre-measure layout stable — which
+   * matters for the load-more trigger, since a big under-estimate makes rows
+   * grow after measurement and can otherwise shove the trigger point around.
+   * Set this to roughly a surface's real row height when rows are taller than
+   * the single-line default (e.g. issue rows carrying a title + description).
+   */
+  estimateSize?: number;
+  /**
+   * Size the scroll body to fill from its own top edge down to the viewport
+   * bottom (measured live), instead of inheriting a bounded height from the
+   * parent. Use this when the table is the main content of a page whose header
+   * height varies — it always yields a single inner scroll region regardless of
+   * how tall the header/nav above it is, so the page body never scrolls (which
+   * would otherwise starve the virtualizer's load-more trigger of scroll
+   * events). When false (default) the caller must give the table a bounded-height
+   * container (e.g. `h-[calc(100vh-20rem)]` or a flex `min-h-0` parent).
+   */
+  fillViewport?: boolean;
+  /**
+   * When set, the table scrolls the row whose `original.id` matches this id into
+   * view (centered) once it appears in the row model. Used for deep links (e.g.
+   * `?issueId=`) — the caller loads the full set so the target is present, then
+   * passes its id here; the virtualizer scrolls to it even though its DOM row
+   * isn't rendered until it's near the window. Fires once per id value.
+   */
+  scrollToRowId?: string | number | null;
+  /**
+   * When set, the row whose `original.id` matches is drawn with a persistent
+   * highlight ring. Pair with `scrollToRowId` so a deep-linked row is both
+   * scrolled to and visually marked; the caller clears it (e.g. on user scroll)
+   * when the highlight should fade.
+   */
+  highlightRowId?: string | number | null;
   testIdPrefix?: string;
   rowTestIdPrefix?: string;
 }
@@ -140,6 +219,8 @@ export function VirtualizedDataTable({
   onExpandedChange,
   getSubRows,
   subRowsLabel,
+  rowSelection,
+  onRowSelectionChange,
   flexColumnId,
   columnSizingStorageKey,
   hasMore = false,
@@ -149,6 +230,10 @@ export function VirtualizedDataTable({
   onRetryLoadMore,
   emptyMessage,
   resetKey: externalResetKey,
+  estimateSize = ESTIMATED_ROW_HEIGHT,
+  fillViewport = false,
+  scrollToRowId,
+  highlightRowId,
   testIdPrefix = "virtualized-table",
   rowTestIdPrefix = "virtualized-row",
 }: VirtualizedDataTableProps) {
@@ -268,16 +353,19 @@ export function VirtualizedDataTable({
     getSubRows,
     enableSorting: true,
     enableColumnResizing: true,
+    enableRowSelection: rowSelection !== undefined,
     columnResizeMode: "onChange",
     state: {
       columnVisibility,
       sorting,
       columnSizing,
+      ...(rowSelection !== undefined && { rowSelection }),
       ...(grouping !== undefined && { grouping }),
       ...(expanded !== undefined && { expanded }),
     },
     ...(onGroupingChange !== undefined && { onGroupingChange }),
     ...(onExpandedChange !== undefined && { onExpandedChange }),
+    ...(onRowSelectionChange !== undefined && { onRowSelectionChange }),
     onSortingChange: handleSortingChange,
     onColumnVisibilityChange: handleVisibilityChange,
     onColumnSizingChange: setColumnSizing,
@@ -329,28 +417,55 @@ export function VirtualizedDataTable({
     [sortConfig, grouping, columns, externalResetKey]
   );
 
-  const { scrollRef, sentinelRef, virtualItems, totalSize, measureElement } =
-    useVirtualizedInfiniteList({
-      count: rows.length,
-      estimateSize: ESTIMATED_ROW_HEIGHT,
-      overscan: 8,
-      hasMore,
-      isLoading,
-      onLoadMore: onLoadMore ?? (() => {}),
-      boundToViewport: false,
-      resetKey,
-    });
+  const {
+    scrollRef,
+    sentinelRef,
+    virtualizer,
+    virtualItems,
+    totalSize,
+    measureElement,
+    maxHeight,
+  } = useVirtualizedInfiniteList({
+    count: rows.length,
+    estimateSize,
+    overscan: 8,
+    hasMore,
+    isLoading,
+    onLoadMore: onLoadMore ?? (() => {}),
+    boundToViewport: fillViewport,
+    resetKey,
+  });
+
+  // Deep-link scroll: once the target row is present in the row model, scroll
+  // the virtualizer to it (centered). Guarded so it fires once per id value —
+  // re-running on every `rows` change (each appended page) would keep yanking
+  // the scroll position back. The virtualizer scrolls by estimated offset even
+  // though the row's DOM node isn't rendered until it's near the window.
+  const scrolledToRef = useRef<string | number | null | undefined>(undefined);
+  useEffect(() => {
+    if (scrollToRowId == null) return;
+    if (scrolledToRef.current === scrollToRowId) return;
+    const index = rows.findIndex(
+      (r) => String(r.original?.id) === String(scrollToRowId)
+    );
+    if (index < 0) return;
+    scrolledToRef.current = scrollToRowId;
+    virtualizer.scrollToIndex(index, { align: "center" });
+  }, [scrollToRowId, rows, virtualizer]);
 
   const headers = table.getHeaderGroups().at(-1)?.headers ?? [];
 
   return (
     <div
-      className="h-full overflow-x-auto rounded-lg border-2 border-primary/10"
+      className={cn(
+        "overflow-x-auto rounded-lg border-2 border-primary/10",
+        !fillViewport && "h-full"
+      )}
       role="table"
       data-testid={testIdPrefix}
     >
       <div
-        className="flex h-full min-h-0 flex-col"
+        className={cn("flex min-h-0 flex-col", !fillViewport && "h-full")}
         style={{ width: tableWidth, minWidth: hasFlex ? totalWidth : "100%" }}
       >
         {/* Header — stays put vertically (lives above the scroll body) and
@@ -405,9 +520,9 @@ export function VirtualizedDataTable({
                       )}
                     </button>
                   ) : null}
-                  <span className="min-w-0 truncate">
+                  <TruncatedHeaderLabel>
                     {flexRender(column.columnDef.header, header.getContext())}
-                  </span>
+                  </TruncatedHeaderLabel>
                   {isSortable && column.id !== "expander" && (
                     <button
                       onClick={() => onSortChange?.(column.id)}
@@ -451,7 +566,15 @@ export function VirtualizedDataTable({
             (flex-1) so it works inside a bounded panel or card. */}
         <div
           ref={scrollRef}
-          className="relative min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+          className={cn(
+            "relative min-h-0 overflow-y-auto overflow-x-hidden",
+            !fillViewport && "flex-1"
+          )}
+          style={
+            fillViewport
+              ? { height: maxHeight ?? undefined, minHeight: 200 }
+              : undefined
+          }
           data-testid={`${testIdPrefix}-scroll`}
         >
           {rows.length === 0 && !isLoading ? (
@@ -468,6 +591,9 @@ export function VirtualizedDataTable({
                 if (!row) return null;
                 const isGrouped = row.getIsGrouped();
                 const isSubRow = row.depth > 0;
+                const isHighlighted =
+                  highlightRowId != null &&
+                  String(row.original?.id) === String(highlightRowId);
                 return (
                   <div
                     // Key by the virtual item (index), not the data id, so React
@@ -490,7 +616,9 @@ export function VirtualizedDataTable({
                             // below) so the run of sub-rows reads as one group and the
                             // next (unshaded) parent row is clearly the boundary.
                             "bg-muted/40 hover:bg-muted/60"
-                          : "hover:bg-muted/50"
+                          : "hover:bg-muted/50",
+                      isHighlighted &&
+                        "bg-primary/10 outline outline-4 -outline-offset-2 outline-primary"
                     )}
                     style={{
                       width: tableWidth,

--- a/testplanit/hooks/useVirtualizedInfiniteList.indexTrigger.test.tsx
+++ b/testplanit/hooks/useVirtualizedInfiniteList.indexTrigger.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "~/test/test-utils";
+
+// The virtualizer-index trigger fires off `virtualizer.getVirtualItems()`, which
+// the REAL TanStack virtualizer renders empty under jsdom (no layout). So mock
+// the virtualizer to return a controllable window of virtual items, letting us
+// drive the "last rendered row" directly. IntersectionObserver is intentionally
+// left undefined here so the sentinel-observer path stays inert and we test the
+// index trigger in isolation.
+let mockVirtualItems: Array<{
+  index: number;
+  key: number;
+  start: number;
+  size: number;
+}> = [];
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => mockVirtualItems,
+    getTotalSize: () => 10_000,
+    measureElement: () => undefined,
+    scrollToOffset: () => undefined,
+  }),
+}));
+
+import { useVirtualizedInfiniteList } from "./useVirtualizedInfiniteList";
+
+function row(index: number) {
+  return { index, key: index, start: index * 40, size: 40 };
+}
+
+function Harness(props: {
+  count: number;
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+  loadMoreThreshold?: number;
+}) {
+  const { scrollRef, sentinelRef } = useVirtualizedInfiniteList({
+    estimateSize: 40,
+    boundToViewport: false,
+    ...props,
+  });
+  return (
+    <div ref={scrollRef} data-testid="scroll" style={{ height: 400 }}>
+      <div ref={sentinelRef} data-testid="sentinel" />
+    </div>
+  );
+}
+
+describe("useVirtualizedInfiniteList — virtualizer-index trigger", () => {
+  beforeEach(() => {
+    mockVirtualItems = [];
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires when the last rendered row is within the threshold of the end", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    render(
+      <Harness
+        count={100}
+        hasMore
+        isLoading={false}
+        onLoadMore={onLoadMore}
+        loadMoreThreshold={10}
+      />
+    );
+    // 95 >= 100 - 1 - 10 (=89) → load.
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire when the last rendered row is far from the end", () => {
+    mockVirtualItems = [row(20)];
+    const onLoadMore = vi.fn();
+    render(
+      <Harness
+        count={100}
+        hasMore
+        isLoading={false}
+        onLoadMore={onLoadMore}
+        loadMoreThreshold={10}
+      />
+    );
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire while a fetch is in flight", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    render(
+      <Harness count={100} hasMore isLoading={true} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when there is nothing more to load", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    render(
+      <Harness
+        count={100}
+        hasMore={false}
+        isLoading={false}
+        onLoadMore={onLoadMore}
+      />
+    );
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("fires at most once per count — a re-render at the same count does not double-fire", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <Harness count={100} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Scroll shifts the window (new array) but count hasn't advanced — the
+    // pending guard must block a second call (this is the abort-loop guard).
+    mockVirtualItems = [row(96)];
+    rerender(
+      <Harness count={100} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again once count advances (a page landed) and we're still near the end", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <Harness count={100} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Page landed: count grew and the last rendered row is near the new end.
+    mockVirtualItems = [row(145)];
+    rerender(
+      <Harness count={150} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops firing once the loaded window pulls back from the end", () => {
+    mockVirtualItems = [row(95)];
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <Harness count={100} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Page landed (count 150) but the user hasn't scrolled — the last rendered
+    // row is still ~95, now far from the end → no further load.
+    mockVirtualItems = [row(95)];
+    rerender(
+      <Harness count={150} hasMore isLoading={false} onLoadMore={onLoadMore} />
+    );
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/testplanit/hooks/useVirtualizedInfiniteList.ts
+++ b/testplanit/hooks/useVirtualizedInfiniteList.ts
@@ -49,6 +49,15 @@ export interface UseVirtualizedInfiniteListOptions {
   onLoadMore: () => void;
   /** Distance (px) below the viewport at which to prefetch the next page. */
   loadMoreMargin?: number;
+  /**
+   * How many rows from the end the last *rendered* row must reach before the
+   * next page is pulled. This virtualizer-index trigger is the reliable one on
+   * long lists — it re-evaluates on every scroll render and doesn't depend on a
+   * zero-height sentinel's intersection (which dynamic row measurement can shove
+   * out of range). Complements the sentinel observer; both funnel through one
+   * guard so they can't double-fire.
+   */
+  loadMoreThreshold?: number;
   /** Space (px) to leave below the list when filling the viewport. */
   bottomMargin?: number;
   /**
@@ -77,6 +86,7 @@ export function useVirtualizedInfiniteList({
   isLoading,
   onLoadMore,
   loadMoreMargin = 300,
+  loadMoreThreshold = 10,
   bottomMargin = 16,
   boundToViewport = true,
   resetKey,
@@ -127,10 +137,35 @@ export function useVirtualizedInfiniteList({
   stateRef.current.isLoading = isLoading;
   stateRef.current.onLoadMore = onLoadMore;
 
-  const maybeLoadMore = useCallback(() => {
+  // Single funnel for BOTH load-more triggers (the sentinel observer below and
+  // the virtualizer-index trigger further down). `pendingLoadRef` guarantees at
+  // most one in-flight request across both paths. This is load-bearing: the two
+  // triggers fire on the same "near the bottom" condition, so without a shared
+  // guard they double-call `onLoadMore`; `fetchNextPage` defaults to
+  // `cancelRefetch: true`, so each extra call cancels and restarts the in-flight
+  // page, blipping `isFetchingNextPage` into an abort/re-fire loop that never
+  // settles (a permanent bottom-of-list spinner).
+  const pendingLoadRef = useRef(false);
+  const requestLoad = useCallback(() => {
     const s = stateRef.current;
-    if (s.isIntersecting && s.hasMore && !s.isLoading) s.onLoadMore();
+    if (!s.hasMore || s.isLoading || pendingLoadRef.current) return;
+    pendingLoadRef.current = true;
+    s.onLoadMore();
   }, []);
+
+  // Release the guard only when `count` actually changes — a new page landed
+  // (grew) or the scope reset (shrank). Keying the reset on real data arrival,
+  // NOT on the `isLoading` flag flickering, is what keeps it race-free: an
+  // isLoading-based reset re-opens the exact double-fire window above.
+  useEffect(() => {
+    pendingLoadRef.current = false;
+  }, [count]);
+
+  // Sentinel/fill path: defer to the shared guard, and only when the sentinel is
+  // actually in view (short result set, or scrolled to the bottom).
+  const maybeLoadMore = useCallback(() => {
+    if (stateRef.current.isIntersecting) requestLoad();
+  }, [requestLoad]);
 
   // Only wire the sentinel once the container is mounted and bounded, so an
   // unbounded first paint can't fire a burst of page loads before the height
@@ -162,6 +197,24 @@ export function useVirtualizedInfiniteList({
     maybeLoadMore();
   }, [count, hasMore, isLoading, maybeLoadMore]);
 
+  // Primary, reliable trigger: watch the virtualizer's own last-rendered row.
+  // The virtualizer re-renders on every scroll (that's how it swaps the visible
+  // window), so `virtualItems` changes as the user scrolls; when the last
+  // rendered row reaches within `loadMoreThreshold` of the end, pull the next
+  // page. Unlike the sentinel observer this can't be "jumped over" by dynamic
+  // measurement. Both triggers funnel through `requestLoad`, whose
+  // `pendingLoadRef` guard prevents them from double-firing (see above). It's
+  // inherently bounded: after a page lands, `count` grows while the last
+  // rendered index (fixed by the current scroll position) falls back outside
+  // the threshold, so it stops until the user scrolls further.
+  const virtualItems = virtualizer.getVirtualItems();
+  useEffect(() => {
+    if (!hasMore || isLoading) return;
+    const last = virtualItems[virtualItems.length - 1];
+    if (!last) return;
+    if (last.index >= count - 1 - loadMoreThreshold) requestLoad();
+  }, [virtualItems, count, hasMore, isLoading, requestLoad, loadMoreThreshold]);
+
   // Scroll back to the top when the query/scope changes so the new result set
   // starts from the top. Measurements are intentionally NOT cleared here:
   // calling virtualizer.measure() drops the cached row heights, and when a
@@ -180,7 +233,7 @@ export function useVirtualizedInfiniteList({
     scrollRef,
     sentinelRef,
     virtualizer,
-    virtualItems: virtualizer.getVirtualItems(),
+    virtualItems,
     totalSize: virtualizer.getTotalSize(),
     measureElement: virtualizer.measureElement,
     maxHeight,


### PR DESCRIPTION
## Description

Replaces paged `DataTable`s with a virtualized, infinite-scroll table (`VirtualizedDataTable`) on the app's high-volume list surfaces. Large result sets render as one continuous, page-seam-free list — only the visible window is in the DOM — instead of page-by-page. Surfaces that previously fetched the entire filtered set just to compute a total now run a single query instead of two.

`VirtualizedDataTable` gains a few capabilities to cover the converted surfaces:

- **`fillViewport`** — self-measuring height for full-page tables, yielding a single inner scroll region regardless of header/nav height (no more page-body scroll starving the load-more trigger).
- **`rowSelection`** — controlled checkbox selection state (used by the admin configurations bulk-edit).
- **`scrollToRowId` / `highlightRowId`** — deep-link scroll-to + highlight (e.g. `?issueId=`).
- **`estimateSize`** — better pre-measure layout for taller rows.

**Converted surfaces:** `/issues`, `/tags`, `/users`, `/projects/issues`, `/tags/[tagId]`, both project-tags pages, webhook deliveries, and the admin pages (users, api-tokens, code-repositories, groups, integrations, llm, milestones, projects, prompts, roles, scim, tags, issues, notifications, app-config, workflow review-toggle list).

**Layout note:** full-page single tables use `fillViewport`; tab-embedded tables (webhook deliveries, tag-detail tabs) use bounded heights, because `fillViewport`'s viewport measurement does not bound correctly inside Radix Tabs.

**Intentionally not converted:** `admin/statuses` (no pagination), the `admin/workflows` main list (row drag-reorder), and `admin/trash/SoftDeletedDataTable`.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Performance improvement
- [x] Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests — full `precommit` suite green (9,798 passed / 184 skipped); co-located component tests updated for every converted surface.
- [x] Manual testing — verified infinite scroll + windowing on `/projects/issues` and webhook deliveries (spot-checked with ~3,000 seeded rows: DOM holds only a screenful, pages fetch on scroll, sort/filter reset correctly).

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chrome
- Node version: project default

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Net change is heavily subtractive (~+1,954 / −3,633) — most of it is removing per-page pagination boilerplate in favor of the shared hook + component.
