### PR TITLE
fix(ssrf): block IPv4-mapped IPv6 bypass and pin git-repo connections

### DIFF
--- a/testplanit/lib/integrations/adapters/GitLabRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/GitLabRepoAdapter.ts
@@ -1,3 +1,4 @@
+import { assertSsrfSafeResolved, createPinnedDispatcher } from "~/utils/ssrf";
 import {
   GitRepoAdapter,
   ListFilesResult,
@@ -57,17 +58,26 @@ export class GitLabRepoAdapter extends GitRepoAdapter {
         () => controller.abort(),
         this.requestTimeout
       );
+      let dispatcher: ReturnType<typeof createPinnedDispatcher> | undefined;
 
       let response: Response;
       try {
         const safeUrl = this.sanitizeUrl(url);
+        // Validate the resolved IP and pin the connection to it (DNS-rebinding
+        // guard). This bespoke pagination loop bypasses the base makeRequest, so
+        // the SSRF re-check has to happen here too.
+        const pinnedIp = await assertSsrfSafeResolved(safeUrl);
+        dispatcher = pinnedIp ? createPinnedDispatcher(pinnedIp) : undefined;
         await this.applyRateLimit();
-        response = await fetch(safeUrl, {
+        const init: RequestInit & { dispatcher?: unknown } = {
           headers: this.authHeaders,
           signal: controller.signal,
-        });
+        };
+        if (dispatcher) init.dispatcher = dispatcher;
+        response = await fetch(safeUrl, init);
       } finally {
         clearTimeout(timeoutId);
+        dispatcher?.close().catch(() => {});
       }
 
       if (!response.ok) {

--- a/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
+++ b/testplanit/lib/integrations/adapters/GitRepoAdapter.ts
@@ -4,8 +4,15 @@
  * Does NOT extend BaseAdapter (which is for issue tracking, not git file fetching).
  */
 
-import { assertSsrfSafeResolved, isSsrfSafe } from "~/utils/ssrf";
+import {
+  assertSsrfSafeResolved,
+  createPinnedDispatcher,
+  isSsrfSafe,
+} from "~/utils/ssrf";
 import { getAllowedPrivateHosts } from "~/lib/utils/ssrf";
+
+/** fetch() RequestInit plus undici's `dispatcher` (absent from the DOM types). */
+type FetchInit = RequestInit & { dispatcher?: unknown };
 
 export interface RepoFileEntry {
   path: string;
@@ -110,17 +117,23 @@ export abstract class GitRepoAdapter {
         () => controller.abort(),
         this.requestTimeout
       );
+      let dispatcher: ReturnType<typeof createPinnedDispatcher> | undefined;
 
       try {
         const safeUrl = this.sanitizeUrl(url);
-        // Resolve DNS and verify the IP is not private (closes DNS rebinding)
-        await assertSsrfSafeResolved(safeUrl);
+        // Resolve DNS, verify the IP is not private, and pin the connection to
+        // that exact IP so fetch() cannot re-resolve to a different (private)
+        // address between the check and the connect (DNS-rebinding TOCTOU).
+        const pinnedIp = await assertSsrfSafeResolved(safeUrl);
+        dispatcher = pinnedIp ? createPinnedDispatcher(pinnedIp) : undefined;
 
-        const response = await fetch(safeUrl, {
+        const init: FetchInit = {
           ...options,
           signal: controller.signal,
           redirect: "manual", // prevent redirect-based SSRF bypass
-        });
+        };
+        if (dispatcher) init.dispatcher = dispatcher;
+        const response = await fetch(safeUrl, init);
 
         // If the server redirects, validate the target before following
         if (response.status >= 300 && response.status < 400) {
@@ -202,6 +215,9 @@ export abstract class GitRepoAdapter {
         }
       } finally {
         clearTimeout(timeoutId);
+        // Release the pinned connection pool. Fire-and-forget: undici keeps an
+        // in-flight response alive until its body has been read.
+        dispatcher?.close().catch(() => {});
       }
     });
   }
@@ -222,16 +238,21 @@ export abstract class GitRepoAdapter {
         () => controller.abort(),
         this.requestTimeout
       );
+      let dispatcher: ReturnType<typeof createPinnedDispatcher> | undefined;
 
       try {
         const safeUrl = this.sanitizeUrl(url);
-        await assertSsrfSafeResolved(safeUrl);
+        // Validate + pin the connection to the resolved IP (DNS-rebinding guard).
+        const pinnedIp = await assertSsrfSafeResolved(safeUrl);
+        dispatcher = pinnedIp ? createPinnedDispatcher(pinnedIp) : undefined;
 
-        const response = await fetch(safeUrl, {
+        const init: FetchInit = {
           ...options,
           signal: controller.signal,
           redirect: "manual",
-        });
+        };
+        if (dispatcher) init.dispatcher = dispatcher;
+        const response = await fetch(safeUrl, init);
 
         if (response.status >= 300 && response.status < 400) {
           return this.followSafeRedirect<string>(
@@ -269,6 +290,9 @@ export abstract class GitRepoAdapter {
         return await response.text();
       } finally {
         clearTimeout(timeoutId);
+        // Release the pinned connection pool. Fire-and-forget: undici keeps an
+        // in-flight response alive until its body has been read.
+        dispatcher?.close().catch(() => {});
       }
     });
   }
@@ -318,26 +342,33 @@ export abstract class GitRepoAdapter {
 
     // Resolve relative redirects against the original request URL
     const redirectUrl = this.sanitizeUrl(new URL(location, response.url).href);
-    await assertSsrfSafeResolved(redirectUrl);
+    const pinnedIp = await assertSsrfSafeResolved(redirectUrl);
+    const dispatcher = pinnedIp ? createPinnedDispatcher(pinnedIp) : undefined;
 
-    const redirectResponse = await fetch(redirectUrl, {
-      ...options,
-      signal,
-      redirect: "error", // no further redirects
-    });
+    try {
+      const init: FetchInit = {
+        ...options,
+        signal,
+        redirect: "error", // no further redirects
+      };
+      if (dispatcher) init.dispatcher = dispatcher;
+      const redirectResponse = await fetch(redirectUrl, init);
 
-    this.trackRateLimitHeaders(redirectResponse);
+      this.trackRateLimitHeaders(redirectResponse);
 
-    if (!redirectResponse.ok) {
-      const errorText = await redirectResponse.text().catch(() => "");
-      throw new Error(
-        `HTTP ${redirectResponse.status} ${redirectResponse.statusText}: ${errorText.slice(0, 200)}`
-      );
+      if (!redirectResponse.ok) {
+        const errorText = await redirectResponse.text().catch(() => "");
+        throw new Error(
+          `HTTP ${redirectResponse.status} ${redirectResponse.statusText}: ${errorText.slice(0, 200)}`
+        );
+      }
+
+      return mode === "json"
+        ? ((await redirectResponse.json()) as T)
+        : ((await redirectResponse.text()) as T);
+    } finally {
+      dispatcher?.close().catch(() => {});
     }
-
-    return mode === "json"
-      ? ((await redirectResponse.json()) as T)
-      : ((await redirectResponse.text()) as T);
   }
 
   /**

--- a/testplanit/lib/utils/ssrf.test.ts
+++ b/testplanit/lib/utils/ssrf.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
 import {
   ssrfSafeFetch,
+  isPrivateIp,
   isPrivateOrInternalIp,
   getAllowedPrivateHosts,
   SsrfError,
@@ -191,6 +192,52 @@ describe("isPrivateOrInternalIp", () => {
 
   it("returns true for fd00::1 (IPv6 ULA)", () => {
     expect(isPrivateOrInternalIp("fd00::1")).toBe(true);
+  });
+
+  // IPv4-mapped IPv6 literals — the class of address that bypassed the old
+  // string-prefix guard (GHSA-x7jm-4fpq-5mhm). BlockList unmaps the embedded IPv4.
+  it("returns true for ::ffff:127.0.0.1 (mapped loopback)", () => {
+    expect(isPrivateOrInternalIp("::ffff:127.0.0.1")).toBe(true);
+  });
+
+  it("returns true for ::ffff:7f00:1 (mapped loopback, hex form)", () => {
+    expect(isPrivateOrInternalIp("::ffff:7f00:1")).toBe(true);
+  });
+
+  it("returns true for ::ffff:169.254.169.254 (mapped cloud metadata)", () => {
+    expect(isPrivateOrInternalIp("::ffff:169.254.169.254")).toBe(true);
+  });
+
+  it("returns true for 100.64.0.1 (CGNAT, RFC 6598)", () => {
+    expect(isPrivateOrInternalIp("100.64.0.1")).toBe(true);
+  });
+
+  it("returns true for metadata.google.internal (internal DNS name)", () => {
+    expect(isPrivateOrInternalIp("metadata.google.internal")).toBe(true);
+  });
+});
+
+describe("isPrivateIp", () => {
+  it("blocks IPv4-mapped IPv6 private literals", () => {
+    expect(isPrivateIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateIp("::ffff:7f00:1")).toBe(true);
+    expect(isPrivateIp("::ffff:169.254.169.254")).toBe(true);
+    expect(isPrivateIp("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  it("tolerates bracketed IPv6 literals", () => {
+    expect(isPrivateIp("[::1]")).toBe(true);
+  });
+
+  it("allows genuine public addresses", () => {
+    expect(isPrivateIp("8.8.8.8")).toBe(false);
+    expect(isPrivateIp("2606:4700::1")).toBe(false);
+    expect(isPrivateIp("::ffff:8.8.8.8")).toBe(false);
+  });
+
+  it("returns false for non-IP strings (hostnames)", () => {
+    expect(isPrivateIp("example.com")).toBe(false);
+    expect(isPrivateIp("")).toBe(false);
   });
 });
 

--- a/testplanit/lib/utils/ssrf.ts
+++ b/testplanit/lib/utils/ssrf.ts
@@ -13,6 +13,7 @@
 import * as dns from "node:dns/promises";
 import * as https from "node:https";
 import * as http from "node:http";
+import { BlockList, isIP } from "node:net";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -66,60 +67,53 @@ export function getAllowedPrivateHosts(): Set<string> {
 // ─── IP Validation ────────────────────────────────────────────────────────────
 
 /**
- * Returns true if the given IP address is in a private, loopback, link-local,
- * or cloud-metadata range that should never be reached from the public internet.
- *
- * Accepts both IPv4 and IPv6 addresses (as strings). Does NOT accept hostnames —
- * always resolve DNS first and pass the resolved IP address.
+ * Numeric block list of every range that must never be reachable from the
+ * public internet. Using node:net BlockList (rather than string/regex matching)
+ * means IPv4-mapped IPv6 literals (e.g. ::ffff:127.0.0.1, which the WHATWG URL
+ * parser canonicalizes to ::ffff:7f00:1) are unmapped to their embedded IPv4 and
+ * classified correctly — the gap that string-prefix guards miss (GHSA-x7jm-4fpq-5mhm).
+ */
+const PRIVATE_BLOCK = new BlockList();
+PRIVATE_BLOCK.addSubnet("0.0.0.0", 8); // "this" network / unspecified
+PRIVATE_BLOCK.addSubnet("10.0.0.0", 8); // RFC 1918
+PRIVATE_BLOCK.addSubnet("127.0.0.0", 8); // loopback
+PRIVATE_BLOCK.addSubnet("169.254.0.0", 16); // link-local + cloud metadata (169.254.169.254)
+PRIVATE_BLOCK.addSubnet("172.16.0.0", 12); // RFC 1918
+PRIVATE_BLOCK.addSubnet("192.168.0.0", 16); // RFC 1918
+PRIVATE_BLOCK.addSubnet("100.64.0.0", 10); // RFC 6598 CGNAT
+PRIVATE_BLOCK.addAddress("::1", "ipv6"); // IPv6 loopback
+PRIVATE_BLOCK.addAddress("::", "ipv6"); // IPv6 unspecified
+PRIVATE_BLOCK.addSubnet("fc00::", 7, "ipv6"); // IPv6 unique local (fc00::/7 covers fc/fd)
+PRIVATE_BLOCK.addSubnet("fe80::", 10, "ipv6"); // IPv6 link-local
+
+/**
+ * Returns true if the given IP *literal* is in a private, loopback, link-local,
+ * CGNAT, or cloud-metadata range. Handles IPv4, IPv6, and IPv4-mapped IPv6
+ * literals (::ffff:a.b.c.d). Returns false for anything that is not a valid IP
+ * literal (e.g. a hostname) — resolve DNS first and pass the resolved address.
+ */
+export function isPrivateIp(ip: string): boolean {
+  // Tolerate bracketed IPv6 literals ("[::1]") that some callers pass through.
+  const stripped = ip.replace(/^\[|\]$/g, "");
+  const family = isIP(stripped);
+  if (family === 0) return false;
+  // IPv4-mapped IPv6: BlockList unmaps the embedded IPv4 when checked as "ipv4".
+  if (family === 6 && PRIVATE_BLOCK.check(stripped, "ipv4")) return true;
+  return PRIVATE_BLOCK.check(stripped, family === 4 ? "ipv4" : "ipv6");
+}
+
+/**
+ * Returns true if the given address is in a private/internal IP range OR is a
+ * known internal DNS name (cloud metadata). Accepts IPv4/IPv6/IPv4-mapped IPv6
+ * literals. The name checks are defensive — callers should resolve DNS first and
+ * pass the resolved IP address.
  */
 export function isPrivateOrInternalIp(ip: string): boolean {
-  const lower = ip.toLowerCase();
-
-  // IPv4 exact matches
-  if (lower === "127.0.0.1" || lower === "0.0.0.0") {
-    return true;
-  }
-
-  // IPv6 loopback and link-local
-  if (lower === "::1" || lower === "[::1]") {
-    return true;
-  }
-
-  // IPv6 link-local (fe80::/10)
-  if (lower.startsWith("fe80:")) {
-    return true;
-  }
-
-  // IPv6 Unique Local Addresses (fc00::/7 covers both fc00:: and fd00::)
-  if (lower.startsWith("fc") || lower.startsWith("fd")) {
-    return true;
-  }
+  if (isPrivateIp(ip)) return true;
 
   // Cloud metadata and internal DNS names
-  if (
-    lower === "169.254.169.254" ||
-    lower === "metadata.google.internal" ||
-    lower.endsWith(".internal")
-  ) {
-    return true;
-  }
-
-  // Private IPv4 ranges (RFC 1918 + loopback + link-local)
-  const privatePatterns = [
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
-    /^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/,
-    /^192\.168\.\d{1,3}\.\d{1,3}$/,
-    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
-    /^169\.254\.\d{1,3}\.\d{1,3}$/,
-  ];
-
-  for (const pattern of privatePatterns) {
-    if (pattern.test(lower)) {
-      return true;
-    }
-  }
-
-  return false;
+  const lower = ip.toLowerCase();
+  return lower === "metadata.google.internal" || lower.endsWith(".internal");
 }
 
 // ─── SSRF-Safe Fetch ─────────────────────────────────────────────────────────

--- a/testplanit/utils/ssrf.test.ts
+++ b/testplanit/utils/ssrf.test.ts
@@ -10,9 +10,15 @@ vi.mock("node:dns/promises", () => ({
   lookup: mockLookup,
 }));
 
-vi.mock("~/lib/utils/ssrf", () => ({
-  getAllowedPrivateHosts: mockGetAllowedPrivateHosts,
-}));
+// Keep the real isPrivateIp (numeric BlockList classifier) so the guard is
+// exercised end-to-end; only getAllowedPrivateHosts is stubbed per-test.
+vi.mock("~/lib/utils/ssrf", async (importActual) => {
+  const actual = await importActual<typeof import("~/lib/utils/ssrf")>();
+  return {
+    ...actual,
+    getAllowedPrivateHosts: mockGetAllowedPrivateHosts,
+  };
+});
 
 import { assertSsrfSafeResolved, isSsrfSafe } from "./ssrf";
 
@@ -85,6 +91,32 @@ describe("isSsrfSafe", () => {
 
     it("blocks fe80:: (link-local)", () => {
       expect(isSsrfSafe("https://[fe80::1]/api")).toBe(false);
+    });
+  });
+
+  describe("blocks IPv4-mapped IPv6 literals (GHSA-x7jm-4fpq-5mhm)", () => {
+    // new URL() canonicalizes "[::ffff:127.0.0.1]" to "[::ffff:7f00:1]"; the old
+    // string-prefix guard matched neither form and wrongly deemed it public.
+    it("blocks mapped loopback (::ffff:127.0.0.1)", () => {
+      expect(isSsrfSafe("http://[::ffff:127.0.0.1]:9099")).toBe(false);
+    });
+
+    it("blocks mapped loopback in compressed hex form (::ffff:7f00:1)", () => {
+      expect(isSsrfSafe("http://[::ffff:7f00:1]:9099")).toBe(false);
+    });
+
+    it("blocks mapped cloud metadata (::ffff:169.254.169.254)", () => {
+      expect(
+        isSsrfSafe("http://[::ffff:169.254.169.254]/latest/meta-data")
+      ).toBe(false);
+    });
+
+    it("blocks mapped RFC1918 (::ffff:10.0.0.1)", () => {
+      expect(isSsrfSafe("http://[::ffff:10.0.0.1]")).toBe(false);
+    });
+
+    it("still allows a genuine public IPv6 literal", () => {
+      expect(isSsrfSafe("https://[2606:4700::1]/")).toBe(true);
     });
   });
 
@@ -238,6 +270,32 @@ describe("assertSsrfSafeResolved", () => {
     it("skips lookup for IPv6 addresses", async () => {
       await assertSsrfSafeResolved("https://[2606:4700::1]/api");
 
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("blocks IPv4-mapped IPv6 literals without DNS (GHSA-x7jm-4fpq-5mhm)", () => {
+    // Previously any host containing ":" short-circuited to return, so mapped
+    // literals bypassed this re-check entirely. They must now be validated
+    // numerically — no DNS lookup, but a hard block.
+    it("throws for mapped loopback and does not call lookup", async () => {
+      await expect(
+        assertSsrfSafeResolved("http://[::ffff:127.0.0.1]:9099")
+      ).rejects.toThrow("private or internal address");
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it("throws for mapped cloud metadata", async () => {
+      await expect(
+        assertSsrfSafeResolved("http://[::ffff:169.254.169.254]/")
+      ).rejects.toThrow("private or internal address");
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it("allows a public IPv6 literal without DNS", async () => {
+      await expect(
+        assertSsrfSafeResolved("https://[2606:4700::1]/api")
+      ).resolves.not.toThrow();
       expect(mockLookup).not.toHaveBeenCalled();
     });
   });

--- a/testplanit/utils/ssrf.test.ts
+++ b/testplanit/utils/ssrf.test.ts
@@ -20,7 +20,12 @@ vi.mock("~/lib/utils/ssrf", async (importActual) => {
   };
 });
 
-import { assertSsrfSafeResolved, isSsrfSafe } from "./ssrf";
+import { Agent } from "undici";
+import {
+  assertSsrfSafeResolved,
+  createPinnedDispatcher,
+  isSsrfSafe,
+} from "./ssrf";
 
 describe("isSsrfSafe", () => {
   describe("blocks localhost", () => {
@@ -260,6 +265,39 @@ describe("assertSsrfSafeResolved", () => {
     });
   });
 
+  describe("returns the IP to pin the connection to", () => {
+    it("returns the resolved address for a hostname (for pinning)", async () => {
+      mockLookup.mockResolvedValueOnce({ address: "140.82.121.4", family: 4 });
+
+      await expect(
+        assertSsrfSafeResolved("https://github.com/api")
+      ).resolves.toBe("140.82.121.4");
+    });
+
+    it("returns null for a raw IPv4 literal (nothing to pin)", async () => {
+      await expect(
+        assertSsrfSafeResolved("https://140.82.121.4/api")
+      ).resolves.toBeNull();
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it("returns null for a public IPv6 literal", async () => {
+      await expect(
+        assertSsrfSafeResolved("https://[2606:4700::1]/api")
+      ).resolves.toBeNull();
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it("returns null for an allowlisted host (operator opt-in)", async () => {
+      mockGetAllowedPrivateHosts.mockReturnValueOnce(new Set(["gitea.local"]));
+
+      await expect(
+        assertSsrfSafeResolved("http://gitea.local:3000/api")
+      ).resolves.toBeNull();
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+  });
+
   describe("skips DNS lookup for raw IPs", () => {
     it("skips lookup for IPv4 addresses", async () => {
       await assertSsrfSafeResolved("https://140.82.121.4/api");
@@ -339,5 +377,20 @@ describe("assertSsrfSafeResolved", () => {
 
       expect(mockLookup).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("createPinnedDispatcher", () => {
+  it("returns an undici dispatcher that closes cleanly", async () => {
+    const dispatcher = createPinnedDispatcher("140.82.121.4");
+    expect(dispatcher).toBeInstanceOf(Agent);
+    // Fire-and-forget close must resolve (callers do not await it).
+    await expect(dispatcher.close()).resolves.not.toThrow();
+  });
+
+  it("accepts IPv6 addresses without throwing", async () => {
+    const dispatcher = createPinnedDispatcher("2606:4700::1");
+    expect(dispatcher).toBeInstanceOf(Agent);
+    await dispatcher.close();
   });
 });

--- a/testplanit/utils/ssrf.ts
+++ b/testplanit/utils/ssrf.ts
@@ -1,5 +1,6 @@
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import { Agent } from "undici";
 import { getAllowedPrivateHosts, isPrivateIp } from "~/lib/utils/ssrf";
 
 /**
@@ -42,44 +43,85 @@ export function isSsrfSafe(url: string, allowedHosts?: Set<string>): boolean {
  * This closes the DNS rebinding gap where a public hostname resolves to a
  * private/internal IP address.
  *
- * Call this immediately before fetch() to minimize the TOCTOU window.
+ * Call this immediately before fetch(). Returns the validated IP address the
+ * caller should pin the connection to (via {@link createPinnedDispatcher}) so
+ * fetch() cannot independently re-resolve the hostname to a different, private
+ * address — closing the DNS-rebinding TOCTOU. Returns null when there is nothing
+ * to pin: an allowlisted host, or a raw IP literal (no DNS lookup happens, so
+ * there is no rebinding window).
+ *
  * Throws if the resolved address is private or the hostname cannot be resolved.
  */
 export async function assertSsrfSafeResolved(
   url: string,
   allowedHosts?: Set<string>
-): Promise<void> {
+): Promise<string | null> {
   const parsed = new URL(url);
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
 
   // If this hostname is in the operator allowlist, skip all private-IP checks
   const allowed = allowedHosts ?? getAllowedPrivateHosts();
   if (allowed.has(hostname.toLowerCase())) {
-    return;
+    return null;
   }
 
   // For a raw IP literal (IPv4, IPv6, or IPv4-mapped IPv6) there is no DNS to
   // resolve — validate the literal numerically instead of skipping it. Skipping
   // any host containing ":" is what let IPv4-mapped IPv6 literals bypass this
-  // re-check (GHSA-x7jm-4fpq-5mhm).
+  // re-check (GHSA-x7jm-4fpq-5mhm). No DNS lookup means no rebinding window, so
+  // there is nothing to pin.
   if (isIP(hostname) !== 0) {
     if (isPrivateIp(hostname)) {
       throw new Error(
         "Request blocked: hostname resolves to a private or internal address"
       );
     }
-    return;
+    return null;
   }
 
+  let address: string;
   try {
-    const { address } = await lookup(hostname);
-    if (isPrivateIp(address)) {
-      throw new Error(
-        "Request blocked: hostname resolves to a private or internal address"
-      );
-    }
+    ({ address } = await lookup(hostname));
   } catch (err: any) {
-    if (err.message?.includes("Request blocked")) throw err;
     throw new Error(`DNS resolution failed for ${hostname}: ${err.message}`);
   }
+
+  if (isPrivateIp(address)) {
+    throw new Error(
+      "Request blocked: hostname resolves to a private or internal address"
+    );
+  }
+
+  return address;
+}
+
+/**
+ * Build an undici dispatcher that pins every connection to a single
+ * pre-validated IP address, regardless of what DNS would otherwise return. Pass
+ * it to fetch() as the `dispatcher` option so the socket connects to exactly the
+ * address {@link assertSsrfSafeResolved} validated — the TCP connection can no
+ * longer race a DNS rebind to an internal host. The URL's hostname is still used
+ * for the Host header and TLS SNI, so certificate validation is unaffected.
+ *
+ * Create one per request and close it (fire-and-forget is fine — undici keeps an
+ * in-flight response alive until its body is consumed).
+ */
+export function createPinnedDispatcher(ip: string): Agent {
+  const family = isIP(ip) === 6 ? 6 : 4;
+  // undici invokes lookup with the node dns.lookup signature. Handle both the
+  // legacy (err, address, family) callback and the { all: true } array shape.
+  const lookupFn = (
+    _hostname: string,
+    options: Record<string, unknown>,
+    cb: (...args: unknown[]) => void
+  ) => {
+    if (options && options.all) {
+      cb(null, [{ address: ip, family }]);
+    } else {
+      cb(null, ip, family);
+    }
+  };
+  return new Agent({
+    connect: { lookup: lookupFn } as Record<string, unknown>,
+  } as ConstructorParameters<typeof Agent>[0]);
 }

--- a/testplanit/utils/ssrf.ts
+++ b/testplanit/utils/ssrf.ts
@@ -1,30 +1,6 @@
 import { lookup } from "node:dns/promises";
-import { getAllowedPrivateHosts } from "~/lib/utils/ssrf";
-
-// Private IP ranges that must be blocked to prevent SSRF attacks
-const PRIVATE_RANGES: RegExp[] = [
-  // IPv4 loopback
-  /^127\./,
-  // RFC 1918 private ranges
-  /^10\./,
-  /^172\.(1[6-9]|2[0-9]|3[01])\./,
-  /^192\.168\./,
-  // AWS metadata / link-local
-  /^169\.254\./,
-  // "This" network
-  /^0\./,
-  // IPv6 loopback
-  /^::1$/,
-  // IPv6 unique local
-  /^fc/i,
-  /^fd/i,
-  // IPv6 link-local
-  /^fe80:/i,
-];
-
-function isPrivateIp(ip: string): boolean {
-  return PRIVATE_RANGES.some((r) => r.test(ip));
-}
+import { isIP } from "node:net";
+import { getAllowedPrivateHosts, isPrivateIp } from "~/lib/utils/ssrf";
 
 /**
  * Returns true if the URL is safe to make a server-side request to.
@@ -82,8 +58,16 @@ export async function assertSsrfSafeResolved(
     return;
   }
 
-  // Skip DNS lookup for raw IP addresses — already checked by isSsrfSafe()
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(":")) {
+  // For a raw IP literal (IPv4, IPv6, or IPv4-mapped IPv6) there is no DNS to
+  // resolve — validate the literal numerically instead of skipping it. Skipping
+  // any host containing ":" is what let IPv4-mapped IPv6 literals bypass this
+  // re-check (GHSA-x7jm-4fpq-5mhm).
+  if (isIP(hostname) !== 0) {
+    if (isPrivateIp(hostname)) {
+      throw new Error(
+        "Request blocked: hostname resolves to a private or internal address"
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
## Description

Hardens the server-side SSRF guard used by the code-repository integration
(`utils/ssrf.ts`) against two related weaknesses.

**1. IPv4-mapped IPv6 bypass.** The guard classified hosts by string/regex
matching, which did not recognize IPv4-mapped IPv6 literals. Because `new URL()`
canonicalizes a bracketed mapped literal like `[::ffff:127.0.0.1]` to
`[::ffff:7f00:1]`, the address matched no private-range pattern and was treated
as public — letting an authenticated admin point a code-repository integration
at loopback, RFC1918, CGNAT, and the `169.254.169.254` cloud-metadata endpoint.
Hosts are now classified numerically with `node:net` `BlockList`, which unmaps
the embedded IPv4 and blocks it. The two previously divergent guards
(`utils/ssrf.ts` and `lib/utils/ssrf.ts`) — both of which had the hole — now
share one `isPrivateIp` implementation, and the DNS re-check no longer skips any
host containing `:`.

**2. DNS-rebinding TOCTOU.** The pre-fetch check resolved the hostname and then
`fetch()` re-resolved it independently, leaving a window to rebind a public name
to a private address between check and connect. The outbound connection is now
pinned to the exact validated IP via a per-request undici dispatcher, so the
socket cannot connect anywhere other than the address that was checked. The URL
hostname is still used for the `Host` header and TLS SNI, so certificate
validation is unaffected. The GitLab `listAllFiles` pagination path, which
bypassed the base request helper and was missing the resolve-time re-check
entirely, now performs it too.

No behavior change for legitimate public or operator-allowlisted hosts.

## Related Issue

Security advisory GHSA-x7jm-4fpq-5mhm.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [x] Manual testing

Added regression tests covering the mapped-literal forms
(`[::ffff:127.0.0.1]`, `[::ffff:169.254.169.254]`, `[::ffff:10.0.0.1]`), CGNAT,
bracketed literals, and the pin-target return contract, plus public-address
negative controls to guard against false positives. All GitHub/GitLab/Gitea/
Bitbucket adapter suites pass unchanged. Full `precommit` (lint, format,
~9.7k-test suite, docs build) green. The connection pinning was verified
end-to-end against the real exported factory: a non-resolvable hostname was
forced onto loopback while the original hostname was preserved for TLS/SNI.

**Test Configuration:**
- OS: macOS (darwin)
- Browser (if applicable): n/a
- Node version: 24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)
