### PR TITLE
enhancement(auth): enter an existing sign-in code from the Magic Link dialog

### DIFF
--- a/testplanit/app/[locale]/signin/page.tsx
+++ b/testplanit/app/[locale]/signin/page.tsx
@@ -105,6 +105,10 @@ const Signin: NextPage = () => {
   const [passwordlessCode, setPasswordlessCode] = useState("");
   const [isVerifyingCode, setIsVerifyingCode] = useState(false);
   const [passwordlessError, setPasswordlessError] = useState("");
+  // "Already have a code?" mode: code entry without client-side pending
+  // state. The HttpOnly verifier cookie identifies the pending sign-in
+  // server-side, so this works even after the dialog was closed and reopened.
+  const [showCodeEntry, setShowCodeEntry] = useState(false);
   const [adminEmail, setAdminEmail] = useState<string | null>(null);
   const [sessionCleared, setSessionCleared] = useState(false);
   // 2FA state
@@ -453,16 +457,19 @@ const Signin: NextPage = () => {
   }
 
   async function handleVerifyPasswordlessCode() {
-    if (!passwordlessPendingId || isVerifyingCode) return;
+    if (isVerifyingCode) return;
     const code = passwordlessCode.replace(/[\s-]/g, "");
     if (code.length < 8) return;
 
     setIsVerifyingCode(true);
     setPasswordlessError("");
 
+    // pendingId is optional: without it the server resolves the pending
+    // sign-in from this browser's verifier cookie ("Already have a code?"
+    // after the dialog was closed).
     const result = await signIn("passwordless-complete", {
       redirect: false,
-      pendingId: passwordlessPendingId,
+      ...(passwordlessPendingId ? { pendingId: passwordlessPendingId } : {}),
       code,
     });
 
@@ -511,6 +518,71 @@ const Signin: NextPage = () => {
     return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [magicLinkSent, passwordlessPendingId]);
+
+  // Shared relay-code entry (error + OTP slots + verify button), used by both
+  // the post-request waiting view and the standalone "Already have a code?"
+  // view.
+  const passwordlessCodeEntry = (
+    <>
+      {passwordlessError && (
+        <div className="p-3 bg-destructive/10 border border-destructive rounded-md">
+          <p className="text-sm text-destructive text-center">
+            {passwordlessError}
+          </p>
+        </div>
+      )}
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {t("auth.signin.passwordless.codeLabel")}
+        </label>
+        <div className="flex justify-center">
+          <InputOTP
+            maxLength={8}
+            value={passwordlessCode}
+            onChange={(value) => setPasswordlessCode(value.toUpperCase())}
+            onComplete={() => void handleVerifyPasswordlessCode()}
+            pattern="^[a-zA-Z0-9]*$"
+            pasteTransformer={(pasted) => pasted.replace(/[\s-]/g, "")}
+            autoComplete="one-time-code"
+            disabled={isVerifyingCode}
+            data-testid="passwordless-code-input"
+          >
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+              <InputOTPSlot index={3} />
+            </InputOTPGroup>
+            <InputOTPSeparator />
+            <InputOTPGroup>
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+              <InputOTPSlot index={6} />
+              <InputOTPSlot index={7} />
+            </InputOTPGroup>
+          </InputOTP>
+        </div>
+      </div>
+      <Button
+        type="button"
+        className="w-full"
+        onClick={handleVerifyPasswordlessCode}
+        disabled={
+          isVerifyingCode || passwordlessCode.replace(/[\s-]/g, "").length < 8
+        }
+        data-testid="passwordless-verify-code-button"
+      >
+        {isVerifyingCode ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("auth.signin.passwordless.verifying")}
+          </>
+        ) : (
+          t("auth.signin.passwordless.verifyCode")
+        )}
+      </Button>
+    </>
+  );
 
   return (
     <div className="flex items-center justify-center">
@@ -762,6 +834,7 @@ const Signin: NextPage = () => {
             setPasswordlessCode("");
             setPasswordlessError("");
             setIsVerifyingCode(false);
+            setShowCodeEntry(false);
           }
         }}
       >
@@ -773,7 +846,44 @@ const Signin: NextPage = () => {
             </DialogDescription>
           </DialogHeader>
 
-          {!magicLinkSent ? (
+          {!magicLinkSent && showCodeEntry ? (
+            <>
+              <div className="py-4 space-y-3">
+                <p className="text-sm text-muted-foreground text-center">
+                  {t("auth.signin.passwordless.codeEntryDescription")}
+                </p>
+                {passwordlessCodeEntry}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCodeEntry(false);
+                    setPasswordlessCode("");
+                    setPasswordlessError("");
+                  }}
+                  className="text-xs text-primary hover:underline w-full text-center"
+                >
+                  {t("auth.signin.passwordless.backToRequest")}
+                </button>
+              </div>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => {
+                    setShowMagicLinkInput(false);
+                    magicLinkForm.reset();
+                    setPasswordlessCode("");
+                    setPasswordlessError("");
+                    setShowCodeEntry(false);
+                  }}
+                  disabled={isVerifyingCode}
+                >
+                  {t("common.actions.close")}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : !magicLinkSent ? (
             <Form {...magicLinkForm}>
               <form
                 onSubmit={magicLinkForm.handleSubmit(handleSendMagicLink)}
@@ -806,6 +916,17 @@ const Signin: NextPage = () => {
                     </FormItem>
                   )}
                 />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCodeEntry(true);
+                    setPasswordlessError("");
+                  }}
+                  className="text-xs text-primary hover:underline w-full text-center"
+                  data-testid="passwordless-have-code-button"
+                >
+                  {t("auth.signin.passwordless.haveCode")}
+                </button>
                 <DialogFooter>
                   <Button
                     type="button"
@@ -850,68 +971,7 @@ const Signin: NextPage = () => {
                     <p className="text-sm text-muted-foreground text-center">
                       {t("auth.signin.passwordless.waitingInstructions")}
                     </p>
-                    {passwordlessError && (
-                      <div className="p-3 bg-destructive/10 border border-destructive rounded-md">
-                        <p className="text-sm text-destructive text-center">
-                          {passwordlessError}
-                        </p>
-                      </div>
-                    )}
-                    <div className="space-y-2">
-                      <label className="text-sm font-medium">
-                        {t("auth.signin.passwordless.codeLabel")}
-                      </label>
-                      <div className="flex justify-center">
-                        <InputOTP
-                          maxLength={8}
-                          value={passwordlessCode}
-                          onChange={(value) =>
-                            setPasswordlessCode(value.toUpperCase())
-                          }
-                          onComplete={() => void handleVerifyPasswordlessCode()}
-                          pattern="^[a-zA-Z0-9]*$"
-                          pasteTransformer={(pasted) =>
-                            pasted.replace(/[\s-]/g, "")
-                          }
-                          autoComplete="one-time-code"
-                          disabled={isVerifyingCode}
-                          data-testid="passwordless-code-input"
-                        >
-                          <InputOTPGroup>
-                            <InputOTPSlot index={0} />
-                            <InputOTPSlot index={1} />
-                            <InputOTPSlot index={2} />
-                            <InputOTPSlot index={3} />
-                          </InputOTPGroup>
-                          <InputOTPSeparator />
-                          <InputOTPGroup>
-                            <InputOTPSlot index={4} />
-                            <InputOTPSlot index={5} />
-                            <InputOTPSlot index={6} />
-                            <InputOTPSlot index={7} />
-                          </InputOTPGroup>
-                        </InputOTP>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      className="w-full"
-                      onClick={handleVerifyPasswordlessCode}
-                      disabled={
-                        isVerifyingCode ||
-                        passwordlessCode.replace(/[\s-]/g, "").length < 8
-                      }
-                      data-testid="passwordless-verify-code-button"
-                    >
-                      {isVerifyingCode ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          {t("auth.signin.passwordless.verifying")}
-                        </>
-                      ) : (
-                        t("auth.signin.passwordless.verifyCode")
-                      )}
-                    </Button>
+                    {passwordlessCodeEntry}
                   </div>
                 )}
               </div>
@@ -926,6 +986,7 @@ const Signin: NextPage = () => {
                     setPasswordlessPendingId(null);
                     setPasswordlessCode("");
                     setPasswordlessError("");
+                    setShowCodeEntry(false);
                   }}
                   className="w-full"
                 >

--- a/testplanit/lib/passwordless.test.ts
+++ b/testplanit/lib/passwordless.test.ts
@@ -508,6 +508,40 @@ describe("authorizePasswordlessComplete (NextAuth provider)", () => {
     expect(rows.get(created.id)!.status).toBe("PENDING");
   });
 
+  it("derives the pending sign-in from the cookie when pendingId is omitted", async () => {
+    // "Already have a code?": the dialog was closed and reopened, losing its
+    // client-side pendingId — the verifier cookie alone must suffice.
+    const { db, rows } = makeFakeDb();
+    const created = await createPendingAuth(db, { email: "a@example.com" });
+    db.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "a@example.com",
+      name: "Alice",
+      isActive: true,
+    });
+
+    const authorize = authorizePasswordlessComplete(db);
+    const user = await authorize(
+      { code: created.code },
+      makeReq(encodeVerifierCookie(created.id, created.verifier))
+    );
+    expect(user).toEqual({
+      id: "user-1",
+      email: "a@example.com",
+      name: "Alice",
+    });
+    expect(rows.get(created.id)!.status).toBe("CONSUMED");
+  });
+
+  it("fails code-only completion without a verifier cookie", async () => {
+    const { db } = makeFakeDb();
+    const created = await createPendingAuth(db, { email: "a@example.com" });
+    const authorize = authorizePasswordlessComplete(db);
+    await expect(authorize({ code: created.code }, makeReq())).rejects.toThrow(
+      "PASSWORDLESS_NO_VERIFIER"
+    );
+  });
+
   it("fails when the cookie belongs to a different pending sign-in", async () => {
     const { db } = makeFakeDb();
     const created = await createPendingAuth(db, { email: "a@example.com" });

--- a/testplanit/lib/passwordless.ts
+++ b/testplanit/lib/passwordless.ts
@@ -510,19 +510,27 @@ export function authorizePasswordlessComplete(prisma: PendingAuthDb) {
   ): Promise<{ id: string; email: string; name: string | null } | null> => {
     if (!isPasswordlessDeviceBoundEnabled()) return null;
 
-    const pendingId = credentials?.pendingId;
-    if (!pendingId || (!credentials?.linkToken && !credentials?.code)) {
+    if (!credentials?.linkToken && !credentials?.code) {
       throw new Error(PASSWORDLESS_ERRORS.invalid);
     }
 
     const cookieHeader =
       typeof req?.headers?.cookie === "string" ? req.headers.cookie : null;
     const bound = parseVerifierFromCookieHeader(cookieHeader);
-    if (!bound || bound.pendingId !== pendingId) {
+    if (
+      !bound ||
+      (credentials.pendingId && bound.pendingId !== credentials.pendingId)
+    ) {
       // Original window lost its cookie (or a foreign browser is posting):
       // the UI tells the user to request a fresh link.
       throw new Error(PASSWORDLESS_ERRORS.no_verifier);
     }
+
+    // pendingId may be omitted (e.g. the sign-in dialog was closed and
+    // reopened, losing its client state): the verifier cookie already names
+    // the one pending sign-in this browser requested, so fall back to it.
+    // When the client does send an id it must match the cookie's.
+    const pendingId = credentials.pendingId || bound.pendingId;
 
     const result = await consumePendingAuth(prisma, {
       pendingId,

--- a/testplanit/messages/de-DE.json
+++ b/testplanit/messages/de-DE.json
@@ -418,7 +418,7 @@
       }
     },
     "filter": {
-      "placeholder": "Filter {item}..."
+      "placeholder": "{item} filtern..."
     },
     "access": {
       "admin": "Administrator",
@@ -1072,7 +1072,7 @@
         "apple": "Weiter mit Apple",
         "microsoft": "Mit Microsoft fortfahren",
         "samlProvider": "Melden Sie sich mit {name}an.",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Mit einmalig verwendbarem Magic Link anmelden",
         "emailLogin": "Mit der E-Mail fortfahren"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Zurück zur Anmeldeseite"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Klicken Sie auf den Link in der E-Mail, um sich in diesem Browser anzumelden, oder geben Sie unten den Code aus der E-Mail ein.",
+        "codeLabel": "Anmeldecode",
+        "verifyCode": "Code überprüfen",
+        "verifying": "Überprüfung läuft...",
+        "invalidCode": "Dieser Code ist nicht richtig. Überprüfen Sie die E-Mail und versuchen Sie es erneut.",
+        "codeExpired": "Diese Anmeldeanfrage ist abgelaufen. Fordern Sie einen neuen Link an.",
+        "tooManyAttempts": "Zu viele fehlgeschlagene Versuche. Fordern Sie einen neuen Link an, um es erneut zu versuchen.",
+        "windowLost": "Dieses Fenster kann die Anmeldung nicht mehr abschließen. Fordern Sie einen neuen Link an.",
+        "genericError": "Wir konnten Sie nicht anmelden. Fordern Sie einen neuen Link an und versuchen Sie es erneut.",
+        "tooManyRequests": "Zu viele Anmeldeanfragen. Bitte warten Sie einen Moment und versuchen Sie es erneut.",
+        "haveCode": "Haben Sie bereits einen Anmeldecode?",
+        "codeEntryDescription": "Geben Sie den Code aus Ihrer Anmelde-E-Mail ein. Codes funktionieren nur in dem Browser, in dem Sie den Link angefordert haben.",
+        "backToRequest": "Stattdessen einen neuen Link anfordern"
       },
       "twoFactor": {
         "title": "Zwei-Faktor-Authentifizierung",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Wenden Sie sich an den Systemadministrator."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Sie werden angemeldet...",
+      "completeErrorTitle": "Wir konnten Sie nicht anmelden",
+      "requestNewLink": "Neuen Link anfordern",
+      "codeTitle": "Ihr Anmeldecode",
+      "codeInstructions": "Sie haben den Anmeldelink auf einem anderen Gerät oder Browser geöffnet. Geben Sie diesen Code auf dem Anmeldebildschirm ein, auf dem Sie ihn ursprünglich angefordert haben.",
+      "codeCloseNotice": "Sie können dieses Fenster schließen, sobald Sie den Code eingegeben haben.",
+      "expiredTitle": "Dieser Anmeldelink ist nicht mehr gültig",
+      "expiredBody": "Der Link ist möglicherweise abgelaufen oder wurde bereits verwendet. Fordern Sie einen neuen von der Anmeldeseite an — das dauert nur einen Moment."
     },
     "errors": {
       "accessDenied": "Zugriff verweigert. Ihr Konto ist möglicherweise inaktiv oder Sie haben keine Berechtigung zum Anmelden.",
       "configuration": "Es gibt ein Problem mit der Serverkonfiguration.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Dieser Anmeldelink ist abgelaufen oder wurde bereits verwendet. Magic Links können nur einmal verwendet werden — bitte fordern Sie einen neuen an, um sich anzumelden.",
       "invalid2FACode": "Ungültiger Bestätigungscode. Bitte versuchen Sie es erneut.",
       "twoFactorTokenRequired": "Token erforderlich",
       "verificationCodeRequired": "Ein Bestätigungscode ist erforderlich."
@@ -1212,7 +1215,7 @@
       "noProvidersAvailable": "Derzeit sind keine SSO-Anbieter für die Verknüpfung verfügbar.",
       "linkingInfo": "Durch die Verknüpfung eines SSO-Anbieters können Sie sich mit dessen Hilfe anstelle Ihres Passworts anmelden. Ihre bestehenden Kontodaten bleiben davon unberührt.",
       "signInWithGoogle": "Mit Google anmelden",
-      "enterpriseSamlSso": "Enterprise SAML SSO",
+      "enterpriseSamlSso": "Enterprise SAML-SSO",
       "linkProvider": "Linkanbieter",
       "linking": "Verknüpfung...",
       "noProvidersContactAdmin": "Derzeit sind keine SSO-Anbieter verfügbar. Bitte wenden Sie sich an Ihren Administrator."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Die Einträge in der Datenbank bleiben erhalten (sie werden entkoppelt).",
           "switchWarning3": "Ersetzen Sie die aktuelle Problemintegrationskonfiguration durch die neue.",
           "switchWarning4": "Entfernen Sie den für die aktuelle Integration konfigurierten eingehenden Webhook.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Probleme importieren",
+          "importTitle": "Probleme aus {name} importieren",
+          "importDescription": "Rufen Sie Probleme aus diesem verknüpften Projekt in Ihr Projekt ab. Vorhandene Probleme werden nicht dupliziert, und importierte Probleme bleiben durch Synchronisierung aktuell.",
+          "importUpdatedWithin": "Aktualisiert innerhalb",
+          "importLastDays": "Letzte {days} Tage",
+          "importMax": "Maximal zu importieren",
+          "importPreview": "Vorschau",
+          "importPreviewResult": "~{count, plural, one {# Problem} other {# Probleme}} entsprechen diesem Filter. Bis zu {cap} werden importiert.",
+          "importOverCap": "Das überschreitet die Obergrenze von {cap}; nur die {cap} zuletzt aktualisierten werden importiert.",
+          "importStart": "Importieren",
+          "importStarted": "Import gestartet. Probleme werden in Kürze angezeigt.",
+          "importFailed": "Import fehlgeschlagen",
+          "importPreviewFailed": "Übereinstimmungen konnten nicht geschätzt werden"
         },
         "integrationAssigned": "Integration erfolgreich zugewiesen",
         "integrationAssignError": "Fehler beim Zuordnen der Problemintegration zum Projekt",
@@ -1402,10 +1405,10 @@
             "description": "Stellen Sie eine Verbindung zu Azure DevOps her, um Arbeitselemente zu verfolgen."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Verbinden Sie sich mit einer selbst gehosteten Redmine-Instanz zur Problemverfolgung."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Verbinden Sie sich mit einer selbst gehosteten MantisBT-Instanz zur Problemverfolgung."
           }
         }
       },
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook wieder aktiviert",
         "toastReEnableFailed": "Reaktivierung fehlgeschlagen: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Eingehender Redmine-Webhook",
+        "inboundRedmineScopeHint": "Das Plugin redmine_webhook signiert Anfragen nicht, daher ist diese Webhook-URL die Zugangsdaten — behandeln Sie sie als Geheimnis und wechseln Sie sie, falls sie offengelegt wird.",
+        "setupStepsRedmineStep1": "Installieren Sie das Plugin redmine_webhook auf Ihrem Redmine-Server (Redmine verfügt über keine integrierten Webhooks).",
+        "setupStepsRedmineStep2": "Öffnen Sie in Ihrem Redmine-Projekt Einstellungen → Module und aktivieren Sie Webhooks.",
+        "setupStepsRedmineStep3": "Öffnen Sie Einstellungen → Webhooks, fügen Sie die obige URL ein und speichern Sie.",
+        "setupStepsRedmineStep4": "Erstellen oder aktualisieren Sie ein Problem in Redmine; der Status des verknüpften Problems wird hier synchronisiert.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Eingehender MantisBT-Webhook",
+        "inboundMantisbtScopeHint": "Ein MantisBT-Webhook-Plugin signiert Anfragen nicht, daher ist diese Webhook-URL die Zugangsdaten — behandeln Sie sie als Geheimnis und wechseln Sie sie, falls sie offengelegt wird.",
+        "setupStepsMantisbtStep1": "Installieren und aktivieren Sie ein MantisBT-Webhook-Plugin auf Ihrem MantisBT-Server (MantisBT verfügt über keine integrierten Webhooks).",
+        "setupStepsMantisbtStep2": "Wählen Sie in der Plugin-Konfiguration die Ereignisse „Problem erstellt“ und „Problem aktualisiert“ aus.",
+        "setupStepsMantisbtStep3": "Fügen Sie die obige URL als Webhook-Ziel ein und speichern Sie.",
+        "setupStepsMantisbtStep4": "Erstellen oder aktualisieren Sie ein Problem in MantisBT; der Status des verknüpften Problems wird hier synchronisiert."
       },
       "aiModels": {
         "description": "KI-Modelle für die intelligente Generierung und Analyse von Testfällen konfigurieren",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Dateien werden gescannt in {scope}…",
           "scanningFilesCount": "Dateien in {scope}… werden durchsucht ({count, number} gefunden)",
           "filtering": "Anwenden von Filtern auf {count, number} Dateien…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Durch den Anbieter ratenbegrenzt — erneuter Versuch in {seconds, number}s…"
         },
         "cache": {
           "title": "Cache-Einstellungen",
@@ -1913,8 +1916,8 @@
         "networkError": "Netzwerkfehler während der Cache-Aktualisierung",
         "refreshSuccess": "Cache aktualisiert: {fileCount} Dateien ({contentCached} Inhalt zwischengespeichert)",
         "refreshRateLimited": "Cache aktualisiert: {fileCount} Dateien aufgelistet, {contentCached}/{fileCount} Inhalte zwischengespeichert (Rate begrenzt – erneut aktualisieren, um den Vorgang abzuschließen)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Cache aktualisiert: {fileCount} Dateien",
+        "refreshInProgress": "Die Cache-Aktualisierung läuft noch im Hintergrund. Diese Seite wird aktualisiert, sobald sie abgeschlossen ist.",
         "validation": {
           "pathRequired": "Pfad erforderlich",
           "patternRequired": "Ein Schnittmuster ist erforderlich.",
@@ -2006,7 +2009,7 @@
       "cellNotRun": "Ungetestet",
       "cellSummary": "{pass, number} bestanden, {fail, number} fehlgeschlagen, {notRun, number} nicht ausgeführt",
       "popoverTitle": "{count, plural, =1 {# Iteration} other {# Iterationen}}",
-      "iterationUnlabeled": "Iteration #{index, number}",
+      "iterationUnlabeled": "Iteration Nr. {index, number}",
       "popoverInflightHint": "Die während des Fluges aufgezeichneten Iterationen erscheinen hier.",
       "popoverNoTimestamp": "—",
       "filterStatus": "{count, plural, =0 {Status} one {Status (#)} other {Status (#)}}",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Aktivität",
+      "title": "Aktivitätsprotokoll",
+      "description": "Alle für diese Sitzung aufgezeichneten Änderungen."
     },
     "title": "{count, plural, =1 {Sitzung} other {Sitzungen}}",
     "labels": {
@@ -2337,7 +2340,7 @@
         "deleteAvatarConfirm": "Möchten Sie Ihren Eintrag {name} wirklich löschen?",
         "emailDisabledForSso": "Die E-Mail-Adresse kann für SSO-Konten nicht geändert werden. Bitte aktualisieren Sie diese über Ihren Identitätsanbieter.",
         "emailEditableForBoth": "Sie können sich sowohl mit E-Mail/Passwort als auch mit SSO anmelden. Änderungen der E-Mail-Adresse wirken sich nur auf die Passwortauthentifizierung aus.",
-        "linkSsoProvider": "Link SSO Provider",
+        "linkSsoProvider": "SSO-Anbieter verknüpfen",
         "nameDisabledForScim": "Der Name wird von Ihrem Identitätsanbieter über SCIM verwaltet und kann hier nicht geändert werden.",
         "emailDisabledForScim": "Die E-Mail-Verwaltung erfolgt durch Ihren Identitätsanbieter über SCIM und kann hier nicht geändert werden."
       },
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
+        "title": "Audit-Protokoll",
+        "description": "Von diesem Benutzer durchgeführte Aktionen",
+        "noEntries": "Noch keine Aktivität aufgezeichnet.",
+        "loadMore": "Wird geladen",
+        "viewDetails": "Details anzeigen",
+        "columnAction": "Aktion",
+        "columnEntityType": "Typ",
         "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "columnTimestamp": "Zeitstempel",
+        "allActions": "Alle Aktionen",
+        "allTypes": "Alle Typen",
+        "noMatchingEntries": "Keine Einträge entsprechen den ausgewählten Filtern.",
+        "showing": "{loaded} von {total} Einträgen"
       },
       "mentionedComments": {
         "title": "In den Kommentaren erwähnt",
@@ -2510,9 +2513,9 @@
       "historyView": "Testfallverlauf anzeigen"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Aktivität",
+      "title": "Aktivitätsprotokoll",
+      "description": "Alle für diesen Testfall aufgezeichneten Änderungen."
     },
     "fields": {
       "optionNotFound": "Option nicht gefunden",
@@ -2856,7 +2859,7 @@
         "comma": "Komma (,)",
         "semicolon": "Semikolon (;)",
         "colon": "Doppelpunkt (:)",
-        "pipe": "Pipe (|)"
+        "pipe": "Senkrechter Strich (|)"
       },
       "textLongFormat": {
         "label": "Text im Langformat"
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# Paar verknüpft} other {# Paare verknüpft}}",
       "bulkError": "Es sind einige Vorgänge fehlgeschlagen. Bitte versuchen Sie es erneut.",
       "tableHint": "Klicken Sie auf eine Zeile oder auf die Schaltfläche „Vergleichen“, um ein Duplikatpaar zu überprüfen und aufzulösen.",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} vs. {caseB}",
       "comparisonDescription": "Vergleichen Sie diese potenziellen Duplikate und entscheiden Sie, wie Sie sie auflösen möchten.",
       "selectPrimary": "Klicken Sie auf einen Fall, um ihn als primären Fall für die Zusammenführung auszuwählen.",
       "selectedAsPrimary": "Als primär ausgewählt",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Aktivität",
+      "title": "Aktivitätsprotokoll",
+      "description": "Alle für diesen Testlauf aufgezeichneten Änderungen."
     },
     "notFound": "Testlauf nicht gefunden.",
     "add": {
@@ -3561,7 +3564,7 @@
     "imports": {
       "description": "Daten aus externen Testmanagement-Tools in TestPlanIt importieren.",
       "tabs": {
-        "testmoJson": "Testmo JSON"
+        "testmoJson": "Testmo-JSON"
       },
       "testmo": {
         "intro": "Laden Sie einen Testmo-JSON-Export hoch, um dessen Inhalt zu analysieren und Ihre Migrationszuordnung vorzubereiten.",
@@ -3725,7 +3728,7 @@
         "jobLoadFailed": "Der Importauftrag konnte nicht geladen werden.",
         "uploadProgressAnalyzing": "Upload abgeschlossen. Datei wird analysiert…",
         "uploadProgressComplete": "Upload abgeschlossen",
-        "etaLabel": "ETA: {time}",
+        "etaLabel": "Voraussichtliche Fertigstellung: {time}",
         "startImportButton": "Import starten",
         "workflowCreate": {
           "nameLabel": "Workflow-Name",
@@ -4073,7 +4076,7 @@
           "description": "Konfigurieren Sie Ihren SAML-Identitätsanbieter. Diese Details erhalten Sie von Ihrem SAML-IdP.",
           "entryPoint": "SSO-Einstiegspunkt-URL",
           "issuer": "Aussteller (Unternehmens-ID)",
-          "callbackUrl": "ACS (Callback) URL",
+          "callbackUrl": "ACS (Callback)-URL",
           "logoutUrl": "SLO-Abmelde-URL (optional)",
           "entryPointPlaceholder": "https://your-idp.com/sso/saml",
           "issuerPlaceholder": "urn:your-idp:entity-id",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Ja",
       "scimUserLockedTitle": "Der Benutzer wird von SCIM verwaltet.",
       "scimUserLockedDescription": "Name, E-Mail-Adresse und Aktivitätsstatus dieses Benutzers werden von Ihrem Identitätsanbieter verwaltet. Nehmen Sie dort Änderungen vor, um diese hier zu aktualisieren.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Verwaltet durch Gruppenzuordnung",
+      "groupMappingOverrideDescription": "Die Zugriffsebene dieses Benutzers wird durch eine SCIM-Gruppenzuordnung gesteuert und kann bei der nächsten Synchronisierung zurückgesetzt werden.",
+      "groupMappingBadge": "Gruppe zugeordnet"
     },
     "security": {
       "title": "Sicherheit",
@@ -4622,16 +4625,16 @@
         "errorToast": "Token konnte nicht widerrufen werden. {reason}"
       },
       "probe": {
-        "button": "Test SCIM",
+        "button": "SCIM testen",
         "testing": "Testen…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — Token funktioniert mit /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Der SCIM-Endpunkt konnte nicht erreicht werden. Bitte versuchen Sie es erneut."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Standardmäßig zugeordneter Zugriff",
+      "fallbackDefaultDescription": "Zugriffsebene, die Benutzern zugewiesen wird, die durch keine Gruppenzuordnung abgedeckt sind.",
+      "fallbackDefaultLabel": "Standard-Zugriffsebene",
+      "fallbackDefaultSaved": "Standard-Fallback gespeichert"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Verwaltet von SCIM. Verwaltung über die SCIM-Administrationsseite.",
       "scimNameLockedTitle": "Die Gruppe wird von SCIM verwaltet.",
       "scimNameLockedDescription": "Name und Mitglieder dieser Gruppe werden von Ihrem Identitätsanbieter verwaltet. Nehmen Sie dort Änderungen vor, um diese hier zu aktualisieren.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Zugeordneter Zugriff",
+      "mappedAccessLabel": "Zugeordnete Zugriffsebene",
+      "mappedAccessNone": "Keine Zuordnung",
+      "mappedAccessSelect": "Zugriffsebene auswählen...",
+      "downgradeConfirmTitle": "Zugriffsänderung bestätigen",
+      "downgradeConfirmDescription": "Der Zugriff von {count, plural, one {# Benutzer} other {# Benutzern}} würde herabgestuft. Fortfahren?",
+      "downgradeConfirmApplyAnyway": "Trotzdem anwenden",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5026,7 +5029,7 @@
         "configVariants": "Konfigurationsvarianten",
         "repositories": "Repositories",
         "repositoryFolders": "Repository-Ordner",
-        "repositoryCaseLinks": "Repository Case Links",
+        "repositoryCaseLinks": "Repository-Fallverknüpfungen",
         "repositoryCaseVersions": "Repository-Fallversionen",
         "testRunStepResults": "Ergebnisse des Testlaufs",
         "issueConfigs": "Problemkonfigurationen",
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Aktiv",
         "inactive": "Inaktiv",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Autorisierung ausstehend"
       },
       "connectedProjects": "Verbundene Projekte",
       "noIntegrations": "Keine Probleme bei der Integrationskonfiguration",
       "testConnection": "Testverbindung",
       "testSuccess": "Verbindung erfolgreich",
       "testSuccessDescription": "Die Problemintegration ist ordnungsgemäß konfiguriert und verbunden.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Zugangsdaten sehen gut aus",
+      "testCredentialsSavedDescription": "Ihre OAuth-Client-ID und Ihr Client-Secret sind gültig. Speichern Sie die Integration und klicken Sie dann auf „Autorisieren“, um Ihr Konto zu verbinden — OAuth 2.0 verbindet pro Benutzer, daher bleibt sie inaktiv, bis mindestens eine Person autorisiert hat.",
       "testFailed": "Verbindung fehlgeschlagen",
       "testFailedDescription": "Verbindung zum externen Dienst konnte nicht hergestellt werden.",
       "testError": "Testfehler",
       "testErrorDescription": "Beim Testen der Verbindung ist ein Fehler aufgetreten.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autorisieren",
+      "reauthorize": "Erneut autorisieren",
+      "authorizeHint": "Autorisieren Sie sich beim Anbieter, um Ihr Konto zu verbinden und die Einrichtung abzuschließen",
+      "syncInProgress": "Verknüpfte Probleme werden erneut synchronisiert...",
+      "syncIntegration": "Verknüpfte Probleme erneut synchronisieren",
+      "syncIntegrationHint": "Synchronisiert nur bereits in TestPlanIt verknüpfte Probleme erneut. Neue Probleme werden nicht aus dem externen Tracker importiert.",
       "syncSuccess": "Synchronisierung in der Warteschlange",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Verknüpfte Probleme von „{name}“ werden im Hintergrund erneut synchronisiert. Dies kann einen Moment dauern. Die Tabelle wird automatisch aktualisiert, sobald der Vorgang abgeschlossen ist.",
       "syncError": "Synchronisierung fehlgeschlagen",
       "syncErrorDescription": "Der Synchronisierungsauftrag für diese Problemintegration konnte nicht in die Warteschlange gestellt werden. Bitte versuchen Sie es später erneut.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Verbinden Sie sich mit einer selbst gehosteten Redmine-Instanz zur Problemverfolgung"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Verbinden Sie sich mit einer selbst gehosteten MantisBT-Instanz zur Problemverfolgung"
         }
       },
       "filterPlaceholder": "Filterintegrationen...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Verwenden Sie stattdessen OAuth 2.0, um eine genaue Zuordnung der Meldungen pro Benutzer ohne Administratorrechte zu gewährleisten.",
         "tokenCreatorNoticeTitle": "Urheber des Problems",
         "tokenCreatorNoticeDescription": "Durch diese Integration erstellte Probleme werden immer dem Konto zugeordnet, dem dieses Zugriffstoken gehört, und nicht dem TestPlanIt-Benutzer, der sie erstellt hat. Die API dieses Anbieters erlaubt es nicht, den Ersteller im Namen eines anderen Benutzers festzulegen.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "Callback-URL (Weiterleitungs-URI)",
+        "callbackUrlDescription": "Registrieren Sie genau diese URL als Callback-/Weiterleitungs-URI in der OAuth-App Ihres Anbieters. Sie muss exakt übereinstimmen, sonst schlägt die Autorisierung fehl.",
+        "callbackUrlCopy": "Kopieren",
+        "callbackUrlCopied": "Kopiert",
         "forgeApiKeyLabel": "Forge API-Schlüssel",
         "forgeApiKeyDescription": "Wird von der Atlassian Forge-App zur Authentifizierung von Anfragen aus Jira-Vorgangspanels verwendet. Generieren Sie hier einen Schlüssel und fügen Sie ihn in die Einstellungen Ihrer Forge-App ein.",
         "forgeApiKeyPlaceholder": "Klicken Sie auf Generieren, um einen API-Schlüssel zu erstellen.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Redmine-API-Schlüssel",
+        "redmineApiKeyPlaceholder": "Geben Sie Ihren Redmine-API-Schlüssel ein",
+        "redmineApiKeyHelp": "Zu finden unter Mein Konto → API-Zugriffsschlüssel (aktivieren Sie die REST-API unter Administration → Einstellungen → API)",
+        "redmineUrl": "Redmine-URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "Die Basis-URL Ihrer Redmine-Instanz",
+        "mantisBTApiKey": "MantisBT-API-Token",
+        "mantisBTApiKeyPlaceholder": "Geben Sie Ihr MantisBT-API-Token ein",
+        "mantisBTApiKeyHelp": "Erstellen Sie eines unter Ihren MantisBT-Kontoeinstellungen → API-Token",
+        "mantisBTUrl": "MantisBT-URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "Die Basis-URL Ihrer MantisBT-Instanz"
       },
       "authType": {
         "api_key": "API-Schlüssel",
@@ -5361,7 +5364,7 @@
         "deploymentName": "Bereitstellungsname",
         "deploymentNamePlaceholder": "Geben Sie den Bereitstellungsnamen ein...",
         "deploymentNameDescription": "Name der Azure OpenAI-Bereitstellung",
-        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, etc.",
+        "defaultModelPlaceholder": "gpt-4o, claude-3-5-sonnet-20241022, usw.",
         "defaultModelDescription": "Das standardmäßig zu verwendende Modell",
         "maxTokensPerRequest": "Maximale Anzahl an Token pro Anfrage",
         "maxRequestsPerMinute": "Maximale Anfragen pro Minute",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Testfälle aus URL generieren (Anforderungen)",
         "generate_from_url_app": "Testfälle aus URL generieren (Anwendungstests)",
         "automation_candidates": "Bericht über Automatisierungskandidaten",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "KI-Schrittableitung"
       }
     },
     "elasticsearch": {
@@ -5577,7 +5580,7 @@
         "repo-cache": "Repository-Cache",
         "copy-move": "Kopieren & Verschieben",
         "duplicate-scan": "Duplikatscan",
-        "magic-select": "Magic Select",
+        "magic-select": "Magische Auswahl",
         "step-scan": "Schrittsequenz-Scan"
       },
       "status": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Systemweites Prüfprotokoll zur Überwachung von Sicherheit und Compliance anzeigen",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Zeigen Sie den Audit-Trail der in diesem Projekt durchgeführten Aktionen an.",
       "filterPlaceholder": "Suche nach Entität, Benutzer oder Aktion...",
       "filterAction": "Aktion",
       "filterEntityType": "Entitätstyp",
       "allActions": "Alle Aktionen",
       "allEntityTypes": "Alle Entitätstypen",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Alle Benutzer",
+      "allProjects": "Alle Projekte",
+      "showing": "{loaded} von {total} Einträgen werden angezeigt",
       "viewDetails": "Details anzeigen",
       "detailTitle": "Details zum Audit-Protokoll",
       "userInfo": "Benutzerinformationen",
@@ -5714,8 +5717,8 @@
       "systemActor": "System",
       "systemActorTooltip": "Die Aktion wurde vom System und nicht von einem angemeldeten Benutzer ausgeführt.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "zugehörige Änderungen",
+      "groupedEntry": "Gruppierte Änderungen aus einer einzelnen Aktion"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "wartet noch auf Ihre Bewertung von",
         "reviewReminderEmailMessage": "Zur Erinnerung: Die Überprüfungsanfrage von {actorName}am {entityLabel} \"{entityName}\" im Projekt \"{projectName}\" ist seit {hoursPending} Stunden ausstehend.",
         "reviewReminderHoursPending": "Ausstehend für {hoursPending, plural, one {# Stunde} other {# Stunden}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "KI-abgeleitete Testschritte bereit",
+        "aiStepsDerivedMessage": "{count, plural, one {# Testfall wurde} other {# Testfälle wurden}} mit KI-abgeleiteten Schritten versehen — auf Richtigkeit prüfen.",
+        "aiStepsDerivedReviewLink": "Testlauf überprüfen"
       }
     },
     "issues": {
@@ -6033,7 +6036,7 @@
     "durationRange": "Dauer: {from}s - {to}s",
     "seconds": "{seconds}s",
     "testCases": "{count, plural, one {# Testfall} other {# Testfälle}}",
-    "estimate": "Est: {value}",
+    "estimate": "Geschätzt: {value}",
     "partOf": "(Teil von {parent})",
     "status": "Status: {status}"
   },
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Gruppenname\nEin klarer, prägnanter und beschreibender Name oder ein oder mehrere Schlüsselwörter, die in allen Projekten verwendet werden.\n\n– Hilft Teammitgliedern, schnell verwandte Testfälle, Testläufe und Sitzungen zu finden.",
       "users": "## Benutzer\nZeigt die Benutzer an, die dieser Gruppe zugeordnet sind.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Zugeordnete Zugriffsebene\nMitglieder dieser Gruppe erhalten bei der nächsten Synchronisierung mindestens diese Zugriffsebene.\n\n- Die höchste Ebene aller Gruppen eines Benutzers setzt sich durch\n- „Keine Zuordnung“ bedeutet, dass diese Gruppe den Zugriff nicht beeinflusst — Mitglieder greifen auf den auf der SCIM-Seite festgelegten Standard zurück\n- Eine manuelle Zugriffsänderung bei einem Benutzer übernimmt Vorrang vor der Zuordnung (und wird auf dem Bearbeitungsbildschirm dieses Benutzers markiert)"
     },
     "template": {
       "name": "## Template Name\nEin eindeutiger und beschreibender Name für diese Vorlage (z. B. 'Standard Test Case', 'API Test Results').",
@@ -6209,7 +6212,7 @@
       "authType": "## Authentifizierungstyp\nWählen Sie die Authentifizierungsmethode für den externen Dienst.\n\n- **API-Schlüssel:** Einfache Authentifizierung mit E-Mail-Adresse und API-Token\n- **OAuth 2.0:** Sichere Authentifizierung über den OAuth-Flow\n- **Persönliches Zugriffstoken:** Direkte tokenbasierte Authentifizierung",
       "email": "## E-Mail-Adresse\nIhre E-Mail-Adresse für den externen Dienst.\n\n- Wird für die API-Schlüsselauthentifizierung verwendet.\n- Muss mit dem Konto übereinstimmen, das das API-Token generiert hat.\n- Erforderlich für Jira und ähnliche Dienste.",
       "apiToken": "## API-Token\nGenerieren Sie einen API-Token in Ihren Kontoeinstellungen beim externen Dienst.\n\n- Normalerweise zu finden unter Kontoeinstellungen → Sicherheit → API-Tokens\n- Gewährleistet sicheren Zugriff, ohne Ihr Passwort preiszugeben\n- Kann bei Bedarf widerrufen und neu generiert werden",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira-URL\nDie Basis-URL Ihrer Jira-Instanz.\n\n- Format: https://your-site.atlassian.net\n- Fügen Sie nicht /browse oder andere Pfade hinzu\n- Muss von diesem Server aus erreichbar sein",
       "clientId": "## OAuth-Client-ID\nDie Client-ID aus Ihrer OAuth-Anwendungskonfiguration.\n\n- Erstellt in der Entwicklerkonsole des externen Dienstes.\n- Wird verwendet, um Ihre Anwendung während des OAuth-Ablaufs zu identifizieren.\n- Kann sicher in Konfigurationsdateien weitergegeben werden.",
       "clientSecret": "## OAuth-Clientgeheimnis\nDas Clientgeheimnis aus Ihrer OAuth-Anwendungskonfiguration.\n\n- Wird zusammen mit der Client-ID erstellt.\n- Muss vertraulich und sicher aufbewahrt werden.\n- Wird zur Authentifizierung Ihrer Anwendung verwendet.",
       "personalAccessToken": "## Persönliches Zugriffstoken\nEin persönliches Zugriffstoken mit den entsprechenden Berechtigungen für den externen Dienst.\n\n- Wird in Ihren Kontoeinstellungen generiert.\n- Sollte Lese- und Schreibberechtigungen besitzen.\n- Sicherer als die Passwortauthentifizierung.",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## Instanz-URL\nDie Basis-URL Ihrer selbstgehosteten Instanz.\n\n- Format: https://git.example.com\n- Keine abschließenden Schrägstriche oder Pfade einfügen.\n- Muss von diesem Server aus erreichbar sein.",
       "projectPath": "## Projektpfad\nDer vollständige Pfad zu Ihrem GitLab-Projekt.\n\n- Format: Namespace/Projekt oder Gruppe/Untergruppe/Projekt\n- Beispiel: meine-organisation/mein-projekt\n- In der Projekt-URL zu finden: gitlab.com/Namespace/Projekt",
       "platform": "## Plattform\nDie selbstgehostete Git-Plattform, mit der Sie sich verbinden.\n\n- **Gitea**: gitea.io-basierte Instanzen\n- **Forgejo**: forgejo.org-basierte Instanzen (Gitea-Fork)\n- **Gogs**: gogs.io-basierte Instanzen\n\nDies steuert, welches Symbol angezeigt wird und kann die API-Kompatibilität beeinflussen.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine-API-Schlüssel\nIhr persönlicher REST-API-Zugriffsschlüssel.\n\n- Aktivieren Sie die REST-API unter Administration → Einstellungen → API\n- Kopieren Sie Ihren Schlüssel aus Mein Konto → API-Zugriffsschlüssel\n- Beschränkt auf die Berechtigungen Ihres Benutzers; verwenden Sie für gemeinsam genutzte Integrationen ein Dienstkonto",
+      "redmineUrl": "## Redmine-URL\nDie Basis-URL Ihrer Redmine-Instanz.\n\n- Format: https://redmine.example.com\n- Fügen Sie nicht /issues oder andere Pfade hinzu\n- Muss von diesem Server aus erreichbar sein",
+      "mantisBTApiKey": "## MantisBT-API-Token\nIhr persönliches REST-API-Token.\n\n- Erstellen Sie eines unter Ihren MantisBT-Kontoeinstellungen → API-Token\n- Beschränkt auf die Berechtigungen Ihres Benutzers; verwenden Sie für gemeinsam genutzte Integrationen ein Dienstkonto",
+      "mantisBTUrl": "## MantisBT-URL\nDie Basis-URL Ihrer MantisBT-Instanz.\n\n- Format: https://mantisbt.example.com\n- Fügen Sie nicht /api/rest oder andere Pfade hinzu\n- Muss von diesem Server aus erreichbar sein",
+      "githubBaseUrl": "## API-Basis-URL\nVollständiges GitHub-API-Verzeichnis für GitHub Enterprise Server.\n\n- Endet üblicherweise auf /api/v3\n- Lassen Sie das Feld leer, um api.github.com zu verwenden\n- Muss von diesem Server aus erreichbar sein"
     },
     "config": {
       "name": "## Konfigurationsname\nEin klarer, beschreibender Name für diese Konfiguration.\n\n- Hilft dabei, die verschiedenen Kombinationen zu beschreiben, aus denen die Konfiguration besteht (z. B. \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\" usw.).",
@@ -6602,7 +6605,7 @@
           "content": "Konfigurieren Sie KI-Modelle und -Einstellungen für die automatisierte Testfallgenerierung und intelligente Funktionen. Verwalten Sie API-Schlüssel und Modellpräferenzen."
         },
         "sso": {
-          "title": "Single Sign-On",
+          "title": "Einmalanmeldung",
           "content": "Konfigurieren Sie SSO-Anbieter und Authentifizierungsmethoden. Richten Sie SAML-, OAuth- und andere Identitätsanbieterintegrationen für einen nahtlosen Benutzerzugriff ein."
         },
         "appConfig": {
@@ -6716,7 +6719,7 @@
       "addDimension": "Dimension hinzufügen...",
       "addMetric": "Metrik hinzufügen...",
       "runReport": "Laufbericht",
-      "exportCsv": "Export CSV",
+      "exportCsv": "CSV exportieren",
       "noResultsFound": "Keine Ergebnisse gefunden.",
       "selectAtLeastOneDimensionAndMetric": "Wählen Sie mindestens eine Dimension und eine Metrik aus.",
       "noDataMatchingCriteria": "Es wurden keine Daten gefunden, die den ausgewählten Dimensionen und Metriken entsprechen.",
@@ -6861,7 +6864,7 @@
           "highPriority": "Aufmerksamkeit erforderlich",
           "lowPriority": "Niedrigere Priorität",
           "recencyAxis": "Ausfall Aktualität",
-          "flipsAxis": "Flip Count",
+          "flipsAxis": "Anzahl der Wechsel",
           "oldFailures": "Älter",
           "recentFailures": "Jüngste",
           "failureRate": "Ausfallrate",
@@ -6951,7 +6954,7 @@
           "executions": "{count} läuft",
           "forecast": "{value} Prognose",
           "forecastUnset": "Keine Prognose",
-          "flakiness": "Flips {value}%",
+          "flakiness": "Wechselt {value}%",
           "flakinessUnset": "Keine Flip-Daten",
           "createdLabel": "Erstellt"
         },
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours} Std. {minutes} Min"
           },
           "relativeAge": {
             "today": "Heute",
@@ -7441,7 +7444,7 @@
         "selectedFile": "Ausgewählte Datei",
         "delimiter": "Feldtrennzeichen",
         "delimiters": {
-          "tab": "Tab (\\t)"
+          "tab": "Tabulator (\\t)"
         },
         "hasHeaders": "Die erste Zeile enthält die Spaltenüberschriften.",
         "encoding": "Dateikodierung",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Suchen",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
+      "title": "Gespeicherte Suchen",
+      "save": "Suche speichern",
+      "saveTitle": "Suche speichern",
+      "saveDescription": "Benennen Sie diese Suche, damit Sie sie später wiederfinden können.",
+      "saveAction": "Speichern",
       "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "namePlaceholder": "z. B. Fehlgeschlagene Testläufe in diesem Sprint",
+      "nameRequired": "Geben Sie einen Namen für diese Suche ein.",
+      "loginRequired": "Sie müssen angemeldet sein, um Suchen zu speichern.",
       "descriptionLabel": "Beschreibung (optional)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "Wofür diese Suche gedacht ist",
+      "saved": "Suche gespeichert",
+      "savedDescription": "„{name}“ befindet sich jetzt in Ihren gespeicherten Suchen.",
+      "saveFailed": "Die Suche konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+      "empty": "Noch keine gespeicherten Suchen",
+      "emptyHint": "Speichern Sie eine Suche, um sie später wiederzufinden.",
+      "loaded": "„{name}“ geladen",
+      "loadFailed": "Diese gespeicherte Suche ist nicht mehr gültig.",
+      "edit": "Bearbeiten",
+      "editTitle": "Gespeicherte Suche bearbeiten",
+      "edited": "Gespeicherte Suche aktualisiert",
+      "editFailed": "Die Suche konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
       "delete": "Löschen",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Gespeicherte Suche löschen?",
+      "deleteConfirm": "„{name}“ wird aus Ihren gespeicherten Suchen entfernt. Dies kann nicht rückgängig gemacht werden.",
+      "deleted": "Gespeicherte Suche gelöscht",
+      "deleteFailed": "Die Suche konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
     },
     "bulk": {
       "crossProjectHint": "(über mehrere Projekte hinweg)",
@@ -7697,14 +7700,14 @@
       "intro": "Klicken Sie auf die Schaltfläche unten, um sich anzumelden:",
       "signInButton": "Anmelden",
       "copyPasteIntro": "Oder kopieren Sie diesen Link und fügen Sie ihn in Ihren Browser ein:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Aus Sicherheitsgründen kann dieser Link nur einmal verwendet werden. Fordern Sie einen neuen Link an, wenn Sie sich erneut anmelden müssen.",
       "disclaimer": "Wenn Sie diese E-Mail nicht angefordert haben, können Sie sie getrost ignorieren.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Bei TestPlanIt anmelden\n\nKlicken Sie auf den folgenden Link, um sich anzumelden:\n{url}\n\nAus Sicherheitsgründen kann dieser Link nur einmal verwendet werden. Fordern Sie einen neuen Link an, wenn Sie sich erneut anmelden müssen.\n\nWenn Sie diese E-Mail nicht angefordert haben, können Sie sie ignorieren."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Öffnen Sie dies auf einem anderen Gerät? Geben Sie diesen Code auf dem Anmeldebildschirm ein, auf dem Sie den Link angefordert haben:",
+      "deviceNotice": "Dieser Link meldet Sie in dem Browser an, in dem Sie ihn angefordert haben. Wenn Sie ihn an einem anderen Ort öffnen, wird Ihnen der obige Code angezeigt, den Sie in Ihrem ursprünglichen Fenster eingeben können.",
+      "textBody": "Bei TestPlanIt anmelden\n\nKlicken Sie auf den folgenden Link, um sich anzumelden:\n{url}\n\nÖffnen Sie dies auf einem anderen Gerät? Geben Sie diesen Code auf dem Anmeldebildschirm ein, auf dem Sie den Link angefordert haben: {code}\n\nWenn Sie diese E-Mail nicht angefordert haben, können Sie sie ignorieren."
     }
   },
   "comments": {
@@ -8048,7 +8051,7 @@
     "iterationIssueTitleSnapshot": "Iteration {n} von {total} Problem: {caseName}",
     "iterationIssueTitleCiExtended": "Iteration {n} (CI-extended) Problem: {caseName}",
     "iterationIssueProseSnapshot": "Iteration {n} von {total} auf {label}.",
-    "iterationIssueProseCiExtended": "Iteration {n} (CI-extended) on {label}.",
+    "iterationIssueProseCiExtended": "Iteration {n} (CI-erweitert) auf {label}.",
     "iterationIssueTableHeaderParameter": "Parameter",
     "iterationIssueTableHeaderValue": "Wert",
     "iterationIssueDeepLinkLabel": "Iteration in TestPlanIt anzeigen",
@@ -8078,14 +8081,14 @@
     "overrideUnsavedDiscard": "Änderungen verwerfen",
     "iterationBulkConfirmTitle": "Markiere {count, plural, =1 {# Iteration} other {# Iterationen}} als {action}?",
     "iterationBulkConfirmDescription": "Für jede ausgewählte Iteration wird ein neues Ergebnis mit dem Status \"{statusName} \" ausgegeben.",
-    "iterationBulkConfirm": "Mark {action}",
+    "iterationBulkConfirm": "{action} markieren",
     "iterationBulkConfirmReplace": "Ersetzen Sie durch {action}",
     "iterationBulkOverwriteWarning": "{count, plural, =1 {# der ausgewählten Iterationen haben bereits ein Ergebnis geliefert.} other {# der ausgewählten Iterationen haben bereits ein Ergebnis geliefert.}} Ein neues Ergebnis wird gespeichert und das aktuelle ersetzt.",
     "iterationBulkReasonLabel": "Grund (optional)",
     "iterationBulkReasonHelp": "Wird bei jedem Ergebnis vermerkt.",
     "iterationBulkSuccess": "{count, plural, =1 {# Iteration} other {# Iterationen}} markiert {action}",
     "iterationBulkError": "Iterationen konnten nicht markiert werden",
-    "iterationBulkNa": "Mark N/A",
+    "iterationBulkNa": "N/A markieren",
     "iterationListLoadError": "Iterationen konnten nicht geladen werden.",
     "iterationResetUntestedMissing": "Nicht getesteter Status nicht gefunden",
     "overrideTitle": "Werte für Iteration überschreiben {n}",

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1095,7 +1095,10 @@
         "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
         "windowLost": "This window can no longer complete the sign-in. Request a new link.",
         "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again.",
+        "haveCode": "Already have a sign-in code?",
+        "codeEntryDescription": "Enter the code from your sign-in email. Codes only work in the browser where you requested the link.",
+        "backToRequest": "Request a new link instead"
       },
       "twoFactor": {
         "title": "Two-Factor Authentication",

--- a/testplanit/messages/es-ES.json
+++ b/testplanit/messages/es-ES.json
@@ -1072,7 +1072,7 @@
         "apple": "Continuar con Apple",
         "microsoft": "Continuar con Microsoft",
         "samlProvider": "Iniciar sesión con {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Iniciar sesión con Magic Link de un solo uso",
         "emailLogin": "Continuar con el email"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Volver a iniciar sesión"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Haga clic en el enlace del correo electrónico para iniciar sesión desde este navegador, o introduzca el código del correo electrónico a continuación.",
+        "codeLabel": "Código de inicio de sesión",
+        "verifyCode": "Verificar código",
+        "verifying": "Verificando...",
+        "invalidCode": "Ese código no es correcto. Revise el correo electrónico e inténtelo de nuevo.",
+        "codeExpired": "Esta solicitud de inicio de sesión ha expirado. Solicite un nuevo enlace.",
+        "tooManyAttempts": "Demasiados intentos incorrectos. Solicite un nuevo enlace para intentarlo de nuevo.",
+        "windowLost": "Esta ventana ya no puede completar el inicio de sesión. Solicite un nuevo enlace.",
+        "genericError": "No pudimos iniciar su sesión. Solicite un nuevo enlace e inténtelo de nuevo.",
+        "tooManyRequests": "Demasiadas solicitudes de inicio de sesión. Espere un momento e inténtelo de nuevo.",
+        "haveCode": "¿Ya tiene un código de inicio de sesión?",
+        "codeEntryDescription": "Introduzca el código de su correo electrónico de inicio de sesión. Los códigos solo funcionan en el navegador donde solicitó el enlace.",
+        "backToRequest": "Solicitar un nuevo enlace en su lugar"
       },
       "twoFactor": {
         "title": "Autenticación de dos factores",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Contacte al administrador del sistema"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Iniciando su sesión...",
+      "completeErrorTitle": "No pudimos iniciar su sesión",
+      "requestNewLink": "Solicitar un nuevo enlace",
+      "codeTitle": "Su código de inicio de sesión",
+      "codeInstructions": "Abrió el enlace de inicio de sesión en un dispositivo o navegador diferente. Introduzca este código en la pantalla de inicio de sesión donde lo solicitó originalmente.",
+      "codeCloseNotice": "Puede cerrar esta ventana una vez que haya introducido el código.",
+      "expiredTitle": "Este enlace de inicio de sesión ya no es válido",
+      "expiredBody": "El enlace puede haber expirado o ya haberse utilizado. Solicite uno nuevo desde la página de inicio de sesión; solo toma un momento."
     },
     "errors": {
       "accessDenied": "Acceso denegado. Es posible que tu cuenta esté inactiva o que no tengas permiso para iniciar sesión.",
       "configuration": "Hay un problema con la configuración del servidor.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Este enlace de inicio de sesión ha expirado o ya se utilizó. Los Magic Links solo se pueden usar una vez; solicite uno nuevo para iniciar sesión.",
       "invalid2FACode": "Código de verificación no válido. Inténtalo de nuevo.",
       "twoFactorTokenRequired": "Se requiere token",
       "verificationCodeRequired": "Se requiere un código de verificación."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Conservar los problemas en la base de datos (se desenlazan)",
           "switchWarning3": "Reemplaza la configuración actual de integración de incidencias con la nueva",
           "switchWarning4": "Elimine el webhook entrante configurado para la integración actual.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Importar incidencias",
+          "importTitle": "Importar incidencias de {name}",
+          "importDescription": "Extraiga incidencias de este proyecto vinculado a su proyecto. Las incidencias existentes no se duplican y las incidencias importadas se mantienen actualizadas mediante sincronización.",
+          "importUpdatedWithin": "Actualizado dentro de",
+          "importLastDays": "Últimos {days} días",
+          "importMax": "Máximo a importar",
+          "importPreview": "Vista previa",
+          "importPreviewResult": "{count, plural, one {~# incidencia coincide con este filtro} other {~# incidencias coinciden con este filtro}}. Se importarán hasta {cap}.",
+          "importOverCap": "Eso supera el límite de {cap}; solo se importarán las {cap} más recientemente actualizadas.",
+          "importStart": "Importar",
+          "importStarted": "Importación iniciada. Las incidencias aparecerán en breve.",
+          "importFailed": "Error al importar",
+          "importPreviewFailed": "No se pudieron estimar las coincidencias"
         },
         "integrationAssigned": "Integración asignada correctamente",
         "integrationAssignError": "No se pudo asignar la integración de la incidencia al proyecto",
@@ -1402,10 +1405,10 @@
             "description": "Conéctese a Azure DevOps para el seguimiento de elementos de trabajo."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Conéctese a una instancia autohospedada de Redmine para el seguimiento de incidencias."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Conéctese a una instancia autohospedada de MantisBT para el seguimiento de incidencias."
           }
         }
       },
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook reactivado",
         "toastReEnableFailed": "No se pudo volver a habilitar: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Webhook entrante de Redmine",
+        "inboundRedmineScopeHint": "El complemento redmine_webhook no firma las solicitudes, por lo que esta URL de webhook es la credencial: trátela como un secreto y rótela si se expone.",
+        "setupStepsRedmineStep1": "Instale el complemento redmine_webhook en su servidor Redmine (Redmine no tiene webhooks integrados).",
+        "setupStepsRedmineStep2": "En su proyecto de Redmine, abra Configuración → Módulos y habilite Webhooks.",
+        "setupStepsRedmineStep3": "Abra Configuración → Webhooks, pegue la URL anterior y guarde.",
+        "setupStepsRedmineStep4": "Cree o actualice una incidencia en Redmine; el estado de la incidencia vinculada se sincronizará aquí.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Webhook entrante de MantisBT",
+        "inboundMantisbtScopeHint": "Un complemento de webhook de MantisBT no firma las solicitudes, por lo que esta URL de webhook es la credencial: trátela como un secreto y rótela si se expone.",
+        "setupStepsMantisbtStep1": "Instale y habilite un complemento de webhook de MantisBT en su servidor MantisBT (MantisBT no tiene webhooks integrados).",
+        "setupStepsMantisbtStep2": "En la configuración del complemento, elija los eventos de incidencia creada e incidencia actualizada.",
+        "setupStepsMantisbtStep3": "Pegue la URL anterior como destino del webhook y guarde.",
+        "setupStepsMantisbtStep4": "Cree o actualice una incidencia en MantisBT; el estado de la incidencia vinculada se sincronizará aquí."
       },
       "aiModels": {
         "description": "Configurar modelos IA para generar y analizar casos de prueba inteligentes",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Escaneando archivos en {scope}…",
           "scanningFilesCount": "Escaneando archivos en {scope}… ({count, number} encontrados)",
           "filtering": "Aplicando filtros a los archivos {count, number}…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Limitado por el proveedor — reintentando en {seconds, number}s…"
         },
         "cache": {
           "title": "Configuración de caché",
@@ -1913,8 +1916,8 @@
         "networkError": "Error de red durante la actualización de caché",
         "refreshSuccess": "Caché actualizada: {fileCount} archivos ({contentCached} contenidos almacenados en caché)",
         "refreshRateLimited": "Caché actualizada: {fileCount} archivos listados, {contentCached}/{fileCount} contenidos almacenados en caché (velocidad limitada; actualice nuevamente para completar)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Caché actualizada: {fileCount} archivos",
+        "refreshInProgress": "La actualización de la caché sigue ejecutándose en segundo plano. Se actualizará aquí cuando termine.",
         "validation": {
           "pathRequired": "La ruta es obligatoria",
           "patternRequired": "Se requiere patrón",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Actividad",
+      "title": "Registro de actividad",
+      "description": "Todos los cambios registrados para esta sesión."
     },
     "title": "{count, plural, =1 {Sesión} other {Sesiones}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "Registro de auditoría",
+        "description": "Acciones realizadas por este usuario",
+        "noEntries": "Aún no hay actividad registrada.",
+        "loadMore": "Cargando",
+        "viewDetails": "Ver detalles",
+        "columnAction": "Acción",
+        "columnEntityType": "Tipo",
+        "columnEntityName": "Nombre",
+        "columnTimestamp": "Marca de tiempo",
+        "allActions": "Todas las acciones",
+        "allTypes": "Todos los tipos",
+        "noMatchingEntries": "Ninguna entrada coincide con los filtros seleccionados.",
+        "showing": "{loaded} de {total} entradas"
       },
       "mentionedComments": {
         "title": "Mencionado en los comentarios",
@@ -2510,9 +2513,9 @@
       "historyView": "Ver Historial de Casos de Prueba"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Actividad",
+      "title": "Registro de actividad",
+      "description": "Todos los cambios registrados para este caso de prueba."
     },
     "fields": {
       "optionNotFound": "Opción no encontrada",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Actividad",
+      "title": "Registro de actividad",
+      "description": "Todos los cambios registrados para esta ejecución de prueba."
     },
     "notFound": "No se encontró ejecución de prueba.",
     "add": {
@@ -3534,7 +3537,7 @@
       "junit": "JUnit",
       "datasets": "Conjuntos de datos compartidos",
       "testCaseParameters": "Parámetros del caso de prueba",
-      "llm": "AI Models",
+      "llm": "Modelos de IA",
       "prompts": "Configuraciones de aviso",
       "exportTemplates": "Exportar plantillas",
       "codeRepositories": "Repositorios de código",
@@ -3561,7 +3564,7 @@
     "imports": {
       "description": "Importa datos de herramientas externas de gestión de pruebas a TestPlanIt.",
       "tabs": {
-        "testmoJson": "Testmo JSON"
+        "testmoJson": "JSON de Testmo"
       },
       "testmo": {
         "intro": "Sube una exportación JSON de Testmo para analizar su contenido y preparar tu mapeo de migración.",
@@ -3945,7 +3948,7 @@
           "ssoUrl": "URL SSO (punto de entrada)",
           "entityId": "ID de entidad (emisor)",
           "certificate": "X.509 Certificado",
-          "callbackUrl": "Callback URL",
+          "callbackUrl": "URL de retorno",
           "logoutUrl": "URL de cierre de sesión (opcional)",
           "wantAssertionsSigned": "Requerir afirmaciones firmadas",
           "wantAssertionsSignedDescription": "Rechazar las respuestas cuya aserción SAML no esté firmada. Esto protege la identidad autenticada y debe permanecer habilitado.",
@@ -4073,7 +4076,7 @@
           "description": "Configure su configuración de SAML Identity Provider. Puede obtener estos detalles desde su SAML IdP.",
           "entryPoint": "URL del punto de entrada SSO",
           "issuer": "Emisor (ID de entidad)",
-          "callbackUrl": "ACS (Callback) URL",
+          "callbackUrl": "URL de ACS (Callback)",
           "logoutUrl": "URL de cierre de sesión de SLO (opcional)",
           "entryPointPlaceholder": "https://tu-idp.com/sso/saml",
           "issuerPlaceholder": "urn:su-idp:entity-id",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Sí",
       "scimUserLockedTitle": "El usuario es gestionado por SCIM.",
       "scimUserLockedDescription": "El nombre, el correo electrónico y el estado de actividad de este usuario son gestionados por tu proveedor de identidad. Realiza los cambios necesarios allí para actualizarlos aquí.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Gestionado por Mapeo de grupos",
+      "groupMappingOverrideDescription": "El nivel de acceso de este usuario está regido por un mapeo de grupos SCIM y puede revertirse en la próxima sincronización.",
+      "groupMappingBadge": "Grupo mapeado"
     },
     "security": {
       "title": "Seguridad",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "Prueba SCIM",
         "testing": "Probando…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — el token funciona con /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "No se pudo acceder al punto final SCIM. Reintentando."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Acceso mapeado predeterminado",
+      "fallbackDefaultDescription": "Nivel de acceso asignado a usuarios no cubiertos por ningún mapeo de grupos.",
+      "fallbackDefaultLabel": "Nivel de acceso predeterminado",
+      "fallbackDefaultSaved": "Valor predeterminado de respaldo guardado"
     },
     "tags": {
       "add": {
@@ -4857,7 +4860,7 @@
       "combinations": {
         "title": "Combinaciones",
         "description": "Administrar combinaciones globales",
-        "confirmDescription": "The following {count, number} Configurations will be created:",
+        "confirmDescription": "Se crearán las siguientes {count, number} configuraciones:",
         "addCombination": "Añadir combinación",
         "editCombination": "Editar combinación",
         "selectCombination": "Seleccione combinaciones",
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Gestionado por SCIM. Gestione desde la página de administración de SCIM.",
       "scimNameLockedTitle": "El grupo está gestionado por SCIM.",
       "scimNameLockedDescription": "El nombre y los miembros de este grupo son gestionados por tu proveedor de identidad. Realiza los cambios necesarios allí para actualizarlos aquí.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Acceso mapeado",
+      "mappedAccessLabel": "Nivel de acceso mapeado",
+      "mappedAccessNone": "Sin mapeo",
+      "mappedAccessSelect": "Seleccionar nivel de acceso...",
+      "downgradeConfirmTitle": "Confirmar cambio de acceso",
+      "downgradeConfirmDescription": "{count, plural, one {# usuario tendría su acceso reducido} other {# usuarios tendrían su acceso reducido}}. ¿Desea continuar?",
+      "downgradeConfirmApplyAnyway": "Aplicar de todos modos",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Activo",
         "inactive": "Inactivo",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Esperando autorización"
       },
       "connectedProjects": "Proyectos conectados",
       "noIntegrations": "No hay integraciones de problemas configuradas",
       "testConnection": "Probar conexión",
       "testSuccess": "Conexión exitosa",
       "testSuccessDescription": "La integración de problemas está correctamente configurada y conectada",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Las credenciales son correctas",
+      "testCredentialsSavedDescription": "Su ID de cliente y secreto de OAuth son válidos. Guarde la integración y luego haga clic en Autorizar para conectar su cuenta; OAuth 2.0 se conecta por usuario, por lo que permanece inactiva hasta que al menos una persona autorice.",
       "testFailed": "Error de conexión",
       "testFailedDescription": "No se puede conectar al servicio externo",
       "testError": "Error de prueba",
       "testErrorDescription": "Ocurrió un error mientras se probaba la conexión",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autorizar",
+      "reauthorize": "Reautorizar",
+      "authorizeHint": "Autorice con el proveedor para conectar su cuenta y finalizar la configuración",
+      "syncInProgress": "Resincronizando incidencias vinculadas...",
+      "syncIntegration": "Resincronizar incidencias vinculadas",
+      "syncIntegrationHint": "Solo resincroniza las incidencias ya vinculadas en TestPlanIt. Las incidencias nuevas no se importan desde el rastreador externo.",
       "syncSuccess": "Sincronización en cola",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Las incidencias vinculadas de \"{name}\" se están resincronizando en segundo plano. Esto puede tardar unos momentos. La tabla se actualizará automáticamente cuando termine.",
       "syncError": "Sincronización fallida",
       "syncErrorDescription": "No se pudo poner en cola la tarea de sincronización para esta integración. Inténtelo de nuevo más tarde.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Conéctese a una instancia autohospedada de Redmine para el seguimiento de incidencias"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Conéctese a una instancia autohospedada de MantisBT para el seguimiento de incidencias"
         }
       },
       "filterPlaceholder": "Integraciones de filtros...",
@@ -5208,10 +5211,10 @@
         "authTypeHelp": "Elija cómo autenticarse con el servicio externo",
         "emailPlaceholder": "tu-email@ejemplo.com",
         "emailHelp": "Dirección de correo electrónico de tu cuenta",
-        "apiToken": "API Token",
+        "apiToken": "Token de API",
         "apiTokenPlaceholder": "Introduzca su token API",
         "apiTokenHelp": "Generar un token API desde la configuración de tu cuenta",
-        "jiraUrl": "Jira URL",
+        "jiraUrl": "URL de Jira",
         "jiraUrlPlaceholder": "https://su-sitio.atlassian.net",
         "jiraUrlHelp": "La URL de tu instancia de Jira",
         "clientId": "ID de cliente",
@@ -5223,7 +5226,7 @@
         "cloudId": "ID de la nube",
         "cloudIdPlaceholder": "Introduzca su ID de Atlassian Cloud",
         "cloudIdHelp": "Su ID de instancia de Atlassian Cloud (encontrado en su URL de Jira)",
-        "apiUrl": "API URL",
+        "apiUrl": "URL de la API",
         "apiUrlPlaceholder": "https://api.example.com",
         "apiUrlHelp": "La URL base para la API de servicio",
         "personalAccessTokenPlaceholder": "Introduzca su token de acceso personal",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Utilice OAuth 2.0 para una atribución precisa de los reporteros por usuario sin necesidad de permisos de administrador.",
         "tokenCreatorNoticeTitle": "Atribución del autor del problema",
         "tokenCreatorNoticeDescription": "Los problemas creados mediante esta integración siempre se registran con el nombre de la cuenta propietaria del token de acceso, no con el del usuario de TestPlanIt que los creó. La API de este proveedor no permite asignar el creador a otro usuario.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL de devolución de llamada (URI de redirección)",
+        "callbackUrlDescription": "Registre esta URL exacta como el URI de devolución de llamada/redirección en la aplicación OAuth de su proveedor. Debe coincidir exactamente o la autorización fallará.",
+        "callbackUrlCopy": "Copiar",
+        "callbackUrlCopied": "Copiado",
         "forgeApiKeyLabel": "Clave API de Forge",
         "forgeApiKeyDescription": "La aplicación Atlassian Forge lo utiliza para autenticar solicitudes de los paneles de incidencias de Jira. Genere una clave aquí y péguela en la configuración de Forge.",
         "forgeApiKeyPlaceholder": "Haga clic en Generar para crear una clave API",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Clave API de Redmine",
+        "redmineApiKeyPlaceholder": "Introduzca su clave API de Redmine",
+        "redmineApiKeyHelp": "Se encuentra en Mi cuenta → Clave de acceso a la API (habilite la API REST en Administración → Configuración → API)",
+        "redmineUrl": "URL de Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "La URL base de su instancia de Redmine",
+        "mantisBTApiKey": "Token de API de MantisBT",
+        "mantisBTApiKeyPlaceholder": "Introduzca su token de API de MantisBT",
+        "mantisBTApiKeyHelp": "Cree uno en la configuración de su cuenta de MantisBT → Tokens de API",
+        "mantisBTUrl": "URL de MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "La URL base de su instancia de MantisBT"
       },
       "authType": {
         "api_key": "Clave API",
@@ -5355,7 +5358,7 @@
         "customLlm": "LLM personalizado",
         "apiKeyPlaceholder": "Introduzca su clave API...",
         "apiKeyDescription": "Su clave API para la autenticación con el proveedor",
-        "endpoint": "Endpoint URL",
+        "endpoint": "URL del punto de conexión",
         "endpointPlaceholder": "https://api.provider.com/v1",
         "endpointV1Hint": "Consejo: Si utiliza un proxy (por ejemplo, LiteLLM), intente agregar /v1 al final de la URL de su punto final.",
         "deploymentName": "Nombre de despliegue",
@@ -5487,7 +5490,7 @@
         "warning": "Esta acción no se puede deshacer. Todos los proyectos que utilicen esta configuración volverán a la configuración de solicitud predeterminada."
       },
       "llmColumn": "Máster en Derecho",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} LLM",
       "cannotDeleteDefault": "No se puede eliminar la configuración predeterminada del mensaje. Primero, configure otra como predeterminada.",
       "defaultChanged": "La configuración del mensaje predeterminado se actualizó correctamente.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Generar casos de prueba a partir de una URL (Requisitos)",
         "generate_from_url_app": "Generar casos de prueba a partir de una URL (Pruebas de aplicaciones)",
         "automation_candidates": "Informe de candidatos para la automatización",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Derivación de pasos por IA"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Visualizar el registro de auditoría de todo el sistema para el seguimiento de la seguridad y el cumplimiento",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Vea el registro de auditoría de las acciones realizadas en este proyecto.",
       "filterPlaceholder": "Buscar por entidad, usuario o acción...",
       "filterAction": "Acción",
       "filterEntityType": "Tipo de entidad",
       "allActions": "Todas las acciones",
       "allEntityTypes": "Todos los tipos de entidades",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Todos los usuarios",
+      "allProjects": "Todos los proyectos",
+      "showing": "Mostrando {loaded} de {total} entradas",
       "viewDetails": "Ver detalles",
       "detailTitle": "Detalles del registro de auditoría",
       "userInfo": "Información del usuario",
@@ -5714,8 +5717,8 @@
       "systemActor": "Sistema",
       "systemActorTooltip": "Acción realizada por el sistema, no por un usuario que haya iniciado sesión.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "cambios relacionados",
+      "groupedEntry": "Cambios agrupados de una sola acción"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "todavía está esperando tu reseña de",
         "reviewReminderEmailMessage": "Recordatorio: La solicitud de revisión de {actorName}en {entityLabel} \"{entityName}\" en el proyecto \"{projectName}\" ha estado pendiente durante {hoursPending} horas.",
         "reviewReminderHoursPending": "Pendiente durante {hoursPending, plural, one {# hora} other {# horas}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Pasos de prueba derivados por IA listos",
+        "aiStepsDerivedMessage": "{count, plural, one {# caso de prueba recibió pasos derivados por IA} other {# casos de prueba recibieron pasos derivados por IA}} — revíselos para verificar su precisión.",
+        "aiStepsDerivedReviewLink": "Revisar ejecución de prueba"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Nombre del grupo\nUn nombre claro, conciso, descriptivo o palabras clave que se utilizan en todos los proyectos.\n\n- Ayuda a los miembros del equipo a encontrar rápidamente casos de prueba, ejecuciones de pruebas y sesiones.",
       "users": "## Usuarios\nIndica los usuarios que están asignados a este grupo.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Nivel de acceso mapeado\nA los miembros de este grupo se les otorga al menos este nivel de acceso en la próxima sincronización.\n\n- Prevalece el nivel más alto entre todos los grupos de un usuario\n- \"Sin mapeo\" significa que este grupo no afecta el acceso; los miembros vuelven al valor predeterminado establecido en la página SCIM\n- Un cambio manual de acceso en un usuario prevalece sobre el mapeo (y se marca en la pantalla de edición de ese usuario)"
     },
     "template": {
       "name": "## Nombre de la plantilla\nUn nombre único y descriptivo para esta plantilla (por ejemplo, 'Caso Estándar de Prueba', 'Resultados de prueba API').",
@@ -6209,7 +6212,7 @@
       "authType": "## Autenticación Tipo\nElija cómo autenticar con el servicio externo.\n\n- **Clave API:** Autenticación simple usando email y token API\n- **OAuth 2. :** Autenticación segura usando OAuth flow\n- **token de acceso personal:** Autenticación directa basada en token",
       "email": "## Dirección de correo electrónico\nLa dirección de correo electrónico de su cuenta para el servicio externo.\n\n- Utilizado para autenticación de clave API\n- Debe coincidir con la cuenta que generó el token API\n- Requerido para Jira y servicios similares",
       "apiToken": "## Token de API\nGenera un token API desde la configuración de tu cuenta en el servicio externo.\n\n- Usualmente se encuentra en la configuración de la cuenta → Seguridad → Tokens API\n- Provee acceso seguro sin exponer su contraseña\n- Puede ser revocado y regenerado según sea necesario",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL de Jira\nLa URL base de su instancia de Jira.\n\n- Formato: https://your-site.atlassian.net\n- No incluya /browse ni otras rutas\n- Debe ser accesible desde este servidor",
       "clientId": "## ID de cliente OAuth\nEl ID de cliente de la configuración de la aplicación OAuth.\n\n- Creado en la consola de desarrollo del servicio externo\n- Utilizado para identificar tu aplicación durante el flujo OAuth\n- Seguro para compartir en los archivos de configuración",
       "clientSecret": "## OAuth Client Secret\nThe Client Secret from your OAuth application configuration.\n\n- Creado junto a la ID de cliente\n- Debe mantenerse confidencial y seguro\n- Utilizado para autenticar tu aplicación",
       "personalAccessToken": "## Token de Acceso personal\nUn token de acceso personal con los permisos apropiados para el servicio externo.\n\n- Generado en la configuración de tu cuenta\n- Debería tener permisos para leer y escribir asuntos\n- Más seguro que la autenticación de contraseña",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL de instancia\nLa URL base de su instancia autohospedada.\n\n- Formato: https://git.example.com\n- No incluya barras diagonales ni rutas al final.\n- Debe ser accesible desde este servidor.",
       "projectPath": "## Ruta del proyecto\nLa ruta completa a tu proyecto de GitLab.\n\n- Formato: espacio de nombres/proyecto o grupo/subgrupo/proyecto\n- Ejemplo: my-org/my-project\n- Se encuentra en la URL del proyecto: gitlab.com/namespace/project",
       "platform": "## Plataforma\nLa plataforma Git autoalojada a la que te estás conectando.\n\n- **Gitea**: instancias basadas en gitea.io\n- **Forgejo**: instancias basadas en forgejo.org (bifurcación de Gitea)\n- **Gogs**: instancias basadas en gogs.io\n\nEsto controla qué icono se muestra y puede afectar la compatibilidad de la API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Clave API de Redmine\nSu clave de acceso personal a la API REST.\n\n- Habilite la API REST en Administración → Configuración → API\n- Copie su clave desde Mi cuenta → Clave de acceso a la API\n- Limitada a los permisos de su usuario; use una cuenta de servicio para integraciones compartidas",
+      "redmineUrl": "## URL de Redmine\nLa URL base de su instancia de Redmine.\n\n- Formato: https://redmine.example.com\n- No incluya /issues ni otras rutas\n- Debe ser accesible desde este servidor",
+      "mantisBTApiKey": "## Token de API de MantisBT\nSu token personal de la API REST.\n\n- Créelo en la configuración de su cuenta de MantisBT → Tokens de API\n- Limitado a los permisos de su usuario; use una cuenta de servicio para integraciones compartidas",
+      "mantisBTUrl": "## URL de MantisBT\nLa URL base de su instancia de MantisBT.\n\n- Formato: https://mantisbt.example.com\n- No incluya /api/rest ni otras rutas\n- Debe ser accesible desde este servidor",
+      "githubBaseUrl": "## URL Base de la API\nRuta raíz completa de la API de GitHub para GitHub Enterprise Server.\n\n- Normalmente termina en /api/v3\n- Déjelo en blanco para usar api.github.com\n- Debe ser accesible desde este servidor"
     },
     "config": {
       "name": "## Nombre de la configuración\nUn nombre claro y descriptivo para esta configuración.\n\n- Ayuda a describir las combinaciones variantes que componen la configuración (por ejemplo, \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", etc.).",
@@ -6716,7 +6719,7 @@
       "addDimension": "Añadir dimensión...",
       "addMetric": "Añadir métrica...",
       "runReport": "Ejecutar informe",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Exportar CSV",
       "noResultsFound": "No se han encontrado resultados.",
       "selectAtLeastOneDimensionAndMetric": "Seleccione al menos una dimensión y una métrica.",
       "noDataMatchingCriteria": "No se encontraron datos que coincidan con las dimensiones y métricas seleccionadas.",
@@ -7441,7 +7444,7 @@
         "selectedFile": "Archivo seleccionado",
         "delimiter": "Delimitador de campos",
         "delimiters": {
-          "tab": "Tab (\\t)"
+          "tab": "Tabulación (\\t)"
         },
         "hasHeaders": "La primera fila contiene cabeceras de columna",
         "encoding": "Codificación de archivos",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Buscar",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Búsquedas guardadas",
+      "save": "Guardar búsqueda",
+      "saveTitle": "Guardar búsqueda",
+      "saveDescription": "Asigne un nombre a esta búsqueda para poder consultarla más adelante.",
+      "saveAction": "Guardar",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "p. ej. Ejecuciones fallidas de este sprint",
+      "nameRequired": "Introduzca un nombre para esta búsqueda.",
+      "loginRequired": "Debe iniciar sesión para guardar búsquedas.",
       "descriptionLabel": "Descripción (opcional)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "Para qué es esta búsqueda",
+      "saved": "Búsqueda guardada",
+      "savedDescription": "“{name}” ahora está en sus búsquedas guardadas.",
+      "saveFailed": "No se pudo guardar la búsqueda. Inténtelo de nuevo.",
+      "empty": "Aún no hay búsquedas guardadas",
+      "emptyHint": "Guarde una búsqueda para consultarla más adelante.",
+      "loaded": "Se cargó “{name}”",
+      "loadFailed": "Esta búsqueda guardada ya no es válida.",
+      "edit": "Editar",
+      "editTitle": "Editar búsqueda guardada",
+      "edited": "Búsqueda guardada actualizada",
+      "editFailed": "No se pudo actualizar la búsqueda. Inténtelo de nuevo.",
       "delete": "Borrar",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "¿Eliminar búsqueda guardada?",
+      "deleteConfirm": "“{name}” se eliminará de sus búsquedas guardadas. Esta acción no se puede deshacer.",
+      "deleted": "Búsqueda guardada eliminada",
+      "deleteFailed": "No se pudo eliminar la búsqueda. Inténtelo de nuevo."
     },
     "bulk": {
       "crossProjectHint": "(que abarca múltiples proyectos)",
@@ -7671,7 +7674,7 @@
   },
   "email": {
     "greeting": "Hola,",
-    "greetingWithName": "Hi {name},",
+    "greetingWithName": "Hola {name},",
     "notification": {
       "intro": "Tienes una nueva notificación:",
       "viewDetails": "Ver detalles",
@@ -7697,14 +7700,14 @@
       "intro": "Haz clic en el botón de abajo para iniciar sesión:",
       "signInButton": "Iniciar sesión",
       "copyPasteIntro": "O bien, copie y pegue este enlace en su navegador:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Por su seguridad, este enlace solo se puede usar una vez. Solicite un nuevo enlace si necesita iniciar sesión de nuevo.",
       "disclaimer": "Si no solicitaste este correo electrónico, puedes ignorarlo sin problema.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Inicie sesión en TestPlanIt\n\nHaga clic en el siguiente enlace para iniciar sesión:\n{url}\n\nPor su seguridad, este enlace solo se puede usar una vez. Solicite un nuevo enlace si necesita iniciar sesión de nuevo.\n\nSi no solicitó este correo electrónico, puede ignorarlo con seguridad."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "¿Está abriendo esto en un dispositivo diferente? Introduzca este código en la pantalla de inicio de sesión donde solicitó el enlace:",
+      "deviceNotice": "Este enlace inicia su sesión desde el navegador donde lo solicitó. Si lo abre en cualquier otro lugar, se le mostrará el código anterior para introducirlo en su ventana original.",
+      "textBody": "Inicie sesión en TestPlanIt\n\nHaga clic en el siguiente enlace para iniciar sesión:\n{url}\n\n¿Está abriendo esto en un dispositivo diferente? Introduzca este código en la pantalla de inicio de sesión donde solicitó el enlace: {code}\n\nSi no solicitó este correo electrónico, puede ignorarlo con seguridad."
     }
   },
   "comments": {

--- a/testplanit/messages/fr-FR.json
+++ b/testplanit/messages/fr-FR.json
@@ -1072,7 +1072,7 @@
         "apple": "Continuez avec Apple",
         "microsoft": "Continuez avec Microsoft",
         "samlProvider": "Connectez-vous avec {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Se connecter avec un lien magique à usage unique",
         "emailLogin": "Poursuivre par courriel"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Retour à la page de connexion"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Cliquez sur le lien dans l'e-mail pour vous connecter depuis ce navigateur, ou saisissez le code de l'e-mail ci-dessous.",
+        "codeLabel": "Code de connexion",
+        "verifyCode": "Vérifier le code",
+        "verifying": "Vérification en cours...",
+        "invalidCode": "Ce code n'est pas correct. Vérifiez l'e-mail et réessayez.",
+        "codeExpired": "Cette demande de connexion a expiré. Demandez un nouveau lien.",
+        "tooManyAttempts": "Trop de tentatives incorrectes. Demandez un nouveau lien pour réessayer.",
+        "windowLost": "Cette fenêtre ne peut plus terminer la connexion. Demandez un nouveau lien.",
+        "genericError": "Nous n'avons pas pu vous connecter. Demandez un nouveau lien et réessayez.",
+        "tooManyRequests": "Trop de demandes de connexion. Veuillez patienter un instant et réessayer.",
+        "haveCode": "Vous avez déjà un code de connexion ?",
+        "codeEntryDescription": "Saisissez le code de votre e-mail de connexion. Les codes ne fonctionnent que dans le navigateur où vous avez demandé le lien.",
+        "backToRequest": "Demander un nouveau lien à la place"
       },
       "twoFactor": {
         "title": "Authentification à deux facteurs",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Contactez l'administrateur système"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Connexion en cours...",
+      "completeErrorTitle": "Nous n'avons pas pu vous connecter",
+      "requestNewLink": "Demander un nouveau lien",
+      "codeTitle": "Votre code de connexion",
+      "codeInstructions": "Vous avez ouvert le lien de connexion sur un autre appareil ou navigateur. Saisissez ce code sur l'écran de connexion où vous l'avez initialement demandé.",
+      "codeCloseNotice": "Vous pouvez fermer cette fenêtre une fois le code saisi.",
+      "expiredTitle": "Ce lien de connexion n'est plus valide",
+      "expiredBody": "Le lien a peut-être expiré ou a déjà été utilisé. Demandez-en un nouveau depuis la page de connexion — cela ne prend qu'un instant."
     },
     "errors": {
       "accessDenied": "Accès refusé. Votre compte est peut-être inactif ou vous n'avez pas l'autorisation de vous connecter.",
       "configuration": "Il y a un problème avec la configuration du serveur.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Ce lien de connexion a expiré ou a déjà été utilisé. Les liens magiques ne peuvent être utilisés qu'une seule fois — veuillez en demander un nouveau pour vous connecter.",
       "invalid2FACode": "Code de vérification invalide. Veuillez réessayer.",
       "twoFactorTokenRequired": "Un jeton est requis.",
       "verificationCodeRequired": "Un code de vérification est requis."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Conserver les problèmes dans la base de données (ils seront dissociés).",
           "switchWarning3": "Remplacez la configuration d'intégration actuelle par la nouvelle.",
           "switchWarning4": "Supprimez le webhook entrant configuré pour l'intégration actuelle.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Importer des problèmes",
+          "importTitle": "Importer des problèmes depuis {name}",
+          "importDescription": "Récupérez les problèmes de ce projet lié dans votre projet. Les problèmes existants ne sont pas dupliqués, et les problèmes importés restent à jour grâce à la synchronisation.",
+          "importUpdatedWithin": "Mis à jour depuis",
+          "importLastDays": "Les {days} derniers jours",
+          "importMax": "Maximum à importer",
+          "importPreview": "Aperçu",
+          "importPreviewResult": "~{count, plural, one {# problème correspond} other {# problèmes correspondent}} à ce filtre. Jusqu'à {cap} seront importés.",
+          "importOverCap": "Cela dépasse la limite de {cap} ; seuls les {cap} plus récemment mis à jour seront importés.",
+          "importStart": "Importer",
+          "importStarted": "Importation démarrée. Les problèmes apparaîtront bientôt.",
+          "importFailed": "L'importation a échoué",
+          "importPreviewFailed": "Impossible d'estimer les correspondances"
         },
         "integrationAssigned": "Intégration attribuée avec succès",
         "integrationAssignError": "Échec de l'attribution de l'intégration du problème au projet",
@@ -1402,10 +1405,10 @@
             "description": "Connectez-vous à Azure DevOps pour le suivi des éléments de travail."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Connectez-vous à une instance Redmine auto-hébergée pour le suivi des problèmes."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Connectez-vous à une instance MantisBT auto-hébergée pour le suivi des problèmes."
           }
         }
       },
@@ -1418,7 +1421,7 @@
         "inboundAddButtonAllConfigured": "L'adaptateur entrant est déjà configuré.",
         "inboundAddButtonNoIntegration": "Attribuez une intégration de problème à ce projet avant d'ajouter un webhook entrant.",
         "inboundEmptyWithIntegration": "Aucun webhook entrant configuré. <link>Ajoutez-en un</link> pour recevoir les mises à jour des problèmes de votre intégration de problèmes assignée.",
-        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "inboundEmptyNoIntegration": "Une <link>intégration de ticket</link> est requise pour recevoir les mises à jour de tickets entrantes. Attribuez-en une à votre projet pour commencer.",
         "deliveriesEmptyNoConfigs": "Aucune livraison par webhook pour le moment — créez un webhook entrant ou sortant sur les autres onglets pour commencer à les recevoir.",
         "noConfig": "Aucun webhook configuré",
         "createButton": "Créer un webhook",
@@ -1583,7 +1586,7 @@
         "inboundGitlabTitle": "Webhook entrant GitLab",
         "inboundGitlabScopeHint": "Les événements GitLab <code>Issue Hook</code> mettent à jour les tickets TestPlanIt liés. Les autres types d'événements sont acceptés, mais ne mettent pas à jour les tickets.",
         "inboundGiteaTitle": "Webhook entrant Gitea",
-        "inboundGiteaScopeHint": "Gitea <code>issues</code> events update linked TestPlanIt issues. Other event types are accepted but do not update issues.",
+        "inboundGiteaScopeHint": "Les événements <code>issues</code> de Gitea mettent à jour les tickets TestPlanIt liés. Les autres types d'événements sont acceptés, mais ne mettent pas à jour les tickets.",
         "inboundAdoTitle": "Webhook entrant Azure DevOps",
         "inboundAdoScopeHint": "Azure DevOps : les événements <code>workitem.updated</code> mettent à jour les tickets TestPlanIt associés. Les autres événements sont acceptés, mais ne mettent pas à jour les tickets.",
         "inboundAdoUsername": "Nom d'utilisateur",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook réactivé",
         "toastReEnableFailed": "Échec de la réactivation : {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Webhook entrant Redmine",
+        "inboundRedmineScopeHint": "Le plugin redmine_webhook ne signe pas les requêtes, cette URL de webhook constitue donc l'identifiant — traitez-la comme un secret et faites-la pivoter si elle est exposée.",
+        "setupStepsRedmineStep1": "Installez le plugin redmine_webhook sur votre serveur Redmine (Redmine ne dispose pas de webhooks intégrés).",
+        "setupStepsRedmineStep2": "Dans votre projet Redmine, ouvrez Paramètres → Modules et activez les Webhooks.",
+        "setupStepsRedmineStep3": "Ouvrez Paramètres → Webhooks, collez l'URL ci-dessus, puis enregistrez.",
+        "setupStepsRedmineStep4": "Créez ou mettez à jour un problème dans Redmine ; le statut du problème lié sera synchronisé ici.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Webhook entrant MantisBT",
+        "inboundMantisbtScopeHint": "Un plugin de webhook MantisBT ne signe pas les requêtes, cette URL de webhook constitue donc l'identifiant — traitez-la comme un secret et faites-la pivoter si elle est exposée.",
+        "setupStepsMantisbtStep1": "Installez et activez un plugin de webhook MantisBT sur votre serveur MantisBT (MantisBT ne dispose pas de webhooks intégrés).",
+        "setupStepsMantisbtStep2": "Dans la configuration du plugin, choisissez les événements de création et de mise à jour de problème.",
+        "setupStepsMantisbtStep3": "Collez l'URL ci-dessus comme cible du webhook et enregistrez.",
+        "setupStepsMantisbtStep4": "Créez ou mettez à jour un problème dans MantisBT ; le statut du problème lié sera synchronisé ici."
       },
       "aiModels": {
         "description": "Configurer les modèles d'IA pour la génération et l'analyse intelligentes des cas de test",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Analyse des fichiers dans {scope}…",
           "scanningFilesCount": "Analyse des fichiers dans {scope}… ({count, number} trouvé)",
           "filtering": "Application des filtres aux fichiers {count, number}…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Limité par le fournisseur — nouvelle tentative dans {seconds, number}s…"
         },
         "cache": {
           "title": "Paramètres du cache",
@@ -1913,8 +1916,8 @@
         "networkError": "Erreur réseau lors de l'actualisation du cache",
         "refreshSuccess": "Cache actualisé : {fileCount} fichiers ({contentCached} contenus mis en cache)",
         "refreshRateLimited": "Cache actualisé : {fileCount} fichiers listés, {contentCached}/{fileCount} contenus mis en cache (limite de débit — actualisez à nouveau pour terminer)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Cache actualisé : {fileCount} fichiers",
+        "refreshInProgress": "L'actualisation du cache est toujours en cours en arrière-plan. Cela se mettra à jour ici une fois terminé.",
         "validation": {
           "pathRequired": "Le chemin d'accès est requis.",
           "patternRequired": "Un modèle est requis.",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Activité",
+      "title": "Journal d'activité",
+      "description": "Toutes les modifications enregistrées pour cette session."
     },
     "title": "{count, plural, =1 {Session} other {Sessions}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
+        "title": "Journal d'audit",
+        "description": "Actions effectuées par cet utilisateur",
+        "noEntries": "Aucune activité enregistrée pour le moment.",
+        "loadMore": "Chargement",
+        "viewDetails": "Voir les détails",
         "columnAction": "Action",
         "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "columnEntityName": "Nom",
+        "columnTimestamp": "Horodatage",
+        "allActions": "Toutes les actions",
+        "allTypes": "Tous les types",
+        "noMatchingEntries": "Aucune entrée ne correspond aux filtres sélectionnés.",
+        "showing": "{loaded} sur {total} entrées"
       },
       "mentionedComments": {
         "title": "Mentionné dans les commentaires",
@@ -2510,9 +2513,9 @@
       "historyView": "Historique des cas de test"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Activité",
+      "title": "Journal d'activité",
+      "description": "Toutes les modifications enregistrées pour ce cas de test."
     },
     "fields": {
       "optionNotFound": "Option introuvable",
@@ -2594,8 +2597,8 @@
       "copying": "Copie de…",
       "copyComplete": "{count, plural, =1 {1 cas copié dans {folder}} other {# cas copiés dans {folder}}}{dest, select, samename {} crossProject { dans {projectName}} other {}}",
       "moveComplete": "{count, plural, =1 {1 cas déplacé vers {folder}} other {# cas déplacés vers {folder}}}{dest, select, samename {} crossProject { dans {projectName}} other {}}",
-      "copyError": "{count, plural, =1 {Failed to copy 1 case to {folder}} other {Failed to copy # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
-      "moveError": "{count, plural, =1 {Failed to move 1 case to {folder}} other {Failed to move # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {Échec de la copie de 1 cas vers {folder}} other {Échec de la copie de # cas vers {folder}}}{dest, select, samename {} crossProject { dans {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {Échec du déplacement de 1 cas vers {folder}} other {Échec du déplacement de # cas vers {folder}}}{dest, select, samename {} crossProject { dans {projectName}} other {}}",
       "copyAlreadyRunning": "Une autre copie est déjà en cours de traitement. Veuillez patienter jusqu'à la fin.",
       "currentSuffix": "(Actuel)",
       "moveDisabledSameFolder": "Les dossiers sont déjà dans ce dossier",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# paire liée} other {# paires liées}}",
       "bulkError": "Certaines opérations ont échoué. Veuillez réessayer.",
       "tableHint": "Cliquez sur une ligne ou sur le bouton Comparer pour examiner et résoudre les doublons.",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} contre {caseB}",
       "comparisonDescription": "Comparez ces doublons potentiels et choisissez comment les résoudre.",
       "selectPrimary": "Cliquez sur un dossier pour le sélectionner comme dossier principal à fusionner.",
       "selectedAsPrimary": "Sélectionné comme principal",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Activité",
+      "title": "Journal d'activité",
+      "description": "Toutes les modifications enregistrées pour cette exécution de test."
     },
     "notFound": "Exécution de test introuvable.",
     "add": {
@@ -3370,7 +3373,7 @@
       "success": {
         "title": "Test effectué avec succès",
         "description": "{name} a été ajouté au projet",
-        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for {name}"
+        "descriptionMultiple": "{count, plural, one {# exécution de test a été créée} other {# exécutions de test ont été créées}} pour {name}"
       },
       "estimates": {
         "manual": "Temps manuel estimé",
@@ -3380,7 +3383,7 @@
       "creatingProgress": "Création d'un test {current, number} de {total, number}..."
     },
     "magicSelect": {
-      "title": "Magic Select",
+      "title": "Sélection magique",
       "description": "Sélection de cas de test automatisée par l'IA en fonction du contexte d'exécution de vos tests",
       "counting": "Recherche de cas de test pertinents...",
       "reasoning": "Raisonnement IA",
@@ -3585,7 +3588,7 @@
           "datasetsProcessed": "{processed, number} jeu de données{processed, plural, one {} other {s}} traité",
           "datasetsProcessedWithTotal": "{processed, number} de {total, number} ensemble de données{total, plural, one {} other {s}} traité",
           "rowsProcessed": "{value, number} lignes traitées",
-          "itemsProcessed": "{processed, number} of {total, number} items processed",
+          "itemsProcessed": "{processed, number} sur {total, number} éléments traités",
           "analysisInProgress": "Analyse de l'exportation…",
           "cancel": "Annuler l'importation",
           "cancelRequested": "Annulation demandée",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Oui",
       "scimUserLockedTitle": "L'utilisateur est géré par SCIM",
       "scimUserLockedDescription": "Le nom, l'adresse e-mail et le statut actif de cet utilisateur sont gérés par votre fournisseur d'identité. Modifiez ces informations auprès de ce dernier pour les mettre à jour ici.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Géré par le mappage de groupe",
+      "groupMappingOverrideDescription": "Le niveau d'accès de cet utilisateur est régi par un mappage de groupe SCIM et peut être rétabli lors de la prochaine synchronisation.",
+      "groupMappingBadge": "Groupe mappé"
     },
     "security": {
       "title": "Sécurité",
@@ -4492,7 +4495,7 @@
       "forceAllUsersDialogTitle": "Forcer le changement de mot de passe pour tous les utilisateurs",
       "forceAllUsersDialogDescription": "Cela obligera les utilisateurs utilisant l'authentification {count, number} à changer leur mot de passe lors de leur prochaine connexion.",
       "forceAllUsersDialogWarning": "Cette action est irréversible.",
-      "forceAllUsersDialogConfirm": "Force Change",
+      "forceAllUsersDialogConfirm": "Forcer le changement",
       "saved": "Paramètres de sécurité enregistrés",
       "saveFailed": "Impossible d'enregistrer les paramètres de sécurité",
       "forceAllSuccess": "Changement de mot de passe requis pour les utilisateurs {count, number}",
@@ -4622,16 +4625,16 @@
         "errorToast": "Impossible de révoquer le jeton. {reason}"
       },
       "probe": {
-        "button": "Test SCIM",
+        "button": "Tester SCIM",
         "testing": "Test…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — le jeton fonctionne avec /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Impossible de joindre le point de terminaison SCIM. Veuillez réessayer."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Accès mappé par défaut",
+      "fallbackDefaultDescription": "Niveau d'accès attribué aux utilisateurs non couverts par un mappage de groupe.",
+      "fallbackDefaultLabel": "Niveau d'accès par défaut",
+      "fallbackDefaultSaved": "Valeur par défaut de secours enregistrée"
     },
     "tags": {
       "add": {
@@ -4830,7 +4833,7 @@
         "description": "Remplacez les affectations de projet sur les configurations sélectionnées. Le nom de la configuration n'est pas modifiable en masse.",
         "applyButton": "{count, plural, one {Appliquer à 1 configuration} other {Appliquer à # configurations}}",
         "deleteButton": "{count, plural, one {Supprimer 1 configuration} other {Supprimer # configurations}}",
-        "deleteConfirmTitle": "{count, plural, one {Delete 1 configuration?} other {Delete # configurations?}}",
+        "deleteConfirmTitle": "{count, plural, one {Supprimer 1 configuration ?} other {Supprimer # configurations ?}}",
         "deleteConfirmMessage": "{count, plural, one {Ceci supprimera 1 configuration. Cette action est irréversible.} other {Ceci supprimera # configurations. Cette action est irréversible.}}",
         "applyEnabledLabel": "État activé de la modification"
       },
@@ -4916,14 +4919,14 @@
       "scimManagedTooltip": "Géré par SCIM. Gérer depuis la page d'administration SCIM.",
       "scimNameLockedTitle": "Le groupe est géré par SCIM",
       "scimNameLockedDescription": "Le nom et les membres de ce groupe sont gérés par votre fournisseur d'identité. Modifiez-les sur ce dernier pour les mettre à jour ici.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
-      "downgradeConfirmUserRow": "{name}: {from} → {to}",
+      "mappedAccessColumnHeader": "Accès mappé",
+      "mappedAccessLabel": "Niveau d'accès mappé",
+      "mappedAccessNone": "Aucun mappage",
+      "mappedAccessSelect": "Sélectionnez le niveau d'accès...",
+      "downgradeConfirmTitle": "Confirmer la modification de l'accès",
+      "downgradeConfirmDescription": "{count, plural, one {# utilisateur aurait} other {# utilisateurs auraient}} un accès réduit. Continuer ?",
+      "downgradeConfirmApplyAnyway": "Appliquer quand même",
+      "downgradeConfirmUserRow": "{name} : {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
     "milestones": {
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Actif",
         "inactive": "Inactif",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "En attente d'autorisation"
       },
       "connectedProjects": "Projets connectés",
       "noIntegrations": "Aucune intégration problématique configurée",
       "testConnection": "Test de connexion",
       "testSuccess": "Connexion réussie",
       "testSuccessDescription": "L'intégration du problème est correctement configurée et connectée.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Les identifiants semblent corrects",
+      "testCredentialsSavedDescription": "Votre ID client et votre secret OAuth sont valides. Enregistrez l'intégration, puis cliquez sur Autoriser pour connecter votre compte — OAuth 2.0 se connecte par utilisateur, elle reste donc inactive jusqu'à ce qu'au moins une personne l'autorise.",
       "testFailed": "Échec de la connexion",
       "testFailedDescription": "Impossible de se connecter au service externe",
       "testError": "Erreur de test",
       "testErrorDescription": "Une erreur s'est produite lors du test de la connexion.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autoriser",
+      "reauthorize": "Réautoriser",
+      "authorizeHint": "Autorisez auprès du fournisseur pour connecter votre compte et terminer la configuration",
+      "syncInProgress": "Resynchronisation des problèmes liés...",
+      "syncIntegration": "Resynchroniser les problèmes liés",
+      "syncIntegrationHint": "Resynchronise uniquement les problèmes déjà liés dans TestPlanIt. Les nouveaux problèmes ne sont pas importés depuis le traqueur externe.",
       "syncSuccess": "Synchronisation en file d'attente",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Les problèmes liés de « {name} » sont en cours de resynchronisation en arrière-plan. Cela peut prendre quelques instants. Le tableau se mettra à jour automatiquement une fois terminé.",
       "syncError": "Échec de la synchronisation",
       "syncErrorDescription": "Impossible de mettre en file d'attente la tâche de synchronisation pour cette intégration. Veuillez réessayer plus tard.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Connectez-vous à une instance Redmine auto-hébergée pour le suivi des problèmes"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Connectez-vous à une instance MantisBT auto-hébergée pour le suivi des problèmes"
         }
       },
       "filterPlaceholder": "Intégrations de filtres...",
@@ -5220,7 +5223,7 @@
         "clientSecret": "Secret du client",
         "clientSecretPlaceholder": "Saisissez votre secret client OAuth",
         "clientSecretHelp": "Le secret client de votre application OAuth",
-        "cloudId": "Cloud ID",
+        "cloudId": "ID Cloud",
         "cloudIdPlaceholder": "Saisissez votre identifiant Atlassian Cloud",
         "cloudIdHelp": "Votre ID d'instance Atlassian Cloud (que vous trouverez dans l'URL de votre Jira)",
         "apiUrl": "URL de l'API",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Utilisez plutôt OAuth 2.0 pour une attribution précise des contributeurs par utilisateur sans autorisation d'administrateur.",
         "tokenCreatorNoticeTitle": "Attribution du créateur du problème",
         "tokenCreatorNoticeDescription": "Les tickets créés via cette intégration sont toujours enregistrés sous le compte propriétaire du jeton d'accès, et non sous celui de l'utilisateur TestPlanIt qui les a créés. L'API de ce fournisseur ne permet pas de définir le créateur pour le compte d'un autre utilisateur.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL de rappel (URI de redirection)",
+        "callbackUrlDescription": "Enregistrez exactement cette URL comme URI de rappel / redirection dans l'application OAuth de votre fournisseur. Elle doit correspondre précisément, sinon l'autorisation échouera.",
+        "callbackUrlCopy": "Copier",
+        "callbackUrlCopied": "Copié",
         "forgeApiKeyLabel": "Clé API Forge",
         "forgeApiKeyDescription": "Utilisée par l'application Atlassian Forge pour authentifier les requêtes provenant des panneaux de tickets Jira. Générez une clé ici et collez-la dans les paramètres de votre application Forge.",
         "forgeApiKeyPlaceholder": "Cliquez sur Générer pour créer une clé API",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Clé API Redmine",
+        "redmineApiKeyPlaceholder": "Saisissez votre clé API Redmine",
+        "redmineApiKeyHelp": "Se trouve sous Mon compte → Clé d'accès API (activez l'API REST dans Administration → Paramètres → API)",
+        "redmineUrl": "URL Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "L'URL de base de votre instance Redmine",
+        "mantisBTApiKey": "Jeton API MantisBT",
+        "mantisBTApiKeyPlaceholder": "Saisissez votre jeton API MantisBT",
+        "mantisBTApiKeyHelp": "Créez-en un dans les paramètres de votre compte MantisBT → Jetons API",
+        "mantisBTUrl": "URL MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "L'URL de base de votre instance MantisBT"
       },
       "authType": {
         "api_key": "Clé API",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Générer des cas de test à partir d'une URL (exigences)",
         "generate_from_url_app": "Générer des cas de test à partir d'une URL (tests d'application)",
         "automation_candidates": "Rapport des candidats à l'automatisation",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Dérivation des étapes par IA"
       }
     },
     "elasticsearch": {
@@ -5577,7 +5580,7 @@
         "repo-cache": "Cache du dépôt",
         "copy-move": "Copier et déplacer",
         "duplicate-scan": "Analyse en double",
-        "magic-select": "Magic Select",
+        "magic-select": "Sélection magique",
         "step-scan": "Analyse de la séquence d'étapes"
       },
       "status": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Consultez l'historique d'audit à l'échelle du système pour le suivi de la sécurité et de la conformité.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Consultez le journal d'audit des actions effectuées dans ce projet.",
       "filterPlaceholder": "Recherche par entité, utilisateur ou action...",
       "filterAction": "Action",
       "filterEntityType": "Type d'entité",
       "allActions": "Toutes les actions",
       "allEntityTypes": "Tous les types d'entités",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Tous les utilisateurs",
+      "allProjects": "Tous les projets",
+      "showing": "Affichage de {loaded} sur {total} entrées",
       "viewDetails": "Voir les détails",
       "detailTitle": "Détails du journal d'audit",
       "userInfo": "Informations utilisateur",
@@ -5714,8 +5717,8 @@
       "systemActor": "Système",
       "systemActorTooltip": "Action effectuée par le système, et non par un utilisateur connecté",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "modifications associées",
+      "groupedEntry": "Modifications groupées issues d'une seule action"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "attend toujours votre avis sur",
         "reviewReminderEmailMessage": "Rappel : la demande de révision de {actorName}sur {entityLabel} \"{entityName}\" dans le projet \"{projectName}\" est en attente depuis {hoursPending} heures.",
         "reviewReminderHoursPending": "En attente depuis {hoursPending, plural, one {# heure} other {# heures}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Étapes de test dérivées par IA prêtes",
+        "aiStepsDerivedMessage": "{count, plural, one {# cas de test a reçu} other {# cas de test ont reçu}} des étapes dérivées par IA — vérifiez leur exactitude.",
+        "aiStepsDerivedReviewLink": "Examiner l'exécution de test"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Nom du groupe\nUn nom ou des mots-clés clairs, concis et descriptifs utilisés dans tous les projets.\n\n- Permet aux membres de l'équipe de trouver rapidement les cas de test, les exécutions de test et les sessions associés.",
       "users": "## Utilisateurs\nIndique les utilisateurs affectés à ce groupe.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Niveau d'accès mappé\nLes membres de ce groupe reçoivent au moins ce niveau d'accès lors de la prochaine synchronisation.\n\n- Le niveau le plus élevé parmi tous les groupes d'un utilisateur l'emporte\n- « Aucun mappage » signifie que ce groupe n'affecte pas l'accès — les membres reviennent à la valeur par défaut définie sur la page SCIM\n- Une modification manuelle de l'accès d'un utilisateur prend le pas sur le mappage (et est signalée sur l'écran de modification de cet utilisateur)"
     },
     "template": {
       "name": "## Nom du modèle\nUn nom unique et descriptif pour ce modèle (par exemple, 'Cas de test standard', 'Résultats des tests d'API').",
@@ -6209,7 +6212,7 @@
       "authType": "## Type d'authentification\nChoisissez le mode d'authentification auprès du service externe.\n\n- **Clé API :** Authentification simple par e-mail et jeton API\n- **OAuth 2.0 :** Authentification sécurisée via le flux OAuth\n- **Jeton d'accès personnel :** Authentification directe par jeton",
       "email": "## Adresse e-mail\nVotre adresse e-mail de compte pour le service externe.\n\n- Utilisée pour l'authentification par clé API.\n- Doit correspondre au compte qui a généré le jeton API.\n- Requis pour Jira et les services similaires.",
       "apiToken": "## Jeton API\nGénérez un jeton API depuis les paramètres de votre compte sur le service externe.\n\n- Généralement disponible dans Paramètres du compte → Sécurité → Jetons API\n- Permet un accès sécurisé sans divulguer votre mot de passe\n- Peut être révoqué et régénéré à tout moment",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL Jira\nL'URL de base de votre instance Jira.\n\n- Format : https://votre-site.atlassian.net\n- N'incluez pas /browse ni d'autres chemins\n- Doit être accessible depuis ce serveur",
       "clientId": "## ID client OAuth\nL'ID client issu de la configuration de votre application OAuth.\n\n- Créé dans la console développeur du service externe\n- Utilisé pour identifier votre application lors du flux OAuth\n- Peut être partagé en toute sécurité dans les fichiers de configuration",
       "clientSecret": "## Secret client OAuth\nLe secret client de la configuration de votre application OAuth.\n\n- Créé en même temps que l'ID client.\n- Doit rester confidentiel et sécurisé.\n- Utilisé pour authentifier votre application.",
       "personalAccessToken": "## Jeton d'accès personnel\nUn jeton d'accès personnel disposant des autorisations appropriées pour le service externe.\n\n- Généré dans les paramètres de votre compte\n- Doit disposer des autorisations de lecture et d'écriture\n- Plus sécurisé que l'authentification par mot de passe",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL de l'instance\nL'URL de base de votre instance auto-hébergée.\n\n- Format : https://git.example.com\n- N'incluez pas de barres obliques finales ni de chemins\n- Doit être accessible depuis ce serveur",
       "projectPath": "## Chemin du projet\nLe chemin complet vers votre projet GitLab.\n\n- Format : espace_de_noms/projet ou groupe/sous-groupe/projet\n- Exemple : mon-org/mon-projet\n- Présent dans l'URL du projet : gitlab.com/espace_de_noms/projet",
       "platform": "## Plateforme\nLa plateforme Git auto-hébergée à laquelle vous vous connectez.\n\n- **Gitea** : instances basées sur gitea.io\n- **Forgejo** : instances basées sur forgejo.org (fork de Gitea)\n- **Gogs** : instances basées sur gogs.io\n\nCeci détermine l’icône affichée et peut affecter la compatibilité de l’API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Clé API Redmine\nVotre clé d'accès API REST personnelle.\n\n- Activez l'API REST dans Administration → Paramètres → API\n- Copiez votre clé depuis Mon compte → Clé d'accès API\n- Limitée aux autorisations de votre utilisateur ; utilisez un compte de service pour les intégrations partagées",
+      "redmineUrl": "## URL Redmine\nL'URL de base de votre instance Redmine.\n\n- Format : https://redmine.example.com\n- N'incluez pas /issues ni d'autres chemins\n- Doit être accessible depuis ce serveur",
+      "mantisBTApiKey": "## Jeton API MantisBT\nVotre jeton API REST personnel.\n\n- Créez-en un dans les paramètres de votre compte MantisBT → Jetons API\n- Limité aux autorisations de votre utilisateur ; utilisez un compte de service pour les intégrations partagées",
+      "mantisBTUrl": "## URL MantisBT\nL'URL de base de votre instance MantisBT.\n\n- Format : https://mantisbt.example.com\n- N'incluez pas /api/rest ni d'autres chemins\n- Doit être accessible depuis ce serveur",
+      "githubBaseUrl": "## URL de base de l'API\nRacine complète de l'API GitHub pour GitHub Enterprise Server.\n\n- Se termine généralement par /api/v3\n- Laissez ce champ vide pour utiliser api.github.com\n- Doit être accessible depuis ce serveur"
     },
     "config": {
       "name": "## Nom de la configuration\nUn nom clair et descriptif pour cette configuration.\n\n- Permet de décrire les combinaisons de variantes qui composent la configuration (par exemple « Chrome, Windows 10 », « Safari/macOS 15.5 », « Edge/Windows 11 », etc.).",
@@ -6951,7 +6954,7 @@
           "executions": "{count} court",
           "forecast": "{value} prévision",
           "forecastUnset": "Aucune prévision",
-          "flakiness": "Flips {value}%",
+          "flakiness": "Bascule {value} %",
           "flakinessUnset": "Aucune donnée de retournement",
           "createdLabel": "Créé"
         },
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours} h {minutes} min"
           },
           "relativeAge": {
             "today": "aujourd'hui",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Recherche",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Recherches enregistrées",
+      "save": "Enregistrer la recherche",
+      "saveTitle": "Enregistrer la recherche",
+      "saveDescription": "Nommez cette recherche pour pouvoir la retrouver plus tard.",
+      "saveAction": "Enregistrer",
+      "nameLabel": "Nom",
+      "namePlaceholder": "ex. Exécutions échouées ce sprint",
+      "nameRequired": "Saisissez un nom pour cette recherche.",
+      "loginRequired": "Vous devez être connecté pour enregistrer des recherches.",
       "descriptionLabel": "Description (facultatif)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "À quoi sert cette recherche",
+      "saved": "Recherche enregistrée",
+      "savedDescription": "« {name} » figure désormais dans vos recherches enregistrées.",
+      "saveFailed": "Impossible d'enregistrer la recherche. Veuillez réessayer.",
+      "empty": "Aucune recherche enregistrée pour le moment",
+      "emptyHint": "Enregistrez une recherche pour la retrouver plus tard.",
+      "loaded": "« {name} » chargée",
+      "loadFailed": "Cette recherche enregistrée n'est plus valide.",
+      "edit": "Modifier",
+      "editTitle": "Modifier la recherche enregistrée",
+      "edited": "Recherche enregistrée mise à jour",
+      "editFailed": "Impossible de mettre à jour la recherche. Veuillez réessayer.",
       "delete": "Supprimer",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Supprimer la recherche enregistrée ?",
+      "deleteConfirm": "« {name} » sera retirée de vos recherches enregistrées. Cette action est irréversible.",
+      "deleted": "Recherche enregistrée supprimée",
+      "deleteFailed": "Impossible de supprimer la recherche. Veuillez réessayer."
     },
     "bulk": {
       "crossProjectHint": "(s'étendant sur plusieurs projets)",
@@ -7697,14 +7700,14 @@
       "intro": "Cliquez sur le bouton ci-dessous pour vous connecter :",
       "signInButton": "Se connecter",
       "copyPasteIntro": "Ou copiez et collez ce lien dans votre navigateur :",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Pour votre sécurité, ce lien ne peut être utilisé qu'une seule fois. Demandez un nouveau lien si vous devez vous reconnecter.",
       "disclaimer": "Si vous n'avez pas demandé cet e-mail, vous pouvez l'ignorer sans problème.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Connectez-vous à TestPlanIt\n\nCliquez sur le lien ci-dessous pour vous connecter :\n{url}\n\nPour votre sécurité, ce lien ne peut être utilisé qu'une seule fois. Demandez un nouveau lien si vous devez vous reconnecter.\n\nSi vous n'avez pas demandé cet e-mail, vous pouvez l'ignorer en toute sécurité."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Vous ouvrez ceci sur un autre appareil ? Saisissez ce code sur l'écran de connexion où vous avez demandé le lien :",
+      "deviceNotice": "Ce lien vous connecte depuis le navigateur où vous l'avez demandé. Si vous l'ouvrez ailleurs, le code ci-dessus vous sera présenté pour être saisi dans votre fenêtre d'origine.",
+      "textBody": "Connectez-vous à TestPlanIt\n\nCliquez sur le lien ci-dessous pour vous connecter :\n{url}\n\nVous ouvrez ceci sur un autre appareil ? Saisissez ce code sur l'écran de connexion où vous avez demandé le lien : {code}\n\nSi vous n'avez pas demandé cet e-mail, vous pouvez l'ignorer en toute sécurité."
     }
   },
   "comments": {
@@ -8090,7 +8093,7 @@
     "iterationResetUntestedMissing": "Statut non testé introuvable",
     "overrideTitle": "Remplacer les valeurs pour l'itération {n}",
     "overrideDescription": "Les modifications n'affectent que cette itération. L'instantané du jeu de données et le jeu de données source restent inchangés. Cette action est consignée dans un journal d'audit.",
-    "overrideValidationItem": "@{param}: {message}",
+    "overrideValidationItem": "@{param} : {message}",
     "overrideSensitiveDenied": "Vous n'êtes pas autorisé à modifier les valeurs sensibles.",
     "datasetSourceLocal": "Locale",
     "datasetSourceShared": "Commun",

--- a/testplanit/messages/it-IT.json
+++ b/testplanit/messages/it-IT.json
@@ -1072,7 +1072,7 @@
         "apple": "Continua con Apple",
         "microsoft": "Continua con Microsoft",
         "samlProvider": "Accedi con {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Accedi con Magic Link a uso singolo",
         "emailLogin": "Continua con l'email"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Torna alla pagina di accesso"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Fai clic sul link nell'email per accedere da questo browser, oppure inserisci il codice dall'email qui sotto.",
+        "codeLabel": "Codice di accesso",
+        "verifyCode": "Verifica codice",
+        "verifying": "Verifica in corso...",
+        "invalidCode": "Il codice non è corretto. Controlla l'email e riprova.",
+        "codeExpired": "Questa richiesta di accesso è scaduta. Richiedi un nuovo link.",
+        "tooManyAttempts": "Troppi tentativi errati. Richiedi un nuovo link per riprovare.",
+        "windowLost": "Questa finestra non può più completare l'accesso. Richiedi un nuovo link.",
+        "genericError": "Non è stato possibile completare l'accesso. Richiedi un nuovo link e riprova.",
+        "tooManyRequests": "Troppe richieste di accesso. Attendi un momento e riprova.",
+        "haveCode": "Hai già un codice di accesso?",
+        "codeEntryDescription": "Inserisci il codice dalla tua email di accesso. I codici funzionano solo nel browser in cui hai richiesto il link.",
+        "backToRequest": "Richiedi invece un nuovo link"
       },
       "twoFactor": {
         "title": "Autenticazione a due fattori",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Contattare l'amministratore di sistema"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Accesso in corso...",
+      "completeErrorTitle": "Non è stato possibile completare l'accesso",
+      "requestNewLink": "Richiedi un nuovo link",
+      "codeTitle": "Il tuo codice di accesso",
+      "codeInstructions": "Hai aperto il link di accesso su un dispositivo o browser diverso. Inserisci questo codice nella schermata di accesso da cui lo hai originariamente richiesto.",
+      "codeCloseNotice": "Puoi chiudere questa finestra una volta inserito il codice.",
+      "expiredTitle": "Questo link di accesso non è più valido",
+      "expiredBody": "Il link potrebbe essere scaduto o già utilizzato. Richiedine uno nuovo dalla pagina di accesso — richiede solo un momento."
     },
     "errors": {
       "accessDenied": "Accesso negato. Il tuo account potrebbe essere inattivo o non hai l'autorizzazione per accedere.",
       "configuration": "Si è verificato un problema con la configurazione del server.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Questo link di accesso è scaduto o è già stato utilizzato. I Magic Link possono essere utilizzati solo una volta — richiedine uno nuovo per accedere.",
       "invalid2FACode": "Codice di verifica non valido. Riprova.",
       "twoFactorTokenRequired": "È necessario il token",
       "verificationCodeRequired": "È richiesto il codice di verifica"
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Conserva i problemi nel database (non vengono più collegati)",
           "switchWarning3": "Sostituisci la configurazione di integrazione del problema corrente con quella nuova",
           "switchWarning4": "Rimuovere il webhook in entrata configurato per l'integrazione corrente",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Importa problemi",
+          "importTitle": "Importa problemi da {name}",
+          "importDescription": "Recupera i problemi da questo progetto collegato nel tuo progetto. I problemi esistenti non vengono duplicati e quelli importati rimangono aggiornati tramite la sincronizzazione.",
+          "importUpdatedWithin": "Aggiornato entro",
+          "importLastDays": "Ultimi {days} giorni",
+          "importMax": "Massimo da importare",
+          "importPreview": "Anteprima",
+          "importPreviewResult": "~{count, plural, one {# problema corrisponde} other {# problemi corrispondono}} a questo filtro. Ne verranno importati fino a {cap}.",
+          "importOverCap": "Questo supera il limite di {cap}; verranno importati solo i {cap} aggiornati più recentemente.",
+          "importStart": "Importa",
+          "importStarted": "Importazione avviata. I problemi appariranno a breve.",
+          "importFailed": "Importazione non riuscita",
+          "importPreviewFailed": "Impossibile stimare le corrispondenze"
         },
         "integrationAssigned": "Integrazione assegnata con successo",
         "integrationAssignError": "Impossibile assegnare l'integrazione del problema al progetto",
@@ -1402,10 +1405,10 @@
             "description": "Connettiti ad Azure DevOps per il monitoraggio degli elementi di lavoro."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Connettiti a un'istanza self-hosted di Redmine per il monitoraggio dei problemi."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Connettiti a un'istanza self-hosted di MantisBT per il monitoraggio dei problemi."
           }
         }
       },
@@ -1455,7 +1458,7 @@
         "outboundCreateTitle": "Nuovo webhook in uscita",
         "outboundCreateName": "Nome",
         "outboundCreateNameHelp": "Un'etichetta per questa destinazione, ad esempio \"Engineering Slack\".",
-        "outboundCreateNamePlaceholder": "Engineering Slack",
+        "outboundCreateNamePlaceholder": "Slack Ingegneria",
         "outboundCreateNameRequired": "Il nome è obbligatorio.",
         "outboundCreateUrlRequired": "È richiesto l'URL.",
         "outboundCreateUrlInvalid": "Inserisci un URL valido (https://example.com/...).",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook riattivato",
         "toastReEnableFailed": "Impossibile riattivare: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Webhook in entrata di Redmine",
+        "inboundRedmineScopeHint": "Il plugin redmine_webhook non firma le richieste, quindi questo URL webhook costituisce la credenziale — trattalo come un segreto e ruotalo se esposto.",
+        "setupStepsRedmineStep1": "Installa il plugin redmine_webhook sul tuo server Redmine (Redmine non dispone di webhook integrati).",
+        "setupStepsRedmineStep2": "Nel tuo progetto Redmine, apri Impostazioni → Moduli e abilita Webhook.",
+        "setupStepsRedmineStep3": "Apri Impostazioni → Webhook, incolla l'URL sopra e salva.",
+        "setupStepsRedmineStep4": "Crea o aggiorna un problema in Redmine; lo stato del problema collegato verrà sincronizzato qui.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Webhook in entrata di MantisBT",
+        "inboundMantisbtScopeHint": "Un plugin webhook di MantisBT non firma le richieste, quindi questo URL webhook costituisce la credenziale — trattalo come un segreto e ruotalo se esposto.",
+        "setupStepsMantisbtStep1": "Installa e abilita un plugin webhook di MantisBT sul tuo server MantisBT (MantisBT non dispone di webhook integrati).",
+        "setupStepsMantisbtStep2": "Nella configurazione del plugin, scegli gli eventi di creazione e aggiornamento del problema.",
+        "setupStepsMantisbtStep3": "Incolla l'URL sopra come destinazione del webhook e salva.",
+        "setupStepsMantisbtStep4": "Crea o aggiorna un problema in MantisBT; lo stato del problema collegato verrà sincronizzato qui."
       },
       "aiModels": {
         "description": "Configurare modelli di intelligenza artificiale per la generazione e l'analisi di casi di test intelligenti",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Scansione dei file in {scope}…",
           "scanningFilesCount": "Scansione dei file in {scope}… ({count, number} trovato)",
           "filtering": "Applicazione dei filtri ai file {count, number}…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Limitato dal provider — nuovo tentativo in {seconds, number}s…"
         },
         "cache": {
           "title": "Impostazioni della cache",
@@ -1913,8 +1916,8 @@
         "networkError": "Errore di rete durante l'aggiornamento della cache",
         "refreshSuccess": "Cache aggiornata: {fileCount} file ({contentCached} contenuto memorizzato nella cache)",
         "refreshRateLimited": "Cache aggiornata: {fileCount} file elencati, {contentCached}/{fileCount} contenuti memorizzati nella cache (frequenza limitata: aggiorna di nuovo per completare)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Cache aggiornata: {fileCount} file",
+        "refreshInProgress": "L'aggiornamento della cache è ancora in esecuzione in background. Verrà aggiornato qui al termine.",
         "validation": {
           "pathRequired": "Il percorso è richiesto",
           "patternRequired": "È richiesto un modello",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Attività",
+      "title": "Registro attività",
+      "description": "Tutte le modifiche registrate per questa sessione."
     },
     "title": "{count, plural, =1 {Sessione} other {Sessioni}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "Registro di controllo",
+        "description": "Azioni eseguite da questo utente",
+        "noEntries": "Nessuna attività registrata al momento.",
+        "loadMore": "Caricamento",
+        "viewDetails": "Visualizza i dettagli",
+        "columnAction": "Azione",
+        "columnEntityType": "Tipo",
+        "columnEntityName": "Nome",
+        "columnTimestamp": "Data e ora",
+        "allActions": "Tutte le azioni",
+        "allTypes": "Tutti i tipi",
+        "noMatchingEntries": "Nessuna voce corrisponde ai filtri selezionati.",
+        "showing": "{loaded} di {total} voci"
       },
       "mentionedComments": {
         "title": "Citato nei commenti",
@@ -2510,9 +2513,9 @@
       "historyView": "Visualizzazione cronologia casi di test"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Attività",
+      "title": "Registro attività",
+      "description": "Tutte le modifiche registrate per questo caso di test."
     },
     "fields": {
       "optionNotFound": "Opzione non trovata",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Attività",
+      "title": "Registro attività",
+      "description": "Tutte le modifiche registrate per questa esecuzione di test."
     },
     "notFound": "Esecuzione del test non trovata.",
     "add": {
@@ -3380,7 +3383,7 @@
       "creatingProgress": "Creazione dell'esecuzione di prova {current, number} di {total, number}..."
     },
     "magicSelect": {
-      "title": "Magic Select",
+      "title": "Selezione Magica",
       "description": "Selezione dei casi di test basata sull'intelligenza artificiale in base al contesto dell'esecuzione del test.",
       "counting": "Cerchiamo casi di test pertinenti...",
       "reasoning": "Ragionamento basato sull'IA",
@@ -3561,7 +3564,7 @@
     "imports": {
       "description": "Importa i dati da strumenti esterni di gestione dei test in TestPlanIt.",
       "tabs": {
-        "testmoJson": "Testmo JSON"
+        "testmoJson": "JSON Testmo"
       },
       "testmo": {
         "intro": "Carica un'esportazione JSON di Testmo per analizzarne il contenuto e preparare la mappatura della migrazione.",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "SÌ",
       "scimUserLockedTitle": "L'utente è gestito da SCIM",
       "scimUserLockedDescription": "Il nome, l'indirizzo email e lo stato attivo di questo utente sono gestiti dal tuo provider di identità. Apporta le modifiche lì per aggiornarli anche qui.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Gestito dalla mappatura dei gruppi",
+      "groupMappingOverrideDescription": "Il livello di accesso di questo utente è governato da una mappatura di gruppo SCIM e potrebbe essere ripristinato alla prossima sincronizzazione.",
+      "groupMappingBadge": "Gruppo mappato"
     },
     "security": {
       "title": "Sicurezza",
@@ -4622,16 +4625,16 @@
         "errorToast": "Impossibile revocare il token. {reason}"
       },
       "probe": {
-        "button": "Test SCIM",
+        "button": "Testa SCIM",
         "testing": "Test…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — il token funziona con /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Impossibile raggiungere l'endpoint SCIM. Riprova."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Accesso mappato predefinito",
+      "fallbackDefaultDescription": "Livello di accesso assegnato agli utenti non coperti da alcuna mappatura di gruppo.",
+      "fallbackDefaultLabel": "Livello di accesso predefinito",
+      "fallbackDefaultSaved": "Predefinito di riserva salvato"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Gestito da SCIM. Gestisci dalla pagina di amministrazione di SCIM.",
       "scimNameLockedTitle": "Il gruppo è gestito da SCIM",
       "scimNameLockedDescription": "Il nome e i membri di questo gruppo sono gestiti dal tuo provider di identità. Apporta le modifiche lì per aggiornarli anche qui.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Accesso mappato",
+      "mappedAccessLabel": "Livello di accesso mappato",
+      "mappedAccessNone": "Nessuna mappatura",
+      "mappedAccessSelect": "Seleziona il livello di accesso...",
+      "downgradeConfirmTitle": "Conferma modifica accesso",
+      "downgradeConfirmDescription": "{count, plural, one {# utente avrebbe l'accesso ridotto} other {# utenti avrebbero l'accesso ridotto}}. Continuare?",
+      "downgradeConfirmApplyAnyway": "Applica comunque",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Attivo",
         "inactive": "Inattivo",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "In attesa di autorizzazione"
       },
       "connectedProjects": "Progetti connessi",
       "noIntegrations": "Nessuna integrazione di problemi configurata",
       "testConnection": "Prova di connessione",
       "testSuccess": "Connessione riuscita",
       "testSuccessDescription": "L'integrazione del problema è configurata e connessa correttamente",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Le credenziali sono corrette",
+      "testCredentialsSavedDescription": "Il tuo ID client e il segreto OAuth sono validi. Salva l'integrazione, quindi fai clic su Autorizza per collegare il tuo account — OAuth 2.0 si collega per singolo utente, quindi rimane inattivo finché almeno una persona non autorizza.",
       "testFailed": "Connessione fallita",
       "testFailedDescription": "Impossibile connettersi al servizio esterno",
       "testError": "Errore di prova",
       "testErrorDescription": "Si è verificato un errore durante il test della connessione",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autorizza",
+      "reauthorize": "Autorizza nuovamente",
+      "authorizeHint": "Autorizza con il provider per collegare il tuo account e completare la configurazione",
+      "syncInProgress": "Nuova sincronizzazione dei problemi collegati in corso...",
+      "syncIntegration": "Sincronizza nuovamente i problemi collegati",
+      "syncIntegrationHint": "Sincronizza nuovamente solo i problemi già collegati in TestPlanIt. I nuovi problemi non vengono importati dal tracker esterno.",
       "syncSuccess": "Sincronizzazione in coda",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "I problemi collegati da \"{name}\" sono in fase di nuova sincronizzazione in background. L'operazione potrebbe richiedere alcuni istanti. La tabella si aggiornerà automaticamente al termine.",
       "syncError": "Sincronizzazione non riuscita",
       "syncErrorDescription": "Impossibile mettere in coda il processo di sincronizzazione per l'integrazione di questo problema. Riprova più tardi.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Connettiti a un'istanza self-hosted di Redmine per il monitoraggio dei problemi"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Connettiti a un'istanza self-hosted di MantisBT per il monitoraggio dei problemi"
         }
       },
       "filterPlaceholder": "Integrazioni di filtri...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Per un'attribuzione accurata delle segnalazioni a ciascun utente senza autorizzazioni di amministratore, utilizzare OAuth 2.0.",
         "tokenCreatorNoticeTitle": "Attribuzione del creatore del problema",
         "tokenCreatorNoticeDescription": "I problemi creati tramite questa integrazione vengono sempre registrati con l'account proprietario di questo token di accesso, non con l'utente di TestPlanIt che li ha creati. L'API di questo provider non consente di impostare l'autore per conto di un altro utente.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL di callback (URI di reindirizzamento)",
+        "callbackUrlDescription": "Registra esattamente questo URL come callback / URI di reindirizzamento nell'app OAuth del tuo provider. Deve corrispondere esattamente, altrimenti l'autorizzazione non riuscirà.",
+        "callbackUrlCopy": "Copia",
+        "callbackUrlCopied": "Copiato",
         "forgeApiKeyLabel": "Chiave API Forge",
         "forgeApiKeyDescription": "Utilizzato dall'app Atlassian Forge per autenticare le richieste provenienti dai pannelli dei ticket Jira. Genera una chiave qui e incollala nelle impostazioni dell'app Forge.",
         "forgeApiKeyPlaceholder": "Fai clic su Genera per creare una chiave API",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Chiave API Redmine",
+        "redmineApiKeyPlaceholder": "Inserisci la tua chiave API Redmine",
+        "redmineApiKeyHelp": "Si trova in Il mio account → Chiave di accesso API (abilita l'API REST in Amministrazione → Impostazioni → API)",
+        "redmineUrl": "URL Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "L'URL di base della tua istanza Redmine",
+        "mantisBTApiKey": "Token API MantisBT",
+        "mantisBTApiKeyPlaceholder": "Inserisci il tuo token API MantisBT",
+        "mantisBTApiKeyHelp": "Creane uno nelle impostazioni del tuo account MantisBT → Token API",
+        "mantisBTUrl": "URL MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "L'URL di base della tua istanza MantisBT"
       },
       "authType": {
         "api_key": "Chiave API",
@@ -5487,7 +5490,7 @@
         "warning": "Questa azione non può essere annullata. Tutti i progetti che utilizzano questa configurazione torneranno alla configurazione predefinita del prompt."
       },
       "llmColumn": "LLM",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} LLM",
       "cannotDeleteDefault": "Impossibile eliminare la configurazione predefinita del prompt. Impostane prima un'altra come predefinita.",
       "defaultChanged": "Configurazione predefinita dei prompt aggiornata correttamente.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Genera casi di test da URL (requisiti)",
         "generate_from_url_app": "Genera casi di test da URL (test dell'applicazione)",
         "automation_candidates": "Rapporto sui candidati all'automazione",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Derivazione dei passaggi AI"
       }
     },
     "elasticsearch": {
@@ -5577,7 +5580,7 @@
         "repo-cache": "Cache del repository",
         "copy-move": "Copia e sposta",
         "duplicate-scan": "Scansione duplicata",
-        "magic-select": "Magic Select",
+        "magic-select": "Selezione magica",
         "step-scan": "Scansione della sequenza dei passaggi"
       },
       "status": {
@@ -5651,7 +5654,7 @@
         "details": {
           "title": "Dettagli del lavoro",
           "failedReason": "Motivo del fallimento",
-          "stacktrace": "Stack Trace",
+          "stacktrace": "Traccia dello stack",
           "data": "Dati di lavoro",
           "returnValue": "Valore di ritorno",
           "options": "Opzioni di lavoro",
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Visualizza il registro di controllo a livello di sistema per il monitoraggio della sicurezza e della conformità.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Visualizza il registro di controllo delle azioni eseguite in questo progetto.",
       "filterPlaceholder": "Cerca per entità, utente o azione...",
       "filterAction": "Azione",
       "filterEntityType": "Tipo di entità",
       "allActions": "Tutte le azioni",
       "allEntityTypes": "Tutti i tipi di entità",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Tutti gli utenti",
+      "allProjects": "Tutti i progetti",
+      "showing": "Visualizzazione di {loaded} su {total} voci",
       "viewDetails": "Visualizza i dettagli",
       "detailTitle": "Dettagli del registro di controllo",
       "userInfo": "Informazioni utente",
@@ -5714,8 +5717,8 @@
       "systemActor": "Sistema",
       "systemActorTooltip": "Azione eseguita dal sistema, non da un utente autenticato.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "modifiche correlate",
+      "groupedEntry": "Modifiche raggruppate da una singola azione"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "è ancora in attesa della tua recensione di",
         "reviewReminderEmailMessage": "Promemoria: la richiesta di revisione di {actorName}su {entityLabel} \"{entityName}\" nel progetto \"{projectName}\" è in sospeso da {hoursPending} ore.",
         "reviewReminderHoursPending": "In attesa da {hoursPending, plural, one {# ore} other {# ore}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Passaggi di test derivati dall'AI pronti",
+        "aiStepsDerivedMessage": "{count, plural, one {# caso di test ha} other {# casi di test hanno}} ricevuto passaggi derivati dall'AI — verificane l'accuratezza.",
+        "aiStepsDerivedReviewLink": "Rivedi l'esecuzione del test"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Nome del gruppo\nUn nome o una o più parole chiave chiare, concise e descrittive, utilizzate in tutti i progetti.\n\n- Aiuta i membri del team a trovare rapidamente casi di test, esecuzioni di test e sessioni correlate.",
       "users": "## Utenti\nIndica gli utenti assegnati a questo gruppo.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Livello di accesso mappato\nAi membri di questo gruppo viene concesso almeno questo livello di accesso alla prossima sincronizzazione.\n\n- Vince il livello più alto tra tutti i gruppi di un utente\n- \"Nessuna mappatura\" significa che questo gruppo non influisce sull'accesso — i membri ricadono sul valore predefinito impostato nella pagina SCIM\n- Una modifica manuale dell'accesso di un utente ha la precedenza sulla mappatura (ed è segnalata nella schermata di modifica di quell'utente)"
     },
     "template": {
       "name": "## Nome modello\nUn nome univoco e descrittivo per questo modello (ad esempio, 'Caso di test standard', 'Risultati del test API').",
@@ -6209,7 +6212,7 @@
       "authType": "## Tipo di autenticazione\nScegli come autenticarti con il servizio esterno.\n\n- **Chiave API:** Autenticazione semplice tramite e-mail e token API\n- **OAuth 2.0:** Autenticazione sicura tramite flusso OAuth\n- **Token di accesso personale:** Autenticazione diretta basata su token",
       "email": "## Indirizzo email\nL'indirizzo email del tuo account per il servizio esterno.\n\n- Utilizzato per l'autenticazione tramite chiave API\n- Deve corrispondere all'account che ha generato il token API\n- Obbligatorio per Jira e servizi simili",
       "apiToken": "## Token API\nGenera un token API dalle impostazioni del tuo account nel servizio esterno.\n\n- Solitamente si trova in Impostazioni account → Sicurezza → Token API\n- Fornisce un accesso sicuro senza esporre la tua password\n- Può essere revocato e rigenerato secondo necessità",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL Jira\nL'URL di base della tua istanza Jira.\n\n- Formato: https://your-site.atlassian.net\n- Non includere /browse o altri percorsi\n- Deve essere accessibile da questo server",
       "clientId": "## ID client OAuth\nID client dalla configurazione dell'applicazione OAuth.\n\n- Creato nella console per sviluppatori del servizio esterno\n- Utilizzato per identificare l'applicazione durante il flusso OAuth\n- Sicuro da condividere nei file di configurazione",
       "clientSecret": "## Segreto client OAuth\nIl segreto client dalla configurazione dell'applicazione OAuth.\n\n- Creato insieme all'ID client\n- Deve essere mantenuto riservato e sicuro\n- Utilizzato per autenticare l'applicazione",
       "personalAccessToken": "## Token di accesso personale\nUn token di accesso personale con autorizzazioni appropriate per il servizio esterno.\n\n- Generato nelle impostazioni del tuo account\n- Dovrebbe avere autorizzazioni per problemi di lettura e scrittura\n- Più sicuro dell'autenticazione tramite password",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL dell'istanza\nL'URL di base della tua istanza self-hosted.\n\n- Formato: https://git.example.com\n- Non includere barre finali o percorsi\n- Deve essere accessibile da questo server",
       "projectPath": "## Percorso del progetto\nIl percorso completo del tuo progetto GitLab.\n\n- Formato: namespace/project o group/subgroup/project\n- Esempio: my-org/my-project\n- Si trova nell'URL del progetto: gitlab.com/namespace/project",
       "platform": "## Piattaforma\nLa piattaforma Git self-hosted a cui ti stai connettendo.\n\n- **Gitea**: istanze basate su gitea.io\n- **Forgejo**: istanze basate su forgejo.org (fork di Gitea)\n- **Gogs**: istanze basate su gogs.io\n\nQuesto controlla quale icona viene mostrata e potrebbe influire sulla compatibilità API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Chiave API Redmine\nLa tua chiave di accesso API REST personale.\n\n- Abilita l'API REST in Amministrazione → Impostazioni → API\n- Copia la tua chiave da Il mio account → Chiave di accesso API\n- Limitata alle autorizzazioni del tuo utente; usa un account di servizio per le integrazioni condivise",
+      "redmineUrl": "## URL Redmine\nL'URL di base della tua istanza Redmine.\n\n- Formato: https://redmine.example.com\n- Non includere /issues o altri percorsi\n- Deve essere accessibile da questo server",
+      "mantisBTApiKey": "## Token API MantisBT\nIl tuo token API REST personale.\n\n- Creane uno nelle impostazioni del tuo account MantisBT → Token API\n- Limitato alle autorizzazioni del tuo utente; usa un account di servizio per le integrazioni condivise",
+      "mantisBTUrl": "## URL MantisBT\nL'URL di base della tua istanza MantisBT.\n\n- Formato: https://mantisbt.example.com\n- Non includere /api/rest o altri percorsi\n- Deve essere accessibile da questo server",
+      "githubBaseUrl": "## URL di base API\nIndirizzo radice completo dell'API GitHub per GitHub Enterprise Server.\n\n- Termina generalmente con /api/v3\n- Lascia vuoto per utilizzare api.github.com\n- Deve essere accessibile da questo server"
     },
     "config": {
       "name": "## Nome della configurazione\nUn nome chiaro e descrittivo per questa configurazione.\n\n- Aiuta a descrivere le combinazioni di varianti che compongono la configurazione (ad esempio \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", ecc.).",
@@ -6716,7 +6719,7 @@
       "addDimension": "Aggiungi dimensione...",
       "addMetric": "Aggiungi metrica...",
       "runReport": "Esegui rapporto",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Esporta in formato CSV",
       "noResultsFound": "Nessun risultato trovato.",
       "selectAtLeastOneDimensionAndMetric": "Selezionare almeno una dimensione e una metrica.",
       "noDataMatchingCriteria": "Nessun dato trovato corrispondente alle dimensioni e alle metriche selezionate.",
@@ -6973,8 +6976,8 @@
             "flakiestNone": "Nessun risultato variabile finora: l'euristica Flakiest First non è ancora in grado di misurare il passaggio da superato a non superato in questo caso.",
             "longestWithDuration": "Previsione dell'esecuzione manuale {duration} — l'automazione dei test manuali di lunga durata recupera una quantità di tempo del tester proporzionalmente maggiore ad ogni esecuzione.",
             "longestNone": "Nessuna previsione o stima impostata: l'euristica Longest to Execute non dispone di dati sulla durata per questo caso.",
-            "oldest": "Authored {age} — long-lived manual cases tend to be mature, stable behaviors that are safe to automate without rework.",
-            "newest": "Authored {age} — newly-authored cases are the most likely to need execution coverage right now.",
+            "oldest": "Creato {age} — i casi manuali di lunga data tendono a rappresentare comportamenti maturi e stabili, sicuri da automatizzare senza necessità di modifiche.",
+            "newest": "Creato {age} — i casi creati di recente sono quelli che più probabilmente necessitano di copertura esecutiva in questo momento.",
             "random": "Campione casuale: incluso come riferimento imparziale; la modalità euristica non ha alcuna preferenza intrinseca per questo caso rispetto agli altri presenti nel campione."
           },
           "flakinessFraction": {
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Ricerca",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Ricerche salvate",
+      "save": "Salva ricerca",
+      "saveTitle": "Salva ricerca",
+      "saveDescription": "Assegna un nome a questa ricerca per poterla ritrovare in seguito.",
+      "saveAction": "Salva",
+      "nameLabel": "Nome",
+      "namePlaceholder": "ad es. Esecuzioni non riuscite in questo sprint",
+      "nameRequired": "Inserisci un nome per questa ricerca.",
+      "loginRequired": "Devi aver effettuato l'accesso per salvare le ricerche.",
       "descriptionLabel": "Descrizione (facoltativa)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "A cosa serve questa ricerca",
+      "saved": "Ricerca salvata",
+      "savedDescription": "“{name}” è ora nelle tue ricerche salvate.",
+      "saveFailed": "Impossibile salvare la ricerca. Riprova.",
+      "empty": "Nessuna ricerca salvata al momento",
+      "emptyHint": "Salva una ricerca per ritrovarla in seguito.",
+      "loaded": "Caricato “{name}”",
+      "loadFailed": "Questa ricerca salvata non è più valida.",
+      "edit": "Modifica",
+      "editTitle": "Modifica ricerca salvata",
+      "edited": "Ricerca salvata aggiornata",
+      "editFailed": "Impossibile aggiornare la ricerca. Riprova.",
       "delete": "Eliminare",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Eliminare la ricerca salvata?",
+      "deleteConfirm": "“{name}” verrà rimossa dalle tue ricerche salvate. Questa azione non può essere annullata.",
+      "deleted": "Ricerca salvata eliminata",
+      "deleteFailed": "Impossibile eliminare la ricerca. Riprova."
     },
     "bulk": {
       "crossProjectHint": "(relativo a più progetti)",
@@ -7697,14 +7700,14 @@
       "intro": "Fai clic sul pulsante qui sotto per accedere:",
       "signInButton": "Registrazione",
       "copyPasteIntro": "Oppure copia e incolla questo link nel tuo browser:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Per motivi di sicurezza, questo link può essere utilizzato solo una volta. Richiedi un nuovo link se devi accedere di nuovo.",
       "disclaimer": "Se non hai richiesto questa email, puoi tranquillamente ignorarla.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Accedi a TestPlanIt\n\nFai clic sul link seguente per accedere:\n{url}\n\nPer motivi di sicurezza, questo link può essere utilizzato solo una volta. Richiedi un nuovo link se devi accedere di nuovo.\n\nSe non hai richiesto questa email, puoi ignorarla in tutta sicurezza."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Stai aprendo questo link su un dispositivo diverso? Inserisci questo codice nella schermata di accesso da cui hai richiesto il link:",
+      "deviceNotice": "Questo link ti consente di accedere dal browser in cui lo hai richiesto. Se lo apri altrove, ti verrà mostrato il codice sopra da inserire nella finestra originale.",
+      "textBody": "Accedi a TestPlanIt\n\nFai clic sul link seguente per accedere:\n{url}\n\nStai aprendo questo link su un dispositivo diverso? Inserisci questo codice nella schermata di accesso da cui hai richiesto il link: {code}\n\nSe non hai richiesto questa email, puoi ignorarla in tutta sicurezza."
     }
   },
   "comments": {
@@ -8078,7 +8081,7 @@
     "overrideUnsavedDiscard": "Scarta le modifiche",
     "iterationBulkConfirmTitle": "Contrassegna {count, plural, =1 {# iterazione} other {# iterazioni}} come {action}?",
     "iterationBulkConfirmDescription": "Ogni iterazione selezionata riceverà un nuovo risultato con stato \"{statusName}\".",
-    "iterationBulkConfirm": "Mark {action}",
+    "iterationBulkConfirm": "Contrassegna {action}",
     "iterationBulkConfirmReplace": "Sostituisci con {action}",
     "iterationBulkOverwriteWarning": "{count, plural, =1 {Il numero di iterazioni selezionate ha già} other {Il numero di iterazioni selezionate ha già}} un risultato. Verrà registrato un nuovo risultato e l'ultimo sostituirà quello corrente.",
     "iterationBulkReasonLabel": "Motivo (facoltativo)",

--- a/testplanit/messages/ja-JP.json
+++ b/testplanit/messages/ja-JP.json
@@ -1072,7 +1072,7 @@
         "apple": "Appleで続ける",
         "microsoft": "Microsoft で続行",
         "samlProvider": "{name}でサインイン",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "使い切りのマジックリンクでサインイン",
         "emailLogin": "メールで続行"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "サインインに戻る"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "メール内のリンクをクリックしてこのブラウザからサインインするか、以下にメール内のコードを入力してください。",
+        "codeLabel": "サインインコード",
+        "verifyCode": "コードを確認",
+        "verifying": "確認中…",
+        "invalidCode": "そのコードは正しくありません。メールを確認して、もう一度お試しください。",
+        "codeExpired": "このサインインリクエストは期限切れです。新しいリンクをリクエストしてください。",
+        "tooManyAttempts": "誤った試行が多すぎます。もう一度試すには新しいリンクをリクエストしてください。",
+        "windowLost": "このウィンドウではサインインを完了できなくなりました。新しいリンクをリクエストしてください。",
+        "genericError": "サインインできませんでした。新しいリンクをリクエストして、もう一度お試しください。",
+        "tooManyRequests": "サインインのリクエストが多すぎます。しばらく待ってから、もう一度お試しください。",
+        "haveCode": "サインインコードをお持ちですか？",
+        "codeEntryDescription": "サインインメールに記載されているコードを入力してください。コードはリンクをリクエストしたブラウザでのみ有効です。",
+        "backToRequest": "代わりに新しいリンクをリクエスト"
       },
       "twoFactor": {
         "title": "二要素認証",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "システム管理者に問い合わせる"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "サインインしています…",
+      "completeErrorTitle": "サインインできませんでした",
+      "requestNewLink": "新しいリンクをリクエスト",
+      "codeTitle": "あなたのサインインコード",
+      "codeInstructions": "サインインリンクを別のデバイスまたはブラウザで開きました。最初にリクエストしたサインイン画面でこのコードを入力してください。",
+      "codeCloseNotice": "コードを入力したら、このウィンドウを閉じても構いません。",
+      "expiredTitle": "このサインインリンクは無効になりました",
+      "expiredBody": "リンクは期限切れか、既に使用されている可能性があります。サインインページから新しいリンクをリクエストしてください — すぐに完了します。"
     },
     "errors": {
       "accessDenied": "アクセスが拒否されました。アカウントが非アクティブであるか、サインインする権限がない可能性があります。",
       "configuration": "サーバー構成に問題があります。",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "このサインインリンクは期限切れか、既に使用されています。マジックリンクは一度しか使用できません — サインインするには新しいリンクをリクエストしてください。",
       "invalid2FACode": "認証コードが無効です。もう一度お試しください。",
       "twoFactorTokenRequired": "トークンが必要です",
       "verificationCodeRequired": "認証コードが必要です"
@@ -1364,19 +1367,19 @@
           "switchWarning2": "データベース内の問題を保存します（リンクが解除されます）",
           "switchWarning3": "現在の問題統合設定を新しいものに置き換えます",
           "switchWarning4": "現在の統合用に設定されている受信ウェブフックを削除します。",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "課題をインポート",
+          "importTitle": "{name}から課題をインポート",
+          "importDescription": "このリンクされたプロジェクトから課題を取得し、あなたのプロジェクトに取り込みます。既存の課題は重複しません。インポートされた課題は同期を通じて最新の状態に保たれます。",
+          "importUpdatedWithin": "更新期間",
+          "importLastDays": "過去{days}日間",
+          "importMax": "インポートする最大数",
+          "importPreview": "プレビュー",
+          "importPreviewResult": "約{count, plural, other {#件の課題}}がこのフィルターに一致します。最大{cap}件までインポートされます。",
+          "importOverCap": "これは上限の{cap}件を超えています。最近更新された{cap}件のみがインポートされます。",
+          "importStart": "インポート",
+          "importStarted": "インポートを開始しました。まもなく課題が表示されます。",
+          "importFailed": "インポートに失敗しました",
+          "importPreviewFailed": "一致数を見積もれませんでした"
         },
         "integrationAssigned": "統合が正常に割り当てられました",
         "integrationAssignError": "問題統合をプロジェクトに割り当てることができませんでした",
@@ -1402,10 +1405,10 @@
             "description": "作業項目の追跡には、Azure DevOpsに接続してください。"
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "課題追跡のために、自己ホスト型のRedmineインスタンスに接続します。"
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "課題追跡のために、自己ホスト型のMantisBTインスタンスに接続します。"
           }
         }
       },
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhookが再び有効化されました",
         "toastReEnableFailed": "再有効化に失敗しました: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Redmineインバウンドウェブフック",
+        "inboundRedmineScopeHint": "redmine_webhookプラグインはリクエストに署名しないため、このウェブフックURLが認証情報となります。シークレットとして扱い、漏えいした場合はローテーションしてください。",
+        "setupStepsRedmineStep1": "Redmineサーバーにredmine_webhookプラグインをインストールしてください（Redmineには組み込みのウェブフック機能がありません）。",
+        "setupStepsRedmineStep2": "Redmineプロジェクトで、[設定] → [モジュール] を開き、ウェブフックを有効にしてください。",
+        "setupStepsRedmineStep3": "[設定] → [ウェブフック] を開き、上記のURLを貼り付けて保存してください。",
+        "setupStepsRedmineStep4": "Redmineで課題を作成または更新すると、リンクされた課題のステータスがここに同期されます。",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "MantisBTインバウンドウェブフック",
+        "inboundMantisbtScopeHint": "MantisBTウェブフックプラグインはリクエストに署名しないため、このウェブフックURLが認証情報となります。シークレットとして扱い、漏えいした場合はローテーションしてください。",
+        "setupStepsMantisbtStep1": "MantisBTサーバーにMantisBTウェブフックプラグインをインストールして有効にしてください（MantisBTには組み込みのウェブフック機能がありません）。",
+        "setupStepsMantisbtStep2": "プラグインの設定で、課題作成イベントと課題更新イベントを選択してください。",
+        "setupStepsMantisbtStep3": "上記のURLをウェブフックの送信先として貼り付けて保存してください。",
+        "setupStepsMantisbtStep4": "MantisBTで課題を作成または更新すると、リンクされた課題のステータスがここに同期されます。"
       },
       "aiModels": {
         "description": "インテリジェントなテストケース生成と分析のための AI モデルを構成する",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "{scope}… のファイルをスキャンしています。",
           "scanningFilesCount": "{scope}… 内のファイルをスキャンしています ({count, number} が見つかりました)",
           "filtering": "{count, number} ファイル… にフィルタを適用しています。",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "プロバイダーによってレート制限されました — {seconds, number}秒後に再試行します…"
         },
         "cache": {
           "title": "キャッシュ設定",
@@ -1913,8 +1916,8 @@
         "networkError": "キャッシュ更新中にネットワークエラーが発生しました",
         "refreshSuccess": "キャッシュが更新されました: {fileCount} 個のファイル ({contentCached} 個のコンテンツがキャッシュされました)",
         "refreshRateLimited": "キャッシュが更新されました: {fileCount} 個のファイルが一覧表示され、 {contentCached}/{fileCount} 個のコンテンツがキャッシュされました (レート制限あり - 完了するには再度更新してください)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "キャッシュを更新しました：{fileCount} 件のファイル",
+        "refreshInProgress": "キャッシュの更新はバックグラウンドで実行中です。完了するとここに反映されます。",
         "validation": {
           "pathRequired": "パスが必要です",
           "patternRequired": "型紙が必要です",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "活動",
+      "title": "活動ログ",
+      "description": "このセッションで記録されたすべての変更です。"
     },
     "title": "{count, plural, =1 {セッション} other {セッション}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "監査ログ",
+        "description": "このユーザーが実行したアクション",
+        "noEntries": "記録された活動はまだありません。",
+        "loadMore": "読み込み中",
+        "viewDetails": "詳細を見る",
+        "columnAction": "アクション",
+        "columnEntityType": "タイプ",
+        "columnEntityName": "名前",
+        "columnTimestamp": "タイムスタンプ",
+        "allActions": "すべてのアクション",
+        "allTypes": "すべてのタイプ",
+        "noMatchingEntries": "選択したフィルターに一致するエントリーはありません。",
+        "showing": "{total}件中{loaded}件のエントリー"
       },
       "mentionedComments": {
         "title": "コメントで言及",
@@ -2510,9 +2513,9 @@
       "historyView": "テストケース履歴ビュー"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "活動",
+      "title": "活動ログ",
+      "description": "このテストケースで記録されたすべての変更です。"
     },
     "fields": {
       "optionNotFound": "オプションが見つかりません",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# ペアがリンクされています} other {# ペアがリンクされています}}",
       "bulkError": "一部の操作が失敗しました。もう一度お試しください。",
       "tableHint": "行をクリックするか、「比較」ボタンをクリックして、重複するペアを確認し、解決してください。",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} 対 {caseB}",
       "comparisonDescription": "これらの重複の可能性のあるものを比較し、解決方法を選択してください。",
       "selectPrimary": "ケースをクリックして、マージのプライマリとして選択します。",
       "selectedAsPrimary": "プライマリとして選択",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "活動",
+      "title": "活動ログ",
+      "description": "このテスト実行で記録されたすべての変更です。"
     },
     "notFound": "テスト実行が見つかりません。",
     "add": {
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "はい",
       "scimUserLockedTitle": "ユーザーはSCIMによって管理されています",
       "scimUserLockedDescription": "このユーザー名、メールアドレス、およびアクティブステータスは、ご利用のIDプロバイダーによって管理されています。こちらで更新するには、そちらで変更してください。",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "グループマッピングによる管理",
+      "groupMappingOverrideDescription": "このユーザーのアクセス階層はSCIMグループマッピングによって管理されており、次回の同期時に元に戻る可能性があります。",
+      "groupMappingBadge": "グループマッピング済み"
     },
     "security": {
       "title": "安全",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "SCIMをテストする",
         "testing": "テスト…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — トークンは /api/scim/v2/Users に対して有効です。",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "SCIMエンドポイントに接続できませんでした。再試行します。"
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "デフォルトのマッピングアクセス",
+      "fallbackDefaultDescription": "どのグループマッピングにも該当しないユーザーに割り当てられるアクセス階層です。",
+      "fallbackDefaultLabel": "デフォルトのアクセス階層",
+      "fallbackDefaultSaved": "フォールバックデフォルトを保存しました"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "SCIMによって管理されています。SCIMの管理ページから管理してください。",
       "scimNameLockedTitle": "このグループはSCIMによって運営されています。",
       "scimNameLockedDescription": "このグループ名とメンバーは、ご利用のIDプロバイダーによって管理されています。こちらで情報を更新するには、そちらで変更してください。",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "マッピングされたアクセス",
+      "mappedAccessLabel": "マッピングされたアクセス階層",
+      "mappedAccessNone": "マッピングされていません",
+      "mappedAccessSelect": "アクセス階層を選択…",
+      "downgradeConfirmTitle": "アクセス変更の確認",
+      "downgradeConfirmDescription": "{count, plural, other {# 人のユーザー}}のアクセスが引き下げられます。続行しますか？",
+      "downgradeConfirmApplyAnyway": "とにかく適用",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "アクティブ",
         "inactive": "非アクティブ",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "承認待ち"
       },
       "connectedProjects": "関連プロジェクト",
       "noIntegrations": "問題統合が設定されていません",
       "testConnection": "テスト接続",
       "testSuccess": "接続成功",
       "testSuccessDescription": "問題統合は適切に構成され、接続されています",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "認証情報は問題ありません",
+      "testCredentialsSavedDescription": "OAuthクライアントIDとシークレットは有効です。インテグレーションを保存してから、[承認]をクリックしてアカウントを接続してください — OAuth 2.0はユーザーごとに接続するため、少なくとも1人が承認するまでは非アクティブのままです。",
       "testFailed": "接続に失敗しました",
       "testFailedDescription": "外部サービスに接続できません",
       "testError": "テストエラー",
       "testErrorDescription": "接続テスト中にエラーが発生しました",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "承認",
+      "reauthorize": "再承認",
+      "authorizeHint": "プロバイダーで承認してアカウントを接続し、セットアップを完了してください",
+      "syncInProgress": "リンクされた課題を再同期しています…",
+      "syncIntegration": "リンクされた課題を再同期",
+      "syncIntegrationHint": "TestPlanItに既にリンクされている課題のみを再同期します。外部トラッカーから新しい課題はインポートされません。",
       "syncSuccess": "同期キュー",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "「{name}」からのリンクされた課題はバックグラウンドで再同期されています。しばらく時間がかかる場合があります。完了すると表が自動的に更新されます。",
       "syncError": "同期に失敗しました",
       "syncErrorDescription": "この問題の統合に関する同期ジョブをキューに追加できませんでした。しばらくしてからもう一度お試しください。",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "課題追跡のために、自己ホスト型のRedmineインスタンスに接続します"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "課題追跡のために、自己ホスト型のMantisBTインスタンスに接続します"
         }
       },
       "filterPlaceholder": "フィルター統合...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "管理者権限なしでユーザーごとの正確な報告者特定を行うには、OAuth 2.0を使用してください。",
         "tokenCreatorNoticeTitle": "問題作成者の帰属表示",
         "tokenCreatorNoticeDescription": "この連携機能を通じて作成された課題は、作成者である TestPlanIt ユーザーではなく、このアクセス トークンを所有するアカウントに記録されます。このプロバイダーの API では、他のユーザーに代わって作成者を設定することはできません。",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "コールバックURL（リダイレクトURI）",
+        "callbackUrlDescription": "このURLを、プロバイダーのOAuthアプリのコールバック／リダイレクトURIとして正確に登録してください。完全に一致しないと承認が失敗します。",
+        "callbackUrlCopy": "コピー",
+        "callbackUrlCopied": "コピーしました",
         "forgeApiKeyLabel": "Forge APIキー",
         "forgeApiKeyDescription": "Atlassian ForgeアプリがJira課題パネルからのリクエストを認証するために使用します。ここでキーを生成し、Forgeアプリの設定に貼り付けてください。",
         "forgeApiKeyPlaceholder": "「生成」をクリックしてAPIキーを作成します。",
@@ -5278,18 +5281,18 @@
         "platformGitea": "ギテア",
         "platformForgejo": "フォルジェホ",
         "platformGogs": "ゴグス",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
+        "redmineApiKey": "Redmine APIキー",
+        "redmineApiKeyPlaceholder": "Redmine APIキーを入力してください",
+        "redmineApiKeyHelp": "[マイアカウント] → [APIアクセスキー] にあります（[管理] → [設定] → [API] でREST APIを有効にしてください）",
         "redmineUrl": "Redmine URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
+        "redmineUrlHelp": "RedmineインスタンスのベースURL",
+        "mantisBTApiKey": "MantisBT APIトークン",
+        "mantisBTApiKeyPlaceholder": "MantisBT APIトークンを入力してください",
+        "mantisBTApiKeyHelp": "MantisBTのアカウント設定 → [APIトークン] で作成してください",
         "mantisBTUrl": "MantisBT URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "MantisBTインスタンスのベースURL"
       },
       "authType": {
         "api_key": "APIキー",
@@ -5487,7 +5490,7 @@
         "warning": "この操作は元に戻せません。この設定を使用しているすべてのプロジェクトは、デフォルトのプロンプト設定に戻ります。"
       },
       "llmColumn": "法学修士",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} 個のLLM",
       "cannotDeleteDefault": "デフォルトのプロンプト設定を削除できません。まず別の設定をデフォルトにしてください。",
       "defaultChanged": "デフォルトのプロンプト設定が正常に更新されました。",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "URLからテストケースを生成する（要件）",
         "generate_from_url_app": "URLからテストケースを生成する（アプリケーションテスト）",
         "automation_candidates": "自動化候補者レポート",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "AIステップ導出"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "セキュリティとコンプライアンスの追跡のためのシステム全体の監査証跡を表示する",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "このプロジェクトで実行されたアクションの監査証跡を表示します。",
       "filterPlaceholder": "エンティティ、ユーザー、またはアクションで検索...",
       "filterAction": "アクション",
       "filterEntityType": "エンティティタイプ",
       "allActions": "すべてのアクション",
       "allEntityTypes": "すべてのエンティティタイプ",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "すべてのユーザー",
+      "allProjects": "すべてのプロジェクト",
+      "showing": "{total}件中{loaded}件を表示中",
       "viewDetails": "詳細を表示",
       "detailTitle": "監査ログの詳細",
       "userInfo": "ユーザー情報",
@@ -5714,8 +5717,8 @@
       "systemActor": "システム",
       "systemActorTooltip": "ログインユーザーではなく、システムによって実行された操作",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "関連する変更",
+      "groupedEntry": "単一のアクションによるグループ化された変更"
     }
   },
   "components": {
@@ -5802,16 +5805,16 @@
         "reviewCommentPreview": "コメント: {comment}",
         "reviewRequestedEmailMessage": "{actorName} は、プロジェクト \"{projectName} \" の {entityLabel} \"{entityName}\" のレビューを依頼しました。",
         "reviewApprovedEmailMessage": "{actorName} がプロジェクト \"{projectName} \" のレビュー依頼を {entityLabel} \"{entityName}\" で承認しました。",
-        "reviewChangesRequestedEmailMessage": "{actorName} requested changes on your review request for {entityLabel} \"{entityName}\" in project \"{projectName}\".",
-        "reviewRejectedEmailMessage": "{actorName} rejected your review request on {entityLabel} \"{entityName}\" in project \"{projectName}\".",
+        "reviewChangesRequestedEmailMessage": "{actorName} がプロジェクト \"{projectName}\" の {entityLabel} \"{entityName}\" に対するレビュー依頼に変更を要求しました。",
+        "reviewRejectedEmailMessage": "{actorName} がプロジェクト \"{projectName}\" の {entityLabel} \"{entityName}\" に対するレビュー依頼を却下しました。",
         "reviewCancelledEmailMessage": "{actorName} は、プロジェクト \"{projectName} \" の {entityLabel} \"{entityName}\" のレビュー要求をキャンセルしました。",
         "reviewReminderTitle": "審査はまだ保留中です",
         "reviewReminderAction": "まだレビューをお待ちしています",
         "reviewReminderEmailMessage": "リマインダー: {actorName}によるプロジェクト \"{projectName}\" の {entityLabel} \"{entityName}\" のレビュー依頼は、 {hoursPending} 時間保留されています。",
         "reviewReminderHoursPending": "{hoursPending, plural, one {# 時間} other {# 時間}} 保留中",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "AI導出のテストステップの準備が完了しました",
+        "aiStepsDerivedMessage": "{count, plural, other {#件のテストケース}}にAI導出のステップが付与されました — 正確性を確認してください。",
+        "aiStepsDerivedReviewLink": "テスト実行を確認"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## グループ名\nすべてのプロジェクトで使用される、明確で簡潔な説明的な名前またはキーワード。\n\n- チームメンバーが関連するテストケース、テスト実行、およびセッションをすばやく見つけるのに役立ちます。",
       "users": "## ユーザー\nこのグループに割り当てられているユーザーを示します。",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## マッピングされたアクセス階層\nこのグループのメンバーには、次回の同期時に少なくともこのアクセス階層が付与されます。\n\n- ユーザーが所属するすべてのグループの中で最も高い階層が適用されます\n- 「マッピングされていません」は、このグループがアクセスに影響しないことを意味します — メンバーはSCIMページで設定されたデフォルトにフォールバックします\n- ユーザーへの手動でのアクセス変更はマッピングより優先されます（そのユーザーの編集画面にフラグが表示されます）"
     },
     "template": {
       "name": "## テンプレート名\nこのテンプレートの一意の説明的な名前 (例: '標準テスト ケース'、'API テスト結果')。",
@@ -6209,7 +6212,7 @@
       "authType": "## 認証タイプ\n外部サービスでの認証方法を選択します。\n\n- **APIキー:** メールとAPIトークンを使用したシンプルな認証\n- **OAuth 2.0:** OAuthフローを使用した安全な認証\n- **個人アクセストークン:** トークンベースの直接認証",
       "email": "## メールアドレス\n外部サービス用のアカウントのメールアドレス。\n\n- APIキー認証に使用されます\n- APIトークンを生成したアカウントと一致する必要があります\n- Jiraなどのサービスに必要です",
       "apiToken": "## APIトークン\n外部サービスのアカウント設定からAPIトークンを生成します。\n\n- 通常はアカウント設定 → セキュリティ → APIトークンにあります\n- パスワードを公開することなく安全なアクセスを提供します\n- 必要に応じて取り消しや再生成が可能です",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\nJiraインスタンスのベースURL。\n\n- 形式: https://your-site.atlassian.net\n- /browseやその他のパスを含めないでください\n- このサーバーからアクセスできる必要があります",
       "clientId": "## OAuthクライアントID\nOAuthアプリケーション構成からのクライアントID。\n\n- 外部サービスの開発者コンソールで作成されます\n- OAuthフロー中にアプリケーションを識別するために使用されます\n- 構成ファイルで安全に共有できます",
       "clientSecret": "## OAuthクライアントシークレット\nOAuthアプリケーション構成からのクライアントシークレット。\n\n- クライアントIDと一緒に作成されます\n- 機密性と安全性を保つ必要があります\n- アプリケーションの認証に使用されます",
       "personalAccessToken": "## 個人アクセストークン\n外部サービスへの適切な権限を持つ個人アクセストークン。\n\n- アカウント設定で生成されます\n- 読み取りと書き込みの問題に対する権限が必要です\n- パスワード認証よりも安全です",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## インスタンス URL\nセルフホスト型インスタンスのベース URL。\n\n- 形式: https://git.example.com\n- 末尾のスラッシュやパスを含めないでください。\n- このサーバーからアクセス可能である必要があります。",
       "projectPath": "## プロジェクトパス\nGitLabプロジェクトへのフルパス。\n\n- 形式: namespace/project または group/subgroup/project\n- 例: my-org/my-project\n- プロジェクトURL: gitlab.com/namespace/project で確認できます。",
       "platform": "## プラットフォーム\n接続先の自己ホスト型 Git プラットフォーム。\n\n- **Gitea**: gitea.io ベースのインスタンス\n- **Forgejo**: forgejo.org ベースのインスタンス (Gitea フォーク)\n- **Gogs**: gogs.io ベースのインスタンス\n\nこれにより、表示されるアイコンが制御され、API の互換性に影響する場合があります。",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine APIキー\nあなたの個人用REST APIアクセスキーです。\n\n- [管理] → [設定] → [API] でREST APIを有効にしてください\n- [マイアカウント] → [APIアクセスキー] からキーをコピーしてください\n- ユーザーの権限に応じたスコープになります。共有インテグレーションにはサービスアカウントを使用してください",
+      "redmineUrl": "## Redmine URL\nRedmineインスタンスのベースURL。\n\n- 形式: https://redmine.example.com\n- /issuesやその他のパスを含めないでください\n- このサーバーからアクセスできる必要があります",
+      "mantisBTApiKey": "## MantisBT APIトークン\nあなたの個人用REST APIトークンです。\n\n- MantisBTのアカウント設定 → [APIトークン] で作成してください\n- ユーザーの権限に応じたスコープになります。共有インテグレーションにはサービスアカウントを使用してください",
+      "mantisBTUrl": "## MantisBT URL\nMantisBTインスタンスのベースURL。\n\n- 形式: https://mantisbt.example.com\n- /api/restやその他のパスを含めないでください\n- このサーバーからアクセスできる必要があります",
+      "githubBaseUrl": "## APIベースURL\nGitHub Enterprise Serverの完全なGitHub APIルート。\n\n- 通常は/api/v3で終わります\n- api.github.comを使用する場合は空白のままにしてください\n- このサーバーからアクセスできる必要があります"
     },
     "config": {
       "name": "## 構成名\nこの構成の明確で分かりやすい名前。\n\n- 構成を構成するバリアントの組み合わせを説明するのに役立ちます (例: \"Chrome、Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", など)。",
@@ -6957,7 +6960,7 @@
         },
         "heuristic": {
           "intro": "このプロジェクトではLLM連携が設定されていないため、ランキングは選択戦略指標から直接構築されます。LLM連携を設定するには（管理画面 → AIモデル）、カスタムフィールド、関連する課題のコンテキスト、ケースコンテンツなどを指標と併せて考慮した、より高度な推論を有効にしてください。",
-          "rankedSummary": "{ranked} of {totalEligible} eligible manual cases ranked.",
+          "rankedSummary": "{totalEligible} 件の対象手動ケースのうち {ranked} 件がランク付けされました。",
           "strategyExplanation": {
             "most_executed": "ケースは手動実行回数（多い順）で並べられています。これは、自動化によってテスターの時間が最も多く節約できる回帰頻度の指標です。",
             "flakiest_first": "ケースは、おおよその不安定さ（合格/不合格の反転）に基づいて順序付けられます。不安定な手動テストは、決定論的な自動化オラクルの最適な候補です。",
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}時間{minutes}分"
           },
           "relativeAge": {
             "today": "今日",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "検索",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "保存された検索",
+      "save": "検索を保存",
+      "saveTitle": "検索を保存",
+      "saveDescription": "後で見返せるように、この検索に名前を付けてください。",
+      "saveAction": "保存",
+      "nameLabel": "名前",
+      "namePlaceholder": "例：今スプリントの失敗した実行",
+      "nameRequired": "この検索の名前を入力してください。",
+      "loginRequired": "検索を保存するにはサインインする必要があります。",
       "descriptionLabel": "説明（任意）",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "この検索の用途",
+      "saved": "検索を保存しました",
+      "savedDescription": "「{name}」を保存された検索に追加しました。",
+      "saveFailed": "検索を保存できませんでした。もう一度お試しください。",
+      "empty": "保存された検索はまだありません",
+      "emptyHint": "検索を保存すると、後で見返すことができます。",
+      "loaded": "「{name}」を読み込みました",
+      "loadFailed": "この保存された検索は無効になりました。",
+      "edit": "編集",
+      "editTitle": "保存された検索を編集",
+      "edited": "保存された検索を更新しました",
+      "editFailed": "検索を更新できませんでした。もう一度お試しください。",
       "delete": "消去",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "保存された検索を削除しますか？",
+      "deleteConfirm": "「{name}」が保存された検索から削除されます。この操作は元に戻せません。",
+      "deleted": "保存された検索を削除しました",
+      "deleteFailed": "検索を削除できませんでした。もう一度お試しください。"
     },
     "bulk": {
       "crossProjectHint": "（複数のプロジェクトにまたがる）",
@@ -7697,14 +7700,14 @@
       "intro": "下のボタンをクリックしてログインしてください。",
       "signInButton": "サインイン",
       "copyPasteIntro": "または、このリンクをコピーしてブラウザに貼り付けてください。",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "セキュリティ保護のため、このリンクは一度しか使用できません。再度サインインする必要がある場合は、新しいリンクをリクエストしてください。",
       "disclaimer": "このメールをリクエストしていない場合は、無視していただいて構いません。",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "TestPlanItにサインイン\n\n下のリンクをクリックしてサインインしてください：\n{url}\n\nセキュリティ保護のため、このリンクは一度しか使用できません。再度サインインする必要がある場合は、新しいリンクをリクエストしてください。\n\nこのメールに心当たりがない場合は、無視していただいて構いません。"
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "別のデバイスでこれを開いていますか？リンクをリクエストしたサインイン画面でこのコードを入力してください：",
+      "deviceNotice": "このリンクは、リクエストしたブラウザからサインインします。他の場所で開いた場合は、上記のコードが表示されるので、元のウィンドウに入力してください。",
+      "textBody": "TestPlanItにサインイン\n\n下のリンクをクリックしてサインインしてください：\n{url}\n\n別のデバイスでこれを開いていますか？リンクをリクエストしたサインイン画面で次のコードを入力してください：{code}\n\nこのメールに心当たりがない場合は、無視していただいて構いません。"
     }
   },
   "comments": {

--- a/testplanit/messages/ko-KR.json
+++ b/testplanit/messages/ko-KR.json
@@ -1072,7 +1072,7 @@
         "apple": "Apple에서 계속 진행하세요",
         "microsoft": "Microsoft에서 계속 진행하세요",
         "samlProvider": "{name}로 로그인하세요",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "일회용 매직링크로 로그인",
         "emailLogin": "이메일로 계속 진행"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "로그인 페이지로 돌아가기"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "이메일의 링크를 클릭하여 이 브라우저에서 로그인하거나, 아래에 이메일의 코드를 입력하세요.",
+        "codeLabel": "로그인 코드",
+        "verifyCode": "코드 확인",
+        "verifying": "확인 중...",
+        "invalidCode": "코드가 올바르지 않습니다. 이메일을 확인하고 다시 시도하세요.",
+        "codeExpired": "이 로그인 요청이 만료되었습니다. 새 링크를 요청하세요.",
+        "tooManyAttempts": "잘못된 시도가 너무 많습니다. 다시 시도하려면 새 링크를 요청하세요.",
+        "windowLost": "이 창에서는 로그인을 완료할 수 없습니다. 새 링크를 요청하세요.",
+        "genericError": "로그인할 수 없습니다. 새 링크를 요청하고 다시 시도하세요.",
+        "tooManyRequests": "로그인 요청이 너무 많습니다. 잠시 기다린 후 다시 시도하세요.",
+        "haveCode": "이미 로그인 코드가 있으신가요?",
+        "codeEntryDescription": "로그인 이메일의 코드를 입력하세요. 코드는 링크를 요청한 브라우저에서만 작동합니다.",
+        "backToRequest": "대신 새 링크 요청"
       },
       "twoFactor": {
         "title": "2단계 인증",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "시스템 관리자에게 문의하십시오."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "로그인하는 중...",
+      "completeErrorTitle": "로그인할 수 없습니다",
+      "requestNewLink": "새 링크 요청",
+      "codeTitle": "로그인 코드",
+      "codeInstructions": "다른 기기나 브라우저에서 로그인 링크를 열었습니다. 원래 요청한 로그인 화면에서 이 코드를 입력하세요.",
+      "codeCloseNotice": "코드를 입력한 후에는 이 창을 닫아도 됩니다.",
+      "expiredTitle": "이 로그인 링크는 더 이상 유효하지 않습니다",
+      "expiredBody": "링크가 만료되었거나 이미 사용되었을 수 있습니다. 로그인 페이지에서 새 링크를 요청하세요 — 잠깐이면 됩니다."
     },
     "errors": {
       "accessDenied": "접근이 거부되었습니다. 계정이 비활성화되었거나 로그인 권한이 없을 수 있습니다.",
       "configuration": "서버 구성에 문제가 있습니다.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "이 로그인 링크가 만료되었거나 이미 사용되었습니다. 매직링크는 한 번만 사용할 수 있습니다 — 로그인하려면 새 링크를 요청하세요.",
       "invalid2FACode": "인증 코드가 잘못되었습니다. 다시 시도해 주세요.",
       "twoFactorTokenRequired": "토큰이 필요합니다",
       "verificationCodeRequired": "인증 코드가 필요합니다."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "데이터베이스에 이슈 정보를 보존합니다(연결 해제됨).",
           "switchWarning3": "현재 문제 통합 구성을 새 구성으로 교체하십시오.",
           "switchWarning4": "현재 통합에 대해 구성된 인바운드 웹훅을 제거합니다.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "이슈 가져오기",
+          "importTitle": "{name}에서 이슈 가져오기",
+          "importDescription": "이 연결된 프로젝트의 이슈를 내 프로젝트로 가져옵니다. 기존 이슈는 중복되지 않으며 가져온 이슈는 동기화를 통해 최신 상태로 유지됩니다.",
+          "importUpdatedWithin": "업데이트 기간",
+          "importLastDays": "최근 {days}일",
+          "importMax": "최대 가져오기 개수",
+          "importPreview": "미리보기",
+          "importPreviewResult": "이 필터와 일치하는 이슈가 약 {count, plural, other {#개}}입니다. 최대 {cap}개까지 가져옵니다.",
+          "importOverCap": "이는 {cap}개의 한도를 초과합니다. 가장 최근에 업데이트된 {cap}개만 가져옵니다.",
+          "importStart": "가져오기",
+          "importStarted": "가져오기가 시작되었습니다. 이슈가 곧 표시됩니다.",
+          "importFailed": "가져오기 실패",
+          "importPreviewFailed": "일치 항목을 추정할 수 없습니다"
         },
         "integrationAssigned": "통합 작업이 성공적으로 완료되었습니다.",
         "integrationAssignError": "이슈 통합을 프로젝트에 할당하는 데 실패했습니다.",
@@ -1402,10 +1405,10 @@
             "description": "작업 항목 추적을 위해 Azure DevOps에 연결하세요."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "이슈 추적을 위해 자체 호스팅 Redmine 인스턴스에 연결하세요."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "이슈 추적을 위해 자체 호스팅 MantisBT 인스턴스에 연결하세요."
           }
         }
       },
@@ -1643,7 +1646,7 @@
         "drawerLabelDirection": "방향",
         "drawerLabelStatusCode": "상태 코드",
         "drawerLabelLatency": "숨어 있음",
-        "drawerLatencyValue": "{ms, number} ms",
+        "drawerLatencyValue": "{ms, number}ms",
         "drawerLatencyUnknown": "—",
         "drawerLabelError": "오류",
         "drawerLabelPayloadDigest": "페이로드 다이제스트",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "웹훅이 다시 활성화되었습니다",
         "toastReEnableFailed": "재활성화에 실패했습니다: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Redmine 인바운드 웹훅",
+        "inboundRedmineScopeHint": "redmine_webhook 플러그인은 요청에 서명하지 않으므로 이 웹훅 URL이 자격 증명 역할을 합니다. 비밀 정보로 취급하고 노출된 경우 교체하세요.",
+        "setupStepsRedmineStep1": "Redmine 서버에 redmine_webhook 플러그인을 설치하세요(Redmine에는 기본 제공 웹훅이 없습니다).",
+        "setupStepsRedmineStep2": "Redmine 프로젝트에서 설정 → 모듈을 열고 웹훅을 활성화하세요.",
+        "setupStepsRedmineStep3": "설정 → 웹훅을 열고 위 URL을 붙여넣은 다음 저장하세요.",
+        "setupStepsRedmineStep4": "Redmine에서 이슈를 생성하거나 업데이트하면 연결된 이슈의 상태가 여기에 동기화됩니다.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "MantisBT 인바운드 웹훅",
+        "inboundMantisbtScopeHint": "MantisBT 웹훅 플러그인은 요청에 서명하지 않으므로 이 웹훅 URL이 자격 증명 역할을 합니다. 비밀 정보로 취급하고 노출된 경우 교체하세요.",
+        "setupStepsMantisbtStep1": "MantisBT 서버에 MantisBT 웹훅 플러그인을 설치하고 활성화하세요(MantisBT에는 기본 제공 웹훅이 없습니다).",
+        "setupStepsMantisbtStep2": "플러그인 설정에서 이슈 생성 및 이슈 업데이트 이벤트를 선택하세요.",
+        "setupStepsMantisbtStep3": "위 URL을 웹훅 대상으로 붙여넣고 저장하세요.",
+        "setupStepsMantisbtStep4": "MantisBT에서 이슈를 생성하거나 업데이트하면 연결된 이슈의 상태가 여기에 동기화됩니다."
       },
       "aiModels": {
         "description": "지능형 테스트 케이스 생성 및 분석을 위한 AI 모델 구성",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "{scope}…에서 파일을 스캔합니다.",
           "scanningFilesCount": "{scope}… 에서 파일을 스캔하는 중입니다 ({count, number} 발견됨)",
           "filtering": "{count, number} 파일…에 필터를 적용합니다.",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "제공업체에서 속도 제한이 적용되어 {seconds, number}초 후 재시도합니다…"
         },
         "cache": {
           "title": "캐시 설정",
@@ -1913,8 +1916,8 @@
         "networkError": "캐시 새로 고침 중 네트워크 오류 발생",
         "refreshSuccess": "캐시 새로 고침됨: {fileCount} 개 파일 ({contentCached} 개 콘텐츠 캐시됨)",
         "refreshRateLimited": "캐시 새로 고침됨: {fileCount} 개의 파일이 나열되었고, {contentCached}/{fileCount} 개의 콘텐츠가 캐시되었습니다(호출 속도 제한됨 - 완료하려면 다시 새로 고침하세요).",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "캐시 새로고침 완료: 파일 {fileCount}개",
+        "refreshInProgress": "캐시 새로고침이 백그라운드에서 계속 실행 중입니다. 완료되면 여기에 업데이트됩니다.",
         "validation": {
           "pathRequired": "경로가 필요합니다",
           "patternRequired": "패턴이 필요합니다",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "활동",
+      "title": "활동 로그",
+      "description": "이 세션에 기록된 모든 변경 사항입니다."
     },
     "title": "{count, plural, =1 {세션} other {세션들}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "감사 로그",
+        "description": "이 사용자가 수행한 작업",
+        "noEntries": "아직 기록된 활동이 없습니다.",
+        "loadMore": "로딩 중",
+        "viewDetails": "자세히 보기",
+        "columnAction": "작업",
+        "columnEntityType": "유형",
+        "columnEntityName": "이름",
+        "columnTimestamp": "타임스탬프",
+        "allActions": "모든 작업",
+        "allTypes": "모든 유형",
+        "noMatchingEntries": "선택한 필터와 일치하는 항목이 없습니다.",
+        "showing": "{total}개 중 {loaded}개 항목"
       },
       "mentionedComments": {
         "title": "댓글에서 언급됨",
@@ -2510,9 +2513,9 @@
       "historyView": "테스트 케이스 기록 보기"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "활동",
+      "title": "활동 로그",
+      "description": "이 테스트 케이스에 기록된 모든 변경 사항입니다."
     },
     "fields": {
       "optionNotFound": "옵션을 찾을 수 없습니다",
@@ -2537,7 +2540,7 @@
       "confirmDelete": "삭제 단계 확인 {number, number}?",
       "createSharedSteps": "공유 생성 {number, plural, one {단계} other {단계}}",
       "sharedStepsName": "공유 단계 이름",
-      "sharedStepsDescription": "Enter a name for your new shared {number, plural, one {step} other {steps}}. This will include {number, plural, one {# selected step} other {# selected steps}}.",
+      "sharedStepsDescription": "새 공유 {number, plural, other {단계}}의 이름을 입력하세요. 여기에는 {number, plural, other {선택한 단계 #개}}가 포함됩니다.",
       "notifications": {
         "noStepsSelectedOrNameEmptyWarning": "공유 단계를 생성하려면 단계를 선택하고 이름을 입력하세요.",
         "failedToCreateSharedStepGroupError": "공유 단계를 생성하는 데 실패했습니다. 다시 시도해 주세요.",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# 연결된 쌍} other {# 연결된 쌍}}",
       "bulkError": "일부 작업에 실패했습니다. 다시 시도해 주세요.",
       "tableHint": "행을 클릭하거나 비교 버튼을 클릭하여 중복된 쌍을 검토하고 해결하세요.",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} 대 {caseB}",
       "comparisonDescription": "이러한 잠재적 중복 항목을 비교하고 해결 방법을 선택하십시오.",
       "selectPrimary": "병합을 위한 기본 사례로 선택하려면 해당 사례를 클릭하십시오.",
       "selectedAsPrimary": "기본으로 선택됨",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "활동",
+      "title": "활동 로그",
+      "description": "이 테스트 실행에 기록된 모든 변경 사항입니다."
     },
     "notFound": "테스트 실행을 찾을 수 없습니다.",
     "add": {
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "예",
       "scimUserLockedTitle": "사용자는 SCIM에 의해 관리됩니다.",
       "scimUserLockedDescription": "이 사용자의 이름, 이메일 및 활성 상태는 ID 공급자가 관리합니다. 여기에서도 해당 정보를 업데이트하려면 ID 공급자에서 변경하십시오.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "그룹 매핑으로 관리됨",
+      "groupMappingOverrideDescription": "이 사용자의 접근 등급은 SCIM 그룹 매핑에 의해 관리되며 다음 동기화 시 되돌아갈 수 있습니다.",
+      "groupMappingBadge": "그룹 매핑됨"
     },
     "security": {
       "title": "보안",
@@ -4490,7 +4493,7 @@
       "saveChanges": "변경 사항 저장",
       "forceAllUsers": "모든 사용자에게 비밀번호 변경 강제 적용",
       "forceAllUsersDialogTitle": "모든 사용자에 대한 비밀번호 강제 변경",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "이렇게 하면 자격 증명 기반 사용자 {count, number}명이 다음 로그인 시 비밀번호를 변경해야 합니다.",
       "forceAllUsersDialogWarning": "이 작업은 되돌릴 수 없습니다.",
       "forceAllUsersDialogConfirm": "강제 변화",
       "saved": "보안 설정이 저장되었습니다",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "SCIM 테스트",
         "testing": "테스트…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — 토큰이 /api/scim/v2/Users에 대해 작동합니다.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "SCIM 엔드포인트에 연결할 수 없습니다. 다시 시도하십시오."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "기본 매핑 접근",
+      "fallbackDefaultDescription": "그룹 매핑에 포함되지 않은 사용자에게 할당되는 접근 등급입니다.",
+      "fallbackDefaultLabel": "기본 접근 등급",
+      "fallbackDefaultSaved": "기본 대체값이 저장되었습니다"
     },
     "tags": {
       "add": {
@@ -4857,7 +4860,7 @@
       "combinations": {
         "title": "조합",
         "description": "글로벌 조합 관리",
-        "confirmDescription": "The following {count, number} Configurations will be created:",
+        "confirmDescription": "다음 {count, number}개의 구성이 생성됩니다:",
         "addCombination": "조합을 추가하세요",
         "editCombination": "조합 편집",
         "selectCombination": "조합을 선택하세요",
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "SCIM에서 관리합니다. SCIM 관리자 페이지에서 관리할 수 있습니다.",
       "scimNameLockedTitle": "이 그룹은 SCIM에서 관리합니다.",
       "scimNameLockedDescription": "이 그룹의 이름과 구성원은 ID 공급자가 관리합니다. 여기에서도 변경 사항을 적용하려면 ID 공급자에서 수정하세요.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "매핑된 접근",
+      "mappedAccessLabel": "매핑된 접근 등급",
+      "mappedAccessNone": "매핑 없음",
+      "mappedAccessSelect": "접근 등급을 선택하세요...",
+      "downgradeConfirmTitle": "접근 변경 확인",
+      "downgradeConfirmDescription": "{count, plural, other {사용자 #명}}의 접근 권한이 낮아집니다. 계속하시겠습니까?",
+      "downgradeConfirmApplyAnyway": "그래도 적용",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "활동적인",
         "inactive": "비활성화됨",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "인증 대기 중"
       },
       "connectedProjects": "연결된 프로젝트",
       "noIntegrations": "문제 없는 통합 구성 완료",
       "testConnection": "테스트 연결",
       "testSuccess": "연결 성공",
       "testSuccessDescription": "이슈 통합이 올바르게 구성되고 연결되었습니다.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "자격 증명이 정상입니다",
+      "testCredentialsSavedDescription": "OAuth 클라이언트 ID와 시크릿이 유효합니다. 통합을 저장한 후 승인을 클릭하여 계정을 연결하세요 — OAuth 2.0은 사용자별로 연결되므로 최소 한 명이 승인할 때까지 비활성 상태로 유지됩니다.",
       "testFailed": "연결 실패",
       "testFailedDescription": "외부 서비스에 연결할 수 없습니다.",
       "testError": "테스트 오류",
       "testErrorDescription": "연결 테스트 중 오류가 발생했습니다.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "승인",
+      "reauthorize": "다시 승인",
+      "authorizeHint": "제공업체를 통해 승인하여 계정을 연결하고 설정을 완료하세요",
+      "syncInProgress": "연결된 이슈를 다시 동기화하는 중...",
+      "syncIntegration": "연결된 이슈 다시 동기화",
+      "syncIntegrationHint": "TestPlanIt에 이미 연결된 이슈만 다시 동기화합니다. 외부 트래커에서 새 이슈를 가져오지는 않습니다.",
       "syncSuccess": "동기화 대기 중",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "\"{name}\"의 연결된 이슈가 백그라운드에서 다시 동기화되고 있습니다. 잠시 시간이 걸릴 수 있습니다. 완료되면 표가 자동으로 업데이트됩니다.",
       "syncError": "동기화 실패",
       "syncErrorDescription": "이 문제 통합에 대한 동기화 작업을 대기열에 추가할 수 없습니다. 나중에 다시 시도해 주세요.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "이슈 추적을 위해 자체 호스팅 Redmine 인스턴스에 연결하세요"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "이슈 추적을 위해 자체 호스팅 MantisBT 인스턴스에 연결하세요"
         }
       },
       "filterPlaceholder": "필터 통합...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "관리자 권한 없이 사용자별 정확한 보고자 식별을 위해서는 OAuth 2.0을 사용하십시오.",
         "tokenCreatorNoticeTitle": "문제 제기자 정보",
         "tokenCreatorNoticeDescription": "이 연동을 통해 생성된 이슈는 항상 해당 액세스 토큰을 소유한 계정으로 기록되며, 이슈를 생성한 TestPlanIt 사용자 계정으로는 기록되지 않습니다. 이 공급자의 API는 다른 사용자를 대신하여 생성자를 설정하는 것을 허용하지 않습니다.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "콜백 URL(리디렉션 URI)",
+        "callbackUrlDescription": "제공업체의 OAuth 앱에 이 정확한 URL을 콜백/리디렉션 URI로 등록하세요. 정확히 일치하지 않으면 승인이 실패합니다.",
+        "callbackUrlCopy": "복사",
+        "callbackUrlCopied": "복사됨",
         "forgeApiKeyLabel": "Forge API 키",
         "forgeApiKeyDescription": "Atlassian Forge 앱에서 Jira 이슈 패널의 요청을 인증하는 데 사용됩니다. 여기에서 키를 생성하고 Forge 앱 설정에 붙여넣으세요.",
         "forgeApiKeyPlaceholder": "API 키를 생성하려면 '생성'을 클릭하세요.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "기테아",
         "platformForgejo": "포르제호",
         "platformGogs": "고그스",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
+        "redmineApiKey": "Redmine API 키",
+        "redmineApiKeyPlaceholder": "Redmine API 키를 입력하세요",
+        "redmineApiKeyHelp": "내 계정 → API 접근 키에서 확인할 수 있습니다(관리 → 설정 → API에서 REST API를 활성화하세요)",
         "redmineUrl": "Redmine URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
+        "redmineUrlHelp": "Redmine 인스턴스의 기본 URL",
+        "mantisBTApiKey": "MantisBT API 토큰",
+        "mantisBTApiKeyPlaceholder": "MantisBT API 토큰을 입력하세요",
+        "mantisBTApiKeyHelp": "MantisBT 계정 설정 → API 토큰에서 생성하세요",
         "mantisBTUrl": "MantisBT URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "MantisBT 인스턴스의 기본 URL"
       },
       "authType": {
         "api_key": "API 키",
@@ -5487,7 +5490,7 @@
         "warning": "이 작업은 되돌릴 수 없습니다. 이 설정을 사용하는 모든 프로젝트는 기본 프롬프트 설정으로 되돌아갑니다."
       },
       "llmColumn": "법학 석사",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number}개의 LLM",
       "cannotDeleteDefault": "기본 프롬프트 구성을 삭제할 수 없습니다. 먼저 다른 설정을 기본값으로 지정하십시오.",
       "defaultChanged": "기본 프롬프트 구성이 성공적으로 업데이트되었습니다.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "URL(요구사항)에서 테스트 케이스 생성",
         "generate_from_url_app": "URL에서 테스트 케이스 생성 (애플리케이션 테스트)",
         "automation_candidates": "자동화 후보 보고서",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "AI 단계 도출"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "보안 및 규정 준수 추적을 위한 시스템 전반의 감사 기록을 확인하세요.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "이 프로젝트에서 수행된 작업의 감사 추적을 확인하세요.",
       "filterPlaceholder": "개체, 사용자 또는 작업으로 검색...",
       "filterAction": "행동",
       "filterEntityType": "엔티티 유형",
       "allActions": "모든 작업",
       "allEntityTypes": "모든 엔티티 유형",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "모든 사용자",
+      "allProjects": "모든 프로젝트",
+      "showing": "{total}개 중 {loaded}개 항목 표시 중",
       "viewDetails": "상세 정보 보기",
       "detailTitle": "감사 로그 세부 정보",
       "userInfo": "사용자 정보",
@@ -5714,8 +5717,8 @@
       "systemActor": "체계",
       "systemActorTooltip": "로그인한 사용자가 아닌 시스템에서 수행한 작업입니다.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "관련 변경 사항",
+      "groupedEntry": "단일 작업에서 그룹화된 변경 사항"
     }
   },
   "components": {
@@ -5801,17 +5804,17 @@
         "reviewTransition": "전환: {from} → {to}",
         "reviewCommentPreview": "댓글: {comment}",
         "reviewRequestedEmailMessage": "{actorName} 님이 프로젝트 \"{projectName} \"에서 {entityLabel} \" \"{entityName}\"에 대한 리뷰를 요청했습니다.",
-        "reviewApprovedEmailMessage": "{actorName} approved your review request on {entityLabel} \"{entityName}\" in project \"{projectName}\".",
-        "reviewChangesRequestedEmailMessage": "{actorName} requested changes on your review request for {entityLabel} \"{entityName}\" in project \"{projectName}\".",
+        "reviewApprovedEmailMessage": "{actorName} 님이 프로젝트 \"{projectName}\"의 {entityLabel} \"{entityName}\"에 대한 검토 요청을 승인했습니다.",
+        "reviewChangesRequestedEmailMessage": "{actorName} 님이 프로젝트 \"{projectName}\"의 {entityLabel} \"{entityName}\"에 대한 검토 요청에 변경을 요청했습니다.",
         "reviewRejectedEmailMessage": "{actorName} 님이 프로젝트 \"{projectName} \"에서 {entityLabel} \"{entityName}\"에 대한 검토 요청을 거부했습니다.",
         "reviewCancelledEmailMessage": "{actorName} 님이 프로젝트 \"{projectName} \"에서 {entityLabel} \"{entityName}\"에 대한 검토 요청을 취소했습니다.",
         "reviewReminderTitle": "검토는 아직 진행 중입니다.",
         "reviewReminderAction": "아직 귀하의 리뷰를 기다리고 있습니다.",
         "reviewReminderEmailMessage": "알림: {actorName}님의 {entityLabel} \"{entityName}\" 프로젝트 \"{projectName}\"에 대한 검토 요청이 {hoursPending} 시간 동안 보류 중입니다.",
         "reviewReminderHoursPending": "대기 시간: {hoursPending, plural, one {#시간} other {#시간}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "AI 기반 테스트 단계 준비 완료",
+        "aiStepsDerivedMessage": "{count, plural, other {테스트 케이스 #개}}에 AI가 도출한 단계가 추가되었습니다 — 정확성을 검토하세요.",
+        "aiStepsDerivedReviewLink": "테스트 실행 검토"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## 그룹 이름\n모든 프로젝트에서 사용되는 명확하고 간결하며 설명적인 이름 또는 키워드입니다.\n\n- 팀 구성원이 관련 테스트 케이스, 테스트 실행 및 세션을 빠르게 찾을 수 있도록 도와줍니다.",
       "users": "## 사용자\n이 그룹에 할당된 사용자를 나타냅니다.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## 매핑된 접근 등급\n이 그룹의 구성원은 다음 동기화 시 최소한 이 접근 등급을 부여받습니다.\n\n- 사용자가 속한 모든 그룹 중 가장 높은 등급이 적용됩니다\n- \"매핑 없음\"은 이 그룹이 접근에 영향을 미치지 않음을 의미합니다 — 구성원은 SCIM 페이지에 설정된 기본값을 따릅니다\n- 사용자에 대한 수동 접근 변경은 매핑을 대체합니다(해당 사용자의 편집 화면에 표시됨)"
     },
     "template": {
       "name": "## 템플릿 이름\n이 템플릿에 대한 고유하고 설명적인 이름입니다(예: '표준 테스트 케이스', 'API 테스트 결과').",
@@ -6209,7 +6212,7 @@
       "authType": "## 인증 유형\n외부 서비스와의 인증 방법을 선택하세요.\n\n- **API 키:** 이메일과 API 토큰을 사용한 간편 인증\n- **OAuth 2.0:** OAuth 흐름을 사용한 보안 인증\n- **개인 액세스 토큰:** 토큰 기반의 직접 인증",
       "email": "## 이메일 주소\n외부 서비스 계정의 이메일 주소입니다.\n\n- API 키 인증에 사용됩니다.\n- API 토큰을 생성한 계정과 일치해야 합니다.\n- Jira 및 유사 서비스에 필수입니다.",
       "apiToken": "## API 토큰\n외부 서비스의 계정 설정에서 API 토큰을 생성하세요.\n\n- 일반적으로 계정 설정 → 보안 → API 토큰에서 찾을 수 있습니다.\n- 비밀번호를 노출하지 않고 안전하게 액세스할 수 있습니다.\n- 필요에 따라 취소하고 다시 생성할 수 있습니다.",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\nJira 인스턴스의 기본 URL입니다.\n\n- 형식: https://your-site.atlassian.net\n- /browse 또는 기타 경로를 포함하지 마세요\n- 이 서버에서 접근 가능해야 합니다",
       "clientId": "## OAuth 클라이언트 ID\nOAuth 애플리케이션 구성에서 가져온 클라이언트 ID입니다.\n\n- 외부 서비스 개발자 콘솔에서 생성\n- OAuth 흐름 중에 애플리케이션을 식별하는 데 사용\n- 구성 파일에서 공유해도 안전함",
       "clientSecret": "## OAuth 클라이언트 시크릿\nOAuth 애플리케이션 구성에서 생성된 클라이언트 시크릿입니다.\n\n- 클라이언트 ID와 함께 생성됩니다.\n- 기밀로 안전하게 보관해야 합니다.\n- 애플리케이션 인증에 사용됩니다.",
       "personalAccessToken": "## 개인 액세스 토큰\n외부 서비스에 대한 적절한 권한이 있는 개인 액세스 토큰입니다.\n\n- 계정 설정에서 생성됩니다.\n- 읽기 및 쓰기 권한이 있어야 합니다.\n- 비밀번호 인증보다 안전합니다.",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## 인스턴스 URL\n자체 호스팅 인스턴스의 기본 URL입니다.\n\n- 형식: https://git.example.com\n- 끝에 슬래시나 경로를 포함하지 마세요.\n- 이 서버에서 접근 가능해야 합니다.",
       "projectPath": "## 프로젝트 경로\nGitLab 프로젝트의 전체 경로입니다.\n\n- 형식: 네임스페이스/프로젝트 또는 그룹/하위그룹/프로젝트\n- 예시: my-org/my-project\n- 프로젝트 URL에서 찾을 수 있습니다: gitlab.com/namespace/project",
       "platform": "## 플랫폼\n연결할 자체 호스팅 Git 플랫폼입니다.\n\n- **Gitea**: gitea.io 기반 인스턴스\n- **Forgejo**: forgejo.org 기반 인스턴스(Gitea 포크)\n- **Gogs**: gogs.io 기반 인스턴스\n\n이 설정은 표시되는 아이콘을 제어하며 API 호환성에 영향을 줄 수 있습니다.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine API 키\n개인 REST API 접근 키입니다.\n\n- 관리 → 설정 → API에서 REST API를 활성화하세요\n- 내 계정 → API 접근 키에서 키를 복사하세요\n- 사용자의 권한 범위로 제한되므로 공유 통합에는 서비스 계정을 사용하세요",
+      "redmineUrl": "## Redmine URL\nRedmine 인스턴스의 기본 URL입니다.\n\n- 형식: https://redmine.example.com\n- /issues 또는 기타 경로를 포함하지 마세요\n- 이 서버에서 접근 가능해야 합니다",
+      "mantisBTApiKey": "## MantisBT API 토큰\n개인 REST API 토큰입니다.\n\n- MantisBT 계정 설정 → API 토큰에서 생성하세요\n- 사용자의 권한 범위로 제한되므로 공유 통합에는 서비스 계정을 사용하세요",
+      "mantisBTUrl": "## MantisBT URL\nMantisBT 인스턴스의 기본 URL입니다.\n\n- 형식: https://mantisbt.example.com\n- /api/rest 또는 기타 경로를 포함하지 마세요\n- 이 서버에서 접근 가능해야 합니다",
+      "githubBaseUrl": "## API 기본 URL\nGitHub Enterprise Server의 전체 GitHub API 루트 경로입니다.\n\n- 일반적으로 /api/v3으로 끝납니다\n- api.github.com을 사용하려면 비워 두세요\n- 이 서버에서 접근 가능해야 합니다"
     },
     "config": {
       "name": "## 구성 이름\n이 구성에 대한 명확하고 설명적인 이름입니다.\n\n- 구성을 구성하는 변형 조합을 설명하는 데 도움이 됩니다(예: \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\" 등).",
@@ -6716,7 +6719,7 @@
       "addDimension": "차원을 더하다...",
       "addMetric": "측정항목을 추가하세요...",
       "runReport": "실행 보고서",
-      "exportCsv": "Export CSV",
+      "exportCsv": "CSV 내보내기",
       "noResultsFound": "검색 결과가 없습니다.",
       "selectAtLeastOneDimensionAndMetric": "최소한 하나의 차원과 하나의 측정 기준을 선택하십시오.",
       "noDataMatchingCriteria": "선택한 차원 및 측정항목과 일치하는 데이터를 찾을 수 없습니다.",
@@ -6957,7 +6960,7 @@
         },
         "heuristic": {
           "intro": "이 프로젝트에는 LLM 통합이 구성되어 있지 않으므로 순위는 선택 전략 지표를 직접 기반으로 계산됩니다. 사용자 지정 필드, 연결된 이슈 컨텍스트 및 사례 콘텐츠를 지표와 함께 고려하여 더욱 정교한 추론을 가능하게 하려면 LLM 통합을 구성하십시오(관리 → AI 모델).",
-          "rankedSummary": "{ranked} of {totalEligible} eligible manual cases ranked.",
+          "rankedSummary": "{totalEligible}개의 적격 수동 사례 중 {ranked}개가 순위가 지정되었습니다.",
           "strategyExplanation": {
             "most_executed": "테스트 케이스는 수동 실행 횟수(가장 높은 것부터) 순으로 정렬됩니다. 이는 자동화를 통해 테스터 시간을 가장 많이 절약할 수 있는 회귀 빈도 지표입니다.",
             "flakiest_first": "테스트 케이스는 대략적인 불안정성(합격/불합격 여부 반전)에 따라 정렬됩니다. 불안정한 수동 테스트는 결정론적 자동화 오라클의 주요 대상입니다.",
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}시간 {minutes}분"
           },
           "relativeAge": {
             "today": "오늘",
@@ -7273,7 +7276,7 @@
         }
       },
       "footer": {
-        "poweredBy": "Powered by"
+        "poweredBy": "제공"
       },
       "manageShares": {
         "title": "주식 관리",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "찾다",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "저장된 검색",
+      "save": "검색 저장",
+      "saveTitle": "검색 저장",
+      "saveDescription": "나중에 다시 볼 수 있도록 이 검색에 이름을 지정하세요.",
+      "saveAction": "저장",
+      "nameLabel": "이름",
+      "namePlaceholder": "예: 이번 스프린트 실패한 실행",
+      "nameRequired": "이 검색의 이름을 입력하세요.",
+      "loginRequired": "검색을 저장하려면 로그인해야 합니다.",
       "descriptionLabel": "설명 (선택 사항)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
-      "delete": "Delete",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "descriptionPlaceholder": "이 검색의 용도",
+      "saved": "검색이 저장되었습니다",
+      "savedDescription": "“{name}” 검색이 저장되었습니다.",
+      "saveFailed": "검색을 저장할 수 없습니다. 다시 시도해 주세요.",
+      "empty": "아직 저장된 검색이 없습니다",
+      "emptyHint": "나중에 다시 보려면 검색을 저장하세요.",
+      "loaded": "“{name}” 불러옴",
+      "loadFailed": "이 저장된 검색은 더 이상 유효하지 않습니다.",
+      "edit": "편집",
+      "editTitle": "저장된 검색 편집",
+      "edited": "저장된 검색이 업데이트되었습니다",
+      "editFailed": "검색을 업데이트할 수 없습니다. 다시 시도해 주세요.",
+      "delete": "삭제",
+      "deleteTitle": "저장된 검색을 삭제하시겠습니까?",
+      "deleteConfirm": "“{name}” 검색이 삭제됩니다. 이 작업은 취소할 수 없습니다.",
+      "deleted": "저장된 검색이 삭제되었습니다",
+      "deleteFailed": "검색을 삭제할 수 없습니다. 다시 시도해 주세요."
     },
     "bulk": {
       "crossProjectHint": "(여러 프로젝트에 걸쳐)",
@@ -7697,14 +7700,14 @@
       "intro": "아래 버튼을 클릭하여 로그인하세요.",
       "signInButton": "로그인",
       "copyPasteIntro": "또는 이 링크를 복사하여 브라우저에 붙여넣으세요.",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "보안을 위해 이 링크는 한 번만 사용할 수 있습니다. 다시 로그인해야 하는 경우 새 링크를 요청하세요.",
       "disclaimer": "이 이메일을 요청하지 않으셨다면 무시하셔도 됩니다.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "TestPlanIt에 로그인\n\n로그인하려면 아래 링크를 클릭하세요:\n{url}\n\n보안을 위해 이 링크는 한 번만 사용할 수 있습니다. 다시 로그인해야 하는 경우 새 링크를 요청하세요.\n\n이 이메일을 요청하지 않으셨다면 무시하셔도 안전합니다."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "다른 기기에서 여셨나요? 링크를 요청한 로그인 화면에서 이 코드를 입력하세요:",
+      "deviceNotice": "이 링크는 요청한 브라우저에서 로그인됩니다. 다른 곳에서 열면 원래 창에 입력할 위의 코드가 표시됩니다.",
+      "textBody": "TestPlanIt에 로그인\n\n로그인하려면 아래 링크를 클릭하세요:\n{url}\n\n다른 기기에서 여셨나요? 링크를 요청한 로그인 화면에서 다음 코드를 입력하세요: {code}\n\n이 이메일을 요청하지 않으셨다면 무시하셔도 안전합니다."
     }
   },
   "comments": {

--- a/testplanit/messages/nl-NL.json
+++ b/testplanit/messages/nl-NL.json
@@ -62,7 +62,7 @@
       "expand": "Uitbreiden",
       "collapse": "Instorten",
       "addResult": "Resultaat toevoegen",
-      "passAndNext": "Pass & Next",
+      "passAndNext": "Slagen & Volgende",
       "viewInRepository": "Bekijk in repository",
       "resultAdded": "Testresultaat toegevoegd",
       "resultAddedDescription": "Het testresultaat is succesvol toegevoegd.",
@@ -146,7 +146,7 @@
             "label": "Formaat van de casus-ID in de testnaam",
             "brackets": "Haakjes — [123]",
             "c": "C-voorvoegsel — C123",
-            "tc": "TC-prefix — TC-123"
+            "tc": "TC-voorvoegsel — TC-123"
           },
           "progress": {
             "initializing": "Importeren initialiseren...",
@@ -370,7 +370,7 @@
       "provider": "Aanbieder",
       "updatedAt": "Bijgewerkt op",
       "tools": "Hulpmiddelen",
-      "codeRepository": "Code Repo",
+      "codeRepository": "Coderepo",
       "aiModels": "Standaard LLM",
       "configKeys": {
         "edit_results_duration": "Bewerken Resultaten Duur",
@@ -418,7 +418,7 @@
       }
     },
     "filter": {
-      "placeholder": "Filter {item}..."
+      "placeholder": "{item} filteren..."
     },
     "access": {
       "admin": "Beheerder",
@@ -1072,7 +1072,7 @@
         "apple": "Doorgaan met Apple",
         "microsoft": "Ga verder met Microsoft",
         "samlProvider": "Meld je aan met {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Aanmelden met eenmalige Magic Link",
         "emailLogin": "Doorgaan met e-mail"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Terug naar inloggen"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Klik op de link in de e-mail om u vanuit deze browser aan te melden, of voer de code uit de e-mail hieronder in.",
+        "codeLabel": "Aanmeldcode",
+        "verifyCode": "Code verifiëren",
+        "verifying": "Bezig met controleren...",
+        "invalidCode": "Die code is niet juist. Controleer de e-mail en probeer het opnieuw.",
+        "codeExpired": "Dit aanmeldingsverzoek is verlopen. Vraag een nieuwe link aan.",
+        "tooManyAttempts": "Te veel onjuiste pogingen. Vraag een nieuwe link aan om het opnieuw te proberen.",
+        "windowLost": "Dit venster kan het aanmelden niet meer voltooien. Vraag een nieuwe link aan.",
+        "genericError": "We konden u niet aanmelden. Vraag een nieuwe link aan en probeer het opnieuw.",
+        "tooManyRequests": "Te veel aanmeldingsverzoeken. Wacht even en probeer het opnieuw.",
+        "haveCode": "Hebt u al een aanmeldcode?",
+        "codeEntryDescription": "Voer de code uit uw aanmeldings-e-mail in. Codes werken alleen in de browser waar u de link hebt aangevraagd.",
+        "backToRequest": "Vraag in plaats daarvan een nieuwe link aan"
       },
       "twoFactor": {
         "title": "Tweefactorauthenticatie",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Neem contact op met de systeembeheerder."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "U wordt aangemeld...",
+      "completeErrorTitle": "We konden u niet aanmelden",
+      "requestNewLink": "Vraag een nieuwe link aan",
+      "codeTitle": "Uw aanmeldcode",
+      "codeInstructions": "U hebt de aanmeldingslink geopend op een ander apparaat of in een andere browser. Voer deze code in op het aanmeldingsscherm waar u deze oorspronkelijk hebt aangevraagd.",
+      "codeCloseNotice": "U kunt dit venster sluiten zodra u de code hebt ingevoerd.",
+      "expiredTitle": "Deze aanmeldingslink is niet meer geldig",
+      "expiredBody": "De link is mogelijk verlopen of al gebruikt. Vraag een nieuwe aan via de aanmeldingspagina — dit duurt maar even."
     },
     "errors": {
       "accessDenied": "Toegang geweigerd. Uw account is mogelijk inactief of u hebt geen toestemming om u aan te melden.",
       "configuration": "Er is een probleem met de serverconfiguratie.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Deze aanmeldingslink is verlopen of al gebruikt. Magic links kunnen maar één keer worden gebruikt — vraag een nieuwe aan om u aan te melden.",
       "invalid2FACode": "Ongeldige verificatiecode. Probeer het opnieuw.",
       "twoFactorTokenRequired": "Token vereist",
       "verificationCodeRequired": "Een verificatiecode is vereist."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Behoud de problemen in de database (ze worden losgekoppeld)",
           "switchWarning3": "Vervang de huidige probleemintegratieconfiguratie door de nieuwe",
           "switchWarning4": "Verwijder de inkomende webhook die is geconfigureerd voor de huidige integratie.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Issues importeren",
+          "importTitle": "Issues importeren vanuit {name}",
+          "importDescription": "Haal issues op vanuit dit gekoppelde project naar uw project. Bestaande issues worden niet gedupliceerd en geïmporteerde issues blijven actueel via synchronisatie.",
+          "importUpdatedWithin": "Bijgewerkt binnen",
+          "importLastDays": "Laatste {days} dagen",
+          "importMax": "Maximum aantal te importeren",
+          "importPreview": "Voorbeeld",
+          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} komen overeen met dit filter. Tot {cap} zullen worden geïmporteerd.",
+          "importOverCap": "Dat overschrijdt de limiet van {cap}; alleen de {cap} meest recent bijgewerkte zullen worden geïmporteerd.",
+          "importStart": "Importeren",
+          "importStarted": "Import gestart. Issues verschijnen binnenkort.",
+          "importFailed": "Importeren mislukt",
+          "importPreviewFailed": "Kan overeenkomsten niet schatten"
         },
         "integrationAssigned": "Integratie succesvol toegewezen",
         "integrationAssignError": "Het is niet gelukt om de probleemintegratie aan het project toe te wijzen",
@@ -1402,10 +1405,10 @@
             "description": "Maak verbinding met Azure DevOps voor het bijhouden van werkitems."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Maak verbinding met een zelfgehoste Redmine-instantie voor het bijhouden van problemen."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Maak verbinding met een zelfgehoste MantisBT-instantie voor het bijhouden van problemen."
           }
         }
       },
@@ -1518,7 +1521,7 @@
           "jiraIssueUpdated": "Jira-ticket bijgewerkt",
           "jiraIssueDeleted": "Jira-ticket verwijderd",
           "githubIssues": "GitHub issues-evenement",
-          "githubPullRequest": "GitHub pull request",
+          "githubPullRequest": "GitHub pull-verzoek",
           "githubPush": "GitHub push",
           "githubIssueComment": "GitHub-probleemreactie",
           "adoWorkitemCreated": "Azure DevOps-werkitem aangemaakt",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook opnieuw ingeschakeld",
         "toastReEnableFailed": "Opnieuw inschakelen mislukt: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Inkomende Redmine-webhook",
+        "inboundRedmineScopeHint": "De redmine_webhook-plugin ondertekent verzoeken niet, dus deze webhook-URL is de referentie — behandel deze als een geheim en wijzig deze als hij wordt blootgesteld.",
+        "setupStepsRedmineStep1": "Installeer de redmine_webhook-plugin op uw Redmine-server (Redmine heeft geen ingebouwde webhooks).",
+        "setupStepsRedmineStep2": "Open in uw Redmine-project Instellingen → Modules en schakel Webhooks in.",
+        "setupStepsRedmineStep3": "Open Instellingen → Webhooks, plak de URL hierboven en sla op.",
+        "setupStepsRedmineStep4": "Maak of update een issue in Redmine; de status van het gekoppelde issue wordt hier gesynchroniseerd.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Inkomende MantisBT-webhook",
+        "inboundMantisbtScopeHint": "Een MantisBT-webhookplugin ondertekent verzoeken niet, dus deze webhook-URL is de referentie — behandel deze als een geheim en wijzig deze als hij wordt blootgesteld.",
+        "setupStepsMantisbtStep1": "Installeer en schakel een MantisBT-webhookplugin in op uw MantisBT-server (MantisBT heeft geen ingebouwde webhooks).",
+        "setupStepsMantisbtStep2": "Selecteer in de plugin-configuratie de events voor het aanmaken en bijwerken van issues.",
+        "setupStepsMantisbtStep3": "Plak de URL hierboven als webhookdoel en sla op.",
+        "setupStepsMantisbtStep4": "Maak of update een issue in MantisBT; de status van het gekoppelde issue wordt hier gesynchroniseerd."
       },
       "aiModels": {
         "description": "Configureer AI-modellen voor het genereren en analyseren van intelligente testcases",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Bestanden scannen in {scope}…",
           "scanningFilesCount": "Bestanden scannen in {scope}… ({count, number} gevonden)",
           "filtering": "Filters toepassen op {count, number} bestanden…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Snelheidslimiet bereikt bij de provider — nieuwe poging over {seconds, number}s…"
         },
         "cache": {
           "title": "Cache-instellingen",
@@ -1913,8 +1916,8 @@
         "networkError": "Netwerkfout tijdens het vernieuwen van de cache.",
         "refreshSuccess": "Cache vernieuwd: {fileCount} bestanden ({contentCached} inhoud in cache opgeslagen)",
         "refreshRateLimited": "Cache vernieuwd: {fileCount} bestanden weergegeven, {contentCached}/{fileCount} inhoud in cache opgeslagen (snelheid beperkt — vernieuw opnieuw om te voltooien)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Cache vernieuwd: {fileCount} bestanden",
+        "refreshInProgress": "Het vernieuwen van de cache wordt nog op de achtergrond uitgevoerd. Dit wordt hier bijgewerkt zodra het is voltooid.",
         "validation": {
           "pathRequired": "Pad is vereist",
           "patternRequired": "Een patroon is vereist.",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Activiteit",
+      "title": "Activiteitenlogboek",
+      "description": "Alle wijzigingen vastgelegd voor deze sessie."
     },
     "title": "{count, plural, =1 {Sessie} other {Sessies}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
+        "title": "Auditlogboek",
+        "description": "Acties uitgevoerd door deze gebruiker",
+        "noEntries": "Nog geen activiteit vastgelegd.",
+        "loadMore": "Bezig met laden",
+        "viewDetails": "Bekijk details",
+        "columnAction": "Actie",
         "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "columnEntityName": "Naam",
+        "columnTimestamp": "Tijdstempel",
+        "allActions": "Alle acties",
+        "allTypes": "Alle typen",
+        "noMatchingEntries": "Geen items komen overeen met de geselecteerde filters.",
+        "showing": "{loaded} van {total} items"
       },
       "mentionedComments": {
         "title": "Vermeld in de reacties",
@@ -2510,9 +2513,9 @@
       "historyView": "Testcase geschiedenisweergave"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Activiteit",
+      "title": "Activiteitenlogboek",
+      "description": "Alle wijzigingen vastgelegd voor deze testcase."
     },
     "fields": {
       "optionNotFound": "Optie niet gevonden",
@@ -2571,7 +2574,7 @@
     "templateNotAssignedWarning": "Deze testcase gebruikt de sjabloon \"{templateName}\", die momenteel niet is toegewezen aan het project \"{projectName}\". Mogelijk moet u deze sjabloon aan het project toewijzen of de testcase aanpassen om een andere sjabloon te gebruiken.",
     "orphanedStepsWarning": "Deze testcase heeft stappen, maar de huidige sjabloon \"{templateName}\" bevat geen veld voor stappen. De stappen kunnen pas worden bewerkt als de testcase een sjabloon met een veld voor stappen heeft.",
     "orphanedFieldsWarning": "Deze testcase heeft {count, plural, =1 {# veldwaarde} other {# veldwaarden}} die {count, plural, =1 {is} other {zijn}} niet opgenomen in de huidige sjabloon \"{templateName}\". {count, plural, =1 {Dit veld is} other {Deze velden zijn}} hieronder weergegeven, maar kunnen mogelijk pas worden bewerkt nadat ze aan de sjabloon zijn toegevoegd.",
-    "title": "Test Case Repository",
+    "title": "Testcase-repository",
     "folders": "Mappen",
     "showDescendants": "Toon alle afstammelingen",
     "addFolder": "Map toevoegen",
@@ -3231,7 +3234,7 @@
       "filters": {
         "hideCompletedSessions": "Verberg voltooide sessies",
         "hideCompletedTestRuns": "Verberg voltooide testruns",
-        "caseTypeLabel": "Case type",
+        "caseTypeLabel": "Casetype",
         "allCases": "Alle"
       }
     },
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Activiteit",
+      "title": "Activiteitenlogboek",
+      "description": "Alle wijzigingen vastgelegd voor deze testrun."
     },
     "notFound": "Testrun niet gevonden.",
     "add": {
@@ -3570,7 +3573,7 @@
             "upload": "Uploaden exporteren",
             "analysis": "Beoordelingsanalyse",
             "mapping": "Toewijzing configureren",
-            "import": "Monitor import"
+            "import": "Import bewaken"
           },
           "stepIndicator": "Stap {step, number} van {total, number}"
         },
@@ -3649,7 +3652,7 @@
           "repository_folders": "Repositorymappen",
           "repository_cases": "Repository-cases",
           "repository_case_steps": "Stappen in het repository-casescenario",
-          "repository_case_tags": "Repository case tags",
+          "repository_case_tags": "Repository-casetags",
           "milestones": "Mijlpalen",
           "runs": "Testruns",
           "run_tests": "Testuitvoeringsgevallen",
@@ -4073,7 +4076,7 @@
           "description": "Stel uw SAML Identity Provider-configuratie in. U kunt deze gegevens opvragen bij uw SAML IdP.",
           "entryPoint": "SSO-invoerpunt-URL",
           "issuer": "Uitgever (Entiteits-ID)",
-          "callbackUrl": "ACS (Callback) URL",
+          "callbackUrl": "ACS (terugbel-) URL",
           "logoutUrl": "SLO-uitlog-URL (optioneel)",
           "entryPointPlaceholder": "https://uw-idp.com/sso/saml",
           "issuerPlaceholder": "urn:uw-idp:entiteits-id",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Ja",
       "scimUserLockedTitle": "De gebruiker wordt beheerd door SCIM.",
       "scimUserLockedDescription": "De naam, het e-mailadres en de actieve status van deze gebruiker worden beheerd door uw identiteitsprovider. Wijzigingen daar doorvoeren om ze hier bij te werken.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Beheerd door groepskoppeling",
+      "groupMappingOverrideDescription": "Het toegangsniveau van deze gebruiker wordt bepaald door een SCIM-groepskoppeling en kan bij de volgende synchronisatie worden teruggezet.",
+      "groupMappingBadge": "Groep gekoppeld"
     },
     "security": {
       "title": "Beveiliging",
@@ -4622,16 +4625,16 @@
         "errorToast": "Kon het token niet intrekken. {reason}"
       },
       "probe": {
-        "button": "Test SCIM",
+        "button": "SCIM testen",
         "testing": "Testen…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — token werkt tegen /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Het SCIM-eindpunt kon niet worden bereikt. Probeer het opnieuw."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Standaard gekoppelde toegang",
+      "fallbackDefaultDescription": "Toegangsniveau toegewezen aan gebruikers die niet onder een groepskoppeling vallen.",
+      "fallbackDefaultLabel": "Standaard toegangsniveau",
+      "fallbackDefaultSaved": "Fallback-standaard opgeslagen"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Beheerd door SCIM. Beheer via de SCIM-beheerpagina.",
       "scimNameLockedTitle": "De groep wordt beheerd door SCIM.",
       "scimNameLockedDescription": "De naam en leden van deze groep worden beheerd door uw identiteitsprovider. Breng daar wijzigingen aan om ze hier bij te werken.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Gekoppelde toegang",
+      "mappedAccessLabel": "Gekoppeld toegangsniveau",
+      "mappedAccessNone": "Geen koppeling",
+      "mappedAccessSelect": "Selecteer toegangsniveau...",
+      "downgradeConfirmTitle": "Toegangswijziging bevestigen",
+      "downgradeConfirmDescription": "{count, plural, one {# gebruiker} other {# gebruikers}} zouden een lager toegangsniveau krijgen. Doorgaan?",
+      "downgradeConfirmApplyAnyway": "Toch toepassen",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5026,7 +5029,7 @@
         "configVariants": "Configuratievarianten",
         "repositories": "Opslagplaatsen",
         "repositoryFolders": "Repository-mappen",
-        "repositoryCaseLinks": "Repository Case Links",
+        "repositoryCaseLinks": "Repository-testcasekoppelingen",
         "repositoryCaseVersions": "Repository Case-versies",
         "testRunStepResults": "Resultaten van de testrunstap",
         "issueConfigs": "Probleemconfiguraties",
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Actief",
         "inactive": "Inactief",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Wachten op autorisatie"
       },
       "connectedProjects": "Verbonden projecten",
       "noIntegrations": "Geen probleemintegraties geconfigureerd",
       "testConnection": "Testverbinding",
       "testSuccess": "Verbinding succesvol",
       "testSuccessDescription": "De probleemintegratie is correct geconfigureerd en aangesloten",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Referenties zien er goed uit",
+      "testCredentialsSavedDescription": "Uw OAuth-client-ID en -secret zijn geldig. Sla de integratie op en klik daarna op Autoriseren om uw account te verbinden — OAuth 2.0 maakt verbinding per gebruiker, dus deze blijft inactief totdat minstens één persoon autoriseert.",
       "testFailed": "Verbinding mislukt",
       "testFailedDescription": "Kan geen verbinding maken met de externe service",
       "testError": "Testfout",
       "testErrorDescription": "Er is een fout opgetreden tijdens het testen van de verbinding",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autoriseren",
+      "reauthorize": "Opnieuw autoriseren",
+      "authorizeHint": "Autoriseer bij de provider om uw account te verbinden en de installatie te voltooien",
+      "syncInProgress": "Gekoppelde issues opnieuw synchroniseren...",
+      "syncIntegration": "Gekoppelde issues opnieuw synchroniseren",
+      "syncIntegrationHint": "Synchroniseert alleen issues die al gekoppeld zijn in TestPlanIt. Nieuwe issues worden niet geïmporteerd vanuit het externe tracksysteem.",
       "syncSuccess": "Synchronisatie in de wachtrij",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Gekoppelde issues van \"{name}\" worden op de achtergrond opnieuw gesynchroniseerd. Dit kan even duren. De tabel wordt automatisch bijgewerkt zodra dit is voltooid.",
       "syncError": "Synchronisatie mislukt",
       "syncErrorDescription": "Het is niet gelukt om een synchronisatietaak voor deze integratie in de wachtrij te plaatsen. Probeer het later opnieuw.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Maak verbinding met een zelfgehoste Redmine-instantie voor het bijhouden van problemen"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Maak verbinding met een zelfgehoste MantisBT-instantie voor het bijhouden van problemen"
         }
       },
       "filterPlaceholder": "Integraties filteren...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Gebruik in plaats daarvan OAuth 2.0 voor nauwkeurige toewijzing van melders per gebruiker, zonder beheerdersrechten.",
         "tokenCreatorNoticeTitle": "Naamsvermelding van de maker van het probleem",
         "tokenCreatorNoticeDescription": "Issues die via deze integratie worden aangemaakt, worden altijd geregistreerd onder het account dat eigenaar is van dit toegangstoken, en niet onder de TestPlanIt-gebruiker die ze heeft aangemaakt. De API van deze provider staat niet toe dat de maker namens een andere gebruiker wordt ingesteld.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "Callback-URL (redirect-URI)",
+        "callbackUrlDescription": "Registreer precies deze URL als de callback-/redirect-URI in de OAuth-app van uw provider. Deze moet exact overeenkomen, anders mislukt de autorisatie.",
+        "callbackUrlCopy": "Kopiëren",
+        "callbackUrlCopied": "Gekopieerd",
         "forgeApiKeyLabel": "Forge API-sleutel",
         "forgeApiKeyDescription": "Deze sleutel wordt door de Atlassian Forge-app gebruikt om verzoeken vanuit Jira-issuepanelen te authenticeren. Genereer hier een sleutel en plak deze in de instellingen van uw Forge-app.",
         "forgeApiKeyPlaceholder": "Klik op Genereren om een API-sleutel aan te maken.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Redmine API-sleutel",
+        "redmineApiKeyPlaceholder": "Voer uw Redmine API-sleutel in",
+        "redmineApiKeyHelp": "Te vinden onder Mijn account → API-toegangssleutel (schakel de REST API in via Administratie → Instellingen → API)",
+        "redmineUrl": "Redmine-URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "De basis-URL van uw Redmine-instantie",
+        "mantisBTApiKey": "MantisBT API-token",
+        "mantisBTApiKeyPlaceholder": "Voer uw MantisBT API-token in",
+        "mantisBTApiKeyHelp": "Maak er een aan bij uw MantisBT-accountinstellingen → API-tokens",
+        "mantisBTUrl": "MantisBT-URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "De basis-URL van uw MantisBT-instantie"
       },
       "authType": {
         "api_key": "API-sleutel",
@@ -5487,7 +5490,7 @@
         "warning": "Deze actie kan niet ongedaan worden gemaakt. Alle projecten die deze configuratie gebruiken, zullen terugkeren naar de standaard promptconfiguratie."
       },
       "llmColumn": "LLM",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} LLM's",
       "cannotDeleteDefault": "De standaard promptconfiguratie kan niet worden verwijderd. Stel eerst een andere prompt als standaard in.",
       "defaultChanged": "De standaard promptconfiguratie is succesvol bijgewerkt.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Testcases genereren vanuit URL (vereisten)",
         "generate_from_url_app": "Testcases genereren vanuit URL (applicatietesten)",
         "automation_candidates": "Rapport over automatiseringskandidaten",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "AI-afleiding van stappen"
       }
     },
     "elasticsearch": {
@@ -5569,7 +5572,7 @@
         "forecast-updates": "Weersverwachtingen",
         "emails": "E-mailwachtrij",
         "issue-sync": "Probleem synchronisatie",
-        "testmo-imports": "Testmo Imports",
+        "testmo-imports": "Testmo-imports",
         "elasticsearch-reindex": "Elasticsearch-herindexering",
         "audit-logs": "Auditlogboeken",
         "budget-alerts": "Budgetwaarschuwingen",
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Bekijk het systeemwijde auditlogboek voor het bijhouden van beveiliging en naleving.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Bekijk het auditspoor van acties die in dit project zijn uitgevoerd.",
       "filterPlaceholder": "Zoeken op entiteit, gebruiker of actie...",
       "filterAction": "Actie",
       "filterEntityType": "Entiteitstype",
       "allActions": "Alle acties",
       "allEntityTypes": "Alle entiteitstypen",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Alle gebruikers",
+      "allProjects": "Alle projecten",
+      "showing": "{loaded} van {total} items weergegeven",
       "viewDetails": "Bekijk details",
       "detailTitle": "Auditlogboekdetails",
       "userInfo": "Gebruikersinformatie",
@@ -5714,8 +5717,8 @@
       "systemActor": "Systeem",
       "systemActorTooltip": "Actie uitgevoerd door het systeem, niet door een ingelogde gebruiker.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "gerelateerde wijzigingen",
+      "groupedEntry": "Gegroepeerde wijzigingen van één actie"
     }
   },
   "components": {
@@ -5757,7 +5760,7 @@
         "assignedMultipleTestCases": "toegewezen aan jou {count, plural, one {# testgeval} other {# testgevallen}}",
         "assignedSession": "je toegewezen aan sessie",
         "mentionedYouInComment": "noemde je in een reactie op",
-        "inProject": "in project",
+        "inProject": "in het project",
         "testRun": "Testrun:",
         "casesInProject": "{count, plural, =1 {# geval} other {# gevallen}} in",
         "sentBy": "Verzonden door {name}",
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "wacht nog steeds op uw beoordeling van",
         "reviewReminderEmailMessage": "Herinnering: Het beoordelingsverzoek van {actorName}voor {entityLabel} \"{entityName}\" in project \"{projectName}\" is al {hoursPending} uur in behandeling.",
         "reviewReminderHoursPending": "In afwachting van {hoursPending, plural, one {# uur} other {# uur}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "AI-afgeleide teststappen gereed",
+        "aiStepsDerivedMessage": "{count, plural, one {# testcase heeft} other {# testcases hebben}} AI-afgeleide stappen gekregen — controleer op juistheid.",
+        "aiStepsDerivedReviewLink": "Testrun controleren"
       }
     },
     "issues": {
@@ -6033,7 +6036,7 @@
     "durationRange": "Duur: {from}s - {to}s",
     "seconds": "{seconds}s",
     "testCases": "{count, plural, one {# testgeval} other {# testgevallen}}",
-    "estimate": "Est: {value}",
+    "estimate": "Schatting: {value}",
     "partOf": "(Deel van {parent})",
     "status": "Status: {status}"
   },
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Groepsnaam\nEen duidelijke, beknopte, beschrijvende naam of trefwoord(en) die in alle projecten wordt gebruikt.\n\n- Helpt teamleden snel gerelateerde testcases, testruns en sessies te vinden.",
       "users": "## Gebruikers\nGeeft de gebruikers aan die aan deze groep zijn toegewezen.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Gekoppeld toegangsniveau\nLeden van deze groep krijgen bij de volgende synchronisatie minimaal dit toegangsniveau.\n\n- Het hoogste niveau van alle groepen van een gebruiker geldt\n- \"Geen koppeling\" betekent dat deze groep geen invloed heeft op de toegang — leden vallen terug op de standaardinstelling op de SCIM-pagina\n- Een handmatige toegangswijziging bij een gebruiker heeft voorrang op de koppeling (en wordt gemarkeerd op het bewerkingsscherm van die gebruiker)"
     },
     "template": {
       "name": "## Sjabloonnaam\nEen unieke en beschrijvende naam voor deze sjabloon (bijv. 'Standaardtestgeval', 'API-testresultaten').",
@@ -6209,7 +6212,7 @@
       "authType": "## Authenticatietype\nKies hoe u wilt authenticeren met de externe service.\n\n- **API-sleutel:** Eenvoudige authenticatie met behulp van e-mail en API-token\n- **OAuth 2.0:** Veilige authenticatie met behulp van de OAuth-stroom\n- **Persoonlijke toegangstoken:** Directe op tokens gebaseerde authenticatie",
       "email": "## E-mailadres\nUw e-mailadres voor de externe service.\n\n- Gebruikt voor API-sleutelauthenticatie\n- Moet overeenkomen met het account dat het API-token heeft gegenereerd\n- Vereist voor Jira en soortgelijke services",
       "apiToken": "## API-token\nGenereer een API-token vanuit uw accountinstellingen in de externe service.\n\n- Meestal te vinden in Accountinstellingen → Beveiliging → API-tokens\n- Biedt veilige toegang zonder uw wachtwoord bloot te stellen\n- Kan indien nodig worden ingetrokken en opnieuw worden gegenereerd",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\nDe basis-URL van uw Jira-instantie.\n\n- Formaat: https://your-site.atlassian.net\n- Voeg geen /browse of andere paden toe\n- Moet toegankelijk zijn vanaf deze server",
       "clientId": "## OAuth Client ID\nDe client-ID van uw OAuth-toepassingsconfiguratie.\n\n- Gemaakt in de ontwikkelaarsconsole van de externe service\n- Gebruikt om uw toepassing te identificeren tijdens de OAuth-stroom\n- Veilig om te delen in configuratiebestanden",
       "clientSecret": "## OAuth Client Secret\nHet clientgeheim uit uw OAuth-toepassingsconfiguratie.\n\n- Gemaakt samen met de client-ID\n- Moet vertrouwelijk en veilig worden bewaard\n- Wordt gebruikt om uw toepassing te verifiëren",
       "personalAccessToken": "## Persoonlijke toegangstoken\nEen persoonlijke toegangstoken met de juiste machtigingen voor de externe service.\n\n- Gemaakt in uw accountinstellingen\n- Moet machtigingen hebben voor lees- en schrijfproblemen\n- Veiliger dan wachtwoordauthenticatie",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## Instantie-URL\nDe basis-URL van uw zelfgehoste instantie.\n\n- Formaat: https://git.example.com\n- Geen afsluitende schuine strepen of paden\n- Moet toegankelijk zijn vanaf deze server",
       "projectPath": "## Projectpad\nHet volledige pad naar je GitLab-project.\n\n- Formaat: namespace/project of groep/subgroep/project\n- Voorbeeld: my-org/my-project\n- Te vinden in de project-URL: gitlab.com/namespace/project",
       "platform": "## Platform\nHet zelfgehoste Git-platform waarmee u verbinding maakt.\n\n- **Gitea**: instanties gebaseerd op gitea.io\n- **Forgejo**: instanties gebaseerd op forgejo.org (fork van Gitea)\n- **Gogs**: instanties gebaseerd op gogs.io\n\nDit bepaalt welk pictogram wordt weergegeven en kan de API-compatibiliteit beïnvloeden.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine API-sleutel\nUw persoonlijke REST API-toegangssleutel.\n\n- Schakel de REST API in via Administratie → Instellingen → API\n- Kopieer uw sleutel via Mijn account → API-toegangssleutel\n- Beperkt tot de rechten van uw gebruiker; gebruik een serviceaccount voor gedeelde integraties",
+      "redmineUrl": "## Redmine URL\nDe basis-URL van uw Redmine-instantie.\n\n- Formaat: https://redmine.example.com\n- Voeg geen /issues of andere paden toe\n- Moet toegankelijk zijn vanaf deze server",
+      "mantisBTApiKey": "## MantisBT API-token\nUw persoonlijke REST API-token.\n\n- Maak er een aan bij uw MantisBT-accountinstellingen → API-tokens\n- Beperkt tot de rechten van uw gebruiker; gebruik een serviceaccount voor gedeelde integraties",
+      "mantisBTUrl": "## MantisBT URL\nDe basis-URL van uw MantisBT-instantie.\n\n- Formaat: https://mantisbt.example.com\n- Voeg geen /api/rest of andere paden toe\n- Moet toegankelijk zijn vanaf deze server",
+      "githubBaseUrl": "## API-basis-URL\nVolledige GitHub API-root voor GitHub Enterprise Server.\n\n- Eindigt doorgaans op /api/v3\n- Laat dit veld leeg om api.github.com te gebruiken\n- Moet toegankelijk zijn vanaf deze server"
     },
     "config": {
       "name": "## Configuratienaam\nEen duidelijke, beschrijvende naam voor deze configuratie.\n\n- Helpt bij het beschrijven van de variantcombinaties waaruit de configuratie bestaat (bijv. \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", enz.).",
@@ -6627,7 +6630,7 @@
           "content": "Elk project heeft een documentatiepagina. Gebruik deze voor testplannen, projectnotities of links naar externe bronnen."
         },
         "documentationContent": {
-          "title": "Rich Text Editor",
+          "title": "Rich Text-editor",
           "content": "De documentatie ondersteunt opmaak met koppen, lijsten, links en afbeeldingen. Probeer deze pagina te bewerken om te zien hoe het werkt."
         },
         "milestones": {
@@ -6716,7 +6719,7 @@
       "addDimension": "Voeg dimensie toe...",
       "addMetric": "Metrisch toevoegen...",
       "runReport": "Rapport uitvoeren",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Exporteer naar CSV",
       "noResultsFound": "Geen resultaten gevonden.",
       "selectAtLeastOneDimensionAndMetric": "Selecteer minimaal één dimensie en één metriek.",
       "noDataMatchingCriteria": "Er zijn geen gegevens gevonden die overeenkomen met de geselecteerde dimensies en statistieken.",
@@ -6848,7 +6851,7 @@
       "flakyTests": {
         "consecutiveRuns": "Laatste opeenvolgende runs",
         "consecutiveRunsHelp": "Aantal recente testuitvoeringen om te analyseren (5-30). Resultaten met de status 'niet getest' worden uitgesloten.",
-        "flipThreshold": "Minimum Flips",
+        "flipThreshold": "Minimum aantal flips",
         "flipThresholdHelp": "Het minimale aantal geslaagde/mislukte overgangen is vereist om als onbetrouwbaar te worden beschouwd.",
         "flips": "Flips",
         "lastNResults": "Laatste {count, plural, one {# Resultaat} other {# Resultaten}}",
@@ -6951,7 +6954,7 @@
           "executions": "{count} loopt",
           "forecast": "{value} voorspelling",
           "forecastUnset": "Geen voorspelling",
-          "flakiness": "Flips {value}%",
+          "flakiness": "Wisselingen {value}%",
           "flakinessUnset": "Geen flip-gegevens",
           "createdLabel": "Gemaakt"
         },
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}u {minutes}m"
           },
           "relativeAge": {
             "today": "Vandaag",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Zoekopdracht",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
+      "title": "Opgeslagen zoekopdrachten",
+      "save": "Zoekopdracht opslaan",
+      "saveTitle": "Zoekopdracht opslaan",
+      "saveDescription": "Geef deze zoekopdracht een naam zodat u die later kunt terugvinden.",
+      "saveAction": "Opslaan",
       "nameLabel": "Naam",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "namePlaceholder": "bijv. Mislukte testruns deze sprint",
+      "nameRequired": "Voer een naam in voor deze zoekopdracht.",
+      "loginRequired": "U moet aangemeld zijn om zoekopdrachten op te slaan.",
       "descriptionLabel": "Beschrijving (optioneel)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "Waarvoor deze zoekopdracht dient",
+      "saved": "Zoekopdracht opgeslagen",
+      "savedDescription": "“{name}” staat nu bij uw opgeslagen zoekopdrachten.",
+      "saveFailed": "Kan de zoekopdracht niet opslaan. Probeer het opnieuw.",
+      "empty": "Nog geen opgeslagen zoekopdrachten",
+      "emptyHint": "Sla een zoekopdracht op om die later terug te vinden.",
+      "loaded": "“{name}” geladen",
+      "loadFailed": "Deze opgeslagen zoekopdracht is niet meer geldig.",
+      "edit": "Bewerken",
+      "editTitle": "Opgeslagen zoekopdracht bewerken",
+      "edited": "Opgeslagen zoekopdracht bijgewerkt",
+      "editFailed": "Kan de zoekopdracht niet bijwerken. Probeer het opnieuw.",
       "delete": "Verwijderen",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Opgeslagen zoekopdracht verwijderen?",
+      "deleteConfirm": "“{name}” wordt verwijderd uit uw opgeslagen zoekopdrachten. Dit kan niet ongedaan worden gemaakt.",
+      "deleted": "Opgeslagen zoekopdracht verwijderd",
+      "deleteFailed": "Kan de zoekopdracht niet verwijderen. Probeer het opnieuw."
     },
     "bulk": {
       "crossProjectHint": "(omvattend meerdere projecten)",
@@ -7697,14 +7700,14 @@
       "intro": "Klik op de onderstaande knop om in te loggen:",
       "signInButton": "Inloggen",
       "copyPasteIntro": "Of kopieer en plak deze link in uw browser:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Voor uw veiligheid kan deze link maar één keer worden gebruikt. Vraag een nieuwe link aan als u opnieuw moet aanmelden.",
       "disclaimer": "Als u deze e-mail niet hebt aangevraagd, kunt u deze gerust negeren.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Aanmelden bij TestPlanIt\n\nKlik op de onderstaande link om u aan te melden:\n{url}\n\nVoor uw veiligheid kan deze link maar één keer worden gebruikt. Vraag een nieuwe link aan als u opnieuw moet aanmelden.\n\nAls u deze e-mail niet hebt aangevraagd, kunt u deze veilig negeren."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Open u dit op een ander apparaat? Voer deze code in op het aanmeldingsscherm waar u de link hebt aangevraagd:",
+      "deviceNotice": "Deze link meldt u aan vanuit de browser waar u deze hebt aangevraagd. Als u deze ergens anders opent, krijgt u de bovenstaande code te zien om in uw oorspronkelijke venster in te voeren.",
+      "textBody": "Aanmelden bij TestPlanIt\n\nKlik op de onderstaande link om u aan te melden:\n{url}\n\nOpent u dit op een ander apparaat? Voer deze code in op het aanmeldingsscherm waar u de link hebt aangevraagd: {code}\n\nAls u deze e-mail niet hebt aangevraagd, kunt u deze veilig negeren."
     }
   },
   "comments": {
@@ -8003,7 +8006,7 @@
     "chipCopyFailedToast": "Het kopiëren van @{label} naar het klembord is mislukt.",
     "iterationResultPanelHeading": "Dien het resultaat in voor iteratie {n} van {total}",
     "iterationAddResult": "Voeg resultaat toe",
-    "iterationPassAndNext": "Pass & Next iteration",
+    "iterationPassAndNext": "Slagen & volgende iteratie",
     "iterationOtherStatuses": "Andere statussen",
     "iterationAllComplete": "Alle iteraties voltooid",
     "hardRefuseTitle": "Kan niet aanmaken — te veel iteraties",
@@ -8078,7 +8081,7 @@
     "overrideUnsavedDiscard": "Wijzigingen negeren",
     "iterationBulkConfirmTitle": "Markeer {count, plural, =1 {# iteratie} other {# iteraties}} als {action}?",
     "iterationBulkConfirmDescription": "Elke geselecteerde iteratie ontvangt een nieuw resultaat met de status \"{statusName}\".",
-    "iterationBulkConfirm": "Mark {action}",
+    "iterationBulkConfirm": "Markeer {action}",
     "iterationBulkConfirmReplace": "Vervangen door {action}",
     "iterationBulkOverwriteWarning": "{count, plural, =1 {# van de geselecteerde iteraties heeft al} other {# van de geselecteerde iteraties heeft al}} een resultaat. Een nieuw resultaat wordt vastgelegd en het meest recente resultaat vervangt het huidige.",
     "iterationBulkReasonLabel": "Reden (optioneel)",

--- a/testplanit/messages/pl-PL.json
+++ b/testplanit/messages/pl-PL.json
@@ -62,7 +62,7 @@
       "expand": "Zwiększać",
       "collapse": "Zawalić się",
       "addResult": "Dodaj wynik",
-      "passAndNext": "Pass & Next",
+      "passAndNext": "Zaliczono i dalej",
       "viewInRepository": "Wyświetl w repozytorium",
       "resultAdded": "Dodano wynik testu",
       "resultAddedDescription": "Wynik testu został pomyślnie dodany.",
@@ -1072,7 +1072,7 @@
         "apple": "Kontynuuj z Apple",
         "microsoft": "Kontynuuj z Microsoft",
         "samlProvider": "Zaloguj się za pomocą {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Zaloguj się za pomocą jednorazowego Magic Link",
         "emailLogin": "Kontynuuj z e-mailem"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Powrót do logowania"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Kliknij link w e-mailu, aby zalogować się z tej przeglądarki, lub wpisz poniżej kod z e-maila.",
+        "codeLabel": "Kod logowania",
+        "verifyCode": "Zweryfikuj kod",
+        "verifying": "Weryfikowanie...",
+        "invalidCode": "Ten kod jest nieprawidłowy. Sprawdź e-mail i spróbuj ponownie.",
+        "codeExpired": "To żądanie logowania wygasło. Poproś o nowy link.",
+        "tooManyAttempts": "Za dużo nieprawidłowych prób. Poproś o nowy link, aby spróbować ponownie.",
+        "windowLost": "To okno nie może już zakończyć logowania. Poproś o nowy link.",
+        "genericError": "Nie udało się Cię zalogować. Poproś o nowy link i spróbuj ponownie.",
+        "tooManyRequests": "Za dużo żądań logowania. Poczekaj chwilę i spróbuj ponownie.",
+        "haveCode": "Masz już kod logowania?",
+        "codeEntryDescription": "Wpisz kod z e-maila logowania. Kody działają tylko w przeglądarce, w której poprosiłeś o link.",
+        "backToRequest": "Poproś o nowy link"
       },
       "twoFactor": {
         "title": "Uwierzytelnianie dwuskładnikowe",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Skontaktuj się z administratorem systemu"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Logowanie...",
+      "completeErrorTitle": "Nie udało się Cię zalogować",
+      "requestNewLink": "Poproś o nowy link",
+      "codeTitle": "Twój kod logowania",
+      "codeInstructions": "Otworzyłeś link do logowania na innym urządzeniu lub w innej przeglądarce. Wpisz ten kod na ekranie logowania, na którym pierwotnie o niego poprosiłeś.",
+      "codeCloseNotice": "Możesz zamknąć to okno po wpisaniu kodu.",
+      "expiredTitle": "Ten link do logowania nie jest już prawidłowy",
+      "expiredBody": "Link może wygasnąć lub zostać już wykorzystany. Poproś o nowy na stronie logowania — to zajmie tylko chwilę."
     },
     "errors": {
       "accessDenied": "Dostęp zabroniony. Twoje konto może być nieaktywne lub nie masz uprawnień do logowania.",
       "configuration": "Wystąpił problem z konfiguracją serwera.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Ten link do logowania wygasł lub został już użyty. Magic linki można wykorzystać tylko raz — poproś o nowy, aby się zalogować.",
       "invalid2FACode": "Nieprawidłowy kod weryfikacyjny. Spróbuj ponownie.",
       "twoFactorTokenRequired": "Token jest wymagany",
       "verificationCodeRequired": "Wymagany jest kod weryfikacyjny"
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Zachowaj problemy w bazie danych (staną się niepowiązane)",
           "switchWarning3": "Zastąp obecną konfigurację integracji problemów nową",
           "switchWarning4": "Usuń przychodzący webhook skonfigurowany dla bieżącej integracji",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Importuj problemy",
+          "importTitle": "Importuj problemy z {name}",
+          "importDescription": "Pobierz problemy z tego powiązanego projektu do swojego projektu. Istniejące problemy nie są duplikowane, a zaimportowane problemy są aktualizowane poprzez synchronizację.",
+          "importUpdatedWithin": "Zaktualizowano w ciągu",
+          "importLastDays": "Ostatnie {days} dni",
+          "importMax": "Maksymalna liczba do importu",
+          "importPreview": "Podgląd",
+          "importPreviewResult": "~{count, plural, one {# problem} few {# problemy} many {# problemów} other {# problemu}} spełnia ten filtr. Zaimportowanych zostanie maksymalnie {cap}.",
+          "importOverCap": "Przekracza to limit {cap}; zostanie zaimportowanych tylko {cap} najnowszych zaktualizowanych problemów.",
+          "importStart": "Importuj",
+          "importStarted": "Import rozpoczęty. Problemy pojawią się wkrótce.",
+          "importFailed": "Import nie powiódł się",
+          "importPreviewFailed": "Nie udało się oszacować dopasowań"
         },
         "integrationAssigned": "Integracja przypisana pomyślnie",
         "integrationAssignError": "Nie udało się przypisać integracji problemu do projektu",
@@ -1402,10 +1405,10 @@
             "description": "Połącz się z usługą Azure DevOps, aby śledzić elementy pracy."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Połącz się z samodzielnie hostowaną instancją Redmine w celu śledzenia problemów."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Połącz się z samodzielnie hostowaną instancją MantisBT w celu śledzenia problemów."
           }
         }
       },
@@ -1519,7 +1522,7 @@
           "jiraIssueDeleted": "Usunięto problem w Jira",
           "githubIssues": "Wydarzenie związane z problemami GitHub",
           "githubPullRequest": "Żądanie ściągnięcia GitHub",
-          "githubPush": "GitHub push",
+          "githubPush": "Push do GitHub",
           "githubIssueComment": "Komentarz do problemu GitHub",
           "adoWorkitemCreated": "Utworzono element roboczy usługi Azure DevOps",
           "adoWorkitemUpdated": "Zaktualizowano element roboczy usługi Azure DevOps",
@@ -1577,7 +1580,7 @@
         "inboundChooserSubmit": "Kontynuować",
         "inboundChooserCancel": "Anulować",
         "inboundEmpty": "Brak skonfigurowanych webhooków przychodzących. Dodaj jeden, aby otrzymywać aktualizacje zgłoszeń z Jira, GitHub, GitLab, Gitea lub Azure DevOps.",
-        "inboundJiraTitle": "Jira inbound webhook",
+        "inboundJiraTitle": "Przychodzący webhook Jira",
         "inboundGithubTitle": "GitHub przychodzący webhook",
         "inboundGithubScopeHint": "Zdarzenia GitHub <code>dotyczące problemów</code> aktualizują powiązane problemy TestPlanIt. Zdarzenia pull request i komentarzy do problemów są akceptowane, ale nie aktualizują jeszcze problemów.",
         "inboundGitlabTitle": "GitLab przychodzący webhook",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Ponownie włączono webhook",
         "toastReEnableFailed": "Nie udało się ponownie włączyć: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Przychodzący webhook Redmine",
+        "inboundRedmineScopeHint": "Wtyczka redmine_webhook nie podpisuje żądań, więc ten adres URL webhooka jest danymi uwierzytelniającymi — traktuj go jako tajny i wymień go, jeśli zostanie ujawniony.",
+        "setupStepsRedmineStep1": "Zainstaluj wtyczkę redmine_webhook na swoim serwerze Redmine (Redmine nie posiada wbudowanych webhooków).",
+        "setupStepsRedmineStep2": "W swoim projekcie Redmine otwórz Ustawienia → Moduły i włącz Webhooki.",
+        "setupStepsRedmineStep3": "Otwórz Ustawienia → Webhooki, wklej powyższy adres URL i zapisz.",
+        "setupStepsRedmineStep4": "Utwórz lub zaktualizuj problem w Redmine; status powiązanego problemu zostanie tutaj zsynchronizowany.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Przychodzący webhook MantisBT",
+        "inboundMantisbtScopeHint": "Wtyczka webhooków MantisBT nie podpisuje żądań, więc ten adres URL webhooka jest danymi uwierzytelniającymi — traktuj go jako tajny i wymień go, jeśli zostanie ujawniony.",
+        "setupStepsMantisbtStep1": "Zainstaluj i włącz wtyczkę webhooków MantisBT na swoim serwerze MantisBT (MantisBT nie posiada wbudowanych webhooków).",
+        "setupStepsMantisbtStep2": "W konfiguracji wtyczki wybierz zdarzenia utworzenia i aktualizacji problemu.",
+        "setupStepsMantisbtStep3": "Wklej powyższy adres URL jako cel webhooka i zapisz.",
+        "setupStepsMantisbtStep4": "Utwórz lub zaktualizuj problem w MantisBT; status powiązanego problemu zostanie tutaj zsynchronizowany."
       },
       "aiModels": {
         "description": "Konfiguruj modele AI do inteligentnego generowania i analizy przypadków testowych",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Skanowanie plików w {scope}…",
           "scanningFilesCount": "Skanowanie plików w {scope}… (znaleziono{count, number})",
           "filtering": "Stosowanie filtrów do plików {count, number}…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Przekroczono limit zapytań u dostawcy — ponawianie za {seconds, number}s…"
         },
         "cache": {
           "title": "Ustawienia pamięci podręcznej",
@@ -1913,8 +1916,8 @@
         "networkError": "Błąd sieciowy podczas odświeżania pamięci podręcznej",
         "refreshSuccess": "Odświeżono pamięć podręczną: {fileCount} plików (zawartość w pamięci podręcznej:{contentCached})",
         "refreshRateLimited": "Odświeżono pamięć podręczną: {fileCount} plików na liście, {contentCached}/{fileCount} zawartości w pamięci podręcznej (ograniczona szybkość — w celu dokończenia należy odświeżyć ponownie)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Odświeżono pamięć podręczną: {fileCount} plików",
+        "refreshInProgress": "Odświeżanie pamięci podręcznej wciąż działa w tle. Ten widok zostanie zaktualizowany po zakończeniu.",
         "validation": {
           "pathRequired": "Ścieżka jest wymagana",
           "patternRequired": "Wzór jest wymagany",
@@ -2009,7 +2012,7 @@
       "iterationUnlabeled": "Iteracja #{index, number}",
       "popoverInflightHint": "W tym miejscu wyświetlane są iteracje w trakcie lotu, po ich zarejestrowaniu.",
       "popoverNoTimestamp": "—",
-      "filterStatus": "{count, plural, =0 {Status} one {Status (#)} other {Status (#)}}",
+      "filterStatus": "{count, plural, =0 {Status} one {Status (#)} few {Status (#)} many {Status (#)} other {Status (#)}}",
       "filterConfig": "{count, plural, =0 {Konfiguracja} one {Konfiguracja (#)} other {Konfiguracja (#)}}",
       "filterDataset": "{count, plural, =0 {Zestaw danych} one {Zestaw danych (#)} other {Zestaw danych (#)}}",
       "filterStatusLabel": "Status",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Aktywność",
+      "title": "Dziennik aktywności",
+      "description": "Wszystkie zmiany odnotowane dla tej sesji."
     },
     "title": "{count, plural, =1 {Sesja} other {Sesje}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "Dziennik audytu",
+        "description": "Działania wykonane przez tego użytkownika",
+        "noEntries": "Nie odnotowano jeszcze żadnej aktywności.",
+        "loadMore": "Ładowanie",
+        "viewDetails": "Zobacz szczegóły",
+        "columnAction": "Działanie",
+        "columnEntityType": "Typ",
+        "columnEntityName": "Nazwa",
+        "columnTimestamp": "Znacznik czasu",
+        "allActions": "Wszystkie działania",
+        "allTypes": "Wszystkie typy",
+        "noMatchingEntries": "Żaden wpis nie spełnia wybranych filtrów.",
+        "showing": "{loaded} z {total} wpisów"
       },
       "mentionedComments": {
         "title": "Wspomniano w komentarzach",
@@ -2510,9 +2513,9 @@
       "historyView": "Widok historii przypadków testowych"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Aktywność",
+      "title": "Dziennik aktywności",
+      "description": "Wszystkie zmiany odnotowane dla tego przypadku testowego."
     },
     "fields": {
       "optionNotFound": "Opcja nie znaleziona",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Aktywność",
+      "title": "Dziennik aktywności",
+      "description": "Wszystkie zmiany odnotowane dla tego przebiegu testu."
     },
     "notFound": "Nie znaleziono przebiegu testowego.",
     "add": {
@@ -3725,7 +3728,7 @@
         "jobLoadFailed": "Nie udało się załadować tego zadania importu.",
         "uploadProgressAnalyzing": "Przesyłanie zakończone. Analizowanie pliku…",
         "uploadProgressComplete": "Przesyłanie zakończone",
-        "etaLabel": "ETA: {time}",
+        "etaLabel": "Szacowany czas: {time}",
         "startImportButton": "Rozpocznij import",
         "workflowCreate": {
           "nameLabel": "Nazwa przepływu pracy",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Tak",
       "scimUserLockedTitle": "Użytkownik jest zarządzany przez SCIM",
       "scimUserLockedDescription": "Nazwa, adres e-mail i status aktywności tego użytkownika są zarządzane przez Twojego dostawcę tożsamości. Wprowadź zmiany, aby je zaktualizować tutaj.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Zarządzane przez mapowanie grup",
+      "groupMappingOverrideDescription": "Poziom dostępu tego użytkownika jest kontrolowany przez mapowanie grup SCIM i może zostać przywrócony przy następnej synchronizacji.",
+      "groupMappingBadge": "Zmapowane przez grupę"
     },
     "security": {
       "title": "Bezpieczeństwo",
@@ -4490,7 +4493,7 @@
       "saveChanges": "Zapisz zmiany",
       "forceAllUsers": "Wymuś zmianę hasła przez wszystkich użytkowników",
       "forceAllUsersDialogTitle": "Wymuś zmianę hasła dla wszystkich użytkowników",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "Wymusi to na {count, number} użytkownikach korzystających z danych logowania zmianę hasła przy następnym logowaniu.",
       "forceAllUsersDialogWarning": "Tej czynności nie można cofnąć.",
       "forceAllUsersDialogConfirm": "Wymuś zmianę",
       "saved": "Ustawienia zabezpieczeń zostały zapisane",
@@ -4622,16 +4625,16 @@
         "errorToast": "Nie udało się cofnąć tokena. {reason}"
       },
       "probe": {
-        "button": "Test SCIM",
+        "button": "Testuj SCIM",
         "testing": "Testowanie…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — token działa poprawnie z /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Nie udało się nawiązać połączenia z punktem końcowym SCIM. Spróbuj ponownie."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Domyślny zmapowany dostęp",
+      "fallbackDefaultDescription": "Poziom dostępu przypisany użytkownikom nieobjętym żadnym mapowaniem grup.",
+      "fallbackDefaultLabel": "Domyślny poziom dostępu",
+      "fallbackDefaultSaved": "Domyślna wartość zastępcza zapisana"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Zarządzane przez SCIM. Zarządzaj ze strony administratora SCIM.",
       "scimNameLockedTitle": "Grupą zarządza SCIM",
       "scimNameLockedDescription": "Nazwą i członkami tej grupy zarządza Twój dostawca tożsamości. Wprowadź zmiany, aby je zaktualizować tutaj.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Zmapowany dostęp",
+      "mappedAccessLabel": "Zmapowany poziom dostępu",
+      "mappedAccessNone": "Brak mapowania",
+      "mappedAccessSelect": "Wybierz poziom dostępu...",
+      "downgradeConfirmTitle": "Potwierdź zmianę dostępu",
+      "downgradeConfirmDescription": "{count, plural, one {# użytkownik będzie mieć obniżony dostęp} few {# użytkownicy będą mieć obniżony dostęp} many {# użytkowników będzie mieć obniżony dostęp} other {# użytkownika będzie mieć obniżony dostęp}}. Kontynuować?",
+      "downgradeConfirmApplyAnyway": "Zastosuj mimo to",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Aktywny",
         "inactive": "Nieaktywny",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Oczekiwanie na autoryzację"
       },
       "connectedProjects": "Połączone projekty",
       "noIntegrations": "Brak skonfigurowanych integracji problemów",
       "testConnection": "Połączenie testowe",
       "testSuccess": "Połączenie pomyślne",
       "testSuccessDescription": "Integracja problemu jest poprawnie skonfigurowana i połączona",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Dane uwierzytelniające są poprawne",
+      "testCredentialsSavedDescription": "Twój identyfikator klienta OAuth i klucz są prawidłowe. Zapisz integrację, a następnie kliknij Autoryzuj, aby połączyć swoje konto — OAuth 2.0 łączy się dla każdego użytkownika indywidualnie, więc pozostaje nieaktywna, dopóki przynajmniej jedna osoba nie przeprowadzi autoryzacji.",
       "testFailed": "Połączenie nieudane",
       "testFailedDescription": "Nie można połączyć się z usługą zewnętrzną",
       "testError": "Błąd testu",
       "testErrorDescription": "Wystąpił błąd podczas testowania połączenia",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autoryzuj",
+      "reauthorize": "Autoryzuj ponownie",
+      "authorizeHint": "Autoryzuj u dostawcy, aby połączyć swoje konto i zakończyć konfigurację",
+      "syncInProgress": "Ponowna synchronizacja powiązanych problemów...",
+      "syncIntegration": "Ponownie zsynchronizuj powiązane problemy",
+      "syncIntegrationHint": "Synchronizuje ponownie tylko problemy już powiązane w TestPlanIt. Nowe problemy nie są importowane z zewnętrznego systemu śledzenia.",
       "syncSuccess": "Synchronizacja w kolejce",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Powiązane problemy z „{name}” są ponownie synchronizowane w tle. Może to potrwać kilka chwil. Tabela zostanie automatycznie zaktualizowana po zakończeniu.",
       "syncError": "Synchronizacja nie powiodła się",
       "syncErrorDescription": "Nie udało się dodać zadania synchronizacji do kolejki dla tej integracji problemu. Spróbuj ponownie później.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Połącz się z samodzielnie hostowaną instancją Redmine w celu śledzenia problemów"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Połącz się z samodzielnie hostowaną instancją MantisBT w celu śledzenia problemów"
         }
       },
       "filterPlaceholder": "Integracje filtrów...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Zamiast tego należy używać protokołu OAuth 2.0 w celu dokładnego przypisywania danych do poszczególnych użytkowników bez konieczności uzyskiwania uprawnień administratora.",
         "tokenCreatorNoticeTitle": "Atrybucja twórcy problemu",
         "tokenCreatorNoticeDescription": "Zgłoszenia utworzone za pośrednictwem tej integracji są zawsze rejestrowane na koncie, do którego należy ten token dostępu, a nie na koncie użytkownika TestPlanIt, który je utworzył. API tego dostawcy nie pozwala na ustawienie autora w imieniu innego użytkownika.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "Adres URL wywołania zwrotnego (URI przekierowania)",
+        "callbackUrlDescription": "Zarejestruj ten dokładny adres URL jako URI wywołania zwrotnego / przekierowania w aplikacji OAuth Twojego dostawcy. Musi się on precyzyjnie zgadzać, w przeciwnym razie autoryzacja się nie powiedzie.",
+        "callbackUrlCopy": "Kopiuj",
+        "callbackUrlCopied": "Skopiowano",
         "forgeApiKeyLabel": "Klucz API Forge",
         "forgeApiKeyDescription": "Używany przez aplikację Atlassian Forge do uwierzytelniania żądań z paneli zgłoszeń Jira. Wygeneruj klucz tutaj i wklej go w ustawieniach aplikacji Forge.",
         "forgeApiKeyPlaceholder": "Kliknij „Generuj”, aby utworzyć klucz API",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Klucz API Redmine",
+        "redmineApiKeyPlaceholder": "Wprowadź swój klucz API Redmine",
+        "redmineApiKeyHelp": "Znajdziesz go w Moje konto → Klucz dostępu API (włącz REST API w Administracja → Ustawienia → API)",
+        "redmineUrl": "Adres URL Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "Podstawowy adres URL Twojej instancji Redmine",
+        "mantisBTApiKey": "Token API MantisBT",
+        "mantisBTApiKeyPlaceholder": "Wprowadź swój token API MantisBT",
+        "mantisBTApiKeyHelp": "Utwórz go w ustawieniach konta MantisBT → Tokeny API",
+        "mantisBTUrl": "Adres URL MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "Podstawowy adres URL Twojej instancji MantisBT"
       },
       "authType": {
         "api_key": "Klucz API",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Generuj przypadki testowe z adresu URL (wymagania)",
         "generate_from_url_app": "Generuj przypadki testowe z adresu URL (testowanie aplikacji)",
         "automation_candidates": "Raport kandydatów do automatyzacji",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Generowanie kroków przez AI"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Przeglądaj ścieżkę audytu w całym systemie, aby śledzić bezpieczeństwo i zgodność",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Zobacz ścieżkę audytu działań wykonanych w tym projekcie.",
       "filterPlaceholder": "Wyszukaj według jednostki, użytkownika lub akcji...",
       "filterAction": "Działanie",
       "filterEntityType": "Typ jednostki",
       "allActions": "Wszystkie akcje",
       "allEntityTypes": "Wszystkie typy jednostek",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Wszyscy użytkownicy",
+      "allProjects": "Wszystkie projekty",
+      "showing": "Wyświetlanie {loaded} z {total} wpisów",
       "viewDetails": "Zobacz szczegóły",
       "detailTitle": "Szczegóły dziennika audytu",
       "userInfo": "Informacje o użytkowniku",
@@ -5714,8 +5717,8 @@
       "systemActor": "System",
       "systemActorTooltip": "Akcja wykonywana przez system, a nie przez zalogowanego użytkownika",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "powiązane zmiany",
+      "groupedEntry": "Pogrupowane zmiany z jednej akcji"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "nadal czekam na Twoją recenzję",
         "reviewReminderEmailMessage": "Przypomnienie: prośba użytkownika {actorName}z dnia {entityLabel} „{entityName}” w projekcie „{projectName}” oczekuje na rozpatrzenie przez {hoursPending} godzin.",
         "reviewReminderHoursPending": "Oczekiwanie na {hoursPending, plural, one {# godzina} other {# godzina}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Kroki testowe wygenerowane przez AI są gotowe",
+        "aiStepsDerivedMessage": "Do {count, plural, one {# przypadku testowego} few {# przypadków testowych} many {# przypadków testowych} other {# przypadku testowego}} dodano kroki wygenerowane przez AI — sprawdź ich poprawność.",
+        "aiStepsDerivedReviewLink": "Przejrzyj przebieg testu"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Nazwa grupy\nJasna, zwięzła, opisowa nazwa lub słowo(a) kluczowe używane we wszystkich projektach.\n\n— Pomaga członkom zespołu szybko znaleźć powiązane przypadki testowe, przebiegi testów i sesje.",
       "users": "## Użytkownicy\nWskazuje użytkowników przypisanych do tej grupy.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Zmapowany poziom dostępu\nCzłonkowie tej grupy otrzymają co najmniej ten poziom dostępu przy następnej synchronizacji.\n\n- Wygrywa najwyższy poziom ze wszystkich grup użytkownika\n- „Brak mapowania” oznacza, że ta grupa nie wpływa na dostęp — członkowie korzystają z wartości domyślnej ustawionej na stronie SCIM\n- Ręczna zmiana dostępu użytkownika ma priorytet nad mapowaniem (i jest oznaczona na ekranie edycji tego użytkownika)"
     },
     "template": {
       "name": "## Nazwa szablonu\nUnikalna i opisowa nazwa tego szablonu (np. „Standardowy przypadek testowy”, „Wyniki testów API”).",
@@ -6209,7 +6212,7 @@
       "authType": "## Typ uwierzytelniania\nWybierz sposób uwierzytelniania za pomocą usługi zewnętrznej.\n\n- **Klucz API:** Proste uwierzytelnianie przy użyciu adresu e-mail i tokenu API\n- **OAuth 2.0:** Bezpieczne uwierzytelnianie przy użyciu przepływu OAuth\n- **Token dostępu osobistego:** Bezpośrednie uwierzytelnianie na podstawie tokenu",
       "email": "## Adres e-mail\nTwój adres e-mail konta dla usługi zewnętrznej.\n\n— używany do uwierzytelniania kluczem API\n— musi być zgodny z kontem, które wygenerowało token API\n— wymagany dla Jira i podobnych usług",
       "apiToken": "## Token API\nWygeneruj token API z ustawień konta w usłudze zewnętrznej.\n\n— Zwykle znajduje się w Ustawieniach konta → Bezpieczeństwo → Tokeny API\n— Zapewnia bezpieczny dostęp bez ujawniania hasła\n— Można go cofnąć i wygenerować ponownie w razie potrzeby",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Adres URL Jira\nPodstawowy adres URL Twojej instancji Jira.\n\n- Format: https://twoja-strona.atlassian.net\n- Nie uwzględniaj ścieżki /browse ani innych ścieżek\n- Musi być dostępny z tego serwera",
       "clientId": "## Identyfikator klienta OAuth\nIdentyfikator klienta z konfiguracji aplikacji OAuth.\n\n— Utworzono w konsoli programisty usługi zewnętrznej\n— Służy do identyfikacji aplikacji podczas przepływu OAuth\n— Można go bezpiecznie udostępniać w plikach konfiguracyjnych",
       "clientSecret": "## Tajny klucz klienta OAuth\nTajny klucz klienta z konfiguracji aplikacji OAuth.\n\n— Tworzony wraz z identyfikatorem klienta\n— Musi być zachowany w tajemnicy i bezpieczny\n— Służy do uwierzytelniania aplikacji",
       "personalAccessToken": "## Osobisty token dostępu\nOsobisty token dostępu z odpowiednimi uprawnieniami do usługi zewnętrznej.\n\n— Generowany w ustawieniach konta\n— Powinien zawierać uprawnienia do odczytu i zapisu\n— Bezpieczniejszy niż uwierzytelnianie hasłem",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## Adres URL instancji\nPodstawowy adres URL samodzielnie hostowanej instancji.\n\n— Format: https://git.example.com\n— Nie należy uwzględniać końcowych ukośników ani ścieżek\n— Musi być dostępny z tego serwera",
       "projectPath": "## Ścieżka projektu\nPełna ścieżka do Twojego projektu GitLab.\n\n- Format: przestrzeń nazw/projekt lub grupa/podgrupa/projekt\n- Przykład: my-org/my-project\n- Znajduje się w adresie URL projektu: gitlab.com/namespace/project",
       "platform": "## Platforma\nSamodzielnie hostowana platforma Git, z którą się łączysz.\n\n- **Gitea**: instancje oparte na gitea.io\n- **Forgejo**: instancje oparte na forgejo.org (fork Gitea)\n- **Gogs**: instancje oparte na gogs.io\n\nKontroluje, która ikona jest wyświetlana, i może mieć wpływ na zgodność z API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Klucz API Redmine\nTwój osobisty klucz dostępu do REST API.\n\n- Włącz REST API w Administracja → Ustawienia → API\n- Skopiuj swój klucz z Moje konto → Klucz dostępu API\n- Zakres odpowiada uprawnieniom Twojego użytkownika; użyj konta serwisowego dla współdzielonych integracji",
+      "redmineUrl": "## Adres URL Redmine\nPodstawowy adres URL Twojej instancji Redmine.\n\n- Format: https://redmine.example.com\n- Nie uwzględniaj /issues ani innych ścieżek\n- Musi być dostępny z tego serwera",
+      "mantisBTApiKey": "## Token API MantisBT\nTwój osobisty token REST API.\n\n- Utwórz go w ustawieniach konta MantisBT → Tokeny API\n- Zakres odpowiada uprawnieniom Twojego użytkownika; użyj konta serwisowego dla współdzielonych integracji",
+      "mantisBTUrl": "## Adres URL MantisBT\nPodstawowy adres URL Twojej instancji MantisBT.\n\n- Format: https://mantisbt.example.com\n- Nie uwzględniaj /api/rest ani innych ścieżek\n- Musi być dostępny z tego serwera",
+      "githubBaseUrl": "## Podstawowy adres URL API\nPełny katalog główny API GitHub dla GitHub Enterprise Server.\n\n- Zazwyczaj kończy się na /api/v3\n- Pozostaw puste, aby użyć api.github.com\n- Musi być dostępny z tego serwera"
     },
     "config": {
       "name": "## Nazwa konfiguracji\nJasna, opisowa nazwa tej konfiguracji.\n\n— Pomaga opisać warianty konfiguracji (np. „Chrome, Windows 10”, „Safari/macOS 15.5”, „Edge/Windows 11” itd.).",
@@ -6716,7 +6719,7 @@
       "addDimension": "Dodaj wymiar...",
       "addMetric": "Dodaj metrykę...",
       "runReport": "Uruchom raport",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Eksportuj CSV",
       "noResultsFound": "Nie znaleziono wyników.",
       "selectAtLeastOneDimensionAndMetric": "Wybierz co najmniej jeden wymiar i jedną metrykę.",
       "noDataMatchingCriteria": "Nie znaleziono danych odpowiadających wybranym wymiarom i metrykom.",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Szukaj",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Zapisane wyszukiwania",
+      "save": "Zapisz wyszukiwanie",
+      "saveTitle": "Zapisz wyszukiwanie",
+      "saveDescription": "Nazwij to wyszukiwanie, aby móc do niego wrócić później.",
+      "saveAction": "Zapisz",
+      "nameLabel": "Nazwa",
+      "namePlaceholder": "np. Nieudane przebiegi w tym sprincie",
+      "nameRequired": "Wprowadź nazwę dla tego wyszukiwania.",
+      "loginRequired": "Aby zapisywać wyszukiwania, musisz być zalogowany.",
       "descriptionLabel": "Opis (opcjonalnie)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "Do czego służy to wyszukiwanie",
+      "saved": "Wyszukiwanie zapisane",
+      "savedDescription": "„{name}” zostało dodane do zapisanych wyszukiwań.",
+      "saveFailed": "Nie udało się zapisać wyszukiwania. Spróbuj ponownie.",
+      "empty": "Brak zapisanych wyszukiwań",
+      "emptyHint": "Zapisz wyszukiwanie, aby wrócić do niego później.",
+      "loaded": "Wczytano „{name}”",
+      "loadFailed": "To zapisane wyszukiwanie nie jest już prawidłowe.",
+      "edit": "Edytuj",
+      "editTitle": "Edytuj zapisane wyszukiwanie",
+      "edited": "Zapisane wyszukiwanie zaktualizowane",
+      "editFailed": "Nie udało się zaktualizować wyszukiwania. Spróbuj ponownie.",
       "delete": "Usuwać",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Usunąć zapisane wyszukiwanie?",
+      "deleteConfirm": "„{name}” zostanie usunięte z zapisanych wyszukiwań. Tej operacji nie można odwrócić.",
+      "deleted": "Zapisane wyszukiwanie usunięte",
+      "deleteFailed": "Nie udało się usunąć wyszukiwania. Spróbuj ponownie."
     },
     "bulk": {
       "crossProjectHint": "(obejmujący wiele projektów)",
@@ -7697,14 +7700,14 @@
       "intro": "Kliknij poniższy przycisk, aby się zalogować:",
       "signInButton": "Zalogować się",
       "copyPasteIntro": "Lub skopiuj i wklej ten link do przeglądarki:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Dla Twojego bezpieczeństwa ten link można wykorzystać tylko raz. Poproś o nowy link, jeśli chcesz się zalogować ponownie.",
       "disclaimer": "Jeśli nie prosiłeś o wysłanie tego e-maila, możesz go bezpiecznie zignorować.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Zaloguj się do TestPlanIt\n\nKliknij poniższy link, aby się zalogować:\n{url}\n\nDla Twojego bezpieczeństwa ten link można wykorzystać tylko raz. Poproś o nowy link, jeśli chcesz się zalogować ponownie.\n\nJeśli nie prosiłeś o ten e-mail, możesz go bezpiecznie zignorować."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Otwierasz to na innym urządzeniu? Wpisz ten kod na ekranie logowania, na którym poprosiłeś o link:",
+      "deviceNotice": "Ten link loguje Cię z przeglądarki, w której o niego poprosiłeś. Jeśli otworzysz go gdzie indziej, zobaczysz powyższy kod do wpisania w oryginalnym oknie.",
+      "textBody": "Zaloguj się do TestPlanIt\n\nKliknij poniższy link, aby się zalogować:\n{url}\n\nOtwierasz to na innym urządzeniu? Wpisz ten kod na ekranie logowania, na którym poprosiłeś o link: {code}\n\nJeśli nie prosiłeś o ten e-mail, możesz go bezpiecznie zignorować."
     }
   },
   "comments": {

--- a/testplanit/messages/pt-BR.json
+++ b/testplanit/messages/pt-BR.json
@@ -1072,7 +1072,7 @@
         "apple": "Continue com a Apple",
         "microsoft": "Continue com a Microsoft",
         "samlProvider": "Faça login com {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Entrar com Link Mágico de uso único",
         "emailLogin": "Continuar com o e-mail"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Voltar para a página de login"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Clique no link do e-mail para entrar a partir deste navegador, ou insira o código do e-mail abaixo.",
+        "codeLabel": "Código de acesso",
+        "verifyCode": "Verificar código",
+        "verifying": "Verificando...",
+        "invalidCode": "Esse código não está correto. Verifique o e-mail e tente novamente.",
+        "codeExpired": "Esta solicitação de acesso expirou. Solicite um novo link.",
+        "tooManyAttempts": "Muitas tentativas incorretas. Solicite um novo link para tentar novamente.",
+        "windowLost": "Esta janela não pode mais concluir o acesso. Solicite um novo link.",
+        "genericError": "Não foi possível concluir seu acesso. Solicite um novo link e tente novamente.",
+        "tooManyRequests": "Muitas solicitações de acesso. Aguarde um momento e tente novamente.",
+        "haveCode": "Já tem um código de acesso?",
+        "codeEntryDescription": "Insira o código do seu e-mail de acesso. Os códigos só funcionam no navegador onde você solicitou o link.",
+        "backToRequest": "Solicitar um novo link em vez disso"
       },
       "twoFactor": {
         "title": "Autenticação de dois fatores",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Contate o administrador do sistema."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Entrando...",
+      "completeErrorTitle": "Não foi possível concluir seu acesso",
+      "requestNewLink": "Solicitar um novo link",
+      "codeTitle": "Seu código de acesso",
+      "codeInstructions": "Você abriu o link de acesso em um dispositivo ou navegador diferente. Insira este código na tela de acesso onde você o solicitou originalmente.",
+      "codeCloseNotice": "Você pode fechar esta janela após inserir o código.",
+      "expiredTitle": "Este link de acesso não é mais válido",
+      "expiredBody": "O link pode ter expirado ou já ter sido usado. Solicite um novo na página de acesso — leva apenas um momento."
     },
     "errors": {
       "accessDenied": "Acesso negado. Sua conta pode estar inativa ou você não tem permissão para fazer login.",
       "configuration": "Existe um problema com a configuração do servidor.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Este link de acesso expirou ou já foi usado. Links mágicos só podem ser usados uma vez — solicite um novo para entrar.",
       "invalid2FACode": "Código de verificação inválido. Tente novamente.",
       "twoFactorTokenRequired": "É necessário um token.",
       "verificationCodeRequired": "É necessário um código de verificação."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Preserve os problemas no banco de dados (eles serão desvinculados).",
           "switchWarning3": "Substitua a configuração de integração de problemas atual pela nova.",
           "switchWarning4": "Remova o webhook de entrada configurado para a integração atual.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Importar Issues",
+          "importTitle": "Importar issues de {name}",
+          "importDescription": "Traga issues deste projeto vinculado para o seu projeto. Issues existentes não são duplicadas, e as issues importadas permanecem atualizadas através da sincronização.",
+          "importUpdatedWithin": "Atualizado dentro de",
+          "importLastDays": "Últimos {days} dias",
+          "importMax": "Máximo para importar",
+          "importPreview": "Pré-visualizar",
+          "importPreviewResult": "~{count, plural, one {# issue corresponde} other {# issues correspondem}} a este filtro. Até {cap} serão importadas.",
+          "importOverCap": "Isso excede o limite de {cap}; apenas as {cap} atualizadas mais recentemente serão importadas.",
+          "importStart": "Importar",
+          "importStarted": "Importação iniciada. As issues aparecerão em breve.",
+          "importFailed": "Falha na importação",
+          "importPreviewFailed": "Não foi possível estimar as correspondências"
         },
         "integrationAssigned": "Integração atribuída com sucesso",
         "integrationAssignError": "Falha ao atribuir a integração de problemas ao projeto",
@@ -1402,10 +1405,10 @@
             "description": "Conecte-se ao Azure DevOps para rastrear itens de trabalho."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Conecte-se a uma instância Redmine auto-hospedada para rastreamento de issues."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Conecte-se a uma instância MantisBT auto-hospedada para rastreamento de issues."
           }
         }
       },
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook reativado",
         "toastReEnableFailed": "Falha ao reativar: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Webhook de entrada do Redmine",
+        "inboundRedmineScopeHint": "O plugin redmine_webhook não assina as solicitações, portanto esta URL de webhook é a credencial — trate-a como um segredo e a substitua se for exposta.",
+        "setupStepsRedmineStep1": "Instale o plugin redmine_webhook em seu servidor Redmine (o Redmine não possui webhooks integrados).",
+        "setupStepsRedmineStep2": "No seu projeto Redmine, abra Configurações → Módulos e habilite Webhooks.",
+        "setupStepsRedmineStep3": "Abra Configurações → Webhooks, cole a URL acima e salve.",
+        "setupStepsRedmineStep4": "Crie ou atualize uma issue no Redmine; o status da issue vinculada será sincronizado aqui.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Webhook de entrada do MantisBT",
+        "inboundMantisbtScopeHint": "Um plugin de webhook do MantisBT não assina as solicitações, portanto esta URL de webhook é a credencial — trate-a como um segredo e a substitua se for exposta.",
+        "setupStepsMantisbtStep1": "Instale e habilite um plugin de webhook do MantisBT em seu servidor MantisBT (o MantisBT não possui webhooks integrados).",
+        "setupStepsMantisbtStep2": "Na configuração do plugin, escolha os eventos de issue criada e issue atualizada.",
+        "setupStepsMantisbtStep3": "Cole a URL acima como o destino do webhook e salve.",
+        "setupStepsMantisbtStep4": "Crie ou atualize uma issue no MantisBT; o status da issue vinculada será sincronizado aqui."
       },
       "aiModels": {
         "description": "Configure modelos de IA para geração e análise inteligentes de casos de teste.",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Analisando arquivos em {scope}…",
           "scanningFilesCount": "Analisando arquivos em {scope}… ({count, number} encontrado)",
           "filtering": "Aplicando filtros a {count, number} arquivos…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Limitado pela taxa do provedor — tentando novamente em {seconds, number}s…"
         },
         "cache": {
           "title": "Configurações de cache",
@@ -1913,8 +1916,8 @@
         "networkError": "Erro de rede durante a atualização do cache",
         "refreshSuccess": "Cache atualizado: {fileCount} arquivos ({contentCached} conteúdo em cache)",
         "refreshRateLimited": "Cache atualizado: {fileCount} arquivos listados, {contentCached}/{fileCount} conteúdo em cache (taxa limitada — atualize novamente para concluir)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Cache atualizado: {fileCount} arquivos",
+        "refreshInProgress": "A atualização do cache ainda está em execução em segundo plano. Isso será atualizado aqui quando terminar.",
         "validation": {
           "pathRequired": "O caminho é obrigatório",
           "patternRequired": "É necessário um padrão.",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Atividade",
+      "title": "Log de Atividade",
+      "description": "Todas as alterações registradas para esta sessão."
     },
     "title": "{count, plural, =1 {Sessão} other {Sessões}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "Log de Auditoria",
+        "description": "Ações realizadas por este usuário",
+        "noEntries": "Nenhuma atividade registrada ainda.",
+        "loadMore": "Carregando",
+        "viewDetails": "Ver detalhes",
+        "columnAction": "Ação",
+        "columnEntityType": "Tipo",
+        "columnEntityName": "Nome",
+        "columnTimestamp": "Data/Hora",
+        "allActions": "Todas as Ações",
+        "allTypes": "Todos os Tipos",
+        "noMatchingEntries": "Nenhuma entrada corresponde aos filtros selecionados.",
+        "showing": "{loaded} de {total} entradas"
       },
       "mentionedComments": {
         "title": "Mencionado nos comentários",
@@ -2510,9 +2513,9 @@
       "historyView": "Visualização do histórico de casos de teste"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Atividade",
+      "title": "Log de Atividade",
+      "description": "Todas as alterações registradas para este caso de teste."
     },
     "fields": {
       "optionNotFound": "Opção não encontrada",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# par vinculado} other {# pares vinculados}}",
       "bulkError": "Algumas operações falharam. Por favor, tente novamente.",
       "tableHint": "Clique em uma linha ou no botão Comparar para revisar e resolver pares duplicados.",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} versus {caseB}",
       "comparisonDescription": "Compare esses possíveis duplicados e escolha como resolvê-los.",
       "selectPrimary": "Clique em um caso para selecioná-lo como o principal para mesclagem.",
       "selectedAsPrimary": "Selecionado como Principal",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Atividade",
+      "title": "Log de Atividade",
+      "description": "Todas as alterações registradas para esta execução de teste."
     },
     "notFound": "Teste de execução não encontrado.",
     "add": {
@@ -3725,7 +3728,7 @@
         "jobLoadFailed": "Não foi possível carregar essa tarefa de importação.",
         "uploadProgressAnalyzing": "Upload concluído. Analisando arquivo…",
         "uploadProgressComplete": "Upload concluído",
-        "etaLabel": "ETA: {time}",
+        "etaLabel": "Tempo estimado: {time}",
         "startImportButton": "Iniciar importação",
         "workflowCreate": {
           "nameLabel": "Nome do fluxo de trabalho",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Sim",
       "scimUserLockedTitle": "O usuário é gerenciado pelo SCIM.",
       "scimUserLockedDescription": "O nome, o e-mail e o status de atividade deste usuário são gerenciados pelo seu provedor de identidade. Faça as alterações necessárias lá para atualizá-los aqui.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Gerenciado pelo Mapeamento de Grupo",
+      "groupMappingOverrideDescription": "O nível de acesso deste usuário é controlado por um mapeamento de grupo SCIM e pode ser revertido na próxima sincronização.",
+      "groupMappingBadge": "Mapeado por Grupo"
     },
     "security": {
       "title": "Segurança",
@@ -4490,7 +4493,7 @@
       "saveChanges": "Salvar alterações",
       "forceAllUsers": "Obrigar todos os usuários a alterar a senha",
       "forceAllUsersDialogTitle": "Forçar alteração de senha para todos os usuários",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "Isto exigirá que {count, number} usuários com base em credenciais alterem sua senha no próximo login.",
       "forceAllUsersDialogWarning": "Esta ação não pode ser desfeita.",
       "forceAllUsersDialogConfirm": "Mudança de Força",
       "saved": "Configurações de segurança salvas",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "Teste SCIM",
         "testing": "Testando…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — o token funciona em /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Não foi possível conectar-se ao endpoint SCIM. Tente novamente."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Acesso Padrão Mapeado",
+      "fallbackDefaultDescription": "Nível de acesso atribuído a usuários não cobertos por nenhum mapeamento de grupo.",
+      "fallbackDefaultLabel": "Nível de acesso padrão",
+      "fallbackDefaultSaved": "Padrão de contingência salvo"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Gerenciado pelo SCIM. Gerencie a partir da página de administração do SCIM.",
       "scimNameLockedTitle": "O grupo é gerenciado pela SCIM.",
       "scimNameLockedDescription": "O nome e os membros deste grupo são gerenciados pelo seu provedor de identidade. Faça as alterações necessárias lá para atualizá-los aqui.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Acesso Mapeado",
+      "mappedAccessLabel": "Nível de Acesso Mapeado",
+      "mappedAccessNone": "Nenhum mapeamento",
+      "mappedAccessSelect": "Selecione o nível de acesso...",
+      "downgradeConfirmTitle": "Confirmar Alteração de Acesso",
+      "downgradeConfirmDescription": "{count, plural, one {# usuário teria} other {# usuários teriam}} seu acesso reduzido. Continuar?",
+      "downgradeConfirmApplyAnyway": "Aplicar mesmo assim",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Ativo",
         "inactive": "Inativo",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Aguardando autorização"
       },
       "connectedProjects": "Projetos Conectados",
       "noIntegrations": "Nenhuma integração configurada",
       "testConnection": "Conexão de teste",
       "testSuccess": "Conexão bem-sucedida",
       "testSuccessDescription": "A integração do problema está configurada e conectada corretamente.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "As credenciais estão corretas",
+      "testCredentialsSavedDescription": "Seu ID de cliente e segredo OAuth são válidos. Salve a integração e clique em Autorizar para conectar sua conta — o OAuth 2.0 conecta por usuário, então permanece inativo até que pelo menos uma pessoa autorize.",
       "testFailed": "Conexão falhou",
       "testFailedDescription": "Não foi possível conectar-se ao serviço externo.",
       "testError": "Erro de teste",
       "testErrorDescription": "Ocorreu um erro ao testar a conexão.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Autorizar",
+      "reauthorize": "Reautorizar",
+      "authorizeHint": "Autorize com o provedor para conectar sua conta e concluir a configuração",
+      "syncInProgress": "Ressincronizando issues vinculadas...",
+      "syncIntegration": "Ressincronizar issues vinculadas",
+      "syncIntegrationHint": "Ressincroniza apenas as issues já vinculadas no TestPlanIt. Novas issues não são importadas do rastreador externo.",
       "syncSuccess": "Sincronização em fila",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "As issues vinculadas de \"{name}\" estão sendo ressincronizadas em segundo plano. Isso pode levar alguns instantes. A tabela será atualizada automaticamente quando concluído.",
       "syncError": "Falha na sincronização",
       "syncErrorDescription": "Não foi possível enfileirar a tarefa de sincronização para esta integração. Tente novamente mais tarde.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Conecte-se a uma instância Redmine auto-hospedada para rastreamento de issues"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Conecte-se a uma instância MantisBT auto-hospedada para rastreamento de issues"
         }
       },
       "filterPlaceholder": "Integrações de filtros...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Utilize o OAuth 2.0 para obter uma atribuição precisa de relatórios por usuário, sem a necessidade de permissões de administrador.",
         "tokenCreatorNoticeTitle": "Atribuição do criador do problema",
         "tokenCreatorNoticeDescription": "Os problemas criados por meio dessa integração são sempre registrados como pertencentes à conta que possui o token de acesso, e não ao usuário do TestPlanIt que os criou. A API desse provedor não permite definir o criador em nome de outro usuário.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL de Retorno (URI de redirecionamento)",
+        "callbackUrlDescription": "Registre esta URL exata como a URI de retorno/redirecionamento no aplicativo OAuth do seu provedor. Ela deve corresponder exatamente ou a autorização falhará.",
+        "callbackUrlCopy": "Copiar",
+        "callbackUrlCopied": "Copiado",
         "forgeApiKeyLabel": "Chave da API do Forge",
         "forgeApiKeyDescription": "Utilizada pelo aplicativo Atlassian Forge para autenticar solicitações dos painéis de problemas do Jira. Gere uma chave aqui e cole-a nas configurações do seu aplicativo Forge.",
         "forgeApiKeyPlaceholder": "Clique em Gerar para criar uma chave de API.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Chave de API do Redmine",
+        "redmineApiKeyPlaceholder": "Insira sua chave de API do Redmine",
+        "redmineApiKeyHelp": "Encontrada em Minha conta → Chave de acesso à API (habilite a API REST em Administração → Configurações → API)",
+        "redmineUrl": "URL do Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "A URL base da sua instância Redmine",
+        "mantisBTApiKey": "Token de API do MantisBT",
+        "mantisBTApiKeyPlaceholder": "Insira seu token de API do MantisBT",
+        "mantisBTApiKeyHelp": "Crie um em suas configurações de conta do MantisBT → Tokens de API",
+        "mantisBTUrl": "URL do MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "A URL base da sua instância MantisBT"
       },
       "authType": {
         "api_key": "Chave de API",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Gerar casos de teste a partir de URL (Requisitos)",
         "generate_from_url_app": "Gerar casos de teste a partir de URL (Teste de Aplicativos)",
         "automation_candidates": "Relatório de Candidatos à Automação",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Derivação de Passos por IA"
       }
     },
     "elasticsearch": {
@@ -5569,7 +5572,7 @@
         "forecast-updates": "Atualizações da previsão",
         "emails": "Fila de e-mails",
         "issue-sync": "Sincronização de Problemas",
-        "testmo-imports": "Testmo Imports",
+        "testmo-imports": "Importações Testmo",
         "elasticsearch-reindex": "Reindexação do Elasticsearch",
         "audit-logs": "Registros de auditoria",
         "budget-alerts": "Alertas orçamentários",
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Visualize o histórico de auditoria de todo o sistema para fins de segurança e conformidade.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Veja o histórico de auditoria das ações realizadas neste projeto.",
       "filterPlaceholder": "Pesquisar por entidade, usuário ou ação...",
       "filterAction": "Ação",
       "filterEntityType": "Tipo de entidade",
       "allActions": "Todas as ações",
       "allEntityTypes": "Todos os tipos de entidade",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Todos os Usuários",
+      "allProjects": "Todos os Projetos",
+      "showing": "Mostrando {loaded} de {total} entradas",
       "viewDetails": "Ver detalhes",
       "detailTitle": "Detalhes do registro de auditoria",
       "userInfo": "Informações do usuário",
@@ -5714,8 +5717,8 @@
       "systemActor": "Sistema",
       "systemActorTooltip": "Ação realizada pelo sistema, não por um usuário conectado.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "alterações relacionadas",
+      "groupedEntry": "Alterações agrupadas de uma única ação"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "Ainda aguardamos sua avaliação de",
         "reviewReminderEmailMessage": "Lembrete: a solicitação de revisão de {actorName}em {entityLabel} \"{entityName}\" no projeto \"{projectName}\" está pendente há {hoursPending} horas.",
         "reviewReminderHoursPending": "Aguardando {hoursPending, plural, one {# hora} other {# horas}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Passos de Teste Derivados por IA Prontos",
+        "aiStepsDerivedMessage": "{count, plural, one {# caso de teste recebeu} other {# casos de teste receberam}} passos derivados por IA — revise a precisão.",
+        "aiStepsDerivedReviewLink": "Revisar execução de teste"
       }
     },
     "issues": {
@@ -5955,7 +5958,7 @@
     "createdInternal": "Problema criado localmente",
     "createdInternalSimpleUrl": "Problema criado internamente e pode ser vinculado por meio de URL simples.",
     "createError": "Falha ao criar o problema",
-    "useIntegration": "Use {provider}",
+    "useIntegration": "Usar {provider}",
     "useIntegrationDescription": "Criar problema em sistema externo",
     "externalProject": "Projeto externo",
     "selectProject": "Selecione o projeto",
@@ -6033,9 +6036,9 @@
     "durationRange": "Duração: {from}s - {to}s",
     "seconds": "{seconds}s",
     "testCases": "{count, plural, one {# caso de teste} other {# casos de teste}}",
-    "estimate": "Est: {value}",
+    "estimate": "Est.: {value}",
     "partOf": "(Parte de {parent})",
-    "status": "Status: {status}"
+    "status": "Estado: {status}"
   },
   "linkedCases": {
     "title": "Casos de teste vinculados",
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Nome do Grupo\nUm nome ou palavra(s)-chave clara(s), concisa(s) e descritiva(s) que seja(m) usada(s) em todos os projetos.\n\n- Ajuda os membros da equipe a encontrar rapidamente casos de teste, execuções de teste e sessões relacionadas.",
       "users": "## Usuários\nIndica os usuários que estão atribuídos a este grupo.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Nível de Acesso Mapeado\nOs membros deste grupo recebem pelo menos este nível de acesso na próxima sincronização.\n\n- O nível mais alto entre todos os grupos de um usuário prevalece\n- \"Nenhum mapeamento\" significa que este grupo não afeta o acesso — os membros retornam ao padrão definido na página SCIM\n- Uma alteração manual de acesso em um usuário substitui o mapeamento (e é sinalizada na tela de edição desse usuário)"
     },
     "template": {
       "name": "## Nome do modelo\nUm nome único e descritivo para este modelo (por exemplo, 'Caso de teste padrão', 'Resultados do teste de API').",
@@ -6209,7 +6212,7 @@
       "authType": "## Tipo de Autenticação\nEscolha como autenticar com o serviço externo.\n\n- **Chave de API:** Autenticação simples usando e-mail e token de API\n- **OAuth 2.0:** Autenticação segura usando o fluxo OAuth\n- **Token de Acesso Pessoal:** Autenticação direta baseada em token",
       "email": "## Endereço de e-mail\nSeu endereço de e-mail para o serviço externo.\n\n- Usado para autenticação da chave da API\n- Deve corresponder à conta que gerou o token da API\n- Obrigatório para o Jira e serviços similares",
       "apiToken": "## Token de API\nGere um token de API nas configurações da sua conta no serviço externo.\n\n- Geralmente encontrado em Configurações da conta → Segurança → Tokens de API\n- Fornece acesso seguro sem expor sua senha\n- Pode ser revogado e regenerado conforme necessário",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL do Jira\nA URL base da sua instância Jira.\n\n- Formato: https://your-site.atlassian.net\n- Não inclua /browse ou outros caminhos\n- Deve ser acessível a partir deste servidor",
       "clientId": "## ID do Cliente OAuth\nO ID do cliente da configuração do seu aplicativo OAuth.\n\n- Criado no console do desenvolvedor do serviço externo\n- Usado para identificar seu aplicativo durante o fluxo OAuth\n- Pode ser compartilhado com segurança em arquivos de configuração",
       "clientSecret": "## Segredo do Cliente OAuth\nO Segredo do Cliente da configuração do seu aplicativo OAuth.\n\n- Criado junto com o ID do Cliente\n- Deve ser mantido em sigilo e segurança\n- Usado para autenticar seu aplicativo",
       "personalAccessToken": "## Token de Acesso Pessoal\nUm token de acesso pessoal com as permissões apropriadas para o serviço externo.\n\n- Gerado nas configurações da sua conta\n- Deve ter permissões de leitura e gravação\n- Mais seguro do que a autenticação por senha",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL da instância\nA URL base da sua instância auto-hospedada.\n\n- Formato: https://git.example.com\n- Não inclua barras ou caminhos no final\n- Deve ser acessível a partir deste servidor",
       "projectPath": "## Caminho do Projeto\nO caminho completo para o seu projeto GitLab.\n\n- Formato: namespace/projeto ou grupo/subgrupo/projeto\n- Exemplo: my-org/my-project\n- Encontrado na URL do projeto: gitlab.com/namespace/project",
       "platform": "## Plataforma\nA plataforma Git auto-hospedada à qual você está se conectando.\n\n- **Gitea**: instâncias baseadas em gitea.io\n- **Forgejo**: instâncias baseadas em forgejo.org (fork do Gitea)\n- **Gogs**: instâncias baseadas em gogs.io\n\nIsso controla qual ícone é exibido e pode afetar a compatibilidade da API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Chave de API do Redmine\nSua chave de acesso pessoal à API REST.\n\n- Habilite a API REST em Administração → Configurações → API\n- Copie sua chave em Minha conta → Chave de acesso à API\n- Restrita às permissões do seu usuário; use uma conta de serviço para integrações compartilhadas",
+      "redmineUrl": "## URL do Redmine\nA URL base da sua instância Redmine.\n\n- Formato: https://redmine.example.com\n- Não inclua /issues ou outros caminhos\n- Deve ser acessível a partir deste servidor",
+      "mantisBTApiKey": "## Token de API do MantisBT\nSeu token pessoal de API REST.\n\n- Crie um em suas configurações de conta do MantisBT → Tokens de API\n- Restrito às permissões do seu usuário; use uma conta de serviço para integrações compartilhadas",
+      "mantisBTUrl": "## URL do MantisBT\nA URL base da sua instância MantisBT.\n\n- Formato: https://mantisbt.example.com\n- Não inclua /api/rest ou outros caminhos\n- Deve ser acessível a partir deste servidor",
+      "githubBaseUrl": "## URL Base da API\nRaiz completa da API do GitHub para o GitHub Enterprise Server.\n\n- Normalmente termina em /api/v3\n- Deixe em branco para usar api.github.com\n- Deve ser acessível a partir deste servidor"
     },
     "config": {
       "name": "## Nome da Configuração\nUm nome claro e descritivo para esta configuração.\n\n- Ajuda a descrever as combinações variantes que compõem a Configuração (ex.: \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", etc.).",
@@ -6716,7 +6719,7 @@
       "addDimension": "Adicionar dimensão...",
       "addMetric": "Adicionar métrica...",
       "runReport": "Executar relatório",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Exportar CSV",
       "noResultsFound": "Nenhum resultado encontrado.",
       "selectAtLeastOneDimensionAndMetric": "Selecione pelo menos uma dimensão e uma métrica.",
       "noDataMatchingCriteria": "Não foram encontrados dados que correspondam às dimensões e métricas selecionadas.",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Procurar",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Buscas salvas",
+      "save": "Salvar busca",
+      "saveTitle": "Salvar busca",
+      "saveDescription": "Nomeie esta busca para poder revisitá-la mais tarde.",
+      "saveAction": "Salvar",
+      "nameLabel": "Nome",
+      "namePlaceholder": "ex.: Execuções com falha nesta sprint",
+      "nameRequired": "Insira um nome para esta busca.",
+      "loginRequired": "Você precisa estar conectado para salvar buscas.",
       "descriptionLabel": "Descrição (opcional)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "Para que serve esta busca",
+      "saved": "Busca salva",
+      "savedDescription": "“{name}” agora está nas suas buscas salvas.",
+      "saveFailed": "Não foi possível salvar a busca. Tente novamente.",
+      "empty": "Ainda não há buscas salvas",
+      "emptyHint": "Salve uma busca para revisitá-la mais tarde.",
+      "loaded": "“{name}” carregada",
+      "loadFailed": "Esta busca salva não é mais válida.",
+      "edit": "Editar",
+      "editTitle": "Editar busca salva",
+      "edited": "Busca salva atualizada",
+      "editFailed": "Não foi possível atualizar a busca. Tente novamente.",
       "delete": "Excluir",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Excluir busca salva?",
+      "deleteConfirm": "“{name}” será removida das suas buscas salvas. Esta ação não pode ser desfeita.",
+      "deleted": "Busca salva excluída",
+      "deleteFailed": "Não foi possível excluir a busca. Tente novamente."
     },
     "bulk": {
       "crossProjectHint": "(abrangendo vários projetos)",
@@ -7697,14 +7700,14 @@
       "intro": "Clique no botão abaixo para iniciar sessão:",
       "signInButton": "Entrar",
       "copyPasteIntro": "Ou copie e cole este link no seu navegador:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Para sua segurança, este link só pode ser usado uma vez. Solicite um novo link se precisar entrar novamente.",
       "disclaimer": "Se você não solicitou este e-mail, pode ignorá-lo sem problemas.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Entre no TestPlanIt\n\nClique no link abaixo para entrar:\n{url}\n\nPara sua segurança, este link só pode ser usado uma vez. Solicite um novo link se precisar entrar novamente.\n\nSe você não solicitou este e-mail, pode ignorá-lo com segurança."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Abrindo isso em um dispositivo diferente? Insira este código na tela de acesso onde você solicitou o link:",
+      "deviceNotice": "Este link permite o acesso a partir do navegador onde você o solicitou. Se você abri-lo em outro lugar, o código acima será exibido para você inserir na sua janela original.",
+      "textBody": "Entre no TestPlanIt\n\nClique no link abaixo para entrar:\n{url}\n\nAbrindo isso em um dispositivo diferente? Insira este código na tela de acesso onde você solicitou o link: {code}\n\nSe você não solicitou este e-mail, pode ignorá-lo com segurança."
     }
   },
   "comments": {
@@ -7888,7 +7891,7 @@
     "renameConfirm": "Renomear",
     "renameNoRefsToast": "Parâmetro renomeado (sem referências existentes)",
     "selectSourceWarningTitle": "Alterar a origem SELECT para \"@{name}\"?",
-    "selectSourceWarningDescription": "Existing dataset values for this parameter may not exist in the new list. {invalidCount, plural, =1 {# row will} other {# rows will}} need attention after this change. Continue?",
+    "selectSourceWarningDescription": "Os valores existentes do conjunto de dados para este parâmetro podem não existir na nova lista. {invalidCount, plural, =1 {# linha precisará} other {# linhas precisarão}} de atenção após esta mudança. Continuar?",
     "selectSourceConfirm": "Alterar fonte",
     "datasetRowSelectAria": "Selecione a linha",
     "datasetSelectAllPageTooltip": "Clique para selecionar todas as linhas desta página. Pressione Shift e clique para selecionar todas as linhas em todas as páginas.",

--- a/testplanit/messages/ru-RU.json
+++ b/testplanit/messages/ru-RU.json
@@ -74,7 +74,7 @@
       "resultDetails": "Подробности результатов",
       "actionsLabel": "Действия",
       "assign": "Назначать",
-      "assignSelected": "Assign {count, plural, one {# case} other {# cases}}",
+      "assignSelected": "Назначить {count, plural, one {# случай} few {# случая} many {# случаев} other {# случая}}",
       "refresh": "Обновить",
       "addResultSelected": "Добавить результат в {count, plural, one {# случай} other {# случаи}}",
       "resultsAdded": "{count, plural, one {# Результат} other {# Результаты}} Добавлено",
@@ -195,7 +195,7 @@
       "internal": "Электронная почта/Пароль",
       "sso": "Только SSO",
       "both": "Электронная почта и единый вход (SSO)",
-      "scim": "SCIM Provisioned"
+      "scim": "Подготовлено через SCIM"
     },
     "status": {
       "deleted": "Удалено",
@@ -1059,7 +1059,7 @@
     "testResults": {
       "import": {
         "iterationCapExceeded": "Индекс итерации {index} превышает максимально допустимое значение {cap}. Уменьшите количество итераций или разделите выполнение.",
-        "iterationCapExceededMulti": "{count} test cases request iteration indexes above the maximum supported value of {cap}. Reduce the iteration count or split the run."
+        "iterationCapExceededMulti": "{count} тестовых случаев запрашивают индексы итераций выше максимально поддерживаемого значения {cap}. Уменьшите количество итераций или разделите запуск."
       }
     }
   },
@@ -1072,7 +1072,7 @@
         "apple": "Продолжить с Apple",
         "microsoft": "Продолжить работу с Microsoft",
         "samlProvider": "Войдите с помощью {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Войти с помощью одноразовой Magic Link",
         "emailLogin": "Продолжить отправку электронного письма"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Вернуться к входу"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Нажмите на ссылку в письме, чтобы войти из этого браузера, или введите код из письма ниже.",
+        "codeLabel": "Код для входа",
+        "verifyCode": "Проверить код",
+        "verifying": "Проверка...",
+        "invalidCode": "Этот код неверен. Проверьте письмо и попробуйте снова.",
+        "codeExpired": "Срок действия этого запроса на вход истёк. Запросите новую ссылку.",
+        "tooManyAttempts": "Слишком много неверных попыток. Запросите новую ссылку, чтобы попробовать снова.",
+        "windowLost": "Это окно больше не может завершить вход. Запросите новую ссылку.",
+        "genericError": "Не удалось выполнить вход. Запросите новую ссылку и попробуйте снова.",
+        "tooManyRequests": "Слишком много запросов на вход. Пожалуйста, подождите немного и попробуйте снова.",
+        "haveCode": "Уже есть код для входа?",
+        "codeEntryDescription": "Введите код из письма для входа. Коды работают только в браузере, где вы запросили ссылку.",
+        "backToRequest": "Запросить новую ссылку"
       },
       "twoFactor": {
         "title": "Двухфакторная аутентификация",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Обратитесь к системному администратору."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Выполняется вход...",
+      "completeErrorTitle": "Не удалось выполнить вход",
+      "requestNewLink": "Запросить новую ссылку",
+      "codeTitle": "Ваш код для входа",
+      "codeInstructions": "Вы открыли ссылку для входа на другом устройстве или в другом браузере. Введите этот код на экране входа, где вы изначально его запросили.",
+      "codeCloseNotice": "Вы можете закрыть это окно после ввода кода.",
+      "expiredTitle": "Эта ссылка для входа больше недействительна",
+      "expiredBody": "Возможно, срок действия ссылки истёк или она уже была использована. Запросите новую на странице входа — это займёт всего мгновение."
     },
     "errors": {
       "accessDenied": "Доступ запрещен. Возможно, ваша учетная запись неактивна или у вас нет разрешения на вход.",
       "configuration": "Возникла проблема с конфигурацией сервера.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Срок действия этой ссылки для входа истёк, либо она уже была использована. Ссылки Magic Link можно использовать только один раз — запросите новую, чтобы войти.",
       "invalid2FACode": "Неверный код подтверждения. Пожалуйста, попробуйте еще раз.",
       "twoFactorTokenRequired": "Требуется токен",
       "verificationCodeRequired": "Требуется код подтверждения."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Сохраните записи в базе данных (они станут несвязанными).",
           "switchWarning3": "Замените текущую конфигурацию интеграции задач на новую.",
           "switchWarning4": "Удалите входящий веб-перехватчик, настроенный для текущей интеграции.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Импортировать задачи",
+          "importTitle": "Импортировать задачи из {name}",
+          "importDescription": "Загрузите задачи из этого связанного проекта в свой проект. Существующие задачи не дублируются, а импортированные задачи остаются актуальными благодаря синхронизации.",
+          "importUpdatedWithin": "Обновлено за",
+          "importLastDays": "Последние {days} дней",
+          "importMax": "Максимум для импорта",
+          "importPreview": "Предварительный просмотр",
+          "importPreviewResult": "Этому фильтру соответствует примерно {count, plural, one {# задача} few {# задачи} many {# задач} other {# задач}}. Будет импортировано не более {cap}.",
+          "importOverCap": "Это превышает лимит в {cap}; будут импортированы только {cap} последних обновлённых задач.",
+          "importStart": "Импорт",
+          "importStarted": "Импорт начат. Задачи появятся в ближайшее время.",
+          "importFailed": "Импорт не удался",
+          "importPreviewFailed": "Не удалось оценить количество совпадений"
         },
         "integrationAssigned": "Интеграция успешно завершена.",
         "integrationAssignError": "Не удалось назначить задачу интеграции в проект.",
@@ -1402,10 +1405,10 @@
             "description": "Подключитесь к Azure DevOps для отслеживания рабочих элементов."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Подключитесь к самостоятельно размещённому экземпляру Redmine для отслеживания проблем."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Подключитесь к самостоятельно размещённому экземпляру MantisBT для отслеживания проблем."
           }
         }
       },
@@ -1519,7 +1522,7 @@
           "jiraIssueDeleted": "Задача в Jira удалена.",
           "githubIssues": "Событие GitHub Issues",
           "githubPullRequest": "Запрос на слияние в GitHub",
-          "githubPush": "GitHub push",
+          "githubPush": "Push в GitHub",
           "githubIssueComment": "комментарий к проблеме на GitHub",
           "adoWorkitemCreated": "Создан элемент задачи Azure DevOps.",
           "adoWorkitemUpdated": "Обновлен рабочий элемент Azure DevOps.",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Веб-хук повторно включен.",
         "toastReEnableFailed": "Не удалось повторно включить: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Входящий веб-хук Redmine",
+        "inboundRedmineScopeHint": "Плагин redmine_webhook не подписывает запросы, поэтому URL этого веб-хука является учётными данными — храните его в секрете и замените, если он был раскрыт.",
+        "setupStepsRedmineStep1": "Установите плагин redmine_webhook на сервере Redmine (в Redmine нет встроенных веб-хуков).",
+        "setupStepsRedmineStep2": "В своём проекте Redmine откройте Настройки → Модули и включите Веб-хуки.",
+        "setupStepsRedmineStep3": "Откройте Настройки → Веб-хуки, вставьте указанный выше URL и сохраните.",
+        "setupStepsRedmineStep4": "Создайте или обновите задачу в Redmine; статус связанной задачи будет синхронизирован здесь.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Входящий веб-хук MantisBT",
+        "inboundMantisbtScopeHint": "Плагин веб-хуков MantisBT не подписывает запросы, поэтому URL этого веб-хука является учётными данными — храните его в секрете и замените, если он был раскрыт.",
+        "setupStepsMantisbtStep1": "Установите и включите плагин веб-хуков MantisBT на своём сервере MantisBT (в MantisBT нет встроенных веб-хуков).",
+        "setupStepsMantisbtStep2": "В настройках плагина выберите события создания и обновления задачи.",
+        "setupStepsMantisbtStep3": "Вставьте указанный выше URL в качестве цели веб-хука и сохраните.",
+        "setupStepsMantisbtStep4": "Создайте или обновите задачу в MantisBT; статус связанной задачи будет синхронизирован здесь."
       },
       "aiModels": {
         "description": "Настройте модели ИИ для интеллектуальной генерации и анализа тестовых примеров.",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Сканирование файлов в {scope}…",
           "scanningFilesCount": "Сканирование файлов в {scope}… ({count, number} найдено)",
           "filtering": "Применение фильтров к {count, number} файлам…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Ограничение скорости запросов провайдером — повторная попытка через {seconds, number} с…"
         },
         "cache": {
           "title": "Настройки кэша",
@@ -1913,8 +1916,8 @@
         "networkError": "Сетевая ошибка во время обновления кэша.",
         "refreshSuccess": "Кэш обновлен: {fileCount} файлов ({contentCached} содержимое кэшировано)",
         "refreshRateLimited": "Кэш обновлен: {fileCount} файлов в списке, содержимое {contentCached}/{fileCount} кэшировано (ограничение скорости — обновите еще раз для завершения)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Кэш обновлён: {fileCount} файлов",
+        "refreshInProgress": "Обновление кэша всё ещё выполняется в фоновом режиме. Информация здесь обновится по завершении.",
         "validation": {
           "pathRequired": "Требуется указать путь.",
           "patternRequired": "Требуется шаблон",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Активность",
+      "title": "Журнал активности",
+      "description": "Все изменения, зафиксированные для этой сессии."
     },
     "title": "{count, plural, =1 {Сессия} other {Сессии}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
+        "title": "Журнал аудита",
+        "description": "Действия, выполненные этим пользователем",
+        "noEntries": "Активность пока не зафиксирована.",
+        "loadMore": "Загрузка",
         "viewDetails": "Просмотреть подробности",
         "columnAction": "Действие",
         "columnEntityType": "Тип",
         "columnEntityName": "Имя",
         "columnTimestamp": "Отметка времени",
         "allActions": "Все действия",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "allTypes": "Все типы",
+        "noMatchingEntries": "Нет записей, соответствующих выбранным фильтрам.",
+        "showing": "{loaded} из {total} записей"
       },
       "mentionedComments": {
         "title": "Упомянуто в комментариях",
@@ -2510,9 +2513,9 @@
       "historyView": "Просмотр истории тестовых случаев"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Активность",
+      "title": "Журнал активности",
+      "description": "Все изменения, зафиксированные для этого тестового случая."
     },
     "fields": {
       "optionNotFound": "Вариант не найден",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Активность",
+      "title": "Журнал активности",
+      "description": "Все изменения, зафиксированные для этого тестового запуска."
     },
     "notFound": "Тестовый запуск не найден.",
     "add": {
@@ -3380,7 +3383,7 @@
       "creatingProgress": "Создание тестового запуска {current, number} из {total, number}..."
     },
     "magicSelect": {
-      "title": "Magic Select",
+      "title": "Магический выбор",
       "description": "Выбор тестовых примеров с помощью ИИ на основе контекста выполнения теста",
       "counting": "Ищу подходящие тестовые примеры...",
       "reasoning": "Логическое мышление ИИ",
@@ -3725,7 +3728,7 @@
         "jobLoadFailed": "Нам не удалось загрузить это задание импорта.",
         "uploadProgressAnalyzing": "Загрузка завершена. Анализ файла…",
         "uploadProgressComplete": "Загрузка завершена",
-        "etaLabel": "ETA: {time}",
+        "etaLabel": "Расчётное время: {time}",
         "startImportButton": "Начать импорт",
         "workflowCreate": {
           "nameLabel": "Название рабочего процесса",
@@ -4436,16 +4439,16 @@
       "forcePasswordChangeFailed": "Не удалось принудительно изменить пароль.",
       "revokePasswordSuccess": "Пароль аннулирован для {name}",
       "revokePasswordFailed": "Не удалось отозвать пароль.",
-      "scimProvisionerBadge": "SCIM Provisioner",
+      "scimProvisionerBadge": "SCIM-провизионер",
       "scimManagedBadge": "СКИМ",
       "scimManagedTooltip": "Управление осуществляется через SCIM. Управление производится со страницы администрирования SCIM.",
       "scimColumnHeader": "СКИМ",
       "scimColumnYes": "Да",
       "scimUserLockedTitle": "Пользователь управляется системой SCIM.",
       "scimUserLockedDescription": "Имя, адрес электронной почты и статус активности этого пользователя управляются вашим поставщиком идентификационных данных. Чтобы обновить их здесь, внесите изменения в этом поставщике.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Управляется сопоставлением групп",
+      "groupMappingOverrideDescription": "Уровень доступа этого пользователя определяется сопоставлением групп SCIM и может быть возвращён к исходному значению при следующей синхронизации.",
+      "groupMappingBadge": "Сопоставлено с группой"
     },
     "security": {
       "title": "Безопасность",
@@ -4490,7 +4493,7 @@
       "saveChanges": "Сохранить изменения",
       "forceAllUsers": "Принудить всех пользователей к смене пароля",
       "forceAllUsersDialogTitle": "Принудительная смена пароля для всех пользователей",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "Это потребует от {count, number} пользователей с учетными данными сменить пароль при следующем входе.",
       "forceAllUsersDialogWarning": "Это действие необратимо.",
       "forceAllUsersDialogConfirm": "Силовое изменение",
       "saved": "Сохранены настройки безопасности",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "Тест SCIM",
         "testing": "Тестирование…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — токен работает с /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Не удалось установить соединение с конечной точкой SCIM. Повторите попытку."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Сопоставленный доступ по умолчанию",
+      "fallbackDefaultDescription": "Уровень доступа, назначаемый пользователям, не охваченным ни одним сопоставлением групп.",
+      "fallbackDefaultLabel": "Уровень доступа по умолчанию",
+      "fallbackDefaultSaved": "Резервное значение по умолчанию сохранено"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Управление осуществляется через SCIM. Управление производится со страницы администрирования SCIM.",
       "scimNameLockedTitle": "Группа управляется компанией SCIM.",
       "scimNameLockedDescription": "Название и участники этой группы управляются вашим поставщиком идентификационных данных. Чтобы обновить данные здесь, внесите изменения там.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Сопоставленный доступ",
+      "mappedAccessLabel": "Сопоставленный уровень доступа",
+      "mappedAccessNone": "Нет сопоставления",
+      "mappedAccessSelect": "Выберите уровень доступа...",
+      "downgradeConfirmTitle": "Подтвердите изменение доступа",
+      "downgradeConfirmDescription": "Уровень доступа будет понижен у {count, plural, one {# пользователя} few {# пользователей} many {# пользователей} other {# пользователей}}. Продолжить?",
+      "downgradeConfirmApplyAnyway": "Всё равно применить",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Активный",
         "inactive": "Неактивный",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Ожидание авторизации"
       },
       "connectedProjects": "Связанные проекты",
       "noIntegrations": "Интеграции для решения проблем не настроены.",
       "testConnection": "Проверить соединение",
       "testSuccess": "Соединение установлено успешно.",
       "testSuccessDescription": "Интеграция проблем настроена и подключена должным образом.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Учётные данные в порядке",
+      "testCredentialsSavedDescription": "Идентификатор клиента OAuth и секрет действительны. Сохраните интеграцию, затем нажмите «Авторизовать», чтобы подключить свою учётную запись — OAuth 2.0 подключается для каждого пользователя отдельно, поэтому интеграция остаётся неактивной, пока хотя бы один человек не авторизуется.",
       "testFailed": "Соединение не удалось.",
       "testFailedDescription": "Не удалось подключиться к внешнему сервису.",
       "testError": "Ошибка теста",
       "testErrorDescription": "Произошла ошибка при проверке соединения.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Авторизовать",
+      "reauthorize": "Повторно авторизовать",
+      "authorizeHint": "Авторизуйтесь у провайдера, чтобы подключить свою учётную запись и завершить настройку",
+      "syncInProgress": "Повторная синхронизация связанных задач...",
+      "syncIntegration": "Повторно синхронизировать связанные задачи",
+      "syncIntegrationHint": "Повторно синхронизирует только задачи, уже связанные в TestPlanIt. Новые задачи не импортируются из внешней системы отслеживания.",
       "syncSuccess": "Синхронизация поставлена в очередь",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Связанные задачи из «{name}» синхронизируются повторно в фоновом режиме. Это может занять некоторое время. Таблица обновится автоматически после завершения.",
       "syncError": "Синхронизация не удалась",
       "syncErrorDescription": "Не удалось поставить в очередь задачу синхронизации для интеграции этой проблемы. Пожалуйста, попробуйте позже.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Подключитесь к самостоятельно размещённому экземпляру Redmine для отслеживания проблем"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Подключитесь к самостоятельно размещённому экземпляру MantisBT для отслеживания проблем"
         }
       },
       "filterPlaceholder": "Интеграция фильтров...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Для точного указания авторства каждого пользователя без прав администратора используйте OAuth 2.0.",
         "tokenCreatorNoticeTitle": "указание авторства выпуска",
         "tokenCreatorNoticeDescription": "Задачи, созданные с помощью этой интеграции, всегда записываются от имени учетной записи, владеющей этим токеном доступа, а не от имени пользователя TestPlanIt, который их создал. API этого поставщика не позволяет устанавливать имя создателя от имени другого пользователя.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL обратного вызова (redirect URI)",
+        "callbackUrlDescription": "Зарегистрируйте именно этот URL в качестве callback / redirect URI в OAuth-приложении вашего провайдера. Он должен точно совпадать, иначе авторизация завершится ошибкой.",
+        "callbackUrlCopy": "Копировать",
+        "callbackUrlCopied": "Скопировано",
         "forgeApiKeyLabel": "Подделать ключ API",
         "forgeApiKeyDescription": "Используется приложением Atlassian Forge для аутентификации запросов из панелей задач Jira. Сгенерируйте ключ здесь и вставьте его в настройки вашего приложения Forge.",
         "forgeApiKeyPlaceholder": "Нажмите «Сгенерировать», чтобы создать ключ API.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Гитеа",
         "platformForgejo": "Форгехо",
         "platformGogs": "Гогс",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "API-ключ Redmine",
+        "redmineApiKeyPlaceholder": "Введите свой API-ключ Redmine",
+        "redmineApiKeyHelp": "Находится в разделе Мой аккаунт → Ключ доступа к API (включите REST API в Администрирование → Настройки → API)",
+        "redmineUrl": "URL Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "Базовый URL вашего экземпляра Redmine",
+        "mantisBTApiKey": "API-токен MantisBT",
+        "mantisBTApiKeyPlaceholder": "Введите свой API-токен MantisBT",
+        "mantisBTApiKeyHelp": "Создайте его в настройках учётной записи MantisBT → API-токены",
+        "mantisBTUrl": "URL MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "Базовый URL вашего экземпляра MantisBT"
       },
       "authType": {
         "api_key": "Ключ API",
@@ -5487,7 +5490,7 @@
         "warning": "Это действие необратимо. Все проекты, использующие эту конфигурацию, вернутся к конфигурации приглашения командной строки по умолчанию."
       },
       "llmColumn": "магистр права",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} LLM",
       "cannotDeleteDefault": "Невозможно удалить конфигурацию приглашения по умолчанию. Сначала установите другую конфигурацию по умолчанию.",
       "defaultChanged": "Настройки приглашения командной строки по умолчанию успешно обновлены.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Создание тестовых сценариев на основе URL-адреса (требования)",
         "generate_from_url_app": "Генерация тестовых сценариев из URL-адреса (тестирование приложений)",
         "automation_candidates": "Отчет о кандидатах на автоматизацию",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Формирование шагов ИИ"
       }
     },
     "elasticsearch": {
@@ -5569,15 +5572,15 @@
         "forecast-updates": "Обновления прогнозов",
         "emails": "Очередь электронных писем",
         "issue-sync": "Синхронизация проблем",
-        "testmo-imports": "Testmo Imports",
-        "elasticsearch-reindex": "Elasticsearch Reindex",
+        "testmo-imports": "Импорт Testmo",
+        "elasticsearch-reindex": "Переиндексация Elasticsearch",
         "audit-logs": "Журналы аудита",
         "budget-alerts": "Уведомления о бюджете",
         "auto-tag": "Автоматическая разметка с помощью ИИ",
         "repo-cache": "Кэш репозитория",
         "copy-move": "Копировать и переместить",
         "duplicate-scan": "Повторное сканирование",
-        "magic-select": "Magic Select",
+        "magic-select": "Волшебный выбор",
         "step-scan": "Пошаговое сканирование"
       },
       "status": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Просматривайте общесистемный журнал аудита для отслеживания безопасности и соответствия требованиям.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Просмотр журнала аудита действий, выполненных в этом проекте.",
       "filterPlaceholder": "Поиск по сущности, пользователю или действию...",
       "filterAction": "Действие",
       "filterEntityType": "Тип сущности",
       "allActions": "Все действия",
       "allEntityTypes": "Все типы сущностей",
-      "allUsers": "All Users",
+      "allUsers": "Все пользователи",
       "allProjects": "Все проекты",
-      "showing": "Showing {loaded} of {total} entries",
+      "showing": "Показано {loaded} из {total} записей",
       "viewDetails": "Просмотреть подробности",
       "detailTitle": "Подробная информация из журнала аудита",
       "userInfo": "Информация о пользователе",
@@ -5714,8 +5717,8 @@
       "systemActor": "Система",
       "systemActorTooltip": "Действие выполняется системой, а не авторизованным пользователем.",
       "sourceScim": "СКИМ",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "связанные изменения",
+      "groupedEntry": "Сгруппированные изменения из одного действия"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "всё ещё ждёт вашего отзыва",
         "reviewReminderEmailMessage": "Напоминание: Запрос на проверку проекта {actorName}по проекту {entityLabel} \"{entityName}\" в проекте \"{projectName}\" находится в ожидании уже {hoursPending} часов.",
         "reviewReminderHoursPending": "Ожидается в течение {hoursPending, plural, one {# часов} other {# часов}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Шаги теста, созданные ИИ, готовы",
+        "aiStepsDerivedMessage": "Для {count, plural, one {# тестового случая} few {# тестовых случаев} many {# тестовых случаев} other {# тестовых случаев}} были сгенерированы шаги ИИ — проверьте их точность.",
+        "aiStepsDerivedReviewLink": "Просмотреть тестовый запуск"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Название группы\nЧеткое, краткое, описательное название или ключевое слово (или слова), используемое во всех проектах.\n\n- Помогает членам команды быстро находить связанные тестовые случаи, тестовые запуски и сессии.",
       "users": "## Пользователи\nУказывает пользователей, назначенных в эту группу.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Сопоставленный уровень доступа\nУчастникам этой группы при следующей синхронизации будет предоставлен как минимум этот уровень доступа.\n\n- Побеждает наивысший уровень среди всех групп пользователя\n- Значение «Нет сопоставления» означает, что эта группа не влияет на доступ — участники получают значение по умолчанию, заданное на странице SCIM\n- Ручное изменение доступа пользователя имеет приоритет над сопоставлением (и отмечается на экране редактирования этого пользователя)"
     },
     "template": {
       "name": "## Название шаблона\nУникальное и описательное имя для этого шаблона (например, «Стандартный тестовый случай», «Результаты тестирования API»).",
@@ -6209,7 +6212,7 @@
       "authType": "## Тип аутентификации\nВыберите способ аутентификации во внешней службе.\n\n- **Ключ API:** Простая аутентификация с использованием электронной почты и токена API\n- **OAuth 2.0:** Безопасная аутентификация с использованием потока OAuth\n- **Персональный токен доступа:** Прямая аутентификация на основе токена",
       "email": "## Адрес электронной почты\nАдрес электронной почты вашей учетной записи для внешнего сервиса.\n\n- Используется для аутентификации по ключу API.\n- Должен совпадать с учетной записью, сгенерировавшей токен API.\n- Требуется для Jira и аналогичных сервисов.",
       "apiToken": "## API-токен\nСгенерируйте API-токен в настройках вашей учетной записи во внешнем сервисе.\n\n- Обычно находится в Настройках учетной записи → Безопасность → API-токены\n- Обеспечивает безопасный доступ без раскрытия вашего пароля\n- Может быть отозван и сгенерирован заново по мере необходимости",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL Jira\nБазовый URL вашего экземпляра Jira.\n\n- Формат: https://your-site.atlassian.net\n- Не включайте /browse или другие пути\n- Должен быть доступен с этого сервера",
       "clientId": "## Идентификатор клиента OAuth\nИдентификатор клиента из конфигурации вашего приложения OAuth.\n\n- Создается в консоли разработчика внешнего сервиса.\n- Используется для идентификации вашего приложения во время процесса OAuth.\n- Можно безопасно передавать в файлах конфигурации.",
       "clientSecret": "## Секрет клиента OAuth\nСекрет клиента из конфигурации вашего приложения OAuth.\n\n- Создается вместе с идентификатором клиента.\n- Должен храниться в конфиденциальности и безопасности.\n- Используется для аутентификации вашего приложения.",
       "personalAccessToken": "## Персональный токен доступа\nПерсональный токен доступа с соответствующими правами доступа к внешнему сервису.\n\n- Генерируется в настройках вашей учетной записи.\n- Должен иметь права на чтение и запись.\n- Более безопасен, чем аутентификация по паролю.",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL экземпляра\nБазовый URL вашего самостоятельно размещенного экземпляра.\n\n- Формат: https://git.example.com\n- Не включайте косые черты или пути в конце\n- Должен быть доступен с этого сервера",
       "projectPath": "## Путь к проекту\nПолный путь к вашему проекту GitLab.\n\n- Формат: пространство имен/проект или группа/подгруппа/проект\n- Пример: my-org/my-project\n- Находится в URL проекта: gitlab.com/namespace/project",
       "platform": "## Платформа\nСамостоятельно размещенная платформа Git, к которой вы подключаетесь.\n\n- **Gitea**: экземпляры на основе gitea.io\n- **Forgejo**: экземпляры на основе forgejo.org (форк Gitea)\n- **Gogs**: экземпляры на основе gogs.io\n\nЭтот параметр определяет, какой значок отображается, и может повлиять на совместимость API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## API-ключ Redmine\nВаш личный ключ доступа к REST API.\n\n- Включите REST API в разделе Администрирование → Настройки → API\n- Скопируйте ключ из раздела Мой аккаунт → Ключ доступа к API\n- Ограничен правами вашего пользователя; для общих интеграций используйте служебную учётную запись",
+      "redmineUrl": "## URL Redmine\nБазовый URL вашего экземпляра Redmine.\n\n- Формат: https://redmine.example.com\n- Не включайте /issues или другие пути\n- Должен быть доступен с этого сервера",
+      "mantisBTApiKey": "## API-токен MantisBT\nВаш личный токен REST API.\n\n- Создайте его в настройках учётной записи MantisBT → API-токены\n- Ограничен правами вашего пользователя; для общих интеграций используйте служебную учётную запись",
+      "mantisBTUrl": "## URL MantisBT\nБазовый URL вашего экземпляра MantisBT.\n\n- Формат: https://mantisbt.example.com\n- Не включайте /api/rest или другие пути\n- Должен быть доступен с этого сервера",
+      "githubBaseUrl": "## Базовый URL API\nПолный корневой адрес GitHub API для GitHub Enterprise Server.\n\n- Обычно заканчивается на /api/v3\n- Оставьте поле пустым, чтобы использовать api.github.com\n- Должен быть доступен с этого сервера"
     },
     "config": {
       "name": "## Название конфигурации\nЧеткое, описательное название для этой конфигурации.\n\n- Помогает описать варианты комбинаций, составляющих конфигурацию (например, \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\" и т. д.).",
@@ -6946,12 +6949,12 @@
         "heuristicBadge": "Эвристический",
         "heuristicBadgeTooltip": "Интеграция с LLM для этого проекта не настроена, поэтому этот рейтинг был сформирован непосредственно на основе метрики стратегии выбора. Настройте LLM (Администрирование → Модели ИИ) для более глубокого анализа, учитывающего пользовательские поля, контекст связанных задач и содержимое обращения.",
         "sourcedFromNewestN": "Топ {ranked} из {total} подходящих случаев, рассматриваемых вручную через {strategy}",
-        "sourcedFromAll": "Ranked all {total} eligible manual cases via {strategy}",
+        "sourcedFromAll": "Ранжированы все {total} подходящих ручных случаев через {strategy}",
         "metric": {
           "executions": "{count} бежит",
           "forecast": "{value} прогноз",
           "forecastUnset": "Нет прогноза",
-          "flakiness": "Flips {value}%",
+          "flakiness": "Переключения {value}%",
           "flakinessUnset": "Нет данных о перевороте",
           "createdLabel": "Созданный"
         },
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}с",
             "minutes": "{minutes}м",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}ч {minutes}м"
           },
           "relativeAge": {
             "today": "сегодня",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Поиск",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
+      "title": "Сохранённые поиски",
+      "save": "Сохранить поиск",
+      "saveTitle": "Сохранить поиск",
+      "saveDescription": "Назовите этот поиск, чтобы вернуться к нему позже.",
       "saveAction": "Сохранять",
       "nameLabel": "Имя",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "namePlaceholder": "например, Неудачные запуски в этом спринте",
+      "nameRequired": "Введите название для этого поиска.",
+      "loginRequired": "Для сохранения поисков необходимо войти в систему.",
       "descriptionLabel": "Описание (необязательно)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
+      "descriptionPlaceholder": "Для чего нужен этот поиск",
+      "saved": "Поиск сохранён",
+      "savedDescription": "«{name}» теперь в ваших сохранённых поисках.",
+      "saveFailed": "Не удалось сохранить поиск. Пожалуйста, попробуйте ещё раз.",
+      "empty": "Сохранённых поисков пока нет",
+      "emptyHint": "Сохраните поиск, чтобы вернуться к нему позже.",
+      "loaded": "Загружено «{name}»",
+      "loadFailed": "Этот сохранённый поиск больше недействителен.",
       "edit": "Редактировать",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "editTitle": "Изменить сохранённый поиск",
+      "edited": "Сохранённый поиск обновлён",
+      "editFailed": "Не удалось обновить поиск. Пожалуйста, попробуйте ещё раз.",
       "delete": "Удалить",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Удалить сохранённый поиск?",
+      "deleteConfirm": "«{name}» будет удалён из ваших сохранённых поисков. Это действие нельзя отменить.",
+      "deleted": "Сохранённый поиск удалён",
+      "deleteFailed": "Не удалось удалить поиск. Пожалуйста, попробуйте ещё раз."
     },
     "bulk": {
       "crossProjectHint": "(охватывает несколько проектов)",
@@ -7697,14 +7700,14 @@
       "intro": "Нажмите кнопку ниже, чтобы войти:",
       "signInButton": "Войти",
       "copyPasteIntro": "Или скопируйте и вставьте эту ссылку в свой браузер:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "В целях безопасности эту ссылку можно использовать только один раз. Если вам нужно войти снова, запросите новую ссылку.",
       "disclaimer": "Если вы не запрашивали это письмо, можете смело его проигнорировать.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Вход в TestPlanIt\n\nНажмите на ссылку ниже, чтобы войти:\n{url}\n\nВ целях безопасности эту ссылку можно использовать только один раз. Если вам нужно войти снова, запросите новую ссылку.\n\nЕсли вы не запрашивали это письмо, вы можете спокойно проигнорировать его."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Открываете это на другом устройстве? Введите этот код на экране входа, где вы запросили ссылку:",
+      "deviceNotice": "Эта ссылка выполняет вход из браузера, в котором вы её запросили. Если вы откроете её в другом месте, вам будет показан код выше, который нужно ввести в исходном окне.",
+      "textBody": "Вход в TestPlanIt\n\nНажмите на ссылку ниже, чтобы войти:\n{url}\n\nОткрываете это на другом устройстве? Введите этот код на экране входа, где вы запросили ссылку: {code}\n\nЕсли вы не запрашивали это письмо, вы можете спокойно проигнорировать его."
     }
   },
   "comments": {
@@ -7753,7 +7756,7 @@
   },
   "autoTag": {
     "actions": {
-      "aiTag": "AI Tag",
+      "aiTag": "Тег ИИ",
       "tagAll": "Отметить всех",
       "aiAutoTag": "Автоматическая маркировка",
       "tagActions": "Действия с тегами",

--- a/testplanit/messages/tr-TR.json
+++ b/testplanit/messages/tr-TR.json
@@ -788,7 +788,7 @@
     "and": "Ve",
     "branding": {
       "name": "TestPlanIt",
-      "logoAlt": "TestPlanIt Logo",
+      "logoAlt": "TestPlanIt Logosu",
       "tagline": "Güneşin altında bulunan her şeyi test edin."
     },
     "table": {
@@ -1072,7 +1072,7 @@
         "apple": "Apple ile devam edin",
         "microsoft": "Microsoft ile devam edin",
         "samlProvider": "{name} ile giriş yapın",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Tek kullanımlık Magic Link ile giriş yapın",
         "emailLogin": "E-posta ile devam edin"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Giriş sayfasına geri dön"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Bu tarayıcıdan giriş yapmak için e-postadaki bağlantıya tıklayın veya aşağıya e-postadaki kodu girin.",
+        "codeLabel": "Giriş kodu",
+        "verifyCode": "Kodu doğrula",
+        "verifying": "Doğrulanıyor...",
+        "invalidCode": "Bu kod doğru değil. E-postayı kontrol edin ve tekrar deneyin.",
+        "codeExpired": "Bu giriş isteğinin süresi doldu. Yeni bir bağlantı isteyin.",
+        "tooManyAttempts": "Çok fazla yanlış deneme yapıldı. Tekrar denemek için yeni bir bağlantı isteyin.",
+        "windowLost": "Bu pencere artık girişi tamamlayamıyor. Yeni bir bağlantı isteyin.",
+        "genericError": "Girişinizi tamamlayamadık. Yeni bir bağlantı isteyip tekrar deneyin.",
+        "tooManyRequests": "Çok fazla giriş isteği yapıldı. Lütfen bir süre bekleyip tekrar deneyin.",
+        "haveCode": "Zaten bir giriş kodunuz mu var?",
+        "codeEntryDescription": "Giriş e-postanızdaki kodu girin. Kodlar yalnızca bağlantıyı istediğiniz tarayıcıda çalışır.",
+        "backToRequest": "Bunun yerine yeni bir bağlantı iste"
       },
       "twoFactor": {
         "title": "İki Faktörlü Kimlik Doğrulama",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Sistem yöneticisiyle iletişime geçin."
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Giriş yapılıyor...",
+      "completeErrorTitle": "Girişinizi tamamlayamadık",
+      "requestNewLink": "Yeni bir bağlantı iste",
+      "codeTitle": "Giriş kodunuz",
+      "codeInstructions": "Giriş bağlantısını farklı bir cihazda veya tarayıcıda açtınız. Bu kodu, orijinal olarak istekte bulunduğunuz giriş ekranına girin.",
+      "codeCloseNotice": "Kodu girdikten sonra bu pencereyi kapatabilirsiniz.",
+      "expiredTitle": "Bu giriş bağlantısı artık geçerli değil",
+      "expiredBody": "Bağlantının süresi dolmuş veya zaten kullanılmış olabilir. Giriş sayfasından yeni bir tane isteyin — yalnızca bir dakikanızı alır."
     },
     "errors": {
       "accessDenied": "Erişim engellendi. Hesabınız devre dışı olabilir veya oturum açma izniniz olmayabilir.",
       "configuration": "Sunucu yapılandırmasında bir sorun var.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Bu giriş bağlantısının süresi doldu veya zaten kullanıldı. Magic Link'ler yalnızca bir kez kullanılabilir — giriş yapmak için lütfen yeni bir tane isteyin.",
       "invalid2FACode": "Geçersiz doğrulama kodu. Lütfen tekrar deneyin.",
       "twoFactorTokenRequired": "Token gereklidir.",
       "verificationCodeRequired": "Doğrulama kodu gereklidir."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Veritabanındaki sorunları saklayın (bağlantıları kesilir).",
           "switchWarning3": "Mevcut entegrasyon yapılandırmasını yenisiyle değiştirin.",
           "switchWarning4": "Mevcut entegrasyon için yapılandırılmış gelen web kancasını kaldırın.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Sorunları İçe Aktar",
+          "importTitle": "{name} kaynağından sorunları içe aktar",
+          "importDescription": "Bu bağlantılı projeden sorunları projenize aktarın. Mevcut sorunlar çoğaltılmaz ve içe aktarılan sorunlar senkronizasyon yoluyla güncel kalır.",
+          "importUpdatedWithin": "Güncelleme aralığı",
+          "importLastDays": "Son {days} gün",
+          "importMax": "İçe aktarılacak maksimum sayı",
+          "importPreview": "Önizleme",
+          "importPreviewResult": "~{count, plural, one {# sorun} other {# sorun}} bu filtreyle eşleşiyor. En fazla {cap} tanesi içe aktarılacak.",
+          "importOverCap": "Bu, {cap} sınırını aşıyor; yalnızca en son güncellenen {cap} tanesi içe aktarılacak.",
+          "importStart": "İçe Aktar",
+          "importStarted": "İçe aktarma başladı. Sorunlar kısa süre içinde görünecek.",
+          "importFailed": "İçe aktarma başarısız oldu",
+          "importPreviewFailed": "Eşleşmeler tahmin edilemedi"
         },
         "integrationAssigned": "Entegrasyon başarıyla atandı.",
         "integrationAssignError": "Sorun entegrasyonu projeye atanamadı.",
@@ -1402,10 +1405,10 @@
             "description": "İş öğesi takibi için Azure DevOps'a bağlanın."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Sorun takibi için kendi sunucunuzda barındırdığınız bir Redmine örneğine bağlanın."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Sorun takibi için kendi sunucunuzda barındırdığınız bir MantisBT örneğine bağlanın."
           }
         }
       },
@@ -1422,7 +1425,7 @@
         "deliveriesEmptyNoConfigs": "Henüz hiçbir webhook gönderimi yok — gönderimleri almaya başlamak için diğer sekmelerde gelen veya giden bir webhook oluşturun.",
         "noConfig": "Hiçbir webhook yapılandırılmadı.",
         "createButton": "Web kancası oluştur",
-        "url": "Webhook URL",
+        "url": "Webhook URL'si",
         "urlHelp": "Bu URL'yi sorun takip sisteminin webhook yapılandırmasına yapıştırın.",
         "secret": "Webhook sırrı",
         "secretHelp": "Bu gizli kodu sorun takip sisteminin webhook yapılandırmasına yapıştırın.",
@@ -1658,7 +1661,7 @@
         "replayConfirm": "Bu, gerçek bir {direction} {adapterType} isteğini tetikleyecektir.",
         "replayAction": "Tekrar oynat",
         "bulkReplayConfirmTitle": "Giden bağlantı hatalarını tekrar oynat?",
-        "bulkReplayConfirm": "Replay {count, number} outbound failures to {configName}? This will fire {count, number} real HTTP requests.",
+        "bulkReplayConfirm": "{configName} için {count, number} giden hatayı yeniden oynatılsın mı? Bu, {count, number} gerçek HTTP isteği tetikleyecektir.",
         "bulkReplayCapExceeded": "Toplu tekrar oynatma, aynı anda en fazla 100 giden işlemle sınırlıdır. Filtreyi daraltın veya ardışık olarak çalıştırın. Şu anda {count, number} tekrar oynatılacaktır.",
         "bulkReplayAction": "Tekrar Oynat {count, number}",
         "healthBadge": {
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook yeniden etkinleştirildi",
         "toastReEnableFailed": "Yeniden etkinleştirme başarısız oldu: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Redmine gelen web kancası",
+        "inboundRedmineScopeHint": "Redmine_webhook eklentisi istekleri imzalamaz, bu nedenle bu web kancası URL'si kimlik bilgisidir — bunu bir gizli bilgi olarak ele alın ve açığa çıkarsa yenileyin.",
+        "setupStepsRedmineStep1": "Redmine sunucunuza redmine_webhook eklentisini yükleyin (Redmine'de yerleşik web kancaları bulunmaz).",
+        "setupStepsRedmineStep2": "Redmine projenizde, Ayarlar → Modüller kısmını açın ve Web Kancalarını etkinleştirin.",
+        "setupStepsRedmineStep3": "Ayarlar → Web Kancaları kısmını açın, yukarıdaki URL'yi yapıştırın ve kaydedin.",
+        "setupStepsRedmineStep4": "Redmine'de bir sorun oluşturun veya güncelleyin; bağlantılı sorunun durumu burada senkronize edilecektir.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "MantisBT gelen web kancası",
+        "inboundMantisbtScopeHint": "Bir MantisBT web kancası eklentisi istekleri imzalamaz, bu nedenle bu web kancası URL'si kimlik bilgisidir — bunu bir gizli bilgi olarak ele alın ve açığa çıkarsa yenileyin.",
+        "setupStepsMantisbtStep1": "MantisBT sunucunuza bir MantisBT web kancası eklentisi yükleyin ve etkinleştirin (MantisBT'de yerleşik web kancaları bulunmaz).",
+        "setupStepsMantisbtStep2": "Eklenti yapılandırmasında, sorun oluşturuldu ve sorun güncellendi olaylarını seçin.",
+        "setupStepsMantisbtStep3": "Yukarıdaki URL'yi web kancası hedefi olarak yapıştırın ve kaydedin.",
+        "setupStepsMantisbtStep4": "MantisBT'de bir sorun oluşturun veya güncelleyin; bağlantılı sorunun durumu burada senkronize edilecektir."
       },
       "aiModels": {
         "description": "Akıllı test senaryosu oluşturma ve analizi için yapay zeka modellerini yapılandırın.",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "{scope}… içindeki dosyalar taranıyor.",
           "scanningFilesCount": "{scope}… içindeki dosyalar taranıyor ({count, number} bulundu)",
           "filtering": "{count, number} dosyalarına filtreler uygulanıyor…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Sağlayıcı tarafından hız sınırlandı — {seconds, number} saniye içinde yeniden deneniyor…"
         },
         "cache": {
           "title": "Önbellek Ayarları",
@@ -1913,8 +1916,8 @@
         "networkError": "Önbellek yenileme sırasında ağ hatası",
         "refreshSuccess": "Önbellek yenilendi: {fileCount} dosya ({contentCached} içerik önbelleğe alındı)",
         "refreshRateLimited": "Önbellek yenilendi: {fileCount} dosya listelendi, {contentCached}/{fileCount} içerik önbelleğe alındı (oran sınırlı — tamamlamak için tekrar yenileyin)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Önbellek yenilendi: {fileCount} dosya",
+        "refreshInProgress": "Önbellek yenileme arka planda hâlâ çalışıyor. Tamamlandığında burada güncellenecek.",
         "validation": {
           "pathRequired": "Yol gereklidir.",
           "patternRequired": "Desen gereklidir.",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Aktivite",
+      "title": "Aktivite Kaydı",
+      "description": "Bu oturum için kaydedilen tüm değişiklikler."
     },
     "title": "{count, plural, =1 {Oturum} other {Oturumlar}}",
     "labels": {
@@ -2171,7 +2174,7 @@
       "createSuccess": "Oturum başarıyla oluşturuldu.",
       "createSuccessMultiple": "{count, number} Oturumlar başarıyla oluşturuldu",
       "duplicateSuccess": "Oturum başarıyla kopyalandı.",
-      "duplicateSuccessMultiple": "{count} Sessions duplicated successfully"
+      "duplicateSuccessMultiple": "{count} Oturum başarıyla kopyalandı"
     },
     "duplicateDialog": {
       "title": "Yinelenen Oturum",
@@ -2199,7 +2202,7 @@
       "noEstimate": "Tahmin belirlenmedi."
     },
     "delete": {
-      "confirmMessage": "Are you sure you want to delete the Session {name}?",
+      "confirmMessage": "{name} Oturumunu silmek istediğinizden emin misiniz?",
       "warning": "Bu oturum projeden kaldırılacaktır. Bu oturuma ait geçmiş veriler projede kalmaya devam edecektir.",
       "toast": {
         "loading": "Oturum siliniyor...",
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
+        "title": "Denetim Kaydı",
+        "description": "Bu kullanıcı tarafından gerçekleştirilen eylemler",
+        "noEntries": "Henüz kaydedilmiş aktivite yok.",
+        "loadMore": "Yükleniyor",
         "viewDetails": "Ayrıntıları görüntüle",
         "columnAction": "Aksiyon",
         "columnEntityType": "Tip",
         "columnEntityName": "İsim",
         "columnTimestamp": "Zaman damgası",
         "allActions": "Tüm Eylemler",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "allTypes": "Tüm Türler",
+        "noMatchingEntries": "Seçilen filtrelerle eşleşen kayıt bulunamadı.",
+        "showing": "{total} kayıttan {loaded} tanesi"
       },
       "mentionedComments": {
         "title": "Yorumlarda bahsedildi",
@@ -2510,9 +2513,9 @@
       "historyView": "Test Durumu Geçmişini Görüntüle"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Aktivite",
+      "title": "Aktivite Kaydı",
+      "description": "Bu test durumu için kaydedilen tüm değişiklikler."
     },
     "fields": {
       "optionNotFound": "Seçenek bulunamadı.",
@@ -3324,7 +3327,7 @@
       "alreadyPendingError": "Bu kuruluş için halihazırda bir inceleme süreci devam etmektedir.",
       "cannotSelfAssign": "Kendinize değerlendirme atayamazsınız; başka bir kullanıcı veya rol seçin.",
       "defaultComment": "Lütfen {fromState} → {toState} geçişini inceleyin.",
-      "defaultCommentRole": "Requesting approval from the {roleName} group to transition from {fromState} → {toState}.",
+      "defaultCommentRole": "{fromState} → {toState} geçişi için {roleName} grubundan onay isteniyor.",
       "ineligibleAssigneeError": "Bu kullanıcı/rol bu alan için yorumları onaylayamaz. Lütfen başka birini seçin.",
       "ineligibleAssigneeErrorUser": "{name} Bu alan için yorumları onaylayamıyor. Lütfen başka bir kullanıcı veya rol seçin.",
       "ineligibleAssigneeErrorRole": "{roleName} rolü bu alan için yorumları onaylayamaz. Başka bir rol veya kullanıcı seçin."
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Aktivite",
+      "title": "Aktivite Kaydı",
+      "description": "Bu test çalıştırması için kaydedilen tüm değişiklikler."
     },
     "notFound": "Test çalıştırması bulunamadı.",
     "add": {
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Evet",
       "scimUserLockedTitle": "Kullanıcı SCIM tarafından yönetilir.",
       "scimUserLockedDescription": "Bu kullanıcının adı, e-postası ve aktiflik durumu kimlik sağlayıcınız tarafından yönetilmektedir. Bunları burada güncellemek için orada değişiklik yapın.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Grup Eşlemesi ile Yönetiliyor",
+      "groupMappingOverrideDescription": "Bu kullanıcının erişim katmanı bir SCIM grup eşlemesi tarafından yönetilmektedir ve bir sonraki senkronizasyonda geri alınabilir.",
+      "groupMappingBadge": "Grup Eşlendi"
     },
     "security": {
       "title": "Güvenlik",
@@ -4490,7 +4493,7 @@
       "saveChanges": "Değişiklikleri Kaydet",
       "forceAllUsers": "Tüm Kullanıcıları Şifrelerini Değiştirmeye Zorla",
       "forceAllUsersDialogTitle": "Tüm Kullanıcılar İçin Şifre Değişikliğini Zorunlu Kıl",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "Bu, {count, number} kimlik bilgisi tabanlı kullanıcının bir sonraki girişte şifresini değiştirmesini gerektirecektir.",
       "forceAllUsersDialogWarning": "Bu işlem geri alınamaz.",
       "forceAllUsersDialogConfirm": "Güç Değişikliği",
       "saved": "Güvenlik ayarları kaydedildi.",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "SCIM'i test edin",
         "testing": "Test ediliyor…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — belirteç /api/scim/v2/Users üzerinde çalışıyor.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "SCIM uç noktasına ulaşılamadı. Tekrar denenecek."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Varsayılan Eşlenmiş Erişim",
+      "fallbackDefaultDescription": "Herhangi bir grup eşlemesi tarafından kapsanmayan kullanıcılara atanan erişim katmanı.",
+      "fallbackDefaultLabel": "Varsayılan erişim katmanı",
+      "fallbackDefaultSaved": "Yedek varsayılan kaydedildi"
     },
     "tags": {
       "add": {
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "SCIM tarafından yönetilir. SCIM yönetim sayfasından yönetin.",
       "scimNameLockedTitle": "Grup SCIM tarafından yönetilmektedir.",
       "scimNameLockedDescription": "Bu grubun adı ve üyeleri kimlik sağlayıcınız tarafından yönetilmektedir. Değişiklikleri orada yaparak buradaki bilgileri güncelleyebilirsiniz.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Eşlenmiş Erişim",
+      "mappedAccessLabel": "Eşlenmiş Erişim Katmanı",
+      "mappedAccessNone": "Eşleme yok",
+      "mappedAccessSelect": "Erişim katmanı seçin...",
+      "downgradeConfirmTitle": "Erişim Değişikliğini Onayla",
+      "downgradeConfirmDescription": "{count, plural, one {# kullanıcının} other {# kullanıcının}} erişimi düşürülecek. Devam edilsin mi?",
+      "downgradeConfirmApplyAnyway": "Yine de uygula",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Aktif",
         "inactive": "Etkin değil",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Yetkilendirme bekleniyor"
       },
       "connectedProjects": "Bağlantılı Projeler",
       "noIntegrations": "Herhangi bir entegrasyon yapılandırılmadı.",
       "testConnection": "Test Bağlantısı",
       "testSuccess": "Bağlantı başarılı",
       "testSuccessDescription": "Sorun entegrasyonu düzgün şekilde yapılandırılmış ve bağlanmıştır.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Kimlik bilgileri uygun görünüyor",
+      "testCredentialsSavedDescription": "OAuth istemci kimliğiniz ve gizli anahtarınız geçerli. Entegrasyonu kaydedin, ardından hesabınızı bağlamak için Yetkilendir'e tıklayın — OAuth 2.0 kullanıcı başına bağlanır, bu nedenle en az bir kişi yetkilendirene kadar etkin olmaz.",
       "testFailed": "Bağlantı başarısız oldu",
       "testFailedDescription": "Harici hizmete bağlanılamadı.",
       "testError": "Test Hatası",
       "testErrorDescription": "Bağlantı test edilirken bir hata oluştu.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Yetkilendir",
+      "reauthorize": "Yeniden yetkilendir",
+      "authorizeHint": "Hesabınızı bağlamak ve kurulumu tamamlamak için sağlayıcı ile yetkilendirin",
+      "syncInProgress": "Bağlantılı sorunlar yeniden senkronize ediliyor...",
+      "syncIntegration": "Bağlantılı sorunları yeniden senkronize et",
+      "syncIntegrationHint": "Yalnızca TestPlanIt'te zaten bağlantılı olan sorunları yeniden senkronize eder. Yeni sorunlar harici izleyiciden içe aktarılmaz.",
       "syncSuccess": "Senkronizasyon Sıraya Alındı",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "\"{name}\" kaynağından bağlantılı sorunlar arka planda yeniden senkronize ediliyor. Bu birkaç dakika sürebilir. Tamamlandığında tablo otomatik olarak güncellenecektir.",
       "syncError": "Senkronizasyon Başarısız",
       "syncErrorDescription": "Bu sorun entegrasyonu için senkronizasyon görevi sıraya alınamadı. Lütfen daha sonra tekrar deneyin.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Sorun takibi için kendi sunucunuzda barındırdığınız bir Redmine örneğine bağlanın"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Sorun takibi için kendi sunucunuzda barındırdığınız bir MantisBT örneğine bağlanın"
         }
       },
       "filterPlaceholder": "Filtre entegrasyonları...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Yönetici izinlerine gerek kalmadan kullanıcı bazında doğru raporlama yapan kişiyi belirlemek için bunun yerine OAuth 2.0 kullanın.",
         "tokenCreatorNoticeTitle": "Sorun yaratıcısının atıfı",
         "tokenCreatorNoticeDescription": "Bu entegrasyon aracılığıyla oluşturulan sorunlar, her zaman bu erişim belirtecinin sahibi olan hesap olarak kaydedilir, sorunu oluşturan TestPlanIt kullanıcısı olarak değil. Bu sağlayıcının API'si, oluşturucuyu başka bir kullanıcı adına ayarlamaya izin vermez.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "Geri çağırma URL'si (yönlendirme URI'si)",
+        "callbackUrlDescription": "Bu tam URL'yi sağlayıcınızın OAuth uygulamasında geri çağırma / yönlendirme URI'si olarak kaydedin. Tam olarak eşleşmelidir, aksi takdirde yetkilendirme başarısız olur.",
+        "callbackUrlCopy": "Kopyala",
+        "callbackUrlCopied": "Kopyalandı",
         "forgeApiKeyLabel": "Forge API Anahtarı",
         "forgeApiKeyDescription": "Atlassian Forge uygulaması tarafından Jira sorun panellerinden gelen istekleri doğrulamak için kullanılır. Buradan bir anahtar oluşturun ve Forge uygulamanızın ayarlarına yapıştırın.",
         "forgeApiKeyPlaceholder": "API anahtarı oluşturmak için Oluştur'a tıklayın.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Redmine API Anahtarı",
+        "redmineApiKeyPlaceholder": "Redmine API anahtarınızı girin",
+        "redmineApiKeyHelp": "Hesabım → API erişim anahtarı altında bulunur (REST API'yi Yönetim → Ayarlar → API kısmından etkinleştirin)",
+        "redmineUrl": "Redmine URL'si",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "Redmine örneğinizin temel URL'si",
+        "mantisBTApiKey": "MantisBT API Belirteci",
+        "mantisBTApiKeyPlaceholder": "MantisBT API belirtecinizi girin",
+        "mantisBTApiKeyHelp": "MantisBT hesap ayarlarınız → API Belirteçleri altında bir tane oluşturun",
+        "mantisBTUrl": "MantisBT URL'si",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "MantisBT örneğinizin temel URL'si"
       },
       "authType": {
         "api_key": "API Anahtarı",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "URL'den Test Senaryoları Oluştur (Gereksinimler)",
         "generate_from_url_app": "URL'den Test Senaryoları Oluşturma (Uygulama Testi)",
         "automation_candidates": "Otomasyon Adayları Raporu",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Yapay Zeka Adım Türetme"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Güvenlik ve uyumluluk takibi için sistem genelindeki denetim kaydını görüntüleyin.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Bu projede gerçekleştirilen eylemlerin denetim izini görüntüleyin.",
       "filterPlaceholder": "Varlık, kullanıcı veya eyleme göre arama yapın...",
       "filterAction": "Aksiyon",
       "filterEntityType": "Varlık Türü",
       "allActions": "Tüm Eylemler",
       "allEntityTypes": "Tüm Varlık Türleri",
-      "allUsers": "All Users",
+      "allUsers": "Tüm Kullanıcılar",
       "allProjects": "Tüm Projeler",
-      "showing": "Showing {loaded} of {total} entries",
+      "showing": "{total} kayıttan {loaded} tanesi gösteriliyor",
       "viewDetails": "Ayrıntıları Görüntüle",
       "detailTitle": "Denetim Günlüğü Ayrıntıları",
       "userInfo": "Kullanıcı Bilgileri",
@@ -5714,8 +5717,8 @@
       "systemActor": "Sistem",
       "systemActorTooltip": "Sistem tarafından gerçekleştirilen işlem, oturum açmış bir kullanıcı tarafından değil.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "ilgili değişiklikler",
+      "groupedEntry": "Tek bir eylemden gruplanmış değişiklikler"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "Hâlâ sizin değerlendirmenizi bekliyor.",
         "reviewReminderEmailMessage": "Hatırlatma: {actorName}'ın {entityLabel} \"{entityName}\" hakkındaki inceleme isteği, \"{projectName}\" projesinde {hoursPending} saattir beklemede.",
         "reviewReminderHoursPending": "Beklemede {hoursPending, plural, one {saat} other {saat}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Yapay Zeka ile Türetilen Test Adımları Hazır",
+        "aiStepsDerivedMessage": "{count, plural, one {# test durumuna} other {# test durumuna}} yapay zeka tarafından türetilmiş adımlar verildi — doğruluğunu inceleyin.",
+        "aiStepsDerivedReviewLink": "Test çalıştırmasını incele"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Grup Adı\nTüm projelerde kullanılan açık, özlü ve açıklayıcı bir ad veya anahtar kelime(ler).\n\n- Ekip üyelerinin ilgili test senaryolarını, test çalıştırmalarını ve oturumlarını hızlı bir şekilde bulmasına yardımcı olur.",
       "users": "## Kullanıcılar\nBu gruba atanmış kullanıcıları gösterir.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Eşlenmiş Erişim Katmanı\nBu grubun üyelerine bir sonraki senkronizasyonda en az bu erişim katmanı verilir.\n\n- Bir kullanıcının tüm gruplarındaki en yüksek katman geçerli olur\n- \"Eşleme yok\" bu grubun erişimi etkilemediği anlamına gelir — üyeler SCIM sayfasında belirlenen varsayılana döner\n- Bir kullanıcı üzerinde yapılan manuel erişim değişikliği eşlemenin yerini alır (ve bu, kullanıcının düzenleme ekranında işaretlenir)"
     },
     "template": {
       "name": "## Şablon Adı\nBu şablon için benzersiz ve açıklayıcı bir ad (örneğin, 'Standart Test Durumu', 'API Test Sonuçları').",
@@ -6209,7 +6212,7 @@
       "authType": "## Kimlik Doğrulama Türü\nHarici hizmetle nasıl kimlik doğrulaması yapacağınızı seçin.\n\n- **API Anahtarı:** E-posta ve API belirteci kullanarak basit kimlik doğrulama\n- **OAuth 2.0:** OAuth akışı kullanarak güvenli kimlik doğrulama\n- **Kişisel Erişim Belirteci:** Doğrudan belirteç tabanlı kimlik doğrulama",
       "email": "## E-posta Adresi\nHarici hizmet için hesap e-posta adresiniz.\n\n- API anahtarı kimlik doğrulaması için kullanılır\n- API belirtecini oluşturan hesapla eşleşmelidir\n- Jira ve benzeri hizmetler için gereklidir",
       "apiToken": "## API Token\nHarici hizmetteki hesap ayarlarınızdan bir API token oluşturun.\n\n- Genellikle Hesap Ayarları → Güvenlik → API Token'ları bölümünde bulunur\n- Parolanızı ifşa etmeden güvenli erişim sağlar\n- Gerektiğinde iptal edilebilir ve yeniden oluşturulabilir",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\nJira örneğinizin temel URL'si.\n\n- Biçim: https://your-site.atlassian.net\n- /browse veya diğer yolları içermeyin\n- Bu sunucudan erişilebilir olmalıdır",
       "clientId": "## OAuth İstemci Kimliği\nOAuth uygulama yapılandırmanızdaki İstemci Kimliği.\n\n- Harici hizmetin geliştirici konsolunda oluşturulur\n- OAuth akışı sırasında uygulamanızı tanımlamak için kullanılır\n- Yapılandırma dosyalarında paylaşılması güvenlidir",
       "clientSecret": "## OAuth İstemci Gizli Anahtarı\nOAuth uygulama yapılandırmanızdaki İstemci Gizli Anahtarı.\n\n- İstemci Kimliği ile birlikte oluşturulur\n- Gizli ve güvenli tutulmalıdır\n- Uygulamanızı doğrulamak için kullanılır",
       "personalAccessToken": "## Kişisel Erişim Belirteci\nHarici hizmet için uygun izinlere sahip kişisel bir erişim belirteci.\n\n- Hesap ayarlarınızda oluşturulur\n- Okuma ve yazma izinlerine sahip olmalıdır\n- Parola doğrulamasından daha güvenlidir",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## Örnek URL'si\nKendi sunucunuzda barındırdığınız örneğin temel URL'si.\n\n- Biçim: https://git.example.com\n- Sondaki eğik çizgileri veya yolları eklemeyin\n- Bu sunucudan erişilebilir olmalıdır",
       "projectPath": "## Proje Yolu\nGitLab projenizin tam yolu.\n\n- Biçim: ad alanı/proje veya grup/alt grup/proje\n- Örnek: my-org/my-project\n- Proje URL'sinde bulunur: gitlab.com/ad alanı/proje",
       "platform": "## Platform\nBağlandığınız kendi sunucunuzda barındırdığınız Git platformu.\n\n- **Gitea**: gitea.io tabanlı örnekler\n- **Forgejo**: forgejo.org tabanlı örnekler (Gitea çatalı)\n- **Gogs**: gogs.io tabanlı örnekler\n\nBu, hangi simgenin gösterileceğini kontrol eder ve API uyumluluğunu etkileyebilir.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine API Anahtarı\nKişisel REST API erişim anahtarınız.\n\n- REST API'yi Yönetim → Ayarlar → API altından etkinleştirin\n- Anahtarınızı Hesabım → API erişim anahtarı kısmından kopyalayın\n- Kullanıcınızın izinleriyle sınırlıdır; paylaşılan entegrasyonlar için bir servis hesabı kullanın",
+      "redmineUrl": "## Redmine URL\nRedmine örneğinizin temel URL'si.\n\n- Biçim: https://redmine.example.com\n- /issues veya diğer yolları içermeyin\n- Bu sunucudan erişilebilir olmalıdır",
+      "mantisBTApiKey": "## MantisBT API Belirteci\nKişisel REST API belirteciniz.\n\n- MantisBT hesap ayarlarınız → API Belirteçleri altında bir tane oluşturun\n- Kullanıcınızın izinleriyle sınırlıdır; paylaşılan entegrasyonlar için bir servis hesabı kullanın",
+      "mantisBTUrl": "## MantisBT URL\nMantisBT örneğinizin temel URL'si.\n\n- Biçim: https://mantisbt.example.com\n- /api/rest veya diğer yolları içermeyin\n- Bu sunucudan erişilebilir olmalıdır",
+      "githubBaseUrl": "## API Temel URL'si\nGitHub Enterprise Server için tam GitHub API kök dizini.\n\n- Genellikle /api/v3 ile biter\n- api.github.com kullanmak için boş bırakın\n- Bu sunucudan erişilebilir olmalıdır"
     },
     "config": {
       "name": "## Yapılandırma Adı\nBu yapılandırma için açık ve açıklayıcı bir ad.\n\n- Yapılandırmayı oluşturan varyant kombinasyonlarını açıklamaya yardımcı olur (örneğin \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", vb.).",
@@ -6957,7 +6960,7 @@
         },
         "heuristic": {
           "intro": "Bu proje için herhangi bir LLM entegrasyonu yapılandırılmamıştır, bu nedenle sıralama doğrudan seçim stratejisi metriğine göre oluşturulmuştur. Özel alanları, bağlantılı sorun bağlamını ve vaka içeriğini metrikle birlikte değerlendiren daha zengin bir akıl yürütme sağlamak için bir LLM entegrasyonu yapılandırın (Yönetici → Yapay Zeka Modelleri).",
-          "rankedSummary": "{ranked} of {totalEligible} eligible manual cases ranked.",
+          "rankedSummary": "{totalEligible} uygun manuel vakadan {ranked} tanesi sıralandı.",
           "strategyExplanation": {
             "most_executed": "Vakalar, manuel yürütme sayısına göre (en yüksekten başlayarak) sıralanmıştır; bu, otomasyonun test uzmanının zamanından en fazla tasarruf sağladığı regresyon sıklığı göstergesidir.",
             "flakiest_first": "Vakalar yaklaşık olarak tutarsızlık derecesine (başarılı/başarısız değişimlerine) göre sıralanır; tutarsız manuel testler, deterministik bir otomasyon kehaneti için ideal adaylardır.",
@@ -6974,7 +6977,7 @@
             "longestWithDuration": "Manuel yürütme tahmini {duration} — uzun süren manuel testlerin otomatikleştirilmesi, her çalıştırmada orantılı olarak daha fazla test uzmanı zamanı kazandırır.",
             "longestNone": "Tahmin veya öngörü belirlenmedi — En Uzun Süreli Yürütme sezgisel algoritmasının bu durum için süre verisi yok.",
             "oldest": "{age} tarafından yazılmıştır — uzun süreli manuel vakalar, yeniden çalışma gerektirmeden otomatikleştirilebilecek olgun ve istikrarlı davranışlar sergileme eğilimindedir.",
-            "newest": "Authored {age} — newly-authored cases are the most likely to need execution coverage right now.",
+            "newest": "{age} önce yazıldı — yeni yazılan vakaların şu anda yürütme kapsamına ihtiyaç duyma olasılığı en yüksektir.",
             "random": "Rastgele örneklem — tarafsız bir referans olarak dahil edilmiştir; sezgisel yöntem, örneklemdeki diğer durumlara kıyasla bu duruma yönelik doğal bir tercihe sahip değildir."
           },
           "flakinessFraction": {
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}sa {minutes}dk"
           },
           "relativeAge": {
             "today": "Bugün",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Aramak",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
+      "title": "Kayıtlı aramalar",
+      "save": "Aramayı kaydet",
+      "saveTitle": "Aramayı kaydet",
+      "saveDescription": "Daha sonra tekrar erişebilmek için bu aramaya bir ad verin.",
       "saveAction": "Kaydetmek",
       "nameLabel": "İsim",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "namePlaceholder": "örn. Bu sprintteki başarısız çalıştırmalar",
+      "nameRequired": "Bu arama için bir ad girin.",
+      "loginRequired": "Aramaları kaydetmek için oturum açmış olmanız gerekir.",
       "descriptionLabel": "Açıklama (isteğe bağlı)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
+      "descriptionPlaceholder": "Bu aramanın amacı",
+      "saved": "Arama kaydedildi",
+      "savedDescription": "\"{name}\" artık kayıtlı aramalarınızda.",
+      "saveFailed": "Arama kaydedilemedi. Lütfen tekrar deneyin.",
+      "empty": "Henüz kayıtlı arama yok",
+      "emptyHint": "Daha sonra tekrar erişmek için bir arama kaydedin.",
+      "loaded": "\"{name}\" yüklendi",
+      "loadFailed": "Bu kayıtlı arama artık geçerli değil.",
       "edit": "Düzenlemek",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "editTitle": "Kayıtlı aramayı düzenle",
+      "edited": "Kayıtlı arama güncellendi",
+      "editFailed": "Arama güncellenemedi. Lütfen tekrar deneyin.",
       "delete": "Silmek",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "Kayıtlı arama silinsin mi?",
+      "deleteConfirm": "\"{name}\" kayıtlı aramalarınızdan kaldırılacak. Bu işlem geri alınamaz.",
+      "deleted": "Kayıtlı arama silindi",
+      "deleteFailed": "Arama silinemedi. Lütfen tekrar deneyin."
     },
     "bulk": {
       "crossProjectHint": "(birden fazla projeyi kapsayan)",
@@ -7697,14 +7700,14 @@
       "intro": "Giriş yapmak için aşağıdaki butona tıklayın:",
       "signInButton": "Giriş Yap",
       "copyPasteIntro": "Veya bu bağlantıyı tarayıcınıza kopyalayıp yapıştırın:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Güvenliğiniz için bu bağlantı yalnızca bir kez kullanılabilir. Tekrar giriş yapmanız gerekirse yeni bir bağlantı isteyin.",
       "disclaimer": "Bu e-postayı siz talep etmediyseniz, güvenle görmezden gelebilirsiniz.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "TestPlanIt'e giriş yapın\n\nGiriş yapmak için aşağıdaki bağlantıya tıklayın:\n{url}\n\nGüvenliğiniz için bu bağlantı yalnızca bir kez kullanılabilir. Tekrar giriş yapmanız gerekirse yeni bir bağlantı isteyin.\n\nBu e-postayı siz talep etmediyseniz, güvenle yok sayabilirsiniz."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Bunu farklı bir cihazda mı açıyorsunuz? Bağlantıyı istediğiniz giriş ekranına bu kodu girin:",
+      "deviceNotice": "Bu bağlantı, istekte bulunduğunuz tarayıcıdan giriş yapmanızı sağlar. Başka bir yerde açarsanız, orijinal pencerenize girmeniz için yukarıdaki kod gösterilecektir.",
+      "textBody": "TestPlanIt'e giriş yapın\n\nGiriş yapmak için aşağıdaki bağlantıya tıklayın:\n{url}\n\nBunu farklı bir cihazda mı açıyorsunuz? Bağlantıyı istediğiniz giriş ekranına bu kodu girin: {code}\n\nBu e-postayı siz talep etmediyseniz, güvenle yok sayabilirsiniz."
     }
   },
   "comments": {
@@ -7948,7 +7951,7 @@
     "importStep2RequiredUnmapped": "Gerekli parametre \"@{name}\" için eşlenmiş CSV sütunu bulunmamaktadır.",
     "importStep2Label": "Harita sütunları",
     "importStep3SummaryOk": "{totalRows, plural, =1 {# satır} other {# satırlar}} ayrıştırıldı, hata yok.",
-    "importStep3SummaryErrors": "{totalRows, plural, =1 {# row} other {# rows}} parsed; {errorCount, plural, =1 {# row has} other {# rows have}} errors.",
+    "importStep3SummaryErrors": "{totalRows, plural, =1 {# satır} other {# satır}} ayrıştırıldı; {errorCount, plural, =1 {# satırda hata var} other {# satırda hata var}}.",
     "importStep3PreviewLimit": "İlk {limit} satır gösteriliyor. Tüm satırlar bir sonraki adımda doğrulanacaktır.",
     "importStep3Label": "Önizleme",
     "importStep4Heading": "İçe aktarmayı onaylayın",
@@ -8078,9 +8081,9 @@
     "overrideUnsavedDiscard": "Değişiklikleri iptal et",
     "iterationBulkConfirmTitle": "Mark {count, plural, =1 {# yineleme} other {# yinelemeler}} olarak {action}?",
     "iterationBulkConfirmDescription": "Seçilen her yineleme, \"{statusName} \" durumuna sahip yeni bir sonuç alacaktır.",
-    "iterationBulkConfirm": "Mark {action}",
+    "iterationBulkConfirm": "{action} olarak işaretle",
     "iterationBulkConfirmReplace": "{action} ile değiştirin",
-    "iterationBulkOverwriteWarning": "{count, plural, =1 {# of the selected iterations already has} other {# of the selected iterations already have}} a result. A new result will be recorded and the latest will replace the current one.",
+    "iterationBulkOverwriteWarning": "{count, plural, =1 {Seçilen yinelemelerden # tanesinde} other {Seçilen yinelemelerden # tanesinde}} zaten bir sonuç var. Yeni bir sonuç kaydedilecek ve en güncel sonuç mevcut olanın yerine geçecek.",
     "iterationBulkReasonLabel": "Sebep (isteğe bağlı)",
     "iterationBulkReasonHelp": "Her sonuç kaydedildi.",
     "iterationBulkSuccess": "{count, plural, =1 {# yineleme} other {# yineleme}} işaretli {action}",

--- a/testplanit/messages/vi-VN.json
+++ b/testplanit/messages/vi-VN.json
@@ -62,7 +62,7 @@
       "expand": "Mở rộng",
       "collapse": "Sụp đổ",
       "addResult": "Thêm kết quả",
-      "passAndNext": "Pass & Next",
+      "passAndNext": "Đạt & Tiếp theo",
       "viewInRepository": "Xem trong kho lưu trữ",
       "resultAdded": "Đã thêm kết quả kiểm tra",
       "resultAddedDescription": "Kết quả kiểm tra đã được thêm thành công.",
@@ -194,7 +194,7 @@
     "auth": {
       "internal": "Email/Mật khẩu",
       "sso": "Chỉ SSO",
-      "both": "Email & SSO",
+      "both": "Email và SSO",
       "scim": "SCIM đã được cấp phép"
     },
     "status": {
@@ -497,7 +497,7 @@
       "moveSuccess": "Vật phẩm đã được di chuyển thành công.",
       "moveError": "Đã xảy ra lỗi trong quá trình di chuyển mục",
       "updateSuccess": "Mục đã được cập nhật thành công.",
-      "updateSuccessCount": "{count, number} items updated successfully",
+      "updateSuccessCount": "{count, number} mục đã được cập nhật thành công",
       "updateError": "Đã xảy ra lỗi trong quá trình cập nhật mục",
       "linkCopied": "Liên kết đã được sao chép vào clipboard",
       "copyFailed": "Không thể sao chép liên kết vào clipboard",
@@ -1072,7 +1072,7 @@
         "apple": "Tiếp tục với Apple",
         "microsoft": "Tiếp tục với Microsoft",
         "samlProvider": "Đăng nhập bằng {name}",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "Đăng nhập bằng Liên kết ma thuật dùng một lần",
         "emailLogin": "Tiếp tục với email"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "Quay lại trang đăng nhập"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "Nhấp vào liên kết trong email để đăng nhập từ trình duyệt này, hoặc nhập mã từ email bên dưới.",
+        "codeLabel": "Mã đăng nhập",
+        "verifyCode": "Xác minh mã",
+        "verifying": "Đang xác minh...",
+        "invalidCode": "Mã đó không đúng. Hãy kiểm tra email và thử lại.",
+        "codeExpired": "Yêu cầu đăng nhập này đã hết hạn. Hãy yêu cầu liên kết mới.",
+        "tooManyAttempts": "Quá nhiều lần thử không đúng. Hãy yêu cầu liên kết mới để thử lại.",
+        "windowLost": "Cửa sổ này không thể hoàn tất đăng nhập nữa. Hãy yêu cầu liên kết mới.",
+        "genericError": "Chúng tôi không thể đăng nhập cho bạn. Hãy yêu cầu liên kết mới và thử lại.",
+        "tooManyRequests": "Quá nhiều yêu cầu đăng nhập. Vui lòng chờ một chút và thử lại.",
+        "haveCode": "Đã có mã đăng nhập?",
+        "codeEntryDescription": "Nhập mã từ email đăng nhập của bạn. Mã chỉ hoạt động trên trình duyệt nơi bạn đã yêu cầu liên kết.",
+        "backToRequest": "Yêu cầu liên kết mới thay thế"
       },
       "twoFactor": {
         "title": "Xác thực hai yếu tố",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "Liên hệ với Quản trị viên hệ thống"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "Đang đăng nhập cho bạn...",
+      "completeErrorTitle": "Chúng tôi không thể đăng nhập cho bạn",
+      "requestNewLink": "Yêu cầu liên kết mới",
+      "codeTitle": "Mã đăng nhập của bạn",
+      "codeInstructions": "Bạn đã mở liên kết đăng nhập trên một thiết bị hoặc trình duyệt khác. Hãy nhập mã này trên màn hình đăng nhập nơi bạn đã yêu cầu ban đầu.",
+      "codeCloseNotice": "Bạn có thể đóng cửa sổ này sau khi đã nhập mã.",
+      "expiredTitle": "Liên kết đăng nhập này không còn hợp lệ",
+      "expiredBody": "Liên kết có thể đã hết hạn hoặc đã được sử dụng. Hãy yêu cầu liên kết mới từ trang đăng nhập — chỉ mất một chút thời gian."
     },
     "errors": {
       "accessDenied": "Truy cập bị từ chối. Tài khoản của bạn có thể không hoạt động hoặc bạn không có quyền đăng nhập.",
       "configuration": "Có vấn đề với cấu hình máy chủ.",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "Liên kết đăng nhập này đã hết hạn hoặc đã được sử dụng. Liên kết ma thuật chỉ có thể được sử dụng một lần — vui lòng yêu cầu liên kết mới để đăng nhập.",
       "invalid2FACode": "Mã xác minh không hợp lệ. Vui lòng thử lại.",
       "twoFactorTokenRequired": "Cần có mã thông báo.",
       "verificationCodeRequired": "Cần có mã xác minh."
@@ -1364,19 +1367,19 @@
           "switchWarning2": "Lưu giữ các vấn đề trong cơ sở dữ liệu (chúng sẽ trở nên không liên kết với nhau)",
           "switchWarning3": "Thay thế cấu hình tích hợp sự cố hiện tại bằng cấu hình mới.",
           "switchWarning4": "Xóa webhook đến được cấu hình cho tích hợp hiện tại.",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "Nhập sự cố",
+          "importTitle": "Nhập sự cố từ {name}",
+          "importDescription": "Kéo các sự cố từ dự án được liên kết này vào dự án của bạn. Các sự cố hiện có sẽ không bị trùng lặp, và các sự cố đã nhập sẽ luôn được cập nhật thông qua đồng bộ.",
+          "importUpdatedWithin": "Đã cập nhật trong vòng",
+          "importLastDays": "{days} ngày qua",
+          "importMax": "Số lượng tối đa để nhập",
+          "importPreview": "Xem trước",
+          "importPreviewResult": "~{count, plural, other {# sự cố}} khớp với bộ lọc này. Tối đa {cap} sẽ được nhập.",
+          "importOverCap": "Vượt quá giới hạn {cap}; chỉ {cap} sự cố được cập nhật gần đây nhất sẽ được nhập.",
+          "importStart": "Nhập",
+          "importStarted": "Đã bắt đầu nhập. Các sự cố sẽ sớm xuất hiện.",
+          "importFailed": "Nhập thất bại",
+          "importPreviewFailed": "Không thể ước tính số lượng khớp"
         },
         "integrationAssigned": "Quá trình tích hợp được thực hiện thành công.",
         "integrationAssignError": "Không thể gán việc tích hợp vấn đề cho dự án.",
@@ -1402,10 +1405,10 @@
             "description": "Kết nối với Azure DevOps để theo dõi các hạng mục công việc."
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "Kết nối với máy chủ Redmine tự lưu trữ để theo dõi sự cố."
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "Kết nối với máy chủ MantisBT tự lưu trữ để theo dõi sự cố."
           }
         }
       },
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook đã được kích hoạt lại.",
         "toastReEnableFailed": "Không thể kích hoạt lại: {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Webhook đến của Redmine",
+        "inboundRedmineScopeHint": "Plugin redmine_webhook không ký các yêu cầu, vì vậy URL webhook này chính là thông tin xác thực — hãy coi đây là bí mật và thay đổi nó nếu bị lộ.",
+        "setupStepsRedmineStep1": "Cài đặt plugin redmine_webhook trên máy chủ Redmine của bạn (Redmine không có webhook tích hợp sẵn).",
+        "setupStepsRedmineStep2": "Trong dự án Redmine của bạn, mở Settings → Modules và bật Webhooks.",
+        "setupStepsRedmineStep3": "Mở Settings → Webhooks, dán URL ở trên vào và lưu lại.",
+        "setupStepsRedmineStep4": "Tạo hoặc cập nhật một sự cố trong Redmine; trạng thái của sự cố được liên kết sẽ đồng bộ tại đây.",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "Webhook đến của MantisBT",
+        "inboundMantisbtScopeHint": "Plugin webhook MantisBT không ký các yêu cầu, vì vậy URL webhook này chính là thông tin xác thực — hãy coi đây là bí mật và thay đổi nó nếu bị lộ.",
+        "setupStepsMantisbtStep1": "Cài đặt và bật một plugin webhook MantisBT trên máy chủ MantisBT của bạn (MantisBT không có webhook tích hợp sẵn).",
+        "setupStepsMantisbtStep2": "Trong cấu hình plugin, chọn các sự kiện tạo và cập nhật sự cố.",
+        "setupStepsMantisbtStep3": "Dán URL ở trên làm đích webhook và lưu lại.",
+        "setupStepsMantisbtStep4": "Tạo hoặc cập nhật một sự cố trong MantisBT; trạng thái của sự cố được liên kết sẽ đồng bộ tại đây."
       },
       "aiModels": {
         "description": "Cấu hình các mô hình AI để tạo và phân tích trường hợp kiểm thử thông minh.",
@@ -1827,7 +1830,7 @@
           "saving": "Tiết kiệm",
           "savedHint": "Tất cả các thay đổi đã được lưu ở phiên bản {version, number}",
           "unsavedHint": "Thay đổi chưa được lưu",
-          "currentVersionLabel": "v{version, number} (current)",
+          "currentVersionLabel": "v{version, number} (hiện tại)",
           "currentVersionInitialLabel": "Hiện hành",
           "historicalVersionLabel": "v{version, number}",
           "historicalReadOnlyBanner": "Bạn đang xem phiên bản {version, number}. Việc chỉnh sửa sẽ tạo ra một phiên bản mới được phân nhánh từ phiên bản này.",
@@ -1840,7 +1843,7 @@
         "versionPicker": {
           "label": "Phiên bản",
           "loadError": "Không thể tải phiên bản",
-          "currentItemLabel": "v{version, number} (current)",
+          "currentItemLabel": "v{version, number} (hiện tại)",
           "currentItemInitialLabel": "Hiện tại — chưa có phiên bản nào được lưu",
           "historicalItemLabel": "v{version, number}",
           "historicalItemBy": "bởi {name}",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "Đang quét các tập tin trong {scope}…",
           "scanningFilesCount": "Đang quét các tập tin trong {scope}… ({count, number} đã tìm thấy)",
           "filtering": "Áp dụng bộ lọc cho các tệp {count, number}…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "Bị giới hạn tốc độ bởi nhà cung cấp — đang thử lại sau {seconds, number} giây…"
         },
         "cache": {
           "title": "Cài đặt bộ nhớ đệm",
@@ -1913,8 +1916,8 @@
         "networkError": "Lỗi mạng trong quá trình làm mới bộ nhớ cache",
         "refreshSuccess": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin ({contentCached} nội dung đã được lưu vào bộ nhớ cache)",
         "refreshRateLimited": "Bộ nhớ cache đã được làm mới: {fileCount} tập tin đã được liệt kê, {contentCached}/{fileCount} nội dung đã được lưu vào bộ nhớ cache (tốc độ truy cập bị giới hạn — hãy làm mới lại để hoàn tất)",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "Đã làm mới bộ nhớ đệm: {fileCount} tệp",
+        "refreshInProgress": "Quá trình làm mới bộ nhớ đệm vẫn đang chạy trong nền. Nó sẽ cập nhật tại đây khi hoàn tất.",
         "validation": {
           "pathRequired": "Cần có đường dẫn.",
           "patternRequired": "Cần có mẫu.",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "Hoạt động",
+      "title": "Nhật ký hoạt động",
+      "description": "Tất cả các thay đổi được ghi lại cho phiên này."
     },
     "title": "{count, plural, =1 {Phiên} other {Các phiên}}",
     "labels": {
@@ -2169,7 +2172,7 @@
     },
     "messages": {
       "createSuccess": "Phiên được tạo thành công",
-      "createSuccessMultiple": "{count, number} Sessions created successfully",
+      "createSuccessMultiple": "{count, number} Phiên đã được tạo thành công",
       "duplicateSuccess": "Phiên làm việc đã được sao chép thành công",
       "duplicateSuccessMultiple": "{count} Phiên đã được sao chép thành công"
     },
@@ -2238,7 +2241,7 @@
       "backToSession": "Trở lại phiên",
       "backToLatest": "Trở lại phiên bản mới nhất",
       "versionInfo": {
-        "created": "Version {number, number} Created",
+        "created": "Phiên bản {number, number} Đã tạo",
         "latestUpdated": "Phiên bản mới nhất {number, number} Đã cập nhật"
       },
       "renderer": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "Nhật ký kiểm toán",
+        "description": "Các hành động được thực hiện bởi người dùng này",
+        "noEntries": "Chưa có hoạt động nào được ghi lại.",
+        "loadMore": "Đang tải",
+        "viewDetails": "Xem chi tiết",
+        "columnAction": "Hành động",
+        "columnEntityType": "Loại",
+        "columnEntityName": "Tên",
+        "columnTimestamp": "Dấu thời gian",
+        "allActions": "Tất cả hành động",
+        "allTypes": "Tất cả các loại",
+        "noMatchingEntries": "Không có mục nào khớp với các bộ lọc đã chọn.",
+        "showing": "{loaded} trong số {total} mục"
       },
       "mentionedComments": {
         "title": "Được đề cập trong phần bình luận",
@@ -2510,9 +2513,9 @@
       "historyView": "Chế độ xem lịch sử trường hợp kiểm thử"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "Hoạt động",
+      "title": "Nhật ký hoạt động",
+      "description": "Tất cả các thay đổi được ghi lại cho trường hợp thử nghiệm này."
     },
     "fields": {
       "optionNotFound": "Không tìm thấy tùy chọn",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# cặp liên kết} other {# các cặp liên kết}}",
       "bulkError": "Một số thao tác đã thất bại. Vui lòng thử lại.",
       "tableHint": "Nhấp vào một hàng hoặc nút So sánh để xem xét và giải quyết cặp trùng lặp.",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} so với {caseB}",
       "comparisonDescription": "So sánh các mục có khả năng trùng lặp này và chọn cách giải quyết chúng.",
       "selectPrimary": "Nhấp vào một trường hợp để chọn nó làm trường hợp chính để hợp nhất.",
       "selectedAsPrimary": "Được chọn làm Chính",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "Hoạt động",
+      "title": "Nhật ký hoạt động",
+      "description": "Tất cả các thay đổi được ghi lại cho lần chạy thử nghiệm này."
     },
     "notFound": "Không tìm thấy kết quả chạy thử nghiệm.",
     "add": {
@@ -3370,7 +3373,7 @@
       "success": {
         "title": "Đã thêm thành công lượt chạy thử nghiệm.",
         "description": "{name} đã được thêm vào dự án",
-        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for {name}"
+        "descriptionMultiple": "{count, plural, other {# lượt chạy thử nghiệm}} đã được tạo cho {name}"
       },
       "estimates": {
         "manual": "Thời gian thao tác bằng tay ước tính",
@@ -3386,7 +3389,7 @@
       "reasoning": "Suy luận AI",
       "reviewSelection": "Xem xét các trường hợp thử nghiệm được đề xuất",
       "viewSuggested": "Xem các trường hợp được đề xuất",
-      "tokenUsage": "{total, number} tokens used",
+      "tokenUsage": "{total, number} token đã sử dụng",
       "noLlmIntegration": "Các tính năng AI yêu cầu tích hợp LLM. Hãy cấu hình tích hợp này trong cài đặt dự án.",
       "configure": {
         "title": "Phạm vi trường hợp thử nghiệm",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "Đúng",
       "scimUserLockedTitle": "Người dùng được quản lý bởi SCIM",
       "scimUserLockedDescription": "Tên, email và trạng thái hoạt động của người dùng này được quản lý bởi nhà cung cấp danh tính của bạn. Hãy thực hiện các thay đổi ở đó để cập nhật chúng ở đây.",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "Được quản lý bởi ánh xạ nhóm",
+      "groupMappingOverrideDescription": "Cấp truy cập của người dùng này được quản lý bởi ánh xạ nhóm SCIM và có thể bị hoàn nguyên vào lần đồng bộ tiếp theo.",
+      "groupMappingBadge": "Đã ánh xạ nhóm"
     },
     "security": {
       "title": "Bảo vệ",
@@ -4490,7 +4493,7 @@
       "saveChanges": "Lưu thay đổi",
       "forceAllUsers": "Buộc tất cả người dùng phải thay đổi mật khẩu.",
       "forceAllUsersDialogTitle": "Buộc thay đổi mật khẩu cho tất cả người dùng",
-      "forceAllUsersDialogDescription": "This will require {count, number} credential-based users to change their password on next login.",
+      "forceAllUsersDialogDescription": "Điều này sẽ yêu cầu {count, number} người dùng có thông tin đăng nhập phải thay đổi mật khẩu của họ trong lần đăng nhập tiếp theo.",
       "forceAllUsersDialogWarning": "Hành động này không thể đảo ngược.",
       "forceAllUsersDialogConfirm": "Thay đổi bắt buộc",
       "saved": "Cài đặt bảo mật đã được lưu",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "Kiểm tra SCIM",
         "testing": "Đang kiểm tra…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — mã thông báo hoạt động với /api/scim/v2/Users.",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "Không thể kết nối đến điểm cuối SCIM. Vui lòng thử lại."
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "Quyền truy cập ánh xạ mặc định",
+      "fallbackDefaultDescription": "Cấp truy cập được gán cho người dùng không thuộc bất kỳ ánh xạ nhóm nào.",
+      "fallbackDefaultLabel": "Cấp truy cập mặc định",
+      "fallbackDefaultSaved": "Đã lưu giá trị mặc định dự phòng"
     },
     "tags": {
       "add": {
@@ -4857,7 +4860,7 @@
       "combinations": {
         "title": "Sự kết hợp",
         "description": "Quản lý các tổ hợp toàn cầu",
-        "confirmDescription": "The following {count, number} Configurations will be created:",
+        "confirmDescription": "{count, number} cấu hình sau đây sẽ được tạo:",
         "addCombination": "Thêm tổ hợp",
         "editCombination": "Chỉnh sửa kết hợp",
         "selectCombination": "Chọn các tổ hợp",
@@ -4916,13 +4919,13 @@
       "scimManagedTooltip": "Được quản lý bởi SCIM. Quản lý từ trang quản trị SCIM.",
       "scimNameLockedTitle": "Tập đoàn được quản lý bởi SCIM.",
       "scimNameLockedDescription": "Tên và thành viên của nhóm này được quản lý bởi nhà cung cấp danh tính của bạn. Hãy thực hiện các thay đổi ở đó để cập nhật thông tin tại đây.",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
+      "mappedAccessColumnHeader": "Quyền truy cập đã ánh xạ",
+      "mappedAccessLabel": "Cấp truy cập đã ánh xạ",
+      "mappedAccessNone": "Không có ánh xạ",
+      "mappedAccessSelect": "Chọn cấp truy cập...",
+      "downgradeConfirmTitle": "Xác nhận thay đổi quyền truy cập",
+      "downgradeConfirmDescription": "{count, plural, other {# người dùng}} sẽ bị giảm quyền truy cập. Tiếp tục?",
+      "downgradeConfirmApplyAnyway": "Vẫn áp dụng",
       "downgradeConfirmUserRow": "{name}: {from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "Tích cực",
         "inactive": "Không hoạt động",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "Đang chờ ủy quyền"
       },
       "connectedProjects": "Các dự án liên kết",
       "noIntegrations": "Không có vấn đề nào được cấu hình tích hợp",
       "testConnection": "Kiểm tra kết nối",
       "testSuccess": "Kết nối thành công",
       "testSuccessDescription": "Việc tích hợp vấn đề đã được cấu hình và kết nối đúng cách.",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "Thông tin xác thực hợp lệ",
+      "testCredentialsSavedDescription": "ID và bí mật của ứng dụng khách OAuth của bạn hợp lệ. Hãy lưu tích hợp, sau đó nhấp vào Ủy quyền để kết nối tài khoản của bạn — OAuth 2.0 kết nối theo từng người dùng, vì vậy nó vẫn ở trạng thái không hoạt động cho đến khi có ít nhất một người ủy quyền.",
       "testFailed": "Kết nối thất bại",
       "testFailedDescription": "Không thể kết nối với dịch vụ bên ngoài",
       "testError": "Lỗi kiểm thử",
       "testErrorDescription": "Đã xảy ra lỗi trong quá trình kiểm tra kết nối.",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "Ủy quyền",
+      "reauthorize": "Ủy quyền lại",
+      "authorizeHint": "Ủy quyền với nhà cung cấp để kết nối tài khoản của bạn và hoàn tất thiết lập",
+      "syncInProgress": "Đang đồng bộ lại các sự cố được liên kết...",
+      "syncIntegration": "Đồng bộ lại các sự cố được liên kết",
+      "syncIntegrationHint": "Chỉ đồng bộ lại các sự cố đã được liên kết trong TestPlanIt. Các sự cố mới sẽ không được nhập từ trình theo dõi bên ngoài.",
       "syncSuccess": "Đã xếp hàng đồng bộ",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "Các sự cố được liên kết từ \"{name}\" đang được đồng bộ lại trong nền. Việc này có thể mất vài phút. Bảng sẽ tự động cập nhật khi hoàn tất.",
       "syncError": "Đồng bộ hóa thất bại",
       "syncErrorDescription": "Không thể xếp hàng công việc đồng bộ cho sự cố tích hợp này. Vui lòng thử lại sau.",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "Kết nối với máy chủ Redmine tự lưu trữ để theo dõi sự cố"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "Kết nối với máy chủ MantisBT tự lưu trữ để theo dõi sự cố"
         }
       },
       "filterPlaceholder": "Tích hợp bộ lọc...",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "Hãy sử dụng OAuth 2.0 để ghi nhận chính xác thông tin người báo cáo mà không cần quyền quản trị viên.",
         "tokenCreatorNoticeTitle": "Ghi nhận người tạo vấn đề",
         "tokenCreatorNoticeDescription": "Các sự cố được tạo ra thông qua quá trình tích hợp này luôn được ghi nhận là do tài khoản sở hữu mã thông báo truy cập đó gây ra, chứ không phải do người dùng TestPlanIt đã tạo ra chúng. API của nhà cung cấp này không cho phép thiết lập người tạo thay mặt người dùng khác.",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "URL gọi lại (redirect URI)",
+        "callbackUrlDescription": "Đăng ký URL chính xác này làm callback / redirect URI trong ứng dụng OAuth của nhà cung cấp của bạn. URL này phải khớp chính xác nếu không quá trình ủy quyền sẽ thất bại.",
+        "callbackUrlCopy": "Sao chép",
+        "callbackUrlCopied": "Đã sao chép",
         "forgeApiKeyLabel": "Khóa API Forge",
         "forgeApiKeyDescription": "Được ứng dụng Atlassian Forge sử dụng để xác thực các yêu cầu từ bảng quản lý sự cố Jira. Tạo khóa tại đây và dán vào cài đặt ứng dụng Forge của bạn.",
         "forgeApiKeyPlaceholder": "Nhấp vào Tạo để tạo khóa API.",
@@ -5278,18 +5281,18 @@
         "platformGitea": "Gitea",
         "platformForgejo": "Forgejo",
         "platformGogs": "Gogs",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
-        "redmineUrl": "Redmine URL",
+        "redmineApiKey": "Khóa API Redmine",
+        "redmineApiKeyPlaceholder": "Nhập khóa API Redmine của bạn",
+        "redmineApiKeyHelp": "Được tìm thấy tại My account → API access key (bật REST API trong Administration → Settings → API)",
+        "redmineUrl": "URL Redmine",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
-        "mantisBTUrl": "MantisBT URL",
+        "redmineUrlHelp": "URL cơ sở của phiên bản Redmine của bạn",
+        "mantisBTApiKey": "Mã thông báo API MantisBT",
+        "mantisBTApiKeyPlaceholder": "Nhập mã thông báo API MantisBT của bạn",
+        "mantisBTApiKeyHelp": "Tạo một mã tại cài đặt tài khoản MantisBT của bạn → API Tokens",
+        "mantisBTUrl": "URL MantisBT",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "URL cơ sở của phiên bản MantisBT của bạn"
       },
       "authType": {
         "api_key": "Khóa API",
@@ -5487,7 +5490,7 @@
         "warning": "Thao tác này không thể hoàn tác. Tất cả các dự án sử dụng cấu hình này sẽ trở về cấu hình nhắc lệnh mặc định."
       },
       "llmColumn": "Thạc sĩ Luật",
-      "mixedLlms": "{count, number} LLMs",
+      "mixedLlms": "{count, number} LLM",
       "cannotDeleteDefault": "Không thể xóa cấu hình lời nhắc mặc định. Hãy thiết lập một cấu hình khác làm mặc định trước.",
       "defaultChanged": "Cấu hình lời nhắc mặc định đã được cập nhật thành công.",
       "featureLabels": {
@@ -5502,7 +5505,7 @@
         "generate_from_url": "Tạo các trường hợp kiểm thử từ URL (Yêu cầu)",
         "generate_from_url_app": "Tạo trường hợp kiểm thử từ URL (Kiểm thử ứng dụng)",
         "automation_candidates": "Báo cáo ứng viên tự động hóa",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "Suy luận bước bằng AI"
       }
     },
     "elasticsearch": {
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "Xem nhật ký kiểm toán toàn hệ thống để theo dõi bảo mật và tuân thủ.",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "Xem dấu vết kiểm toán của các hành động được thực hiện trong dự án này.",
       "filterPlaceholder": "Tìm kiếm theo thực thể, người dùng hoặc hành động...",
       "filterAction": "Hoạt động",
       "filterEntityType": "Loại thực thể",
       "allActions": "Tất cả các hành động",
       "allEntityTypes": "Tất cả các loại thực thể",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "Tất cả người dùng",
+      "allProjects": "Tất cả dự án",
+      "showing": "Đang hiển thị {loaded} trong số {total} mục",
       "viewDetails": "Xem chi tiết",
       "detailTitle": "Chi tiết nhật ký kiểm toán",
       "userInfo": "Thông tin người dùng",
@@ -5714,8 +5717,8 @@
       "systemActor": "Hệ thống",
       "systemActorTooltip": "Hành động này được thực hiện bởi hệ thống, không phải bởi người dùng đã đăng nhập.",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "các thay đổi liên quan",
+      "groupedEntry": "Các thay đổi được nhóm từ một hành động duy nhất"
     }
   },
   "components": {
@@ -5809,9 +5812,9 @@
         "reviewReminderAction": "vẫn đang chờ đánh giá của bạn về",
         "reviewReminderEmailMessage": "Nhắc nhở: Yêu cầu xem xét của {actorName}đối với {entityLabel} \"{entityName}\" trong dự án \"{projectName}\" đã bị chờ xử lý trong {hoursPending} giờ.",
         "reviewReminderHoursPending": "Đang chờ xử lý trong {hoursPending, plural, one {# giờ} other {# giờ}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "Các bước thử nghiệm được AI suy luận đã sẵn sàng",
+        "aiStepsDerivedMessage": "{count, plural, other {# trường hợp thử nghiệm}} đã được cung cấp các bước do AI suy luận — hãy xem xét lại độ chính xác.",
+        "aiStepsDerivedReviewLink": "Xem xét lần chạy thử nghiệm"
       }
     },
     "issues": {
@@ -5925,7 +5928,7 @@
     "unlinkError": "Không thể hủy liên kết",
     "noIssuesFound": "Không phát hiện vấn đề nào.",
     "startTypingToSearch": "Bắt đầu gõ để tìm kiếm các vấn đề",
-    "selectedCount": "{count, number} selected",
+    "selectedCount": "{count, number} đã được chọn",
     "confirmSelection": "Xác nhận lựa chọn",
     "alreadyLinked": "Đã được liên kết",
     "authenticate": "Xác thực",
@@ -6033,7 +6036,7 @@
     "durationRange": "Thời lượng: {from}giây - {to}giây",
     "seconds": "{seconds}s",
     "testCases": "{count, plural, one {# trường hợp thử nghiệm} other {# các trường hợp thử nghiệm}}",
-    "estimate": "Est: {value}",
+    "estimate": "Ước tính: {value}",
     "partOf": "(Một phần của {parent})",
     "status": "Trạng thái: {status}"
   },
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## Tên Nhóm\nMột tên hoặc từ khóa rõ ràng, ngắn gọn, mô tả được sử dụng trong tất cả các dự án.\n\n- Giúp các thành viên nhóm nhanh chóng tìm thấy các trường hợp kiểm thử, các lần chạy thử nghiệm và các phiên liên quan.",
       "users": "## Người dùng\nCho biết những người dùng được chỉ định vào nhóm này.",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## Cấp truy cập đã ánh xạ\nCác thành viên của nhóm này được cấp ít nhất cấp truy cập này vào lần đồng bộ tiếp theo.\n\n- Cấp cao nhất trong tất cả các nhóm của người dùng sẽ được áp dụng\n- \"Không có ánh xạ\" nghĩa là nhóm này không ảnh hưởng đến quyền truy cập — các thành viên sẽ sử dụng giá trị mặc định được đặt trên trang SCIM\n- Việc thay đổi quyền truy cập thủ công trên một người dùng sẽ ghi đè lên ánh xạ (và được đánh dấu trên màn hình chỉnh sửa của người dùng đó)"
     },
     "template": {
       "name": "## Tên mẫu\nMột tên duy nhất và mô tả cho mẫu này (ví dụ: 'Trường hợp kiểm thử tiêu chuẩn', 'Kết quả kiểm thử API').",
@@ -6209,7 +6212,7 @@
       "authType": "## Loại xác thực\nChọn cách xác thực với dịch vụ bên ngoài.\n\n- **Khóa API:** Xác thực đơn giản bằng email và mã thông báo API\n- **OAuth 2.0:** Xác thực an toàn bằng quy trình OAuth\n- **Mã thông báo truy cập cá nhân:** Xác thực trực tiếp dựa trên mã thông báo",
       "email": "## Địa chỉ Email\nĐịa chỉ email tài khoản của bạn cho dịch vụ bên ngoài.\n\n- Được sử dụng để xác thực khóa API\n- Phải trùng khớp với tài khoản đã tạo mã thông báo API\n- Bắt buộc đối với Jira và các dịch vụ tương tự",
       "apiToken": "## Mã thông báo API\nTạo mã thông báo API từ cài đặt tài khoản của bạn trong dịch vụ bên ngoài.\n\n- Thường được tìm thấy trong Cài đặt tài khoản → Bảo mật → Mã thông báo API\n- Cung cấp quyền truy cập an toàn mà không cần tiết lộ mật khẩu của bạn\n- Có thể bị thu hồi và tạo lại khi cần",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## URL Jira\nURL cơ sở của phiên bản Jira của bạn.\n\n- Định dạng: https://your-site.atlassian.net\n- Không bao gồm /browse hoặc các đường dẫn khác\n- Phải có thể truy cập được từ máy chủ này",
       "clientId": "## ID máy khách OAuth\nID máy khách từ cấu hình ứng dụng OAuth của bạn.\n\n- Được tạo trong bảng điều khiển dành cho nhà phát triển của dịch vụ bên ngoài\n- Được sử dụng để xác định ứng dụng của bạn trong quá trình OAuth\n- An toàn để chia sẻ trong các tệp cấu hình",
       "clientSecret": "## Mã bí mật máy khách OAuth\nMã bí mật máy khách từ cấu hình ứng dụng OAuth của bạn.\n\n- Được tạo cùng với ID máy khách\n- Phải được giữ bí mật và an toàn\n- Được sử dụng để xác thực ứng dụng của bạn",
       "personalAccessToken": "## Mã truy cập cá nhân\nMã truy cập cá nhân với các quyền phù hợp cho dịch vụ bên ngoài.\n\n- Được tạo trong cài đặt tài khoản của bạn\n- Nên có quyền đọc và ghi\n- An toàn hơn xác thực bằng mật khẩu",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## URL phiên bản\nURL cơ sở của phiên bản tự lưu trữ của bạn.\n\n- Định dạng: https://git.example.com\n- Không bao gồm dấu gạch chéo hoặc đường dẫn ở cuối\n- Phải có thể truy cập được từ máy chủ này",
       "projectPath": "## Đường dẫn dự án\nĐường dẫn đầy đủ đến dự án GitLab của bạn.\n\n- Định dạng: namespace/project hoặc group/subgroup/project\n- Ví dụ: my-org/my-project\n- Tìm thấy trong URL dự án: gitlab.com/namespace/project",
       "platform": "## Nền tảng\nNền tảng Git tự lưu trữ mà bạn đang kết nối.\n\n- **Gitea**: các phiên bản dựa trên gitea.io\n- **Forgejo**: các phiên bản dựa trên forgejo.org (phiên bản phân nhánh của Gitea)\n- **Gogs**: các phiên bản dựa trên gogs.io\n\nĐiều này kiểm soát biểu tượng nào được hiển thị và có thể ảnh hưởng đến khả năng tương thích API.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Khóa API Redmine\nKhóa truy cập REST API cá nhân của bạn.\n\n- Bật REST API trong Administration → Settings → API\n- Sao chép khóa của bạn từ My account → API access key\n- Được giới hạn theo quyền của người dùng của bạn; sử dụng tài khoản dịch vụ cho các tích hợp dùng chung",
+      "redmineUrl": "## URL Redmine\nURL cơ sở của phiên bản Redmine của bạn.\n\n- Định dạng: https://redmine.example.com\n- Không bao gồm /issues hoặc các đường dẫn khác\n- Phải có thể truy cập được từ máy chủ này",
+      "mantisBTApiKey": "## Mã thông báo API MantisBT\nMã thông báo REST API cá nhân của bạn.\n\n- Tạo một mã tại cài đặt tài khoản MantisBT của bạn → API Tokens\n- Được giới hạn theo quyền của người dùng của bạn; sử dụng tài khoản dịch vụ cho các tích hợp dùng chung",
+      "mantisBTUrl": "## URL MantisBT\nURL cơ sở của phiên bản MantisBT của bạn.\n\n- Định dạng: https://mantisbt.example.com\n- Không bao gồm /api/rest hoặc các đường dẫn khác\n- Phải có thể truy cập được từ máy chủ này",
+      "githubBaseUrl": "## URL cơ sở API\nĐường dẫn gốc API GitHub đầy đủ dành cho GitHub Enterprise Server.\n\n- Thường kết thúc bằng /api/v3\n- Để trống nếu muốn sử dụng api.github.com\n- Phải có thể truy cập được từ máy chủ này"
     },
     "config": {
       "name": "## Tên Cấu Hình\nMột tên rõ ràng, mô tả cho cấu hình này.\n\n- Giúp mô tả các tổ hợp biến thể tạo nên Cấu Hình (ví dụ: \"Chrome, Windows 10\", \"Safari/macOS 15.5\", \"Edge/Windows 11\", v.v.).",
@@ -6716,7 +6719,7 @@
       "addDimension": "Thêm chiều sâu...",
       "addMetric": "Thêm số liệu...",
       "runReport": "Chạy báo cáo",
-      "exportCsv": "Export CSV",
+      "exportCsv": "Xuất CSV",
       "noResultsFound": "Không tìm thấy kết quả nào.",
       "selectAtLeastOneDimensionAndMetric": "Hãy chọn ít nhất một chiều và một chỉ số.",
       "noDataMatchingCriteria": "Không tìm thấy dữ liệu nào phù hợp với các chiều và chỉ số đã chọn.",
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}m",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours}g {minutes}p"
           },
           "relativeAge": {
             "today": "Hôm nay",
@@ -7460,7 +7463,7 @@
       "page3": {
         "title": "Xem trước dữ liệu nhập",
         "showing": "Hiển thị {start, number} đến {end, number} trong tổng số {total, number} bước được chia sẻ",
-        "step": "Shared Step {number, number}",
+        "step": "Bước dùng chung {number, number}",
         "noValue": "(trống)"
       }
     },
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "Tìm kiếm",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "Tìm kiếm đã lưu",
+      "save": "Lưu tìm kiếm",
+      "saveTitle": "Lưu tìm kiếm",
+      "saveDescription": "Đặt tên cho tìm kiếm này để bạn có thể xem lại sau.",
+      "saveAction": "Lưu",
+      "nameLabel": "Tên",
+      "namePlaceholder": "ví dụ: Các lần chạy thất bại trong sprint này",
+      "nameRequired": "Nhập tên cho tìm kiếm này.",
+      "loginRequired": "Bạn phải đăng nhập để lưu tìm kiếm.",
       "descriptionLabel": "Mô tả (tùy chọn)",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
-      "delete": "Delete",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "descriptionPlaceholder": "Mục đích của tìm kiếm này",
+      "saved": "Đã lưu tìm kiếm",
+      "savedDescription": "“{name}” hiện đã có trong các tìm kiếm đã lưu của bạn.",
+      "saveFailed": "Không thể lưu tìm kiếm. Vui lòng thử lại.",
+      "empty": "Chưa có tìm kiếm nào được lưu",
+      "emptyHint": "Lưu một tìm kiếm để xem lại sau.",
+      "loaded": "Đã tải “{name}”",
+      "loadFailed": "Tìm kiếm đã lưu này không còn hợp lệ.",
+      "edit": "Chỉnh sửa",
+      "editTitle": "Chỉnh sửa tìm kiếm đã lưu",
+      "edited": "Đã cập nhật tìm kiếm đã lưu",
+      "editFailed": "Không thể cập nhật tìm kiếm. Vui lòng thử lại.",
+      "delete": "Xóa",
+      "deleteTitle": "Xóa tìm kiếm đã lưu?",
+      "deleteConfirm": "“{name}” sẽ bị xóa khỏi các tìm kiếm đã lưu của bạn. Hành động này không thể hoàn tác.",
+      "deleted": "Đã xóa tìm kiếm đã lưu",
+      "deleteFailed": "Không thể xóa tìm kiếm. Vui lòng thử lại."
     },
     "bulk": {
       "crossProjectHint": "(bao gồm nhiều dự án)",
@@ -7697,14 +7700,14 @@
       "intro": "Nhấp vào nút bên dưới để đăng nhập:",
       "signInButton": "Đăng nhập",
       "copyPasteIntro": "Hoặc sao chép và dán liên kết này vào trình duyệt của bạn:",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "Để đảm bảo an toàn cho bạn, liên kết này chỉ có thể được sử dụng một lần. Hãy yêu cầu liên kết mới nếu bạn cần đăng nhập lại.",
       "disclaimer": "Nếu bạn không yêu cầu nhận email này, bạn có thể bỏ qua nó một cách an toàn.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "Đăng nhập vào TestPlanIt\n\nNhấp vào liên kết bên dưới để đăng nhập:\n{url}\n\nĐể đảm bảo an toàn cho bạn, liên kết này chỉ có thể được sử dụng một lần. Hãy yêu cầu liên kết mới nếu bạn cần đăng nhập lại.\n\nNếu bạn không yêu cầu email này, bạn có thể yên tâm bỏ qua nó."
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "Mở liên kết này trên một thiết bị khác? Hãy nhập mã này trên màn hình đăng nhập nơi bạn đã yêu cầu liên kết:",
+      "deviceNotice": "Liên kết này giúp bạn đăng nhập từ trình duyệt nơi bạn đã yêu cầu nó. Nếu bạn mở nó ở nơi khác, bạn sẽ được hiển thị mã ở trên để nhập vào cửa sổ ban đầu của bạn.",
+      "textBody": "Đăng nhập vào TestPlanIt\n\nNhấp vào liên kết bên dưới để đăng nhập:\n{url}\n\nMở liên kết này trên một thiết bị khác? Hãy nhập mã này trên màn hình đăng nhập nơi bạn đã yêu cầu liên kết: {code}\n\nNếu bạn không yêu cầu email này, bạn có thể yên tâm bỏ qua nó."
     }
   },
   "comments": {
@@ -8078,7 +8081,7 @@
     "overrideUnsavedDiscard": "Hủy bỏ các thay đổi",
     "iterationBulkConfirmTitle": "Đánh dấu {count, plural, =1 {# lần lặp} other {# lần lặp}} là {action}?",
     "iterationBulkConfirmDescription": "Mỗi lần lặp được chọn sẽ nhận được một kết quả mới với trạng thái \"{statusName}\".",
-    "iterationBulkConfirm": "Mark {action}",
+    "iterationBulkConfirm": "Đánh dấu {action}",
     "iterationBulkConfirmReplace": "Thay thế bằng {action}",
     "iterationBulkOverwriteWarning": "{count, plural, =1 {Số lần lặp đã chọn đã có} other {Số lần lặp đã chọn đã có}} kết quả. Một kết quả mới sẽ được ghi lại và kết quả mới nhất sẽ thay thế kết quả hiện tại.",
     "iterationBulkReasonLabel": "Lý do (tùy chọn)",

--- a/testplanit/messages/zh-CN.json
+++ b/testplanit/messages/zh-CN.json
@@ -1072,7 +1072,7 @@
         "apple": "继续使用 Apple",
         "microsoft": "继续使用 Microsoft",
         "samlProvider": "使用 {name}登录",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "使用一次性 Magic Link 登录",
         "emailLogin": "继续通过电子邮件"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "返回登录页面"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "点击邮件中的链接从此浏览器登录，或在下方输入邮件中的验证码。",
+        "codeLabel": "登录验证码",
+        "verifyCode": "验证码",
+        "verifying": "正在核实……",
+        "invalidCode": "该验证码不正确。请检查邮件后重试。",
+        "codeExpired": "此登录请求已过期。请申请新链接。",
+        "tooManyAttempts": "错误尝试次数过多。请申请新链接以重试。",
+        "windowLost": "此窗口无法再完成登录。请申请新链接。",
+        "genericError": "我们无法为您登录。请申请新链接后重试。",
+        "tooManyRequests": "登录请求过多。请稍候片刻后重试。",
+        "haveCode": "已有登录验证码？",
+        "codeEntryDescription": "请输入登录邮件中的验证码。验证码仅在您请求该链接的浏览器中有效。",
+        "backToRequest": "改为申请新链接"
       },
       "twoFactor": {
         "title": "双因素身份验证",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "请联系系统管理员"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "正在为您登录……",
+      "completeErrorTitle": "我们无法为您登录",
+      "requestNewLink": "申请新链接",
+      "codeTitle": "您的登录验证码",
+      "codeInstructions": "您在其他设备或浏览器上打开了登录链接。请在您最初请求该链接的登录界面上输入此验证码。",
+      "codeCloseNotice": "输入验证码后，您可以关闭此窗口。",
+      "expiredTitle": "此登录链接已失效",
+      "expiredBody": "该链接可能已过期或已被使用。请从登录页面申请一个新链接 — 只需片刻即可完成。"
     },
     "errors": {
       "accessDenied": "访问被拒绝。您的帐户可能已停用或您没有登录权限。",
       "configuration": "服务器配置存在问题。",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "此登录链接已过期或已被使用。Magic Link 只能使用一次 — 请重新申请以登录。",
       "invalid2FACode": "验证码无效，请重试。",
       "twoFactorTokenRequired": "需要令牌",
       "verificationCodeRequired": "需要验证码"
@@ -1364,19 +1367,19 @@
           "switchWarning2": "保留数据库中的问题（它们将不再关联）",
           "switchWarning3": "将当前问题集成配置替换为新的配置。",
           "switchWarning4": "移除为当前集成配置的入站 Webhook",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "导入问题",
+          "importTitle": "从 {name} 导入问题",
+          "importDescription": "将此关联项目中的问题拉取到您的项目中。已存在的问题不会重复导入，导入的问题将通过同步保持最新。",
+          "importUpdatedWithin": "更新于",
+          "importLastDays": "最近 {days} 天",
+          "importMax": "最大导入数量",
+          "importPreview": "预览",
+          "importPreviewResult": "约有 {count, plural, other {# 个问题}}符合此筛选条件。最多将导入 {cap} 个。",
+          "importOverCap": "这超过了 {cap} 个的上限；将仅导入最近更新的 {cap} 个。",
+          "importStart": "导入",
+          "importStarted": "导入已开始。问题将很快出现。",
+          "importFailed": "导入失败",
+          "importPreviewFailed": "无法估算匹配数量"
         },
         "integrationAssigned": "集成任务已成功分配",
         "integrationAssignError": "未能将问题集成分配给项目",
@@ -1402,10 +1405,10 @@
             "description": "连接到 Azure DevOps 以跟踪工作项。"
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "连接到自托管的 Redmine 实例以进行问题跟踪。"
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "连接到自托管的 MantisBT 实例以进行问题跟踪。"
           }
         }
       },
@@ -1418,11 +1421,11 @@
         "inboundAddButtonAllConfigured": "入站适配器已配置完成。",
         "inboundAddButtonNoIntegration": "在添加入站 webhook 之前，请先为该项目分配一个问题集成。",
         "inboundEmptyWithIntegration": "未配置任何入站 Webhook。 <link>添加一个</link> 以接收来自您分配的问题集成的更新。",
-        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "inboundEmptyNoIntegration": "接收入站问题更新需要<link>问题集成</link>。请为您的项目分配一个以开始使用。",
         "deliveriesEmptyNoConfigs": "目前还没有 webhook 发送——请在其他标签页上创建入站或出站 webhook 以开始接收它们。",
         "noConfig": "未配置 webhook",
         "createButton": "创建 webhook",
-        "url": "Webhook URL",
+        "url": "网络钩子 URL",
         "urlHelp": "将此 URL 粘贴到问题跟踪器的 webhook 配置中。",
         "secret": "Webhook 秘密",
         "secretHelp": "将此密钥粘贴到问题跟踪器的 webhook 配置中。",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook 已重新启用",
         "toastReEnableFailed": "重新启用失败： {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Redmine 入站 webhook",
+        "inboundRedmineScopeHint": "redmine_webhook 插件不会对请求进行签名，因此此 webhook URL 即为凭据 — 请将其视为机密信息，如泄露应及时轮换。",
+        "setupStepsRedmineStep1": "在您的 Redmine 服务器上安装 redmine_webhook 插件（Redmine 没有内置的 webhook）。",
+        "setupStepsRedmineStep2": "在您的 Redmine 项目中，打开“设置”→“模块”并启用 Webhooks。",
+        "setupStepsRedmineStep3": "打开“设置”→“Webhooks”，粘贴上方的 URL，然后保存。",
+        "setupStepsRedmineStep4": "在 Redmine 中创建或更新一个问题；关联问题的状态将在此处同步。",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "MantisBT 入站 webhook",
+        "inboundMantisbtScopeHint": "MantisBT webhook 插件不会对请求进行签名，因此此 webhook URL 即为凭据 — 请将其视为机密信息，如泄露应及时轮换。",
+        "setupStepsMantisbtStep1": "在您的 MantisBT 服务器上安装并启用一个 MantisBT webhook 插件（MantisBT 没有内置的 webhook）。",
+        "setupStepsMantisbtStep2": "在插件配置中，选择问题创建和问题更新事件。",
+        "setupStepsMantisbtStep3": "将上方的 URL 粘贴为 webhook 目标并保存。",
+        "setupStepsMantisbtStep4": "在 MantisBT 中创建或更新一个问题；关联问题的状态将在此处同步。"
       },
       "aiModels": {
         "description": "配置人工智能模型以实现智能测试用例生成和分析",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "正在扫描 {scope}… 中的文件",
           "scanningFilesCount": "正在扫描 {scope}… 中的文件（已找到{count, number}）",
           "filtering": "对 {count, number} 个文件应用过滤器…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "已被提供程序限速 — 将在 {seconds, number} 秒后重试…"
         },
         "cache": {
           "title": "缓存设置",
@@ -1913,8 +1916,8 @@
         "networkError": "缓存刷新期间出现网络错误",
         "refreshSuccess": "缓存已刷新： {fileCount} 个文件（已缓存{contentCached} 个内容）",
         "refreshRateLimited": "缓存已刷新：列出了 {fileCount} 个文件，缓存了 {contentCached}/{fileCount} 个内容（速率受限——请再次刷新以完成）",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "缓存已刷新：{fileCount} 个文件",
+        "refreshInProgress": "缓存刷新仍在后台运行。完成后将在此处更新。",
         "validation": {
           "pathRequired": "路径是必需的",
           "patternRequired": "需要图案",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "活动",
+      "title": "活动日志",
+      "description": "此会话记录的所有更改。"
     },
     "title": "{count, plural, =1 {会话} other {会话}}",
     "labels": {
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "审计日志",
+        "description": "此用户执行的操作",
+        "noEntries": "尚未记录任何活动。",
+        "loadMore": "加载中",
+        "viewDetails": "查看详情",
+        "columnAction": "操作",
+        "columnEntityType": "类型",
+        "columnEntityName": "名称",
+        "columnTimestamp": "时间戳",
+        "allActions": "所有操作",
+        "allTypes": "所有类型",
+        "noMatchingEntries": "没有符合所选筛选条件的条目。",
+        "showing": "{loaded} / {total} 条条目"
       },
       "mentionedComments": {
         "title": "评论中提到",
@@ -2510,9 +2513,9 @@
       "historyView": "测试用例历史记录视图"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "活动",
+      "title": "活动日志",
+      "description": "此测试用例记录的所有更改。"
     },
     "fields": {
       "optionNotFound": "未找到选项",
@@ -2594,7 +2597,7 @@
       "copying": "正在复制…",
       "copyComplete": "{count, plural, =1 {已复制 1 个案例至 {folder}} other {已复制 # 个案例至 {folder}}}{dest, select, samename {} crossProject { 位于 {projectName}} other {}}",
       "moveComplete": "将 1 个案例移至 {count, plural, =1 {{folder}} other {将 # 个案例移至 {folder}}}{dest, select, samename {} crossProject { 中 {projectName}} other {}}",
-      "copyError": "{count, plural, =1 {Failed to copy 1 case to {folder}} other {Failed to copy # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {无法将 1 个案例复制到 {folder}} other {无法将 # 个案例复制到 {folder}}}{dest, select, samename {} crossProject { 中 {projectName}} other {}}",
       "moveError": "{count, plural, =1 {无法将 1 个案例移动到 {folder}} other {无法将 # 个案例移动到 {folder}}}{dest, select, samename {} crossProject { 中 {projectName}} other {}}",
       "copyAlreadyRunning": "另一份拷贝正在制作中，请稍候。",
       "currentSuffix": "（当前的）",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# 配对链接} other {# 配对链接}}",
       "bulkError": "部分操作失败，请重试。",
       "tableHint": "单击行或“比较”按钮，查看并解决重复项。",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} 对比 {caseB}",
       "comparisonDescription": "比较这些潜在的重复项，并选择如何解决它们。",
       "selectPrimary": "点击案例即可将其选为主合并案例。",
       "selectedAsPrimary": "选为主要",
@@ -3344,7 +3347,7 @@
       "requestChangesDescription": "在您批准此次变更之前，请告知请求者需要更改哪些内容。",
       "requestChangesCommentPlaceholder": "解释需要做出哪些改变。",
       "rejectTitle": "拒绝此审核请求？",
-      "rejectDescription": "Rejecting blocks <requester></requester> from transitioning <name></name> to <state></state>. A new review request must be created to retry.",
+      "rejectDescription": "拒绝将阻止 <requester></requester> 将 <name></name> 转换为 <state></state>。必须创建新的审核请求才能重试。",
       "rejectCommentPlaceholder": "请解释您拒绝此请求的原因。",
       "commentLabel": "评论",
       "confirmRequestChanges": "发送",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "活动",
+      "title": "活动日志",
+      "description": "此测试运行记录的所有更改。"
     },
     "notFound": "未找到测试运行。",
     "add": {
@@ -3370,7 +3373,7 @@
       "success": {
         "title": "测试运行已成功添加",
         "description": "{name} 已添加到项目中",
-        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for {name}"
+        "descriptionMultiple": "已为 {name} 创建 {count, plural, other {# 个测试运行}}"
       },
       "estimates": {
         "manual": "预计人工时间",
@@ -3703,7 +3706,7 @@
         "importProgressDescription": "{count, plural, =0 {所有已导入的记录（涵盖所有跟踪实体）。} =1 {已导入的记录（涵盖所有跟踪实体）。} other {已导入的记录（涵盖所有跟踪实体）。}}",
         "importProgressTotalRemaining": "{count, plural, =0 {无剩余记录} =1 {剩余 1 条记录} other {剩余记录数}}",
         "importProgressProcessed": "{processed, number}/{total, number} 记录已导入",
-        "importProgressAria": "{percent, number}% of import complete",
+        "importProgressAria": "导入完成 {percent, number}%",
         "importProgressPercentLabel": "{percent, number}%",
         "importDurationLabel": "总耗时：",
         "activityLogTitle": "进口活动",
@@ -4022,7 +4025,7 @@
         "defaultAccessUpdateFailed": "更新默认访问级别失败",
         "emailVerificationEnabled": "新用户现在需要进行电子邮件验证。",
         "emailVerificationDisabled": "新用户不再需要进行电子邮件验证。",
-        "emailVerificationDisabledAndVerified": "Email verification disabled and {count, plural, one {# user account} other {# user accounts}} verified",
+        "emailVerificationDisabledAndVerified": "电子邮件验证已禁用，{count, plural, other {# 个用户帐户}}已验证",
         "emailVerificationUpdateFailed": "电子邮件验证设置更新失败",
         "emailServerNotConfigured": "无法启用电子邮件验证：电子邮件服务器未配置",
         "openRegistrationEnabled": "自助注册功能现已启用。",
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "是的",
       "scimUserLockedTitle": "用户由 SCIM 管理",
       "scimUserLockedDescription": "该用户的姓名、电子邮件地址和活动状态由您的身份提供商管理。请在身份提供商处进行更改，以在此处更新这些信息。",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "由组映射管理",
+      "groupMappingOverrideDescription": "此用户的访问层级由 SCIM 组映射控制，可能会在下次同步时被还原。",
+      "groupMappingBadge": "已映射到组"
     },
     "security": {
       "title": "安全",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "测试 SCIM",
         "testing": "测试…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — 令牌对 /api/scim/v2/Users 有效。",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "无法连接到SCIM端点。请重试。"
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "默认映射访问权限",
+      "fallbackDefaultDescription": "分配给未被任何组映射覆盖的用户的访问层级。",
+      "fallbackDefaultLabel": "默认访问层级",
+      "fallbackDefaultSaved": "已保存默认回退设置"
     },
     "tags": {
       "add": {
@@ -4830,8 +4833,8 @@
         "description": "替换所选配置中的项目分配。配置名称无法批量编辑。",
         "applyButton": "{count, plural, one {应用于 1 个配置} other {应用于 # 个配置}}",
         "deleteButton": "{count, plural, one {删除 1 个配置} other {删除 # 个配置}}",
-        "deleteConfirmTitle": "{count, plural, one {Delete 1 configuration?} other {Delete # configurations?}}",
-        "deleteConfirmMessage": "{count, plural, one {This will delete 1 configuration. This action cannot be undone.} other {This will delete # configurations. This action cannot be undone.}}",
+        "deleteConfirmTitle": "{count, plural, other {删除 # 个配置？}}",
+        "deleteConfirmMessage": "{count, plural, other {这将删除 # 个配置。此操作无法撤消。}}",
         "applyEnabledLabel": "更改已启用状态"
       },
       "categories": {
@@ -4857,7 +4860,7 @@
       "combinations": {
         "title": "组合",
         "description": "管理全局组合",
-        "confirmDescription": "The following {count, number} Configurations will be created:",
+        "confirmDescription": "将创建以下 {count, number} 个配置：",
         "addCombination": "添加组合",
         "editCombination": "编辑组合",
         "selectCombination": "选择组合",
@@ -4916,14 +4919,14 @@
       "scimManagedTooltip": "由SCIM管理。请从SCIM管理页面进行管理。",
       "scimNameLockedTitle": "该集团由SCIM管理",
       "scimNameLockedDescription": "此群组的名称和成员由您的身份提供商管理。请在身份提供商处进行更改，以在此处更新。",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
-      "downgradeConfirmUserRow": "{name}: {from} → {to}",
+      "mappedAccessColumnHeader": "映射访问权限",
+      "mappedAccessLabel": "映射访问层级",
+      "mappedAccessNone": "无映射",
+      "mappedAccessSelect": "选择访问层级……",
+      "downgradeConfirmTitle": "确认访问权限更改",
+      "downgradeConfirmDescription": "{count, plural, other {# 位用户}} 的访问权限将被降低。是否继续？",
+      "downgradeConfirmApplyAnyway": "仍然应用",
+      "downgradeConfirmUserRow": "{name}：{from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
     "milestones": {
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "积极的",
         "inactive": "非活跃状态",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "等待授权"
       },
       "connectedProjects": "关联项目",
       "noIntegrations": "未配置任何问题集成",
       "testConnection": "测试连接",
       "testSuccess": "连接成功",
       "testSuccessDescription": "问题集成已正确配置并连接",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "凭据验证通过",
+      "testCredentialsSavedDescription": "您的 OAuth 客户端 ID 和密钥有效。请保存此集成，然后点击“授权”以连接您的账户 — OAuth 2.0 按用户连接，因此在至少有一人授权之前将保持未激活状态。",
       "testFailed": "连接失败",
       "testFailedDescription": "无法连接到外部服务",
       "testError": "测试错误",
       "testErrorDescription": "测试连接时发生错误",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "授权",
+      "reauthorize": "重新授权",
+      "authorizeHint": "向提供程序授权以连接您的账户并完成设置",
+      "syncInProgress": "正在重新同步关联问题……",
+      "syncIntegration": "重新同步关联问题",
+      "syncIntegrationHint": "仅重新同步已在 TestPlanIt 中关联的问题。不会从外部跟踪器导入新问题。",
       "syncSuccess": "同步已排队",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "“{name}”的关联问题正在后台重新同步。这可能需要一些时间。完成后表格将自动更新。",
       "syncError": "同步失败",
       "syncErrorDescription": "无法为此集成问题添加同步任务。请稍后重试。",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "连接到自托管的 Redmine 实例以进行问题跟踪"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "连接到自托管的 MantisBT 实例以进行问题跟踪"
         }
       },
       "filterPlaceholder": "过滤器集成……",
@@ -5211,7 +5214,7 @@
         "apiToken": "API令牌",
         "apiTokenPlaceholder": "请输入您的 API 令牌",
         "apiTokenHelp": "从您的帐户设置中生成 API 令牌",
-        "jiraUrl": "Jira URL",
+        "jiraUrl": "Jira 地址",
         "jiraUrlPlaceholder": "https://your-site.atlassian.net",
         "jiraUrlHelp": "您的 Jira 实例的 URL",
         "clientId": "客户ID",
@@ -5220,10 +5223,10 @@
         "clientSecret": "客户机密",
         "clientSecretPlaceholder": "请输入您的 OAuth 客户端密钥",
         "clientSecretHelp": "来自您的 OAuth 应用程序的客户端密钥",
-        "cloudId": "Cloud ID",
+        "cloudId": "云 ID",
         "cloudIdPlaceholder": "请输入您的 Atlassian 云 ID",
         "cloudIdHelp": "您的 Atlassian Cloud 实例 ID（可在您的 Jira URL 中找到）",
-        "apiUrl": "API URL",
+        "apiUrl": "API 地址",
         "apiUrlPlaceholder": "https://api.example.com",
         "apiUrlHelp": "服务 API 的基本 URL",
         "personalAccessTokenPlaceholder": "请输入您的个人访问令牌",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "请改用 OAuth 2.0，以便在没有管理员权限的情况下准确地按用户进行报告者归属。",
         "tokenCreatorNoticeTitle": "问题创建者归属",
         "tokenCreatorNoticeDescription": "通过此集成创建的问题始终记录为拥有此访问令牌的帐户，而不是创建问题的 TestPlanIt 用户。此提供商的 API 不允许代表其他用户设置创建者。",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "回调 URL（重定向 URI）",
+        "callbackUrlDescription": "请在您的提供程序 OAuth 应用中将此确切 URL 注册为回调 / 重定向 URI。必须完全匹配，否则授权将失败。",
+        "callbackUrlCopy": "复制",
+        "callbackUrlCopied": "已复制",
         "forgeApiKeyLabel": "Forge API 密钥",
         "forgeApiKeyDescription": "Atlassian Forge 应用使用此密钥来验证来自 Jira 问题面板的请求。请在此处生成密钥并将其粘贴到 Forge 应用设置中。",
         "forgeApiKeyPlaceholder": "点击“生成”按钮创建 API 密钥",
@@ -5278,18 +5281,18 @@
         "platformGitea": "吉特亚",
         "platformForgejo": "福尔热",
         "platformGogs": "戈格斯",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
+        "redmineApiKey": "Redmine API 密钥",
+        "redmineApiKeyPlaceholder": "请输入您的 Redmine API 密钥",
+        "redmineApiKeyHelp": "位于“我的账户”→“API 访问密钥”下（需在“管理”→“设置”→“API”中启用 REST API）",
         "redmineUrl": "Redmine URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
+        "redmineUrlHelp": "您的 Redmine 实例的基本 URL",
+        "mantisBTApiKey": "MantisBT API 令牌",
+        "mantisBTApiKeyPlaceholder": "请输入您的 MantisBT API 令牌",
+        "mantisBTApiKeyHelp": "在您的 MantisBT 账户设置 →“API 令牌”下创建一个",
         "mantisBTUrl": "MantisBT URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "您的 MantisBT 实例的基本 URL"
       },
       "authType": {
         "api_key": "API密钥",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "根据 URL 生成测试用例（需求）",
         "generate_from_url_app": "从 URL 生成测试用例（应用程序测试）",
         "automation_candidates": "自动化候选报告",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "AI 步骤推导"
       }
     },
     "elasticsearch": {
@@ -5569,7 +5572,7 @@
         "forecast-updates": "预测更新",
         "emails": "电子邮件队列",
         "issue-sync": "问题同步",
-        "testmo-imports": "Testmo Imports",
+        "testmo-imports": "Testmo 导入",
         "elasticsearch-reindex": "Elasticsearch 重新索引",
         "audit-logs": "审计日志",
         "budget-alerts": "预算警报",
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "查看系统范围内的审计跟踪，以进行安全性和合规性跟踪",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "查看此项目中执行操作的审计记录。",
       "filterPlaceholder": "按实体、用户或操作搜索……",
       "filterAction": "行动",
       "filterEntityType": "实体类型",
       "allActions": "所有操作",
       "allEntityTypes": "所有实体类型",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "所有用户",
+      "allProjects": "所有项目",
+      "showing": "显示 {loaded} / {total} 条条目",
       "viewDetails": "查看详情",
       "detailTitle": "审计日志详情",
       "userInfo": "用户信息",
@@ -5714,8 +5717,8 @@
       "systemActor": "系统",
       "systemActorTooltip": "系统执行的操作，而非登录用户执行的操作。",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "相关更改",
+      "groupedEntry": "来自单个操作的分组更改"
     }
   },
   "components": {
@@ -5802,16 +5805,16 @@
         "reviewCommentPreview": "评论： {comment}",
         "reviewRequestedEmailMessage": "{actorName} 请求您对项目“{projectName}”中的 {entityLabel} “{entityName}”进行审核。",
         "reviewApprovedEmailMessage": "{actorName} 已批准您对 {entityLabel} \"{entityName}\" 的项目 \"{projectName} \" 的审核请求。",
-        "reviewChangesRequestedEmailMessage": "{actorName} requested changes on your review request for {entityLabel} \"{entityName}\" in project \"{projectName}\".",
-        "reviewRejectedEmailMessage": "{actorName} rejected your review request on {entityLabel} \"{entityName}\" in project \"{projectName}\".",
+        "reviewChangesRequestedEmailMessage": "{actorName} 对您在项目\"{projectName}\"中的 {entityLabel} \"{entityName}\" 的审核请求提出了修改建议。",
+        "reviewRejectedEmailMessage": "{actorName} 拒绝了您在项目\"{projectName}\"中的 {entityLabel} \"{entityName}\" 的审核请求。",
         "reviewCancelledEmailMessage": "{actorName} 取消了对 {entityLabel} \"{entityName}\" 在项目 \"{projectName} \" 中的审查请求。",
         "reviewReminderTitle": "审核仍在进行中",
         "reviewReminderAction": "仍在等待您的评论",
         "reviewReminderEmailMessage": "提醒： {actorName}对 {entityLabel} \"{entityName}\" 在项目 \"{projectName}\" 中的审核请求已等待 {hoursPending} 小时。",
         "reviewReminderHoursPending": "等待 {hoursPending, plural, one {小时} other {小时}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "AI 生成的测试步骤已就绪",
+        "aiStepsDerivedMessage": "{count, plural, other {# 个测试用例已}}获得 AI 生成的步骤 — 请检查其准确性。",
+        "aiStepsDerivedReviewLink": "查看测试运行"
       }
     },
     "issues": {
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## 组名称\n一个清晰、简洁、描述性的名称或关键词，用于所有项目。\n\n- 帮助团队成员快速找到相关的测试用例、测试运行和会话。",
       "users": "## 用户\n表示分配给此组的用户。",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## 映射访问层级\n此组的成员在下次同步时将至少获得此访问层级。\n\n- 用户所在的所有组中最高的层级将生效\n- “无映射”表示此组不影响访问权限 — 成员将回退到 SCIM 页面上设置的默认值\n- 对用户的手动访问权限更改会优先于映射（并会在该用户的编辑界面上标记出来）"
     },
     "template": {
       "name": "## 模板名称\n此模板的唯一描述性名称（例如，“标准测试用例”、“API 测试结果”）。",
@@ -6209,7 +6212,7 @@
       "authType": "## 身份验证类型\n选择如何与外部服务进行身份验证。\n\n- **API 密钥：** 使用电子邮件和 API 令牌进行简单身份验证\n- **OAuth 2.0：** 使用 OAuth 流程进行安全身份验证\n- **个人访问令牌：** 基于令牌的直接身份验证",
       "email": "## 电子邮件地址\n您的外部服务帐户电子邮件地址。\n\n- 用于 API 密钥身份验证\n- 必须与生成 API 令牌的帐户匹配\n- Jira 和类似服务必需",
       "apiToken": "## API 令牌\n在外部服务的帐户设置中生成 API 令牌。\n\n- 通常位于“帐户设置”→“安全”→“API 令牌”中。\n- 提供安全访问，无需暴露您的密码。\n- 可根据需要撤销和重新生成。",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\n您的 Jira 实例的基本 URL。\n\n- 格式：https://your-site.atlassian.net\n- 请勿包含 /browse 或其他路径\n- 必须可从此服务器访问",
       "clientId": "## OAuth 客户端 ID\n来自您的 OAuth 应用程序配置的客户端 ID。\n\n- 在外部服务的开发者控制台中创建。\n- 用于在 OAuth 流程中识别您的应用程序。\n- 可以安全地在配置文件中共享。",
       "clientSecret": "## OAuth 客户端密钥\n来自您的 OAuth 应用程序配置的客户端密钥。\n\n- 与客户端 ID 一起创建\n- 必须保密且安全\n- 用于验证您的应用程序",
       "personalAccessToken": "## 个人访问令牌\n具有访问外部服务相应权限的个人访问令牌。\n\n- 在您的帐户设置中生成\n- 应具有读写权限\n- 比密码验证更安全",
@@ -6222,11 +6225,11 @@
       "instanceUrl": "## 实例 URL\n自托管实例的基本 URL。\n\n- 格式：https://git.example.com\n- 请勿包含尾部斜杠或路径\n- 必须可从此服务器访问",
       "projectPath": "## 项目路径\nGitLab 项目的完整路径。\n\n- 格式：命名空间/项目 或 组/子组/项目\n- 例如：my-org/my-project\n- 可在项目 URL 中找到：gitlab.com/namespace/project",
       "platform": "## 平台\n您正在连接的自托管 Git 平台。\n\n- **Gitea**：基于 gitea.io 的实例\n- **Forgejo**：基于 forgejo.org 的实例（Gitea 的分支）\n- **Gogs**：基于 gogs.io 的实例\n\n此设置控制显示的图标，并可能影响 API 兼容性。",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "redmineApiKey": "## Redmine API 密钥\n您的个人 REST API 访问密钥。\n\n- 在“管理”→“设置”→“API”下启用 REST API\n- 从“我的账户”→“API 访问密钥”复制您的密钥\n- 权限范围限定于您用户的权限；共享集成请使用服务账户",
+      "redmineUrl": "## Redmine URL\n您的 Redmine 实例的基本 URL。\n\n- 格式：https://redmine.example.com\n- 请勿包含 /issues 或其他路径\n- 必须可从此服务器访问",
+      "mantisBTApiKey": "## MantisBT API 令牌\n您的个人 REST API 令牌。\n\n- 在您的 MantisBT 账户设置 →“API 令牌”下创建一个\n- 权限范围限定于您用户的权限；共享集成请使用服务账户",
+      "mantisBTUrl": "## MantisBT URL\n您的 MantisBT 实例的基本 URL。\n\n- 格式：https://mantisbt.example.com\n- 请勿包含 /api/rest 或其他路径\n- 必须可从此服务器访问",
+      "githubBaseUrl": "## API 基础 URL\nGitHub Enterprise Server 的完整 GitHub API 根目录。\n\n- 通常以 /api/v3 结尾\n- 留空则使用 api.github.com\n- 必须可从此服务器访问"
     },
     "config": {
       "name": "## 配置名称\n此配置的清晰、描述性名称。\n\n- 有助于描述构成配置的变体组合（例如“Chrome，Windows 10”、“Safari/macOS 15.5”、“Edge/Windows 11”等）。",
@@ -6716,7 +6719,7 @@
       "addDimension": "添加维度……",
       "addMetric": "添加指标……",
       "runReport": "运行报告",
-      "exportCsv": "Export CSV",
+      "exportCsv": "导出 CSV 文件",
       "noResultsFound": "未找到结果。",
       "selectAtLeastOneDimensionAndMetric": "至少选择一个维度和一个指标。",
       "noDataMatchingCriteria": "未找到与所选维度和指标匹配的数据。",
@@ -6957,7 +6960,7 @@
         },
         "heuristic": {
           "intro": "此项目未配置 LLM 集成，因此排名直接基于选择策略指标构建。请配置 LLM 集成（管理 → AI 模型），以启用更丰富的推理，将自定义字段、关联问题上下文和案例内容与指标一起纳入考量。",
-          "rankedSummary": "{ranked} of {totalEligible} eligible manual cases ranked.",
+          "rankedSummary": "已对 {totalEligible} 个符合条件的手动案例中的 {ranked} 个进行排名。",
           "strategyExplanation": {
             "most_executed": "案例按手动执行次数排序（从高到低）——这是回归频率的代理指标，自动化可以直接节省最多的测试人员时间。",
             "flakiest_first": "案例按大致的不稳定性（通过/失败翻转）排序——不稳定的手动测试是确定性自动化预言机的最佳候选对象。",
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}米",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours} 小时 {minutes} 分钟"
           },
           "relativeAge": {
             "today": "今天",
@@ -7373,7 +7376,7 @@
       "verifying": "正在核实……",
       "errors": {
         "emptyPassword": "请输入密码",
-        "tooManyAttempts": "Too many failed attempts. Please try again later{resetAt, select, null {} other { at {resetAt}}}.",
+        "tooManyAttempts": "尝试次数过多。请稍后重试{resetAt, select, null {} other { ，时间为 {resetAt}}}。",
         "genericError": "发生错误，请重试。"
       },
       "attempts": {
@@ -7441,7 +7444,7 @@
         "selectedFile": "选定文件",
         "delimiter": "字段分隔符",
         "delimiters": {
-          "tab": "Tab (\\t)"
+          "tab": "制表符 (\\t)"
         },
         "hasHeaders": "第一行包含列标题。",
         "encoding": "文件编码",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "搜索",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "已保存的搜索",
+      "save": "保存搜索",
+      "saveTitle": "保存搜索",
+      "saveDescription": "为此搜索命名，以便日后重新查看。",
+      "saveAction": "保存",
+      "nameLabel": "名称",
+      "namePlaceholder": "例如：本次冲刺中失败的运行",
+      "nameRequired": "请输入此搜索的名称。",
+      "loginRequired": "您必须登录后才能保存搜索。",
       "descriptionLabel": "描述（可选）",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
+      "descriptionPlaceholder": "此搜索的用途",
+      "saved": "搜索已保存",
+      "savedDescription": "“{name}”现已加入您已保存的搜索。",
+      "saveFailed": "无法保存搜索，请重试。",
+      "empty": "暂无已保存的搜索",
+      "emptyHint": "保存一个搜索以便日后重新查看。",
+      "loaded": "已加载“{name}”",
+      "loadFailed": "此已保存的搜索已失效。",
+      "edit": "编辑",
+      "editTitle": "编辑已保存的搜索",
+      "edited": "已保存的搜索已更新",
+      "editFailed": "无法更新搜索，请重试。",
       "delete": "删除",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "deleteTitle": "删除已保存的搜索？",
+      "deleteConfirm": "“{name}”将从您已保存的搜索中移除。此操作无法撤销。",
+      "deleted": "已保存的搜索已删除",
+      "deleteFailed": "无法删除搜索，请重试。"
     },
     "bulk": {
       "crossProjectHint": "（涉及多个项目）",
@@ -7697,14 +7700,14 @@
       "intro": "点击下方按钮登录：",
       "signInButton": "登入",
       "copyPasteIntro": "或者复制此链接并粘贴到浏览器中：",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "为了您的安全，此链接只能使用一次。如需再次登录，请申请新链接。",
       "disclaimer": "如果您没有请求收到这封邮件，您可以忽略它。",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "登录 TestPlanIt\n\n点击下方链接登录：\n{url}\n\n为了您的安全，此链接只能使用一次。如需再次登录，请申请新链接。\n\n如果您没有请求此邮件，可以放心忽略它。"
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "正在其他设备上打开吗？请在您请求该链接的登录界面上输入以下验证码：",
+      "deviceNotice": "此链接会在您请求它的浏览器中为您登录。如果您在其他地方打开它，系统将显示上方的验证码，供您在原始窗口中输入。",
+      "textBody": "登录 TestPlanIt\n\n点击下方链接登录：\n{url}\n\n正在其他设备上打开吗？请在您请求该链接的登录界面上输入以下验证码：{code}\n\n如果您没有请求此邮件，可以放心忽略它。"
     }
   },
   "comments": {
@@ -7777,7 +7780,7 @@
       "newTagsPopoverTitle": "要创建的新标签",
       "applying": "正在申请……",
       "applySuccess": "{tagCount, plural, one {# 标签} other {# 标签}} 应用于 {entityCount, plural, one {# 实体} other {# 实体集}}",
-      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}, {newCount, plural, one {# new tag} other {# new tags}} created",
+      "applySuccessNewTags": "{tagCount, plural, other {# 个标签}} 已应用于 {entityCount, plural, other {# 个实体}}，创建了 {newCount, plural, other {# 个新标签}}",
       "applyError": "标签应用失败，请重试。",
       "suggestedTags": "建议标签",
       "noSuggestions": "人工智能无法生成任何标签。",
@@ -7807,7 +7810,7 @@
     },
     "wizard": {
       "description": "AI 将分析您整个项目的测试用例、测试运行和会话，并根据其内容建议相关的标签。",
-      "entityLine": "{count, number} {type}",
+      "entityLine": "{count, number} 个{type}",
       "startAnalysis": "开始分析",
       "untaggedOnly": "仅分析没有现有标签的记录",
       "allowNewTags": "允许创建新标签",
@@ -7999,7 +8002,7 @@
     "chipClickToReveal": "点击显示",
     "chipCopyValue": "复制价值",
     "chipCopyAriaLabel": "将 {label} 的值复制到剪贴板",
-    "chipCopiedToast": "Copied @{label} to clipboard",
+    "chipCopiedToast": "已将 @{label} 复制到剪贴板",
     "chipCopyFailedToast": "无法将 @{label} 复制到剪贴板",
     "iterationResultPanelHeading": "提交第 {n} 次迭代的结果，该迭代是 {total} 次迭代的结果。",
     "iterationAddResult": "添加结果",
@@ -8080,7 +8083,7 @@
     "iterationBulkConfirmDescription": "每个选定的迭代都会收到一个状态为“{statusName}”的新结果。",
     "iterationBulkConfirm": "马克 {action}",
     "iterationBulkConfirmReplace": "替换为 {action}",
-    "iterationBulkOverwriteWarning": "{count, plural, =1 {# of the selected iterations already has} other {# of the selected iterations already have}} a result. A new result will be recorded and the latest will replace the current one.",
+    "iterationBulkOverwriteWarning": "{count, plural, =1 {# 个所选迭代已有} other {# 个所选迭代已有}}结果。将记录一个新结果，最新结果将替换当前结果。",
     "iterationBulkReasonLabel": "原因（可选）",
     "iterationBulkReasonHelp": "记录在每项结果中。",
     "iterationBulkSuccess": "{count, plural, =1 {# 迭代次数} other {# 迭代次数}} 已标记 {action}",
@@ -8090,7 +8093,7 @@
     "iterationResetUntestedMissing": "未测试状态未找到",
     "overrideTitle": "覆盖迭代 {n} 的值",
     "overrideDescription": "更改仅影响本次迭代。数据集快照和源数据集保持不变。此操作已记录在审计日志中。",
-    "overrideValidationItem": "@{param}: {message}",
+    "overrideValidationItem": "@{param}：{message}",
     "overrideSensitiveDenied": "您没有权限编辑敏感值。",
     "datasetSourceLocal": "当地的",
     "datasetSourceShared": "共享",

--- a/testplanit/messages/zh-TW.json
+++ b/testplanit/messages/zh-TW.json
@@ -13,10 +13,10 @@
     "file": "文件",
     "selectMultiple": "選擇多個...",
     "searchUsers": "搜尋用戶...",
-    "searchCases": "{count, plural, =0 {Search cases} one {Search # case} other {Search # cases}}",
-    "searchProjects": "{count, plural, =0 {Search projects} one {Search # project} other {Search # projects}}",
+    "searchCases": "{count, plural, =0 {搜尋案例} other {搜尋 # 個案例}}",
+    "searchProjects": "{count, plural, =0 {搜尋專案} other {搜尋 # 個專案}}",
     "searchTags": "搜尋標籤...",
-    "searchRuns": "{count, plural, =0 {Search test runs} one {Search # test run} other {Search # test runs}}",
+    "searchRuns": "{count, plural, =0 {搜尋測試執行} other {搜尋 # 個測試執行}}",
     "searchSessions": "{count, plural, =0 {搜尋會話數} one {搜尋會話數} other {搜尋會話數}}",
     "search": "搜尋...",
     "defaultOption": "預設選項",
@@ -742,20 +742,20 @@
       "editToModifyCases": "編輯測試運行，然後按一下「選定的測試案例」來修改清單。",
       "noTestCasesSelected": "未選擇任何測試用例",
       "editToSelectTestCases": "編輯測試運行以選擇測試案例。",
-      "casesInRun": "{count, plural, =0 {No Test Cases in the Test Run} =1 {1 Test Case in the Test Run} other {# Test Cases in the Test Run}}",
-      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 Unique Case} other {# Unique Cases}} across {configCount, plural, =1 {1 Configuration} other {# Configurations}} ({totalCount, number} total cases)",
+      "casesInRun": "{count, plural, =0 {測試執行中沒有測試案例} =1 {測試執行中有 1 個測試案例} other {測試執行中有 # 個測試案例}}",
+      "casesInRunMultiConfig": "{uniqueCount, plural, =1 {1 個唯一案例} other {# 個唯一案例}}，跨 {configCount, plural, =1 {1 個設定} other {# 個設定}}（共 {totalCount, number} 個案例）",
       "viewTestRunDetails": "查看測試運行詳情",
       "sortByStatus": "按狀態分組",
       "sortByDate": "按日期排序",
-      "testRuns": "{count, plural, =0 {No Test Runs} =1 {1 Test Run} other {# Test Runs}}",
-      "sessions": "{count, plural, =0 {No Sessions} =1 {1 Session} other {# Sessions}}",
+      "testRuns": "{count, plural, =0 {沒有測試執行} =1 {1 個測試執行} other {# 個測試執行}}",
+      "sessions": "{count, plural, =0 {沒有工作階段} =1 {1 個工作階段} other {# 個工作階段}}",
       "noOptions": "暫無選項",
       "multiConfiguration": "屬於多配置組",
       "otherConfigurations": "其他配置",
       "selected": "已選擇： {count}",
       "defaultProjectAccess": "預設項目存取權限",
       "defaultAccessType": "預設存取類型",
-      "assignedUsersCount": "{count, plural, =0 {No Users Assigned} =1 {# User Assigned} other {# Users Assigned}}",
+      "assignedUsersCount": "{count, plural, =0 {未指派使用者} =1 {已指派 # 位使用者} other {已指派 # 位使用者}}",
       "successRate": "成功率",
       "unassigned": "未分配",
       "testRunName": "測試運行名稱",
@@ -1072,7 +1072,7 @@
         "apple": "繼續使用 Apple",
         "microsoft": "繼續使用 Microsoft",
         "samlProvider": "使用 {name} 登入",
-        "magicLink": "Sign in with single-use Magic Link",
+        "magicLink": "使用單次 Magic Link 登入",
         "emailLogin": "繼續透過電子郵件"
       },
       "magicLink": {
@@ -1086,16 +1086,19 @@
         "backToSignIn": "返回登入頁面"
       },
       "passwordless": {
-        "waitingInstructions": "Click the link in the email to sign in from this browser, or enter the code from the email below.",
-        "codeLabel": "Sign-in code",
-        "verifyCode": "Verify code",
-        "verifying": "Verifying...",
-        "invalidCode": "That code isn't right. Check the email and try again.",
-        "codeExpired": "This sign-in request has expired. Request a new link.",
-        "tooManyAttempts": "Too many incorrect attempts. Request a new link to try again.",
-        "windowLost": "This window can no longer complete the sign-in. Request a new link.",
-        "genericError": "We couldn't sign you in. Request a new link and try again.",
-        "tooManyRequests": "Too many sign-in requests. Please wait a moment and try again."
+        "waitingInstructions": "點按電子郵件中的連結以從此瀏覽器登入，或於下方輸入電子郵件中的代碼。",
+        "codeLabel": "登入代碼",
+        "verifyCode": "驗證代碼",
+        "verifying": "正在驗證……",
+        "invalidCode": "該代碼不正確。請檢查電子郵件並再試一次。",
+        "codeExpired": "此登入請求已過期。請申請新的連結。",
+        "tooManyAttempts": "錯誤嘗試次數過多。請申請新的連結以再試一次。",
+        "windowLost": "此視窗已無法完成登入。請申請新的連結。",
+        "genericError": "我們無法讓您登入。請申請新的連結並再試一次。",
+        "tooManyRequests": "登入請求過多。請稍候片刻再試一次。",
+        "haveCode": "已經有登入代碼了嗎？",
+        "codeEntryDescription": "請輸入您登入電子郵件中的代碼。代碼僅在您申請連結時所使用的瀏覽器中有效。",
+        "backToRequest": "改為申請新的連結"
       },
       "twoFactor": {
         "title": "雙重身份驗證",
@@ -1105,19 +1108,19 @@
       "contactAdmin": "請聯絡系統管理員"
     },
     "passwordless": {
-      "completingSignIn": "Signing you in...",
-      "completeErrorTitle": "We couldn't sign you in",
-      "requestNewLink": "Request a new link",
-      "codeTitle": "Your sign-in code",
-      "codeInstructions": "You opened the sign-in link on a different device or browser. Enter this code on the sign-in screen where you originally requested it.",
-      "codeCloseNotice": "You can close this window once you've entered the code.",
-      "expiredTitle": "This sign-in link is no longer valid",
-      "expiredBody": "The link may have expired or already been used. Request a new one from the sign-in page — it only takes a moment."
+      "completingSignIn": "正在為您登入……",
+      "completeErrorTitle": "我們無法讓您登入",
+      "requestNewLink": "申請新的連結",
+      "codeTitle": "您的登入代碼",
+      "codeInstructions": "您在不同的裝置或瀏覽器上開啟了登入連結。請在您最初申請的登入畫面上輸入此代碼。",
+      "codeCloseNotice": "輸入代碼後，您即可關閉此視窗。",
+      "expiredTitle": "此登入連結已失效",
+      "expiredBody": "此連結可能已過期或已被使用。請從登入頁面申請新的連結 — 這只需片刻。"
     },
     "errors": {
       "accessDenied": "訪問被拒絕。您的帳戶可能已停用或您沒有登入權限。",
       "configuration": "伺服器配置存在問題。",
-      "verification": "This sign-in link has expired or was already used. Magic links can only be used once — please request a new one to sign in.",
+      "verification": "此登入連結已過期或已被使用。Magic Link 只能使用一次 — 請重新申請以登入。",
       "invalid2FACode": "驗證碼無效，請重試。",
       "twoFactorTokenRequired": "需要令牌",
       "verificationCodeRequired": "需要驗證碼"
@@ -1364,19 +1367,19 @@
           "switchWarning2": "保留資料庫中的問題（它們將不再關聯）",
           "switchWarning3": "將當前問題整合配置替換為新的配置。",
           "switchWarning4": "移除為目前整合配置的入站 Webhook",
-          "importIssues": "Import Issues",
-          "importTitle": "Import issues from {name}",
-          "importDescription": "Pull issues from this linked project into your project. Existing issues aren't duplicated, and imported issues stay up to date through sync.",
-          "importUpdatedWithin": "Updated within",
-          "importLastDays": "Last {days} days",
-          "importMax": "Maximum to import",
-          "importPreview": "Preview",
-          "importPreviewResult": "~{count, plural, one {# issue} other {# issues}} match this filter. Up to {cap} will be imported.",
-          "importOverCap": "That exceeds the cap of {cap}; only the {cap} most recently updated will be imported.",
-          "importStart": "Import",
-          "importStarted": "Import started. Issues will appear shortly.",
-          "importFailed": "Import failed",
-          "importPreviewFailed": "Couldn't estimate matches"
+          "importIssues": "匯入問題",
+          "importTitle": "從 {name} 匯入問題",
+          "importDescription": "將此已連結專案中的問題拉入您的專案。現有問題不會重複，已匯入的問題將透過同步保持最新。",
+          "importUpdatedWithin": "更新於",
+          "importLastDays": "過去 {days} 天",
+          "importMax": "最多匯入數量",
+          "importPreview": "預覽",
+          "importPreviewResult": "~{count, plural, other {# 個問題}} 符合此篩選條件。最多將匯入 {cap} 個。",
+          "importOverCap": "已超過 {cap} 的上限；僅會匯入最近更新的 {cap} 個。",
+          "importStart": "匯入",
+          "importStarted": "匯入已開始。問題將很快顯示。",
+          "importFailed": "匯入失敗",
+          "importPreviewFailed": "無法估算符合項目"
         },
         "integrationAssigned": "整合任務已成功分配",
         "integrationAssignError": "未能將問題整合分配給項目",
@@ -1402,10 +1405,10 @@
             "description": "連接到 Azure DevOps 以追蹤工作項目。"
           },
           "redmine": {
-            "description": "Connect to a self-hosted Redmine instance for issue tracking."
+            "description": "連接到自架的 Redmine 實例進行問題追蹤。"
           },
           "mantisbt": {
-            "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+            "description": "連接到自架的 MantisBT 實例進行問題追蹤。"
           }
         }
       },
@@ -1418,11 +1421,11 @@
         "inboundAddButtonAllConfigured": "入站適配器已配置完成。",
         "inboundAddButtonNoIntegration": "在新增入站 webhook 之前，請先為該專案指派一個問題整合。",
         "inboundEmptyWithIntegration": "未配置任何入站 Webhook。 <link>新增一個</link> 以接收來自您指派的問題整合的更新。",
-        "inboundEmptyNoIntegration": "An <link>Issue Integration</link> is required to receive inbound issue updates. Assign one to your project to get started.",
+        "inboundEmptyNoIntegration": "需要 <link>問題整合</link> 才能接收傳入的問題更新。請將其指派給您的專案以開始使用。",
         "deliveriesEmptyNoConfigs": "目前還沒有 webhook 發送——請在其他標籤頁上建立入站或出站 webhook 以開始接收它們。",
         "noConfig": "未配置 webhook",
         "createButton": "創建 webhook",
-        "url": "Webhook URL",
+        "url": "網路鉤子網址",
         "urlHelp": "將此 URL 貼到問題追蹤器的 webhook 設定中。",
         "secret": "Webhook 秘密",
         "secretHelp": "將此密鑰貼上到問題追蹤器的 webhook 配置中。",
@@ -1685,19 +1688,19 @@
         "toastReEnableSuccess": "Webhook 已重新啟用",
         "toastReEnableFailed": "重新啟用失敗： {error}",
         "inboundChooserRedmine": "Redmine",
-        "inboundRedmineTitle": "Redmine inbound webhook",
-        "inboundRedmineScopeHint": "The redmine_webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsRedmineStep1": "Install the redmine_webhook plugin on your Redmine server (Redmine has no built-in webhooks).",
-        "setupStepsRedmineStep2": "In your Redmine project, open Settings → Modules and enable Webhooks.",
-        "setupStepsRedmineStep3": "Open Settings → Webhooks, paste the URL above, and save.",
-        "setupStepsRedmineStep4": "Create or update an issue in Redmine; the linked issue’s status will sync here.",
+        "inboundRedmineTitle": "Redmine 入站 webhook",
+        "inboundRedmineScopeHint": "redmine_webhook 外掛程式不會對請求進行簽署，因此此 webhook URL 即為憑證 — 請將其視為機密，若已外洩則應輪換。",
+        "setupStepsRedmineStep1": "在您的 Redmine 伺服器上安裝 redmine_webhook 外掛程式（Redmine 沒有內建的 webhook）。",
+        "setupStepsRedmineStep2": "在您的 Redmine 專案中，開啟「設定」→「模組」並啟用 Webhooks。",
+        "setupStepsRedmineStep3": "開啟「設定」→「Webhooks」，貼上上方的 URL，然後儲存。",
+        "setupStepsRedmineStep4": "在 Redmine 中建立或更新問題；已連結問題的狀態將同步至此處。",
         "inboundChooserMantisbt": "MantisBT",
-        "inboundMantisbtTitle": "MantisBT inbound webhook",
-        "inboundMantisbtScopeHint": "A MantisBT webhook plugin does not sign requests, so this webhook URL is the credential — treat it as a secret and rotate it if exposed.",
-        "setupStepsMantisbtStep1": "Install and enable a MantisBT webhook plugin on your MantisBT server (MantisBT has no built-in webhooks).",
-        "setupStepsMantisbtStep2": "In the plugin configuration, choose the issue created and issue updated events.",
-        "setupStepsMantisbtStep3": "Paste the URL above as the webhook target and save.",
-        "setupStepsMantisbtStep4": "Create or update an issue in MantisBT; the linked issue’s status will sync here."
+        "inboundMantisbtTitle": "MantisBT 入站 webhook",
+        "inboundMantisbtScopeHint": "MantisBT webhook 外掛程式不會對請求進行簽署，因此此 webhook URL 即為憑證 — 請將其視為機密，若已外洩則應輪換。",
+        "setupStepsMantisbtStep1": "在您的 MantisBT 伺服器上安裝並啟用 MantisBT webhook 外掛程式（MantisBT 沒有內建的 webhook）。",
+        "setupStepsMantisbtStep2": "在外掛程式設定中，選擇「問題建立」和「問題更新」事件。",
+        "setupStepsMantisbtStep3": "將上方的 URL 貼上作為 webhook 目標並儲存。",
+        "setupStepsMantisbtStep4": "在 MantisBT 中建立或更新問題；已連結問題的狀態將同步至此處。"
       },
       "aiModels": {
         "description": "配置人工智慧模型以實現智慧測試用例生成和分析",
@@ -1785,9 +1788,9 @@
           "actions": "行動"
         },
         "versionLabel": "v{version, number}",
-        "assignmentsCount": "{count, plural, =0 {0 cases} =1 {# case} other {# cases}}",
+        "assignmentsCount": "{count, plural, =0 {0 個案例} =1 {# 個案例} other {# 個案例}}",
         "rowsCount": "{count, plural, =0 {0 行} =1 {# 行} other {# 行}}",
-        "columnsCount": "{count, plural, =0 {0 columns} =1 {# column} other {# columns}}",
+        "columnsCount": "{count, plural, =0 {0 個欄} =1 {# 個欄} other {# 個欄}}",
         "actionsMenuLabel": "開啟資料集操作",
         "actionOpen": "開啟編輯器",
         "actionDelete": "刪除",
@@ -1817,7 +1820,7 @@
           "error": "無法刪除資料集"
         },
         "deleteSuccess": "已刪除“{name}”",
-        "deleteSuccessWithAssignments": "Deleted \"{name}\" and unassigned {count, plural, =1 {# case} other {# cases}}",
+        "deleteSuccessWithAssignments": "已刪除「{name}」並取消指派 {count, plural, =1 {# 個案例} other {# 個案例}}",
         "editor": {
           "back": "傳回資料集",
           "loadError": "無法載入此資料集",
@@ -1887,7 +1890,7 @@
           "scanningFiles": "正在掃描 {scope}… 中的文件",
           "scanningFilesCount": "正在掃描 {scope}… 中的檔案（已找到{count, number}）",
           "filtering": "對 {count, number} 個檔案套用篩選器…",
-          "rateLimited": "Rate limited by the provider — retrying in {seconds, number}s…"
+          "rateLimited": "被提供者限制速率 — 將在 {seconds, number} 秒後重試…"
         },
         "cache": {
           "title": "快取設定",
@@ -1913,8 +1916,8 @@
         "networkError": "快取刷新期間出現網路錯誤",
         "refreshSuccess": "快取已刷新： {fileCount} 個檔案（已快取{contentCached} 個內容）",
         "refreshRateLimited": "快取已刷新：列出了 {fileCount} 個文件，快取了 {contentCached}/{fileCount} 個內容（速率受限——請再次刷新以完成）",
-        "refreshComplete": "Cache refreshed: {fileCount} files",
-        "refreshInProgress": "Cache refresh is still running in the background. It'll update here when it finishes.",
+        "refreshComplete": "快取已重新整理：{fileCount} 個檔案",
+        "refreshInProgress": "快取重新整理仍在背景執行中。完成後將在此處更新。",
         "validation": {
           "pathRequired": "路徑是必需的",
           "patternRequired": "需要圖案",
@@ -1977,7 +1980,7 @@
           "enabledToast": "草稿案例將不計入運行次數。",
           "disabledToast": "現在可以將草稿案例新增到運行中。",
           "saveError": "更新草稿案例排除設定失敗",
-          "skippedToast": "{count, plural, =1 {1 draft case was skipped because it is in Not Started state} other {# draft cases were skipped because they are in Not Started state}}"
+          "skippedToast": "{count, plural, =1 {已跳過 1 個草稿案例，因其處於未開始狀態} other {已跳過 # 個草稿案例，因其處於未開始狀態}}"
         },
         "editWindow": {
           "label": "結果編輯視窗",
@@ -2011,7 +2014,7 @@
       "popoverNoTimestamp": "—",
       "filterStatus": "{count, plural, =0 {狀態} one {狀態 (#)} other {狀態 (#)}}",
       "filterConfig": "{count, plural, =0 {配置} one {配置 (#)} other {配置 (#)}}",
-      "filterDataset": "{count, plural, =0 {Dataset} one {Dataset (#)} other {Dataset (#)}}",
+      "filterDataset": "{count, plural, =0 {資料集} other {資料集 (#)}}",
       "filterStatusLabel": "地位",
       "filterConfigLabel": "配置",
       "filterDatasetLabel": "數據集",
@@ -2139,9 +2142,9 @@
   },
   "sessions": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this session."
+      "trigger": "活動",
+      "title": "活動日誌",
+      "description": "此工作階段的所有變更記錄。"
     },
     "title": "{count, plural, =1 {會話} other {會話}}",
     "labels": {
@@ -2278,7 +2281,7 @@
   "home": {
     "dashboard": {
       "title": "您的儀錶板",
-      "users": "There {count, plural, =1 {is # User} other {are # Users}}",
+      "users": "{count, plural, =1 {有 # 位使用者} other {有 # 位使用者}}",
       "yourProjects": "您的專案",
       "projects": "您有權存取 {count, plural, =1 {# 項目} other {# 項目集}}",
       "loading": "正在加載儀錶板...",
@@ -2286,7 +2289,7 @@
       "pendingRuns": "待測試運行",
       "activeSessions": "活躍會話",
       "yourActiveSessions": "{count, plural, =0 {無活動會話} =1 {活動會話數} other {活動會話數}}",
-      "yourPendingRuns": "{count, plural, =0 {No Pending Test Runs} =1 {# Active Test Run} other {# Active Test Runs}}",
+      "yourPendingRuns": "{count, plural, =0 {沒有待處理的測試執行} =1 {# 個活動測試執行} other {# 個活動測試執行}}",
       "yourAssignments": "你的作業",
       "totalTime": "預計總時間： ",
       "totalWorkEffort": "總工作量： ",
@@ -2315,10 +2318,10 @@
       "contact": "請聯絡您的專案管理員申請存取權限。"
     },
     "counts": {
-      "testCases": "{count, plural, =0 {# Test Cases} =1 {# Test Case} other {# Test Cases}}",
-      "activeMilestones": "{count, plural, =0 {# Active Milestones} =1 {# Active Milestone} other {# Active Milestones}}",
-      "activeRuns": "{count, plural, =0 {# Active Runs} =1 {# Active Run} other {# Active Runs}}",
-      "activeSessions": "{count, plural, =0 {# Active Sessions} =1 {# Active Session} other {# Active Sessions}}",
+      "testCases": "{count, plural, =0 {# 個測試案例} =1 {# 個測試案例} other {# 個測試案例}}",
+      "activeMilestones": "{count, plural, =0 {# 個活動里程碑} =1 {# 個活動里程碑} other {# 個活動里程碑}}",
+      "activeRuns": "{count, plural, =0 {# 個活動測試執行} =1 {# 個活動測試執行} other {# 個活動測試執行}}",
+      "activeSessions": "{count, plural, =0 {# 個活動工作階段} =1 {# 個活動工作階段} other {# 個活動工作階段}}",
       "issues": "{count, plural, =0 {# 問題} =1 {# 問題} other {# 問題}}"
     }
   },
@@ -2404,19 +2407,19 @@
         }
       },
       "auditLog": {
-        "title": "Audit Log",
-        "description": "Actions performed by this user",
-        "noEntries": "No activity recorded yet.",
-        "loadMore": "Loading",
-        "viewDetails": "View details",
-        "columnAction": "Action",
-        "columnEntityType": "Type",
-        "columnEntityName": "Name",
-        "columnTimestamp": "Timestamp",
-        "allActions": "All Actions",
-        "allTypes": "All Types",
-        "noMatchingEntries": "No entries match the selected filters.",
-        "showing": "{loaded} of {total} entries"
+        "title": "審計日誌",
+        "description": "此使用者執行的操作",
+        "noEntries": "尚無記錄的活動。",
+        "loadMore": "載入中",
+        "viewDetails": "查看詳情",
+        "columnAction": "操作",
+        "columnEntityType": "類型",
+        "columnEntityName": "名稱",
+        "columnTimestamp": "時間戳",
+        "allActions": "所有操作",
+        "allTypes": "所有類型",
+        "noMatchingEntries": "沒有符合所選篩選條件的項目。",
+        "showing": "{total} 個項目中的 {loaded} 個"
       },
       "mentionedComments": {
         "title": "評論中提到",
@@ -2510,9 +2513,9 @@
       "historyView": "測試用例歷史記錄視圖"
     },
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test case."
+      "trigger": "活動",
+      "title": "活動日誌",
+      "description": "此測試案例的所有變更記錄。"
     },
     "fields": {
       "optionNotFound": "未找到選項",
@@ -2570,16 +2573,16 @@
     },
     "templateNotAssignedWarning": "此測試案例使用了範本“{templateName}”，但該範本目前未指派給專案“{projectName}”。您可能需要將此範本指派給項目，或修改測試案例以使用其他範本。",
     "orphanedStepsWarning": "此測試案例包含步驟，但目前範本「{templateName}」不包含「步驟」欄位。在測試案例擁有包含「步驟」欄位的範本之前，無法編輯步驟。",
-    "orphanedFieldsWarning": "This test case has {count, plural, =1 {# field value} other {# field values}} that {count, plural, =1 {is} other {are}} not included in the current template \"{templateName}\". {count, plural, =1 {This field is} other {These fields are}} shown below but may not be editable until added to the template.",
+    "orphanedFieldsWarning": "此測試案例有 {count, plural, =1 {# 個欄位值} other {# 個欄位值}}，{count, plural, =1 {其} other {其}}未包含在目前範本「{templateName}」中。{count, plural, =1 {此欄位} other {這些欄位}}顯示如下，但可能要新增至範本後才能編輯。",
     "title": "測試用例庫",
     "folders": "資料夾",
     "showDescendants": "顯示所有後代",
     "addFolder": "新增資料夾",
     "emptyFolders": "點擊上方的「新增資料夾」按鈕，新增第一個資料夾。",
-    "selectedAllCases": "{count, plural, =0 {Selected all cases} one {Selected # case across all pages} other {Selected # cases across all pages}}",
+    "selectedAllCases": "{count, plural, =0 {已選取所有案例} other {已選取所有頁面中的 # 個案例}}",
     "deselectedAllCases": "已取消選擇所有頁面上的所有案例",
     "selectAllTooltip": "選取/取消選取此頁面上的所有案例",
-    "selectAllShiftTooltip": "{count, plural, =0 {Select/Deselect all cases across all pages} one {Select/Deselect # case across all pages} other {Select/Deselect # cases across all pages}}",
+    "selectAllShiftTooltip": "{count, plural, =0 {選取/取消選取所有頁面中的所有案例} other {選取/取消選取所有頁面中的 # 個案例}}",
     "deselectAllShiftTooltip": "取消選擇/選擇所有頁面上的所有案例",
     "shiftClickHint": "按住 Shift 鍵可選擇/取消選擇所有頁面",
     "treeView": {
@@ -2592,10 +2595,10 @@
       "copy": "複製",
       "promptTitle": "你想做什麼？",
       "copying": "正在複製…",
-      "copyComplete": "{count, plural, =1 {Copied 1 case to {folder}} other {Copied # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
-      "moveComplete": "{count, plural, =1 {Moved 1 case to {folder}} other {Moved # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
-      "copyError": "{count, plural, =1 {Failed to copy 1 case to {folder}} other {Failed to copy # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
-      "moveError": "{count, plural, =1 {Failed to move 1 case to {folder}} other {Failed to move # cases to {folder}}}{dest, select, samename {} crossProject { in {projectName}} other {}}",
+      "copyComplete": "{count, plural, =1 {已複製 1 個案例至 {folder}} other {已複製 # 個案例至 {folder}}}{dest, select, samename {} crossProject { ，位於 {projectName}} other {}}",
+      "moveComplete": "{count, plural, =1 {已移動 1 個案例至 {folder}} other {已移動 # 個案例至 {folder}}}{dest, select, samename {} crossProject { ，位於 {projectName}} other {}}",
+      "copyError": "{count, plural, =1 {複製 1 個案例至 {folder} 失敗} other {複製 # 個案例至 {folder} 失敗}}{dest, select, samename {} crossProject { ，位於 {projectName}} other {}}",
+      "moveError": "{count, plural, =1 {移動 1 個案例至 {folder} 失敗} other {移動 # 個案例至 {folder} 失敗}}{dest, select, samename {} crossProject { ，位於 {projectName}} other {}}",
       "copyAlreadyRunning": "另一份拷貝正在處理中，請稍候。",
       "currentSuffix": "（當前的）",
       "moveDisabledSameFolder": "案例已在此資料夾中",
@@ -2712,7 +2715,7 @@
           "showing": "顯示 {start, number}-{end, number} 共 {total, number} 個案",
           "case": "案例 {number, number}",
           "multiRow": {
-            "aggregated": "Multi-row mode grouped {rows, number} CSV rows into {cases, plural, one {# test case} other {# test cases}}.",
+            "aggregated": "多行模式已將 {rows, number} 個 CSV 行分組為 {cases, plural, other {# 個測試案例}}。",
             "noStepColumn": "已啟用多行模式，但未偵測到步驟列。預期列類型為：步驟內容、步驟、步驟、操作、描述（不區分大小寫）。每個 CSV 行將作為單獨的測試案例匯入。",
             "noKeyColumn": "已啟用多行模式，但未對應 ID 或名稱列。請在上一步對應 ID 或名稱列，以便將行分組到案例中。",
             "noGrouping": "已啟用多行模式，但未對任何行進行分組。每行都有不同的 ID/名稱，因此每一行都將成為單獨的測試案例。對於後續行，請將 ID 和名稱留空，或在屬於相同測試案例的行中重複使用相同的 ID/名稱。"
@@ -2752,7 +2755,7 @@
       "activeRunWarningMessage": "此測試案例屬於 {count, plural, =1 {# 活動測試運行} other {# 活動測試運行}}。刪除它會將這些運行標記為已刪除。"
     },
     "deleteFolder": {
-      "confirmMessage": "{count, plural, =0 {Deleting this folder will also delete all subfolders. Are you sure?} one {Deleting this folder will also delete 1 test case in this folder and all subfolders. Are you sure?} other {Deleting this folder will also delete # test cases in this folder and all subfolders. Are you sure?}}",
+      "confirmMessage": "{count, plural, =0 {刪除此資料夾也將刪除所有子資料夾。您確定嗎？} other {刪除此資料夾也將刪除此資料夾及所有子資料夾中的 # 個測試案例。您確定嗎？}}",
       "warning": "此資料夾及其所有測試案例將從專案中移除。這些測試案例的歷史資料（包括結果）仍將保留在專案中。",
       "confirm": "確認刪除資料夾",
       "success": "資料夾及其所有子資料夾/案例已成功刪除。"
@@ -2917,7 +2920,7 @@
       "retryScan": "重試掃描",
       "analyzing": "{analyzed, number}/{total, number}",
       "aiAnalyzing": "利用人工智慧提升成果…",
-      "scanComplete": "Duplicate analysis complete — {count, plural, =0 {no duplicates found} one {# potential duplicate found} other {# potential duplicates found}}",
+      "scanComplete": "重複項目分析完成 — {count, plural, =0 {未找到重複項目} other {找到 # 個潛在重複項目}}",
       "scanFailed": "重複分析失敗",
       "scanFailedDescription": "發生意外錯誤",
       "pageTitle": "重複候選人",
@@ -2945,7 +2948,7 @@
       "bulkLinkSuccess": "{count, plural, one {# 配對連結} other {# 配對連結}}",
       "bulkError": "部分操作失敗，請重試。",
       "tableHint": "點選行或“比較”按鈕，查看並解決重複項。",
-      "comparisonTitle": "{caseA} vs {caseB}",
+      "comparisonTitle": "{caseA} 對比 {caseB}",
       "comparisonDescription": "比較這些潛在的重複項，並選擇如何解決它們。",
       "selectPrimary": "點擊案例即可選為主合併案例。",
       "selectedAsPrimary": "選為主要",
@@ -2955,7 +2958,7 @@
       "merging": "合併中…",
       "linking": "正在連接…",
       "dismissing": "解僱…",
-      "mergeSuccess": "Cases merged successfully. {runsTransferred, plural, =0 {No test runs transferred} one {# test run transferred} other {# test runs transferred}}.",
+      "mergeSuccess": "案例合併成功。{runsTransferred, plural, =0 {沒有轉移測試執行} other {已轉移 # 個測試執行}}。",
       "linkSuccess": "關聯案例。",
       "dismissSuccess": "該對嫌疑人已被排除。它不會出現在以後的掃描結果中。",
       "resolveError": "解析重複鍵值對失敗，請重試。",
@@ -2973,7 +2976,7 @@
       "duplicateWarningDescription": "{count, plural, one {# 現有案例} other {# 現有案例}} 可能涵蓋類似功能",
       "duplicateWarningReview": "審查",
       "importWarning": "可能重複",
-      "importWarningTooltip": "This case name is similar to {count, plural, one {# existing case} other {# existing cases}}: {names}",
+      "importWarningTooltip": "此案例名稱與 {count, plural, other {# 個現有案例}} 相似：{names}",
       "importIntraWarning": "導入過程中出現重複項",
       "importIntraWarningTooltip": "此匯入中的行 {rows} 具有相同或非常相似的名稱",
       "checkingDuplicates": "正在檢查重複…"
@@ -3010,7 +3013,7 @@
         "saveDocument": "儲存文件要求",
         "fromUrl": "來自 URL",
         "recentGenerations": "最近的從 URL 產生測試案例的作業",
-        "recentJobInfo": "{pages, plural, one {# page} other {# pages}}{hasTestCases, select, true { · {testCases, plural, one {# test case} other {# test cases}}} other {}}",
+        "recentJobInfo": "{pages, plural, other {# 頁}}{hasTestCases, select, true { · {testCases, plural, other {# 個測試案例}}} other {}}",
         "recentJobHasResults": "準備審核",
         "recentJobClickToGenerate": "點擊產生測試用例",
         "recentJobCrawling": "正在爬取... {pages, plural, one {# 頁數} other {# 頁數}} 目前為止",
@@ -3050,7 +3053,7 @@
         "title": "添加備註和指導",
         "description": "提供更多背景資訊和指導，以幫助人工智慧產生更好的測試案例。",
         "quantity": "要產生的測試用例數量",
-        "placeholder": "Add specific instructions for test case generation...\n\nFor example:\n• Focus on security testing\n• Include edge cases and boundary conditions\n• Test both happy path and error scenarios\n• Consider mobile and desktop scenarios\n• Focus on API testing",
+        "placeholder": "新增測試案例生成的具體指示...\n\n例如：\n• 專注於安全性測試\n• 包含邊緣案例與邊界條件\n• 測試正常路徑與錯誤情境\n• 考慮行動裝置與桌面情境\n• 專注於 API 測試",
         "suggestions": "快速建議：",
         "quantityOptions": {
           "justOne": "只有一個",
@@ -3079,12 +3082,12 @@
         "crawledUrls": "{count, plural, one {# 已抓取頁數} other {# 已抓取頁數}}",
         "spaWarning": "此頁面可能需要 JavaScript 渲染。結果可能不完整。",
         "filterByPage": "按頁面篩選",
-        "allPages": "All pages ({pages, plural, one {# page} other {# pages}}, {cases, plural, one {# case} other {# cases}})"
+        "allPages": "所有頁面（{pages, plural, other {# 頁}}，{cases, plural, other {# 個案例}}）"
       },
       "generatingLegacy": "利用人工智慧產生測試用例…",
       "expandProgress": "{done, number} 的 {total, number} 生成",
-      "import": "{count, plural, =0 {Import Test Cases} =1 {Import 1 Test Case} other {Import # Test Cases}}",
-      "importing": "{count, plural, =0 {Importing Test Cases...} =1 {Importing 1 Test Case...} other {Importing # Test Cases...}}",
+      "import": "{count, plural, =0 {匯入測試案例} =1 {匯入 1 個測試案例} other {匯入 # 個測試案例}}",
+      "importing": "{count, plural, =0 {正在匯入測試案例……} =1 {正在匯入 1 個測試案例……} other {正在匯入 # 個測試案例……}}",
       "openInExternalSystem": "開啟方式 {provider}",
       "externalSystem": "外部系統",
       "autoGenerateTags": "自動為測試用例產生標籤",
@@ -3199,7 +3202,7 @@
         "discardAndImport": "放棄編輯並導入"
       },
       "linkedIssuesDroppedTitle": "部分相關問題未包含在內。",
-      "linkedIssuesDropped": "{count, plural, =1 {# linked issue was dropped} other {# linked issues were dropped}} due to token budget: {keys}.",
+      "linkedIssuesDropped": "{count, plural, =1 {# 個連結問題已被捨棄} other {# 個連結問題已被捨棄}}，原因是權杖預算限制：{keys}。",
       "linkedIssuesPreviewHeading": "將會包含的相關問題"
     }
   },
@@ -3252,7 +3255,7 @@
   },
   "reviews": {
     "banner": {
-      "pendingMessage": "Review requested from <assignee></assignee> for transition <fromState></fromState> → <toState></toState> <ago></ago>",
+      "pendingMessage": "已向 <assignee></assignee> 請求審核，用於轉換 <fromState></fromState> → <toState></toState> <ago></ago>",
       "changesRequestedTitle": "請求更改",
       "rejectedTitle": "審查被拒絕",
       "requestAgain": "再次請求復審",
@@ -3273,12 +3276,12 @@
       "gatedOptionBadge": "需要審核",
       "gatedStatesNotSelectable": "建立時無法選擇位於或超出限制狀態的狀態。請選擇第一個限制狀態之前的狀態，然後使用「請求審核」功能跨越該限制。",
       "saveBlockedByFormErrors": "儲存前請解決高亮顯示的表單錯誤。",
-      "bulkBlockedSummary": "{count, plural, one {# case} other {# cases}} blocked by gate \"{gateName}\": {sampleNames}{more, plural, =0 {} other {, and # more}}. Each blocked case needs an approved review for \"{gateName}\" before this transition.",
+      "bulkBlockedSummary": "{count, plural, other {# 個案例}} 被關卡「{gateName}」阻擋：{sampleNames}{more, plural, =0 {} other {，以及另外 # 個}}。每個被阻擋的案例在此轉換前都需要通過「{gateName}」的已核准審核。",
       "toastReviewRequired": "此變更需經批准後方可生效。請申請審核，待審核通過後再試。",
       "toastPendingReviewExists": "此次變更申請已進入審核階段。請等待審核結果，或在重試前取消申請。"
     },
     "inbox": {
-      "iconAria": "{count, plural, =0 {Review inbox} one {Review inbox, # pending} other {Review inbox, # pending}}",
+      "iconAria": "{count, plural, =0 {審核收件箱} other {審核收件箱，# 個待處理}}",
       "pageTitle": "評論",
       "pageDescription": "指派給您的待審核請求（直接指派給您或透過您所擔任的角色指派給您）。",
       "pageDescriptionDecided": "審核您已決定的請求。",
@@ -3338,13 +3341,13 @@
       "requestChanges": "請求更改",
       "reject": "拒絕",
       "approveConfirmTitle": "批准此審核請求？",
-      "approveConfirmDescription": "Approving will permit <requester></requester> to transition <name></name> to <state></state>.",
+      "approveConfirmDescription": "核准將允許 <requester></requester> 將 <name></name> 轉換為 <state></state>。",
       "approvalNoteLabel": "批准說明",
       "approvalNotePlaceholder": "可為請求者新增選用備註（顯示在核准資訊旁）。",
       "requestChangesDescription": "在您批准此變更之前，請告知請求者需要更改哪些內容。",
       "requestChangesCommentPlaceholder": "解釋需要做出哪些改變。",
       "rejectTitle": "拒絕此審核請求？",
-      "rejectDescription": "Rejecting blocks <requester></requester> from transitioning <name></name> to <state></state>. A new review request must be created to retry.",
+      "rejectDescription": "拒絕將阻止 <requester></requester> 將 <name></name> 轉換為 <state></state>。必須建立新的審核請求才能重試。",
       "rejectCommentPlaceholder": "請解釋您拒絕此請求的原因。",
       "commentLabel": "評論",
       "confirmRequestChanges": "傳送",
@@ -3359,9 +3362,9 @@
   },
   "runs": {
     "auditLog": {
-      "trigger": "Activity",
-      "title": "Activity Log",
-      "description": "All changes recorded for this test run."
+      "trigger": "活動",
+      "title": "活動日誌",
+      "description": "此測試執行的所有變更記錄。"
     },
     "notFound": "未找到測試運行。",
     "add": {
@@ -3370,7 +3373,7 @@
       "success": {
         "title": "測試運行已成功添加",
         "description": "{name} 已加入專案中",
-        "descriptionMultiple": "{count, plural, one {# test run has} other {# test runs have}} been created for {name}"
+        "descriptionMultiple": "已為 {name} 建立 {count, plural, other {# 個測試執行}}"
       },
       "estimates": {
         "manual": "預計人工時間",
@@ -3391,7 +3394,7 @@
       "configure": {
         "title": "測試用例範圍",
         "description": "在倉庫中找到 {count, plural, =1 {# 測試案例} other {# 測試案例}}",
-        "descriptionFiltered": "Found {count, plural, =1 {# possibly relevant test case} other {# possibly relevant test cases}} from {total, plural, =1 {# total} other {# total}} in the repository",
+        "descriptionFiltered": "在儲存庫中找到 {count, plural, =1 {# 個可能相關的測試案例} other {# 個可能相關的測試案例}}，共 {total, plural, =1 {# 個} other {# 個}}",
         "noMatchesTitle": "未找到符合的測試案例",
         "noMatchesDescription": "測試運行名稱和描述與任何測試案例都不符。請返回上一步，添加更具體的詳細信息，例如功能名稱、組件名稱或測試案例中出現的關鍵字。",
         "maxResultsTitle": "最大測試案例匹配數",
@@ -3583,7 +3586,7 @@
           "discoveringDatasets": "發現數據集…",
           "scanningFile": "正在掃描 testmo 匯出檔案...",
           "datasetsProcessed": "{processed, number} 資料集{processed, plural, one {} other {s}} 已處理",
-          "datasetsProcessedWithTotal": "{processed, number} of {total, number} dataset{total, plural, one {} other {s}} processed",
+          "datasetsProcessedWithTotal": "已處理 {processed, number}/{total, number} 個資料集{total, plural, other {}}",
           "rowsProcessed": "{value, number} 行已處理",
           "itemsProcessed": "已處理 {processed, number} 項中的 {total, number} 項",
           "analysisInProgress": "分析導出…",
@@ -3701,9 +3704,9 @@
         "mappingDatasetEmptyDescription": "分析過程中未保留任何用於配置的資料集。如果您需要其他數據，請上傳其他匯出檔案。",
         "importProgressTitle": "導入進度",
         "importProgressDescription": "{count, plural, =0 {所有已匯入的記錄（涵蓋所有追蹤實體）。} =1 {已匯入的記錄（涵蓋所有追蹤實體）共 1 個。} other {已匯入的記錄（涵蓋所有追蹤實體）共 7 個。}}",
-        "importProgressTotalRemaining": "{count, plural, =0 {No remaining records} =1 {1 record remaining} other {# records remaining}}",
+        "importProgressTotalRemaining": "{count, plural, =0 {沒有剩餘記錄} =1 {剩餘 1 筆記錄} other {剩餘 # 筆記錄}}",
         "importProgressProcessed": "{processed, number}/{total, number} 記錄已匯入",
-        "importProgressAria": "{percent, number}% of import complete",
+        "importProgressAria": "匯入已完成 {percent, number}%",
         "importProgressPercentLabel": "{percent, number}%",
         "importDurationLabel": "總耗時：",
         "activityLogTitle": "進口活動",
@@ -4022,7 +4025,7 @@
         "defaultAccessUpdateFailed": "更新預設存取等級失敗",
         "emailVerificationEnabled": "新用戶現在需要進行電子郵件驗證。",
         "emailVerificationDisabled": "新用戶不再需要進行電子郵件驗證。",
-        "emailVerificationDisabledAndVerified": "Email verification disabled and {count, plural, one {# user account} other {# user accounts}} verified",
+        "emailVerificationDisabledAndVerified": "已停用電子郵件驗證，並驗證了 {count, plural, other {# 個使用者帳戶}}",
         "emailVerificationUpdateFailed": "電子郵件驗證設定更新失敗",
         "emailServerNotConfigured": "無法啟用電子郵件驗證：電子郵件伺服器未配置",
         "openRegistrationEnabled": "自助註冊功能現已啟用。",
@@ -4363,7 +4366,7 @@
           "fileExtension": "例如，.spec.ts",
           "language": "例如，TypeScript",
           "headerBody": "可選。內容會在頂部渲染一次（例如，導入語句）。",
-          "templateBody": "Enter Mustache template...\n\nAvailable variables:\n'{{name}}', '{{id}}', '{{folder}}', '{{state}}', '{{estimate}}', '{{automated}}', '{{tags}}', '{{createdBy}}', '{{createdAt}}'\n\nSteps section:\n'{{#steps}}{{order}}', '{{step}}', '{{expectedResult}}{{/steps}}'\n\nCustom fields:\n'{{fields.fieldSystemName}}'",
+          "templateBody": "輸入 Mustache 範本...\n\n可用變數：\n'{{name}}'、'{{id}}'、'{{folder}}'、'{{state}}'、'{{estimate}}'、'{{automated}}'、'{{tags}}'、'{{createdBy}}'、'{{createdAt}}'\n\n步驟區段：\n'{{#steps}}{{order}}'、'{{step}}'、'{{expectedResult}}{{/steps}}'\n\n自訂欄位：\n'{{fields.fieldSystemName}}'",
           "footerBody": "可選。內容在底部渲染一次（例如，結束程式碼）。"
         },
         "combobox": {
@@ -4443,9 +4446,9 @@
       "scimColumnYes": "是的",
       "scimUserLockedTitle": "使用者由 SCIM 管理",
       "scimUserLockedDescription": "該使用者的姓名、電子郵件地址和活動狀態由您的身分提供者管理。請在身分提供者處進行更改，以在此處更新這些資訊。",
-      "groupMappingOverrideTitle": "Managed by Group Mapping",
-      "groupMappingOverrideDescription": "This user's access tier is governed by a SCIM group mapping and may be reverted on the next sync.",
-      "groupMappingBadge": "Group Mapped"
+      "groupMappingOverrideTitle": "由群組對應管理",
+      "groupMappingOverrideDescription": "此使用者的存取層級由 SCIM 群組對應管理，可能會在下次同步時被還原。",
+      "groupMappingBadge": "群組已對應"
     },
     "security": {
       "title": "安全",
@@ -4624,14 +4627,14 @@
       "probe": {
         "button": "測試 SCIM",
         "testing": "測試…",
-        "okBanner": "HTTP {status} — token works against /api/scim/v2/Users.",
+        "okBanner": "HTTP {status} — 權杖對 /api/scim/v2/Users 有效。",
         "failBanner": "HTTP {status} — {reason}",
         "networkError": "無法連接到SCIM端點。請重試。"
       },
-      "fallbackDefaultTitle": "Default Mapped Access",
-      "fallbackDefaultDescription": "Access tier assigned to users not covered by any group mapping.",
-      "fallbackDefaultLabel": "Default access tier",
-      "fallbackDefaultSaved": "Fallback default saved"
+      "fallbackDefaultTitle": "預設對應存取",
+      "fallbackDefaultDescription": "指派給未被任何群組對應涵蓋的使用者的存取層級。",
+      "fallbackDefaultLabel": "預設存取層級",
+      "fallbackDefaultSaved": "後備預設值已儲存"
     },
     "tags": {
       "add": {
@@ -4821,7 +4824,7 @@
       "filterPlaceholder": "過濾器配置...",
       "allProjects": "所有項目",
       "selectAllTooltip": "選取/取消選取此頁面上的所有配置",
-      "selectAllShiftTooltip": "{count, plural, =0 {Select/Deselect all configurations across all pages} one {Select/Deselect # configuration across all pages} other {Select/Deselect # configurations across all pages}}",
+      "selectAllShiftTooltip": "{count, plural, =0 {選取/取消選取所有頁面中的所有設定} other {選取/取消選取所有頁面中的 # 個設定}}",
       "deselectAllShiftTooltip": "取消選擇/選擇所有頁面上的所有配置",
       "shiftClickHint": "按住 Shift 鍵可選擇/取消選擇所有頁面",
       "bulkEdit": {
@@ -4830,8 +4833,8 @@
         "description": "取代所選配置中的項目分配。配置名稱無法批次編輯。",
         "applyButton": "{count, plural, one {應用於 1 個配置} other {應用於 # 個配置}}",
         "deleteButton": "{count, plural, one {刪除 1 個設定} other {刪除 # 個設定}}",
-        "deleteConfirmTitle": "{count, plural, one {Delete 1 configuration?} other {Delete # configurations?}}",
-        "deleteConfirmMessage": "{count, plural, one {This will delete 1 configuration. This action cannot be undone.} other {This will delete # configurations. This action cannot be undone.}}",
+        "deleteConfirmTitle": "{count, plural, other {刪除 # 個設定？}}",
+        "deleteConfirmMessage": "{count, plural, other {這將刪除 # 個設定。此操作無法復原。}}",
         "applyEnabledLabel": "更改已啟用狀態"
       },
       "categories": {
@@ -4857,7 +4860,7 @@
       "combinations": {
         "title": "組合",
         "description": "管理全域組合",
-        "confirmDescription": "The following {count, number} Configurations will be created:",
+        "confirmDescription": "將建立以下 {count, number} 個設定：",
         "addCombination": "新增組合",
         "editCombination": "編輯組合",
         "selectCombination": "選擇組合",
@@ -4916,14 +4919,14 @@
       "scimManagedTooltip": "由SCIM管理。請從SCIM管理頁面進行管理。",
       "scimNameLockedTitle": "集團由SCIM管理",
       "scimNameLockedDescription": "此群組的名稱和成員由您的身分提供者管理。請在身分提供者處進行更改，以在此處更新。",
-      "mappedAccessColumnHeader": "Mapped Access",
-      "mappedAccessLabel": "Mapped Access Tier",
-      "mappedAccessNone": "No mapping",
-      "mappedAccessSelect": "Select access tier...",
-      "downgradeConfirmTitle": "Confirm Access Change",
-      "downgradeConfirmDescription": "{count, plural, one {# user} other {# users}} would have their access lowered. Continue?",
-      "downgradeConfirmApplyAnyway": "Apply anyway",
-      "downgradeConfirmUserRow": "{name}: {from} → {to}",
+      "mappedAccessColumnHeader": "對應存取",
+      "mappedAccessLabel": "對應存取層級",
+      "mappedAccessNone": "無對應",
+      "mappedAccessSelect": "選擇存取層級……",
+      "downgradeConfirmTitle": "確認存取變更",
+      "downgradeConfirmDescription": "{count, plural, other {# 位使用者}} 的存取權限將被降低。是否繼續？",
+      "downgradeConfirmApplyAnyway": "仍要套用",
+      "downgradeConfirmUserRow": "{name}：{from} → {to}",
       "downgradeConfirmAccessChange": "{from} → {to}"
     },
     "milestones": {
@@ -4935,7 +4938,7 @@
       "warning": "此里程碑類型將會新增至所有項目。",
       "wizard": {
         "selectProjects": "選擇項目",
-        "projectsSelected": "{count, plural, =0 {No projects selected} one {# project selected} other {# projects selected}}",
+        "projectsSelected": "{count, plural, =0 {未選擇專案} other {已選擇 # 個專案}}",
         "createMilestone": "創建里程碑",
         "noCommonTypesTitle": "沒有常見的里程碑類型",
         "noCommonTypesDescription": "所選項目之間沒有任何共同的里程碑類型。請確保所有選定項目至少有一個共同的里程碑類型，或選擇其他項目。"
@@ -5111,27 +5114,27 @@
       "status": {
         "active": "積極的",
         "inactive": "非活躍狀態",
-        "awaitingAuthorization": "Awaiting authorization"
+        "awaitingAuthorization": "等待授權"
       },
       "connectedProjects": "關聯項目",
       "noIntegrations": "未配置任何問題集成",
       "testConnection": "測試連接",
       "testSuccess": "連線成功",
       "testSuccessDescription": "問題集成已正確配置並連接",
-      "testCredentialsSaved": "Credentials look good",
-      "testCredentialsSavedDescription": "Your OAuth client ID and secret are valid. Save the integration, then click Authorize to connect your account — OAuth 2.0 connects per user, so it stays inactive until at least one person authorizes.",
+      "testCredentialsSaved": "憑證看起來沒問題",
+      "testCredentialsSavedDescription": "您的 OAuth 客戶端 ID 和密鑰有效。請儲存整合，然後點按「授權」以連接您的帳戶 — OAuth 2.0 是按使用者連接的，因此在至少有一人授權之前，此整合將保持未啟用狀態。",
       "testFailed": "連線失敗",
       "testFailedDescription": "無法連線到外部服務",
       "testError": "測試錯誤",
       "testErrorDescription": "測試連線時發生錯誤",
-      "authorize": "Authorize",
-      "reauthorize": "Re-authorize",
-      "authorizeHint": "Authorize with the provider to connect your account and finish setup",
-      "syncInProgress": "Re-syncing linked issues...",
-      "syncIntegration": "Re-sync linked issues",
-      "syncIntegrationHint": "Only re-syncs issues already linked in TestPlanIt. New issues aren't imported from the external tracker.",
+      "authorize": "授權",
+      "reauthorize": "重新授權",
+      "authorizeHint": "向提供者授權以連接您的帳戶並完成設定",
+      "syncInProgress": "正在重新同步已連結的問題……",
+      "syncIntegration": "重新同步已連結的問題",
+      "syncIntegrationHint": "僅重新同步已在 TestPlanIt 中連結的問題。新問題不會從外部追蹤系統匯入。",
       "syncSuccess": "同步已排隊",
-      "syncSuccessDescription": "Linked issues from \"{name}\" are being re-synced in the background. This may take a few moments. The table will update automatically when complete.",
+      "syncSuccessDescription": "來自「{name}」的已連結問題正在背景中重新同步。這可能需要一些時間。完成後表格將自動更新。",
       "syncError": "同步失敗",
       "syncErrorDescription": "無法為此整合問題新增同步任務。請稍後重試。",
       "delete": {
@@ -5178,11 +5181,11 @@
         },
         "redmine": {
           "name": "Redmine",
-          "description": "Connect to a self-hosted Redmine instance for issue tracking"
+          "description": "連接到自架的 Redmine 實例以進行問題追蹤"
         },
         "mantisbt": {
           "name": "MantisBT",
-          "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+          "description": "連接到自架的 MantisBT 實例以進行問題追蹤"
         }
       },
       "filterPlaceholder": "過濾器整合…",
@@ -5211,7 +5214,7 @@
         "apiToken": "API令牌",
         "apiTokenPlaceholder": "請輸入您的 API 令牌",
         "apiTokenHelp": "從您的帳戶設定中產生 API 令牌",
-        "jiraUrl": "Jira URL",
+        "jiraUrl": "Jira 網址",
         "jiraUrlPlaceholder": "https://your-site.atlassian.net",
         "jiraUrlHelp": "您的 Jira 實例的 URL",
         "clientId": "客戶ID",
@@ -5220,10 +5223,10 @@
         "clientSecret": "客戶機密",
         "clientSecretPlaceholder": "請輸入您的 OAuth 用戶端金鑰",
         "clientSecretHelp": "來自您的 OAuth 應用程式的用戶端金鑰",
-        "cloudId": "Cloud ID",
+        "cloudId": "雲端 ID",
         "cloudIdPlaceholder": "請輸入您的 Atlassian 雲端 ID",
         "cloudIdHelp": "您的 Atlassian Cloud 實例 ID（可在您的 Jira URL 中找到）",
-        "apiUrl": "API URL",
+        "apiUrl": "API 網址",
         "apiUrlPlaceholder": "https://api.example.com",
         "apiUrlHelp": "服務 API 的基本 URL",
         "personalAccessTokenPlaceholder": "請輸入您的個人存取令牌",
@@ -5263,10 +5266,10 @@
         "apiKeyWarningPoint4": "請改用 OAuth 2.0，以便在沒有管理員權限的情況下準確地按使用者進行報告者歸屬。",
         "tokenCreatorNoticeTitle": "問題創建者歸屬",
         "tokenCreatorNoticeDescription": "透過此整合建立的問題始終記錄為擁有此存取權杖的帳戶，而不是建立問題的 TestPlanIt 使用者。此提供者的 API 不允許代表其他使用者設定創建者。",
-        "callbackUrlLabel": "Callback URL (redirect URI)",
-        "callbackUrlDescription": "Register this exact URL as the callback / redirect URI in your provider's OAuth app. It must match precisely or authorization will fail.",
-        "callbackUrlCopy": "Copy",
-        "callbackUrlCopied": "Copied",
+        "callbackUrlLabel": "回呼 URL（重新導向 URI）",
+        "callbackUrlDescription": "請在您提供者的 OAuth 應用程式中，將此確切的 URL 註冊為回呼／重新導向 URI。必須完全相符，否則授權將失敗。",
+        "callbackUrlCopy": "複製",
+        "callbackUrlCopied": "已複製",
         "forgeApiKeyLabel": "Forge API 金鑰",
         "forgeApiKeyDescription": "Atlassian Forge 應用程式使用此金鑰來驗證來自 Jira 問題面板的請求。請在此處產生金鑰並將其貼到 Forge 應用程式設定中。",
         "forgeApiKeyPlaceholder": "點選「產生」按鈕建立 API 金鑰",
@@ -5278,18 +5281,18 @@
         "platformGitea": "吉特亞",
         "platformForgejo": "福爾熱",
         "platformGogs": "戈格斯",
-        "redmineApiKey": "Redmine API Key",
-        "redmineApiKeyPlaceholder": "Enter your Redmine API key",
-        "redmineApiKeyHelp": "Found under My account → API access key (enable the REST API in Administration → Settings → API)",
+        "redmineApiKey": "Redmine API 金鑰",
+        "redmineApiKeyPlaceholder": "請輸入您的 Redmine API 金鑰",
+        "redmineApiKeyHelp": "位於「我的帳戶」→「API 存取金鑰」下（請在「管理」→「設定」→「API」中啟用 REST API）",
         "redmineUrl": "Redmine URL",
         "redmineUrlPlaceholder": "https://redmine.example.com",
-        "redmineUrlHelp": "The base URL of your Redmine instance",
-        "mantisBTApiKey": "MantisBT API Token",
-        "mantisBTApiKeyPlaceholder": "Enter your MantisBT API token",
-        "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
+        "redmineUrlHelp": "您的 Redmine 實例的基本 URL",
+        "mantisBTApiKey": "MantisBT API 權杖",
+        "mantisBTApiKeyPlaceholder": "請輸入您的 MantisBT API 權杖",
+        "mantisBTApiKeyHelp": "在您的 MantisBT 帳戶設定 →「API 權杖」下建立一個",
         "mantisBTUrl": "MantisBT URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "您的 MantisBT 實例的基本 URL"
       },
       "authType": {
         "api_key": "API金鑰",
@@ -5502,7 +5505,7 @@
         "generate_from_url": "根據 URL 產生測試案例（需求）",
         "generate_from_url_app": "從 URL 產生測試用例（應用程式測試）",
         "automation_candidates": "自動化候選報告",
-        "derive_case_steps": "AI Step Derivation"
+        "derive_case_steps": "AI 步驟推導"
       }
     },
     "elasticsearch": {
@@ -5569,7 +5572,7 @@
         "forecast-updates": "預測更新",
         "emails": "電子郵件佇列",
         "issue-sync": "問題同步",
-        "testmo-imports": "Testmo Imports",
+        "testmo-imports": "Testmo 匯入",
         "elasticsearch-reindex": "Elasticsearch 重新索引",
         "audit-logs": "審計日誌",
         "budget-alerts": "預算警報",
@@ -5678,15 +5681,15 @@
     },
     "auditLogs": {
       "description": "查看系統範圍內的審計跟踪，以進行安全性和合規性跟踪",
-      "projectDescription": "View the audit trail of actions performed in this project.",
+      "projectDescription": "查看此專案中執行操作的審計追蹤記錄。",
       "filterPlaceholder": "按實體、使用者或操作搜尋…",
       "filterAction": "行動",
       "filterEntityType": "實體類型",
       "allActions": "所有操作",
       "allEntityTypes": "所有實體類型",
-      "allUsers": "All Users",
-      "allProjects": "All Projects",
-      "showing": "Showing {loaded} of {total} entries",
+      "allUsers": "所有使用者",
+      "allProjects": "所有專案",
+      "showing": "顯示 {total} 個項目中的 {loaded} 個",
       "viewDetails": "看詳情",
       "detailTitle": "審計日誌詳情",
       "userInfo": "使用者資訊",
@@ -5714,8 +5717,8 @@
       "systemActor": "系統",
       "systemActorTooltip": "系統執行的操作，而非登入使用者執行的操作。",
       "sourceScim": "SCIM",
-      "relatedChanges": "related changes",
-      "groupedEntry": "Grouped changes from a single action"
+      "relatedChanges": "相關變更",
+      "groupedEntry": "來自單一操作的分組變更"
     }
   },
   "components": {
@@ -5783,7 +5786,7 @@
         "viewUserList": "查看使用者列表",
         "reviewGeneratedCases": "審查產生的測試用例",
         "generateFromUrlCompleteTitle": "頁面抓取成功",
-        "generateFromUrlCompleteMessage": "{pages, plural, one {# page} other {# pages}} crawled from {url} in project \"{projectName}\". Click to review and generate test cases.",
+        "generateFromUrlCompleteMessage": "已從 {url} 爬取 {pages, plural, other {# 頁}}，位於專案「{projectName}」中。按一下以檢閱並產生測試案例。",
         "generateFromUrlFailedTitle": "URL 抓取失敗",
         "reviewRequestedTitle": "請求審查",
         "reviewApprovedTitle": "審核已獲批准",
@@ -5802,16 +5805,16 @@
         "reviewCommentPreview": "評論： {comment}",
         "reviewRequestedEmailMessage": "{actorName} 請您審核項目「{projectName}」中的 {entityLabel} 「{entityName}」進行審核。",
         "reviewApprovedEmailMessage": "{actorName} 已批准您對 {entityLabel} \"{entityName}\" 的項目 \"{projectName} \" 的審核請求。",
-        "reviewChangesRequestedEmailMessage": "{actorName} requested changes on your review request for {entityLabel} \"{entityName}\" in project \"{projectName}\".",
-        "reviewRejectedEmailMessage": "{actorName} rejected your review request on {entityLabel} \"{entityName}\" in project \"{projectName}\".",
+        "reviewChangesRequestedEmailMessage": "{actorName} 對您在專案「{projectName}」中針對 {entityLabel}「{entityName}」的審核請求要求了變更。",
+        "reviewRejectedEmailMessage": "{actorName} 已拒絕您在專案「{projectName}」中針對 {entityLabel}「{entityName}」的審核請求。",
         "reviewCancelledEmailMessage": "{actorName} 取消了對 {entityLabel} \"{entityName}\" 在項目 \"{projectName} \" 中的審查請求。",
         "reviewReminderTitle": "審核仍在進行中",
         "reviewReminderAction": "仍在等待您的評論",
-        "reviewReminderEmailMessage": "Reminder: {actorName}'s review request on {entityLabel} \"{entityName}\" in project \"{projectName}\" has been pending for {hoursPending} hours.",
+        "reviewReminderEmailMessage": "提醒：{actorName} 在專案「{projectName}」中針對 {entityLabel}「{entityName}」的審核請求已待處理 {hoursPending} 小時。",
         "reviewReminderHoursPending": "等待 {hoursPending, plural, one {小時} other {小時}}",
-        "aiStepsDerivedTitle": "AI-Derived Test Steps Ready",
-        "aiStepsDerivedMessage": "{count, plural, one {# test case was} other {# test cases were}} given AI-derived steps — review for accuracy.",
-        "aiStepsDerivedReviewLink": "Review test run"
+        "aiStepsDerivedTitle": "AI 推導測試步驟已就緒",
+        "aiStepsDerivedMessage": "{count, plural, other {# 個測試案例}} 已獲得 AI 推導的步驟 — 請檢查其準確性。",
+        "aiStepsDerivedReviewLink": "檢查測試執行"
       }
     },
     "issues": {
@@ -6068,11 +6071,11 @@
   },
   "help": {
     "project": {
-      "name": "## Project Name\nThe unique identifier for your project.\n\n- Must be unique across all projects\n- Used in navigation and reports\n- Should be clear and descriptive\n- Helps team members identify the project scope",
-      "description": "## Project Description\nAdditional details about the project's purpose and scope.\n\n- Optional but recommended\n- Helps team members understand project goals\n- Can include key objectives or requirements\n- Limited to 256 characters",
-      "icon": "## Project Icon\nA visual identifier for your project.\n\n- Helps quickly identify the project in lists and dashboards\n- Choose from a variety of predefined icons\n- Can be changed at any time\n- Appears in project navigation and reports",
-      "completed": "## Project Status\nIndicates whether the project is active or completed.\n\n- Active projects are available for testing and updates\n- Completed projects are read-only\n- Affects project visibility in dashboards\n- Can be reversed if needed",
-      "completedAt": "## Completion Date\nThe date when the project was marked as completed.\n\n- Automatically set when marking a project as completed\n- Used for reporting and tracking\n- Helps maintain project history\n- Can be modified if needed",
+      "name": "## 專案名稱\n您專案的唯一識別碼。\n\n- 必須在所有專案中保持唯一\n- 用於導覽和報告\n- 應清晰且具描述性\n- 幫助團隊成員了解專案範圍",
+      "description": "## 專案描述\n有關專案目的和範圍的額外詳細資訊。\n\n- 非必填但建議填寫\n- 幫助團隊成員了解專案目標\n- 可包含主要目標或需求\n- 限制為 256 個字元",
+      "icon": "## 專案圖示\n您專案的視覺識別碼。\n\n- 幫助在清單和儀表板中快速識別專案\n- 從多種預定義圖示中選擇\n- 可隨時變更\n- 顯示於專案導覽和報告中",
+      "completed": "## 專案狀態\n表示專案是進行中還是已完成。\n\n- 進行中的專案可供測試和更新\n- 已完成的專案為唯讀\n- 影響專案在儀表板中的可見性\n- 如有需要可還原",
+      "completedAt": "## 完成日期\n專案被標記為已完成的日期。\n\n- 在將專案標記為已完成時自動設定\n- 用於報告和追蹤\n- 幫助維護專案歷史記錄\n- 如有需要可修改",
       "defaultAccess": "## 預設項目存取權限\n定義此項目中使用者和群組的預設存取權限。可以針對每個使用者或每個群組進行覆蓋。",
       "issueTracker": "## 問題追蹤器配置\n選擇用於管理與此項目相關的問題的追蹤器配置。"
     },
@@ -6091,19 +6094,19 @@
       "password": "## 密碼\n使用者帳號密碼。\n\n- 如果設定了無密碼登入方式（Magic Link SSO 提供者或電子郵件伺服器），則此項目為可選 — 留空則必須透過 Magic Link 或 SSO 登入。\n- 如果提供，則必須符合「管理 → 安全性」中設定的密碼策略（最小長度和字元類別）。\n- 用於安全帳戶存取。\n- 應保密。",
       "token": "## 驗證令牌\n輸入您在電子郵件中收到的令牌以驗證您的帳戶。如果您沒有令牌，可以申請一個新的。",
       "confirmPassword": "## 確認密碼\n請重新輸入密碼，並確保輸入正確。\n\n- 必須與密碼完全一致。\n- 有助於防止輸入錯誤。\n- 僅當輸入密碼時需要填寫 — 若密碼欄位為空，則留空。",
-      "access": "## System Access Level\nDetermines the user's system-wide permissions.\n\n- **Admin:** Full system access and configuration\n- **Project Admin:** Can manage assigned projects\n- **User:** Standard access to assigned projects\n- **None:** Can only view their dashboard",
+      "access": "## 系統存取層級\n決定使用者的系統範圍權限。\n\n- **管理員：** 完整的系統存取和設定權限\n- **專案管理員：** 可管理指派的專案\n- **使用者：** 對指派專案的標準存取權限\n- **無：** 僅可檢視其儀表板",
       "role": "## 系統角色\n此角色決定使用者的預設項目權限。\n\n- 定義項目的預設存取等級。\n- 可在角色管理中自訂。\n- 影響可用功能和權限。",
       "active": "## 活動狀態\n控制使用者是否可以存取系統。\n\n- 活動使用者可以登入並存取其指派的資源。\n- 非活動用戶無法登錄，但其資料將會保留。\n  - 使用此選項可暫時停用存取權限，而不會刪除帳戶。",
       "api": "## API 存取\n允許透過 API 端點以程式設計方式存取系統。\n\n- 允許與外部工具和自動化整合。\n- 需要 API 金鑰驗證。\n- 受速率限制和存取控制。",
       "projects": "## 項目分配\n選擇此使用者可以存取的項目。\n\n- 控制哪些項目顯示在使用者的儀表板中。\n- 專案參與的必要條件。\n- 管理者可以稍後修改。\n- 使用「全選」快速指派所有可用項目。",
       "groups": "## 分組分配\n選取此使用者所屬的群組。\n\n- 分組有助於組織使用者和權限。\n- 使用者繼承其所屬群組的權限。\n- 簡化存取管理。\n- 管理員稍後可以修改。",
-      "itemsPerPage": "## Items Per Page\nControls the default number of items shown in tables and lists.\n\n- Affects all paginated views in the application\n- Can be changed at any time\n- Helps manage large data sets efficiently\n- Available options: 10, 25, 50, or 100 items",
-      "dateFormat": "## Date Format\nSets your preferred date display format.\n\n- Applied consistently across the application\n- Helps ensure date interpretation accuracy\n- Changes take effect immediately\n- Examples shown in the dropdown reflect the actual format",
-      "timeFormat": "## Time Format\nSets your preferred time display format.\n\n- Choose between 12-hour and 24-hour formats\n- Applied consistently across the application\n- Changes take effect immediately\n- Examples shown in the dropdown reflect the actual format",
+      "itemsPerPage": "## 每頁項目數\n控制表格和清單中顯示的預設項目數量。\n\n- 影響應用程式中所有分頁檢視\n- 可隨時變更\n- 幫助有效管理大型資料集\n- 可用選項：10、25、50 或 100 個項目",
+      "dateFormat": "## 日期格式\n設定您偏好的日期顯示格式。\n\n- 一致套用於整個應用程式\n- 幫助確保日期解讀的準確性\n- 變更立即生效\n- 下拉式選單中顯示的範例反映實際格式",
+      "timeFormat": "## 時間格式\n設定您偏好的時間顯示格式。\n\n- 可選擇 12 小時制或 24 小時制\n- 一致套用於整個應用程式\n- 變更立即生效\n- 下拉式選單中顯示的範例反映實際格式",
       "timezone": "## 時區\n設定日期和時間顯示的首選時區。\n\n- 在整個應用程式中統一應用",
-      "theme": "## Theme\nChoose your preferred visual theme for the application.\n\n- **System:** Automatically matches your operating system theme\n- **Light:** Clean, bright interface for daytime use\n- **Dark:** Eye-friendly dark mode for low-light environments\n- **Green, Orange, Purple:** A fun pop of color!",
-      "locale": "## Language\nSelect your preferred language for the application interface.\n\n- Changes all text, labels, and messages to your chosen language\n- Date and time formats adjust to match regional conventions\n- Takes effect immediately without requiring a page refresh\n- Available languages depend on installed translations",
-      "notificationMode": "## Notification Preferences\nControls how you receive notifications for work assignments and updates.\n\n- **Use Global Settings:** Follow the system default set by administrators\n- **No Notifications:** Disable all notifications\n- **In-App Only:** Receive notifications only within the application\n- **In-App + Email (Immediate):** Get both in-app notifications and immediate email alerts\n- **In-App + Email (Daily Digest):** Get in-app notifications and a daily email summary\n\nYou can change this preference at any time to suit your workflow."
+      "theme": "## 佈景主題\n選擇您偏好的應用程式視覺佈景主題。\n\n- **系統：** 自動符合您的作業系統佈景主題\n- **淺色：** 適合日間使用的簡潔明亮介面\n- **深色：** 適合低光環境的護眼深色模式\n- **綠色、橙色、紫色：** 有趣的色彩點綴！",
+      "locale": "## 語言\n選擇您偏好的應用程式介面語言。\n\n- 將所有文字、標籤和訊息變更為您選擇的語言\n- 日期和時間格式會調整以符合區域慣例\n- 立即生效，無需重新整理頁面\n- 可用語言取決於已安裝的翻譯",
+      "notificationMode": "## 通知偏好設定\n控制您如何接收工作指派和更新的通知。\n\n- **使用全域設定：** 遵循管理員設定的系統預設值\n- **無通知：** 停用所有通知\n- **僅應用程式內：** 僅在應用程式內接收通知\n- **應用程式內 + 電子郵件（即時）：** 同時取得應用程式內通知和即時電子郵件提醒\n- **應用程式內 + 電子郵件（每日摘要）：** 取得應用程式內通知和每日電子郵件摘要\n\n您可隨時變更此偏好設定以符合您的工作流程。"
     },
     "milestone": {
       "name": "## 里程碑名稱\n一個清晰、描述性的名稱，用於標識專案中的此里程碑。\n\n- 應具有唯一性和意義\n- 幫助團隊成員快速理解里程碑的目的\n- 用於報告和專案追蹤",
@@ -6125,8 +6128,8 @@
       "milestone": "## 里程碑\n將此會話與專案里程碑關聯。\n\n- 協助追蹤測試進度，以達成專案目標。\n- 將相關的測驗會話分組。\n- 支援基於里程碑的報告。",
       "description": "## 描述\n本測試內容的簡要概述。\n\n- 測試的關鍵領域或功能\n- 重要的背景資訊\n- 特殊注意事項或要求",
       "mission": "## 任務\n任務定義了本次測驗的具體目標和目的。\n\n- 你要測試什麼？\n- 重點在於哪些面向？\n- 預期結果是什麼？\n\n清晰的任務有助於維持測驗的專注性和高效率。",
-      "estimate": "## Time Estimate\nEstimated time to complete this testing session.\n\nExamples:\n- \"30m\" for 30 minutes\n- \"1h 30m\" for 1 hour and 30 minutes\n- \"2 days\" for 2 days\n- \"1 week\" for 1 week",
-      "elapsed": "## Elapsed Time\nThe actual time spent on this testing session.\n\nExamples:\n- \"45m\" for 45 minutes\n- \"2h 15m\" for 2 hours and 15 minutes\n- \"3 days\" for 3 days\n\nTrack time accurately to improve future estimates.",
+      "estimate": "## 預估時間\n完成此測試工作階段的預估時間。\n\n範例：\n- 「30m」代表 30 分鐘\n- 「1h 30m」代表 1 小時 30 分鐘\n- 「2 days」代表 2 天\n- 「1 week」代表 1 週",
+      "elapsed": "## 已用時間\n花費在此測試工作階段的實際時間。\n\n範例：\n- 「45m」代表 45 分鐘\n- 「2h 15m」代表 2 小時 15 分鐘\n- 「3 days」代表 3 天\n\n準確記錄時間以改善未來的預估。",
       "state": "## 工作流程狀態\n此測試工作階段在您工作流程中的目前狀態。\n\n- 幫助追蹤會話進度\n- 支援工作流程管理\n- 用於報告和追蹤",
       "assignedTo": "## 指派給\n負責執行本次測試的團隊成員。\n\n- 確定測試執行人\n- 協助資源管理\n- 支持問責和跟踪",
       "tags": "## 標籤\n用於對測試會話進行分類和組織的關鍵字或標籤。\n\n- 方便尋找會話\n- 將相關的測試活動分組\n- 支援篩選和報告",
@@ -6153,7 +6156,7 @@
       "value": "## 值\n此配置的值。"
     },
     "milestoneType": {
-      "icon": "## Milestone Type Icon\nA visual identifier for this milestone type.\n\n- Helps quickly identify the milestone type in lists and dashboards\n- Choose from a variety of predefined icons\n- Can be changed at any time\n- Appears in project navigation and reports",
+      "icon": "## 里程碑類型圖示\n此里程碑類型的視覺識別碼。\n\n- 幫助在清單和儀表板中快速識別里程碑類型\n- 從多種預定義圖示中選擇\n- 可隨時變更\n- 顯示於專案導覽和報告中",
       "name": "## 里程碑類型名稱\n一個清晰、描述性的名稱，用於標識專案中的此里程碑類型。\n\n- 幫助團隊成員快速理解里程碑類型的用途。\n- 用於報告和專案追蹤。",
       "isDefault": "## 預設里程碑類型\n指示此里程碑類型是否為專案的預設類型。\n\n- 預設里程碑類型已預先選擇，適用於新里程碑。\n- 可隨時變更。",
       "projects": "## 關聯項目\n選擇此里程碑類型將適用於哪些項目。\n\n- 如果未選擇任何項目，則里程碑類型將全域可用。\n- 指派給特定項目後，其使用範圍將僅限於這些項目。"
@@ -6175,7 +6178,7 @@
     "group": {
       "name": "## 群組名稱\n一個清晰、簡潔、描述性的名稱或關鍵字，用於所有項目。\n\n- 幫助團隊成員快速找到相關的測試案例、測試運行和會話。",
       "users": "## 使用者\n表示指派給此群組的使用者。",
-      "mappedAccess": "## Mapped Access Tier\nMembers of this group are granted at least this access tier on the next sync.\n\n- The highest tier across all of a user's groups wins\n- \"No mapping\" means this group does not affect access — members fall back to the default set on the SCIM page\n- A manual access change on a user takes over from the mapping (and is flagged on that user's edit screen)"
+      "mappedAccess": "## 對應存取層級\n此群組的成員在下次同步時將獲得至少此存取層級。\n\n- 使用者所有群組中最高的層級將優先套用\n- 「無對應」表示此群組不會影響存取權限 — 成員將退回至 SCIM 頁面上設定的預設值\n- 對使用者進行手動存取變更將取代對應設定（並會在該使用者的編輯畫面上標記）"
     },
     "template": {
       "name": "## 範本名稱\n此範本的唯一描述性名稱（例如，「標準測試案例」、「API 測試結果」）。",
@@ -6199,17 +6202,17 @@
       "costPerOutputToken": "## 每個輸出代幣的成本（美元）\n模型產生的每個輸出（完成）代幣的成本（以美元計）。\n\n- 通常高於輸入代幣的成本\n- 通常高於輸入代幣的成本 \n - 用於成本追蹤與預算提醒\n- 例如：`0.000015` = 每百萬個輸出代幣 155 美元",
       "monthlyBudget": "## 每月預算（美元）\n此整合的選用支出目標。\n\n- 設定為 `0` 可停用預算追蹤。\n- 預算僅供參考，不會影響 LLM 的使用。\n- 您將在達到預算的 80%、90% 和 100% 時收到通知。\n- 費用是根據上述每個代幣的價格計算。",
       "billingPeriodStartDay": "## 帳單週期起始日\n帳單週期開始的日期（1-31）。\n\n- 預設值 `1` 與日曆月一致。\n- 設定為 `15` 表示每月 15 日至 15 日的週期（例如，與您的供應商發票日期一致）。\n- 值 `29-31` 會自動鎖定到較短月份的最後一天（例如，非閏年的 2 月）。\n- 影響**月度預算**支出窗口和**重置支出**操作。",
-      "defaultTemperature": "## Default Temperature\nControls the randomness of model responses (0–2).\n\n- **0:** Deterministic — identical output for the same input\n- **0.3:** Focused — recommended for test generation and code output\n- **1+:** Creative — more varied responses\n- Individual features can override this in Prompt Config",
-      "timeout": "## Request Timeout (ms)\nHow long to wait for a response before the request is cancelled.\n\n- Value is in milliseconds (e.g. `30000` = 30 seconds)\n- Streaming requests (e.g. code export preview) ignore this timeout\n- Increase for slow or large models\n- Range: 5,000 – 600,000 ms",
+      "defaultTemperature": "## 預設溫度\n控制模型回應的隨機性（0–2）。\n\n- **0：**確定性——相同輸入產生相同輸出\n- **0.3：**聚焦——建議用於測試生成與程式碼輸出\n- **1+：**創意——回應更多樣化\n- 個別功能可在提示設定中覆寫此設定",
+      "timeout": "## 請求逾時（毫秒）\n在請求被取消前等待回應的時間。\n\n- 數值以毫秒為單位（例如 `30000` = 30 秒）\n- 串流請求（例如程式碼匯出預覽）會忽略此逾時設定\n- 若模型較慢或較大，可增加此數值\n- 範圍：5,000 – 600,000 毫秒",
       "streamingEnabled": "## 啟用串流\n逐一令牌地傳輸回應，而不是等待完整輸出。\n\n- 匯出模態方塊中即時程式碼預覽所必需。\n- 降低長時間反應的感知延遲。\n- 建議所有支援的供應商啟用。",
       "isDefault": "## 設定為預設整合\n將此整合設為所有 AI 功能的預設整合。\n\n- 一次只能有一個整合設定為預設整合。\n- 未配置特定提供者的功能將使用預設整合。\n- 可隨時變更。"
     },
     "integration": {
       "name": "## 整合名稱\n用於在整個系統中標識此整合的描述性名稱。\n\n- 必須唯一，以便與其他整合區分開來。\n- 用於專案設定與設定。\n- 應清楚地表明服務和用途。",
-      "authType": "## Authentication Type\nChoose how to authenticate with the external service.\n\n- **API Key:** Simple authentication using email and API token\n- **OAuth 2.0:** Secure authentication using OAuth flow\n- **Personal Access Token:** Direct token-based authentication",
+      "authType": "## 驗證類型\n選擇如何與外部服務進行驗證。\n\n- **API 金鑰：** 使用電子郵件和 API 權杖的簡單驗證\n- **OAuth 2.0：** 使用 OAuth 流程的安全驗證\n- **個人存取權杖：** 直接以權杖為基礎的驗證",
       "email": "## 電子郵件地址\n您的外部服務帳號電子郵件地址。\n\n- 用於 API 金鑰驗證\n- 必須與產生 API 令牌的帳戶匹配\n- Jira 和類似服務必需",
       "apiToken": "## API 令牌\n在外部服務的帳戶設定中產生 API 令牌。\n\n- 通常位於「帳號設定」→「安全性」→「API 令牌」中。\n- 提供安全訪問，無需暴露您的密碼。\n- 可依需要撤銷和重新產生。",
-      "jiraUrl": "## Jira URL\nThe base URL of your Jira instance.\n\n- Format: https://your-site.atlassian.net\n- Do not include /browse or other paths\n- Must be accessible from this server",
+      "jiraUrl": "## Jira URL\n您的 Jira 實例的基本 URL。\n\n- 格式：https://your-site.atlassian.net\n- 請勿包含 /browse 或其他路徑\n- 必須可從此伺服器存取",
       "clientId": "## OAuth 用戶端 ID\n來自您的 OAuth 應用程式設定的客戶端 ID。\n\n- 在外部服務的開發者控制台中建立。\n- 用於在 OAuth 流程中識別您的應用程式。\n- 可以安全地在設定檔中共用。",
       "clientSecret": "## OAuth 用戶端金鑰\n來自您的 OAuth 應用程式設定的用戶端金鑰。\n\n- 與客戶端 ID 一起建立\n- 必須保密且安全\n- 用於驗證您的應用程式",
       "personalAccessToken": "## 個人存取權杖\n具有存取外部服務對應權限的個人存取權令牌。\n\n- 在您的帳戶設定中產生\n- 應具有讀寫權限\n- 比密碼驗證更安全",
@@ -6221,12 +6224,12 @@
       "repo": "## 倉庫名稱\n要連結問題的倉庫名稱。\n\n- 確切的倉庫名稱（非完整 URL）\n- 例如：my-project\n- 必須可以使用提供的憑證存取。",
       "instanceUrl": "## 實例 URL\n自託管執行個體的基本 URL。\n\n- 格式：https://git.example.com\n- 請勿包含尾部斜線或路徑\n- 請勿從此伺服器存取",
       "projectPath": "## 專案路徑\nGitLab 專案的完整路徑。\n\n- 格式：命名空間/專案 或 群組/子群組/專案\n- 例如：my-org/my-project\n- 在專案中可找到專案可在專案.",
-      "platform": "## Platform\nThe self-hosted Git platform you are connecting to.\n\n- **Gitea**: gitea.io-based instances\n- **Forgejo**: forgejo.org-based instances (Gitea fork)\n- **Gogs**: gogs.io-based instances\n\nThis controls which icon is shown and may affect API compatibility.",
-      "redmineApiKey": "## Redmine API Key\nYour personal REST API access key.\n\n- Enable the REST API under Administration → Settings → API\n- Copy your key from My account → API access key\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
-      "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
-      "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
-      "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
+      "platform": "## 平台\n您正在連接的自架 Git 平台。\n\n- **Gitea**：基於 gitea.io 的執行個體\n- **Forgejo**：基於 forgejo.org 的執行個體（Gitea 的分支）\n- **Gogs**：基於 gogs.io 的執行個體\n\n這將控制顯示的圖示，並可能影響 API 相容性。",
+      "redmineApiKey": "## Redmine API 金鑰\n您的個人 REST API 存取金鑰。\n\n- 在「管理」→「設定」→「API」下啟用 REST API\n- 從「我的帳戶」→「API 存取金鑰」複製您的金鑰\n- 範圍限於您使用者的權限；共用整合請使用服務帳戶",
+      "redmineUrl": "## Redmine URL\n您的 Redmine 實例的基本 URL。\n\n- 格式：https://redmine.example.com\n- 請勿包含 /issues 或其他路徑\n- 必須可從此伺服器存取",
+      "mantisBTApiKey": "## MantisBT API 權杖\n您的個人 REST API 權杖。\n\n- 在您的 MantisBT 帳戶設定 →「API 權杖」下建立一個\n- 範圍限於您使用者的權限；共用整合請使用服務帳戶",
+      "mantisBTUrl": "## MantisBT URL\n您的 MantisBT 實例的基本 URL。\n\n- 格式：https://mantisbt.example.com\n- 請勿包含 /api/rest 或其他路徑\n- 必須可從此伺服器存取",
+      "githubBaseUrl": "## API 基本 URL\nGitHub Enterprise Server 的完整 GitHub API 根目錄。\n\n- 通常以 /api/v3 結尾\n- 留空則使用 api.github.com\n- 必須可從此伺服器存取"
     },
     "config": {
       "name": "## 設定名稱\n此組態的清晰、描述性名稱。\n\n- 有助於描述構成配置的變體組合（例如「Chrome，Windows 10」、「Safari/macOS 15.5」、「Edge/Windows 11」等）。",
@@ -6250,7 +6253,7 @@
     "issue": {
       "name": "## 問題名稱\n一個清晰、描述性的名稱，在所有項目中使用。\n\n- 有助於描述問題（例如「問題 123」、「錯誤 456」等）。",
       "title": "## 問題標題\n一個易於理解的標題，用來描述問題。\n\n- 提供問題相關的背景資訊。\n- 顯示在清單和問題展示中。\n- 應清晰明了且具描述性。",
-      "externalKey": "## External Key\nThe unique key or identifier from the external issue tracking system.\n\n- For JIRA: Issue key like \"PROJ-123\"\n- For GitHub: Issue number like \"456\"\n- For Azure DevOps: Work item ID\n- Automatically generates the external URL when saved",
+      "externalKey": "## 外部金鑰\n來自外部問題追蹤系統的唯一金鑰或識別碼。\n\n- 適用於 JIRA：問題金鑰，如「PROJ-123」\n- 適用於 GitHub：問題編號，如「456」\n- 適用於 Azure DevOps：工作項目 ID\n- 儲存時會自動產生外部 URL",
       "externalId": "## 外部 ID\n此問題在問題追蹤系統中的唯一識別碼（例如「Issue-123」、「Bug456」等）。\n\n- 這用作基本 URL 中的問題佔位符。",
       "description": "## 描述\n本期內容的簡要概述。\n\n- 正在測試的關鍵領域或功能\n- 重要的背景資訊\n- 特殊考慮或要求",
       "project": "## 項目\n此問題相關的項目。\n\n- 問題可以連結到多個專案的測試案例。\n- 設定主項目有助於組織問題。\n- 可以留空，表示跨專案問題。",
@@ -6279,7 +6282,7 @@
       "iconColor": "## 圖示/顏色\n此工作流程的圖示和顏色。",
       "name": "## 名稱\n一個清晰、描述性的名稱，用於所有項目。\n\n- 有助於描述工作流程（例如「草稿」、「審核中」、「進行中」等）。",
       "workflowType": "## 類型\n工作流程類型（未開始、進行中、已完成）。",
-      "type": "## Workflow Type\nThe category of workflow state (Not Started, In Progress, Completed).\n\n- Determines how this state affects progress tracking\n- Not Started states indicate work hasn't begun\n- In Progress states show active work\n- Completed states mark finished work",
+      "type": "## 工作流程類型\n工作流程狀態的類別（未開始、進行中、已完成）。\n\n- 決定此狀態如何影響進度追蹤\n- 「未開始」狀態表示工作尚未開始\n- 「進行中」狀態表示正在進行的工作\n- 「已完成」狀態表示已完成的工作",
       "isDefault": "## 預設值\n指示此工作流程是否為專案的預設工作流程。\n\n- 預設工作流程已預先選中，用於新的測試運行、會話和自動化。",
       "isEnabled": "## 已啟用\n指示此工作流程是否已啟用。",
       "isActive": "## 活動\n指示此工作流程狀態是否處於作用中且可供使用。\n\n- 更新測試運行、會話或自動化時，可以選擇活動工作流程。\n- 非活動工作流程將會隱藏，但會保留在現有項目中。",
@@ -6415,7 +6418,7 @@
     },
     "codeRepository": {
       "name": "## 儲存庫名稱\n此儲存庫連接的友善顯示名稱。\n\n- 用於在項目代碼上下文設定中標識它。\n- 不需要與提供者上的儲存庫名稱相符。",
-      "provider": "## Git Provider\nThe platform hosting this repository.\n\n- **GitHub** — github.com (cloud or Enterprise)\n- **GitLab** — gitlab.com or self-hosted\n- **Bitbucket Cloud** — bitbucket.org (cloud only)\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — self-hosted Git servers with compatible APIs",
+      "provider": "## Git 提供者\n此儲存庫所在的平台。\n\n- **GitHub** — github.com（雲端版或企業版）\n- **GitLab** — gitlab.com 或自架\n- **Bitbucket Cloud** — bitbucket.org（僅雲端版）\n- **Azure DevOps** — dev.azure.com\n- **Gitea / Forgejo / Gogs** — 具有相容 API 的自架 Git 伺服器",
       "githubToken": "## 個人存取令牌\n具有 **Contents: Read** 權限的 GitHub 令牌。\n\n在下列位置產生：GitHub → 個人資料設定 → 開發者設定 → 個人存取權令牌 → 細粒度令牌。",
       "owner": "## 所有者\n擁有該倉庫的 GitHub 組織或使用者帳戶。\n\n- 例如：`myorg` 或 `myusername`\n- 這是您在 github.com 上的倉庫 URL 中的第一個路徑段。",
       "repo": "## 倉庫\n倉庫名稱，不包含所有者前綴。\n\n- 例如：`my-repo`（而非 `myorg/my-repo`）\n- 這是您在 github.com 上的倉庫 URL 中的第二個路徑段。",
@@ -6716,7 +6719,7 @@
       "addDimension": "添加維度…",
       "addMetric": "添加指標…",
       "runReport": "運行報告",
-      "exportCsv": "Export CSV",
+      "exportCsv": "匯出 CSV",
       "noResultsFound": "未找到結果。",
       "selectAtLeastOneDimensionAndMetric": "至少選擇一個維度和一個指標。",
       "noDataMatchingCriteria": "未找到與所選維度和指標相符的資料。",
@@ -6957,7 +6960,7 @@
         },
         "heuristic": {
           "intro": "此項目未配置 LLM 集成，因此排名直接基於選擇策略指標建構。請配置 LLM 整合（管理 → AI 模型），以啟用更豐富的推理，將自訂欄位、關聯問題上下文和案例內容與指標一起納入考慮。",
-          "rankedSummary": "{ranked} of {totalEligible} eligible manual cases ranked.",
+          "rankedSummary": "已排名 {totalEligible} 個符合條件的手動案例中的 {ranked} 個。",
           "strategyExplanation": {
             "most_executed": "案例以手動執行次數排序（從高到低）－這是迴歸頻率的代理指標，自動化可以直接節省最多的測試人員時間。",
             "flakiest_first": "案例按大致的不穩定性（通過/失敗翻轉）排序——不穩定的手動測試是確定性自動化預言機的最佳候選對象。",
@@ -6987,7 +6990,7 @@
             "seconds": "{seconds}s",
             "minutes": "{minutes}米",
             "hours": "{hours}h",
-            "hoursAndMinutes": "{hours}h {minutes}m"
+            "hoursAndMinutes": "{hours} 小時 {minutes} 分"
           },
           "relativeAge": {
             "today": "今天",
@@ -7373,7 +7376,7 @@
       "verifying": "正在核實…",
       "errors": {
         "emptyPassword": "請輸入密碼",
-        "tooManyAttempts": "Too many failed attempts. Please try again later{resetAt, select, null {} other { at {resetAt}}}.",
+        "tooManyAttempts": "失敗次數過多。請稍後再試{resetAt, select, null {} other { 於 {resetAt}}}。",
         "genericError": "發生錯誤，請重試。"
       },
       "attempts": {
@@ -7441,7 +7444,7 @@
         "selectedFile": "已選文件",
         "delimiter": "字段分隔符",
         "delimiters": {
-          "tab": "Tab (\\t)"
+          "tab": "Tab（\\t）"
         },
         "hasHeaders": "第一行包含列標題。",
         "encoding": "文件編碼",
@@ -7525,33 +7528,33 @@
   "search": {
     "title": "搜尋",
     "savedSearches": {
-      "title": "Saved searches",
-      "save": "Save search",
-      "saveTitle": "Save search",
-      "saveDescription": "Name this search so you can revisit it later.",
-      "saveAction": "Save",
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. Failed runs this sprint",
-      "nameRequired": "Enter a name for this search.",
-      "loginRequired": "You must be signed in to save searches.",
+      "title": "已儲存的搜尋",
+      "save": "儲存搜尋",
+      "saveTitle": "儲存搜尋",
+      "saveDescription": "為此搜尋命名，以便日後重新查看。",
+      "saveAction": "儲存",
+      "nameLabel": "名稱",
+      "namePlaceholder": "例如：本次衝刺中失敗的測試執行",
+      "nameRequired": "請輸入此搜尋的名稱。",
+      "loginRequired": "您必須登入才能儲存搜尋。",
       "descriptionLabel": "描述（可選）",
-      "descriptionPlaceholder": "What this search is for",
-      "saved": "Search saved",
-      "savedDescription": "“{name}” is now in your saved searches.",
-      "saveFailed": "Couldn't save the search. Please try again.",
-      "empty": "No saved searches yet",
-      "emptyHint": "Save a search to revisit it later.",
-      "loaded": "Loaded “{name}”",
-      "loadFailed": "This saved search is no longer valid.",
-      "edit": "Edit",
-      "editTitle": "Edit saved search",
-      "edited": "Saved search updated",
-      "editFailed": "Couldn't update the search. Please try again.",
-      "delete": "Delete",
-      "deleteTitle": "Delete saved search?",
-      "deleteConfirm": "“{name}” will be removed from your saved searches. This can't be undone.",
-      "deleted": "Saved search deleted",
-      "deleteFailed": "Couldn't delete the search. Please try again."
+      "descriptionPlaceholder": "此搜尋的用途",
+      "saved": "搜尋已儲存",
+      "savedDescription": "「{name}」已加入您已儲存的搜尋。",
+      "saveFailed": "無法儲存搜尋，請再試一次。",
+      "empty": "尚無已儲存的搜尋",
+      "emptyHint": "儲存搜尋以便日後重新查看。",
+      "loaded": "已載入「{name}」",
+      "loadFailed": "此已儲存的搜尋已失效。",
+      "edit": "編輯",
+      "editTitle": "編輯已儲存的搜尋",
+      "edited": "已儲存的搜尋已更新",
+      "editFailed": "無法更新搜尋，請再試一次。",
+      "delete": "刪除",
+      "deleteTitle": "刪除已儲存的搜尋？",
+      "deleteConfirm": "「{name}」將從您已儲存的搜尋中移除。此操作無法復原。",
+      "deleted": "已儲存的搜尋已刪除",
+      "deleteFailed": "無法刪除搜尋，請再試一次。"
     },
     "bulk": {
       "crossProjectHint": "（涉及多個項目）",
@@ -7627,7 +7630,7 @@
     "filters": {
       "title": "進階篩選器",
       "active": "過濾器已激活",
-      "activeCount": "{count, plural, =0 {No filters} one {# filter} other {# filters}} active",
+      "activeCount": "{count, plural, =0 {沒有篩選條件} other {# 個篩選條件}} 已啟用",
       "apply": "應用篩選條件",
       "common": "常用過濾器",
       "entitySpecific": "類型特定篩選器",
@@ -7697,14 +7700,14 @@
       "intro": "點擊下方按鈕登入：",
       "signInButton": "登入",
       "copyPasteIntro": "或複製此連結並貼上到瀏覽器中：",
-      "singleUseNotice": "For your security, this link can only be used once. Request a new link if you need to sign in again.",
+      "singleUseNotice": "為了您的安全，此連結只能使用一次。若您需要再次登入，請申請新的連結。",
       "disclaimer": "如果您沒有要求收到這封郵件，您可以忽略它。",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nFor your security, this link can only be used once. Request a new link if you need to sign in again.\n\nIf you did not request this email, you can safely ignore it."
+      "textBody": "登入 TestPlanIt\n\n請點按下方連結登入：\n{url}\n\n為了您的安全，此連結只能使用一次。若您需要再次登入，請申請新的連結。\n\n若您沒有申請此電子郵件，可以安心忽略。"
     },
     "passwordless": {
-      "codeIntro": "Opening this on a different device? Enter this code on the sign-in screen where you requested the link:",
-      "deviceNotice": "This link signs you in from the browser where you requested it. If you open it anywhere else, you'll be shown the code above to enter in your original window.",
-      "textBody": "Sign in to TestPlanIt\n\nClick the link below to sign in:\n{url}\n\nOpening this on a different device? Enter this code on the sign-in screen where you requested the link: {code}\n\nIf you did not request this email, you can safely ignore it."
+      "codeIntro": "在不同裝置上開啟此連結？請在您申請連結的登入畫面上輸入此代碼：",
+      "deviceNotice": "此連結會讓您從申請連結時所使用的瀏覽器登入。若您在其他地方開啟，將會顯示上方的代碼，供您在原始視窗中輸入。",
+      "textBody": "登入 TestPlanIt\n\n請點按下方連結登入：\n{url}\n\n在不同裝置上開啟此連結？請在您申請連結的登入畫面上輸入此代碼：{code}\n\n若您沒有申請此電子郵件，可以安心忽略。"
     }
   },
   "comments": {
@@ -7771,13 +7774,13 @@
       "description": "點擊標籤可切換是否接受標籤。雙擊可編輯標籤名稱。",
       "selectEntity": "選擇一個實體以查看標籤建議。",
       "noTagsSelected": "未選擇任何標籤",
-      "footerSummary": "{assignCount, plural, one {# tag} other {# tags}} will be assigned, {newCount, plural, one {# new tag} other {# new tags}} will be created",
+      "footerSummary": "{assignCount, plural, other {# 個標籤}}將被指派，{newCount, plural, other {# 個新標籤}}將被建立",
       "footerAssignCount": "{assignCount, plural, one {# 標籤} other {# 標籤}} 將會被分配",
       "footerNewCount": "{newCount, plural, one {# 新標籤} other {# 新標籤}} 將創建",
       "newTagsPopoverTitle": "要建立的新標籤",
       "applying": "正在申請…",
-      "applySuccess": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}",
-      "applySuccessNewTags": "{tagCount, plural, one {# tag} other {# tags}} applied to {entityCount, plural, one {# entity} other {# entities}}, {newCount, plural, one {# new tag} other {# new tags}} created",
+      "applySuccess": "{tagCount, plural, other {# 個標籤}}已套用至 {entityCount, plural, other {# 個項目}}",
+      "applySuccessNewTags": "{tagCount, plural, other {# 個標籤}}已套用至 {entityCount, plural, other {# 個項目}}，{newCount, plural, other {# 個新標籤}}已建立",
       "applyError": "標籤應用程式失敗，請重試。",
       "suggestedTags": "建議標籤",
       "noSuggestions": "人工智慧無法產生任何標籤。",
@@ -7948,7 +7951,7 @@
     "importStep2RequiredUnmapped": "必需參數「@{name}」沒有對應的 CSV 欄位。",
     "importStep2Label": "地圖列",
     "importStep3SummaryOk": "{totalRows, plural, =1 {# 行} other {# 行數}} 解析，無錯誤。",
-    "importStep3SummaryErrors": "{totalRows, plural, =1 {# row} other {# rows}} parsed; {errorCount, plural, =1 {# row has} other {# rows have}} errors.",
+    "importStep3SummaryErrors": "已解析 {totalRows, plural, =1 {# 行} other {# 行}}；{errorCount, plural, =1 {# 行有} other {# 行有}} 錯誤。",
     "importStep3PreviewLimit": "顯示前 {limit} 行。下一步將驗證所有行。",
     "importStep3Label": "預覽",
     "importStep4Heading": "確認進口",
@@ -7993,13 +7996,13 @@
     "runPreflightAsync": "將建立 {n, plural, =1 {# 迭代} other {# 迭代}} （後台作業）",
     "runPreflightSoftConfirm": "將建立 {n, plural, =1 {# 迭代} other {# 迭代}} — 需要確認",
     "runPreflightHardRefuse": "無法建立 — {n} 超出 {cap} 上限",
-    "runPreflightTooltip": "{iterations, plural, =1 {# iteration} other {# iterations}} = {cases, plural, =1 {# case} other {# cases}} × {configs, plural, =1 {# config} other {# configs}} × dataset rows",
-    "runPreflightTooltipHeader": "{iterations, plural, =1 {# iteration} other {# iterations}} across {cases, plural, =1 {# parameterized case} other {# parameterized cases}} × {configs, plural, =1 {# config} other {# configs}}",
+    "runPreflightTooltip": "{iterations, plural, =1 {# 次疊代} other {# 次疊代}} = {cases, plural, =1 {# 個案例} other {# 個案例}} × {configs, plural, =1 {# 個設定} other {# 個設定}} × 資料集行",
+    "runPreflightTooltipHeader": "{iterations, plural, =1 {# 次疊代} other {# 次疊代}}，跨 {cases, plural, =1 {# 個參數化案例} other {# 個參數化案例}} × {configs, plural, =1 {# 個設定} other {# 個設定}}",
     "runPreflightTooltipCaseRow": "{title} — {rows, plural, =1 {# 行} other {# 行數}}",
     "chipClickToReveal": "點擊顯示",
     "chipCopyValue": "複製價值",
     "chipCopyAriaLabel": "將 {label} 的值複製到剪貼簿",
-    "chipCopiedToast": "Copied @{label} to clipboard",
+    "chipCopiedToast": "已將 @{label} 複製到剪貼簿",
     "chipCopyFailedToast": "無法將 @{label} 複製到剪貼簿",
     "iterationResultPanelHeading": "提交第 {n} 次迭代的結果，該迭代是 {total} 次迭代的結果。",
     "iterationAddResult": "新增結果",
@@ -8018,7 +8021,7 @@
     "hardRefuseSuggestion2": "取消選擇一個或多個配置。",
     "hardRefuseSuggestion3": "將工作分成多個測試運行。",
     "softConfirmTitle": "產生 {n, plural, =1 {# 迭代次數} other {# 迭代次數}}?",
-    "softConfirmDescription": "{n, plural, =1 {# iteration} other {# iterations}} from {cases, plural, =1 {# case} other {# cases}} × {configs, plural, =1 {# configuration} other {# configurations}}.",
+    "softConfirmDescription": "{n, plural, =1 {# 次疊代} other {# 次疊代}}，來自 {cases, plural, =1 {# 個案例} other {# 個案例}} × {configs, plural, =1 {# 個設定} other {# 個設定}}。",
     "softConfirmGo": "生成迭代",
     "runProgressCounter": "{done} / {total}",
     "runProgressDismissAria": "駁回進度",
@@ -8080,7 +8083,7 @@
     "iterationBulkConfirmDescription": "每個選定的迭代都會收到一個狀態為「{statusName}」的新結果。",
     "iterationBulkConfirm": "馬克 {action}",
     "iterationBulkConfirmReplace": "替換為 {action}",
-    "iterationBulkOverwriteWarning": "{count, plural, =1 {# of the selected iterations already has} other {# of the selected iterations already have}} a result. A new result will be recorded and the latest will replace the current one.",
+    "iterationBulkOverwriteWarning": "{count, plural, =1 {已選取的疊代中有 # 個已有} other {已選取的疊代中有 # 個已有}} 結果。將記錄新結果，且最新結果將取代目前的結果。",
     "iterationBulkReasonLabel": "原因（可選）",
     "iterationBulkReasonHelp": "記錄在每項結果中。",
     "iterationBulkSuccess": "{count, plural, =1 {# 迭代次數} other {# 迭代次數}} 已標記 {action}",
@@ -8090,7 +8093,7 @@
     "iterationResetUntestedMissing": "未測試狀態未找到",
     "overrideTitle": "覆蓋迭代 {n} 的值",
     "overrideDescription": "更改僅影響本次迭代。資料集快照和來源資料集保持不變。此操作已記錄在稽核日誌中。",
-    "overrideValidationItem": "@{param}: {message}",
+    "overrideValidationItem": "@{param}：{message}",
     "overrideSensitiveDenied": "您沒有權限編輯敏感值。",
     "datasetSourceLocal": "當地的",
     "datasetSourceShared": "共享",

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -76,7 +76,7 @@
     "crowdin:upload:sources": "crowdin upload sources",
     "crowdin:upload:translations": "crowdin upload translations",
     "crowdin:download": "crowdin download",
-    "crowdin:pre-translate": "crowdin pre-translate --method=mt --engine-id=609928",
+    "crowdin:pre-translate": "crowdin pre-translate --method=ai --ai-prompt-id=536391",
     "crowdin:sync": "pnpm crowdin:upload:sources && pnpm crowdin:pre-translate && pnpm crowdin:download",
     "elasticsearch:reindex": "tsx scripts/reindexAllEntities.ts",
     "elasticsearch:reindex:fresh": "tsx scripts/reindexAllEntities.ts --fresh",


### PR DESCRIPTION
## Description

Follow-up to #497. Closing the Magic Link dialog stranded users who still had a valid emailed sign-in code: the waiting screen's code entry depended on client-side React state (`pendingId`), which was lost when the dialog closed — with no way back in except requesting a new link.

The dialog's request view now offers **"Already have a sign-in code?"**, which opens a code-entry view that works without any client-side pending state:

- The `passwordless-complete` provider now treats `pendingId` as optional. When the client doesn't send one, the server resolves the pending sign-in from the browser's HttpOnly verifier cookie — which already names exactly one pending row (`v1.<pendingId>.<verifier>`). When the client does send an id, it must still match the cookie's.
- The code-entry UI (error display + OTP slots + verify button) is now shared between the post-request waiting view and the new standalone view, with a "Request a new link instead" affordance to switch back.

Security posture is unchanged: completion still requires the verifier cookie plus the emailed code, codes remain bound to the requesting browser, the 5-attempt lockout and TTL are enforced on the same pending row, and a code entered in a browser without the cookie fails exactly as before (`PASSWORDLESS_NO_VERIFIER` → "request a new link" message).

## Related Issue

N/A — UX gap found while validating #497.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Two new tests in `lib/passwordless.test.ts`: code-only completion succeeds via the cookie-derived pendingId, and code-only completion without a verifier cookie is rejected. Existing suites (provider, routes, claims parity, sign-in page) all pass; `tsc --noEmit` clean.

**Test Configuration:**
- OS: macOS 15 (darwin 25.5)
- Browser (if applicable): N/A
- Node version: 24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The same commit is included in the beta port branch (cherry-picked), so beta gets this behavior together with the base feature.
