### PR TITLE
fix(repository): truncate long folder names in the tree panel

### DIFF
--- a/testplanit/app/[locale]/projects/repository/[projectId]/TreeView.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/TreeView.tsx
@@ -1157,11 +1157,20 @@ const TreeView: React.FC<{
           />
         </Button>
         <IconComponent
-          className={`w-4 h-4 ms-1 ${
+          className={`w-4 h-4 ms-1 shrink-0 ${
             isSelected ? "text-secondary-foreground" : "text-muted-foreground"
           }`}
         />
-        <span className="ms-2 truncate flex-1">{node.data.name}</span>
+        <span
+          className="ms-2 truncate flex-1 min-w-0"
+          title={
+            data && (data.directCaseCount > 0 || data.totalCaseCount > 0)
+              ? `${node.data.name} (${data.directCaseCount}/${data.totalCaseCount})`
+              : node.data.name
+          }
+        >
+          {node.data.name}
+        </span>
 
         {pendingCopyTargets.has(data?.folderId ?? -1) && (
           <Loader2
@@ -1328,6 +1337,7 @@ const TreeView: React.FC<{
           indent={24}
           rowHeight={32}
           overscanCount={0}
+          rowClassName="min-w-0!"
           onScroll={() => {
             // Update visible node count when tree scrolls/renders
             if (treeRef.current) {


### PR DESCRIPTION
## Description

Long folder names widened the repository test-case tree panel instead of truncating, pushing the name (and the `(direct/total)` case-count badges) out of view. This keeps them within the panel.

Root cause: `react-arborist` applies an inline `min-width: max-content` to every tree row, so rows grow to fit their content and the folder-name span's `truncate` never engaged. The fix overrides the row back to `min-width: 0` via the library's `rowClassName` prop (an `!important` class beats the inline style) so each row honors its `100%` width and the name truncates with an ellipsis.

Also in this change:

- The folder icon is fixed-size (`shrink-0`) so it isn't squished by a long name competing for space.
- The full folder name plus its case counts are surfaced through the row `title` tooltip, so hovering reveals what's clipped (e.g. `Folder with a Very Long name (138/138)`).

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Verified in the running app on the repository tree panel: DOM measurements confirm rows now match the panel width exactly (293px = 293px, no row overflows), the computed row `min-width` is `0px` (was `max-content`), and long folder names report as truncated with the full text available via the `title` tooltip. The full unit suite passes locally (9937 passed / 189 skipped).

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chromium (Playwright)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Left panel after the fix: long folder names such as "Long Folder Name Long …", "Folder with a Very Lo…", and "Repository Organi…" truncate with an ellipsis and stay inside the panel; count badges remain right-aligned and visible.

## Additional Notes

Targets the `beta` branch. Single-file change to `TreeView.tsx` (12 insertions, 2 deletions).
