### PR TITLE
fix(audit): stop FK-poison re-poll loop in CDC audit-log writer

### DIFF
--- a/testplanit/lib/audit/__tests__/correlationProjectFkPoison.test.ts
+++ b/testplanit/lib/audit/__tests__/correlationProjectFkPoison.test.ts
@@ -1,0 +1,450 @@
+/**
+ * FK-poison regression (auditLogWorker Loop B / lib/audit/correlation).
+ *
+ * BUG: `AuditLog.projectId` has an FK to Projects with ON DELETE SET NULL. When a project is deleted
+ * the DB cascade emits many child-delete DataChangeLog rows whose captured projectId still points at
+ * the now-gone project. writeAuditLogRows wrote them in ONE transaction, so a single dangling id made
+ * the whole batch INSERT abort with a 23503 FK violation — nothing got marked processed and the
+ * worker re-polled the same head-of-line batch forever, freezing that tenant's audit pipeline.
+ * ON DELETE SET NULL does NOT help: it only rewrites existing rows, never a fresh INSERT.
+ *
+ * FIX: writeAuditLogRows resolves the batch's live project ids once and nulls any dangling reference
+ * before inserting (primary), and runs the batch under a SAVEPOINT so a residual constraint error is
+ * isolated row-by-row instead of wedging everything (backstop).
+ *
+ * These are pure unit tests: a faithful in-memory fake models the two Postgres behaviours the bug and
+ * fix depend on — (1) a projectId that isn't a live Projects row raises 23503 and ABORTS the
+ * transaction, and (2) SAVEPOINT / ROLLBACK TO SAVEPOINT recovers from that abort. (The abort +
+ * savepoint recovery was additionally verified against the real ew schema during development.)
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  pollDataChangeLogsOnce,
+  writeAuditLogRows,
+  type MaterializedRow,
+  type RawPrismaClient,
+  type RawTxClient,
+} from "../correlation";
+
+interface InsertedRow {
+  action: string;
+  entityId: string;
+  operationId: string | null;
+  sourceTable: string;
+  projectId: number | null;
+}
+
+interface RawDclSeed {
+  id: number;
+  seq: number;
+  table: string;
+  op: string;
+  pk: string;
+  changed_cols: Record<string, { old: unknown; new: unknown }> | null;
+  actor: string | null;
+  actor_name: string | null;
+  actor_email: string | null;
+  entity_name: string | null;
+  project_id: string | null;
+  operation_id: string | null;
+  tenant: string | null;
+  txid: string;
+  ts: Date;
+  processed: boolean;
+}
+
+interface FakeDbOptions {
+  /** Project ids the resolve SELECT ("SELECT id FROM Projects WHERE id = ANY") reports as existing. */
+  existingProjectIds?: Set<number>;
+  /**
+   * Project ids the simulated FK actually accepts at INSERT time. Defaults to existingProjectIds;
+   * set it SMALLER than existingProjectIds to simulate a TOCTOU race (resolve says a project exists,
+   * but it was deleted by a concurrent tx before the insert, so the FK still rejects it).
+   */
+  fkValidProjectIds?: Set<number>;
+  /** DataChangeLog rows the poll SELECT returns. */
+  seededRows?: RawDclSeed[];
+  /** entityIds that are un-insertable regardless of projectId — models a non-FK residual constraint. */
+  poisonEntityIds?: Set<string>;
+}
+
+/**
+ * A minimal but faithful Postgres-transaction fake. It routes the module's raw SQL by content and
+ * simulates: FK 23503 on a projectId that isn't accepted, the resulting transaction-abort state
+ * (every statement errors until a ROLLBACK TO SAVEPOINT), the ON CONFLICT DO NOTHING idempotency
+ * index, and SAVEPOINT/RELEASE/ROLLBACK-TO with rollback of the rows inserted since the savepoint.
+ */
+function makeFakeDb(opts: FakeDbOptions = {}) {
+  const existingProjectIds = opts.existingProjectIds ?? new Set<number>();
+  const fkValidProjectIds = opts.fkValidProjectIds ?? existingProjectIds;
+  const poisonEntityIds = opts.poisonEntityIds ?? new Set<string>();
+  const seededRows = opts.seededRows ?? [];
+
+  const inserted: InsertedRow[] = [];
+  const insertSqls: string[] = [];
+  const processedIds: number[] = [];
+  const savepoints: Array<{ name: string; mark: number }> = [];
+  let aborted = false;
+
+  const abortGuard = () => {
+    if (aborted) {
+      throw new Error(
+        "current transaction is aborted, commands ignored until end of transaction block"
+      );
+    }
+  };
+
+  const identityKey = (r: InsertedRow) =>
+    `${r.operationId ?? ""}|${r.sourceTable}|${r.entityId}|${r.action}`;
+
+  const doInsert = (sql: string, values: unknown[]): number => {
+    abortGuard();
+    insertSqls.push(sql);
+    const row: InsertedRow = {
+      action: values[3] as string,
+      entityId: values[5] as string,
+      operationId: (values[9] as string | null) ?? null,
+      sourceTable: values[10] as string,
+      projectId: (values[11] as number | null) ?? null,
+    };
+    // Non-FK residual constraint (fails even with projectId = null).
+    if (poisonEntityIds.has(row.entityId)) {
+      aborted = true;
+      const e = new Error("residual check constraint violation") as Error & {
+        code?: string;
+      };
+      e.code = "23514";
+      throw e;
+    }
+    // The projectId FK: a value that isn't a live Projects row raises 23503 and aborts the tx.
+    if (
+      row.projectId != null &&
+      !fkValidProjectIds.has(Number(row.projectId))
+    ) {
+      aborted = true;
+      const e = new Error(
+        'insert or update on table "AuditLog" violates foreign key constraint "AuditLog_projectId_fkey"'
+      ) as Error & { code?: string };
+      e.code = "23503";
+      throw e;
+    }
+    // ON CONFLICT (operationId, sourceTable, entityId, action) WHERE operationId IS NOT NULL DO NOTHING.
+    if (
+      row.operationId != null &&
+      inserted.some((x) => identityKey(x) === identityKey(row))
+    ) {
+      return 0;
+    }
+    inserted.push(row);
+    return 1;
+  };
+
+  const tx = {
+    $queryRaw: async (strings: TemplateStringsArray) => {
+      abortGuard();
+      const sql = strings.join(" ");
+      if (
+        sql.includes('FROM "DataChangeLog"') &&
+        sql.includes("processed = false")
+      ) {
+        return seededRows;
+      }
+      return []; // pass-3 backfill and anything else
+    },
+    $executeRaw: async (
+      strings: TemplateStringsArray,
+      ...values: unknown[]
+    ) => {
+      const sql = strings.join(" ");
+      if (sql.includes('INSERT INTO "AuditLog"')) return doInsert(sql, values);
+      if (sql.includes('UPDATE "DataChangeLog"')) {
+        abortGuard();
+        const ids = (values[0] as Array<bigint | number>) ?? [];
+        for (const id of ids) processedIds.push(Number(id));
+        return ids.length;
+      }
+      abortGuard();
+      return 0;
+    },
+    $queryRawUnsafe: async (sql: string, ...params: unknown[]) => {
+      abortGuard();
+      if (sql.includes('FROM "Projects" WHERE id = ANY')) {
+        const ids = (params[0] as Array<number | string>) ?? [];
+        return ids
+          .filter((id) => existingProjectIds.has(Number(id)))
+          .map((id) => ({ id: Number(id) }));
+      }
+      return []; // two-hop lookups etc.
+    },
+    $executeRawUnsafe: async (sql: string) => {
+      const parts = sql.trim().split(/\s+/);
+      if (parts[0] === "SAVEPOINT") {
+        abortGuard(); // Postgres rejects SAVEPOINT while aborted
+        savepoints.push({ name: parts[1], mark: inserted.length });
+        return 0;
+      }
+      if (parts[0] === "ROLLBACK" && parts[2] === "SAVEPOINT") {
+        const name = parts[3];
+        for (let i = savepoints.length - 1; i >= 0; i--) {
+          if (savepoints[i].name === name) {
+            inserted.length = savepoints[i].mark; // undo inserts since the savepoint
+            break;
+          }
+        }
+        aborted = false; // ROLLBACK TO clears the aborted state
+        return 0;
+      }
+      if (parts[0] === "RELEASE" && parts[1] === "SAVEPOINT") {
+        abortGuard(); // our code never RELEASEs while aborted
+        const name = parts[2];
+        for (let i = savepoints.length - 1; i >= 0; i--) {
+          if (savepoints[i].name === name) {
+            savepoints.splice(i); // pop it and any nested above
+            break;
+          }
+        }
+        return 0;
+      }
+      abortGuard();
+      return 0;
+    },
+  };
+
+  const client = {
+    ...tx,
+    $transaction: async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx),
+  };
+
+  return {
+    tx: tx as unknown as RawTxClient,
+    client: client as unknown as RawPrismaClient,
+    inserted,
+    insertSqls,
+    processedIds,
+    isAborted: () => aborted,
+  };
+}
+
+/** Build a DataChangeLog seed row (root project-scoped table, hard delete) for the poll-level test. */
+function dclRow(
+  over: Partial<RawDclSeed> & Pick<RawDclSeed, "id" | "table" | "pk">
+): RawDclSeed {
+  return {
+    seq: over.id,
+    op: "D",
+    changed_cols: { name: { old: "was", new: null } },
+    actor: "actor-1",
+    actor_name: "Actor One",
+    actor_email: "actor@example.com",
+    entity_name: `${over.table}-${over.pk}`,
+    project_id: null,
+    operation_id: null,
+    tenant: null,
+    txid: "5555",
+    ts: new Date("2026-07-08T00:00:00Z"),
+    processed: false,
+    ...over,
+  };
+}
+
+/** Build a MaterializedRow for the writeAuditLogRows-level backstop tests. */
+function mkMat(
+  over: Partial<MaterializedRow> & Pick<MaterializedRow, "entityId">
+): MaterializedRow {
+  return {
+    sourceRowId: 1,
+    sourceTable: "Sessions",
+    op: "D",
+    entityType: "Sessions",
+    action: "DELETE",
+    actor: "actor-1",
+    userName: "Actor One",
+    userEmail: "actor@example.com",
+    entityName: "Sess",
+    projectId: null,
+    operationId: "op-1",
+    tenant: null,
+    changes: { name: { old: "was", new: null } },
+    ...over,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("writeAuditLogRows — projectId FK poison", () => {
+  it("HEADLINE: a poison batch (mixed valid/dangling projectId across multiple tables incl. a Projects delete) commits, dangling ids nulled, and every source row is processed=true", async () => {
+    const VALID = 100; // a project that still exists
+    const DELETED = 999; // the cascade-deleted project (its own + children's captured projectId)
+
+    // Models the cascade of deleting project 999: the Projects row itself plus child root entities
+    // (Sessions/TestRuns/Milestones) whose captured project_id still points at 999. Plus one row on a
+    // surviving project (VALID) and one with no project scope, to pin "kept" and "stays null".
+    const seededRows: RawDclSeed[] = [
+      dclRow({
+        id: 1,
+        table: "Projects",
+        pk: "999",
+        project_id: String(DELETED),
+      }),
+      dclRow({
+        id: 2,
+        table: "Sessions",
+        pk: "11",
+        project_id: String(DELETED),
+      }),
+      dclRow({
+        id: 3,
+        table: "TestRuns",
+        pk: "22",
+        project_id: String(DELETED),
+      }),
+      dclRow({
+        id: 4,
+        table: "Milestones",
+        pk: "33",
+        project_id: String(DELETED),
+      }),
+      dclRow({ id: 5, table: "Sessions", pk: "12", project_id: String(VALID) }),
+      dclRow({ id: 6, table: "Sessions", pk: "13", project_id: null }),
+    ];
+
+    const db = makeFakeDb({
+      existingProjectIds: new Set([VALID]), // 999 is gone; only 100 resolves as existing
+      seededRows,
+    });
+
+    const result = await pollDataChangeLogsOnce(db.client, { batchSize: 500 });
+
+    // The batch committed rather than aborting on the dangling id.
+    expect(result.processed).toBe(6);
+    expect(result.auditLogsWritten).toBe(6);
+    expect(db.isAborted()).toBe(false);
+
+    const byEntity = new Map(
+      db.inserted.map((r) => [`${r.sourceTable}:${r.entityId}`, r.projectId])
+    );
+    // Dangling references (the deleted project 999) are nulled — matching ON DELETE SET NULL intent.
+    expect(byEntity.get("Projects:999")).toBeNull();
+    expect(byEntity.get("Sessions:11")).toBeNull();
+    expect(byEntity.get("TestRuns:22")).toBeNull();
+    expect(byEntity.get("Milestones:33")).toBeNull();
+    // A live project id is preserved; a row with no project scope stays null.
+    expect(byEntity.get("Sessions:12")).toBe(VALID);
+    expect(byEntity.get("Sessions:13")).toBeNull();
+
+    // Every source row was marked processed=true (cursor advanced — no infinite re-poll).
+    expect([...db.processedIds].sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+
+    // Idempotency is preserved: every INSERT still carries the ON CONFLICT DO NOTHING arbiter.
+    expect(db.insertSqls).toHaveLength(6);
+    for (const sql of db.insertSqls) {
+      expect(sql).toContain(
+        'ON CONFLICT ("operationId", "sourceTable", "entityId", "action")'
+      );
+    }
+  });
+
+  it("resolves valid ids in a single batch query and nulls only the danglers (no per-row check)", async () => {
+    const db = makeFakeDb({ existingProjectIds: new Set([7]) });
+    const written = await writeAuditLogRows(db.tx, [
+      mkMat({ entityId: "a", projectId: "7" }), // exists → kept
+      mkMat({ entityId: "b", projectId: "8" }), // dangling → nulled
+      mkMat({ entityId: "c", projectId: null }), // none → null
+    ]);
+    expect(written).toBe(3);
+    expect(db.inserted.map((r) => [r.entityId, r.projectId])).toEqual([
+      ["a", 7],
+      ["b", null],
+      ["c", null],
+    ]);
+  });
+});
+
+describe("writeAuditLogRows — residual-error isolation backstop", () => {
+  it("absorbs a TOCTOU race: an FK error the resolve missed is isolated and retried with projectId=NULL, and the batch still commits", async () => {
+    // resolve REPORTS 999 as existing, but the FK REJECTS it — a project deleted by a concurrent tx
+    // between the resolve and the insert. The fast batch INSERT aborts; the row-by-row backstop
+    // isolates the offender and re-inserts it with a null projectId.
+    const db = makeFakeDb({
+      existingProjectIds: new Set([100, 999]), // resolve lies about 999
+      fkValidProjectIds: new Set([100]), // the DB FK only accepts 100
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const written = await writeAuditLogRows(db.tx, [
+      mkMat({ entityId: "a", projectId: "100" }),
+      mkMat({ entityId: "b", projectId: "999" }), // FK-rejected → retried as null
+      mkMat({ entityId: "c", projectId: null }),
+    ]);
+
+    expect(written).toBe(3);
+    expect(db.isAborted()).toBe(false);
+    const byEntity = new Map(db.inserted.map((r) => [r.entityId, r.projectId]));
+    expect(byEntity.get("a")).toBe(100);
+    expect(byEntity.get("b")).toBeNull(); // dangling id nulled, row preserved (not dropped)
+    expect(byEntity.get("c")).toBeNull();
+    expect(warn).toHaveBeenCalled(); // logged the nulling
+    expect(err).toHaveBeenCalled(); // logged the batch-level fallback
+  });
+
+  it("skips a genuinely un-insertable row (fails even with projectId=NULL) instead of wedging the batch", async () => {
+    const db = makeFakeDb({
+      existingProjectIds: new Set([100]),
+      poisonEntityIds: new Set(["POISON"]), // un-insertable regardless of projectId
+    });
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const written = await writeAuditLogRows(db.tx, [
+      mkMat({ entityId: "a", projectId: "100" }),
+      mkMat({ entityId: "POISON", projectId: null }),
+      mkMat({ entityId: "c", projectId: null }),
+    ]);
+
+    // The poison row is dropped (logged); the good rows still commit — no throw, no infinite retry.
+    expect(written).toBe(2);
+    expect(db.isAborted()).toBe(false);
+    expect(db.inserted.map((r) => r.entityId).sort()).toEqual(["a", "c"]);
+    expect(err).toHaveBeenCalled();
+  });
+
+  it("through pollDataChangeLogsOnce: a mid-batch FK abort recovers AND the cursor still advances (processed=true)", async () => {
+    // End-to-end of the transaction: even when the backstop fires (an FK error the resolve missed),
+    // the isolation recovery leaves the transaction usable so the processed=true UPDATE still runs —
+    // the whole point of the fix (no stuck head-of-line batch).
+    const seededRows: RawDclSeed[] = [
+      dclRow({ id: 10, table: "Sessions", pk: "11", project_id: "777" }), // resolve lies; FK rejects
+      dclRow({ id: 20, table: "Sessions", pk: "12", project_id: "100" }), // genuinely valid
+    ];
+    const db = makeFakeDb({
+      existingProjectIds: new Set([777, 100]), // resolve reports 777 as live
+      fkValidProjectIds: new Set([100]), // ...but the FK rejects it (deleted under us)
+      seededRows,
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await pollDataChangeLogsOnce(db.client, { batchSize: 500 });
+
+    expect(result.processed).toBe(2);
+    expect(result.auditLogsWritten).toBe(2);
+    expect(db.isAborted()).toBe(false);
+    const byEntity = new Map(db.inserted.map((r) => [r.entityId, r.projectId]));
+    expect(byEntity.get("11")).toBeNull(); // FK-rejected id nulled by the backstop
+    expect(byEntity.get("12")).toBe(100);
+    // Cursor advanced for BOTH source rows despite the mid-batch abort.
+    expect([...db.processedIds].sort((a, b) => a - b)).toEqual([10, 20]);
+  });
+
+  it("returns 0 without touching the DB for an empty batch", async () => {
+    const db = makeFakeDb();
+    expect(await writeAuditLogRows(db.tx, [])).toBe(0);
+    expect(db.inserted).toHaveLength(0);
+    expect(db.insertSqls).toHaveLength(0);
+  });
+});

--- a/testplanit/lib/audit/correlation.ts
+++ b/testplanit/lib/audit/correlation.ts
@@ -372,14 +372,6 @@ export function deriveAction(row: RawDclRow): AuditActionLiteral {
 }
 
 /**
- * Insert the materialized rows into AuditLog inside the given transaction, idempotently. Each row is
- * a single INSERT carrying `ON CONFLICT (audit_log_cdc_idempotency columns) DO NOTHING` — a partial
- * unique index over (operationId, sourceTable, entityId, action) WHERE operationId IS NOT NULL — so
- * a re-poll over already-materialized non-null-operationId rows inserts nothing. Returns the count
- * actually inserted (conflicts return 0 rowcount). Uses raw SQL because the named partial-index
- * conflict arbiter is not expressible through the Prisma model API.
- */
-/**
  * Join two diff entries for the SAME column into one, comma-listing the distinct
  * displayed values (e.g. two workflow assignments → `newName: "Default, Smoke"`).
  */
@@ -484,48 +476,180 @@ export function summarizeBulkCaseChanges(
   });
 }
 
+/** Savepoint names for the FK-poison isolation backstop in writeAuditLogRows (constant, not row data). */
+const BATCH_SAVEPOINT = "audit_cdc_batch";
+const ROW_SAVEPOINT = "audit_cdc_row";
+
+/** Coerce a materialized row's projectId to a finite integer, or null when absent/unparseable. */
+function toProjectId(raw: string | null): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve which of the batch's referenced project ids still exist. `AuditLog.projectId` has an FK to
+ * Projects (ON DELETE SET NULL), but SET NULL only rewrites EXISTING rows — it does nothing for a
+ * fresh INSERT, so a captured projectId that points at an already-deleted project would 23503-abort
+ * the whole batch INSERT (and, since inserts + the processed=true cursor share one transaction, wedge
+ * the tenant's audit pipeline in an infinite re-poll). Resolving the live set once per batch lets us
+ * null the danglers before the write — matching the FK's SET NULL intent while preserving the audit
+ * trail. One query for the whole batch (no per-row N+1).
+ */
+async function resolveExistingProjectIds(
+  tx: RawTxClient,
+  materialized: MaterializedRow[]
+): Promise<Set<number>> {
+  const referenced = new Set<number>();
+  for (const m of materialized) {
+    const pid = toProjectId(m.projectId);
+    if (pid != null) referenced.add(pid);
+  }
+  if (referenced.size === 0) return referenced;
+  const rows = await tx.$queryRawUnsafe<
+    Array<{ id: number | bigint | string }>
+  >(`SELECT id FROM "Projects" WHERE id = ANY($1::int[])`, [...referenced]);
+  return new Set(rows.map((r) => Number(r.id)));
+}
+
+/**
+ * Insert ONE materialized row into AuditLog, idempotently. Carries `ON CONFLICT (operationId,
+ * sourceTable, entityId, action) WHERE operationId IS NOT NULL DO NOTHING` — a partial unique index —
+ * so a re-poll over already-materialized non-null-operationId rows inserts nothing. Returns the count
+ * actually inserted (a conflict returns 0). `projectId` is passed already-validated (or null); raw
+ * SQL is required because the named partial-index conflict arbiter is not expressible through the
+ * Prisma model API. AuditLog.id is @default(cuid()) (generated app-side by Prisma, NOT in Postgres),
+ * so a raw INSERT must supply it — gen_random_uuid()::text is a fine unique id; the idempotency index
+ * (not the PK) is what de-dupes CDC rows.
+ */
+async function insertAuditLogRow(
+  tx: RawTxClient,
+  m: MaterializedRow,
+  projectId: number | null
+): Promise<number> {
+  const changesJson = JSON.stringify(m.changes);
+  const metadataJson = JSON.stringify({
+    cdc: true,
+    sourceTable: m.sourceTable,
+    sourceRowId: String(m.sourceRowId),
+    tenant: m.tenant,
+  });
+  const result = await tx.$executeRaw`
+    INSERT INTO "AuditLog"
+      ("id", "userId", "userName", "userEmail", "action", "entityType", "entityId", "entityName", "changes", "metadata", "operationId", "sourceTable", "projectId", "timestamp")
+    VALUES (
+      gen_random_uuid()::text,
+      ${m.actor},
+      ${m.userName},
+      ${m.userEmail},
+      ${m.action}::"AuditAction",
+      ${m.entityType},
+      ${m.entityId},
+      ${m.entityName},
+      ${changesJson}::jsonb,
+      ${metadataJson}::jsonb,
+      ${m.operationId},
+      ${m.sourceTable},
+      ${projectId},
+      now()
+    )
+    ON CONFLICT ("operationId", "sourceTable", "entityId", "action") WHERE "operationId" IS NOT NULL
+    DO NOTHING
+  `;
+  return Number(result) || 0;
+}
+
+/**
+ * Slow path (only entered after the fast batch INSERT hit a residual constraint error): re-insert the
+ * rows one at a time under a per-row SAVEPOINT so a single un-insertable row is isolated instead of
+ * wedging the whole batch. On an error the row is retried once with projectId forced NULL — this
+ * absorbs the narrow TOCTOU race where a project is deleted by a concurrent transaction between the
+ * batch resolve and the insert (SET-NULL semantics again). If it STILL fails it is logged and skipped
+ * so the poll can never infinite-loop on one poison row (criterion: a single bad row must not wedge
+ * the batch). The good rows still commit with the outer transaction.
+ */
+async function insertRowsIsolated(
+  tx: RawTxClient,
+  materialized: MaterializedRow[],
+  existingProjectIds: Set<number>
+): Promise<number> {
+  let written = 0;
+  for (const m of materialized) {
+    const pid = toProjectId(m.projectId);
+    const safePid = pid != null && existingProjectIds.has(pid) ? pid : null;
+    await tx.$executeRawUnsafe(`SAVEPOINT ${ROW_SAVEPOINT}`);
+    try {
+      written += await insertAuditLogRow(tx, m, safePid);
+    } catch {
+      await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT ${ROW_SAVEPOINT}`);
+      try {
+        // Retry with no project association (a project must have vanished under us mid-batch).
+        written += await insertAuditLogRow(tx, m, null);
+        console.warn(
+          `[correlation] nulled dangling projectId for AuditLog row (source ${m.sourceTable}:${String(m.sourceRowId)}) after FK error`
+        );
+      } catch (secondErr) {
+        await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT ${ROW_SAVEPOINT}`);
+        console.error(
+          `[correlation] skipping un-insertable AuditLog row (source ${m.sourceTable}:${String(m.sourceRowId)}):`,
+          secondErr
+        );
+      }
+    }
+    await tx.$executeRawUnsafe(`RELEASE SAVEPOINT ${ROW_SAVEPOINT}`);
+  }
+  return written;
+}
+
+/**
+ * Insert the materialized rows into AuditLog inside the given transaction, idempotently, and return
+ * the count actually written. Two-layer FK-poison protection (a captured projectId can point at a
+ * since-deleted project — see resolveExistingProjectIds):
+ *   1. PRIMARY — resolve the batch's live project ids once and null any dangling reference before the
+ *      write. This alone fixes the reported infinite-loop bug (a committed cascade delete leaves the
+ *      project simply absent, so its id is nulled and the INSERT never violates the FK).
+ *   2. BACKSTOP — run the batch under a SAVEPOINT; if a residual constraint error slips through (e.g.
+ *      a concurrent delete between the resolve and the insert), roll the batch back and re-insert
+ *      row-by-row so the single offender is isolated/skipped rather than aborting every row. This
+ *      guarantees one un-insertable row can never wedge the batch in a re-poll loop again.
+ * The happy path costs one extra resolve SELECT plus a SAVEPOINT/RELEASE pair; the per-row isolation
+ * only runs on an actual error. Idempotency (ON CONFLICT DO NOTHING) is identical on both paths.
+ */
 export async function writeAuditLogRows(
   tx: RawTxClient,
   materialized: MaterializedRow[]
 ): Promise<number> {
-  let written = 0;
-  for (const m of materialized) {
-    const changesJson = JSON.stringify(m.changes);
-    const metadataJson = JSON.stringify({
-      cdc: true,
-      sourceTable: m.sourceTable,
-      sourceRowId: String(m.sourceRowId),
-      tenant: m.tenant,
-    });
-    // cuid()-style id is provided by a DB default? AuditLog.id has @default(cuid()) which Prisma
-    // generates application-side, NOT in Postgres. For a raw INSERT we must supply the id, so use
-    // gen_random_uuid()::text — a stable unique id; the idempotency index (not the PK) is what
-    // de-dupes CDC rows, so any unique id is correct here.
-    const result = await tx.$executeRaw`
-      INSERT INTO "AuditLog"
-        ("id", "userId", "userName", "userEmail", "action", "entityType", "entityId", "entityName", "changes", "metadata", "operationId", "sourceTable", "projectId", "timestamp")
-      VALUES (
-        gen_random_uuid()::text,
-        ${m.actor},
-        ${m.userName},
-        ${m.userEmail},
-        ${m.action}::"AuditAction",
-        ${m.entityType},
-        ${m.entityId},
-        ${m.entityName},
-        ${changesJson}::jsonb,
-        ${metadataJson}::jsonb,
-        ${m.operationId},
-        ${m.sourceTable},
-        ${m.projectId ? Number(m.projectId) : null},
-        now()
-      )
-      ON CONFLICT ("operationId", "sourceTable", "entityId", "action") WHERE "operationId" IS NOT NULL
-      DO NOTHING
-    `;
-    written += Number(result) || 0;
+  if (materialized.length === 0) return 0;
+
+  const existingProjectIds = await resolveExistingProjectIds(tx, materialized);
+
+  // Fast path: one savepoint wraps the whole batch. Sanitized rows never FK-violate, so this commits
+  // in the overwhelming common case; the savepoint only matters if a residual error appears.
+  await tx.$executeRawUnsafe(`SAVEPOINT ${BATCH_SAVEPOINT}`);
+  try {
+    let written = 0;
+    for (const m of materialized) {
+      const pid = toProjectId(m.projectId);
+      const safePid = pid != null && existingProjectIds.has(pid) ? pid : null;
+      written += await insertAuditLogRow(tx, m, safePid);
+    }
+    await tx.$executeRawUnsafe(`RELEASE SAVEPOINT ${BATCH_SAVEPOINT}`);
+    return written;
+  } catch (batchErr) {
+    // A residual constraint error aborted the batch INSERT. Undo the partial batch and isolate.
+    await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT ${BATCH_SAVEPOINT}`);
+    console.error(
+      "[correlation] batch AuditLog insert hit a constraint error; retrying rows in isolation:",
+      batchErr
+    );
+    const written = await insertRowsIsolated(
+      tx,
+      materialized,
+      existingProjectIds
+    );
+    await tx.$executeRawUnsafe(`RELEASE SAVEPOINT ${BATCH_SAVEPOINT}`);
+    return written;
   }
-  return written;
 }
 
 /** The minimal raw-client surface this module needs (prismaBase satisfies it). */
@@ -542,6 +666,8 @@ export interface RawTxClient {
     query: string,
     ...values: unknown[]
   ) => Promise<T>;
+  /** Used for the FK-poison isolation savepoints in writeAuditLogRows (SAVEPOINT/RELEASE/ROLLBACK TO). */
+  $executeRawUnsafe: (query: string, ...values: unknown[]) => Promise<number>;
 }
 export interface RawPrismaClient extends RawTxClient {
   $transaction: <T>(fn: (tx: RawTxClient) => Promise<T>) => Promise<T>;


### PR DESCRIPTION
## Description

Fixes a foreign-key "poison" bug that can freeze a tenant's entire audit pipeline.

`AuditLog.projectId` has an FK to `Projects` with `ON DELETE SET NULL`. When a project is deleted, the DB cascade emits many child-delete `DataChangeLog` outbox rows (ProjectAssignment, Sessions, TestRuns, Milestones, …) whose captured `projectId` still points at the now-gone project. The CDC consumer's `writeAuditLogRows` materialized the whole batch in **one transaction**, so a single dangling id aborted the entire multi-row INSERT with a `23503` FK violation. Nothing got marked `processed`, and the worker re-polled the same head-of-line batch forever — an infinite ~1/sec error loop that froze that tenant's `DataChangeLog → AuditLog` materialization. `ON DELETE SET NULL` doesn't help here: it only rewrites *existing* rows, never a fresh INSERT.

**Fix (two layers, in `lib/audit/correlation.ts`):**

1. **Primary — resolve + null.** Resolve the batch's live project ids once (`SELECT id FROM "Projects" WHERE id = ANY($ids)`) and null any dangling reference before the write. A committed cascade delete leaves the project simply absent, so its id is nulled and the INSERT never violates the FK — matching the FK's `ON DELETE SET NULL` intent while preserving the audit trail (rows are **not** dropped).
2. **Backstop — savepoint isolation.** Run the batch under a `SAVEPOINT`; if a residual constraint error still slips through (e.g. a project deleted by a concurrent transaction between the resolve and the insert — the TOCTOU race), roll back and re-insert row-by-row under per-row savepoints, retrying the offender once with `projectId = NULL` and skipping (with a log) any genuinely un-insertable row. One bad row can never wedge the batch again.

`ON CONFLICT (operationId, sourceTable, entityId, action) DO NOTHING` idempotency is unchanged on both paths. The happy path costs one extra resolve `SELECT` plus a `SAVEPOINT`/`RELEASE` pair; per-row isolation only runs on an actual error.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

New unit file `lib/audit/__tests__/correlationProjectFkPoison.test.ts` (6 tests) with a faithful in-memory fake that models the two Postgres behaviours the bug/fix depend on (a non-live `projectId` raises `23503` and aborts the tx; `SAVEPOINT`/`ROLLBACK TO SAVEPOINT` recovers):

- Headline: a poison batch (mixed valid/dangling `projectId` across multiple tables incl. a `Projects` delete) **commits**, danglers are nulled, valid ids kept, and every source row is `processed=true`.
- Single batch resolve query (no per-row check); TOCTOU retry-with-NULL; genuinely-un-insertable row is skipped not wedged; cursor still advances after the backstop fires; empty-batch no-op.

The `23503`-aborts + savepoint-recovery behaviour and the exact `INSERT`/resolve SQL were additionally verified against the real database schema (in a fully rolled-back transaction) during development.

`pnpm precommit` is green: eslint + `tsc --noEmit`, prettier `format:check`, and the full unit suite (**9845 passed / 184 skipped**).

**Test Configuration:**
- OS: macOS (darwin)
- Browser (if applicable): N/A
- Node version: 24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The FK-poison protection lives in the shared `writeAuditLogRows`/`pollDataChangeLogsOnce` in `lib/audit/correlation.ts`, which backs the `auditLogWorker` Loop B (CDC consumer), so both single-tenant and multi-tenant poll paths are covered.
