### PR TITLE
fix(admin/llm): surface real provider error on AI model Test Connection

### DIFF
--- a/testplanit/app/api/admin/llm/test-credentials/route.ts
+++ b/testplanit/app/api/admin/llm/test-credentials/route.ts
@@ -113,6 +113,14 @@ export async function POST(request: NextRequest) {
       // Connection test result obtained
 
       if (!isConnected) {
+        // The adapter records the real failure reason (HTTP status + provider
+        // message) when it can; prefer it over the generic fallback so admins
+        // see what actually went wrong (bad key, model not permitted, etc.).
+        const detail = adapter.getLastTestConnectionError();
+        if (detail) {
+          console.warn("Test connection failed for %s: %s", provider, detail);
+        }
+
         // Try to provide more specific error messages
         let errorMessage: string;
 
@@ -132,6 +140,8 @@ export async function POST(request: NextRequest) {
           errorMessage = `Failed to connect to Ollama at ${endpoint || "http://localhost:11434"}. Make sure Ollama is running.`;
         } else if (!endpoint) {
           errorMessage = "Endpoint URL is required";
+        } else if (detail) {
+          errorMessage = `Failed to connect to ${provider}: ${detail}`;
         } else {
           errorMessage = `Failed to connect to ${provider}. Please check your credentials and endpoint.`;
         }

--- a/testplanit/lib/llm/adapters/anthropic.adapter.ts
+++ b/testplanit/lib/llm/adapters/anthropic.adapter.ts
@@ -72,7 +72,13 @@ export class AnthropicAdapter extends BaseLlmAdapter {
   constructor(config: LlmAdapterConfig) {
     super(config);
     this.apiKey = config.apiKey || "";
-    this.baseUrl = config.baseUrl || "https://api.anthropic.com/v1";
+    // Strip trailing slashes so appending `/messages` can't produce a double
+    // slash (e.g. a user-supplied `.../v1/` becoming `.../v1//messages`).
+    // Mirrors the normalization the available-models route already does.
+    this.baseUrl = (config.baseUrl || "https://api.anthropic.com/v1").replace(
+      /\/+$/,
+      ""
+    );
 
     if (!this.apiKey) {
       throw this.createError(
@@ -257,10 +263,12 @@ export class AnthropicAdapter extends BaseLlmAdapter {
   }
 
   async testConnection(): Promise<boolean> {
+    this.lastTestConnectionError = undefined;
+    const url = `${this.baseUrl}/messages`;
     try {
       // Send a minimal chat request to the same endpoint used by actual calls.
       // This catches misconfigurations like a missing /v1 path segment.
-      const response = await this.safeFetch(`${this.baseUrl}/messages`, {
+      const response = await this.safeFetch(url, {
         method: "POST",
         headers: this.getAnthropicHeaders(),
         body: JSON.stringify({
@@ -272,10 +280,60 @@ export class AnthropicAdapter extends BaseLlmAdapter {
       });
 
       // 200 = success, 400 = bad request (but endpoint is reachable and authenticated)
-      return response.status === 200 || response.status === 400;
-    } catch {
+      if (response.status === 200 || response.status === 400) {
+        return true;
+      }
+
+      // Capture the real reason (status + provider message) so the admin UI
+      // can show it instead of a generic "failed to connect". A proxy like
+      // LiteLLM, for example, returns 401/403 here when the key isn't
+      // authorized for the selected model.
+      const body = await response.text().catch(() => "");
+      this.lastTestConnectionError = this.summarizeHttpError(
+        response.status,
+        response.statusText,
+        body
+      );
+      return false;
+    } catch (error: any) {
+      if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+        this.lastTestConnectionError = `Request timed out after 10s (${url}).`;
+      } else {
+        this.lastTestConnectionError = `Network error reaching ${url}: ${
+          error?.message ?? "unknown error"
+        }`;
+      }
       return false;
     }
+  }
+
+  /**
+   * Build a concise one-line reason from a failed HTTP response. Handles the
+   * common JSON error shapes — Anthropic/OpenAI `{ error: { message } }`,
+   * FastAPI/LiteLLM `{ detail }`, and plain `{ message }` — and falls back to
+   * a truncated raw body.
+   */
+  private summarizeHttpError(
+    status: number,
+    statusText: string,
+    body: string
+  ): string {
+    let detail = "";
+    try {
+      const json = JSON.parse(body);
+      const candidate =
+        json?.error?.message ??
+        (typeof json?.error === "string" ? json.error : undefined) ??
+        json?.detail ??
+        json?.message;
+      if (typeof candidate === "string") {
+        detail = candidate;
+      }
+    } catch {
+      detail = body.trim().slice(0, 300);
+    }
+    const base = statusText ? `${status} ${statusText}` : `${status}`;
+    return detail ? `${base}: ${detail}` : base;
   }
 
   getProviderName(): string {

--- a/testplanit/lib/llm/adapters/base.adapter.ts
+++ b/testplanit/lib/llm/adapters/base.adapter.ts
@@ -59,6 +59,15 @@ function sanitizeUrl(url: string): string {
 export abstract class BaseLlmAdapter {
   protected config: LlmAdapterConfig;
 
+  /**
+   * Detail about why the most recent `testConnection()` attempt failed
+   * (HTTP status + provider message, or a network/timeout description).
+   * Adapters set this so callers can surface the real reason instead of a
+   * generic "failed to connect". Undefined after a successful attempt or
+   * when an adapter doesn't record detail.
+   */
+  protected lastTestConnectionError?: string;
+
   constructor(config: LlmAdapterConfig) {
     this.config = config;
     if (config.baseUrl) {
@@ -141,6 +150,14 @@ export abstract class BaseLlmAdapter {
    */
   getDefaultModel(): string {
     return this.config.config.defaultModel;
+  }
+
+  /**
+   * Return the reason the most recent `testConnection()` call failed, if the
+   * adapter recorded one. See {@link lastTestConnectionError}.
+   */
+  getLastTestConnectionError(): string | undefined {
+    return this.lastTestConnectionError;
   }
 
   /**


### PR DESCRIPTION
## Problem

In **Admin > AI Models > Add AI Model**, clicking **Test Connection** always showed a generic `Failed to connect to <provider>. Please check your credentials and endpoint.` — the adapter caught the provider's HTTP error and dropped it, so nothing useful reached the toast *or* the server logs.

This made a common, config-side problem impossible to diagnose from the app: with a **LiteLLM proxy** (e.g. `llm.refract.ai`), `GET /v1/models` returns **all** models on the proxy, so the model dropdown populates fine — but the key is **team/model-scoped**, so `POST /v1/messages` for a disallowed model returns:

```
HTTP 403 {"error":{"message":"User not allowed to access model. No default model access,
only team models allowed. Tried to access claude-haiku-4-5",
"type":"key_model_access_denied","code":"403"}}
```

The user only saw "Failed to connect," with no hint that it was a key-permissions issue on a specific model.

## Change

- **`base.adapter.ts`** — add a `lastTestConnectionError` slot + `getLastTestConnectionError()` getter so callers can read the real reason off any adapter.
- **`anthropic.adapter.ts`** — `testConnection()` no longer catches-and-drops the failure. On a non-`200/400` response it records the status + parsed provider message (handles Anthropic/OpenAI `{error:{message}}`, LiteLLM/FastAPI `{detail}`, plain `{message}`, or a truncated raw body) and distinguishes timeouts/network errors. The success path (`200/400 -> true`) is unchanged.
- **`test-credentials/route.ts`** — prefer that detail in the response/toast and `console.warn` it server-side; fall back to the existing generic message when no detail was recorded.
- **`anthropic.adapter.ts`** — normalize a trailing slash on the endpoint so a user-supplied `.../v1/` + `/messages` can't become `.../v1//messages` (mirrors what the available-models route already does).

After this, the same failure surfaces as:

> Failed to connect to ANTHROPIC: 403: User not allowed to access model. No default model access, only team models allowed. Tried to access claude-haiku-4-5

## Scope / safety

- Behavior-preserving on success; extra work only runs on failure.
- Only the **Anthropic** adapter populates the detail today; other providers keep their current generic message (the base plumbing is generic, so extending OpenAI/Gemini/etc. later is trivial).
- Existing **anthropic + base adapter tests (54) pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)