### PR TITLE
fix(docker): wire SELF_HOSTED into prod build args so self-host images load

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -56,20 +56,46 @@ the full stack (app, workers, Postgres, Valkey, Elasticsearch, MinIO):
 docker compose -f testplanit/docker-compose.prod.yml up -d --build
 ```
 
-### Custom domain (optional)
+### Images and custom domains
 
-`BASE_DOMAIN` is a **build-time** argument that enables Next.js image
-optimization for a wildcard domain — it's only needed if you serve multiple
-subdomains (`a.example.com`, `b.example.com`, …) from a single image. A
-single-domain install does not need it. To set it, build with:
+How TestPlanIt serves uploaded images (project icons, avatars, attachments) is
+fixed at **build time** by the `SELF_HOSTED` build argument. This is the single
+most common self-hosting gotcha, so read this before your first build.
+
+> ⚠️ `SELF_HOSTED` (and `BASE_DOMAIN` below) are **build-time** arguments. They
+> are baked into the Next.js standalone build (`.next/required-server-files.json`)
+> and the running server reads that frozen config. Setting them only at runtime
+> in `.env.production` is **too late and silently has no effect** — the symptom
+> is broken images that return `400` from `/_next/image`. They must reach
+> `next build`, i.e. the `prod` service's `build.args` (already wired in the
+> compose file). Compose fills those from your shell / default `.env` /
+> `--env-file` — **not** from the `.env.production` `env_file`, which only injects
+> runtime variables into the container.
+
+**Default — `SELF_HOSTED=true` (recommended for self-hosting).** The compose file
+defaults to this. Next.js's image optimizer is turned **off**, so `<Image>`
+renders a plain `<img>` pointing straight at your storage. One build then works
+on **any** domain with no allowlist to configure, and `BASE_DOMAIN` is ignored.
+The default build needs nothing extra:
 
 ```bash
-docker build --build-arg BASE_DOMAIN=example.com \
-  --target production -f testplanit/Dockerfile -t testplanit:local .
+docker compose -f testplanit/docker-compose.prod.yml up -d --build
 ```
 
-(or add `args: { BASE_DOMAIN: "${BASE_DOMAIN}" }` under the `prod` service's
-`build:` block in the compose file).
+**Optional — `SELF_HOSTED=false` (Next.js image optimizer on).** Turn the
+optimizer back on only if you want automatic image resizing/re-encoding. You must
+then set `BASE_DOMAIN` to your real domain: it is baked into `next.config`'s image
+`remotePatterns` allowlist so the optimizer accepts `*.your-domain` storage URLs.
+Requests for any host outside the allowlist (including the `example.com` default)
+return `400`.
+
+```bash
+SELF_HOSTED=false BASE_DOMAIN=example.com \
+  docker compose -f testplanit/docker-compose.prod.yml up -d --build
+```
+
+Both are wired through the `prod` service's `build.args` in the compose file
+(`SELF_HOSTED: ${SELF_HOSTED:-true}` and `BASE_DOMAIN: ${BASE_DOMAIN:-example.com}`).
 
 ## Upgrading an existing database
 

--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -50,6 +50,14 @@ The Docker Compose setup starts these containerized services:
 
   The Background Workers figure is steady-state for a typical single-tenant install. One always-on worker (SCIM access recompute) idles near 1.4GB on its own regardless of whether SCIM is configured, which is why the fleet no longer fits in the old 512MB floor. Individual workers also restart at higher ceilings under load (forecast and SCIM access recompute at 2GB, the webhook workers at 3GB each — whose steady-state RSS can approach 1.9GB each in busy multi-tenant clusters). Multi-tenant operators should size the worker fleet well above the recommended figure; see the [worker memory tiers](./background-processes.md) for the per-worker breakdown.
 
+  **Tuning the caps.** The compose file caps the worker fleet at `4G` of memory and Postgres at `2` CPUs. Raise either without editing the file by setting environment variables in your shell, the default `.env`, or `--env-file` — **not** `.env.production`, which is a runtime `env_file` and is not read during compose variable substitution:
+
+  ```bash
+  # e.g. a 32GB host running large Testmo imports:
+  WORKERS_MEMORY_LIMIT=20G POSTGRES_CPU_LIMIT=4 \
+    docker compose -f testplanit/docker-compose.prod.yml up -d --build
+  ```
+
 - 25GB+ disk space for data and images
 
 ## Installation & Setup Steps

--- a/docs/docs/file-storage.md
+++ b/docs/docs/file-storage.md
@@ -326,6 +326,37 @@ Files are accessed directly through signed URLs generated during upload. The sys
 - Ensure storage credentials are valid
 - Review bucket permissions
 
+### Broken Images (400 from `/_next/image`)
+
+**Issue**: Project icons or avatars are broken in some places (e.g. the header
+Projects dropdown) but fine in others (e.g. Admin → Projects). The browser
+console shows repeated `Failed to load resource: 400` for `image`.
+
+**Cause**: Next.js's image optimizer is on and rejecting your storage host. It
+only serves URLs whose host+path are in `next.config`'s `remotePatterns`
+allowlist, which is baked at **build time** from `BASE_DOMAIN`. If `BASE_DOMAIN`
+didn't reach the build (or doesn't match your real domain), `/_next/image`
+returns `400`. Components that render through `<ProjectIcon>` (Admin) set
+`unoptimized` and bypass the optimizer, which is why they still work — that's the
+"some places" symptom.
+
+**Solutions**:
+
+- **Recommended:** rebuild with `SELF_HOSTED=true` (the compose default) so the
+  optimizer is off and images load straight from storage on any domain. It must
+  be a **build arg** — a runtime `.env.production` value is read too late and has
+  no effect. See [Images and custom domains](./building-from-source.md#images-and-custom-domains).
+- Confirm what the running image actually baked (this is authoritative — not a
+  browser cache issue if it says `false`):
+  ```bash
+  docker exec testplanit-prod \
+    grep -o '"unoptimized":[a-z]*' /app/testplanit/.next/required-server-files.json
+  # → "unoptimized":true on a correct self-hosted build
+  ```
+- If you want the optimizer on instead, rebuild with `SELF_HOSTED=false` **and**
+  `BASE_DOMAIN=<your real domain>`.
+- After a correct rebuild, hard-refresh (Cmd/Ctrl+Shift+R) to drop cached `400`s.
+
 ### Storage Configuration
 
 **Issue**: Storage backend not working

--- a/testplanit/docker-compose.prod.yml
+++ b/testplanit/docker-compose.prod.yml
@@ -8,7 +8,19 @@ services:
       args:
         # Baked into next.config's image remotePatterns at build time so the
         # Next.js image optimizer accepts <subdomain>.${BASE_DOMAIN} MinIO URLs.
+        # Only consulted when SELF_HOSTED is false (optimizer on).
         BASE_DOMAIN: ${BASE_DOMAIN:-example.com}
+        # Self-hosted default: turn OFF Next's image optimizer at BUILD time, so
+        # <Image> renders a plain <img> pointing straight at your storage — no
+        # remotePatterns allowlist to satisfy, so one build works on any domain.
+        # This MUST be a build arg: next.config bakes images.unoptimized into the
+        # standalone build (.next/required-server-files.json), and the running
+        # server reads that frozen config — a runtime/env_file var is too late and
+        # silently has no effect (broken images with 400s from /_next/image).
+        # Set SELF_HOSTED=false to run the optimizer instead; then BASE_DOMAIN
+        # above must be your real domain. Substitution reads the build environment
+        # (shell / default .env / --env-file), NOT the .env.production env_file.
+        SELF_HOSTED: ${SELF_HOSTED:-true}
     env_file:
       - .env.production
     ports:
@@ -34,10 +46,12 @@ services:
       resources:
         limits:
           # Recommended ceiling for the worker fleet (see the resource-allocation
-          # table in docs: Installation > Docker Setup). Raise it for very large
-          # Testmo imports or busy multi-tenant clusters, host RAM permitting
-          # (see docs: Background Processes > Worker memory tiers).
-          memory: 4G
+          # table in docs: Installation > Docker Setup). Raise via
+          # WORKERS_MEMORY_LIMIT for very large Testmo imports or busy multi-tenant
+          # clusters, host RAM permitting (see docs: Background Processes > Worker
+          # memory tiers). Set in the build/deploy environment (shell / default
+          # .env / --env-file), not the .env.production env_file.
+          memory: ${WORKERS_MEMORY_LIMIT:-4G}
     depends_on:
       prod:
         condition: service_started
@@ -104,8 +118,10 @@ services:
       # new layout (github.com/docker-library/postgres/issues/1400).
       PGDATA: /var/lib/postgresql/data
     # Cap Postgres CPU usage so the app, workers, nginx, and valkey keep their
-    # share of the host; tune to your host's core count.
-    cpus: "2"
+    # share of the host; tune POSTGRES_CPU_LIMIT to your host's core count. Set in
+    # the deploy environment (shell / default .env / --env-file), not the
+    # .env.production env_file.
+    cpus: "${POSTGRES_CPU_LIMIT:-2}"
     command: >
       postgres
       -c max_parallel_workers=2


### PR DESCRIPTION
## Problem

On a self-hosted instance, uploaded images (project icons, avatars) render broken with repeated `400`s from `/_next/image` in **some** components (header Projects dropdown, tags page, copy-move dialog) while working in others (Admin → Projects) — a confusing "some places" symptom.

**Root cause:** `next.config.ts` sets `unoptimized: process.env.SELF_HOSTED === "true"`, which Next evaluates at **build time** and freezes into the standalone build (`.next/required-server-files.json`). The `prod` service in `docker-compose.prod.yml` only passed `BASE_DOMAIN` as a build arg — **not** `SELF_HOSTED`. An operator who sets `SELF_HOSTED=true` in `.env.production` (a runtime `env_file`) never affects the build, so `next build` bakes `unoptimized: false`, the optimizer stays on, and it rejects any storage host that isn't in the baked `remotePatterns` allowlist → `400`.

The per-component split is because `<ProjectIcon>` (Admin) sets `unoptimized` and routes through the storage proxy, bypassing the optimizer; the broken spots render a raw `<Image src={iconUrl}>`.

## Changes

- **`docker-compose.prod.yml`**: add `SELF_HOSTED: ${SELF_HOSTED:-true}` to the `prod` `build.args` (default on for self-hosting — optimizer off, one image works on any domain). Set `SELF_HOSTED=false` + a real `BASE_DOMAIN` to run the optimizer instead.
- **`docker-compose.prod.yml`**: parameterize per-host knobs so the file no longer needs forking — `memory: ${WORKERS_MEMORY_LIMIT:-4G}` (workers) and `cpus: "${POSTGRES_CPU_LIMIT:-2}"` (Postgres).
- **Docs**:
  - `building-from-source.md` — "Custom domain" → **"Images and custom domains"**, documenting `SELF_HOSTED` and a ⚠️ that these are build-time args (a runtime `.env.production` value silently has no effect).
  - `docker-setup.md` — documents the `WORKERS_MEMORY_LIMIT` / `POSTGRES_CPU_LIMIT` knobs and where compose reads them from.
  - `file-storage.md` — new Troubleshooting entry: **Broken Images (400 from `/_next/image`)** with the authoritative baked-config check.

## Verify

Confirmed fixed on a live self-hosted instance. After rebuild:

```bash
docker exec testplanit-prod \
  grep -o '"unoptimized":[a-z]*' /app/testplanit/.next/required-server-files.json
# → "unoptimized":true
```

## Notes

Base is **`beta`**: these edits build on the beta version of `docker-compose.prod.yml`, which has structurally diverged from `main` (static IPs, `zenstack migrate deploy`, the `args:` block). They do not apply cleanly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)