### PR TITLE
feat(nginx): local overrides + custom-error-pages drop-in

### DIFF
--- a/testplanit/.gitignore
+++ b/testplanit/.gitignore
@@ -78,3 +78,9 @@ app/api/.audit-route-inventory.txt
 app/api/.bearer-token-audit-inventory.txt
 app/actions/.audit-action-inventory.txt
 lib/.queue-add-inventory.md
+
+# Local nginx overrides (custom error pages, etc.): keep the README + *.example
+# tracked; the operator's real *.conf and pages stay local and untracked.
+/nginx-local/*
+!/nginx-local/README.md
+!/nginx-local/*.example

--- a/testplanit/docker-compose.prod.yml
+++ b/testplanit/docker-compose.prod.yml
@@ -247,6 +247,9 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./maintenance.html:/etc/nginx/maintenance.html:ro
+      # Per-deployment overrides (custom error pages, etc.). Tracked dir holds
+      # only a README + *.example; real *.conf and pages are gitignored/local.
+      - ./nginx-local:/etc/nginx/local:ro
     networks:
       testplanit-net:
         ipv4_address: 172.19.0.60

--- a/testplanit/nginx-local/README.md
+++ b/testplanit/nginx-local/README.md
@@ -1,0 +1,46 @@
+# Local nginx overrides
+
+This directory is bind-mounted into the nginx container at `/etc/nginx/local`
+(see the `nginx` service in `docker-compose.prod.yml`), and `nginx.conf` loads
+every `*.conf` here via:
+
+```nginx
+include /etc/nginx/local/*.conf;
+```
+
+Use it for **per-deployment** nginx config that should not be committed —
+typically custom, branded error pages. Everything here is gitignored **except**
+this README and any `*.example` file, so your customizations survive
+`git pull` and container rebuilds without living in version control.
+
+> The include does **not** enable `proxy_intercept_errors`. An included file can
+> therefore only restyle errors nginx generates itself — chiefly **502 / 504**
+> (shown when the app is down or redeploying) and any nginx-level 404/500.
+> Responses proxied from the app (its own 404/500, API routes, RSC/data fetches,
+> missing assets) pass through untouched. `503` is reserved for maintenance mode.
+
+## Custom error pages — quick start
+
+1. Copy the example config into an active one (the `.example` suffix is inert;
+   only real `*.conf` files are loaded):
+
+   ```bash
+   cp nginx-local/error-pages.conf.example nginx-local/error-pages.conf
+   ```
+
+2. Drop your self-contained HTML pages in `nginx-local/error-pages/`. The example
+   expects `404.html`, `500.html`, and `502.html`. Make them **fully
+   self-contained** (inline CSS/SVG, no dependency on the app being up — a 502
+   page is shown precisely when the app is down).
+
+3. Apply — nginx uses a bind mount, so no image rebuild is needed:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d --force-recreate nginx
+   ```
+
+To verify the config parses before reloading:
+
+```bash
+docker exec testplanit-nginx nginx -t
+```

--- a/testplanit/nginx-local/error-pages.conf.example
+++ b/testplanit/nginx-local/error-pages.conf.example
@@ -1,0 +1,20 @@
+# Custom error pages — copy to `error-pages.conf` to activate (only real *.conf
+# files are loaded by the include hook in nginx.conf; this .example is inert).
+#
+# proxy_intercept_errors is intentionally NOT enabled, so these replace ONLY
+# errors nginx itself generates — chiefly 502/504 when the app is down or
+# redeploying. Responses proxied from the app pass through untouched.
+#
+# 503 is deliberately left alone — it is owned by the maintenance-mode handler.
+#
+# Put the referenced HTML files in ./error-pages/ (self-contained: inline
+# CSS/SVG, no dependency on the app being reachable).
+
+error_page 404 /__error-pages/404.html;
+error_page 500 /__error-pages/500.html;
+error_page 502 504 /__error-pages/502.html;
+
+location ^~ /__error-pages/ {
+    internal;
+    alias /etc/nginx/local/error-pages/;
+}

--- a/testplanit/nginx.conf
+++ b/testplanit/nginx.conf
@@ -14,6 +14,13 @@ http {
         set $app_upstream    http://prod:3000;
         set $minio_upstream  http://minio:9000;
 
+        # Optional per-deployment overrides (e.g. custom error pages). Drop *.conf
+        # files into ./nginx-local (bind-mounted at /etc/nginx/local, gitignored);
+        # see nginx-local/README.md. No-op when the directory is empty. This does
+        # NOT enable proxy_intercept_errors, so app responses pass through
+        # untouched — an included file can only restyle nginx-generated errors.
+        include /etc/nginx/local/*.conf;
+
         # Maintenance mode - returns 503 if /etc/nginx/maintenance.json exists
         error_page 503 @maintenance;
 


### PR DESCRIPTION
## What

Adds a bind-mounted, gitignored `nginx-local/` drop-in so operators can supply **per-deployment** nginx config — chiefly branded error pages — that survives rebuilds and `git pull` **without forking `nginx.conf`**.

- `nginx.conf`: `include /etc/nginx/local/*.conf;` at server scope (no-op when empty).
- `docker-compose.prod.yml`: mount `./nginx-local:/etc/nginx/local:ro` on the `nginx` service (alongside the existing `nginx.conf` / `maintenance.html` mounts).
- `.gitignore`: ignore `nginx-local/*` except `README.md` and `*.example`.
- `nginx-local/README.md` + `nginx-local/error-pages.conf.example`: document the mechanism and give a ready-to-copy error-page config.

Operators' real `error-pages.conf` and HTML pages stay **local and untracked**.

## Important: no interception

The include deliberately does **not** enable `proxy_intercept_errors`. An included file can therefore only restyle errors **nginx generates itself** — chiefly **502 / 504** (shown when the app is down or redeploying) and any nginx-level 404/500. Responses proxied from the app (its own 404/500, API routes, RSC/data fetches, missing assets) pass through untouched. `503` remains owned by the maintenance-mode handler.

This is the safe default for a Next.js upstream, where blanket interception would turn API/RSC/asset errors into HTML.

## Usage

```bash
cp nginx-local/error-pages.conf.example nginx-local/error-pages.conf
# add self-contained nginx-local/error-pages/{404,500,502}.html
docker compose -f docker-compose.prod.yml up -d --force-recreate nginx
```

## Verification

`nginx -t` passes with an example config + pages mounted:

```
nginx: configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

Base is **`beta`** (same active deploy branch as the prior compose changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)