### PR TITLE
fix(live): stop SSE issue invalidation from livelocking slow queries

### DIFF
--- a/testplanit/.env.example
+++ b/testplanit/.env.example
@@ -10,6 +10,23 @@
 # Default connects to the database service defined in docker-compose.yml via the host-mapped port (5432)
 DATABASE_URL="postgresql://user:password@postgres:5432/testplanit?schema=public"
 
+# Client-side connection pool (pg.Pool) — OPTIONAL, sane defaults applied
+# These are set explicitly in lib/db/poolConfig.ts because node-postgres'
+# own defaults (max 10, unbounded wait for a free slot) let a burst of slow
+# queries queue every other request indefinitely and hang the whole app.
+# Per process, and one pool per replica — total must stay under the server's
+# max_connections. Default 20.
+# DATABASE_POOL_MAX=20
+# Max ms a query waits for a free pool slot before failing. Default 10000.
+# 0 restores the unbounded wait — not recommended, that is the outage default.
+# DATABASE_POOL_CONNECTION_TIMEOUT_MS=10000
+# Ms an unused client sits in the pool before being closed. Default 10000.
+# DATABASE_POOL_IDLE_TIMEOUT_MS=10000
+# Server-side per-statement deadline in ms. UNSET by default: workers run
+# legitimately long statements (bulk import, magic-select, milestone sync, ES
+# reindex) that a blanket timeout would abort. Set it on the web process only.
+# DATABASE_STATEMENT_TIMEOUT_MS=30000
+
 # Connection pooler (pgbouncer) support — OPTIONAL
 # When a transaction-mode pooler (e.g. pgbouncer) sits in front of Postgres:
 #   1. Append "&pgbouncer=true" to DATABASE_URL above so Prisma disables named

--- a/testplanit/hooks/useIssueUpdateStream.test.ts
+++ b/testplanit/hooks/useIssueUpdateStream.test.ts
@@ -117,4 +117,19 @@ describe("scheduleIssueInvalidation", () => {
       predicate({ queryKey: ["zenstack", "Projects", "findMany", {}] })
     ).toBe(false);
   });
+
+  // Regression guard for the 2026-07-23 outage. TanStack's default
+  // (cancelRefetch: true) aborts the in-flight request on every invalidation
+  // pass, so a query slower than the issue-event interval is restarted forever
+  // and never resolves. A steady Jira sync stream then pins a case-detail page
+  // in permanent refetch, holding pg pool slots and starving every other route.
+  it("leaves an in-flight refetch alone instead of cancelling it", () => {
+    const invalidateQueries = vi.fn();
+    scheduleIssueInvalidation({ invalidateQueries } as any);
+    vi.advanceTimersByTime(250);
+
+    expect(invalidateQueries.mock.calls[0][1]).toEqual({
+      cancelRefetch: false,
+    });
+  });
 });

--- a/testplanit/hooks/useIssueUpdateStream.ts
+++ b/testplanit/hooks/useIssueUpdateStream.ts
@@ -58,9 +58,33 @@ export function scheduleIssueInvalidation(queryClient: QueryClient): void {
     invalidateTimer = null;
     const client = pendingQueryClient;
     pendingQueryClient = null;
-    void client?.invalidateQueries({
-      predicate: (query) => isIssueBearingQueryKey(query.queryKey),
-    });
+    void client?.invalidateQueries(
+      {
+        predicate: (query) => isIssueBearingQueryKey(query.queryKey),
+      },
+      // cancelRefetch:false is load-bearing, not a tweak. TanStack's default
+      // (true) ABORTS the in-flight request and restarts it on every
+      // invalidation pass. When a matched query is slower than the interval
+      // between issue events, it is cancelled and restarted forever and never
+      // resolves — a livelock, not just churn.
+      //
+      // That is exactly what took prod down on 2026-07-23: a Jira sync burst
+      // published issue events continuously while a browser sat on
+      // /projects/repository/:projectId/:caseId. Both heavy findFirst queries
+      // on that page are issue-bearing (they pull `caseIssues` / `issues`) and
+      // take 17-25s server-side, so each 200ms pass killed the in-flight
+      // request and issued a new one: 677 requests for a single case in three
+      // minutes, every one of them aborted (nginx 499), each still holding a
+      // pg pool slot until the server noticed the abort. The pool (10) stayed
+      // saturated and every other route queued behind it.
+      //
+      // With cancelRefetch:false an in-flight fetch is left alone to finish;
+      // the invalidation still marks the query stale, so it refetches once the
+      // current attempt settles. Slow queries make progress instead of
+      // starving, and the request rate is bounded by completion rather than by
+      // the event rate.
+      { cancelRefetch: false }
+    );
   }, INVALIDATE_COALESCE_MS);
 }
 

--- a/testplanit/lib/db/poolConfig.test.ts
+++ b/testplanit/lib/db/poolConfig.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getPoolConfig,
+  getPoolConnectionTimeoutMs,
+  getPoolIdleTimeoutMs,
+  getPoolMax,
+  getStatementTimeoutMs,
+} from "./poolConfig";
+
+const ENV_KEYS = [
+  "DATABASE_POOL_MAX",
+  "DATABASE_POOL_CONNECTION_TIMEOUT_MS",
+  "DATABASE_POOL_IDLE_TIMEOUT_MS",
+  "DATABASE_STATEMENT_TIMEOUT_MS",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("getPoolMax", () => {
+  it("defaults to 20 rather than node-postgres' 10", () => {
+    expect(getPoolMax()).toBe(20);
+  });
+
+  it("reads an explicit override", () => {
+    process.env.DATABASE_POOL_MAX = "50";
+    expect(getPoolMax()).toBe(50);
+  });
+
+  it.each(["", "   ", "abc", "-5", "0"])(
+    "falls back to the default for %o",
+    (raw) => {
+      process.env.DATABASE_POOL_MAX = raw;
+      expect(getPoolMax()).toBe(20);
+    }
+  );
+});
+
+describe("getPoolConnectionTimeoutMs", () => {
+  // The whole point of the module: pg's default of 0 means "queue forever",
+  // which is what let a slow-query burst hang every route in the app.
+  it("defaults to a finite 10s wait, not pg's unbounded 0", () => {
+    expect(getPoolConnectionTimeoutMs()).toBe(10_000);
+  });
+
+  it("honours an explicit 0 as opt-in unbounded waiting", () => {
+    process.env.DATABASE_POOL_CONNECTION_TIMEOUT_MS = "0";
+    expect(getPoolConnectionTimeoutMs()).toBe(0);
+  });
+
+  it("rejects negative and non-numeric values", () => {
+    process.env.DATABASE_POOL_CONNECTION_TIMEOUT_MS = "-1";
+    expect(getPoolConnectionTimeoutMs()).toBe(10_000);
+    process.env.DATABASE_POOL_CONNECTION_TIMEOUT_MS = "soon";
+    expect(getPoolConnectionTimeoutMs()).toBe(10_000);
+  });
+});
+
+describe("getPoolIdleTimeoutMs", () => {
+  it("defaults to 10s and allows 0 to disable eviction", () => {
+    expect(getPoolIdleTimeoutMs()).toBe(10_000);
+    process.env.DATABASE_POOL_IDLE_TIMEOUT_MS = "0";
+    expect(getPoolIdleTimeoutMs()).toBe(0);
+  });
+});
+
+describe("getStatementTimeoutMs", () => {
+  // Opt-in on purpose: workers run multi-minute statements (bulk import,
+  // magic-select, milestone sync, ES reindex) that a default would abort.
+  it("is undefined unless explicitly configured", () => {
+    expect(getStatementTimeoutMs()).toBeUndefined();
+  });
+
+  it("reads a positive override", () => {
+    process.env.DATABASE_STATEMENT_TIMEOUT_MS = "30000";
+    expect(getStatementTimeoutMs()).toBe(30_000);
+  });
+
+  it.each(["0", "-1", "nope", "  "])("ignores %o", (raw) => {
+    process.env.DATABASE_STATEMENT_TIMEOUT_MS = raw;
+    expect(getStatementTimeoutMs()).toBeUndefined();
+  });
+});
+
+describe("getPoolConfig", () => {
+  it("bounds the pool and the wait for a slot by default", () => {
+    expect(getPoolConfig()).toEqual({
+      max: 20,
+      connectionTimeoutMillis: 10_000,
+      idleTimeoutMillis: 10_000,
+    });
+  });
+
+  it("omits statement_timeout entirely when unset", () => {
+    expect(getPoolConfig()).not.toHaveProperty("statement_timeout");
+  });
+
+  it("includes statement_timeout only when configured", () => {
+    process.env.DATABASE_STATEMENT_TIMEOUT_MS = "30000";
+    expect(getPoolConfig()).toMatchObject({ statement_timeout: 30_000 });
+  });
+});

--- a/testplanit/lib/db/poolConfig.ts
+++ b/testplanit/lib/db/poolConfig.ts
@@ -1,0 +1,111 @@
+// lib/db/poolConfig.ts
+//
+// Single source of truth for the pg connection-pool settings shared by every
+// runtime ZenStack client (the app client in lib/zenstack.ts and the
+// per-tenant worker clients in lib/multiTenantDb.ts).
+//
+// Kept dependency-light (only reads process.env) so it can be imported from the
+// Kysely routing dialect, the app client, and workers alike — same shape as
+// replicaConfig.ts.
+//
+// Why this module exists: `new Pool({ connectionString })` with no options
+// silently inherits node-postgres' defaults, and two of those defaults turned a
+// slow-query incident into a full outage on 2026-07-23 —
+//
+//   max: 10                    → only 10 concurrent queries process-wide.
+//   connectionTimeoutMillis: 0 → "wait forever" for a free slot.
+//
+// Once ten 17-25s queries held every slot, every other request queued behind
+// them with no deadline, so the whole app hung while postgres itself sat idle
+// at 3 of 100 connections. Unbounded queueing is the part that turns saturation
+// into an outage: without a deadline nothing sheds load, and the queue only
+// drains when someone restarts the process.
+
+import type { PoolConfig } from "pg";
+
+/** node-postgres' own default, kept explicit so the baseline is visible. */
+const DEFAULT_MAX_CONNECTIONS = 20;
+/** Max wait for a free pool slot before the query fails. 0 would mean forever. */
+const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
+/** How long an unused client sits in the pool before it is closed. */
+const DEFAULT_IDLE_TIMEOUT_MS = 10_000;
+
+function readPositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  { allowZero = false } = {}
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < 0) return fallback;
+  if (parsed === 0 && !allowZero) return fallback;
+  return Math.floor(parsed);
+}
+
+/**
+ * Pool size per process. Remember this is multiplied by the number of processes
+ * pointing at the same database (web + workers, plus one pool per configured
+ * read replica), and postgres' own `max_connections` is the ceiling for the
+ * total. Default 20.
+ */
+export function getPoolMax(): number {
+  return readPositiveInt(process.env.DATABASE_POOL_MAX, DEFAULT_MAX_CONNECTIONS);
+}
+
+/**
+ * How long a query waits for a free pool slot before failing. Defaults to
+ * 10000. Set to 0 to restore node-postgres' unbounded wait — which is what
+ * allowed a slow-query burst to hang every route in the app, so prefer a finite
+ * value. A request that fails here surfaces as a 500 in seconds instead of
+ * hanging until the client gives up.
+ */
+export function getPoolConnectionTimeoutMs(): number {
+  return readPositiveInt(
+    process.env.DATABASE_POOL_CONNECTION_TIMEOUT_MS,
+    DEFAULT_CONNECTION_TIMEOUT_MS,
+    { allowZero: true }
+  );
+}
+
+/** Idle-client eviction window. Defaults to 10000; 0 disables eviction. */
+export function getPoolIdleTimeoutMs(): number {
+  return readPositiveInt(
+    process.env.DATABASE_POOL_IDLE_TIMEOUT_MS,
+    DEFAULT_IDLE_TIMEOUT_MS,
+    { allowZero: true }
+  );
+}
+
+/**
+ * Server-side per-statement deadline, in milliseconds. OPT-IN (unset = no
+ * timeout, postgres' default) because this module is shared with the worker
+ * clients, and workers legitimately run multi-minute statements — bulk import,
+ * magic-select, milestone sync, Elasticsearch reindex. A blanket default here
+ * would abort those mid-flight. Set DATABASE_STATEMENT_TIMEOUT_MS on the web
+ * process only if you want runaway queries capped there.
+ */
+export function getStatementTimeoutMs(): number | undefined {
+  const raw = process.env.DATABASE_STATEMENT_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+/**
+ * The pg.Pool options every runtime client should be built with. Passed through
+ * `createDialect(..., poolConfig)` so the primary pool and each replica pool are
+ * configured identically.
+ */
+export function getPoolConfig(): Omit<PoolConfig, "connectionString"> {
+  const statementTimeoutMs = getStatementTimeoutMs();
+  return {
+    max: getPoolMax(),
+    connectionTimeoutMillis: getPoolConnectionTimeoutMs(),
+    idleTimeoutMillis: getPoolIdleTimeoutMs(),
+    ...(statementTimeoutMs !== undefined
+      ? { statement_timeout: statementTimeoutMs }
+      : {}),
+  };
+}

--- a/testplanit/lib/multiTenantDb.ts
+++ b/testplanit/lib/multiTenantDb.ts
@@ -4,6 +4,7 @@
 import { ZenStackClient } from "@zenstackhq/orm";
 import * as fs from "fs";
 
+import { getPoolConfig } from "~/lib/db/poolConfig";
 import { createDialect } from "~/lib/db/readWriteDialect";
 import { type DbClient } from "~/lib/zenstack";
 import { schema } from "~/zenstack/schema";
@@ -234,7 +235,13 @@ export function getAllTenantIds(): string[] {
 function createTenantDbClient(config: TenantConfig): DbClient {
   const client = new ZenStackClient(schema, {
     // Per-tenant replicas only (never the process-wide app replica list).
-    dialect: createDialect(config.databaseUrl, config.replicaUrls ?? []),
+    // Pool sizing is process-wide (see lib/db/poolConfig.ts) and applies per
+    // tenant client, so DATABASE_POOL_MAX is multiplied by the tenant count.
+    dialect: createDialect(
+      config.databaseUrl,
+      config.replicaUrls ?? [],
+      getPoolConfig()
+    ),
   });
 
   return client;

--- a/testplanit/lib/zenstack.ts
+++ b/testplanit/lib/zenstack.ts
@@ -21,6 +21,7 @@ import { PolicyPlugin } from "@zenstackhq/plugin-policy";
 
 import { schema } from "~/zenstack/schema";
 
+import { getPoolConfig } from "./db/poolConfig";
 import { createDialect } from "./db/readWriteDialect";
 import { getReplicaUrls } from "./db/replicaConfig";
 import { sideEffectsPlugin } from "./zenstack-plugins/sideEffectsPlugin";
@@ -30,7 +31,14 @@ function createClients() {
   // spread across replicas and writes/transactions stay on the primary; when it
   // is unset this is a plain single-pool Postgres dialect (unchanged behaviour).
   const rawClient = new ZenStackClient(schema, {
-    dialect: createDialect(process.env.DATABASE_URL ?? "", getReplicaUrls()),
+    // getPoolConfig(): explicit pool sizing + a bounded wait for a free slot.
+    // Without it pg defaults to max:10 and an UNBOUNDED connect wait, so a
+    // burst of slow queries queues every other request forever (2026-07-23).
+    dialect: createDialect(
+      process.env.DATABASE_URL ?? "",
+      getReplicaUrls(),
+      getPoolConfig()
+    ),
   });
   const baseClient = rawClient.$use(sideEffectsPlugin);
   // dangerouslyAllowRawSql: the sideEffectsPlugin's beforeEntityMutation hook


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-07-23 15:29–15:32 UTC prod outage, plus the connection-pool defaults that amplified it into a full app hang.

The app never crashed — no OOM, no stack trace, container exit code 0. It was livelocked, and the restart is the only reason the container stopped.

## Root cause

`hooks/useIssueUpdateStream.ts` invalidated on every SSE issue event using TanStack's default `cancelRefetch: true`, which **aborts the in-flight request** and restarts it. Any matched query slower than the interval between issue events is cancelled and restarted forever and never resolves.

The chain:

1. A Jira sync burst (worker `refresh-issue` + milestone sync) published issue events continuously.
2. A browser sat on `/projects/repository/9/87003`. That page runs two heavy `repositoryCases.findFirst` queries — `TestCaseDetailsView.tsx:502` and `TestResultHistory.tsx:783`.
3. Both match `isIssueBearingQueryKey` (one pulls `caseIssues`, the other `issues`), so **every** 200ms pass invalidated both.
4. Each pass killed the in-flight request and issued a new one. The queries take 17–25s, so they could never finish.

Evidence from the logs — 677 requests for a **single** case id in three minutes, alternating **339 / 338** between exactly the two query shapes, every one aborted (nginx 499). Only ~105 ever reached postgres.

```
15:28  200 x611          <- healthy
15:29  200 x231  499 x400
15:30  200 x124  499 x468
15:31  200 x1    499 x221   <- app effectively dead
```

## Amplifier: pool defaults

Both runtime clients built `new Pool({connectionString})` with no options, inheriting node-postgres' defaults — `max: 10` and `connectionTimeoutMillis: 0` (**queue forever**). Ten slow queries held every slot and everything else queued with no deadline, so nothing shed load and the queue only drained on restart, while postgres itself sat idle at 3 of 100 connections.

> Note: this stack is ZenStack v3 + Kysely + `pg`, **not** Prisma — Prisma's `connection_limit` / `num_cpus*2+1` formula does not apply here.

## Changes

**`hooks/useIssueUpdateStream.ts`** — pass `{ cancelRefetch: false }`. An in-flight fetch is left to finish; the invalidation still marks the query stale so it refetches once the current attempt settles. Request rate becomes bounded by completion rather than by the event rate.

**`lib/db/poolConfig.ts`** (new) — single source of truth for `pg.Pool` options, wired into `lib/zenstack.ts` and `lib/multiTenantDb.ts`:

| Env var | Default | Why |
|---|---|---|
| `DATABASE_POOL_MAX` | 20 | Up from pg's 10; per process, stays under `max_connections=100` |
| `DATABASE_POOL_CONNECTION_TIMEOUT_MS` | 10000 | Replaces the unbounded wait — fails fast instead of queueing forever |
| `DATABASE_POOL_IDLE_TIMEOUT_MS` | 10000 | Explicit rather than inherited |
| `DATABASE_STATEMENT_TIMEOUT_MS` | *unset* | Opt-in |

`statement_timeout` is deliberately **not** defaulted: this module is shared with the worker clients, and workers run legitimately multi-minute statements (bulk import, magic-select, milestone sync, ES reindex) that a blanket timeout would abort mid-flight.

`lib/rawDbClient.ts` is left alone — it's the seed/e2e script factory with explicitly independent, short-lived pools.

## Scope checked

`useMilestoneLiveStream` and `useTestRunLiveStream` don't invalidate, so this defect is localized to the issue stream.

## Testing

- 27 new/updated tests pass — `lib/db/poolConfig.test.ts` (new, 20) and `hooks/useIssueUpdateStream.test.ts` (regression guard asserting `cancelRefetch: false` is passed)
- Surrounding suites green: 91 passed / 5 skipped across `lib/db/` + `lib/multiTenantDb.test.ts`
- `tsc --noEmit`: no errors in any changed file (77 pre-existing errors in untouched files are unaffected)

## Not addressed here

- `/version` is a 307 redirect touching neither the ORM nor the DB, which is why the ELB healthcheck stayed green through the entire outage. It should become a real readiness probe.
- Those `findFirst` queries are inherently slow at 17–25s, which ties back to the ACL planner-collapse investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
