### PR TITLE
chore(db): size the connection pools per service

### DIFF
--- a/testplanit/docker-compose.prod.yml
+++ b/testplanit/docker-compose.prod.yml
@@ -23,6 +23,21 @@ services:
         SELF_HOSTED: ${SELF_HOSTED:-true}
     env_file:
       - .env.production
+    environment:
+      # Per-service pool size (overrides any DATABASE_POOL_MAX in the shared
+      # .env.production env_file). See lib/db/poolConfig.ts.
+      #
+      # Budget against postgres max_connections=300 (297 usable after the 3
+      # superuser-reserved): prod 100 + workers 60 = 160 peak, leaving ~137 for
+      # psql sessions, `migrate deploy`, and one-off containers. Raising either
+      # value past that budget trades an app-side queue for postgres refusing
+      # connections outright (FATAL 53300), which is strictly worse.
+      #
+      # Note the host has 4 vCPUs, so concurrency beyond ~4x that mostly queues
+      # inside postgres rather than adding throughput. The pool is sized for
+      # burst absorption, not parallelism: it exists so a handful of slow
+      # queries can't occupy every slot and stall unrelated routes.
+      DATABASE_POOL_MAX: ${PROD_DATABASE_POOL_MAX:-100}
     ports:
       - "${DOCKER_PROD_APP_PORT:-30000}:3000"
     networks:
@@ -38,6 +53,13 @@ services:
       target: workers
     env_file:
       - .env.production
+    environment:
+      # Worker-side pool. Smaller than prod's because the fleet's summed BullMQ
+      # concurrency (~30 across sync/audit/email/copy-move/... queues) is the
+      # real upper bound on simultaneous queries here; 60 leaves room for the
+      # bursty ones without eating into prod's share of the 297-connection
+      # budget. See the note on the prod service above.
+      DATABASE_POOL_MAX: ${WORKERS_DATABASE_POOL_MAX:-60}
     networks:
       testplanit-net:
         ipv4_address: 172.19.0.11


### PR DESCRIPTION
## Summary

Follow-up to #519. That PR added `lib/db/poolConfig.ts` but left every service on the default of 20 connections. Since `prod` and `workers` share the `.env.production` env_file, per-service values need a compose-level `environment:` override.

| Service | `DATABASE_POOL_MAX` | Override var |
|---|---|---|
| prod | 100 | `PROD_DATABASE_POOL_MAX` |
| workers | 60 | `WORKERS_DATABASE_POOL_MAX` |

## Connection budget

`max_connections` was raised 100 → 300 on the deploy host via `ALTER SYSTEM` (persisted to `postgresql.auto.conf`, applied with a postgres restart).

```
297 usable (300 - 3 superuser-reserved)
-100  prod
- 60  workers
-----
 137  headroom: psql, migrate deploy, one-off containers
```

Pushing either value past that budget would trade an app-side queue for postgres refusing connections outright (`FATAL 53300`), which is strictly worse.

## Why these numbers

Workers get the smaller share because the fleet's summed BullMQ concurrency (~30 across the sync / audit / email / copy-move / magic-select queues) is the real upper bound on simultaneous queries there — a larger pool would sit idle.

Sized for **burst absorption, not parallelism**. The host has 4 vCPUs, so concurrency much beyond that mostly queues inside postgres rather than adding throughput. The point is that a handful of 17–25s queries can no longer occupy every slot and stall unrelated routes — the mechanism that turned a slow-query burst into a full outage on 2026-07-23.

## Deployed

Already applied to prod ahead of this merge; this PR brings the repo in line with the running config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
