### PR TITLE
chore(cli): correct repository.url casing for npm provenance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -56,7 +56,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/testplanit/testplanit.git",
+    "url": "https://github.com/TestPlanIt/testplanit.git",
     "directory": "cli"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
## Description

Corrects the `repository.url` in `cli/package.json` from a lowercase org (`https://github.com/testplanit/testplanit.git`) to the canonical case (`https://github.com/TestPlanIt/testplanit.git`).

### Why

npm **trusted publishing** validates the package's `repository.url` against the provenance derived from the GitHub repo, which is the canonical `TestPlanIt/testplanit`. The lowercase value failed that check:

```
E422 … Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/testplanit/testplanit.git",
expected to match "https://github.com/TestPlanIt/testplanit" from provenance
```

`changeset publish` (in the Package Release workflow) attempts every workspace package whose local version isn't on npm, including `@testplanit/cli`. That E422 — combined with a changesets CLI bug (`isAlreadyPublishedError` reading `.includes` of the malformed error → `TypeError`) — crashed the whole publish step and failed the run, even though every `packages/*` package published successfully. `@testplanit/cli` is the **only** workspace package with the wrong casing; `api`, `mcp-server`, `playwright-reporter`, and `wdio-reporter` already use `TestPlanIt`.

This also unblocks `@testplanit/cli`'s own future releases (`cli-semantic-release.yml`), which use trusted publishing and would hit the identical provenance failure.

## Related Issue

Closes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

`cli/package.json` validated as parseable JSON. No changeset added — `@testplanit/cli` is in the changesets `ignore` list and is released via `cli-semantic-release.yml`, not Changesets. The `chore(cli):` type intentionally does **not** cut a cli release; it only corrects the metadata so the next publish (and future `packages-release` runs) validate provenance instead of crashing.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- A follow-up worth considering (out of scope here): `packages-release.yml` runs `pnpm changeset publish` with no filter, so it keeps trying to publish `@testplanit/cli` even though cli is in the changesets `ignore` list and has its own release workflow. Excluding cli from that publish step would stop `packages-release` from touching it at all.
- A matching PR targets `beta` (same one-line fix).
