### PR TITLE
chore(cli): correct repository.url casing for npm provenance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -56,7 +56,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/testplanit/testplanit.git",
+    "url": "https://github.com/TestPlanIt/testplanit.git",
     "directory": "cli"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
## Description

Beta counterpart of #524. Corrects `cli/package.json` `repository.url` from a lowercase org (`https://github.com/testplanit/testplanit.git`) to the canonical case (`https://github.com/TestPlanIt/testplanit.git`).

### Why

npm **trusted publishing** validates the package's `repository.url` against the provenance derived from the GitHub repo (`TestPlanIt/testplanit`). The lowercase value fails that check:

```
E422 … Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/testplanit/testplanit.git",
expected to match "https://github.com/TestPlanIt/testplanit" from provenance
```

`changeset publish` attempts `@testplanit/cli`, that E422 (plus a changesets CLI crash handling the malformed error) failed the Package Release workflow even though every `packages/*` package published fine. `@testplanit/cli` is the only workspace package with the wrong casing.

## Related Issue

Closes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

`cli/package.json` validated as parseable JSON. No changeset — `@testplanit/cli` is in the changesets `ignore` list and releases via `cli-semantic-release.yml`; the `chore(cli):` type does not cut a cli release, it only corrects the metadata.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Same one-line fix as #524 (targets `main`).
