### PR TITLE
ci(packages-release): stop changeset publish from touching @testplanit/cli

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -84,7 +84,18 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          # `changeset publish` publishes every non-private workspace package
+          # and ignores the changesets `ignore` list at publish time, so it also
+          # tries to (re)publish `@testplanit/cli` — which is released by its own
+          # `cli-semantic-release.yml` pipeline and is already on npm. That
+          # redundant attempt crashes the run. Hide cli from `changeset publish`
+          # by marking it private for the duration of this step only (the runner
+          # is ephemeral and this runs on the publish path, not the version-PR
+          # path, so it is never committed). cli/package.json stays non-private
+          # everywhere else, so `@semantic-release/npm` still publishes cli.
+          publish: |
+            node -e "const f='cli/package.json',fs=require('fs');const p=JSON.parse(fs.readFileSync(f));p.private=true;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+            pnpm changeset publish
           version: pnpm changeset version
           title: 'chore(packages): version packages'
           commit: 'chore(packages): version packages'


### PR DESCRIPTION
## Description

`packages-release.yml`'s `pnpm changeset publish` publishes **every** non-private workspace package and ignores the changesets `ignore` list at publish time — so it also tries to (re)publish `@testplanit/cli`, which is released by its **own** pipeline (`cli-semantic-release.yml`, via `@semantic-release/npm`) and is already on npm at `1.3.0`.

That redundant attempt fails and crashes `@changesets/cli@2.31.0`'s error handler:

```
🦋  error TypeError: Cannot read properties of undefined (reading 'includes')
    at isAlreadyPublishedError (…/@changesets/cli/dist/changesets-cli.cjs.js:873:17)
    at internalPublish (…:957:41)
[ELIFECYCLE] Command failed with exit code 1.
```

The crash aborts the whole job **before the real packages publish**. On the most recent run that left `@testplanit/api@0.7.0`, `@testplanit/mcp-server@0.3.0`, `@testplanit/wdio-reporter@0.5.1`, and `@testplanit/playwright-reporter@0.2.3` version-bumped in the repo but **not published to npm**. (The earlier E422 provenance error on cli was a separate issue, already fixed in #524.)

## The fix

Marking cli `"private": true` would stop `changeset publish` from touching it — but `@semantic-release/npm` also skips private packages, so that would **break cli's real publisher**. Instead, hide cli from `changeset publish` for the duration of that step only: mark it private at runtime, right before publishing.

```yaml
publish: |
  node -e "const f='cli/package.json',fs=require('fs');const p=JSON.parse(fs.readFileSync(f));p.private=true;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
  pnpm changeset publish
```

- Runs on the **publish** path only (not the version-PR path), and the runner is ephemeral, so it is **never committed** — `cli/package.json` stays non-private everywhere else.
- The other four packages still publish, `createGithubReleases` still works.
- `cli-semantic-release.yml` (separate workflow, its own checkout) is unaffected and keeps publishing cli.
- Matches the workflow's existing intent — its test/build steps already enumerate only `api`, `wdio-reporter`, `playwright-reporter`, `mcp-server`; cli was never meant to be a packages-release package.

## Related Issue

Closes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

`packages-release.yml` YAML validated; the `publish` block extracts to the intended two-line script. Full verification is the workflow run itself.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

- **This merge unblocks the stuck packages automatically.** `packages-release.yml` triggers on changes to itself, so merging this to `main` re-runs the publish — which (with the fix) skips cli and publishes the four stuck versions. No manual `npm publish` or separate re-run needed.
- A matching PR targets `beta` to keep the workflow in sync ahead of `beta → main` (the workflow only runs from `main`, so nothing publishes from beta).
