### PR TITLE
ci(packages-release): stop changeset publish from touching @testplanit/cli

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -84,7 +84,18 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          # `changeset publish` publishes every non-private workspace package
+          # and ignores the changesets `ignore` list at publish time, so it also
+          # tries to (re)publish `@testplanit/cli` — which is released by its own
+          # `cli-semantic-release.yml` pipeline and is already on npm. That
+          # redundant attempt crashes the run. Hide cli from `changeset publish`
+          # by marking it private for the duration of this step only (the runner
+          # is ephemeral and this runs on the publish path, not the version-PR
+          # path, so it is never committed). cli/package.json stays non-private
+          # everywhere else, so `@semantic-release/npm` still publishes cli.
+          publish: |
+            node -e "const f='cli/package.json',fs=require('fs');const p=JSON.parse(fs.readFileSync(f));p.private=true;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+            pnpm changeset publish
           version: pnpm changeset version
           title: 'chore(packages): version packages'
           commit: 'chore(packages): version packages'


### PR DESCRIPTION
## Description

Beta counterpart of #529. Keeps `packages-release.yml` in sync ahead of `beta → main`.

`pnpm changeset publish` publishes every non-private workspace package and ignores the changesets `ignore` list at publish time, so it also tries to (re)publish `@testplanit/cli` — released by its own `cli-semantic-release.yml` pipeline and already on npm. That redundant attempt crashes `@changesets/cli`'s error handler and aborts the run before the real packages publish.

Marking cli `"private": true` would fix it but also disables its real publisher (`@semantic-release/npm` skips private packages). Instead, hide cli from `changeset publish` for the duration of that step only — an ephemeral, uncommitted runtime mutation on the publish path — so the other packages publish and GitHub releases are still created, while cli keeps releasing via its own pipeline.

Note: `packages-release.yml` only runs from `main`, so nothing publishes from `beta`; this is purely to avoid workflow drift.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

Same one-file change as #529 (cherry-picked); YAML validated.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Same fix as #529 (targets `main`).
