### PR TITLE
ci(packages-release): fix cli-exclusion publish command

### DIFF
--- a/.github/scripts/packages-publish.mjs
+++ b/.github/scripts/packages-publish.mjs
@@ -1,0 +1,33 @@
+// Publish the Changesets-managed packages, excluding @testplanit/cli.
+//
+// `pnpm changeset publish` publishes every non-private workspace package and
+// does NOT honor the changesets `ignore` list at publish time, so it also tries
+// to (re)publish @testplanit/cli — which is released by its own
+// `cli-semantic-release.yml` pipeline and is already on npm. That redundant
+// attempt fails and crashes `@changesets/cli`'s error handler, aborting the run
+// before the real packages publish.
+//
+// Marking cli `"private": true` permanently would stop that, but it would also
+// disable cli's real publisher (`@semantic-release/npm` skips private packages).
+// So we mark cli private only here. This script is the `publish` command for the
+// changesets action, which runs it ONLY on the publish path (not the version-PR
+// path), and the runner is ephemeral — so the change is never committed.
+// cli/package.json stays non-private everywhere else.
+//
+// NOTE: the changesets action tokenizes the `publish` input (it does not run it
+// through a shell), so the workflow must invoke this as a single command
+// (`node .github/scripts/packages-publish.mjs`) rather than an inline multi-line
+// script.
+import { readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const cliPkgPath = "cli/package.json";
+const cliPkg = JSON.parse(readFileSync(cliPkgPath, "utf8"));
+cliPkg.private = true;
+writeFileSync(cliPkgPath, `${JSON.stringify(cliPkg, null, 2)}\n`);
+
+// Inherit stdio so `changeset publish`'s output still flows to the changesets
+// action (it parses the published packages and tags from it). Mirrors the
+// original `pnpm changeset publish` invocation.
+const result = spawnSync("pnpm", ["changeset", "publish"], { stdio: "inherit" });
+process.exit(result.status ?? 1);

--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -84,18 +84,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # `changeset publish` publishes every non-private workspace package
-          # and ignores the changesets `ignore` list at publish time, so it also
-          # tries to (re)publish `@testplanit/cli` — which is released by its own
-          # `cli-semantic-release.yml` pipeline and is already on npm. That
-          # redundant attempt crashes the run. Hide cli from `changeset publish`
-          # by marking it private for the duration of this step only (the runner
-          # is ephemeral and this runs on the publish path, not the version-PR
-          # path, so it is never committed). cli/package.json stays non-private
-          # everywhere else, so `@semantic-release/npm` still publishes cli.
-          publish: |
-            node -e "const f='cli/package.json',fs=require('fs');const p=JSON.parse(fs.readFileSync(f));p.private=true;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
-            pnpm changeset publish
+          # Wrapper for `pnpm changeset publish` that hides @testplanit/cli from
+          # the publish (cli is released by its own cli-semantic-release.yml
+          # pipeline; changeset publish ignores the changesets `ignore` list and
+          # would otherwise crash trying to republish it). See the script header.
+          # Must stay a single command: the changesets action tokenizes this
+          # input rather than running it through a shell, so a multi-line block
+          # or shell operators do NOT work here.
+          publish: node .github/scripts/packages-publish.mjs
           version: pnpm changeset version
           title: 'chore(packages): version packages'
           commit: 'chore(packages): version packages'


### PR DESCRIPTION
## Description

Fix-forward for #529. That change added the cli exclusion as a multi-line `publish: |` block — but the **changesets action tokenizes the `publish` input** (executable + args) instead of running it through a shell, so the block was mangled:

```
node -e const f='cli/package.json',… 
pnpm changeset publish        ← swallowed into node's -e script
[eval]:2  pnpm  ^
ReferenceError: pnpm is not defined
```

`node -e` consumed the second line as JavaScript, so **nothing published** and the run failed.

## The fix

Move the cli-hiding logic into a single-command script and point `publish:` at it — a single token the action tokenizes correctly (same shape as the original `pnpm changeset publish`):

```yaml
publish: node .github/scripts/packages-publish.mjs
```

`.github/scripts/packages-publish.mjs`:
1. Marks `cli/package.json` `private: true` — **runtime only**, on the publish path only, never committed (ephemeral runner). This hides cli from `changeset publish`, which otherwise ignores the changesets `ignore` list and crashes trying to republish the already-on-npm `@testplanit/cli`.
2. Runs `pnpm changeset publish` with **inherited stdio**, so its output still reaches the changesets action (for published-package/tag parsing and `createGithubReleases`).

cli keeps releasing via its own `cli-semantic-release.yml` (unaffected — separate workflow, separate checkout).

## Verified locally

- `node --check` passes on the script.
- The mutation was tested against a copy of `cli/package.json`: sets `private: true`, preserves `name`/`version`/`repository.url`, emits valid JSON with a trailing newline.
- The `publish` input is a single command (`node .github/scripts/packages-publish.mjs`) — the exact failure mode of #529 (multi-line/shell parsing) can't recur.

Full end-to-end verification is the workflow run itself.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

- **Still unblocks the stuck packages** (`api@0.7.0`, `mcp-server@0.3.0`, `wdio-reporter@0.5.1`, `playwright-reporter@0.2.3`): `packages-release.yml` triggers on changes to itself, so merging this re-runs the publish — now correctly skipping cli and publishing the four stuck versions.
- Matching PR targets `beta`.
