### PR TITLE
ci(packages-release): fix cli-exclusion publish command

### DIFF
--- a/.github/scripts/packages-publish.mjs
+++ b/.github/scripts/packages-publish.mjs
@@ -1,0 +1,33 @@
+// Publish the Changesets-managed packages, excluding @testplanit/cli.
+//
+// `pnpm changeset publish` publishes every non-private workspace package and
+// does NOT honor the changesets `ignore` list at publish time, so it also tries
+// to (re)publish @testplanit/cli — which is released by its own
+// `cli-semantic-release.yml` pipeline and is already on npm. That redundant
+// attempt fails and crashes `@changesets/cli`'s error handler, aborting the run
+// before the real packages publish.
+//
+// Marking cli `"private": true` permanently would stop that, but it would also
+// disable cli's real publisher (`@semantic-release/npm` skips private packages).
+// So we mark cli private only here. This script is the `publish` command for the
+// changesets action, which runs it ONLY on the publish path (not the version-PR
+// path), and the runner is ephemeral — so the change is never committed.
+// cli/package.json stays non-private everywhere else.
+//
+// NOTE: the changesets action tokenizes the `publish` input (it does not run it
+// through a shell), so the workflow must invoke this as a single command
+// (`node .github/scripts/packages-publish.mjs`) rather than an inline multi-line
+// script.
+import { readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const cliPkgPath = "cli/package.json";
+const cliPkg = JSON.parse(readFileSync(cliPkgPath, "utf8"));
+cliPkg.private = true;
+writeFileSync(cliPkgPath, `${JSON.stringify(cliPkg, null, 2)}\n`);
+
+// Inherit stdio so `changeset publish`'s output still flows to the changesets
+// action (it parses the published packages and tags from it). Mirrors the
+// original `pnpm changeset publish` invocation.
+const result = spawnSync("pnpm", ["changeset", "publish"], { stdio: "inherit" });
+process.exit(result.status ?? 1);

--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -84,18 +84,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # `changeset publish` publishes every non-private workspace package
-          # and ignores the changesets `ignore` list at publish time, so it also
-          # tries to (re)publish `@testplanit/cli` — which is released by its own
-          # `cli-semantic-release.yml` pipeline and is already on npm. That
-          # redundant attempt crashes the run. Hide cli from `changeset publish`
-          # by marking it private for the duration of this step only (the runner
-          # is ephemeral and this runs on the publish path, not the version-PR
-          # path, so it is never committed). cli/package.json stays non-private
-          # everywhere else, so `@semantic-release/npm` still publishes cli.
-          publish: |
-            node -e "const f='cli/package.json',fs=require('fs');const p=JSON.parse(fs.readFileSync(f));p.private=true;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
-            pnpm changeset publish
+          # Wrapper for `pnpm changeset publish` that hides @testplanit/cli from
+          # the publish (cli is released by its own cli-semantic-release.yml
+          # pipeline; changeset publish ignores the changesets `ignore` list and
+          # would otherwise crash trying to republish it). See the script header.
+          # Must stay a single command: the changesets action tokenizes this
+          # input rather than running it through a shell, so a multi-line block
+          # or shell operators do NOT work here.
+          publish: node .github/scripts/packages-publish.mjs
           version: pnpm changeset version
           title: 'chore(packages): version packages'
           commit: 'chore(packages): version packages'


### PR DESCRIPTION
## Description

Beta counterpart of #531. Fix-forward for the beta cli-exclusion change (#530), whose multi-line `publish: |` block was mangled by the changesets action (it tokenizes the `publish` input instead of running it through a shell), causing `node -e` to swallow the `pnpm changeset publish` line (`ReferenceError: pnpm is not defined`).

Replaces it with a single-command `publish: node .github/scripts/packages-publish.mjs`. The script marks `cli/package.json` private at runtime (publish path only, never committed), then runs `pnpm changeset publish` with inherited stdio so its output still reaches the changesets action. cli keeps releasing via `cli-semantic-release.yml`.

Note: `packages-release.yml` only runs from `main`, so nothing publishes from `beta`; this keeps the workflow in sync ahead of `beta → main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

Cherry-picked from #531; `node --check` passes on the script and the `publish` input is a single command.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Same fix as #531 (targets `main`).
