### PR TITLE
ci(packages): drop redundant prepublishOnly build to fix publish race

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,7 +24,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/playwright-testplanit-reporter/package.json
+++ b/packages/playwright-testplanit-reporter/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/wdio-testplanit-reporter/package.json
+++ b/packages/wdio-testplanit-reporter/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## Description

Fixes the intermittent publish failure where `@testplanit/playwright-reporter` fails its publish-time build with:

```
$ pnpm build
$ tsup
src/index.ts(30,51): error TS2307: Cannot find module '@testplanit/api' or its corresponding type declarations.
Error: error occurred in dts build
```

### Root cause — a build race, not a config bug

- `packages-release.yml` already builds **every** package in its **Build packages** step *before* `changeset publish`.
- Each package also had `prepublishOnly: pnpm build`, so `changeset publish` **rebuilt them again**, and it runs those builds **concurrently**.
- Every tsup config uses **`clean: true`**, so a build **deletes `dist/` before regenerating**. While `@testplanit/api` is rebuilding, `packages/api/dist/index.d.ts` briefly doesn't exist.
- A dependent's concurrent **dts** build reads that file for type resolution. `@testplanit/playwright-reporter` re-exports types from `@testplanit/api`, so it hit the empty window → `TS2307`. `@testplanit/wdio-reporter` re-exports from the same package with an **identical** tsup/tsconfig and built fine in the same run — it just landed outside api's clean window. Same config, same run, one wins one loses = a race.

This is unrelated to the recent API changes (TS2307 is "module not found," not a type error) and to the cli-exclusion fix.

### The fix

Remove the redundant `prepublishOnly: pnpm build` from the four packages. `changeset publish` then packs the already-built `dist/` (the workflow's Build step + committed `dist/`; `files` is `["dist"]`) **without rebuilding** — no `clean`, no race, deterministic.

## Related Issue

Closes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

All four `package.json` files validated as parseable JSON after the removal (one line removed each). The workflow's Build step (unchanged) still builds all four before publish; `files: ["dist"]` and committed `dist/` guarantee a valid tarball.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

- **No changeset intentionally.** There's no CI gate requiring one, and adding one would wrongly re-bump the three packages already published this cycle (`api@0.7.0`, `mcp-server@0.3.0`, `wdio-reporter@0.5.1`). On merge, `packages-release` re-runs and publishes only the still-unpublished `@testplanit/playwright-reporter@0.2.3` (the others skip as already-published) — now without the race.
- The pre-publish build was redundant here (CI is the only publish path, and it builds first). Manual `npm publish` of an individual package would no longer auto-build, but that isn't how these ship.
- A matching PR targets `beta`.
