### PR TITLE
ci(packages): drop redundant prepublishOnly build to fix publish race

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,7 +24,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/playwright-testplanit-reporter/package.json
+++ b/packages/playwright-testplanit-reporter/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/wdio-testplanit-reporter/package.json
+++ b/packages/wdio-testplanit-reporter/package.json
@@ -20,7 +20,6 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:cov": "vitest --coverage",
-    "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## Description

Beta counterpart of #533. Removes the redundant `prepublishOnly: pnpm build` from the four published packages.

`packages-release.yml` already builds every package before `changeset publish`, but each package also rebuilt via `prepublishOnly` — concurrently, with tsup `clean: true`. While `@testplanit/api` rebuilt (deleting its `dist/`), a dependent's concurrent dts build (e.g. `@testplanit/playwright-reporter`, re-exporting types from `@testplanit/api`) read `packages/api/dist/index.d.ts` in the empty window → `TS2307: Cannot find module '@testplanit/api'`. Same config as `wdio-reporter`, which built fine in the same run — a race.

Removing `prepublishOnly` makes `changeset publish` pack the already-built `dist/` (workflow build + committed `dist/`, `files: ["dist"]`) without rebuilding: no clean, no race.

Note: `packages-release.yml` only runs from `main`, so nothing publishes from `beta`; this keeps the packages in sync ahead of `beta → main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

Cherry-picked from #533; all four `package.json` files validated as parseable JSON.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Same fix as #533 (targets `main`). No changeset (intentional — would wrongly re-bump already-published packages).
