### PR TITLE
ci(packages-release): skip already-published packages in publish

### DIFF
--- a/.github/scripts/packages-publish.mjs
+++ b/.github/scripts/packages-publish.mjs
@@ -1,33 +1,80 @@
-// Publish the Changesets-managed packages, excluding @testplanit/cli.
+// Publish the Changesets-managed packages robustly.
 //
-// `pnpm changeset publish` publishes every non-private workspace package and
-// does NOT honor the changesets `ignore` list at publish time, so it also tries
-// to (re)publish @testplanit/cli — which is released by its own
-// `cli-semantic-release.yml` pipeline and is already on npm. That redundant
-// attempt fails and crashes `@changesets/cli`'s error handler, aborting the run
-// before the real packages publish.
+// This is the `publish` command for the changesets action. It marks certain
+// packages `private` at runtime so `pnpm changeset publish` skips them, then
+// runs the publish. The mutations are runtime-only: this runs on the publish
+// path (not the version-PR path) and the runner is ephemeral, so nothing is
+// committed and the packages stay non-private everywhere else.
 //
-// Marking cli `"private": true` permanently would stop that, but it would also
-// disable cli's real publisher (`@semantic-release/npm` skips private packages).
-// So we mark cli private only here. This script is the `publish` command for the
-// changesets action, which runs it ONLY on the publish path (not the version-PR
-// path), and the runner is ephemeral — so the change is never committed.
-// cli/package.json stays non-private everywhere else.
+// Two things get skipped, both to avoid `@changesets/cli` crashing. When
+// `changeset publish` tries to publish a version that is ALREADY on npm, the
+// `pnpm publish` "already published" error is not handled by changesets'
+// `isAlreadyPublishedError` (it reads `.includes` on `undefined` → throws), so
+// the whole publish aborts:
 //
-// NOTE: the changesets action tokenizes the `publish` input (it does not run it
+//   1. @testplanit/cli — released by its own `cli-semantic-release.yml`
+//      pipeline (via `@semantic-release/npm`, over OIDC) and always already on
+//      npm. `changeset publish` ignores the changesets `ignore` list at publish
+//      time, so it would otherwise try to republish cli and crash. We can't set
+//      cli `private` permanently — that would also disable its real publisher.
+//
+//   2. Any package whose EXACT version is already published. changesets' own
+//      "is it published?" detection is unreliable in this workspace (it reports
+//      already-published versions as new — e.g. on a re-run after a partial
+//      publish), so it re-attempts them and crashes. We check the registry
+//      directly (`npm view <name>@<version>`), which is reliable, and skip the
+//      ones that already exist. `changeset publish` then only ever attempts
+//      genuinely-new versions.
+//
+// NOTE: the changesets action TOKENIZES the `publish` input (it does not run it
 // through a shell), so the workflow must invoke this as a single command
-// (`node .github/scripts/packages-publish.mjs`) rather than an inline multi-line
-// script.
-import { readFileSync, writeFileSync } from "node:fs";
+// (`node .github/scripts/packages-publish.mjs`) — no multi-line blocks or shell
+// operators.
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
-const cliPkgPath = "cli/package.json";
-const cliPkg = JSON.parse(readFileSync(cliPkgPath, "utf8"));
-cliPkg.private = true;
-writeFileSync(cliPkgPath, `${JSON.stringify(cliPkg, null, 2)}\n`);
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function markPrivate(pkgPath, reason) {
+  const pkg = readJson(pkgPath);
+  if (pkg.private) return;
+  pkg.private = true;
+  writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(
+    `[packages-publish] excluding ${pkg.name}@${pkg.version} from changeset publish (${reason})`,
+  );
+}
+
+// Direct registry check — reliable, unlike changesets' internal detection.
+// `npm view <name>@<version> version` exits 0 and echoes the version when it is
+// published, and exits non-zero (E404) when it is not.
+function isPublished(name, version) {
+  const result = spawnSync("npm", ["view", `${name}@${version}`, "version"], {
+    encoding: "utf8",
+  });
+  return result.status === 0 && result.stdout.trim() === version;
+}
+
+// 1. Always exclude @testplanit/cli (released by cli-semantic-release.yml).
+if (existsSync("cli/package.json")) {
+  markPrivate("cli/package.json", "released by cli-semantic-release.yml");
+}
+
+// 2. Exclude any packages/* whose exact version is already on npm.
+for (const entry of readdirSync("packages", { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const pkgPath = `packages/${entry.name}/package.json`;
+  if (!existsSync(pkgPath)) continue;
+  const pkg = readJson(pkgPath);
+  if (pkg.private || !pkg.name || !pkg.version) continue;
+  if (isPublished(pkg.name, pkg.version)) {
+    markPrivate(pkgPath, "already on npm");
+  }
+}
 
 // Inherit stdio so `changeset publish`'s output still flows to the changesets
-// action (it parses the published packages and tags from it). Mirrors the
-// original `pnpm changeset publish` invocation.
+// action (it parses the published packages and tags from it).
 const result = spawnSync("pnpm", ["changeset", "publish"], { stdio: "inherit" });
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## Description

Fixes the recurring `changeset publish` crash that has failed this workflow repeatedly:

```
🦋  error TypeError: Cannot read properties of undefined (reading 'includes')
    at isAlreadyPublishedError (…/@changesets/cli/dist/changesets-cli.cjs.js:873:17)
    at internalPublish (…:957:41)
```

### Root cause

`@changesets/cli@2.31.0` crashes the moment `changeset publish` tries to publish a version that is **already on npm** — it doesn't handle pnpm's "already published" error shape (`isAlreadyPublishedError` reads `.includes` on `undefined`). And its own "is it published?" detection is unreliable in this workspace: it reports already-published versions as new and re-attempts them.

That's exactly what happened after #533 merged: `api@0.7.0`, `mcp-server@0.3.0`, and `wdio-reporter@0.5.1` were already published (from the prior run), but changesets flagged them as unpublished, re-attempted them, and crashed on the first one — before ever reaching the still-unpublished `playwright-reporter@0.2.3`. (Direct `npm view` confirms all three exist; the flaky detection is inside changesets.) This is the same crash class that hit `@testplanit/cli`.

### The fix

Extend the publish wrapper (`.github/scripts/packages-publish.mjs`) to check the registry **directly** — `npm view <name>@<version> version`, which is reliable (exit 0 + version when published, non-zero when not) — and mark any already-published package `private` before publishing, alongside the existing cli exclusion. So `changeset publish` only ever attempts genuinely-new versions and **cannot** hit the already-published crash. Mutations are runtime-only (publish path, ephemeral runner) — never committed.

Together with #533 (which removed the redundant `prepublishOnly` build race), this makes the publish robust against both re-runs and multi-package races.

## Verified locally

- `node --check` passes.
- Dry-run of the detection against the live registry prints exactly:
  - `cli` → excluded (always)
  - `api@0.7.0`, `mcp-server@0.3.0`, `wdio-reporter@0.5.1` → **excluded (already on npm)**
  - `playwright-reporter@0.2.3` → **publish (new)**
- So the next run attempts only `playwright-reporter@0.2.3` — no already-published version is touched, so the crash can't occur.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

- Merging this re-triggers `packages-release`, which should finally publish `@testplanit/playwright-reporter@0.2.3` and go green.
- A matching PR targets `beta`.
- Root not addressed here: changesets' unreliable published-detection and its crash-on-already-published are `@changesets/cli` issues; a future `@changesets/cli` upgrade may fix both, at which point this wrapper could be simplified.
