### PR TITLE
ci(packages-release): trigger on changes to the publish script

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -23,6 +23,8 @@ on:
       - 'packages/**'
       - '.changeset/**'
       - '.github/workflows/packages-release.yml'
+      # The publish command lives here; a fix to it must be able to trigger a run.
+      - '.github/scripts/packages-publish.mjs'
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

The `packages-release` publish command now lives in `.github/scripts/packages-publish.mjs`, but that path was not in the workflow's `paths` filter. So when a fix to the publish script is merged to `main`, it does **not** trigger a publish run — it only takes effect on the next run triggered by some other path (or a manual `workflow_dispatch`). That's exactly the gap that made #535 (a script-only fix) merge without publishing the pending package until it was dispatched by hand.

Add the publish script to the trigger `paths` so a change to it self-triggers a run.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

YAML `paths` block reviewed. Merging this PR touches `.github/workflows/packages-release.yml` (already a trigger path), so it will run once — a harmless no-op now that every package is published (the script skips already-published versions).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Targeted to the specific script (`.github/scripts/packages-publish.mjs`) rather than `.github/scripts/**`, so unrelated helper scripts don't trigger publish runs. A matching PR targets `beta`.
