### PR TITLE
ci(packages-release): trigger on changes to the publish script

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -23,6 +23,8 @@ on:
       - 'packages/**'
       - '.changeset/**'
       - '.github/workflows/packages-release.yml'
+      # The publish command lives here; a fix to it must be able to trigger a run.
+      - '.github/scripts/packages-publish.mjs'
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Beta counterpart of #537. Adds `.github/scripts/packages-publish.mjs` to the `packages-release` trigger `paths`, so a fix to the publish script self-triggers a run instead of silently not running until some other path changes (the gap that made #535 need a manual dispatch).

Note: `packages-release.yml` only runs from `main`, so nothing publishes from `beta`; this keeps the workflow in sync ahead of `beta → main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Same one-line-ish change as #537 (targets `main`).
