### PR TITLE
chore(ci): retire node20-era actions and the Node 22 pin

### DIFF
--- a/.github/workflows/a11y-smoke.yml
+++ b/.github/workflows/a11y-smoke.yml
@@ -86,12 +86,12 @@ jobs:
       A11Y_THEME: ${{ matrix.theme }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload accessibility report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: a11y-smoke-${{ matrix.theme }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/cli-semantic-release.yml
+++ b/.github/workflows/cli-semantic-release.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Description

Retires the last Node 20-era GitHub Actions. `a11y-smoke.yml` was the only workflow still on `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` — all of which declare a Node 20 runtime that runners now force onto Node 24 with a deprecation warning on every run. It is aligned with the other workflows (`checkout@v7`, `setup-node@v5`, `upload-artifact@v7`) and its `node-version` moves from 22 to 24. `pnpm/action-setup` goes v4 → v6 in all five workflows; no invocation changes are needed because every workflow already resolves the pnpm version from the root `packageManager` field, which is v6's preferred mode.

## Related Issue

N/A — deprecation warnings observed on the #539/#540 PR runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Version-only action bumps; verified no workflow passes inputs removed in the new majors, and that the pnpm resolution mode matches v6's contract. The workflows exercise themselves on this PR's own CI run.

**Test Configuration:**
- OS: n/a (CI configuration)
- Browser (if applicable): n/a
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

The "No files were found: testplanit/e2e/a11y/results/…" artifact warning seen on the same runs is a separate issue — the a11y scan produced no output on that run, so the job's own logs are the place to look; this PR deliberately does not mask the warning.
