### PR TITLE
enhancement(workers): cache tenant configs and back off idle multi-tenant polling

### DIFF
--- a/testplanit/lib/audit/__tests__/pollAcrossTenants.test.ts
+++ b/testplanit/lib/audit/__tests__/pollAcrossTenants.test.ts
@@ -127,6 +127,39 @@ describe("pollDataChangeLogsAcrossTenants (multi-tenant Loop B supervisor)", () 
     errSpy.mockRestore();
   });
 
+  it("backs off an idle multi-tenant client while the single-tenant client keeps the fixed cadence", async () => {
+    vi.useFakeTimers();
+    try {
+      const idleTenant = makeEmptyClient();
+      const singleTenant = makeEmptyClient();
+      const runningRef = { running: true };
+      const listClients = (): TenantPollClient[] => [
+        { tenantId: "idle", client: idleTenant.client },
+        // tenantId undefined = the single-tenant client — exempt from backoff.
+        { tenantId: undefined, client: singleTenant.client },
+      ];
+
+      const loop = pollDataChangeLogsAcrossTenants(listClients, runningRef, {
+        pollIntervalMs: 100,
+        maxIdlePollIntervalMs: 10_000,
+      });
+
+      // 1s of cycles at 100ms cadence. The idle tenant's empty polls double
+      // its interval (200, 400, 800…), so it is polled at ~t=0/200/600 only,
+      // while the exempt client is polled every cycle.
+      await vi.advanceTimersByTimeAsync(1_000);
+      runningRef.running = false;
+      await vi.advanceTimersByTimeAsync(200);
+      await loop;
+
+      expect(singleTenant.calls()).toBeGreaterThanOrEqual(8);
+      expect(idleTenant.calls()).toBeLessThanOrEqual(4);
+      expect(idleTenant.calls()).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops cycling once runningRef flips false", async () => {
     const a = makeEmptyClient();
     const runningRef = { running: true };

--- a/testplanit/lib/audit/correlation.ts
+++ b/testplanit/lib/audit/correlation.ts
@@ -55,11 +55,14 @@ import {
   type HumanizedColEntry,
   type HumanizedCols,
 } from "~/lib/audit/humanize";
+import { createTenantPollBackoff } from "~/lib/tenantPollBackoff";
 
 /** Batch cap — keeps the FOR UPDATE SKIP LOCKED transaction small (research: ≤ 500). */
 const DEFAULT_BATCH_SIZE = 500;
 /** Idle sleep between empty polls. */
 const DEFAULT_POLL_INTERVAL_MS = 500;
+/** Per-tenant backoff ceiling for idle multi-tenant clients (see pollDataChangeLogsAcrossTenants). */
+const DEFAULT_MAX_IDLE_POLL_MS = 300_000;
 /** Humanization cache TTL (catalog data is infrequently updated). */
 const HUMANIZE_TTL_MS = 60_000;
 
@@ -1003,14 +1006,29 @@ export async function pollDataChangeLogsOnce(
  * Per-client failures are isolated (logged; the cycle continues with the next tenant). It sleeps
  * `pollIntervalMs` only when NO client had work this cycle, so a backlog on any tenant drains fast.
  * Single-tenant callers pass a `listClients` returning exactly one entry with `tenantId: undefined`.
+ *
+ * Multi-tenant clients (tenantId defined) back off adaptively: a tenant whose polls keep coming
+ * back empty doubles its own interval up to `maxIdlePollIntervalMs`, and snaps back to every-cycle
+ * polling on the first poll that finds rows — a tenant with a backlog drains at full cadence until
+ * empty. This bounds the idle Postgres fan-out across a mostly-hibernated fleet. The single-tenant
+ * client (tenantId undefined) is exempt and keeps the fixed cadence: its database is local to the
+ * deployment and prompt audit visibility matters more than one idle poll per interval.
  */
 export async function pollDataChangeLogsAcrossTenants(
   listClients: () => TenantPollClient[],
   runningRef: { running: boolean },
-  opts: { batchSize?: number; pollIntervalMs?: number } = {}
+  opts: {
+    batchSize?: number;
+    pollIntervalMs?: number;
+    maxIdlePollIntervalMs?: number;
+  } = {}
 ): Promise<void> {
   const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const backoff = createTenantPollBackoff({
+    baseIntervalMs: pollIntervalMs,
+    maxIntervalMs: opts.maxIdlePollIntervalMs ?? DEFAULT_MAX_IDLE_POLL_MS,
+  });
 
   while (runningRef.running) {
     let clients: TenantPollClient[];
@@ -1026,16 +1044,30 @@ export async function pollDataChangeLogsAcrossTenants(
       continue;
     }
 
+    backoff.prune(
+      clients.flatMap(({ tenantId }) =>
+        tenantId !== undefined ? [tenantId] : []
+      )
+    );
+
     let anyProcessed = false;
     for (const { tenantId, client } of clients) {
       if (!runningRef.running) break;
+      if (tenantId !== undefined && !backoff.shouldPoll(tenantId)) continue;
       try {
         const { processed } = await pollDataChangeLogsOnce(client, {
           batchSize,
         });
         if (processed > 0) anyProcessed = true;
+        if (tenantId !== undefined) {
+          if (processed > 0) backoff.recordWork(tenantId);
+          else backoff.recordEmpty(tenantId);
+        }
       } catch (err) {
         // Per-tenant isolation: one tenant's poll failure must not starve the others.
+        // A failing tenant backs off like an idle one so an unreachable database
+        // is not hammered every cycle.
+        if (tenantId !== undefined) backoff.recordEmpty(tenantId);
         console.error(
           `[correlation] Loop B poll failed${tenantId ? ` for tenant ${tenantId}` : ""}, continuing:`,
           err

--- a/testplanit/lib/multiTenantPrisma.test.ts
+++ b/testplanit/lib/multiTenantPrisma.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Store original env values
@@ -156,6 +159,163 @@ describe("multiTenantPrisma", () => {
       expect(configs.size).toBe(0);
 
       consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe("config file caching", () => {
+    // The "Loaded N tenant configurations from <file>" log line fires exactly
+    // once per actual file read+parse, so counting it observes cache behaviour
+    // without reaching into module internals.
+    let tmpDir: string;
+    let configFile: string;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    const fileLoadCount = () =>
+      logSpy.mock.calls.filter(
+        (args: unknown[]) =>
+          typeof args[0] === "string" &&
+          args[0].includes(`tenant configurations from ${configFile}`)
+      ).length;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tenant-configs-"));
+      configFile = path.join(tmpDir, "tenants.json");
+      process.env.MULTI_TENANT_MODE = "true";
+      process.env.TENANT_CONFIG_FILE = configFile;
+      logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      logSpy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      delete process.env.TENANT_CONFIG_FILE;
+    });
+
+    it("reads and parses the config file only once within the recheck window", async () => {
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+        })
+      );
+      const { loadTenantConfigs, getAllTenantIds, getTenantConfig } =
+        await resetModule();
+
+      expect(loadTenantConfigs().size).toBe(1);
+      expect(fileLoadCount()).toBe(1);
+
+      // Hot path: repeated resolutions hit the cache, no re-read, no log spam.
+      for (let i = 0; i < 50; i++) {
+        loadTenantConfigs();
+        getAllTenantIds();
+        getTenantConfig("tenant-a");
+      }
+      expect(fileLoadCount()).toBe(1);
+    });
+
+    it("re-stats after the recheck window but does not re-parse an unchanged file", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-25T00:00:00Z"));
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+        })
+      );
+      const { loadTenantConfigs } = await resetModule();
+
+      loadTenantConfigs();
+      expect(fileLoadCount()).toBe(1);
+
+      vi.advanceTimersByTime(31_000);
+      expect(loadTenantConfigs().size).toBe(1);
+      expect(fileLoadCount()).toBe(1); // stat matched — no re-read
+    });
+
+    it("picks up a changed config file after the recheck window", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-25T00:00:00Z"));
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+        })
+      );
+      const { loadTenantConfigs } = await resetModule();
+
+      expect(loadTenantConfigs().size).toBe(1);
+
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+          "tenant-b": { databaseUrl: "postgresql://localhost/b" },
+        })
+      );
+
+      // Within the window the cache is served stale by design.
+      expect(loadTenantConfigs().size).toBe(1);
+
+      vi.advanceTimersByTime(31_000);
+      const configs = loadTenantConfigs();
+      expect(configs.size).toBe(2);
+      expect(configs.get("tenant-b")?.databaseUrl).toBe(
+        "postgresql://localhost/b"
+      );
+      expect(fileLoadCount()).toBe(2);
+    });
+
+    it("reloadTenantConfigs forces an immediate re-read", async () => {
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+        })
+      );
+      const { loadTenantConfigs, reloadTenantConfigs } = await resetModule();
+
+      loadTenantConfigs();
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+          "tenant-b": { databaseUrl: "postgresql://localhost/b" },
+        })
+      );
+
+      expect(reloadTenantConfigs().size).toBe(2);
+      expect(fileLoadCount()).toBe(2);
+    });
+
+    it("getTenantPrismaClient force-reloads once for a tenant missing from the cache", async () => {
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+        })
+      );
+      const { loadTenantConfigs, getTenantPrismaClient } = await resetModule();
+
+      expect(loadTenantConfigs().size).toBe(1);
+
+      // Tenant provisioned at runtime: the file gains tenant-b while the
+      // cache is still fresh. Resolving its client must not wait out the
+      // recheck window.
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          "tenant-a": { databaseUrl: "postgresql://localhost/a" },
+          "tenant-b": { databaseUrl: "postgresql://localhost/b" },
+        })
+      );
+
+      expect(getTenantPrismaClient("tenant-b")).toBeTruthy();
+
+      // A genuinely unknown tenant still throws after the forced reload.
+      expect(() => getTenantPrismaClient("tenant-nope")).toThrow(
+        "No configuration found for tenant: tenant-nope"
+      );
     });
   });
 

--- a/testplanit/lib/multiTenantPrisma.ts
+++ b/testplanit/lib/multiTenantPrisma.ts
@@ -61,6 +61,36 @@ const TENANT_CONFIG_FILE =
   process.env.TENANT_CONFIG_FILE || "/config/tenants.json";
 
 /**
+ * How often the cached configs re-stat the config file for changes. The file is
+ * the only config source that can change at runtime (env vars are fixed at
+ * process start), so a cheap stat bounds staleness without re-reading and
+ * re-parsing the JSON on every resolution — the worker poll loops resolve a
+ * tenant client once per tenant per cycle, and an unconditional re-read there
+ * costs hundreds of milli-cores per pod at idle. A config change (tenant
+ * provisioned, credentials rotated) is picked up within this window.
+ */
+const CONFIG_RECHECK_INTERVAL_MS = 30_000;
+
+/**
+ * Stat signature (inode:mtime:size) of the file backing the current cache;
+ * null when the file was absent. Kubernetes updates a projected ConfigMap by
+ * atomically swapping a symlinked data directory, so a plain fs.watch on the
+ * path silently detaches — statSync follows the symlink chain to the live
+ * target, and the inode+mtime+size triple changes on every swap.
+ */
+let cachedConfigFileSignature: string | null = null;
+let configLastCheckedAt = 0;
+
+function statConfigFileSignature(): string | null {
+  try {
+    const stat = fs.statSync(TENANT_CONFIG_FILE);
+    return `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Load tenant configurations from file
  */
 function loadTenantsFromFile(filePath: string): Map<string, TenantConfig> {
@@ -109,12 +139,27 @@ export function reloadTenantConfigs(): Map<string, TenantConfig> {
  * 1. Config file (TENANT_CONFIG_FILE env var or /config/tenants.json)
  * 2. TENANT_CONFIGS environment variable (JSON string)
  * 3. Individual environment variables: TENANT_<ID>_DATABASE_URL, etc.
+ *
+ * The result is cached; every CONFIG_RECHECK_INTERVAL_MS the config file is
+ * re-statted and the cache is rebuilt only when the file actually changed.
  */
 export function loadTenantConfigs(): Map<string, TenantConfig> {
   if (tenantConfigs) {
-    return tenantConfigs;
+    const now = Date.now();
+    if (now - configLastCheckedAt < CONFIG_RECHECK_INTERVAL_MS) {
+      return tenantConfigs;
+    }
+    configLastCheckedAt = now;
+    if (statConfigFileSignature() === cachedConfigFileSignature) {
+      return tenantConfigs;
+    }
+    // File changed (ConfigMap symlink swap / credential rotation) — rebuild.
   }
 
+  // Stat BEFORE reading so a swap that lands mid-rebuild produces a signature
+  // mismatch on the next recheck instead of being silently absorbed.
+  configLastCheckedAt = Date.now();
+  cachedConfigFileSignature = statConfigFileSignature();
   tenantConfigs = new Map();
 
   // Priority 1: Load from config file
@@ -216,9 +261,18 @@ function createTenantPrismaClient(config: TenantConfig): PrismaClient {
  * Automatically invalidates cached clients when credentials change
  */
 export function getTenantPrismaClient(tenantId: string): PrismaClient {
-  // Always reload config from file to get latest credentials
-  reloadTenantConfigs();
-  const config = getTenantConfig(tenantId);
+  // Resolve through the cached loader (a Map hit on the hot path; the file is
+  // re-statted at most every CONFIG_RECHECK_INTERVAL_MS, so rotated credentials
+  // are still picked up within that window and invalidate the client below).
+  let config = getTenantConfig(tenantId);
+
+  if (!config) {
+    // A tenant missing from the cache may have just been provisioned — force
+    // one reload before giving up so new tenants are usable without waiting
+    // out the recheck window.
+    reloadTenantConfigs();
+    config = getTenantConfig(tenantId);
+  }
 
   if (!config) {
     throw new Error(`No configuration found for tenant: ${tenantId}`);

--- a/testplanit/lib/tenantPollBackoff.test.ts
+++ b/testplanit/lib/tenantPollBackoff.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { createTenantPollBackoff } from "./tenantPollBackoff";
+
+const makeClock = (start = 0) => {
+  const clock = { t: start };
+  return {
+    clock,
+    now: () => clock.t,
+    advance: (ms: number) => {
+      clock.t += ms;
+    },
+  };
+};
+
+describe("createTenantPollBackoff", () => {
+  it("polls an unknown tenant immediately", () => {
+    const { now } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+    expect(backoff.shouldPoll("a")).toBe(true);
+  });
+
+  it("doubles the interval on consecutive empty polls: base×2, ×4, ×8", () => {
+    const { now, advance } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+
+    backoff.recordEmpty("a"); // next eligible at +2000
+    expect(backoff.shouldPoll("a")).toBe(false);
+    advance(1999);
+    expect(backoff.shouldPoll("a")).toBe(false);
+    advance(1);
+    expect(backoff.shouldPoll("a")).toBe(true);
+
+    backoff.recordEmpty("a"); // next eligible at +4000
+    advance(3999);
+    expect(backoff.shouldPoll("a")).toBe(false);
+    advance(1);
+    expect(backoff.shouldPoll("a")).toBe(true);
+
+    backoff.recordEmpty("a"); // next eligible at +8000
+    advance(7999);
+    expect(backoff.shouldPoll("a")).toBe(false);
+    advance(1);
+    expect(backoff.shouldPoll("a")).toBe(true);
+  });
+
+  it("caps the interval at maxIntervalMs", () => {
+    const { now, advance } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 5000,
+      now,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      backoff.recordEmpty("a");
+    }
+    advance(4999);
+    expect(backoff.shouldPoll("a")).toBe(false);
+    advance(1);
+    expect(backoff.shouldPoll("a")).toBe(true);
+  });
+
+  it("snaps back to every-cycle polling after work is found, and re-starts backoff from the base", () => {
+    const { now, advance } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+
+    backoff.recordEmpty("a");
+    backoff.recordEmpty("a");
+    backoff.recordEmpty("a");
+    expect(backoff.shouldPoll("a")).toBe(false);
+
+    backoff.recordWork("a");
+    expect(backoff.shouldPoll("a")).toBe(true);
+
+    // A mid-drain sequence of non-empty polls never re-backs-off.
+    backoff.recordWork("a");
+    backoff.recordWork("a");
+    expect(backoff.shouldPoll("a")).toBe(true);
+
+    // After the drain, backoff restarts from the base interval (not the
+    // previously accumulated one).
+    backoff.recordEmpty("a");
+    advance(2000);
+    expect(backoff.shouldPoll("a")).toBe(true);
+  });
+
+  it("tracks tenants independently", () => {
+    const { now } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+
+    backoff.recordEmpty("idle");
+    expect(backoff.shouldPoll("idle")).toBe(false);
+    expect(backoff.shouldPoll("active")).toBe(true);
+  });
+
+  it("prune drops state for removed tenants and keeps the rest", () => {
+    const { now } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+
+    backoff.recordEmpty("kept");
+    backoff.recordEmpty("removed");
+    backoff.prune(["kept"]);
+
+    expect(backoff.shouldPoll("kept")).toBe(false);
+    // Removed tenant's state is gone — if re-added it polls immediately.
+    expect(backoff.shouldPoll("removed")).toBe(true);
+  });
+
+  it("reset clears all state", () => {
+    const { now } = makeClock();
+    const backoff = createTenantPollBackoff({
+      baseIntervalMs: 1000,
+      maxIntervalMs: 60_000,
+      now,
+    });
+
+    backoff.recordEmpty("a");
+    backoff.reset();
+    expect(backoff.shouldPoll("a")).toBe(true);
+  });
+});

--- a/testplanit/lib/tenantPollBackoff.ts
+++ b/testplanit/lib/tenantPollBackoff.ts
@@ -1,0 +1,91 @@
+// lib/tenantPollBackoff.ts
+//
+// Adaptive per-tenant poll backoff shared by the multi-tenant worker poll
+// loops (webhook outbox poller, audit Loop B CDC supervisor). Those loops
+// sweep every configured tenant database each cycle; on a fleet where most
+// tenants are idle or hibernated that keeps hundreds of idle Postgres
+// backends alive and puts a permanent CPU floor under the connection pooler.
+//
+// A tenant whose polls keep coming back empty doubles its own poll interval
+// (base × 2^misses) up to a ceiling, and snaps back to every-cycle polling on
+// the first poll that finds work — so an active tenant is indistinguishable
+// from the fixed-cadence behaviour, a draining backlog is never throttled
+// mid-drain, and the latency cost is bounded and paid only on the first event
+// after a quiet period. Errors back off the same way an empty poll does, so an
+// unreachable tenant database is not hammered every cycle.
+
+export interface TenantPollBackoffOptions {
+  /** Poll interval for an active tenant (zero consecutive empty polls). */
+  baseIntervalMs: number;
+  /** Interval ceiling for a fully backed-off idle tenant. */
+  maxIntervalMs: number;
+  /** Clock override for tests. */
+  now?: () => number;
+}
+
+export interface TenantPollBackoff {
+  /** Whether this tenant is due for a poll this cycle. */
+  shouldPoll(tenantId: string): boolean;
+  /** Record a poll that found no work (or failed): lengthen this tenant's interval. */
+  recordEmpty(tenantId: string): void;
+  /** Record a poll that found work: snap back to every-cycle polling. */
+  recordWork(tenantId: string): void;
+  /** Drop state for tenants no longer in the active set. */
+  prune(activeTenantIds: Iterable<string>): void;
+  /** Clear all state (tests). */
+  reset(): void;
+}
+
+interface BackoffState {
+  consecutiveEmptyPolls: number;
+  nextEligibleAt: number;
+}
+
+/** Exponent cap; with any sane base the ceiling is reached long before this. */
+const MAX_MISSES = 30;
+
+export function createTenantPollBackoff(
+  options: TenantPollBackoffOptions
+): TenantPollBackoff {
+  const { baseIntervalMs, maxIntervalMs } = options;
+  // Resolved per call (not captured) so vitest fake timers are honoured even
+  // when the backoff instance was created before vi.useFakeTimers() ran.
+  const now = options.now ?? (() => Date.now());
+  const state = new Map<string, BackoffState>();
+
+  return {
+    shouldPoll(tenantId: string): boolean {
+      const entry = state.get(tenantId);
+      return !entry || now() >= entry.nextEligibleAt;
+    },
+
+    recordEmpty(tenantId: string): void {
+      const misses = Math.min(
+        (state.get(tenantId)?.consecutiveEmptyPolls ?? 0) + 1,
+        MAX_MISSES
+      );
+      const interval = Math.min(baseIntervalMs * 2 ** misses, maxIntervalMs);
+      state.set(tenantId, {
+        consecutiveEmptyPolls: misses,
+        nextEligibleAt: now() + interval,
+      });
+    },
+
+    recordWork(tenantId: string): void {
+      state.delete(tenantId);
+    },
+
+    prune(activeTenantIds: Iterable<string>): void {
+      const active = new Set(activeTenantIds);
+      for (const tenantId of state.keys()) {
+        if (!active.has(tenantId)) {
+          state.delete(tenantId);
+        }
+      }
+    },
+
+    reset(): void {
+      state.clear();
+    },
+  };
+}

--- a/testplanit/workers/webhookOutboxWorker.test.ts
+++ b/testplanit/workers/webhookOutboxWorker.test.ts
@@ -29,7 +29,11 @@ vi.mock("../lib/multiTenantPrisma", () => ({
   disconnectAllTenantClients: vi.fn(),
 }));
 
-import { pollAllTenantsOnce, pollOnce } from "./webhookOutboxWorker";
+import {
+  pollAllTenantsOnce,
+  pollOnce,
+  resetTenantBackoffForTests,
+} from "./webhookOutboxWorker";
 
 const sampleRow = {
   id: "outbox-1",
@@ -216,9 +220,11 @@ describe("webhookOutboxWorker.pollAllTenantsOnce", () => {
     mockIsMultiTenantMode.mockReset();
     mockGetAllTenantIds.mockReset();
     mockGetTenantPrismaClient.mockReset();
+    resetTenantBackoffForTests();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -306,5 +312,80 @@ describe("webhookOutboxWorker.pollAllTenantsOnce", () => {
 
     expect(n).toBe(0);
     expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it("multi-tenant mode: an idle tenant is skipped until its backoff interval elapses, then re-polled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T00:00:00Z"));
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a", "tenant-b"]);
+    mockGetTenantPrismaClient.mockReturnValue({ __mock: "tenantDb" });
+    mockClaim.mockResolvedValue([]);
+    mockGetQueue.mockReturnValue({ add: vi.fn() });
+
+    // Pass 1: both tenants polled, both come back empty.
+    await pollAllTenantsOnce();
+    expect(mockClaim).toHaveBeenCalledTimes(2);
+
+    // Pass 2 immediately after: both are backed off — no polls at all.
+    await pollAllTenantsOnce();
+    expect(mockClaim).toHaveBeenCalledTimes(2);
+
+    // After the first backoff interval (base 2s × 2 = 4s) both are due again.
+    vi.advanceTimersByTime(4_000);
+    await pollAllTenantsOnce();
+    expect(mockClaim).toHaveBeenCalledTimes(4);
+  });
+
+  it("multi-tenant mode: a poll that claims rows snaps the tenant back to every-cycle polling", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T00:00:00Z"));
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a"]);
+    mockGetTenantPrismaClient.mockReturnValue({ __mock: "tenantDb" });
+    mockFanout.mockResolvedValue(["c1"]);
+    mockGetQueue.mockReturnValue({ add: vi.fn() });
+
+    // Empty poll → tenant backs off.
+    mockClaim.mockResolvedValueOnce([]);
+    await pollAllTenantsOnce();
+    expect(mockClaim).toHaveBeenCalledTimes(1);
+
+    // Due again after the interval; this time the poll finds work.
+    vi.advanceTimersByTime(4_000);
+    mockClaim.mockResolvedValueOnce([sampleRow]);
+    const n = await pollAllTenantsOnce();
+    expect(n).toBe(1);
+    expect(mockClaim).toHaveBeenCalledTimes(2);
+
+    // Snap-back: the very next pass polls again with no waiting.
+    mockClaim.mockResolvedValueOnce([]);
+    await pollAllTenantsOnce();
+    expect(mockClaim).toHaveBeenCalledTimes(3);
+  });
+
+  it("multi-tenant mode: a tenant-level error backs off like an empty poll", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T00:00:00Z"));
+    mockIsMultiTenantMode.mockReturnValue(true);
+    mockGetAllTenantIds.mockReturnValue(["tenant-a"]);
+    mockGetTenantPrismaClient.mockImplementation(() => {
+      throw new Error("tenant db unreachable");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await pollAllTenantsOnce();
+    expect(mockGetTenantPrismaClient).toHaveBeenCalledTimes(1);
+
+    // Immediately after the failure the tenant is backed off — not re-tried.
+    await pollAllTenantsOnce();
+    expect(mockGetTenantPrismaClient).toHaveBeenCalledTimes(1);
+
+    // Due again once the interval elapses.
+    vi.advanceTimersByTime(4_000);
+    await pollAllTenantsOnce();
+    expect(mockGetTenantPrismaClient).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/testplanit/workers/webhookOutboxWorker.ts
+++ b/testplanit/workers/webhookOutboxWorker.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/multiTenantPrisma";
 import { prisma } from "../lib/prisma";
 import { getWebhookDispatchQueue } from "../lib/queues";
+import { createTenantPollBackoff } from "../lib/tenantPollBackoff";
 import { claimOutboxBatch, fanoutToConfigs } from "../lib/webhooks/outbox";
 
 /**
@@ -18,7 +19,8 @@ import { claimOutboxBatch, fanoutToConfigs } from "../lib/webhooks/outbox";
  * can run concurrently without double-claiming.
  *
  * Multi-tenant mode: iterates getAllTenantIds() once per cadence and
- * polls each tenant's database via getTenantPrismaClient(tenantId). The
+ * polls each due tenant's database via getTenantPrismaClient(tenantId) —
+ * idle tenants back off adaptively (see tenantBackoff below). The
  * per-tenant tenantId is stamped onto every enqueued dispatch job so the
  * dispatch worker routes to the correct tenant DB.
  *
@@ -30,6 +32,26 @@ import { claimOutboxBatch, fanoutToConfigs } from "../lib/webhooks/outbox";
 
 const POLL_INTERVAL_MS = 2_000;
 const BATCH_SIZE = 100;
+
+/**
+ * Multi-tenant only: an idle tenant's poll interval doubles per consecutive
+ * empty poll up to this ceiling (~150x fewer polls than the base cadence), and
+ * snaps back to POLL_INTERVAL_MS on the first poll that claims rows. Bounds
+ * the idle Postgres fan-out across a mostly-hibernated fleet; the latency cost
+ * is paid only on the first outbox event after a tenant's quiet period.
+ * Single-tenant mode keeps the fixed cadence.
+ */
+const MAX_IDLE_POLL_INTERVAL_MS = 300_000;
+
+const tenantBackoff = createTenantPollBackoff({
+  baseIntervalMs: POLL_INTERVAL_MS,
+  maxIntervalMs: MAX_IDLE_POLL_INTERVAL_MS,
+});
+
+/** Test hook: clears per-tenant backoff state between test cases. */
+export function resetTenantBackoffForTests(): void {
+  tenantBackoff.reset();
+}
 
 let stopRequested = false;
 let inflight: Promise<number> | null = null;
@@ -111,13 +133,26 @@ export async function pollAllTenantsOnce(): Promise<number> {
     return 0;
   }
 
+  tenantBackoff.prune(tenantIds);
+
   let total = 0;
   for (const tenantId of tenantIds) {
+    if (!tenantBackoff.shouldPoll(tenantId)) {
+      continue;
+    }
     try {
       const client = getTenantPrismaClient(tenantId);
       const claimed = await pollOnce(client, tenantId);
       total += claimed;
+      if (claimed > 0) {
+        tenantBackoff.recordWork(tenantId);
+      } else {
+        tenantBackoff.recordEmpty(tenantId);
+      }
     } catch (err) {
+      // An unreachable tenant backs off like an idle one so a down database
+      // is not hammered every cycle; it self-heals on the next successful poll.
+      tenantBackoff.recordEmpty(tenantId);
       console.error(
         `[WebhookOutboxWorker] Poll error for tenant ${tenantId}:`,
         err


### PR DESCRIPTION
## Description

Eliminates the idle CPU floor in the shared multi-tenant workers. With zero job activity, the `audit-log-worker` and `webhook-outbox-worker` processes were consuming ~430m CPU per pod and emitting ~54 log lines/second, and the poll loops kept idle Postgres backends open for every configured tenant — including hibernated ones.

Two independent fixes:

**Tenant config caching.** `getTenantPrismaClient()` unconditionally reloaded the tenant config file on every call — once per tenant per poll cycle — re-reading and re-parsing the JSON and logging `Loaded N tenant configurations` each time. The loader now caches the parsed configs with a 30-second recheck window and only rebuilds when a stat signature (inode:mtime:size) shows the file actually changed. The signature check is robust to the atomic symlink swap Kubernetes uses for projected ConfigMap updates. An unknown tenant triggers a one-shot forced reload before failing, so tenants provisioned at runtime still resolve immediately. The load log line now fires only on real (re)loads, turning it into a useful config-change signal.

**Adaptive per-tenant poll backoff.** Both multi-tenant poll loops (webhook outbox poller and the audit CDC consumer) swept every tenant database every cycle regardless of activity. A new shared `tenantPollBackoff` helper doubles an idle tenant's poll interval per consecutive empty poll (capped at 5 minutes) and snaps back to the base cadence on the first poll that finds work — so a tenant with a backlog drains at full speed and never re-backs-off mid-drain. Poll errors back off the same way, so an unreachable tenant database isn't hammered every cycle. Single-tenant deployments are exempt and keep today's fixed cadence, preserving prompt webhook dispatch and audit visibility for self-hosted installs.

## Related Issue

N/A — diagnosed from production profiling of the shared workers deployment.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

New coverage: `tenantPollBackoff` interval doubling/cap/snap-back/prune semantics; config-cache behavior (single parse within the window, stat-only recheck on unchanged file, pickup of a changed file, forced reload for unknown tenants); outbox worker skip/re-poll, snap-back after claimed rows, and error backoff under fake timers; CDC supervisor backing off an idle multi-tenant client while the single-tenant client keeps the fixed cadence. Full `pnpm precommit` passes (9,930 tests).

**Test Configuration:**
- OS: macOS 26 (darwin 25.5.0)
- Browser (if applicable): N/A
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Behavior changes to be aware of: config-file changes (new tenant, rotated credentials) are picked up within 30 seconds plus the kubelet's projected-volume sync period, instead of the next poll cycle; and an idle tenant's first event after a quiet period can wait up to 5 minutes for pickup (webhook outbox and audit materialization). Both loops return to full cadence immediately once work appears.
