### PR TITLE
enhancement: per-template default field selection for Generate Test Cases wizard

### DIFF
--- a/docs/docs/user-guide/llm-test-generation.md
+++ b/docs/docs/user-guide/llm-test-generation.md
@@ -59,10 +59,11 @@ Choose your test generation source:
 - Choose the test case template to use for generated cases
 - All template fields are displayed for review
 - Select which fields to populate with AI-generated content
+- Fields start selected or deselected according to the template's per-field generation default, configured by an administrator in Templates & Fields (fields are included by default unless excluded there)
 - Required fields are always included and cannot be deselected
-- Optional fields can be included or excluded based on your needs
+- Optional fields can be included or excluded based on your needs, regardless of the template default
 - Deselected fields are named in the AI request as fields it must not return, and any value it returns for one is discarded — so an excluded field is never populated, never shown in the review step, and never written on import
-- Your selection persists for the rest of the wizard. Changing the template resets it to all fields.
+- Your selection persists for the rest of the wizard. Changing the template resets it to that template's defaults.
 
 ### Step 3: Configure Generation
 

--- a/docs/docs/user-guide/templates-fields.md
+++ b/docs/docs/user-guide/templates-fields.md
@@ -35,7 +35,7 @@ The Templates table lists all defined templates with columns for:
 2. Enter a unique **Name** for the template.
 3. Use the **Enabled** switch to activate the template.
 4. Use the **Default** switch if this should be the default template. (Setting a new default will unset the previous one and apply this template to all projects).
-5. **Select Case Fields:** Choose available Case Fields from the dropdown and add them to the selected list. You can reorder the selected fields using drag-and-drop.
+5. **Select Case Fields:** Choose available Case Fields from the dropdown and add them to the selected list. You can reorder the selected fields using drag-and-drop. The sparkles toggle on each selected field controls whether it starts selected in the Generate Test Cases wizard — turn it off for fields the AI cannot meaningfully fill in (internal IDs, tester notes, etc.). Users can still select or deselect any non-required field in the wizard.
 6. **Select Result Fields:** Similarly, choose and order the Result Fields for this template.
 7. **Assign Projects:** Use the multi-select dropdown to assign this template to specific projects. If this template is marked as **Default**, it will automatically apply to all projects, and this selection might be disabled or ignored.
 8. Click "Submit".

--- a/testplanit/app/[locale]/admin/fields/AddTemplate.tsx
+++ b/testplanit/app/[locale]/admin/fields/AddTemplate.tsx
@@ -163,6 +163,17 @@ export function AddTemplate({ open, onClose }: AddTemplateProps) {
     }
   };
 
+  // Flip whether the field starts selected in the Generate Test Cases wizard.
+  const handleToggleGenerateDefault = (id: string | number) => {
+    setSelectedCaseFields((prev) =>
+      prev.map((f) =>
+        f.id === id
+          ? { ...f, generateDefaultEnabled: f.generateDefaultEnabled === false }
+          : f
+      )
+    );
+  };
+
   const handleRemoveField = (id: number, type: string) => {
     // console.log(`removing ID: ${id} from ${type} fields`);
 
@@ -226,6 +237,7 @@ export function AddTemplate({ open, onClose }: AddTemplateProps) {
             caseFieldId: Number(field.id),
             templateId: newTemplate!.id,
             order: index + 1,
+            generateDefaultEnabled: field.generateDefaultEnabled !== false,
           })),
         });
       }
@@ -391,6 +403,7 @@ export function AddTemplate({ open, onClose }: AddTemplateProps) {
                         onRemove={(item) =>
                           handleRemoveField(Number(item), "case")
                         }
+                        onToggleGenerateDefault={handleToggleGenerateDefault}
                       />
                     </div>
                   </FormControl>

--- a/testplanit/app/[locale]/admin/fields/EditTemplate.tsx
+++ b/testplanit/app/[locale]/admin/fields/EditTemplate.tsx
@@ -61,6 +61,7 @@ type FormValues = z.infer<ReturnType<typeof buildFormSchema>>;
 interface ExtendedTemplateCaseField {
   caseFieldId: number;
   order: number;
+  generateDefaultEnabled?: boolean;
 }
 
 interface ExtendedTemplateResultField {
@@ -203,6 +204,7 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
           caseFields.find((field) => field.id === cf.caseFieldId)
             ?.displayName || "Unknown Field",
         order: cf.order,
+        generateDefaultEnabled: cf.generateDefaultEnabled ?? true,
       }))
       .sort((a, b) => a.order - b.order);
 
@@ -255,6 +257,17 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
       setSelectedResultFields((prev) => [...prev, field]);
       setAvailableResultFields((prev) => prev.filter((f) => f.id !== field.id));
     }
+  };
+
+  // Flip whether the field starts selected in the Generate Test Cases wizard.
+  const handleToggleGenerateDefault = (id: string | number) => {
+    setSelectedCaseFields((prev) =>
+      prev.map((f) =>
+        f.id === id
+          ? { ...f, generateDefaultEnabled: f.generateDefaultEnabled === false }
+          : f
+      )
+    );
   };
 
   const handleRemoveField = (id: string | number, type: string) => {
@@ -320,6 +333,7 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
               typeof field.id === "string" ? parseInt(field.id, 10) : field.id,
             templateId: template.id,
             order: index + 1,
+            generateDefaultEnabled: field.generateDefaultEnabled !== false,
           })),
         });
       }
@@ -454,6 +468,7 @@ export function EditTemplate({ template, open, onClose }: EditTemplateProps) {
                         items={selectedCaseFields}
                         setItems={setSelectedCaseFields}
                         onRemove={(item) => handleRemoveField(item, "case")}
+                        onToggleGenerateDefault={handleToggleGenerateDefault}
                       />
                     </div>
                   </FormControl>

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.test.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.test.tsx
@@ -199,6 +199,22 @@ describe("GenerateTestCasesWizard — case-field eligibility", () => {
     );
   });
 
+  it("seeds the selection from the per-template generation defaults", () => {
+    const src = readWizard();
+    // The templates query must fetch the admin-configured default flag.
+    expect(src).toMatch(/generateDefaultEnabled:\s*true,/);
+    // Seeding selects default-enabled fields plus required fields — required
+    // fields can never be deselected, so a default-off required field must
+    // still start checked.
+    expect(src).toMatch(
+      /cf\.generateDefaultEnabled !== false \|\| cf\.caseField\.isRequired/
+    );
+    // A loaded template whose fields are all default-off must still claim the
+    // seed; keying the guard on the selection size would let a templates
+    // refetch wipe the user's manual selections.
+    expect(src).toMatch(/if \(visibleFields\.length > 0\)/);
+  });
+
   it("sends the deselected field names so the prompt can forbid them", () => {
     const src = readWizard();
     // Only visible-but-unchecked fields are named — hidden fields must not leak

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -1606,6 +1606,7 @@ export function GenerateTestCasesWizard({
           caseFieldId: true,
           templateId: true,
           order: true,
+          generateDefaultEnabled: true,
           caseField: {
             include: {
               fieldOptions: {
@@ -1734,9 +1735,11 @@ export function GenerateTestCasesWizard({
     }
   }, [templates]);
 
-  // Auto-select all fields when the user changes template in the wizard flow.
-  // Skip when currentStep is REVIEW_GENERATED — that means we restored from a
-  // job result and selectedFieldIds was already set explicitly.
+  // Auto-select the template's default fields when the user changes template
+  // in the wizard flow: fields the admin marked generateDefaultEnabled, plus
+  // required fields (which can never be deselected). Skip when currentStep is
+  // REVIEW_GENERATED — that means we restored from a job result and
+  // selectedFieldIds was already set explicitly.
   useEffect(() => {
     if (
       selectedTemplateId &&
@@ -1746,17 +1749,23 @@ export function GenerateTestCasesWizard({
     ) {
       const template = templates.find((t) => t.id === selectedTemplateId);
       if (template) {
-        const allFieldIds = new Set(
-          template.caseFields
-            .filter(isTemplateFieldVisible)
+        const visibleFields = template.caseFields.filter(
+          isTemplateFieldVisible
+        );
+        const defaultFieldIds = new Set(
+          visibleFields
+            .filter(
+              (cf) =>
+                cf.generateDefaultEnabled !== false || cf.caseField.isRequired
+            )
             .map((cf) => cf.caseFieldId)
         );
         // An empty caseFields array (still loading) must not lock the
         // selection at zero fields.
-        if (allFieldIds.size > 0) {
+        if (visibleFields.length > 0) {
           seededFieldsTemplateIdRef.current = selectedTemplateId;
         }
-        setSelectedFieldIds(allFieldIds);
+        setSelectedFieldIds(defaultFieldIds);
       }
     }
   }, [selectedTemplateId, templates, currentStep, isTemplateFieldVisible]);

--- a/testplanit/components/DraggableCaseFields.test.tsx
+++ b/testplanit/components/DraggableCaseFields.test.tsx
@@ -57,18 +57,28 @@ vi.mock("@dnd-kit/utilities", () => ({
 // Mock lucide-react icons
 vi.mock("lucide-react", () => ({
   GripVertical: () => <svg data-testid="grip-vertical-icon" />,
+  Sparkles: () => <svg data-testid="sparkles-icon" />,
   Trash2: () => <svg data-testid="trash2-icon" />,
 }));
 
 // Mock UI button
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, onClick, type, variant, className, disabled }: any) => (
+  Button: ({
+    children,
+    onClick,
+    type,
+    variant,
+    className,
+    disabled,
+    ...rest
+  }: any) => (
     <button
       type={type || "button"}
       onClick={onClick}
       className={className}
       disabled={disabled}
       data-variant={variant}
+      {...rest}
     >
       {children}
     </button>
@@ -222,6 +232,77 @@ describe("DraggableCaseFields", () => {
       expect(screen.getByText("Field Alpha")).toBeInTheDocument();
       expect(screen.getByText("Field Beta")).toBeInTheDocument();
       expect(screen.getByText("Field Gamma")).toBeInTheDocument();
+    });
+  });
+
+  describe("Generate-default toggle", () => {
+    it("does not render the toggle when onToggleGenerateDefault is not provided", () => {
+      render(
+        <DraggableList
+          items={createItems()}
+          setItems={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId("sparkles-icon")).not.toBeInTheDocument();
+    });
+
+    it("renders one toggle per item, pressed by default", () => {
+      render(
+        <DraggableList
+          items={createItems()}
+          setItems={vi.fn()}
+          onRemove={vi.fn()}
+          onToggleGenerateDefault={vi.fn()}
+        />
+      );
+
+      expect(screen.getAllByTestId("sparkles-icon")).toHaveLength(3);
+      // Fields default to included in the Generate Test Cases wizard.
+      expect(screen.getByTestId("generate-default-toggle-1")).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+    });
+
+    it("shows an unpressed toggle when generateDefaultEnabled is false", () => {
+      const items: DraggableField[] = [
+        { id: "1", label: "Field Alpha", generateDefaultEnabled: false },
+      ];
+
+      render(
+        <DraggableList
+          items={items}
+          setItems={vi.fn()}
+          onRemove={vi.fn()}
+          onToggleGenerateDefault={vi.fn()}
+        />
+      );
+
+      expect(screen.getByTestId("generate-default-toggle-1")).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    });
+
+    it("calls onToggleGenerateDefault with the item id, not onRemove", () => {
+      const onRemove = vi.fn();
+      const onToggleGenerateDefault = vi.fn();
+
+      render(
+        <DraggableList
+          items={createItems()}
+          setItems={vi.fn()}
+          onRemove={onRemove}
+          onToggleGenerateDefault={onToggleGenerateDefault}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId("generate-default-toggle-2"));
+
+      expect(onToggleGenerateDefault).toHaveBeenCalledWith("2");
+      expect(onRemove).not.toHaveBeenCalled();
     });
   });
 

--- a/testplanit/components/DraggableCaseFields.tsx
+++ b/testplanit/components/DraggableCaseFields.tsx
@@ -14,22 +14,37 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
-import { GripVertical, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { GripVertical, Sparkles, Trash2 } from "lucide-react";
 
 import { CSS } from "@dnd-kit/utilities";
 
 export interface DraggableField {
   id: string | number;
   label: string;
+  // Per-template default for the Generate Test Cases wizard. Only meaningful
+  // when the list is rendered with onToggleGenerateDefault.
+  generateDefaultEnabled?: boolean;
 }
 
 const DraggableItem = ({
   id,
   label,
+  generateDefaultEnabled,
   onRemove,
-}: DraggableField & { onRemove: (id: string | number) => void }) => {
+  onToggleGenerateDefault,
+}: DraggableField & {
+  onRemove: (id: string | number) => void;
+  onToggleGenerateDefault?: (id: string | number) => void;
+}) => {
+  const t = useTranslations("admin.templates");
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
 
@@ -42,6 +57,14 @@ const DraggableItem = ({
     e.preventDefault();
     e.stopPropagation();
     onRemove(id);
+  };
+
+  const generateOn = generateDefaultEnabled !== false;
+
+  const handleToggleGenerate = (e: any) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onToggleGenerateDefault?.(id);
   };
 
   return (
@@ -57,14 +80,37 @@ const DraggableItem = ({
           <GripVertical size={20} />
           {label}
         </div>
-        <Button
-          type="button"
-          variant="link"
-          onClick={handleClick}
-          className="text-destructive p-0 -my-1"
-        >
-          <Trash2 size={20} />
-        </Button>
+        <div className="flex items-center">
+          {onToggleGenerateDefault && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={handleToggleGenerate}
+                  aria-pressed={generateOn}
+                  className={`p-0 -my-1 mr-2 ${
+                    generateOn ? "text-primary" : "text-muted-foreground/40"
+                  }`}
+                  data-testid={`generate-default-toggle-${id}`}
+                >
+                  <Sparkles size={20} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {generateOn ? t("generateDefaultOn") : t("generateDefaultOff")}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Button
+            type="button"
+            variant="link"
+            onClick={handleClick}
+            className="text-destructive p-0 -my-1"
+          >
+            <Trash2 size={20} />
+          </Button>
+        </div>
       </div>
     </div>
   );
@@ -74,10 +120,12 @@ const DraggableList = ({
   items,
   setItems,
   onRemove,
+  onToggleGenerateDefault,
 }: {
   items: DraggableField[];
   setItems: (items: DraggableField[]) => void;
   onRemove: (id: string | number) => void;
+  onToggleGenerateDefault?: (id: string | number) => void;
 }) => {
   const activationConstraint: PointerActivationConstraint = {
     distance: 5, // Requires the pointer to move 5 pixels before activating
@@ -113,7 +161,9 @@ const DraggableList = ({
             key={item.id}
             id={item.id}
             label={item.label}
+            generateDefaultEnabled={item.generateDefaultEnabled}
             onRemove={onRemove}
+            onToggleGenerateDefault={onToggleGenerateDefault}
           />
         ))}
       </SortableContext>

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -4572,6 +4572,8 @@
           "warning": "Case Field will be removed from any Templates. This action cannot be undone."
         }
       },
+      "generateDefaultOn": "Included by default in the Generate Test Cases wizard. Click to exclude it by default.",
+      "generateDefaultOff": "Excluded by default in the Generate Test Cases wizard. Click to include it by default.",
       "resultFields": {
         "description": "Manage result fields",
         "add": {
@@ -6582,7 +6584,7 @@
       "name": "## Template Name\nA unique and descriptive name for this template (e.g., 'Standard Test Case', 'API Test Results').",
       "isEnabled": "## Enabled\nIf checked, this template will be available for selection when creating new test cases or defining test run structures. If a template is set as 'Default', it must also be 'Enabled'.",
       "isDefault": "## Default\nIf checked, this template will be automatically selected for new projects or as the default for all projects if no project-specific default is set. Only one template can be the default across all projects. Enabling this will disable any other template currently set as default.",
-      "caseFields": "## Case Fields\nSelect and order the custom fields that will be available when creating or editing test cases using this template.\n\n- Add fields from the dropdown to include them in the template\n- Drag and drop to reorder fields\n- The order determines how fields appear in forms\n- Only enabled case fields are available for selection\n- Case fields define the structure and data captured for test cases",
+      "caseFields": "## Case Fields\nSelect and order the custom fields that will be available when creating or editing test cases using this template.\n\n- Add fields from the dropdown to include them in the template\n- Drag and drop to reorder fields\n- The order determines how fields appear in forms\n- Only enabled case fields are available for selection\n- Case fields define the structure and data captured for test cases\n- The sparkles toggle controls whether a field starts selected in the Generate Test Cases wizard; users can still change the selection there",
       "resultFields": "## Result Fields\nSelect and order the custom fields that will be available when adding test results using this template.\n\n- Add fields from the dropdown to include them in the template\n- Drag and drop to reorder fields\n- The order determines how fields appear when entering test results\n- Only enabled result fields are available for selection\n- Result fields capture additional data specific to test execution outcomes",
       "projects": "## Associated Projects\nSelect which projects this template will be available for. If no projects are selected, the template will be available globally. Assigning a template to specific projects restricts its use to only those projects."
     },

--- a/testplanit/migrations/20260727000000_add_generate_default_enabled/migration.sql
+++ b/testplanit/migrations/20260727000000_add_generate_default_enabled/migration.sql
@@ -1,0 +1,4 @@
+-- Per-template default for the Generate Test Cases wizard: when false, the
+-- assigned case field starts unchecked in the wizard (users can still select
+-- it manually). Existing assignments keep the current always-on behavior.
+ALTER TABLE "TemplateCaseAssignment" ADD COLUMN "generateDefaultEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -1114,11 +1114,12 @@ model TemplateProjectAssignment {
 }
 
 model TemplateCaseAssignment {
-    caseFieldId Int
-    caseField   CaseFields @relation(fields: [caseFieldId], references: [id], onDelete: Cascade)
-    templateId  Int
-    template    Templates  @relation(fields: [templateId], references: [id], onDelete: Cascade)
-    order       Int        @default(0)
+    caseFieldId            Int
+    caseField              CaseFields @relation(fields: [caseFieldId], references: [id], onDelete: Cascade)
+    templateId             Int
+    template               Templates  @relation(fields: [templateId], references: [id], onDelete: Cascade)
+    order                  Int        @default(0)
+    generateDefaultEnabled Boolean    @default(true)
 
     @@id([caseFieldId, templateId])
     @@deny('all', auth() == null)


### PR DESCRIPTION
## Description

Adds a per-template default for which case fields start selected in the Generate Test Cases wizard. When users generate test cases, every template case field is currently enabled by default — including fields an LLM can't meaningfully fill in (internal IDs, tester gotcha notes, etc.).

Admins can now flip a sparkles toggle on each selected case field in the Add/Edit Template dialogs (case fields only, not result fields). Fields toggled off start unchecked in the wizard; everything defaults to on, so existing templates behave exactly as before.

- New `generateDefaultEnabled Boolean @default(true)` on `TemplateCaseAssignment`, with an additive migration (`20260727000000_add_generate_default_enabled`). Existing rows and importer-created assignments default to on.
- The wizard seeds its field selection from the flag, plus required fields (which can never be deselected — a default-off required field still starts checked). Users can still manually check/uncheck any optional field, and Select All / Required Only behave as before.
- The seeding guard now locks once the template's fields have loaded rather than once the selection is non-empty, so a template whose fields are all default-off can't have manual selections wiped by a background refetch.
- Tooltip i18n keys, help-popover text, and user-guide docs updated.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Full `pnpm precommit` (11,026 tests) green. New unit tests cover the DraggableList toggle (render/off-state/click isolation) and the wizard's default-based seeding. Manual UAT against a live instance: toggle rendering and persistence in Add/Edit Template (verified in the DB), wizard seeding of default-off fields, manual override, and template-switch reseeding.

**Test Configuration:**
- OS: macOS (Darwin 25.5)
- Browser (if applicable): Chromium
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Result fields intentionally do not get the toggle — generation only populates case fields. Globally disabled case fields remain hidden from the wizard entirely (existing behavior), independent of this flag.
