### PR TITLE
feat(reporters): add excludeSkipped option to omit skipped results from runs

### DIFF
--- a/.changeset/reporters-exclude-skipped.md
+++ b/.changeset/reporters-exclude-skipped.md
@@ -1,0 +1,6 @@
+---
+"@testplanit/wdio-reporter": minor
+"@testplanit/playwright-reporter": minor
+---
+
+Add an `excludeSkipped` option to both reporters. When enabled, skipped results are not reported to TestPlanIt at all — they don't appear on the run and don't count toward its totals. The check runs before any API work, so a spec whose tests were all skipped never creates a test run. For the WebdriverIO reporter this also covers `pending` results and Cucumber scenarios whose steps were skipped. Default is disabled: skipped results keep being reported exactly as before.

--- a/docs/docs/sdk/playwright-configuration.md
+++ b/docs/docs/sdk/playwright-configuration.md
@@ -42,6 +42,7 @@ reporter: [
 | `uploadAttachments` | `boolean` | `true` | Upload Playwright attachments (screenshots, videos, traces) to the result — see [Attachment Uploads](./playwright-attachments.md) |
 | `attachmentTypes` | `string[]` | all | Restrict which attachments upload, by attachment name or content-type prefix (e.g. `['image/']`) |
 | `includeStackTrace` | `boolean` | `true` | Include stack traces for failures |
+| `excludeSkipped` | `boolean` | `false` | Don't report skipped tests — they won't appear on the run or count toward its totals |
 | `completeRunOnFinish` | `boolean` | `true` | Mark run as complete when tests finish |
 | `timeout` | `number` | `30000` | API request timeout in ms |
 | `maxRetries` | `number` | `3` | Retry attempts for failed requests |

--- a/docs/docs/sdk/wdio-configuration.md
+++ b/docs/docs/sdk/wdio-configuration.md
@@ -35,6 +35,7 @@ These options apply to the **reporter**. If you're using the [Launcher Service](
 | `tagIds` | `(number \| string)[]` | - | Tags to apply to the test run (IDs or names). Tags that don't exist are created automatically |
 | `uploadScreenshots` | `boolean` | `true` | Upload intercepted screenshots to TestPlanIt (requires screenshot capture — see [Screenshot Uploads](./wdio-screenshots.md)) |
 | `includeStackTrace` | `boolean` | `true` | Include stack traces for failures |
+| `excludeSkipped` | `boolean` | `false` | Don't report skipped tests — they won't appear on the run or count toward its totals. Also covers pending results and Cucumber scenarios whose steps were skipped |
 | `completeRunOnFinish` | `boolean` | `true` | Mark run as complete when tests finish |
 | `oneReport` | `boolean` | `true` | Combine parallel workers from the same spec file into a single test run. Does not persist across spec file batches — use the [Launcher Service](./wdio-launcher-service.md) for that |
 | `timeout` | `number` | `30000` | API request timeout in ms |

--- a/docs/docs/sdk/wdio-overview.md
+++ b/docs/docs/sdk/wdio-overview.md
@@ -150,6 +150,7 @@ The following reporter options **still apply** when using the service:
 | `caseIdPattern` | Parse case IDs from test titles |
 | `uploadScreenshots` | Upload intercepted screenshots |
 | `includeStackTrace` | Include stack traces for failures |
+| `excludeSkipped` | Don't report skipped tests |
 | `timeout`, `maxRetries`, `verbose` | API and logging behavior per worker |
 
 :::tip

--- a/packages/playwright-testplanit-reporter/README.md
+++ b/packages/playwright-testplanit-reporter/README.md
@@ -104,6 +104,7 @@ caseIdPattern: /TEST-(\d+)/g  // JIRA-style:         "TEST-12345 should work"
 | `runAttachments` | `RunAttachmentInput[]` | No | - | Files to attach to the run (logs, reports, videos). Supports `{env:VAR}` |
 | `runMetadata` | `Record<string, string \| number \| boolean>` | No | - | Key/value metadata rendered into the run's documentation. Supports `{env:VAR}` |
 | `includeStackTrace` | `boolean` | No | `true` | Include stack traces in results |
+| `excludeSkipped` | `boolean` | No | `false` | Don't report skipped tests to TestPlanIt |
 | `completeRunOnFinish` | `boolean` | No | `true` | Mark the test run as completed when the run finishes |
 | `timeout` | `number` | No | `30000` | API request timeout in ms |
 | `maxRetries` | `number` | No | `3` | Number of retries for failed API requests |

--- a/packages/playwright-testplanit-reporter/src/reporter.test.ts
+++ b/packages/playwright-testplanit-reporter/src/reporter.test.ts
@@ -316,6 +316,36 @@ describe('TestPlanItReporter (Playwright)', () => {
   });
 
   // -------------------------------------------------------------------------
+  describe('excludeSkipped', () => {
+    it('reports skipped results by default', async () => {
+      await run(reporter, makeTest('[100] is skipped', buildParent({ project: 'chromium' })), makeResult({ status: 'skipped' }));
+      const arg = lastArg(clientMock.createJUnitTestResult);
+      expect(arg.type).toBe('SKIPPED');
+      expect(arg.statusId).toBe(STATUS_IDS.skipped);
+    });
+
+    it('does not report skipped results when excludeSkipped is enabled', async () => {
+      reporter = new TestPlanItReporter({ ...defaultOptions, excludeSkipped: true });
+      await run(reporter, makeTest('[100] is skipped', buildParent({ project: 'chromium' })), makeResult({ status: 'skipped' }));
+      expect(clientMock.createJUnitTestResult).not.toHaveBeenCalled();
+      // An all-skipped spec never creates a run.
+      expect(clientMock.createTestRun).not.toHaveBeenCalled();
+      expect(clientMock.completeTestRun).not.toHaveBeenCalled();
+    });
+
+    it('still reports non-skipped results when excludeSkipped is enabled', async () => {
+      reporter = new TestPlanItReporter({ ...defaultOptions, excludeSkipped: true });
+      reporter.onTestEnd(makeTest('[1] skipped one', buildParent({ project: 'chromium' })), makeResult({ status: 'skipped' }));
+      reporter.onTestEnd(makeTest('[2] passed one', buildParent({ project: 'chromium' })), makeResult({ status: 'passed' }));
+      await reporter.onEnd(FULL_RESULT);
+      expect(calls(clientMock.createJUnitTestResult)).toHaveLength(1);
+      const arg = lastArg(clientMock.createJUnitTestResult);
+      expect(arg.repositoryCaseId).toBe(2);
+      expect(arg.type).toBe('PASSED');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   describe('reporting flow', () => {
     it('creates the run, suite, and JUnit result for a linked test', async () => {
       reporter.onBegin({} as any, {} as any);

--- a/packages/playwright-testplanit-reporter/src/reporter.ts
+++ b/packages/playwright-testplanit-reporter/src/reporter.ts
@@ -105,6 +105,7 @@ export default class TestPlanItReporter implements Reporter {
       createFolderHierarchy: false,
       uploadAttachments: true,
       includeStackTrace: true,
+      excludeSkipped: false,
       completeRunOnFinish: true,
       timeout: 30000,
       maxRetries: 3,
@@ -363,6 +364,12 @@ export default class TestPlanItReporter implements Reporter {
     attachments: PendingAttachment[],
   ): Promise<void> {
     try {
+      // Checked before any API work so an all-skipped spec never creates a run.
+      if (this.options.excludeSkipped && result.status === 'skipped') {
+        this.log(`Excluding skipped test (excludeSkipped): ${result.testName}`);
+        return;
+      }
+
       // Skip results we can't link before doing any work (avoids empty runs).
       if (caseIds.length === 0 && !this.options.autoCreateTestCases) {
         console.warn(

--- a/packages/playwright-testplanit-reporter/src/types.ts
+++ b/packages/playwright-testplanit-reporter/src/types.ts
@@ -238,6 +238,14 @@ export interface TestPlanItReporterOptions {
   includeStackTrace?: boolean;
 
   /**
+   * Whether to exclude skipped tests from the report. When enabled, skipped
+   * results are not sent to TestPlanIt at all — they don't appear on the run
+   * and don't count toward its totals.
+   * @default false
+   */
+  excludeSkipped?: boolean;
+
+  /**
    * Links to attach to the test run right after the reporter creates it
    * (e.g. a CI build URL). Rendered as clickable link attachments on the run
    * detail page.

--- a/packages/wdio-testplanit-reporter/README.md
+++ b/packages/wdio-testplanit-reporter/README.md
@@ -157,6 +157,7 @@ This strategy is opt-in and runs **before** name/create resolution. On no match 
 | `templateId` | `number \| string` | No | - | Template for auto-created cases (ID or name) |
 | `uploadScreenshots` | `boolean` | No | `true` | Upload intercepted screenshots |
 | `includeStackTrace` | `boolean` | No | `true` | Include stack traces in results |
+| `excludeSkipped` | `boolean` | No | `false` | Don't report skipped tests to TestPlanIt |
 | `completeRunOnFinish` | `boolean` | No | `true` | Mark test run as completed when done |
 | `oneReport` | `boolean` | No | `true` | Combine parallel workers from the same spec file into a single test run. Does not persist across spec file batches — use the service for that |
 | `timeout` | `number` | No | `30000` | API request timeout in ms |

--- a/packages/wdio-testplanit-reporter/src/reporter.test.ts
+++ b/packages/wdio-testplanit-reporter/src/reporter.test.ts
@@ -489,6 +489,64 @@ describe("TestPlanItReporter", () => {
     });
   });
 
+  describe("excludeSkipped", () => {
+    const testStats = (overrides: Partial<TestStats> = {}): TestStats =>
+      ({
+        type: "test",
+        title: "[123] should pass",
+        fullTitle: "Suite > [123] should pass",
+        uid: "test-uid",
+        cid: "0-0",
+        state: "passed",
+        duration: 1500,
+        start: new Date("2024-01-01T00:00:00Z"),
+        end: new Date("2024-01-01T00:00:01.5Z"),
+        retries: 0,
+        ...overrides,
+      }) as TestStats;
+
+    // Await the async reportResult operations tracked on the reporter.
+    const flush = async (r: TestPlanItReporter) => {
+      const ops = (r as unknown as { pendingOperations: Set<Promise<void>> }).pendingOperations;
+      for (let i = 0; i < 10 && ops.size > 0; i++) {
+        await Promise.allSettled([...ops]);
+      }
+    };
+
+    it("reports skipped results by default", async () => {
+      reporter.onTestSkip(testStats({ title: "[789] is skipped", state: "skipped" }));
+      await flush(reporter);
+
+      expect(apiMocks.createJUnitTestResult).toHaveBeenCalledTimes(1);
+      expect(apiMocks.createJUnitTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "SKIPPED", statusId: 3 })
+      );
+    });
+
+    it("does not report skipped results when excludeSkipped is enabled", async () => {
+      const r = new TestPlanItReporter({ ...defaultOptions, excludeSkipped: true });
+      r.onTestSkip(testStats({ title: "[789] is skipped", state: "skipped" }));
+      await flush(r);
+
+      expect(apiMocks.createJUnitTestResult).not.toHaveBeenCalled();
+      // An all-skipped spec never initializes or creates a run.
+      expect(r.getState().initialized).toBe(false);
+      expect(r.getState().testRunId).toBeUndefined();
+    });
+
+    it("still reports non-skipped results when excludeSkipped is enabled", async () => {
+      const r = new TestPlanItReporter({ ...defaultOptions, excludeSkipped: true });
+      r.onTestSkip(testStats({ title: "[789] is skipped", state: "skipped" }));
+      r.onTestPass(testStats({ title: "[123] passes" }));
+      await flush(r);
+
+      expect(apiMocks.createJUnitTestResult).toHaveBeenCalledTimes(1);
+      expect(apiMocks.createJUnitTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryCaseId: 123, type: "PASSED" })
+      );
+    });
+  });
+
   describe("getState", () => {
     it("should return current state", () => {
       const state = reporter.getState();

--- a/packages/wdio-testplanit-reporter/src/reporter.ts
+++ b/packages/wdio-testplanit-reporter/src/reporter.ts
@@ -93,6 +93,7 @@ export default class TestPlanItReporter extends WDIOReporter {
       createFolderHierarchy: false,
       uploadScreenshots: true,
       includeStackTrace: true,
+      excludeSkipped: false,
       completeRunOnFinish: true,
       oneReport: true,
       timeout: 30000,
@@ -1153,6 +1154,17 @@ export default class TestPlanItReporter extends WDIOReporter {
    */
   private async reportResult(result: TrackedTestResult, caseIds: number[]): Promise<void> {
     try {
+      // Checked before any API work so an all-skipped spec never creates a
+      // run. Catches both the Mocha/Jasmine per-test path and the Cucumber
+      // per-scenario path, which both funnel through here.
+      if (
+        this.reporterOptions.excludeSkipped &&
+        (result.status === 'skipped' || result.status === 'pending')
+      ) {
+        this.log(`Excluding skipped test (excludeSkipped): ${result.testName}`);
+        return;
+      }
+
       // Check if this result can be reported BEFORE initializing
       // This prevents creating empty test runs for tests without case IDs.
       // matchByCustomField is also a resolution path, so its presence keeps the

--- a/packages/wdio-testplanit-reporter/src/types.ts
+++ b/packages/wdio-testplanit-reporter/src/types.ts
@@ -275,6 +275,15 @@ export interface TestPlanItReporterOptions extends Reporters.Options {
   includeStackTrace?: boolean;
 
   /**
+   * Whether to exclude skipped tests from the report. When enabled, skipped
+   * (and pending) results — including Cucumber scenarios whose steps were
+   * skipped — are not sent to TestPlanIt at all: they don't appear on the run
+   * and don't count toward its totals.
+   * @default false
+   */
+  excludeSkipped?: boolean;
+
+  /**
    * Whether to mark the test run as completed when all tests finish
    * @default true
    */


### PR DESCRIPTION
## Description

Adds an `excludeSkipped` option to both the WebdriverIO and Playwright reporters. When enabled, skipped results are not reported to TestPlanIt at all — they don't appear on the run and don't count toward its totals. Default is disabled, so skipped results keep being reported exactly as before.

The check runs at the top of each reporter's `reportResult`, before any API work, so:

- A spec whose tests were all skipped never initializes the reporter or creates an empty test run.
- Excluded results generate no "no case ID found" warnings.
- Explicit run-level calls (`attachToRun` / `setRunMetadata`) are unaffected — they're handled on a separate path.

For the WebdriverIO reporter the filter also covers `pending` results (which map to SKIPPED) and Cucumber scenarios whose steps were skipped, since both the Mocha/Jasmine per-test path and the Cucumber per-scenario path funnel through `reportResult`.

Includes a changeset (minor for `@testplanit/wdio-reporter` and `@testplanit/playwright-reporter`), README option rows, and docs updates (`docs/docs/sdk/playwright-configuration.md`, `wdio-configuration.md`, and the `wdio-overview.md` service-compatibility table — `excludeSkipped` still applies per worker when using the launcher service).

Twin of the same change on `beta` (fcdcd9c2a).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

Three new tests per reporter: skipped results are reported by default; with `excludeSkipped: true` a skipped result produces no API calls and no test run; non-skipped results still report. Full package suites pass (wdio 155, playwright 121) and both packages type-check clean.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

The reporter sources on `main` and `beta` were identical before this change, so this is a clean cherry-pick of the beta commit.
