### PR TITLE
fix(integrations): transfer description images to created issues as attachments

### DIFF
--- a/docs/docs/user-guide/integrations.md
+++ b/docs/docs/user-guide/integrations.md
@@ -72,6 +72,7 @@ Full bi-directional integration with Atlassian Jira, supporting both Cloud and S
 
 - Create Jira issues directly from TestPlanIt
 - Rich text formatting preserved using Atlassian Document Format (ADF)
+- Images and videos embedded in the issue description are uploaded to the created Jira issue as attachments
 - Automatic user matching between TestPlanIt and Jira
 - Support for custom fields and issue types
 - Real-time status synchronization
@@ -125,6 +126,7 @@ Connect to Azure DevOps Boards for work item tracking.
 - Support for all work item types defined in your Azure DevOps process
 - Search work items by text or by exact ID (e.g., `42`)
 - Priority field supported (maps to work item priority)
+- Images and videos embedded in the description are uploaded to the created work item as attachments
 - Personal Access Token authentication
 - Inbound webhook support for real-time status sync
 - Works with both Azure DevOps Services (cloud) and Azure DevOps Server (on-premises)

--- a/testplanit/app/api/integrations/[id]/create-issue/route.test.ts
+++ b/testplanit/app/api/integrations/[id]/create-issue/route.test.ts
@@ -42,6 +42,11 @@ vi.mock("@/lib/integrations/IntegrationManager", () => ({
   },
 }));
 
+vi.mock("@/lib/integrations/editorMediaAttachments", () => ({
+  resolveEditorMediaAttachments: vi.fn(),
+}));
+
+import { resolveEditorMediaAttachments } from "@/lib/integrations/editorMediaAttachments";
 import { IntegrationManager } from "@/lib/integrations/IntegrationManager";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
@@ -253,6 +258,123 @@ describe("POST /api/integrations/[id]/create-issue", () => {
       );
 
       expect(mockGetAdapter).toHaveBeenCalledWith("1", undefined, "user-1");
+    });
+  });
+
+  describe("Embedded description media", () => {
+    const descriptionDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: { src: "/api/storage/uploads/document-images/1/shot.png" },
+        },
+      ],
+    };
+
+    const attachmentAdapter: any = {
+      createIssue: vi.fn(),
+      uploadAttachment: vi.fn(),
+      getCapabilities: vi.fn(),
+    };
+
+    beforeEach(() => {
+      (getServerSession as any).mockResolvedValue(mockSession);
+      (prisma.userIntegrationAuth.findFirst as any).mockResolvedValue(null);
+      (prisma.integration.findUnique as any).mockResolvedValue({
+        id: 1,
+        authType: "API_KEY",
+        status: "ACTIVE",
+        provider: "JIRA",
+      });
+      (IntegrationManager.getInstance as any).mockReturnValue({
+        getAdapter: vi.fn().mockResolvedValue(attachmentAdapter),
+      });
+      attachmentAdapter.createIssue.mockResolvedValue({
+        id: "ext-123",
+        key: "PROJ-1",
+        title: "Test Issue",
+        url: "https://example.com/issues/PROJ-1",
+        status: "Open",
+      });
+      attachmentAdapter.uploadAttachment.mockResolvedValue({
+        id: "att-1",
+        url: "https://example.com/attachments/att-1",
+      });
+      attachmentAdapter.getCapabilities.mockReturnValue({ attachments: true });
+      (resolveEditorMediaAttachments as any).mockResolvedValue([]);
+    });
+
+    it("uploads media resolved from the description to the created issue", async () => {
+      (resolveEditorMediaAttachments as any).mockResolvedValue([
+        { filename: "shot.png", buffer: Buffer.from("png-bytes") },
+      ]);
+
+      const response = await POST(
+        createRequest({
+          title: "With image",
+          projectId: "PROJ",
+          description: descriptionDoc,
+        }),
+        params
+      );
+
+      expect(response.status).toBe(200);
+      expect(resolveEditorMediaAttachments).toHaveBeenCalledWith(
+        descriptionDoc
+      );
+      expect(attachmentAdapter.uploadAttachment).toHaveBeenCalledWith(
+        "PROJ-1",
+        expect.any(Buffer),
+        "shot.png"
+      );
+    });
+
+    it("an attachment upload failure does not fail issue creation", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      (resolveEditorMediaAttachments as any).mockResolvedValue([
+        { filename: "a.png", buffer: Buffer.from("a") },
+        { filename: "b.png", buffer: Buffer.from("b") },
+      ]);
+      attachmentAdapter.uploadAttachment.mockRejectedValueOnce(
+        new Error("HTTP 413: attachment too large")
+      );
+
+      const response = await POST(
+        createRequest({
+          title: "With images",
+          projectId: "PROJ",
+          description: descriptionDoc,
+        }),
+        params
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.key).toBe("PROJ-1");
+      expect(attachmentAdapter.uploadAttachment).toHaveBeenCalledTimes(2);
+      consoleError.mockRestore();
+    });
+
+    it("skips media transfer when the adapter does not support attachments", async () => {
+      attachmentAdapter.getCapabilities.mockReturnValue({
+        attachments: false,
+      });
+
+      const response = await POST(
+        createRequest({
+          title: "No attachments",
+          projectId: "PROJ",
+          description: descriptionDoc,
+        }),
+        params
+      );
+
+      expect(response.status).toBe(200);
+      expect(resolveEditorMediaAttachments).not.toHaveBeenCalled();
+      expect(attachmentAdapter.uploadAttachment).not.toHaveBeenCalled();
     });
   });
 

--- a/testplanit/app/api/integrations/[id]/create-issue/route.ts
+++ b/testplanit/app/api/integrations/[id]/create-issue/route.ts
@@ -1,4 +1,5 @@
 import { IntegrationManager } from "@/lib/integrations/IntegrationManager";
+import { resolveEditorMediaAttachments } from "@/lib/integrations/editorMediaAttachments";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
@@ -350,6 +351,27 @@ export async function POST(
 
     // console.log(`[CREATE-ISSUE] Final issue data being sent:`, JSON.stringify(issueData, null, 2));
     const createdIssue = await adapter.createIssue(issueData);
+
+    // Media embedded in the description editor (images/videos) lives in
+    // TestPlanIt storage — the tracker only receives the converted description
+    // text. Transfer it as attachments on the created issue. Failures are
+    // non-fatal: the issue itself was created and linked.
+    if (adapter.uploadAttachment && adapter.getCapabilities().attachments) {
+      const externalIssueId = createdIssue.key || createdIssue.id;
+      const embeddedMedia = await resolveEditorMediaAttachments(
+        validatedData.description
+      );
+      for (const { filename, buffer } of embeddedMedia) {
+        try {
+          await adapter.uploadAttachment(externalIssueId, buffer, filename);
+        } catch (error) {
+          console.error(
+            `[CREATE-ISSUE] Failed to attach "${filename}" to ${externalIssueId}:`,
+            error
+          );
+        }
+      }
+    }
 
     // If linked to TestPlanit entities, create the link in our database
     if (

--- a/testplanit/lib/integrations/adapters/BaseAdapter.ts
+++ b/testplanit/lib/integrations/adapters/BaseAdapter.ts
@@ -220,6 +220,12 @@ export abstract class BaseAdapter implements IssueAdapter {
       ...((options.headers as Record<string, string>) || {}),
     };
 
+    // A FormData body must let fetch set the multipart boundary itself — a
+    // preset JSON Content-Type would corrupt the upload.
+    if (options.body instanceof FormData) {
+      delete headers["Content-Type"];
+    }
+
     // Add authentication headers based on auth type
     switch (this.authData.type) {
       case "oauth":

--- a/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
@@ -73,6 +73,115 @@ describe("JiraAdapter", () => {
     });
   });
 
+  describe("uploadAttachment", () => {
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accountId: "test-user" }),
+      });
+      await adapter.authenticate({
+        type: "api_key",
+        email: "test@example.com",
+        apiToken: "test-token",
+        baseUrl: "https://test.atlassian.net",
+      });
+    });
+
+    it("posts multipart form data with the CSRF-bypass header (API key)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve([
+            {
+              id: 10500,
+              content:
+                "https://test.atlassian.net/secure/attachment/10500/screenshot.png",
+            },
+          ]),
+      });
+
+      const result = await adapter.uploadAttachment(
+        "TEST-123",
+        Buffer.from("png-bytes"),
+        "screenshot.png"
+      );
+
+      const [url, options] = mockFetch.mock.calls.at(-1)!;
+      expect(url).toBe(
+        "https://test.atlassian.net/rest/api/3/issue/TEST-123/attachments"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.headers["X-Atlassian-Token"]).toBe("no-check");
+      // fetch must set the multipart boundary itself — a preset JSON
+      // Content-Type would corrupt the upload.
+      expect(options.headers["Content-Type"]).toBeUndefined();
+      expect(options.body).toBeInstanceOf(FormData);
+      expect((options.body.get("file") as File).name).toBe("screenshot.png");
+      expect(result).toEqual({
+        id: "10500",
+        url: "https://test.atlassian.net/secure/attachment/10500/screenshot.png",
+      });
+    });
+
+    it("posts through the OAuth gateway without a JSON content type", async () => {
+      vi.stubEnv("JIRA_CLIENT_ID", "test-client-id");
+      vi.stubEnv("JIRA_CLIENT_SECRET", "test-client-secret");
+      vi.stubEnv("JIRA_REDIRECT_URI", "https://app.com/callback");
+
+      const oauthAdapter = new JiraAdapter({ provider: "JIRA" });
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: "cloud-123", url: "https://allego.atlassian.net" },
+          ]),
+      });
+      await oauthAdapter.authenticate({
+        type: "oauth",
+        accessToken: "test-access-token",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ id: 42, content: "https://x/42" }]),
+      });
+
+      const result = await oauthAdapter.uploadAttachment(
+        "ABT-1",
+        Buffer.from("png-bytes"),
+        "screenshot.png"
+      );
+
+      const [url, options] = mockFetch.mock.calls.at(-1)!;
+      expect(url).toBe(
+        "https://api.atlassian.com/ex/jira/cloud-123/rest/api/3/issue/ABT-1/attachments"
+      );
+      expect(options.headers["Authorization"]).toBe("Bearer test-access-token");
+      expect(options.headers["X-Atlassian-Token"]).toBe("no-check");
+      expect(options.headers["Content-Type"]).toBeUndefined();
+      expect(options.body).toBeInstanceOf(FormData);
+      expect(result).toEqual({ id: "42", url: "https://x/42" });
+
+      vi.unstubAllEnvs();
+    });
+
+    it("throws when Jira returns no attachment metadata", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      });
+
+      await expect(
+        adapter.uploadAttachment("TEST-123", Buffer.from("x"), "a.png")
+      ).rejects.toThrow("Failed to upload attachment - no id returned");
+    });
+  });
+
   describe("authenticate", () => {
     it("should authenticate successfully with API key", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
@@ -770,6 +770,60 @@ describe("JiraAdapter", () => {
       expect(result.labels).toEqual(["bug", "priority"]);
     });
 
+    it("builds the browse url from the admin-entered baseUrl (API key)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockJiraIssue),
+      });
+
+      const result = await adapter.getIssue("TEST-123");
+
+      expect(result.url).toBe("https://test.atlassian.net/browse/TEST-123");
+    });
+
+    it("builds the browse url from the OAuth site host, not the api.atlassian.com gateway", async () => {
+      vi.stubEnv("JIRA_CLIENT_ID", "test-client-id");
+      vi.stubEnv("JIRA_CLIENT_SECRET", "test-client-secret");
+      vi.stubEnv("JIRA_REDIRECT_URI", "https://app.com/callback");
+
+      // OAuth adapter has no baseUrl — the site host is only knowable from the
+      // accessible-resources response captured during authentication.
+      const oauthAdapter = new JiraAdapter({ provider: "JIRA" });
+
+      mockFetch.mockReset();
+      // accessible-resources: cloud id + canonical site url.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: "cloud-123", url: "https://allego.atlassian.net" },
+          ]),
+      });
+      await oauthAdapter.authenticate({
+        type: "oauth",
+        accessToken: "test-access-token",
+      });
+
+      // The issue's `self` echoes the api.atlassian.com gateway (as Jira does
+      // for all OAuth REST traffic) — splitting it would yield a broken link.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockJiraIssue,
+            key: "ABT-47646",
+            self: "https://api.atlassian.com/ex/jira/cloud-123/rest/api/3/issue/10001",
+          }),
+      });
+
+      const result = await oauthAdapter.getIssue("ABT-47646");
+
+      expect(result.url).toBe("https://allego.atlassian.net/browse/ABT-47646");
+      expect(result.url).not.toContain("api.atlassian.com");
+
+      vi.unstubAllEnvs();
+    });
+
     it("maps Jira fields.components[].name into IssueData.components", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/testplanit/lib/integrations/adapters/JiraAdapter.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.ts
@@ -33,6 +33,7 @@ export class JiraAdapter extends BaseAdapter {
   private clientSecret: string;
   private redirectUri: string;
   private cloudId?: string;
+  private siteUrl?: string;
   private baseUrl?: string;
   private deployment: JiraDeploymentType = "cloud";
   private apiVersion: JiraApiVersion = "3";
@@ -277,6 +278,7 @@ export class JiraAdapter extends BaseAdapter {
           throw new Error("No accessible Jira resources found");
         }
         this.cloudId = resources[0].id;
+        this.siteUrl = resources[0].url;
       }
     } else {
       throw new Error(
@@ -892,6 +894,10 @@ export class JiraAdapter extends BaseAdapter {
     );
   }
 
+  private userFacingBaseUrl(): string {
+    return (this.baseUrl ?? this.siteUrl ?? "").replace(/\/+$/, "");
+  }
+
   private mapJiraIssue(jiraIssue: any): IssueData {
     // Validate that we have the required data structure
     if (!jiraIssue) {
@@ -960,7 +966,14 @@ export class JiraAdapter extends BaseAdapter {
       customFields: this.extractCustomFields(fields),
       createdAt: new Date(fields.created),
       updatedAt: new Date(fields.updated),
-      url: `${jiraIssue.self.split("/rest/")[0]}/browse/${jiraIssue.key}`,
+      // Prefer the canonical site base. Under OAuth, jiraIssue.self points at
+      // the api.atlassian.com/ex/jira/{cloudId} gateway, so splitting it would
+      // yield a broken "open in Jira" link; userFacingBaseUrl() resolves to the
+      // real site host. Fall back to the self-derived host only when no base is
+      // known (defensive — should not happen for authenticated adapters).
+      url: this.userFacingBaseUrl()
+        ? `${this.userFacingBaseUrl()}/browse/${jiraIssue.key}`
+        : `${jiraIssue.self.split("/rest/")[0]}/browse/${jiraIssue.key}`,
     };
   }
 

--- a/testplanit/lib/integrations/adapters/JiraAdapter.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.ts
@@ -487,6 +487,12 @@ export class JiraAdapter extends BaseAdapter {
         this.authScheme
       );
 
+      // A FormData body must let fetch set the multipart boundary itself — a
+      // preset JSON Content-Type would corrupt the upload.
+      if (options.body instanceof FormData) {
+        delete headers["Content-Type"];
+      }
+
       const response = await fetch(url, {
         ...options,
         headers,
@@ -640,6 +646,34 @@ export class JiraAdapter extends BaseAdapter {
     }
 
     return this.getIssue(issueId);
+  }
+
+  async uploadAttachment(
+    issueId: string,
+    file: Buffer,
+    filename: string
+  ): Promise<{ id: string; url: string }> {
+    const form = new FormData();
+    form.append("file", new Blob([new Uint8Array(file)]), filename);
+
+    // Jira answers with an array of metadata for the uploaded files.
+    const response = await this.makeRequest<any>(
+      this.buildUrl(
+        `/rest/api/${this.apiVersion}/issue/${issueId}/attachments`
+      ),
+      {
+        method: "POST",
+        body: form,
+        // Jira rejects attachment uploads without this CSRF-bypass header.
+        headers: { "X-Atlassian-Token": "no-check" },
+      }
+    );
+
+    const attachment = Array.isArray(response) ? response[0] : response;
+    if (!attachment?.id) {
+      throw new Error("Failed to upload attachment - no id returned");
+    }
+    return { id: String(attachment.id), url: attachment.content ?? "" };
   }
 
   async getIssue(issueId: string): Promise<IssueData> {

--- a/testplanit/lib/integrations/editorMediaAttachments.test.ts
+++ b/testplanit/lib/integrations/editorMediaAttachments.test.ts
@@ -1,0 +1,228 @@
+import { Readable } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockS3Send = vi.fn();
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class MockS3Client {
+    send = mockS3Send;
+  },
+  GetObjectCommand: vi.fn(),
+}));
+
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  extractEditorMediaSrcs,
+  filenameForEditorMediaSrc,
+  resolveEditorMediaAttachments,
+} from "./editorMediaAttachments";
+
+describe("editorMediaAttachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("AWS_BUCKET_NAME", "test-bucket");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("extractEditorMediaSrcs", () => {
+    it("collects image and video srcs anywhere in the doc, deduplicated, in order", () => {
+      const doc = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "before " },
+              { type: "image", attrs: { src: "/api/storage/uploads/a.png" } },
+            ],
+          },
+          { type: "video", attrs: { src: "/api/storage/uploads/b.mp4" } },
+          {
+            type: "blockquote",
+            content: [
+              { type: "image", attrs: { src: "/api/storage/uploads/a.png" } },
+            ],
+          },
+        ],
+      };
+
+      expect(extractEditorMediaSrcs(doc)).toEqual([
+        "/api/storage/uploads/a.png",
+        "/api/storage/uploads/b.mp4",
+      ]);
+    });
+
+    it("returns an empty list for non-doc input and nodes without a src", () => {
+      expect(extractEditorMediaSrcs(null)).toEqual([]);
+      expect(extractEditorMediaSrcs("plain text")).toEqual([]);
+      expect(
+        extractEditorMediaSrcs({
+          type: "doc",
+          content: [{ type: "image", attrs: {} }],
+        })
+      ).toEqual([]);
+    });
+  });
+
+  describe("filenameForEditorMediaSrc", () => {
+    it("strips the presigned-upload timestamp suffix", () => {
+      expect(
+        filenameForEditorMediaSrc(
+          "https://minio.example.com/test-bucket/uploads/documentation-images/5/screenshot.png_1753651200000",
+          0
+        )
+      ).toBe("screenshot.png");
+    });
+
+    it("recovers the original name from proxy-upload keys", () => {
+      expect(
+        filenameForEditorMediaSrc(
+          "/api/storage/uploads/document-images/5/screenshot.png_1753651200000_screenshot.png",
+          0
+        )
+      ).toBe("screenshot.png");
+    });
+
+    it("decodes URL-encoded names and passes plain names through", () => {
+      expect(
+        filenameForEditorMediaSrc(
+          "https://minio.example.com/test-bucket/uploads/my%20shot.png_1753651200000",
+          0
+        )
+      ).toBe("my shot.png");
+      expect(filenameForEditorMediaSrc("/api/storage/uploads/img.png", 0)).toBe(
+        "img.png"
+      );
+    });
+
+    it("synthesizes a name for base64 data URIs from the mime subtype", () => {
+      expect(
+        filenameForEditorMediaSrc("data:image/png;base64,iVBORw0KGgo=", 2)
+      ).toBe("embedded-media-3.png");
+    });
+  });
+
+  describe("resolveEditorMediaAttachments", () => {
+    const s3Response = (bytes: string, contentType?: string) => ({
+      Body: Readable.from([Buffer.from(bytes)]),
+      ContentType: contentType,
+    });
+
+    const docWith = (...srcs: string[]) => ({
+      type: "doc",
+      content: srcs.map((src) => ({ type: "image", attrs: { src } })),
+    });
+
+    it("reads proxy-served srcs from storage by object key", async () => {
+      mockS3Send.mockResolvedValueOnce(s3Response("png-bytes", "image/png"));
+
+      const result = await resolveEditorMediaAttachments(
+        docWith(
+          "/api/storage/uploads/document-images/5/shot.png_1753651200000_shot.png"
+        )
+      );
+
+      expect(GetObjectCommand).toHaveBeenCalledWith({
+        Bucket: "test-bucket",
+        Key: "uploads/document-images/5/shot.png_1753651200000_shot.png",
+      });
+      expect(result).toEqual([
+        {
+          filename: "shot.png",
+          buffer: Buffer.from("png-bytes"),
+          mimeType: "image/png",
+        },
+      ]);
+    });
+
+    it("maps path-style presigned URLs on the configured endpoint to keys", async () => {
+      vi.stubEnv("AWS_PUBLIC_ENDPOINT_URL", "https://minio.example.com");
+      mockS3Send.mockResolvedValueOnce(s3Response("bytes"));
+
+      await resolveEditorMediaAttachments(
+        docWith(
+          "https://minio.example.com/test-bucket/uploads/documentation-images/5/shot.png_1753651200000"
+        )
+      );
+
+      expect(GetObjectCommand).toHaveBeenCalledWith({
+        Bucket: "test-bucket",
+        Key: "uploads/documentation-images/5/shot.png_1753651200000",
+      });
+    });
+
+    it("maps virtual-hosted AWS URLs to keys", async () => {
+      mockS3Send.mockResolvedValueOnce(s3Response("bytes"));
+
+      await resolveEditorMediaAttachments(
+        docWith(
+          "https://test-bucket.s3.us-east-1.amazonaws.com/uploads/documentation-images/5/shot.png_1753651200000"
+        )
+      );
+
+      expect(GetObjectCommand).toHaveBeenCalledWith({
+        Bucket: "test-bucket",
+        Key: "uploads/documentation-images/5/shot.png_1753651200000",
+      });
+    });
+
+    it("never fetches srcs that point outside this instance's storage", async () => {
+      const result = await resolveEditorMediaAttachments(
+        docWith("https://evil.example.com/uploads/anything.png")
+      );
+
+      expect(mockS3Send).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("decodes base64 data URIs without touching storage", async () => {
+      const result = await resolveEditorMediaAttachments(
+        docWith(
+          `data:image/png;base64,${Buffer.from("inline").toString("base64")}`
+        )
+      );
+
+      expect(mockS3Send).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          filename: "embedded-media-1.png",
+          buffer: Buffer.from("inline"),
+          mimeType: "image/png",
+        },
+      ]);
+    });
+
+    it("skips files that fail to load and keeps the rest", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockS3Send
+        .mockRejectedValueOnce(new Error("NoSuchKey"))
+        .mockResolvedValueOnce(s3Response("ok-bytes", "image/jpeg"));
+
+      const result = await resolveEditorMediaAttachments(
+        docWith(
+          "/api/storage/uploads/missing.png",
+          "/api/storage/uploads/ok.jpg"
+        )
+      );
+
+      expect(result).toEqual([
+        {
+          filename: "ok.jpg",
+          buffer: Buffer.from("ok-bytes"),
+          mimeType: "image/jpeg",
+        },
+      ]);
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    it("returns an empty list for plain-string descriptions", async () => {
+      expect(await resolveEditorMediaAttachments("just text")).toEqual([]);
+      expect(await resolveEditorMediaAttachments(undefined)).toEqual([]);
+    });
+  });
+});

--- a/testplanit/lib/integrations/editorMediaAttachments.ts
+++ b/testplanit/lib/integrations/editorMediaAttachments.ts
@@ -1,0 +1,213 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "stream";
+
+/**
+ * Media embedded in TipTap editor content (images/videos) lives in TestPlanIt
+ * storage — external trackers only ever receive the converted description
+ * text, so embedded files must be transferred separately as attachments.
+ * This module extracts the media references from a TipTap doc and resolves
+ * them to file buffers readable from this instance's own storage.
+ */
+
+export interface EditorMediaAttachment {
+  filename: string;
+  buffer: Buffer;
+  mimeType?: string;
+}
+
+/**
+ * Collect the distinct `src` values of image and video nodes anywhere in a
+ * TipTap doc, in document order.
+ */
+export function extractEditorMediaSrcs(doc: unknown): string[] {
+  const srcs: string[] = [];
+  const seen = new Set<string>();
+  const walk = (node: any): void => {
+    if (!node || typeof node !== "object") return;
+    if (
+      (node.type === "image" || node.type === "video") &&
+      typeof node.attrs?.src === "string" &&
+      node.attrs.src.length > 0 &&
+      !seen.has(node.attrs.src)
+    ) {
+      seen.add(node.attrs.src);
+      srcs.push(node.attrs.src);
+    }
+    if (Array.isArray(node.content)) {
+      node.content.forEach(walk);
+    }
+  };
+  walk(doc);
+  return srcs;
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Derive a human-readable filename for an editor media src.
+ *
+ * Editor uploads land in storage under two key shapes, both ending in a
+ * basename that embeds the original filename next to an upload timestamp:
+ *  - presigned PUT:  `<original name>_<epoch millis>`
+ *  - upload proxy:   `<original name>_<epoch millis>_<original name>`
+ * Strip the timestamp decoration back off so the attachment carries the name
+ * the user uploaded. Base64 data URIs have no name — synthesize one from the
+ * mime subtype and the media's position in the document.
+ */
+export function filenameForEditorMediaSrc(src: string, index: number): string {
+  if (src.startsWith("data:")) {
+    const subtype = /^data:(?:image|video)\/([a-z0-9.-]+)/i.exec(src)?.[1];
+    const extension = subtype ? subtype.replace(/[^a-z0-9]/gi, "") : "bin";
+    return `embedded-media-${index + 1}.${extension}`;
+  }
+
+  const path = src.split(/[?#]/)[0];
+  const basename = safeDecode(path.split("/").filter(Boolean).pop() ?? "");
+  if (!basename) {
+    return `embedded-media-${index + 1}`;
+  }
+
+  const proxyShape = /^.*_\d{13}_(.+)$/.exec(basename);
+  if (proxyShape) {
+    return proxyShape[1];
+  }
+  return basename.replace(/_\d{13}$/, "");
+}
+
+/**
+ * Map an editor media src to an object key in this instance's storage bucket,
+ * or null when the src does not point at our storage (external URLs are never
+ * fetched). Recognized shapes:
+ *  - `/api/storage/<key>` — the storage proxy route (relative or absolute)
+ *  - `<endpoint>/<bucket>/<key>` — path-style presigned upload against the
+ *    configured public or internal endpoint
+ *  - `https://<bucket>.s3.<region>.amazonaws.com/<key>` — virtual-hosted AWS
+ */
+function storageKeyForSrc(src: string): string | null {
+  const proxyMarker = "/api/storage/";
+  const proxyIndex = src.indexOf(proxyMarker);
+  if (proxyIndex !== -1) {
+    const key = src.slice(proxyIndex + proxyMarker.length).split(/[?#]/)[0];
+    return key ? safeDecode(key) : null;
+  }
+
+  const bucket = process.env.AWS_BUCKET_NAME;
+  if (!bucket || !/^https?:\/\//i.test(src)) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    return null;
+  }
+  const pathname = safeDecode(url.pathname).replace(/^\/+/, "");
+
+  const endpointOrigins = [
+    process.env.AWS_PUBLIC_ENDPOINT_URL,
+    process.env.AWS_ENDPOINT_URL,
+  ]
+    .filter((endpoint): endpoint is string => Boolean(endpoint))
+    .map((endpoint) => {
+      try {
+        return new URL(endpoint).origin;
+      } catch {
+        return null;
+      }
+    });
+  if (endpointOrigins.includes(url.origin)) {
+    return pathname.startsWith(`${bucket}/`)
+      ? pathname.slice(bucket.length + 1)
+      : pathname;
+  }
+
+  if (
+    url.hostname.startsWith(`${bucket}.`) &&
+    url.hostname.endsWith(".amazonaws.com")
+  ) {
+    return pathname;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the media embedded in a TipTap description to attachment payloads.
+ * Only base64 data URIs and this instance's own storage are read; srcs that
+ * point elsewhere are skipped, as is any individual file that fails to load —
+ * the caller uploads whatever could be resolved.
+ */
+export async function resolveEditorMediaAttachments(
+  description: unknown
+): Promise<EditorMediaAttachment[]> {
+  if (!description || typeof description !== "object") {
+    return [];
+  }
+  const srcs = extractEditorMediaSrcs(description);
+  if (srcs.length === 0) {
+    return [];
+  }
+
+  const bucketName = process.env.AWS_BUCKET_NAME;
+  let s3Client: S3Client | null = null;
+
+  const attachments: EditorMediaAttachment[] = [];
+  for (const [index, src] of srcs.entries()) {
+    try {
+      if (src.startsWith("data:")) {
+        const dataUri =
+          /^data:([a-z0-9.+-]+\/[a-z0-9.+-]+)?(?:;[^,]*)?;base64,(.*)$/i.exec(
+            src
+          );
+        if (!dataUri) continue;
+        attachments.push({
+          filename: filenameForEditorMediaSrc(src, index),
+          buffer: Buffer.from(dataUri[2], "base64"),
+          mimeType: dataUri[1] || undefined,
+        });
+        continue;
+      }
+
+      const key = storageKeyForSrc(src);
+      if (!key || !bucketName) continue;
+
+      s3Client ??= new S3Client({
+        region: process.env.AWS_REGION || process.env.AWS_BUCKET_REGION,
+        credentials: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+        },
+        endpoint: process.env.AWS_ENDPOINT_URL,
+        forcePathStyle: process.env.AWS_ENDPOINT_URL ? true : false,
+      });
+
+      const response = await s3Client.send(
+        new GetObjectCommand({ Bucket: bucketName, Key: key })
+      );
+      if (!response.Body) continue;
+
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of response.Body as Readable) {
+        chunks.push(chunk);
+      }
+      attachments.push({
+        filename: filenameForEditorMediaSrc(src, index),
+        buffer: Buffer.concat(chunks),
+        mimeType: response.ContentType || undefined,
+      });
+    } catch (error) {
+      console.error(
+        `[editorMediaAttachments] Failed to resolve embedded media "${src}":`,
+        error
+      );
+    }
+  }
+  return attachments;
+}


### PR DESCRIPTION
## Description

Images and videos added to the issue description through the TipTap editor are uploaded to TestPlanIt's S3/MinIO storage, with only a URL embedded in the description JSON. The ADF conversion silently dropped those nodes and nothing ever transferred the underlying files, so Jira issues created from TestPlanIt lost every embedded image.

This PR transfers embedded description media to the tracker as attachments after the issue is created:

- **`lib/integrations/editorMediaAttachments.ts`** (new): walks the TipTap doc for `image`/`video` nodes, maps each `src` back to a storage object key (storage proxy paths, path-style presigned URLs on the configured endpoint, virtual-hosted AWS URLs, and pasted base64 data URIs), reads the bytes, and restores the original filename by stripping upload-timestamp decoration. External URLs are never fetched, so there is no SSRF surface.
- **`JiraAdapter.uploadAttachment()`** (new): multipart POST to `/rest/api/{v}/issue/{key}/attachments` with `X-Atlassian-Token: no-check`, working for both API-key/Data Center and OAuth (through the cloud gateway). Both `makeRequest` paths now drop the preset JSON `Content-Type` for `FormData` bodies so fetch can set the multipart boundary.
- **`create-issue` route**: after `adapter.createIssue()`, resolves description media and uploads each file to the created issue. The wiring is adapter-generic (gated on `uploadAttachment` + the `attachments` capability), so Azure DevOps work items get the same transfer through its existing `uploadAttachment`. Per-file failures are logged and never fail the issue creation itself.
- **Docs**: feature bullets added for Jira and Azure DevOps in the integrations guide.

Images appear in the tracker's attachment section rather than inline in the description body; inline ADF embedding on Jira Cloud requires Media API file IDs that the REST attachment endpoint does not return.

## Related Issue

Closes #553

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

13 new tests: media extraction/filename derivation/key mapping/external-URL skip in `editorMediaAttachments.test.ts`; multipart + CSRF-bypass header behavior for both auth modes in `JiraAdapter.test.ts`; route wiring (upload called, failure non-fatal, capability gating) in the create-issue `route.test.ts`. Full `pnpm precommit` (lint, type-check, unit suite) passes.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): N/A
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

N/A

## Additional Notes

The GitHub/GitLab/Gitea/Redmine/MantisBT adapters declare `attachments: false`, so their behavior is unchanged.
