### PR TITLE
fix(runs): exclude soft-deleted cases from run summary counts

### DIFF
--- a/testplanit/lib/services/testRunSummary.test.ts
+++ b/testplanit/lib/services/testRunSummary.test.ts
@@ -124,6 +124,35 @@ describe("getTestRunSummary", () => {
     expect(summary.issues).toHaveLength(1);
     expect(summary.issues[0].projectIds).toEqual([42]);
   });
+
+  it("excludes soft-deleted TestRunCases rows from every regular-run summary query", async () => {
+    // Regression guard for run 92851: a soft-delete migration (removing a
+    // case from a run sets isDeleted instead of hard-deleting the row)
+    // never reached getRegularRunSummary's raw SQL, so removed cases kept
+    // inflating the header count (header showed 311, case list showed 211
+    // — 100 soft-deleted rows still being summed). Every query that reads
+    // "TestRunCases" must filter isDeleted = false.
+    const fakeClient = makeFakeClient({
+      testRunType: "REGULAR",
+      forecastManual: null,
+      issues: [],
+      workflowType: "IN_PROGRESS",
+    });
+
+    await getTestRunSummary(1, {
+      client: fakeClient as any,
+      includeCaseDetails: true,
+    });
+
+    const queriesAgainstTestRunCases = fakeClient.$queryRaw.mock.calls
+      .map(([tpl]) => (tpl as TemplateStringsArray).join(" "))
+      .filter((sql) => sql.includes('"TestRunCases" trc'));
+
+    expect(queriesAgainstTestRunCases.length).toBeGreaterThanOrEqual(4);
+    for (const sql of queriesAgainstTestRunCases) {
+      expect(sql).toMatch(/trc\."isDeleted"\s*=\s*false/);
+    }
+  });
 });
 
 interface FakeClientOptions {

--- a/testplanit/lib/services/testRunSummary.ts
+++ b/testplanit/lib/services/testRunSummary.ts
@@ -159,6 +159,7 @@ export async function getRegularRunSummary(
     LEFT JOIN "Status" s ON trc."statusId" = s.id
     LEFT JOIN "Color" c ON s."colorId" = c.id
     WHERE trc."testRunId" = ${testRunId}
+      AND trc."isDeleted" = false
     GROUP BY trc."statusId", s.name, c.value, s."isCompleted", s."isSuccess", s."isFailure"
     ORDER BY trc."statusId" ASC NULLS LAST
   `;
@@ -178,6 +179,7 @@ export async function getRegularRunSummary(
     FROM "TestRunResults" trr
     JOIN "TestRunCases" trc ON trr."testRunCaseId" = trc.id
     WHERE trc."testRunId" = ${testRunId}
+      AND trc."isDeleted" = false
       AND trr."isDeleted" = false
   `;
 
@@ -190,6 +192,7 @@ export async function getRegularRunSummary(
     JOIN "RepositoryCases" rc ON trc."repositoryCaseId" = rc.id
     LEFT JOIN "TestRunResults" trr ON trr."testRunCaseId" = trc.id AND trr."isDeleted" = false
     WHERE trc."testRunId" = ${testRunId}
+      AND trc."isDeleted" = false
       AND trr.id IS NULL
   `;
 
@@ -255,6 +258,7 @@ export async function getRegularRunSummary(
           AND trr."isDeleted" = false
       ) result_count ON true
       WHERE trc."testRunId" = ${testRunId}
+        AND trc."isDeleted" = false
       ORDER BY trc."order" ASC
       LIMIT 1000
     `;


### PR DESCRIPTION
## Summary
Run detail pages could show a mismatched case count between the summary header and the case list (e.g. run 92851: header showed **311**, case list showed **211**).

## Root cause
`getRegularRunSummary`'s raw SQL (`statusCounts`, `elapsedResult`, `estimateResult`, `caseDetails` in `lib/services/testRunSummary.ts`) never filtered `TestRunCases.isDeleted`. Cases soft-removed from a run (soft-delete introduced in 5457653a) still counted toward the header/status-bar totals, while the case list (`app/[locale]/projects/runs/[projectId]/[runId]/page.tsx`) and `getPerCaseIterationCounts` already correctly filtered `isDeleted: false`.

For run 92851: 311 total `TestRunCases` rows, 100 soft-deleted → 211 active. Confirmed by re-running the exact query with/without the filter against the DB.

This isn't specific to one run — it affects every REGULAR run that has had ≥1 case removed since 5457653a (68 runs at last count).

## Fix
Add `AND trc."isDeleted" = false` to all four queries in `getRegularRunSummary`, matching the filter already used elsewhere. No data backfill needed — `totalCases` is computed live, not cached, so the fix applies immediately to every affected run.

## Tests
Added a regression test asserting every query in `getRegularRunSummary` that reads `TestRunCases` includes the `isDeleted = false` filter, so a future query addition to this function can't reintroduce the gap silently. `npx vitest run lib/services/testRunSummary.test.ts` — 12/12 passing. Lint and `tsc --noEmit` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)