### PR TITLE
fix(auth): stop blocking Jira/OAuth callbacks and stale isApi grants

### DIFF
--- a/testplanit/lib/session-cache.ts
+++ b/testplanit/lib/session-cache.ts
@@ -12,6 +12,15 @@
  *
  * The `lastActiveAt` update is separate and runs at most once every
  * 5 minutes per user, matching the pre-existing throttle.
+ *
+ * `isApi` is also re-read here by proxy.ts before it rejects an external
+ * API request: `token.isApi` is baked into the session JWT at
+ * login/refresh time and can otherwise lag a DB grant for the life of the
+ * session, since flipping the admin toggle doesn't touch the user's
+ * existing token. Routing that check through this cache means an admin
+ * grant takes effect within the 60s TTL instead of requiring re-login —
+ * see the `PATCH /api/users/[userId]` route, which already calls
+ * `invalidateSessionUserCache` after every update, for the sub-60s case.
  */
 
 import type {
@@ -39,11 +48,18 @@ export interface CachedSessionUser {
   authMethod: AuthMethod | null;
   preferences: UserPreferences | null;
   lastActiveAt: string | null; // ISO string
+  isApi: boolean;
 }
 
 type SelectedUser = Pick<
   User,
-  "name" | "access" | "image" | "emailVerified" | "authMethod" | "lastActiveAt"
+  | "name"
+  | "access"
+  | "image"
+  | "emailVerified"
+  | "authMethod"
+  | "lastActiveAt"
+  | "isApi"
 > & { userPreferences: UserPreferences | null };
 
 /**
@@ -78,6 +94,7 @@ export async function getCachedSessionUser(
       emailVerified: true,
       authMethod: true,
       lastActiveAt: true,
+      isApi: true,
       userPreferences: true,
     },
   });
@@ -106,6 +123,7 @@ export async function getCachedSessionUser(
     authMethod: user.authMethod ?? null,
     preferences,
     lastActiveAt: user.lastActiveAt ? user.lastActiveAt.toISOString() : null,
+    isApi: user.isApi,
   };
 
   // 4. Populate cache (best-effort)

--- a/testplanit/proxy.test.ts
+++ b/testplanit/proxy.test.ts
@@ -17,10 +17,20 @@ vi.mock("./i18n/navigation", () => ({
   defaultLocale: "en-US",
 }));
 
+// Mock lib/session-cache (used for the isApi short-TTL re-check, so tests
+// don't hit a real DB/Valkey connection)
+vi.mock("~/lib/session-cache", () => ({
+  getCachedSessionUser: vi.fn(),
+}));
+
 import { getToken } from "next-auth/jwt";
+import { getCachedSessionUser } from "~/lib/session-cache";
 import middlewareWithPreferences from "./proxy";
 
 const mockGetToken = getToken as ReturnType<typeof vi.fn>;
+const mockGetCachedSessionUser = getCachedSessionUser as ReturnType<
+  typeof vi.fn
+>;
 
 // Helper to create a mock NextRequest
 function createMockRequest(
@@ -37,6 +47,10 @@ describe("External API Access Control", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.NEXTAUTH_SECRET = "test-secret";
+    // Default: no cached user (cache miss / DB unreachable) — matches
+    // pre-fix behavior of trusting token.isApi alone, so existing tests
+    // don't need to know about the cache re-check.
+    mockGetCachedSessionUser.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -367,6 +381,121 @@ describe("External API Access Control", () => {
       });
 
       const request = createMockRequest("/api/reports/automation-trends", {});
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("OAuth integration route exemption", () => {
+    it("should not apply API access control to the Jira OAuth callback route", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false,
+      });
+
+      // Simulates the real-world redirect: Atlassian navigates the user's
+      // browser back to us with no same-origin signals at all.
+      const request = createMockRequest(
+        "/api/integrations/oauth/jira/callback?code=abc&state=xyz",
+        {}
+      );
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).not.toBe(403);
+    });
+
+    it("should not apply API access control to the OAuth auth (redirect-out) route", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false,
+      });
+
+      const request = createMockRequest(
+        "/api/integrations/oauth/github/auth",
+        {}
+      );
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).not.toBe(403);
+    });
+
+    it("should still block unrelated routes nested under /api/integrations", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false,
+      });
+
+      const request = createMockRequest("/api/integrations/jira/test-info", {});
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("isApi short-TTL cache re-check", () => {
+    it("should allow a request when the JWT's isApi is stale but the cache reflects a fresh grant", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false, // stale — baked in before the admin enabled API access
+      });
+      mockGetCachedSessionUser.mockResolvedValue({ isApi: true });
+
+      const request = createMockRequest("/api/model/users", {});
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).not.toBe(403);
+      expect(mockGetCachedSessionUser).toHaveBeenCalledWith("user-123");
+    });
+
+    it("should still block when both the JWT and the cache say isApi is false", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false,
+      });
+      mockGetCachedSessionUser.mockResolvedValue({ isApi: false });
+
+      const request = createMockRequest("/api/model/users", {});
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should not consult the cache when the JWT already grants isApi", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: true,
+      });
+
+      const request = createMockRequest("/api/model/users", {});
+
+      const response = await middlewareWithPreferences(request);
+
+      expect(response.status).not.toBe(403);
+      expect(mockGetCachedSessionUser).not.toHaveBeenCalled();
+    });
+
+    it("should still block when the cache lookup misses (e.g. DB unreachable)", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-123",
+        access: "USER",
+        isApi: false,
+      });
+      mockGetCachedSessionUser.mockResolvedValue(null);
+
+      const request = createMockRequest("/api/model/users", {});
 
       const response = await middlewareWithPreferences(request);
 

--- a/testplanit/proxy.ts
+++ b/testplanit/proxy.ts
@@ -4,6 +4,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { checkApiRateLimit, type RateLimitResult } from "~/lib/api-rate-limit";
 import { normalizeRecordKeyPath } from "~/lib/recordKeyRoutes";
+import { getCachedSessionUser } from "~/lib/session-cache";
 import { defaultLocale, locales } from "./i18n/navigation";
 
 const middleware = createMiddleware({
@@ -70,6 +71,22 @@ function isExternalApiRequest(request: NextRequest): boolean {
 
   // No browser-specific headers found - treat as external API request
   return true;
+}
+
+/**
+ * Matches the OAuth "connect an integration" routes (e.g.
+ * /api/integrations/oauth/jira/auth and /api/integrations/oauth/jira/callback).
+ *
+ * The callback leg is hit via a genuine cross-site browser redirect: the
+ * provider (auth.atlassian.com, github.com, etc.) navigates the user's
+ * browser back to us with Origin/Referer set to the provider's own domain,
+ * not ours. That trips isExternalApiRequest() even though this is an
+ * ordinary session-cookie-authenticated browser flow, not a programmatic
+ * API call — the route itself still enforces auth via getServerSession.
+ * Both legs are exempted for symmetry.
+ */
+function isOAuthIntegrationRoute(pathname: string): boolean {
+  return /^\/api\/integrations\/oauth\/[^/]+\/(auth|callback)$/.test(pathname);
 }
 
 export default async function middlewareWithPreferences(request: NextRequest) {
@@ -226,9 +243,24 @@ export default async function middlewareWithPreferences(request: NextRequest) {
     // no-token branch above and are authorized by the report routes via the
     // internal bypass token.)
     const isShareBypass = pathname.startsWith("/api/share/");
-    if (!isShareBypass && isExternalApiRequest(request)) {
+    const isOAuthBypass = isOAuthIntegrationRoute(pathname);
+    if (!isShareBypass && !isOAuthBypass && isExternalApiRequest(request)) {
       // For external API requests, user must have isApi enabled
-      if (!token.isApi) {
+      let hasApiAccess = token.isApi === true;
+
+      // token.isApi is baked into the JWT at login/refresh time and can lag
+      // a DB grant for the life of the session (its JWT is only refreshed on
+      // sign-in or an explicit client-side update — enabling the admin
+      // toggle doesn't touch a user's existing session). Before blocking,
+      // re-check against the same short-TTL cache the session callback uses
+      // (see lib/session-cache.ts), so a grant takes effect within seconds
+      // instead of requiring the user to log out and back in.
+      if (!hasApiAccess && token.sub) {
+        const cached = await getCachedSessionUser(token.sub);
+        hasApiAccess = cached?.isApi === true;
+      }
+
+      if (!hasApiAccess) {
         return NextResponse.json(
           { error: "External API access not enabled for this account" },
           { status: 403 }


### PR DESCRIPTION
## Problem

A user with `isApi` already enabled on their account still got 403'd during Jira OAuth2 authentication with:

```json
{"error": "External API access not enabled for this account"}
```

Two compounding bugs in `proxy.ts`'s external-API gate:

1. **OAuth callback misclassified as an external API call.** `isExternalApiRequest()` treats any request missing same-origin browser signals (`Sec-Fetch-Site`, matching `Origin`/`Referer`) as external. That's a reasonable curl/Postman heuristic, but it also matches the genuine cross-site redirect an OAuth provider (`auth.atlassian.com`, `github.com`, ...) sends the browser back to `/api/integrations/oauth/[type]/callback` after the user authorizes — even though the route already authenticates via `getServerSession`.

2. **Stale JWT claim.** `token.isApi` is baked into the session JWT at login/refresh time and only re-read from the DB on sign-in, an explicit `session.update()`, or a token missing `access` entirely. The admin "API Access" toggle (`PATCH /api/users/[userId]`) never touches the target user's existing session, so an already-logged-in user stays blocked for up to the full 30-day session lifetime after being granted access — which is exactly what happened here.

## Fix

- Exempt `/api/integrations/oauth/[type]/{auth,callback}` from `isExternalApiRequest()`, matching the existing `isShareBypass` pattern.
- Before rejecting on `token.isApi: false`, re-check against the same 60s Valkey-backed cache the session callback already uses (`lib/session-cache.ts`). The `isApi` PATCH route already calls `invalidateSessionUserCache` on every update, so a grant now takes effect on the next request instead of requiring re-login.

## Testing

- Added 7 new cases to `proxy.test.ts`: both OAuth route legs exempted, an unrelated `/api/integrations/*` route still blocked, cache-overrides-stale-JWT, both-false-still-blocks, JWT-true-skips-the-cache-call (no extra load on the common path), cache-miss-still-blocks (fail-safe — a bad cache/DB lookup can only preserve today's block, never bypass it).
- Mocked `~/lib/session-cache` in `proxy.test.ts`, which also fixes 8 pre-existing tests that were silently attempting a real DB connection once this fetch was introduced.
- `proxy.test.ts` (29/29) and `server/auth.test.ts` (12/12, unaffected) pass. Lint and Prettier clean on all three touched files. `pnpm type-check` narrowed to these two files is clean (the full repo type-check has pre-existing, unrelated failures from other in-progress work on this branch's base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)