### PR TITLE
fix(integrations): stop using unreadable credentials and return actionable errors

### DIFF
--- a/testplanit/app/[locale]/projects/settings/[projectId]/integrations/project-integration-settings.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/integrations/project-integration-settings.tsx
@@ -139,17 +139,23 @@ export function ProjectIntegrationSettings({
         `/api/integrations/${integration.id}/projects`
       );
 
+      // 401 means the stored authorization must be renewed. Any other failure
+      // is reported with the message the API returned, which names what to
+      // fix — a re-authorize prompt would send the admin somewhere that
+      // cannot resolve a rejected API key or a wrong site URL.
       if (response.status === 401) {
         setNeedsAuth(true);
         return;
       }
 
+      const data = await response.json().catch(() => null);
+
       if (!response.ok) {
-        throw new Error("Failed to load projects");
+        toast.error(data?.error ?? t("integration.loadProjectsError"));
+        return;
       }
 
-      const data = await response.json();
-      setExternalProjects(data.projects || []);
+      setExternalProjects(data?.projects || []);
     } catch {
       toast.error(t("integration.loadProjectsError"));
     } finally {

--- a/testplanit/app/api/integrations/[id]/projects/route.ts
+++ b/testplanit/app/api/integrations/[id]/projects/route.ts
@@ -2,12 +2,22 @@ import { getEnhancedDb } from "@/lib/auth/utils";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { getIntegrationClient } from "~/lib/integrations";
+import {
+  integrationErrorBody,
+  responseStatusForIntegrationError,
+  toIntegrationError,
+} from "~/lib/integrations/errors";
 import { authOptions } from "~/server/auth";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Captured for the catch block, which needs the provider to build a typed
+  // error and the auth type to decide whether re-authorization is offerable.
+  let provider = "";
+  let authType = "";
+
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user) {
@@ -33,6 +43,9 @@ export async function GET(
         { status: 404 }
       );
     }
+
+    provider = integration.provider;
+    authType = integration.authType;
 
     // For API key integrations, we don't need user-specific auth
     let userAuth = null;
@@ -64,22 +77,22 @@ export async function GET(
   } catch (error) {
     console.error("Error fetching integration projects:", error);
 
-    // Check if it's an authentication error from the external API
-    if (
-      error instanceof Error &&
-      (error.message.includes("401") ||
-        error.message.includes("Unauthorized") ||
-        error.message.includes("Bad credentials"))
-    ) {
+    const integrationError = toIntegrationError(error, provider);
+
+    // An OAuth integration whose token was rejected is recoverable by
+    // re-authorizing, and the settings UI branches on 401 to offer that. Every
+    // other failure — including API-key credentials the provider rejected —
+    // is not fixable by re-authorizing, so it returns the actionable message
+    // instead of a re-auth prompt that would lead nowhere.
+    if (integrationError.kind === "auth" && authType === "OAUTH2") {
       return NextResponse.json(
-        { error: "Authentication expired or invalid" },
+        { ...integrationErrorBody(integrationError), requiresAuth: true },
         { status: 401 }
       );
     }
 
-    return NextResponse.json(
-      { error: "Failed to fetch projects" },
-      { status: 500 }
-    );
+    return NextResponse.json(integrationErrorBody(integrationError), {
+      status: responseStatusForIntegrationError(integrationError),
+    });
   }
 }

--- a/testplanit/app/api/integrations/[id]/search/route.test.ts
+++ b/testplanit/app/api/integrations/[id]/search/route.test.ts
@@ -253,10 +253,11 @@ describe("GET /api/integrations/[id]/search", () => {
   });
 
   describe("Error handling", () => {
-    it("returns 500 when adapter.searchIssues throws generic error", async () => {
+    it("returns 4xx without echoing the adapter's message when search fails", async () => {
       (getServerSession as any).mockResolvedValue(mockSession);
       mockDb.integration.findUnique.mockResolvedValue({
         id: 1,
+        provider: "JIRA",
         authType: "API_KEY",
         credentials: { apiToken: "key" },
         userIntegrationAuths: [],
@@ -268,11 +269,13 @@ describe("GET /api/integrations/[id]/search", () => {
       const response = await GET(createRequest("test"), params);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toContain("External search failed");
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      expect(data.error).not.toContain("External search failed");
+      expect(data.kind).toBe("upstream");
     });
 
-    it("returns 401 with authUrl when adapter throws 401 error on OAuth integration", async () => {
+    it("returns 401 with authUrl when the provider rejects an OAuth token", async () => {
       (getServerSession as any).mockResolvedValue(mockSession);
       mockDb.integration.findUnique.mockResolvedValue({
         id: 1,
@@ -283,7 +286,10 @@ describe("GET /api/integrations/[id]/search", () => {
           { userId: "user-1", accessToken: "expired-token", isActive: true },
         ],
       });
-      mockAdapter.searchIssues.mockRejectedValue(new Error("401 Unauthorized"));
+      // The shape BaseAdapter.makeRequest throws on a non-2xx response.
+      mockAdapter.searchIssues.mockRejectedValue(
+        new Error('HTTP 401: {"message":"Unauthorized"}')
+      );
 
       const response = await GET(createRequest("test"), params);
       const data = await response.json();
@@ -293,6 +299,30 @@ describe("GET /api/integrations/[id]/search", () => {
       expect(data.authUrl).toBe(
         "/api/integrations/oauth/jira/auth?integrationId=1&returnUrl=%2Fintegrations%2Fauth-complete"
       );
+    });
+
+    it("does not offer re-authorization when an API-key credential is rejected", async () => {
+      (getServerSession as any).mockResolvedValue(mockSession);
+      mockDb.integration.findUnique.mockResolvedValue({
+        id: 1,
+        provider: "JIRA",
+        authType: "API_KEY",
+        credentials: { apiToken: "key" },
+        userIntegrationAuths: [],
+      });
+      mockAdapter.searchIssues.mockRejectedValue(
+        new Error('HTTP 401: {"message":"Unauthorized"}')
+      );
+
+      const response = await GET(createRequest("test"), params);
+      const data = await response.json();
+
+      // Re-authorizing cannot fix a rejected API key, so the actionable
+      // message is returned instead of a re-auth prompt.
+      expect(response.status).toBe(400);
+      expect(data.requiresAuth).toBeUndefined();
+      expect(data.kind).toBe("auth");
+      expect(data.error).toMatch(/API token/);
     });
   });
 });

--- a/testplanit/app/api/integrations/[id]/search/route.ts
+++ b/testplanit/app/api/integrations/[id]/search/route.ts
@@ -1,5 +1,10 @@
 import { getEnhancedDb } from "@/lib/auth/utils";
 import { IntegrationManager } from "@/lib/integrations/IntegrationManager";
+import {
+  integrationErrorBody,
+  responseStatusForIntegrationError,
+  toIntegrationError,
+} from "~/lib/integrations/errors";
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "~/server/auth";
@@ -147,20 +152,20 @@ export async function GET(
         total,
       });
     } catch (error: any) {
-      // Check if this is an auth error
-      if (
-        error.message?.includes("401") ||
-        error.message?.includes("Unauthorized")
-      ) {
+      const integrationError = toIntegrationError(error, integration.provider);
+
+      if (integrationError.kind === "auth") {
         // Only OAuth integrations can be repaired by the user re-authorizing;
-        // expired API keys/PATs are fixed by an admin on the integration.
+        // expired API keys/PATs are fixed by an admin on the integration, so
+        // those get the actionable message instead of a re-auth prompt that
+        // cannot resolve them.
         if (
           integration.authType !== "API_KEY" &&
           integration.authType !== "PERSONAL_ACCESS_TOKEN"
         ) {
           return Response.json(
             {
-              error: "Authentication expired",
+              ...integrationErrorBody(integrationError),
               authUrl: buildOAuthKickoffUrl(
                 integration.provider,
                 integrationId
@@ -169,24 +174,25 @@ export async function GET(
             },
             { status: 401 }
           );
-        } else {
-          return Response.json(
-            {
-              error: "Authentication expired",
-              requiresAuth: true,
-            },
-            { status: 401 }
-          );
         }
+
+        return Response.json(integrationErrorBody(integrationError), {
+          status: responseStatusForIntegrationError(integrationError),
+        });
       }
 
-      throw error;
+      throw integrationError;
     }
   } catch (error: any) {
     console.error("Search error:", error);
-    return Response.json(
-      { error: error.message || "Failed to search issues" },
-      { status: 500 }
-    );
+
+    // `toIntegrationError` is idempotent, so an error already typed by the
+    // inner catch passes through unchanged. Responding with its `userMessage`
+    // rather than `error.message` keeps adapter internals and upstream
+    // response bodies out of the client.
+    const integrationError = toIntegrationError(error, "");
+    return Response.json(integrationErrorBody(integrationError), {
+      status: responseStatusForIntegrationError(integrationError),
+    });
   }
 }

--- a/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
+++ b/testplanit/app/api/integrations/oauth/[type]/auth/route.ts
@@ -4,6 +4,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { AuthenticationService } from "~/lib/integrations/AuthenticationService";
 import { IntegrationManager } from "~/lib/integrations/IntegrationManager";
 import { authOptions } from "~/server/auth";
+import {
+  integrationErrorBody,
+  responseStatusForIntegrationError,
+  toIntegrationError,
+} from "~/lib/integrations/errors";
 
 export async function GET(
   request: NextRequest,
@@ -105,9 +110,14 @@ export async function GET(
   } catch (error) {
     const { type } = await params;
     console.error(`Error in OAuth auth endpoint for ${type}:`, error);
-    return NextResponse.json(
-      { error: "Failed to initiate OAuth flow" },
-      { status: 500 }
-    );
+
+    // Most failures here originate from building the adapter — decrypting the
+    // stored client credentials, or reaching the provider. Those are all
+    // admin-fixable configuration problems, so surface what to fix instead of
+    // a bare 500.
+    const integrationError = toIntegrationError(error, type.toUpperCase());
+    return NextResponse.json(integrationErrorBody(integrationError), {
+      status: responseStatusForIntegrationError(integrationError),
+    });
   }
 }

--- a/testplanit/app/api/integrations/test-connection/route.test.ts
+++ b/testplanit/app/api/integrations/test-connection/route.test.ts
@@ -50,7 +50,10 @@ describe("POST /api/integrations/test-connection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
-    (isEncrypted as any).mockReturnValue(false);
+    // Identity crypto: stored fixtures are treated as ciphertext that
+    // decrypts to itself. Cleartext secrets are now refused, so a fixture
+    // marked unencrypted would be rejected before any probe runs.
+    (isEncrypted as any).mockReturnValue(true);
     (decrypt as any).mockImplementation((val: string) => Promise.resolve(val));
     (baseDb.integration.update as any).mockResolvedValue({});
   });
@@ -325,6 +328,47 @@ describe("POST /api/integrations/test-connection", () => {
       // Activation for OAuth happens only in the authorization callback once
       // a real user token exists — never from the admin-side test.
       expect(baseDb.integration.update).not.toHaveBeenCalled();
+    });
+
+    it("reports corrupt credentials instead of testing with an undecryptable value", async () => {
+      (getServerSession as any).mockResolvedValue(mockSession);
+      (baseDb.integration.findUnique as any).mockResolvedValue({
+        id: 8,
+        provider: "JIRA",
+        authType: "API_KEY",
+        credentials: { email: "a@b.com", apiToken: "corrupt-ciphertext" },
+        settings: { baseUrl: "https://mycompany.atlassian.net" },
+      });
+      (decrypt as any).mockRejectedValue(new Error("Failed to decrypt data"));
+
+      const response = await POST(createRequest({ integrationId: 8 }));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toMatch(/re-enter/i);
+      // The undecryptable value is never sent upstream as a credential.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("refuses a cleartext secret rather than testing with it as-is", async () => {
+      (getServerSession as any).mockResolvedValue(mockSession);
+      (baseDb.integration.findUnique as any).mockResolvedValue({
+        id: 9,
+        provider: "JIRA",
+        authType: "API_KEY",
+        credentials: { email: "a@b.com", apiToken: "plaintext-token" },
+        settings: { baseUrl: "https://mycompany.atlassian.net" },
+      });
+      (isEncrypted as any).mockReturnValue(false);
+
+      const response = await POST(createRequest({ integrationId: 9 }));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toMatch(/re-enter/i);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
@@ -879,7 +923,7 @@ describe("POST /api/integrations/test-connection — Jira Data Center", () => {
 
   describe("D4: persists resolved deploymentType/authScheme", () => {
     beforeEach(() => {
-      (isEncrypted as any).mockReturnValue(false);
+      (isEncrypted as any).mockReturnValue(true);
     });
 
     it("fills in deploymentType/authScheme on a successful test when unset", async () => {

--- a/testplanit/app/api/integrations/test-connection/route.ts
+++ b/testplanit/app/api/integrations/test-connection/route.ts
@@ -1,5 +1,9 @@
 import { baseDb } from "@/lib/db";
-import { decrypt, isEncrypted } from "@/utils/encryption";
+import { resolveStoredCredentials } from "@/lib/integrations/credentials";
+import {
+  isIntegrationApiError,
+  responseStatusForIntegrationError,
+} from "@/lib/integrations/errors";
 import { IntegrationProvider } from "~/zenstack/models";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
@@ -796,46 +800,31 @@ export const POST = withAuditContext(async (req: NextRequest) => {
       // always failed against the originally-saved config.
       authType = body.authType ?? integration.authType;
 
-      // Decrypt stored credentials as a base; request-provided (form) values win.
+      // Decrypt stored credentials as a base; request-provided (form) values
+      // win. A failure here is reported to the admin instead of being worked
+      // around: the previous fallback sent the unreadable stored value
+      // upstream as if it were a credential.
       const storedCredentials: Record<string, string> = {};
-      if (
-        integration.credentials &&
-        typeof integration.credentials === "object"
-      ) {
-        // Check if credentials are stored with an 'encrypted' key (PUT route format)
-        if (
-          "encrypted" in integration.credentials &&
-          typeof integration.credentials.encrypted === "string"
-        ) {
-          try {
-            const decrypted = await decrypt(integration.credentials.encrypted);
-            Object.assign(storedCredentials, JSON.parse(decrypted));
-          } catch (e) {
-            console.error("Failed to decrypt credentials:", e);
-          }
-        } else {
-          // Handle individual field encryption or plain text
-          const encryptedCreds = integration.credentials as Record<
-            string,
-            string
-          >;
-          for (const [key, value] of Object.entries(encryptedCreds)) {
-            if (value && typeof value === "string") {
-              try {
-                // Check if the value is encrypted using the utility function
-                storedCredentials[key] = isEncrypted(value)
-                  ? await decrypt(value)
-                  : value;
-              } catch {
-                // If decryption fails, use the value as-is
-                console.warn(
-                  `Failed to decrypt credential ${key}, using as-is`
-                );
-                storedCredentials[key] = value;
-              }
-            }
-          }
+      try {
+        Object.assign(
+          storedCredentials,
+          await resolveStoredCredentials(
+            integration.credentials,
+            integration.provider
+          )
+        );
+      } catch (error) {
+        if (isIntegrationApiError(error)) {
+          console.error(
+            `Cannot read stored credentials for integration ${integration.id}:`,
+            error.cause ?? error
+          );
+          return NextResponse.json(
+            { success: false, error: error.userMessage },
+            { status: responseStatusForIntegrationError(error) }
+          );
         }
+        throw error;
       }
       // Fill only the credentials the form did not supply (request wins).
       for (const [key, value] of Object.entries(storedCredentials)) {

--- a/testplanit/components/admin/integrations/IntegrationErrorAlert.tsx
+++ b/testplanit/components/admin/integrations/IntegrationErrorAlert.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+
+/**
+ * Renders a connection failure returned by the integration API.
+ *
+ * The message comes from the server as prose (see lib/integrations/errors.ts)
+ * and may name a URL the admin has to visit — an API token page, for example.
+ * A toast is the wrong container for that, so it is rendered inline and the
+ * URL is made clickable.
+ */
+export function IntegrationErrorAlert({
+  title,
+  message,
+}: {
+  title: string;
+  message: string;
+}) {
+  return (
+    <Alert variant="destructive" data-testid="integration-error-alert">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <p className="whitespace-pre-line">{linkify(message)}</p>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+// Split keeps the capture group; the test pattern is a separate, non-global
+// copy because `lastIndex` on a global regex makes repeated `.test()` calls
+// alternate between true and false.
+const URL_SPLIT_PATTERN = /(https?:\/\/[^\s)]+)/g;
+const URL_TEST_PATTERN = /^https?:\/\/[^\s)]+$/;
+
+function linkify(message: string) {
+  return message.split(URL_SPLIT_PATTERN).map((part, index) =>
+    URL_TEST_PATTERN.test(part) ? (
+      <a
+        key={index}
+        href={part}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        {part}
+      </a>
+    ) : (
+      part
+    )
+  );
+}

--- a/testplanit/components/admin/integrations/IntegrationModal.tsx
+++ b/testplanit/components/admin/integrations/IntegrationModal.tsx
@@ -30,6 +30,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod/v4";
 import { IntegrationConfigForm } from "./IntegrationConfigForm";
+import { IntegrationErrorAlert } from "./IntegrationErrorAlert";
 import { IntegrationTypeSelector } from "./IntegrationTypeSelector";
 
 interface IntegrationModalProps {
@@ -89,6 +90,7 @@ export function IntegrationModal({
   );
   const [isTesting, setIsTesting] = useState(false);
   const [testPassed, setTestPassed] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
 
   // Upsert (not create) so re-adding an integration with the same name
   // as a soft-deleted one resurrects the row with the new payload
@@ -175,6 +177,7 @@ export function IntegrationModal({
 
   const handleTestConnection = async () => {
     setIsTesting(true);
+    setTestError(null);
     const values = form.getValues();
 
     try {
@@ -207,6 +210,7 @@ export function IntegrationModal({
           });
         }
         setTestPassed(true);
+        setTestError(null);
       } else {
         // The route returns a `capabilities` object describing each
         // probe it ran (connection / searchIssues / readIssue). When
@@ -230,12 +234,17 @@ export function IntegrationModal({
             ? failed.join("\n")
             : data.error || t("testFailedDescription");
         toast.error(t("testFailed"), { description });
+        // Kept on screen after the toast expires: these messages name the
+        // exact remedy (and sometimes a URL to visit), which is more than a
+        // transient toast can carry.
+        setTestError(description);
         setTestPassed(false);
       }
     } catch {
       toast.error(t("testError"), {
         description: t("testErrorDescription"),
       });
+      setTestError(t("testErrorDescription"));
     } finally {
       setIsTesting(false);
     }
@@ -319,6 +328,7 @@ export function IntegrationModal({
 
   const handleClose = () => {
     setTestPassed(false);
+    setTestError(null);
     onClose();
   };
 
@@ -415,6 +425,13 @@ export function IntegrationModal({
                   }
                   isEdit={!!integration}
                 />
+
+                {testError && (
+                  <IntegrationErrorAlert
+                    title={t("testFailed")}
+                    message={testError}
+                  />
+                )}
 
                 <div className="flex justify-between">
                   <div className="flex gap-2">

--- a/testplanit/lib/integrations/IntegrationManager.invalidation.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.invalidation.test.ts
@@ -33,9 +33,13 @@ const {
 vi.mock("@/lib/rawDb", () => ({
   rawDb: { integration: { findUnique: findUniqueMock } },
 }));
+// Identity crypto: fixtures store credential values verbatim, so these tests
+// exercise cache scoping rather than the cipher.
 vi.mock("@/utils/encryption", () => ({
   EncryptionService: { decrypt: vi.fn((e: string) => e) },
   getMasterKey: vi.fn(() => "test-master-key"),
+  decrypt: vi.fn(async (e: string) => e),
+  isEncrypted: vi.fn(() => true),
 }));
 vi.mock("./AuthenticationService", () => ({
   AuthenticationService: { storeUserAuth: vi.fn() },

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -28,11 +28,17 @@ vi.mock("@/lib/valkey", () => ({
 }));
 
 // Mock encryption
+// Identity crypto: fixtures store credential values verbatim, so the tests
+// exercise adapter wiring rather than the cipher. `isEncrypted` reports true
+// for the same reason — refusal of cleartext secrets is covered against the
+// real implementation in credentials.test.ts.
 vi.mock("@/utils/encryption", () => ({
   EncryptionService: {
     decrypt: vi.fn((encrypted: string) => encrypted),
   },
   getMasterKey: vi.fn(() => "test-master-key"),
+  decrypt: vi.fn(async (encrypted: string) => encrypted),
+  isEncrypted: vi.fn(() => true),
 }));
 
 // Mock AuthenticationService so token persistence during refresh is observable
@@ -47,7 +53,7 @@ vi.mock("./AuthenticationService", () => ({
 // Get the mocked rawDb
 import { rawDb } from "@/lib/rawDb";
 import valkeyConnection from "@/lib/valkey";
-import { EncryptionService } from "@/utils/encryption";
+import { EncryptionService, decrypt, isEncrypted } from "@/utils/encryption";
 import { AuthenticationService } from "./AuthenticationService";
 
 const mockDb = rawDb as unknown as {
@@ -69,6 +75,10 @@ describe("IntegrationManager", () => {
     vi.mocked(valkeyConnection!.del).mockResolvedValue(1);
     vi.mocked(valkeyConnection!.publish).mockResolvedValue(0);
     mockDb.userIntegrationAuth.findUnique.mockResolvedValue(null);
+    // clearAllMocks resets calls but not implementations, so re-assert the
+    // identity crypto defaults for tests that override them.
+    vi.mocked(decrypt).mockImplementation(async (v: string) => v);
+    vi.mocked(isEncrypted).mockReturnValue(true);
     // Get fresh instance and clear any cached state
     manager = IntegrationManager.getInstance();
     manager.clearAllAdapters();
@@ -130,7 +140,7 @@ describe("IntegrationManager", () => {
   describe("buildAdapterConfig (OAuth)", () => {
     it("decrypts per-integration OAuth client credentials and computes the redirect URI", async () => {
       vi.stubEnv("NEXTAUTH_URL", "https://app.example.com");
-      vi.mocked(EncryptionService.decrypt).mockReturnValue(
+      vi.mocked(decrypt).mockResolvedValue(
         JSON.stringify({ clientId: "gh-client", clientSecret: "gh-secret" })
       );
 
@@ -1085,7 +1095,7 @@ describe("IntegrationManager", () => {
 
       mockDb.integration.findUnique.mockResolvedValue(mockIntegration);
 
-      vi.mocked(EncryptionService.decrypt).mockReturnValue(
+      vi.mocked(decrypt).mockResolvedValue(
         JSON.stringify({
           email: "test@example.com",
           apiToken: "decrypted-token",
@@ -1100,10 +1110,37 @@ describe("IntegrationManager", () => {
 
       await manager.getAdapter("5");
 
-      expect(EncryptionService.decrypt).toHaveBeenCalledWith(
-        "encrypted-credentials-string",
-        "test-master-key"
+      expect(decrypt).toHaveBeenCalledWith("encrypted-credentials-string");
+    });
+
+    it("refuses to build an adapter when a stored secret is cleartext", async () => {
+      vi.mocked(isEncrypted).mockReturnValue(false);
+
+      mockDb.integration.findUnique.mockResolvedValue({
+        id: 6,
+        name: "Jira Cleartext",
+        provider: "JIRA",
+        status: "ACTIVE",
+        authType: "API_KEY",
+        credentials: {
+          email: "test@example.com",
+          apiToken: "cleartext-token",
+        },
+        settings: { baseUrl: "https://test.atlassian.net" },
+        userIntegrationAuths: [],
+      });
+
+      const mockFetch = vi.fn();
+      global.fetch = mockFetch;
+
+      const error = await manager.getAdapter("6").then(
+        () => null,
+        (e) => e
       );
+
+      expect(error?.kind).toBe("credentials_corrupt");
+      // The credential is never forwarded to the provider.
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -4,6 +4,8 @@ import valkeyConnection, { createSubscriberClient } from "@/lib/valkey";
 import { EncryptionService, getMasterKey } from "@/utils/encryption";
 import type { Integration, IntegrationProvider } from "~/zenstack/models";
 import { AuthenticationService } from "./AuthenticationService";
+import { resolveStoredCredentials } from "./credentials";
+import { credentialsCorruptError } from "./errors";
 import { AzureDevOpsAdapter } from "./adapters/AzureDevOpsAdapter";
 import { GiteaAdapter } from "./adapters/GiteaAdapter";
 import { GitHubAdapter } from "./adapters/GitHubAdapter";
@@ -169,17 +171,13 @@ export class IntegrationManager {
         integration.authType === "PERSONAL_ACCESS_TOKEN") &&
       integration.credentials
     ) {
-      let credentials = integration.credentials as any;
-
-      // Check if credentials are encrypted
-      if (typeof credentials === "object" && "encrypted" in credentials) {
-        // Decrypt credentials
-        const decrypted = EncryptionService.decrypt(
-          credentials.encrypted as string,
-          masterKey
-        );
-        credentials = JSON.parse(decrypted);
-      }
+      // Throws when a secret cannot be decrypted or was stored in cleartext,
+      // so an unreadable value is never forwarded to the provider as a
+      // credential.
+      const credentials = await resolveStoredCredentials(
+        integration.credentials,
+        integration.provider
+      );
 
       // Add API key auth data from credentials
       if (credentials.email) authData.email = credentials.email;
@@ -206,13 +204,20 @@ export class IntegrationManager {
       const auth = integration.userIntegrationAuths[0];
       authData.expiresAt = auth.tokenExpiresAt || undefined;
 
-      // Decrypt sensitive fields
-      let accessToken = auth.accessToken
-        ? EncryptionService.decrypt(auth.accessToken, masterKey)
-        : undefined;
-      let refreshToken = auth.refreshToken
-        ? EncryptionService.decrypt(auth.refreshToken, masterKey)
-        : undefined;
+      // Decrypt sensitive fields. A stored token that will not decrypt is
+      // surfaced as a re-authorization prompt rather than a raw crypto error.
+      let accessToken: string | undefined;
+      let refreshToken: string | undefined;
+      try {
+        accessToken = auth.accessToken
+          ? EncryptionService.decrypt(auth.accessToken, masterKey)
+          : undefined;
+        refreshToken = auth.refreshToken
+          ? EncryptionService.decrypt(auth.refreshToken, masterKey)
+          : undefined;
+      } catch (error) {
+        throw credentialsCorruptError(integration.provider, { cause: error });
+      }
 
       // Transparently refresh an access token within TOKEN_REFRESH_MARGIN_MS
       // of expiry. Refresh on behalf of the token's owner: read paths (issue
@@ -369,13 +374,24 @@ export class IntegrationManager {
         row.tokenExpiresAt.getTime() >
           Date.now() + IntegrationManager.TOKEN_REFRESH_MARGIN_MS
       ) {
-        return {
-          accessToken: EncryptionService.decrypt(row.accessToken, masterKey),
-          refreshToken: row.refreshToken
-            ? EncryptionService.decrypt(row.refreshToken, masterKey)
-            : undefined,
-          expiresAt: row.tokenExpiresAt,
-        };
+        try {
+          return {
+            accessToken: EncryptionService.decrypt(row.accessToken, masterKey),
+            refreshToken: row.refreshToken
+              ? EncryptionService.decrypt(row.refreshToken, masterKey)
+              : undefined,
+            expiresAt: row.tokenExpiresAt,
+          };
+        } catch (error) {
+          // Treated as "the winner did not produce a usable token" so the
+          // caller falls through with the stale one, rather than escaping
+          // this helper as a raw crypto error.
+          console.error(
+            `Failed to decrypt tokens refreshed by another process for auth ${authId}:`,
+            error
+          );
+          return null;
+        }
       }
     }
     return null;
@@ -416,14 +432,10 @@ export class IntegrationManager {
     // register their own OAuth app. Decrypt them and pass them to the adapter
     // along with the redirect URI for the generic OAuth callback route.
     if (integration.authType === "OAUTH2" && integration.credentials) {
-      let credentials = integration.credentials as any;
-      if (typeof credentials === "object" && "encrypted" in credentials) {
-        const decrypted = EncryptionService.decrypt(
-          credentials.encrypted as string,
-          getMasterKey()
-        );
-        credentials = JSON.parse(decrypted);
-      }
+      const credentials = await resolveStoredCredentials(
+        integration.credentials,
+        integration.provider
+      );
       if (credentials.clientId) config.clientId = credentials.clientId;
       if (credentials.clientSecret)
         config.clientSecret = credentials.clientSecret;

--- a/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IntegrationApiError } from "../errors";
 
 const mockValkeyGet = vi.fn();
 const mockValkeySet = vi.fn();
@@ -8,7 +9,6 @@ vi.mock("~/lib/valkey", () => ({
     set: (...args: unknown[]) => mockValkeySet(...args),
   },
 }));
-
 import { JiraAdapter } from "./JiraAdapter";
 
 // Mock global fetch
@@ -241,20 +241,81 @@ describe("JiraAdapter", () => {
       );
     });
 
-    it("should throw error when API authentication fails", async () => {
-      mockFetch.mockResolvedValueOnce({
+    it("should throw a typed auth error when API authentication fails", async () => {
+      // v3 /myself, then the serverInfo deployment probe.
+      mockFetch.mockResolvedValue({
         ok: false,
+        status: 401,
         statusText: "Unauthorized",
       });
 
-      await expect(
-        adapter.authenticate({
+      const error = await adapter
+        .authenticate({
           type: "api_key",
           email: "test@example.com",
           apiToken: "invalid-token",
           baseUrl: "https://test.atlassian.net",
         })
-      ).rejects.toThrow("Jira API authentication failed: Unauthorized");
+        .then(
+          () => null,
+          (e) => e
+        );
+
+      expect(error).toBeInstanceOf(IntegrationApiError);
+      expect(error.kind).toBe("auth");
+      expect(error.status).toBe(401);
+      expect(error.provider).toBe("JIRA");
+      expect(error.userMessage).toMatch(/API token/);
+    });
+
+    it("classifies the failure from response.status, not response.statusText", async () => {
+      // The HTTP reason phrase is optional and servers may omit it. Nothing
+      // downstream may depend on the word "Unauthorized" appearing.
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "",
+      });
+
+      const error = await adapter
+        .authenticate({
+          type: "api_key",
+          email: "test@example.com",
+          apiToken: "invalid-token",
+          baseUrl: "https://test.atlassian.net",
+        })
+        .then(
+          () => null,
+          (e) => e
+        );
+
+      expect(error).toBeInstanceOf(IntegrationApiError);
+      expect(error.kind).toBe("auth");
+      expect(error.status).toBe(401);
+    });
+
+    it("distinguishes a permission failure from a credential failure", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      });
+
+      const error = await adapter
+        .authenticate({
+          type: "api_key",
+          email: "test@example.com",
+          apiToken: "valid-token",
+          baseUrl: "https://test.atlassian.net",
+        })
+        .then(
+          () => null,
+          (e) => e
+        );
+
+      expect(error).toBeInstanceOf(IntegrationApiError);
+      expect(error.kind).toBe("permission");
+      expect(error.userMessage).toMatch(/permission/i);
     });
 
     it("throws a clear error for a bare API token against Jira Cloud (no email/username)", async () => {
@@ -273,14 +334,21 @@ describe("JiraAdapter", () => {
         statusText: "Unauthorized",
       });
 
-      await expect(
-        adapter.authenticate({
+      const error = await adapter
+        .authenticate({
           type: "api_key",
           apiToken: "bare-token",
           baseUrl: "https://test.atlassian.net",
         })
-      ).rejects.toThrow(
-        /Jira Cloud authentication requires an email address paired with the API token/
+        .then(
+          () => null,
+          (e) => e
+        );
+
+      expect(error).toBeInstanceOf(IntegrationApiError);
+      expect(error.kind).toBe("auth");
+      expect(error.userMessage).toMatch(
+        /Jira Cloud requires an account email paired with an API token/
       );
     });
 

--- a/testplanit/lib/integrations/adapters/JiraAdapter.ts
+++ b/testplanit/lib/integrations/adapters/JiraAdapter.ts
@@ -24,6 +24,7 @@ import {
   userRefField,
 } from "./jiraDeployment";
 import { adfToWikiMarkup } from "./jiraWikiMarkup";
+import { IntegrationApiError, integrationErrorFromStatus } from "../errors";
 
 /**
  * Board -> project ownership is near-static (boards rarely move between
@@ -256,9 +257,7 @@ export class JiraAdapter extends BaseAdapter {
           { headers }
         );
         if (!response.ok) {
-          throw new Error(
-            `Jira API authentication failed: ${response.statusText}`
-          );
+          throw integrationErrorFromStatus("JIRA", response.status);
         }
         this.apiKeyAuthActive = true;
       } else {
@@ -295,9 +294,7 @@ export class JiraAdapter extends BaseAdapter {
               { headers }
             );
             if (!v2Response.ok) {
-              throw new Error(
-                `Jira API authentication failed: ${v2Response.statusText}`
-              );
+              throw integrationErrorFromStatus("JIRA", v2Response.status);
             }
             this.apiKeyAuthActive = true;
           } else if (!this.authCreds.email && !this.authCreds.username) {
@@ -306,15 +303,16 @@ export class JiraAdapter extends BaseAdapter {
             // bare token — Cloud's API-key auth only accepts Basic
             // email:apiToken, so that guess can never succeed here. Surface
             // this explicitly instead of an opaque 401/403.
-            throw new Error(
-              "Jira Cloud authentication requires an email address paired with the API token (Basic auth) — a bare API token alone cannot authenticate against Jira Cloud."
+            throw new IntegrationApiError(
+              "JIRA",
+              v3Response.status,
+              "auth",
+              "Jira Cloud requires an account email paired with an API token — a bare API token alone cannot authenticate against Jira Cloud. Add the email address for the account that owns the token, or create a token at https://id.atlassian.com/manage-profile/security/api-tokens."
             );
           } else {
             // serverInfo reports Cloud but v3 /myself 404'd — surface the
             // original failure rather than silently switching versions.
-            throw new Error(
-              `Jira API authentication failed: ${v3Response.statusText}`
-            );
+            throw integrationErrorFromStatus("JIRA", v3Response.status);
           }
         }
       }

--- a/testplanit/lib/integrations/credentials.test.ts
+++ b/testplanit/lib/integrations/credentials.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { encrypt } from "@/utils/encryption";
+import { resolveStoredCredentials } from "./credentials";
+import { isIntegrationApiError } from "./errors";
+
+describe("resolveStoredCredentials", () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = "test-encryption-key-for-testing-purposes";
+  });
+
+  const expectCorrupt = async (raw: unknown) => {
+    const error = await resolveStoredCredentials(raw, "JIRA").then(
+      () => null,
+      (e) => e
+    );
+    expect(isIntegrationApiError(error)).toBe(true);
+    expect(error.kind).toBe("credentials_corrupt");
+    return error;
+  };
+
+  it("returns an empty map for absent credentials", async () => {
+    expect(await resolveStoredCredentials(null, "JIRA")).toEqual({});
+    expect(await resolveStoredCredentials(undefined, "JIRA")).toEqual({});
+  });
+
+  it("decrypts the single-blob shape written by the admin routes", async () => {
+    const encrypted = await encrypt(
+      JSON.stringify({ email: "a@b.com", apiToken: "secret-token" })
+    );
+
+    expect(await resolveStoredCredentials({ encrypted }, "JIRA")).toEqual({
+      email: "a@b.com",
+      apiToken: "secret-token",
+    });
+  });
+
+  it("decrypts the legacy per-field shape", async () => {
+    const stored = {
+      email: "a@b.com",
+      apiToken: await encrypt("secret-token"),
+    };
+
+    expect(await resolveStoredCredentials(stored, "JIRA")).toEqual({
+      email: "a@b.com",
+      apiToken: "secret-token",
+    });
+  });
+
+  it("refuses a secret stored in cleartext rather than using it as-is", async () => {
+    // The production incident: a cleartext apiToken was forwarded to Jira as
+    // a bearer credential.
+    await expectCorrupt({ email: "a@b.com", apiToken: "plaintext-token" });
+  });
+
+  it("refuses a cleartext password on the Data Center credential shape", async () => {
+    await expectCorrupt({ username: "svc", password: "hunter2" });
+  });
+
+  it("refuses an undecryptable blob rather than returning empty credentials", async () => {
+    const encrypted = await encrypt(JSON.stringify({ apiToken: "x" }));
+    await expectCorrupt({ encrypted: `${encrypted.slice(0, -5)}XXXXX` });
+  });
+
+  it("refuses an undecryptable per-field secret", async () => {
+    const apiToken = await encrypt("secret-token");
+    await expectCorrupt({ apiToken: `${apiToken.slice(0, -5)}XXXXX` });
+  });
+
+  it("refuses a blob that decrypts to something that is not JSON", async () => {
+    await expectCorrupt({ encrypted: await encrypt("not json at all") });
+  });
+
+  it("passes non-secret identifiers through in the clear", async () => {
+    const stored = {
+      email: "a@b.com",
+      username: "svc",
+      clientId: "public-client-id",
+      apiToken: await encrypt("secret-token"),
+    };
+
+    const resolved = await resolveStoredCredentials(stored, "JIRA");
+    expect(resolved.email).toBe("a@b.com");
+    expect(resolved.username).toBe("svc");
+    expect(resolved.clientId).toBe("public-client-id");
+  });
+
+  it("skips empty values without treating them as corrupt", async () => {
+    expect(
+      await resolveStoredCredentials({ email: "a@b.com", apiToken: "" }, "JIRA")
+    ).toEqual({ email: "a@b.com" });
+  });
+
+  it("round-trips every secret key it recognizes", async () => {
+    const stored = {
+      apiToken: await encrypt("t1"),
+      password: await encrypt("t2"),
+      personalAccessToken: await encrypt("t3"),
+      clientSecret: await encrypt("t4"),
+    };
+
+    expect(await resolveStoredCredentials(stored, "JIRA")).toEqual({
+      apiToken: "t1",
+      password: "t2",
+      personalAccessToken: "t3",
+      clientSecret: "t4",
+    });
+  });
+});

--- a/testplanit/lib/integrations/credentials.ts
+++ b/testplanit/lib/integrations/credentials.ts
@@ -1,0 +1,100 @@
+import { decrypt, isEncrypted } from "@/utils/encryption";
+import { credentialsCorruptError } from "./errors";
+
+/**
+ * Reading stored integration credentials.
+ *
+ * Two storage shapes exist. Current writers (POST /api/integrations and PUT
+ * /api/integrations/[id]) serialize the whole credential object and store one
+ * ciphertext under `{ encrypted }`. Older rows store one key per field, each
+ * value encrypted individually.
+ *
+ * Both shapes are read here, and neither may fall back to using an
+ * unreadable value. A credential that cannot be decrypted is a corrupt
+ * record, not a credential: forwarding it upstream authenticates nothing,
+ * burns a rate-limit slot, and — when the stored value is cleartext — sends
+ * the operator's real secret to whatever host the base URL points at.
+ */
+
+/**
+ * Credential fields that must be encrypted at rest. Everything else in the
+ * credential object (identifiers such as `email`, `username`, `clientId`) is
+ * not a secret and is stored in the clear by design.
+ */
+export const SECRET_CREDENTIAL_KEYS = new Set([
+  "apiToken",
+  "password",
+  "personalAccessToken",
+  "clientSecret",
+  "accessToken",
+  "refreshToken",
+  "privateKey",
+  "webhookSecret",
+  "token",
+  "secret",
+]);
+
+export const isSecretCredentialKey = (key: string): boolean =>
+  SECRET_CREDENTIAL_KEYS.has(key);
+
+const hasEncryptedBlob = (
+  value: Record<string, unknown>
+): value is { encrypted: string } =>
+  "encrypted" in value && typeof value.encrypted === "string";
+
+/**
+ * Decrypt stored integration credentials into a plain field map.
+ *
+ * Throws `IntegrationApiError` with kind `credentials_corrupt` when a secret
+ * cannot be decrypted or was stored in cleartext. Callers must let that
+ * propagate rather than proceeding with partial credentials — the point is
+ * that no outbound request is made with a value we could not read.
+ */
+export const resolveStoredCredentials = async (
+  raw: unknown,
+  provider: string
+): Promise<Record<string, string>> => {
+  if (!raw || typeof raw !== "object") return {};
+
+  const stored = raw as Record<string, unknown>;
+
+  if (hasEncryptedBlob(stored)) {
+    let decrypted: string;
+    try {
+      decrypted = await decrypt(stored.encrypted);
+    } catch (error) {
+      throw credentialsCorruptError(provider, { cause: error });
+    }
+
+    try {
+      return JSON.parse(decrypted) as Record<string, string>;
+    } catch (error) {
+      throw credentialsCorruptError(provider, { cause: error });
+    }
+  }
+
+  const resolved: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(stored)) {
+    if (typeof value !== "string" || value === "") continue;
+
+    if (!isSecretCredentialKey(key)) {
+      resolved[key] = value;
+      continue;
+    }
+
+    // A secret stored in cleartext is refused rather than used. Re-saving the
+    // integration rewrites it through the encrypting write path.
+    if (!isEncrypted(value)) {
+      throw credentialsCorruptError(provider);
+    }
+
+    try {
+      resolved[key] = await decrypt(value);
+    } catch (error) {
+      throw credentialsCorruptError(provider, { cause: error });
+    }
+  }
+
+  return resolved;
+};

--- a/testplanit/lib/integrations/errors.test.ts
+++ b/testplanit/lib/integrations/errors.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  IntegrationApiError,
+  credentialsCorruptError,
+  integrationErrorBody,
+  integrationErrorFromStatus,
+  isIntegrationApiError,
+  responseStatusForIntegrationError,
+  toIntegrationError,
+} from "./errors";
+
+describe("integrationErrorFromStatus", () => {
+  it.each([
+    [401, "auth"],
+    [403, "permission"],
+    [404, "not_found"],
+    [429, "rate_limited"],
+    [500, "upstream"],
+    [418, "upstream"],
+  ])("maps upstream %i to kind %s", (status, kind) => {
+    expect(integrationErrorFromStatus("JIRA", status).kind).toBe(kind);
+  });
+
+  it("names the API token requirement for a rejected Jira credential", () => {
+    const error = integrationErrorFromStatus("JIRA", 401);
+    expect(error.userMessage).toMatch(/API token/);
+    expect(error.userMessage).toContain(
+      "id.atlassian.com/manage-profile/security/api-tokens"
+    );
+  });
+
+  it("does not give Jira-specific advice for other providers", () => {
+    const error = integrationErrorFromStatus("GITHUB", 401);
+    expect(error.userMessage).toContain("GitHub");
+    expect(error.userMessage).not.toMatch(/atlassian/i);
+  });
+
+  it("keeps the numeric status and provider on the error", () => {
+    const error = integrationErrorFromStatus("GITLAB", 403);
+    expect(error.status).toBe(403);
+    expect(error.provider).toBe("GITLAB");
+    expect(isIntegrationApiError(error)).toBe(true);
+  });
+});
+
+describe("toIntegrationError", () => {
+  it("passes an already-typed error through unchanged", () => {
+    const original = integrationErrorFromStatus("JIRA", 401);
+    expect(toIntegrationError(original, "JIRA")).toBe(original);
+  });
+
+  it("recovers the status from a makeRequest HTTP error", () => {
+    const error = toIntegrationError(
+      new Error('HTTP 403: {"message":"Forbidden"}'),
+      "JIRA"
+    );
+    expect(error.kind).toBe("permission");
+    expect(error.status).toBe(403);
+  });
+
+  it("never echoes the upstream response body to the user", () => {
+    const error = toIntegrationError(
+      new Error('HTTP 401: {"token":"super-secret-value"}'),
+      "JIRA"
+    );
+    expect(error.userMessage).not.toContain("super-secret-value");
+  });
+
+  it.each([
+    ["fetch failed", "fetch failed"],
+    ["timeout", "Request timeout after 30000ms: https://example.com"],
+  ])("classifies %s as unreachable", (_label, message) => {
+    expect(toIntegrationError(new Error(message), "JIRA").kind).toBe(
+      "unreachable"
+    );
+  });
+
+  it("classifies a DNS failure carried on error.cause as unreachable", () => {
+    const error = new Error("fetch failed");
+    (error as Error & { cause?: unknown }).cause = Object.assign(
+      new Error("getaddrinfo ENOTFOUND bad.example.com"),
+      { code: "ENOTFOUND" }
+    );
+    expect(toIntegrationError(error, "JIRA").kind).toBe("unreachable");
+  });
+
+  it("classifies an aborted request as unreachable", () => {
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    expect(toIntegrationError(error, "JIRA").kind).toBe("unreachable");
+  });
+
+  it("falls back to a generic upstream error without leaking the message", () => {
+    const error = toIntegrationError(
+      new Error("Cannot read properties of undefined (reading 'values')"),
+      "JIRA"
+    );
+    expect(error.kind).toBe("upstream");
+    expect(error.userMessage).not.toContain("Cannot read properties");
+  });
+
+  it("handles a non-Error throw", () => {
+    const error = toIntegrationError("something odd", "JIRA");
+    expect(error.kind).toBe("upstream");
+    expect(error.status).toBe(0);
+  });
+});
+
+describe("responseStatusForIntegrationError", () => {
+  it("never returns 401, which would be read as an expired app session", () => {
+    const statuses = ([401, 403, 404, 429, 500] as const).map((upstream) =>
+      responseStatusForIntegrationError(
+        integrationErrorFromStatus("JIRA", upstream)
+      )
+    );
+    expect(statuses).not.toContain(401);
+  });
+
+  it("keeps every integration failure in the 4xx range", () => {
+    const statuses = ([401, 403, 404, 429, 500, 502] as const).map((upstream) =>
+      responseStatusForIntegrationError(
+        integrationErrorFromStatus("JIRA", upstream)
+      )
+    );
+    for (const status of statuses) {
+      expect(status).toBeGreaterThanOrEqual(400);
+      expect(status).toBeLessThan(500);
+    }
+  });
+
+  it("preserves permission and rate-limit semantics", () => {
+    expect(
+      responseStatusForIntegrationError(integrationErrorFromStatus("JIRA", 403))
+    ).toBe(403);
+    expect(
+      responseStatusForIntegrationError(integrationErrorFromStatus("JIRA", 429))
+    ).toBe(429);
+  });
+
+  it("returns 400 for corrupt stored credentials", () => {
+    expect(
+      responseStatusForIntegrationError(credentialsCorruptError("JIRA"))
+    ).toBe(400);
+  });
+});
+
+describe("credentialsCorruptError", () => {
+  it("tells the admin to re-enter the credentials", () => {
+    const error = credentialsCorruptError("JIRA");
+    expect(error.kind).toBe("credentials_corrupt");
+    expect(error.status).toBe(0);
+    expect(error.userMessage).toMatch(/re-enter/i);
+  });
+});
+
+describe("integrationErrorBody", () => {
+  it("exposes the user message and upstream status, not the internal message", () => {
+    const error = new IntegrationApiError(
+      "JIRA",
+      401,
+      "auth",
+      "Friendly text."
+    );
+    expect(integrationErrorBody(error)).toEqual({
+      error: "Friendly text.",
+      kind: "auth",
+      provider: "JIRA",
+      upstreamStatus: 401,
+    });
+  });
+});

--- a/testplanit/lib/integrations/errors.ts
+++ b/testplanit/lib/integrations/errors.ts
@@ -1,0 +1,253 @@
+/**
+ * Typed errors for external issue-tracker integrations.
+ *
+ * Adapters throw `IntegrationApiError` so consumers can branch on
+ * `kind`/`status` rather than substring-matching `error.message`. Message
+ * matching was the previous approach and is unreliable: it couples every
+ * caller to the exact wording of a string built for humans, and it silently
+ * stops working when an upstream omits the HTTP reason phrase.
+ */
+
+export type IntegrationErrorKind =
+  /** Upstream rejected the credentials (401). */
+  | "auth"
+  /** Credentials are valid but lack permission on the target (403). */
+  | "permission"
+  /** Site/base URL or resource does not exist (404). */
+  | "not_found"
+  /** Upstream is throttling us (429). */
+  | "rate_limited"
+  /** DNS/TCP/TLS failure or timeout — nothing answered. */
+  | "unreachable"
+  /** Stored credentials could not be decrypted, or are not encrypted at all. */
+  | "credentials_corrupt"
+  /** Anything else, including upstream 5xx. */
+  | "upstream";
+
+export class IntegrationApiError extends Error {
+  constructor(
+    readonly provider: string,
+    /** Upstream HTTP status, or 0 when no response was received. */
+    readonly status: number,
+    readonly kind: IntegrationErrorKind,
+    /** Safe to render to an end user — carries no internals. */
+    readonly userMessage: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`${provider} API error ${status} (${kind})`, options);
+    this.name = "IntegrationApiError";
+  }
+}
+
+export const isIntegrationApiError = (
+  error: unknown
+): error is IntegrationApiError => error instanceof IntegrationApiError;
+
+const JIRA_API_TOKEN_URL =
+  "https://id.atlassian.com/manage-profile/security/api-tokens";
+
+const providerLabel = (provider: string): string => {
+  const known: Record<string, string> = {
+    JIRA: "Jira",
+    GITHUB: "GitHub",
+    GITLAB: "GitLab",
+    GITEA: "Gitea",
+    AZURE_DEVOPS: "Azure DevOps",
+    REDMINE: "Redmine",
+    MANTISBT: "MantisBT",
+    BITBUCKET: "Bitbucket",
+  };
+  return known[provider.toUpperCase()] ?? provider;
+};
+
+const userMessageForStatus = (provider: string, status: number): string => {
+  const label = providerLabel(provider);
+  switch (status) {
+    case 401:
+      return provider.toUpperCase() === "JIRA"
+        ? `${label} rejected the credentials. Jira Cloud requires your account email plus an API token — an account password will not work for API access. Create a token at ${JIRA_API_TOKEN_URL} and re-enter it.`
+        : `${label} rejected the credentials. Check the token or password and re-enter it.`;
+    case 403:
+      return `The credentials are valid, but the account does not have permission to access this project in ${label}. Grant that account access, or use credentials for an account that already has it.`;
+    case 404:
+      return `${label} returned "not found" for that address. Check the site URL on the integration — it should be the base address of your instance, with no path.`;
+    case 429:
+      return `${label} is rate limiting requests. Wait a moment and try again.`;
+    default:
+      return status >= 500
+        ? `${label} returned a server error (${status}). This is a problem on their side — try again shortly.`
+        : `${label} rejected the request (HTTP ${status}).`;
+  }
+};
+
+const kindForStatus = (status: number): IntegrationErrorKind => {
+  switch (status) {
+    case 401:
+      return "auth";
+    case 403:
+      return "permission";
+    case 404:
+      return "not_found";
+    case 429:
+      return "rate_limited";
+    default:
+      return "upstream";
+  }
+};
+
+/**
+ * Build a typed error from an upstream HTTP status.
+ *
+ * Always pass `response.status`. Classification must not depend on
+ * `response.statusText`: the reason phrase is optional, servers may send it
+ * empty, and a message assembled from it then loses the only signal a
+ * consumer had.
+ */
+export const integrationErrorFromStatus = (
+  provider: string,
+  status: number,
+  options?: { userMessage?: string; cause?: unknown }
+): IntegrationApiError =>
+  new IntegrationApiError(
+    provider,
+    status,
+    kindForStatus(status),
+    options?.userMessage ?? userMessageForStatus(provider, status),
+    { cause: options?.cause }
+  );
+
+export const credentialsCorruptError = (
+  provider: string,
+  options?: { cause?: unknown }
+): IntegrationApiError =>
+  new IntegrationApiError(
+    provider,
+    0,
+    "credentials_corrupt",
+    `The stored credentials for this ${providerLabel(provider)} integration could not be read. Re-enter them on the integration and save again.`,
+    { cause: options?.cause }
+  );
+
+const NETWORK_ERROR_CODES = [
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "CERT_HAS_EXPIRED",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+];
+
+const isNetworkError = (error: Error): boolean => {
+  if (error.name === "AbortError" || error.name === "TimeoutError") return true;
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code && NETWORK_ERROR_CODES.includes(code)) return true;
+  const causeCode = (error.cause as NodeJS.ErrnoException | undefined)?.code;
+  if (causeCode && NETWORK_ERROR_CODES.includes(causeCode)) return true;
+  return (
+    error.message === "fetch failed" ||
+    /^Request timeout after \d+ms/.test(error.message)
+  );
+};
+
+/**
+ * Normalize any thrown value into an `IntegrationApiError`.
+ *
+ * Recognizes, in order: an already-typed error; `BaseAdapter.makeRequest`'s
+ * `HTTP <status>: <body>` message, matched on the numeric status; and
+ * network/timeout failures. Anything else becomes a generic `upstream` error
+ * whose `userMessage` omits the original text, so adapter internals and
+ * upstream response bodies are never echoed back to the client.
+ */
+export const toIntegrationError = (
+  error: unknown,
+  provider: string
+): IntegrationApiError => {
+  if (isIntegrationApiError(error)) return error;
+
+  if (error instanceof Error) {
+    const httpMatch = error.message.match(/^HTTP (\d{3}):/);
+    if (httpMatch) {
+      return integrationErrorFromStatus(provider, parseInt(httpMatch[1], 10), {
+        cause: error,
+      });
+    }
+
+    // Provider SDKs (octokit and friends) attach the status to the error
+    // object. Reading the property is exact, unlike matching the message.
+    const carried = error as { status?: unknown; statusCode?: unknown };
+    const carriedStatus =
+      typeof carried.status === "number"
+        ? carried.status
+        : typeof carried.statusCode === "number"
+          ? carried.statusCode
+          : undefined;
+    if (carriedStatus && carriedStatus >= 400 && carriedStatus <= 599) {
+      return integrationErrorFromStatus(provider, carriedStatus, {
+        cause: error,
+      });
+    }
+
+    if (isNetworkError(error)) {
+      return new IntegrationApiError(
+        provider,
+        0,
+        "unreachable",
+        `Could not reach ${providerLabel(provider)}. Check the site URL on the integration, and that the instance is reachable from this server.`,
+        { cause: error }
+      );
+    }
+  }
+
+  return new IntegrationApiError(
+    provider,
+    0,
+    "upstream",
+    `The request to ${providerLabel(provider)} could not be completed. Check the integration settings and try again.`,
+    { cause: error }
+  );
+};
+
+/**
+ * HTTP status this API returns for a given upstream failure.
+ *
+ * Never 401: a 401 from our own origin trips client-side NextAuth session
+ * handling and bounces the user to the sign-in screen, when it is the
+ * *upstream* credentials that were rejected, not the user's session.
+ *
+ * Never 5xx either. Every one of these is a configuration problem the admin
+ * can act on, and keeping them in the 4xx range means the JSON body survives
+ * to the client and alerting is not paged for customer misconfiguration.
+ */
+export const responseStatusForIntegrationError = (
+  error: IntegrationApiError
+): number => {
+  switch (error.kind) {
+    case "permission":
+      return 403;
+    case "rate_limited":
+      return 429;
+    default:
+      return 400;
+  }
+};
+
+export interface IntegrationErrorBody {
+  error: string;
+  kind: IntegrationErrorKind;
+  provider: string;
+  /** Upstream status, 0 when no response was received. */
+  upstreamStatus: number;
+}
+
+export const integrationErrorBody = (
+  error: IntegrationApiError
+): IntegrationErrorBody => ({
+  error: error.userMessage,
+  kind: error.kind,
+  provider: error.provider,
+  upstreamStatus: error.status,
+});

--- a/testplanit/utils/encryption.test.ts
+++ b/testplanit/utils/encryption.test.ts
@@ -193,15 +193,36 @@ describe("isEncrypted", () => {
     expect(isEncrypted(shortBase64)).toBe(false);
   });
 
-  it("should return true for base64 strings meeting minimum length", () => {
-    // Create a buffer of exactly the minimum length
-    const minLength = 32 + 16 + 16; // salt + iv + tag
-    const longEnough = Buffer.alloc(minLength).toString("base64");
+  it("should return true for base64 strings carrying a ciphertext body", () => {
+    const header = 32 + 16 + 16; // salt + iv + tag
+    const longEnough = Buffer.alloc(header + 1).toString("base64");
     expect(isEncrypted(longEnough)).toBe(true);
+  });
+
+  it("should return false for a header-sized value with no ciphertext", () => {
+    // salt + iv + tag exactly: structurally impossible for encrypt() output,
+    // which always appends at least one byte of ciphertext.
+    const headerOnly = Buffer.alloc(32 + 16 + 16).toString("base64");
+    expect(isEncrypted(headerOnly)).toBe(false);
   });
 
   it("should return false for invalid base64", () => {
     expect(isEncrypted("not!valid@base64#string")).toBe(false);
+  });
+
+  it("should return false for long plaintext that decodes past the minimum length", () => {
+    // Buffer.from(..., "base64") ignores non-alphabet characters instead of
+    // throwing, so a long passphrase used to decode to >= 64 bytes and get
+    // classified as ciphertext.
+    const plaintext = "correct horse battery staple ".repeat(4);
+    expect(plaintext.length).toBeGreaterThan(64);
+    expect(isEncrypted(plaintext)).toBe(false);
+  });
+
+  it("should return false for non-canonical base64", () => {
+    const encrypted = Buffer.alloc(80).toString("base64");
+    expect(isEncrypted(`${encrypted}\n`)).toBe(false);
+    expect(isEncrypted(encrypted.replace(/=+$/, ""))).toBe(false);
   });
 });
 

--- a/testplanit/utils/encryption.ts
+++ b/testplanit/utils/encryption.ts
@@ -131,15 +131,28 @@ export const decrypt = async (encryptedText: string): Promise<string> => {
   }
 };
 
-// Utility to check if a string is encrypted (base64 format check)
+/**
+ * Whether a stored string looks like output of `encrypt()`.
+ *
+ * `Buffer.from(value, "base64")` never throws — it skips characters outside
+ * the base64 alphabet — so a length check alone accepted arbitrary plaintext
+ * of sufficient length and, symmetrically, could reject nothing. This checks
+ * that the value is *canonical* base64 (the exact form `toString("base64")`
+ * produces) and that it decodes to a full salt + IV + tag plus at least one
+ * byte of ciphertext.
+ *
+ * A false positive is no longer load-bearing: callers must treat a decrypt
+ * failure as a corrupt credential rather than falling back to the raw value.
+ */
 export const isEncrypted = (value: string): boolean => {
-  try {
-    const decoded = Buffer.from(value, "base64");
-    // Check if the decoded buffer has the expected minimum length
-    return decoded.length >= saltLength + ivLength + tagLength;
-  } catch {
-    return false;
-  }
+  if (typeof value !== "string" || value.length === 0) return false;
+  if (value.length % 4 !== 0) return false;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
+
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.toString("base64") !== value) return false;
+
+  return decoded.length > saltLength + ivLength + tagLength;
 };
 
 // EncryptionService class for object encryption/decryption


### PR DESCRIPTION
## Description

Beta port of #580 (which targets `main`). Same fix; the beta-specific resolutions are listed below.

A Jira integration whose stored `apiToken` failed to decrypt had that raw stored value forwarded to Jira as a credential. Jira rejected it, and the 401 surfaced as an HTTP 500 with no actionable message.

- New `lib/integrations/credentials.ts` is the single reader for stored credentials, covering both the `{ encrypted }` blob and legacy per-field shapes. A secret that is cleartext or will not decrypt is refused rather than used as-is.
- `test-connection` and `IntegrationManager` both route through it. `IntegrationManager` previously had **no** encryption check on the per-field shape at all, and it serves projects, search, and create-issue.
- New `IntegrationApiError` carries provider, numeric upstream status, kind, and a user-facing message, replacing `error.message` substring matching and the hardcoded 500s in the OAuth auth and search routes. Responses stay 4xx and no longer echo the adapter message or upstream body.
- `isEncrypted` now requires canonical base64 plus a non-empty ciphertext body; the old length-only check classified long plaintext as ciphertext because `Buffer.from(v, "base64")` skips invalid characters instead of throwing.
- The Jira 401 message names the account-email + API-token requirement and links the token page.

## Beta-specific resolutions

Four files conflicted. Beta's versions were kept and the fix applied on top:

- **`search/route.ts`** — beta already split OAuth from API-key and uses `buildOAuthKickoffUrl(provider, integrationId)` rather than `adapter.getAuthorizationUrl(userId)`. Both preserved; the branch is now driven by the typed error's `kind`, and the API-key case returns the actionable message instead of a bare `"Authentication expired"` 401.
- **`test-connection/route.ts`** — kept beta's `baseDb` / `~/zenstack/models` imports and its `storedCredentials` base map with request-wins merge semantics, populating it through the resolver.
- **`IntegrationManager.test.ts` / `JiraAdapter.test.ts`** — additive conflicts; both sides kept (beta's valkey and `rawDb` mocks alongside the new crypto mock defaults).

Two beta-only follow-ons, in code that does not exist on `main`:

- `IntegrationManager` has extra `EncryptionService.decrypt` calls in its distributed refresh-lock path. The one at the re-read inside the lock is already inside a catch that deliberately falls through with the stale token, so it was left alone. `waitForRefreshedTokens` is called **outside** any try, so a decrypt failure there escaped as a raw 500; it now returns `null`, which is exactly the "the winner did not produce a usable token" case its caller already handles.
- `IntegrationManager.invalidation.test.ts` needed the same encryption-mock completion.

## Related Issue

N/A — from a production support ticket.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

`pnpm precommit` green on this branch (exit 0): type-check clean, lint 0 errors, 12519 unit tests passing, docs build succeeds.

New coverage ports cleanly: `errors.test.ts`, `credentials.test.ts`, plus route- and manager-level tests that corrupt or cleartext credentials return 400 with a re-enter message and make **no** outbound request.

**Test Configuration:**
- OS: macOS (darwin 25.5.0)
- Browser (if applicable): n/a
- Node version: v22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

n/a

## Additional Notes

Installs storing a secret in cleartext will now fail closed with "re-enter the credentials" instead of silently sending that secret upstream. Re-saving the integration rewrites it through the encrypting write path.

`app/api/integrations/jira/issue-details/route.ts` still matches on `error.message?.includes("Unauthorized")`. It was outside the handoff's scope and is identical on `main`, so it was left alone on both branches rather than introducing drift.
