### PR TITLE
fix(integrations): accept cleartext credentials, refuse only undecryptable ones

### DIFF
--- a/testplanit/app/api/integrations/test-connection/route.test.ts
+++ b/testplanit/app/api/integrations/test-connection/route.test.ts
@@ -351,7 +351,7 @@ describe("POST /api/integrations/test-connection", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("refuses a cleartext secret rather than testing with it as-is", async () => {
+    it("tests with a cleartext secret, which is what the admin UI writes", async () => {
       (getServerSession as any).mockResolvedValue(mockSession);
       (prisma.integration.findUnique as any).mockResolvedValue({
         id: 9,
@@ -361,14 +361,19 @@ describe("POST /api/integrations/test-connection", () => {
         settings: { baseUrl: "https://mycompany.atlassian.net" },
       });
       (isEncrypted as any).mockReturnValue(false);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ accountId: "u1" }),
+      });
 
       const response = await POST(createRequest({ integrationId: 9 }));
-      const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data.success).toBe(false);
-      expect(data.error).toMatch(/re-enter/i);
-      expect(mockFetch).not.toHaveBeenCalled();
+      // Refusing this shape would break every integration created through the
+      // admin form, which saves credentials unencrypted.
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalled();
     });
   });
 

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -841,18 +841,19 @@ describe("IntegrationManager", () => {
       expect(decrypt).toHaveBeenCalledWith("encrypted-credentials-string");
     });
 
-    it("refuses to build an adapter when a stored secret is cleartext", async () => {
-      vi.mocked(isEncrypted).mockReturnValue(false);
+    it("refuses to build an adapter when a stored secret will not decrypt", async () => {
+      vi.mocked(isEncrypted).mockReturnValue(true);
+      vi.mocked(decrypt).mockRejectedValue(new Error("Failed to decrypt data"));
 
       mockPrisma.integration.findUnique.mockResolvedValue({
         id: 6,
-        name: "Jira Cleartext",
+        name: "Jira Corrupt",
         provider: "JIRA",
         status: "ACTIVE",
         authType: "API_KEY",
         credentials: {
           email: "test@example.com",
-          apiToken: "cleartext-token",
+          apiToken: "looks-encrypted-but-is-not",
         },
         settings: { baseUrl: "https://test.atlassian.net" },
         userIntegrationAuths: [],
@@ -867,8 +868,33 @@ describe("IntegrationManager", () => {
       );
 
       expect(error?.kind).toBe("credentials_corrupt");
-      // The credential is never forwarded to the provider.
+      // The unreadable credential is never forwarded to the provider.
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("builds an adapter from cleartext credentials, which the admin UI writes", async () => {
+      vi.mocked(isEncrypted).mockReturnValue(false);
+
+      mockPrisma.integration.findUnique.mockResolvedValue({
+        id: 7,
+        name: "Jira Cleartext",
+        provider: "JIRA",
+        status: "ACTIVE",
+        authType: "API_KEY",
+        credentials: {
+          email: "test@example.com",
+          apiToken: "cleartext-token",
+        },
+        settings: { baseUrl: "https://test.atlassian.net" },
+        userIntegrationAuths: [],
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ accountId: "test-user" }),
+      });
+
+      expect(await manager.getAdapter("7")).toBeTruthy();
     });
   });
 

--- a/testplanit/lib/integrations/credentials.test.ts
+++ b/testplanit/lib/integrations/credentials.test.ts
@@ -46,14 +46,34 @@ describe("resolveStoredCredentials", () => {
     });
   });
 
-  it("refuses a secret stored in cleartext rather than using it as-is", async () => {
-    // The production incident: a cleartext apiToken was forwarded to Jira as
-    // a bearer credential.
-    await expectCorrupt({ email: "a@b.com", apiToken: "plaintext-token" });
+  it("accepts a cleartext secret, which is what the admin UI writes", async () => {
+    // The integration form saves through the generated ZenStack model
+    // endpoint, which stores credentials verbatim. Refusing this shape would
+    // break every integration created through the admin UI.
+    expect(
+      await resolveStoredCredentials(
+        { email: "a@b.com", apiToken: "plaintext-token" },
+        "JIRA"
+      )
+    ).toEqual({ email: "a@b.com", apiToken: "plaintext-token" });
   });
 
-  it("refuses a cleartext password on the Data Center credential shape", async () => {
-    await expectCorrupt({ username: "svc", password: "hunter2" });
+  it("accepts a cleartext OAuth client secret", async () => {
+    expect(
+      await resolveStoredCredentials(
+        { clientId: "abc", clientSecret: "shh" },
+        "JIRA"
+      )
+    ).toEqual({ clientId: "abc", clientSecret: "shh" });
+  });
+
+  it("accepts a cleartext password on the Data Center credential shape", async () => {
+    expect(
+      await resolveStoredCredentials(
+        { username: "svc", password: "hunter2" },
+        "JIRA"
+      )
+    ).toEqual({ username: "svc", password: "hunter2" });
   });
 
   it("refuses an undecryptable blob rather than returning empty credentials", async () => {

--- a/testplanit/lib/integrations/credentials.ts
+++ b/testplanit/lib/integrations/credentials.ts
@@ -4,16 +4,20 @@ import { credentialsCorruptError } from "./errors";
 /**
  * Reading stored integration credentials.
  *
- * Two storage shapes exist. Current writers (POST /api/integrations and PUT
- * /api/integrations/[id]) serialize the whole credential object and store one
- * ciphertext under `{ encrypted }`. Older rows store one key per field, each
- * value encrypted individually.
+ * Three storage shapes exist:
  *
- * Both shapes are read here, and neither may fall back to using an
- * unreadable value. A credential that cannot be decrypted is a corrupt
- * record, not a credential: forwarding it upstream authenticates nothing,
- * burns a rate-limit slot, and — when the stored value is cleartext — sends
- * the operator's real secret to whatever host the base URL points at.
+ *  - `{ encrypted }` — one ciphertext for the whole credential object, from
+ *    POST /api/integrations and PUT /api/integrations/[id].
+ *  - per-field ciphertext — one key per field, each value encrypted.
+ *  - per-field cleartext — one key per field, stored verbatim. This is what
+ *    the admin integration form produces: it saves through the generated
+ *    ZenStack model endpoint, which has no encryption step. Despite the
+ *    `credentials` comment in schema.zmodel, nothing encrypts on that path.
+ *
+ * All three are read here. What is *not* accepted is a value that looks like
+ * ciphertext but fails to decrypt: that is a corrupt record, not a
+ * credential, and forwarding it upstream authenticates nothing while burning
+ * a rate-limit slot. That case is the one behind the production incident.
  */
 
 /**
@@ -78,15 +82,22 @@ export const resolveStoredCredentials = async (
   for (const [key, value] of Object.entries(stored)) {
     if (typeof value !== "string" || value === "") continue;
 
-    if (!isSecretCredentialKey(key)) {
+    // Cleartext is accepted because it is what the admin UI writes: the
+    // integration form saves through the generated ZenStack model endpoint,
+    // which persists `credentials` verbatim with no encryption step. Refusing
+    // it here would break every integration created that way.
+    //
+    // A value that *looks* encrypted but will not decrypt is a different
+    // case, and is the one behind the production incident — it is refused
+    // below rather than forwarded to the provider as a credential.
+    if (!isEncrypted(value)) {
+      if (isSecretCredentialKey(key)) {
+        console.warn(
+          `Integration secret "${key}" is stored unencrypted (provider ${provider}).`
+        );
+      }
       resolved[key] = value;
       continue;
-    }
-
-    // A secret stored in cleartext is refused rather than used. Re-saving the
-    // integration rewrites it through the encrypting write path.
-    if (!isEncrypted(value)) {
-      throw credentialsCorruptError(provider);
     }
 
     try {


### PR DESCRIPTION
## Description

Regression fix for #580, which is merged. #580 made the credential reader refuse any secret stored in cleartext. That broke every integration saved through the admin form — including Jira OAuth 2.0 authorization, which fails with:

> The stored credentials for this Jira integration could not be read. Re-enter them on the integration and save again.

**Why #580 was wrong about this.** Its PR body claimed both admin write paths encrypt correctly. That checked the REST routes but missed that the UI never calls them: `IntegrationModal` saves through `useUpsertIntegration` / `useUpdateIntegration`, which are ZenStack-generated hooks posting to the generic model endpoint. That path persists `credentials` verbatim, with no encryption step — `schema.zmodel:3440` comments `// Encrypted OAuth credentials or API keys`, but there is no `@encrypted` attribute or plugin behind it. So cleartext is the shape the application itself produces, on its primary write path.

#580 conflated two different failures. The production incident was a value that *looked* like ciphertext and *failed to decrypt* being forwarded to Jira anyway. Cleartext storage is a separate problem, and refusing it on read turns a working integration into a broken one.

This keeps the fix for the incident and drops the overreach:

- A value that is not encrypted is used as stored, and a secret field in that state logs a warning naming the field.
- A value that looks like ciphertext and will not decrypt is still refused, so it is never sent upstream as a credential.
- The `{ encrypted }` blob path is unchanged: a decrypt or JSON-parse failure is still refused.

Nothing else from #580 changes — the typed `IntegrationApiError`, the removal of substring matching, the 500 fixes, and the UI surfacing are all untouched.

## Follow-up worth filing separately

Integration secrets — OAuth client secrets, API tokens, PATs — are stored unencrypted by the app's main write path. That is the real defect the incident exposed, and it needs a write-path change plus a migration for existing rows, not a read-path refusal. I did not attempt it here because it is a larger change than a regression fix should carry, and because encrypting on write without migrating existing rows would break them the same way this PR is repairing.

## Related Issue

Regression from #580.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

`pnpm precommit` green (exit 0): type-check clean, lint 0 errors, 9997 unit tests passing, docs build succeeds.

Tests changed to match corrected behavior:

- `credentials.test.ts` — cleartext `apiToken`, cleartext OAuth `clientId`/`clientSecret`, and a cleartext Data Center `username`/`password` all resolve rather than throwing. The undecryptable cases still throw.
- `IntegrationManager.test.ts` — splits into "refuses to build an adapter when a stored secret will not decrypt" (no outbound request) and "builds an adapter from cleartext credentials".
- `test-connection/route.test.ts` — a cleartext secret now runs the probe instead of returning 400.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

One residual risk, unchanged in kind from #580: `isEncrypted` is a heuristic, so a cleartext secret that happens to be canonical base64 decoding to more than 64 bytes would be treated as ciphertext and refused. Atlassian secrets use a URL-safe alphabet that fails the check, so this is unlikely in practice, but it is the reason the heuristic should stop being load-bearing once secrets are actually encrypted at rest.
