### PR TITLE
fix(deps): force deepmerge-ts 8 to resolve stack-exhaustion advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,7 @@ overrides:
   immutable: ^4.3.9
   sharp: '>=0.35.0'
   websocket-driver: '>=0.7.5'
+  deepmerge-ts: ^8.0.1
 
 patchedDependencies:
   gray-matter@4.0.3: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
@@ -9870,8 +9871,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -24206,7 +24207,7 @@ snapshots:
   '@prisma/config@6.19.3':
     dependencies:
       c12: 3.1.0
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.21.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -24215,7 +24216,7 @@ snapshots:
   '@prisma/config@7.8.0':
     dependencies:
       c12: 3.3.4
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -29350,7 +29351,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -121,6 +121,7 @@ overrides:
   'immutable': '^4.3.9'
   'sharp': '>=0.35.0'
   'websocket-driver': '>=0.7.5'
+  'deepmerge-ts': '^8.0.1'
 
 patchedDependencies:
   gray-matter@4.0.3: patches/gray-matter@4.0.3.patch


### PR DESCRIPTION
## Description

Resolves Dependabot alert #500 — **deepmerge-ts stack exhaustion when merging recursive object graphs** (GHSA-ggr8-5vv4-36mx / CVE-2026-40345, high severity).

The patched release (8.0.0, current 8.0.1) shipped upstream on 2026-08-16. The only consumers in our tree are `@prisma/config` 6.19.3 and 7.8.0 (via the prisma CLI and `@prisma/internals`/`@zenstackhq/sdk`), and Prisma pins `deepmerge-ts` at exactly `7.1.5` even in its latest release — so no Prisma bump resolves this. This PR adds a `'deepmerge-ts': '^8.0.1'` entry to the `pnpm-workspace.yaml` overrides instead, following the same pattern as the previous dependency-security sweeps.

Notes on the cross-major override:

- The lockfile now resolves a single `deepmerge-ts@8.0.1` copy, consumed by both `@prisma/config` versions.
- deepmerge-ts 8.0.0's breaking changes (Map values now deep-merge by default; type-level renames) do not affect Prisma's plain-object config merging.

## Related Issue

N/A — resolves open Dependabot alert #500 (GHSA-ggr8-5vv4-36mx). The remaining two open alerts (`image-size` #496/#497) still have no patched release upstream and are not addressed here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

Full `pnpm precommit` gate (zenstack format, lint, format:check, Vitest suite, docs build). Manually verified the overridden path: the ZenStack/Prisma codegen postinstall runs green, `prisma validate` passes (exercises `@prisma/config`'s config loading, where deepmerge-ts runs), generated hooks are byte-identical, and `grep` of the lockfile confirms 8.0.1 is the only installed copy.

**Test Configuration:**
- OS: macOS (Darwin 25.5.0)
- Browser (if applicable): N/A
- Node version: v24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Exposure was low to begin with: deepmerge-ts runs during CLI/codegen-time config merging, not on attacker-reachable runtime input. The override is cheap insurance and clears the alert.
