### PR TITLE
docs(docker): fix drift between Docker deployment docs and compose files

### DIFF
--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -87,6 +87,17 @@ The Docker Compose setup starts these containerized services:
     ```bash
     # REQUIRED CHANGES for production:
 
+    # Database — the bundled Postgres container creates the testplanit_prod database
+    DATABASE_URL="postgresql://user:password@postgres:5432/testplanit_prod?schema=public"
+
+    # Job queue — the shipped default points at localhost, which inside a
+    # container is the container itself; use the valkey service hostname
+    VALKEY_URL="valkey://valkey:6379"
+
+    # Search — same localhost issue; use the elasticsearch service hostname
+    # (leave empty to disable search if you don't run the with-elasticsearch profile)
+    ELASTICSEARCH_NODE="http://elasticsearch:9200"
+
     # Application URL (change to your domain)
     NEXTAUTH_URL="https://yourdomain.com"
 
@@ -110,7 +121,7 @@ The Docker Compose setup starts these containerized services:
     EMAIL_FROM=noreply@yourdomain.com
     ```
 
-    **Important:** The `.env.production` file contains many other variables (database, Valkey, Elasticsearch, MinIO connections) that are already configured correctly for Docker. Only modify the variables shown above unless you're using external services.
+    **Important:** `.env.example` ships with local-development values, so the connection URLs above must be changed to the Docker service hostnames as shown. The remaining variables (MinIO connection, ports, feature flags) work as shipped — only modify them if you're using external services.
 
     ### Optional: Change External Docker Ports
 

--- a/testplanit/DEPLOYMENT.md
+++ b/testplanit/DEPLOYMENT.md
@@ -7,7 +7,7 @@ TestPlanIt ships with Docker Compose files that let you build and run the full s
 ## 1. Prerequisites
 
 - Docker 24+ and Docker Compose Plugin 2+
-- At least 4 CPUs, 8 GB RAM, and 20 GB free disk space
+- At least 4 CPUs, 8 GB RAM (14 GB recommended for the full stack), and 25 GB free disk space
 - Access to the TestPlanIt source code (clone or release archive)
 
 ---

--- a/testplanit/DOCKER-PROFILES.md
+++ b/testplanit/DOCKER-PROFILES.md
@@ -14,7 +14,7 @@ TestPlanIt's production Docker setup (`docker-compose.prod.yml`) uses Docker Com
 
 | Profile              | Service         | Purpose                                       |
 | -------------------- | --------------- | --------------------------------------------- |
-| `with-postgres`      | PostgreSQL 15   | Database storage                              |
+| `with-postgres`      | PostgreSQL 18   | Database storage                              |
 | `with-valkey`        | Valkey 8        | Redis-compatible cache and job queue          |
 | `with-elasticsearch` | Elasticsearch 9 | Full-text search engine                       |
 | `with-minio`         | MinIO + Nginx   | S3-compatible file storage with reverse proxy |
@@ -54,7 +54,7 @@ docker compose -f docker-compose.prod.yml \
 
 **Included Services:**
 
-- `postgres` - PostgreSQL 15 database
+- `postgres` - PostgreSQL 18 database
 - `db-init-prod` - Initializes schema and seeds data
 
 **Environment Variables:**
@@ -264,7 +264,8 @@ Configure external AWS RDS (DATABASE*URL) and S3 (AWS*\* vars).
    - Consider hybrid approach: managed database + self-hosted cache
 
 5. **Backup Strategy**:
-   - With Docker services: Backup `./docker-data/` directories
+   - PostgreSQL data lives in the `testplanit-postgres-data` named volume — back it up with `pg_dump` (or snapshot the volume)
+   - Valkey, Elasticsearch, and MinIO data: Backup the `./docker-data/` directories
    - With external services: Use cloud-native backup solutions (RDS snapshots, S3 versioning, etc.)
 
 6. **Networking**:
@@ -287,7 +288,7 @@ Configure external AWS RDS (DATABASE*URL) and S3 (AWS*\* vars).
 
 **Issue**: Data not persisting
 
-- **Solution**: Check `./docker-data/` volumes are mounted correctly for Docker services
+- **Solution**: PostgreSQL persists in the `testplanit-postgres-data` named volume; Valkey, Elasticsearch, and MinIO use `./docker-data/` bind mounts — check the mounts for the affected service
 
 ## See Also
 


### PR DESCRIPTION
## Description

Fixes factual drift between the Docker deployment docs and what the compose files / `.env.example` actually ship (surfaced while reviewing #585):

- **docs/docs/docker-setup.md**: the production section claimed the copied `.env.example` values were "already configured correctly for Docker," but the shipped file contains local-development values — `VALKEY_URL=valkey://localhost:6379` (background jobs can't connect from inside a container), `ELASTICSEARCH_NODE=http://localhost:9200` (search unreachable), and a `DATABASE_URL` pointing at the `testplanit` database while `docker-compose.prod.yml` creates `testplanit_prod`. These three are now listed in the "required changes for production" block with the Docker service hostnames, and the note is corrected.
- **testplanit/DEPLOYMENT.md**: sizing said 8 GB RAM / 20 GB disk; aligned with `docs/docs/docker-setup.md` and `docs/docs/deployment.md` (8 GB minimum, 14 GB recommended for the full stack, 25 GB disk).
- **testplanit/DOCKER-PROFILES.md**: still said "PostgreSQL 15" (compose ships `postgres:18-alpine`), and its backup/troubleshooting tips pointed at `./docker-data/` for all services — Postgres data now lives in the `testplanit-postgres-data` named volume; only Valkey, Elasticsearch, and MinIO use the bind mounts.

## Related Issue

N/A — drift found while reviewing #585.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Every corrected statement was verified against `docker-compose.prod.yml`, `docker-compose.dev.yml`, and `.env.example` (service images, volume mounts, port defaults, shipped env values). `pnpm precommit` (lint, type-check, unit tests) passes.

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**

- OS: macOS
- Browser (if applicable): N/A
- Node version: 22

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Docs-only change; no runtime behavior affected. `external-database-deployment.md`'s "PostgreSQL 15+" was left as-is (it's a version floor for external servers, not a claim about the bundled container), and the dev-container path was left alone (`docker-compose.dev.yml` overrides `VALKEY_URL` itself).
