### PR TITLE
fix(milestones): count removed and automated run-cases correctly

### DIFF
--- a/testplanit/app/api/milestones/[milestoneId]/burndown/route.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/burndown/route.ts
@@ -78,6 +78,7 @@ export async function GET(
         JOIN "TestRuns" tr ON trc."testRunId" = tr.id
         WHERE tr."milestoneId" = ANY(${allMilestoneIds}::int[])
           AND tr."isDeleted" = false
+          AND trc."isDeleted" = false
       `,
       baseDb.$queryRaw<Array<{ count: bigint }>>`
         SELECT COUNT(*) AS count
@@ -111,6 +112,7 @@ export async function GET(
               ON trr."testRunCaseId" = trc.id AND trr."isDeleted" = false
             WHERE tr."milestoneId" = ANY(${allMilestoneIds}::int[])
               AND tr."isDeleted" = false
+              AND trc."isDeleted" = false
               AND NOT (tr."testRunType"::text = ANY(${automatedTypes}::text[]))
             GROUP BY trc.id
           ) fe
@@ -123,6 +125,7 @@ export async function GET(
           JOIN "TestRuns" tr ON trc."testRunId" = tr.id
           WHERE tr."milestoneId" = ANY(${allMilestoneIds}::int[])
             AND tr."isDeleted" = false
+            AND trc."isDeleted" = false
             AND tr."testRunType"::text = ANY(${automatedTypes}::text[])
           GROUP BY 1
         `,

--- a/testplanit/app/api/milestones/[milestoneId]/export/route.test.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/export/route.test.ts
@@ -356,7 +356,7 @@ describe("GET /api/milestones/[milestoneId]/export", () => {
           statusColor: "#0f0",
           runName: "Sprint 1 Run",
           completedAt: new Date("2026-07-01T10:00:00.000Z"),
-          testRunCaseId: 900,
+          hasResult: true,
         },
         {
           externalKey: "ABT-1",
@@ -367,7 +367,7 @@ describe("GET /api/milestones/[milestoneId]/export", () => {
           statusColor: null,
           runName: null,
           completedAt: null,
-          testRunCaseId: null,
+          hasResult: false,
         },
         {
           externalKey: "ABT-2",
@@ -378,7 +378,7 @@ describe("GET /api/milestones/[milestoneId]/export", () => {
           statusColor: null,
           runName: null,
           completedAt: null,
-          testRunCaseId: null,
+          hasResult: false,
         },
       ]);
 
@@ -412,6 +412,56 @@ describe("GET /api/milestones/[milestoneId]/export", () => {
           statusColor: null,
           runName: null,
           executedAt: null,
+        },
+      ]);
+    });
+
+    // Regression: automated (JUnit/TestNG/Mocha/etc.) runs never denormalise a
+    // status onto TestRunCases.statusId, so the query falls back to the case's
+    // latest JUnitTestResult. Such a row arrives with hasResult=true and a real
+    // status but no run-case id — it must export as executed, not blank.
+    it("reports an automated-only case from its JUnit result, not as 'Not run'", async () => {
+      (getServerSession as any).mockResolvedValue(adminSession);
+      (baseDb.milestoneIssue.findMany as any).mockResolvedValue([
+        {
+          issueId: 501,
+          source: "SYNCED",
+          issue: {
+            id: 501,
+            name: "ABT-1",
+            title: "Story one",
+            externalKey: "ABT-1",
+            externalStatus: "Open",
+            status: "open",
+          },
+        },
+      ]);
+      (baseDb.$queryRaw as any).mockResolvedValue([
+        {
+          externalKey: "ABT-1",
+          title: "Story one",
+          issueName: "ABT-1",
+          caseName: "CI smoke test",
+          statusName: "Passed",
+          statusColor: "#0f0",
+          runName: "Web Smoke Tests - DEV #1503",
+          completedAt: new Date("2026-08-14T15:02:30.000Z"),
+          hasResult: true,
+        },
+      ]);
+
+      const [req, ctx] = createRequest("1");
+      const body = await (await GET(req, ctx)).json();
+
+      expect(body.traceability).toEqual([
+        {
+          issueKey: "ABT-1",
+          issueTitle: "Story one",
+          caseName: "CI smoke test",
+          statusName: "Passed",
+          statusColor: "#0f0",
+          runName: "Web Smoke Tests - DEV #1503",
+          executedAt: "2026-08-14T15:02:30.000Z",
         },
       ]);
     });

--- a/testplanit/app/api/milestones/[milestoneId]/export/route.ts
+++ b/testplanit/app/api/milestones/[milestoneId]/export/route.ts
@@ -276,6 +276,12 @@ export async function GET(
     // with a null case (a coverage gap); a linked case with no in-scope result
     // is left null ("Not run"). Same descendant-inclusive result scope as
     // coverage; mirrors that query's linked_cases/latest_result CTEs.
+    //
+    // Automated (JUnit/TestNG/Mocha/etc.) runs never denormalise a status onto
+    // TestRunCases.statusId — their outcome lives in JUnitTestResult — so a
+    // status-less run-case is skipped in latest_result and the case falls back
+    // to latest_junit. Without that, an automated-only case reported blank,
+    // indistinguishable from "Not run", despite having real results.
     const traceabilityRaw =
       memberRows.length > 0
         ? await baseDb.$queryRaw<
@@ -288,7 +294,7 @@ export async function GET(
               statusColor: string | null;
               runName: string | null;
               completedAt: Date | null;
-              testRunCaseId: number | null;
+              hasResult: boolean | null;
             }>
           >`
             WITH member_issues AS (
@@ -316,6 +322,7 @@ export async function GET(
               FROM linked_cases lc
               LEFT JOIN "TestRunCases" trc
                 ON trc."repositoryCaseId" = lc."caseId" AND trc."isDeleted" = false
+                AND trc."statusId" IS NOT NULL
               LEFT JOIN "TestRuns" tr
                 ON tr.id = trc."testRunId"
                 AND tr."milestoneId" = ANY(${allMilestoneIds}::int[])
@@ -323,16 +330,53 @@ export async function GET(
               LEFT JOIN "Color" col ON col.id = s."colorId"
               WHERE tr.id IS NOT NULL OR trc.id IS NULL
               ORDER BY lc."issueId", lc."caseId", trc."completedAt" DESC NULLS LAST, trc.id DESC
+            ),
+            latest_junit AS (
+              SELECT DISTINCT ON (lc."issueId", lc."caseId")
+                lc."issueId",
+                lc."caseId",
+                s.name AS "statusName",
+                col.value AS "statusColor",
+                tr.name AS "runName",
+                jr."executedAt" AS "completedAt"
+              FROM linked_cases lc
+              JOIN "JUnitTestResult" jr ON jr."repositoryCaseId" = lc."caseId"
+              JOIN "JUnitTestSuite" js ON js.id = jr."testSuiteId"
+              JOIN "TestRuns" tr
+                ON tr.id = js."testRunId"
+                AND tr."isDeleted" = false
+                AND tr."milestoneId" = ANY(${allMilestoneIds}::int[])
+              JOIN "Status" s
+                ON s.id = jr."statusId"
+                AND s."systemName" IS DISTINCT FROM 'untested'
+              LEFT JOIN "Color" col ON col.id = s."colorId"
+              ORDER BY lc."issueId", lc."caseId", jr."executedAt" DESC NULLS LAST, jr.id DESC
+            ),
+            effective AS (
+              SELECT
+                lc."issueId",
+                lc."caseId",
+                (lr."testRunCaseId" IS NOT NULL OR lj."caseId" IS NOT NULL)
+                  AS "hasResult",
+                COALESCE(lr."statusName", lj."statusName") AS "statusName",
+                COALESCE(lr."statusColor", lj."statusColor") AS "statusColor",
+                COALESCE(lr."runName", lj."runName") AS "runName",
+                COALESCE(lr."completedAt", lj."completedAt") AS "completedAt"
+              FROM linked_cases lc
+              LEFT JOIN latest_result lr
+                ON lr."issueId" = lc."issueId" AND lr."caseId" = lc."caseId"
+              LEFT JOIN latest_junit lj
+                ON lj."issueId" = lc."issueId" AND lj."caseId" = lc."caseId"
             )
             SELECT
               mi."externalKey", mi.title, mi."issueName",
               lc."caseName",
-              lr."statusName", lr."statusColor", lr."runName",
-              lr."completedAt", lr."testRunCaseId"
+              e."statusName", e."statusColor", e."runName",
+              e."completedAt", e."hasResult"
             FROM member_issues mi
             LEFT JOIN linked_cases lc ON lc."issueId" = mi."issueId"
-            LEFT JOIN latest_result lr
-              ON lr."issueId" = lc."issueId" AND lr."caseId" = lc."caseId"
+            LEFT JOIN effective e
+              ON e."issueId" = lc."issueId" AND e."caseId" = lc."caseId"
             ORDER BY mi."externalKey" NULLS LAST, mi."issueName", lc."caseName" NULLS FIRST
           `
         : [];
@@ -340,11 +384,9 @@ export async function GET(
       issueKey: r.externalKey || r.issueName || "",
       issueTitle: r.title || r.issueName || "",
       caseName: r.caseName ?? null,
-      // A row with a linked case but no in-scope TestRunCases id = "Not run".
+      // A row with a linked case but no in-scope result at all = "Not run".
       statusName:
-        r.caseName != null && r.testRunCaseId != null
-          ? (r.statusName ?? null)
-          : null,
+        r.caseName != null && r.hasResult ? (r.statusName ?? null) : null,
       statusColor: r.statusColor ?? null,
       runName: r.runName ?? null,
       executedAt: r.completedAt ? r.completedAt.toISOString() : null,

--- a/testplanit/app/api/users/[userId]/dashboard/route.ts
+++ b/testplanit/app/api/users/[userId]/dashboard/route.ts
@@ -131,6 +131,10 @@ export async function GET(
       LEFT JOIN "Status" latest_result_status ON latest_result."statusId" = latest_result_status.id
       WHERE trc."assignedToId" = ${userId}
         AND trc."isCompleted" = false
+        -- Removing a case from a run soft-deletes its TestRunCases row rather
+        -- than dropping it, so without this the assignee keeps seeing work that
+        -- is no longer part of any run.
+        AND trc."isDeleted" = false
         AND tr."isDeleted" = false
         AND p."isDeleted" = false
       ORDER BY tr.id, trc.id

--- a/testplanit/lib/services/milestoneMemberCoverage.ts
+++ b/testplanit/lib/services/milestoneMemberCoverage.ts
@@ -110,6 +110,12 @@ export async function getMemberCoverage(
   // Cases with no run-case rollup at all fall back to their latest in-scope
   // automated (JUnit) result — automated submissions don't always add the
   // case to the run's composition, and those executions still count.
+  //
+  // "No run-case rollup" includes a run-case row that carries no status:
+  // automated (JUnit/TestNG/Mocha/etc.) runs record their outcome in
+  // JUnitTestResult and never denormalise it onto TestRunCases.statusId, so
+  // latest_result skips status-less rows. Without that they'd win precedence
+  // over the JUnit fallback with a NULL status and report "Not run".
   const rows = await db.$queryRaw<
     Array<{
       issueId: number;
@@ -141,6 +147,7 @@ export async function getMemberCoverage(
       LEFT JOIN "TestRunCases" trc
         ON trc."repositoryCaseId" = lc."caseId"
         AND trc."isDeleted" = false
+        AND trc."statusId" IS NOT NULL
       LEFT JOIN "TestRuns" tr
         ON tr.id = trc."testRunId"
         AND tr."isDeleted" = false
@@ -256,6 +263,7 @@ export async function getMemberCoverage(
       LEFT JOIN "TestRunCases" trc
         ON trc."repositoryCaseId" = lc."caseId"
         AND trc."isDeleted" = false
+        AND trc."statusId" IS NOT NULL
       LEFT JOIN "TestRuns" tr
         ON tr.id = trc."testRunId"
         AND tr."isDeleted" = false

--- a/testplanit/lib/services/milestoneSummary.test.ts
+++ b/testplanit/lib/services/milestoneSummary.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/db", () => ({
+  baseDb: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import { baseDb } from "~/lib/db";
+import { calculateMilestoneCompletion } from "./milestoneSummary";
+
+/**
+ * `calculateMilestoneCompletion` first fetches the milestone's non-deleted
+ * runs (split into regular vs. automated by `testRunType`), then queries
+ * completion for each half independently:
+ *   1. TestRuns (id, testRunType) — the split
+ *   2. Manual completion (only if there are regular run ids) — TestRunCases
+ *   3. Automated completion (only if there are automated run ids) — JUnitTestResult
+ *
+ * `Promise.all` starts the manual call before the automated one, so mocking
+ * `$queryRaw` with a fixed call-order sequence is safe.
+ */
+const mockQueryRaw = baseDb.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+
+describe("calculateMilestoneCompletion", () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+  });
+
+  it("returns 0 when the milestone has no runs at all", async () => {
+    mockQueryRaw.mockResolvedValueOnce([]); // TestRuns split — nothing
+
+    const rate = await calculateMilestoneCompletion([485]);
+
+    expect(rate).toBe(0);
+    // Neither the manual nor automated completion query should even run.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("computes completion from TestRunCases.statusId for manual (REGULAR) runs", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([{ id: 1, testRunType: "REGULAR" }]) // split
+      .mockResolvedValueOnce([{ total: BigInt(10), completed: BigInt(4) }]); // manual completion
+
+    const rate = await calculateMilestoneCompletion([485]);
+
+    expect(rate).toBe(40);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  // Regression test for the bug where automated (JUnit/TestNG/Mocha/etc.) run
+  // cases never get a status denormalized onto TestRunCases.statusId — their
+  // real outcome lives in JUnitTestResult instead — so the milestone
+  // completion % used to read every automated case as permanently incomplete,
+  // even after the run finished.
+  it("computes completion from JUnitTestResult for automated runs, not TestRunCases.statusId", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([{ id: 2, testRunType: "MOCHA" }]) // split
+      .mockResolvedValueOnce([{ total: BigInt(500), completed: BigInt(500) }]); // automated completion (all passed)
+
+    const rate = await calculateMilestoneCompletion([594]);
+
+    expect(rate).toBe(100);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("combines manual and automated runs into a single completion percentage", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        { id: 1, testRunType: "REGULAR" },
+        { id: 2, testRunType: "MOCHA" },
+      ]) // split
+      .mockResolvedValueOnce([{ total: BigInt(10), completed: BigInt(2) }]) // manual: 2/10
+      .mockResolvedValueOnce([{ total: BigInt(90), completed: BigInt(88) }]); // automated: 88/90
+
+    const rate = await calculateMilestoneCompletion([485]);
+
+    // (2 + 88) / (10 + 90) = 90%
+    expect(rate).toBe(90);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it("caps completion at 100%", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([{ id: 1, testRunType: "REGULAR" }])
+      .mockResolvedValueOnce([{ total: BigInt(5), completed: BigInt(5) }]);
+
+    const rate = await calculateMilestoneCompletion([485]);
+
+    expect(rate).toBe(100);
+  });
+});

--- a/testplanit/lib/services/milestoneSummary.ts
+++ b/testplanit/lib/services/milestoneSummary.ts
@@ -52,46 +52,16 @@ export type MilestoneSummaryData = {
   scopeCount: number;
 };
 
-export async function calculateMilestoneCompletion(
+/**
+ * Split a milestone (rollup)'s non-deleted test runs into manual vs.
+ * automated/imported (JUnit, TestNG, Mocha, etc.) run IDs. Automated runs
+ * record their outcomes in JUnitTestResult, not TestRunCases.statusId /
+ * TestRunResults, so any per-case status or elapsed aggregation needs to
+ * treat the two separately.
+ */
+async function splitRunIdsByAutomation(
   milestoneIds: number[]
-): Promise<number> {
-  // Get total test cases in all test runs for these milestones
-  const totalCasesResult = await baseDb.$queryRaw<Array<{ count: bigint }>>`
-    SELECT COUNT(*) as count
-    FROM "TestRunCases" trc
-    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
-    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
-      AND tr."isDeleted" = false
-  `;
-  const totalTestCases = Number(totalCasesResult[0]?.count || 0);
-
-  if (totalTestCases === 0) {
-    return 0;
-  }
-
-  // Get count of completed test cases (where TestRunCases.status.isCompleted = true)
-  const completedCasesResult = await baseDb.$queryRaw<Array<{ count: bigint }>>`
-    SELECT COUNT(*) as count
-    FROM "TestRunCases" trc
-    JOIN "TestRuns" tr ON trc."testRunId" = tr.id
-    JOIN "Status" s ON trc."statusId" = s.id
-    WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
-      AND tr."isDeleted" = false
-      AND s."isCompleted" = true
-  `;
-  const completedTestCases = Number(completedCasesResult[0]?.count || 0);
-
-  // Calculate percentage, capped at 100%
-  return Math.min((completedTestCases / totalTestCases) * 100, 100);
-}
-
-export async function getTestRunSegments(
-  milestoneIds: number[]
-): Promise<MilestoneSegment[]> {
-  // Split the milestone's runs into manual vs. automated. Automated/imported
-  // runs (JUnit, TestNG, etc.) record their outcomes in JUnitTestResult, not
-  // TestRunResults, so they need a separate aggregation path — otherwise every
-  // automated case looks "pending" with zero elapsed.
+): Promise<{ regularRunIds: number[]; automatedRunIds: number[] }> {
   const runs = await baseDb.$queryRaw<
     Array<{ id: number; testRunType: string }>
   >`
@@ -107,6 +77,90 @@ export async function getTestRunSegments(
   const automatedRunIds = runs
     .filter((r) => automatedTypes.has(r.testRunType))
     .map((r) => r.id);
+  return { regularRunIds, automatedRunIds };
+}
+
+export async function calculateMilestoneCompletion(
+  milestoneIds: number[]
+): Promise<number> {
+  // Automated (JUnit/TestNG/Mocha/etc.) run cases never get a status
+  // denormalized onto TestRunCases.statusId — their real pass/fail outcome
+  // lives in JUnitTestResult (see getAutomatedTestRunSegments below). Reading
+  // TestRunCases.statusId for them unconditionally would count every
+  // automated case as incomplete forever, even after the run finished, so
+  // completion is computed separately for each half and summed.
+  const { regularRunIds, automatedRunIds } =
+    await splitRunIdsByAutomation(milestoneIds);
+
+  const [manual, automated] = await Promise.all([
+    getManualCaseCompletion(regularRunIds),
+    getAutomatedCaseCompletion(automatedRunIds),
+  ]);
+
+  const totalTestCases = manual.total + automated.total;
+  if (totalTestCases === 0) {
+    return 0;
+  }
+
+  const completedTestCases = manual.completed + automated.completed;
+
+  // Calculate percentage, capped at 100%
+  return Math.min((completedTestCases / totalTestCases) * 100, 100);
+}
+
+async function getManualCaseCompletion(
+  runIds: number[]
+): Promise<{ total: number; completed: number }> {
+  if (runIds.length === 0) return { total: 0, completed: 0 };
+
+  const result = await baseDb.$queryRaw<
+    Array<{ total: bigint; completed: bigint }>
+  >`
+    SELECT
+      COUNT(*) as total,
+      COUNT(*) FILTER (WHERE s."isCompleted" = true) as completed
+    FROM "TestRunCases" trc
+    LEFT JOIN "Status" s ON trc."statusId" = s.id
+    WHERE trc."testRunId" = ANY(${runIds}::int[])
+      AND trc."isDeleted" = false
+  `;
+  return {
+    total: Number(result[0]?.total || 0),
+    completed: Number(result[0]?.completed || 0),
+  };
+}
+
+async function getAutomatedCaseCompletion(
+  runIds: number[]
+): Promise<{ total: number; completed: number }> {
+  if (runIds.length === 0) return { total: 0, completed: 0 };
+
+  const result = await baseDb.$queryRaw<
+    Array<{ total: bigint; completed: bigint }>
+  >`
+    SELECT
+      COUNT(*) as total,
+      COUNT(*) FILTER (WHERE s."isCompleted" = true) as completed
+    FROM "JUnitTestResult" jr
+    JOIN "JUnitTestSuite" su ON jr."testSuiteId" = su.id
+    LEFT JOIN "Status" s ON jr."statusId" = s.id
+    WHERE su."testRunId" = ANY(${runIds}::int[])
+  `;
+  return {
+    total: Number(result[0]?.total || 0),
+    completed: Number(result[0]?.completed || 0),
+  };
+}
+
+export async function getTestRunSegments(
+  milestoneIds: number[]
+): Promise<MilestoneSegment[]> {
+  // Split the milestone's runs into manual vs. automated. Automated/imported
+  // runs (JUnit, TestNG, etc.) record their outcomes in JUnitTestResult, not
+  // TestRunResults, so they need a separate aggregation path — otherwise every
+  // automated case looks "pending" with zero elapsed.
+  const { regularRunIds, automatedRunIds } =
+    await splitRunIdsByAutomation(milestoneIds);
 
   const [manual, automated] = await Promise.all([
     getManualTestRunSegments(regularRunIds),
@@ -165,6 +219,7 @@ async function getManualTestRunSegments(
       LEFT JOIN "Color" c ON s."colorId" = c.id
       WHERE tr.id = ANY(${runIds}::int[])
         AND tr."isDeleted" = false
+        AND trc."isDeleted" = false
       GROUP BY tr.id, tr.name, tr."testRunType", trc."statusId", s.name, c.value, s.order
     )
     SELECT


### PR DESCRIPTION
Milestone rollups over-reported open work, most visibly on Web 9.2, which showed
~64,600 open items at ~2% complete when the real figure is ~970 at ~97%.

Three independent defects, all in how run-case completion is read.

## 1. Soft-deleted run-cases were counted

`calculateMilestoneCompletion`, its manual-run segments, and the burndown
totals/day-buckets all joined `TestRunCases` without filtering `isDeleted`.
Removing a case from a run soft-deletes the row, so removed cases still inflated
the denominator.

Nine milestones affected. Web 9.2 was 94.7% phantom; Admin Tool 9.2 was 98.4%
(6,277 deleted vs 103 live cases).

## 2. Automated run-cases were read from the wrong column

Automated runs (JUnit, TestNG, Mocha, etc.) record outcomes in `JUnitTestResult`
and never denormalise a status onto `TestRunCases.statusId` — reporter-SDK
submissions leave the row entirely empty. `calculateMilestoneCompletion` read
that column unconditionally, so every automated case counted as permanently
incomplete.

It now splits manual from automated the way `getTestRunSegments` in the same file
already did, reading each from its own source. At least 12 milestones across every
project were understated, several at 100%.

The same wrong-source assumption is fixed in two more consumers:

- **Export traceability** joined `TestRunCases -> Status` with no automated
  fallback, so an automated-only case exported blank and read as "Not run". It now
  falls back to the case's latest `JUnitTestResult`. On current data, 53 rows in
  9.2's export reported a result with no status; now none do.

- **Member coverage** did query `JUnitTestResult`, but its precedence test was
  "a run-case row exists" rather than "a run-case row has a status". Automated runs
  do create the row, just empty, so the null-status row won precedence and the JUnit
  fallback never engaged. Skipping status-less rows drops falsely "Not run" cases in
  9.2 from 156 to 89.

## 3. Phantom dashboard to-dos (separate commit)

The "assigned to me" query filtered soft-deleted runs and projects but not
soft-deleted run-cases, so removed work stayed in assignees' task lists
indefinitely. 45,969 phantom items across 9 users and 10 runs.

## Notes for review

- **No backfill required.** `JUnitTestResult` has always been populated (1.2M rows,
  zero null `statusId`, zero missing `executedAt`), so these reads correct historical
  and future data alike.
- **Deliberately not fixed:** making the reporter SDK populate
  `TestRunCases.statusId`. It would correct only new rows, leave 187,846 existing ones
  empty, and owe a backfill that "latest result wins" gets wrong for automated runs.
- The two SQL-only fixes (export, member coverage) were verified read-only against a
  prod clone; `milestoneMemberCoverage.integration.test.ts` is `describe.skip` without a
  live DB, so they are not covered by an executable test in CI.

## Testing

151 tests pass across the milestone and dashboard suites; typecheck clean. Added
`lib/services/milestoneSummary.test.ts` (5 tests) covering the manual/automated
completion split, plus a regression test for the automated-only export case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
