### PR TITLE
fix(reports): resolve automated run-case status in the remaining consumers

### DIFF
--- a/testplanit/app/api/duplicate-scan/case-details/route.ts
+++ b/testplanit/app/api/duplicate-scan/case-details/route.ts
@@ -74,6 +74,7 @@ async function fetchCaseDetails(caseId: number) {
         take: 1,
         select: {
           id: true,
+          testRunId: true,
           status: { select: { id: true, name: true } },
           createdAt: true,
           testRun: { select: { name: true } },
@@ -84,6 +85,26 @@ async function fetchCaseDetails(caseId: number) {
 
   if (!result) {
     return result;
+  }
+
+  // The last run may be an automated one (JUnit, TestNG, Mocha, etc.), which
+  // records its outcome in JUnitTestResult and leaves TestRunCases.statusId
+  // empty. Without this the panel shows a run name and date with a blank
+  // status — which reads as "never executed" for the automation-heavy cases
+  // that dominate duplicate scans.
+  const lastRun = result.testRuns?.[0];
+  if (lastRun && lastRun.status == null) {
+    const latestAutomated = await baseDb.jUnitTestResult.findFirst({
+      where: {
+        repositoryCaseId: caseId,
+        testSuite: { testRunId: lastRun.testRunId },
+      },
+      select: { status: { select: { id: true, name: true } } },
+      orderBy: [{ executedAt: "desc" }, { id: "desc" }],
+    });
+    if (latestAutomated?.status) {
+      lastRun.status = latestAutomated.status;
+    }
   }
 
   // Remap the explicit join (caseTags) back to the prior tags shape so the

--- a/testplanit/app/api/report-builder/drill-down/route.test.ts
+++ b/testplanit/app/api/report-builder/drill-down/route.test.ts
@@ -678,4 +678,85 @@ describe("POST /api/report-builder/drill-down", () => {
       );
     });
   });
+
+  // Automated runs leave TestRunCases.statusId empty and record the outcome in
+  // JUnitTestResult, so the milestone-completion drill-down has to resolve the
+  // status from there — otherwise it renders "Completed: No" for every
+  // automated case and contradicts the metric it drills into.
+  describe("milestoneCompletion automated status resolution", () => {
+    const passed = {
+      id: 2,
+      name: "Passed",
+      isCompleted: true,
+      color: { value: "#0f0" },
+    };
+
+    const setUpRunCases = (rows: any[]) => {
+      (getModelForMetric as any).mockReturnValue("testRunCases");
+      (getQueryBuilderForMetric as any).mockReturnValue(() => ({
+        where: { isDeleted: false },
+        include: { status: { include: { color: true } } },
+      }));
+      (baseDb as any).testRunCases = {
+        findMany: vi.fn().mockResolvedValue(rows),
+        count: vi.fn().mockResolvedValue(rows.length),
+        groupBy: vi.fn().mockResolvedValue([]),
+      };
+    };
+
+    const request = () =>
+      createRequest({
+        context: {
+          metricId: "milestoneCompletion",
+          reportType: "project-health",
+          projectId: 1,
+          dimensions: {},
+        },
+      });
+
+    it("fills a status-less run-case from its latest JUnit result", async () => {
+      setUpRunCases([
+        { id: 11, repositoryCaseId: 501, testRunId: 90, status: null },
+      ]);
+      (baseDb as any).jUnitTestResult.findMany.mockResolvedValue([
+        { id: 7, repositoryCaseId: 501, testSuite: { testRunId: 90 }, status: passed },
+      ]);
+
+      const data = await (await POST(request())).json();
+
+      expect(data.data[0].status).toEqual(passed);
+    });
+
+    it("leaves a genuinely unexecuted run-case without a status", async () => {
+      setUpRunCases([
+        { id: 12, repositoryCaseId: 502, testRunId: 90, status: null },
+      ]);
+      (baseDb as any).jUnitTestResult.findMany.mockResolvedValue([]);
+
+      const data = await (await POST(request())).json();
+
+      expect(data.data[0].status).toBeNull();
+    });
+
+    it("does not overwrite a manual run-case's own status", async () => {
+      const failed = {
+        id: 3,
+        name: "Failed",
+        isCompleted: true,
+        color: { value: "#f00" },
+      };
+      setUpRunCases([
+        { id: 13, repositoryCaseId: 503, testRunId: 91, status: failed },
+      ]);
+      (baseDb as any).jUnitTestResult.findMany.mockResolvedValue([
+        { id: 9, repositoryCaseId: 503, testSuite: { testRunId: 91 }, status: passed },
+      ]);
+
+      const data = await (await POST(request())).json();
+
+      expect(data.data[0].status).toEqual(failed);
+      // A row that already has a status is never looked up.
+      expect((baseDb as any).jUnitTestResult.findMany).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/testplanit/app/api/report-builder/drill-down/route.test.ts
+++ b/testplanit/app/api/report-builder/drill-down/route.test.ts
@@ -719,7 +719,12 @@ describe("POST /api/report-builder/drill-down", () => {
         { id: 11, repositoryCaseId: 501, testRunId: 90, status: null },
       ]);
       (baseDb as any).jUnitTestResult.findMany.mockResolvedValue([
-        { id: 7, repositoryCaseId: 501, testSuite: { testRunId: 90 }, status: passed },
+        {
+          id: 7,
+          repositoryCaseId: 501,
+          testSuite: { testRunId: 90 },
+          status: passed,
+        },
       ]);
 
       const data = await (await POST(request())).json();
@@ -749,7 +754,12 @@ describe("POST /api/report-builder/drill-down", () => {
         { id: 13, repositoryCaseId: 503, testRunId: 91, status: failed },
       ]);
       (baseDb as any).jUnitTestResult.findMany.mockResolvedValue([
-        { id: 9, repositoryCaseId: 503, testSuite: { testRunId: 91 }, status: passed },
+        {
+          id: 9,
+          repositoryCaseId: 503,
+          testSuite: { testRunId: 91 },
+          status: passed,
+        },
       ]);
 
       const data = await (await POST(request())).json();

--- a/testplanit/app/api/report-builder/drill-down/route.ts
+++ b/testplanit/app/api/report-builder/drill-down/route.ts
@@ -270,13 +270,16 @@ async function handleMilestoneReadinessDrillDown(
  */
 async function resolveAutomatedRunCaseStatuses(rows: any[]) {
   const pending = (rows ?? []).filter(
-    (r) => r?.status == null && r?.repositoryCaseId != null && r?.testRunId != null
+    (r) =>
+      r?.status == null && r?.repositoryCaseId != null && r?.testRunId != null
   );
   if (pending.length === 0) return;
 
   const results = await baseDb.jUnitTestResult.findMany({
     where: {
-      repositoryCaseId: { in: [...new Set(pending.map((r) => r.repositoryCaseId))] },
+      repositoryCaseId: {
+        in: [...new Set(pending.map((r) => r.repositoryCaseId))],
+      },
       testSuite: {
         testRunId: { in: [...new Set(pending.map((r) => r.testRunId))] },
       },
@@ -300,7 +303,9 @@ async function resolveAutomatedRunCaseStatuses(rows: any[]) {
   }
 
   for (const row of pending) {
-    const resolved = latestByCaseRun.get(`${row.repositoryCaseId}:${row.testRunId}`);
+    const resolved = latestByCaseRun.get(
+      `${row.repositoryCaseId}:${row.testRunId}`
+    );
     if (resolved) row.status = resolved;
   }
 }

--- a/testplanit/app/api/report-builder/drill-down/route.ts
+++ b/testplanit/app/api/report-builder/drill-down/route.ts
@@ -261,6 +261,50 @@ async function handleMilestoneReadinessDrillDown(
   return Response.json(response);
 }
 
+/**
+ * Fill in `status` on run-case rows that carry none, from the case's latest
+ * JUnitTestResult within the same run. Mutates the rows in place so the
+ * response shape stays identical to a manually-executed case — the drill-down
+ * columns read `row.status` and shouldn't have to know which table it came
+ * from. Rows that genuinely never executed keep a null status.
+ */
+async function resolveAutomatedRunCaseStatuses(rows: any[]) {
+  const pending = (rows ?? []).filter(
+    (r) => r?.status == null && r?.repositoryCaseId != null && r?.testRunId != null
+  );
+  if (pending.length === 0) return;
+
+  const results = await baseDb.jUnitTestResult.findMany({
+    where: {
+      repositoryCaseId: { in: [...new Set(pending.map((r) => r.repositoryCaseId))] },
+      testSuite: {
+        testRunId: { in: [...new Set(pending.map((r) => r.testRunId))] },
+      },
+    },
+    select: {
+      id: true,
+      repositoryCaseId: true,
+      testSuite: { select: { testRunId: true } },
+      status: { include: { color: true } },
+    },
+    // Latest first, so the first row seen for a (case, run) pair wins.
+    orderBy: [{ executedAt: "desc" }, { id: "desc" }],
+  });
+
+  const latestByCaseRun = new Map<string, unknown>();
+  for (const result of results) {
+    const key = `${result.repositoryCaseId}:${result.testSuite?.testRunId}`;
+    if (!latestByCaseRun.has(key)) {
+      latestByCaseRun.set(key, result.status);
+    }
+  }
+
+  for (const row of pending) {
+    const resolved = latestByCaseRun.get(`${row.repositoryCaseId}:${row.testRunId}`);
+    if (resolved) row.status = resolved;
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
     // Check authentication
@@ -402,6 +446,15 @@ export async function POST(req: NextRequest) {
       model.findMany(query),
       model.count({ where: query.where }),
     ]);
+
+    // Automated runs (JUnit, TestNG, Mocha, etc.) never denormalise a status
+    // onto TestRunCases.statusId — the outcome lives in JUnitTestResult — so a
+    // run-case with no status here may well have executed. Resolve those before
+    // shaping the response, otherwise the drill-down reports "Completed: No"
+    // for every automated case and contradicts the metric it drills into.
+    if (context.metricId === "milestoneCompletion") {
+      await resolveAutomatedRunCaseStatuses(rawData);
+    }
 
     // Transform data to ensure 'name' field is populated correctly
     const data = rawData.map((record: any) => {

--- a/testplanit/app/api/report-builder/project-health/route.ts
+++ b/testplanit/app/api/report-builder/project-health/route.ts
@@ -3,6 +3,7 @@ import { getProjectRelevantIssueIds } from "@/lib/projectIssueIds";
 import { NextRequest } from "next/server";
 import { authorizeReportRequest } from "~/utils/reportApiUtils";
 import { buildDateFilter } from "~/utils/reportUtils";
+import { AUTOMATED_TEST_RUN_TYPES } from "~/utils/testResultTypes";
 
 // Note: Project health uses custom milestone and issue-based logic
 // This doesn't fit the existing shared patterns but could be a candidate
@@ -194,11 +195,14 @@ const METRIC_REGISTRY: Record<
     id: "milestoneCompletion",
     label: "Milestone Completion (%)",
     aggregate: async (baseDb, projectId, groupBy, filters, _dims) => {
-      // Completion = distinct run-cases whose rolled-up status is completed,
-      // over all run-cases in the milestone's live runs. The run-case status
-      // rollup is written by manual execution and the automated-result import
-      // alike, so both sources count — and a case executed N times counts
-      // once.
+      // Completion is counted from whichever table actually holds the outcome:
+      // manual runs roll their status up onto TestRunCases.statusId, while
+      // automated runs (JUnit, TestNG, Mocha, etc.) record theirs in
+      // JUnitTestResult and leave the run-case row empty. Reading only the
+      // run-case status — as this metric used to — counts every automated case
+      // as permanently incomplete. Mirrors `calculateMilestoneCompletion` in
+      // lib/services/milestoneSummary.ts so the report and the milestone page
+      // agree.
       const milestones = await baseDb.milestones.findMany({
         where: {
           projectId: Number(projectId),
@@ -217,37 +221,59 @@ const METRIC_REGISTRY: Record<
         return groupBy.length === 0 ? [{ milestoneCompletion: null }] : [];
       }
 
-      const runCases = await baseDb.testRunCases.findMany({
-        where: {
-          isDeleted: false,
-          testRun: {
-            isDeleted: false,
-            milestoneId: { in: milestones.map((m: any) => m.id) },
-          },
-        },
-        select: {
-          testRun: { select: { milestoneId: true } },
-          status: { select: { isCompleted: true } },
-        },
-      });
+      const milestoneIds = milestones.map((m: any) => m.id);
+      const automatedTypes = [...AUTOMATED_TEST_RUN_TYPES];
+
+      // Aggregated in Postgres rather than by loading every run-case row into
+      // memory, which on a large project meant pulling ~1M rows to count them.
+      const completionRows = await baseDb.$queryRaw<
+        Array<{ milestoneId: number; total: bigint; completed: bigint }>
+      >`
+        WITH manual AS (
+          SELECT tr."milestoneId" AS milestone_id,
+                 COUNT(*) AS total,
+                 COUNT(*) FILTER (WHERE s."isCompleted" = true) AS completed
+          FROM "TestRunCases" trc
+          JOIN "TestRuns" tr ON tr.id = trc."testRunId" AND tr."isDeleted" = false
+          LEFT JOIN "Status" s ON s.id = trc."statusId"
+          WHERE trc."isDeleted" = false
+            AND tr."milestoneId" = ANY(${milestoneIds}::int[])
+            AND NOT (tr."testRunType"::text = ANY(${automatedTypes}::text[]))
+          GROUP BY 1
+        ),
+        automated AS (
+          SELECT tr."milestoneId" AS milestone_id,
+                 COUNT(*) AS total,
+                 COUNT(*) FILTER (WHERE s."isCompleted" = true) AS completed
+          FROM "JUnitTestResult" jr
+          JOIN "JUnitTestSuite" js ON js.id = jr."testSuiteId"
+          JOIN "TestRuns" tr ON tr.id = js."testRunId" AND tr."isDeleted" = false
+          LEFT JOIN "Status" s ON s.id = jr."statusId"
+          WHERE tr."milestoneId" = ANY(${milestoneIds}::int[])
+            AND tr."testRunType"::text = ANY(${automatedTypes}::text[])
+          GROUP BY 1
+        )
+        SELECT
+          COALESCE(m.milestone_id, a.milestone_id) AS "milestoneId",
+          COALESCE(m.total, 0) + COALESCE(a.total, 0) AS total,
+          COALESCE(m.completed, 0) + COALESCE(a.completed, 0) AS completed
+        FROM manual m
+        FULL OUTER JOIN automated a ON a.milestone_id = m.milestone_id
+      `;
 
       const countsByMilestone = new Map<
         number,
         { total: number; completed: number }
       >();
-      runCases.forEach((rc: any) => {
-        const milestoneId = rc.testRun?.milestoneId;
-        if (milestoneId == null) return;
-        const entry = countsByMilestone.get(milestoneId) ?? {
-          total: 0,
-          completed: 0,
-        };
-        entry.total++;
-        if (rc.status?.isCompleted === true) {
-          entry.completed++;
+      completionRows.forEach(
+        (row: { milestoneId: number; total: bigint; completed: bigint }) => {
+          if (row.milestoneId == null) return;
+          countsByMilestone.set(row.milestoneId, {
+            total: Number(row.total),
+            completed: Number(row.completed),
+          });
         }
-        countsByMilestone.set(milestoneId, entry);
-      });
+      );
 
       const grouped = new Map<string, any>();
       milestones.forEach((milestone: any) => {

--- a/testplanit/components/TestRunCaseDetails.tsx
+++ b/testplanit/components/TestRunCaseDetails.tsx
@@ -245,6 +245,37 @@ export function TestRunCaseDetails({
   const hasRequiredResultField =
     (requiredResultFieldAssignments?.length ?? 0) > 0;
 
+  // Automated runs (JUnit, TestNG, Mocha, etc.) record their outcome in
+  // JUnitTestResult and never denormalise it onto TestRunCases.statusId, so
+  // `currentStatus` arrives null for a case that has in fact executed. Only
+  // fetched when there is no run-case status to show — a manual case never
+  // pays for this. Scoped to this case and run rather than added to the run's
+  // own testCases select, which is deliberately thin (a run can hold thousands
+  // of unpaginated cases).
+  const { data: automatedResults } = useClientQueries(
+    schema
+  ).jUnitTestResult.useFindMany(
+    {
+      where: {
+        repositoryCaseId: caseId,
+        testSuite: { testRunId },
+      },
+      select: {
+        status: {
+          select: {
+            id: true,
+            name: true,
+            color: { select: { value: true } },
+          },
+        },
+      },
+      orderBy: [{ executedAt: "desc" }, { id: "desc" }],
+      take: 1,
+    },
+    { enabled: !currentStatus && testRunId != null }
+  );
+  const automatedStatus = automatedResults?.[0]?.status ?? null;
+
   const { data: _templates } = useClientQueries(schema).templates.useFindMany({
     where: {
       isDeleted: false,
@@ -310,7 +341,7 @@ export function TestRunCaseDetails({
     (status: Status) => status.isSuccess === true
   );
 
-  const displayStatus = currentStatus || defaultStatus;
+  const displayStatus = currentStatus || automatedStatus || defaultStatus;
   if (!displayStatus) return null;
 
   const handleStatusChange = (statusId: string) => {


### PR DESCRIPTION
Follow-up to #589. That PR fixed the milestone rollups; a sweep of the rest of the
codebase found four more consumers making the same assumption — that
`TestRunCases.statusId` is populated for every run.

It isn't. Automated runs (JUnit, TestNG, Mocha, etc.) record their outcome in
`JUnitTestResult` and leave the run-case row entirely empty, so each of these
treated an executed automated case as never run. **1,276 repository cases** have no
status-carrying run-case at all and render blank or Untested across these surfaces
today.

## What's fixed

**Project-health "Milestone Completion (%)"** — read the run-case status
unconditionally. Now counts manual and automated cases from their own sources,
mirroring `calculateMilestoneCompletion` so the report and the milestone page agree.
Verified read-only against a prod clone:

| Milestone | Before | After |
|---|---|---|
| 594 (Web 9.2 automation child) | 0% — 0 / 12,790 | 100% — 31,992 / 31,992 |
| 485 (Web 9.2) | 50.2% — 1,409 / 2,806 | 80.7% — 3,701 / 4,586 |

This also moves the count into Postgres. It previously loaded *every* run-case row
for the whole project into Node just to tally them — ~1M rows on Web.

**Milestone-completion drill-down** — rendered "Completed: No" for every automated
case, contradicting the metric it drills into. The route now fills a status-less
run-case from its latest `JUnitTestResult` in the same run, so the existing column
keeps reading `row.status` unchanged.

**Duplicate-scan "Last Run"** — showed a run name and date with a blank status. Now
falls back to the case's latest automated result for that run. Worst-hit surface,
since automation-sourced cases dominate duplicate scans.

**Run-case detail sheet** — fell back to Untested for automated cases. Users reach it
straight from the Latest Results chips, which *deliberately* include JUnit
executions, so clicking a green passing chip opened a sheet reading "Untested". The
lookup is scoped to the open case and only fires when there's no run-case status,
rather than widening the run's deliberately thin `testCases` select.

## Notes for review

- **No backfill required**, same as #589 — `JUnitTestResult` has always been populated.
- The four sites are independent; each can be reverted alone if needed.
- `lib/matrix/matrixAggregation.ts` and `matrixCellCount.ts` still omit
  `trc."isDeleted"` (6 queries). Left out deliberately — 2 rows affected system-wide
  today. Folded into the follow-up below instead.

## The bigger picture

This is now **eight** consumers that independently got the same rule wrong, across raw
SQL, ORM queries, and React render logic. No lint rule would have caught the
`displayStatus ||` fallback or the TanStack column accessor. The durable fix is a
single canonical accessor for effective case status, with these as its first
consumers — written up separately, worth scheduling rather than waiting for a ninth.

## Testing

317 tests pass across report-builder, drill-down, duplicate-scan, and milestone
suites; typecheck clean. Added 3 regression tests covering automated resolution,
genuinely-unexecuted cases, and not overwriting a manual case's own status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
