### PR TITLE
feat(integrations): add ClickUp outbound integration (OAuth2)

### DIFF
--- a/testplanit/app/[locale]/admin/integrations/columns.tsx
+++ b/testplanit/app/[locale]/admin/integrations/columns.tsx
@@ -8,7 +8,7 @@ import { MantisBTIcon } from "@/components/shared/mantisbt-icon";
 import { Link, Plug } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
-import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
+import { siClickup, siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { AuthorizeIntegrationButton } from "./AuthorizeIntegrationButton";
 import { DeleteIntegrationButton } from "./DeleteIntegrationButton";
 import { EditIntegrationButton } from "./EditIntegrationButton";
@@ -45,6 +45,11 @@ const providerIcons: Record<string, React.ReactNode> = {
   ),
   MANTISBT: <MantisBTIcon className="h-4 w-4 text-[#59A635]" />,
   SIMPLE_URL: <Link className="h-4 w-4" />,
+  CLICKUP: (
+    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#7B68EE]" fill="currentColor">
+      <path d={siClickup.path} />
+    </svg>
+  ),
 };
 
 export interface ExtendedIntegration extends Integration {

--- a/testplanit/app/[locale]/admin/integrations/columns.tsx
+++ b/testplanit/app/[locale]/admin/integrations/columns.tsx
@@ -46,7 +46,11 @@ const providerIcons: Record<string, React.ReactNode> = {
   MANTISBT: <MantisBTIcon className="h-4 w-4 text-[#59A635]" />,
   SIMPLE_URL: <Link className="h-4 w-4" />,
   CLICKUP: (
-    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#7B68EE]" fill="currentColor">
+    <svg
+      viewBox="0 0 24 24"
+      className="h-4 w-4 text-[#7B68EE]"
+      fill="currentColor"
+    >
       <path d={siClickup.path} />
     </svg>
   ),

--- a/testplanit/app/[locale]/admin/issues/EditIssue.tsx
+++ b/testplanit/app/[locale]/admin/issues/EditIssue.tsx
@@ -38,6 +38,12 @@ const constructExternalUrl = (
   baseUrl: string | undefined,
   externalKey: string
 ): string | null => {
+  // ClickUp is not self-hosted — task URLs are always app.clickup.com,
+  // independent of any configured baseUrl.
+  if (provider === IntegrationProvider.CLICKUP) {
+    return `https://app.clickup.com/t/${externalKey}`;
+  }
+
   if (!baseUrl) {
     return null;
   }

--- a/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/GenerateTestCasesWizard.tsx
@@ -2217,6 +2217,8 @@ export function GenerateTestCasesWizard({
         return "Redmine";
       case "MANTISBT":
         return "MantisBT";
+      case "CLICKUP":
+        return "ClickUp";
       case "SIMPLE_URL":
         return externalSystem;
       default:

--- a/testplanit/app/[locale]/projects/settings/[projectId]/integrations/page.tsx
+++ b/testplanit/app/[locale]/projects/settings/[projectId]/integrations/page.tsx
@@ -92,6 +92,7 @@ export default function ProjectIntegrationsPage() {
             "REDMINE",
             "MANTISBT",
             "SIMPLE_URL",
+            "CLICKUP",
           ],
         },
       },
@@ -113,6 +114,7 @@ export default function ProjectIntegrationsPage() {
         "REDMINE",
         "MANTISBT",
         "SIMPLE_URL",
+        "CLICKUP",
       ].includes(pi.integration.provider)
   );
 

--- a/testplanit/app/api/integrations/test-connection/route.ts
+++ b/testplanit/app/api/integrations/test-connection/route.ts
@@ -870,6 +870,11 @@ export const POST = withAuditContext(async (req: NextRequest) => {
       case IntegrationProvider.SIMPLE_URL:
         result = await testSimpleUrlConnection(testCredentials, testSettings);
         break;
+      case IntegrationProvider.CLICKUP:
+        // ClickUp is OAuth-only — same "credentials present, user
+        // authorization pending" check as the other OAuth2 providers above.
+        result = checkOAuthClientConfig(testCredentials);
+        break;
       default:
         result = {
           success: false,

--- a/testplanit/components/admin/integrations/IntegrationConfigForm.tsx
+++ b/testplanit/components/admin/integrations/IntegrationConfigForm.tsx
@@ -177,6 +177,8 @@ const authTypeFields: Record<string, FieldConfig[]> = {
     [PAT_FIELD],
   [`${IntegrationProvider.GITEA}_${IntegrationAuthType.OAUTH2}`]:
     OAUTH_CLIENT_FIELDS,
+  [`${IntegrationProvider.CLICKUP}_${IntegrationAuthType.OAUTH2}`]:
+    OAUTH_CLIENT_FIELDS,
 };
 
 const providerFields: Record<IntegrationProvider, FieldConfig[]> = {
@@ -320,6 +322,28 @@ const providerFields: Record<IntegrationProvider, FieldConfig[]> = {
       help: "config.mantisBTUrlHelp",
       isCredential: false,
       required: true,
+    },
+  ],
+  [IntegrationProvider.CLICKUP]: [
+    {
+      // ClickUp Team (workspace) ID — needed to walk the Space/Folder/List
+      // hierarchy for the project (List) picker.
+      name: "teamId",
+      label: "config.clickupTeamId",
+      placeholder: "config.clickupTeamIdPlaceholder",
+      help: "config.clickupTeamIdHelp",
+      isCredential: false,
+      required: true,
+    },
+    {
+      // Default List tasks are created in. Optional: a specific List can be
+      // chosen per-issue via the project picker instead.
+      name: "listId",
+      label: "config.clickupListId",
+      placeholder: "config.clickupListIdPlaceholder",
+      help: "config.clickupListIdHelp",
+      isCredential: false,
+      required: false,
     },
   ],
 };

--- a/testplanit/components/admin/integrations/IntegrationModal.tsx
+++ b/testplanit/components/admin/integrations/IntegrationModal.tsx
@@ -80,6 +80,7 @@ const providerAuthTypes: Record<IntegrationProvider, IntegrationAuthType[]> = {
   ],
   [IntegrationProvider.REDMINE]: [IntegrationAuthType.API_KEY],
   [IntegrationProvider.MANTISBT]: [IntegrationAuthType.API_KEY],
+  [IntegrationProvider.CLICKUP]: [IntegrationAuthType.OAUTH2],
 };
 
 export function IntegrationModal({

--- a/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
+++ b/testplanit/components/admin/integrations/IntegrationTypeSelector.tsx
@@ -11,7 +11,7 @@ import { IntegrationProvider } from "@prisma/client";
 import { Link } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
-import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
+import { siClickup, siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 import { MantisBTIcon } from "@/components/shared/mantisbt-icon";
 import { cn } from "~/utils";
@@ -74,6 +74,10 @@ const integrationTypes: { type: IntegrationProvider; icon: ReactNode }[] = [
   {
     type: IntegrationProvider.MANTISBT,
     icon: <MantisBTIcon className="h-4 w-4 shrink-0 text-[#59A635]" />,
+  },
+  {
+    type: IntegrationProvider.CLICKUP,
+    icon: <BrandIcon path={siClickup.path} className="text-[#7B68EE]" />,
   },
 ];
 

--- a/testplanit/components/admin/integrations/integration-icon.tsx
+++ b/testplanit/components/admin/integrations/integration-icon.tsx
@@ -1,6 +1,6 @@
 import { IntegrationProvider } from "@prisma/client";
 import { Bug } from "lucide-react";
-import { siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
+import { siClickup, siGithub, siGitlab, siJira, siRedmine } from "simple-icons";
 import { GiteaPlatformIcon } from "@/components/shared/gitea-family-icon";
 import { MantisBTIcon } from "@/components/shared/mantisbt-icon";
 import { cn } from "~/utils";
@@ -71,6 +71,14 @@ export function IntegrationIcon({
       return (
         <div className={cn(baseClass, "bg-[#59A635] text-white")}>
           <MantisBTIcon className="h-5 w-5" />
+        </div>
+      );
+    case "CLICKUP":
+      return (
+        <div className={cn(baseClass, "bg-[#7B68EE] text-white")}>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
+            <path d={siClickup.path} />
+          </svg>
         </div>
       );
     default:

--- a/testplanit/components/tables/IssuesDisplay.tsx
+++ b/testplanit/components/tables/IssuesDisplay.tsx
@@ -479,9 +479,11 @@ export const IssuesDisplay: React.FC<IssueDisplayProps> = ({
                 ? "Redmine"
                 : integrationProvider === "MANTISBT"
                   ? "MantisBT"
-                  : integrationProvider === "SIMPLE_URL"
-                    ? "External"
-                    : integrationProvider;
+                  : integrationProvider === "CLICKUP"
+                    ? "ClickUp"
+                    : integrationProvider === "SIMPLE_URL"
+                      ? "External"
+                      : integrationProvider;
 
     return (
       <div

--- a/testplanit/docs/integrations/clickup.md
+++ b/testplanit/docs/integrations/clickup.md
@@ -1,0 +1,58 @@
+# ClickUp Integration
+
+TestPlanIt can push issues to ClickUp — creating and updating ClickUp tasks,
+searching for tasks, and commenting when an issue is linked to a test case —
+via an OAuth2 app registered with ClickUp. This mirrors the GitHub/Jira
+integrations: create an `Integration` row (Admin → Integrations), authorize
+it against your ClickUp workspace, then attach it to a project (Project
+Settings → Integrations).
+
+## 1. Register a ClickUp OAuth app
+
+1. Go to `https://app.clickup.com/settings/apps` and create a new app.
+2. Set the **Redirect URL** to:
+
+   ```
+   <your TestPlanIt URL>/api/integrations/oauth/clickup/callback
+   ```
+
+   This must match exactly what TestPlanIt sends during authorization —
+   TestPlanIt derives it from `NEXTAUTH_URL`, so the value shown on the
+   integration's config form (once you select ClickUp) is the one to copy.
+3. Copy the app's **Client ID** and **Client Secret** — you'll paste these
+   into TestPlanIt in the next step.
+
+No environment variables need to be set for this integration: the client ID
+and secret are stored per-`Integration` row (encrypted), not in `.env`. The
+only prerequisite is that `NEXTAUTH_URL` is already configured, as it is for
+every OAuth-based integration.
+
+## 2. Create the Integration in TestPlanIt
+
+1. Admin → Integrations → Add Integration → **ClickUp**.
+2. Paste the **Client ID** / **Client Secret** from step 1.
+3. Fill in:
+   - **ClickUp Team (Workspace) ID** — required. Visible in the ClickUp URL
+     (`app.clickup.com/<teamId>/...`).
+   - **Default ClickUp List ID** — optional. The List new tasks are created
+     in by default; a different List can be chosen per issue instead.
+4. Save, then click **Authorize** and complete ClickUp's consent screen.
+
+## 3. Link the integration to a project
+
+Project Settings → Integrations → select the ClickUp integration you just
+authorized.
+
+## Notes and limitations
+
+- **Authentication is OAuth2 only** — there is no personal-API-token mode
+  for this integration.
+- **ClickUp OAuth access tokens do not expire** and there is no refresh
+  endpoint, unlike GitHub/GitLab OAuth apps — you will not be asked to
+  re-authorize periodically.
+- **ClickUp has no flat "project" concept.** Tasks live in a List, nested
+  under an optional Folder, under a Space, under the Team (workspace) you
+  configured. The project picker in TestPlanIt's issue-linking flow lists
+  every List as `Space / [Folder /] List`.
+- Custom fields and file attachments are not yet supported by this
+  integration.

--- a/testplanit/docs/integrations/clickup.md
+++ b/testplanit/docs/integrations/clickup.md
@@ -19,6 +19,7 @@ Settings → Integrations).
    This must match exactly what TestPlanIt sends during authorization —
    TestPlanIt derives it from `NEXTAUTH_URL`, so the value shown on the
    integration's config form (once you select ClickUp) is the one to copy.
+
 3. Copy the app's **Client ID** and **Client Secret** — you'll paste these
    into TestPlanIt in the next step.
 

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -95,6 +95,7 @@ describe("IntegrationManager", () => {
       expect(manager.isTypeRegistered("GITHUB")).toBe(true);
       expect(manager.isTypeRegistered("AZURE_DEVOPS")).toBe(true);
       expect(manager.isTypeRegistered("SIMPLE_URL")).toBe(true);
+      expect(manager.isTypeRegistered("CLICKUP")).toBe(true);
     });
 
     it("should return false for unregistered types", () => {

--- a/testplanit/lib/integrations/IntegrationManager.test.ts
+++ b/testplanit/lib/integrations/IntegrationManager.test.ts
@@ -85,7 +85,8 @@ describe("IntegrationManager", () => {
       expect(types).toContain("GITEA");
       expect(types).toContain("REDMINE");
       expect(types).toContain("MANTISBT");
-      expect(types).toHaveLength(8);
+      expect(types).toContain("CLICKUP");
+      expect(types).toHaveLength(9);
     });
   });
 

--- a/testplanit/lib/integrations/IntegrationManager.ts
+++ b/testplanit/lib/integrations/IntegrationManager.ts
@@ -5,6 +5,7 @@ import { AuthenticationService } from "./AuthenticationService";
 import { resolveStoredCredentials } from "./credentials";
 import { credentialsCorruptError } from "./errors";
 import { AzureDevOpsAdapter } from "./adapters/AzureDevOpsAdapter";
+import { ClickUpAdapter } from "./adapters/ClickUpAdapter";
 import { GiteaAdapter } from "./adapters/GiteaAdapter";
 import { GitHubAdapter } from "./adapters/GitHubAdapter";
 import { GitLabAdapter } from "./adapters/GitLabAdapter";
@@ -56,6 +57,7 @@ export class IntegrationManager {
     this.registerAdapter("GITEA", GiteaAdapter);
     this.registerAdapter("REDMINE", RedmineAdapter);
     this.registerAdapter("MANTISBT", MantisBTAdapter);
+    this.registerAdapter("CLICKUP", ClickUpAdapter);
   }
 
   /**

--- a/testplanit/lib/integrations/adapters/BaseAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/BaseAdapter.test.ts
@@ -429,6 +429,64 @@ describe("BaseAdapter", () => {
       );
     });
 
+    it("should send the raw OAuth token with no Bearer prefix for ClickUp", async () => {
+      const clickupAdapter = new TestAdapter({
+        provider: "CLICKUP",
+        baseUrl: "https://api.clickup.com/api/v2",
+      });
+      await clickupAdapter.authenticate({
+        type: "oauth",
+        accessToken: "cu_test-token",
+        baseUrl: "https://api.clickup.com/api/v2",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: "test" }),
+      });
+
+      await clickupAdapter.testMakeRequest(
+        "https://api.clickup.com/api/v2/task/1"
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.clickup.com/api/v2/task/1",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "cu_test-token",
+          }),
+        })
+      );
+    });
+
+    it("should still add Bearer prefix for OAuth on non-ClickUp providers", async () => {
+      const githubOAuthAdapter = new TestAdapter({
+        provider: "GITHUB",
+        baseUrl: "https://api.github.com",
+      });
+      await githubOAuthAdapter.authenticate({
+        type: "oauth",
+        accessToken: "gho_test-token",
+        baseUrl: "https://api.github.com",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: "test" }),
+      });
+
+      await githubOAuthAdapter.testMakeRequest("https://api.github.com/user");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.github.com/user",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer gho_test-token",
+          }),
+        })
+      );
+    });
+
     it("should add Basic auth header", async () => {
       const basicAdapter = new TestAdapter({
         provider: "TEST",

--- a/testplanit/lib/integrations/adapters/BaseAdapter.ts
+++ b/testplanit/lib/integrations/adapters/BaseAdapter.ts
@@ -229,7 +229,12 @@ export abstract class BaseAdapter implements IssueAdapter {
     // Add authentication headers based on auth type
     switch (this.authData.type) {
       case "oauth":
-        headers["Authorization"] = `Bearer ${this.authData.accessToken}`;
+        // ClickUp does not use the "Bearer" prefix on its Authorization
+        // header for OAuth access tokens.
+        headers["Authorization"] =
+          this.config.provider === "CLICKUP"
+            ? this.authData.accessToken!
+            : `Bearer ${this.authData.accessToken}`;
         break;
       case "api_key":
         // Some APIs use Authorization header with token prefix

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ClickUpAdapter } from "./ClickUpAdapter";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("ClickUpAdapter", () => {
+  let adapter: ClickUpAdapter;
+
+  const mockClickUpTask = {
+    id: "abc123",
+    custom_id: null,
+    name: "Test Task",
+    markdown_description: "This is a test task description",
+    status: { status: "in progress" },
+    priority: { priority: "high" },
+    date_created: "1700000000000",
+    date_updated: "1700000100000",
+    url: "https://app.clickup.com/t/abc123",
+    creator: {
+      id: 1,
+      username: "reporter-user",
+      email: "reporter@example.com",
+    },
+    assignees: [
+      { id: 2, username: "assignee-user", email: "assignee@example.com" },
+    ],
+    tags: [{ name: "bug" }, { name: "priority:high" }],
+    list: { id: "901234567" },
+  };
+
+  const authenticateAdapter = async (a: ClickUpAdapter) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ user: { id: 1, username: "testuser" } }),
+    });
+    await a.authenticate({ type: "oauth", accessToken: "cu_valid_token" });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new ClickUpAdapter({
+      provider: "CLICKUP",
+      listId: "901234567",
+      teamId: "9013456789",
+    });
+  });
+
+  describe("getCapabilities", () => {
+    it("returns the correct capabilities for ClickUp", () => {
+      expect(adapter.getCapabilities()).toEqual({
+        createIssue: true,
+        updateIssue: true,
+        linkIssue: true,
+        syncIssue: true,
+        searchIssues: true,
+        webhooks: false,
+        customFields: false,
+        attachments: false,
+        linkedIssues: false,
+        comments: true,
+      });
+    });
+  });
+
+  describe("authenticate", () => {
+    it("authenticates successfully with a valid OAuth token", async () => {
+      await expect(authenticateAdapter(adapter)).resolves.not.toThrow();
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.clickup.com/api/v2/user",
+        expect.any(Object)
+      );
+    });
+
+    it("throws when authData.type is not oauth", async () => {
+      await expect(
+        adapter.authenticate({ type: "api_key", apiKey: "pk_something" })
+      ).rejects.toThrow("only supports OAuth");
+    });
+
+    it("throws when no access token is provided", async () => {
+      await expect(
+        adapter.authenticate({ type: "oauth" })
+      ).rejects.toThrow("requires an access token");
+    });
+
+    it("throws when the token validation request fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Unauthorized"),
+      });
+
+      await expect(
+        adapter.authenticate({ type: "oauth", accessToken: "bad-token" })
+      ).rejects.toThrow("Invalid ClickUp OAuth access token");
+    });
+
+    it("sends the raw access token with no Bearer prefix", async () => {
+      await authenticateAdapter(adapter);
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers.Authorization).toBe("cu_valid_token");
+    });
+  });
+
+  describe("OAuth", () => {
+    const oauthAdapter = () =>
+      new ClickUpAdapter({
+        provider: "CLICKUP",
+        clientId: "client-123",
+        clientSecret: "secret-456",
+        redirectUri:
+          "https://app.example.com/api/integrations/oauth/clickup/callback",
+      });
+
+    it("advertises OAuth support", () => {
+      expect(oauthAdapter().supportsOAuth).toBe(true);
+    });
+
+    it("builds the authorization URL with client id, redirect uri, and state (no scope)", () => {
+      const url = new URL(oauthAdapter().getAuthorizationUrl("state-xyz"));
+      expect(url.origin + url.pathname).toBe("https://app.clickup.com/api");
+      expect(url.searchParams.get("client_id")).toBe("client-123");
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "https://app.example.com/api/integrations/oauth/clickup/callback"
+      );
+      expect(url.searchParams.get("state")).toBe("state-xyz");
+      expect(url.searchParams.has("scope")).toBe(false);
+    });
+
+    it("exchanges an authorization code for an access token", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "cu_new_token" }),
+      });
+
+      const tokens = await oauthAdapter().exchangeCodeForTokens("auth-code");
+
+      expect(tokens).toEqual({ accessToken: "cu_new_token" });
+      const [calledUrl, options] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe("https://api.clickup.com/api/v2/oauth/token");
+      expect(options.method).toBe("POST");
+      const body = JSON.parse(options.body);
+      expect(body).toMatchObject({
+        client_id: "client-123",
+        client_secret: "secret-456",
+        code: "auth-code",
+      });
+    });
+
+    it("throws when the token exchange returns an err field", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ err: "Invalid code" }),
+      });
+
+      await expect(
+        oauthAdapter().exchangeCodeForTokens("bad-code")
+      ).rejects.toThrow("Invalid code");
+    });
+
+    it("throws when the token exchange response is not ok", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        text: () => Promise.resolve("Bad request"),
+      });
+
+      await expect(
+        oauthAdapter().exchangeCodeForTokens("bad-code")
+      ).rejects.toThrow("Failed to exchange code for tokens");
+    });
+
+    it("refreshTokens throws — ClickUp OAuth tokens do not expire", async () => {
+      await expect(
+        oauthAdapter().refreshTokens("some-refresh-token")
+      ).rejects.toThrow("do not expire and cannot be refreshed");
+    });
+  });
+
+  describe("createIssue", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("creates a task in the configured list", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockClickUpTask),
+      });
+
+      const result = await adapter.createIssue({
+        title: "Test Task",
+        description: "This is a test task description",
+        projectId: "",
+        priority: "high",
+        assigneeId: "2",
+        labels: ["bug"],
+      });
+
+      const [calledUrl, options] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe(
+        "https://api.clickup.com/api/v2/list/901234567/task"
+      );
+      expect(options.method).toBe("POST");
+      const body = JSON.parse(options.body);
+      expect(body).toMatchObject({
+        name: "Test Task",
+        markdown_description: "This is a test task description",
+        priority: 2, // "high" -> 2
+        assignees: [2],
+        tags: ["bug"],
+      });
+      expect(result.id).toBe("abc123");
+    });
+
+    it("uses CreateIssueData.projectId as the list id when provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockClickUpTask),
+      });
+
+      await adapter.createIssue({
+        title: "Test Task",
+        projectId: "999888777",
+      });
+
+      const [calledUrl] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe(
+        "https://api.clickup.com/api/v2/list/999888777/task"
+      );
+    });
+
+    it("throws when no list id can be resolved", async () => {
+      const noListAdapter = new ClickUpAdapter({ provider: "CLICKUP" });
+      await authenticateAdapter(noListAdapter);
+
+      await expect(
+        noListAdapter.createIssue({ title: "Test Task", projectId: "" })
+      ).rejects.toThrow("ClickUp List ID not configured");
+    });
+  });
+
+  describe("updateIssue", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("sends an add/rem delta for assignee updates, not a flat array", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockClickUpTask),
+      });
+
+      await adapter.updateIssue("abc123", { assigneeId: "2" });
+
+      const [calledUrl, options] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe("https://api.clickup.com/api/v2/task/abc123");
+      expect(options.method).toBe("PUT");
+      const body = JSON.parse(options.body);
+      expect(body.assignees).toEqual({ add: [2], rem: [] });
+    });
+
+    it("passes status through verbatim", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockClickUpTask),
+      });
+
+      await adapter.updateIssue("abc123", { status: "in progress" });
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.status).toBe("in progress");
+    });
+  });
+
+  describe("getIssue", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("maps a ClickUp task, parsing epoch-millisecond timestamps", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockClickUpTask),
+      });
+
+      const result = await adapter.getIssue("abc123");
+
+      expect(result.createdAt).toEqual(new Date(1700000000000));
+      expect(result.updatedAt).toEqual(new Date(1700000100000));
+      expect(result.status).toBe("in progress");
+      expect(result.priority).toBe("high");
+      expect(result.assignee).toEqual({
+        id: "2",
+        name: "assignee-user",
+        email: "assignee@example.com",
+      });
+      expect(result.reporter).toEqual({
+        id: "1",
+        name: "reporter-user",
+        email: "reporter@example.com",
+      });
+      expect(result.labels).toEqual(["bug", "priority:high"]);
+      expect(result.key).toBe("abc123");
+    });
+
+    it("falls back to custom_id for the key when present", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ ...mockClickUpTask, custom_id: "TP-42" }),
+      });
+
+      const result = await adapter.getIssue("abc123");
+      expect(result.key).toBe("TP-42");
+    });
+  });
+
+  describe("searchIssues", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("builds query params for status/assignee/updatedWithinDays", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ tasks: [mockClickUpTask], last_page: true }),
+      });
+
+      await adapter.searchIssues({
+        status: ["open", "in progress"],
+        assignee: "2",
+        updatedWithinDays: 7,
+      });
+
+      const [calledUrl] = mockFetch.mock.calls[0];
+      const url = new URL(calledUrl);
+      expect(url.searchParams.getAll("statuses[]")).toEqual([
+        "open",
+        "in progress",
+      ]);
+      expect(url.searchParams.getAll("assignees[]")).toEqual(["2"]);
+      expect(url.searchParams.has("date_updated_gt")).toBe(true);
+    });
+
+    it("filters client-side on query since ClickUp has no server-side text search", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tasks: [
+              mockClickUpTask,
+              { ...mockClickUpTask, id: "def456", name: "Unrelated task" },
+            ],
+            last_page: true,
+          }),
+      });
+
+      const result = await adapter.searchIssues({ query: "Test Task" });
+
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].id).toBe("abc123");
+      expect(result.total).toBe(1);
+    });
+
+    it("throws when no list id can be resolved", async () => {
+      const noListAdapter = new ClickUpAdapter({ provider: "CLICKUP" });
+      await authenticateAdapter(noListAdapter);
+
+      await expect(noListAdapter.searchIssues({})).rejects.toThrow(
+        "ClickUp List ID not configured"
+      );
+    });
+  });
+
+  describe("comments", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("getIssueComments maps ClickUp comments", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            comments: [
+              {
+                id: 555,
+                comment_text: "Looks good",
+                date: "1700000200000",
+                user: { username: "reviewer" },
+              },
+            ],
+          }),
+      });
+
+      const comments = await adapter.getIssueComments("abc123");
+      expect(comments).toEqual([
+        {
+          id: "555",
+          author: "reviewer",
+          body: "Looks good",
+          created: "1700000200000",
+        },
+      ]);
+    });
+
+    it("getIssueComments fails soft, returning an empty array on error", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("Not found"),
+      });
+
+      const comments = await adapter.getIssueComments("abc123");
+      expect(comments).toEqual([]);
+    });
+
+    it("linkToTestCase posts a comment with comment_text", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await adapter.linkToTestCase("abc123", "TC-1");
+
+      const [calledUrl, options] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe(
+        "https://api.clickup.com/api/v2/task/abc123/comment"
+      );
+      const body = JSON.parse(options.body);
+      expect(body.comment_text).toContain("TC-1");
+    });
+  });
+
+  describe("getProjects", () => {
+    beforeEach(async () => {
+      await authenticateAdapter(adapter);
+    });
+
+    it("walks Team -> Space -> Folder/List and flattens to id/key/name", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({ spaces: [{ id: "space1", name: "Engineering" }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              folders: [
+                {
+                  id: "folder1",
+                  name: "Sprint 1",
+                  lists: [{ id: "list1", name: "Backlog" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({ lists: [{ id: "list2", name: "Folderless" }] }),
+        });
+
+      const projects = await adapter.getProjects();
+
+      expect(projects).toEqual(
+        expect.arrayContaining([
+          {
+            id: "list1",
+            key: "list1",
+            name: "Engineering / Sprint 1 / Backlog",
+          },
+          { id: "list2", key: "list2", name: "Engineering / Folderless" },
+        ])
+      );
+    });
+
+    it("throws when teamId is not configured", async () => {
+      const noTeamAdapter = new ClickUpAdapter({
+        provider: "CLICKUP",
+        listId: "901234567",
+      });
+      await authenticateAdapter(noTeamAdapter);
+
+      await expect(noTeamAdapter.getProjects()).rejects.toThrow(
+        "Team (workspace) ID not configured"
+      );
+    });
+  });
+});

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
@@ -80,9 +80,9 @@ describe("ClickUpAdapter", () => {
     });
 
     it("throws when no access token is provided", async () => {
-      await expect(
-        adapter.authenticate({ type: "oauth" })
-      ).rejects.toThrow("requires an access token");
+      await expect(adapter.authenticate({ type: "oauth" })).rejects.toThrow(
+        "requires an access token"
+      );
     });
 
     it("throws when the token validation request fails", async () => {
@@ -198,7 +198,8 @@ describe("ClickUpAdapter", () => {
         labels: ["bug"],
       });
 
-      const [calledUrl, options] = mockFetch.mock.calls[0];
+      const [calledUrl, options] =
+        mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       expect(calledUrl).toBe(
         "https://api.clickup.com/api/v2/list/901234567/task"
       );
@@ -225,7 +226,7 @@ describe("ClickUpAdapter", () => {
         projectId: "999888777",
       });
 
-      const [calledUrl] = mockFetch.mock.calls[0];
+      const [calledUrl] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       expect(calledUrl).toBe(
         "https://api.clickup.com/api/v2/list/999888777/task"
       );
@@ -254,7 +255,8 @@ describe("ClickUpAdapter", () => {
 
       await adapter.updateIssue("abc123", { assigneeId: "2" });
 
-      const [calledUrl, options] = mockFetch.mock.calls[0];
+      const [calledUrl, options] =
+        mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       expect(calledUrl).toBe("https://api.clickup.com/api/v2/task/abc123");
       expect(options.method).toBe("PUT");
       const body = JSON.parse(options.body);
@@ -269,7 +271,7 @@ describe("ClickUpAdapter", () => {
 
       await adapter.updateIssue("abc123", { status: "in progress" });
 
-      const [, options] = mockFetch.mock.calls[0];
+      const [, options] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       const body = JSON.parse(options.body);
       expect(body.status).toBe("in progress");
     });
@@ -309,8 +311,7 @@ describe("ClickUpAdapter", () => {
     it("falls back to custom_id for the key when present", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () =>
-          Promise.resolve({ ...mockClickUpTask, custom_id: "TP-42" }),
+        json: () => Promise.resolve({ ...mockClickUpTask, custom_id: "TP-42" }),
       });
 
       const result = await adapter.getIssue("abc123");
@@ -336,7 +337,7 @@ describe("ClickUpAdapter", () => {
         updatedWithinDays: 7,
       });
 
-      const [calledUrl] = mockFetch.mock.calls[0];
+      const [calledUrl] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       const url = new URL(calledUrl);
       expect(url.searchParams.getAll("statuses[]")).toEqual([
         "open",
@@ -427,7 +428,8 @@ describe("ClickUpAdapter", () => {
 
       await adapter.linkToTestCase("abc123", "TC-1");
 
-      const [calledUrl, options] = mockFetch.mock.calls[0];
+      const [calledUrl, options] =
+        mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
       expect(calledUrl).toBe(
         "https://api.clickup.com/api/v2/task/abc123/comment"
       );
@@ -446,7 +448,9 @@ describe("ClickUpAdapter", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
-            Promise.resolve({ spaces: [{ id: "space1", name: "Engineering" }] }),
+            Promise.resolve({
+              spaces: [{ id: "space1", name: "Engineering" }],
+            }),
         })
         .mockResolvedValueOnce({
           ok: true,

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.test.ts
@@ -375,6 +375,80 @@ describe("ClickUpAdapter", () => {
         "ClickUp List ID not configured"
       );
     });
+
+    it("computes the ClickUp page from its fixed page size, not the caller's limit", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [], last_page: true }),
+      });
+
+      // A bulk-import-style call: 50 items already consumed (one ClickUp
+      // page's worth of tasks minus some), requesting the next 50. ClickUp
+      // itself pages in batches of 100, so this must still ask for
+      // ClickUp page 1 (tasks 101-200), not page 2 (dividing 100 by the
+      // caller's limit of 50) which would skip tasks 101-200 entirely.
+      await adapter.searchIssues({ limit: 50, offset: 100 });
+
+      const [calledUrl] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("page")).toBe("1");
+    });
+
+    it("scans additional ClickUp pages to find a query match past the first page", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              tasks: [
+                { ...mockClickUpTask, id: "page0-task", name: "No match here" },
+              ],
+              last_page: false,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              tasks: [mockClickUpTask],
+              last_page: true,
+            }),
+        });
+
+      const result = await adapter.searchIssues({ query: "Test Task" });
+
+      // Two ClickUp task pages fetched (plus the one auth call from
+      // authenticateAdapter() in beforeEach) — the interactive search
+      // dialog only calls searchIssues() once and never re-requests with a
+      // later page, so the adapter itself must keep scanning until it
+      // finds a match or runs out of pages.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].id).toBe("abc123");
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("stops scanning once enough matches are found without exhausting all pages", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tasks: [mockClickUpTask],
+            last_page: false,
+          }),
+      });
+
+      const result = await adapter.searchIssues({
+        query: "Test Task",
+        limit: 1,
+      });
+
+      // One task page fetched (plus the one auth call from
+      // authenticateAdapter() in beforeEach).
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result.issues).toHaveLength(1);
+      expect(result.hasMore).toBe(true);
+    });
   });
 
   describe("comments", () => {

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
@@ -1,0 +1,455 @@
+import { tiptapToMarkdown } from "~/lib/tiptap/tiptapToMarkdown";
+import { BaseAdapter } from "./BaseAdapter";
+import {
+  AuthenticationData,
+  CreateIssueData,
+  IssueAdapterCapabilities,
+  IssueComment,
+  IssueData,
+  IssueSearchOptions,
+  UpdateIssueData,
+} from "./IssueAdapter";
+
+/**
+ * Detect a TipTap doc by structural shape. Mirrors the same check the
+ * GitHub/Jira/Azure DevOps adapters use, so every adapter agrees on what
+ * "rich" input looks like (D-15).
+ */
+function isTiptapDoc(value: unknown): value is { type: "doc"; content: any[] } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "type" in value &&
+    (value as { type: unknown }).type === "doc"
+  );
+}
+
+/**
+ * Coerce a CreateIssueData/UpdateIssueData description into the markdown
+ * string ClickUp expects for `markdown_description`. TipTap docs are
+ * rendered via the hand-rolled GFM serializer (INT-05); strings pass
+ * through unchanged.
+ */
+function renderClickUpDescription(description: unknown): string {
+  if (description === undefined || description === null) return "";
+  if (isTiptapDoc(description)) return tiptapToMarkdown(description);
+  if (typeof description === "string") return description;
+  // Defensive: stringify any other shape so the task body is never
+  // `[object Object]` in ClickUp.
+  return String(description);
+}
+
+/** ClickUp priority is an integer 1 (urgent) through 4 (low); unknown values default to "normal". */
+function mapPriorityToClickUp(priority: string): number {
+  const map: Record<string, number> = {
+    urgent: 1,
+    high: 2,
+    normal: 3,
+    low: 4,
+  };
+  return map[priority.toLowerCase()] ?? 3;
+}
+
+/**
+ * ClickUp integration adapter using OAuth2 authentication.
+ *
+ * Deviations from the other adapters (GitHub/Jira/GitLab) worth calling out:
+ *  - ClickUp has no flat "project" concept. Tasks live in a List, which is
+ *    nested under an optional Folder, under a Space, under a Team
+ *    (workspace). `settings.teamId` is required for `getProjects()`, and
+ *    `settings.listId` is the default target list for `createIssue`/
+ *    `searchIssues` when `CreateIssueData.projectId`/`IssueSearchOptions.projectId`
+ *    isn't itself a list id.
+ *  - ClickUp OAuth access tokens do not expire and there is no refresh
+ *    endpoint — `refreshTokens()` is implemented only for interface
+ *    completeness and is never expected to be called in practice.
+ *  - ClickUp does not use the `Bearer` prefix on its Authorization header
+ *    for OAuth tokens (unlike GitHub/GitLab/Jira Cloud) — see the
+ *    `CLICKUP` branch added to `BaseAdapter.makeRequest()`.
+ *  - ClickUp timestamps (`date_created`/`date_updated`) are epoch-millisecond
+ *    *strings*, not ISO-8601 strings.
+ */
+export class ClickUpAdapter extends BaseAdapter {
+  public supportsOAuth = true;
+
+  private baseUrl = "https://api.clickup.com/api/v2";
+
+  // ClickUp hierarchy context, plumbed per-integration via settings.
+  private teamId?: string;
+  private listId?: string;
+
+  // OAuth client credentials, plumbed per-integration by IntegrationManager.
+  private clientId?: string;
+  private clientSecret?: string;
+  private redirectUri?: string;
+
+  constructor(config: any) {
+    super(config);
+
+    if (config.teamId) this.teamId = config.teamId;
+    if (config.listId) this.listId = config.listId;
+
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.redirectUri = config.redirectUri;
+  }
+
+  getCapabilities(): IssueAdapterCapabilities {
+    return {
+      createIssue: true,
+      updateIssue: true,
+      linkIssue: true,
+      syncIssue: true,
+      searchIssues: true,
+      // No inbound webhook receiver implemented in this scope.
+      webhooks: false,
+      // ClickUp custom fields exist per-List; not mapped in v1 — future work.
+      customFields: false,
+      // Attachment upload not implemented in v1 — future work.
+      attachments: false,
+      // ClickUp task links/dependencies exist but are out of MVP scope.
+      linkedIssues: false,
+      comments: true,
+    };
+  }
+
+  protected async performAuthentication(
+    authData: AuthenticationData
+  ): Promise<void> {
+    if (authData.type !== "oauth") {
+      throw new Error("ClickUp adapter only supports OAuth authentication");
+    }
+
+    if (!authData.accessToken) {
+      throw new Error("ClickUp OAuth authentication requires an access token");
+    }
+
+    // Validate the token. makeRequest sends the raw token (no "Bearer"
+    // prefix) for ClickUp's oauth auth type.
+    try {
+      await this.makeRequest(`${this.baseUrl}/user`);
+    } catch {
+      throw new Error("Invalid ClickUp OAuth access token");
+    }
+  }
+
+  /**
+   * Build the OAuth authorization URL the user is redirected to for consent.
+   * ClickUp does not use OAuth scopes — access is granted per-workspace by
+   * the user during the consent step.
+   */
+  getAuthorizationUrl(state: string): string {
+    const params = new URLSearchParams({
+      client_id: this.clientId || "",
+      redirect_uri: this.redirectUri || "",
+      state,
+    });
+    return `https://app.clickup.com/api?${params.toString()}`;
+  }
+
+  /**
+   * Exchange the authorization code for an access token. ClickUp OAuth
+   * tokens do not expire, so no refresh token or expiry is returned.
+   */
+  async exchangeCodeForTokens(code: string): Promise<{
+    accessToken: string;
+    refreshToken?: string;
+    expiresAt?: Date;
+  }> {
+    const response = await fetch(`${this.baseUrl}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to exchange code for tokens: ${error}`);
+    }
+
+    const data = await response.json();
+    if (data.err) {
+      throw new Error(`Failed to exchange code for tokens: ${data.err}`);
+    }
+
+    return { accessToken: data.access_token };
+  }
+
+  /**
+   * ClickUp OAuth access tokens do not expire and there is no refresh
+   * endpoint. IntegrationManager only calls this when a stored token's
+   * expiry has passed, which never happens for ClickUp since
+   * `exchangeCodeForTokens` never sets `expiresAt`. Implemented purely for
+   * interface completeness / defensive future-proofing.
+   */
+  async refreshTokens(_refreshToken: string): Promise<{
+    accessToken: string;
+    refreshToken?: string;
+    expiresAt?: Date;
+  }> {
+    throw new Error("ClickUp OAuth tokens do not expire and cannot be refreshed");
+  }
+
+  async createIssue(data: CreateIssueData): Promise<IssueData> {
+    const listId = data.projectId || this.listId;
+    if (!listId) {
+      throw new Error(
+        "ClickUp List ID not configured. Expected settings.listId or CreateIssueData.projectId."
+      );
+    }
+
+    const payload: Record<string, unknown> = {
+      name: data.title,
+      markdown_description: renderClickUpDescription(data.description),
+    };
+    if (data.priority !== undefined) {
+      payload.priority = mapPriorityToClickUp(data.priority);
+    }
+    if (data.assigneeId) {
+      payload.assignees = [Number(data.assigneeId)];
+    }
+    if (data.labels !== undefined) {
+      payload.tags = data.labels;
+    }
+
+    const response = await this.makeRequest<any>(
+      `${this.baseUrl}/list/${listId}/task`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }
+    );
+
+    return this.mapClickUpTask(response);
+  }
+
+  async updateIssue(
+    issueId: string,
+    data: UpdateIssueData
+  ): Promise<IssueData> {
+    const payload: Record<string, unknown> = {};
+
+    if (data.title !== undefined) {
+      payload.name = data.title;
+    }
+    if (data.description !== undefined) {
+      payload.markdown_description = renderClickUpDescription(
+        data.description
+      );
+    }
+    if (data.status !== undefined) {
+      // ClickUp statuses are free-text and defined per-List; pass through
+      // verbatim rather than mapping to a fixed open/closed pair.
+      payload.status = data.status;
+    }
+    if (data.priority !== undefined) {
+      payload.priority = mapPriorityToClickUp(data.priority);
+    }
+    if (data.assigneeId !== undefined) {
+      // ClickUp's task-update endpoint takes an add/remove delta for
+      // assignees rather than the flat replacement array GitHub/GitLab use.
+      payload.assignees = { add: [Number(data.assigneeId)], rem: [] };
+    }
+    if (data.labels !== undefined) {
+      payload.tags = data.labels;
+    }
+
+    const response = await this.makeRequest<any>(
+      `${this.baseUrl}/task/${issueId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(payload),
+      }
+    );
+
+    return this.mapClickUpTask(response);
+  }
+
+  async getIssue(issueId: string): Promise<IssueData> {
+    const response = await this.makeRequest<any>(
+      `${this.baseUrl}/task/${issueId}`
+    );
+    return this.mapClickUpTask(response);
+  }
+
+  async searchIssues(options: IssueSearchOptions): Promise<{
+    issues: IssueData[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const listId = options.projectId || this.listId;
+    if (!listId) {
+      throw new Error(
+        "ClickUp List ID not configured. Expected settings.listId or IssueSearchOptions.projectId."
+      );
+    }
+
+    const limit = options.limit || 100;
+    const params = new URLSearchParams();
+    params.set("page", String(Math.floor((options.offset || 0) / limit)));
+    params.set("include_closed", "true");
+    if (options.status && options.status.length > 0) {
+      for (const s of options.status) params.append("statuses[]", s);
+    }
+    if (options.assignee) {
+      params.append("assignees[]", options.assignee);
+    }
+    if (options.updatedWithinDays && options.updatedWithinDays > 0) {
+      params.set(
+        "date_updated_gt",
+        String(Date.now() - Math.floor(options.updatedWithinDays) * 86_400_000)
+      );
+    }
+
+    const response = await this.makeRequest<any>(
+      `${this.baseUrl}/list/${listId}/task?${params.toString()}`
+    );
+    const tasks: any[] = response.tasks || [];
+
+    // ClickUp's list-tasks endpoint has no server-side free-text search
+    // qualifier (unlike GitHub's `q=`); filter client-side as a documented
+    // fallback when a query is supplied.
+    const filtered = options.query
+      ? tasks.filter((t) =>
+          t.name?.toLowerCase().includes(options.query!.toLowerCase())
+        )
+      : tasks;
+
+    return {
+      issues: filtered.map((t) => this.mapClickUpTask(t)),
+      total: filtered.length,
+      hasMore: response.last_page === false,
+    };
+  }
+
+  async getIssueComments(issueId: string): Promise<IssueComment[]> {
+    try {
+      const response = await this.makeRequest<any>(
+        `${this.baseUrl}/task/${issueId}/comment`
+      );
+      const comments: any[] = response.comments || [];
+      return comments.map((c) => ({
+        id: c.id != null ? String(c.id) : undefined,
+        author: c.user?.username || "Unknown",
+        body: c.comment_text ?? "",
+        created: c.date ?? "",
+      }));
+    } catch (error) {
+      const status = this.parseStatusFromError(error);
+      const level = status === null || status >= 500 ? "error" : "warn";
+      console[level](
+        `[ClickUpAdapter] getIssueComments failed for %s:`,
+        issueId,
+        error
+      );
+      return [];
+    }
+  }
+
+  protected async addComment(issueId: string, comment: string): Promise<void> {
+    await this.makeRequest(`${this.baseUrl}/task/${issueId}/comment`, {
+      method: "POST",
+      body: JSON.stringify({ comment_text: comment }),
+    });
+  }
+
+  /**
+   * ClickUp has no flat "project" concept — walk the Team → Space →
+   * (Folder →) List hierarchy and flatten it to the generic
+   * `{id, key, name}` shape the rest of the app expects, where `id` is the
+   * ClickUp List id `createIssue`/`searchIssues` target.
+   */
+  async getProjects(): Promise<
+    Array<{ id: string; key: string; name: string }>
+  > {
+    if (!this.teamId) {
+      throw new Error("ClickUp Team (workspace) ID not configured (settings.teamId).");
+    }
+
+    const spacesResponse = await this.makeRequest<any>(
+      `${this.baseUrl}/team/${this.teamId}/space`
+    );
+    const spaces: any[] = spacesResponse.spaces || [];
+
+    const results: Array<{ id: string; key: string; name: string }> = [];
+    for (const space of spaces) {
+      const [foldersResponse, folderlessListsResponse] = await Promise.all([
+        this.makeRequest<any>(`${this.baseUrl}/space/${space.id}/folder`),
+        this.makeRequest<any>(`${this.baseUrl}/space/${space.id}/list`),
+      ]);
+
+      for (const list of folderlessListsResponse.lists || []) {
+        results.push({
+          id: list.id,
+          key: list.id,
+          name: `${space.name} / ${list.name}`,
+        });
+      }
+      for (const folder of foldersResponse.folders || []) {
+        for (const list of folder.lists || []) {
+          results.push({
+            id: list.id,
+            key: list.id,
+            name: `${space.name} / ${folder.name} / ${list.name}`,
+          });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  private mapClickUpTask(task: any): IssueData {
+    return {
+      id: task.id,
+      // ClickUp custom task IDs are optional (Business plan+); fall back to
+      // the ClickUp task id when absent.
+      key: task.custom_id || task.id,
+      title: task.name,
+      description: task.markdown_description ?? task.description,
+      status: task.status?.status ?? "unknown",
+      priority: task.priority?.priority,
+      assignee: task.assignees?.[0]
+        ? {
+            id: String(task.assignees[0].id),
+            name: task.assignees[0].username,
+            email: task.assignees[0].email,
+          }
+        : undefined,
+      reporter: task.creator
+        ? {
+            id: String(task.creator.id),
+            name: task.creator.username,
+            email: task.creator.email,
+          }
+        : undefined,
+      labels: (task.tags || []).map((t: any) => t.name),
+      customFields: {
+        _clickup_list_id: task.list?.id,
+      },
+      // ClickUp timestamps are epoch-millisecond strings, not ISO-8601.
+      createdAt: new Date(Number(task.date_created)),
+      updatedAt: new Date(Number(task.date_updated)),
+      url: task.url,
+    };
+  }
+
+  async linkToTestCase(
+    issueId: string,
+    testCaseId: string,
+    metadata?: any
+  ): Promise<void> {
+    const comment = `Linked to test case: ${testCaseId}${
+      metadata ? `\n\nMetadata: ${JSON.stringify(metadata, null, 2)}` : ""
+    }`;
+    await this.addComment(issueId, comment);
+  }
+
+  async syncIssue(issueId: string): Promise<IssueData> {
+    return this.getIssue(issueId);
+  }
+}

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
@@ -191,7 +191,9 @@ export class ClickUpAdapter extends BaseAdapter {
     refreshToken?: string;
     expiresAt?: Date;
   }> {
-    throw new Error("ClickUp OAuth tokens do not expire and cannot be refreshed");
+    throw new Error(
+      "ClickUp OAuth tokens do not expire and cannot be refreshed"
+    );
   }
 
   async createIssue(data: CreateIssueData): Promise<IssueData> {
@@ -237,9 +239,7 @@ export class ClickUpAdapter extends BaseAdapter {
       payload.name = data.title;
     }
     if (data.description !== undefined) {
-      payload.markdown_description = renderClickUpDescription(
-        data.description
-      );
+      payload.markdown_description = renderClickUpDescription(data.description);
     }
     if (data.status !== undefined) {
       // ClickUp statuses are free-text and defined per-List; pass through
@@ -367,7 +367,9 @@ export class ClickUpAdapter extends BaseAdapter {
     Array<{ id: string; key: string; name: string }>
   > {
     if (!this.teamId) {
-      throw new Error("ClickUp Team (workspace) ID not configured (settings.teamId).");
+      throw new Error(
+        "ClickUp Team (workspace) ID not configured (settings.teamId)."
+      );
     }
 
     const spacesResponse = await this.makeRequest<any>(

--- a/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
+++ b/testplanit/lib/integrations/adapters/ClickUpAdapter.ts
@@ -39,6 +39,21 @@ function renderClickUpDescription(description: unknown): string {
   return String(description);
 }
 
+/**
+ * ClickUp's Get Tasks endpoint always returns this many tasks per page,
+ * regardless of any limit the caller requests — pagination math must be
+ * done in terms of this fixed size, never the caller's `limit`.
+ */
+const CLICKUP_TASK_PAGE_SIZE = 100;
+
+/**
+ * Upper bound on ClickUp pages scanned for one text-query search, so a
+ * huge List with no match can't turn an interactive search into an
+ * unbounded fetch loop (MAX_QUERY_SCAN_PAGES * CLICKUP_TASK_PAGE_SIZE
+ * tasks scanned at most).
+ */
+const MAX_QUERY_SCAN_PAGES = 20;
+
 /** ClickUp priority is an integer 1 (urgent) through 4 (low); unknown values default to "normal". */
 function mapPriorityToClickUp(priority: string): number {
   const map: Record<string, number> = {
@@ -276,21 +291,17 @@ export class ClickUpAdapter extends BaseAdapter {
     return this.mapClickUpTask(response);
   }
 
-  async searchIssues(options: IssueSearchOptions): Promise<{
-    issues: IssueData[];
-    total: number;
-    hasMore: boolean;
-  }> {
-    const listId = options.projectId || this.listId;
-    if (!listId) {
-      throw new Error(
-        "ClickUp List ID not configured. Expected settings.listId or IssueSearchOptions.projectId."
-      );
-    }
-
-    const limit = options.limit || 100;
+  /**
+   * Build the query string for one page of ClickUp's Get Tasks call.
+   * `page` is a ClickUp page index (each page is CLICKUP_TASK_PAGE_SIZE
+   * items) — never the caller's `limit`, which ClickUp does not honor.
+   */
+  private buildSearchParams(
+    page: number,
+    options: IssueSearchOptions
+  ): URLSearchParams {
     const params = new URLSearchParams();
-    params.set("page", String(Math.floor((options.offset || 0) / limit)));
+    params.set("page", String(page));
     params.set("include_closed", "true");
     if (options.status && options.status.length > 0) {
       for (const s of options.status) params.append("statuses[]", s);
@@ -304,25 +315,76 @@ export class ClickUpAdapter extends BaseAdapter {
         String(Date.now() - Math.floor(options.updatedWithinDays) * 86_400_000)
       );
     }
+    return params;
+  }
 
-    const response = await this.makeRequest<any>(
-      `${this.baseUrl}/list/${listId}/task?${params.toString()}`
+  async searchIssues(options: IssueSearchOptions): Promise<{
+    issues: IssueData[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const listId = options.projectId || this.listId;
+    if (!listId) {
+      throw new Error(
+        "ClickUp List ID not configured. Expected settings.listId or IssueSearchOptions.projectId."
+      );
+    }
+
+    // ClickUp's Get Tasks endpoint always pages in fixed batches of
+    // CLICKUP_TASK_PAGE_SIZE and ignores the caller's `limit` entirely —
+    // translating `offset` into a ClickUp page number via the caller's
+    // `limit` (as opposed to ClickUp's actual page size) would silently
+    // skip or re-request the wrong slice of tasks once the two diverge
+    // (e.g. a bulk import requesting 50 at a time against 100-per-page
+    // responses). Always divide by ClickUp's real page size instead.
+    const startPage = Math.floor(
+      (options.offset || 0) / CLICKUP_TASK_PAGE_SIZE
     );
-    const tasks: any[] = response.tasks || [];
+    const limit = options.limit || 100;
+
+    if (!options.query) {
+      const response = await this.makeRequest<any>(
+        `${this.baseUrl}/list/${listId}/task?${this.buildSearchParams(startPage, options).toString()}`
+      );
+      const tasks: any[] = response.tasks || [];
+      return {
+        issues: tasks.map((t) => this.mapClickUpTask(t)),
+        total: tasks.length,
+        hasMore: response.last_page === false,
+      };
+    }
 
     // ClickUp's list-tasks endpoint has no server-side free-text search
-    // qualifier (unlike GitHub's `q=`); filter client-side as a documented
-    // fallback when a query is supplied.
-    const filtered = options.query
-      ? tasks.filter((t) =>
-          t.name?.toLowerCase().includes(options.query!.toLowerCase())
-        )
-      : tasks;
+    // qualifier (unlike GitHub's `q=`). A single page can't be relied on to
+    // contain every match (interactive callers like the issue-link search
+    // dialog make one searchIssues() call and never inspect `hasMore`), so
+    // scan forward across ClickUp pages — capped at
+    // MAX_QUERY_SCAN_PAGES — accumulating matches until there are enough
+    // to satisfy `limit` or the list is exhausted.
+    const query = options.query.toLowerCase();
+    const matches: any[] = [];
+    let page = startPage;
+    let exhausted = false;
+    while (
+      matches.length < limit &&
+      page < startPage + MAX_QUERY_SCAN_PAGES &&
+      !exhausted
+    ) {
+      const response = await this.makeRequest<any>(
+        `${this.baseUrl}/list/${listId}/task?${this.buildSearchParams(page, options).toString()}`
+      );
+      const tasks: any[] = response.tasks || [];
+      for (const t of tasks) {
+        if (t.name?.toLowerCase().includes(query)) matches.push(t);
+      }
+      exhausted = response.last_page === true || tasks.length === 0;
+      page++;
+    }
 
     return {
-      issues: filtered.map((t) => this.mapClickUpTask(t)),
-      total: filtered.length,
-      hasMore: response.last_page === false,
+      issues: matches.slice(0, limit).map((t) => this.mapClickUpTask(t)),
+      total: matches.length,
+      hasMore: !exhausted,
     };
   }
 

--- a/testplanit/lib/integrations/errors.ts
+++ b/testplanit/lib/integrations/errors.ts
@@ -56,6 +56,7 @@ const providerLabel = (provider: string): string => {
     REDMINE: "Redmine",
     MANTISBT: "MantisBT",
     BITBUCKET: "Bitbucket",
+    CLICKUP: "ClickUp",
   };
   return known[provider.toUpperCase()] ?? provider;
 };

--- a/testplanit/lib/integrations/index.ts
+++ b/testplanit/lib/integrations/index.ts
@@ -2,6 +2,7 @@
 export { AzureDevOpsAdapter } from "./adapters/AzureDevOpsAdapter";
 // Adapter exports
 export { BaseAdapter } from "./adapters/BaseAdapter";
+export { ClickUpAdapter } from "./adapters/ClickUpAdapter";
 export { GitHubAdapter } from "./adapters/GitHubAdapter";
 // Types
 export type {

--- a/testplanit/lib/services/jira-link-service.test.ts
+++ b/testplanit/lib/services/jira-link-service.test.ts
@@ -34,6 +34,7 @@ vi.mock("@prisma/client", () => ({
     GITEA: "GITEA",
     REDMINE: "REDMINE",
     MANTISBT: "MANTISBT",
+    CLICKUP: "CLICKUP",
   },
 }));
 
@@ -780,6 +781,7 @@ describe("JiraLinkService", () => {
                 "GITEA",
                 "REDMINE",
                 "MANTISBT",
+                "CLICKUP",
               ],
             },
           },

--- a/testplanit/lib/services/jira-link-service.ts
+++ b/testplanit/lib/services/jira-link-service.ts
@@ -12,6 +12,7 @@ const ISSUE_TRACKING_PROVIDERS = [
   IntegrationProvider.GITEA,
   IntegrationProvider.REDMINE,
   IntegrationProvider.MANTISBT,
+  IntegrationProvider.CLICKUP,
 ];
 
 export class JiraLinkService {

--- a/testplanit/messages/en-US.json
+++ b/testplanit/messages/en-US.json
@@ -1409,6 +1409,9 @@
           },
           "mantisbt": {
             "description": "Connect to a self-hosted MantisBT instance for issue tracking."
+          },
+          "clickup": {
+            "description": "Connect to ClickUp for task tracking and project management."
           }
         }
       },
@@ -5186,6 +5189,10 @@
         "mantisbt": {
           "name": "MantisBT",
           "description": "Connect to a self-hosted MantisBT instance for issue tracking"
+        },
+        "clickup": {
+          "name": "ClickUp",
+          "description": "Connect to ClickUp for task tracking and project management"
         }
       },
       "filterPlaceholder": "Filter integrations...",
@@ -5298,7 +5305,13 @@
         "mantisBTApiKeyHelp": "Create one under your MantisBT account settings → API Tokens",
         "mantisBTUrl": "MantisBT URL",
         "mantisBTUrlPlaceholder": "https://mantisbt.example.com",
-        "mantisBTUrlHelp": "The base URL of your MantisBT instance"
+        "mantisBTUrlHelp": "The base URL of your MantisBT instance",
+        "clickupTeamId": "ClickUp Team (Workspace) ID",
+        "clickupTeamIdPlaceholder": "e.g. 9013456789",
+        "clickupTeamIdHelp": "Found in the ClickUp URL after app.clickup.com/",
+        "clickupListId": "Default ClickUp List ID",
+        "clickupListIdPlaceholder": "e.g. 901234567",
+        "clickupListIdHelp": "The List tasks are created in by default; can be overridden per issue"
       },
       "authType": {
         "api_key": "API Key",
@@ -6235,6 +6248,8 @@
       "redmineUrl": "## Redmine URL\nThe base URL of your Redmine instance.\n\n- Format: https://redmine.example.com\n- Do not include /issues or other paths\n- Must be accessible from this server",
       "mantisBTApiKey": "## MantisBT API Token\nYour personal REST API token.\n\n- Create one under your MantisBT account settings → API Tokens\n- Scoped to your user’s permissions; use a service account for shared integrations",
       "mantisBTUrl": "## MantisBT URL\nThe base URL of your MantisBT instance.\n\n- Format: https://mantisbt.example.com\n- Do not include /api/rest or other paths\n- Must be accessible from this server",
+      "clickupTeamId": "## ClickUp Team (Workspace) ID\nThe numeric ID of the ClickUp Team (also called Workspace) tasks belong to.\n\n- Found in the ClickUp URL: app.clickup.com/{teamId}/...\n- Required to browse Spaces/Folders/Lists when picking a project",
+      "clickupListId": "## Default ClickUp List ID\nThe List new tasks are created in by default.\n\n- Found in the ClickUp URL, or via the List's \"Copy link\" option\n- Optional — a specific List can be chosen per issue instead",
       "githubBaseUrl": "## API Base URL\nFull GitHub API root for GitHub Enterprise Server.\n\n- Typically ends in /api/v3\n- Leave blank to use api.github.com\n- Must be accessible from this server"
     },
     "config": {

--- a/testplanit/prisma/schema.prisma
+++ b/testplanit/prisma/schema.prisma
@@ -189,6 +189,7 @@ enum IntegrationProvider {
   GITEA
   REDMINE
   MANTISBT
+  CLICKUP
 }
 
 enum AdapterType {

--- a/testplanit/schema.zmodel
+++ b/testplanit/schema.zmodel
@@ -3344,6 +3344,7 @@ enum IntegrationProvider {
     GITEA
     REDMINE
     MANTISBT
+    CLICKUP
 
     @@deny('all', !auth())
     @@allow('update', auth().access == 'ADMIN')


### PR DESCRIPTION
## Description

Adds ClickUp as a Project Integration (OAuth2), following the existing `IssueAdapter` pattern used by Jira/GitHub/GitLab/Gitea/Redmine/MantisBT — not the `lib/webhooks` outbound-webhook registry, which is a fixed-URL POST dispatcher unsuited to calling ClickUp's REST API directly (different endpoint per action, non-`Bearer` auth header).

- `testplanit/lib/integrations/adapters/ClickUpAdapter.ts`: OAuth2-only `IssueAdapter` implementing `createIssue`/`updateIssue`/`getIssue`/`searchIssues`/comments, plus a `getProjects()` List picker that walks ClickUp's Team → Space → Folder → List hierarchy (ClickUp has no flat "project").
- Handles ClickUp-specific quirks explicitly: OAuth tokens that don't expire/refresh, the `{assignees:{add,rem}}` delta update shape, epoch-millisecond timestamps, and the 1(urgent)–4(low) integer priority scale.
- `BaseAdapter.ts`: ClickUp's OAuth header omits the `Bearer` prefix (unlike GitHub/GitLab/Jira Cloud) — added a one-line provider branch with a regression test guarding the other providers.
- Schema: added `CLICKUP` to `IntegrationProvider` only (in `schema.zmodel`, hand-mirrored into `prisma/schema.prisma`) — `AdapterType` (the separate `lib/webhooks` enum) is intentionally untouched, since this is not a webhook-dispatch adapter.
- Registered in `IntegrationManager`, wired into the admin Integrations UI (type selector, icon, config form fields for Team ID / default List ID, OAuth-only auth type), the project integrations picker allowlist, the test-connection OAuth-config check, and a few provider-label switches.
- Docs: `testplanit/docs/integrations/clickup.md` covering OAuth app registration and redirect URI setup.

## Related Issue

N/A — no tracking issue; this was scoped directly from a feature request to integrate ClickUp.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

New/extended unit tests: `ClickUpAdapter.test.ts` (capabilities, auth, the no-`Bearer` header, OAuth authorize/exchange/refresh, create/update/get/search, comments, List hierarchy walk), `BaseAdapter.test.ts` (ClickUp-vs-other-providers OAuth header regression), `IntegrationManager.test.ts` (registration smoke test).

**Update:** `pnpm install` has now been run, which triggers the `zenstack generate` postinstall hook — `prisma/schema.prisma` matched the hand-mirrored version exactly, and the generated `lib/openapi/zenstack-openapi.json` picked up the new `CLICKUP` enum value. With dependencies installed:
- `pnpm type-check` — clean, no errors.
- `pnpm exec eslint` on every file touched by this PR — clean.
- `pnpm exec vitest run` on `ClickUpAdapter.test.ts`, `BaseAdapter.test.ts`, `IntegrationManager.test.ts` — **96/96 passing** (this pass caught two real test bugs — wrong `mock.calls` index after an auth call, and a stale hardcoded adapter-count assertion — both fixed).

**Still outstanding before merge:**
- A manual OAuth round-trip against a real ClickUp OAuth app (register one at `https://app.clickup.com/settings/apps`; see `testplanit/docs/integrations/clickup.md`) — not done, since it requires a live ClickUp workspace/credentials and a running dev server/DB.
- The broader `pnpm test` / `pnpm test:e2e` suites (only the ClickUp-related files above were run, not the full repo suite).

**Test Configuration:**
- OS: macOS (Darwin)
- Browser (if applicable): N/A
- Node version: 24.5.0 (per `.tool-versions` convention; not verified in this environment)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (typecheck + eslint clean on all touched files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (96/96 passing on the touched test files; full repo suite not run)
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla) (per the CLA page: submitting this PR under my git commit signature constitutes signing it)

## Screenshots (if applicable)

N/A — this PR is backend/adapter code plus admin-settings form fields; no new screens.

## Additional Notes

`schema.zmodel` is the source of truth for the schema change; `prisma/schema.prisma` was hand-mirrored in this PR since the dev environment used to write this couldn't run `pnpm generate:dev`. A maintainer (or CI) should regenerate it properly and confirm no drift before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

