### PR TITLE
fix(helm): track the app release line in the chart version

### DIFF
--- a/testplanit/helm/testplanit/Chart.yaml
+++ b/testplanit/helm/testplanit/Chart.yaml
@@ -7,11 +7,13 @@ description: |
   Valkey, Elasticsearch, and MinIO that can each be swapped for managed services
   (RDS / ElastiCache / OpenSearch / S3).
 type: application
-# Chart version — bump on chart changes (independent of the app image version).
-version: 0.1.1
-# appVersion is intentionally unset: the application image is bring-your-own
-# (its domain is baked at build time), so the running app version is whatever
-# image tag the operator supplies via `image.tag`.
+# Chart version — tracks the app release line it ships against.
+version: 1.0.0
+# The application release this chart ships against. Surfaces on every object as
+# the standard app.kubernetes.io/version label. Operators who pin `image.tag`
+# to a different release should expect that label to reflect this value, not
+# their override.
+appVersion: "1.0.0"
 kubeVersion: ">=1.25.0-0"
 home: https://testplanit.com
 sources:


### PR DESCRIPTION
## Description

The Helm chart sat at `0.1.1` while the app shipped `1.0.0`, and `appVersion` was unset — so every rendered object carried an empty `app.kubernetes.io/version` label.

Sets both `version` and `appVersion` to `1.0.0`.

The `appVersion` omission was deliberate once. Its stated rationale was that the application image is bring-your-own because the image bakes its domain at build time — true of the SaaS image, but not of `testplanit-selfhost`, which is domain-agnostic and multi-arch and is what the chart now defaults to. That constraint is gone, so the chart can name the release it ships against.

`image.tag` stays `latest` by default. Pinning it to a release is already documented in `values.yaml` and is unchanged here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

`helm lint` passes, and `helm template` now renders `app.kubernetes.io/version: "1.0.0"` on every object where it was previously empty. Image references resolve to `ghcr.io/testplanit/testplanit-selfhost:latest` and `:latest-workers`, matching what `release-selfhost.yml` publishes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

This does not by itself make the chart installable. `ghcr.io/testplanit/testplanit-selfhost` has never been published, so a `helm install` from the current chart still fails to pull. That needs the package to be seeded once with a `write:packages` credential — `GITHUB_TOKEN` cannot create a package that does not yet exist, which is why `release-selfhost.yml` failed with `denied: permission_denied: write_package`.

Chart publishing is also still manual (`helm push`); no workflow does it. That is why the chart version drifted from the app in the first place, and is worth automating in `release-selfhost.yml` as a follow-up.
