### PR TITLE
fix(deps): pin the conventionalcommits preset to the line semantic-release supports

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1236,8 +1236,8 @@ importers:
         specifier: ^10.0.5
         version: 10.0.5
       conventional-changelog-conventionalcommits:
-        specifier: ^10.4.0
-        version: 10.4.0
+        specifier: ^9.3.1
+        version: 9.3.1
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -3185,10 +3185,6 @@ packages:
     resolution: {integrity: sha512-mEJuYGFxIDST1H7CpksyE6a3HRVRQmeDal26O+bCHTEZlPp7iKvs5KD1FOmd2palng+S60dPFFG+UuoZDRILwA==}
     peerDependencies:
       react: '>=18.0.0'
-
-  '@conventional-changelog/template@1.4.0':
-    resolution: {integrity: sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==}
-    engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -9299,9 +9295,9 @@ packages:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.4.0:
-    resolution: {integrity: sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -20472,8 +20468,6 @@ snapshots:
       csstype: 3.2.3
       react: 18.3.1
 
-  '@conventional-changelog/template@1.4.0': {}
-
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -28718,9 +28712,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.4.0:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.4.0
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.4.0:
     dependencies:

--- a/testplanit/package.json
+++ b/testplanit/package.json
@@ -363,7 +363,7 @@
     "autoprefixer": "^10.5.5",
     "baseline-browser-mapping": "^2.11.21",
     "concurrently": "^10.0.5",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "cross-env": "^10.1.0",
     "dotenv": "^17.4.2",
     "dotenv-cli": "^11.0.0",


### PR DESCRIPTION
## Description

The first app release attempt after the 1.0 graduation ([run 34182722798](https://github.com/TestPlanIt/testplanit/actions/runs/34182722798)) computed `1.0.1` correctly and then died in `generateNotes`:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer"
```

`semantic-release@25.0.9` bundles `@semantic-release/release-notes-generator@14.1.1`, which depends on `conventional-changelog-writer: ^8.0.0`. The preset was pinned at `^10.4.0`, and the 10.x line pulls `@conventional-changelog/template` and requires writer 9. The two could never agree, so **no app release could be cut at all**.

The 9.x line declares no writer constraint (`compare-func` is its only dependency) and is the line that pairs with `release-notes-generator@14`. Pinned to `^9.3.1`.

## Related Issue

Blocks all app releases after v1.0.0.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

`semantic-release --dry-run --no-ci` now runs to completion:

```
✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
exit=0, 0 error lines
```

Previously the same command aborted at that step with the handlebars error above.

The lockfile delta is limited to the preset swap and dropping the `@conventional-changelog/template` transitive that carried the writer-9 requirement. The package is a devDependency used only by the release pipeline, so no application code path is affected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

**Merging this will cut v1.0.1.** `fix(deps)` is configured `release: false`, but the `fix(helm)` commit from #615 is already sitting on `main` unreleased and is a patch-level change — so once the pipeline works, semantic-release will publish v1.0.1 containing the chart version bump. That is the intended outcome and doubles as end-to-end proof the fix holds.

This mismatch arrived with the beta tree: the semantic-release plugin majors were taken on `beta` (beta.10) and flagged at the time as unproven until the next `main` release. This was that release.
