### PR TITLE
chore(dependabot): hold the majors that break the build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-resizable-panels"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7 is held: typescript-eslint refuses to load against it
+      # ("typescript-eslint does not support TS 7.0"), so `pnpm lint` dies
+      # before any test runs and the whole grouped PR fails its required check.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "undici"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "bullmq"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Description

TypeScript 7 was never encoded as a held major, so Dependabot keeps proposing it inside the grouped dev-dependencies PR. `typescript-eslint` hard-refuses to load against it:

```
Error: typescript-eslint does not support TS 7.0.
```

so `eslint .` exits before a single test runs and the required `Test` check fails. The PR is dead on arrival every week — #606 was the most recent, bumping TS `5.9.3 -> 7.0.2` across the six non-app workspaces.

Adds major-ignores for `typescript`, `undici`, and `bullmq` — the deferred majors that currently only produce unmergeable PRs. ESLint and `@eslint/js` were already covered.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

YAML parses and the ignore list resolves to eight entries. Effect is verifiable on the next scheduled Dependabot run — grouped dev-dependency PRs should stop carrying TS 7.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code

## Additional Notes

`@changesets/cli` is deliberately **not** in this list. `main` took Changesets 3 in #593, and the 1.0 graduation merge reverted it to `^2.31.1` as a side effect of taking beta's tree wholesale. Whether that revert stands is a real decision — the current `changesets/action@v1` + CLI v2 pairing is internally consistent and published the 1.0.0 packages fine, but it undoes a merged PR that Dependabot originally drove. Cementing it with an ignore rule would settle that by accident.

Minor/patch updates for all three ignored packages continue to flow normally; only majors are held.
