### PR TITLE
docs(install): point self-hosters at the self-host image

### DIFF
--- a/docs/blog/2026-09-08-v1.0-release.md
+++ b/docs/blog/2026-09-08-v1.0-release.md
@@ -108,8 +108,10 @@ pnpm build
 For Docker deployments:
 
 ```bash
-docker pull ghcr.io/testplanit/testplanit:latest
+docker pull ghcr.io/testplanit/testplanit-selfhost:latest
 ```
+
+Self-hosted deployments use the `testplanit-selfhost` image — domain-agnostic, so one image serves any hostname, and published for both `linux/amd64` and `linux/arm64`.
 
 If you've been on the beta channel, v1.0.0 is the graduation of that line — upgrade as usual.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -22,9 +22,19 @@ TestPlanIt applies database schema changes with versioned migrations (`zenstack 
 A routine upgrade with Docker:
 
 ```bash
-docker pull ghcr.io/testplanit/testplanit:latest
+docker pull ghcr.io/testplanit/testplanit-selfhost:latest
 docker compose up -d   # pending migrations apply on startup
 ```
+
+:::note Which image to pull
+
+Self-hosted deployments use **`testplanit-selfhost`**. It is domain-agnostic, so
+one image serves any hostname, and it is published for both `linux/amd64` and
+`linux/arm64`. The `testplanit` image is built for the hosted service, bakes its
+domain in at build time, and is `arm64` only — pulling it on an x86 host fails
+with `no matching manifest for linux/amd64`.
+
+:::
 
 A routine upgrade from source:
 
@@ -51,7 +61,7 @@ npx zenstack migrate resolve --applied 20260625193632_init --schema schema.zmode
 # `docker compose run --rm --no-deps --entrypoint "" prod` for `docker run --rm --entrypoint ""`):
 docker run --rm --entrypoint "" \
   -e DATABASE_URL="postgresql://user:password@host:5432/testplanit" \
-  ghcr.io/testplanit/testplanit:latest \
+  ghcr.io/testplanit/testplanit-selfhost:latest \
   npx zenstack migrate resolve --applied 20260625193632_init --schema schema.zmodel
 ```
 


### PR DESCRIPTION
## Description

The upgrade guide and the 1.0 announcement both told self-hosters to pull `ghcr.io/testplanit/testplanit:latest`. That is the **hosted-service** image — it bakes `BASE_DOMAIN` at build time and is published for `linux/arm64` only, so on an x86 host the pull fails outright:

```
no matching manifest for linux/amd64
```

The image self-hosters want is **`testplanit-selfhost`**: domain-agnostic and multi-arch (`linux/amd64` + `linux/arm64`). It is already what the Helm chart and the Kubernetes guide default to; only these two references were left pointing at the wrong one.

Changes:

- `docs/docs/installation.md` — the routine Docker upgrade and the pre-1.0 baseline `docker run`, plus a short note explaining which image is which
- `docs/blog/2026-09-08-v1.0-release.md` — the 1.0 upgrade command

Historical release posts are left alone: their commands were correct when written, before the two images diverged.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Manual testing

`pnpm --filter docs build` compiles clean, and no references to the SaaS image remain anywhere under `docs/docs/` or in the 1.0 post.

Verified against the registry that the self-host tags now resolve multi-arch:

```
1.0.0            linux/amd64, linux/arm64
v1.0.0           linux/amd64, linux/arm64
1.0.0-workers    linux/amd64, linux/arm64
latest           linux/amd64, linux/arm64
latest-workers   linux/amd64, linux/arm64
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

## Additional Notes

This was live-breaking for x86 self-hosters following the 1.0 upgrade instructions, since `testplanit-selfhost` did not exist at all until tonight.
