### PR TITLE
fix(release): dispatch the self-host image build on every release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -78,16 +78,24 @@ jobs:
             echo "released=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Trigger Docker build
+      # Both image builds must be dispatched explicitly. semantic-release tags
+      # its own `chore(release): X [skip ci]` commit, and GitHub honours
+      # [skip ci] natively for tag pushes — so the `on: push: tags` triggers in
+      # release.yml and release-selfhost.yml never fire for a released version.
+      - name: Trigger image builds
         if: steps.release.outputs.released == 'true' && steps.release.outputs.version != '' && steps.release.outputs.version != 'v'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           VERSION="${{ steps.release.outputs.version }}"
-          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Triggering Docker build for version: $VERSION"
-            gh workflow run release.yml -f tag=$VERSION
-          else
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Invalid version format: $VERSION"
             exit 1
           fi
+          # SaaS images (ghcr.io/testplanit/testplanit) — arm64, hosted fleet.
+          echo "Triggering Docker build for version: $VERSION"
+          gh workflow run release.yml -f tag=$VERSION
+          # Public self-host images (ghcr.io/testplanit/testplanit-selfhost) —
+          # multi-arch, what the Helm chart and compose self-hosters pull.
+          echo "Triggering self-host image build for version: $VERSION"
+          gh workflow run release-selfhost.yml -f tag=$VERSION


### PR DESCRIPTION
## Description

Releases ship SaaS images and **silently no self-host images**. v1.0.1 is the first version to hit it: `release-selfhost.yml` never ran, so the Helm chart and docker-compose self-hosters have nothing to pull for that version.

Neither image build can rely on its `on: push: tags` trigger. semantic-release tags its own `chore(release): X [skip ci]` commit, and GitHub honours `[skip ci]` **natively for tag pushes** — so a tag created by semantic-release fires no tag-triggered workflow at all. `release.yml` only works because this job dispatches it explicitly. `release-selfhost.yml` was added later, on `beta`, and was never wired into that step.

Dispatches both, and hoists the version-format check to a single guard up front rather than nesting the success path inside it.

## Related Issue

v1.0.1 has SaaS images but no self-host images; needs a manual `release-selfhost.yml` dispatch to backfill.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

Workflow YAML parses, the step resolves, and both dispatches are present:

```
dispatches: gh workflow run release.yml  |  gh workflow run release-selfhost.yml
```

End-to-end verification requires the next real release, since the step only runs when `steps.release.outputs.released == 'true'`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

The two images are not interchangeable and both are needed on every release:

- `ghcr.io/testplanit/testplanit` — SaaS, `linux/arm64` only, bakes `BASE_DOMAIN` at build time; the hosted fleet runs these.
- `ghcr.io/testplanit/testplanit-selfhost` — public, domain-agnostic, `linux/amd64` + `linux/arm64`; what the Helm chart defaults to.

v1.0.1's self-host images still need a one-off `gh workflow run release-selfhost.yml -f tag=v1.0.1` to backfill; this only prevents recurrence.
