### PR TITLE
feat(release): publish the Helm chart alongside the self-host images

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -168,3 +168,28 @@ jobs:
         else
           echo "Skipping 'latest' — $VERSION is not the newest release"
         fi
+
+    # The Helm chart ships from here too, after the images it references exist.
+    # Publishing it by hand is what let the chart drift to 0.1.1 while the app
+    # reached 1.0.0.
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+
+    - name: Package and publish the Helm chart
+      run: |
+        VERSION="${{ github.event.inputs.tag || github.ref_name }}"; VERSION_NUM="${VERSION#v}"
+
+        # version and appVersion are set from the release tag rather than read
+        # from Chart.yaml, so the published chart can never disagree with the
+        # release it deploys. Chart.yaml keeps its own values for local `helm
+        # template`/`lint`; only the published artifact is stamped here.
+        helm package testplanit/helm/testplanit \
+          --version "${VERSION_NUM}" \
+          --app-version "${VERSION_NUM}" \
+          -d "${RUNNER_TEMP}"
+
+        echo "${{ secrets.GITHUB_TOKEN }}" | \
+          helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+        helm push "${RUNNER_TEMP}/testplanit-${VERSION_NUM}.tgz" \
+          "oci://ghcr.io/${OWNER_LC}/charts"


### PR DESCRIPTION
## Description

Nothing publishes the Helm chart. Every version so far has gone up by hand, which is how it drifted to `0.1.1` while the app reached `1.0.0` — and why `1.0.0` had to be pushed manually after the release was already out.

Packages and pushes the chart from `merge-manifests`, after the images it references exist, so a chart is never published pointing at images that failed to build.

`version` and `appVersion` are stamped from the release tag with `helm package --version/--app-version` rather than read from `Chart.yaml`, so the published chart cannot disagree with the release it deploys and no one has to remember to bump a file. `Chart.yaml` keeps its own values for local `helm template` / `helm lint`; only the published artifact is stamped.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Manual testing

Workflow YAML parses and the two new steps land in the right order at the end of `merge-manifests`:

```
- Create multi-arch manifests
- Move 'latest' if this is the newest release
- Set up Helm
- Package and publish the Helm chart
```

The exact `helm package` command was run locally against the current chart:

```
$ helm package testplanit/helm/testplanit --version 1.0.1 --app-version 1.0.1
Successfully packaged chart and saved it to: /tmp/chartcheck/testplanit-1.0.1.tgz
$ tar -xzOf testplanit-1.0.1.tgz testplanit/Chart.yaml | grep -E '^(version|appVersion):'
appVersion: 1.0.1
version: 1.0.1
```

The push itself can only be exercised by a real release run.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

**One thing to check before relying on this.** `ghcr.io/testplanit/charts/testplanit` was created by hand, so the repository may not hold Write access to that package. `GITHUB_TOKEN` can push to a package linked to the repo with the Write role, but cannot claim one it has no access to — the same wall `release-selfhost.yml` hit on its first run against `testplanit-selfhost` (`denied: permission_denied: write_package`).

Worth confirming on the package's *Manage Actions access* page that the `testplanit` repo is listed with **Write** before the next release, rather than discovering it mid-release.

Prereleases are already excluded at the trigger level (`!v*-*`), so beta tags publish no chart.
