### PR TITLE
chore(dependabot): hold the conventionalcommits preset at 9.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,15 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "bullmq"
         update-types: ["version-update:semver-major"]
+      # Pinned to 9.x on purpose (#616). The 10.x line requires
+      # conventional-changelog-writer@9, but semantic-release 25 bundles
+      # @semantic-release/release-notes-generator 14, which depends on writer
+      # ^8 — the two cannot agree, and generateNotes dies with
+      # `Missing helper: ... requires conventional-changelog-writer@9 or newer`,
+      # blocking every app release. Only unhold this alongside a
+      # semantic-release major that ships a writer-9 generator.
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Description

#616 pinned `conventional-changelog-conventionalcommits` to `^9.3.1` to unbreak the release pipeline. Dependabot immediately proposed `^10.4.0` again in the next dev-dependencies group (#620).

Merging that would restore the exact failure #616 fixed: the 10.x line requires `conventional-changelog-writer@9`, `semantic-release@25` bundles `@semantic-release/release-notes-generator@14` which depends on writer `^8`, and `generateNotes` dies with

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer"
```

before any release is cut — blocking **all** app releases, as it did earlier tonight.

The hold was missing from the batch added in #617; that was an oversight, since #616 had pinned the package minutes before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

YAML parses; the ignore list now covers nine packages. #617's holds are already confirmed working — the regenerated group PR (#620) no longer carries TypeScript 7, where its predecessor (#606) did.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code

## Additional Notes

Only majors are held; 9.x minors and patches still flow. Unhold this alongside a semantic-release major that ships a writer-9 generator.

**#620 should not be merged until this lands**, and even then it wants a look: it also carries `vitest` and `@vitest/coverage-v8` 4 → 5, `@semantic-release/changelog` 6 → 7, `@semantic-release/git` 10 → 11, and `@changesets/changelog-github` 0.7 → 1.0. Those are majors riding inside a grouped dev-dependency bump, and the changesets one interacts with the CLI v2-vs-v3 question left open by the 1.0 graduation merge reverting #593.
