### PR TITLE
fix(import): keep JSON test steps intact on manual create and CSV import

### DIFF
--- a/docs/docs/import-export.md
+++ b/docs/docs/import-export.md
@@ -136,6 +136,10 @@ Steps can also contain markdown formatting:
 [{"step":{"type":"doc","content":[...]},"expectedResult":{"type":"doc","content":[...]}}]
 ```
 
+**Separate Expected Result column** — if your file keeps the expected result in its own column, map that column to **Expected Result** on the mapping page. The Steps cell is then imported as a single step, however many lines it spans, with that column as its expected result. Cells in the JSON or labeled export formats keep the expected results they already contain.
+
+**JSON payloads** — a Steps or Expected Result cell that holds a JSON value (a request body, an API response) is imported as a single step, verbatim, with its indentation kept. It is not split into one step per line and not read as Markdown.
+
 ##### Multiple Rows per Case (Multi-Row Mode)
 
 Choose **"Test cases can span multiple rows"** on the first wizard page to import CSVs where one test case spans several rows — one row per step. This is the shape TestPlanIt's own multi-row export emits, and it matches the format used by many third-party tools.

--- a/testplanit/app/[locale]/projects/repository/[projectId]/ImportCasesWizard.tsx
+++ b/testplanit/app/[locale]/projects/repository/[projectId]/ImportCasesWizard.tsx
@@ -461,9 +461,10 @@ export function ImportCasesWizard({
         type: "Steps",
       },
       {
-        // Multi-row mode only: pairs with the row's "steps" column so users
-        // can map a custom column header (e.g. "Outcome") to the per-step
-        // expected result instead of relying on alias-based auto-detection.
+        // Pairs with the row's "steps" column. Multi-row mode: names the
+        // per-step expected result column instead of relying on alias-based
+        // auto-detection. Single-row mode: the Steps cell becomes one step
+        // carrying this cell as its expected result.
         id: "expectedResult",
         displayName: tCommon("fields.expectedResult"),
         isRequired: false,
@@ -1405,12 +1406,13 @@ export function ImportCasesWizard({
    */
   const renderStepsPreview = (
     stepsValue: string,
-    aggregatedSteps?: AggregatedStep[]
+    aggregatedSteps?: AggregatedStep[],
+    expectedResult?: string
   ) => {
     const steps =
       aggregatedSteps && aggregatedSteps.length > 0
         ? [...aggregatedSteps].sort((a, b) => a.order - b.order)
-        : parseStepsCell(stepsValue ?? "");
+        : parseStepsCell(stepsValue ?? "", expectedResult);
 
     if (steps.length === 0) {
       return stepsValue ? (
@@ -1442,6 +1444,19 @@ export function ImportCasesWizard({
         ))}
       </div>
     );
+  };
+
+  // The mapped Expected Result cell of a single-row case, or undefined when the
+  // column isn't mapped (or multi-row aggregation owns the expected results).
+  const singleRowExpectedResult = (
+    caseData: Record<string, any>
+  ): string | undefined => {
+    if (rowMode === "multi") return undefined;
+    const mapping = fieldMappings.find(
+      (m) => m.templateField === "expectedResult"
+    );
+    if (!mapping) return undefined;
+    return caseData[mapping.csvColumn]?.toString() ?? "";
   };
 
   // Helper function to parse and render tags
@@ -1484,11 +1499,15 @@ export function ImportCasesWizard({
   const renderFieldValue = (
     field: { id: string; type: string } | undefined,
     value: string,
-    aggregatedSteps?: AggregatedStep[]
+    aggregatedSteps?: AggregatedStep[],
+    expectedResult?: string
   ) => {
     const isStepsField = field?.id === "steps" || field?.type === "Steps";
 
-    if (!value && !(isStepsField && aggregatedSteps?.length)) {
+    if (
+      !value &&
+      !(isStepsField && (aggregatedSteps?.length || expectedResult))
+    ) {
       return (
         <span className="text-muted-foreground">
           {tGlobal("sharedSteps.importWizard.page3.noValue")}
@@ -1508,7 +1527,7 @@ export function ImportCasesWizard({
     }
 
     if (isStepsField) {
-      return renderStepsPreview(value, aggregatedSteps);
+      return renderStepsPreview(value, aggregatedSteps, expectedResult);
     }
 
     if (field?.id === "tags" || field?.type === "Tags") {
@@ -1680,7 +1699,10 @@ export function ImportCasesWizard({
                             {renderFieldValue(
                               field,
                               value,
-                              caseData._aggregatedSteps
+                              caseData._aggregatedSteps,
+                              field?.id === "steps"
+                                ? singleRowExpectedResult(caseData)
+                                : undefined
                             )}
                           </div>
                         </div>

--- a/testplanit/app/actions/importGeneratedTestCases.integration.test.ts
+++ b/testplanit/app/actions/importGeneratedTestCases.integration.test.ts
@@ -497,5 +497,91 @@ describeIntegration(
         expect(rootFolders.length).toBe(1);
       }
     );
+
+    // A JSON body cannot carry NaN, but a server action restores it from the
+    // wire, and TipTap leaves one in a document pasted from HTML with a
+    // non-numeric `<ol start>` or table `colwidth`. Before the importer
+    // normalized its input, ZenStack rejected the whole version row:
+    // "Invalid create args for model RepositoryCaseVersions … expected
+    // string, received array at data.steps".
+    it(
+      "persists a step document that arrived with NaN instead of rejecting the version",
+      { timeout: 60_000 },
+      async () => {
+        const baseDb = await importDb();
+        const { importGeneratedTestCases } =
+          await import("./importGeneratedTestCases");
+        const { tag, project, template, workflow, repo, folder } =
+          await seedFixture(baseDb);
+
+        const pastedList = {
+          type: "doc",
+          content: [
+            {
+              type: "orderedList",
+              attrs: { start: NaN },
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "one" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        const result = await importGeneratedTestCases({
+          projectId: project.id,
+          projectName: project.name,
+          repositoryId: repo.id,
+          folderId: folder.id,
+          folderName: folder.name,
+          templateId: template.id,
+          templateName: template.templateName,
+          stateId: workflow.id,
+          stateName: workflow.name,
+          maxOrder: 0,
+          autoGenerateTags: false,
+          source: "MANUAL",
+          testCases: [
+            {
+              id: `${tag}-nan`,
+              name: `${tag}-pasted-case`,
+              fieldValues: {},
+              steps: [{ step: pastedList, expectedResult: pastedList }],
+            },
+          ],
+          fieldMappings: [],
+        } as any);
+
+        expect(result.errors).toEqual([]);
+        expect(result.status).toBe("success");
+        const caseId = result.importedIds[0];
+        cleanup.repositoryCaseIds.push(caseId);
+
+        const version = await baseDb.repositoryCaseVersions.findFirst({
+          where: { repositoryCaseId: caseId, version: 1 },
+          select: { steps: true },
+        });
+        const versionSteps = (version?.steps as any[]) ?? [];
+        expect(versionSteps).toHaveLength(1);
+        expect(versionSteps[0].step.content[0].attrs.start).toBeNull();
+        expect(
+          versionSteps[0].expectedResult.content[0].attrs.start
+        ).toBeNull();
+
+        const stepRows = await baseDb.steps.findMany({
+          where: { testCaseId: caseId },
+          select: { step: true },
+        });
+        expect(stepRows).toHaveLength(1);
+        expect((stepRows[0].step as any).content[0].attrs.start).toBeNull();
+      }
+    );
   }
 );

--- a/testplanit/app/api/repository/import/route.test.ts
+++ b/testplanit/app/api/repository/import/route.test.ts
@@ -915,6 +915,46 @@ describe("CSV Import API Route", () => {
       });
     });
 
+    it("imports a multi-line Steps cell as one step with the mapped Expected Result column (regression)", async () => {
+      const stepsCell =
+        '{\n  "task_id": "abc-123",\n  "document": "pan card"\n}';
+      const file =
+        `Name,Description,Steps,Expected Result\n` +
+        `Test with valid pan card image,Verify PAN extraction,"${stepsCell.replace(/"/g, '""')}","{ ""status"": ""completed"" }"`;
+
+      const request = createRequest({
+        projectId: 1,
+        file,
+        delimiter: ",",
+        hasHeaders: true,
+        encoding: "UTF-8",
+        templateId: 1,
+        importLocation: "single_folder",
+        folderId: 1,
+        fieldMappings: [
+          { csvColumn: "Name", templateField: "name" },
+          { csvColumn: "Description", templateField: "description" },
+          { csvColumn: "Steps", templateField: "steps" },
+          { csvColumn: "Expected Result", templateField: "expectedResult" },
+        ],
+      });
+
+      const response = await POST(request);
+      const result = await parseSSEResponse(response);
+
+      expect(result.error).toBeUndefined();
+      expect(result.complete?.errors ?? []).toEqual([]);
+      expect(mockEnhancedDb.steps.create).toHaveBeenCalledTimes(1);
+      const { data } = mockEnhancedDb.steps.create.mock.calls[0][0];
+      expect(data.order).toBe(0);
+      expect(JSON.stringify(data.step)).toContain(
+        '\\"task_id\\": \\"abc-123\\"'
+      );
+      expect(JSON.stringify(data.expectedResult)).toContain(
+        '\\"status\\": \\"completed\\"'
+      );
+    });
+
     it("imports multi-row CSV by collapsing continuation rows into one case (regression)", async () => {
       const file = [
         "ID,Name,Description,Step #,Step Content,Expected Result",

--- a/testplanit/app/api/repository/import/route.ts
+++ b/testplanit/app/api/repository/import/route.ts
@@ -333,11 +333,26 @@ export const POST = withAuditContext(async (request: NextRequest) => {
             fieldValues: {},
           };
 
+          const cellOf = (csvColumn: string) =>
+            body.hasHeaders
+              ? row[csvColumn]
+              : row[parseInt(csvColumn.replace(/\D/g, "")) - 1];
+          const expectedResultMapping =
+            body.rowMode === "multi"
+              ? undefined
+              : body.fieldMappings.find(
+                  (m) => m.templateField === "expectedResult"
+                );
+          const stepOptions = expectedResultMapping
+            ? {
+                expectedResult:
+                  cellOf(expectedResultMapping.csvColumn)?.toString() ?? "",
+              }
+            : undefined;
+
           // Map fields
           for (const mapping of body.fieldMappings) {
-            const csvValue = body.hasHeaders
-              ? row[mapping.csvColumn]
-              : row[parseInt(mapping.csvColumn.replace(/\D/g, "")) - 1];
+            const csvValue = cellOf(mapping.csvColumn);
 
             if (mapping.templateField === "folder") {
               caseData.folderPath = csvValue;
@@ -381,7 +396,8 @@ export const POST = withAuditContext(async (request: NextRequest) => {
                   const validatedValue = validateFieldValue(
                     csvValue,
                     field.caseField,
-                    rowIndex + 1
+                    rowIndex + 1,
+                    stepOptions
                   );
                   // Store steps separately for insertion into Steps table (not CaseFieldValues)
                   caseData.steps = validatedValue;
@@ -407,7 +423,8 @@ export const POST = withAuditContext(async (request: NextRequest) => {
                   const validatedValue = validateFieldValue(
                     csvValue,
                     field.caseField,
-                    rowIndex + 1
+                    rowIndex + 1,
+                    stepOptions
                   );
                   // Steps type fields go to the Steps table, not CaseFieldValues
                   if (field.caseField.type.type === "Steps") {
@@ -1150,7 +1167,8 @@ export const POST = withAuditContext(async (request: NextRequest) => {
 function validateFieldValue(
   value: any,
   field: CaseFields & { type: CaseFieldTypes; fieldOptions?: any[] },
-  _rowNumber: number
+  _rowNumber: number,
+  stepOptions?: { expectedResult: string }
 ): any {
   if (!value && field.isRequired) {
     throw new Error(`Required field cannot be empty`);
@@ -1266,13 +1284,15 @@ function validateFieldValue(
     case "Steps":
       // Same parse the wizard preview runs, so the preview and the import
       // never disagree on the step count.
-      return parseStepsCell(value.toString()).map((s) => ({
-        step: ensureTipTapJSON(s.step),
-        expectedResult: s.expectedResult
-          ? ensureTipTapJSON(s.expectedResult)
-          : null,
-        order: s.order,
-      }));
+      return parseStepsCell(value.toString(), stepOptions?.expectedResult).map(
+        (s) => ({
+          step: ensureTipTapJSON(s.step),
+          expectedResult: s.expectedResult
+            ? ensureTipTapJSON(s.expectedResult)
+            : null,
+          order: s.order,
+        })
+      );
 
     default:
       return value;

--- a/testplanit/components/tiptap/TipTapEditor.tsx
+++ b/testplanit/components/tiptap/TipTapEditor.tsx
@@ -37,6 +37,7 @@ import { Markdown } from "@tiptap/markdown";
 import { Slice } from "@tiptap/pm/model";
 import { ImageWithResize } from "./ImageWithResize";
 // Import browser-compatible generateJSON from core
+import { isJsonText } from "~/lib/utils/isJsonText";
 import {
   convertMarkdownToTipTapJSON,
   isLikelyMarkdown,
@@ -363,7 +364,7 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
         },
         handlePaste: (view, event) => {
           const text = event.clipboardData?.getData("text/plain");
-          if (!text || !isLikelyMarkdown(text)) {
+          if (!text || isJsonText(text) || !isLikelyMarkdown(text)) {
             return false;
           }
           try {

--- a/testplanit/lib/services/testCaseImport.test.ts
+++ b/testplanit/lib/services/testCaseImport.test.ts
@@ -1,8 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { createQuerySchemaFactory } from "@zenstackhq/orm";
+import { describe, expect, it, vi } from "vitest";
+
+const auditedTransactionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/audit/auditedTransaction", () => ({
+  auditedTransaction: auditedTransactionMock,
+}));
+
+vi.mock("~/lib/services/reviewGate", () => ({
+  resolveCreateStateRemap: vi.fn(async () => null),
+}));
+
 import {
   ImportInputSchema,
   persistGeneratedTestCases,
 } from "~/lib/services/testCaseImport";
+import { schema as zenstackSchema } from "~/zenstack/schema";
 
 /**
  * Server actions and JSON bodies do NOT deliver `undefined` values: React's
@@ -93,5 +106,156 @@ describe("persistGeneratedTestCases input validation", () => {
     expect(result.status).toBe("error");
     expect(result.message).toBe("Invalid input data");
     expect(result.errors[0]).toMatch(/^folderId: /);
+  });
+});
+
+describe("persistGeneratedTestCases JSON columns", () => {
+  function stubTx(captured: { version?: any; steps?: any }) {
+    return {
+      issue: { findFirst: vi.fn(async () => null) },
+      tags: { upsert: vi.fn() },
+      repositoryFolders: {
+        findUnique: vi.fn(),
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(),
+        create: vi.fn(),
+      },
+      workflows: { findUnique: vi.fn(async () => null) },
+      repositoryCases: {
+        findFirst: vi.fn(async () => null),
+        create: vi.fn(async () => ({ id: 500 })),
+        update: vi.fn(async () => ({ id: 500 })),
+      },
+      repositoryCaseIssue: { createMany: vi.fn(async () => ({ count: 0 })) },
+      repositoryCaseTag: { createMany: vi.fn(async () => ({ count: 0 })) },
+      attachments: { create: vi.fn() },
+      repositoryCaseVersions: {
+        create: vi.fn(async ({ data }: any) => {
+          captured.version = data;
+          return { id: 900 };
+        }),
+      },
+      caseFieldValues: { createMany: vi.fn() },
+      caseFieldVersionValues: { createMany: vi.fn() },
+      steps: {
+        createMany: vi.fn(async ({ data }: any) => {
+          captured.steps = data;
+        }),
+      },
+      testCaseParameter: { createMany: vi.fn() },
+      dataSet: { create: vi.fn() },
+      dataSetVersion: { create: vi.fn() },
+      dataSetRow: { createMany: vi.fn() },
+    };
+  }
+
+  /**
+   * A JSON body cannot carry NaN or Infinity, but React server actions do
+   * (Flight tags them and the server restores them). TipTap leaves both in a
+   * document when pasted HTML has a non-numeric `<ol start>` or table
+   * `colwidth`, and ZenStack's JsonValue validator then rejects the whole
+   * RepositoryCaseVersions.steps column ("expected string, received array at
+   * data.steps"). The importer has to hand the columns what a JSON body would
+   * have delivered.
+   */
+  it("stores NaN and Infinity from the server-action wire as null so the JSON columns validate", async () => {
+    const pastedList = {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { start: NaN },
+          content: [
+            {
+              type: "listItem",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "one" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const pastedTable = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  attrs: {
+                    colspan: 1,
+                    rowspan: Infinity,
+                    colwidth: [NaN],
+                    style: null,
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "key" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const captured: { version?: any; steps?: any } = {};
+    auditedTransactionMock.mockImplementationOnce(async (fn: any) =>
+      fn(stubTx(captured))
+    );
+    const result = await persistGeneratedTestCases(
+      {
+        ...buildInput(),
+        testCases: [
+          {
+            id: "case-1",
+            name: "Pasted case",
+            fieldValues: {},
+            tagIds: [],
+            issueIds: [],
+            steps: [{ step: pastedList, expectedResult: pastedTable }],
+          },
+        ],
+      } as any,
+      { userId: "u1", userName: "User" }
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.errors).toEqual([]);
+
+    const versionStep = captured.version.steps[0];
+    expect(versionStep.step.content[0].attrs.start).toBeNull();
+    const header = versionStep.expectedResult.content[0].content[0].content[0];
+    expect(header.attrs).toEqual({
+      colspan: 1,
+      rowspan: null,
+      colwidth: [null],
+      style: null,
+    });
+    expect(captured.steps[0].step.content[0].attrs.start).toBeNull();
+
+    const createSchema = createQuerySchemaFactory(
+      zenstackSchema as any
+    ).makeCreateSchema("RepositoryCaseVersions");
+    expect(createSchema.safeParse({ data: captured.version }).success).toBe(
+      true
+    );
+    // Negative control: the raw wire payload is what the validator rejects.
+    expect(
+      createSchema.safeParse({
+        data: {
+          ...captured.version,
+          steps: [{ step: pastedList, expectedResult: pastedTable }],
+        },
+      }).success
+    ).toBe(false);
   });
 });

--- a/testplanit/lib/services/testCaseImport.ts
+++ b/testplanit/lib/services/testCaseImport.ts
@@ -286,7 +286,10 @@ export async function persistGeneratedTestCases(
   input: ImportInput,
   author: ImportAuthor
 ): Promise<ImportResult> {
-  const parseResult = ImportInputSchema.safeParse(input);
+  // Server actions restore NaN / Infinity from the wire; the JSON columns take neither.
+  const parseResult = ImportInputSchema.safeParse(
+    JSON.parse(JSON.stringify(input))
+  );
   if (!parseResult.success) {
     return {
       status: "error",

--- a/testplanit/lib/utils/isJsonText.ts
+++ b/testplanit/lib/utils/isJsonText.ts
@@ -1,0 +1,17 @@
+/**
+ * Whole-text JSON data (an object or array) that is not a TipTap document.
+ * Such text is content to keep verbatim, never markdown or step lines to
+ * interpret.
+ */
+export const isJsonText = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (!/^[[{]/.test(trimmed)) return false;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (
+      typeof parsed === "object" && parsed !== null && parsed.type !== "doc"
+    );
+  } catch {
+    return false;
+  }
+};

--- a/testplanit/lib/utils/parseExportedSteps.test.ts
+++ b/testplanit/lib/utils/parseExportedSteps.test.ts
@@ -169,6 +169,14 @@ describe("tryParseJsonSteps", () => {
   it("returns null for JSON that isn't an array", () => {
     expect(tryParseJsonSteps('{"step":"x"}')).toBeNull();
   });
+
+  it("returns null for an array that isn't a list of steps", () => {
+    expect(tryParseJsonSteps('["open", "click"]')).toBeNull();
+    expect(
+      tryParseJsonSteps('[{"task_id": "abc"}, {"task_id": "def"}]')
+    ).toBeNull();
+    expect(tryParseJsonSteps("[]")).toBeNull();
+  });
 });
 
 describe("parseStepsCell", () => {
@@ -223,5 +231,50 @@ describe("parseStepsCell", () => {
   it("returns nothing for an empty cell", () => {
     expect(parseStepsCell("")).toEqual([]);
     expect(parseStepsCell("   ")).toEqual([]);
+  });
+
+  it("keeps a JSON payload as one verbatim step even with no Expected Result column mapped", () => {
+    const object = '{\n  "task_id": "abc",\n  "document": "pan card"\n}';
+    expect(parseStepsCell(object)).toEqual([
+      { step: object, expectedResult: "", order: 0 },
+    ]);
+
+    const records = '[\n  {"task_id": "abc"},\n  {"task_id": "def"}\n]';
+    expect(parseStepsCell(records)).toEqual([
+      { step: records, expectedResult: "", order: 0 },
+    ]);
+  });
+
+  it("keeps a multi-line cell as one step when an Expected Result column is mapped", () => {
+    const cell = '{\n  "task_id": "abc",\n  "document": "pan card"\n}';
+
+    expect(parseStepsCell(cell, "status: success")).toEqual([
+      { step: cell, expectedResult: "status: success", order: 0 },
+    ]);
+  });
+
+  it("lets JSON and labeled cells keep their own expected results when a column is mapped", () => {
+    const json = JSON.stringify([
+      { step: "Open page", expectedResult: "Page loads" },
+      { step: "Click save", expectedResult: "Saved" },
+    ]);
+    expect(
+      parseStepsCell(json, "ignored").map((s) => s.expectedResult)
+    ).toEqual(["Page loads", "Saved"]);
+
+    const labeled = "Step 1:\nOpen the page\nExpected Result 1:\nIt loads";
+    expect(parseStepsCell(labeled, "ignored")).toEqual([
+      { step: "Open the page", expectedResult: "It loads", order: 0 },
+    ]);
+  });
+
+  it("attaches an empty mapped expected result and drops a row with neither", () => {
+    expect(parseStepsCell("Do the thing", "")).toEqual([
+      { step: "Do the thing", expectedResult: "", order: 0 },
+    ]);
+    expect(parseStepsCell("", "Only a result")).toEqual([
+      { step: "", expectedResult: "Only a result", order: 0 },
+    ]);
+    expect(parseStepsCell("", "")).toEqual([]);
   });
 });

--- a/testplanit/lib/utils/parseExportedSteps.ts
+++ b/testplanit/lib/utils/parseExportedSteps.ts
@@ -1,4 +1,5 @@
 import { extractTextFromNode } from "~/utils/extractTextFromJson";
+import { isJsonText } from "./isJsonText";
 
 export interface ParsedExportedStep {
   step: string;
@@ -69,18 +70,35 @@ export function parseLabeledSteps(text: string): ParsedExportedStep[] {
  * `---`), and the legacy one-step-per-line form where a `|` splits the action
  * from its expected result.
  *
+ * `expectedResult` is the row's mapped Expected Result cell. When that column
+ * is mapped the cell is one step carrying it, however many lines it spans;
+ * the JSON and labeled forms keep the expected results they already hold.
+ * Any other JSON value in the cell (a payload, not steps) is one step too.
+ *
  * The import wizard's preview and the import route both call this — a preview
  * that parses the cell its own way shows a different step count than the one
  * the import creates.
  */
-export function parseStepsCell(text: string): ParsedExportedStep[] {
+export function parseStepsCell(
+  text: string,
+  expectedResult?: string
+): ParsedExportedStep[] {
   const stepsText = text?.toString() ?? "";
-  if (!stepsText.trim()) return [];
 
   const jsonParsed = tryParseJsonSteps(stepsText);
   if (jsonParsed) return jsonParsed;
 
   if (hasLabeledStepFormat(stepsText)) return parseLabeledSteps(stepsText);
+
+  if (expectedResult !== undefined || isJsonText(stepsText)) {
+    const step = stepsText.trim();
+    const expected = expectedResult?.toString().trim() ?? "";
+    return step || expected
+      ? [{ step, expectedResult: expected, order: 0 }]
+      : [];
+  }
+
+  if (!stepsText.trim()) return [];
 
   return stepsText
     .split(/\n/)
@@ -104,6 +122,12 @@ export function tryParseJsonSteps(text: string): ParsedExportedStep[] | null {
     return null;
   }
   if (!Array.isArray(parsed)) return null;
+  // Only the export shape is a list of steps; any other array is a payload.
+  const isStepShaped = (item: unknown) =>
+    typeof item === "object" &&
+    item !== null &&
+    ("step" in item || "expectedResult" in item);
+  if (parsed.length === 0 || !parsed.every(isStepShaped)) return null;
 
   return parsed.map((item: any, index) => {
     const stepValue = item?.step;

--- a/testplanit/utils/tiptapConversion.test.ts
+++ b/testplanit/utils/tiptapConversion.test.ts
@@ -7,6 +7,7 @@ import {
   isLikelyMarkdown,
   serializeTipTapJSON,
 } from "./tiptapConversion";
+import { isJsonText } from "~/lib/utils/isJsonText";
 
 describe("convertTextToTipTapJSON", () => {
   it("should convert simple text to TipTap JSON doc", () => {
@@ -273,6 +274,62 @@ describe("convertMarkdownToTipTapJSON", () => {
     const result = convertMarkdownToTipTapJSON(md);
     expect(result.type).toBe("doc");
     expect(result.content!.length).toBeGreaterThan(1);
+  });
+});
+
+describe("isJsonText", () => {
+  it("recognizes a JSON object or array that is not a document", () => {
+    expect(isJsonText('{\n  "task_id": "abc"\n}')).toBe(true);
+    expect(isJsonText('  [1, 2, {"a": null}]  ')).toBe(true);
+  });
+
+  it("rejects documents, prose and broken JSON", () => {
+    expect(isJsonText('{"type":"doc","content":[]}')).toBe(false);
+    expect(isJsonText("Click **Save** and check [x](y)")).toBe(false);
+    expect(isJsonText('{"task_id": ')).toBe(false);
+    expect(isJsonText("42")).toBe(false);
+  });
+});
+
+describe("ensureTipTapJSON with JSON text", () => {
+  const collectText = (node: any): string[] =>
+    node.type === "text"
+      ? [node.text]
+      : (node.content ?? []).flatMap(collectText);
+  const collectMarks = (node: any): string[] => [
+    ...(node.marks ?? []).map((m: any) => m.type),
+    ...(node.content ?? []).flatMap(collectMarks),
+  ];
+
+  it("keeps JSON verbatim instead of reading it as markdown", () => {
+    const text = [
+      "{",
+      '  "glob": "*.png or *.jpg",',
+      '  "note": "**not bold** and [not a link](https://x.y)",',
+      '  "steps": "- not a list"',
+      "}",
+    ].join("\n");
+
+    const doc = ensureTipTapJSON(text);
+
+    expect(doc.type).toBe("doc");
+    expect(doc.content?.every((n) => n.type === "paragraph")).toBe(true);
+    expect(collectMarks(doc)).toEqual([]);
+    // One text node per line, indentation included, joined by hard breaks.
+    expect(collectText(doc)).toEqual(text.split("\n"));
+  });
+
+  it("normalizes CRLF line endings from spreadsheet cells", () => {
+    const doc = ensureTipTapJSON('{\r\n  "a": 1\r\n}');
+    expect(collectText(doc)).toEqual(["{", '  "a": 1', "}"]);
+  });
+
+  it("still returns a serialized document as the document itself", () => {
+    const serialized = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "x" }] }],
+    });
+    expect(ensureTipTapJSON(serialized)).toEqual(JSON.parse(serialized));
   });
 });
 

--- a/testplanit/utils/tiptapConversion.ts
+++ b/testplanit/utils/tiptapConversion.ts
@@ -7,6 +7,7 @@ import { generateJSON } from "@tiptap/html";
 import { StarterKit } from "@tiptap/starter-kit";
 import { marked } from "marked";
 import { emptyEditorContent } from "~/app/constants/backend";
+import { isJsonText } from "~/lib/utils/isJsonText";
 
 const tiptapConversionExtensions = [
   StarterKit.configure({
@@ -215,6 +216,48 @@ export const convertTextToTipTapJSON = (text: string): JSONContent => {
   return convertHtmlToTipTapJSON(html);
 };
 
+/**
+ * A serialized TipTap document, or `null` when the text is anything else —
+ * including JSON that is not a document.
+ */
+const parseTipTapDocument = (text: string): JSONContent | null => {
+  if (!text.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && parsed.type === "doc"
+      ? (parsed as JSONContent)
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Text as paragraphs of hard-broken lines, kept verbatim: no markdown, list
+ * or inline-formatting interpretation, and indentation intact.
+ */
+export const convertPlainTextToTipTapJSON = (text: string): JSONContent => {
+  const trimmed = text ? text.replace(/\r\n?/g, "\n").trim() : "";
+  if (!trimmed) {
+    return emptyEditorContent as JSONContent;
+  }
+
+  const paragraphs = trimmed
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/^\n+|\n+$/g, ""))
+    .filter((block) => block.length > 0)
+    .map((block) => {
+      const content: JSONContent[] = [];
+      block.split("\n").forEach((line, index) => {
+        if (index > 0) content.push({ type: "hardBreak" });
+        if (line.length > 0) content.push({ type: "text", text: line });
+      });
+      return { type: "paragraph", content };
+    });
+
+  return { type: "doc", content: paragraphs };
+};
+
 export const ensureTipTapJSON = (value: any): JSONContent => {
   if (value === null || value === undefined) {
     return emptyEditorContent as JSONContent;
@@ -226,15 +269,11 @@ export const ensureTipTapJSON = (value: any): JSONContent => {
       return emptyEditorContent as JSONContent;
     }
 
-    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-      try {
-        const parsed = JSON.parse(trimmed);
-        if (parsed && typeof parsed === "object" && parsed.type === "doc") {
-          return parsed as JSONContent;
-        }
-      } catch {
-        // fall through to plain-text handling
-      }
+    const document = parseTipTapDocument(trimmed);
+    if (document) return document;
+
+    if (isJsonText(trimmed)) {
+      return convertPlainTextToTipTapJSON(trimmed);
     }
 
     if (/<\/?[a-z]/i.test(trimmed) && trimmed.includes(">")) {


### PR DESCRIPTION
## Description

Two customer-reported failures on 1.0.x, both in the same feature (JSON payloads as test steps), plus the latent third one found on the way.

- **"Create Test Case" failed with `Invalid create args for model "RepositoryCaseVersions": Validation error: Invalid input: expected string, received array at "data.steps" or …`.** The message is ZenStack's JSON-value validator rejecting a non-finite number somewhere inside the step documents. A JSON body can never carry one, but React server actions do: Flight encodes `NaN` / `±Infinity` / `-0` and the server restores them, and TipTap leaves a `NaN` in a document pasted from HTML with a non-numeric `<ol start>` or table `colwidth`. `persistGeneratedTestCases` now normalizes its input to exactly what a JSON body would have delivered (`NaN` and `Infinity` become `null`), for every caller of the service.
- **A single-row CSV whose Steps cell held a pretty-printed JSON object imported as one step per line (`{`, `"task_id": …`, …) with no expected results, although an Expected Result column was mapped.** `parseStepsCell` recognizes the export's JSON array and the labeled block format and otherwise falls back to one step per line, and the wizard's Expected Result mapping was only honored by multi-row aggregation. Now a mapped Expected Result column makes the Steps cell a single step carrying it; any whole-cell JSON value (an object, or an array that isn't the export's step shape) is a single verbatim step even without the mapping; and an array is only read as steps when every item is step-shaped (`["a","b"]` used to produce two empty steps). The route, the wizard preview and the docs follow the parser, so the preview count matches what the import creates.
- **JSON text was run through markdown detection**, on paste in the editor and in `ensureTipTapJSON` on import. Pretty JSON containing `[text](url)` was flattened into one paragraph with bold, italic and code marks, and `"*.png or *.jpg"` picked up italics. Whole-text JSON now stays verbatim with its indentation, as paragraphs of hard-broken lines.

## Related Issue

Customer report (no issue filed).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests — `lib/services/testCaseImport.test.ts` (NaN/Infinity stored as null, asserted against the real ZenStack create-schema with a negative control on the raw payload), `lib/utils/parseExportedSteps.test.ts` (24), `app/api/repository/import/route.test.ts` (new single-row Expected Result regression: the reported CSV shape yields one step with the expected result), `utils/tiptapConversion.test.ts` (`isJsonText`, verbatim JSON, CRLF cells), plus the wizard and editor suites: 151 tests across the six touched suites. Each fix was mutation-checked: reverting only that fix fails its tests.
- [x] Integration tests — `app/actions/importGeneratedTestCases.integration.test.ts` against a live database (`RUN_DB_INTEGRATION=1`): a NaN-bearing step document now persists; against the unfixed service the same case reproduces the reported error text verbatim.
- [ ] E2E tests
- [x] Manual testing — full `pnpm precommit` gate (866 test files, 12,945 tests passed, 0 lint errors, docs site built) and `tsc --noEmit` on the final tree. Not exercised in a browser: the wizard preview and the editor paste guard.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): n/a
- Node version: v24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

## Additional Notes

The server-action fix also sits uncommitted in the `release/v1.1` worktree; it reaches 1.1 through the usual main → 1.1 merge instead.
