### PR TITLE
ci: gate pushes with a11y-smoke and resolve the deferred code-scanning findings

### DIFF
--- a/.github/workflows/a11y-smoke.yml
+++ b/.github/workflows/a11y-smoke.yml
@@ -16,12 +16,24 @@ name: A11y Smoke (Accessible themes)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main, 'release/**']
+    paths:
+      - "testplanit/app/**"
+      - "testplanit/components/**"
+      - "testplanit/styles/globals.css"
+      - "testplanit/e2e/a11y/**"
+      - ".github/workflows/a11y-smoke.yml"
   pull_request:
     paths:
       - "testplanit/app/**"
       - "testplanit/components/**"
       - "testplanit/styles/globals.css"
       - "testplanit/e2e/a11y/**"
+      - ".github/workflows/a11y-smoke.yml"
+
+permissions:
+  contents: read
 
 defaults:
   run:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-cli:
     strategy:

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -26,6 +26,9 @@ on:
       - "testplanit/db/**"
       - ".github/workflows/db-integration.yml"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: testplanit

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -20,6 +20,9 @@ on:
         default: 'docs'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-amd64:
     runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -35,6 +35,9 @@ on:
       - "testplanit/schema.zmodel"
       - ".github/workflows/e2e-smoke.yml"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: testplanit

--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -33,6 +33,9 @@ on:
       - '.github/scripts/packages-publish.mjs'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -29,6 +29,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-amd64:
     runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   # Build + publish ARM64 images natively on a macOS arm64 runner (Colima).
   build-arm64:

--- a/testplanit/app/api/admin/llm/available-models/pricing.ts
+++ b/testplanit/app/api/admin/llm/available-models/pricing.ts
@@ -8,6 +8,7 @@
 // LlmProviderConfig cost fields use ("Cost Per 1M Input Tokens").
 
 import { isCloudMetadataHostname } from "~/lib/utils/ssrf";
+import { stripTrailingSlashes } from "~/lib/utils/url";
 
 export interface ModelPricing {
   input: number;
@@ -41,10 +42,10 @@ export function assertAllowedUrl(url: string): URL {
  * as their endpoint. Strip that suffix to recover the API base URL.
  */
 export function stripChatCompletionsSuffix(endpoint: string): string {
-  return endpoint
-    .trim()
-    .replace(/\/+$/, "")
-    .replace(/\/chat\/completions$/, "");
+  return stripTrailingSlashes(endpoint.trim()).replace(
+    /\/chat\/completions$/,
+    ""
+  );
 }
 
 function roundToDbScale(value: number): number {
@@ -160,7 +161,7 @@ export async function fetchLiteLlmPricing(
   apiKey?: string
 ): Promise<ModelPricingMap> {
   try {
-    const base = endpoint.trim().replace(/\/+$/, "");
+    const base = stripTrailingSlashes(endpoint.trim());
     const url = assertAllowedUrl(`${base}/model/info`);
     const headers: Record<string, string> = {};
     if (apiKey) {

--- a/testplanit/components/OfficeDocumentPreview.test.tsx
+++ b/testplanit/components/OfficeDocumentPreview.test.tsx
@@ -6,7 +6,9 @@ import { OfficeDocumentPreview } from "./OfficeDocumentPreview";
 // Hoisted mock fns so the vi.mock factories (which are hoisted above imports)
 // can reference them safely.
 const mocks = vi.hoisted(() => ({
-  renderAsync: vi.fn(async () => {}),
+  renderAsync: vi.fn(
+    async (_buffer: ArrayBuffer, _container: HTMLElement) => {}
+  ),
   xlsxRead: vi.fn(
     (): {
       SheetNames: string[];
@@ -89,6 +91,35 @@ describe("OfficeDocumentPreview", () => {
       "/api/storage/a.docx",
       expect.objectContaining({ signal: expect.anything() })
     );
+  });
+
+  it("strips script-capable link schemes from a rendered Word document", async () => {
+    mocks.renderAsync.mockImplementationOnce(async (_buffer, container) => {
+      container.innerHTML = [
+        '<a href="javascript:alert(1)">js</a>',
+        '<a href="data:text/html,hi">data</a>',
+        '<a href="vbscript:MsgBox(1)">vbs</a>',
+        '<a href="https://example.com/spec">external</a>',
+      ].join("");
+    });
+    render(
+      <OfficeDocumentPreview
+        fileURL="/api/storage/links.docx"
+        name="links.docx"
+        kind="word"
+        size="large"
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByText("external")).toHaveAttribute("target", "_blank")
+    );
+    expect(screen.getByText("external")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer"
+    );
+    for (const label of ["js", "data", "vbs"]) {
+      expect(screen.getByText(label)).not.toHaveAttribute("href");
+    }
   });
 
   it("parses and sanitizes an Excel document at large size", async () => {

--- a/testplanit/components/OfficeDocumentPreview.tsx
+++ b/testplanit/components/OfficeDocumentPreview.tsx
@@ -12,6 +12,17 @@ import styles from "./OfficeDocumentPreview.module.css";
  * in the browser, so a very large document can't freeze the tab. */
 const MAX_PREVIEW_BYTES = 25 * 1024 * 1024;
 
+/** Link schemes a rendered document may keep; anything else loses its href. */
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function isSafeLinkHref(href: string): boolean {
+  try {
+    return SAFE_LINK_PROTOCOLS.has(new URL(href, document.baseURI).protocol);
+  } catch {
+    return false;
+  }
+}
+
 type PreviewStatus = "loading" | "ready" | "error" | "tooLarge" | "empty";
 
 interface OfficeDocumentPreviewProps {
@@ -104,15 +115,16 @@ export const OfficeDocumentPreview: React.FC<OfficeDocumentPreviewProps> = ({
             ignoreLastRenderedPageBreak: true,
           });
           if (!active) return;
-          // Neutralize javascript: links and force external links to open safely.
+          // Drop script-capable links and force the rest to open safely.
           container.querySelectorAll("a").forEach((anchor) => {
             const href = anchor.getAttribute("href")?.trim() ?? "";
-            if (href.toLowerCase().startsWith("javascript:")) {
+            if (!href) return;
+            if (!isSafeLinkHref(href)) {
               anchor.removeAttribute("href");
-            } else if (href) {
-              anchor.setAttribute("target", "_blank");
-              anchor.setAttribute("rel", "noopener noreferrer");
+              return;
             }
+            anchor.setAttribute("target", "_blank");
+            anchor.setAttribute("rel", "noopener noreferrer");
           });
           setStatus("ready");
         } else if (kind === "excel") {

--- a/testplanit/lib/llm/adapters/anthropic.adapter.test.ts
+++ b/testplanit/lib/llm/adapters/anthropic.adapter.test.ts
@@ -77,6 +77,31 @@ describe("AnthropicAdapter", () => {
       const adapter = new AnthropicAdapter(config);
       expect(adapter.getProviderName()).toBe("Anthropic");
     });
+
+    it("strips trailing slashes from the base URL", async () => {
+      const adapter = new AnthropicAdapter(
+        createTestConfig({ baseUrl: "https://proxy.example.com/v1///" })
+      );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "Response" }],
+          model: "claude-3-5-sonnet-20241022",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 10 },
+        }),
+      });
+
+      await adapter.chat({
+        messages: [{ role: "user", content: "Hello" }],
+        userId: "user-123",
+        feature: "test",
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://proxy.example.com/v1/messages"
+      );
+    });
   });
 
   describe("chat", () => {

--- a/testplanit/lib/llm/adapters/anthropic.adapter.ts
+++ b/testplanit/lib/llm/adapters/anthropic.adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from "../types";
 import { contentImages, flattenToText } from "../content";
 import { BaseLlmAdapter } from "./base.adapter";
+import { stripTrailingSlashes } from "~/lib/utils/url";
 
 type AnthropicContentBlock =
   | { type: "text"; text: string }
@@ -107,9 +108,8 @@ export class AnthropicAdapter extends BaseLlmAdapter {
     // Strip trailing slashes so appending `/messages` can't produce a double
     // slash (e.g. a user-supplied `.../v1/` becoming `.../v1//messages`).
     // Mirrors the normalization the available-models route already does.
-    this.baseUrl = (config.baseUrl || "https://api.anthropic.com/v1").replace(
-      /\/+$/,
-      ""
+    this.baseUrl = stripTrailingSlashes(
+      config.baseUrl || "https://api.anthropic.com/v1"
     );
 
     if (!this.apiKey) {

--- a/testplanit/lib/scim/rate-limit.test.ts
+++ b/testplanit/lib/scim/rate-limit.test.ts
@@ -75,6 +75,9 @@ describe("checkScimTokenRateLimit", () => {
     });
 
     it("A2: 50th call still allowed (remaining=0); 51st blocked", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-06T00:00:00.500Z").getTime());
+
       const tokenId = "tk_a2";
       for (let i = 1; i < SCIM_RPS_LIMIT; i++) {
         const r = await checkScimTokenRateLimit(tokenId);
@@ -168,6 +171,9 @@ describe("checkScimTokenRateLimit", () => {
 
   describe("Group C — in-memory fallback", () => {
     it("C1: when valkeyConnection is null, uses internal Map (counter increments per call)", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-06T00:00:00.500Z").getTime());
+
       const tokenId = "tk_c1";
       const r1 = await checkScimTokenRateLimit(tokenId);
       const r2 = await checkScimTokenRateLimit(tokenId);

--- a/testplanit/lib/utils/url.test.ts
+++ b/testplanit/lib/utils/url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { stripTrailingSlashes } from "./url";
+
+describe("stripTrailingSlashes", () => {
+  it("removes every trailing slash", () => {
+    expect(stripTrailingSlashes("https://proxy.example.com/v1///")).toBe(
+      "https://proxy.example.com/v1"
+    );
+  });
+
+  it("leaves strings without a trailing slash untouched", () => {
+    expect(stripTrailingSlashes("https://proxy.example.com/v1")).toBe(
+      "https://proxy.example.com/v1"
+    );
+    expect(stripTrailingSlashes("")).toBe("");
+  });
+
+  it("keeps interior slashes", () => {
+    expect(stripTrailingSlashes("a//b/")).toBe("a//b");
+  });
+
+  it("empties a string made only of slashes", () => {
+    expect(stripTrailingSlashes("////")).toBe("");
+  });
+
+  it("handles a long run of interior slashes in linear time", () => {
+    const input = `${"/".repeat(200_000)}x`;
+    expect(stripTrailingSlashes(input)).toBe(input);
+  });
+});

--- a/testplanit/lib/utils/url.ts
+++ b/testplanit/lib/utils/url.ts
@@ -1,0 +1,8 @@
+// A loop rather than /\/+$/: that regex backtracks quadratically on long runs of "/".
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}

--- a/testplanit/services/forecastService.ts
+++ b/testplanit/services/forecastService.ts
@@ -191,7 +191,8 @@ export async function updateRepositoryCaseForecast(
         await syncRepositoryCaseToElasticsearch(current.id).catch(
           (error: unknown) => {
             console.error(
-              `Failed to sync case ${current.id} forecast to Elasticsearch:`,
+              "Failed to sync case %s forecast to Elasticsearch:",
+              current.id,
               error
             );
           }
@@ -237,7 +238,8 @@ export async function updateRepositoryCaseForecast(
     };
   } catch (error) {
     console.error(
-      `Error updating group forecast for RepositoryCase ID ${repositoryCaseId}:`,
+      "Error updating group forecast for RepositoryCase ID %s:",
+      repositoryCaseId,
       error
     );
     throw error;
@@ -348,7 +350,8 @@ export async function updateTestRunForecast(
         // document carries both forecast fields too (`testRunSearch`).
         await syncTestRunToElasticsearch(testRunId).catch((error: unknown) => {
           console.error(
-            `Failed to sync run ${testRunId} cleared forecast to Elasticsearch:`,
+            "Failed to sync run %s cleared forecast to Elasticsearch:",
+            testRunId,
             error
           );
         });
@@ -412,7 +415,8 @@ export async function updateTestRunForecast(
       // See the cleared-forecast write above — same plugin bypass.
       await syncTestRunToElasticsearch(testRunId).catch((error: unknown) => {
         console.error(
-          `Failed to sync run ${testRunId} forecast to Elasticsearch:`,
+          "Failed to sync run %s forecast to Elasticsearch:",
+          testRunId,
           error
         );
       });
@@ -425,7 +429,8 @@ export async function updateTestRunForecast(
     }
   } catch (error) {
     console.error(
-      `Error updating forecast for TestRun ID ${testRunId}:`,
+      "Error updating forecast for TestRun ID %s:",
+      testRunId,
       error
     );
     throw error;

--- a/testplanit/services/testRunService.test.ts
+++ b/testplanit/services/testRunService.test.ts
@@ -229,7 +229,8 @@ describe("testRunService", () => {
       await updateTestRunForecast(1);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Error updating forecast for TestRun 1:",
+        "Error updating forecast for TestRun %s:",
+        1,
         expect.any(Error)
       );
       expect(mockUpdate).not.toHaveBeenCalled();
@@ -247,7 +248,8 @@ describe("testRunService", () => {
       await updateTestRunForecast(1);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Error updating forecast for TestRun 1:",
+        "Error updating forecast for TestRun %s:",
+        1,
         expect.any(Error)
       );
 

--- a/testplanit/services/testRunService.ts
+++ b/testplanit/services/testRunService.ts
@@ -73,7 +73,8 @@ export async function updateTestRunForecast(testRunId: number): Promise<void> {
     // Best-effort: search drift must not fail the forecast update.
     await syncTestRunToElasticsearch(testRunId).catch((error: unknown) => {
       console.error(
-        `Failed to sync run ${testRunId} forecast to Elasticsearch:`,
+        "Failed to sync run %s forecast to Elasticsearch:",
+        testRunId,
         error
       );
     });
@@ -82,7 +83,7 @@ export async function updateTestRunForecast(testRunId: number): Promise<void> {
       `Updated forecast for TestRun ${testRunId} to forecastManual=${totalForecastManual}, forecastAutomated=${totalForecastAutomated}`
     );
   } catch (error) {
-    console.error(`Error updating forecast for TestRun ${testRunId}:`, error);
+    console.error("Error updating forecast for TestRun %s:", testRunId, error);
     // Depending on requirements, you might want to re-throw the error
     // or implement more specific error handling.
   }


### PR DESCRIPTION
## Description

Post-1.0 hardening deferred from the v1.0.0 release: the two CI gaps and the deferred code-scanning findings recorded in #605.

**CI**

- `a11y-smoke.yml` now also runs on push to `main` and `release/**` (with its own path in both filters), so a critical violation can no longer sit on a release branch unscanned between pull requests. `beta` is not in the list because it was retired in #628.
- All eight workflows that had no top-level `permissions:` block now declare `contents: read`. CodeQL had only flagged the three whose jobs carry no block at all (`a11y-smoke`, `db-integration`, `e2e-smoke`); the five release workflows already grant write per job, so there this documents the existing guarantee with no behavior change.

**Code scanning**

- `OfficeDocumentPreview.tsx` (incomplete URL scheme check): confirmed as a real gap. The `href` of a link in a rendered Word document stays in the DOM with `target="_blank"`, and only a literal `javascript:` prefix was stripped. Links now go through the URL parser and keep their `href` only for `http:`, `https:`, `mailto:` and `tel:`, which also covers `data:`, `vbscript:` and tab-obfuscated schemes.
- Polynomial ReDoS (`anthropic.adapter.ts`, `pricing.ts` x2): `/\/+$/` backtracks quadratically on long runs of `/`. The three flagged sites now use a new `stripTrailingSlashes` loop helper in `lib/utils/url.ts`. Identical regexes elsewhere were not flagged and are unchanged.
- Externally-controlled format string (`forecastService.ts`, `testRunService.ts`): triaged as benign. Each site is a multi-argument `console.error` whose first argument interpolates an id, so a `%s` in the id could only garble a log line. All seven calls now pass a literal `%s` format with the id as an argument, so the alert stops reappearing on every line shift.

The `stripHtmlTags.ts` and available-models SSRF findings were assessed and dismissed in the issue and are untouched here.

## Related Issue

Closes #605

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing

New tests: `lib/utils/url.test.ts` (including a 200k-slash input that would time out under the regex), a Word-preview test that renders `javascript:`, `data:` and `vbscript:` links and checks they lose their `href` while an `https:` link gets `target` and `rel`, and an adapter test that a base URL with trailing slashes still requests `.../v1/messages`. `testRunService.test.ts` assertions were updated for the new `console.error` argument shape.

The full `pnpm precommit` chain (ESLint, type-check, Prettier, case-status check, full Vitest suite, docs build) passes locally.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): n/a
- Node version: 24.17.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

n/a

## Additional Notes

- Every alert named in the issue was already dismissed as "false positive" on 2026-09-08, so nothing reopens on GitHub; this PR is the record of the verdicts.
- Merging under the `ci:` title cuts no release.
- The push trigger costs two roughly 40-minute `ubuntu-latest` jobs per qualifying push to `main` or `release/**`.
- Not done here: bookmark links (`#anchor`) in Word previews resolve to `http(s):` and still open in a new tab, which predates this change; and the `build-cli` job in `cli-release.yml` holds `contents: write` it does not use.
