### PR TITLE
feat(uploads): make UPLOAD_MAX_MB take effect on prebuilt images

### DIFF
--- a/docs/docs/file-storage.md
+++ b/docs/docs/file-storage.md
@@ -219,7 +219,7 @@ A file over the limit is rejected before it is stored, with a message naming the
 maximum for that type.
 
 Attachments and inline document images share one knob, `UPLOAD_MAX_MB` (default
-`10`). Set it in the `.env` that Docker Compose reads, then rebuild:
+`10`). Set it in the `.env` that Docker Compose reads, then restart:
 
 ```bash
 # testplanit/.env
@@ -227,15 +227,16 @@ UPLOAD_MAX_MB=100
 ```
 
 ```bash
-docker compose -f docker-compose.prod.yml build prod
 docker compose -f docker-compose.prod.yml up -d prod
 ```
 
-A **rebuild** is required, not just a restart. Next.js freezes the matching
-server-action body limit into the standalone build, so a runtime-only change
-silently has no effect and uploads keep failing with an opaque error. Project
-icons and avatars are deliberately fixed — they are UI thumbnails, not
-operator-sized user payloads.
+No rebuild is needed, on an image you built or one you pulled. Next.js freezes
+the matching server-action body limit into the standalone build, so the
+container entrypoint rewrites that frozen value from `UPLOAD_MAX_MB` on every
+start — one variable drives both the transport limit and the per-file check. On
+Kubernetes, set `config.uploadMaxMb` in your Helm values instead. Project icons
+and avatars are deliberately fixed — they are UI thumbnails, not operator-sized
+user payloads.
 
 The bundled nginx separately caps any request body sent to the app at 10 MB. In
 proxy mode the file travels through the app server, so that ceiling applies to

--- a/docs/docs/kubernetes-deployment.md
+++ b/docs/docs/kubernetes-deployment.md
@@ -88,6 +88,14 @@ secrets:
 #   tag: "1.0.0"                  # pin instead of latest
 ```
 
+:::note Upload ceiling
+Attachments and inline images are capped at 10 MB per file by default. Raise
+`config.uploadMaxMb` and keep `ingress.annotations`'
+`nginx.ingress.kubernetes.io/proxy-body-size` (default `100m`) at or above it —
+whichever is lower rejects the upload. It applies on a pod restart; the image
+needs no rebuild.
+:::
+
 :::tip Live updates (SSE)
 The notification bell and live milestone / test-run updates use long-lived SSE
 streams. The chart's default ingress annotations do not disable proxy buffering, so

--- a/testplanit/Dockerfile
+++ b/testplanit/Dockerfile
@@ -137,9 +137,10 @@ ARG BASE_DOMAIN
 ARG SELF_HOSTED
 ENV SELF_HOSTED=${SELF_HOSTED}
 # Sizes serverActions.bodySizeLimit in next.config.ts. Next freezes experimental
-# config into the standalone output, so this has to be present at BUILD time --
-# a runtime-only value is too late. The production stage re-declares it for
-# app/actions/uploadFile.ts, which reads it at runtime.
+# config into the standalone output, so this sets the image's DEFAULT ceiling;
+# docker-entrypoint.sh re-syncs the frozen value from the runtime UPLOAD_MAX_MB
+# so a prebuilt image stays configurable. The production stage re-declares the
+# ARG for app/actions/uploadFile.ts, which reads it at runtime.
 ARG UPLOAD_MAX_MB
 ENV UPLOAD_MAX_MB=${UPLOAD_MAX_MB}
 ENV NODE_ENV=production
@@ -164,10 +165,11 @@ RUN npm run build
 # ---- Production ----
 FROM node:24-alpine AS production
 WORKDIR /app
-# Read at runtime by app/actions/uploadFile.ts. Defaulted from the same build arg
-# so an image built for a larger ceiling stays self-consistent under plain
+# Read at runtime by app/actions/uploadFile.ts, and by docker-entrypoint.sh to
+# re-sync Next's frozen server-action body limit. Defaulted from the same build
+# arg so an image built for a larger ceiling stays self-consistent under plain
 # `docker run`; compose passes it again via `environment:` so one variable in
-# .env drives both the baked body limit and the runtime per-file limit.
+# .env drives both the body limit and the per-file limit.
 ARG UPLOAD_MAX_MB
 ENV UPLOAD_MAX_MB=${UPLOAD_MAX_MB}
 ENV NODE_ENV=production

--- a/testplanit/docker-compose.prod.yml
+++ b/testplanit/docker-compose.prod.yml
@@ -22,9 +22,11 @@ services:
         # (shell / default .env / --env-file), NOT the .env.production env_file.
         SELF_HOSTED: ${SELF_HOSTED:-true}
         # Per-file upload ceiling in MB (attachments and inline document
-        # images). Baked into next.config's serverActions.bodySizeLimit at build
-        # time, so changing it needs a rebuild, not just a restart. Raise the
-        # bundled nginx to match via nginx-local/ -- see nginx-local/README.md.
+        # images). Baked into next.config's serverActions.bodySizeLimit as the
+        # image default; the entrypoint re-syncs it from the `environment:` value
+        # below on every start, so changing it needs a restart, not a rebuild.
+        # Raise the bundled nginx to match via nginx-local/ -- see
+        # nginx-local/README.md.
         # Substitution reads the build environment (shell / default .env /
         # --env-file), NOT the .env.production env_file.
         UPLOAD_MAX_MB: ${UPLOAD_MAX_MB:-10}
@@ -45,9 +47,9 @@ services:
       # burst absorption, not parallelism: it exists so a handful of slow
       # queries can't occupy every slot and stall unrelated routes.
       DATABASE_POOL_MAX: ${PROD_DATABASE_POOL_MAX:-100}
-      # Same value as the build arg above -- uploadFile.ts reads it at runtime
-      # while next.config bakes it at build time. Both resolve from one
-      # UPLOAD_MAX_MB in .env, so they cannot drift.
+      # Same value as the build arg above -- uploadFile.ts reads it at runtime,
+      # and the entrypoint re-syncs Next's frozen body limit from it at boot.
+      # Both resolve from one UPLOAD_MAX_MB in .env, so they cannot drift.
       UPLOAD_MAX_MB: ${UPLOAD_MAX_MB:-10}
     ports:
       - "${DOCKER_PROD_APP_PORT:-30000}:3000"

--- a/testplanit/docker-entrypoint.sh
+++ b/testplanit/docker-entrypoint.sh
@@ -29,5 +29,16 @@ DATABASE_URL="$INIT_DATABASE_URL" tsx scripts/apply-triggers.ts
 echo "Setting up PostgreSQL extensions..."
 DATABASE_URL="$INIT_DATABASE_URL" tsx db/setup-extensions.ts
 
+# UPLOAD_MAX_MB drives both the per-file check in app/actions/uploadFile.ts
+# (read at runtime) and Next's server-action body limit, which `next build`
+# freezes into the standalone output (inlined in server.js and in
+# .next/required-server-files.json). Rewrite those frozen copies so one variable
+# still drives both on an image this operator did not build -- the published
+# self-host images and the Helm chart ship a build-time default that would
+# otherwise be the real ceiling. No-op when the variable is unset, and never
+# fatal: if the file cannot be written the baked default stays in effect.
+tsx scripts/set-upload-body-limit.ts ||
+  echo "warning: could not sync the server-action body limit; the built-in default stays in effect"
+
 echo "Starting application..."
 exec "$@"

--- a/testplanit/helm/testplanit/README.md
+++ b/testplanit/helm/testplanit/README.md
@@ -175,6 +175,7 @@ commonly changed keys:
 | `workers.resources` | Worker tier size (keep `replicaCount` at 1). |
 | `workers.crawlScreenshots` | URL-crawl page screenshots for AI generation context (default `true`; set `false` to disable). |
 | `config.auth.*` | Signup / password / magic-link / email-verification toggles. |
+| `config.uploadMaxMb` | Per-file ceiling (MB) for attachments and inline images. Keep `ingress.annotations`' `proxy-body-size` at or above it. |
 | `config.email.*`, `secrets.emailPassword` | Outbound SMTP. |
 | `config.extraEnv`, `secrets.extraEnv`, `server.extraEnv`, `workers.extraEnv` | Escape hatches for any other env (OAuth clients, tuning knobs, read replicas, …). |
 | `postgresql.*`, `redis.*`, `elasticsearch.*`, `objectStorage.*` | Bundle or point at managed services. |

--- a/testplanit/helm/testplanit/templates/configmap.yaml
+++ b/testplanit/helm/testplanit/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
   NODE_ENV: "production"
   NEXTAUTH_URL: {{ required "appUrl is required (the public https URL of this instance)" .Values.appUrl | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
+  # Per-file upload ceiling. The entrypoint re-syncs Next's frozen server-action
+  # body limit from this, so it applies on a pod restart without a rebuild.
+  UPLOAD_MAX_MB: {{ .Values.config.uploadMaxMb | quote }}
   # Authentication surface
   ENABLE_SIGNUP: {{ .Values.config.auth.enableSignup | quote }}
   ENABLE_PASSWORD_AUTH: {{ .Values.config.auth.enablePasswordAuth | quote }}

--- a/testplanit/helm/testplanit/values.yaml
+++ b/testplanit/helm/testplanit/values.yaml
@@ -217,6 +217,13 @@ ingress:
 # -----------------------------------------------------------------------------
 config:
   nodeOptions: "--max-old-space-size=4096"
+  # Per-file ceiling in MB for attachments and inline document images (project
+  # icons and avatars are fixed UI thumbnails and ignore this). Drives the app's
+  # own check and, via the container entrypoint, Next's server-action body
+  # limit — so it takes effect on a restart, with no image rebuild.
+  # Keep ingress.annotations' nginx.ingress.kubernetes.io/proxy-body-size at or
+  # above this value, or the proxy rejects a large upload before the app sees it.
+  uploadMaxMb: 10
   # Authentication surface. Defaults suit an internal enterprise install
   # (password auth on, open signup off). Magic Link needs SMTP configured.
   auth:

--- a/testplanit/next.config.ts
+++ b/testplanit/next.config.ts
@@ -170,11 +170,13 @@ const nextConfig: NextConfig = {
     // to maxSize turns the friendly "File is too large" into an opaque
     // server-action error. The 10mb of headroom covers that overhead.
     //
-    // Like SELF_HOSTED, this MUST be set from a build ARG: Next freezes
-    // experimental config into the standalone build
+    // Next freezes experimental config into the standalone build
     // (.next/required-server-files.json) and the running server reads that
-    // frozen copy, so a runtime-only env var is too late and silently has no
-    // effect (uploads fail at the proxy layer with no useful message).
+    // frozen copy, so the build ARG sets the image's DEFAULT ceiling. It is not
+    // the last word: docker-entrypoint.sh rewrites the frozen value from the
+    // runtime UPLOAD_MAX_MB at boot (scripts/set-upload-body-limit.ts), which is
+    // what keeps a prebuilt image configurable. Keep the 10mb of headroom in
+    // step with BODY_LIMIT_HEADROOM_MB there.
     serverActions: {
       bodySizeLimit: `${uploadMaxMb + 10}mb`,
     },

--- a/testplanit/nginx-local/README.md
+++ b/testplanit/nginx-local/README.md
@@ -66,7 +66,8 @@ Two rules matter:
 - Raise the app's own per-upload limit to match — nginx only sets the outer
   ceiling, so a larger `client_max_body_size` on its own just moves the
   rejection from nginx to the app. Set `UPLOAD_MAX_MB` in the `.env` Compose
-  reads and rebuild the `prod` image (it is baked at build time). See
+  reads and restart the app containers — the entrypoint re-syncs Next's frozen
+  body limit from it, so no rebuild is needed. See
   [File Storage](../../docs/docs/file-storage.md#file-size-limits).
 
 Apply and verify the same way as above.

--- a/testplanit/scripts/set-upload-body-limit.test.ts
+++ b/testplanit/scripts/set-upload-body-limit.test.ts
@@ -6,9 +6,11 @@ import {
   BODY_LIMIT_HEADROOM_MB,
   FROZEN_CONFIG_FILES,
   bodySizeLimitFor,
+  describeSync,
   parseUploadMaxMb,
   replaceBodySizeLimit,
   syncBodySizeLimit,
+  type FileResult,
 } from "./set-upload-body-limit";
 
 // Shaped like the real standalone output: server.js carries the config inlined
@@ -130,6 +132,67 @@ describe("set-upload-body-limit", () => {
       "missing",
       "missing",
     ]);
+  });
+
+  describe("boot output", () => {
+    const warnings = (results: FileResult[]) =>
+      describeSync(results, "100")
+        .filter((line) => line.level === "warn")
+        .map((line) => line.message);
+
+    // The silent-revert case this exists to catch: a Next release that moves
+    // the frozen config would otherwise drop the ceiling back to the baked
+    // default with nothing in the logs.
+    it("warns when there is no limit to rewrite", () => {
+      expect(warnings([{ file: "server.js", status: "no-match" }])).toEqual([
+        expect.stringContaining(
+          "no serverActions.bodySizeLimit found in server.js"
+        ),
+      ]);
+    });
+
+    it("warns when a copy could not be written", () => {
+      expect(
+        warnings([{ file: "server.js", status: "failed", error: "EROFS" }])
+      ).toEqual([expect.stringContaining("could not write server.js")]);
+    });
+
+    // Dev and the workers image have no standalone tree at all.
+    it("stays quiet when every copy is absent", () => {
+      expect(
+        warnings([
+          { file: "server.js", status: "missing" },
+          { file: ".next/required-server-files.json", status: "missing" },
+        ])
+      ).toEqual([]);
+    });
+
+    it("warns when only some copies are absent", () => {
+      expect(
+        warnings([
+          { file: "server.js", status: "updated", from: "20mb", to: "110mb" },
+          { file: ".next/required-server-files.json", status: "missing" },
+        ])
+      ).toEqual([
+        expect.stringContaining("missing from an otherwise complete"),
+      ]);
+    });
+
+    it("reports each rewrite and stays quiet about no-ops", () => {
+      const lines = describeSync(
+        [
+          { file: "server.js", status: "updated", from: "20mb", to: "110mb" },
+          { file: ".next/required-server-files.json", status: "unchanged" },
+        ],
+        "100"
+      );
+      expect(lines).toEqual([
+        {
+          level: "log",
+          message: expect.stringContaining("server.js: 20mb -> 110mb"),
+        },
+      ]);
+    });
   });
 
   it("leaves a build that never set the key alone", () => {

--- a/testplanit/scripts/set-upload-body-limit.test.ts
+++ b/testplanit/scripts/set-upload-body-limit.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import {
+  BODY_LIMIT_HEADROOM_MB,
+  FROZEN_CONFIG_FILES,
+  bodySizeLimitFor,
+  parseUploadMaxMb,
+  replaceBodySizeLimit,
+  syncBodySizeLimit,
+} from "./set-upload-body-limit";
+
+// Shaped like the real standalone output: server.js carries the config inlined
+// as a JSON literal, required-server-files.json as compact JSON.
+const serverJs = (limit: string) =>
+  `const currentPort = parseInt(process.env.PORT, 10) || 3000\n` +
+  `const nextConfig = {"env":{},"experimental":{"serverActions":{"bodySizeLimit":"${limit}"}},"images":{"unoptimized":true}}\n` +
+  `process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig)\n`;
+
+const requiredServerFiles = (limit: string) =>
+  JSON.stringify({
+    version: 1,
+    config: {
+      images: { unoptimized: true },
+      experimental: { serverActions: { bodySizeLimit: limit } },
+    },
+    files: ["server.js"],
+  });
+
+function writeStandalone(limit: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "standalone-"));
+  mkdirSync(join(dir, ".next"));
+  writeFileSync(join(dir, "server.js"), serverJs(limit));
+  writeFileSync(
+    join(dir, ".next", "required-server-files.json"),
+    requiredServerFiles(limit)
+  );
+  return dir;
+}
+
+const limitsIn = (dir: string) =>
+  FROZEN_CONFIG_FILES.map(
+    (f) =>
+      readFileSync(join(dir, f), "utf-8").match(
+        /"bodySizeLimit":"([^"]*)"/
+      )?.[1]
+  );
+
+describe("set-upload-body-limit", () => {
+  it("keeps the headroom next.config.ts adds for multipart overhead", () => {
+    expect(bodySizeLimitFor(100)).toBe(`${100 + BODY_LIMIT_HEADROOM_MB}mb`);
+    // Guards against the two drifting apart: next.config.ts sizes the build-time
+    // default with the same headroom this script re-applies at boot.
+    const nextConfig = readFileSync(
+      join(__dirname, "..", "next.config.ts"),
+      "utf-8"
+    );
+    expect(nextConfig).toContain(
+      `\${uploadMaxMb + ${BODY_LIMIT_HEADROOM_MB}}mb`
+    );
+  });
+
+  it.each(["", undefined, "0", "-5", "abc"])(
+    "leaves the baked limit alone when UPLOAD_MAX_MB is %o",
+    (raw) => {
+      expect(parseUploadMaxMb(raw)).toBeNull();
+      const dir = writeStandalone("20mb");
+      expect(syncBodySizeLimit(dir, raw)).toBeNull();
+      expect(limitsIn(dir)).toEqual(["20mb", "20mb"]);
+    }
+  );
+
+  it("raises both frozen copies to match UPLOAD_MAX_MB", () => {
+    const dir = writeStandalone("20mb");
+    expect(syncBodySizeLimit(dir, "100")).toEqual([
+      {
+        file: join(dir, "server.js"),
+        status: "updated",
+        from: "20mb",
+        to: "110mb",
+      },
+      {
+        file: join(dir, ".next/required-server-files.json"),
+        status: "updated",
+        from: "20mb",
+        to: "110mb",
+      },
+    ]);
+    expect(limitsIn(dir)).toEqual(["110mb", "110mb"]);
+  });
+
+  // Authoritative in both directions, so an image built for a large ceiling
+  // cannot keep accepting oversized bodies after the operator lowers the knob.
+  it("lowers both frozen copies too", () => {
+    const dir = writeStandalone("110mb");
+    syncBodySizeLimit(dir, "10");
+    expect(limitsIn(dir)).toEqual(["20mb", "20mb"]);
+  });
+
+  it("matches the spaced spelling required-server-files.json uses", () => {
+    const spaced = '{"serverActions": {"bodySizeLimit": "20mb"}}';
+    const { text, from, occurrences } = replaceBodySizeLimit(spaced, "110mb");
+    expect({ from, occurrences }).toEqual({ from: "20mb", occurrences: 1 });
+    expect(text).toBe('{"serverActions": {"bodySizeLimit": "110mb"}}');
+  });
+
+  it("changes nothing but the limit", () => {
+    const before = serverJs("20mb");
+    const { text, from, occurrences } = replaceBodySizeLimit(before, "110mb");
+    expect({ from, occurrences }).toEqual({ from: "20mb", occurrences: 1 });
+    expect(text).toBe(before.replace('"20mb"', '"110mb"'));
+    // images.unoptimized is the other build-frozen value the self-host image
+    // depends on -- rewriting must not disturb it.
+    expect(text).toContain('"images":{"unoptimized":true}');
+  });
+
+  it("is a no-op when the limit already matches", () => {
+    const dir = writeStandalone("110mb");
+    expect(syncBodySizeLimit(dir, "100")?.map((r) => r.status)).toEqual([
+      "unchanged",
+      "unchanged",
+    ]);
+  });
+
+  // The workers image has no standalone tree; boot must not fail there.
+  it("reports missing files instead of throwing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "empty-"));
+    expect(syncBodySizeLimit(dir, "100")?.map((r) => r.status)).toEqual([
+      "missing",
+      "missing",
+    ]);
+  });
+
+  it("leaves a build that never set the key alone", () => {
+    const dir = mkdtempSync(join(tmpdir(), "no-key-"));
+    mkdirSync(join(dir, ".next"));
+    writeFileSync(join(dir, "server.js"), "const nextConfig = {}\n");
+    writeFileSync(join(dir, ".next", "required-server-files.json"), "{}");
+    expect(syncBodySizeLimit(dir, "100")?.map((r) => r.status)).toEqual([
+      "no-match",
+      "no-match",
+    ]);
+    expect(readFileSync(join(dir, "server.js"), "utf-8")).toBe(
+      "const nextConfig = {}\n"
+    );
+  });
+});

--- a/testplanit/scripts/set-upload-body-limit.ts
+++ b/testplanit/scripts/set-upload-body-limit.ts
@@ -126,20 +126,71 @@ export function syncBodySizeLimit(
   );
 }
 
+export type LogLine = { level: "log" | "warn"; message: string };
+
+/**
+ * Turn the per-file results into boot output. The case worth shouting about is
+ * "no-match": the operator asked for a ceiling and there was nothing to rewrite,
+ * which is what a future Next release changing where it freezes the config would
+ * look like. Without a warning that reverts the limit to the baked default
+ * silently, and the next person to hit it sees only an opaque upload failure.
+ */
+export function describeSync(
+  results: FileResult[],
+  rawUploadMaxMb: string
+): LogLine[] {
+  const lines: LogLine[] = [];
+  const matched = results.filter(
+    (r) => r.status === "updated" || r.status === "unchanged"
+  );
+  for (const result of results) {
+    switch (result.status) {
+      case "updated":
+        lines.push({
+          level: "log",
+          message: `Server-action body limit in ${result.file}: ${result.from} -> ${result.to} (UPLOAD_MAX_MB=${rawUploadMaxMb})`,
+        });
+        break;
+      case "failed":
+        lines.push({
+          level: "warn",
+          message: `WARNING: could not write ${result.file} (${result.error}). UPLOAD_MAX_MB=${rawUploadMaxMb} will NOT apply to uploads; the limit built into the image stays in effect.`,
+        });
+        break;
+      case "no-match":
+        lines.push({
+          level: "warn",
+          message: `WARNING: no serverActions.bodySizeLimit found in ${result.file}, so UPLOAD_MAX_MB=${rawUploadMaxMb} will NOT apply to uploads. Next may have changed where it freezes this config -- see testplanit/scripts/set-upload-body-limit.ts.`,
+        });
+        break;
+      case "missing":
+        // All copies missing is the normal non-production case (dev, the
+        // workers image). Some present and some not is not: say so.
+        if (matched.length > 0) {
+          lines.push({
+            level: "warn",
+            message: `WARNING: ${result.file} is missing from an otherwise complete standalone build; UPLOAD_MAX_MB=${rawUploadMaxMb} was applied to the copies that are present.`,
+          });
+        }
+        break;
+      case "unchanged":
+        break;
+    }
+  }
+  return lines;
+}
+
 export function main(): void {
-  const results = syncBodySizeLimit(process.cwd(), process.env.UPLOAD_MAX_MB);
+  const raw = process.env.UPLOAD_MAX_MB;
+  const results = syncBodySizeLimit(process.cwd(), raw);
   if (results === null) {
     return;
   }
-  for (const result of results) {
-    if (result.status === "updated") {
-      console.log(
-        `Server-action body limit in ${result.file}: ${result.from} -> ${result.to} (UPLOAD_MAX_MB=${process.env.UPLOAD_MAX_MB})`
-      );
-    } else if (result.status === "failed") {
-      console.warn(
-        `Server-action body limit in ${result.file}: left as built (${result.error}).`
-      );
+  for (const { level, message } of describeSync(results, raw as string)) {
+    if (level === "warn") {
+      console.warn(message);
+    } else {
+      console.log(message);
     }
   }
 }

--- a/testplanit/scripts/set-upload-body-limit.ts
+++ b/testplanit/scripts/set-upload-body-limit.ts
@@ -1,0 +1,151 @@
+/**
+ * Sync Next's frozen server-action body limit with UPLOAD_MAX_MB at boot.
+ *
+ * next.config.ts sizes experimental.serverActions.bodySizeLimit from
+ * UPLOAD_MAX_MB and `next build` freezes it into the standalone output, in two
+ * places: inlined into the `nextConfig` literal in server.js (handed to the
+ * server through __NEXT_PRIVATE_STANDALONE_CONFIG) and in
+ * .next/required-server-files.json (read by the render worker). The running
+ * server reads those frozen copies, never next.config.ts.
+ *
+ * So on an image the operator did not build -- the published self-host images,
+ * the Helm chart -- the value baked at build time is the real ceiling: raising
+ * UPLOAD_MAX_MB at runtime moves only app/actions/uploadFile.ts's own check, and
+ * a file sized between the two limits is rejected by Next before the action
+ * runs, with an opaque error instead of the friendly "File is too large".
+ *
+ * docker-entrypoint.sh runs this before starting the server so UPLOAD_MAX_MB is
+ * the single knob it is documented to be, whoever built the image. It is
+ * deliberately non-fatal: an unwritable file (read-only root filesystem) leaves
+ * the baked default in place rather than blocking boot.
+ */
+import { readFileSync, renameSync, writeFileSync } from "fs";
+import { join } from "path";
+
+// Mirrors the headroom in next.config.ts. Server actions carry uploads as
+// multipart FormData, so the transport limit has to sit above the per-file
+// ceiling or encoding overhead turns "File is too large" into an opaque error.
+export const BODY_LIMIT_HEADROOM_MB = 10;
+
+// Both frozen copies, relative to the standalone app directory (the entrypoint
+// runs from /app/testplanit, where server.js lives).
+export const FROZEN_CONFIG_FILES = [
+  "server.js",
+  ".next/required-server-files.json",
+];
+
+// Narrow on purpose: server.js is generated JavaScript with the config inlined
+// as a JSON literal, so a targeted key rewrite is safer than parsing it.
+const LIMIT_PATTERN = /("bodySizeLimit"\s*:\s*")([^"]*)(")/g;
+
+export type FileResult = {
+  file: string;
+  status: "updated" | "unchanged" | "missing" | "no-match" | "failed";
+  from?: string;
+  to?: string;
+  error?: string;
+};
+
+/** Mirrors the parse in next.config.ts and app/actions/uploadFile.ts. */
+export function parseUploadMaxMb(raw: string | undefined): number | null {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function bodySizeLimitFor(uploadMaxMb: number): string {
+  return `${uploadMaxMb + BODY_LIMIT_HEADROOM_MB}mb`;
+}
+
+export function replaceBodySizeLimit(
+  source: string,
+  limit: string
+): { text: string; from?: string; occurrences: number } {
+  let occurrences = 0;
+  let from: string | undefined;
+  const text = source.replace(LIMIT_PATTERN, (_match, open, current, close) => {
+    occurrences += 1;
+    from ??= current;
+    return `${open}${limit}${close}`;
+  });
+  return { text, from, occurrences };
+}
+
+function syncFile(filePath: string, limit: string): FileResult {
+  const file = filePath;
+  let source: string;
+  try {
+    source = readFileSync(filePath, "utf-8");
+  } catch (error) {
+    // Normal outside the production image: the workers image has no standalone
+    // tree, and dev reads next.config.ts directly.
+    const err = error as NodeJS.ErrnoException;
+    return err.code === "ENOENT"
+      ? { file, status: "missing" }
+      : { file, status: "failed", error: err.message };
+  }
+
+  const { text, from, occurrences } = replaceBodySizeLimit(source, limit);
+  if (occurrences === 0) {
+    // A build that never set serverActions.bodySizeLimit. Nothing to keep in
+    // step, and inserting the key into generated output is not worth the risk.
+    return { file, status: "no-match" };
+  }
+  if (text === source) {
+    return { file, status: "unchanged", from, to: limit };
+  }
+
+  // Write-and-rename: a container killed mid-write must never leave the server
+  // with a truncated server.js.
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    writeFileSync(tmpPath, text, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    return { file, status: "failed", error: (error as Error).message };
+  }
+  return { file, status: "updated", from, to: limit };
+}
+
+/**
+ * Rewrite every frozen copy under `rootDir` to match `rawUploadMaxMb`.
+ * Authoritative in both directions, so an image built for a large ceiling
+ * cannot keep accepting oversized bodies after the operator lowers the knob.
+ * Unset or invalid leaves the build-time value in place.
+ */
+export function syncBodySizeLimit(
+  rootDir: string,
+  rawUploadMaxMb: string | undefined
+): FileResult[] | null {
+  const uploadMaxMb = parseUploadMaxMb(rawUploadMaxMb);
+  if (uploadMaxMb === null) {
+    return null;
+  }
+  const limit = bodySizeLimitFor(uploadMaxMb);
+  return FROZEN_CONFIG_FILES.map((relative) =>
+    syncFile(join(rootDir, relative), limit)
+  );
+}
+
+export function main(): void {
+  const results = syncBodySizeLimit(process.cwd(), process.env.UPLOAD_MAX_MB);
+  if (results === null) {
+    return;
+  }
+  for (const result of results) {
+    if (result.status === "updated") {
+      console.log(
+        `Server-action body limit in ${result.file}: ${result.from} -> ${result.to} (UPLOAD_MAX_MB=${process.env.UPLOAD_MAX_MB})`
+      );
+    } else if (result.status === "failed") {
+      console.warn(
+        `Server-action body limit in ${result.file}: left as built (${result.error}).`
+      );
+    }
+  }
+}
+
+// tsx runs this file directly from docker-entrypoint.sh; the test imports the
+// functions above without triggering the CLI.
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Description

`next.config.ts` sizes `serverActions.bodySizeLimit` from `UPLOAD_MAX_MB`, and `next build` freezes that value into the standalone output **twice**: inlined into the `nextConfig` literal in `server.js` (handed to the server through `__NEXT_PRIVATE_STANDALONE_CONFIG`) and again in `.next/required-server-files.json` (read by the render worker). The running server reads those frozen copies, never `next.config.ts`.

So on an image the operator did not build — the published `testplanit-selfhost` images, and therefore the Helm chart — the build-time default was the real ceiling. Raising `UPLOAD_MAX_MB` at runtime moved only the per-file check in `app/actions/uploadFile.ts`, and a file sized between the two limits was rejected by Next before the action ran, with an opaque server-action error instead of the friendly "File is too large". The docs promised one knob; prebuilt images had half of one.

The chart shows the mismatch plainly: its ingress already allows `100m` request bodies while the image it pulls caps uploads at 10 MB.

`docker-entrypoint.sh` now runs `scripts/set-upload-body-limit.ts` before starting the server, rewriting both frozen copies from `UPLOAD_MAX_MB`:

- **Authoritative in both directions** — a lowered `UPLOAD_MAX_MB` lowers the transport limit too, so the two can never drift apart.
- **Non-fatal** — an unwritable file (read-only root filesystem) logs a warning and leaves the baked default in place rather than blocking boot. Missing files (the workers image has no standalone tree) are a silent no-op.
- **Narrow** — a targeted rewrite of the `bodySizeLimit` key, not a parse-and-reserialize of generated JavaScript. Atomic write-and-rename, so a container killed mid-write can never leave a truncated `server.js`.

The build ARG stays as the image default, and `UPLOAD_MAX_MB` now applies on a **restart** rather than a rebuild — for self-hosters on Compose and for the chart, which gains `config.uploadMaxMb`.

## Related Issue

N/A — found while checking whether a Compose deployment could move from locally-built images to the published self-host ones.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

13 new unit tests in `scripts/set-upload-body-limit.test.ts` cover both frozen-file shapes (`server.js` inlines the config compact, `required-server-files.json` is pretty-printed with a space after the colon), raising and lowering, idempotence, missing files, a build that never set the key, and that nothing but the limit changes. One test asserts the `+10mb` headroom stays in step with `next.config.ts`, so the two cannot drift silently. The existing 15 `app/actions/uploadFile.test.ts` tests still pass.

Manual test against the real standalone output of a running v1.0.x production container:

```
$ UPLOAD_MAX_MB=100 tsx scripts/set-upload-body-limit.ts
Server-action body limit in .../server.js: 20mb -> 110mb (UPLOAD_MAX_MB=100)
Server-action body limit in .../.next/required-server-files.json: 20mb -> 110mb (UPLOAD_MAX_MB=100)

$ node --check server.js && echo OK      # OK
$ diff original server.js                # exactly one line differs
$ UPLOAD_MAX_MB=100 tsx scripts/...      # second run: silent no-op
```

**Test Configuration:**
- OS: Ubuntu 24.04 (linux/amd64), Docker Compose deployment
- Node version: 24 (image), 22 local
- Browser (if applicable): n/a

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have signed the [CLA](https://testplanit.com/cla)

## Additional Notes

Targeted at `release/v1.1` rather than `main`: it adds a capability rather than fixing a regression, so it belongs in the next release line.

Docs updated to match the new behaviour: `file-storage.md` and `nginx-local/README.md` said a **rebuild** was required — they now say restart. `kubernetes-deployment.md` gains a note tying `config.uploadMaxMb` to the ingress `proxy-body-size` annotation, since whichever is lower rejects the upload.

Worth a reviewer's eye: patching generated output at boot is unusual. The alternative — leaving `bodySizeLimit` at a generous fixed value and letting the runtime check in `uploadFile.ts` be the only enforcement — is simpler but drops the transport-level guard for anyone without a proxy limit in front of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AniY9mXRRDFNEKWTDwbiEc
