### PR TITLE
fix(search): aggregate repository case facets on their keyword fields

### DIFF
--- a/testplanit/services/elasticsearchService.integration.test.ts
+++ b/testplanit/services/elasticsearchService.integration.test.ts
@@ -70,6 +70,12 @@ describe("elasticsearchService", () => {
       expect(repositoryCaseMapping.properties.folderPath).toEqual({
         type: "keyword",
       });
+
+      // creatorName carries the keyword subfield the creators facet aggregates on
+      expect(repositoryCaseMapping.properties.creatorName).toEqual({
+        type: "text",
+        fields: { keyword: { type: "keyword" } },
+      });
     });
   });
 

--- a/testplanit/services/elasticsearchService.ts
+++ b/testplanit/services/elasticsearchService.ts
@@ -105,7 +105,12 @@ export const repositoryCaseMapping = {
     isDeleted: { type: "boolean" as const },
     createdAt: { type: "date" as const },
     creatorId: { type: "keyword" as const },
-    creatorName: { type: "text" as const },
+    creatorName: {
+      type: "text" as const,
+      fields: {
+        keyword: { type: "keyword" as const },
+      },
+    },
     tags: {
       type: "nested" as const,
       properties: {

--- a/testplanit/services/repositoryCaseSearch.test.ts
+++ b/testplanit/services/repositoryCaseSearch.test.ts
@@ -177,5 +177,29 @@ describe("repositoryCaseSearch", () => {
       expect(filters).toContainEqual({ term: { isArchived: false } });
       expect(filters).toContainEqual({ term: { isDeleted: false } });
     });
+
+    it("should aggregate facets on the fields as they are mapped", async () => {
+      mockClient.search.mockResolvedValue({
+        hits: {
+          hits: [],
+          total: { value: 0 },
+        },
+        took: 10,
+      });
+
+      await searchRepositoryCases({
+        facets: ["projects", "templates", "states", "creators", "folders"],
+      });
+
+      const searchCall = mockClient.search.mock.calls[0][0];
+
+      expect(searchCall.aggs).toEqual({
+        projects: { terms: { field: "projectName", size: 50 } },
+        templates: { terms: { field: "templateName", size: 20 } },
+        states: { terms: { field: "stateName", size: 20 } },
+        creators: { terms: { field: "creatorName.keyword", size: 50 } },
+        folders: { terms: { field: "folderPath", size: 100 } },
+      });
+    });
   });
 });

--- a/testplanit/services/repositoryCaseSearch.ts
+++ b/testplanit/services/repositoryCaseSearch.ts
@@ -200,17 +200,17 @@ function buildAggregations(facets?: string[]) {
     switch (facet) {
       case "projects":
         aggs.projects = {
-          terms: { field: "projectName.keyword", size: 50 },
+          terms: { field: "projectName", size: 50 },
         };
         break;
       case "templates":
         aggs.templates = {
-          terms: { field: "templateName.keyword", size: 20 },
+          terms: { field: "templateName", size: 20 },
         };
         break;
       case "states":
         aggs.states = {
-          terms: { field: "stateName.keyword", size: 20 },
+          terms: { field: "stateName", size: 20 },
         };
         break;
       case "creators":
@@ -235,7 +235,7 @@ function buildAggregations(facets?: string[]) {
         break;
       case "folders":
         aggs.folders = {
-          terms: { field: "folderPath.keyword", size: 100 },
+          terms: { field: "folderPath", size: 100 },
         };
         break;
     }

--- a/testplanit/services/unifiedElasticsearchService.test.ts
+++ b/testplanit/services/unifiedElasticsearchService.test.ts
@@ -58,6 +58,12 @@ describe("unifiedElasticsearchService", () => {
         type: "text",
         analyzer: "standard",
       });
+
+      // creatorName carries the keyword subfield the creators facet aggregates on
+      expect(mapping.properties.creatorName).toEqual({
+        type: "text",
+        fields: { keyword: { type: "keyword" } },
+      });
     });
 
     it("should have mappings for all entity types", () => {

--- a/testplanit/services/unifiedElasticsearchService.ts
+++ b/testplanit/services/unifiedElasticsearchService.ts
@@ -155,6 +155,12 @@ export const ENTITY_MAPPINGS = {
       automated: { type: "boolean" as const },
       isArchived: { type: "boolean" as const },
       isDeleted: { type: "boolean" as const },
+      creatorName: {
+        type: "text" as const,
+        fields: {
+          keyword: { type: "keyword" as const },
+        },
+      },
       tags: {
         type: "nested" as const,
         properties: {


### PR DESCRIPTION
## Description

The `projects`, `templates`, `states` and `folders` facets returned by `POST /api/repository-cases/search` were always empty. `searchRepositoryCases` aggregated on `<field>.keyword`, but `projectName`, `templateName`, `stateName` and `folderPath` are mapped `keyword` with no subfield, so every one of those aggregations targeted an unmapped field. Elasticsearch answers that with `buckets: []` and no error, which is why it read as "no data" rather than a fault. The four aggregations now target the fields directly.

`creatorName` is the one text field the facets use, and its `.keyword` subfield only existed on the live index through dynamic mapping: the reindex worker builds `testplanit-repository-cases` from the unified entity mapping, which never declared the field at all, while the first-sync path builds it from `repositoryCaseMapping`, which declared it as plain `text`. A fresh index from that second path would have broken the `creators` facet the other way round. Both mappings now declare the subfield, so the facet no longer depends on which code path created the index.

Not changed: the unified search facet counts (`/api/search`) are a separate, pre-existing gap and are tracked as a v1.1 enhancement. The repository page's own filter counts come from Postgres and were never affected.

## Related Issue

Found while investigating the repository search facets (no issue filed).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Unit tests — `services/repositoryCaseSearch.test.ts` asserts the exact aggregation request for the five facets; `services/elasticsearchService.integration.test.ts` and `services/unifiedElasticsearchService.test.ts` assert the `creatorName` mapping shape. 32 tests across the three suites.
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing — ran the same aggregations against the live index with and without the `.keyword` suffix (suffixed: 0 buckets for all four; direct: 47 projects, 19 templates, 3 states, 25 folders), then exercised `searchRepositoryCases` itself against that index through a script and got the same buckets back through the facet parser. Full `pnpm precommit` gate: 867 test files and 12,953 tests passed, 0 lint errors, `tsc --noEmit` clean, docs site built.

**Test Configuration:**
- OS: macOS
- Browser (if applicable): n/a
- Node version: v24.14.0

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

## Additional Notes

Existing indices keep their current mapping: index creation is skipped when the index already exists, and the reindex worker rebuilds from scratch. Indices created by the reindex worker already carry a dynamically mapped `creatorName.keyword`, so the query change is effective on them without a reindex.
