### PR TITLE
fix(editor): skip the read-only content sync on a destroyed editor

### DIFF
--- a/testplanit/components/tiptap/TipTapEditor.tsx
+++ b/testplanit/components/tiptap/TipTapEditor.tsx
@@ -406,7 +406,9 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
   // reset the caret. Mirrors the read-only editor in
   // components/comments/CommentItem.tsx.
   useEffect(() => {
-    if (!editor || !readOnly) return;
+    // A destroyed editor (route change, StrictMode re-mount) still satisfies
+    // the null check but has no command manager any more.
+    if (!editor || editor.isDestroyed || !readOnly) return;
     const next = validateContent(content);
     if (JSON.stringify(editor.getJSON()) === JSON.stringify(next)) return;
     editor.commands.setContent(next, { emitUpdate: false });


### PR DESCRIPTION
## Description

The read-only content sync in `TipTapEditor` runs in an effect that can fire after TipTap has destroyed the editor (route change, StrictMode re-mount). The instance still passes the null check but has no command manager, so `setContent` threw `Cannot read properties of null (reading 'commands')` in the console. The effect now also returns on `editor.isDestroyed`.

## Related Issue

Seen during v1.1 UAT while switching pages; the same code is on main.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing — the console error no longer appears when navigating between pages with read-only editors on the v1.1 feature branch, which carries the same one-line guard

**Test Configuration:**
- OS: macOS
- Browser (if applicable): Chrome
- Node version: 24

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have signed the [CLA](https://testplanit.com/cla)

## Screenshots (if applicable)

## Additional Notes

One-line guard, no behaviour change for a live editor.
